### PR TITLE
Enforce type parameter bounds on generic alias arguments

### DIFF
--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -231,16 +231,25 @@ type FuncType struct {
 // describe their generics the same way. Var is the quantified inference variable that
 // stands for the parameter. It is minted one level deeper than the enclosing binding
 // and freshened per use by freshenAbove, rather than a named parameter resolved by a
-// substitution pass. The declared constraint is Var's upper bound. `<U extends T>` sets
+// substitution pass. The declared constraint is seeded as Var's upper bound. `<U: T>` sets
 // Var.UpperBounds to [T], so constrain and freshenAbove enforce and copy it with no new
 // machinery. Default is the type filled in when a type argument is omitted. It is nil
 // when the parameter is required. Type-argument resolution reads it, and constraint
 // solving ignores it. Name is the source name kept for display, since TypeVarType
 // carries none.
+//
+// Constraint is that same declared constraint kept where solving cannot overwrite it. A
+// variable's upper-bound list grows whenever a constraint flows into the variable, so
+// Var.UpperBounds[0] is the declared constraint only for a parameter that solving has not
+// touched. `fn g<U>(u: U) { f(u) }` calling `fn f<A: string>(a: A)` appends string to the
+// unbounded U, which puts an inferred bound at index 0. Constraint stays nil for that U,
+// because a parameter written with no `:` clause declares nothing. Read Constraint, not
+// Var.UpperBounds, to answer what the source wrote.
 type TypeParam struct {
-	Name    string
-	Var     *TypeVarType
-	Default Type // nil ⇒ required
+	Name       string
+	Var        *TypeVarType
+	Default    Type // nil ⇒ required
+	Constraint Type // nil ⇒ unbounded
 }
 
 // LifetimeParam is one quantified lifetime parameter, the lifetime-sort analogue of TypeParam,

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -474,11 +474,13 @@ func acceptParams(ps []*FuncParam, v TypeVisitor, pol Polarity) ([]*FuncParam, b
 	return out, changed
 }
 
-// acceptTypeParams rewrites each type parameter's binding variable and its default so a
-// rewriting visitor copies both. The main such visitor is freshenAbove. The binding
-// variable is visited as a Type and must stay a *TypeVarType. freshenAbove replaces it
-// with a fresh variable whose bounds it has already freshened, so the constraint carried
-// as the variable's upper bound rides along on the copy. The default is visited
+// acceptTypeParams rewrites each type parameter's binding variable, its default, and its
+// declared constraint, so a rewriting visitor copies all three. The main such visitor is
+// freshenAbove. The binding variable is visited as a Type and must stay a *TypeVarType.
+// freshenAbove replaces it with a fresh variable whose bounds it has already freshened, so
+// the constraint carried as the variable's upper bound rides along on the copy. The
+// Constraint field is the same type reachable through a second path, and it is rewritten
+// here so the copy's field and the copy's variable agree. The default is visited
 // covariantly and may reference the variable or an earlier parameter, which Accept
 // rewrites through the visitor's cache. Copy-on-write mirrors acceptParams. A changed
 // parameter gets a fresh *TypeParam and unchanged ones keep their pointer.
@@ -491,12 +493,16 @@ func acceptTypeParams(tps []*TypeParam, v TypeVisitor, pol Polarity) ([]*TypePar
 		if def != nil {
 			def = def.Accept(v, pol)
 		}
-		if nv != tp.Var || def != tp.Default {
+		cons := tp.Constraint
+		if cons != nil {
+			cons = cons.Accept(v, pol)
+		}
+		if nv != tp.Var || def != tp.Default || cons != tp.Constraint {
 			if !changed {
 				out = append([]*TypeParam(nil), tps...)
 				changed = true
 			}
-			out[i] = &TypeParam{Name: tp.Name, Var: nv, Default: def}
+			out[i] = &TypeParam{Name: tp.Name, Var: nv, Default: def, Constraint: cons}
 		}
 	}
 	return out, changed

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -261,7 +261,44 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 			args[i] = c.freshAt(lvl)
 		}
 	}
+	c.checkAliasArgBounds(params, args, ref)
 	return &soltype.AliasType{Name: at.Name, TypeArgs: args, LifetimeArgs: ltArgs}
+}
+
+// checkAliasArgBounds reports each type argument of a generic alias reference that does not
+// satisfy its parameter's declared bound. Given `type Box<T: string> = {v: T}`, the
+// reference `Box<number>` is rejected here and `Box<"a">` is accepted. A parameter written
+// without a `:` clause has no bound recorded, so it keeps accepting every argument.
+//
+// A bound may name any sibling parameter, as the `B: A` of `type P<A, B: A> = [A, B]` does,
+// so the reference's own arguments are substituted into the bound before the comparison.
+// `P<number, 1>` therefore compares 1 against number rather than against the symbolic A.
+//
+// The comparison runs as a discard-only trial. Its purpose is to report, and the bounds it
+// would otherwise record land on the declaration's parameter vars, which every reference to
+// the alias shares. Rolling them back keeps one reference's argument out of the next one's
+// comparison.
+//
+// buildAliasInstance runs once per written reference, so a bad argument reports once no
+// matter how many times expansion later unfolds the alias.
+func (c *checker) checkAliasArgBounds(params []*soltype.TypeParam, args []soltype.Type, ref *ast.TypeRefTypeAnn) {
+	subst := newTypeSubst(params, args, nil, nil)
+	for i, p := range params {
+		// resolveTypeParams records at most one upper bound per parameter, itself an
+		// IntersectionType for a `<T: A & B>` bound, so the first bound is the whole declared
+		// constraint. A parameter with no bound has an empty list.
+		if len(p.Var.UpperBounds) == 0 {
+			continue
+		}
+		bound := p.Var.UpperBounds[0].Accept(subst, soltype.Positive)
+		// Blame the written argument. A trailing argument filled from its parameter's default
+		// has no node of its own, so it falls back to the whole reference.
+		var site ast.Node = ref
+		if i < len(ref.TypeArgs) {
+			site = ref.TypeArgs[i]
+		}
+		c.blameConstraintErrors(site, c.ctx.trialUnderProbe(args[i], bound))
+	}
 }
 
 // resolveAliasLifetimeArgs resolves a reference's `<'a, ...>` lifetime arguments and checks

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -263,50 +263,80 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 			args[i] = c.freshAt(lvl)
 		}
 	}
-	c.checkAliasArgBounds(params, args, ref)
+	c.checkAliasArgBounds(params, args, ltParams, ltArgs, ref)
 	return &soltype.AliasType{Name: at.Name, TypeArgs: args, LifetimeArgs: ltArgs}
 }
 
 // checkAliasArgBounds reports each type argument of a generic alias reference that does not
 // satisfy its parameter's declared bound. Given `type Box<T: string> = {v: T}`, the
 // reference `Box<number>` is rejected here and `Box<"a">` is accepted. A parameter written
-// without a `:` clause records no upper bound, so it keeps accepting every argument.
+// without a `:` clause declares no constraint, so it keeps accepting every argument.
 //
 // A bound may name any sibling parameter, as the `B: A` of `type P<A, B: A> = [A, B]` does,
-// so the reference's own arguments are substituted into the bound before the comparison.
-// `P<number, 1>` therefore compares 1 against number rather than against the symbolic A.
+// so the reference's own arguments and lifetime arguments are substituted into the bound
+// before the comparison, the same substitution expandAlias applies to the body. `P<number,
+// 1>` therefore compares 1 against number rather than against the symbolic A.
 //
-// Each comparison is a trial whose recorded bounds are thrown away. A live constraint would
-// instead bound whatever variables the argument contains, and an argument is often another
-// declaration's own parameter variable — the `T` of `type Outer<T: string> = Box<T>` is one.
-// Throwing the trial's bounds away leaves every parameter variable holding exactly the
-// constraint its `<…>` clause wrote.
+// The comparison is a live constraint rather than a discarded trial, which is what makes an
+// argument that is itself a type variable behave the way the generic-function and class
+// positions do. `fn g<U>(u: U) -> Box<U>` records string on U and reports nothing at the
+// declaration, and the later `g(1)` is what fails. Discarding the constraint instead would
+// drop that bound and let `g(1)` through.
+//
+// While a dep_graph component is still resolving bodies, an argument may name a sibling
+// alias whose own Body is nil, which expands to ErrorType and absorbs. Each comparison is
+// queued during that window and replayed by runDeferredAliasBounds once every body is
+// filled, so `type A = {b: Box<A>}` compares the finished A against string.
 //
 // buildAliasInstance runs once per written reference, so a bad argument reports once no
 // matter how many times expansion later unfolds the alias.
-func (c *checker) checkAliasArgBounds(params []*soltype.TypeParam, args []soltype.Type, ref *ast.TypeRefTypeAnn) {
-	bounded := func(p *soltype.TypeParam) bool { return len(p.Var.UpperBounds) > 0 }
+func (c *checker) checkAliasArgBounds(
+	params []*soltype.TypeParam,
+	args []soltype.Type,
+	ltParams []*soltype.LifetimeParam,
+	ltArgs []soltype.Lifetime,
+	ref *ast.TypeRefTypeAnn,
+) {
+	bounded := func(p *soltype.TypeParam) bool { return p.Constraint != nil }
 	if !slices.ContainsFunc(params, bounded) {
 		// Every parameter is unbounded, so there is nothing to compare and no substitution to
 		// build. This is the common shape for a generic alias.
 		return
 	}
-	subst := newTypeSubst(params, args, nil, nil)
+	subst := newTypeSubst(params, args, ltParams, ltArgs)
 	for i, p := range params {
 		if !bounded(p) {
 			continue
 		}
-		// resolveTypeParams records at most one upper bound per parameter, itself an
-		// IntersectionType for a `<T: A & B>` bound, so the first bound is the whole declared
-		// constraint.
-		bound := p.Var.UpperBounds[0].Accept(subst, soltype.Positive)
+		// Read the declared constraint from the parameter rather than from its var's upper
+		// bounds. A `<T: A & B>` bound resolves to one IntersectionType, so this is the whole
+		// of what the source wrote, and it cannot be displaced by a bound solving inferred.
+		bound := p.Constraint.Accept(subst, soltype.Positive)
 		// Blame the written argument. A trailing argument filled from its parameter's default
 		// has no node of its own, so the blame falls back to the whole reference.
 		var site ast.Node = ref
 		if i < len(ref.TypeArgs) {
 			site = ref.TypeArgs[i]
 		}
-		c.blameConstraintErrors(site, c.ctx.trialUnderProbe(args[i], bound))
+		if c.deferAliasBounds {
+			c.deferredAliasBounds = append(c.deferredAliasBounds, deferredAliasBound{
+				arg: args[i], bound: bound, site: site,
+			})
+			continue
+		}
+		c.constrain(site, args[i], bound)
+	}
+}
+
+// runDeferredAliasBounds replays and clears the comparisons checkAliasArgBounds queued while
+// the component's bodies were still resolving. It runs after checkProductive, so an argument
+// naming a sibling alias reaches that alias's finished Body, and an alias the productivity
+// check rejected is already marked so its reference absorbs instead of expanding forever.
+func (c *checker) runDeferredAliasBounds() {
+	pending := c.deferredAliasBounds
+	c.deferredAliasBounds = nil
+	for _, p := range pending {
+		c.constrain(p.site, p.arg, p.bound)
 	}
 }
 

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"slices"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -268,31 +270,38 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 // checkAliasArgBounds reports each type argument of a generic alias reference that does not
 // satisfy its parameter's declared bound. Given `type Box<T: string> = {v: T}`, the
 // reference `Box<number>` is rejected here and `Box<"a">` is accepted. A parameter written
-// without a `:` clause has no bound recorded, so it keeps accepting every argument.
+// without a `:` clause records no upper bound, so it keeps accepting every argument.
 //
 // A bound may name any sibling parameter, as the `B: A` of `type P<A, B: A> = [A, B]` does,
 // so the reference's own arguments are substituted into the bound before the comparison.
 // `P<number, 1>` therefore compares 1 against number rather than against the symbolic A.
 //
-// The comparison runs as a discard-only trial. Its purpose is to report, and the bounds it
-// would otherwise record land on the declaration's parameter vars, which every reference to
-// the alias shares. Rolling them back keeps one reference's argument out of the next one's
-// comparison.
+// Each comparison is a trial whose recorded bounds are thrown away. A live constraint would
+// instead bound whatever variables the argument contains, and an argument is often another
+// declaration's own parameter variable — the `T` of `type Outer<T: string> = Box<T>` is one.
+// Throwing the trial's bounds away leaves every parameter variable holding exactly the
+// constraint its `<…>` clause wrote.
 //
 // buildAliasInstance runs once per written reference, so a bad argument reports once no
 // matter how many times expansion later unfolds the alias.
 func (c *checker) checkAliasArgBounds(params []*soltype.TypeParam, args []soltype.Type, ref *ast.TypeRefTypeAnn) {
+	bounded := func(p *soltype.TypeParam) bool { return len(p.Var.UpperBounds) > 0 }
+	if !slices.ContainsFunc(params, bounded) {
+		// Every parameter is unbounded, so there is nothing to compare and no substitution to
+		// build. This is the common shape for a generic alias.
+		return
+	}
 	subst := newTypeSubst(params, args, nil, nil)
 	for i, p := range params {
-		// resolveTypeParams records at most one upper bound per parameter, itself an
-		// IntersectionType for a `<T: A & B>` bound, so the first bound is the whole declared
-		// constraint. A parameter with no bound has an empty list.
-		if len(p.Var.UpperBounds) == 0 {
+		if !bounded(p) {
 			continue
 		}
+		// resolveTypeParams records at most one upper bound per parameter, itself an
+		// IntersectionType for a `<T: A & B>` bound, so the first bound is the whole declared
+		// constraint.
 		bound := p.Var.UpperBounds[0].Accept(subst, soltype.Positive)
 		// Blame the written argument. A trailing argument filled from its parameter's default
-		// has no node of its own, so it falls back to the whole reference.
+		// has no node of its own, so the blame falls back to the whole reference.
 		var site ast.Node = ref
 		if i < len(ref.TypeArgs) {
 			site = ref.TypeArgs[i]

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -267,29 +267,11 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 	return &soltype.AliasType{Name: at.Name, TypeArgs: args, LifetimeArgs: ltArgs}
 }
 
-// checkAliasArgBounds reports each type argument of a generic alias reference that does not
-// satisfy its parameter's declared bound. Given `type Box<T: string> = {v: T}`, the
-// reference `Box<number>` is rejected here and `Box<"a">` is accepted. A parameter written
-// without a `:` clause declares no constraint, so it keeps accepting every argument.
-//
-// A bound may name any sibling parameter, as the `B: A` of `type P<A, B: A> = [A, B]` does,
-// so the reference's own arguments and lifetime arguments are substituted into the bound
-// before the comparison, the same substitution expandAlias applies to the body. `P<number,
-// 1>` therefore compares 1 against number rather than against the symbolic A.
-//
-// The comparison is a live constraint rather than a discarded trial, which is what makes an
-// argument that is itself a type variable behave the way the generic-function and class
-// positions do. `fn g<U>(u: U) -> Box<U>` records string on U and reports nothing at the
-// declaration, and the later `g(1)` is what fails. Discarding the constraint instead would
-// drop that bound and let `g(1)` through.
-//
-// While a dep_graph component is still resolving bodies, an argument may name a sibling
-// alias whose own Body is nil, which expands to ErrorType and absorbs. Each comparison is
-// queued during that window and replayed by runDeferredAliasBounds once every body is
-// filled, so `type A = {b: Box<A>}` compares the finished A against string.
-//
-// buildAliasInstance runs once per written reference, so a bad argument reports once no
-// matter how many times expansion later unfolds the alias.
+// checkAliasArgBounds reports a type argument that does not satisfy its parameter's declared
+// bound, so `type Box<T: string>` rejects `Box<number>`. Arguments are substituted into the
+// bound first, which lets a bound name a sibling as the `B: A` of `type P<A, B: A>` does. The
+// comparison is live rather than a discarded trial, so an argument that is itself a variable
+// carries the bound to its instantiation the way the function and class positions do.
 func (c *checker) checkAliasArgBounds(
 	params []*soltype.TypeParam,
 	args []soltype.Type,
@@ -328,10 +310,8 @@ func (c *checker) checkAliasArgBounds(
 	}
 }
 
-// runDeferredAliasBounds replays and clears the comparisons checkAliasArgBounds queued while
-// the component's bodies were still resolving. It runs after checkProductive, so an argument
-// naming a sibling alias reaches that alias's finished Body, and an alias the productivity
-// check rejected is already marked so its reference absorbs instead of expanding forever.
+// runDeferredAliasBounds replays and clears the checks checkAliasArgBounds queued while the
+// component's bodies were nil, since an unfilled alias argument expands to ErrorType and absorbs.
 func (c *checker) runDeferredAliasBounds() {
 	pending := c.deferredAliasBounds
 	c.deferredAliasBounds = nil

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -385,3 +385,191 @@ func TestInferGenericTypeAliasArityErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestInferGenericTypeAliasParamBounds covers the bound a generic alias declares on a type
+// parameter, `type Box<T: string>`. A reference supplying an argument outside the bound is
+// rejected at the reference, and one inside it is accepted. A bound may name a sibling
+// parameter, so the reference's own arguments are substituted into the bound before the
+// comparison, and an argument filled from a parameter's default is checked the same way.
+func TestInferGenericTypeAliasParamBounds(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "ArgumentOutsideBound",
+			src: `
+				type Box<T: string> = {v: T}
+				val b: Box<number> = {v: 1}
+			`,
+			want: []string{"cannot constrain number <: string"},
+		},
+		{
+			name: "ArgumentInsideBound",
+			src: `
+				type Box<T: string> = {v: T}
+				val b: Box<"a"> = {v: "a"}
+			`,
+		},
+		{
+			name: "UnboundedParamAcceptsAnyArgument",
+			src: `
+				type Id<T> = T
+				val a: Id<number> = 1
+				val b: Id<string> = "hi"
+			`,
+		},
+		{
+			name: "IntersectionBound",
+			src: `
+				type Box<T: string & "a"> = {v: T}
+				val b: Box<"b"> = {v: "b"}
+			`,
+			want: []string{`cannot constrain "b" <: "a"`},
+		},
+		{
+			name: "SiblingBoundSatisfied",
+			src: `
+				type P<A, B: A> = [A, B]
+				val p: P<number, 1> = [1, 1]
+			`,
+		},
+		{
+			name: "SiblingBoundViolated",
+			src: `
+				type P<A, B: A> = [A, B]
+				val p: P<string, 1> = ["a", 1]
+			`,
+			want: []string{"cannot constrain 1 <: string"},
+		},
+		{
+			name: "DefaultedArgumentChecked",
+			src: `
+				type Pair<T, U: string = T> = [T, U]
+				val p: Pair<number> = [1, 1]
+			`,
+			want: []string{"cannot constrain number <: string"},
+		},
+		{
+			name: "AliasBodyReferenceChecked",
+			src: `
+				type Box<T: string> = {v: T}
+				type Outer = Box<number>
+			`,
+			want: []string{"cannot constrain number <: string"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			var msgs []string
+			for _, e := range errs {
+				msgs = append(msgs, e.Message())
+			}
+			require.Equal(t, tt.want, msgs)
+		})
+	}
+}
+
+// TestInferGenericTypeAliasParamBoundBlamesArgument checks that the mismatch points at the
+// offending type argument in the reference rather than at the alias declaration. In
+// `val b: Box<number>` the reported span covers `number`.
+func TestInferGenericTypeAliasParamBoundBlamesArgument(t *testing.T) {
+	src := "type Box<T: string> = {v: T}\nval b: Box<number> = {v: 1}"
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain number <: string", errs[0].Message())
+	span := errs[0].Span()
+	require.Equal(t, 2, span.Start.Line)
+	require.Equal(t, 12, span.Start.Column)
+	require.Equal(t, 2, span.End.Line)
+	require.Equal(t, 18, span.End.Column)
+}
+
+// TestInferGenericTypeAliasParamBoundReportedOncePerReference checks that the bound is
+// checked where a reference resolves, not where the alias expands. Each of the two bad
+// references reports exactly once, and a recursive alias whose parameter carries a bound
+// reports once for the whole reference rather than once per expansion lap.
+func TestInferGenericTypeAliasParamBoundReportedOncePerReference(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "TwoBadReferences",
+			src: `
+				type Box<T: string> = {v: T}
+				val a: Box<number> = {v: 1}
+				val b: Box<boolean> = {v: true}
+			`,
+			want: []string{
+				"cannot constrain number <: string",
+				"cannot constrain boolean <: string",
+			},
+		},
+		{
+			name: "RecursiveAlias",
+			src: `
+				type List<T: string> = {head: T, tail?: List<T>}
+				val l: List<number> = {head: 1}
+			`,
+			want: []string{"cannot constrain number <: string"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			var msgs []string
+			for _, e := range errs {
+				msgs = append(msgs, e.Message())
+			}
+			require.Equal(t, tt.want, msgs)
+		})
+	}
+}
+
+// TestTypeParamBoundEnforcedInEveryPosition is the regression guard for the three positions
+// that already enforced a type parameter's bound before the alias position joined them: a
+// generic function declaration, a generic function annotation, and a class reference. Each
+// instantiates its parameter at a type the bound rejects and reports the same mismatch.
+func TestTypeParamBoundEnforcedInEveryPosition(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "GenericFunctionDeclaration",
+			src: `
+				fn f<A: string>(a: A) -> A { return a }
+				val x = f(5)
+			`,
+			want: "cannot constrain 5 <: string",
+		},
+		{
+			name: "GenericFunctionAnnotation",
+			src: `
+				val g: fn<A: string>(a: A) -> A = fn (a) { return a }
+				val x = g(5)
+			`,
+			want: "cannot constrain 5 <: string",
+		},
+		{
+			name: "ClassReference",
+			src: `
+				class Box<T: string> { value: T }
+				val b = Box(1)
+			`,
+			want: "cannot constrain 1 <: string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, errs[0].Message())
+		})
+	}
+}

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -573,3 +573,135 @@ func TestTypeParamBoundEnforcedInEveryPosition(t *testing.T) {
 		})
 	}
 }
+
+// TestInferGenericTypeAliasBoundOnVariableArgument covers a type argument that is itself a
+// type variable rather than a concrete type. The comparison is a live constraint, so the
+// alias's bound lands on that variable and the diagnostic surfaces where the variable is
+// instantiated, the same way the generic-function and class positions behave. Nothing is
+// reported at the declaration that forwards the variable.
+func TestInferGenericTypeAliasBoundOnVariableArgument(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "ForwardingDeclarationIsQuiet",
+			src: `
+				type Box<T: string> = {v: T}
+				fn g<U>(u: U) -> Box<U> { return {v: u} }
+			`,
+		},
+		{
+			name: "InstantiationReportsThroughReturn",
+			src: `
+				type Box<T: string> = {v: T}
+				fn g<U>(u: U) -> Box<U> { return {v: u} }
+				val x = g(1)
+			`,
+			want: []string{"cannot constrain 1 <: string"},
+		},
+		{
+			name: "InstantiationReportsThroughParameter",
+			src: `
+				type Box<T: string> = {v: T}
+				fn f<U>(b: Box<U>) -> U { return b.v }
+				val x = f({v: 1})
+			`,
+			want: []string{"cannot constrain 1 <: string"},
+		},
+		{
+			name: "InstantiationReportsThroughClassField",
+			src: `
+				type Box<T: string> = {v: T}
+				class C<U> { b: Box<U> }
+				val c = C({v: 1})
+			`,
+			want: []string{"cannot constrain 1 <: string"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			var msgs []string
+			for _, e := range errs {
+				msgs = append(msgs, e.Message())
+			}
+			require.Equal(t, tt.want, msgs)
+		})
+	}
+}
+
+// TestInferGenericTypeAliasBoundOnSiblingAliasArgument covers a type argument naming an
+// alias in the same dep_graph component, whose body is still nil while the reference
+// resolves. The comparison is queued and replayed once every body in the component is
+// filled, so the finished body is what the bound sees. Checking against the half-built
+// sibling instead would expand it to an error type, which absorbs and reports nothing.
+func TestInferGenericTypeAliasBoundOnSiblingAliasArgument(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "SelfRecursiveArgument",
+			src: `
+				type Box<T: string> = {v: T}
+				type A = {b: Box<A>}
+			`,
+			want: []string{"cannot constrain object <: string"},
+		},
+		{
+			name: "MutuallyRecursiveArgument",
+			src: `
+				type Box<T: string> = {v: T}
+				type A = {b: Box<B>}
+				type B = A
+			`,
+			want: []string{"cannot constrain object <: string"},
+		},
+		{
+			name: "NonRecursiveSiblingArgument",
+			src: `
+				type Box<T: string> = {v: T}
+				type B = {x: number}
+				type A = {b: Box<B>}
+			`,
+			want: []string{"cannot constrain object <: string"},
+		},
+		{
+			name: "SatisfiedSiblingArgument",
+			src: `
+				type Box<T: string> = {v: T}
+				type S = "a"
+				type A = {b: Box<S>}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			var msgs []string
+			for _, e := range errs {
+				msgs = append(msgs, e.Message())
+			}
+			require.Equal(t, tt.want, msgs)
+		})
+	}
+}
+
+// TestInferGenericTypeAliasBoundUnderConditional guards the case that rules out reading a
+// parameter's inferred upper bounds instead of its declared constraint. Resolving the then
+// branch of `if T : string` constrains X's own T against Box's bound, which leaves string on
+// that variable even though X declares T unbounded. `X<number>` selects the else branch and
+// is number, so reading the variable's bounds would reject a well-typed program.
+func TestInferGenericTypeAliasBoundUnderConditional(t *testing.T) {
+	src := `
+		type Box<T: string> = {v: T}
+		type X<T> = if T : string { Box<T> } else { number }
+		val a: X<number> = 1
+		val b: X<"a"> = {v: "a"}
+	`
+	_, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+}

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -83,6 +83,27 @@ type checker struct {
 	// saved and restored around each operand, so an `infer` in a nested conditional's Then branch is
 	// rejected even though the outer Extends is still being walked.
 	inCondExtends bool
+
+	// deferAliasBounds routes checkAliasArgBounds to deferredAliasBounds instead of
+	// constraining on the spot. inferComponent sets it around the enum and alias body
+	// loops, the window in which a sibling alias in the same dep_graph component is bound
+	// but its Body is still nil. Constraining an argument that names such a sibling would
+	// expand it to ErrorType, which absorbs, so `type A = {b: Box<A>}` would accept A
+	// against Box's `string` bound.
+	deferAliasBounds bool
+
+	// deferredAliasBounds holds the comparisons raised during that window, replayed by
+	// runDeferredAliasBounds once every body in the component is filled.
+	deferredAliasBounds []deferredAliasBound
+}
+
+// deferredAliasBound is one `arg <: bound` comparison checkAliasArgBounds postponed until
+// the enclosing dep_graph component finished resolving its bodies. site is the node the
+// resulting diagnostic blames, the written type argument where there is one.
+type deferredAliasBound struct {
+	arg   soltype.Type
+	bound soltype.Type
+	site  ast.Node
 }
 
 // fieldKey identifies a written field by the receiver variable's ID and the

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1808,8 +1808,8 @@ func TestInferMethodOverloadUniformMutReceiverAccepted(t *testing.T) {
 // A declared bound rides on the binder, so gating the binder gates the bound with it: the
 // call below passes 1 to a parameter written `T: string` and no mismatch is reported. The
 // class's own `<U: number>` binder is a separate mechanism and still enforces, which the
-// last case shows. Lifting the gate should flip this test and enable
-// TestInferClassMethodTypeParamBounds below.
+// last case shows. Lifting the gate, tracked by issue #957, should flip this test and
+// enable TestInferClassMethodTypeParamBounds below.
 func TestInferClassMethodTypeParamsGated(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1868,10 +1868,10 @@ func TestInferClassMethodTypeParamsGated(t *testing.T) {
 	}
 }
 
-// DISABLED until a method's own type parameters are supported — the per-instance
-// projection inferMemberFunc names, which lets two calls to one generic method instantiate
-// independently. Today the binder is reported as unsupported and the member infers
-// monomorphically, which TestInferClassMethodTypeParamsGated pins.
+// DISABLED until issue #957 lands support for a method's own type parameters — the
+// per-instance projection inferMemberFunc names, which lets two calls to one generic method
+// instantiate independently. Today the binder is reported as unsupported and the member
+// infers monomorphically, which TestInferClassMethodTypeParamsGated pins.
 //
 // Once the gate lifts, a method's `<T: string>` should enforce its bound at the call the
 // same way a generic function's does, since both route their binder through

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1797,3 +1797,158 @@ func TestInferMethodOverloadUniformMutReceiverAccepted(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, "number", values["r"])
 }
+
+// TestInferClassMethodTypeParamsGated pins the gate on a method's own `<T>` binder.
+// inferMemberFunc calls inferFunc with allowTypeParams=false, because a member's type
+// parameter needs a per-instance projection the class-body freeze does not apply, so
+// resolving it would collapse two calls onto one shared var. The binder is reported as an
+// unsupported feature and the member infers monomorphically, which leaves each `T` in the
+// signature an unbound name.
+//
+// A declared bound rides on the binder, so gating the binder gates the bound with it: the
+// call below passes 1 to a parameter written `T: string` and no mismatch is reported. The
+// class's own `<U: number>` binder is a separate mechanism and still enforces, which the
+// last case shows. Lifting the gate should flip this test and enable
+// TestInferClassMethodTypeParamBounds below.
+func TestInferClassMethodTypeParamsGated(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "InstanceMethodBinderIsGated",
+			src: `
+				class C {
+					pick<T: string>(self, x: T) -> T { return x },
+				}
+				val c = C()
+				val r = c.pick(1)
+			`,
+			want: []string{
+				"Unsupported: TypeParam",
+				"Unsupported: TypeRefTypeAnn",
+				"Unsupported: TypeRefTypeAnn",
+			},
+		},
+		{
+			name: "StaticMethodBinderIsGated",
+			src: `
+				class C {
+					static pick<T: string>(x: T) -> T { return x },
+				}
+				val r = C.pick(1)
+			`,
+			want: []string{
+				"Unsupported: TypeParam",
+				"Unsupported: TypeRefTypeAnn",
+				"Unsupported: TypeRefTypeAnn",
+			},
+		},
+		{
+			name: "ClassBinderStillEnforcesItsBound",
+			src: `
+				class C<U: number> {
+					v: U,
+				}
+				val c = C("z")
+			`,
+			want: []string{`cannot constrain "z" <: number`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			var msgs []string
+			for _, e := range errs {
+				msgs = append(msgs, e.Message())
+			}
+			require.Equal(t, tt.want, msgs)
+		})
+	}
+}
+
+// DISABLED until a method's own type parameters are supported — the per-instance
+// projection inferMemberFunc names, which lets two calls to one generic method instantiate
+// independently. Today the binder is reported as unsupported and the member infers
+// monomorphically, which TestInferClassMethodTypeParamsGated pins.
+//
+// Once the gate lifts, a method's `<T: string>` should enforce its bound at the call the
+// same way a generic function's does, since both route their binder through
+// resolveTypeParams. These cases carry that intended behavior: a satisfying argument is
+// accepted, a violating one reports the mismatch, an unbounded binder accepts anything, a
+// bound naming a sibling parameter resolves, and two calls to one method instantiate
+// independently rather than sharing a var. Re-enable by removing the comment wrapper.
+func TestInferClassMethodTypeParamBounds(t *testing.T) {
+	/*
+		tests := []struct {
+			name string
+			src  string
+			want []string
+		}{
+			{
+				name: "ArgumentInsideBound",
+				src: `
+					class C {
+						pick<T: string>(self, x: T) -> T { return x },
+					}
+					val c = C()
+					val r = c.pick("a")
+				`,
+			},
+			{
+				name: "ArgumentOutsideBound",
+				src: `
+					class C {
+						pick<T: string>(self, x: T) -> T { return x },
+					}
+					val c = C()
+					val r = c.pick(1)
+				`,
+				want: []string{"cannot constrain 1 <: string"},
+			},
+			{
+				name: "UnboundedBinderAcceptsAnyArgument",
+				src: `
+					class C {
+						pick<T>(self, x: T) -> T { return x },
+					}
+					val c = C()
+					val r = c.pick(1)
+				`,
+			},
+			{
+				name: "SiblingBoundViolated",
+				src: `
+					class C {
+						pair<A, B: A>(self, a: A, b: B) -> A { return a },
+					}
+					val c = C()
+					val r = c.pair(1, "y")
+				`,
+				want: []string{`cannot constrain "y" <: 1`},
+			},
+			{
+				name: "TwoCallsInstantiateIndependently",
+				src: `
+					class C {
+						pick<T: string>(self, x: T) -> T { return x },
+					}
+					val c = C()
+					val a = c.pick("a")
+					val b = c.pick("b")
+				`,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, _, errs := inferSource(t, tt.src)
+				var msgs []string
+				for _, e := range errs {
+					msgs = append(msgs, e.Message())
+				}
+				require.Equal(t, tt.want, msgs)
+			})
+		}
+	*/
+}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -394,6 +394,15 @@ func (c *checker) inferComponent(
 	// below fill it, so a generic alias reference's bound check is queued rather than run
 	// against a half-built sibling. runDeferredAliasBounds replays the queue once the
 	// bodies are in place.
+	//
+	// The flag is set and cleared by plain assignment rather than saved and restored under
+	// a defer, which holds on three properties of this function. inferDepGraph calls
+	// inferComponent in a flat loop and nothing the two loops reach re-enters it, so the
+	// flag is never already set on entry. inferComponent has no early return, so the clear
+	// below is always reached. Phases 1 and 2 above already resolved every value
+	// declaration and its annotations, so the only bound checks inside the window are the
+	// ones these loops raise. Clearing before the replay is what keeps the window that
+	// narrow: a check queued after runDeferredAliasBounds would never be replayed.
 	c.deferAliasBounds = true
 	// Every enum body resolves its variant parameters against the fully pre-bound
 	// identities above, so a parameter naming a sibling enum or class resolves.

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -390,11 +390,9 @@ func (c *checker) inferComponent(
 			}
 		}
 	}
-	// The two loops below fill bodies that are still nil, so a generic alias reference's bound
-	// check is queued rather than run against a half-built sibling. Plain assignment is safe
-	// because inferComponent never nests and has no early return, and phases 1 and 2 already
-	// resolved every value declaration. Do not convert this to a defer, because a check queued
-	// after runDeferredAliasBounds would never be replayed.
+	// The two loops below fill bodies that are still nil, so a bound check inside them is queued
+	// rather than run against a half-built sibling. Do not convert this to a defer, because a
+	// check queued after runDeferredAliasBounds would never be replayed.
 	c.deferAliasBounds = true
 	// Every enum body resolves its variant parameters against the fully pre-bound
 	// identities above, so a parameter naming a sibling enum or class resolves.

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -390,6 +390,11 @@ func (c *checker) inferComponent(
 			}
 		}
 	}
+	// An identity in this component is bound but its Body is still nil until the two loops
+	// below fill it, so a generic alias reference's bound check is queued rather than run
+	// against a half-built sibling. runDeferredAliasBounds replays the queue once the
+	// bodies are in place.
+	c.deferAliasBounds = true
 	// Every enum body resolves its variant parameters against the fully pre-bound
 	// identities above, so a parameter naming a sibling enum or class resolves.
 	for _, sh := range enumShells {
@@ -400,9 +405,11 @@ func (c *checker) inferComponent(
 	for _, sh := range aliasShells {
 		c.inferAliasBody(sh)
 	}
+	c.deferAliasBounds = false
 	// Every body in the component is resolved, so the alias reference graph the productivity
 	// check reads is complete.
 	c.checkProductive(aliasShells)
+	c.runDeferredAliasBounds()
 
 	// Report any remaining non-value decl as unsupported. A class was pre-bound above and
 	// is completed at its value key, so skip it rather than mis-reporting it.

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -390,19 +390,11 @@ func (c *checker) inferComponent(
 			}
 		}
 	}
-	// An identity in this component is bound but its Body is still nil until the two loops
-	// below fill it, so a generic alias reference's bound check is queued rather than run
-	// against a half-built sibling. runDeferredAliasBounds replays the queue once the
-	// bodies are in place.
-	//
-	// The flag is set and cleared by plain assignment rather than saved and restored under
-	// a defer, which holds on three properties of this function. inferDepGraph calls
-	// inferComponent in a flat loop and nothing the two loops reach re-enters it, so the
-	// flag is never already set on entry. inferComponent has no early return, so the clear
-	// below is always reached. Phases 1 and 2 above already resolved every value
-	// declaration and its annotations, so the only bound checks inside the window are the
-	// ones these loops raise. Clearing before the replay is what keeps the window that
-	// narrow: a check queued after runDeferredAliasBounds would never be replayed.
+	// The two loops below fill bodies that are still nil, so a generic alias reference's bound
+	// check is queued rather than run against a half-built sibling. Plain assignment is safe
+	// because inferComponent never nests and has no early return, and phases 1 and 2 already
+	// resolved every value declaration. Do not convert this to a defer, because a check queued
+	// after runDeferredAliasBounds would never be replayed.
 	c.deferAliasBounds = true
 	// Every enum body resolves its variant parameters against the fully pre-bound
 	// identities above, so a parameter naming a sibling enum or class resolves.

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -37,6 +37,10 @@ func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypePar
 		if p.Constraint != nil {
 			if ct, ok := c.resolveTypeAnn(scope, p.Constraint, lvl); ok {
 				c.ctx.addUpperBound(out[i].Var, ct)
+				// Keep the declared constraint where later solving cannot overwrite it. The
+				// var's upper-bound list grows as constraints flow in, so a reader that wants
+				// what the source wrote reads this field instead.
+				out[i].Constraint = ct
 			}
 		}
 		if p.Default != nil {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,8 @@ importers:
 
   fixtures/bin_only: {}
 
+  fixtures/class_field_name_collision: {}
+
   fixtures/class_with_computed_members: {}
 
   fixtures/class_with_fluent_mutating_methods: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,6 @@ importers:
 
   fixtures/bin_only: {}
 
-  fixtures/class_field_name_collision: {}
-
   fixtures/class_with_computed_members: {}
 
   fixtures/class_with_fluent_mutating_methods: {}


### PR DESCRIPTION
Adds checking that type arguments supplied to generic aliases satisfy their parameters' declared bounds. For example, `type Box<T: string> = {v: T}` now rejects `Box<number>` and accepts `Box<"a">`.

**Key changes:**

- Added `checkAliasArgBounds` to validate each type argument against its parameter's constraint, substituting sibling parameter arguments into the bound before comparison (e.g., `type P<A, B: A>` checks the second argument against the first).
- Bounds are checked at the reference site, not at the alias declaration, so the diagnostic blames the offending argument.
- Introduced deferred bound checking via `deferAliasBounds` and `runDeferredAliasBounds` to handle the window when a dep_graph component is resolving bodies. This prevents false rejections when an argument names a sibling alias whose body is still nil.
- Extended `TypeParam` with a `Constraint` field to preserve the declared bound separately from the variable's inferred upper bounds, which grow as constraints flow in during solving.
- Updated `acceptTypeParams` in the type visitor to rewrite the constraint field alongside the variable and default, ensuring copies stay consistent.
- Integrated bound checking into `buildAliasInstance` and wired deferred checks into `inferComponent`.

The implementation mirrors how generic functions and classes already enforce bounds, but queues comparisons during component resolution to avoid expanding half-built siblings to error types.

https://claude.ai/code/session_01Kw55votF5voqYpWq6ougHc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generic type parameters now preserve their declared constraints separately from inferred bounds.
  * Generic type aliases validate type and lifetime arguments against declared constraints, including defaulted arguments.
* **Bug Fixes**
  * Improved constraint checking across aliases, functions, classes, variables, sibling aliases, and conditional types.
  * Diagnostics now identify the relevant argument or reference and avoid duplicate reports.
* **Documentation**
  * Clarified constraint syntax and the distinction between declared constraints and inferred bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->