### PR TITLE
Expand alias branches in conditionals to enable recursion

### DIFF
--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2359,9 +2359,9 @@ func TestInferCondDistributionThroughNesting(t *testing.T) {
 
 // A distributed member reaches an alias reference written in a branch, so each member instantiates
 // that alias with itself. `Branch<"a" | 1>` admits `"y"`, from `IsStr<"a">` on the string member, and
-// `"num"` from the other member, which is what TypeScript reduces the same alias to. reduce leaves an
-// alias in a result position under its own name, so the stored type is checked through constrain,
-// which expands it; a rejected value names the residual form the annotation holds.
+// `"num"` from the other member, which is what TypeScript reduces the same alias to. `IsStr`'s body
+// is a conditional, so the branch reduction expands the reference and decides it, and a rejected
+// value names the branch results rather than the alias that produced one of them.
 func TestInferCondDistributionIntoBranchAlias(t *testing.T) {
 	const aliases = `
 		type IsStr<T> = if T : string { "y" } else { "n" }
@@ -2384,7 +2384,7 @@ func TestInferCondDistributionIntoBranchAlias(t *testing.T) {
 			// "n" is what IsStr yields for a non-string argument, which no member produces here.
 			name:    "UnreachableBranchRejected",
 			src:     aliases + `val x: Branch<"a" | 1> = "n"`,
-			wantErr: `cannot constrain "n" <: "num" | IsStr<"a">`,
+			wantErr: `cannot constrain "n" <: "num" | "y"`,
 		},
 	}
 	for _, tt := range tests {
@@ -2453,6 +2453,238 @@ func TestInferCondCaptureFromConstraint(t *testing.T) {
 			nodes, ctx, errs := inferTypeNodes(t, tt.src)
 			require.Empty(t, errs)
 			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// awaitedAlias is `Awaited<T>` written in Escalier, the recursive conditional that strips every layer
+// of `Promise` off a type. Every case below prepends this one definition, since what they assert is
+// that it reduces the way TypeScript's `Awaited<T>` does.
+const awaitedAlias = `
+	type Awaited<T> = if T : Promise<infer U> { Awaited<U> } else { T }
+`
+
+// `Awaited<T>` strips promises to any depth. Each lap captures the payload of one `Promise` and hands
+// it back to the alias. The lap whose argument is not a promise selects Else and returns it, so the
+// recursion ends on the first non-promise. Every expectation matches TypeScript's reduction of the
+// same argument.
+//
+// Recursion is what sets these cases apart from a conditional whose branches name only written types.
+// The Then branch names the alias being defined, so deciding the conditional once is not enough.
+// reduceBranch expands that reference, decides the conditional in its body, and repeats until a lap
+// selects Else.
+func TestInferAwaited(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// One layer. The capture is the payload, and the next lap returns it unchanged.
+			name:         "OneLayer",
+			src:          `type Result = Awaited<Promise<number>>`,
+			wantExpanded: "number",
+		},
+		{
+			// A nested promise, the shape `await` does not flatten on its own. Each lap strips one
+			// layer, so two laps reach the payload.
+			name:         "TwoLayers",
+			src:          `type Result = Awaited<Promise<Promise<string>>>`,
+			wantExpanded: "string",
+		},
+		{
+			// Depth is not fixed, so four layers reduce the same way one does.
+			name:         "FourLayers",
+			src:          `type Result = Awaited<Promise<Promise<Promise<Promise<number>>>>>`,
+			wantExpanded: "number",
+		},
+		{
+			// A non-promise argument selects Else on the first lap and comes back unchanged.
+			name:         "NonPromise",
+			src:          `type Result = Awaited<number>`,
+			wantExpanded: "number",
+		},
+		{
+			// A promise payload that is itself structural is returned whole.
+			name:         "ObjectPayload",
+			src:          `type Result = Awaited<Promise<{a: number}>>`,
+			wantExpanded: "{a: number}",
+		},
+		{
+			// The Check is a naked type parameter, so a union argument distributes and each member
+			// unwraps on its own.
+			name:         "UnionDistributes",
+			src:          `type Result = Awaited<Promise<number> | string>`,
+			wantExpanded: "number | string",
+		},
+		{
+			// Each member recurses to its own depth before the results union.
+			name:         "UnionOfPromisesAtDifferentDepths",
+			src:          `type Result = Awaited<Promise<number> | Promise<Promise<string>>>`,
+			wantExpanded: "number | string",
+		},
+		{
+			// The argument is another operator's result rather than a written type. The alias
+			// reference is ground, so the `Check <: Extends` probe expands it, and `Awaited` unwraps
+			// the promise the function returns. `Awaited<ReturnType<F>>` is how a caller names the
+			// value an async function resolves to.
+			name: "OverReturnType",
+			src: `
+				type ReturnType<F> = if F : fn () -> infer R { R } else { never }
+				type Fetch = fn () -> Promise<number>
+				type Result = Awaited<ReturnType<Fetch>>
+			`,
+			wantExpanded: "number",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, awaitedAlias+tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// `Awaited<T>` over an unfilled type parameter stays symbolic, the same as any other conditional
+// whose Check has not grounded. Reducing it yields the alias body with the recursive reference
+// intact, so the recursion runs once an instantiation supplies the argument.
+func TestInferAwaitedStaysSymbolic(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, awaitedAlias+`type Wrapper<T> = Awaited<T>`)
+	require.Empty(t, errs)
+	require.Equal(t, "Awaited<t3>", soltype.Print(nodes["Wrapper"]))
+	require.Equal(t,
+		"if t3 : Promise<infer U> { Awaited<U> } else { t3 }",
+		soltype.Print(expandAliasResidual(ctx, nodes["Wrapper"])))
+}
+
+// constrain reduces an `Awaited<…>` annotation to check a value against it, while the stored type
+// keeps the name the source wrote. A value of the unwrapped type is accepted and a mismatch is
+// rejected against that unwrapped type, so the diagnostic names what the recursion arrived at
+// rather than the annotation.
+func TestInferAwaitedConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "UnwrappedValueAccepted",
+			src:  `val x: Awaited<Promise<Promise<number>>> = 5`,
+		},
+		{
+			name:    "MismatchNamesUnwrappedType",
+			src:     `val x: Awaited<Promise<Promise<number>>> = "hi"`,
+			wantErr: `cannot constrain "hi" <: number`,
+		},
+		{
+			name: "ArgumentChecksThroughParameterType",
+			src: `
+				fn take(v: Awaited<Promise<string>>) -> number { return 1 }
+				val r = take(5)
+			`,
+			wantErr: "cannot constrain 5 <: string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, awaitedAlias+tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// A branch that names an alias expands only when that alias's body is itself an unreduced operator,
+// which is what a recursive conditional needs to reach a value. A branch naming an alias whose body
+// is ordinary structure keeps the name the source wrote, matching how every other reduction treats a
+// named type. Both cases reduce the same conditional shape and differ only in what the branch alias
+// stands for.
+func TestInferCondBranchAliasExpandsOnlyOperators(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// The branch alias's body is a conditional, so it expands and decides.
+			name: "OperatorBodyReduces",
+			src: `
+				type IsStr<T> = if T : string { "y" } else { "n" }
+				type Pick<T> = if T : string { IsStr<T> } else { "num" }
+				type Result = Pick<"a">
+			`,
+			wantExpanded: `"y"`,
+		},
+		{
+			// The branch alias's body is an object, so the reference stands as written.
+			name: "StructuralBodyKeepsTheName",
+			src: `
+				type List<T> = {head: T, tail: List<T>}
+				type Pick<T> = if T : number { List<T> } else { boolean }
+				type Result = Pick<number>
+			`,
+			wantExpanded: "List<number>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A recursive conditional whose branch never stops recursing terminates anyway, leaving the alias
+// reference symbolic. `Awaited<T>` stops because a lap eventually selects Else. An alias whose Then
+// branch always wins has no such lap, so what ends the walk is one of the guards expandAliasGuarded
+// applies. A conditional guards its branches, so checkProductive accepts every alias written here and
+// the stop has to come from reduction.
+func TestInferAwaitedShapeWithoutBaseCaseTerminates(t *testing.T) {
+	// `Loop` calls itself with the argument it was given, so the second lap repeats the first's
+	// instantiation state and the active-state guard stops it there. The result is the reference the
+	// source wrote.
+	t.Run("RepeatingStateStopsAtTheRepeat", func(t *testing.T) {
+		nodes, ctx, errs := inferTypeNodes(t, `
+			type Loop<T> = if T : T { Loop<T> } else { T }
+			type Result = Loop<number>
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "Loop<number>", soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+	})
+
+	// `Grow` wraps its argument in a tuple every lap, so no instantiation state ever repeats and
+	// maxExpandDepth is the guard that runs out. The nested case puts a second conditional between the
+	// alias and its recursive reference, so the branch reduction reaches that reference through
+	// another reduction rather than directly. Both must spend one expansion per lap. A branch that
+	// expanded twice would keep growing past the exhausted budget, which is why each case asserts the
+	// exact layer count rather than only that reduction finished.
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "DirectBranch", body: `if T : T { Grow<[T]> } else { T }`},
+		{name: "BranchNestsAnotherConditional", body: `if T : T { if T : T { Grow<[T]> } else { T } } else { T }`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name+"StopsOnTheDepthBudget", func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, `
+				type Grow<T> = `+tt.body+`
+				type Result = Grow<number>
+			`)
+			require.Empty(t, errs)
+			reduced := soltype.Print(expandAliasResidual(ctx, nodes["Result"]))
+			require.True(t, strings.HasPrefix(reduced, "Grow<[["),
+				"expected a truncated Grow reference, got %s", reduced)
+			// Each lap adds one tuple layer and spends one unit of depth. The reference left behind is
+			// the argument built for the lap the exhausted budget stopped, so it carries one layer more
+			// than the budget allowed laps.
+			require.Equal(t, maxExpandDepth+1, strings.Count(reduced, "["))
 		})
 	}
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -67,7 +67,9 @@ const maxTemplateLitCombinations = 10_000
 // alias itself gets under constrain. A `keyof T` over a type parameter has no ground key set, so
 // it stays the symbolic KeyofType.
 //
-// An alias reached through an operand is made safe by a four-part termination strategy:
+// An alias is reached two ways: through an operand, and through the branch a conditional selected,
+// which reduceBranch expands so a recursive conditional such as `Awaited<T>` reaches a value. Both
+// are made safe by a four-part termination strategy:
 //
 //   - checkProductive rejects an alias whose recursion emits no structure and marks its AliasDef
 //     NotProductive. Such an alias names no type, so the evaluator declines to expand it at all
@@ -190,9 +192,47 @@ func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 		return e.reduceCondInfer(t, check, extends)
 	}
 	if e.ctx.condExtends(check, extends, e.seen) {
-		return e.reduce(t.Then)
+		return e.reduceBranch(t.Then)
 	}
-	return e.reduce(t.Else)
+	return e.reduceBranch(t.Else)
+}
+
+// reduceBranch reduces the branch a conditional selected. It is reduce plus one rule: a branch that
+// names an alias whose body is itself an unreduced operator expands, and that body reduces in turn.
+// The rule is what lets a conditional recurse to a value.
+//
+//	type Awaited<T> = if T : Promise<infer U> { Awaited<U> } else { T }
+//
+// `Awaited<Promise<Promise<number>>>` selects Then and lands on `Awaited<Promise<number>>`. An alias
+// is not an operator, so reduce alone hands that reference back unchanged and the answer keeps one
+// promise the source asked to strip. Expanding it reaches the inner conditional, which selects Then
+// again on `Awaited<number>`. That conditional selects Else and yields `number`.
+//
+// A branch naming an alias whose body is ordinary structure keeps the name the source wrote, so
+// `if T : number { List<T> } else { boolean }` reduces to `List<number>` rather than to the object
+// `List` stands for. Every other reduction treats a named type the same way. It expands an alias to
+// read through it, never to replace it.
+//
+// expandAliasGuarded supplies the termination guard, so a branch that recurses without ever selecting
+// Else leaves the alias reference symbolic. A recursion whose instantiation state repeats stops at
+// the repeat, and the depth and character budgets stop one whose state never repeats.
+//
+// Each lap spends exactly one expansion. The body reduces through reduce, and the conditional in that
+// body is what reaches the next lap. A second expansion per lap would re-expand the reference a
+// truncated inner lap handed back, and the walk would keep growing after the budget that truncated it
+// had already run out. Reading the alias off the branch as written, rather than off what reduce
+// returned for it, keeps that second expansion out of a branch that nests another conditional.
+func (e *typeEvaluator) reduceBranch(branch soltype.Type) soltype.Type {
+	alias, ok := branch.(*soltype.AliasType)
+	if !ok {
+		return e.reduce(branch)
+	}
+	return e.expandAliasGuarded(alias, aliasItself, func(body soltype.Type) soltype.Type {
+		if !isResidualOp(body) {
+			return alias
+		}
+		return e.reduce(body)
+	})
 }
 
 // distributeCond decides a distributive conditional one union member at a time and unions the
@@ -277,13 +317,13 @@ func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check, extends solt
 	}
 	captured, ok := e.ctx.trialCaptures(check, substituteInfer(extends, holes), vars, e.seen.Clone())
 	if !ok {
-		return e.reduce(t.Else)
+		return e.reduceBranch(t.Else)
 	}
 	captures := make(map[int]soltype.Type, len(decls))
 	for i, id := range decls {
 		captures[id] = captured[i]
 	}
-	return e.reduce(substituteInfer(t.Then, captures))
+	return e.reduceBranch(substituteInfer(t.Then, captures))
 }
 
 // inferDeclIDs returns the ids of the `infer` declarations t holds, in first-appearance order with

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -198,30 +198,10 @@ func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 }
 
 // reduceBranch reduces the branch a conditional selected. It is reduce plus one rule: a branch that
-// names an alias whose body is itself an unreduced operator expands, and that body reduces in turn.
-// The rule is what lets a conditional recurse to a value.
-//
-//	type Awaited<T> = if T : Promise<infer U> { Awaited<U> } else { T }
-//
-// `Awaited<Promise<Promise<number>>>` selects Then and lands on `Awaited<Promise<number>>`. An alias
-// is not an operator, so reduce alone hands that reference back unchanged and the answer keeps one
-// promise the source asked to strip. Expanding it reaches the inner conditional, which selects Then
-// again on `Awaited<number>`. That conditional selects Else and yields `number`.
-//
-// A branch naming an alias whose body is ordinary structure keeps the name the source wrote, so
-// `if T : number { List<T> } else { boolean }` reduces to `List<number>` rather than to the object
-// `List` stands for. Every other reduction treats a named type the same way. It expands an alias to
-// read through it, never to replace it.
-//
-// expandAliasGuarded supplies the termination guard, so a branch that recurses without ever selecting
-// Else leaves the alias reference symbolic. A recursion whose instantiation state repeats stops at
-// the repeat, and the depth and character budgets stop one whose state never repeats.
-//
-// Each lap spends exactly one expansion. The body reduces through reduce, and the conditional in that
-// body is what reaches the next lap. A second expansion per lap would re-expand the reference a
-// truncated inner lap handed back, and the walk would keep growing after the budget that truncated it
-// had already run out. Reading the alias off the branch as written, rather than off what reduce
-// returned for it, keeps that second expansion out of a branch that nests another conditional.
+// names an alias whose body is an unreduced operator expands and reduces. That lets a recursive
+// conditional like `Awaited<T> = if T : Promise<infer U> { Awaited<U> } else { T }` reach a value.
+// An alias body of ordinary structure keeps its name, so a branch naming `List<T>` still yields
+// `List<number>`. expandAliasGuarded terminates a recursion with no base case, one expansion a lap.
 func (e *typeEvaluator) reduceBranch(branch soltype.Type) soltype.Type {
 	alias, ok := branch.(*soltype.AliasType)
 	if !ok {


### PR DESCRIPTION
Recursive conditionals like `Awaited<T>` need to expand alias references in their branches so the inner conditional can be decided in the next recursion lap. This change adds `reduceBranch`, which expands an alias branch only if its body is an unreduced operator (like a conditional), allowing the recursion to reach a value while keeping structural aliases named as written.

**Key changes:**

- Added `reduceBranch` method that expands alias branches containing operators but preserves names for structural aliases
- Updated `reduceCond` and `reduceCondInfer` to call `reduceBranch` instead of `reduce` when handling conditional branches
- Updated documentation in `typeops.go` to explain the two-way alias reachability (through operands and through conditional branches) and the four-part termination strategy
- Fixed test expectation in `TestInferCondDistributionIntoBranchAlias` to reflect the new behavior where rejected values name the expanded branch results rather than the alias

**Implementation details:**

`reduceBranch` uses `expandAliasGuarded` with a callback that checks `isResidualOp` on the alias body. If the body is an operator, it reduces that body (which may be another conditional that recurses). If the body is structural, it returns the alias reference unchanged. This ensures each recursion lap spends exactly one expansion, preventing the walk from growing past the depth budget.

The change is guarded by the existing termination strategy: active-state detection stops repeating instantiations, and depth/character budgets stop unbounded growth.

https://claude.ai/code/session_01KYVZU8hTfy3BJDELZ9GqwV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional type evaluation so aliases containing operators are reduced correctly.
  * Added support for recursively unwrapping promise-like types through `Awaited`.
  * Preserved symbolic results for unresolved type parameters.
  * Added safeguards to prevent non-terminating evaluation of recursive type definitions.
  * Improved constraint diagnostics and branch evaluation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->