### PR TITLE
Add Exact and Inexact intrinsics for exactness control

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -73,9 +73,9 @@ func typePrec(t Type) int {
 		// A template literal is backtick-delimited, so like an object or a `Name<args>` reference
 		// it is an atom that never needs outer parens.
 		return precAtom
-	case *StringIntrinsicType:
-		// `Uppercase<T>` renders as a name with an argument list, the same atom shape a class or
-		// alias reference takes, so it never needs outer parens.
+	case *StringIntrinsicType, *ExactnessType:
+		// `Uppercase<T>` and `Exact<T>` render as a name with an argument list, the same atom shape
+		// a class or alias reference takes, so neither needs outer parens.
 		return precAtom
 	default:
 		// PrimType, LitType, TupleType, ObjectType, ClassType, AliasType, Void, NullType,
@@ -490,6 +490,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 			}
 		case *StringIntrinsicType:
 			walk(t.Operand)
+		case *ExactnessType:
+			walk(t.Operand)
 		case *RecursiveType:
 			walk(t.Body)
 		case *PromiseType:
@@ -683,6 +685,11 @@ func (p *namedPrinter) printType(t Type) string {
 		// `Uppercase<T>` and its three siblings render under the operator's name with the operand as
 		// the sole argument, so `Capitalize<K>` round-trips. The operand prints with no minimum since
 		// the `<…>` brackets stop anything from binding across it.
+		return t.Kind.String() + "<" + p.printType(t.Operand) + ">"
+	case *ExactnessType:
+		// `Exact<T>` and `Inexact<T>` render under the operator's name with the operand as the sole
+		// argument, so the annotation round-trips. The operand prints with no minimum since the
+		// `<…>` brackets stop anything from binding across it.
 		return t.Kind.String() + "<" + p.printType(t.Operand) + ">"
 	case *ObjectType:
 		elems := make([]string, 0, len(t.Elems)+1)

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -969,6 +969,41 @@ type StringIntrinsicType struct {
 	Operand Type
 }
 
+// ExactnessKind names the two exactness intrinsics. `Exact<T>` closes a type's trailing `...` marker
+// and `Inexact<T>` opens it. exact-types §6.1 and §6.2 specify the pair.
+type ExactnessKind int
+
+const (
+	MakeExact ExactnessKind = iota
+	MakeInexact
+)
+
+// String renders the operator's surface name, used by the printer to render `Exact<T>` and by the
+// resolver to register the two intrinsics under their reference names.
+func (k ExactnessKind) String() string {
+	switch k {
+	case MakeExact:
+		return "Exact"
+	case MakeInexact:
+		return "Inexact"
+	}
+	panic(fmt.Sprintf("ExactnessKind.String: unhandled kind %d", int(k)))
+}
+
+// ExactnessType is the residual `Exact<T>` or `Inexact<T>` operator. Like KeyofType it is inert: it
+// carries no bounds, constrain never records one against it, and it flows through the solver's
+// structural machinery untouched, rendering `Exact<T>` the way the source wrote it.
+//
+// An evaluator reduces it once its operand grounds to a type carrying a trailing `...` marker. An
+// object, a tuple, a function, and a union each carry one. `Inexact` sets that marker and `Exact`
+// clears it, so `Inexact<{x: number}>` reduces to `{x: number, ...}`. An operand with no such
+// marker, a primitive or a literal, reduces to itself. An abstract operand such as a type parameter
+// stays symbolic.
+type ExactnessType struct {
+	Kind    ExactnessKind
+	Operand Type
+}
+
 // RecursiveType is the μ-knot, the finite form of a type whose unfolding never ends. Body is one
 // level of that unfolding and Binder is the variable Body names itself through, so `μX0.{next: X0}`
 // is the type of a value whose `next` field holds another value of the same type. Unfolding it
@@ -1019,6 +1054,7 @@ func (*MappedKeyType) isType()       {}
 func (*RestSpreadType) isType()      {}
 func (*TemplateLitType) isType()     {}
 func (*StringIntrinsicType) isType() {}
+func (*ExactnessType) isType()       {}
 func (*RecursiveType) isType()       {}
 func (*RecursiveVarType) isType()    {}
 func (*PrimType) isType()            {}
@@ -1132,6 +1168,10 @@ func LevelOf(t Type) int {
 	case *StringIntrinsicType:
 		// A string-intrinsic residual's level is its operand's, the same single-child rule the
 		// KeyofType arm follows.
+		return LevelOf(t.Operand)
+	case *ExactnessType:
+		// An `Exact<T>` residual's level is its operand's, the same single-child rule the KeyofType
+		// arm follows.
 		return LevelOf(t.Operand)
 	case *RecursiveType:
 		// A μ-knot's level is its body's, the same single-child rule the KeyofType arm follows, so a

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -306,6 +306,23 @@ func (t *StringIntrinsicType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *ExactnessType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// The operand walks in the current polarity, the same single-child covariant visit KeyofType
+	// uses. The residual is inert — the visit rebuilds it around a rewritten operand without
+	// reducing the operator, so extrude/coalesce/freshenAbove carry `Exact<T>` through untouched.
+	operand := cur.Operand.Accept(v, pol)
+	out := cur
+	if operand != cur.Operand {
+		out = &ExactnessType{Kind: cur.Kind, Operand: operand}
+	}
+	return v.ExitType(out, pol)
+}
+
 func (t *RecursiveType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1415,6 +1415,11 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// KeyofType arm.
 		b, ok := b.(*soltype.StringIntrinsicType)
 		return ok && a.Kind == b.Kind && equalTypeWith(a.Operand, b.Operand, ctx)
+	case *soltype.ExactnessType:
+		// Two exactness residuals are equal when they name the same operator over equal operands,
+		// compared structurally without reducing, the single-child analogue of the KeyofType arm.
+		b, ok := b.(*soltype.ExactnessType)
+		return ok && a.Kind == b.Kind && equalTypeWith(a.Operand, b.Operand, ctx)
 	}
 	return false
 }

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -234,7 +234,7 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen *seenPairs) (soltype.Typ
 	case *soltype.RecursiveType:
 		return unfoldRecursive(t), nil, true
 	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType,
-		*soltype.TemplateLitType, *soltype.StringIntrinsicType:
+		*soltype.TemplateLitType, *soltype.StringIntrinsicType, *soltype.ExactnessType:
 		return c.reduceResidual(t, seen)
 	case *soltype.TupleType:
 		if !tupleHasSpread(t) {
@@ -999,12 +999,14 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		if _, ok := super.(*soltype.UndefinedType); ok {
 			return nil
 		}
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.TemplateLitType, *soltype.StringIntrinsicType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.TemplateLitType, *soltype.StringIntrinsicType,
+		*soltype.ExactnessType:
 		// A residual type-level operator the pre-switch could not ground reaches here: a `keyof T`,
-		// `T[K]`, `on${T}`, or `Uppercase<T>` over a type parameter, or an expanding recursive
-		// alias. constrain treats every such operator inert, neither decomposing nor reducing it, so
-		// two residuals are compatible only when structurally identical. A reflexive `keyof T <: keyof
-		// T` succeeds without recording any bound, and a residual against any other concrete fails.
+		// `T[K]`, `on${T}`, `Uppercase<T>`, or `Exact<T>` over a type parameter, or an expanding
+		// recursive alias. constrain treats every such operator inert, neither decomposing nor
+		// reducing it, so two residuals are compatible only when structurally identical. A reflexive
+		// `keyof T <: keyof T` succeeds without recording any bound, and a residual against any
+		// other concrete fails.
 		// When super is a variable the case falls through to the superVar arm below, which records the
 		// whole residual as one lower bound, keeping the operator symbolic on the coalesced binding. A
 		// tuple carrying a `...P` spread is handled inertly in the TupleType arm above, the spread

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -280,6 +280,20 @@ type NoIndexSignatureError struct {
 	site   ast.Node
 }
 
+// ExactNonFinalClassError fires when `Exact<C>` names a class that is not declared `final`. A
+// non-final class can be subclassed. A subclass instance carries members the class does not declare,
+// so the class's instance type admits keys nothing at the use site can rule out. Escalier fixes a
+// class's exactness where the class is declared, so no use-site form closes an open instance type
+// (exact-types §2.6.2). The fix is to declare the class `final`.
+//
+// It is minted during reduction, once the operand has grounded to a class. `Exact<T>` over a type
+// parameter stays symbolic and reports nothing.
+type ExactNonFinalClassError struct {
+	Class *soltype.ClassType
+	prov  NodeResolver
+	site  ast.Node
+}
+
 // MutabilityMismatchError fires on RefType <: RefType when the sub is an immutable
 // borrow but the super is mutable: writing through the mutable target would mutate a
 // value the source only lent out as read-only, so an immutable reference cannot fill
@@ -472,6 +486,7 @@ func (*TemplateLitTooComplexError) isSolverError()   {}
 func (*RequiredUncountableKeysError) isSolverError() {}
 func (*IndexSignatureKeyError) isSolverError()       {}
 func (*NoIndexSignatureError) isSolverError()        {}
+func (*ExactNonFinalClassError) isSolverError()      {}
 func (*MutabilityMismatchError) isSolverError()      {}
 func (*BorrowEscapeError) isSolverError()            {}
 func (*ClassIntoExactObjectError) isSolverError()    {}
@@ -602,6 +617,13 @@ func (e *NoIndexSignatureError) Span() ast.Span {
 	return spanOf(e.prov, e.Object, e.site)
 }
 func (e *NoIndexSignatureError) Related() []ast.Span { return nil }
+
+func (e *ExactNonFinalClassError) Span() ast.Span {
+	// The class reference is the operand the source wrote a span for. Blame it, else the
+	// constraint site.
+	return spanOf(e.prov, e.Class, e.site)
+}
+func (e *ExactNonFinalClassError) Related() []ast.Span { return nil }
 
 func (e *MutabilityMismatchError) Span() ast.Span {
 	// The immutable source borrow is the actual value; blame it, degrade to the
@@ -1818,6 +1840,13 @@ func (e *NoIndexSignatureError) Message() string {
 		soltype.Print(e.Object), describe(e.Index))
 }
 
+func (e *ExactNonFinalClassError) Message() string {
+	name := soltype.Print(e.Class)
+	return fmt.Sprintf("class %s is not final, so a subclass instance may carry members %s does not "+
+		"declare and Exact<%s> cannot close it; declare %s as `final` instead",
+		name, name, name, name)
+}
+
 func (e *TemplateLitTooComplexError) Message() string {
 	return fmt.Sprintf("template literal type %s is too complex to reduce; it expands to more than %d members",
 		soltype.Print(e.Template), maxTemplateLitCombinations)
@@ -2103,6 +2132,10 @@ func describe(t soltype.Type) string {
 	case *soltype.StringIntrinsicType:
 		// An intrinsic string-operator residual renders `Uppercase<operand>` structurally, recursing
 		// like the keyof arm. The operand renders in describe's raw mid-constrain form.
+		return t.Kind.String() + "<" + describe(t.Operand) + ">"
+	case *soltype.ExactnessType:
+		// An exactness residual renders `Exact<operand>` structurally, recursing like the keyof arm.
+		// The operand renders in describe's raw mid-constrain form.
 		return t.Kind.String() + "<" + describe(t.Operand) + ">"
 	case *soltype.RecursiveType:
 		// A μ-knot renders `μX0.<body>`, recursing like the keyof arm, so a rejected constraint over

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -359,6 +359,8 @@ func (c *checker) blameConstraintErrors(n ast.Node, errs []SolverError) {
 			err.prov, err.site = c.prov, n
 		case *NoIndexSignatureError:
 			err.prov, err.site = c.prov, n
+		case *ExactNonFinalClassError:
+			err.prov, err.site = c.prov, n
 		case *FuncArityMismatchError:
 			err.prov, err.site = c.prov, n
 		case *MutabilityMismatchError:

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -476,3 +476,36 @@ func TestInferExactOnNonFinalClassErrors(t *testing.T) {
 			"and Exact<Point> cannot close it; declare Point as `final` instead",
 		e.errs[0].Message())
 }
+
+// A borrow of an errored pointee is errored too, so the diagnostic the pointee's reduction reported
+// is the one a constraint site names. Reducing the borrow to the error sentinel is what carries it
+// there. A reduction that ends on a residual reports no diagnostic at all, so the site would
+// otherwise blame that residual and never say which class is not final.
+//
+// The bare and borrowed spellings therefore report the same message. Each case pairs a parameter the
+// operator annotates with an argument, since the reduction only surfaces at a constraint site.
+func TestInferExactOnBorrowedNonFinalClassErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		ann  string
+	}{
+		{"Bare", "Exact<Point>"},
+		{"OwnedMut", "Exact<mut Point>"},
+		{"MutBorrow", "Exact<&mut Point>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, `
+				class Point {
+					x: number,
+				}
+				fn f(p: `+tt.ann+`) -> number { return 1 }
+				fn g(q: Point) -> number { return f(q) }
+			`)
+			require.Len(t, errs, 1)
+			require.Contains(t, errs[0].Message(),
+				"class Point is not final, so a subclass instance may carry members Point does not "+
+					"declare and Exact<Point> cannot close it; declare Point as `final` instead")
+		})
+	}
+}

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -342,6 +342,33 @@ func TestInferExactnessIntrinsics(t *testing.T) {
 			wantExpanded: "Point",
 		},
 		{
+			// A class's exactness is fixed where the class is declared, so `Inexact` has no use-site
+			// form to open a final class's instance type with and leaves the class unchanged.
+			name: "InexactFinalClass",
+			src: `
+				final class Point {
+					x: number,
+				}
+				type Result = Inexact<Point>
+			`,
+			wantSymbolic: "Inexact<Point>",
+			wantExpanded: "Point",
+		},
+		{
+			// A non-final class instance type is already open, so `Inexact` has nothing to change.
+			// The `Exact` direction over the same class is the one that is rejected, in
+			// TestInferExactOnNonFinalClassErrors.
+			name: "InexactNonFinalClass",
+			src: `
+				class Point {
+					x: number,
+				}
+				type Result = Inexact<Point>
+			`,
+			wantSymbolic: "Inexact<Point>",
+			wantExpanded: "Point",
+		},
+		{
 			// The operator composes with the rest of the suite: closing an object's key set closes
 			// the key union `keyof` projects from it.
 			name: "KeyofOverExactOperand",

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -271,6 +271,17 @@ func TestInferExactnessIntrinsics(t *testing.T) {
 			wantExpanded: "fn (a: number) -> string",
 		},
 		{
+			// A generic function's `<T>` binder is part of its type, so rewriting the marker leaves
+			// the binder and every position naming it in place.
+			name: "InexactGenericFunc",
+			src: `
+				type G = fn <T>(x: T) -> T
+				type Result = Inexact<G>
+			`,
+			wantSymbolic: "Inexact<G>",
+			wantExpanded: "fn <T>(x: T, ...) -> T",
+		},
+		{
 			name: "InexactUnion",
 			src: `
 				type Color = "red" | "green" | "blue"
@@ -441,6 +452,91 @@ func TestInferExactnessIntrinsicChecksConstraints(t *testing.T) {
 			val r = f({x: 1})
 		`)
 		require.Empty(t, errs)
+	})
+}
+
+// Function exactness inverts the asymmetry objects have. An object grows toward its inexact form, so
+// exact `<:` inexact. A function's accept-set shrinks, so an exact function tolerates fewer calls
+// than its inexact counterpart and inexact `<:` exact instead (exact-types §4.2.1.1). A conditional
+// decides its branch with the same subtype check, so the operators move a function type across that
+// boundary in the direction the marker names.
+//
+// This is the behavior `Inexact<F>` exists for. Subtyping alone never widens an exact function into
+// an inexact one, so the operator is the only way to write that step (§6.2).
+func TestInferExactnessIntrinsicOnFuncSubtyping(t *testing.T) {
+	tests := []struct {
+		name string
+		cond string
+		want string
+	}{
+		{
+			// An exact function does not satisfy an inexact one: its accept-set refuses the extra
+			// arguments the inexact type's callers may pass.
+			name: "ExactAgainstInexactFails",
+			cond: "if ExactF : LooseF { \"yes\" } else { \"no\" }",
+			want: `"no"`,
+		},
+		{
+			// The reverse holds. An inexact function already tolerates every call the exact type
+			// admits, so it satisfies the narrower one.
+			name: "InexactAgainstExactHolds",
+			cond: "if LooseF : ExactF { \"yes\" } else { \"no\" }",
+			want: `"yes"`,
+		},
+		{
+			// `Inexact` moves the exact operand across that boundary, flipping the first case. This
+			// is the widening subtyping cannot give you.
+			name: "InexactOperandFlipsTheCheck",
+			cond: "if Inexact<ExactF> : LooseF { \"yes\" } else { \"no\" }",
+			want: `"yes"`,
+		},
+		{
+			// `Exact` moves the inexact operand the other way, so it stops satisfying the inexact
+			// pattern that the bare `LooseF` satisfied.
+			name: "ExactOperandFlipsTheCheck",
+			cond: "if Exact<LooseF> : LooseF { \"yes\" } else { \"no\" }",
+			want: `"no"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, `
+				type ExactF = fn (a: number) -> string
+				type LooseF = fn (a: number, ...) -> string
+				type Result = `+tt.cond+`
+			`)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// `Inexact<F>` rewrites a type, not a value. An exact function value still fails to fill a slot the
+// operator widened, since the reduced annotation is an ordinary inexact function type and the
+// exact-does-not-satisfy-inexact rule applies to it unchanged. Converting a value is what
+// exact-types §6.6's separate `exact<T>(v)` operator is for, which this milestone does not add.
+func TestInferInexactFuncAnnotationDoesNotWidenAValue(t *testing.T) {
+	t.Run("exact function fills the exact slot", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			type F = fn (a: number) -> string
+			fn exactFn(a: number) -> string { return "x" }
+			fn take(cb: F) -> number { return 1 }
+			val r = take(exactFn)
+		`)
+		require.Empty(t, errs)
+	})
+
+	t.Run("the same value fails the widened slot", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			type F = fn (a: number) -> string
+			fn exactFn(a: number) -> string { return "x" }
+			fn take(cb: Inexact<F>) -> number { return 1 }
+			val r = take(exactFn)
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t,
+			"3:4-3:50: cannot constrain function of arity 1 <: function of arity 1",
+			msgWithSpan(errs[0]))
 	})
 }
 

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -1,0 +1,451 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// Exactness derives from an operator's operands rather than being declared on the result
+// (exact-types §7). Each case names an operand through an alias and asserts the stored `Result`
+// stays symbolic. Reducing it — the expansion constrain performs to check a constraint — yields a
+// type whose trailing `...` marker came from the operand's. The exact and inexact spellings of one
+// operand sit next to each other so the derivation is visible as a pair.
+func TestInferOperatorExactnessPropagates(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			// An exact tuple's index set is closed: it has exactly the positions it lists.
+			name: "KeyofExactTuple",
+			src: `
+				type Tup = [number, string]
+				type Result = keyof Tup
+			`,
+			wantSymbolic: "keyof Tup",
+			wantExpanded: "0 | 1",
+		},
+		{
+			// An inexact tuple has unknown trailing positions, so its index set is open and carries
+			// the indices those positions occupy in a trailing `...`.
+			name: "KeyofInexactTuple",
+			src: `
+				type Tup = [number, string, ...]
+				type Result = keyof Tup
+			`,
+			wantSymbolic: "keyof Tup",
+			wantExpanded: "0 | 1 | ...",
+		},
+		{
+			// `T[keyof T]` over an exact object reads every key the object declares, and those are
+			// all the keys it has, so the value union is closed.
+			name: "IndexEveryKeyOfExactObject",
+			src: `
+				type Obj = {a: number, b: string}
+				type Result = Obj[keyof Obj]
+			`,
+			wantSymbolic: "Obj[keyof Obj]",
+			wantExpanded: "number | string",
+		},
+		{
+			// `keyof` over an inexact object yields an open key set, and each key the access could
+			// not enumerate holds a value the union does not list, so the value union is open too.
+			name: "IndexEveryKeyOfInexactObject",
+			src: `
+				type Obj = {a: number, b: string, ...}
+				type Result = Obj[keyof Obj]
+			`,
+			wantSymbolic: "Obj[keyof Obj]",
+			wantExpanded: "number | string | ...",
+		},
+		{
+			// The tuple twin: an inexact tuple's open index set carries into the element union.
+			name: "IndexEveryIndexOfInexactTuple",
+			src: `
+				type Tup = [number, string, ...]
+				type Result = Tup[keyof Tup]
+			`,
+			wantSymbolic: "Tup[keyof Tup]",
+			wantExpanded: "number | string | ...",
+		},
+		{
+			// An exact target union lists every member, so reading K off each reads every value K
+			// can hold.
+			name: "IndexExactUnionTarget",
+			src: `
+				type U = {k: number} | {k: string}
+				type Result = U["k"]
+			`,
+			wantSymbolic: `U["k"]`,
+			wantExpanded: "number | string",
+		},
+		{
+			// An inexact target union has unlisted members, and the value each holds at K is not
+			// among the ones the access read.
+			name: "IndexInexactUnionTarget",
+			src: `
+				type U = {k: number} | {k: string} | ...
+				type Result = U["k"]
+			`,
+			wantSymbolic: `U["k"]`,
+			wantExpanded: "number | string | ...",
+		},
+		{
+			// A conditional over an exact union decides every member, so the branches those members
+			// selected are the only results. Each member wraps itself, so the two results differ and
+			// neither absorbs the other.
+			name: "CondDistributeExactUnion",
+			src: `
+				type Wrap<T> = if T : string { [T] } else { boolean }
+				type Result = Wrap<"a" | "b">
+			`,
+			wantSymbolic: `Wrap<"a" | "b">`,
+			wantExpanded: `["a"] | ["b"]`,
+		},
+		{
+			// An inexact union's tail is unknown-typed, and `unknown : string` is undecidable, so
+			// which branch those members select cannot be worked out and the result stays open.
+			name: "CondDistributeInexactUnion",
+			src: `
+				type Wrap<T> = if T : string { [T] } else { boolean }
+				type Result = Wrap<"a" | "b" | ...>
+			`,
+			wantSymbolic: `Wrap<"a" | "b" | ...>`,
+			wantExpanded: `["a"] | ["b"] | ...`,
+		},
+		{
+			// Every interpolation names a closed set of choices, so the strings the template
+			// produces are a closed set too.
+			name: "TemplateLitExactInterp",
+			src: `
+				type Side = "left" | "right"
+				type Result = ` + "`pad-${Side}`" + `
+			`,
+			wantSymbolic: "`pad-${Side}`",
+			wantExpanded: `"pad-left" | "pad-right"`,
+		},
+		{
+			// An interpolation naming an open set of choices produces an open set of strings.
+			name: "TemplateLitInexactInterp",
+			src: `
+				type Side = "left" | "right" | ...
+				type Result = ` + "`pad-${Side}`" + `
+			`,
+			wantSymbolic: "`pad-${Side}`",
+			wantExpanded: `"pad-left" | "pad-right" | ...`,
+		},
+		{
+			// A string intrinsic maps each member of a closed operand union, and that is every
+			// string the operand names.
+			name: "StringIntrinsicExactOperand",
+			src: `
+				type Names = "a" | "b"
+				type Result = Uppercase<Names>
+			`,
+			wantSymbolic: "Uppercase<Names>",
+			wantExpanded: `"A" | "B"`,
+		},
+		{
+			// An open operand union names strings the transform never sees, so the result is open.
+			name: "StringIntrinsicInexactOperand",
+			src: `
+				type Names = "a" | "b" | ...
+				type Result = Uppercase<Names>
+			`,
+			wantSymbolic: "Uppercase<Names>",
+			wantExpanded: `"A" | "B" | ...`,
+		},
+		{
+			// An intersection carries both operands' members, so its key sets union. An inexact
+			// operand's open key set leaves the whole union open.
+			name: "KeyofIntersectionWithInexactMember",
+			src: `
+				type I = {a: number} & {b: string, ...}
+				type Result = keyof I
+			`,
+			wantSymbolic: "keyof I",
+			wantExpanded: `"a" | "b" | ...`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, result)))
+		})
+	}
+}
+
+// `Exact<T>` clears a type's trailing `...` marker and `Inexact<T>` sets it (exact-types §6.1,
+// §6.2). Each case stores the operator unreduced, so `Result` renders the way the source wrote it,
+// and reduces it to assert the marker the operator wrote.
+func TestInferExactnessIntrinsics(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			// The object case: `Inexact` opens a closed member list.
+			name: "InexactObject",
+			src: `
+				type Point = {x: number, y: number}
+				type Result = Inexact<Point>
+			`,
+			wantSymbolic: "Inexact<Point>",
+			wantExpanded: "{x: number, y: number, ...}",
+		},
+		{
+			// The dual: `Exact` closes an open member list.
+			name: "ExactObject",
+			src: `
+				type Headers = {"content-type": string, ...}
+				type Result = Exact<Headers>
+			`,
+			wantSymbolic: "Exact<Headers>",
+			wantExpanded: `{"content-type": string}`,
+		},
+		{
+			// Applying an operator to a type that already carries its marker changes nothing.
+			name: "ExactOfExactObject",
+			src: `
+				type Point = {x: number}
+				type Result = Exact<Point>
+			`,
+			wantSymbolic: "Exact<Point>",
+			wantExpanded: "{x: number}",
+		},
+		{
+			// The two operators round-trip, so wrapping and unwrapping recovers the operand.
+			name: "RoundTrip",
+			src: `
+				type Point = {x: number, y: number}
+				type Result = Exact<Inexact<Point>>
+			`,
+			wantSymbolic: "Exact<Inexact<Point>>",
+			wantExpanded: "{x: number, y: number}",
+		},
+		{
+			name: "InexactTuple",
+			src: `
+				type Pair = [string, number]
+				type Result = Inexact<Pair>
+			`,
+			wantSymbolic: "Inexact<Pair>",
+			wantExpanded: "[string, number, ...]",
+		},
+		{
+			name: "ExactTuple",
+			src: `
+				type Pair = [string, number, ...]
+				type Result = Exact<Pair>
+			`,
+			wantSymbolic: "Exact<Pair>",
+			wantExpanded: "[string, number]",
+		},
+		{
+			// An inexact function tolerates extra arguments. Subtyping cannot widen an exact
+			// function into one, so `Inexact<F>` is how a program asks for that widening.
+			name: "InexactFunc",
+			src: `
+				type F = fn (a: number) -> string
+				type Result = Inexact<F>
+			`,
+			wantSymbolic: "Inexact<F>",
+			wantExpanded: "fn (a: number, ...) -> string",
+		},
+		{
+			name: "ExactFunc",
+			src: `
+				type F = fn (a: number, ...) -> string
+				type Result = Exact<F>
+			`,
+			wantSymbolic: "Exact<F>",
+			wantExpanded: "fn (a: number) -> string",
+		},
+		{
+			name: "InexactUnion",
+			src: `
+				type Color = "red" | "green" | "blue"
+				type Result = Inexact<Color>
+			`,
+			wantSymbolic: "Inexact<Color>",
+			wantExpanded: `"blue" | "green" | "red" | ...`,
+		},
+		{
+			name: "ExactUnion",
+			src: `
+				type Color = "red" | "green" | "blue" | ...
+				type Result = Exact<Color>
+			`,
+			wantSymbolic: "Exact<Color>",
+			wantExpanded: `"blue" | "green" | "red"`,
+		},
+		{
+			// Closing a one-member union collapses it to that member, since the wrapper only ever
+			// carried the open tail.
+			name: "ExactSingleMemberUnion",
+			src: `
+				type Obj = {only: number, ...}
+				type Result = Exact<keyof Obj>
+			`,
+			wantSymbolic: "Exact<keyof Obj>",
+			wantExpanded: `"only"`,
+		},
+		{
+			// A primitive names one kind of value with no member list to close, so neither
+			// operator has anything to change.
+			name: "ExactPrimitive",
+			src: `
+				type Result = Exact<number>
+			`,
+			wantSymbolic: "Exact<number>",
+			wantExpanded: "number",
+		},
+		{
+			// Mutability is orthogonal to exactness, so the operator reaches the pointee.
+			name: "InexactThroughMut",
+			src: `
+				type Point = {x: number}
+				type Result = Inexact<mut Point>
+			`,
+			wantSymbolic: "Inexact<mut Point>",
+			wantExpanded: "mut {x: number, ...}",
+		},
+		{
+			// An intersection's exactness is its members', so the operator reaches each of them.
+			name: "InexactThroughIntersection",
+			src: `
+				type I = {a: number} & {b: string}
+				type Result = Inexact<I>
+			`,
+			wantSymbolic: "Inexact<I>",
+			wantExpanded: "{a: number, ...} & {b: string, ...}",
+		},
+		{
+			// A final class has no subclasses to widen it, so its instance type is already exact.
+			name: "ExactFinalClass",
+			src: `
+				final class Point {
+					x: number,
+				}
+				type Result = Exact<Point>
+			`,
+			wantSymbolic: "Exact<Point>",
+			wantExpanded: "Point",
+		},
+		{
+			// The operator composes with the rest of the suite: closing an object's key set closes
+			// the key union `keyof` projects from it.
+			name: "KeyofOverExactOperand",
+			src: `
+				type Obj = {a: number, b: string, ...}
+				type Result = keyof Exact<Obj>
+			`,
+			wantSymbolic: "keyof Exact<Obj>",
+			wantExpanded: `"a" | "b"`,
+		},
+		{
+			// The dual composition: opening an object's key set opens the key union.
+			name: "KeyofOverInexactOperand",
+			src: `
+				type Obj = {a: number, b: string}
+				type Result = keyof Inexact<Obj>
+			`,
+			wantSymbolic: "keyof Inexact<Obj>",
+			wantExpanded: `"a" | "b" | ...`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, result)))
+		})
+	}
+}
+
+// An operator over a type parameter has no operand to read a marker off, so it stays symbolic and
+// renders the way the source wrote it. That is what lets it sit unreduced in a signature until a
+// call grounds it. The reflexive `Inexact<T> <: Inexact<T>` the `return x` raises succeeds inertly
+// by structural identity, with neither side reduced.
+func TestInferExactnessIntrinsicStaysSymbolic(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f<T>(x: Inexact<T>) -> Inexact<T> { return x }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T>(x: Inexact<T>) -> Inexact<T>", values["f"])
+}
+
+// constrain reduces an exactness residual when it checks a constraint against one, so the marker the
+// operator wrote is what the check enforces. Each case pairs a value against an annotation the
+// operator built, since the marker only shows up as an accept or a reject.
+func TestInferExactnessIntrinsicChecksConstraints(t *testing.T) {
+	t.Run("inexact parameter accepts an extra property", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			type Point = {x: number}
+			fn f(p: Inexact<Point>) -> number { return 1 }
+			val r = f({x: 1, y: 2})
+		`)
+		require.Empty(t, errs)
+	})
+
+	t.Run("exact parameter rejects an extra property", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			type Open = {x: number, ...}
+			fn f(p: Exact<Open>) -> number { return 1 }
+			val r = f({x: 1, y: 2})
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "4:24-4:25: object has extra property: y", msgWithSpan(errs[0]))
+	})
+
+	t.Run("exact parameter accepts an exactly-matching argument", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			type Open = {x: number, ...}
+			fn f(p: Exact<Open>) -> number { return 1 }
+			val r = f({x: 1})
+		`)
+		require.Empty(t, errs)
+	})
+}
+
+// A user-defined type named `Exact` shadows the intrinsic, since the type scope resolves first. The
+// reference then names that alias rather than the operator, so it expands to the alias body.
+func TestInferExactnessIntrinsicShadowedByUserType(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Exact<T> = [T]
+		type Result = Exact<number>
+	`)
+	require.Empty(t, errs)
+	result := nodes["Result"]
+	require.Equal(t, "Exact<number>", soltype.Print(result))
+	require.Equal(t, "[number]", soltype.Print(expandAliasResidual(ctx, result)))
+}
+
+// A non-final class can be subclassed, so a subclass instance carries members the class does not
+// declare. Escalier fixes a class's exactness where the class is declared, so there is no use-site
+// form that closes an open instance type and `Exact<C>` is rejected.
+func TestInferExactOnNonFinalClassErrors(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		class Point {
+			x: number,
+		}
+		type Result = Exact<Point>
+	`)
+	require.Empty(t, errs)
+	e := newTypeEvaluator(ctx, newSeenPairs())
+	require.Equal(t, "error", soltype.Print(e.reduce(nodes["Result"])))
+	require.Len(t, e.errs, 1)
+	require.Equal(t,
+		"class Point is not final, so a subclass instance may carry members Point does not declare "+
+			"and Exact<Point> cannot close it; declare Point as `final` instead",
+		e.errs[0].Message())
+}

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -170,6 +170,29 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 			wantSymbolic: "keyof I",
 			wantExpanded: `"a" | "b" | ...`,
 		},
+		{
+			// `Exact` and `Inexact` are the two operators that run the other way. Every case above
+			// reads a marker off its operand and carries it to the result; these two write the
+			// marker the operator names onto whatever their operand carried. A function's marker is
+			// its trailing `...`, so widening an exact function adds one.
+			name: "InexactOverExactFunc",
+			src: `
+				type ExactF = fn (a: number) -> string
+				type Result = Inexact<ExactF>
+			`,
+			wantSymbolic: "Inexact<ExactF>",
+			wantExpanded: "fn (a: number, ...) -> string",
+		},
+		{
+			// The dual, tightening an inexact function by clearing that marker.
+			name: "ExactOverInexactFunc",
+			src: `
+				type InexactF = fn (a: number, ...) -> string
+				type Result = Exact<InexactF>
+			`,
+			wantSymbolic: "Exact<InexactF>",
+			wantExpanded: "fn (a: number) -> string",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -282,6 +282,27 @@ func TestInferExactnessIntrinsics(t *testing.T) {
 			wantExpanded: "fn <T>(x: T, ...) -> T",
 		},
 		{
+			// The round trip holds for a function too, so widening an exact function and tightening
+			// the result recovers the operand.
+			name: "RoundTripFuncFromExact",
+			src: `
+				type F = fn (a: number) -> string
+				type Result = Exact<Inexact<F>>
+			`,
+			wantSymbolic: "Exact<Inexact<F>>",
+			wantExpanded: "fn (a: number) -> string",
+		},
+		{
+			// And from the other end, tightening an inexact function and widening the result.
+			name: "RoundTripFuncFromInexact",
+			src: `
+				type F = fn (a: number, ...) -> string
+				type Result = Inexact<Exact<F>>
+			`,
+			wantSymbolic: "Inexact<Exact<F>>",
+			wantExpanded: "fn (a: number, ...) -> string",
+		},
+		{
 			name: "InexactUnion",
 			src: `
 				type Color = "red" | "green" | "blue"
@@ -450,6 +471,29 @@ func TestInferExactnessIntrinsicChecksConstraints(t *testing.T) {
 			type Open = {x: number, ...}
 			fn f(p: Exact<Open>) -> number { return 1 }
 			val r = f({x: 1})
+		`)
+		require.Empty(t, errs)
+	})
+
+	// The converted function type is usable as the form the operator named, not merely rendered as
+	// it. Each case passes the argument only the converted form admits, so the check would fail
+	// against the operand the source wrote.
+	t.Run("tightened parameter accepts an exact function", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			type LooseF = fn (a: number, ...) -> string
+			fn exactFn(a: number) -> string { return "x" }
+			fn take(cb: Exact<LooseF>) -> number { return 1 }
+			val r = take(exactFn)
+		`)
+		require.Empty(t, errs)
+	})
+
+	t.Run("widened parameter accepts an inexact function", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			type ExactF = fn (a: number) -> string
+			declare fn looseFn(a: number, ...) -> string
+			fn take(cb: Inexact<ExactF>) -> number { return 1 }
+			val r = take(looseFn)
 		`)
 		require.Empty(t, errs)
 	})

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -82,6 +82,9 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		if t, ok := c.resolveStringIntrinsic(scope, ta, lvl); ok {
 			return t, true
 		}
+		if t, ok := c.resolveExactnessIntrinsic(scope, ta, lvl); ok {
+			return t, true
+		}
 		return c.reportUnsupported(ta), false
 	case *ast.ObjectTypeAnn:
 		return c.resolveObjectTypeAnn(scope, ta, lvl)
@@ -625,15 +628,57 @@ var stringIntrinsics = map[string]soltype.StringIntrinsicKind{
 // name or arity reports ok=false so the caller falls through to its unsupported-feature recovery. An
 // unsupported operand recovers to a fresh var, cascade-safe like the Promise<bad> recovery.
 func (c *checker) resolveStringIntrinsic(scope *Scope, ta *ast.TypeRefTypeAnn, lvl int) (soltype.Type, bool) {
-	kind, ok := stringIntrinsics[ast.QualIdentToString(ta.Name)]
-	if !ok || len(ta.TypeArgs) != 1 || len(ta.LifetimeArgs) > 0 || ta.Lifetime != nil {
+	kind, named := stringIntrinsics[ast.QualIdentToString(ta.Name)]
+	if !named {
+		return nil, false
+	}
+	operand, ok := c.unaryIntrinsicOperand(scope, ta, lvl)
+	if !ok {
+		return nil, false
+	}
+	t := &soltype.StringIntrinsicType{Kind: kind, Operand: operand}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// unaryIntrinsicOperand resolves the sole type argument of a one-argument intrinsic reference such
+// as `Uppercase<T>` or `Exact<T>`. ok=false means the reference is not the one-argument form those
+// intrinsics take, because its arity is not one or it carries a lifetime argument. The caller then
+// reports no match, and its own caller falls through to the unsupported-feature recovery. An
+// unsupported operand recovers to a fresh var, cascade-safe like the Promise<bad> recovery.
+func (c *checker) unaryIntrinsicOperand(scope *Scope, ta *ast.TypeRefTypeAnn, lvl int) (soltype.Type, bool) {
+	if len(ta.TypeArgs) != 1 || len(ta.LifetimeArgs) > 0 || ta.Lifetime != nil {
 		return nil, false
 	}
 	operand, ok := c.resolveTypeAnn(scope, ta.TypeArgs[0], lvl)
 	if !ok {
 		operand = c.freshAt(lvl)
 	}
-	t := &soltype.StringIntrinsicType{Kind: kind, Operand: operand}
+	return operand, true
+}
+
+// exactnessIntrinsics maps each exactness operator's reference name to its kind, so an `Exact<T>`
+// reference resolves to an ExactnessType residual. A user-defined type of the same name takes
+// precedence, since resolveScopedTypeRef runs first.
+var exactnessIntrinsics = map[string]soltype.ExactnessKind{
+	"Exact":   soltype.MakeExact,
+	"Inexact": soltype.MakeInexact,
+}
+
+// resolveExactnessIntrinsic lowers an `Exact<T>` or `Inexact<T>` reference to an ExactnessType
+// residual, stored unreduced so the annotation prints the way the source wrote it. It matches only a
+// single-argument reference with no lifetime arguments; any other name or arity reports ok=false so
+// the caller falls through to its unsupported-feature recovery.
+func (c *checker) resolveExactnessIntrinsic(scope *Scope, ta *ast.TypeRefTypeAnn, lvl int) (soltype.Type, bool) {
+	kind, named := exactnessIntrinsics[ast.QualIdentToString(ta.Name)]
+	if !named {
+		return nil, false
+	}
+	operand, ok := c.unaryIntrinsicOperand(scope, ta, lvl)
+	if !ok {
+		return nil, false
+	}
+	t := &soltype.ExactnessType{Kind: kind, Operand: operand}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1585,27 +1585,10 @@ func (e *typeEvaluator) reduceStringIntrinsic(kind soltype.StringIntrinsicKind, 
 }
 
 // reduceExactness reduces `Exact<T>` and `Inexact<T>` by rewriting the trailing `...` marker on the
-// grounded operand. `Exact` clears the marker and `Inexact` sets it, so `Inexact<{x: number}>`
-// reduces to `{x: number, ...}` and `Exact<{x: number, ...}>` back to `{x: number}` (exact-types
-// §6.1, §6.2). The operand is grounded first, so a named alias expands to its body.
-//
-// Four kinds of type carry the marker and take it from the operator: an object, a tuple, a function,
-// and a union. Two more pass the operator inward rather than answering themselves. An intersection
-// rewrites each of its members, since its exactness is its members' (§7.7). A borrow rewrites its
-// pointee, since mutability is orthogonal to exactness and `mut T` carries T's (§7.11).
-//
-// A type with no exactness notion reduces to itself. A primitive, a literal, `never`, `unknown`,
-// `void`, `null`, `undefined`, and a promise each name a single kind of value with no member list to
-// close, so neither operator has anything to change (§7.13).
-//
-// `Exact<C>` over a class C that is not declared `final` is an error, since a subclass instance
-// carries members C does not declare and Escalier has no use-site form that closes an open instance
-// type (§2.6.2). Every other class case leaves the class unchanged: a final class is already exact,
-// and `Inexact<C>` would need the same absent use-site form to open one.
-//
-// Any other operand keeps the operator symbolic as an `ExactnessType` rebuilt around the grounded
-// operand. A type parameter, an unexpanded alias, and an operator whose own operands are not ground
-// each land there.
+// grounded operand, so `Inexact<{x: number}>` reduces to `{x: number, ...}` and
+// `Exact<{x: number, ...}>` back to `{x: number}` (exact-types §6.1, §6.2). Grounding first expands
+// a named alias to its body. A type with no marker to rewrite reduces to itself, and an operand
+// that never grounds keeps the operator symbolic.
 func (e *typeEvaluator) reduceExactness(kind soltype.ExactnessKind, operand soltype.Type) soltype.Type {
 	reduced := e.groundOperand(operand)
 	inexact := kind == soltype.MakeInexact
@@ -1632,12 +1615,15 @@ func (e *typeEvaluator) reduceExactness(kind soltype.ExactnessKind, operand solt
 		// collapses it to that member: `Exact<"only" | ...>` reduces to `"only"`.
 		return newUnion(nil, op.Types, inexact)
 	case *soltype.IntersectionType:
+		// An intersection's exactness is its members', so the operator reaches each of them (§7.7).
 		parts := make([]soltype.Type, len(op.Types))
 		for i, m := range op.Types {
 			parts[i] = e.reduceExactness(kind, m)
 		}
 		return newIntersection(nil, parts)
 	case *soltype.RefType:
+		// Mutability is orthogonal to exactness and `mut T` carries T's, so the operator reaches the
+		// pointee (§7.11).
 		reducedInner := e.reduceExactness(kind, op.Inner)
 		if _, errored := reducedInner.(*soltype.ErrorType); errored {
 			// The pointee's own reduction reported a diagnostic and returned the error sentinel, as

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -152,6 +152,8 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		return e.reduceTemplateLit(t)
 	case *soltype.StringIntrinsicType:
 		return e.reduceStringIntrinsic(t.Kind, t.Operand)
+	case *soltype.ExactnessType:
+		return e.reduceExactness(t.Kind, t.Operand)
 	default:
 		return t
 	}
@@ -214,6 +216,13 @@ func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 //
 // Each member reduces through a copy of the conditional with Distribute cleared: the member is no
 // longer a union, and clearing it states that this pass already applied the rule.
+//
+// An inexact Check union names only some of its members. The rest sit in a tail of unknown type.
+// `unknown : Extends` is undecidable for every Extends other than `unknown` itself, so which branch
+// those members select cannot be worked out. The result union keeps the tail, which stands for
+// whatever those undecided members contribute. Over `"a" | "b" | ...`, the alias
+// `type Wrap<T> = if T : string { "yes" } else { "no" }` therefore reduces to `"yes" | ...`
+// (exact-types §7.4.3).
 func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.UnionType) soltype.Type {
 	parts := make([]soltype.Type, len(check.Types))
 	for i, member := range check.Types {
@@ -224,7 +233,7 @@ func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.Union
 			Else:    substituteOccurrences(t.Else, t.Check, member),
 		})
 	}
-	return newUnion(nil, parts, false)
+	return newUnion(nil, parts, check.Inexact)
 }
 
 // substituteOccurrences rewrites every occurrence of the from type inside in to the to type,
@@ -926,10 +935,11 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, inexact bool) soltype.
 		// would raise goes unreported, as in `keyof keyof {a: number}["z"]`, where the unknown key
 		// is never reached. The result is `never` either way.
 		return &soltype.NeverType{}
-	case *soltype.IndexType, *soltype.CondType:
-		// The operand is itself an operator — an indexed access or a conditional. Reduce it first,
-		// then take keyof its value, so a ground conditional operand selects its branch and
-		// `keyof` projects that branch's keys. If the inner operator stays symbolic because its own
+	case *soltype.IndexType, *soltype.CondType, *soltype.ExactnessType:
+		// The operand is itself an operator — an indexed access, a conditional, or an
+		// `Exact`/`Inexact`. Reduce it first, then take keyof its value, so a ground conditional
+		// operand selects its branch and `keyof` projects that branch's keys, and a ground
+		// `Exact<T>` closes T's key set. If the inner operator stays symbolic because its own
 		// operands are not ground, wrap it as `keyof <inner>` rather than re-reducing the same shape
 		// forever. A mapped member arrives inside an ObjectType, so the ObjectType arm below covers
 		// it: grounding the object emits the member's fields and `keyof` projects their names.
@@ -1070,12 +1080,16 @@ func (e *typeEvaluator) keyofObject(obj *soltype.ObjectType) soltype.Type {
 // deviates from TypeScript, whose keyof of a tuple also includes "length" and the other
 // Array.prototype members. Those are inherited rather than own keys, so Escalier omits them.
 // TODO: decide how keyof should account for inherited prototype members once interop is designed.
+//
+// An inexact tuple has unknown trailing positions, so its index set is open the same way an inexact
+// object's key set is. `keyof [number, string, ...]` reduces to `0 | 1 | ...`, where the tail stands
+// for the indices those unknown positions occupy (exact-types §7.1).
 func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
 	keys := make([]soltype.Type, 0, len(tup.Elems))
 	for i := range tup.Elems {
 		keys = append(keys, &soltype.LitType{Lit: &soltype.NumLit{Value: float64(i)}})
 	}
-	return newUnion(nil, keys, false)
+	return newUnion(nil, keys, tup.Inexact)
 }
 
 // keyofUnion intersects the keys of a union operand's members. A value typed `A | B` is either
@@ -1178,6 +1192,10 @@ func intersectTypes(a, b []soltype.Type) []soltype.Type {
 
 // keyofIntersection unions the keys of each member of an intersection operand: `keyof (A & B)`
 // reduces to `keyof A | keyof B`, since an intersection carries the members of all its operands.
+//
+// Exactness needs no seed here. An inexact member reduces to an inexact key union, and newUnion
+// carries a member union's marker out to the union it splices that member into. So
+// `keyof ({a: number} & {b: string, ...})` reduces to `"a" | "b" | ...` on its own.
 func (e *typeEvaluator) keyofIntersection(members []soltype.Type, inexact bool) soltype.Type {
 	parts := make([]soltype.Type, len(members))
 	for i, m := range members {
@@ -1209,12 +1227,17 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 	idx := e.reduce(index)
 	// A union index distributes member-wise. `T[keyof T]` rides this once `keyof T` reduces to
 	// its `"a" | "b"` key union, so the access yields the union of the members' value types.
+	//
+	// An inexact key union names keys the access cannot enumerate. Each key it does not name holds
+	// a value the result does not list, so the result union is open too (exact-types §7.3). This is
+	// what carries an inexact object's openness into `T[keyof T]`. Over `type Obj = {a: number, ...}`,
+	// `keyof Obj` reduces to `"a" | ...` and `Obj[keyof Obj]` to `number | ...`.
 	if u, ok := idx.(*soltype.UnionType); ok {
 		parts := make([]soltype.Type, len(u.Types))
 		for i, m := range u.Types {
 			parts[i] = e.reduceIndex(target, m, inexact)
 		}
-		return newUnion(nil, parts, false)
+		return newUnion(nil, parts, u.Inexact)
 	}
 	switch tgt := target.(type) {
 	case *soltype.AliasType:
@@ -1222,13 +1245,14 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 	case *soltype.TypeofType:
 		// `(typeof x)[K]` resolves the query to the value's type, then indexes that type.
 		return e.reduceIndex(tgt.Ty, idx, inexact)
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
-		// The target is itself an operator — a `keyof`, an indexed access, or a conditional. Reduce
-		// it first, then index its value, so a ground conditional target selects its branch and the
-		// access reduces over that. When the target stays symbolic because its own operands are not
-		// ground, keep the access wrapped around the reduced target rather than re-reducing the same
-		// shape forever. A mapped member arrives inside an ObjectType, which grounds through the
-		// object path before the access reads one of its emitted fields.
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.ExactnessType:
+		// The target is itself an operator — a `keyof`, an indexed access, a conditional, or an
+		// `Exact`/`Inexact`. Reduce it first, then index its value, so a ground conditional target
+		// selects its branch and the access reduces over that. When the target stays symbolic
+		// because its own operands are not ground, keep the access wrapped around the reduced
+		// target rather than re-reducing the same shape forever. A mapped member arrives inside an
+		// ObjectType, which grounds through the object path before the access reads one of its
+		// emitted fields.
 		inner := e.reduce(target)
 		if isResidualOp(inner) {
 			return &soltype.IndexType{Target: inner, Index: idx, Inexact: inexact}
@@ -1260,11 +1284,14 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 		// operand. A union value is one of its members, so every member must carry K — a member
 		// lacking it records its own absence diagnostic through reduceIndex. Each member indexes
 		// with the same reduced key.
+		//
+		// An inexact target union has unlisted members, and the value each holds at K is not among
+		// the ones the access read, so the result union is open too (exact-types §7.6).
 		parts := make([]soltype.Type, len(tgt.Types))
 		for i, m := range tgt.Types {
 			parts[i] = e.reduceIndex(m, idx, inexact)
 		}
-		return newUnion(nil, parts, false)
+		return newUnion(nil, parts, tgt.Inexact)
 	case *soltype.IntersectionType:
 		return e.reduceIndexIntersection(tgt, idx, inexact)
 	default:
@@ -1417,12 +1444,18 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, i
 // operator the evaluator could not ground — keeps that interpolation and stays a `TemplateLitType`,
 // so the whole template reduces later once the interpolation grounds. A product that would exceed
 // maxTemplateLitCombinations is rejected with a diagnostic rather than materialized.
+//
+// The result is exact only when every interpolation is, since an interpolation that names an open
+// set of choices produces an open set of strings (exact-types §5.6). `on${"a" | "b"}` reduces to
+// the exact `"ona" | "onb"`, while `on${"a" | "b" | ...}` reduces to `"ona" | "onb" | ...`.
 func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Type {
 	interpChoices := make([][]soltype.Type, len(t.Interps))
 	combinations := 1
+	openChoices := false
 	for i, interp := range t.Interps {
 		reduced := e.groundOperand(interp)
 		if u, ok := reduced.(*soltype.UnionType); ok {
+			openChoices = openChoices || u.Inexact
 			// Ground each union member too, so a reducible member — an alias to a literal, or a
 			// nested operator such as `keyof O` — collapses to its string literal before the product
 			// rather than surviving as a residual interpolation.
@@ -1447,7 +1480,7 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 	for _, combo := range combos {
 		parts = append(parts, foldTemplatePart(t.Quasis, combo))
 	}
-	return newUnion(nil, parts, false)
+	return newUnion(nil, parts, openChoices)
 }
 
 // foldTemplatePart folds one cartesian-product combination into a single template result. It
@@ -1531,6 +1564,9 @@ func stringifyLit(t soltype.Type) (string, bool) {
 // first grounded, so a named alias expands to its body. An operand that is not a string literal,
 // such as a type parameter, keeps the operator symbolic as a `StringIntrinsicType` rebuilt around the
 // grounded operand.
+//
+// An inexact operand union names strings the transform never sees, so the result union is open too:
+// `Uppercase<"a" | "b" | ...>` reduces to `"A" | "B" | ...`.
 func (e *typeEvaluator) reduceStringIntrinsic(kind soltype.StringIntrinsicKind, operand soltype.Type) soltype.Type {
 	reduced := e.groundOperand(operand)
 	switch op := reduced.(type) {
@@ -1539,13 +1575,87 @@ func (e *typeEvaluator) reduceStringIntrinsic(kind soltype.StringIntrinsicKind, 
 		for i, m := range op.Types {
 			parts[i] = e.reduceStringIntrinsic(kind, m)
 		}
-		return newUnion(nil, parts, false)
+		return newUnion(nil, parts, op.Inexact)
 	case *soltype.LitType:
 		if s, ok := op.Lit.(*soltype.StrLit); ok {
 			return strLitType(applyStringIntrinsic(kind, s.Value))
 		}
 	}
 	return &soltype.StringIntrinsicType{Kind: kind, Operand: reduced}
+}
+
+// reduceExactness reduces `Exact<T>` and `Inexact<T>` by rewriting the trailing `...` marker on the
+// grounded operand. `Exact` clears the marker and `Inexact` sets it, so `Inexact<{x: number}>`
+// reduces to `{x: number, ...}` and `Exact<{x: number, ...}>` back to `{x: number}` (exact-types
+// §6.1, §6.2). The operand is grounded first, so a named alias expands to its body.
+//
+// Four kinds of type carry the marker and take it from the operator: an object, a tuple, a function,
+// and a union. Two more pass the operator inward rather than answering themselves. An intersection
+// rewrites each of its members, since its exactness is its members' (§7.7). A borrow rewrites its
+// pointee, since mutability is orthogonal to exactness and `mut T` carries T's (§7.11).
+//
+// A type with no exactness notion reduces to itself. A primitive, a literal, `never`, `unknown`,
+// `void`, `null`, `undefined`, and a promise each name a single kind of value with no member list to
+// close, so neither operator has anything to change (§7.13).
+//
+// `Exact<C>` over a class C that is not declared `final` is an error, since a subclass instance
+// carries members C does not declare and Escalier has no use-site form that closes an open instance
+// type (§2.6.2). Every other class case leaves the class unchanged: a final class is already exact,
+// and `Inexact<C>` would need the same absent use-site form to open one.
+//
+// Any other operand keeps the operator symbolic as an `ExactnessType` rebuilt around the grounded
+// operand. A type parameter, an unexpanded alias, and an operator whose own operands are not ground
+// each land there.
+func (e *typeEvaluator) reduceExactness(kind soltype.ExactnessKind, operand soltype.Type) soltype.Type {
+	reduced := e.groundOperand(operand)
+	inexact := kind == soltype.MakeInexact
+	switch op := reduced.(type) {
+	case *soltype.ObjectType:
+		// An object still carrying a `...A` spread or a `[K]: V for K in Keys` member has no final
+		// member list, so its own exactness is not settled yet and the operator stays symbolic.
+		if soltype.HasResidualElem(op.Elems) {
+			break
+		}
+		return &soltype.ObjectType{Elems: op.Elems, Inexact: inexact}
+	case *soltype.TupleType:
+		// A tuple still carrying a `...P` spread has no final element list, mirroring the object arm.
+		if hasRestSpread(op.Elems) {
+			break
+		}
+		return &soltype.TupleType{Elems: op.Elems, Inexact: inexact}
+	case *soltype.FuncType:
+		rewritten := *op
+		rewritten.Inexact = inexact
+		return &rewritten
+	case *soltype.UnionType:
+		// newUnion rather than a direct rebuild, so clearing the marker on a one-member union
+		// collapses it to that member: `Exact<"only" | ...>` reduces to `"only"`.
+		return newUnion(nil, op.Types, inexact)
+	case *soltype.IntersectionType:
+		parts := make([]soltype.Type, len(op.Types))
+		for i, m := range op.Types {
+			parts[i] = e.reduceExactness(kind, m)
+		}
+		return newIntersection(nil, parts)
+	case *soltype.RefType:
+		pointee, ok := e.reduceExactness(kind, op.Inner).(soltype.RefInner)
+		if !ok {
+			// The pointee stayed symbolic, so the operator over the borrow has no answer either.
+			break
+		}
+		return &soltype.RefType{Mut: op.Mut, Lt: op.Lt, Inner: pointee}
+	case *soltype.ClassType:
+		if kind == soltype.MakeExact && !op.Final {
+			e.errs = append(e.errs, &ExactNonFinalClassError{Class: op})
+			return &soltype.ErrorType{}
+		}
+		return op
+	case *soltype.PrimType, *soltype.LitType, *soltype.NeverType, *soltype.UnknownType,
+		*soltype.Void, *soltype.NullType, *soltype.UndefinedType, *soltype.PromiseType,
+		*soltype.ErrorType:
+		return reduced
+	}
+	return &soltype.ExactnessType{Kind: kind, Operand: reduced}
 }
 
 // applyStringIntrinsic transforms one string by the named intrinsic operator. Uppercase and Lowercase
@@ -1599,13 +1709,15 @@ func mappedKeyName(t soltype.Type) (string, bool) {
 
 // isResidualOp reports whether t is an unreduced type-level operator at its top level. That is a
 // `keyof`, an indexed access, a conditional, a `...P` tuple-spread element, a template literal whose
-// interpolation stayed abstract, an intrinsic string operator over an abstract operand, or an object
-// carrying a mapped member whose key set never ground. The evaluator consults it to stop re-reducing
-// an operand whose reduction stayed symbolic.
+// interpolation stayed abstract, an intrinsic string operator over an abstract operand, an
+// `Exact`/`Inexact` operator over an abstract operand, or an object carrying a mapped member whose
+// key set never ground. The evaluator consults it to stop re-reducing an operand whose reduction
+// stayed symbolic.
 func isResidualOp(t soltype.Type) bool {
 	switch t.(type) {
 	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType,
-		*soltype.RestSpreadType, *soltype.TemplateLitType, *soltype.StringIntrinsicType:
+		*soltype.RestSpreadType, *soltype.TemplateLitType, *soltype.StringIntrinsicType,
+		*soltype.ExactnessType:
 		return true
 	}
 	return objectHasMapped(t)

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1638,7 +1638,17 @@ func (e *typeEvaluator) reduceExactness(kind soltype.ExactnessKind, operand solt
 		}
 		return newIntersection(nil, parts)
 	case *soltype.RefType:
-		pointee, ok := e.reduceExactness(kind, op.Inner).(soltype.RefInner)
+		reducedInner := e.reduceExactness(kind, op.Inner)
+		if _, errored := reducedInner.(*soltype.ErrorType); errored {
+			// The pointee's own reduction reported a diagnostic and returned the error sentinel, as
+			// `Exact<&mut C>` over a non-final C does. A borrow of an errored pointee is errored too.
+			// The sentinel absorbs in both directions under constrain, so the pointee's diagnostic is
+			// the only one a constraint site sees. Staying symbolic here would drop that diagnostic,
+			// since a reduction that ends on a residual reports none, and the site would blame the
+			// residual instead of naming the class that is not final.
+			return reducedInner
+		}
+		pointee, ok := reducedInner.(soltype.RefInner)
 		if !ok {
 			// The pointee stayed symbolic, so the operator over the borrow has no answer either.
 			break


### PR DESCRIPTION
Implements the `Exact<T>` and `Inexact<T>` intrinsic type operators from the exact-types specification. These operators allow explicit control over whether a type's trailing `...` marker (which indicates an open/inexact type) is set or cleared.

**Key changes:**

- Added `ExactnessType` and `ExactnessKind` to represent the two operators in the type system
- Implemented `reduceExactness` to evaluate these operators when their operands ground, clearing or setting the `...` marker on objects, tuples, functions, and unions
- Updated `keyof`, indexed access, conditionals, and template literals to propagate exactness from their operands to their results, so `keyof {a: number, ...}` yields `"a" | ...` rather than just `"a"`
- Added `ExactNonFinalClassError` to reject `Exact<C>` when `C` is not declared `final`, since subclass instances may carry undeclared members
- Integrated the operators into type resolution, reduction, constraint checking, and the visitor pattern
- Added comprehensive test coverage for operator propagation through various type constructs and for the intrinsics themselves

The operators stay symbolic when applied to type parameters, allowing them to appear in generic signatures and be resolved at call sites. User-defined types named `Exact` or `Inexact` shadow the intrinsics, following the normal scoping rules.

https://claude.ai/code/session_01DEFFKJFBP3C4FNNWbRPqTz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Exact<T>` and `Inexact<T>` type operators.
  * Exactness now works across objects, tuples, functions, unions, intersections, references, classes, and other type expressions.
  * Exactness markers are preserved through operations such as `keyof`, indexed access, conditional types, template literals, and string utilities.
* **Bug Fixes**
  * Added clear diagnostics when `Exact<T>` is used with a non-final class.
  * Improved constraint checking and type comparisons involving exactness operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->