### PR TITLE
Render recursive types as μ-knots in coalesced inference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,17 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
 - Name the value, not the technique that produced it. Don't write "union-find"
   when you mean the merge classes it computed, or "the visitor" when you mean
   the walk's result. Refer to the thing the code hands around.
+- Backtick a word that carries both an ordinary meaning and a specialized one,
+  whenever the specialized one is intended. Without the backticks a reader
+  parses the sentence as plain prose and has to start over on reaching the code.
+  "collapsing to never or unknown" reads as a claim about frequency.
+  "collapsing to `never` or `unknown`" names the two lattice bounds. This covers
+  type and keyword names such as `never`, `unknown`, `error`, `void`, `null`,
+  `undefined`, `number`, `string`, and `object`, and it covers any identifier
+  whose name is itself a common word, such as the `open` parameter marker or the
+  `seen` set. Backtick only the specialized sense. "it never needs parens" and
+  "an unknown key" stay bare, because there the ordinary meaning is the intended
+  one. Apply this when reviewing a comment as well as when writing one.
 - Treat a comment as draft-then-revise, not one-shot. After writing any comment
   longer than a sentence or two, reread it as someone with no prior context.
   Fix every unexplained term and every sentence that needs a second pass.

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -16,7 +16,6 @@ import (
 // (KeyofType); the `...T` spread prefix lands with tuple/object spread types.
 const (
 	precFunc         = 2 // fn (...) -> T — return type is greedy, needs parens in union/intersection
-	precRecursive    = 2 // μX0.T — the body is greedy too, so a knot parenthesizes where a fn does
 	precUnion        = 3 // A | B
 	precIntersection = 4 // A & B
 	precPrefix       = 5 // mut T, 'a T, keyof T — a prefix binds looser than an atom
@@ -58,10 +57,10 @@ func typePrec(t Type) int {
 		// A mapped type's key variable renders as its bare name, an atom.
 		return precAtom
 	case *RecursiveType:
-		// A μ-knot's body runs to the end of the enclosing form, so `μX0.A | X0 | number` would read
-		// as one knot over the whole union. Ranking it below precUnion puts the parens on the knot:
-		// `(μX0.A | X0) | number`.
-		return precRecursive
+		// A μ-knot is self-delimiting, because printType parenthesizes any body that is not itself
+		// an atom, so it never needs outer parens. `μX0.{next: X0} | number` and
+		// `μX0.(number | X0) | number` both read correctly with no wrapper.
+		return precAtom
 	case *RecursiveVarType:
 		// A μ-knot's bound variable renders as its bare name, an atom.
 		return precAtom
@@ -779,11 +778,16 @@ func (p *namedPrinter) printType(t Type) string {
 		return t.Name
 	case *RecursiveType:
 		// `μX0.<body>`, the μ form for a recursive type. Escalier has no surface syntax for one, so
-		// this is the standard notation rather than a mirror of a parser form. The body prints with
-		// no minimum precedence, because nothing follows the knot inside its own rendering and so
-		// the greedy body needs no parens. precRecursive is what puts the parens on the knot when it
-		// sits inside a union or intersection.
-		return "μ" + t.Binder.DisplayName() + "." + p.printType(t.Body)
+		// this is the standard notation rather than a mirror of a parser form.
+		//
+		// The body prints at precAtom, so it is parenthesized unless it is already self-delimiting.
+		// A μ binder is greedy, meaning it extends to the end of the enclosing form, so a body that
+		// could run on has to be bounded here or it would swallow whatever follows the knot:
+		// `μX0.number | X0` beside a `| string` would read as one three-member union. An object,
+		// tuple, or bare name carries its own delimiter and needs nothing, which is why the common
+		// `μX0.{next: X0}` stays bare. Bounding the body here is also what makes the knot an atom,
+		// so it never needs parens of its own at the use site.
+		return "μ" + t.Binder.DisplayName() + "." + p.printTypeMinPrec(t.Body, precAtom)
 	case *RecursiveVarType:
 		// A reference to the enclosing knot's binder renders as that binder's bare name, so
 		// `μX0.{next: X0}` names one binding twice.

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -15,7 +15,10 @@ import (
 // prefix forms — the `mut`/lifetime borrow prefix (RefType) and the `keyof` operator
 // (KeyofType); the `...T` spread prefix lands with tuple/object spread types.
 const (
-	precFunc         = 2 // fn (...) -> T — return type is greedy, needs parens in union/intersection
+	precFunc = 2 // fn (...) -> T — return type is greedy, needs parens in union/intersection
+	// precRecursive is μX0.T. The body is greedy the same way a function's return type is, so a
+	// knot inside a union or intersection needs the same parens, and it shares precFunc's level.
+	precRecursive    = 2
 	precUnion        = 3 // A | B
 	precIntersection = 4 // A & B
 	precPrefix       = 5 // mut T, 'a T, keyof T — a prefix binds looser than an atom
@@ -55,6 +58,11 @@ func typePrec(t Type) int {
 		return precAtom
 	case *MappedKeyType:
 		// A mapped type's key variable renders as its bare name, an atom.
+		return precAtom
+	case *RecursiveType:
+		return precRecursive
+	case *RecursiveVarType:
+		// A μ-knot's bound variable renders as its bare name, an atom.
 		return precAtom
 	case *RestSpreadType:
 		// A `...P` spread element only appears inside a tuple's bracket list, which prints each
@@ -482,6 +490,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 			}
 		case *StringIntrinsicType:
 			walk(t.Operand)
+		case *RecursiveType:
+			walk(t.Body)
 		case *PromiseType:
 			walk(t.Inner)
 		case *RefType:
@@ -583,12 +593,14 @@ func (p *namedPrinter) printTypeMinPrec(t Type, minPrec int) string {
 //
 // An InferType renders as a name in both forms, `infer U` at the binder and a bare `U` at a
 // reference, and a TypeofType renders as the identifier it names rather than the value's type, so
-// both are leaves. An alias or class reference is not, even though one with no type arguments
-// renders as a bare name: its argument list is exactly what a diagnostic needs bounded.
+// both are leaves. A RecursiveVarType renders as its binder's name, so it is one too. An alias or
+// class reference is not, even though one with no type arguments renders as a bare name: its
+// argument list is exactly what a diagnostic needs bounded.
 func isPrintLeaf(t Type) bool {
 	switch t.(type) {
 	case *TypeVarType, *PrimType, *LitType, *NeverType, *UnknownType, *ErrorType,
-		*Void, *NullType, *UndefinedType, *MappedKeyType, *InferType, *TypeofType:
+		*Void, *NullType, *UndefinedType, *MappedKeyType, *InferType, *TypeofType,
+		*RecursiveVarType:
 		return true
 	}
 	return false
@@ -764,6 +776,17 @@ func (p *namedPrinter) printType(t Type) string {
 		// A mapped type's key variable renders as the bare name the source bound it under, so a
 		// stored mapped type round-trips to `{[K]: T[K] for K in keyof T}`.
 		return t.Name
+	case *RecursiveType:
+		// `μX0.<body>`, the μ form for a recursive type. Escalier has no surface syntax for one, so
+		// this is the standard notation rather than a mirror of a parser form. The body prints with
+		// no minimum precedence: nothing follows the knot inside its own rendering, so the greedy
+		// body needs no parens, and precRecursive puts the parens on the knot when it sits inside a
+		// union or intersection.
+		return "μ" + t.Binder.DisplayName() + "." + p.printType(t.Body)
+	case *RecursiveVarType:
+		// A reference to the enclosing knot's binder renders as that binder's bare name, so
+		// `μX0.{next: X0}` names one binding twice.
+		return t.DisplayName()
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -15,10 +15,8 @@ import (
 // prefix forms — the `mut`/lifetime borrow prefix (RefType) and the `keyof` operator
 // (KeyofType); the `...T` spread prefix lands with tuple/object spread types.
 const (
-	precFunc = 2 // fn (...) -> T — return type is greedy, needs parens in union/intersection
-	// precRecursive is μX0.T. The body is greedy the same way a function's return type is, so a
-	// knot inside a union or intersection needs the same parens, and it shares precFunc's level.
-	precRecursive    = 2
+	precFunc         = 2 // fn (...) -> T — return type is greedy, needs parens in union/intersection
+	precRecursive    = 2 // μX0.T — the body is greedy too, so a knot parenthesizes where a fn does
 	precUnion        = 3 // A | B
 	precIntersection = 4 // A & B
 	precPrefix       = 5 // mut T, 'a T, keyof T — a prefix binds looser than an atom
@@ -60,6 +58,9 @@ func typePrec(t Type) int {
 		// A mapped type's key variable renders as its bare name, an atom.
 		return precAtom
 	case *RecursiveType:
+		// A μ-knot's body runs to the end of the enclosing form, so `μX0.A | X0 | number` would read
+		// as one knot over the whole union. Ranking it below precUnion puts the parens on the knot:
+		// `(μX0.A | X0) | number`.
 		return precRecursive
 	case *RecursiveVarType:
 		// A μ-knot's bound variable renders as its bare name, an atom.
@@ -779,9 +780,9 @@ func (p *namedPrinter) printType(t Type) string {
 	case *RecursiveType:
 		// `μX0.<body>`, the μ form for a recursive type. Escalier has no surface syntax for one, so
 		// this is the standard notation rather than a mirror of a parser form. The body prints with
-		// no minimum precedence: nothing follows the knot inside its own rendering, so the greedy
-		// body needs no parens, and precRecursive puts the parens on the knot when it sits inside a
-		// union or intersection.
+		// no minimum precedence, because nothing follows the knot inside its own rendering and so
+		// the greedy body needs no parens. precRecursive is what puts the parens on the knot when it
+		// sits inside a union or intersection.
 		return "μ" + t.Binder.DisplayName() + "." + p.printType(t.Body)
 	case *RecursiveVarType:
 		// A reference to the enclosing knot's binder renders as that binder's bare name, so

--- a/internal/soltype/recursive_test.go
+++ b/internal/soltype/recursive_test.go
@@ -1,0 +1,152 @@
+package soltype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// knot builds `μ<name>.<body>` where body is produced from the binder, so a test reads as the μ
+// form it asserts. The callback receives the binder's reference node, which is the same node the
+// body must name for the knot to be recursive.
+func knot(id int, name string, body func(ref *RecursiveVarType) Type) *RecursiveType {
+	binder := &RecursiveVarType{ID: id, Name: name}
+	return &RecursiveType{Binder: binder, Body: body(binder)}
+}
+
+// TestPrintRecursive covers the μ form's rendering: the binder's name, the reference inside the
+// body, the unnamed binder's debug fallback, and the parenthesization a knot needs when it sits
+// inside a union or intersection, since its body is greedy the way a function's return type is.
+func TestPrintRecursive(t *testing.T) {
+	selfNext := knot(0, "X0", func(ref *RecursiveVarType) Type {
+		return &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "next", Type: ref}}}
+	})
+	tests := []struct {
+		name string
+		in   Type
+		want string
+	}{
+		{
+			name: "self-referential object",
+			in:   selfNext,
+			want: "μX0.{next: X0}",
+		},
+		{
+			name: "unnamed binder falls back to the r{ID} debug form",
+			in: knot(7, "", func(ref *RecursiveVarType) Type {
+				return &TupleType{Elems: []Type{ref}}
+			}),
+			want: "μr7.[r7]",
+		},
+		{
+			name: "nested knots each name their own binder",
+			in: knot(0, "X0", func(outer *RecursiveVarType) Type {
+				return &ObjectType{Elems: []ObjTypeElem{
+					&PropertyElem{Name: "up", Type: outer},
+					&PropertyElem{Name: "down", Type: knot(1, "X1", func(inner *RecursiveVarType) Type {
+						return &TupleType{Elems: []Type{outer, inner}}
+					})},
+				}}
+			}),
+			want: "μX0.{up: X0, down: μX1.[X0, X1]}",
+		},
+		{
+			// The knot's body would swallow the `| number` tail, so a union member parenthesizes it.
+			name: "knot inside a union is parenthesized",
+			in:   &UnionType{Types: []Type{selfNext, numP()}},
+			want: "(μX0.{next: X0}) | number",
+		},
+		{
+			name: "knot inside an intersection is parenthesized",
+			in:   &IntersectionType{Types: []Type{selfNext, numP()}},
+			want: "(μX0.{next: X0}) & number",
+		},
+		{
+			// A knot nested in a property is delimited by the braces, so it needs no parens.
+			name: "knot in a property needs no parens",
+			in:   &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "head", Type: selfNext}}},
+			want: "{head: μX0.{next: X0}}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, Print(tt.in))
+		})
+	}
+}
+
+// TestLevelOfRecursive pins the split that lets a knot cross a level boundary: the body's
+// variables lift the level so the freshener and extruder prune descends into them, while the binder
+// and its references contribute nothing.
+func TestLevelOfRecursive(t *testing.T) {
+	inner := &TypeVarType{ID: 0, Level: 3}
+	tests := []struct {
+		name string
+		ty   Type
+		want int
+	}{
+		{
+			name: "bare binder reference is level 0",
+			ty:   &RecursiveVarType{ID: 0, Name: "X0"},
+			want: 0,
+		},
+		{
+			name: "knot over a variable-free body is level 0",
+			ty: knot(0, "X0", func(ref *RecursiveVarType) Type {
+				return &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "next", Type: ref}}}
+			}),
+			want: 0,
+		},
+		{
+			name: "knot takes its body's level",
+			ty: knot(0, "X0", func(ref *RecursiveVarType) Type {
+				return &ObjectType{Elems: []ObjTypeElem{
+					&PropertyElem{Name: "next", Type: ref},
+					&PropertyElem{Name: "value", Type: inner},
+				}}
+			}),
+			want: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, LevelOf(tt.ty))
+		})
+	}
+}
+
+// TestAcceptRecursive pins the visitor arm: the body is rewritten, the binder carries through
+// unchanged, and an unchanged body keeps the knot's pointer so identity-keyed caches stay valid.
+func TestAcceptRecursive(t *testing.T) {
+	original := knot(0, "X0", func(ref *RecursiveVarType) Type {
+		return &ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "next", Type: ref},
+			&PropertyElem{Name: "value", Type: numP()},
+		}}
+	})
+
+	t.Run("body is rewritten and the binder is preserved", func(t *testing.T) {
+		out := original.Accept(&primSwapper{}, Positive)
+		rewritten, ok := out.(*RecursiveType)
+		require.True(t, ok, "the visit must rebuild a knot, got %T", out)
+		require.Same(t, original.Binder, rewritten.Binder)
+		require.Equal(t, "μX0.{next: X0, value: string}", Print(rewritten))
+	})
+
+	t.Run("an unchanged body keeps the knot's pointer", func(t *testing.T) {
+		require.Same(t, original, original.Accept(identityVisitor{}, Positive))
+	})
+}
+
+// primSwapper rewrites every number to a string, so a visit that reaches a knot's body is visible
+// in the rendered result.
+type primSwapper struct{}
+
+func (s *primSwapper) EnterType(t Type, _ Polarity) EnterResult { return EnterResult{} }
+
+func (s *primSwapper) ExitType(t Type, _ Polarity) Type {
+	if p, ok := t.(*PrimType); ok && p.Prim == NumPrim {
+		return strP()
+	}
+	return t
+}

--- a/internal/soltype/recursive_test.go
+++ b/internal/soltype/recursive_test.go
@@ -15,11 +15,17 @@ func knot(id int, name string, body func(ref *RecursiveVarType) Type) *Recursive
 }
 
 // TestPrintRecursive covers the μ form's rendering: the binder's name, the reference inside the
-// body, the unnamed binder's debug fallback, and the parens a knot needs inside a union or
-// intersection. It needs them because its body is greedy the way a function's return type is.
+// body, the unnamed binder's debug fallback, and where the parens fall.
+//
+// A μ binder is greedy, so the parens go on the BODY, and only when the body is not already
+// self-delimiting. That keeps the common object-bodied knot bare and leaves the knot itself an atom,
+// so it needs no parens at any use site.
 func TestPrintRecursive(t *testing.T) {
 	selfNext := knot(0, "X0", func(ref *RecursiveVarType) Type {
 		return &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "next", Type: ref}}}
+	})
+	looseBody := knot(0, "X0", func(ref *RecursiveVarType) Type {
+		return &UnionType{Types: []Type{numP(), ref}}
 	})
 	tests := []struct {
 		name string
@@ -51,15 +57,37 @@ func TestPrintRecursive(t *testing.T) {
 			want: "μX0.{up: X0, down: μX1.[X0, X1]}",
 		},
 		{
-			// The knot's body would swallow the `| number` tail, so a union member parenthesizes it.
-			name: "knot inside a union is parenthesized",
+			// A body that carries its own delimiter cannot run on, so nothing is parenthesized: not
+			// the body, and not the knot at the use site.
+			name: "self-delimiting body needs no parens in a union",
 			in:   &UnionType{Types: []Type{selfNext, numP()}},
-			want: "(μX0.{next: X0}) | number",
+			want: "μX0.{next: X0} | number",
 		},
 		{
-			name: "knot inside an intersection is parenthesized",
+			name: "self-delimiting body needs no parens in an intersection",
 			in:   &IntersectionType{Types: []Type{selfNext, numP()}},
-			want: "(μX0.{next: X0}) & number",
+			want: "μX0.{next: X0} & number",
+		},
+		{
+			// A union body would swallow anything following the knot, so the body is bounded. The
+			// knot itself stays bare, which is the whole point of bounding the body.
+			name: "union body is parenthesized",
+			in:   looseBody,
+			want: "μX0.(number | X0)",
+		},
+		{
+			name: "a bounded body lets the knot sit bare in a union",
+			in:   &UnionType{Types: []Type{looseBody, strP()}},
+			want: "μX0.(number | X0) | string",
+		},
+		{
+			// Every non-atom body is bounded for the same reason a union one is, since a μ binder
+			// runs to the end of the enclosing form.
+			name: "prefix body is parenthesized",
+			in: knot(0, "X0", func(ref *RecursiveVarType) Type {
+				return &KeyofType{Operand: ref}
+			}),
+			want: "μX0.(keyof X0)",
 		},
 		{
 			// A knot nested in a property is delimited by the braces, so it needs no parens.

--- a/internal/soltype/recursive_test.go
+++ b/internal/soltype/recursive_test.go
@@ -15,8 +15,8 @@ func knot(id int, name string, body func(ref *RecursiveVarType) Type) *Recursive
 }
 
 // TestPrintRecursive covers the μ form's rendering: the binder's name, the reference inside the
-// body, the unnamed binder's debug fallback, and the parenthesization a knot needs when it sits
-// inside a union or intersection, since its body is greedy the way a function's return type is.
+// body, the unnamed binder's debug fallback, and the parens a knot needs inside a union or
+// intersection. It needs them because its body is greedy the way a function's return type is.
 func TestPrintRecursive(t *testing.T) {
 	selfNext := knot(0, "X0", func(ref *RecursiveVarType) Type {
 		return &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "next", Type: ref}}}
@@ -75,9 +75,9 @@ func TestPrintRecursive(t *testing.T) {
 	}
 }
 
-// TestLevelOfRecursive pins the split that lets a knot cross a level boundary: the body's
-// variables lift the level so the freshener and extruder prune descends into them, while the binder
-// and its references contribute nothing.
+// TestLevelOfRecursive pins the split that lets a knot cross a level boundary. The body's variables
+// lift the level so the freshener and extruder prune descends into them, while the binder and its
+// references contribute nothing.
 func TestLevelOfRecursive(t *testing.T) {
 	inner := &TypeVarType{ID: 0, Level: 3}
 	tests := []struct {

--- a/internal/soltype/recursive_test.go
+++ b/internal/soltype/recursive_test.go
@@ -166,8 +166,8 @@ func TestAcceptRecursive(t *testing.T) {
 	})
 }
 
-// primSwapper rewrites every number to a string, so a visit that reaches a knot's body is visible
-// in the rendered result.
+// primSwapper rewrites every `number` to a `string`, so a visit that reaches a knot's body is
+// visible in the rendered result.
 type primSwapper struct{}
 
 func (s *primSwapper) EnterType(t Type, _ Polarity) EnterResult { return EnterResult{} }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -914,7 +914,8 @@ type StringIntrinsicType struct {
 // a structural type.
 //
 // coalesce mints one when its walk re-enters an inference variable already on the current path, so a
-// recursive position renders as the shape it stands for rather than collapsing to never or unknown.
+// recursive position renders as the shape it stands for rather than collapsing to `never` or
+// `unknown`.
 // `fn f() { return {next: f()} }` infers `fn () -> {next: μX0.{next: X0}}`.
 type RecursiveType struct {
 	Binder *RecursiveVarType

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -1,6 +1,9 @@
 package soltype
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 // Type is the sealed interface for all soltype nodes. (Production name for the
 // spike's SimpleType; marker renamed isSimpleType -> isType.)
@@ -893,45 +896,6 @@ func (k StringIntrinsicKind) String() string {
 	panic(fmt.Sprintf("StringIntrinsicKind.String: unhandled kind %d", int(k)))
 }
 
-// RecursiveType is the μ-knot, the finite form of a type whose unfolding never ends. Body is one
-// level of that unfolding and Binder is the variable Body names itself through, so
-// `μX0.{next: X0}` is the type of a value whose `next` field holds another value of the same type.
-// Unfolding it substitutes the whole knot for its binder in Body, which is how constrain compares a
-// knot against a structural type.
-//
-// coalesce mints one when its walk re-enters an inference variable already on the current path, so
-// a recursive position renders as the shape it stands for rather than collapsing to never or
-// unknown. `fn f() { return {next: f()} }` infers `fn () -> {next: μX0.{next: X0}}`.
-type RecursiveType struct {
-	Binder *RecursiveVarType
-	Body   Type
-}
-
-// RecursiveVarType is the variable a RecursiveType binds, the `X0` of `μX0.{next: X0}`. It is a
-// leaf that carries no bounds, and nothing constrains against it: unfolding the enclosing knot
-// replaces it with that knot before any comparison reaches it.
-//
-// ID is the binding this node stands for. The binder and every reference to it carry one id, so
-// unfolding reaches exactly the positions that binding stands at. A nested knot draws a distinct
-// id, which is what makes its own binding shadow the enclosing one. Name is the display name its
-// producer assigned, `X0`, `X1`, and so on; DisplayName falls back to a raw `r{ID}` form when a
-// producer left it empty.
-type RecursiveVarType struct {
-	ID   int
-	Name string
-}
-
-// DisplayName is the name a μ-binder renders under: the name its producer assigned, else the raw
-// `r{ID}` debug form. The fallback mirrors printType's `t{ID}` for an unnamed inference variable,
-// so a hand-built knot still renders legibly. It is exported because the solver's describe renders
-// raw mid-constrain types through the same name.
-func (v *RecursiveVarType) DisplayName() string {
-	if v.Name != "" {
-		return v.Name
-	}
-	return "r" + fmt.Sprint(v.ID)
-}
-
 // StringIntrinsicType is the residual intrinsic string operator `Uppercase<T>` and its three
 // siblings. Like KeyofType it is inert: it carries no bounds, constrain never records
 // one against it, and it flows through the solver's structural machinery untouched, rendering
@@ -943,9 +907,46 @@ type StringIntrinsicType struct {
 	Operand Type
 }
 
+// RecursiveType is the μ-knot, the finite form of a type whose unfolding never ends. Body is one
+// level of that unfolding and Binder is the variable Body names itself through, so `μX0.{next: X0}`
+// is the type of a value whose `next` field holds another value of the same type. Unfolding it
+// substitutes the whole knot for its binder in Body, which is how constrain compares a knot against
+// a structural type.
+//
+// coalesce mints one when its walk re-enters an inference variable already on the current path, so a
+// recursive position renders as the shape it stands for rather than collapsing to never or unknown.
+// `fn f() { return {next: f()} }` infers `fn () -> {next: μX0.{next: X0}}`.
+type RecursiveType struct {
+	Binder *RecursiveVarType
+	Body   Type
+}
+
+// RecursiveVarType is the variable a RecursiveType binds, the `X0` of `μX0.{next: X0}`. It is a leaf
+// that carries no bounds, and nothing constrains against it. Unfolding the enclosing knot replaces
+// it with that knot before any comparison reaches it.
+//
+// ID is the binding this node stands for. The binder and every reference to it carry one id, so
+// unfolding reaches exactly the positions that binding stands at. A nested knot draws a distinct id,
+// which is what makes its own binding shadow the enclosing one. Name is the display name its
+// producer assigned, `X0`, `X1`, and so on; DisplayName supplies a fallback when a producer left it
+// empty.
+type RecursiveVarType struct {
+	ID   int
+	Name string
+}
+
+// DisplayName is the name a μ-binder renders under: the name its producer assigned, else the raw
+// `r{ID}` debug form, mirroring printType's `t{ID}` for an unnamed inference variable. It is
+// exported so the solver's describe, the second per-node renderer beside printType, names a binder
+// the same way.
+func (v *RecursiveVarType) DisplayName() string {
+	if v.Name != "" {
+		return v.Name
+	}
+	return "r" + strconv.Itoa(v.ID)
+}
+
 func (*TypeVarType) isType()         {}
-func (*RecursiveType) isType()       {}
-func (*RecursiveVarType) isType()    {}
 func (*KeyofType) isType()           {}
 func (*IndexType) isType()           {}
 func (*TypeofType) isType()          {}
@@ -955,6 +956,8 @@ func (*MappedKeyType) isType()       {}
 func (*RestSpreadType) isType()      {}
 func (*TemplateLitType) isType()     {}
 func (*StringIntrinsicType) isType() {}
+func (*RecursiveType) isType()       {}
+func (*RecursiveVarType) isType()    {}
 func (*PrimType) isType()            {}
 func (*LitType) isType()             {}
 func (*FuncType) isType()            {}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -534,7 +534,9 @@ type RefType struct {
 // verdict and is rejected at the inference join where it forms. ClassType is a
 // RefInner too, so a `mut 'a Point` borrows a class instance. AliasType is a
 // RefInner as well, so a `mut 'a Point` over a type alias borrows through the same
-// machinery.
+// machinery. RecursiveType joins them for the same reason an AliasType does: a μ-knot over an
+// object is a borrowable value, and admitting it keeps RefType.Accept from peeling the `mut`
+// wrapper off a borrow whose inner coalesced to a knot.
 type RefInner interface {
 	Type
 	isRefInner()
@@ -547,6 +549,7 @@ func (*UnionType) isRefInner()        {}
 func (*IntersectionType) isRefInner() {}
 func (*ClassType) isRefInner()        {}
 func (*AliasType) isRefInner()        {}
+func (*RecursiveType) isRefInner()    {}
 
 // PromiseType is the result of an `async fn` and the requirement of an `await`.
 // M3 carries it as a dedicated concrete (not a generic TypeRefType), keeping the
@@ -890,6 +893,45 @@ func (k StringIntrinsicKind) String() string {
 	panic(fmt.Sprintf("StringIntrinsicKind.String: unhandled kind %d", int(k)))
 }
 
+// RecursiveType is the μ-knot, the finite form of a type whose unfolding never ends. Body is one
+// level of that unfolding and Binder is the variable Body names itself through, so
+// `μX0.{next: X0}` is the type of a value whose `next` field holds another value of the same type.
+// Unfolding it substitutes the whole knot for its binder in Body, which is how constrain compares a
+// knot against a structural type.
+//
+// coalesce mints one when its walk re-enters an inference variable already on the current path, so
+// a recursive position renders as the shape it stands for rather than collapsing to never or
+// unknown. `fn f() { return {next: f()} }` infers `fn () -> {next: μX0.{next: X0}}`.
+type RecursiveType struct {
+	Binder *RecursiveVarType
+	Body   Type
+}
+
+// RecursiveVarType is the variable a RecursiveType binds, the `X0` of `μX0.{next: X0}`. It is a
+// leaf that carries no bounds, and nothing constrains against it: unfolding the enclosing knot
+// replaces it with that knot before any comparison reaches it.
+//
+// ID is the binding this node stands for. The binder and every reference to it carry one id, so
+// unfolding reaches exactly the positions that binding stands at. A nested knot draws a distinct
+// id, which is what makes its own binding shadow the enclosing one. Name is the display name its
+// producer assigned, `X0`, `X1`, and so on; DisplayName falls back to a raw `r{ID}` form when a
+// producer left it empty.
+type RecursiveVarType struct {
+	ID   int
+	Name string
+}
+
+// DisplayName is the name a μ-binder renders under: the name its producer assigned, else the raw
+// `r{ID}` debug form. The fallback mirrors printType's `t{ID}` for an unnamed inference variable,
+// so a hand-built knot still renders legibly. It is exported because the solver's describe renders
+// raw mid-constrain types through the same name.
+func (v *RecursiveVarType) DisplayName() string {
+	if v.Name != "" {
+		return v.Name
+	}
+	return "r" + fmt.Sprint(v.ID)
+}
+
 // StringIntrinsicType is the residual intrinsic string operator `Uppercase<T>` and its three
 // siblings. Like KeyofType it is inert: it carries no bounds, constrain never records
 // one against it, and it flows through the solver's structural machinery untouched, rendering
@@ -902,6 +944,8 @@ type StringIntrinsicType struct {
 }
 
 func (*TypeVarType) isType()         {}
+func (*RecursiveType) isType()       {}
+func (*RecursiveVarType) isType()    {}
 func (*KeyofType) isType()           {}
 func (*IndexType) isType()           {}
 func (*TypeofType) isType()          {}
@@ -1023,6 +1067,13 @@ func LevelOf(t Type) int {
 		// A string-intrinsic residual's level is its operand's, the same single-child rule the
 		// KeyofType arm follows.
 		return LevelOf(t.Operand)
+	case *RecursiveType:
+		// A μ-knot's level is its body's, the same single-child rule the KeyofType arm follows, so a
+		// knot whose body holds an out-of-level variable lifts the level and the freshener/extruder
+		// prune descends into the body. Binder is a binding this node owns rather than a variable the
+		// solver generalizes, so it contributes nothing. That split is what carries a knot across a
+		// level boundary intact: the body's variables are freshened and the binder is left alone.
+		return LevelOf(t.Body)
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:
@@ -1052,9 +1103,10 @@ func LevelOf(t Type) int {
 		return maxMemberLevel(t.Types)
 	default:
 		// PrimType, LitType, Void, NullType, UndefinedType, NeverType, UnknownType,
-		// ErrorType, InferType, MappedKeyType: childless leaves. ErrorType is a sentinel at level 0.
-		// An InferType names a capture and a MappedKeyType names a mapped type's key, both of which
-		// the evaluator substitutes rather than the solver generalizing, so none lifts the level.
+		// ErrorType, InferType, MappedKeyType, RecursiveVarType: childless leaves. ErrorType is a
+		// sentinel at level 0. An InferType names a capture, a MappedKeyType names a mapped type's key,
+		// and a RecursiveVarType names an enclosing μ-knot's binder; each is substituted by the
+		// evaluator or by unfolding rather than generalized by the solver, so none lifts the level.
 		return 0
 	}
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -313,11 +313,11 @@ func (t *RecursiveType) Accept(v TypeVisitor, pol Polarity) Type {
 	}
 	cur := descendReplacement(t, e)
 	// The body walks in the current polarity, the same single-child covariant visit PromiseType
-	// uses: a knot stands for the type its body unfolds to, and unfolding introduces no variance
+	// uses. A knot stands for the type its body unfolds to, and unfolding introduces no variance
 	// flip. Binder is the binding this node owns rather than a type to rewrite, so it carries
-	// through and every reference to it inside the rewritten body stays bound to it. That is how a
-	// knot crosses a level boundary intact — extrude freshens the body's inference variables and
-	// leaves the binder alone.
+	// through and every reference to it inside the rewritten body stays bound to it. That split is
+	// how a knot crosses a level boundary intact. extrude freshens the body's inference variables
+	// and leaves the binder alone.
 	body := cur.Body.Accept(v, pol)
 	out := cur
 	if body != cur.Body {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -87,6 +87,8 @@ func (t *SkolemType) Accept(v TypeVisitor, pol Polarity) Type    { return accept
 func (t *InferType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 func (t *MappedKeyType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
 
+func (t *RecursiveVarType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
+
 func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {
@@ -300,6 +302,26 @@ func (t *StringIntrinsicType) Accept(v TypeVisitor, pol Polarity) Type {
 	out := cur
 	if operand != cur.Operand {
 		out = &StringIntrinsicType{Kind: cur.Kind, Operand: operand}
+	}
+	return v.ExitType(out, pol)
+}
+
+func (t *RecursiveType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// The body walks in the current polarity, the same single-child covariant visit PromiseType
+	// uses: a knot stands for the type its body unfolds to, and unfolding introduces no variance
+	// flip. Binder is the binding this node owns rather than a type to rewrite, so it carries
+	// through and every reference to it inside the rewritten body stays bound to it. That is how a
+	// knot crosses a level boundary intact — extrude freshens the body's inference variables and
+	// leaves the binder alone.
+	body := cur.Body.Accept(v, pol)
+	out := cur
+	if body != cur.Body {
+		out = &RecursiveType{Binder: cur.Binder, Body: body}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -61,9 +61,9 @@ func coalesceKeeping(t soltype.Type, pol soltype.Polarity, keep set.Set[*soltype
 // that rule lives in one place.
 //
 // A binder is OPEN while the walk is inlining the variable it stands for. Re-entering that variable
-// is the cycle the knot represents: ref hands back a μ-variable so the body names itself there
+// is the cycle the knot represents. ref hands back a μ-variable so the body names itself there
 // rather than degenerating to never or unknown, and tie wraps the finished body in a RecursiveType.
-// A binder no cycle reached names nothing, so tie leaves such a body alone.
+// A binder that no cycle reached names nothing, so tie returns such a body unwrapped.
 type muBinders struct {
 	// open holds the binder for each variable currently on the walk's path. Both coalescers guard
 	// re-entry with a seen-set keyed by the variable alone, so a variable has at most one open
@@ -74,10 +74,9 @@ type muBinders struct {
 	count int
 }
 
-// muBinder is one open μ-binder: the walk that opened it, the polarity its origin variable was
-// entered at, and the μ-variable a cycle back to that origin renders as.
+// muBinder is one open μ-binder: the polarity its origin variable was entered at, and the
+// μ-variable a cycle back to that origin renders as.
 type muBinder struct {
-	m   *muBinders
 	pol soltype.Polarity
 	// v is minted on the first cycle that reaches this binder and stays nil otherwise, which is
 	// both the signal tie reads and the reason the ids count knots rather than path entries.
@@ -90,7 +89,7 @@ func (m *muBinders) push(v *soltype.TypeVarType, pol soltype.Polarity) *muBinder
 	if m.open == nil {
 		m.open = map[*soltype.TypeVarType]*muBinder{}
 	}
-	b := &muBinder{m: m, pol: pol}
+	b := &muBinder{pol: pol}
 	m.open[v] = b
 	return b
 }
@@ -101,8 +100,8 @@ func (m *muBinders) pop(v *soltype.TypeVarType) {
 
 // ref returns the μ-variable to stand in for a cycle back to v at pol, or nil when no knot can be
 // tied there. The polarity must match the one v's open binder was pushed at. A cycle reached at the
-// opposite polarity would name a body built from v's other bound direction — its lower bounds where
-// the position needs its uppers — so the caller falls back to the polarity identity.
+// opposite polarity would name a body built from v's other bound direction, its lower bounds where
+// the position needs its uppers. The caller falls back to the polarity identity there.
 func (m *muBinders) ref(v *soltype.TypeVarType, pol soltype.Polarity) soltype.Type {
 	b, ok := m.open[v]
 	if !ok || b.pol != pol {
@@ -115,11 +114,11 @@ func (m *muBinders) ref(v *soltype.TypeVarType, pol soltype.Polarity) soltype.Ty
 	return b.v
 }
 
-// tie closes a knot over body, or returns body unchanged when no cycle named the binder. A body
+// tie closes a knot over body, or returns body unchanged when no cycle named this binder. A body
 // that is nothing but the bare μ-variable pins no type at all, since `μX0.X0` has no unfolding that
-// mentions a type, so it collapses to the polarity identity — the value an empty-bounds position
-// takes.
-func (m *muBinders) tie(b *muBinder, pol soltype.Polarity, body soltype.Type) soltype.Type {
+// mentions a type. It collapses to the polarity identity instead, the value an empty-bounds
+// position takes.
+func (b *muBinder) tie(pol soltype.Polarity, body soltype.Type) soltype.Type {
 	if b.v == nil {
 		return body
 	}
@@ -147,7 +146,9 @@ func muBinderName(i int) string {
 // the path is a genuine cycle.
 type coalescer struct {
 	seen set.Set[*soltype.TypeVarType]
-	mu   muBinders
+	// mu holds the μ-binder open for each variable on that same path, so a cycle back to one
+	// renders as a reference the finished body closes over as a knot.
+	mu muBinders
 	// keep holds variables retained symbolically rather than inlined to their bounds —
 	// a generic class's own type-parameter vars, set only by coalesceKeeping. It is nil
 	// for a plain coalesce, and a nil Set reads as empty, so the check below is inert on
@@ -175,8 +176,9 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	// loops back on itself with no concrete type breaking the cycle. It renders as a reference to
 	// the μ-binder minted for that variable, so the finished body closes over the loop as a knot
 	// and `fn f() { return {next: f()} }` reads `fn () -> {next: μX0.{next: X0}}`. A cycle the
-	// binder cannot cover — one reached at the opposite polarity, see muBinders.ref — collapses to
-	// the polarity identity instead, the same value the position takes when its bounds are empty.
+	// binder cannot cover, meaning one reached at the opposite polarity, collapses to the polarity
+	// identity instead. See muBinders.ref. That is the same value the position takes when its
+	// bounds are empty.
 	if c.seen.Contains(v) {
 		if ref := c.mu.ref(v, pol); ref != nil {
 			return soltype.EnterResult{Type: ref, SkipChildren: true}
@@ -207,7 +209,7 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
 	inlined := widenVar(v, pol, combine(pol, dedup(bounds), v.Open))
-	return soltype.EnterResult{Type: c.mu.tie(binder, pol, inlined), SkipChildren: true}
+	return soltype.EnterResult{Type: binder.tie(pol, inlined), SkipChildren: true}
 }
 
 func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
@@ -441,7 +443,8 @@ type schemeCoalescer struct {
 	// A binder with no such bound is absent here and keeps its original pointer.
 	cleaned map[*soltype.TypeVarType]*soltype.TypeVarType
 	seen    set.Set[*soltype.TypeVarType]
-	mu      muBinders
+	// mu is coalescer.mu's twin, keyed by the co-occurrence representative the seen-set uses.
+	mu muBinders
 }
 
 func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
@@ -465,12 +468,12 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	// parameter rather than a second name for the same type.
 	rep = c.displayBinder(rep)
 	if c.seen.Contains(rep) {
-		// A cycle back to a variable already on the path. A retained type parameter keeps its
-		// name: the quantifier already binds it, so the name IS the recursive reference and no
-		// separate binder is needed. An inlined variable has no name to come back to, so the cycle
-		// renders as a reference to the μ-binder minted for it and the finished body closes over
-		// the loop as a knot. A cycle the binder cannot cover — one reached at the opposite
-		// polarity, see muBinders.ref — collapses to the polarity identity.
+		// A cycle back to a variable already on the path. A retained type parameter keeps its name.
+		// The quantifier already binds it, so the name IS the recursive reference and no separate
+		// binder is needed. An inlined variable has no name to come back to, so the cycle renders
+		// as a reference to the μ-binder minted for it and the finished body closes over the loop
+		// as a knot. A cycle the binder cannot cover, meaning one reached at the opposite polarity,
+		// collapses to the polarity identity. See muBinders.ref.
 		if retain {
 			return soltype.EnterResult{Type: rep, SkipChildren: true}
 		}
@@ -515,7 +518,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
 	inlined := widenVar(v, pol, combine(pol, dedup(parts), v.Open))
-	return soltype.EnterResult{Type: c.mu.tie(binder, pol, inlined), SkipChildren: true}
+	return soltype.EnterResult{Type: binder.tie(pol, inlined), SkipChildren: true}
 }
 
 func (c *schemeCoalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
@@ -1352,9 +1355,9 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		return ok && ctx.sameMappedKey(a, b)
 	case *soltype.RecursiveType:
 		// Two μ-knots are equal when their bodies are equal under a pairing of their binders, so
-		// `μX0.{next: X0}` equals `μX1.{next: X1}` — the alpha-equivalence a generic function's
-		// positional type parameters compare under. Pairing the binders before descending is what
-		// lets each side's references to its own binder match the other's.
+		// `μX0.{next: X0}` equals `μX1.{next: X1}`. That is the alpha-equivalence a generic
+		// function's positional type parameters compare under. Pairing the binders before
+		// descending is what lets each side's references to its own binder match the other's.
 		b, ok := b.(*soltype.RecursiveType)
 		if !ok {
 			return false

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -62,7 +62,8 @@ func coalesceKeeping(t soltype.Type, pol soltype.Polarity, keep set.Set[*soltype
 //
 // A binder is OPEN while the walk is inlining the variable it stands for. Re-entering that variable
 // is the cycle the knot represents. ref hands back a μ-variable so the body names itself there
-// rather than degenerating to never or unknown, and tie wraps the finished body in a RecursiveType.
+// rather than degenerating to `never` or `unknown`, and tie wraps the finished body in a
+// RecursiveType.
 // A binder that no cycle reached names nothing, so tie returns such a body unwrapped.
 type muBinders struct {
 	// open holds the binder for each variable currently on the walk's path. Both coalescers guard
@@ -188,7 +189,7 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	c.seen.Add(v)
 	defer c.seen.Remove(v) // path-scoped: pop on the way back up (panic-safe)
 	binder := c.mu.push(v, pol)
-	defer c.mu.pop(v) // path-scoped like seen, so a binder is open only while v is on the path
+	defer c.mu.pop(v) // path-scoped like `seen`, so a binder is open only while v is on the path
 	// Uniform inline: drop the variable, keep only its (recursively coalesced)
 	// bounds in the current polarity.
 	bs := v.BoundsAt(pol)
@@ -485,7 +486,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	c.seen.Add(rep)
 	defer c.seen.Remove(rep) // path-scoped: pop on the way back up (panic-safe)
 	binder := c.mu.push(rep, pol)
-	defer c.mu.pop(rep) // path-scoped like seen, so a binder is open only while rep is on the path
+	defer c.mu.pop(rep) // path-scoped like `seen`, so a binder is open only while rep is on the path
 
 	// v's own bounds, not the representative's.
 	bs := v.BoundsAt(pol)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strconv"
 
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -56,6 +57,85 @@ func coalesceKeeping(t soltype.Type, pol soltype.Polarity, keep set.Set[*soltype
 	return coalesceLifetimes(c, pol) // D4: resolve borrow lifetimes to their display form
 }
 
+// muBinders turns a cycle in the bound graph into a finite μ-knot. Both coalescers embed it, so
+// that rule lives in one place.
+//
+// A binder is OPEN while the walk is inlining the variable it stands for. Re-entering that variable
+// is the cycle the knot represents: ref hands back a μ-variable so the body names itself there
+// rather than degenerating to never or unknown, and tie wraps the finished body in a RecursiveType.
+// A binder no cycle reached names nothing, so tie leaves such a body alone.
+type muBinders struct {
+	// open holds the binder for each variable currently on the walk's path. Both coalescers guard
+	// re-entry with a seen-set keyed by the variable alone, so a variable has at most one open
+	// binder and the polarity it was entered at rides on the binder itself.
+	open map[*soltype.TypeVarType]*muBinder
+	// count numbers the μ-variables this walk has minted, so nested knots draw distinct ids and
+	// distinct display names.
+	count int
+}
+
+// muBinder is one open μ-binder: the walk that opened it, the polarity its origin variable was
+// entered at, and the μ-variable a cycle back to that origin renders as.
+type muBinder struct {
+	m   *muBinders
+	pol soltype.Polarity
+	// v is minted on the first cycle that reaches this binder and stays nil otherwise, which is
+	// both the signal tie reads and the reason the ids count knots rather than path entries.
+	v *soltype.RecursiveVarType
+}
+
+// push opens the binder for a variable the walk is about to inline at pol. The caller pops it on
+// the way back up, so a binder is open exactly while its origin sits on the path.
+func (m *muBinders) push(v *soltype.TypeVarType, pol soltype.Polarity) *muBinder {
+	if m.open == nil {
+		m.open = map[*soltype.TypeVarType]*muBinder{}
+	}
+	b := &muBinder{m: m, pol: pol}
+	m.open[v] = b
+	return b
+}
+
+func (m *muBinders) pop(v *soltype.TypeVarType) {
+	delete(m.open, v)
+}
+
+// ref returns the μ-variable to stand in for a cycle back to v at pol, or nil when no knot can be
+// tied there. The polarity must match the one v's open binder was pushed at. A cycle reached at the
+// opposite polarity would name a body built from v's other bound direction — its lower bounds where
+// the position needs its uppers — so the caller falls back to the polarity identity.
+func (m *muBinders) ref(v *soltype.TypeVarType, pol soltype.Polarity) soltype.Type {
+	b, ok := m.open[v]
+	if !ok || b.pol != pol {
+		return nil
+	}
+	if b.v == nil {
+		b.v = &soltype.RecursiveVarType{ID: m.count, Name: muBinderName(m.count)}
+		m.count++
+	}
+	return b.v
+}
+
+// tie closes a knot over body, or returns body unchanged when no cycle named the binder. A body
+// that is nothing but the bare μ-variable pins no type at all, since `μX0.X0` has no unfolding that
+// mentions a type, so it collapses to the polarity identity — the value an empty-bounds position
+// takes.
+func (m *muBinders) tie(b *muBinder, pol soltype.Polarity, body soltype.Type) soltype.Type {
+	if b.v == nil {
+		return body
+	}
+	if body == soltype.Type(b.v) {
+		return emptyOf(pol)
+	}
+	return &soltype.RecursiveType{Binder: b.v, Body: body}
+}
+
+// muBinderName is the display name for the i-th μ-variable a walk mints: X0, X1, …, so a recursive
+// type renders `μX0.{next: X0}`. It follows typeParamName's generated-name convention on a
+// different letter, so a knot's binder never reads as a type parameter.
+func muBinderName(i int) string {
+	return "X" + strconv.Itoa(i)
+}
+
 // coalescer is the soltype-visitor form of coalesce. The structural arms and the
 // variance flip come from soltype.Accept (the shared rewriting visitor); the var
 // node — whose bounds are a side graph, not tree children — is the whole content
@@ -67,6 +147,7 @@ func coalesceKeeping(t soltype.Type, pol soltype.Polarity, keep set.Set[*soltype
 // the path is a genuine cycle.
 type coalescer struct {
 	seen set.Set[*soltype.TypeVarType]
+	mu   muBinders
 	// keep holds variables retained symbolically rather than inlined to their bounds —
 	// a generic class's own type-parameter vars, set only by coalesceKeeping. It is nil
 	// for a plain coalesce, and a nil Set reads as empty, so the check below is inert on
@@ -90,16 +171,22 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	if c.keep.Contains(v) {
 		return soltype.EnterResult{Type: v, SkipChildren: true}
 	}
-	// Re-entering a variable already on the current path is an ungrounded recursive
-	// position (no concrete type breaks the cycle). It collapses to the polarity
-	// identity — the same value the position degenerates to when its bounds are
-	// empty — which keeps the inline walk total. A precise μ-bound rendering of
-	// such recursion is M3.
+	// Re-entering a variable already on the current path is a recursive position: the bound graph
+	// loops back on itself with no concrete type breaking the cycle. It renders as a reference to
+	// the μ-binder minted for that variable, so the finished body closes over the loop as a knot
+	// and `fn f() { return {next: f()} }` reads `fn () -> {next: μX0.{next: X0}}`. A cycle the
+	// binder cannot cover — one reached at the opposite polarity, see muBinders.ref — collapses to
+	// the polarity identity instead, the same value the position takes when its bounds are empty.
 	if c.seen.Contains(v) {
+		if ref := c.mu.ref(v, pol); ref != nil {
+			return soltype.EnterResult{Type: ref, SkipChildren: true}
+		}
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
 	c.seen.Add(v)
 	defer c.seen.Remove(v) // path-scoped: pop on the way back up (panic-safe)
+	binder := c.mu.push(v, pol)
+	defer c.mu.pop(v) // path-scoped like seen, so a binder is open only while v is on the path
 	// Uniform inline: drop the variable, keep only its (recursively coalesced)
 	// bounds in the current polarity.
 	bs := v.BoundsAt(pol)
@@ -119,7 +206,8 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	if len(bounds) == 0 {
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
-	return soltype.EnterResult{Type: widenVar(v, pol, combine(pol, dedup(bounds), v.Open)), SkipChildren: true}
+	inlined := widenVar(v, pol, combine(pol, dedup(bounds), v.Open))
+	return soltype.EnterResult{Type: c.mu.tie(binder, pol, inlined), SkipChildren: true}
 }
 
 func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
@@ -353,6 +441,7 @@ type schemeCoalescer struct {
 	// A binder with no such bound is absent here and keeps its original pointer.
 	cleaned map[*soltype.TypeVarType]*soltype.TypeVarType
 	seen    set.Set[*soltype.TypeVarType]
+	mu      muBinders
 }
 
 func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
@@ -376,16 +465,24 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	// parameter rather than a second name for the same type.
 	rep = c.displayBinder(rep)
 	if c.seen.Contains(rep) {
-		// A cycle back to a variable already on the path: a retained type parameter
-		// keeps its name (a rough μ-reference, refined in M3's precise μ-rendering),
-		// an inlined variable collapses to the polarity identity.
+		// A cycle back to a variable already on the path. A retained type parameter keeps its
+		// name: the quantifier already binds it, so the name IS the recursive reference and no
+		// separate binder is needed. An inlined variable has no name to come back to, so the cycle
+		// renders as a reference to the μ-binder minted for it and the finished body closes over
+		// the loop as a knot. A cycle the binder cannot cover — one reached at the opposite
+		// polarity, see muBinders.ref — collapses to the polarity identity.
 		if retain {
 			return soltype.EnterResult{Type: rep, SkipChildren: true}
+		}
+		if ref := c.mu.ref(rep, pol); ref != nil {
+			return soltype.EnterResult{Type: ref, SkipChildren: true}
 		}
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
 	c.seen.Add(rep)
 	defer c.seen.Remove(rep) // path-scoped: pop on the way back up (panic-safe)
+	binder := c.mu.push(rep, pol)
+	defer c.mu.pop(rep) // path-scoped like seen, so a binder is open only while rep is on the path
 
 	// v's own bounds, not the representative's.
 	bs := v.BoundsAt(pol)
@@ -417,7 +514,8 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		// already leave parts=[rep]. Collapse to the polarity identity.
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
-	return soltype.EnterResult{Type: widenVar(v, pol, combine(pol, dedup(parts), v.Open)), SkipChildren: true}
+	inlined := widenVar(v, pol, combine(pol, dedup(parts), v.Open))
+	return soltype.EnterResult{Type: c.mu.tie(binder, pol, inlined), SkipChildren: true}
 }
 
 func (c *schemeCoalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
@@ -841,6 +939,12 @@ type alphaCtx struct {
 	// nothing.
 	keyAToB map[int]int
 	keyBToA map[int]int
+	// recAToB and recBToA pair the binders of two μ-knots, bound when a pair of knots meets, the
+	// way bindMappedKeys pairs two mapped types' keys. This bijection is what makes two knots
+	// equal up to a consistent renaming of their binders. They start nil and allocate on the first
+	// pairing, so a comparison over types carrying no knot allocates nothing.
+	recAToB map[int]int
+	recBToA map[int]int
 }
 
 // bindTypeParams pairs two generic FuncTypes' type parameters positionally, so every
@@ -924,6 +1028,33 @@ func (ctx *alphaCtx) sameMappedKey(a, b *soltype.MappedKeyType) bool {
 	}
 	if _, ok := ctx.keyBToA[b.ID]; ok {
 		return false // b's binding corresponds to some other binding on a's side
+	}
+	return a.ID == b.ID
+}
+
+// bindRecursiveBinders pairs the binders of two μ-knots, so every later reference to one side's
+// binder must match the other's partner. Two knots built by separate coalescing walks therefore
+// compare equal even though each numbered its binders from zero, the same reason bindMappedKeys
+// pairs two mapped types' key bindings.
+func (ctx *alphaCtx) bindRecursiveBinders(a, b *soltype.RecursiveVarType) {
+	if ctx.recAToB == nil {
+		ctx.recAToB = map[int]int{}
+		ctx.recBToA = map[int]int{}
+	}
+	ctx.recAToB[a.ID] = b.ID
+	ctx.recBToA[b.ID] = a.ID
+}
+
+// sameRecursiveVar reports whether two μ-variables stand for corresponding binders under the
+// pairing the enclosing pair of knots recorded. A reference may be reached with no pairing, which
+// happens when a knot's body is compared on its own, away from the knot that binds it. That case
+// falls back to id equality, the rule sameMappedKey applies to an unpaired binding.
+func (ctx *alphaCtx) sameRecursiveVar(a, b *soltype.RecursiveVarType) bool {
+	if j, ok := ctx.recAToB[a.ID]; ok {
+		return j == b.ID
+	}
+	if _, ok := ctx.recBToA[b.ID]; ok {
+		return false // b's binder corresponds to some other binder on a's side
 	}
 	return a.ID == b.ID
 }
@@ -1219,6 +1350,23 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// the enclosing pair of mapped types recorded.
 		b, ok := b.(*soltype.MappedKeyType)
 		return ok && ctx.sameMappedKey(a, b)
+	case *soltype.RecursiveType:
+		// Two μ-knots are equal when their bodies are equal under a pairing of their binders, so
+		// `μX0.{next: X0}` equals `μX1.{next: X1}` — the alpha-equivalence a generic function's
+		// positional type parameters compare under. Pairing the binders before descending is what
+		// lets each side's references to its own binder match the other's.
+		b, ok := b.(*soltype.RecursiveType)
+		if !ok {
+			return false
+		}
+		ctx.bindRecursiveBinders(a.Binder, b.Binder)
+		return equalTypeWith(a.Body, b.Body, ctx)
+	case *soltype.RecursiveVarType:
+		// Two references to a μ-binder are equal when their binders correspond under the pairing
+		// the enclosing pair of knots recorded. The binder names are not compared, the same way two
+		// functions' type parameters compare by position rather than by name.
+		b, ok := b.(*soltype.RecursiveVarType)
+		return ok && ctx.sameRecursiveVar(a, b)
 	case *soltype.RestSpreadType:
 		// Two `...P` spread elements are equal when their operands are, compared structurally
 		// without reducing. The enclosing TupleType arm compares element lists positionally, so a

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -134,9 +134,9 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 
 // evalTypeOperator evaluates the outermost transparent type operator of t to the type it stands
 // for, so constrain can check a constraint against that while the stored residual keeps its name.
-// An alias expands to its body, a μ-knot unfolds one level, a `typeof` query resolves to the
-// value's type, a `keyof` reduces
-// to its key set, an indexed access `T[K]` reduces to the type at that key, a conditional selects
+// An alias expands to its body, a μ-knot unfolds one level, a `typeof` query resolves to the value's
+// type, a `keyof` reduces to its key set, an indexed access `T[K]` reduces to the type at that key,
+// a conditional selects
 // its Then or Else branch, a mapped type emits one field per key, a template literal reduces to the
 // union of string literals its interpolations produce, an intrinsic string operator such as
 // `Uppercase<T>` reduces over its string-literal operand, and a tuple carrying a `...P` spread
@@ -1374,8 +1374,8 @@ func (c *Context) extrudeOuterAsLower(lt soltype.Lifetime, v *soltype.LifetimeVa
 
 // unfoldRecursive unfolds a μ-knot one level: it returns the knot's body with the whole knot
 // substituted for every reference to its binder, so `μX0.{next: X0}` unfolds to
-// `{next: μX0.{next: X0}}`. That is how constrain compares a knot against a structural type —
-// the pre-switch treats it as a transparent operator and recurses on the unfolding.
+// `{next: μX0.{next: X0}}`. That is how a knot is compared against a structural type. The
+// pre-switch treats it as a transparent operator and recurses on the unfolding.
 //
 // The substituted node is the knot itself rather than a copy, which is what makes a recursive
 // comparison terminate. Unfolding both sides of `knot <: knot` reaches the same pair of pointers
@@ -1389,7 +1389,7 @@ func unfoldRecursive(t *soltype.RecursiveType) soltype.Type {
 // recursiveUnfolder replaces every reference to one μ-binder with the knot that binds it. A nested
 // knot rebinding the same id shadows the outer binding, so its subtree is skipped and its own
 // references stay bound to it. That guard is what keeps the substitution correct without relying on
-// globally unique ids: coalescing numbers binders per walk, so two walks whose display types are
+// globally unique ids. Coalescing numbers binders per walk, so two walks whose display types are
 // later composed into one type can each contribute a knot bound to id 0.
 type recursiveUnfolder struct {
 	id   int

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -134,7 +134,8 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 
 // evalTypeOperator evaluates the outermost transparent type operator of t to the type it stands
 // for, so constrain can check a constraint against that while the stored residual keeps its name.
-// An alias expands to its body, a `typeof` query resolves to the value's type, a `keyof` reduces
+// An alias expands to its body, a μ-knot unfolds one level, a `typeof` query resolves to the
+// value's type, a `keyof` reduces
 // to its key set, an indexed access `T[K]` reduces to the type at that key, a conditional selects
 // its Then or Else branch, a mapped type emits one field per key, a template literal reduces to the
 // union of string literals its interpolations produce, an intrinsic string operator such as
@@ -152,6 +153,8 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen set.Set[constraintKey]) 
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
 		return t.Ty, nil, true
+	case *soltype.RecursiveType:
+		return unfoldRecursive(t), nil, true
 	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType,
 		*soltype.TemplateLitType, *soltype.StringIntrinsicType:
 		return c.reduceResidual(t, seen)
@@ -1368,6 +1371,46 @@ func (c *Context) extrudeOuterAsLower(lt soltype.Lifetime, v *soltype.LifetimeVa
 	}
 	return c.extrudeLt(lt, soltype.Positive, v.Level, map[ltExtrudeKey]*soltype.LifetimeVar{})
 }
+
+// unfoldRecursive unfolds a μ-knot one level: it returns the knot's body with the whole knot
+// substituted for every reference to its binder, so `μX0.{next: X0}` unfolds to
+// `{next: μX0.{next: X0}}`. That is how constrain compares a knot against a structural type —
+// the pre-switch treats it as a transparent operator and recurses on the unfolding.
+//
+// The substituted node is the knot itself rather than a copy, which is what makes a recursive
+// comparison terminate. Unfolding both sides of `knot <: knot` reaches the same pair of pointers
+// one level down, and constrain's seen-set already holds it, so the derivation closes
+// coinductively instead of unfolding forever.
+func unfoldRecursive(t *soltype.RecursiveType) soltype.Type {
+	// Substitution is polarity-blind, so the root polarity handed to Accept is arbitrary.
+	return t.Body.Accept(&recursiveUnfolder{id: t.Binder.ID, knot: t}, soltype.Positive)
+}
+
+// recursiveUnfolder replaces every reference to one μ-binder with the knot that binds it. A nested
+// knot rebinding the same id shadows the outer binding, so its subtree is skipped and its own
+// references stay bound to it. That guard is what keeps the substitution correct without relying on
+// globally unique ids: coalescing numbers binders per walk, so two walks whose display types are
+// later composed into one type can each contribute a knot bound to id 0.
+type recursiveUnfolder struct {
+	id   int
+	knot *soltype.RecursiveType
+}
+
+func (u *recursiveUnfolder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	switch t := t.(type) {
+	case *soltype.RecursiveVarType:
+		if t.ID == u.id {
+			return soltype.EnterResult{Type: u.knot, SkipChildren: true}
+		}
+	case *soltype.RecursiveType:
+		if t.Binder.ID == u.id {
+			return soltype.EnterResult{Type: t, SkipChildren: true}
+		}
+	}
+	return soltype.EnterResult{}
+}
+
+func (u *recursiveUnfolder) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // extrude copies t so that variables inner to lvl are replaced by fresh variables
 // at lvl, wired to the originals through the polarity-appropriate bound

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2003,6 +2003,14 @@ func describe(t soltype.Type) string {
 		// An intrinsic string-operator residual renders `Uppercase<operand>` structurally, recursing
 		// like the keyof arm. The operand renders in describe's raw mid-constrain form.
 		return t.Kind.String() + "<" + describe(t.Operand) + ">"
+	case *soltype.RecursiveType:
+		// A μ-knot renders `μX0.<body>` structurally, recursing like the keyof arm, so a rejected
+		// constraint over a recursive type names the shape it stands for. The body renders in
+		// describe's raw mid-constrain form.
+		return "μ" + t.Binder.DisplayName() + "." + describe(t.Body)
+	case *soltype.RecursiveVarType:
+		// A reference to the enclosing knot's binder renders as that binder's name.
+		return t.DisplayName()
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
 		// recursing like the Promise arm. The lifetime is deliberately NOT rendered: D2

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2004,12 +2004,15 @@ func describe(t soltype.Type) string {
 		// like the keyof arm. The operand renders in describe's raw mid-constrain form.
 		return t.Kind.String() + "<" + describe(t.Operand) + ">"
 	case *soltype.RecursiveType:
-		// A μ-knot renders `μX0.<body>` structurally, recursing like the keyof arm, so a rejected
-		// constraint over a recursive type names the shape it stands for. The body renders in
-		// describe's raw mid-constrain form.
+		// A μ-knot renders `μX0.<body>`, recursing like the keyof arm, so a rejected constraint over
+		// a recursive type says so instead of falling to the default `?`. The body renders in
+		// describe's nominal form, so a knot over an object reads `μX0.object` and the binder's name
+		// has nothing referring back to it. Naming the recursion is the point here. The coalesced
+		// printer is what renders the fields.
 		return "μ" + t.Binder.DisplayName() + "." + describe(t.Body)
 	case *soltype.RecursiveVarType:
-		// A reference to the enclosing knot's binder renders as that binder's name.
+		// A reference to the enclosing knot's binder renders as that binder's name. It is reachable
+		// through a body describe does render structurally, such as a tuple or a union.
 		return t.DisplayName()
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),

--- a/internal/solver/recursive_test.go
+++ b/internal/solver/recursive_test.go
@@ -233,9 +233,17 @@ func TestConstrainRecursiveUnfolds(t *testing.T) {
 	}
 
 	t.Run("two alpha-equivalent knots are mutual subtypes", func(t *testing.T) {
-		c := &Context{}
-		require.Empty(t, Messages(c.Constrain(selfNext(), selfNext())))
-		require.Empty(t, Messages(c.Constrain(selfNext(), selfNext())))
+		// The two knots number their binders differently, so a comparison that only succeeded on
+		// identical operands would not settle either direction. Each direction runs on its own
+		// Context, so neither can be decided by state the other left behind.
+		left := muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+			return exactObj(propElem("next", ref))
+		})
+		right := muKnot(4, "X1", func(ref *soltype.RecursiveVarType) soltype.Type {
+			return exactObj(propElem("next", ref))
+		})
+		require.Empty(t, Messages((&Context{}).Constrain(left, right)))
+		require.Empty(t, Messages((&Context{}).Constrain(right, left)))
 	})
 
 	t.Run("a knot satisfies its own unfolding and the reverse", func(t *testing.T) {

--- a/internal/solver/recursive_test.go
+++ b/internal/solver/recursive_test.go
@@ -100,36 +100,60 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "reassigning a recursive binding compares two knots",
-			src:     "fn f() { return {next: f()} }\nfn h() { var a = f()\n a = f()\n return a }",
+			name: "reassigning a recursive binding compares two knots",
+			src: `
+				fn f() { return {next: f()} }
+				fn h() {
+					var a = f()
+					a = f()
+					return a
+				}
+			`,
 			binding: "h",
 			want:    "fn () -> {next: μX0.{next: X0}}",
 		},
 		{
-			name:    "a member chain over a recursive result still renders a knot",
-			src:     "fn f() { return {next: f()} }\nval c = f().next.next",
+			name: "a member chain over a recursive result still renders a knot",
+			src: `
+				fn f() { return {next: f()} }
+				val c = f().next.next
+			`,
 			binding: "c",
 			want:    "μX0.{next: X0}",
 		},
 		{
-			name:    "a recursive result through a type parameter still renders a knot",
-			src:     "fn f() { return {next: f()} }\nfn id(x) { return x }\nval d = id(f())",
+			name: "a recursive result through a type parameter still renders a knot",
+			src: `
+				fn f() { return {next: f()} }
+				fn id(x) { return x }
+				val d = id(f())
+			`,
 			binding: "d",
 			want:    "{next: μX0.{next: X0}}",
 		},
 		{
 			// The tuple shape reaches the same reassignment path, so a coalesced knot over a tuple
 			// unfolds and closes the way one over an object does, through constrain's tuple arm.
-			name:    "reassigning a recursive tuple binding compares two knots",
-			src:     "fn f() { return [f()] }\nfn h() { var a = f()\n a = f()\n return a }",
+			name: "reassigning a recursive tuple binding compares two knots",
+			src: `
+				fn f() { return [f()] }
+				fn h() {
+					var a = f()
+					a = f()
+					return a
+				}
+			`,
 			binding: "h",
 			want:    "fn () -> [μX0.[X0]]",
 		},
 		{
 			// Destructuring is how a recursive tuple is read apart, since a value-level index
 			// expression is unsupported for any tuple, recursive or not.
-			name:    "destructuring a recursive tuple still renders a knot",
-			src:     "fn f() { return [f()] }\nval [inner] = f()",
+			name: "destructuring a recursive tuple still renders a knot",
+			src: `
+				fn f() { return [f()] }
+				val [inner] = f()
+			`,
 			binding: "inner",
 			want:    "μX0.[X0]",
 		},

--- a/internal/solver/recursive_test.go
+++ b/internal/solver/recursive_test.go
@@ -16,52 +16,104 @@ func muKnot(id int, name string, body func(ref *soltype.RecursiveVarType) soltyp
 	return &soltype.RecursiveType{Binder: binder, Body: body(binder)}
 }
 
-// TestInferRecursiveRendersMuKnot is PR9e's headline: a cyclic bound graph coalesces to a μ-knot,
-// so a recursive position names the shape it stands for rather than collapsing to the polarity
-// identity — never in covariant position, unknown in contravariant.
+// TestInferRecursiveRendersMuKnot is the milestone's headline case. A cyclic bound graph coalesces
+// to a μ-knot, so a recursive position names the shape it stands for rather than collapsing to the
+// polarity identity, which is never in covariant position and unknown in contravariant.
 //
-// Each source builds the cycle a different way. The recursive call inside an object literal makes
-// the return variable's own lower bound mention it; the tuple case does the same through a
-// positional element; the two-field case shows the knot carrying a retained type parameter beside
-// the recursive field, so the knot and the quantifier coexist. The one unrolled level in front of
-// each knot is a monomorphic-recursion artifact: each call site instantiates its own return
-// variable, so the outer shape comes from the call and the knot from the variable the body's
-// recursive call flows through.
+// Each source builds the cycle a different way:
+//
+//   - the recursive call inside an object literal makes the return variable's own lower bound
+//     mention it;
+//   - the tuple case does the same through a positional element;
+//   - the two-field case carries a retained type parameter beside the recursive field, so the knot
+//     and the quantifier coexist;
+//   - the mutual pair runs the cycle through a second binding.
+//
+// The one unrolled level in front of each knot is a monomorphic-recursion artifact. Each call site
+// instantiates its own return variable, so the outer shape comes from the call and the knot from the
+// variable the body's recursive call flows through.
 func TestInferRecursiveRendersMuKnot(t *testing.T) {
 	tests := []struct {
-		name string
-		src  string
-		want string
+		name    string
+		src     string
+		binding string
+		want    string
 	}{
 		{
-			name: "recursion through an object property",
-			src:  `fn f() { return {next: f()} }`,
-			want: "fn () -> {next: μX0.{next: X0}}",
+			name:    "recursion through an object property",
+			src:     `fn f() { return {next: f()} }`,
+			binding: "f",
+			want:    "fn () -> {next: μX0.{next: X0}}",
 		},
 		{
-			name: "recursion through a tuple element",
-			src:  `fn f() { return [f()] }`,
-			want: "fn () -> [μX0.[X0]]",
+			name:    "recursion through a tuple element",
+			src:     `fn f() { return [f()] }`,
+			binding: "f",
+			want:    "fn () -> [μX0.[X0]]",
 		},
 		{
-			name: "knot beside a retained type parameter",
-			src:  `fn f(x) { return {next: f(x), value: x} }`,
-			want: "fn <T0>(x: T0) -> {next: μX0.{next: X0, value: T0}, value: T0}",
+			name:    "knot beside a retained type parameter",
+			src:     `fn f(x) { return {next: f(x), value: x} }`,
+			binding: "f",
+			want:    "fn <T0>(x: T0) -> {next: μX0.{next: X0, value: T0}, value: T0}",
 		},
 		{
-			name: "mutual recursion closes on whichever binding is rendered",
+			// Mutual recursion runs the same cycle through two bindings, so the knot closes one lap
+			// out at whichever binding is being rendered.
+			name: "mutual recursion closes the knot one lap out",
 			src: `
 				fn ping() { return {p: pong()} }
 				fn pong() { return {q: ping()} }
 			`,
-			want: "fn () -> {p: μX0.{q: {p: X0}}}",
+			binding: "ping",
+			want:    "fn () -> {p: μX0.{q: {p: X0}}}",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tt.src)
-			require.Empty(t, errs)
-			require.Equal(t, tt.want, values["f"]+values["ping"])
+			require.Empty(t, Messages(errs))
+			require.Equal(t, tt.want, values[tt.binding])
+		})
+	}
+}
+
+// TestInferRecursiveThroughConstrain covers the path that feeds a coalesced knot back into the
+// solver, so the constrain arm is exercised from source rather than only unit-tested. A reassignable
+// binding's stored type is its coalesced display type. inferAssign copies that with freshenAll and
+// constrains the new value against the copy, so `a = f()` compares one knot against another. A
+// member read walks through the knot the same way, since reading `next` off it unfolds it first.
+func TestInferRecursiveThroughConstrain(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		binding string
+		want    string
+	}{
+		{
+			name:    "reassigning a recursive binding keeps the knot",
+			src:     "fn f() { return {next: f()} }\nfn h() { var a = f()\n a = f()\n return a }",
+			binding: "h",
+			want:    "fn () -> {next: μX0.{next: X0}}",
+		},
+		{
+			name:    "reading through a knot unfolds it",
+			src:     "fn f() { return {next: f()} }\nval c = f().next.next",
+			binding: "c",
+			want:    "μX0.{next: X0}",
+		},
+		{
+			name:    "a knot flows through a generic function's type parameter",
+			src:     "fn f() { return {next: f()} }\nfn id(x) { return x }\nval d = id(f())",
+			binding: "d",
+			want:    "{next: μX0.{next: X0}}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, Messages(errs))
+			require.Equal(t, tt.want, values[tt.binding])
 		})
 	}
 }
@@ -70,7 +122,7 @@ func TestInferRecursiveRendersMuKnot(t *testing.T) {
 // bound graph, without the extra variable layer a real call site introduces.
 //
 // A variable whose bound mentions itself in the SAME polarity it was entered at ties a knot. One
-// that only comes back at the OPPOSITE polarity cannot: the body was built from the variable's
+// that only comes back at the OPPOSITE polarity cannot. The body was built from the variable's
 // bounds in one direction, and naming it from a position that needs the other direction would claim
 // the wrong type. That case keeps the polarity identity.
 func TestCoalesceRecursiveVarPolarities(t *testing.T) {
@@ -169,9 +221,9 @@ func TestEqualTypeRecursive(t *testing.T) {
 	}
 }
 
-// TestConstrainRecursiveUnfolds pins the constrain arm: a knot is transparent, so a constraint on
+// TestConstrainRecursiveUnfolds pins the constrain arm. A knot is transparent, so a constraint on
 // one runs against its one-level unfolding. Two knots compared against each other close
-// coinductively through the seen-set — unfolding substitutes the knot's own pointer, so the pair the
+// coinductively through the seen-set. Unfolding substitutes the knot's own pointer, so the pair the
 // recursion returns to is the pair the seen-set already holds.
 func TestConstrainRecursiveUnfolds(t *testing.T) {
 	selfNext := func() soltype.Type {

--- a/internal/solver/recursive_test.go
+++ b/internal/solver/recursive_test.go
@@ -78,12 +78,21 @@ func TestInferRecursiveRendersMuKnot(t *testing.T) {
 	}
 }
 
-// TestInferRecursiveThroughConstrain covers the path that feeds a coalesced knot back into the
-// solver, so the constrain arm is exercised from source rather than only unit-tested. A reassignable
-// binding's stored type is its coalesced display type. inferAssign copies that with freshenAll and
-// constrains the new value against the copy, so `a = f()` compares one knot against another. A
-// member read walks through the knot the same way, since reading `next` off it unfolds it first.
-func TestInferRecursiveThroughConstrain(t *testing.T) {
+// TestInferRecursiveThroughSourcePaths runs a recursive type through the value paths a program
+// actually uses. The cases split into two groups, which reach the knot differently.
+//
+// Reassignment is the one path that feeds a COALESCED knot back into the solver. A reassignable
+// binding's stored type is its display type, so inferAssign copies that with freshenAll and
+// constrains the new value against the copy, and `a = f()` compares one knot against another through
+// constrain's unfolding. Removing the RecursiveType arm from evalTypeOperator fails exactly these
+// two cases, with `cannot constrain object <: μX0.object` and its tuple twin. Both carriers are
+// covered because constrain decomposes objects and tuples in separate arms.
+//
+// A read and a generic call run on the RAW bound graph instead. instantiate freshens a scheme's
+// Body, not its coalesced display, so no knot exists while the member chain, the destructuring
+// pattern, or the type parameter is being solved. Those cases pin that the recursive shape survives
+// the round trip and still renders as a knot once the resulting binding is displayed.
+func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 	tests := []struct {
 		name    string
 		src     string
@@ -91,22 +100,38 @@ func TestInferRecursiveThroughConstrain(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "reassigning a recursive binding keeps the knot",
+			name:    "reassigning a recursive binding compares two knots",
 			src:     "fn f() { return {next: f()} }\nfn h() { var a = f()\n a = f()\n return a }",
 			binding: "h",
 			want:    "fn () -> {next: μX0.{next: X0}}",
 		},
 		{
-			name:    "reading through a knot unfolds it",
+			name:    "a member chain over a recursive result still renders a knot",
 			src:     "fn f() { return {next: f()} }\nval c = f().next.next",
 			binding: "c",
 			want:    "μX0.{next: X0}",
 		},
 		{
-			name:    "a knot flows through a generic function's type parameter",
+			name:    "a recursive result through a type parameter still renders a knot",
 			src:     "fn f() { return {next: f()} }\nfn id(x) { return x }\nval d = id(f())",
 			binding: "d",
 			want:    "{next: μX0.{next: X0}}",
+		},
+		{
+			// The tuple shape reaches the same reassignment path, so a coalesced knot over a tuple
+			// unfolds and closes the way one over an object does, through constrain's tuple arm.
+			name:    "reassigning a recursive tuple binding compares two knots",
+			src:     "fn f() { return [f()] }\nfn h() { var a = f()\n a = f()\n return a }",
+			binding: "h",
+			want:    "fn () -> [μX0.[X0]]",
+		},
+		{
+			// Destructuring is how a recursive tuple is read apart, since a value-level index
+			// expression is unsupported for any tuple, recursive or not.
+			name:    "destructuring a recursive tuple still renders a knot",
+			src:     "fn f() { return [f()] }\nval [inner] = f()",
+			binding: "inner",
+			want:    "μX0.[X0]",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/recursive_test.go
+++ b/internal/solver/recursive_test.go
@@ -18,7 +18,7 @@ func muKnot(id int, name string, body func(ref *soltype.RecursiveVarType) soltyp
 
 // TestInferRecursiveRendersMuKnot is the milestone's headline case. A cyclic bound graph coalesces
 // to a μ-knot, so a recursive position names the shape it stands for rather than collapsing to the
-// polarity identity, which is never in covariant position and unknown in contravariant.
+// polarity identity. That identity is `never` in covariant position and `unknown` in contravariant.
 //
 // Each source builds the cycle a different way:
 //
@@ -192,7 +192,7 @@ func TestCoalesceRecursiveVarPolarities(t *testing.T) {
 	t.Run("cycle through a contravariant position keeps the polarity identity", func(t *testing.T) {
 		// v's lower bound is `fn (v) -> number`, so the walk enters v covariantly and comes back to
 		// it contravariantly at the parameter. Inlining there would need v's UPPER bounds, which the
-		// body under construction does not hold, so the parameter renders unknown.
+		// body under construction does not hold, so the parameter renders `unknown`.
 		c := &Context{}
 		v := c.freshVar(0)
 		v.LowerBounds = []soltype.Type{&soltype.FuncType{

--- a/internal/solver/recursive_test.go
+++ b/internal/solver/recursive_test.go
@@ -1,0 +1,288 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// muKnot builds `μ<name>.<body>` where body is produced from the binder, so a test reads as the μ
+// form it asserts. The callback receives the binder's reference node, which is the node the body
+// must name for the knot to be recursive.
+func muKnot(id int, name string, body func(ref *soltype.RecursiveVarType) soltype.Type) *soltype.RecursiveType {
+	binder := &soltype.RecursiveVarType{ID: id, Name: name}
+	return &soltype.RecursiveType{Binder: binder, Body: body(binder)}
+}
+
+// TestInferRecursiveRendersMuKnot is PR9e's headline: a cyclic bound graph coalesces to a μ-knot,
+// so a recursive position names the shape it stands for rather than collapsing to the polarity
+// identity — never in covariant position, unknown in contravariant.
+//
+// Each source builds the cycle a different way. The recursive call inside an object literal makes
+// the return variable's own lower bound mention it; the tuple case does the same through a
+// positional element; the two-field case shows the knot carrying a retained type parameter beside
+// the recursive field, so the knot and the quantifier coexist. The one unrolled level in front of
+// each knot is a monomorphic-recursion artifact: each call site instantiates its own return
+// variable, so the outer shape comes from the call and the knot from the variable the body's
+// recursive call flows through.
+func TestInferRecursiveRendersMuKnot(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "recursion through an object property",
+			src:  `fn f() { return {next: f()} }`,
+			want: "fn () -> {next: μX0.{next: X0}}",
+		},
+		{
+			name: "recursion through a tuple element",
+			src:  `fn f() { return [f()] }`,
+			want: "fn () -> [μX0.[X0]]",
+		},
+		{
+			name: "knot beside a retained type parameter",
+			src:  `fn f(x) { return {next: f(x), value: x} }`,
+			want: "fn <T0>(x: T0) -> {next: μX0.{next: X0, value: T0}, value: T0}",
+		},
+		{
+			name: "mutual recursion closes on whichever binding is rendered",
+			src: `
+				fn ping() { return {p: pong()} }
+				fn pong() { return {q: ping()} }
+			`,
+			want: "fn () -> {p: μX0.{q: {p: X0}}}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"]+values["ping"])
+		})
+	}
+}
+
+// TestCoalesceRecursiveVarPolarities pins the two coalescing rules directly on a hand-built cyclic
+// bound graph, without the extra variable layer a real call site introduces.
+//
+// A variable whose bound mentions itself in the SAME polarity it was entered at ties a knot. One
+// that only comes back at the OPPOSITE polarity cannot: the body was built from the variable's
+// bounds in one direction, and naming it from a position that needs the other direction would claim
+// the wrong type. That case keeps the polarity identity.
+func TestCoalesceRecursiveVarPolarities(t *testing.T) {
+	t.Run("same-polarity cycle ties a knot", func(t *testing.T) {
+		c := &Context{}
+		v := c.freshVar(0)
+		v.LowerBounds = []soltype.Type{exactObj(propElem("next", v))}
+		require.Equal(t, "μX0.{next: X0}", soltype.Print(coalesce(v, soltype.Positive)))
+	})
+
+	t.Run("negative-position cycle ties a knot too", func(t *testing.T) {
+		c := &Context{}
+		v := c.freshVar(0)
+		v.UpperBounds = []soltype.Type{exactObj(propElem("next", v))}
+		require.Equal(t, "μX0.{next: X0}", soltype.Print(coalesce(v, soltype.Negative)))
+	})
+
+	t.Run("cycle through a contravariant position keeps the polarity identity", func(t *testing.T) {
+		// v's lower bound is `fn (v) -> number`, so the walk enters v covariantly and comes back to
+		// it contravariantly at the parameter. Inlining there would need v's UPPER bounds, which the
+		// body under construction does not hold, so the parameter renders unknown.
+		c := &Context{}
+		v := c.freshVar(0)
+		v.LowerBounds = []soltype.Type{&soltype.FuncType{
+			Params: []*soltype.FuncParam{identParam("x", v)},
+			Ret:    num(),
+		}}
+		require.Equal(t, "fn (x: unknown) -> number", soltype.Print(coalesce(v, soltype.Positive)))
+	})
+
+	t.Run("a bare self-edge pins no type and keeps the polarity identity", func(t *testing.T) {
+		// `μX0.X0` has no unfolding that mentions a type, so the knot collapses.
+		c := &Context{}
+		v := c.freshVar(0)
+		v.LowerBounds = []soltype.Type{v}
+		require.Equal(t, "never", soltype.Print(coalesce(v, soltype.Positive)))
+	})
+}
+
+// TestEqualTypeRecursive pins the alpha-equivalence rule: two knots are equal when their bodies
+// match under a pairing of their binders, so binder ids and names carry no weight. The bijection
+// must be consistent, so two knots that name their binders at different positions are not equal.
+func TestEqualTypeRecursive(t *testing.T) {
+	selfNext := func(id int, name string) soltype.Type {
+		return muKnot(id, name, func(ref *soltype.RecursiveVarType) soltype.Type {
+			return exactObj(propElem("next", ref))
+		})
+	}
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "alpha-equivalent knots are equal",
+			a:    selfNext(0, "X0"),
+			b:    selfNext(4, "X1"),
+			want: true,
+		},
+		{
+			name: "differing bodies are not equal",
+			a:    selfNext(0, "X0"),
+			b: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+				return exactObj(propElem("prev", ref))
+			}),
+			want: false,
+		},
+		{
+			name: "a knot never equals its own one-level unfolding",
+			a:    selfNext(0, "X0"),
+			b:    exactObj(propElem("next", selfNext(0, "X0"))),
+			want: false,
+		},
+		{
+			// Both bodies hold two fields naming a binder, but a names its own at `here` where b
+			// names its own at `there`, so no consistent pairing covers both.
+			name: "an inconsistent binder pairing is not equal",
+			a: muKnot(0, "X0", func(outer *soltype.RecursiveVarType) soltype.Type {
+				return muKnot(1, "X1", func(inner *soltype.RecursiveVarType) soltype.Type {
+					return exactObj(propElem("here", outer), propElem("there", inner))
+				})
+			}),
+			b: muKnot(0, "X0", func(outer *soltype.RecursiveVarType) soltype.Type {
+				return muKnot(1, "X1", func(inner *soltype.RecursiveVarType) soltype.Type {
+					return exactObj(propElem("here", inner), propElem("there", outer))
+				})
+			}),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+			require.Equal(t, tt.want, equalType(tt.b, tt.a), "equality must be symmetric")
+		})
+	}
+}
+
+// TestConstrainRecursiveUnfolds pins the constrain arm: a knot is transparent, so a constraint on
+// one runs against its one-level unfolding. Two knots compared against each other close
+// coinductively through the seen-set — unfolding substitutes the knot's own pointer, so the pair the
+// recursion returns to is the pair the seen-set already holds.
+func TestConstrainRecursiveUnfolds(t *testing.T) {
+	selfNext := func() soltype.Type {
+		return muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+			return exactObj(propElem("next", ref))
+		})
+	}
+
+	t.Run("two alpha-equivalent knots are mutual subtypes", func(t *testing.T) {
+		c := &Context{}
+		require.Empty(t, Messages(c.Constrain(selfNext(), selfNext())))
+		require.Empty(t, Messages(c.Constrain(selfNext(), selfNext())))
+	})
+
+	t.Run("a knot satisfies its own unfolding and the reverse", func(t *testing.T) {
+		c := &Context{}
+		unfolded := exactObj(propElem("next", selfNext()))
+		require.Empty(t, Messages(c.Constrain(selfNext(), unfolded)))
+		require.Empty(t, Messages(c.Constrain(unfolded, selfNext())))
+	})
+
+	t.Run("a knot rejects a structural type its unfolding does not match", func(t *testing.T) {
+		// The knot unfolds before the comparison, so the rejection is reported at the property where
+		// the unfolded shape and the target disagree, naming the operands describe reached there.
+		c := &Context{}
+		errs := c.Constrain(selfNext(), exactObj(propElem("next", num())))
+		require.Equal(t, []string{"cannot constrain object <: number"}, Messages(errs))
+	})
+
+	t.Run("a knot flows into a variable as one lower bound", func(t *testing.T) {
+		// The pre-switch only unwraps an operator when the other side is concrete, so a variable
+		// super records the whole knot and the binding renders as the μ form rather than its
+		// unfolding.
+		c := &Context{}
+		v := c.freshVar(0)
+		require.Empty(t, Messages(c.Constrain(selfNext(), v)))
+		require.Equal(t, "μX0.{next: X0}", soltype.Print(coalesce(v, soltype.Positive)))
+	})
+}
+
+// TestDescribeRecursive pins the raw mid-constrain renderer's knot arms, so a diagnostic naming a
+// knot reads as the μ form rather than describe's default `?`. describe is the second per-node type
+// renderer beside soltype.Print, and both must carry every kind.
+func TestDescribeRecursive(t *testing.T) {
+	knot := muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+		return exactObj(propElem("next", ref), propElem("value", num()))
+	})
+	require.Equal(t, "μX0.object", describe(knot))
+	require.Equal(t, "X0", describe(knot.Binder))
+	require.Equal(t, "r7", describe(&soltype.RecursiveVarType{ID: 7}))
+}
+
+// TestExtrudeRecursiveKeepsBinder pins that a knot crosses a level boundary intact. LevelOf reads
+// the body and skips the binder, so the prune descends to freshen the body's out-of-level variable
+// while the binder and every reference to it are left alone. If the binder were an inference
+// variable, extrude would freshen it and desync it from its uses in the body.
+func TestExtrudeRecursiveKeepsBinder(t *testing.T) {
+	c := &Context{}
+	inner := c.freshVar(3)
+	original := muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+		return exactObj(propElem("next", ref), propElem("value", inner))
+	})
+
+	out := c.extrude(original, soltype.Positive, 0, map[extrudeKey]*soltype.TypeVarType{})
+	extruded, ok := out.(*soltype.RecursiveType)
+	require.True(t, ok, "extrusion must yield a knot, got %T", out)
+	require.Same(t, original.Binder, extruded.Binder)
+
+	body, ok := extruded.Body.(*soltype.ObjectType)
+	require.True(t, ok, "the knot's body must stay an object, got %T", extruded.Body)
+	next, ok := body.Prop("next")
+	require.True(t, ok)
+	require.Same(t, original.Binder, next.Type, "the binder reference must stay bound to the binder")
+
+	value, ok := body.Prop("value")
+	require.True(t, ok)
+	fresh, ok := value.Type.(*soltype.TypeVarType)
+	require.True(t, ok, "the out-of-level variable must be freshened, got %T", value.Type)
+	require.NotSame(t, inner, fresh)
+	require.Equal(t, 0, fresh.Level)
+}
+
+// TestUnfoldRecursiveShadowing pins the substitution's binding discipline: a nested knot rebinding
+// the same id shadows the outer binding, so its references stay bound to it. Coalescing numbers
+// binders per walk, so two walks whose display types are composed into one type can each contribute
+// a knot bound to id 0, which is what makes the case worth guarding.
+func TestUnfoldRecursiveShadowing(t *testing.T) {
+	shadowed := muKnot(0, "X0", func(outer *soltype.RecursiveVarType) soltype.Type {
+		return exactObj(
+			propElem("outer", outer),
+			propElem("shadow", muKnot(0, "X0", func(inner *soltype.RecursiveVarType) soltype.Type {
+				return exactObj(propElem("inner", inner))
+			})),
+		)
+	})
+	require.Equal(t,
+		"{outer: μX0.{outer: X0, shadow: μX0.{inner: X0}}, shadow: μX0.{inner: X0}}",
+		soltype.Print(unfoldRecursive(shadowed)))
+}
+
+// TestConstrainRecursiveSeenSetCloses pins that the coinductive close is what makes a recursive
+// comparison terminate rather than the unwrap budget. A budget cut-off would surface an
+// ExpansionLimitError, so an empty error list proves the seen-set closed the derivation.
+func TestConstrainRecursiveSeenSetCloses(t *testing.T) {
+	c := &Context{}
+	left := muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+		return exactObj(propElem("next", ref), propElem("value", num()))
+	})
+	right := muKnot(1, "X1", func(ref *soltype.RecursiveVarType) soltype.Type {
+		return exactObj(propElem("next", ref), propElem("value", num()))
+	})
+	require.Empty(t, Messages(c.constrain(left, right, set.NewSet[constraintKey](), false)))
+	require.Equal(t, 0, c.unwrapDepth, "the unwrap budget must unwind to zero")
+}

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -1,7 +1,6 @@
 package solver
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/ast"
@@ -14,12 +13,10 @@ import (
 // case must thread the path-scoped `seen` set (like the FuncType/TupleType cases)
 // or the cycle is never detected and coalescing never terminates.
 //
-// The assertion is intentionally loose: the test's real contract is that
-// inference TERMINATES (reaching the assertions at all proves that) and produces
-// a sane shape — a function returning an object bottoming out in `never`. The
-// exact unrolling depth (`{x: {x: never}}`) is a monomorphic-recursion artifact
-// that later coalesce/printer changes may legitimately alter; pinning it would
-// conflate "terminates" with "renders this exact shape".
+// The cycle closes as a μ-knot, so the recursive position names the shape it stands for. The one
+// unrolled level in front of it is a monomorphic-recursion artifact: each call site instantiates
+// its own return variable, so the outer object comes from the call and the knot from the variable
+// the body's recursive call flows through.
 //
 // NOTE: a regression that bypasses the `seen` guard stack-overflows here, which
 // is a fatal (uncatchable) crash that takes down the whole package test binary
@@ -29,11 +26,7 @@ import (
 func TestInferModuleRecursiveRecordTerminates(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f() { return {x: f()} }`)
 	require.Empty(t, errs, "unexpected inference errors")
-	got := values["f"]
-	require.True(t, strings.HasPrefix(got, "fn () -> {x:"),
-		"want a function returning a record with field x, got %q", got)
-	require.Contains(t, got, "never",
-		"ungrounded recursion should bottom out in never, got %q", got)
+	require.Equal(t, "fn () -> {x: μX0.{x: X0}}", values["f"])
 }
 
 // A top-level FuncDecl's inferred type must be recorded in the Info side table on


### PR DESCRIPTION
When type inference encounters a cycle in the bound graph—a variable whose bounds mention itself—coalesce now renders it as a finite μ-knot rather than collapsing to the polarity identity (never/unknown). This makes recursive types visible in inferred signatures: `fn f() { return {next: f()} }` now infers `fn () -> {next: μX0.{next: X0}}` instead of `fn () -> {next: never}`.

**Key changes:**

- Added `RecursiveType` and `RecursiveVarType` to the type system to represent μ-knots and their bound variables. A knot's body is one level of unfolding; the binder is the variable the body names itself through.
- Implemented `muBinders` in coalesce to track open binders on the walk path. When a variable is re-entered at the same polarity it was entered at, a μ-variable is minted and the finished body is wrapped in a `RecursiveType`. Cycles at opposite polarity still collapse to the identity (the current behavior for contravariant positions).
- Added `unfoldRecursive` to constrain, which substitutes the whole knot for its binder in the body. This makes knots transparent to structural comparison: a knot is compared against its one-level unfolding, and two knots close coinductively through the seen-set.
- Extended the type visitor, printer, and equality checker to handle knots. The printer renders them as `μX0.{...}` with proper precedence and parenthesization in unions/intersections. Equality is alpha-equivalence: two knots are equal when their bodies match under a consistent pairing of their binders.
- Updated both `coalescer` and `schemeCoalescer` to mint and tie knots during their walks, so recursive types appear in both plain coalesce and generic-scheme coalesce.
- Added comprehensive tests covering knot rendering, constrain behavior, alpha-equivalence, and the coinductive close of recursive comparisons.

https://claude.ai/code/session_017DsBg4AEM7CBEdqmdGyChP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recursive (μ-knot) types in type inference and constraint solving.
  * Recursive types can now be unfolded, compared for structural equivalence, and rendered clearly in diagnostics.
  * Improved handling of recursive records, generic parameters, nested binders, and cyclic type relationships.

* **Bug Fixes**
  * Prevented recursive inference and constraint processing from collapsing incorrectly or exceeding termination limits.

* **Tests**
  * Added comprehensive coverage for recursive type rendering, inference, unfolding, equality, visitor behavior, and termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->