### PR TITLE
Add comprehensive test suite for TypeScript utility types

### DIFF
--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -438,3 +438,56 @@ func TestInferMutObjectAnnotation(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
 }
+
+// `unknown` in annotation position resolves to the top of the lattice. Every type is a subtype of
+// it through constrain's `_ <: unknown` rule, so an annotated binding accepts any initializer and
+// renders as `unknown`. It is the counterpart of the `never` annotation at the other end of the
+// lattice, and the bound that admits every type at a position whose value is never read.
+func TestInferUnknownAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "AcceptsPrimitive",
+			src:  `val u: unknown = 5`,
+			want: "unknown",
+		},
+		{
+			name: "AcceptsObject",
+			src:  `val u: unknown = {a: 1}`,
+			want: "unknown",
+		},
+		{
+			name: "AcceptsFunction",
+			src:  `val u: unknown = fn () { return 1 }`,
+			want: "unknown",
+		},
+		{
+			// A nested position resolves the same way, so `unknown` composes rather than being
+			// special-cased at the top of an annotation.
+			name: "NestedInObject",
+			src:  `val u: {a: unknown} = {a: "s"}`,
+			want: "{a: unknown}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["u"])
+		})
+	}
+}
+
+// Two `unknown` annotations in one module each resolve without tripping the provenance table.
+// soltype.UnknownType has no fields, so Go gives every instance one address, and Prov is keyed by
+// pointer identity — recording against it would file both under a single entry and panic the
+// debugProv guard on the second. The arm skips recording for that reason, the same as `never`.
+func TestInferUnknownAnnotationTwiceInOneModule(t *testing.T) {
+	values, _, errs := inferSource(t, "val u: unknown = 1\nval v: unknown = \"s\"")
+	require.Empty(t, errs)
+	require.Equal(t, "unknown", values["u"])
+	require.Equal(t, "unknown", values["v"])
+}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -31,6 +31,16 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		// panic on the second. A caller that needs a span for a rejected `never` falls back to the
 		// constraint site.
 		return &soltype.NeverType{}, true
+	case *ast.UnknownTypeAnn:
+		// `unknown` is the top of the lattice. Every type is a subtype of it through
+		// constrain's `_ <: unknown` rule, so it is the bound that admits any type at a
+		// position whose value is never read, as `fn () -> unknown` does in a type
+		// parameter's constraint.
+		//
+		// No provenance is recorded, for the reason the NeverTypeAnn arm above gives:
+		// soltype.UnknownType has no fields, so every `&soltype.UnknownType{}` shares one
+		// address and the pointer-keyed Prov table cannot tell two of them apart.
+		return &soltype.UnknownType{}, true
 	case *ast.LitTypeAnn:
 		return c.resolveLitTypeAnn(ta)
 	case *ast.TypeRefTypeAnn:

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -1,0 +1,684 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// utilityTypeDecls is the TypeScript utility-type suite written in Escalier. Every test in this
+// file prepends it, so one definition of each utility backs every assertion below.
+//
+// Nothing here is compiler machinery. Each utility is an ordinary generic type alias built from
+// the type-level operators, so the suite is the end-to-end check that those operators compose the
+// way TypeScript's do. Library resolution is import-only, with no ambient global library, so these
+// are also the definitions a `std:*` module would export once the solver resolves such imports.
+//
+// The three translations from TypeScript's surface syntax to Escalier's:
+//
+//   - `{[K]?: T[K] for K in keyof T}` is the mapped type TypeScript writes
+//     `{[K in keyof T]?: T[K]}`.
+//   - `if C : E { A } else { B }` is the conditional TypeScript writes `C extends E ? A : B`.
+//   - The bracketed expression in `{[if K : Ks { never } else { K }]: T[K] for K in keyof T}` is
+//     the key remapping TypeScript writes with an `as` clause.
+//
+// `ReturnType<F>` matches a nullary function only. TestUtilityTypeReturnTypeIsAritySpecific
+// records why the arity-agnostic TypeScript definition has no Escalier equivalent.
+//
+// `NonNullable<T>`, `Parameters<F>`, `ConstructorParameters<C>`, and `InstanceType<C>` are the
+// four utilities the suite cannot express yet. Each has a disabled test at the end of this file
+// naming what it waits on.
+//
+// Two declarations at the end are not TypeScript utilities. `EventName<K>` is a template-literal
+// type that builds a handler name from an event name. `Point` is the sample object several tests
+// map over.
+const utilityTypeDecls = `
+	type Partial<T> = {[K]?: T[K] for K in keyof T}
+	type Required<T> = {[K]-?: T[K] for K in keyof T}
+	type Readonly<T> = {readonly [K]: T[K] for K in keyof T}
+	type Pick<T, Ks> = {[K]: T[K] for K in keyof T if K : Ks}
+	type Omit<T, Ks> = {[if K : Ks { never } else { K }]: T[K] for K in keyof T}
+	type Record<Ks, V> = {[K: Ks]: V}
+	type Exclude<U, V> = if U : V { never } else { U }
+	type Extract<U, V> = if U : V { U } else { never }
+	type ReturnType<F> = if F : fn () -> infer R { R } else { never }
+	type Awaited<T> = if T : Promise<infer U> { Awaited<U> } else { T }
+	type EventName<K> = ` + "`on${Capitalize<K>}`" + `
+	type Point = {x: number, y: string}
+`
+
+// utilityReduction is the shape every reduction table in this file uses. src declares a `Result`
+// alias over the utilities. wantExpanded is what TypeScript reduces the same application to.
+type utilityReduction struct {
+	name         string
+	src          string
+	wantExpanded string
+}
+
+// runUtilityReductions infers each case's source with utilityTypeDecls prepended and asserts what
+// its `Result` alias reduces to. A stored alias reference stays symbolic, so the assertion runs
+// through expandAliasResidual, the expansion constrain performs when it checks a constraint
+// against such a reference.
+func runUtilityReductions(t *testing.T, tests []utilityReduction) {
+	t.Helper()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, utilityTypeDecls+tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// Each case applies one utility to ground arguments and asserts the reduction against what
+// TypeScript reduces the same application to.
+func TestUtilityTypeReductions(t *testing.T) {
+	runUtilityReductions(t, []utilityReduction{
+		// `Partial<T>` adds `?` to every field. The mapped type's `?` modifier is what does it.
+		{
+			name:         "Partial",
+			src:          `type Result = Partial<{a: number, b: string}>`,
+			wantExpanded: "{a?: number, b?: string}",
+		},
+		{
+			// Applying it twice changes nothing, since the modifier adds a marker a field may
+			// already carry.
+			name:         "PartialIsIdempotent",
+			src:          `type Result = Partial<Partial<{a: number}>>`,
+			wantExpanded: "{a?: number}",
+		},
+		{
+			// `keyof {}` is `never`, the empty key set, so the map emits no fields.
+			name:         "PartialOfEmptyObject",
+			src:          `type Result = Partial<{}>`,
+			wantExpanded: "{}",
+		},
+		// `Required<T>` clears `?` from every field, the `-?` modifier's job. A field that was
+		// already required is unaffected.
+		{
+			name:         "Required",
+			src:          `type Result = Required<{a?: number, b: string}>`,
+			wantExpanded: "{a: number, b: string}",
+		},
+		{
+			// The two modifiers invert each other, so `Required` undoes `Partial` exactly.
+			name:         "RequiredUndoesPartial",
+			src:          `type Result = Required<Partial<Point>>`,
+			wantExpanded: "{x: number, y: string}",
+		},
+		// `Readonly<T>` marks every field readonly.
+		{
+			name:         "Readonly",
+			src:          `type Result = Readonly<Point>`,
+			wantExpanded: "{readonly x: number, readonly y: string}",
+		},
+		{
+			// The two modifiers are independent, so a readonly map over an optional one keeps both
+			// markers on each field.
+			name:         "ReadonlyOfPartial",
+			src:          `type Result = Readonly<Partial<{a: number}>>`,
+			wantExpanded: "{readonly a?: number}",
+		},
+		// `Pick<T, Ks>` keeps the keys `Ks` names. The `if K : Ks` filter drops every key that is
+		// not a subtype of `Ks`, and the value expression `T[K]` reads each kept key's type.
+		{
+			name:         "Pick",
+			src:          `type Result = Pick<{a: number, b: string, c: boolean}, "a" | "c">`,
+			wantExpanded: "{a: number, c: boolean}",
+		},
+		{
+			name:         "PickSingleKey",
+			src:          `type Result = Pick<Point, "x">`,
+			wantExpanded: "{x: number}",
+		},
+		{
+			// The map is homomorphic, written over `keyof T`, so each kept field carries the
+			// source member's own `?` and `readonly` markers.
+			name:         "PickKeepsMarkers",
+			src:          `type Result = Pick<{a?: number, readonly b: string, c: boolean}, "a" | "b">`,
+			wantExpanded: "{a?: number, readonly b: string}",
+		},
+		{
+			// `never` is the empty key set, so every key fails the filter.
+			name:         "PickNoKeys",
+			src:          `type Result = Pick<{a: number}, never>`,
+			wantExpanded: "{}",
+		},
+		// `Omit<T, Ks>` is `Pick`'s complement. The bracketed expression remaps a named key to
+		// `never`, which drops the field.
+		{
+			name:         "Omit",
+			src:          `type Result = Omit<{a: number, b: string, c: boolean}, "b">`,
+			wantExpanded: "{a: number, c: boolean}",
+		},
+		{
+			name:         "OmitSeveralKeys",
+			src:          `type Result = Omit<{a: number, b: string, c: boolean}, "a" | "c">`,
+			wantExpanded: "{b: string}",
+		},
+		{
+			name:         "OmitKeepsMarkers",
+			src:          `type Result = Omit<{a?: number, readonly b: string}, "b">`,
+			wantExpanded: "{a?: number}",
+		},
+		// `Record<Ks, V>` gives every key in `Ks` the same value type. The value expression never
+		// names the key, so no indexed access is involved.
+		{
+			name:         "Record",
+			src:          `type Result = Record<"a" | "b", number>`,
+			wantExpanded: "{a: number, b: number}",
+		},
+		{
+			name:         "RecordOverKeyof",
+			src:          `type Result = Record<keyof Point, boolean>`,
+			wantExpanded: "{x: boolean, y: boolean}",
+		},
+		{
+			// A primitive key constraint has no keys to enumerate, so the map reduces to an index
+			// signature rather than to a field list.
+			name:         "RecordOverPrimitiveKey",
+			src:          `type Result = Record<string, number>`,
+			wantExpanded: "{[K: string]: number}",
+		},
+		// `Exclude<U, V>` drops the members of `U` assignable to `V`. `U` is a naked type
+		// parameter, so the conditional distributes over the union and decides each member alone.
+		{
+			name:         "Exclude",
+			src:          `type Result = Exclude<"a" | "b" | "c", "a">`,
+			wantExpanded: `"b" | "c"`,
+		},
+		{
+			// Dropping two of the three members leaves the survivor as a lone literal rather than
+			// a one-member union.
+			name:         "ExcludeSeveralMembers",
+			src:          `type Result = Exclude<"a" | "b" | "c", "a" | "b">`,
+			wantExpanded: `"c"`,
+		},
+		{
+			// Excluding every member leaves `never`, the empty union.
+			name:         "ExcludeEveryMember",
+			src:          `type Result = Exclude<"a" | "b", "a" | "b">`,
+			wantExpanded: "never",
+		},
+		{
+			name:         "ExcludeMatchesNothing",
+			src:          `type Result = Exclude<"a" | "b", "z">`,
+			wantExpanded: `"a" | "b"`,
+		},
+		{
+			// The members need not be literals. `string` is assignable to `string` and `number` is
+			// not, so the primitive union narrows the same way a literal union does.
+			name:         "ExcludeOverPrimitives",
+			src:          `type Result = Exclude<string | number, string>`,
+			wantExpanded: "number",
+		},
+		{
+			// The key set an operator produced feeds `Exclude` like any other union.
+			name:         "ExcludeOverKeyof",
+			src:          `type Result = Exclude<keyof Point, "x">`,
+			wantExpanded: `"y"`,
+		},
+		// `Extract<U, V>` is `Exclude`'s complement, keeping the members `Exclude` drops.
+		{
+			name:         "Extract",
+			src:          `type Result = Extract<"a" | "b" | "c", "a" | "c">`,
+			wantExpanded: `"a" | "c"`,
+		},
+		{
+			name:         "ExtractMatchesNothing",
+			src:          `type Result = Extract<"a" | "b", "z">`,
+			wantExpanded: "never",
+		},
+		{
+			name:         "ExtractOverPrimitives",
+			src:          `type Result = Extract<string | number | boolean, string | boolean>`,
+			wantExpanded: "string | boolean",
+		},
+		// `ReturnType<F>` reads the return type off a function through an `infer` capture.
+		{
+			name:         "ReturnType",
+			src:          `type Result = ReturnType<fn () -> string>`,
+			wantExpanded: "string",
+		},
+		{
+			// A non-function argument matches no function pattern, so the conditional selects Else.
+			name:         "ReturnTypeOfNonFunction",
+			src:          `type Result = ReturnType<number>`,
+			wantExpanded: "never",
+		},
+		// `Awaited<T>` strips every layer of `Promise`, recursing on its own capture.
+		{
+			name:         "Awaited",
+			src:          `type Result = Awaited<Promise<Promise<number>>>`,
+			wantExpanded: "number",
+		},
+		{
+			// The composition an async caller writes to name the value a function resolves to. The
+			// inner utility grounds first, then the outer one unwraps what it produced.
+			name:         "AwaitedOfReturnType",
+			src:          `type Result = Awaited<ReturnType<fn () -> Promise<number>>>`,
+			wantExpanded: "number",
+		},
+		// The four string intrinsics reduce over a string-literal operand.
+		{
+			name:         "Uppercase",
+			src:          `type Result = Uppercase<"hello">`,
+			wantExpanded: `"HELLO"`,
+		},
+		{
+			name:         "Lowercase",
+			src:          `type Result = Lowercase<"HELLO">`,
+			wantExpanded: `"hello"`,
+		},
+		{
+			name:         "Capitalize",
+			src:          `type Result = Capitalize<"hello">`,
+			wantExpanded: `"Hello"`,
+		},
+		{
+			name:         "Uncapitalize",
+			src:          `type Result = Uncapitalize<"Hello">`,
+			wantExpanded: `"hello"`,
+		},
+		{
+			// An intrinsic maps over a union member-wise.
+			name:         "CapitalizeOverUnion",
+			src:          `type Result = Capitalize<"click" | "focus">`,
+			wantExpanded: `"Click" | "Focus"`,
+		},
+		{
+			// The template-literal case. The interpolation runs an intrinsic over an event-name
+			// union, and the template takes the cartesian product over the union it produces.
+			name:         "EventName",
+			src:          `type Result = EventName<keyof {click: number, focus: string}>`,
+			wantExpanded: `"onClick" | "onFocus"`,
+		},
+	})
+}
+
+// One utility applied to another is what the suite is really verifying. Each operator's result is
+// an ordinary type, so it feeds the next operator with no special casing. Every expectation below
+// matches TypeScript's reduction of the same composition.
+func TestUtilityTypeComposition(t *testing.T) {
+	runUtilityReductions(t, []utilityReduction{
+		{
+			// A narrowed key set, then an optional map over what survived.
+			name:         "PartialOfPick",
+			src:          `type Result = Partial<Pick<{a: number, b: string, c: boolean}, "a" | "b">>`,
+			wantExpanded: "{a?: number, b?: string}",
+		},
+		{
+			// Two key-set narrowings in sequence. `Omit` drops `c`, then `Pick` keeps `b` of what
+			// is left.
+			name:         "PickOfOmit",
+			src:          `type Result = Pick<Omit<{a: number, b: string, c: boolean}, "c">, "b">`,
+			wantExpanded: "{b: string}",
+		},
+		{
+			// `Omit` reads its key set off the object `Partial` emitted, so the `?` markers
+			// `Partial` added survive the drop.
+			name:         "OmitOfPartial",
+			src:          `type Result = Omit<Partial<Point>, "x">`,
+			wantExpanded: "{y?: string}",
+		},
+		{
+			name:         "ReadonlyOfRecord",
+			src:          `type Result = Readonly<Record<"a" | "b", number>>`,
+			wantExpanded: "{readonly a: number, readonly b: number}",
+		},
+		{
+			// An alias reference in the value position is left symbolic rather than expanded, the
+			// same transparent-but-named treatment an alias gets everywhere else. It reduces at the
+			// constraint site, which TestUtilityTypeConstraints checks by assigning `{x: {y: 1}}`
+			// to this type.
+			name:         "RecordOfRecord",
+			src:          `type Result = Record<"x", Record<"y", number>>`,
+			wantExpanded: `{x: Record<"y", number>}`,
+		},
+		{
+			// A key remapping that renames rather than drops. Each key is capitalized and prefixed
+			// through a template literal, and the value expression still reads the original key.
+			// This is the `Getters<T>` shape, and it needs no machinery beyond the mapped type, the
+			// template literal, and the `Capitalize` intrinsic.
+			name: "GettersRenameEveryKey",
+			src: `
+				type Getters<T> = {[` + "`get${Capitalize<K>}`" + `]: T[K] for K in keyof T}
+				type Result = Getters<{name: string, age: number}>
+			`,
+			wantExpanded: "{getAge: number, getName: string}",
+		},
+	})
+}
+
+// A utility used as a value's annotation is the end-to-end path. constrain reduces the reference
+// to check the initializer against it, with no test-only expansion in between. The accepting cases
+// prove the reduction is reachable from a real constraint. The rejecting ones prove the diagnostic
+// names the type the reduction arrived at rather than the annotation the source wrote.
+func TestUtilityTypeConstraints(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		wantErrs []string // empty ⇒ expect no error
+	}{
+		{
+			// Every field is optional, so an object supplying one of the two keys is accepted.
+			name: "PartialAcceptsPartialObject",
+			src:  `val v: Partial<Point> = {x: 1}`,
+		},
+		{
+			name: "PartialAcceptsEmptyObject",
+			src:  `val v: Partial<Point> = {}`,
+		},
+		{
+			// Optional does not mean untyped. The value at a supplied key is still checked, and
+			// the message names `number` rather than `Partial<Point>`.
+			name:     "PartialChecksSuppliedValue",
+			src:      `val v: Partial<Point> = {x: "no"}`,
+			wantErrs: []string{`cannot constrain "no" <: number`},
+		},
+		{
+			name: "PickAcceptsKeptKey",
+			src:  `val v: Pick<Point, "x"> = {x: 1}`,
+		},
+		{
+			// The reduced object is exact, so a key the filter dropped is not accepted back.
+			name:     "PickRejectsDroppedKey",
+			src:      `val v: Pick<Point, "x"> = {x: 1, y: "s"}`,
+			wantErrs: []string{"object has extra property: y"},
+		},
+		{
+			name:     "PickChecksValue",
+			src:      `val v: Pick<Point, "x"> = {x: "s"}`,
+			wantErrs: []string{`cannot constrain "s" <: number`},
+		},
+		{
+			name: "OmitAcceptsRemainingKey",
+			src:  `val v: Omit<Point, "y"> = {x: 1}`,
+		},
+		{
+			// The omitted key is gone and the kept one is still required, so supplying only the
+			// omitted key fails on both counts.
+			name:     "OmitRejectsOmittedKey",
+			src:      `val v: Omit<Point, "y"> = {y: "s"}`,
+			wantErrs: []string{"object is missing property: x", "object has extra property: y"},
+		},
+		{
+			name: "RecordAcceptsEveryKey",
+			src:  `val v: Record<"a" | "b", number> = {a: 1, b: 2}`,
+		},
+		{
+			// `Record` emits required fields, so every key in the union must be supplied.
+			name:     "RecordRequiresEveryKey",
+			src:      `val v: Record<"a" | "b", number> = {a: 1}`,
+			wantErrs: []string{"object is missing property: b"},
+		},
+		{
+			name: "RecordOfRecordAcceptsNestedObject",
+			src:  `val v: Record<"x", Record<"y", number>> = {x: {y: 1}}`,
+		},
+		{
+			// `Required` cleared the markers `Partial` added, so the object must supply both keys.
+			name:     "RequiredRestoresEveryKey",
+			src:      `val v: Required<Partial<Point>> = {x: 1}`,
+			wantErrs: []string{"object is missing property: y"},
+		},
+		{
+			name: "ReadonlyAcceptsWholeObject",
+			src:  `val v: Readonly<Point> = {x: 1, y: "s"}`,
+		},
+		{
+			name: "ExcludeAcceptsSurvivingMember",
+			src:  `val v: Exclude<"a" | "b", "a"> = "b"`,
+		},
+		{
+			// The excluded member is gone from the union, and the message names the one member
+			// left rather than the annotation.
+			name:     "ExcludeRejectsRemovedMember",
+			src:      `val v: Exclude<"a" | "b", "a"> = "a"`,
+			wantErrs: []string{`cannot constrain "a" <: "b"`},
+		},
+		{
+			name: "ExtractAcceptsKeptMember",
+			src:  `val v: Extract<"a" | "b", "a"> = "a"`,
+		},
+		{
+			name: "AwaitedAcceptsUnwrappedPayload",
+			src:  `val v: Awaited<Promise<Promise<number>>> = 5`,
+		},
+		{
+			name:     "AwaitedRejectsOtherType",
+			src:      `val v: Awaited<Promise<Promise<number>>> = "s"`,
+			wantErrs: []string{`cannot constrain "s" <: number`},
+		},
+		{
+			name: "UppercaseAcceptsMappedLiteral",
+			src:  `val v: Uppercase<"ab"> = "AB"`,
+		},
+		{
+			name:     "UppercaseRejectsUnmappedLiteral",
+			src:      `val v: Uppercase<"ab"> = "ab"`,
+			wantErrs: []string{`cannot constrain "ab" <: "AB"`},
+		},
+		{
+			name: "EventNameAcceptsHandlerName",
+			src:  `val v: EventName<"click"> = "onClick"`,
+		},
+		{
+			// The intrinsic capitalized the interpolation, so the lowercase spelling is rejected.
+			name:     "EventNameRejectsUncapitalizedName",
+			src:      `val v: EventName<"click"> = "onclick"`,
+			wantErrs: []string{`cannot constrain "onclick" <: "onClick"`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, utilityTypeDecls+tt.src)
+			messages := make([]string, len(errs))
+			for i, err := range errs {
+				messages[i] = err.Message()
+			}
+			if len(tt.wantErrs) == 0 {
+				require.Empty(t, messages)
+				return
+			}
+			require.Equal(t, tt.wantErrs, messages)
+		})
+	}
+}
+
+// A utility applied to an unfilled type parameter has no ground operand to reduce, so it stays the
+// alias reference the source wrote and renders that way in the enclosing signature. This is what
+// lets a utility appear in a generic function's signature at all. The reduction waits for the call
+// site that supplies the argument.
+func TestUtilityTypeStaysSymbolicOverTypeParameter(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "Partial",
+			src:  `fn f<T>(p: Partial<T>) -> Partial<T> { return p }`,
+			want: "fn <T>(p: Partial<T>) -> Partial<T>",
+		},
+		{
+			name: "Required",
+			src:  `fn f<T>(p: Required<T>) -> Required<T> { return p }`,
+			want: "fn <T>(p: Required<T>) -> Required<T>",
+		},
+		{
+			name: "Pick",
+			src:  `fn f<T, Ks>(p: Pick<T, Ks>) -> Pick<T, Ks> { return p }`,
+			want: "fn <T, Ks>(p: Pick<T, Ks>) -> Pick<T, Ks>",
+		},
+		{
+			name: "Exclude",
+			src:  `fn f<U, V>(p: Exclude<U, V>) -> Exclude<U, V> { return p }`,
+			want: "fn <U, V>(p: Exclude<U, V>) -> Exclude<U, V>",
+		},
+		{
+			name: "Record",
+			src:  `fn f<V>(p: Record<"a", V>) -> Record<"a", V> { return p }`,
+			want: `fn <V>(p: Record<"a", V>) -> Record<"a", V>`,
+		},
+		{
+			name: "Awaited",
+			src:  `fn f<T>(p: Awaited<T>) -> Awaited<T> { return p }`,
+			want: "fn <T>(p: Awaited<T>) -> Awaited<T>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, utilityTypeDecls+tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// TypeScript writes `ReturnType<F>` as `F extends (...args: any) => infer R ? R : never`, one
+// definition that reads the return off a function of any arity. Escalier has no equivalent, so
+// `ReturnType<F>` above matches a nullary function and reduces to `never` for every other arity.
+//
+// The blocker is the accept-set rule, which constrain uses to decide function subtyping. A
+// function type's accept-set is the range of argument counts it tolerates, and `sub <: super`
+// holds only when accept(sub) contains accept(super). Both sides here are exact, so their
+// accept-sets are single points and containment forces equal arity. Widening the pattern does not
+// help. A rest parameter or the inexact `fn (...)` marker lifts the pattern's upper bound to
+// infinity, which a fixed-arity argument then fails to contain.
+//
+// So the arity-agnostic definition needs a decision about how a conditional's `Check <: Extends`
+// probe treats arity, not just the rest-parameter annotation surface M7.5 adds.
+func TestUtilityTypeReturnTypeIsAritySpecific(t *testing.T) {
+	runUtilityReductions(t, []utilityReduction{
+		{
+			// The arity the pattern was written for.
+			name:         "NullaryMatches",
+			src:          `type Result = ReturnType<fn () -> string>`,
+			wantExpanded: "string",
+		},
+		{
+			// One parameter, so the accept-sets are [1, 1] against [0, 0] and the pattern does not
+			// match. TypeScript reduces this to `string`.
+			name:         "UnaryDoesNotMatch",
+			src:          `type Result = ReturnType<fn (x: number) -> string>`,
+			wantExpanded: "never",
+		},
+		{
+			// A pattern written for the argument's arity does match, so the `infer` capture itself
+			// is not what is missing. The parameter position is `never` because parameters are
+			// contravariant, so the bottom type is the one every argument type accepts.
+			name: "PatternWrittenForTheArityMatches",
+			src: `
+				type ReturnType1<F> = if F : fn (a: never) -> infer R { R } else { never }
+				type Result = ReturnType1<fn (x: number) -> string>
+			`,
+			wantExpanded: "string",
+		},
+	})
+}
+
+// DISABLED until the soltype literal set covers `null` and `undefined`. That extension is owed
+// from M2 and has not landed. The Prim/Lit note in internal/soltype/type.go records it.
+// `resolveLitTypeAnn` reports `Unsupported: LitTypeAnn` for both spellings, so the `null |
+// undefined` operand `NonNullable<T>` tests against cannot be written. Re-enable by removing the
+// comment wrapper once the annotation surface and constrain's `NullType` arm exist, and add
+//
+//	type NonNullable<T> = if T : null | undefined { never } else { T }
+//
+// to utilityTypeDecls, which is where runUtilityReductions reads each utility's definition from.
+func TestUtilityTypeNonNullable(t *testing.T) {
+	/*
+		runUtilityReductions(t, []utilityReduction{
+			{
+				// The naked type parameter distributes, so each member is decided alone and the two
+				// absence markers drop out.
+				name:         "StripsBothMarkers",
+				src:          `type Result = NonNullable<string | null | undefined>`,
+				wantExpanded: "string",
+			},
+			{
+				name:         "LeavesOtherMembers",
+				src:          `type Result = NonNullable<string | number>`,
+				wantExpanded: "string | number",
+			},
+			{
+				name:         "EveryMemberStripped",
+				src:          `type Result = NonNullable<null | undefined>`,
+				wantExpanded: "never",
+			},
+		})
+	*/
+}
+
+// DISABLED until M7.5. `Parameters<F>` binds one `infer` name to a function's whole parameter list,
+// which needs a rest parameter in the pattern. `resolveFuncTypeAnn` reports `Unsupported: rest
+// parameter in function type annotation` and recovers the parameter to a positional one, because
+// checking a rest parameter's trailing arguments needs `Array<T>` and M7.5 is where the real
+// `Array` lands. `ConstructorParameters<C>` waits on that plus a `new (…)` member in an object
+// type annotation, which `objTypeAnnElemInner` does not parse.
+//
+// Both also need the arity decision TestUtilityTypeReturnTypeIsAritySpecific describes, since a
+// rest parameter in the pattern widens its accept-set the same way the inexact marker does.
+//
+// Re-enable by removing the comment wrapper and adding both definitions to utilityTypeDecls:
+//
+//	type Parameters<F> = if F : fn (...args: infer P) -> unknown { P } else { never }
+//	type ConstructorParameters<C> = if C : {new (...args: infer P) -> unknown} { P } else { never }
+func TestUtilityTypeParameters(t *testing.T) {
+	/*
+		runUtilityReductions(t, []utilityReduction{
+			{
+				// The capture is the parameter list as a tuple, in source order.
+				name:         "ParameterList",
+				src:          `type Result = Parameters<fn (x: number, y: string) -> boolean>`,
+				wantExpanded: "[number, string]",
+			},
+			{
+				name:         "NullaryParameterList",
+				src:          `type Result = Parameters<fn () -> boolean>`,
+				wantExpanded: "[]",
+			},
+			{
+				name:         "NonFunction",
+				src:          `type Result = Parameters<number>`,
+				wantExpanded: "never",
+			},
+			{
+				name:         "ConstructorParameterList",
+				src:          `type Result = ConstructorParameters<{new (x: number) -> {a: number}}>`,
+				wantExpanded: "[number]",
+			},
+		})
+	*/
+}
+
+// DISABLED until an object type annotation accepts a `new (…)` member. `InstanceType<C>` reads the
+// return type off a constructor signature, and `objTypeAnnElemInner` has no arm for `new`, so
+// `{new (…) -> infer R}` fails to parse. The representation is not what is missing. The printer
+// already renders the form, as internal/solver/infer_class_test.go shows a class's static side
+// printing `{new (x: number, y: number) -> Vec, …}`.
+//
+// Re-enable by removing the comment wrapper and adding
+//
+//	type InstanceType<C> = if C : {new (a: never) -> infer R} { R } else { never }
+//
+// to utilityTypeDecls. The pattern is written for a one-parameter constructor, since it inherits
+// the arity restriction TestUtilityTypeReturnTypeIsAritySpecific describes.
+func TestUtilityTypeInstanceType(t *testing.T) {
+	/*
+		runUtilityReductions(t, []utilityReduction{
+			{
+				name:         "ConstructorReturn",
+				src:          `type Result = InstanceType<{new (x: number) -> {a: number}}>`,
+				wantExpanded: "{a: number}",
+			},
+			{
+				name:         "NonConstructor",
+				src:          `type Result = InstanceType<number>`,
+				wantExpanded: "never",
+			},
+		})
+	*/
+}

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -580,11 +580,13 @@ func TestUtilityTypeReturnTypeIsAritySpecific(t *testing.T) {
 	})
 }
 
-// DISABLED until the soltype literal set covers `null` and `undefined`. That extension is owed
-// from M2 and has not landed. The Prim/Lit note in internal/soltype/type.go records it.
-// `resolveLitTypeAnn` reports `Unsupported: LitTypeAnn` for both spellings, so the `null |
-// undefined` operand `NonNullable<T>` tests against cannot be written. Re-enable by removing the
-// comment wrapper once the annotation surface and constrain's `NullType` arm exist, and add
+// DISABLED until M9 PR16, which gives `null` and `undefined` a surface. `soltype.NullType` and
+// `soltype.UndefinedType` already exist as atoms and `undefined` is already inferred, since reading
+// an optional property yields `number | undefined`. What no annotation reaches is either atom, so
+// `resolveLitTypeAnn` reports `Unsupported: LitTypeAnn` for both spellings and the `null |
+// undefined` operand `NonNullable<T>` tests against cannot be written. `constrain` also carries a
+// reflexive arm for `UndefinedType` and none for `NullType`. Re-enable by removing the comment
+// wrapper once both exist, and add
 //
 //	type NonNullable<T> = if T : null | undefined { never } else { T }
 //

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -230,6 +230,58 @@ func TestUtilityTypeReductions(t *testing.T) {
 			src:          `type Result = Exclude<keyof Point, "x">`,
 			wantExpanded: `"y"`,
 		},
+		// A union of objects narrows the same way a union of literals does. Each member is decided
+		// by an ordinary subtype test, so the whole object shape takes part rather than just a
+		// name.
+		{
+			name:         "ExcludeFromObjectUnion",
+			src:          `type Result = Exclude<{a: number} | {b: string}, {a: number}>`,
+			wantExpanded: "{b: string}",
+		},
+		{
+			// Dropping one arm of a discriminated union by naming only its tag. The `...` marker is
+			// what makes the target match a member that carries fields beyond `kind`, so an exact
+			// `{kind: "a"}` would drop nothing. The union is written inline because a union reached
+			// through an alias does not distribute — see TestUtilityTypeDistributesOverUnionAlias.
+			name:         "ExcludeDiscriminatedArm",
+			src:          `type Result = Exclude<{kind: "a", x: number} | {kind: "b", y: string}, {kind: "a", ...}>`,
+			wantExpanded: `{kind: "b", y: string}`,
+		},
+		{
+			name:         "ExcludeEveryObjectMember",
+			src:          `type Result = Exclude<{a: number} | {b: string}, {a: number} | {b: string}>`,
+			wantExpanded: "never",
+		},
+		{
+			// An object member is decided by the same rule as a primitive one, so the two mix in
+			// one union. The survivors render in canonical order rather than source order.
+			name:         "ExcludeFromMixedUnion",
+			src:          `type Result = Exclude<{a: number} | string | number, {a: number}>`,
+			wantExpanded: "number | string",
+		},
+		{
+			// `{...}` is the object with no declared fields and an open tail, so every object is a
+			// subtype of it and only the non-object member survives.
+			name:         "ExcludeEveryObjectViaOpenTarget",
+			src:          `type Result = Exclude<{a: number} | {b: string} | number, {...}>`,
+			wantExpanded: "number",
+		},
+		{
+			// Exactness diverges from TypeScript here. `{a: number}` is exact, so a member carrying
+			// `b` as well is not a subtype of it and is kept. TypeScript's object types are
+			// width-tolerant, so it drops `{a: number, b: string}` and reduces this to
+			// `{c: boolean}`. ExcludeWiderMemberViaOpenTarget below is the spelling that agrees.
+			name:         "ExcludeExactTargetKeepsWiderMember",
+			src:          `type Result = Exclude<{a: number, b: string} | {c: boolean}, {a: number}>`,
+			wantExpanded: "{c: boolean} | {a: number, b: string}",
+		},
+		{
+			// The `...` marker restores width tolerance, so the wider member is dropped and the
+			// result matches TypeScript's reduction of the exact-target spelling above.
+			name:         "ExcludeWiderMemberViaOpenTarget",
+			src:          `type Result = Exclude<{a: number, b: string} | {c: boolean}, {a: number, ...}>`,
+			wantExpanded: "{c: boolean}",
+		},
 		// `Extract<U, V>` is `Exclude`'s complement, keeping the members `Exclude` drops.
 		{
 			name:         "Extract",
@@ -245,6 +297,45 @@ func TestUtilityTypeReductions(t *testing.T) {
 			name:         "ExtractOverPrimitives",
 			src:          `type Result = Extract<string | number | boolean, string | boolean>`,
 			wantExpanded: "string | boolean",
+		},
+		{
+			name:         "ExtractFromObjectUnion",
+			src:          `type Result = Extract<{a: number} | {b: string}, {a: number}>`,
+			wantExpanded: "{a: number}",
+		},
+		{
+			// Selecting one arm of a discriminated union by its tag, the complement of
+			// ExcludeDiscriminatedArm and the way a caller narrows to a single case.
+			name:         "ExtractDiscriminatedArm",
+			src:          `type Result = Extract<{kind: "a", x: number} | {kind: "b", y: string}, {kind: "a", ...}>`,
+			wantExpanded: `{kind: "a", x: number}`,
+		},
+		{
+			// The subtype test is structural all the way down, so two members differing only
+			// inside a nested object are told apart.
+			name:         "ExtractNestedObject",
+			src:          `type Result = Extract<{a: {b: number}} | {a: {b: string}}, {a: {b: number}}>`,
+			wantExpanded: "{a: {b: number}}",
+		},
+		{
+			// Every object is a subtype of the open empty object, so nothing is dropped.
+			name:         "ExtractEveryObjectViaOpenTarget",
+			src:          `type Result = Extract<{a: number} | {b: string}, {...}>`,
+			wantExpanded: "{a: number} | {b: string}",
+		},
+		{
+			// The exactness divergence again, seen from the keeping side. `{a: number}` is exact, so
+			// it matches no member and the result is empty. TypeScript keeps `{a: number, b: string}`
+			// here, and ExtractWiderMembersViaOpenTarget below is the spelling that agrees.
+			name:         "ExtractExactTargetMatchesNoWiderMember",
+			src:          `type Result = Extract<{a: number, b: string} | {c: boolean}, {a: number}>`,
+			wantExpanded: "never",
+		},
+		{
+			// With the `...` marker both members carrying `a` are kept, matching TypeScript.
+			name:         "ExtractWiderMembersViaOpenTarget",
+			src:          `type Result = Extract<{a: number, b: string} | {a: number}, {a: number, ...}>`,
+			wantExpanded: "{a: number} | {a: number, b: string}",
 		},
 		// `ReturnType<F>` reads the return type off a function through an `infer` capture.
 		{
@@ -641,6 +732,76 @@ func TestUtilityTypeAliasParameterConstraint(t *testing.T) {
 			require.Equal(t, tt.wantErr, errs[0].Message())
 		})
 	}
+}
+
+// DISABLED until a conditional distributes over a union reached through an alias. Not tracked by an
+// issue yet.
+//
+// A distributive conditional decides each member of its Check alone, which is what makes
+// `Exclude` and `Extract` narrow a union rather than test it whole. Distribution fires only when
+// the Check reduces to a `UnionType`. `reduce` returns an alias reference unchanged, since an alias
+// is not an operator, so an argument that names its union through an alias never reaches that test
+// and the conditional decides the whole alias in one step.
+//
+// The effect is that the same union behaves differently depending on how it was written.
+// `Exclude<"a" | "b", "a">` reduces to `"b"`, while `type Names = "a" | "b"` followed by
+// `Exclude<Names, "a">` reduces to `Names`, because `Names <: "a"` fails and Else returns the
+// argument untouched. `Extract` reduces to `never` for the same reason. A `keyof P` argument does
+// distribute, since `keyof` reduction produces a real union before the test runs.
+//
+// This reaches every distributive utility and it hits the shape most likely to be written, since a
+// discriminated union is normally given a name. The fix is for the distribution test to ground an
+// alias Check the way `groundOperand` does elsewhere, rather than reading `reduce`'s output
+// directly.
+func TestUtilityTypeDistributesOverUnionAlias(t *testing.T) {
+	/*
+		runUtilityReductions(t, []utilityReduction{
+			{
+				// The literal-union case, which reduces to `"b"` when the union is written inline.
+				name: "ExcludeOverAliasedLiteralUnion",
+				src: `
+					type Names = "a" | "b"
+					type Result = Exclude<Names, "a">
+				`,
+				wantExpanded: `"b"`,
+			},
+			{
+				name: "ExtractOverAliasedLiteralUnion",
+				src: `
+					type Names = "a" | "b"
+					type Result = Extract<Names, "a">
+				`,
+				wantExpanded: `"a"`,
+			},
+			{
+				// The shape that motivates it: a named discriminated union narrowed by its tag.
+				name: "ExcludeArmOfAliasedDiscriminatedUnion",
+				src: `
+					type Event = {kind: "a", x: number} | {kind: "b", y: string}
+					type Result = Exclude<Event, {kind: "a", ...}>
+				`,
+				wantExpanded: `{kind: "b", y: string}`,
+			},
+			{
+				name: "ExtractArmOfAliasedDiscriminatedUnion",
+				src: `
+					type Event = {kind: "a", x: number} | {kind: "b", y: string}
+					type Result = Extract<Event, {kind: "a", ...}>
+				`,
+				wantExpanded: `{kind: "a", x: number}`,
+			},
+			{
+				// An alias naming another alias resolves to the same union, so it distributes too.
+				name: "ExcludeOverIndirectAlias",
+				src: `
+					type Names = "a" | "b"
+					type Mid = Names
+					type Result = Exclude<Mid, "a">
+				`,
+				wantExpanded: `"b"`,
+			},
+		})
+	*/
 }
 
 // DISABLED until M9 PR16, which gives `null` and `undefined` a surface. `soltype.NullType` and

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -634,9 +634,8 @@ func TestUtilityTypeNonNullable(t *testing.T) {
 //
 // Both pieces also need the arity decision TestUtilityTypeReturnTypeIsAritySpecific describes,
 // since a rest parameter in the pattern widens its accept-set the same way the inexact marker does.
-// M9 PR14 covers all three. `ConstructorParameters<C>` waits on PR14 plus a `new (…)` member in an
-// object type annotation, which `objTypeAnnElemInner` does not parse, so it stays disabled after
-// PR14 lands.
+// M9 PR14 covers all three. `ConstructorParameters<C>` waits on PR14 plus the `new (…)` member M9
+// PR15 adds, so it stays disabled until both land.
 //
 // Re-enable by removing the comment wrapper and adding both definitions to utilityTypeDecls:
 //
@@ -670,11 +669,11 @@ func TestUtilityTypeParameters(t *testing.T) {
 	*/
 }
 
-// DISABLED until an object type annotation accepts a `new (…)` member. `InstanceType<C>` reads the
-// return type off a constructor signature, and `objTypeAnnElemInner` has no arm for `new`, so
-// `{new (…) -> infer R}` fails to parse. The representation is not what is missing. The printer
-// already renders the form, as internal/solver/infer_class_test.go shows a class's static side
-// printing `{new (x: number, y: number) -> Vec, …}`.
+// DISABLED until M9 PR15, which adds a `new (…)` member to object type annotations.
+// `InstanceType<C>` reads the return type off a constructor signature, and `objTypeAnnElemInner`
+// has no arm for `new`, so `{new (…) -> infer R}` fails to parse. The representation is not what is
+// missing. The printer already renders the form, as internal/solver/infer_class_test.go shows a
+// class's static side printing `{new (x: number, y: number) -> Vec, …}`.
 //
 // Re-enable by removing the comment wrapper and adding
 //

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -549,7 +549,8 @@ func TestUtilityTypeStaysSymbolicOverTypeParameter(t *testing.T) {
 // infinity, which a fixed-arity argument then fails to contain.
 //
 // So the arity-agnostic definition needs a decision about how a conditional's `Check <: Extends`
-// probe treats arity, not just the rest-parameter annotation surface M7.5 adds.
+// probe treats arity, not just a rest parameter in the annotation. M9 PR14 makes that decision and
+// replaces these cases.
 func TestUtilityTypeReturnTypeIsAritySpecific(t *testing.T) {
 	runUtilityReductions(t, []utilityReduction{
 		{
@@ -631,11 +632,11 @@ func TestUtilityTypeNonNullable(t *testing.T) {
 // on `FuncParam.Rest` in internal/soltype/type.go. A pattern match over a written function type
 // reads no element type, so it needs no `Array`.
 //
-// `ConstructorParameters<C>` waits on both pieces plus a `new (…)` member in an object type
-// annotation, which `objTypeAnnElemInner` does not parse.
-//
-// Both also need the arity decision TestUtilityTypeReturnTypeIsAritySpecific describes, since a
-// rest parameter in the pattern widens its accept-set the same way the inexact marker does.
+// Both pieces also need the arity decision TestUtilityTypeReturnTypeIsAritySpecific describes,
+// since a rest parameter in the pattern widens its accept-set the same way the inexact marker does.
+// M9 PR14 covers all three. `ConstructorParameters<C>` waits on PR14 plus a `new (…)` member in an
+// object type annotation, which `objTypeAnnElemInner` does not parse, so it stays disabled after
+// PR14 lands.
 //
 // Re-enable by removing the comment wrapper and adding both definitions to utilityTypeDecls:
 //

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -28,8 +28,15 @@ import (
 // `Omit<T, Ks>` reads `Exclude`, so the two definitions are coupled. Order in this source does not
 // matter, since the dependency graph orders the declarations.
 //
-// `ReturnType<F>` matches a nullary function only. TestUtilityTypeReturnTypeIsAritySpecific
-// records why the arity-agnostic TypeScript definition has no Escalier equivalent.
+// `ReturnType<F>` bounds `F` to `fn () -> unknown`, so an argument that is not a nullary function
+// is rejected at the reference. `unknown` is the top of the lattice and a function type's return is
+// covariant, so that bound admits every nullary function and no other type. The bound is enforced,
+// which TestUtilityTypeAliasParameterConstraint pins directly.
+//
+// Nullary is not a choice; it is the arity the pattern can match.
+// TestUtilityTypeReturnTypeIsAritySpecific records why the arity-agnostic TypeScript definition has
+// no Escalier equivalent, and the bound turns what was a silent reduction to `never` for every
+// other arity into a diagnostic.
 //
 // `NonNullable<T>`, `Parameters<F>`, `ConstructorParameters<C>`, and `InstanceType<C>` are the
 // four utilities the suite cannot express yet. Each has a disabled test at the end of this file
@@ -47,7 +54,7 @@ const utilityTypeDecls = `
 	type Record<Ks, V> = {[K: Ks]: V}
 	type Exclude<U, V> = if U : V { never } else { U }
 	type Extract<U, V> = if U : V { U } else { never }
-	type ReturnType<F> = if F : fn () -> infer R { R } else { never }
+	type ReturnType<F: fn () -> unknown> = if F : fn () -> infer R { R } else { never }
 	type Awaited<T> = if T : Promise<infer U> { Awaited<U> } else { T }
 	type EventName<K> = ` + "`on${Capitalize<K>}`" + `
 	type Point = {x: number, y: string}
@@ -248,12 +255,8 @@ func TestUtilityTypeReductions(t *testing.T) {
 			src:          `type Result = ReturnType<fn () -> string>`,
 			wantExpanded: "string",
 		},
-		{
-			// A non-function argument matches no function pattern, so the conditional selects Else.
-			name:         "ReturnTypeOfNonFunction",
-			src:          `type Result = ReturnType<number>`,
-			wantExpanded: "never",
-		},
+		// A non-function argument is rejected by the bound rather than reduced, so it lives in
+		// TestUtilityTypeAliasParameterConstraint with the other rejections.
 		// `Awaited<T>` strips every layer of `Promise`, recursing on its own capture.
 		{
 			name:         "Awaited",
@@ -546,7 +549,7 @@ func TestUtilityTypeStaysSymbolicOverTypeParameter(t *testing.T) {
 
 // TypeScript writes `ReturnType<F>` as `F extends (...args: any) => infer R ? R : never`, one
 // definition that reads the return off a function of any arity. Escalier has no equivalent, so
-// `ReturnType<F>` above matches a nullary function and reduces to `never` for every other arity.
+// `ReturnType<F>` above matches a nullary function and rejects every other arity at the bound.
 //
 // The blocker is the accept-set rule, which constrain uses to decide function subtyping. A
 // function type's accept-set is the range of argument counts it tolerates, and `sub <: super`
@@ -567,13 +570,6 @@ func TestUtilityTypeReturnTypeIsAritySpecific(t *testing.T) {
 			wantExpanded: "string",
 		},
 		{
-			// One parameter, so the accept-sets are [1, 1] against [0, 0] and the pattern does not
-			// match. TypeScript reduces this to `string`.
-			name:         "UnaryDoesNotMatch",
-			src:          `type Result = ReturnType<fn (x: number) -> string>`,
-			wantExpanded: "never",
-		},
-		{
 			// A pattern written for the argument's arity does match, so the `infer` capture itself
 			// is not what is missing. The parameter position is `never` because parameters are
 			// contravariant, so the bottom type is the one every argument type accepts.
@@ -585,68 +581,86 @@ func TestUtilityTypeReturnTypeIsAritySpecific(t *testing.T) {
 			wantExpanded: "string",
 		},
 	})
+
+	// A one-parameter argument is where the restriction bites. Its accept-set is [1, 1] against the
+	// bound's [0, 0], so the bound rejects it and the diagnostic names the two arities. TypeScript
+	// reduces the same reference to `string`.
+	_, _, errs := inferSource(t, utilityTypeDecls+`type Result = ReturnType<fn (x: number) -> string>`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain function of arity 1 <: function of arity 0", errs[0].Message())
 }
 
-// DISABLED until alias instantiation checks its arguments against its parameters' bounds, tracked
-// as escalier-lang/escalier#955.
+// A bound on an alias's type parameter is checked at the reference, so `ReturnType<F>` rejects an
+// argument that is not a nullary function instead of reducing it through the Else branch. The last
+// two cases pin the same check on the simplest alias that can carry a bound, so a failure there is
+// about the check rather than about anything the operator track added.
 //
-// `ReturnType<F>` would read better with `F` bounded to a function type, so `ReturnType<number>`
-// were rejected at the reference rather than reduced to `never` through the Else branch. Writing
-// the bound is not the obstacle. `resolveTypeParams` resolves a `<F: …>` clause into an upper bound
-// on the parameter's var, and `type ReturnType<F: fn () -> never> = …` parses and lowers today.
-//
-// The obstacle is that nothing consults that bound. `expandAlias` instantiates through
-// `newTypeSubst`, which replaces each parameter with its argument and never constrains the argument
-// against the parameter's var, so `type Box<T: string> = {v: T}` accepts `Box<number>` with no
-// diagnostic. A generic *function* does enforce its bound, because the call site constrains each
-// argument against the instantiated var, which is why `fn f<A: string>(a: A)` rejects `f(5)` with
-// `cannot constrain 5 <: string`.
-//
-// A second obstacle is specific to this bound. A function type's return is covariant, so the bound
-// that admits every function has to be `fn () -> unknown`, and `unknown` has no annotation surface.
-// A bound written `fn () -> never` instead says `F` returns `never`, which is not what it looks
-// like it says.
-//
-// The expected message below assumes the check reports through `constrain`, matching the generic
-// function case. An implementation that reports at the reference instead would word it differently.
+// The bound is written `fn () -> unknown` because a function type's return is covariant, so only
+// the top of the lattice admits every nullary function. A bound written `fn () -> never` would
+// instead say `F` returns `never` and would reject `fn () -> string`.
 func TestUtilityTypeAliasParameterConstraint(t *testing.T) {
-	/*
-		tests := []struct {
-			name    string
-			src     string
-			wantErr string // "" ⇒ expect no error
-		}{
-			{
-				// The bound admits every function, so a function argument passes.
-				name: "FunctionArgumentPasses",
-				src:  `type Result = ReturnType<fn () -> string>`,
-			},
-			{
-				// A non-function is rejected at the reference rather than reduced through Else.
-				name:    "NonFunctionArgumentRejected",
-				src:     `type Result = ReturnType<number>`,
-				wantErr: "cannot constrain number <: fn () -> unknown",
-			},
-			{
-				// The same gap on the simplest possible alias, so a failure here is about the
-				// bound check rather than about anything the operator track added.
-				name:    "BoundOnPlainAlias",
-				src:     `type Box<T: string> = {v: T}` + "\n" + `type Result = Box<number>`,
-				wantErr: "cannot constrain number <: string",
-			},
-		}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, _, errs := inferSource(t, utilityTypeDecls+tt.src)
-				if tt.wantErr == "" {
-					require.Empty(t, errs)
-					return
-				}
-				require.Len(t, errs, 1)
-				require.Equal(t, tt.wantErr, errs[0].Message())
-			})
-		}
-	*/
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			// The bound admits every nullary function, whatever it returns.
+			name: "FunctionArgumentPasses",
+			src:  `type Result = ReturnType<fn () -> string>`,
+		},
+		{
+			// A structural return is still a return, so the bound is about the shape of `F` alone.
+			name: "ObjectReturningFunctionPasses",
+			src:  `type Result = ReturnType<fn () -> {a: number}>`,
+		},
+		{
+			// A non-function is rejected at the reference. The message names `function` rather than
+			// the written bound, since that is how the mismatch renders once the argument is not a
+			// function at all.
+			name:    "NonFunctionArgumentRejected",
+			src:     `type Result = ReturnType<number>`,
+			wantErr: "cannot constrain number <: function",
+		},
+		{
+			// The bound admits every type at the simplest alias that can carry one.
+			name: "PlainAliasAcceptsBoundedArgument",
+			src:  `type Box<T: string> = {v: T}` + "\n" + `type Result = Box<"a">`,
+		},
+		{
+			name:    "PlainAliasRejectsUnboundedArgument",
+			src:     `type Box<T: string> = {v: T}` + "\n" + `type Result = Box<number>`,
+			wantErr: "cannot constrain number <: string",
+		},
+		{
+			// An unbounded parameter still accepts everything, so the check reads each parameter's
+			// own bound rather than applying one uniformly.
+			name: "UnboundedParameterAcceptsAnything",
+			src:  `type Id<T> = T` + "\n" + `type Result = Id<number>`,
+		},
+		{
+			// A bound naming an earlier sibling is checked against the argument that filled it, so
+			// `B` is compared against `string` rather than against `A`'s var.
+			name: "SiblingBoundAccepts",
+			src:  `type P<A: string, B: A> = [A, B]` + "\n" + `type Result = P<string, "a">`,
+		},
+		{
+			name:    "SiblingBoundRejects",
+			src:     `type P<A: string, B: A> = [A, B]` + "\n" + `type Result = P<string, number>`,
+			wantErr: "cannot constrain number <: string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, utilityTypeDecls+tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
 }
 
 // DISABLED until M9 PR16, which gives `null` and `undefined` a surface. `soltype.NullType` and

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -20,8 +20,13 @@ import (
 //   - `{[K]?: T[K] for K in keyof T}` is the mapped type TypeScript writes
 //     `{[K in keyof T]?: T[K]}`.
 //   - `if C : E { A } else { B }` is the conditional TypeScript writes `C extends E ? A : B`.
-//   - The bracketed expression in `{[if K : Ks { never } else { K }]: T[K] for K in keyof T}` is
-//     the key remapping TypeScript writes with an `as` clause.
+//   - The trailing `if K : Ks` clause on a mapped type filters its key set, dropping every key
+//     that fails the test. TypeScript has no filter clause and expresses the same thing as an `as`
+//     remapping to `never`. Escalier has that bracketed form too, which `Getters<T>` in
+//     TestUtilityTypeComposition uses to rename rather than to drop.
+//
+// `Omit<T, Ks>` reads `Exclude`, so the two definitions are coupled. Order in this source does not
+// matter, since the dependency graph orders the declarations.
 //
 // `ReturnType<F>` matches a nullary function only. TestUtilityTypeReturnTypeIsAritySpecific
 // records why the arity-agnostic TypeScript definition has no Escalier equivalent.
@@ -38,7 +43,7 @@ const utilityTypeDecls = `
 	type Required<T> = {[K]-?: T[K] for K in keyof T}
 	type Readonly<T> = {readonly [K]: T[K] for K in keyof T}
 	type Pick<T, Ks> = {[K]: T[K] for K in keyof T if K : Ks}
-	type Omit<T, Ks> = {[if K : Ks { never } else { K }]: T[K] for K in keyof T}
+	type Omit<T, Ks> = {[K]: T[K] for K in keyof T if K : Exclude<K, Ks>}
 	type Record<Ks, V> = {[K: Ks]: V}
 	type Exclude<U, V> = if U : V { never } else { U }
 	type Extract<U, V> = if U : V { U } else { never }
@@ -145,8 +150,10 @@ func TestUtilityTypeReductions(t *testing.T) {
 			src:          `type Result = Pick<{a: number}, never>`,
 			wantExpanded: "{}",
 		},
-		// `Omit<T, Ks>` is `Pick`'s complement. The bracketed expression remaps a named key to
-		// `never`, which drops the field.
+		// `Omit<T, Ks>` is `Pick`'s complement, and the same filter clause expresses it. `Exclude`
+		// sends a key named by `Ks` to `never` and every other key to itself, so `K : Exclude<K,
+		// Ks>` reads as "keep `K` when it survives the exclusion". A dropped key tests `"b" <:
+		// never`, which fails.
 		{
 			name:         "Omit",
 			src:          `type Result = Omit<{a: number, b: string, c: boolean}, "b">`,
@@ -578,6 +585,68 @@ func TestUtilityTypeReturnTypeIsAritySpecific(t *testing.T) {
 			wantExpanded: "string",
 		},
 	})
+}
+
+// DISABLED until alias instantiation checks its arguments against its parameters' bounds. No
+// milestone owns that yet.
+//
+// `ReturnType<F>` would read better with `F` bounded to a function type, so `ReturnType<number>`
+// were rejected at the reference rather than reduced to `never` through the Else branch. Writing
+// the bound is not the obstacle. `resolveTypeParams` resolves a `<F: …>` clause into an upper bound
+// on the parameter's var, and `type ReturnType<F: fn () -> never> = …` parses and lowers today.
+//
+// The obstacle is that nothing consults that bound. `expandAlias` instantiates through
+// `newTypeSubst`, which replaces each parameter with its argument and never constrains the argument
+// against the parameter's var, so `type Box<T: string> = {v: T}` accepts `Box<number>` with no
+// diagnostic. A generic *function* does enforce its bound, because the call site constrains each
+// argument against the instantiated var, which is why `fn f<A: string>(a: A)` rejects `f(5)` with
+// `cannot constrain 5 <: string`.
+//
+// A second obstacle is specific to this bound. A function type's return is covariant, so the bound
+// that admits every function has to be `fn () -> unknown`, and `unknown` has no annotation surface.
+// A bound written `fn () -> never` instead says `F` returns `never`, which is not what it looks
+// like it says.
+//
+// The expected message below assumes the check reports through `constrain`, matching the generic
+// function case. An implementation that reports at the reference instead would word it differently.
+func TestUtilityTypeAliasParameterConstraint(t *testing.T) {
+	/*
+		tests := []struct {
+			name    string
+			src     string
+			wantErr string // "" ⇒ expect no error
+		}{
+			{
+				// The bound admits every function, so a function argument passes.
+				name: "FunctionArgumentPasses",
+				src:  `type Result = ReturnType<fn () -> string>`,
+			},
+			{
+				// A non-function is rejected at the reference rather than reduced through Else.
+				name:    "NonFunctionArgumentRejected",
+				src:     `type Result = ReturnType<number>`,
+				wantErr: "cannot constrain number <: fn () -> unknown",
+			},
+			{
+				// The same gap on the simplest possible alias, so a failure here is about the
+				// bound check rather than about anything the operator track added.
+				name:    "BoundOnPlainAlias",
+				src:     `type Box<T: string> = {v: T}` + "\n" + `type Result = Box<number>`,
+				wantErr: "cannot constrain number <: string",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, _, errs := inferSource(t, utilityTypeDecls+tt.src)
+				if tt.wantErr == "" {
+					require.Empty(t, errs)
+					return
+				}
+				require.Len(t, errs, 1)
+				require.Equal(t, tt.wantErr, errs[0].Message())
+			})
+		}
+	*/
 }
 
 // DISABLED until M9 PR16, which gives `null` and `undefined` a surface. `soltype.NullType` and

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -587,8 +587,8 @@ func TestUtilityTypeReturnTypeIsAritySpecific(t *testing.T) {
 	})
 }
 
-// DISABLED until alias instantiation checks its arguments against its parameters' bounds. No
-// milestone owns that yet.
+// DISABLED until alias instantiation checks its arguments against its parameters' bounds, tracked
+// as escalier-lang/escalier#955.
 //
 // `ReturnType<F>` would read better with `F` bounded to a function type, so `ReturnType<number>`
 // were rejected at the reference rather than reduced to `never` through the Else branch. Writing

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -612,12 +612,27 @@ func TestUtilityTypeNonNullable(t *testing.T) {
 	*/
 }
 
-// DISABLED until M7.5. `Parameters<F>` binds one `infer` name to a function's whole parameter list,
-// which needs a rest parameter in the pattern. `resolveFuncTypeAnn` reports `Unsupported: rest
-// parameter in function type annotation` and recovers the parameter to a positional one, because
-// checking a rest parameter's trailing arguments needs `Array<T>` and M7.5 is where the real
-// `Array` lands. `ConstructorParameters<C>` waits on that plus a `new (…)` member in an object
-// type annotation, which `objTypeAnnElemInner` does not parse.
+// DISABLED until a rest parameter can be written in a function type annotation and an `infer`
+// clause in that position captures a tuple. Two separate pieces are missing.
+//
+// The annotation surface is the first. `resolveFuncTypeAnn` reports `Unsupported: rest parameter in
+// function type annotation` and recovers the parameter to a positional one, because `acceptSet` and
+// `hasRest` assume a rest parameter is last and the parser does not enforce that.
+//
+// The capture rule is the second, and lifting the rejection does not supply it. `Parameters<F>`
+// binds one `infer` name to the whole parameter list, so matching `fn (x: number, y: string) ->
+// boolean` has to gather both parameters into `[number, string]`. constrain's function arm walks
+// only the positions the two sides share and never collects the surplus ones, so the capture would
+// come out as a variable bounded by `number` rather than as a tuple. TypeScript reaches the tuple
+// through a variadic-tuple inference rule that has no counterpart here.
+//
+// The `Array<T>` that M7.5 lands is a different concern. It supplies the element type a typed rest
+// parameter checks its trailing *arguments* against at a call site, which is the deferral recorded
+// on `FuncParam.Rest` in internal/soltype/type.go. A pattern match over a written function type
+// reads no element type, so it needs no `Array`.
+//
+// `ConstructorParameters<C>` waits on both pieces plus a `new (…)` member in an object type
+// annotation, which `objTypeAnnElemInner` does not parse.
 //
 // Both also need the arity decision TestUtilityTypeReturnTypeIsAritySpecific describes, since a
 // rest parameter in the pattern widens its accept-set the same way the inexact marker does.

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -28,15 +28,12 @@ import (
 // `Omit<T, Ks>` reads `Exclude`, so the two definitions are coupled. Order in this source does not
 // matter, since the dependency graph orders the declarations.
 //
-// `ReturnType<F>` bounds `F` to `fn () -> unknown`, so an argument that is not a nullary function
-// is rejected at the reference. `unknown` is the top of the lattice and a function type's return is
-// covariant, so that bound admits every nullary function and no other type. The bound is enforced,
-// which TestUtilityTypeAliasParameterConstraint pins directly.
-//
-// Nullary is not a choice; it is the arity the pattern can match.
-// TestUtilityTypeReturnTypeIsAritySpecific records why the arity-agnostic TypeScript definition has
-// no Escalier equivalent, and the bound turns what was a silent reduction to `never` for every
-// other arity into a diagnostic.
+// `ReturnType<F>` carries no bound on `F`, so an argument that is not a nullary function reduces
+// through the Else branch to `never` rather than being rejected. A bound would read better, and
+// alias bounds are enforced since #956, but no writable bound admits every function: a function
+// type's return is covariant, so the bound has to be `fn () -> unknown`, and that pins the arity to
+// nullary alongside it. M9 PR14 settles what the bound becomes once the pattern matches any arity.
+// TestUtilityTypeReturnTypeIsAritySpecific records the arity restriction itself.
 //
 // `NonNullable<T>`, `Parameters<F>`, `ConstructorParameters<C>`, and `InstanceType<C>` are the
 // four utilities the suite cannot express yet. Each has a disabled test at the end of this file
@@ -54,7 +51,7 @@ const utilityTypeDecls = `
 	type Record<Ks, V> = {[K: Ks]: V}
 	type Exclude<U, V> = if U : V { never } else { U }
 	type Extract<U, V> = if U : V { U } else { never }
-	type ReturnType<F: fn () -> unknown> = if F : fn () -> infer R { R } else { never }
+	type ReturnType<F> = if F : fn () -> infer R { R } else { never }
 	type Awaited<T> = if T : Promise<infer U> { Awaited<U> } else { T }
 	type EventName<K> = ` + "`on${Capitalize<K>}`" + `
 	type Point = {x: number, y: string}
@@ -255,8 +252,14 @@ func TestUtilityTypeReductions(t *testing.T) {
 			src:          `type Result = ReturnType<fn () -> string>`,
 			wantExpanded: "string",
 		},
-		// A non-function argument is rejected by the bound rather than reduced, so it lives in
-		// TestUtilityTypeAliasParameterConstraint with the other rejections.
+		{
+			// A non-function argument matches no function pattern, so the conditional selects Else.
+			// TypeScript rejects the same reference, because its `ReturnType` constrains `T` to a
+			// function type. M9 PR14 settles the bound that would do the same here.
+			name:         "ReturnTypeOfNonFunction",
+			src:          `type Result = ReturnType<number>`,
+			wantExpanded: "never",
+		},
 		// `Awaited<T>` strips every layer of `Promise`, recursing on its own capture.
 		{
 			name:         "Awaited",
@@ -549,7 +552,7 @@ func TestUtilityTypeStaysSymbolicOverTypeParameter(t *testing.T) {
 
 // TypeScript writes `ReturnType<F>` as `F extends (...args: any) => infer R ? R : never`, one
 // definition that reads the return off a function of any arity. Escalier has no equivalent, so
-// `ReturnType<F>` above matches a nullary function and rejects every other arity at the bound.
+// `ReturnType<F>` above matches a nullary function and reduces to `never` for every other arity.
 //
 // The blocker is the accept-set rule, which constrain uses to decide function subtyping. A
 // function type's accept-set is the range of argument counts it tolerates, and `sub <: super`
@@ -570,6 +573,13 @@ func TestUtilityTypeReturnTypeIsAritySpecific(t *testing.T) {
 			wantExpanded: "string",
 		},
 		{
+			// One parameter, so the accept-sets are [1, 1] against [0, 0] and the pattern does not
+			// match. TypeScript reduces this to `string`.
+			name:         "UnaryDoesNotMatch",
+			src:          `type Result = ReturnType<fn (x: number) -> string>`,
+			wantExpanded: "never",
+		},
+		{
 			// A pattern written for the argument's arity does match, so the `infer` capture itself
 			// is not what is missing. The parameter position is `never` because parameters are
 			// contravariant, so the bottom type is the one every argument type accepts.
@@ -581,23 +591,12 @@ func TestUtilityTypeReturnTypeIsAritySpecific(t *testing.T) {
 			wantExpanded: "string",
 		},
 	})
-
-	// A one-parameter argument is where the restriction bites. Its accept-set is [1, 1] against the
-	// bound's [0, 0], so the bound rejects it and the diagnostic names the two arities. TypeScript
-	// reduces the same reference to `string`.
-	_, _, errs := inferSource(t, utilityTypeDecls+`type Result = ReturnType<fn (x: number) -> string>`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain function of arity 1 <: function of arity 0", errs[0].Message())
 }
 
-// A bound on an alias's type parameter is checked at the reference, so `ReturnType<F>` rejects an
-// argument that is not a nullary function instead of reducing it through the Else branch. The last
-// two cases pin the same check on the simplest alias that can carry a bound, so a failure there is
-// about the check rather than about anything the operator track added.
-//
-// The bound is written `fn () -> unknown` because a function type's return is covariant, so only
-// the top of the lattice admits every nullary function. A bound written `fn () -> never` would
-// instead say `F` returns `never` and would reject `fn () -> string`.
+// A bound on an alias's type parameter is checked at the reference, so an argument that fails it is
+// rejected there rather than substituted into the body. These cases pin that on the simplest alias
+// that can carry a bound, since the corpus itself carries none — see `ReturnType<F>` in
+// utilityTypeDecls for why.
 func TestUtilityTypeAliasParameterConstraint(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -605,30 +604,11 @@ func TestUtilityTypeAliasParameterConstraint(t *testing.T) {
 		wantErr string // "" ⇒ expect no error
 	}{
 		{
-			// The bound admits every nullary function, whatever it returns.
-			name: "FunctionArgumentPasses",
-			src:  `type Result = ReturnType<fn () -> string>`,
-		},
-		{
-			// A structural return is still a return, so the bound is about the shape of `F` alone.
-			name: "ObjectReturningFunctionPasses",
-			src:  `type Result = ReturnType<fn () -> {a: number}>`,
-		},
-		{
-			// A non-function is rejected at the reference. The message names `function` rather than
-			// the written bound, since that is how the mismatch renders once the argument is not a
-			// function at all.
-			name:    "NonFunctionArgumentRejected",
-			src:     `type Result = ReturnType<number>`,
-			wantErr: "cannot constrain number <: function",
-		},
-		{
-			// The bound admits every type at the simplest alias that can carry one.
-			name: "PlainAliasAcceptsBoundedArgument",
+			name: "AcceptsBoundedArgument",
 			src:  `type Box<T: string> = {v: T}` + "\n" + `type Result = Box<"a">`,
 		},
 		{
-			name:    "PlainAliasRejectsUnboundedArgument",
+			name:    "RejectsUnboundedArgument",
 			src:     `type Box<T: string> = {v: T}` + "\n" + `type Result = Box<number>`,
 			wantErr: "cannot constrain number <: string",
 		},

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -133,21 +133,23 @@ spike work rather than inventing it:
 
 ## PR-by-PR breakdown
 
-Twenty PRs across five tracks. Track A builds the evaluator and the core
+Twenty-one PRs across five tracks. Track A builds the evaluator and the core
 operators in dependency order. Track B adds spread and template-literal
 operators, which hang off the backbone but are independent of each other. Track C
 adds exactness propagation and the recursion static-check. Track D is the two
 function-signature effects, which touch `FuncType` and not the evaluator at all,
-so it runs fully in parallel with A–C. Track E is the capstone verification.
+so it runs fully in parallel with A–C. Track E is the capstone verification and the
+one follow-on it turned up.
 
 The two heaviest concerns — the evaluator backbone and the conditional/`infer`
 matcher — are each split in two so no single PR carries both a new representation
 and a new algorithm: PR1a/PR1b and PR3a/PR3b below.
 
-Sixteen of the twenty were planned up front. PR9c through PR9f were added to Track C
+Sixteen of the twenty-one were planned up front. PR9c through PR9f were added to Track C
 after PR9b's review, which turned up one soundness question, one wrong answer, and one
 representation the milestone assumed exists. They are described together in "the
-recursion-safety follow-on group" below.
+recursion-safety follow-on group" below. PR14 was added to Track E after PR13, which
+found `Parameters<F>` inexpressible and identified what it waits on.
 
 ### PR1a — Residual-node representation + inert plumbing
 
@@ -779,14 +781,8 @@ them expressible at all under import-only resolution.
   resolves. `soltype`'s literal set carries no `NullLit` or `UndefinedLit`, an extension
   owed from M2, so `resolveLitTypeAnn` reports both as unsupported.
 - `Parameters<F>` binds one `infer` name to a whole parameter list, which the pattern
-  writes as a rest parameter. `resolveFuncTypeAnn` reports a rest parameter unsupported,
-  because `acceptSet` and `hasRest` assume it is last and the parser does not enforce that.
-  Lifting the rejection is not enough on its own. The match must gather the argument's
-  parameters into a tuple, and constrain's function arm walks only the positions the two
-  sides share. TypeScript reaches the tuple through a variadic-tuple inference rule with no
-  counterpart here. The `Array<T>` M7.5 lands is a different concern — it supplies the
-  element type a rest parameter checks its trailing *arguments* against at a call site, and
-  a pattern match over a written function type reads no element type.
+  writes as a rest parameter. Neither the annotation surface nor the tuple capture exists.
+  PR14 below covers both.
 - `ConstructorParameters<C>` and `InstanceType<C>` match a `new (…)` member, which
   `objTypeAnnElemInner` does not parse. The printer already renders the form on a class's
   static side, so the gap is the annotation surface rather than the representation.
@@ -797,11 +793,108 @@ super` by containment over the argument counts each side tolerates, and two exac
 types have single-point accept-sets, so containment forces equal arity. Widening the pattern
 does not help, because a rest parameter or the inexact `fn (...)` marker lifts its upper
 bound to infinity, which a fixed-arity argument then fails to contain. So the arity-agnostic
-definition needs a decision about how a conditional's `Check <: Extends` probe treats arity,
-beyond the rest-parameter surface M7.5 adds.
+definition needs a decision about how a conditional's `Check <: Extends` probe treats arity.
+PR14 makes that decision and unlocks both utilities together.
 
 **Depends on** PR2, PR3b, PR4, PR7, PR12. Verifies the whole operator suite
 composes.
+
+### PR14 — Rest parameters in function type annotations + `Parameters<F>` / `ReturnType<F>`
+
+PR13 left `Parameters<F>` disabled and `ReturnType<F>` matching one arity. Both wait
+on the same three pieces, so this PR lands them together. None of the three is the
+`Array<T>` M7.5 lands. That `Array<T>` supplies the element type a typed rest
+parameter checks its trailing *arguments* against at a call site, which is the
+deferral recorded on `FuncParam.Rest`
+([soltype/type.go:191-193](../../internal/soltype/type.go)). A pattern match over a
+written function type reads no element type, so no definition of `Array` — minimal,
+full, or opaque — moves this PR forward.
+
+**Data structures.** No new node. `soltype.FuncParam.Rest` already exists and is
+already plumbed end to end: the visitor carries it through a rewrite
+([soltype/visitor.go](../../internal/soltype/visitor.go)), `equalType` compares it
+([coalesce.go:1245](../../internal/solver/coalesce.go)), the canonical ordering ranks
+it ([lattice.go:473](../../internal/solver/lattice.go)), and the printer renders
+`...xs: T` ([soltype/print.go:1043](../../internal/soltype/print.go)). Nothing sets
+it. This PR is its first producer. A tuple-typed rest parameter reuses `TupleType`.
+
+**Algorithms.**
+
+1. **The annotation surface.** `resolveFuncTypeAnn`
+   ([type_ann.go:721-725](../../internal/solver/type_ann.go)) reports a `RestPat`
+   unsupported and recovers it to a positional parameter, because `acceptSet` and
+   `hasRest` assume a rest parameter is last and the parser does not enforce that.
+   Enforce it at resolution instead. A `RestPat` in the final position sets `Rest`,
+   and one written anywhere else reports a full-message error. The parameter keeps
+   the inner `IdentPat`, so `mirrorParamPat` needs no new arm and the printer's
+   existing `Rest` case renders the round trip.
+2. **A tuple in the rest parameter's type slot.** The note on `FuncParam.Rest` reads
+   `...xs: T[]`, an array. TypeScript's `Parameters` works because a rest parameter
+   may instead be tuple-typed, and that is what lets `infer P` bind a tuple. Give
+   each shape its own arity contribution. An array-typed rest binds zero or more
+   arguments, so it adds nothing to the accept-set floor and lifts the ceiling to ∞,
+   which is what `acceptSet` does today. A tuple-typed rest binds exactly its length,
+   so it adds that length to both ends, and an inexact tuple lifts the ceiling to ∞
+   again. Only the tuple branch is exercisable in this PR, since writing an
+   array-typed rest parameter needs the `Array<T>` M7.5 supplies. The array branch is
+   the existing behavior, kept and given a name.
+3. **The gather rule in `constrain`'s function arm.** The arm pairs the positions the
+   two sides share and never collects the surplus ones, so an `infer` variable in a
+   rest slot captures the first parameter's type rather than a tuple. Let `k` be the
+   super's rest index. Pair positions `[0, k)` contravariantly as today, build a
+   `TupleType` from `sub.Params[k:]`, and constrain the rest parameter's type against
+   it in the same contravariant orientation. The trial then records that tuple as an
+   upper bound on the `infer` variable, and `capturedBound`
+   ([probe.go:387](../../internal/solver/probe.go)) returns the meet of the uppers,
+   which is the tuple itself. A sub with fewer than `k` parameters is the genuine
+   arity failure and still reports one.
+4. **Ordering against the accept-set gate.** The gate rejects the match today. A
+   pattern `fn (...args: P) -> R` has accept-set [0, ∞) and a `fn (x: number) ->
+   string` argument has [1, 1], so both clauses of `loSub <= loSup && hiSub >= hiSup`
+   fail. Once the rest slot's type is a tuple its arity is known, but at the moment
+   the gate runs that type is still an unsolved inference variable. Run the gather
+   first, so the variable is fixed before the gate evaluates. The gather assigns every
+   sub parameter a position, which is what the gate exists to verify, so for this
+   shape it is satisfied by construction. The alternative is to exempt a
+   variable-typed rest slot from the gate outright, which is a smaller change and a
+   weaker invariant.
+
+   The laxity this introduces stays confined to pattern matching, which is what makes
+   it safe. A rest slot holds an unsolved inference variable only inside a
+   `reduceCondInfer` trial. In an ordinary value-level constraint both sides are
+   written types, so a `...args: [number, string]` slot keeps its [2, 2] accept-set
+   and still rejects a one-parameter function. TypeScript reaches the same place by
+   being lax everywhere. This keeps the strict rule for values and relaxes only the
+   match.
+
+**Open detail.** A surplus *optional* parameter has no faithful tuple counterpart —
+`TupleType.Elems` is a plain `[]Type` with no per-element optionality. Decide between
+widening such an element with `undefined` and rejecting the match, and record which.
+
+**Wiring.** Re-enable `TestUtilityTypeParameters`'s `Parameters<F>` cases in
+[utility_types_test.go](../../internal/solver/utility_types_test.go) and move the
+definition into `utilityTypeDecls`. Rewrite `ReturnType<F>` there to the
+arity-agnostic `if F : fn (...args: infer P) -> infer R { R } else { never }`, and
+replace `TestUtilityTypeReturnTypeIsAritySpecific` with the cases it currently
+records as not reducing.
+
+**Accept.** `Parameters<fn (x: number, y: string) -> boolean>` ⇒ `[number, string]`;
+`Parameters<fn () -> boolean>` ⇒ `[]`; `Parameters<number>` ⇒ `never`.
+`ReturnType<fn (x: number) -> string>` ⇒ `string`, matching TypeScript, and the same
+for every other arity. A rest parameter written anywhere but last reports a
+full-message error. A function type carrying one round-trips through the printer as
+`fn (...xs: T) -> R`. A value-level `fn (x: number) -> string` is still rejected
+against a `fn (...args: [number, string]) -> string` slot, so the relaxation reaches
+only the match.
+
+**Out of scope.** Rest parameters in a function *declaration*, which `bindPat`
+reports unsupported ([pattern.go:240-244](../../internal/solver/pattern.go)) and
+which pulls in the value-level element checking M7.5 owns. `ConstructorParameters<C>`
+needs all of the above plus a `new (…)` member in an object type annotation, which
+`objTypeAnnElemInner` does not parse, so it stays disabled here.
+
+**Depends on** PR3b for the `infer` matcher the capture runs through, and PR13 for
+the corpus and the disabled test it re-enables. Independent of PR4–PR12.
 
 ---
 
@@ -841,6 +934,12 @@ PR1a's inert-plumbing cost is its floor rather than its estimate. PR9f is a grap
 algorithm in one new file, sized like PR4, and it is the one PR here worth deferring
 until a real library type motivates it.
 
+PR14 sits below the M4/M6 band on volume and above it on care. The representation is
+already built and plumbed, so the diff is one resolver arm, one `acceptSet` refinement,
+and one gather in `constrain`'s function arm. What makes it worth its own PR is that
+the gather changes how the hottest arm in the package pairs positions, and the arity
+ordering it forces is a semantic decision rather than a mechanical one.
+
 ## Dependency graph
 
 A PR marked ✅ has merged, and the number after it is the merged pull request. An
@@ -874,6 +973,7 @@ PR10 (throws clause)                       ── needs M3 only; parallel to eve
  └─► PR11 (generators)                     ── also needs M7.5 (+PR3b/PR12 for the async-gen accept case)
 
 PR13 (TS utility-type suite)               ── needs PR2, PR3b, PR4, PR7, PR12
+ └─► PR14 (rest params in fn type anns + Parameters<F>)  ── also needs PR3b
 ```
 
 PR9b replaced PR9's regularity condition with the productivity condition, so PR9's
@@ -883,7 +983,7 @@ to intersect the members' key sets, and #937 capped total alias expansion with a
 monotonic budget. #938 added the `{[K: Keys]: Value}` index-signature shorthand to
 PR4's mapped types.
 
-Everything still open is PR8, PR9d, PR9f, PR10, PR11, and PR13. PR8 is partly
+Everything still open is PR8, PR9d, PR9f, PR10, PR11, PR13, and PR14. PR8 is partly
 seeded — #922 threads an object's exactness through `keyof` — but the rest of the
 operators and the `Exact` / `Inexact` intrinsics are untouched.
 
@@ -916,6 +1016,7 @@ graph TD
     PR11["PR11 (generators)"]
     PR12["PR12 ✅ #952 (Awaited<T>)"]
     PR13["PR13 (TS utility-type suite)"]
+    PR14["PR14 (rest params in fn type anns + Parameters<F>)"]
 
     M7 -.-> PR1a
     M75 -.-> PR11
@@ -952,6 +1053,8 @@ graph TD
     PR10 --> PR11
     PR11 --> PR13
     PR12 --> PR13
+    PR13 --> PR14
+    PR3b --> PR14
 
     linkStyle default stroke:#888
     style PR1a fill:#e06666,stroke:#2e7d32,stroke-width:4px,color:#fff
@@ -987,8 +1090,10 @@ graph TD
   and only if a real library type needs it.
 - **Track D** — PR10 (throws) has no operator dependency and can start on day one
   alongside PR1a; PR11 (generators) follows PR10.
-- **Track E** — PR13 is the final join, waiting on PR2, PR3b, PR4, PR7, PR12.
+- **Track E** — PR13 is the final join, waiting on PR2, PR3b, PR4, PR7, PR12. PR14
+  follows it and is the milestone's last PR, since it is the one gap PR13 found that
+  the operator track can close on its own.
 
 The critical path is `M7 → PR1a → PR1b → PR3a → PR3b → PR4 → PR8`, and — for the
-async-generator accept case — `M7 → PR1a → PR1b → PR3b → PR12 → PR13`. The follow-on
-group sits off both: nothing in PR1a–PR13 waits on PR9c–PR9f.
+async-generator accept case — `M7 → PR1a → PR1b → PR3b → PR12 → PR13 → PR14`. The
+follow-on group sits off both: nothing in PR1a–PR14 waits on PR9c–PR9f.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -772,6 +772,28 @@ corpus *and* the source of those shipped declarations; the operators PR1b–PR12
 land are what make them reduce. So M9 does not just verify the utilities, it makes
 them expressible at all under import-only resolution.
 
+**Four utilities the landed operators cannot express.** Each has a disabled test in
+[utility_types_test.go](../../internal/solver/utility_types_test.go) naming its blocker.
+
+- `NonNullable<T>` tests its argument against `null | undefined`, and neither spelling
+  resolves. `soltype`'s literal set carries no `NullLit` or `UndefinedLit`, an extension
+  owed from M2, so `resolveLitTypeAnn` reports both as unsupported.
+- `Parameters<F>` binds one `infer` name to a whole parameter list, which the pattern
+  writes as a rest parameter. `resolveFuncTypeAnn` reports a rest parameter unsupported,
+  since checking its trailing arguments needs the real `Array<T>` from M7.5.
+- `ConstructorParameters<C>` and `InstanceType<C>` match a `new (…)` member, which
+  `objTypeAnnElemInner` does not parse. The printer already renders the form on a class's
+  static side, so the gap is the annotation surface rather than the representation.
+
+**`ReturnType<F>` reduces for one arity at a time.** TypeScript's definition matches a
+function of any arity through a rest parameter. Escalier's accept-set rule decides `sub <:
+super` by containment over the argument counts each side tolerates, and two exact function
+types have single-point accept-sets, so containment forces equal arity. Widening the pattern
+does not help, because a rest parameter or the inexact `fn (...)` marker lifts its upper
+bound to infinity, which a fixed-arity argument then fails to contain. So the arity-agnostic
+definition needs a decision about how a conditional's `Check <: Extends` probe treats arity,
+beyond the rest-parameter surface M7.5 adds.
+
 **Depends on** PR2, PR3b, PR4, PR7, PR12. Verifies the whole operator suite
 composes.
 
@@ -831,7 +853,7 @@ PR1a ✅ #914 (residual-node representation + inert plumbing)
       │         ├─► PR9 ✅ #940 (CheckRegular)      ── also needs PR1b
       │         │    └─► PR9b ✅ #941 (productivity check + coinductive comparison)
       │         │         └─► PR9d (phantom type-parameter erasure)
-      │         └─► PR12 (Awaited<T>)              ── also needs PR1b, M7.5
+      │         └─► PR12 ✅ #952 (Awaited<T>)       ── also needs PR1b, M7.5
       ├─► PR5 ✅ #920 (object spread types)
       ├─► PR6 ✅ #918 (tuple spread types)
       ├─► PR7 ✅ #924 (template literal types + intrinsics)
@@ -855,7 +877,7 @@ to intersect the members' key sets, and #937 capped total alias expansion with a
 monotonic budget. #938 added the `{[K: Keys]: Value}` index-signature shorthand to
 PR4's mapped types.
 
-Everything still open is PR8, PR9d, PR9f, PR10, PR11, PR12, and PR13. PR8 is partly
+Everything still open is PR8, PR9d, PR9f, PR10, PR11, and PR13. PR8 is partly
 seeded — #922 threads an object's exactness through `keyof` — but the rest of the
 operators and the `Exact` / `Inexact` intrinsics are untouched.
 
@@ -886,7 +908,7 @@ graph TD
     M3["M3 (let-generalization + coalescing)"]
     PR10["PR10 (throws clause)"]
     PR11["PR11 (generators)"]
-    PR12["PR12 (Awaited<T>)"]
+    PR12["PR12 ✅ #952 (Awaited<T>)"]
     PR13["PR13 (TS utility-type suite)"]
 
     M7 -.-> PR1a
@@ -940,6 +962,7 @@ graph TD
     style PR9b stroke:#2e7d32,stroke-width:4px
     style PR9c stroke:#2e7d32,stroke-width:4px
     style PR9e stroke:#2e7d32,stroke-width:4px
+    style PR12 stroke:#2e7d32,stroke-width:4px
 ```
 
 ### Parallelism

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -133,7 +133,7 @@ spike work rather than inventing it:
 
 ## PR-by-PR breakdown
 
-Twenty-one PRs across five tracks. Track A builds the evaluator and the core
+Twenty-two PRs across five tracks. Track A builds the evaluator and the core
 operators in dependency order. Track B adds spread and template-literal
 operators, which hang off the backbone but are independent of each other. Track C
 adds exactness propagation and the recursion static-check. Track D is the two
@@ -145,11 +145,11 @@ The two heaviest concerns — the evaluator backbone and the conditional/`infer`
 matcher — are each split in two so no single PR carries both a new representation
 and a new algorithm: PR1a/PR1b and PR3a/PR3b below.
 
-Sixteen of the twenty-one were planned up front. PR9c through PR9f were added to Track C
+Sixteen of the twenty-two were planned up front. PR9c through PR9f were added to Track C
 after PR9b's review, which turned up one soundness question, one wrong answer, and one
 representation the milestone assumed exists. They are described together in "the
-recursion-safety follow-on group" below. PR14 was added to Track E after PR13, which
-found `Parameters<F>` inexpressible and identified what it waits on.
+recursion-safety follow-on group" below. PR14 and PR15 were added to Track E after PR13,
+which found four utilities inexpressible and identified what each waits on.
 
 ### PR1a — Residual-node representation + inert plumbing
 
@@ -785,7 +785,8 @@ them expressible at all under import-only resolution.
   PR14 below covers both.
 - `ConstructorParameters<C>` and `InstanceType<C>` match a `new (…)` member, which
   `objTypeAnnElemInner` does not parse. The printer already renders the form on a class's
-  static side, so the gap is the annotation surface rather than the representation.
+  static side, so the gap is the annotation surface rather than the representation. PR15
+  below covers it.
 
 **`ReturnType<F>` reduces for one arity at a time.** TypeScript's definition matches a
 function of any arity through a rest parameter. Escalier's accept-set rule decides `sub <:
@@ -890,11 +891,97 @@ only the match.
 **Out of scope.** Rest parameters in a function *declaration*, which `bindPat`
 reports unsupported ([pattern.go:240-244](../../internal/solver/pattern.go)) and
 which pulls in the value-level element checking M7.5 owns. `ConstructorParameters<C>`
-needs all of the above plus a `new (…)` member in an object type annotation, which
-`objTypeAnnElemInner` does not parse, so it stays disabled here.
+needs all of the above plus the `new (…)` member PR15 adds, so it stays disabled here.
 
 **Depends on** PR3b for the `infer` matcher the capture runs through, and PR13 for
 the corpus and the disabled test it re-enables. Independent of PR4–PR12.
+
+### PR15 — `new (…)` members in object type annotations + `ConstructorParameters<C>` / `InstanceType<C>`
+
+The last two utilities PR13 disabled. Both match a constructor signature, and every
+layer but two already carries one, so this PR is mostly connecting parts that exist.
+
+**Data structures.** No new node in either `ast` or `soltype`.
+
+- `ast.ConstructorTypeAnn{Fn *FuncTypeAnn}` is already an `ObjTypeAnnElem`
+  ([ast/type_ann.go:219](../../internal/ast/type_ann.go)). The `.d.ts` interop bridge
+  builds one ([interop/helper.go:176](../../internal/interop/helper.go)), the AST
+  printer renders it ([printer/printer.go:1312](../../internal/printer/printer.go)),
+  and the old checker resolves it
+  ([checker/infer_type_ann.go:402](../../internal/checker/infer_type_ann.go)). The
+  parser is the only layer that never produces one.
+- `soltype.ConstructorElem{Fn *FuncType}` exists
+  ([soltype/type.go:335](../../internal/soltype/type.go)) and is plumbed end to end:
+  `ObjectType.Constructor()` looks one up, the printer renders `new (params) -> ret`
+  ([soltype/print.go:945](../../internal/soltype/print.go)), `equalType` compares it
+  ([coalesce.go:1479](../../internal/solver/coalesce.go)), and `constrain` already
+  checks one as a super requirement
+  ([constrain.go:779](../../internal/solver/constrain.go)). Class inference is its
+  only producer ([infer_class.go:157](../../internal/solver/infer_class.go)).
+
+**Algorithms.**
+
+1. **Parse the member.** `objTypeAnnElemInner`
+   ([parser/type_ann.go:804](../../internal/parser/type_ann.go)) has no `new` arm, so
+   `{new (x: number) -> T}` fails with `Expected a property name`. `new` is already a
+   keyword token ([parser/lexer.go:79](../../internal/parser/lexer.go)). Add the arm
+   ahead of the `objExprKey` call and parse the signature through the existing
+   function-type-annotation path, so type parameters and the `-> R` return need no new
+   parsing.
+2. **Resolve it.** `resolveObjectTypeAnn`
+   ([type_ann.go](../../internal/solver/type_ann.go)) reports every member that is not
+   a property, spread, or mapped type as `object type member other than a property or
+   spread`. Add a `*ast.ConstructorTypeAnn` arm on both of its paths that lowers the
+   signature through `resolveFuncTypeAnn` and emits a `ConstructorElem`. The
+   residual-free path routes members through `newObjElemBuilder`, which dedups by
+   name, and a `ConstructorElem` is unnamed, so it is appended outside the builder. A
+   second `new` signature in one annotation reports a full-message error, since
+   `ObjectType.Constructor()` returns exactly one.
+3. **Decide how a statics-free class value matches.** `classValue`
+   ([infer_class.go:145-159](../../internal/solver/infer_class.go)) binds a class with
+   no static members to its bare constructor `FuncType` and one with statics to an
+   object carrying a `ConstructorElem`. So `typeof Point` renders `fn (x: number) ->
+   Point` for the first and `{new (x: number) -> Point, origin: number}` for the
+   second, while TypeScript's `InstanceType<typeof C>` matches the `new` form for
+   both. `constrain` checks a constructor requirement only in its object-sub against
+   object-super arm, so the statics-free shape would take the Else branch and reduce
+   to `never`. Two ways out:
+   - Let a constructor-only object super be satisfied by a bare `FuncType` sub, a
+     targeted rule beside the existing `ConstructorElem` arm. Rendering is unchanged
+     and the diff is one arm.
+   - Drop `classValue`'s no-statics shortcut so every class value is an object.
+     Uniform, but it rewrites every rendered class-value type and moves the path a
+     `Point(…)` call resolves through, so it churns snapshots broadly.
+
+   The first is recommended. Record whichever is chosen, because a reader who meets
+   `fn (x: number) -> Point` will otherwise not see why `InstanceType` matches it.
+4. **Check `keyof` over a constructor-carrying object.** `keyofObject`
+   ([typeops.go:1053](../../internal/solver/typeops.go)) projects property, getter, and
+   setter names. A `ConstructorElem` is unnamed, so confirm it is skipped rather than
+   projected as an empty-string key, and pin the case.
+
+**Wiring.** Re-enable `TestUtilityTypeInstanceType` and the `ConstructorParameters<C>`
+cases in `TestUtilityTypeParameters`
+([utility_types_test.go](../../internal/solver/utility_types_test.go)), moving both
+definitions into `utilityTypeDecls`. Add parser and printer round-trip coverage for
+the new member.
+
+**Accept.** `{new (x: number) -> {a: number}}` parses, resolves, and round-trips
+through both printers. `ConstructorParameters<{new (x: number, y: string) -> T}>` ⇒
+`[number, string]`; `InstanceType<{new (x: number) -> {a: number}}>` ⇒ `{a: number}`;
+both over a non-constructor argument ⇒ `never`. `InstanceType<typeof Point>` ⇒ `Point`
+for a class with statics and for one without, which is what step 3 settles. A second
+`new` signature in one annotation reports a full-message error.
+
+**Depends on** PR14 for the rest parameter and the tuple capture
+`ConstructorParameters<C>` binds through, and PR13 for the corpus and the disabled
+tests it re-enables. `InstanceType<C>` needs only steps 1 and 3 when its pattern is
+written at a fixed arity, so that half could land without PR14 if the two are
+sequenced apart.
+
+**Leaves one utility disabled.** After this PR `NonNullable<T>` is the only member of
+the suite still unexpressible, waiting on `null` and `undefined` in `soltype`'s
+literal set.
 
 ---
 
@@ -940,6 +1027,11 @@ and one gather in `constrain`'s function arm. What makes it worth its own PR is 
 the gather changes how the hottest arm in the package pairs positions, and the arity
 ordering it forces is a semantic decision rather than a mechanical one.
 
+PR15 is the smallest PR in Track E and spans the most layers, since the parser, the
+resolver, and `constrain` each need one arm and none of them needs a new node. Its one
+judgment call is how a statics-free class value matches a `new (…)` pattern, and the
+recommended answer keeps the diff to a single arm.
+
 ## Dependency graph
 
 A PR marked ✅ has merged, and the number after it is the merged pull request. An
@@ -974,6 +1066,7 @@ PR10 (throws clause)                       ── needs M3 only; parallel to eve
 
 PR13 (TS utility-type suite)               ── needs PR2, PR3b, PR4, PR7, PR12
  └─► PR14 (rest params in fn type anns + Parameters<F>)  ── also needs PR3b
+      └─► PR15 (new (…) members in obj type anns + ConstructorParameters<C>)
 ```
 
 PR9b replaced PR9's regularity condition with the productivity condition, so PR9's
@@ -983,7 +1076,7 @@ to intersect the members' key sets, and #937 capped total alias expansion with a
 monotonic budget. #938 added the `{[K: Keys]: Value}` index-signature shorthand to
 PR4's mapped types.
 
-Everything still open is PR8, PR9d, PR9f, PR10, PR11, PR13, and PR14. PR8 is partly
+Everything still open is PR8, PR9d, PR9f, PR10, PR11, PR13, PR14, and PR15. PR8 is partly
 seeded — #922 threads an object's exactness through `keyof` — but the rest of the
 operators and the `Exact` / `Inexact` intrinsics are untouched.
 
@@ -1017,6 +1110,7 @@ graph TD
     PR12["PR12 ✅ #952 (Awaited<T>)"]
     PR13["PR13 (TS utility-type suite)"]
     PR14["PR14 (rest params in fn type anns + Parameters<F>)"]
+    PR15["PR15 (new (…) in obj type anns + ConstructorParameters<C>)"]
 
     M7 -.-> PR1a
     M75 -.-> PR11
@@ -1055,6 +1149,7 @@ graph TD
     PR12 --> PR13
     PR13 --> PR14
     PR3b --> PR14
+    PR14 --> PR15
 
     linkStyle default stroke:#888
     style PR1a fill:#e06666,stroke:#2e7d32,stroke-width:4px,color:#fff
@@ -1090,10 +1185,11 @@ graph TD
   and only if a real library type needs it.
 - **Track D** — PR10 (throws) has no operator dependency and can start on day one
   alongside PR1a; PR11 (generators) follows PR10.
-- **Track E** — PR13 is the final join, waiting on PR2, PR3b, PR4, PR7, PR12. PR14
-  follows it and is the milestone's last PR, since it is the one gap PR13 found that
-  the operator track can close on its own.
+- **Track E** — PR13 is the final join, waiting on PR2, PR3b, PR4, PR7, PR12. PR14 and
+  PR15 follow it in that order, closing the gaps PR13 found that the operator track can
+  close on its own. PR15's `InstanceType<C>` half is separable from PR14 and could run
+  alongside it if the two are sequenced apart.
 
 The critical path is `M7 → PR1a → PR1b → PR3a → PR3b → PR4 → PR8`, and — for the
-async-generator accept case — `M7 → PR1a → PR1b → PR3b → PR12 → PR13 → PR14`. The
-follow-on group sits off both: nothing in PR1a–PR14 waits on PR9c–PR9f.
+async-generator accept case — `M7 → PR1a → PR1b → PR3b → PR12 → PR13 → PR14 → PR15`.
+The follow-on group sits off both: nothing in PR1a–PR15 waits on PR9c–PR9f.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -133,7 +133,7 @@ spike work rather than inventing it:
 
 ## PR-by-PR breakdown
 
-Twenty-two PRs across five tracks. Track A builds the evaluator and the core
+Twenty-three PRs across five tracks. Track A builds the evaluator and the core
 operators in dependency order. Track B adds spread and template-literal
 operators, which hang off the backbone but are independent of each other. Track C
 adds exactness propagation and the recursion static-check. Track D is the two
@@ -145,11 +145,11 @@ The two heaviest concerns — the evaluator backbone and the conditional/`infer`
 matcher — are each split in two so no single PR carries both a new representation
 and a new algorithm: PR1a/PR1b and PR3a/PR3b below.
 
-Sixteen of the twenty-two were planned up front. PR9c through PR9f were added to Track C
+Sixteen of the twenty-three were planned up front. PR9c through PR9f were added to Track C
 after PR9b's review, which turned up one soundness question, one wrong answer, and one
 representation the milestone assumed exists. They are described together in "the
-recursion-safety follow-on group" below. PR14 and PR15 were added to Track E after PR13,
-which found four utilities inexpressible and identified what each waits on.
+recursion-safety follow-on group" below. PR14 through PR16 were added to Track E after
+PR13, which found four utilities inexpressible and identified what each waits on.
 
 ### PR1a — Residual-node representation + inert plumbing
 
@@ -778,8 +778,8 @@ them expressible at all under import-only resolution.
 [utility_types_test.go](../../internal/solver/utility_types_test.go) naming its blocker.
 
 - `NonNullable<T>` tests its argument against `null | undefined`, and neither spelling
-  resolves. `soltype`'s literal set carries no `NullLit` or `UndefinedLit`, an extension
-  owed from M2, so `resolveLitTypeAnn` reports both as unsupported.
+  resolves. The two atoms exist in `soltype`, but no annotation reaches them, so
+  `resolveLitTypeAnn` reports both as unsupported. PR16 below covers it.
 - `Parameters<F>` binds one `infer` name to a whole parameter list, which the pattern
   writes as a rest parameter. Neither the annotation surface nor the tuple capture exists.
   PR14 below covers both.
@@ -980,8 +980,97 @@ written at a fixed arity, so that half could land without PR14 if the two are
 sequenced apart.
 
 **Leaves one utility disabled.** After this PR `NonNullable<T>` is the only member of
-the suite still unexpressible, waiting on `null` and `undefined` in `soltype`'s
-literal set.
+the suite still unexpressible. PR16 covers it.
+
+### PR16 — `null` and `undefined` + `NonNullable<T>`
+
+The last utility the suite cannot express, and the one gap that touches neither
+function parameters nor constructor signatures. Both atoms already exist in `soltype`
+and one of them is already inferred. What is missing is the surface that writes them
+down and the `constrain` arm that compares them.
+
+The asymmetry is concrete. Given `val o: {a?: number} = {}`, reading `o.a` infers
+`number | undefined`, because the optional-property arm constrains an
+`UndefinedType` into the read
+([constrain.go:809](../../internal/solver/constrain.go)). No annotation can name that
+type, so the checker infers a type the source cannot write.
+
+**Data structures.** No new node.
+
+- `soltype.NullType` and `soltype.UndefinedType` are atoms already
+  ([soltype/type.go:641](../../internal/soltype/type.go)), with leaf `Accept` arms
+  ([soltype/visitor.go:81-82](../../internal/soltype/visitor.go)), printing
+  ([soltype/print.go:648-650](../../internal/soltype/print.go)), `equalType`
+  ([coalesce.go:1187-1191](../../internal/solver/coalesce.go)), a canonical union
+  order that places them after the data members
+  ([lattice.go:612-648](../../internal/solver/lattice.go)), and error rendering
+  ([errors.go:2131-2133](../../internal/solver/errors.go)).
+- `ast.NullLit` and `ast.UndefinedLit` exist and parse
+  ([ast/expr.go:188-189](../../internal/ast/expr.go)).
+- Neither atom is a member of `soltype.Lit`. Nothing about them routes through
+  `LitType`, which is what makes the surface work below a signature change rather than
+  two new switch cases.
+
+**Algorithms.**
+
+1. **The missing `constrain` arm.** `UndefinedType` has a reflexive arm
+   ([constrain.go:998](../../internal/solver/constrain.go)) and `NullType` has none,
+   so even a hand-built `null <: null` fails. Add the twin. Both stay unrelated to
+   `Void` and to every data type, matching TypeScript under strict null checks, and
+   both reach the top through the existing `_ <: unknown` rule. This arm is what lets
+   `NonNullable<T>`'s probe decide `null <: null | undefined` through the union-super
+   arm.
+2. **The annotation, expression, and pattern surface.** Three sites read `litTypeOf`
+   ([pattern.go:691](../../internal/solver/pattern.go)), which returns a
+   `*soltype.LitType` and covers only number, string, and boolean. `resolveLitTypeAnn`
+   reports `Unsupported: LitTypeAnn` ([type_ann.go:420](../../internal/solver/type_ann.go)),
+   the literal-pattern arm rejects a `null` match arm
+   ([pattern.go:124](../../internal/solver/pattern.go)), and the exhaustiveness
+   comparison cannot match one
+   ([infer_expr.go:2872](../../internal/solver/infer_expr.go)). `inferLiteral` rejects
+   both separately, so `val n = null` reports `Unsupported: NullLit`
+   ([infer_expr.go:20-36](../../internal/solver/infer_expr.go)). Since the two are
+   atoms, `litTypeOf`'s return type does not fit them. Either widen it to
+   `soltype.Type` or add a sibling that returns an atom and have each caller consult
+   both. Either way all four sites gain the two cases together, so writing `null` as a
+   type, as a value, and as a match arm lands as one behavior rather than three.
+3. **The provenance hazard.** `NullType` and `UndefinedType` are empty structs, so Go
+   gives every `&soltype.NullType{}` the same address, and `Prov` is keyed by pointer
+   identity. Recording provenance against one would file every `null` in a module under
+   a single entry, so each would report the last one's span, and the `debugProv` guard
+   would panic on the second. Skip `recordProv` for both, the way the `NeverTypeAnn`
+   arm already does and documents
+   ([type_ann.go:22-32](../../internal/solver/type_ann.go)). This is the one trap here.
+   `resolveLitTypeAnn` records unconditionally today, so the new cases must return
+   before that line rather than fall through it.
+4. **Keep them out of widening.** `widen`
+   ([widen.go:26-36](../../internal/solver/widen.go)) widens a literal to its
+   primitive. `null` and `undefined` are already their own widest form with no
+   primitive above them. Its switch is over `*soltype.LitType`, so an atom falls
+   through untouched. Confirm and pin that rather than assume it.
+5. **`NonNullable<T>`.** Written `if T : null | undefined { never } else { T }`. `T` is
+   a naked type parameter, so the conditional distributes over a union and decides each
+   member alone, which is PR3b machinery. The evaluator needs nothing new.
+
+**Wiring.** Re-enable `TestUtilityTypeNonNullable`
+([utility_types_test.go](../../internal/solver/utility_types_test.go)) and move the
+definition into `utilityTypeDecls`.
+
+**Accept.** `NonNullable<string | null | undefined>` ⇒ `string`;
+`NonNullable<null | undefined>` ⇒ `never`; `NonNullable<string | number>` unchanged.
+`val x: number | undefined = o.a` for `o: {a?: number}` is accepted, closing the gap
+above. `val n: null = null` round-trips, and a `null` match arm binds. A union renders
+in the documented canonical order, which `lattice.go:612-614` describes as
+`T0 | number | null | void | undefined` and which no annotation could write before.
+
+**Out of scope.** Narrowing `null` out of a union through a test such as `if x != null`,
+which is flow-sensitive rather than representational. Optional chaining. Codegen, which
+is M10.
+
+**Depends on** PR3b for the distributive conditional and PR13 for the corpus and the
+disabled test it re-enables. Independent of PR14 and PR15.
+
+**Completes the suite.** With this PR every utility PR13 lists reduces.
 
 ---
 
@@ -1032,6 +1121,12 @@ resolver, and `constrain` each need one arm and none of them needs a new node. I
 judgment call is how a statics-free class value matches a `new (…)` pattern, and the
 recommended answer keeps the diff to a single arm.
 
+PR16 is comparable, and its cost is spread the same way. The atoms and their comparison,
+ordering, and rendering already exist, so the work is one `constrain` arm plus the four
+sites that turn a written `null` into one. What earns it a PR of its own is that those
+sites span the annotation, expression, and pattern walks, and that the shared
+`litTypeOf` they read cannot return an atom as it stands.
+
 ## Dependency graph
 
 A PR marked ✅ has merged, and the number after it is the merged pull request. An
@@ -1065,8 +1160,9 @@ PR10 (throws clause)                       ── needs M3 only; parallel to eve
  └─► PR11 (generators)                     ── also needs M7.5 (+PR3b/PR12 for the async-gen accept case)
 
 PR13 (TS utility-type suite)               ── needs PR2, PR3b, PR4, PR7, PR12
- └─► PR14 (rest params in fn type anns + Parameters<F>)  ── also needs PR3b
-      └─► PR15 (new (…) members in obj type anns + ConstructorParameters<C>)
+ ├─► PR14 (rest params in fn type anns + Parameters<F>)  ── also needs PR3b
+ │    └─► PR15 (new (…) members in obj type anns + ConstructorParameters<C>)
+ └─► PR16 (null + undefined + NonNullable<T>)            ── also needs PR3b
 ```
 
 PR9b replaced PR9's regularity condition with the productivity condition, so PR9's
@@ -1076,7 +1172,7 @@ to intersect the members' key sets, and #937 capped total alias expansion with a
 monotonic budget. #938 added the `{[K: Keys]: Value}` index-signature shorthand to
 PR4's mapped types.
 
-Everything still open is PR8, PR9d, PR9f, PR10, PR11, PR13, PR14, and PR15. PR8 is partly
+Everything still open is PR8, PR9d, PR9f, PR10, PR11, PR13, PR14, PR15, and PR16. PR8 is partly
 seeded — #922 threads an object's exactness through `keyof` — but the rest of the
 operators and the `Exact` / `Inexact` intrinsics are untouched.
 
@@ -1111,6 +1207,7 @@ graph TD
     PR13["PR13 (TS utility-type suite)"]
     PR14["PR14 (rest params in fn type anns + Parameters<F>)"]
     PR15["PR15 (new (…) in obj type anns + ConstructorParameters<C>)"]
+    PR16["PR16 (null + undefined + NonNullable<T>)"]
 
     M7 -.-> PR1a
     M75 -.-> PR11
@@ -1150,6 +1247,8 @@ graph TD
     PR13 --> PR14
     PR3b --> PR14
     PR14 --> PR15
+    PR13 --> PR16
+    PR3b --> PR16
 
     linkStyle default stroke:#888
     style PR1a fill:#e06666,stroke:#2e7d32,stroke-width:4px,color:#fff
@@ -1188,8 +1287,9 @@ graph TD
 - **Track E** — PR13 is the final join, waiting on PR2, PR3b, PR4, PR7, PR12. PR14 and
   PR15 follow it in that order, closing the gaps PR13 found that the operator track can
   close on its own. PR15's `InstanceType<C>` half is separable from PR14 and could run
-  alongside it if the two are sequenced apart.
+  alongside it if the two are sequenced apart. PR16 hangs off PR13 directly and shares
+  nothing with either, so it runs concurrently with both.
 
 The critical path is `M7 → PR1a → PR1b → PR3a → PR3b → PR4 → PR8`, and — for the
 async-generator accept case — `M7 → PR1a → PR1b → PR3b → PR12 → PR13 → PR14 → PR15`.
-The follow-on group sits off both: nothing in PR1a–PR15 waits on PR9c–PR9f.
+The follow-on group sits off both: nothing in PR1a–PR16 waits on PR9c–PR9f.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -788,7 +788,7 @@ them expressible at all under import-only resolution.
   static side, so the gap is the annotation surface rather than the representation. PR15
   below covers it.
 
-**`ReturnType<F>` reduces for one arity at a time.** TypeScript's definition matches a
+**`ReturnType<F>` matches one arity at a time.** TypeScript's definition matches a
 function of any arity through a rest parameter. Escalier's accept-set rule decides `sub <:
 super` by containment over the argument counts each side tolerates, and two exact function
 types have single-point accept-sets, so containment forces equal arity. Widening the pattern
@@ -796,6 +796,12 @@ does not help, because a rest parameter or the inexact `fn (...)` marker lifts i
 bound to infinity, which a fixed-arity argument then fails to contain. So the arity-agnostic
 definition needs a decision about how a conditional's `Check <: Extends` probe treats arity.
 PR14 makes that decision and unlocks both utilities together.
+
+The corpus bounds the parameter, `type ReturnType<F: fn () -> unknown> = …`, so an argument
+of any other shape is rejected at the reference rather than reduced through the Else branch.
+`unknown` is the only bound that admits every nullary function, since a function type's
+return is covariant, and it reaches annotation position through the `UnknownTypeAnn` arm this
+PR adds. Bound enforcement on alias arguments landed in #956.
 
 **Depends on** PR2, PR3b, PR4, PR7, PR12. Verifies the whole operator suite
 composes.
@@ -875,9 +881,9 @@ widening such an element with `undefined` and rejecting the match, and record wh
 **Wiring.** Re-enable `TestUtilityTypeParameters`'s `Parameters<F>` cases in
 [utility_types_test.go](../../internal/solver/utility_types_test.go) and move the
 definition into `utilityTypeDecls`. Rewrite `ReturnType<F>` there to the
-arity-agnostic `if F : fn (...args: infer P) -> infer R { R } else { never }`, and
-replace `TestUtilityTypeReturnTypeIsAritySpecific` with the cases it currently
-records as not reducing.
+arity-agnostic `if F : fn (...args: infer P) -> infer R { R } else { never }`, widen its
+bound from `fn () -> unknown` to whatever shape the arity decision settles on, and replace
+`TestUtilityTypeReturnTypeIsAritySpecific` with the cases it currently records as rejected.
 
 **Accept.** `Parameters<fn (x: number, y: string) -> boolean>` ⇒ `[number, string]`;
 `Parameters<fn () -> boolean>` ⇒ `[]`; `Parameters<number>` ⇒ `never`.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -797,27 +797,30 @@ bound to infinity, which a fixed-arity argument then fails to contain. So the ar
 definition needs a decision about how a conditional's `Check <: Extends` probe treats arity.
 PR14 makes that decision and unlocks both utilities together.
 
-The corpus bounds the parameter, `type ReturnType<F: fn () -> unknown> = …`, so an argument
-of any other shape is rejected at the reference rather than reduced through the Else branch.
-`unknown` is the only bound that admits every nullary function, since a function type's
-return is covariant, and it reaches annotation position through the `UnknownTypeAnn` arm this
-PR adds. Bound enforcement on alias arguments landed in #956.
+The corpus leaves `F` unbounded, so `ReturnType<number>` reduces to `never` where
+TypeScript reports an error. Alias bounds are enforced since #956, so the bound is the only
+missing half, but no writable bound admits every function. A function type's return is
+covariant, so the bound would have to be `fn () -> unknown`, and that pins the arity to
+nullary alongside it. PR14 step 5 adds the `Function` top type the bound needs. This PR does
+add the `UnknownTypeAnn` arm `resolveTypeAnn` was missing, since `unknown` is the lattice top
+and had no annotation surface.
 
 **Depends on** PR2, PR3b, PR4, PR7, PR12. Verifies the whole operator suite
 composes.
 
 ### PR14 — Rest parameters in function type annotations + `Parameters<F>` / `ReturnType<F>`
 
-PR13 left `Parameters<F>` disabled and `ReturnType<F>` matching one arity. Both wait
-on the same three pieces, so this PR lands them together. None of the three is the
-`Array<T>` M7.5 lands. That `Array<T>` supplies the element type a typed rest
+PR13 left `Parameters<F>` disabled and `ReturnType<F>` matching one arity with no bound
+on `F`. Both wait on the same rest-parameter work, so this PR lands them together, plus
+the top type a bound on `F` needs. None of the pieces is the `Array<T>` M7.5 lands. That `Array<T>` supplies the element type a typed rest
 parameter checks its trailing *arguments* against at a call site, which is the
 deferral recorded on `FuncParam.Rest`
 ([soltype/type.go:191-193](../../internal/soltype/type.go)). A pattern match over a
 written function type reads no element type, so no definition of `Array` — minimal,
 full, or opaque — moves this PR forward.
 
-**Data structures.** No new node. `soltype.FuncParam.Rest` already exists and is
+**Data structures.** One new atom, `soltype.FunctionType`, described in step 5. The
+rest-parameter half needs no new node. `soltype.FuncParam.Rest` already exists and is
 already plumbed end to end: the visitor carries it through a rewrite
 ([soltype/visitor.go](../../internal/soltype/visitor.go)), `equalType` compares it
 ([coalesce.go:1245](../../internal/solver/coalesce.go)), the canonical ordering ranks
@@ -874,22 +877,54 @@ it. This PR is its first producer. A tuple-typed rest parameter reuses `TupleTyp
    being lax everywhere. This keeps the strict rule for values and relaxes only the
    match.
 
+5. **A bound that admits every function.** `ReturnType<F>` should reject
+   `ReturnType<number>` at the reference rather than reduce it through the Else branch.
+   TypeScript reports that error, because its `ReturnType` constrains `T` to a function
+   type. Alias bounds are enforced since #956, so the bound itself is the only missing
+   half, and the arity-agnostic pattern makes one harder to find rather than easier.
+
+   Every writable bound pins an arity. `fn () -> unknown` admits only nullary functions,
+   since a function type's return is covariant and `unknown` is the only type above every
+   return. A rest-parameter bound carries the [0, ∞) accept-set that a fixed-arity
+   argument fails to contain. Step 4's relaxation does not rescue either one, because a
+   bound is a real constraint at the reference rather than a `reduceCondInfer` trial.
+
+   Add a `Function` top type, the supertype of every `FuncType`, matching the type
+   TypeScript spells the same way. It names no signature, so it imposes no arity, which
+   makes `F: Function` an ordinary sound constraint. The cost is one `soltype` atom with
+   the usual leaf plumbing, meaning `isType()`, a visitor arm, printing, `equalType`, and
+   canonical ordering, plus one `constrain` arm admitting any `FuncType`. That is PR16's
+   `NullType` shape. It is separable from the rest-parameter work and can land on either
+   side of it.
+
+   Two alternatives were weighed and rejected. Giving an `unknown`-typed rest slot the
+   meaning "any arity" needs no new node, but it is unsound at value level. A binding
+   `val g: fn (...args: unknown) -> string = f` would accept a one-parameter `f`, and a
+   holder of `g` may then call it with none. Confining that shape to bounds and patterns
+   would make it a wart rather than a type. Leaving `ReturnType<F>` unbounded costs
+   nothing and is what the corpus does today, but it forgoes a diagnostic TypeScript
+   reports.
+
 **Open detail.** A surplus *optional* parameter has no faithful tuple counterpart —
 `TupleType.Elems` is a plain `[]Type` with no per-element optionality. Decide between
 widening such an element with `undefined` and rejecting the match, and record which.
 
 **Wiring.** Re-enable `TestUtilityTypeParameters`'s `Parameters<F>` cases in
 [utility_types_test.go](../../internal/solver/utility_types_test.go) and move the
-definition into `utilityTypeDecls`. Rewrite `ReturnType<F>` there to the
-arity-agnostic `if F : fn (...args: infer P) -> infer R { R } else { never }`, widen its
-bound from `fn () -> unknown` to whatever shape the arity decision settles on, and replace
-`TestUtilityTypeReturnTypeIsAritySpecific` with the cases it currently records as rejected.
+definition into `utilityTypeDecls`. Rewrite `ReturnType<F>` there to the arity-agnostic
+`type ReturnType<F: Function> = if F : fn (...args: infer P) -> infer R { R } else { never }`
+and drop `TestUtilityTypeReturnTypeIsAritySpecific`, whose cases all reduce once the
+pattern matches any arity. Move its `ReturnTypeOfNonFunction` case from
+`TestUtilityTypeReductions` to the bound-rejection table, since the bound catches it before
+the Else branch does.
 
 **Accept.** `Parameters<fn (x: number, y: string) -> boolean>` ⇒ `[number, string]`;
-`Parameters<fn () -> boolean>` ⇒ `[]`; `Parameters<number>` ⇒ `never`.
-`ReturnType<fn (x: number) -> string>` ⇒ `string`, matching TypeScript, and the same
-for every other arity. A rest parameter written anywhere but last reports a
-full-message error. A function type carrying one round-trips through the printer as
+`Parameters<fn () -> boolean>` ⇒ `[]`. `ReturnType<fn (x: number) -> string>` ⇒ `string`,
+matching TypeScript, and the same for every other arity. `ReturnType<number>` and
+`Parameters<number>` are each rejected at the reference by the `Function` bound, with a
+full message, rather than reducing to `never`. A `Function` annotation accepts a function
+of any arity and rejects every non-function. A rest parameter written anywhere but last
+reports a full-message error. A function type carrying one round-trips through the printer as
 `fn (...xs: T) -> R`. A value-level `fn (x: number) -> string` is still rejected
 against a `fn (...args: [number, string]) -> string` slot, so the relaxation reaches
 only the match.
@@ -900,7 +935,9 @@ which pulls in the value-level element checking M7.5 owns. `ConstructorParameter
 needs all of the above plus the `new (…)` member PR15 adds, so it stays disabled here.
 
 **Depends on** PR3b for the `infer` matcher the capture runs through, and PR13 for
-the corpus and the disabled test it re-enables. Independent of PR4–PR12.
+the corpus and the disabled test it re-enables. Independent of PR4–PR12. The `Function`
+top type in step 5 depends on nothing here and splits off cleanly if the PR needs
+dividing.
 
 ### PR15 — `new (…)` members in object type annotations + `ConstructorParameters<C>` / `InstanceType<C>`
 
@@ -1116,11 +1153,13 @@ PR1a's inert-plumbing cost is its floor rather than its estimate. PR9f is a grap
 algorithm in one new file, sized like PR4, and it is the one PR here worth deferring
 until a real library type motivates it.
 
-PR14 sits below the M4/M6 band on volume and above it on care. The representation is
-already built and plumbed, so the diff is one resolver arm, one `acceptSet` refinement,
-and one gather in `constrain`'s function arm. What makes it worth its own PR is that
-the gather changes how the hottest arm in the package pairs positions, and the arity
-ordering it forces is a semantic decision rather than a mechanical one.
+PR14 sits below the M4/M6 band on volume and above it on care. The rest-parameter
+representation is already built and plumbed, so that half is one resolver arm, one
+`acceptSet` refinement, and one gather in `constrain`'s function arm. What makes it worth
+its own PR is that the gather changes how the hottest arm in the package pairs positions,
+and the arity ordering it forces is a semantic decision rather than a mechanical one. The
+`Function` top type in step 5 adds one atom with leaf plumbing, and splits off cleanly if
+the PR grows past the band.
 
 PR15 is the smallest PR in Track E and spans the most layers, since the parser, the
 resolver, and `constrain` each need one arm and none of them needs a new node. Its one

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -780,7 +780,13 @@ them expressible at all under import-only resolution.
   owed from M2, so `resolveLitTypeAnn` reports both as unsupported.
 - `Parameters<F>` binds one `infer` name to a whole parameter list, which the pattern
   writes as a rest parameter. `resolveFuncTypeAnn` reports a rest parameter unsupported,
-  since checking its trailing arguments needs the real `Array<T>` from M7.5.
+  because `acceptSet` and `hasRest` assume it is last and the parser does not enforce that.
+  Lifting the rejection is not enough on its own. The match must gather the argument's
+  parameters into a tuple, and constrain's function arm walks only the positions the two
+  sides share. TypeScript reaches the tuple through a variadic-tuple inference rule with no
+  counterpart here. The `Array<T>` M7.5 lands is a different concern — it supplies the
+  element type a rest parameter checks its trailing *arguments* against at a call site, and
+  a pattern match over a written function type reads no element type.
 - `ConstructorParameters<C>` and `InstanceType<C>` match a `new (…)` member, which
   `objTypeAnnElemInner` does not parse. The printer already renders the form on a class's
   static side, so the gap is the annotation surface rather than the representation.


### PR DESCRIPTION
Adds `utility_types_test.go` with end-to-end tests verifying that TypeScript's standard utility types (`Partial`, `Required`, `Readonly`, `Pick`, `Omit`, `Record`, `Exclude`, `Extract`, `ReturnType`, `Awaited`, and the string intrinsics) reduce correctly when expressed in Escalier using the type-level operators from PR1b–PR12.

The test suite covers three reduction paths:
- **Ground reductions**: Each utility applied to concrete types reduces to the expected form, matching TypeScript's behavior.
- **Compositions**: Utilities applied to other utilities compose correctly (e.g., `Partial<Pick<T, Ks>>`).
- **Constraints**: Utilities used as value annotations enforce the reduced type through the constraint system, not the annotation syntax.
- **Symbolic references**: Utilities applied to unfilled type parameters stay symbolic in generic signatures, deferring reduction to call sites.

The suite also documents four utilities that cannot yet be expressed:
- `NonNullable<T>` awaits `null` and `undefined` literals in `soltype`.
- `Parameters<F>` and `ConstructorParameters<C>` await rest parameters in function type annotations (M7.5).
- `InstanceType<C>` awaits `new (…)` members in object type annotations.

Additionally, `ReturnType<F>` is arity-specific in Escalier due to the accept-set rule for function subtyping, unlike TypeScript's arity-agnostic definition. A disabled test documents this limitation and the decision needed to resolve it.

Updates the M9 implementation plan to describe these four blockers and the `ReturnType` arity constraint.

https://claude.ai/code/session_016tTEhTa34dmvevgJ79Hhi6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for TypeScript-style utility types, including mapped, conditional, string, and template-literal utilities.
  - Added validation for utility type composition, constraints, symbolic behavior, and function return-type arity.
  - Documented currently unsupported utility type scenarios through disabled test cases.

- **Documentation**
  - Updated the M9 implementation plan with revised milestones, dependencies, sequencing, and follow-up work for utility type support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->