### PR TITLE
Add `null` and `undefined` as writable type annotations

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1172,6 +1172,10 @@ func printPat(pat Pat) (string, bool) {
 		return "_", true
 	case *LitPat:
 		return printLit(p.Lit), true
+	case *NullPat:
+		return "null", true
+	case *UndefinedPat:
+		return "undefined", true
 	case *TuplePat:
 		parts := make([]string, len(p.Elems))
 		for i, e := range p.Elems {

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -560,6 +560,16 @@ func TestPrintDestructuringParamPatterns(t *testing.T) {
 			want: "5",
 		},
 		{
+			name: "null",
+			pat:  &NullPat{},
+			want: "null",
+		},
+		{
+			name: "undefined",
+			pat:  &UndefinedPat{},
+			want: "undefined",
+		},
+		{
 			name: "nested object in tuple",
 			pat: &TuplePat{Elems: []Pat{
 				&ObjectPat{Fields: []*ObjectPatField{{Name: "x", Value: &IdentPat{Name: "x"}}}},

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -148,6 +148,19 @@ type LitPat struct{ Lit Lit }
 
 func (*LitPat) isPat() {}
 
+// NullPat matches the value `null` and binds nothing. Its type is NullType, an
+// atom rather than a member of Lit, so LitPat has no field that can carry it and
+// `null` needs a pattern of its own.
+type NullPat struct{}
+
+func (*NullPat) isPat() {}
+
+// UndefinedPat matches the value `undefined` and binds nothing, the twin of
+// NullPat for the UndefinedType atom.
+type UndefinedPat struct{}
+
+func (*UndefinedPat) isPat() {}
+
 // WildcardPat (`_`) matches anything and binds nothing (M4 E1).
 type WildcardPat struct{}
 

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -999,6 +999,16 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		if _, ok := super.(*soltype.UndefinedType); ok {
 			return nil
 		}
+	case *soltype.NullType:
+		// `null` relates only to itself, the twin of the UndefinedType arm above. It is
+		// unrelated to `undefined`, to `void`, and to every data type, matching TypeScript
+		// under strict null checks. It still reaches the top of the lattice through the
+		// `_ <: unknown` rule. `NonNullable<T>` reduces through this arm. Its probe asks
+		// whether `null <: null | undefined`, which walks the union-super arm, and that arm
+		// needs one member the sub satisfies.
+		if _, ok := super.(*soltype.NullType); ok {
+			return nil
+		}
 	case *soltype.KeyofType, *soltype.IndexType, *soltype.TemplateLitType, *soltype.StringIntrinsicType,
 		*soltype.ExactnessType:
 		// A residual type-level operator the pre-switch could not ground reaches here: a `keyof T`,

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -12,12 +12,16 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferLiteral types a literal expression as its singleton soltype.LitType and
-// records it in Info. M1's soltype.Lit set is num/str/bool only; the remaining
-// ast literal kinds (regex, bigint, null, undefined) fall through to the M2
-// subset guard until later milestones extend soltype.Lit (§ soltype/type.go
-// Prim/Lit note).
+// inferLiteral types a literal expression and records it in Info. A number, string, or
+// boolean literal types as its singleton soltype.LitType. `null` and `undefined` type as
+// the atoms atomLitOf returns. Neither carries provenance, for the reason atomLitOf gives.
+// The remaining ast literal kinds, regex and bigint, fall through to the subset guard
+// until soltype.Lit grows a member for each (§ soltype/type.go Prim/Lit note).
 func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
+	if atom, _, isAtom := atomLitOf(e.Lit); isAtom {
+		c.recordType(e, atom)
+		return atom
+	}
 	var lit soltype.Lit
 	switch l := e.Lit.(type) {
 	case *ast.NumLit:
@@ -2658,13 +2662,16 @@ func (c *checker) unionMatchExhaustive(scope *Scope, e *ast.MatchExpr, u *soltyp
 
 // unionMemberCovered reports whether some unguarded arm covers a single union member,
 // dispatching on the member's kind. A literal member needs an equal literal pattern, a
-// nominal member an instance or extractor pattern naming its class, and a structural
-// object or tuple member an irrefutable pattern of its shape. Any other member kind has
-// no covering pattern short of a catch-all, which the caller has already checked.
+// `null` or `undefined` member an arm spelling that same word, a nominal member an
+// instance or extractor pattern naming its class, and a structural object or tuple
+// member an irrefutable pattern of its shape. Any other member kind has no covering
+// pattern short of a catch-all, which the caller has already checked.
 func (c *checker) unionMemberCovered(scope *Scope, member soltype.Type, arms []*ast.MatchCase) bool {
 	switch m := member.(type) {
 	case *soltype.LitType:
 		return c.litMemberCovered(m, arms)
+	case *soltype.NullType, *soltype.UndefinedType:
+		return atomMemberCovered(member, arms)
 	case *soltype.ClassType:
 		return c.nominalMemberCovered(scope, m, arms)
 	case *soltype.ObjectType, *soltype.TupleType:
@@ -2870,6 +2877,26 @@ func (c *checker) litMemberCovered(member *soltype.LitType, arms []*ast.MatchCas
 			continue
 		}
 		if lt, ok := c.litTypeOf(armLit.Lit); ok && member.Equal(lt) {
+			return true
+		}
+	}
+	return false
+}
+
+// atomMemberCovered reports whether some unguarded arm is a `null` or `undefined` pattern
+// matching the given union member, which is one of those two atoms. It is the atom twin of
+// litMemberCovered, and the caller has likewise already excluded an unguarded catch-all.
+// equalType decides the match, since neither atom carries a value to compare.
+func atomMemberCovered(member soltype.Type, arms []*ast.MatchCase) bool {
+	for _, arm := range arms {
+		if arm.Guard != nil {
+			continue
+		}
+		armLit, ok := arm.Pattern.(*ast.LitPat)
+		if !ok {
+			continue
+		}
+		if atom, _, isAtom := atomLitOf(armLit.Lit); isAtom && equalType(atom, member) {
 			return true
 		}
 	}

--- a/internal/solver/infer_expr_test.go
+++ b/internal/solver/infer_expr_test.go
@@ -25,6 +25,10 @@ func TestInferLiteral(t *testing.T) {
 		{"number", ast.NewNumber(5, testSpan()), "5"},
 		{"string", ast.NewString("hello", testSpan()), `"hello"`},
 		{"boolean", ast.NewBoolean(true, testSpan()), "true"},
+		// `null` and `undefined` type as soltype atoms rather than singleton LitTypes,
+		// so they take the atomLitOf path through inferLiteral.
+		{"null", ast.NewNull(testSpan()), "null"},
+		{"undefined", ast.NewUndefined(testSpan()), "undefined"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -39,15 +43,15 @@ func TestInferLiteral(t *testing.T) {
 	}
 }
 
-// A literal kind outside M1's soltype.Lit set (regex, bigint, null, undefined)
-// is an M2 subset miss, not a crash.
+// A literal kind with no soltype form, regex or bigint, is a subset miss rather than a
+// crash. Both wait on a soltype.Lit member of their own.
 func TestInferLiteralUnsupported(t *testing.T) {
 	c := newChecker()
-	e := ast.NewLitExpr(ast.NewNull(testSpan()))
+	e := ast.NewLitExpr(ast.NewRegex("/a/", testSpan()))
 	got := c.inferExpr(NewScope(), 0, e)
 	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported: NullLit", c.errs[0].Message())
+	require.Equal(t, "Unsupported: RegexLit", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 

--- a/internal/solver/infer_null_undefined_test.go
+++ b/internal/solver/infer_null_undefined_test.go
@@ -3,6 +3,8 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,16 +59,50 @@ func TestInferNullUndefinedAnnotationRoundTrip(t *testing.T) {
 	}
 }
 
-// Two `null` annotations in one module each resolve without tripping the provenance table.
-// soltype.NullType has no fields, so Go gives every instance one address, and Prov is keyed by
-// pointer identity — recording against it would file both under a single entry and panic the
-// debugProv guard on the second. resolveLitTypeAnn returns the atom before its recordProv call
-// for that reason, the same as the `never` and `unknown` arms.
-func TestInferNullAnnotationTwiceInOneModule(t *testing.T) {
+// One module can name both atoms without either binding disturbing the other.
+func TestInferNullAndUndefinedAnnotationsInOneModule(t *testing.T) {
 	values, _, errs := inferSource(t, "val n: null = null\nval u: undefined = undefined")
 	require.Empty(t, errs)
 	require.Equal(t, "null", values["n"])
 	require.Equal(t, "undefined", values["u"])
+}
+
+// resolveLitTypeAnn returns each atom before its recordProv call, so no `null` or `undefined`
+// annotation ever reaches the Prov side table. soltype.NullType has no fields, so Go gives
+// every instance one address, and Prov is keyed by pointer identity. Recording against it
+// would file every `null` in the module under a single entry, and each would then report the
+// last one's span.
+//
+// The guard that catches such a write is checker.debugProv, which panics when one type pointer
+// is recorded against two different nodes. inferSource leaves it off, so this test drives the
+// resolver directly with the guard on. Two separately constructed annotations are enough to
+// trip it, since they are distinct ast nodes carrying one shared soltype pointer.
+func TestResolveAtomAnnotationRecordsNoProvenance(t *testing.T) {
+	tests := []struct {
+		name string
+		lit  ast.Lit
+	}{
+		{"null", ast.NewNull(testSpan())},
+		{"undefined", ast.NewUndefined(testSpan())},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newChecker()
+			c.debugProv = true
+			scope := NewScope()
+			first := ast.NewLitTypeAnn(tt.lit, testSpan())
+			second := ast.NewLitTypeAnn(tt.lit, testSpan())
+
+			firstType, ok := c.resolveTypeAnn(scope, first, 0)
+			require.True(t, ok)
+			require.NotPanics(t, func() { c.resolveTypeAnn(scope, second, 0) })
+			require.Empty(t, c.errs)
+			require.Empty(t, c.prov, "an atom annotation must record no provenance")
+			// The two annotations resolve to the same atom, which is what makes a Prov entry
+			// unsafe in the first place.
+			require.Equal(t, tt.name, soltype.Print(firstType))
+		})
+	}
 }
 
 // Each atom relates only to itself. It is unrelated to the other atom, to `void`, and to every

--- a/internal/solver/infer_null_undefined_test.go
+++ b/internal/solver/infer_null_undefined_test.go
@@ -1,0 +1,188 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M9 PR16: `null` and `undefined` as a written surface ---
+
+// Both words name a type in annotation position and a value in expression position, so an
+// annotated binding round-trips the atom it was written with.
+func TestInferNullUndefinedAnnotationRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "Null",
+			src:  `val n: null = null`,
+			want: "null",
+		},
+		{
+			name: "Undefined",
+			src:  `val n: undefined = undefined`,
+			want: "undefined",
+		},
+		{
+			// A nested position resolves the same way, so each atom composes rather than
+			// being special-cased at the top of an annotation.
+			name: "NestedInObject",
+			src:  `val n: {a: null} = {a: null}`,
+			want: "{a: null}",
+		},
+		{
+			// Neither atom is a soltype.Lit, so an unannotated binding has no primitive to
+			// widen toward and keeps the atom. widen's switch is over LitType only.
+			name: "UnannotatedValKeepsAtom",
+			src:  `val n = null`,
+			want: "null",
+		},
+		{
+			// A `var` widens its initializer so the cell can later hold another value of the
+			// same primitive. `null` is already its own widest form, so widen leaves it be.
+			name: "UnannotatedVarKeepsAtom",
+			src:  `var n = undefined`,
+			want: "undefined",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["n"])
+		})
+	}
+}
+
+// Two `null` annotations in one module each resolve without tripping the provenance table.
+// soltype.NullType has no fields, so Go gives every instance one address, and Prov is keyed by
+// pointer identity — recording against it would file both under a single entry and panic the
+// debugProv guard on the second. resolveLitTypeAnn returns the atom before its recordProv call
+// for that reason, the same as the `never` and `unknown` arms.
+func TestInferNullAnnotationTwiceInOneModule(t *testing.T) {
+	values, _, errs := inferSource(t, "val n: null = null\nval u: undefined = undefined")
+	require.Empty(t, errs)
+	require.Equal(t, "null", values["n"])
+	require.Equal(t, "undefined", values["u"])
+}
+
+// Each atom relates only to itself. It is unrelated to the other atom, to `void`, and to every
+// data type, which is TypeScript's behavior under strict null checks.
+func TestInferNullUndefinedUnrelated(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "NullIsNotUndefined",
+			src:  `val n: null = undefined`,
+			want: "1:15-1:24: cannot constrain undefined <: null",
+		},
+		{
+			name: "UndefinedIsNotNull",
+			src:  `val n: undefined = null`,
+			want: "1:20-1:24: cannot constrain null <: undefined",
+		},
+		{
+			name: "NullIsNotANumber",
+			src:  `val n: number = null`,
+			want: "1:17-1:21: cannot constrain null <: number",
+		},
+		{
+			name: "NumberIsNotNull",
+			src:  `val n: null = 5`,
+			want: "1:15-1:16: cannot constrain 5 <: null",
+		},
+		{
+			// `void` is the result of a statement block with no value, which the body of
+			// `g` below produces. It is a third atom, distinct from both absence markers.
+			name: "NullIsNotVoid",
+			src:  "fn g() {}\nval n: null = g()",
+			want: "2:15-2:18: cannot constrain void <: null",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+		})
+	}
+}
+
+// Every type is a subtype of the top of the lattice, so each atom reaches `unknown` through
+// constrain's `_ <: unknown` rule rather than through an arm of its own.
+func TestInferNullUndefinedFlowIntoUnknown(t *testing.T) {
+	_, _, errs := inferSource(t, "val n: unknown = null\nval u: unknown = undefined")
+	require.Empty(t, errs)
+}
+
+// Reading an optional property joins `undefined` into the result, so `o.a` for
+// `o: {a?: number}` infers `number | undefined`. That type is now writable, which closes the
+// gap where the checker inferred a type no annotation could name.
+func TestInferOptionalPropertyReadAgainstWrittenUndefined(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val o: {a?: number} = {}
+		val x: number | undefined = o.a
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number | undefined", values["x"])
+}
+
+// A union renders its data members before its absence markers, which typeKindOrder fixes as
+// NullType, then Void, then UndefinedType. The source order below is the reverse, so the render
+// shows the canonical order rather than the written one.
+func TestInferNullUndefinedUnionCanonicalOrder(t *testing.T) {
+	values, _, errs := inferSource(t, `val u: undefined | null | number = 5`)
+	require.Empty(t, errs)
+	require.Equal(t, "number | null | undefined", values["u"])
+}
+
+// A `null` match arm binds against a union scrutinee that carries the atom, and the two arms
+// together cover every member, so the match needs no catch-all. The catch-all arm still binds
+// the whole union, since only an object or tuple pattern narrows a union scrutinee — a `null`
+// arm leaves the members after it alone, exactly as a literal arm does.
+func TestInferMatchNullArmCoversUnionMember(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number | null) {
+			return match x {
+				null => 0,
+				n => n
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (x: number | null) -> number | null", values["f"])
+}
+
+// A union member no arm names leaves the match non-exhaustive. The `null` arm covers the
+// `null` member, so `undefined` is what escapes.
+func TestInferMatchNullArmMissingUndefinedMember(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(x: null | undefined) {
+			return match x {
+				null => 0
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "3:11-5:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+}
+
+// Naming both atoms covers a scrutinee made of nothing else.
+func TestInferMatchBothAtomArmsCoverUnion(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: null | undefined) {
+			return match x {
+				null => 0,
+				undefined => 1
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (x: null | undefined) -> 0 | 1", values["f"])
+}

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -249,6 +249,27 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 			wantExpanded: "never",
 		},
 		{
+			// `null` and `undefined` have no members either, so each projects the empty key set
+			// the same way a primitive does. A mapped type over one reduces to `{}` rather than
+			// stalling on an unreduced `keyof null`.
+			name: "NullAtom",
+			src: `
+				type N = null
+				type Result = keyof N
+			`,
+			wantSymbolic: "keyof N",
+			wantExpanded: "never",
+		},
+		{
+			name: "UndefinedAtom",
+			src: `
+				type U = undefined
+				type Result = keyof U
+			`,
+			wantSymbolic: "keyof U",
+			wantExpanded: "never",
+		},
+		{
 			// A recursive alias terminates: projecting its keys never descends into the recursive
 			// `children` field value.
 			name: "RecursiveAlias",

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -121,6 +121,13 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		return &soltype.WildcardPat{}
 
 	case *ast.LitPat:
+		if atom, atomPat, isAtom := atomLitOf(p.Lit); isAtom {
+			// A `null` or `undefined` arm asserts the atom is an admissible value of the
+			// scrutinee, the same direction as the literal case below, and binds nothing.
+			c.constrain(p, atom, scrutinee)
+			c.recordType(p, atom)
+			return atomPat
+		}
 		lt, ok := c.litTypeOf(p.Lit)
 		if !ok {
 			c.reportUnsupported(p.Lit)
@@ -686,8 +693,33 @@ func propReq(name string, t soltype.Type, optional bool) *soltype.ObjectType {
 	}
 }
 
+// atomLitOf lowers `null` and `undefined` to the soltype type each one names and to the
+// pattern that matches it. They are the two literals whose type is not a LitType, since
+// soltype.Lit has no member for either. litTypeOf below therefore cannot return them, and
+// every site that turns a written literal into a type asks this function first. ok=false
+// for every other literal kind, which litTypeOf covers.
+//
+// The caller must not record provenance against the returned type. soltype.NullType and
+// soltype.UndefinedType are empty structs, so Go gives every instance of one the same
+// address, and the Prov side table is keyed by pointer identity. Recording against one
+// would file every `null` in the module under a single entry, so each would report the
+// last one's span, and the debugProv guard would panic on the second. The NeverTypeAnn
+// and UnknownTypeAnn arms in resolveTypeAnn skip recording for the same reason.
+func atomLitOf(lit ast.Lit) (soltype.Type, soltype.Pat, bool) {
+	switch lit.(type) {
+	case *ast.NullLit:
+		return &soltype.NullType{}, &soltype.NullPat{}, true
+	case *ast.UndefinedLit:
+		return &soltype.UndefinedType{}, &soltype.UndefinedPat{}, true
+	}
+	return nil, nil, false
+}
+
 // litTypeOf lowers an ast literal to its soltype LitType, mirroring inferLiteral.
 // ok=false for a literal kind outside the M-subset (the caller reports it).
+// `null` and `undefined` also return ok=false here even though each has a soltype
+// form, since neither form is a LitType. A caller that accepts them asks atomLitOf
+// above first.
 func (c *checker) litTypeOf(lit ast.Lit) (*soltype.LitType, bool) {
 	switch l := lit.(type) {
 	case *ast.NumLit:

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -425,11 +425,21 @@ func (c *checker) resolveKeyOfTypeAnn(scope *Scope, ta *ast.KeyOfTypeAnn, lvl in
 	return t, true
 }
 
-// resolveLitTypeAnn lowers a string, number, or boolean literal type annotation to its LitType,
-// reusing litTypeOf. It is the annotation home for a literal type, which an indexed access needs
-// for its key, so `Point["x"]` carries `"x"` as a LitTypeAnn index. A literal with no soltype
-// form, such as a regex, a bigint, null, or undefined, reports unsupported and recovers.
+// resolveLitTypeAnn lowers a literal type annotation to the type it names. A string, number, or
+// boolean literal becomes its LitType through litTypeOf. This is the annotation home for a literal
+// type, which an indexed access needs for its key, so `Point["x"]` carries `"x"` as a LitTypeAnn
+// index.
+//
+// `null` and `undefined` become the atoms atomLitOf returns. That makes both writable in an
+// annotation, so a binding can be declared `val n: null = null` and `NonNullable<T>` can test
+// its argument against `null | undefined`. The atom returns above the recordProv call below,
+// since neither atom can carry provenance. atomLitOf explains why.
+//
+// A literal with no soltype form, such as a regex or a bigint, reports unsupported and recovers.
 func (c *checker) resolveLitTypeAnn(ta *ast.LitTypeAnn) (soltype.Type, bool) {
+	if atom, _, isAtom := atomLitOf(ta.Lit); isAtom {
+		return atom, true
+	}
 	lit, ok := c.litTypeOf(ta.Lit)
 	if !ok {
 		return c.reportUnsupported(ta), false
@@ -820,6 +830,9 @@ func (c *checker) mirrorParamPat(pat ast.Pat) soltype.Pat {
 	case *ast.WildcardPat:
 		return &soltype.WildcardPat{}
 	case *ast.LitPat:
+		if _, atomPat, isAtom := atomLitOf(p.Lit); isAtom {
+			return atomPat
+		}
 		if lt, ok := c.litTypeOf(p.Lit); ok {
 			return &soltype.LitPat{Lit: lt.Lit}
 		}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1000,7 +1000,13 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, inexact bool) soltype.
 	case *soltype.IntersectionType:
 		// An intersection carries every operand's members, so its key sets union.
 		return e.keyofIntersection(op.Types, inexact)
-	case *soltype.PrimType, *soltype.LitType, *soltype.NeverType, *soltype.UnknownType:
+	case *soltype.PrimType, *soltype.LitType, *soltype.NeverType, *soltype.UnknownType,
+		*soltype.NullType, *soltype.UndefinedType:
+		// None of these carries a readable member, so its key set is empty. `null` and
+		// `undefined` reach this arm once an annotation can name them, and a mapped type
+		// over either needs the ground `never` to build its empty result. Without it,
+		// `Partial<null>` stays the residual `{[K: keyof null]?: null[K]}` and rejects the
+		// `{}` that should satisfy it.
 		return &soltype.NeverType{}
 	default:
 		return &soltype.KeyofType{Operand: operand, Inexact: inexact}

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -35,6 +35,22 @@ import (
 // nullary alongside it. M9 PR14 settles what the bound becomes once the pattern matches any arity.
 // TestUtilityTypeReturnTypeIsAritySpecific records the arity restriction itself.
 //
+// `NonNullable<T>` is a conditional here, where TypeScript writes the intersection `T & {}`. That
+// intersection is not translatable, for two independent reasons.
+//
+// The first is what the empty object type means. TypeScript's `{}` is the non-nullish top, the
+// type of every value except `null` and `undefined`, so `string <: {}` holds and `string & {}`
+// stays `string`. Escalier's `{...}` is the inexact OBJECT type, so it admits an object of any
+// shape and nothing else. `val a: {...} = 5` is rejected with "cannot constrain 5 <: object".
+// Writing `T & {...}` would therefore leave `NonNullable<string>` uninhabited instead of `string`,
+// and it would strip `void` alongside the two absence markers.
+//
+// The second is that an intersection does not reduce. Nothing distributes one over a union or
+// detects an empty one, so `NonNullable<string | null>` would stall as the residual
+// `(string | null) & {...}` rather than grounding. The conditional needs neither piece. `T` is a
+// naked type parameter, so it distributes over the argument and decides each member alone, which
+// is machinery the conditional evaluator already carries.
+//
 // `Parameters<F>`, `ConstructorParameters<C>`, and `InstanceType<C>` are the three utilities the
 // suite cannot express yet. Each has a disabled test at the end of this file naming what it waits
 // on.

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -104,6 +104,14 @@ func TestUtilityTypeReductions(t *testing.T) {
 			src:          `type Result = Partial<{}>`,
 			wantExpanded: "{}",
 		},
+		{
+			// `null` carries no readable member, so `keyof null` is the empty key set too and the
+			// map emits no fields. Mapping over an atom is degenerate rather than an error, which
+			// is how a primitive argument behaves as well.
+			name:         "PartialOfNull",
+			src:          `type Result = Partial<null>`,
+			wantExpanded: "{}",
+		},
 		// `Required<T>` clears `?` from every field, the `-?` modifier's job. A field that was
 		// already required is unaffected.
 		{

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -35,9 +35,9 @@ import (
 // nullary alongside it. M9 PR14 settles what the bound becomes once the pattern matches any arity.
 // TestUtilityTypeReturnTypeIsAritySpecific records the arity restriction itself.
 //
-// `NonNullable<T>`, `Parameters<F>`, `ConstructorParameters<C>`, and `InstanceType<C>` are the
-// four utilities the suite cannot express yet. Each has a disabled test at the end of this file
-// naming what it waits on.
+// `Parameters<F>`, `ConstructorParameters<C>`, and `InstanceType<C>` are the three utilities the
+// suite cannot express yet. Each has a disabled test at the end of this file naming what it waits
+// on.
 //
 // Two declarations at the end are not TypeScript utilities. `EventName<K>` is a template-literal
 // type that builds a handler name from an event name. `Point` is the sample object several tests
@@ -52,6 +52,7 @@ const utilityTypeDecls = `
 	type Exclude<U, V> = if U : V { never } else { U }
 	type Extract<U, V> = if U : V { U } else { never }
 	type ReturnType<F> = if F : fn () -> infer R { R } else { never }
+	type NonNullable<T> = if T : null | undefined { never } else { T }
 	type Awaited<T> = if T : Promise<infer U> { Awaited<U> } else { T }
 	type EventName<K> = ` + "`on${Capitalize<K>}`" + `
 	type Point = {x: number, y: string}
@@ -804,39 +805,28 @@ func TestUtilityTypeDistributesOverUnionAlias(t *testing.T) {
 	*/
 }
 
-// DISABLED until M9 PR16, which gives `null` and `undefined` a surface. `soltype.NullType` and
-// `soltype.UndefinedType` already exist as atoms and `undefined` is already inferred, since reading
-// an optional property yields `number | undefined`. What no annotation reaches is either atom, so
-// `resolveLitTypeAnn` reports `Unsupported: LitTypeAnn` for both spellings and the `null |
-// undefined` operand `NonNullable<T>` tests against cannot be written. `constrain` also carries a
-// reflexive arm for `UndefinedType` and none for `NullType`. Re-enable by removing the comment
-// wrapper once both exist, and add
-//
-//	type NonNullable<T> = if T : null | undefined { never } else { T }
-//
-// to utilityTypeDecls, which is where runUtilityReductions reads each utility's definition from.
+// `NonNullable<T>` strips the two absence markers from a union. `T` is a naked type parameter, so
+// the conditional distributes over the argument and decides each member alone.
 func TestUtilityTypeNonNullable(t *testing.T) {
-	/*
-		runUtilityReductions(t, []utilityReduction{
-			{
-				// The naked type parameter distributes, so each member is decided alone and the two
-				// absence markers drop out.
-				name:         "StripsBothMarkers",
-				src:          `type Result = NonNullable<string | null | undefined>`,
-				wantExpanded: "string",
-			},
-			{
-				name:         "LeavesOtherMembers",
-				src:          `type Result = NonNullable<string | number>`,
-				wantExpanded: "string | number",
-			},
-			{
-				name:         "EveryMemberStripped",
-				src:          `type Result = NonNullable<null | undefined>`,
-				wantExpanded: "never",
-			},
-		})
-	*/
+	runUtilityReductions(t, []utilityReduction{
+		{
+			name:         "StripsBothMarkers",
+			src:          `type Result = NonNullable<string | null | undefined>`,
+			wantExpanded: "string",
+		},
+		{
+			// Distributing rebuilds the union, so the result comes back in the canonical
+			// order lattice.go documents rather than the source order.
+			name:         "LeavesOtherMembers",
+			src:          `type Result = NonNullable<string | number>`,
+			wantExpanded: "number | string",
+		},
+		{
+			name:         "EveryMemberStripped",
+			src:          `type Result = NonNullable<null | undefined>`,
+			wantExpanded: "never",
+		},
+	})
 }
 
 // DISABLED until a rest parameter can be written in a function type annotation and an `infer`


### PR DESCRIPTION
Implements M9 PR16 to make `null` and `undefined` available as written surface syntax in type annotations and patterns, closing the gap where these types could be inferred but not explicitly named.

## Changes

- **Type atoms**: Added `NullPat` and `UndefinedPat` to `soltype/type.go` to represent patterns matching `null` and `undefined` values, since neither is a `LitType`.

- **Annotation resolution**: Modified `resolveLitTypeAnn` in `type_ann.go` to recognize `null` and `undefined` literals and return their corresponding atom types without recording provenance (both atoms are empty structs with shared pointer identity, so provenance recording would incorrectly file all occurrences under a single entry).

- **Expression inference**: Updated `inferLiteral` in `infer_expr.go` to handle `null` and `undefined` through a new `atomLitOf` helper that returns the atom type and pattern for these literals.

- **Pattern matching**: Extended `bindPatMode` in `pattern.go` to recognize `null` and `undefined` patterns in match arms, constraining them against the scrutinee and binding nothing.

- **Union exhaustiveness**: Added `atomMemberCovered` function to check whether a match arm covers a `null` or `undefined` union member, mirroring the existing `litMemberCovered` logic.

- **Type constraints**: Added a reflexive constraint rule for `NullType` in `constrain.go` so `null <: null` succeeds, matching TypeScript's strict null checks behavior.

- **Keyof reduction**: Updated `reduceKeyof` in `typeops.go` to treat `null` and `undefined` as having empty key sets (like primitives), allowing mapped types like `Partial<null>` to reduce to `{}`.

- **Utility type**: Re-enabled `TestUtilityTypeNonNullable` in `utility_types_test.go` by uncommenting the test and adding the `NonNullable<T>` definition to `utilityTypeDecls`, now that `null | undefined` can be written.

- **Pattern printing**: Added cases to `printPat` in `soltype/print.go` to render `NullPat` and `UndefinedPat` as `"null"` and `"undefined"`.

## Implementation notes

The `atomLitOf` helper centralizes the lowering of `null` and `undefined` literals to their atom types and patterns. It explicitly avoids recording provenance because both `NullType` and `UndefinedType` are empty structs, giving every instance the same pointer address. Recording against them would incorrectly consolidate all occurrences in the module under a single provenance entry, causing each to report the last one's span. This mirrors the existing behavior of `NeverTypeAnn` and `UnknownTypeAnn` in `resolveTypeAnn`.

Each atom relates only to itself and flows into `unknown` through the existing `_ <: unknown` rule, matching TypeScript's strict null checks semantics.

https://claude.ai/code/session_011rjmbspmbbXXG28GSdLCBT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `null` and `undefined` values in type inference, annotations, patterns, constraints, and match exhaustiveness.
  * Added support for `NonNullable<T>`, removing `null` and `undefined` from types.
  * `keyof null` and `keyof undefined` now resolve to `never`.

* **Bug Fixes**
  * Improved rendering of `null` and `undefined` in destructuring parameters.
  * Added handling for optional-property reads and unions involving these values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->