### PR TITLE
Detect phantom type parameters in aliases

### DIFF
--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -43,6 +43,16 @@ type AliasDef struct {
 	// alias and expandAliasGuarded declines to expand it, so no reduction can reach a
 	// resolved body before the flag is set.
 	NotProductive bool
+
+	// PhantomParams holds one entry per TypeParam, true when no argument passed to that
+	// parameter can appear in the type an instantiation denotes. markPhantomParams computes it,
+	// and internAlias drops a phantom parameter's argument when it renders an alias reference's
+	// canonical identity, so two references differing only in those arguments intern to one
+	// representative. See phantom.go for what makes a parameter phantom.
+	//
+	// It is nil for an alias no fixed point ran over, which is an enum's synthesized alias. A
+	// nil slice marks nothing phantom, so every argument stays in the identity key.
+	PhantomParams []bool
 }
 
 // expandAlias unfolds an alias reference to its registered AliasDef Body, the shared

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -287,12 +287,14 @@ func (c *Context) reduceResidual(t soltype.Type, seen *seenPairs) (soltype.Type,
 }
 
 // maxUnwrapDepth caps how many type operators constrain may evaluate along one constraint path.
-// Almost every unwrap chain is a handful of steps and settles on its own. Two rules already close
+// Almost every unwrap chain is a handful of steps and settles on its own. Three rules already close
 // the recursive ones: the reflexive shortcut settles a comparison between the same alias
-// instantiation, and the seen-set settles one whose pairs repeat, which is every regular recursive
-// alias. What is left is a comparison between two different instantiations of a productive but
-// non-regular alias, `Deep<number> <: Deep<string>` for `type Deep<T> = {a: Deep<{b: T}>}`. That
-// one reaches a pair no earlier lap reached on every lap, so nothing closes it and the walk has no
+// instantiation, erasing the arguments of phantom parameters brings two instantiations that denote
+// one type under that shortcut, and the seen-set settles a comparison whose pairs repeat, which is
+// every regular recursive alias. What is left is a comparison between two instantiations of a
+// productive but non-regular alias whose parameter does reach the type it denotes,
+// `Nest<number> <: Nest<string>` for `type Nest<T> = {here: T, deeper: Nest<{b: T}>}`. That one
+// reaches a pair no earlier lap reached on every lap, so nothing closes it and the walk has no
 // finite answer to find. This budget stops it with an ExpansionLimitError.
 //
 // It is the constrain-side twin of the evaluator's maxExpandDepth and carries the same value, since
@@ -333,9 +335,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 	// recursive aliases with no finite normal form. Each lap of `type Deep<T> = {a: Deep<{b: T}>}`
 	// carries a payload no earlier lap did, first `{b: number}` and then `{b: {b: number}}`. So
 	// unfolding `Deep<number> <: Deep<number>` reaches a fresh pair every lap and the seen-set below
-	// never closes it, while the canonical identity aliasKey builds settles it in one step. Only an
-	// alias operand takes the shortcut. Any other type reaching here as both operands is decided by
-	// the arms below without unfolding anything, so the shortcut would save nothing.
+	// never closes it, while the canonical identity aliasKey builds settles it in one step. That
+	// identity erases the arguments of parameters no instantiation's type depends on, so it also
+	// settles `Deep<number> <: Deep<string>`, where the two sides are the same infinite tree. Only
+	// an alias operand takes the shortcut. Any other type reaching here as both operands is decided
+	// by the arms below without unfolding anything, so the shortcut would save nothing.
 	if _, subIsAlias := sub.(*soltype.AliasType); subIsAlias && key.sub == key.super {
 		return nil
 	}

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -126,7 +126,11 @@ func (c *Context) internAlias(at *soltype.AliasType) *soltype.AliasType {
 	// class, so two aliases sharing a local name across namespaces never collide on one key,
 	// and a nested recursive alias such as List<List<number>> serializes finitely because an
 	// argument renders under its own name without expanding.
-	k := soltype.PrintQualified(at)
+	//
+	// An argument a phantom parameter receives is erased first, since no instantiation's type
+	// depends on it. `type Deep<T> = {a: Deep<{b: T}>}` denotes `{a: {a: …}}` whatever T is, so
+	// Deep<number> and Deep<string> both key on "Deep" and share a representative.
+	k := soltype.PrintQualified(c.erasePhantomArgs(at))
 	if c.aliasInterns == nil {
 		c.aliasInterns = map[string]*soltype.AliasType{}
 	}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -406,8 +406,16 @@ func (c *checker) inferComponent(
 	}
 	c.deferAliasBounds = false
 	// Every body in the component is resolved, so the alias reference graph the productivity
-	// check reads is complete.
+	// check and the phantom-parameter fixed point read is complete. Both run before any
+	// constraint reaches an alias in the component, which is what lets constrain trust the marks
+	// they leave on each AliasDef.
 	c.checkProductive(aliasShells)
+	markPhantomParams(aliasShells)
+	// The deferred bound comparisons run last, after the marks are in place. Each one goes
+	// through constrain, which interns an alias operand's canonical identity, and internAlias
+	// drops the arguments of phantom parameters when it renders that key. Interning a reference
+	// before its alias is marked would key it under its full arguments and keep that
+	// representative for the rest of the run, so the same type could hold two identities.
 	c.runDeferredAliasBounds()
 
 	// Report any remaining non-value decl as unsupported. A class was pre-bound above and

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -70,6 +70,11 @@ func markPhantomParams(shells []*aliasShell) {
 // Only a reference whose target shares the referring alias's component can close a recursion, and
 // only such a reference gates its arguments behind a parameter. A reference to an alias in another
 // component expands finitely, so an argument reaching it reaches the denoted type.
+//
+// Everything below but the collector repeats unguardedCycles in productivity.go, and #965 tracks
+// lifting it into a shared helper. The two graphs stay distinct: that one records a reference only
+// where no type constructor encloses it, so `type Deep<T> = {a: Deep<{b: T}>}` gives it no edge at
+// all and reading it here would leave every parameter relevant.
 func aliasComponents(shells []*aliasShell) map[string]int {
 	names := make([]string, 0, len(shells))
 	for _, sh := range shells {

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -1,0 +1,250 @@
+package solver
+
+import (
+	"slices"
+
+	"github.com/escalier-lang/escalier/internal/graph"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// A type parameter is phantom when no argument passed to it can appear in the type the alias
+// denotes. The opposite is a relevant parameter, one the denoted type does depend on.
+//
+// `type Deep<T> = {a: Deep<{b: T}>}` has a phantom T. Unfolding it once emits `{a: …}` and hands
+// `{b: T}` to the next unfolding, so the payload is always one unfolding further in than the
+// structure emitted so far and never lands in it. `Deep<number>` and `Deep<string>` are both the
+// infinite type `{a: {a: {a: …}}}`, and TypeScript treats them as interchangeable.
+//
+// A parameter the body never mentions is phantom too. `type Ignore<T> = number` denotes `number`
+// whatever T is.
+//
+// markPhantomParams records the phantom parameters on each AliasDef, and internAlias drops their
+// arguments when it renders an alias reference's canonical identity. Two references that differ only
+// in phantom arguments then intern to one representative, so constrain's reflexive rule settles
+// `Deep<number> <: Deep<string>` in one step. Without the erasure the two sides unfold against each
+// other, reach a pair no earlier unfolding reached every time, and hit maxUnwrapDepth.
+//
+// A relevant parameter keeps its argument, so the comparison still decides on it.
+// `type Nest<T> = {here: T, deeper: Nest<{b: T}>}` writes T at `here`, so
+// `Nest<number> <: Nest<string>` still reports the `number` against `string` mismatch.
+//
+// The erasure reaches no further than that identity key. The reference node keeps every argument the
+// source wrote, so expandAlias substitutes them unchanged and a binding renders under them.
+
+// markPhantomParams computes and stores the phantom parameters of every alias in shells, which are
+// the aliases of one dep_graph component. Their bodies must be resolved first, since the walk reads
+// AliasDef.Body.
+//
+// The rule is a fixed point over those bodies. Start with every parameter phantom, and mark one
+// relevant when it occurs at a position the denoted type reaches. Every position in a body reaches
+// it except the arguments of a reference back into the alias's own strongly connected component,
+// which reach it only when the parameter they are passed to is itself relevant. Marking one
+// parameter relevant can therefore open a position that marks another, so the walk repeats until a
+// pass marks nothing new.
+func markPhantomParams(shells []*aliasShell) {
+	if len(shells) == 0 {
+		return
+	}
+	sccOf := aliasComponents(shells)
+
+	// phantom[qname][i] is true while parameter i of that alias is still believed unreachable.
+	phantom := map[string][]bool{}
+	for _, sh := range shells {
+		marks := make([]bool, len(sh.def.TypeParams))
+		for i := range marks {
+			marks[i] = true
+		}
+		phantom[sh.qname] = marks
+	}
+
+	for {
+		changed := false
+		for _, sh := range shells {
+			slots := map[*soltype.TypeVarType]int{}
+			for i, p := range sh.def.TypeParams {
+				if p.Var != nil {
+					slots[p.Var] = i
+				}
+			}
+			w := &phantomWalker{
+				name:      sh.qname,
+				scc:       sccOf[sh.qname],
+				sccOf:     sccOf,
+				slots:     slots,
+				phantom:   phantom,
+				reachable: true,
+			}
+			sh.def.Body.Accept(w, soltype.Positive)
+			changed = changed || w.changed
+		}
+		if !changed {
+			break
+		}
+	}
+
+	for _, sh := range shells {
+		sh.def.PhantomParams = phantom[sh.qname]
+	}
+}
+
+// aliasComponents groups the component's aliases into the strongly connected components of the
+// graph whose vertices are those aliases and whose edges are the alias references in their bodies,
+// at any depth. It returns each alias's component number.
+//
+// Only a reference whose target shares the referring alias's component can close a recursion, and
+// only such a reference gates its arguments behind a parameter. A reference to an alias in another
+// component expands finitely, so an argument reaching it reaches the denoted type.
+func aliasComponents(shells []*aliasShell) map[string]int {
+	names := make([]string, 0, len(shells))
+	for _, sh := range shells {
+		names = append(names, sh.qname)
+	}
+	within := set.FromSlice(names)
+	refs := map[string][]string{}
+	for _, sh := range shells {
+		collector := &aliasRefCollector{within: within, found: set.NewSet[string]()}
+		sh.def.Body.Accept(collector, soltype.Positive)
+		out := collector.found.ToSlice()
+		slices.Sort(out)
+		refs[sh.qname] = out
+	}
+	slices.Sort(names)
+
+	sccOf := map[string]int{}
+	for i, component := range graph.StronglyConnectedComponents(names, func(n string) []string { return refs[n] }) {
+		for _, name := range component {
+			sccOf[name] = i
+		}
+	}
+	return sccOf
+}
+
+// aliasRefCollector walks an alias body and records which of a fixed set of alias names it
+// references, at any depth and in any position. It rewrites nothing, so every node it visits comes
+// back unchanged. It is the unguarded-reference collector's counterpart in productivity.go, which
+// records only the references no type constructor encloses.
+type aliasRefCollector struct {
+	within set.Set[string]
+	found  set.Set[string]
+}
+
+func (v *aliasRefCollector) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if at, ok := t.(*soltype.AliasType); ok && v.within.Contains(at.Name) {
+		v.found.Add(at.Name)
+	}
+	return soltype.EnterResult{}
+}
+
+func (v *aliasRefCollector) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// phantomWalker walks one alias body and clears a phantom mark for each of the alias's own type
+// parameters that it finds at a position the type the alias denotes reaches. It rewrites nothing, so
+// every node it visits comes back unchanged.
+type phantomWalker struct {
+	// name is the walked alias's qualified name, the key its own marks live under in phantom.
+	name string
+	// scc is the walked alias's component number, so a reference into that same component is
+	// recognized as one that can close a recursion.
+	scc   int
+	sccOf map[string]int
+	// slots maps each of the walked alias's type-parameter variables to its declaration position.
+	// The body holds those variables symbolically, so an occurrence is found by pointer identity.
+	slots map[*soltype.TypeVarType]int
+	// phantom is the marks of every alias in the component, shared across the fixed point's
+	// passes. The walker reads other aliases' marks to decide whether an argument slot reaches the
+	// denoted type, and clears its own.
+	phantom map[string][]bool
+	// reachable is true while the node being visited sits at a position the type an instantiation
+	// denotes reaches. It starts true at the body root and goes false inside an argument handed to a
+	// phantom parameter of a same-component reference.
+	reachable bool
+	// changed records whether this pass cleared any mark, which is what the fixed point iterates on.
+	changed bool
+}
+
+func (w *phantomWalker) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	switch t := t.(type) {
+	case *soltype.TypeVarType:
+		if !w.reachable {
+			return soltype.EnterResult{}
+		}
+		marks := w.phantom[w.name]
+		if i, own := w.slots[t]; own && i < len(marks) && marks[i] {
+			marks[i] = false
+			w.changed = true
+		}
+	case *soltype.AliasType:
+		if id, known := w.sccOf[t.Name]; !known || id != w.scc {
+			// A reference out of the component expands finitely, so its arguments carry the
+			// current reachability rather than being gated behind a parameter.
+			return soltype.EnterResult{}
+		}
+		// A reference back into the component hands each argument to one parameter, so the argument
+		// reaches this alias's denoted type only when that parameter reaches the referenced alias's.
+		// Walking the arguments here, rather than letting Accept walk them, is what lets each one
+		// carry its own reachability.
+		target := w.phantom[t.Name]
+		outer := w.reachable
+		for i, arg := range t.TypeArgs {
+			// An argument past the referenced alias's parameter list is an arity mismatch already
+			// reported at the reference. Read it as reaching the denoted type, the conservative
+			// answer, rather than as phantom.
+			gated := i < len(target) && target[i]
+			w.reachable = outer && !gated
+			arg.Accept(w, pol)
+		}
+		w.reachable = outer
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (w *phantomWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// erasePhantomArgs rewrites t, dropping from every alias reference in it the arguments its alias's
+// phantom parameters would receive. internAlias renders the result to build a canonical identity
+// key, so two references differing only in erased arguments produce the same key. The rewrite
+// reaches nested references too, so `Nest<Deep<number>>` and `Nest<Deep<string>>` both render as
+// `Nest<Deep>` even though Nest's own parameter is relevant.
+//
+// The result is a rendering input, not a type to check or expand. It returns t itself when no
+// reference in it has a phantom argument to drop, which is the common case.
+func (c *Context) erasePhantomArgs(t soltype.Type) soltype.Type {
+	return t.Accept(&phantomEraser{ctx: c}, soltype.Positive)
+}
+
+type phantomEraser struct {
+	ctx *Context
+}
+
+func (e *phantomEraser) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	return soltype.EnterResult{}
+}
+
+// ExitType drops the phantom arguments of an alias reference. It runs bottom-up on already-rewritten
+// children, so an argument that survives has had its own nested references erased.
+func (e *phantomEraser) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
+	at, ok := t.(*soltype.AliasType)
+	if !ok || len(at.TypeArgs) == 0 {
+		return t
+	}
+	// Most aliases have nothing phantom, so answer those without allocating.
+	def, registered := e.ctx.aliasDef(at.Name)
+	if !registered || !slices.Contains(def.PhantomParams, true) {
+		return t
+	}
+	kept := make([]soltype.Type, 0, len(at.TypeArgs))
+	for i, arg := range at.TypeArgs {
+		if i < len(def.PhantomParams) && def.PhantomParams[i] {
+			continue
+		}
+		kept = append(kept, arg)
+	}
+	if len(kept) == len(at.TypeArgs) {
+		// An arity mismatch left fewer arguments than parameters, so no phantom slot was
+		// actually filled. Keep the node rather than allocating a copy of it.
+		return t
+	}
+	return &soltype.AliasType{Name: at.Name, TypeArgs: kept, LifetimeArgs: at.LifetimeArgs}
+}

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -9,39 +9,14 @@ import (
 )
 
 // A type parameter is phantom when no argument passed to it can appear in the type the alias
-// denotes. The opposite is a relevant parameter, one the denoted type does depend on.
-//
-// `type Deep<T> = {a: Deep<{b: T}>}` has a phantom T. Unfolding it once emits `{a: …}` and hands
-// `{b: T}` to the next unfolding, so the payload is always one unfolding further in than the
-// structure emitted so far and never lands in it. `Deep<number>` and `Deep<string>` are both the
-// infinite type `{a: {a: {a: …}}}`, and TypeScript treats them as interchangeable.
-//
-// A parameter the body never mentions is phantom too. `type Ignore<T> = number` denotes `number`
-// whatever T is.
-//
-// markPhantomParams records the phantom parameters on each AliasDef, and internAlias drops their
-// arguments when it renders an alias reference's canonical identity. Two references that differ only
-// in phantom arguments then intern to one representative, so constrain's reflexive rule settles
-// `Deep<number> <: Deep<string>` in one step. Without the erasure the two sides unfold against each
-// other, reach a pair no earlier unfolding reached every time, and hit maxUnwrapDepth.
-//
-// A relevant parameter keeps its argument, so the comparison still decides on it.
-// `type Nest<T> = {here: T, deeper: Nest<{b: T}>}` writes T at `here`, so
-// `Nest<number> <: Nest<string>` still reports the `number` against `string` mismatch.
-//
-// The erasure reaches no further than that identity key. The reference node keeps every argument the
-// source wrote, so expandAlias substitutes them unchanged and a binding renders under them.
+// denotes. `type Deep<T> = {a: Deep<{b: T}>}` pushes `{b: T}` one unfolding deeper forever, so
+// `Deep<number>` and `Deep<string>` are both the infinite type `{a: {a: …}}`.
 
-// markPhantomParams computes and stores the phantom parameters of every alias in shells, which are
-// the aliases of one dep_graph component. Their bodies must be resolved first, since the walk reads
-// AliasDef.Body.
-//
-// The rule is a fixed point over those bodies. Start with every parameter phantom, and mark one
-// relevant when it occurs at a position the denoted type reaches. Every position in a body reaches
-// it except the arguments of a reference back into the alias's own strongly connected component,
-// which reach it only when the parameter they are passed to is itself relevant. Marking one
-// parameter relevant can therefore open a position that marks another, so the walk repeats until a
-// pass marks nothing new.
+// markPhantomParams marks the aliases of one dep_graph component, whose bodies must already be
+// resolved, so internAlias can drop a phantom argument from a reference's identity key. It is a
+// fixed point: a parameter starts phantom and turns relevant where it occurs, except inside the
+// arguments of a same-component reference, which reach the type only if the parameter they fill
+// does.
 func markPhantomParams(shells []*aliasShell) {
 	if len(shells) == 0 {
 		return
@@ -202,14 +177,9 @@ func (w *phantomWalker) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 
 func (w *phantomWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
-// erasePhantomArgs rewrites t, dropping from every alias reference in it the arguments its alias's
-// phantom parameters would receive. internAlias renders the result to build a canonical identity
-// key, so two references differing only in erased arguments produce the same key. The rewrite
-// reaches nested references too, so `Nest<Deep<number>>` and `Nest<Deep<string>>` both render as
-// `Nest<Deep>` even though Nest's own parameter is relevant.
-//
-// The result is a rendering input, not a type to check or expand. It returns t itself when no
-// reference in it has a phantom argument to drop, which is the common case.
+// erasePhantomArgs drops from every alias reference in t the arguments its phantom parameters
+// receive, nested ones included, so internAlias renders two references differing only there to one
+// key. It is a rendering input, not a type to check or expand, and returns t when nothing drops.
 func (c *Context) erasePhantomArgs(t soltype.Type) soltype.Type {
 	return t.Accept(&phantomEraser{ctx: c}, soltype.Positive)
 }

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -1,0 +1,104 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A phantom parameter's argument cannot appear in the type an instantiation denotes, so two
+// instantiations that differ only in those arguments are one type and check against each other in
+// both directions. Each case below names a different reason the argument never lands in that type.
+func TestInferPhantomArgumentsCompareEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			// The recursive reference hands `{b: T}` to the next unfolding, so the payload is always
+			// one unfolding deeper than the structure emitted so far. `Deep<number>` and
+			// `Deep<string>` are both `{a: {a: {a: …}}}`.
+			name: "PayloadAlwaysOneUnfoldingAhead",
+			src: `
+				type Deep<T> = {a: Deep<{b: T}>}
+				declare fn make() -> Deep<number>
+				val d: Deep<string> = make()
+			`,
+		},
+		{
+			// The same pair the other way round, since the erasure is a property of the identity
+			// rather than of one side of the constraint.
+			name: "PayloadAlwaysOneUnfoldingAheadReversed",
+			src: `
+				type Deep<T> = {a: Deep<{b: T}>}
+				declare fn make() -> Deep<string>
+				val d: Deep<number> = make()
+			`,
+		},
+		{
+			// Mutual recursion. P's parameter reaches only Q's parameter and Q's reaches only P's, so
+			// neither ever lands in the `{a: {b: {a: …}}}` the pair denotes. The fixed point has to
+			// settle both together, since each is phantom only because the other is.
+			name: "MutuallyRecursivePair",
+			src: `
+				type P<T> = {a: Q<T>}
+				type Q<U> = {b: P<U>}
+				declare fn make() -> P<number>
+				val d: P<string> = make()
+			`,
+		},
+		{
+			// A parameter the body never mentions. `Ignore<T>` denotes `number` whatever T is, so no
+			// recursion is involved at all.
+			name: "ParameterUnusedInTheBody",
+			src: `
+				type Ignore<T> = number
+				declare fn make() -> Ignore<number>
+				val d: Ignore<string> = make()
+			`,
+		},
+		{
+			// The erasure reaches a nested reference, so a relevant parameter carrying a phantom
+			// instantiation still compares equal. Hold's own T is relevant, since it lands at `held`.
+			name: "PhantomInstantiationInsideARelevantArgument",
+			src: `
+				type Deep<T> = {a: Deep<{b: T}>}
+				type Hold<T> = {held: T}
+				declare fn make() -> Hold<Deep<number>>
+				val d: Hold<Deep<string>> = make()
+			`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Empty(t, messagesWithSpan(errs))
+		})
+	}
+}
+
+// A parameter that does reach the type an alias denotes stays relevant, so its argument stays in the
+// canonical identity and a mismatch is still reported. `Nest<T>` writes T at `here`, inside the
+// object every unfolding emits, which is what separates it from `Deep<T>` above.
+func TestInferRelevantParameterKeepsItsArgument(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Nest<T> = {here: T, deeper: Nest<{b: T}>}
+		declare fn make() -> Nest<number>
+		val d: Nest<string> = make()
+	`)
+	require.Contains(t, messagesWithSpan(errs), "4:25-4:31: cannot constrain number <: string")
+}
+
+// The erasure is confined to the canonical identity constrain keys on. A reference still carries the
+// arguments the source wrote, so a binding renders under those and not under an erased form.
+func TestInferPhantomArgumentSurvivesInTheRenderedType(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		type Deep<T> = {a: Deep<{b: T}>}
+		declare fn make() -> Deep<number>
+		val d: Deep<string> = make()
+		fn f(p: Deep<number>) -> Deep<number> { return p }
+	`)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t, "Deep<string>", values["d"])
+	require.Equal(t, "fn (p: Deep<number>) -> Deep<number>", values["f"])
+}

--- a/internal/solver/productivity.go
+++ b/internal/solver/productivity.go
@@ -74,6 +74,11 @@ func (c *checker) checkProductive(shells []*aliasShell) {
 // the dep_graph component and whose edges are the unguarded alias references in their bodies. A
 // component of two or more aliases is a cycle. A component of one is a cycle only when that alias's
 // body names itself unguarded.
+//
+// Everything below but the collector repeats aliasComponents in phantom.go, and #965 tracks lifting
+// it into a shared helper. The two graphs stay distinct: that one records a reference at any depth,
+// which would make a guarded recursion look unguarded and reject an alias that emits structure every
+// lap.
 func unguardedCycles(shells []*aliasShell) map[string]set.Set[string] {
 	names := make([]string, 0, len(shells))
 	for _, sh := range shells {

--- a/internal/solver/productivity.go
+++ b/internal/solver/productivity.go
@@ -31,9 +31,10 @@ import (
 // `type Deep<T> = {a: Deep<{b: T}>}` is productive and not regular. It emits `{a: …}` every lap, so
 // `Deep<number>` is a well-defined infinite tree, but its payloads are `{b: number}`, then
 // `{b: {b: number}}`, and so on, all distinct. No finite normal form exists for it, so the
-// evaluator cannot materialize it. constrain compares two such aliases by their names and
-// arguments instead of unfolding them, which is what makes accepting them useful rather than only
-// permissive.
+// evaluator cannot materialize it. constrain compares two such aliases by their canonical identity
+// instead of unfolding them, which is what makes accepting them useful rather than only permissive.
+// That identity keeps only the arguments the denoted type depends on — see markPhantomParams —
+// which is why `Deep<number>` and `Deep<string>` compare equal rather than diverging.
 //
 // Mutual recursion goes through the alias reference graph. A recursive reference means a reference
 // to any alias in the same strongly connected component, so `type A = B` paired with `type B = A`

--- a/internal/solver/productivity_test.go
+++ b/internal/solver/productivity_test.go
@@ -249,18 +249,21 @@ func TestInferNonRegularAliasChecks(t *testing.T) {
 	}
 }
 
-// Comparing two different instantiations of a non-regular alias has no finite answer. Every lap
-// reaches a pair of instantiations no earlier lap did, so neither the reflexive shortcut nor the
-// coinductive seen-set closes it. maxUnwrapDepth stops the walk, and the diagnostic names the alias
-// rather than the arguments the walk had grown by then.
+// Comparing two instantiations of a non-regular alias whose parameter reaches the type it denotes
+// has no finite answer. Every lap reaches a pair of instantiations no earlier lap did, so neither
+// the reflexive shortcut nor the coinductive seen-set closes it. The walk reports the mismatch it
+// finds at the first `here` field, then runs on until maxUnwrapDepth stops it, and that diagnostic
+// names the alias rather than the arguments the walk had grown by then. `Deep`, whose parameter never
+// reaches the type it denotes, settles instead — see TestInferPhantomArgumentsCompareEqual.
 func TestInferNonRegularAliasComparisonDoesNotSettle(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		type Deep<T> = {a: Deep<{b: T}>}
-		declare fn make() -> Deep<number>
-		val d: Deep<string> = make()
+		type Nest<T> = {here: T, deeper: Nest<{b: T}>}
+		declare fn make() -> Nest<number>
+		val d: Nest<string> = make()
 	`)
 	require.Equal(t, []string{
-		"4:25-4:31: comparing two instantiations of `Deep` reached the limit of 200 type-operator " +
+		"4:25-4:31: cannot constrain number <: string",
+		"4:25-4:31: comparing two instantiations of `Nest` reached the limit of 200 type-operator " +
 			"expansions and was cut off; either the two sides recurse without ever repeating a pair " +
 			"the check can close on, or their alias chains run deeper than the limit unfolds",
 	}, messagesWithSpan(errs))

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -133,19 +133,20 @@ spike work rather than inventing it:
 
 ## PR-by-PR breakdown
 
-Twenty-five PRs across five tracks. Track A builds the evaluator and the core
+Twenty-eight PRs across six tracks. Track A builds the evaluator and the core
 operators in dependency order. Track B adds spread and template-literal
 operators, which hang off the backbone but are independent of each other. Track C
 adds exactness propagation and the recursion static-check. Track D is the
 function-signature effects and the exception machinery around them, which touch
 `FuncType` and not the evaluator at all, so it runs fully in parallel with A–C.
-Track E is the capstone verification and the follow-ons it turned up.
+Track E is the capstone verification and the follow-ons it turned up. Track F brings a
+class reference's type arguments up to the checking an alias reference already gets.
 
 The two heaviest concerns — the evaluator backbone and the conditional/`infer`
 matcher — are each split in two so no single PR carries both a new representation
 and a new algorithm: PR1a/PR1b and PR3a/PR3b below.
 
-Sixteen of the twenty-five were planned up front. PR9c through PR9f were added to Track C
+Sixteen of the twenty-eight were planned up front. PR9c through PR9f were added to Track C
 after PR9b's review, which turned up one soundness question, one wrong answer, and one
 representation the milestone assumed exists. They are described together in "the
 recursion-safety follow-on group" below. PR14 through PR16 were added to Track E after
@@ -158,6 +159,11 @@ its own signature and into the promise it returns, which is where a rejection be
 which needs PR10b's `try` to be catchable. Both were assumed by
 [01-milestones.md](01-milestones.md) — its M9 accept list calls for "a `try`/`catch` test
 for the body-narrowing rule" — without a PR to build them.
+
+PR17 through PR19 were added as Track F after PR9d's review, which found that a written
+type argument is never checked against its parameter's declared bound. #956 has since
+closed that for aliases, and for enums with it, since an enum registers as a transparent
+alias. What the review turned up beyond it stays open, and Track F is that remainder.
 
 ### PR1a — Residual-node representation + inert plumbing
 
@@ -1279,6 +1285,138 @@ disabled test it re-enables. Independent of PR14 and PR15.
 
 **Completes the suite.** With this PR every utility PR13 lists reduces.
 
+### The generic-parameter checking group (PR17–PR19)
+
+These three came out of PR9d's review. That PR's accept criteria assumed a type parameter's
+declared bound is checked against the argument a reference writes, and at the time nothing
+checked it anywhere. #956 closed the alias half, and enums came with it, since
+`inferEnumDecl` registers an enum as a transparent alias and a reference to one resolves
+through `buildAliasInstance`. A **class** reference resolves through `buildClassInstance`
+([infer_class.go](../../internal/solver/infer_class.go)) instead, which resolves exactly the
+arguments the source wrote and checks nothing about them. Pulling on that turned up a third
+gap, in how a parameter's default is resolved, that neither path handles.
+
+Two terms carry the group. A **type parameter's bound** is the `T: number` of
+`type Hold<T: number> = …`, the upper bound an argument must satisfy. A **default** is the
+`= number` of `type Hold<T = number> = …`, the argument a reference may omit.
+[resolveTypeParams](../../internal/solver/type_params.go) resolves both, and #956 added the
+`TypeParam.Constraint` field that keeps the declared bound where later solving cannot
+overwrite it — a class's constructor body writes inferred upper bounds onto the same
+parameter var, so the var's bound list is not what the source declared.
+
+Why the function and constructor positions already work is worth stating, since it explains
+why only a written type argument is left. A parameter's var carries its bound, so calling
+`fn f<T: number>(x: T)` as `f("hi")` records `"hi"` against it and `constrain` reports the
+mismatch, and `class Box<T: A>` renders its constructor `fn <T>(value: T & A)` so
+`Box(Other())` does the same. Both work because a **value** flows into the parameter. A
+written type argument flows nowhere on the class path: `buildClassInstance` substitutes it
+into the body and the bound goes with the var it was attached to.
+
+The three land in dependency order. PR17 is independent and fixes the worst answer of the
+group. PR18 needs it, so the class path does not start filling defaults while a default can
+still leak a declaration var. PR19 needs PR18's helper, which is the one place that pairs a
+written argument with the parameter it fills.
+
+### PR17 — A default may name only an earlier parameter
+
+`resolveTypeParams` resolves a default in a second pass, after every sibling name is
+declared, so `type Pair<T = U, U = number>` resolves `T`'s default to `U`'s **parameter
+var**. Instantiation cannot fill that: `buildAliasInstance` substitutes only the parameters
+before the one it is filling, so the var survives into the instance and behaves as a live
+inference variable.
+
+The result is worse than a bad rendering. The var belongs to the declaration, so every
+reference to the alias shares it. Given `type Pair<T = U, U = number> = {a: T, b: U}`,
+`val p: Pair = {a: 1, b: 2}` alongside `val q: Pair = {a: "s", b: 3}` infers `p` as
+`Pair<1 | "s", number>` — `q`'s value widened the type of `p`. A self-referential default
+`type Loop<T = T> = {v: T}` leaks the same way.
+
+**Data structures.** A `TypeParamDefaultForwardRefError` naming the parameter, the parameter
+its default reaches, and the declaration node.
+
+**Algorithms.** In `resolveTypeParams`' second pass, resolve parameter `i`'s default against
+a scope holding only parameters `0..i-1`. A later or self reference then finds the name
+undeclared and is reported, instead of silently resolving to the sibling's var.
+
+The restriction applies to the default position alone. Pass one declares every parameter
+name before any bound or default is read, and a bound needs that: `<T: U, U: T>` is a legal
+mutual F-bound, and an F-bound `<T: Foo<T>>` names the parameter being declared. Only a
+default has to be substitutable positionally, so only a default is restricted.
+
+Recover by dropping the default, which leaves the parameter required and lets the existing
+arity diagnostic name the omission. TypeScript draws the same line, rejecting a default that
+names a later parameter.
+
+**Accept.** `type Pair<T = U, U = number>` and `type Loop<T = T>` are rejected with a
+full-message error. `type Pair<T = number, U = T>` still resolves, since `U`'s default names
+an earlier parameter. `<T: U, U: T>` still resolves, since the restriction does not touch
+bounds. No declaration var reaches an instance, so two references to one alias no longer
+share an argument.
+
+**Depends on** M7, landed. Independent of the operator track.
+
+### PR18 — Class type-parameter defaults and arity at a type reference
+
+`buildAliasInstance` checks a reference's argument count against the alias's parameters and
+fills a trailing omitted argument from its default. `buildClassInstance` does neither. It
+resolves exactly the arguments the reference wrote and returns them, so
+`class Box<T = number>` referenced bare as `Box` yields the declaration handle, whose
+unconstrained parameter var coalesces to `never` and renders `Box<never>` rather than
+`Box<number>`. A reference that supplies too many arguments, `Box<number, string>` on a
+one-parameter class, carries the extra one with no diagnostic. An enum needs neither fix:
+`enum Opt<T = number>` referenced bare already infers `Opt<number>` through the alias path.
+
+**Data structures.** A `ClassArityMismatchError`, the nominal twin of
+`AliasArityMismatchError`, carrying the same required/total/got triple so the two render
+alike.
+
+**Algorithms.** Factor the arity check and the default filling out of `buildAliasInstance`
+into one helper over a `[]*soltype.TypeParam` and a reference's written arguments, returning
+one argument per parameter. Both instance builders call it, so an alias and a class resolve a
+defaulted or miscounted reference the same way. The helper is also the one place that pairs a
+written argument with the parameter it fills, which is what PR19 needs.
+
+**Accept.** `class Box<T = number>` referenced bare infers `Box<number>`.
+`Box<number, string>` on a one-parameter class reports a full-message arity error. Every
+alias and enum arity and default case that passes today still passes, since the shared helper
+is `buildAliasInstance`'s existing logic moved rather than rewritten.
+
+**Depends on** PR17, so the class path does not inherit the forward-reference leak the moment
+it starts filling defaults. Independent of the operator track.
+
+### PR19 — Class type-argument bound checking
+
+`class Box<T: A>` accepts `Box<Other>` in an annotation with no diagnostic. #956 built the
+alias-side answer — `checkAliasArgBounds`, its deferral through `deferredAliasBounds` for a
+sibling whose body is not yet filled, and the live rather than discarded comparison that
+leaves a bound on a caller's variable — so this PR is that machinery reaching a second
+caller, not a second design.
+
+**Algorithms.**
+- Check each argument `buildClassInstance` resolves against its parameter's
+  `TypeParam.Constraint`, substituting the reference's own arguments into the bound first so
+  a bound naming a sibling parameter, `<T, K: keyof T>`, reaches the argument that filled it.
+  PR18's helper is where the pairing happens.
+- **Reuse #956's comparison rather than reimplementing it.** It is live, not a discarded
+  trial, which is what makes a type-variable argument defer to the caller's instantiation
+  instead of silently passing. Factoring the alias check's body into a shared routine over a
+  parameter list and an argument list keeps one answer to that question.
+- **A class in a dep_graph component with an unfilled sibling defers the same way.** A class
+  body resolves after its own pre-binding, so a bound naming a sibling class can reach a
+  registered-but-empty `ClassDef`. Route through the same deferral list #956 added, replayed
+  once the component's bodies are filled.
+- An argument that fails its bound is reported and then kept rather than replaced with a
+  recovery var, so a later diagnostic names the type the source wrote.
+
+**Accept.** `Box<Other>` against `class Box<T: A>` reports a full-message bound error, and
+`Box<B>` for a subclass `B` of `A` passes. `Box(Other())` keeps reporting the
+`cannot constrain Other <: A` it reports today, so the inference path and the check path do
+not double-report one mismatch. A forwarding declaration `fn g<U>(u: U) -> Box<U>` defers to
+its call site, matching what #956 settled for the alias position.
+
+**Depends on** PR18 for the helper and #956 for the comparison. Independent of the operator
+track.
+
 ---
 
 ## Sizing note
@@ -1338,6 +1476,11 @@ sites that turn a written `null` into one. What earns it a PR of its own is that
 sites span the annotation, expression, and pattern walks, and that the shared
 `litTypeOf` they read cannot return an atom as it stands.
 
+Track F is small, and shrank when #956 landed: PR17 is a scope restriction in one pass of
+`resolveTypeParams` plus its diagnostic, PR18 moves `buildAliasInstance`'s arity-and-default
+logic into a helper the class path also calls, so most of its diff is a move, and PR19 routes
+#956's existing comparison to that helper. None of the three designs anything new.
+
 ## Dependency graph
 
 A PR marked ✅ has merged, and the number after it is the merged pull request. An
@@ -1376,6 +1519,10 @@ PR13 (TS utility-type suite)               ── needs PR2, PR3b, PR4, PR7, PR1
  ├─► PR14 (rest params in fn type anns + Parameters<F>)  ── also needs PR3b
  │    └─► PR15 (new (…) members in obj type anns + ConstructorParameters<C>)
  └─► PR16 (null + undefined + NonNullable<T>)            ── also needs PR3b
+
+PR17 (default names only an earlier param) ── needs M7 only
+ └─► PR18 (class type-param defaults + arity at a type reference)
+      └─► PR19 (class type-argument bound checking)  ── also needs #956
 ```
 
 PR9b replaced PR9's regularity condition with the productivity condition, so PR9's
@@ -1386,9 +1533,9 @@ monotonic budget. #938 added the `{[K: Keys]: Value}` index-signature shorthand 
 PR4's mapped types.
 
 Everything still open is PR8, PR9d, PR9f, PR10, PR10b, PR10c, PR11, PR13, PR14, PR15,
-and PR16. PR8 is partly
-seeded — #922 threads an object's exactness through `keyof` — but the rest of the
-operators and the `Exact` / `Inexact` intrinsics are untouched.
+PR16, and Track F's PR17 through PR19. PR8 is partly seeded — #922 threads an object's
+exactness through `keyof` — but the rest of the operators and the `Exact` / `Inexact`
+intrinsics are untouched.
 
 The same graph in mermaid, with the operator-track critical path
 (PR1a → PR1b → PR3a → PR3b → PR4 → PR8) highlighted, merged PRs outlined in green,
@@ -1425,6 +1572,9 @@ graph TD
     PR14["PR14 (rest params in fn type anns + Parameters<F>)"]
     PR15["PR15 (new (…) in obj type anns + ConstructorParameters<C>)"]
     PR16["PR16 (null + undefined + NonNullable<T>)"]
+    PR17["PR17 (default names only an earlier param)"]
+    PR18["PR18 (class type-param defaults + arity at a type reference)"]
+    PR19["PR19 (class type-argument bound checking)"]
 
     M7 -.-> PR1a
     M75 -.-> PR10c
@@ -1470,6 +1620,8 @@ graph TD
     PR14 --> PR15
     PR13 --> PR16
     PR3b --> PR16
+    PR17 --> PR18
+    PR18 --> PR19
 
     linkStyle default stroke:#888
     style PR1a fill:#e06666,stroke:#2e7d32,stroke-width:4px,color:#fff
@@ -1514,7 +1666,12 @@ graph TD
   close on its own. PR15's `InstanceType<C>` half is separable from PR14 and could run
   alongside it if the two are sequenced apart. PR16 hangs off PR13 directly and shares
   nothing with either, so it runs concurrently with both.
+- **Track F** — a chain, PR17 → PR18 → PR19, and nothing outside it waits on any of the
+  three, so it can run start to finish alongside any other track. The order is both the
+  dependency order and the value order: PR17 fixes a wrong answer, PR18 fixes a second one
+  and builds the helper, PR19 routes #956's comparison to it.
 
 The critical path is `M7 → PR1a → PR1b → PR3a → PR3b → PR4 → PR8`, and — for the
 async-generator accept case — `M7 → PR1a → PR1b → PR3b → PR12 → PR13 → PR14 → PR15`.
-The follow-on group sits off both: nothing in PR1a–PR16 waits on PR9c–PR9f.
+The follow-on group sits off both: nothing in PR1a–PR16 waits on PR9c–PR9f, and nothing
+waits on Track F.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -133,7 +133,7 @@ spike work rather than inventing it:
 
 ## PR-by-PR breakdown
 
-Twenty-eight PRs across six tracks. Track A builds the evaluator and the core
+Twenty-nine PRs across six tracks. Track A builds the evaluator and the core
 operators in dependency order. Track B adds spread and template-literal
 operators, which hang off the backbone but are independent of each other. Track C
 adds exactness propagation and the recursion static-check. Track D is the
@@ -146,7 +146,7 @@ The two heaviest concerns — the evaluator backbone and the conditional/`infer`
 matcher — are each split in two so no single PR carries both a new representation
 and a new algorithm: PR1a/PR1b and PR3a/PR3b below.
 
-Sixteen of the twenty-eight were planned up front. PR9c through PR9f were added to Track C
+Sixteen of the twenty-nine were planned up front. PR9c through PR9f were added to Track C
 after PR9b's review, which turned up one soundness question, one wrong answer, and one
 representation the milestone assumed exists. They are described together in "the
 recursion-safety follow-on group" below. PR14 through PR16 were added to Track E after
@@ -160,10 +160,11 @@ which needs PR10b's `try` to be catchable. Both were assumed by
 [01-milestones.md](01-milestones.md) — its M9 accept list calls for "a `try`/`catch` test
 for the body-narrowing rule" — without a PR to build them.
 
-PR17 through PR19 were added as Track F after PR9d's review, which found that a written
+PR17 through PR20 were added as Track F after PR9d's review, which found that a written
 type argument is never checked against its parameter's declared bound. #956 has since
 closed that for aliases, and for enums with it, since an enum registers as a transparent
-alias. What the review turned up beyond it stays open, and Track F is that remainder.
+alias. What the review turned up beyond it stays open, and Track F is that remainder, plus
+PR20, which surfaces the erasure PR9d performs silently.
 
 ### PR1a — Residual-node representation + inert plumbing
 
@@ -1285,7 +1286,7 @@ disabled test it re-enables. Independent of PR14 and PR15.
 
 **Completes the suite.** With this PR every utility PR13 lists reduces.
 
-### The generic-parameter checking group (PR17–PR19)
+### The generic-parameter checking group (PR17–PR20)
 
 These three came out of PR9d's review. That PR's accept criteria assumed a type parameter's
 declared bound is checked against the argument a reference writes, and at the time nothing
@@ -1312,10 +1313,12 @@ mismatch, and `class Box<T: A>` renders its constructor `fn <T>(value: T & A)` s
 written type argument flows nowhere on the class path: `buildClassInstance` substitutes it
 into the body and the bound goes with the var it was attached to.
 
-The three land in dependency order. PR17 is independent and fixes the worst answer of the
-group. PR18 needs it, so the class path does not start filling defaults while a default can
-still leak a declaration var. PR19 needs PR18's helper, which is the one place that pairs a
-written argument with the parameter it fills.
+The first three land in dependency order. PR17 is independent and fixes the worst answer of
+the group. PR18 needs it, so the class path does not start filling defaults while a default
+can still leak a declaration var. PR19 needs PR18's helper, which is the one place that pairs
+a written argument with the parameter it fills. PR20 sits apart from the chain: it is the
+only one that reports on a declaration rather than a reference, and it hangs off PR9d rather
+than off any of the other three.
 
 ### PR17 — A default may name only an earlier parameter
 
@@ -1417,6 +1420,77 @@ its call site, matching what #956 settled for the alias position.
 **Depends on** PR18 for the helper and #956 for the comparison. Independent of the operator
 track.
 
+### PR20 — Warn on a phantom type parameter
+
+PR9d computes, for every alias parameter, whether an argument passed to it can appear in the
+type the alias denotes, and erases the ones that cannot from the alias's canonical identity.
+That erasure is silent. `type Deep<T> = {a: Deep<{b: T}>}` reads as a type parameterized by
+T, and it is not. `Deep<number>` and `Deep<string>` are one type, so a caller who wrote the
+argument expecting it to mean something gets no signal. `type Ignore<T> = number` is the
+degenerate form of the same thing.
+
+This PR reports both, at warning severity. It is the type-sort twin of
+`UnusedLifetimeParamError` ([errors.go](../../internal/solver/errors.go)), which fires on a
+`<'a>` binder no `&'a` references and is likewise always a warning: the program is
+well-typed, and the binder is dead weight.
+
+**The warning cannot read PR9d's marks directly.** `AliasDef.PhantomParams` answers "can an
+argument reach the denoted type", and it is computed over the alias body alone, which is
+correct for erasure and wrong as a use-check. Two shapes come back phantom while the
+parameter is doing real work:
+
+- `type Foo<T, U: T> = {x: U}` marks T phantom. T constrains U.
+- `type Pair<T, U = T> = {b: U}` marks T phantom. T supplies U's default, and `Pair<number>`
+  still denotes `{b: number}`.
+
+Neither argument reaches the denoted type through T's own slot, so erasing T is right in
+both — `Pair<number>` and `Pair<string>` keep distinct identities through U's slot, which is
+relevant. But warning on either would be a false positive.
+
+**Data structures.** Two diagnostics, both warnings, both blaming the parameter's declaration
+node:
+
+- `UnusedTypeParamError` — the parameter occurs nowhere.
+- `UnreachableTypeParamError` — the parameter occurs, but no argument passed to it can appear
+  in the denoted type. Its message names the consequence rather than the analysis, since that
+  is what a reader can act on: `Deep<number>` and `Deep<string>` are the same type.
+
+**Algorithms.** One occurrence pass over the positions PR9d's body walk skips, joined with
+the marks it already computed. A parameter is *mentioned* when its var occurs in the alias
+body, in a sibling parameter's `Constraint`, or in a sibling parameter's `Default`. Its own
+bound does not count, since `<T: number>` constrains T rather than using it. Then:
+
+- not mentioned anywhere ⇒ `UnusedTypeParamError`;
+- mentioned only in the body, and marked phantom ⇒ `UnreachableTypeParamError`;
+- mentioned in a sibling's bound or default ⇒ no warning, whatever the mark says;
+- not marked phantom ⇒ no warning.
+
+It runs beside `markPhantomParams` in the same per-component pass, which is the point where
+every body in the component is resolved and the marks are final.
+
+**An escape hatch is the open question.** Rust makes the analogous case a hard error and
+supplies `PhantomData` to opt in. Escalier has no such marker and needs none, because a
+parameter that genuinely cannot reach the denoted type cannot brand a type either — the two
+instantiations *are* the same type, so there is no nominal distinction to preserve. What is
+left is a parameter left unused mid-edit, which a warning should not obstruct. A leading
+underscore, `type Ignore<_T> = number`, is the cheap convention and the recommended answer.
+Settle it in this PR rather than shipping the warning with no way to quiet it.
+
+**Scope.** Aliases only, since `PhantomParams` exists only for them, and an enum comes along
+free because it registers as a transparent alias. A class declares type parameters through
+the same `resolveTypeParams` and would warn the same way, but nothing computes reachability
+for a class body. The unused tier needs no reachability and extends to classes cheaply; the
+unreachable tier does not, and is deliberately left out rather than half-built.
+
+**Accept.** `type Ignore<T> = number` warns that T is never used. `type Deep<T> =
+{a: Deep<{b: T}>}` warns that no argument to T can appear in the type, and the message names
+`Deep<number>` and `Deep<string>` as the same type. `type Foo<T, U: T> = {x: U}`,
+`type Pair<T, U = T> = {b: U}`, and `type List<T> = {head: T}` warn about nothing. Both
+diagnostics are warnings, so no program that checks today stops checking.
+
+**Depends on** PR9d for the marks and for `phantom.go`, where the pass belongs. Independent of
+PR17–PR19 and of the operator track.
+
 ---
 
 ## Sizing note
@@ -1479,7 +1553,9 @@ sites span the annotation, expression, and pattern walks, and that the shared
 Track F is small, and shrank when #956 landed: PR17 is a scope restriction in one pass of
 `resolveTypeParams` plus its diagnostic, PR18 moves `buildAliasInstance`'s arity-and-default
 logic into a helper the class path also calls, so most of its diff is a move, and PR19 routes
-#956's existing comparison to that helper. None of the three designs anything new.
+#956's existing comparison to that helper. None of the three designs anything new. PR20 is
+one occurrence pass and two warnings, sized like PR17; its cost is the escape-hatch decision
+rather than the code.
 
 ## Dependency graph
 
@@ -1523,6 +1599,8 @@ PR13 (TS utility-type suite)               ── needs PR2, PR3b, PR4, PR7, PR1
 PR17 (default names only an earlier param) ── needs M7 only
  └─► PR18 (class type-param defaults + arity at a type reference)
       └─► PR19 (class type-argument bound checking)  ── also needs #956
+
+PR20 (warn on a phantom type parameter)    ── needs PR9d only
 ```
 
 PR9b replaced PR9's regularity condition with the productivity condition, so PR9's
@@ -1533,7 +1611,7 @@ monotonic budget. #938 added the `{[K: Keys]: Value}` index-signature shorthand 
 PR4's mapped types.
 
 Everything still open is PR8, PR9d, PR9f, PR10, PR10b, PR10c, PR11, PR13, PR14, PR15,
-PR16, and Track F's PR17 through PR19. PR8 is partly seeded — #922 threads an object's
+PR16, and Track F's PR17 through PR20. PR8 is partly seeded — #922 threads an object's
 exactness through `keyof` — but the rest of the operators and the `Exact` / `Inexact`
 intrinsics are untouched.
 
@@ -1575,6 +1653,7 @@ graph TD
     PR17["PR17 (default names only an earlier param)"]
     PR18["PR18 (class type-param defaults + arity at a type reference)"]
     PR19["PR19 (class type-argument bound checking)"]
+    PR20["PR20 (warn on a phantom type parameter)"]
 
     M7 -.-> PR1a
     M75 -.-> PR10c
@@ -1622,6 +1701,7 @@ graph TD
     PR3b --> PR16
     PR17 --> PR18
     PR18 --> PR19
+    PR9d --> PR20
 
     linkStyle default stroke:#888
     style PR1a fill:#e06666,stroke:#2e7d32,stroke-width:4px,color:#fff
@@ -1669,7 +1749,8 @@ graph TD
 - **Track F** — a chain, PR17 → PR18 → PR19, and nothing outside it waits on any of the
   three, so it can run start to finish alongside any other track. The order is both the
   dependency order and the value order: PR17 fixes a wrong answer, PR18 fixes a second one
-  and builds the helper, PR19 routes #956's comparison to it.
+  and builds the helper, PR19 routes #956's comparison to it. PR20 is off the chain, waiting
+  only on PR9d, so it can land as soon as the marks exist.
 
 The critical path is `M7 → PR1a → PR1b → PR3a → PR3b → PR4 → PR8`, and — for the
 async-generator accept case — `M7 → PR1a → PR1b → PR3b → PR12 → PR13 → PR14 → PR15`.


### PR DESCRIPTION
Adds detection and erasure of phantom type parameters in recursive type aliases. A type parameter is phantom when no argument passed to it can appear in the type the alias denotes — for example, `T` in `type Deep<T> = {a: Deep<{b: T}>}` is phantom because the payload is always one unfolding deeper than the structure emitted.

Two alias instantiations that differ only in phantom arguments denote the same type and should compare equal in both directions. Without this change, comparing `Deep<number>` against `Deep<string>` reaches a new pair on every unfolding and hits the expansion limit. With phantom erasure, both instantiations intern to the same canonical identity and the reflexive rule settles them in one step.

**Key changes:**

- `phantom.go` (new): Implements `markPhantomParams` to compute phantom parameters via fixed-point iteration over alias bodies. A parameter is phantom if it never reaches a position the denoted type emits, except when passed to a phantom parameter of a same-component reference. Also implements `erasePhantomArgs` to drop phantom arguments when rendering canonical identities for constraint caching.

- `constrain.go`: Refactors the seen-set from `set.Set[constraintKey]` to a new `constraintCache` struct with two records: `active` for pairs on the current derivation path (coinductive rule) and `proved` for pairs decided outright (memoization). This separation ensures the coinductive assumption is path-scoped and doesn't leak to unrelated constraints. Updated `constrain`, `constrainUnwrapped`, `evalTypeOperator`, and `reduceResidual` to use the cache. Updated `aliasKey` to call `erasePhantomArgs` so phantom arguments don't affect the canonical identity.

- `context.go`: Added `assumptionsUsed` counter to distinguish pairs proved outright from those proved only under an enclosing frame's assumption, enabling correct cache population.

- `aliases.go`: Added `PhantomParams` field to `AliasDef` to record which parameters are phantom.

- `module.go`: Calls `markPhantomParams` after resolving all alias bodies in a component, before any constraint reaches them.

- `infer.go`: Deduplicates identical constraint diagnostics (same span and message) that arise from invariant field checking, which asks both directions at multiple levels.

- `constrain_test.go`, `productivity_test.go`: Updated tests to reflect that phantom parameters no longer cause expansion limits, and added tests for the path-scoped seen-set and nested `mut` performance.

- `phantom_test.go` (new): Tests that phantom instantiations compare equal, relevant parameters keep their arguments, and phantom arguments survive in rendered types.

https://claude.ai/code/session_017vrNdvWd6W6TrqTRD5fJb6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generic type inference by correctly handling parameters that do not affect an alias’s resulting type.
  * Prevented duplicate type-checking diagnostics from appearing.
  * Improved recursive type comparisons and constraint evaluation for more reliable results.

* **Performance**
  * Reduced potential slowdowns when checking deeply nested mutable types.

* **Diagnostics**
  * Updated error reporting for complex recursive and non-regular type aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->