### PR TITLE
Implement throws clause inference and checking

### DIFF
--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -3799,3 +3799,52 @@
     span: 1:1-1:8,
 }
 ---
+
+[TestParseExprNoErrors/FuncExprWithThrowsAndNoReturnType - 1]
+&ast.FuncExpr{
+    FuncSig: ast.FuncSig{
+        Params: []*ast.Param{
+            &ast.Param{
+                Pattern: &ast.IdentPat{
+                    Name: "a",
+                    span: 1:5-1:6,
+                },
+            },
+            &ast.Param{
+                Pattern: &ast.IdentPat{
+                    Name: "b",
+                    span: 1:8-1:9,
+                },
+            },
+        },
+        Throws: &ast.TypeRefTypeAnn{
+            Name: &ast.Ident{
+                Name: "Error",
+                span: 1:18-1:23,
+            },
+            span: 1:18-1:23,
+        },
+    },
+    Body: &ast.Block{
+        Stmts: []ast.Stmt{
+            &ast.ExprStmt{
+                Expr: &ast.BinaryExpr{
+                    Left: &ast.IdentExpr{
+                        Name: "a",
+                        span: 1:26-1:27,
+                    },
+                    Op: "+",
+                    Right: &ast.IdentExpr{
+                        Name: "b",
+                        span: 1:30-1:31,
+                    },
+                    span: 1:26-1:31,
+                },
+                span: 1:26-1:31,
+            },
+        },
+        Span: 1:24-1:33,
+    },
+    span: 1:1-1:33,
+}
+---

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -5833,3 +5833,59 @@
     span: 2:5-3:18,
 }
 ---
+
+[TestParseModuleNoErrors/FuncDeclWithThrowsAndNoReturnType - 1]
+&ast.DeclStmt{
+    Decl: &ast.FuncDecl{
+        Name: &ast.Ident{
+            Name: "divide",
+            span: 2:8-2:14,
+        },
+        FuncSig: ast.FuncSig{
+            Params: []*ast.Param{
+                &ast.Param{
+                    Pattern: &ast.IdentPat{
+                        Name: "a",
+                        span: 2:15-2:16,
+                    },
+                },
+                &ast.Param{
+                    Pattern: &ast.IdentPat{
+                        Name: "b",
+                        span: 2:18-2:19,
+                    },
+                },
+            },
+            Throws: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "DivisionByZeroError",
+                    span: 2:28-2:47,
+                },
+                span: 2:28-2:47,
+            },
+        },
+        Body: &ast.Block{
+            Stmts: []ast.Stmt{
+                &ast.ReturnStmt{
+                    Expr: &ast.BinaryExpr{
+                        Left: &ast.IdentExpr{
+                            Name: "a",
+                            span: 3:13-3:14,
+                        },
+                        Op: "/",
+                        Right: &ast.IdentExpr{
+                            Name: "b",
+                            span: 3:17-3:18,
+                        },
+                        span: 3:13-3:18,
+                    },
+                    span: 3:6-3:18,
+                },
+            },
+            Span: 2:48-4:6,
+        },
+        span: 2:5-4:6,
+    },
+    span: 2:5-4:6,
+}
+---

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -2333,3 +2333,60 @@
     },
 }
 ---
+
+[TestParseTypeAnnNoErrors/ObjectMethodWithThrows - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.MethodTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "parse",
+                span: 1:2-1:7,
+            },
+            Fn: &ast.FuncTypeAnn{
+                Return: &ast.NumberTypeAnn{
+                    span: 1:17-1:23,
+                },
+                Throws: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "SyntaxError",
+                        span: 1:31-1:42,
+                    },
+                    span: 1:31-1:42,
+                },
+                span: 1:7-1:42,
+            },
+            Receiver: &ast.MethodReceiver{
+                Span_: 1:8-1:12,
+            },
+        },
+    },
+    span: 1:1-1:43,
+}
+---
+
+[TestParseTypeAnnNoErrors/FuncWithThrows - 1]
+&ast.FuncTypeAnn{
+    Params: []*ast.Param{
+        &ast.Param{
+            Pattern: &ast.IdentPat{
+                Name: "x",
+                span: 1:4-1:5,
+            },
+            TypeAnn: &ast.NumberTypeAnn{
+                span: 1:7-1:13,
+            },
+        },
+    },
+    Return: &ast.BooleanTypeAnn{
+        span: 1:18-1:25,
+    },
+    Throws: &ast.TypeRefTypeAnn{
+        Name: &ast.Ident{
+            Name: "Error",
+            span: 1:33-1:38,
+        },
+        span: 1:33-1:38,
+    },
+    span: 1:1-1:38,
+}
+---

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -691,24 +691,18 @@ func (p *Parser) parseConstructorElem(
 	// `throws` may appear in either order relative to `->` (the arrow form
 	// is itself an error). Accept whichever comes first; if both appear we
 	// keep the first one and discard the second.
+	throwsType := p.throwsClause()
 	next = p.lexer.peek()
-	var throwsType ast.TypeAnn
-	if next.Type == Throws {
-		p.lexer.consume()
-		throwsType = p.typeAnn()
-		next = p.lexer.peek()
-	}
 	if next.Type == Arrow {
 		p.reportError(next.Span, "constructors cannot declare a return type")
 		p.lexer.consume()
 		_ = p.typeAnn()
-		next = p.lexer.peek()
-		// A `throws` after `->` is also tolerated, but we already errored.
-		if next.Type == Throws && throwsType == nil {
-			p.lexer.consume()
-			throwsType = p.typeAnn()
-			next = p.lexer.peek()
+		// A `throws` after `->` is also tolerated, but we already errored. A second one
+		// after a clause we already read is left unconsumed, so the first wins.
+		if throwsType == nil {
+			throwsType = p.throwsClause()
 		}
+		next = p.lexer.peek()
 	}
 
 	var body *ast.Block
@@ -840,11 +834,8 @@ modifiers_done:
 			next = p.lexer.peek()
 		}
 
-		if next.Type == Throws {
-			p.lexer.consume()
-			throwsType = p.typeAnn()
-			next = p.lexer.peek()
-		}
+		throwsType = p.throwsClause()
+		next = p.lexer.peek()
 
 		// Optionally parse block
 		if next.Type == OpenBrace {
@@ -948,12 +939,7 @@ modifiers_done:
 			returnType = p.typeAnn()
 		}
 
-		var throwsType ast.TypeAnn
-		next = p.lexer.peek()
-		if next.Type == Throws {
-			p.lexer.consume()
-			throwsType = p.typeAnn()
-		}
+		throwsType := p.throwsClause()
 
 		// Optionally parse block
 		var body *ast.Block
@@ -1161,7 +1147,6 @@ func (p *Parser) fnDecl(start ast.Location, export bool, declare bool, async boo
 	end := token.Span.End
 
 	var returnType ast.TypeAnn
-	var throwsType ast.TypeAnn
 	token = p.lexer.peek()
 	if token.Type == Arrow {
 		p.lexer.consume()
@@ -1175,19 +1160,9 @@ func (p *Parser) fnDecl(start ast.Location, export bool, declare bool, async boo
 		}
 	}
 
-	// The throws clause is parsed outside the arrow branch, so a function that lets its
-	// return type be inferred can still declare what it raises: `fn f() throws string
-	// { … }`. Methods, getters, and constructors already parse the two independently.
-	token = p.lexer.peek()
-	if token.Type == Throws {
-		p.lexer.consume()
-		throwsTypeAnn := p.typeAnn()
-		if throwsTypeAnn == nil {
-			p.reportError(token.Span, "Expected type annotation after 'throws'")
-		} else {
-			throwsType = throwsTypeAnn
-			end = throwsType.Span().End
-		}
+	throwsType := p.throwsClause()
+	if throwsType != nil {
+		end = throwsType.Span().End
 	}
 
 	// A `declare fn` has no body, so leave it nil. Only a non-declare function parses a

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -883,8 +883,12 @@ modifiers_done:
 			// param, if there isn't exactly one value param after it
 			// (instance), or if there isn't exactly one param (static).
 			p.expect(CloseParen, AlwaysConsume)
-			next = p.lexer.peek()
 		}
+
+		// A setter has no return type to write, but it can still declare what it raises,
+		// so the clause is read here as it is on a getter or a method.
+		throwsType := p.throwsClause()
+		next = p.lexer.peek()
 
 		// Optionally parse block
 		if next.Type == OpenBrace {
@@ -895,7 +899,7 @@ modifiers_done:
 		span := ast.Span{Start: start, End: p.lexer.currentLocation, SourceID: p.lexer.source.ID}
 		return &ast.SetterElem{
 			Name:     name,
-			Fn:       ast.NewFuncExpr(lifetimeParams, typeParams, params, nil, nil, false, body, span),
+			Fn:       ast.NewFuncExpr(lifetimeParams, typeParams, params, nil, throwsType, false, body, span),
 			Receiver: receiver,
 			Static:   isStatic,
 			Private:  isPrivate,

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -1173,18 +1173,20 @@ func (p *Parser) fnDecl(start ast.Location, export bool, declare bool, async boo
 			end = typeAnn.Span().End
 			returnType = typeAnn
 		}
+	}
 
-		// Check for throws clause after return type
-		token = p.lexer.peek()
-		if token.Type == Throws {
-			p.lexer.consume()
-			throwsTypeAnn := p.typeAnn()
-			if throwsTypeAnn == nil {
-				p.reportError(token.Span, "Expected type annotation after 'throws'")
-			} else {
-				throwsType = throwsTypeAnn
-				end = throwsType.Span().End
-			}
+	// The throws clause is parsed outside the arrow branch, so a function that lets its
+	// return type be inferred can still declare what it raises: `fn f() throws string
+	// { … }`. Methods, getters, and constructors already parse the two independently.
+	token = p.lexer.peek()
+	if token.Type == Throws {
+		p.lexer.consume()
+		throwsTypeAnn := p.typeAnn()
+		if throwsTypeAnn == nil {
+			p.reportError(token.Span, "Expected type annotation after 'throws'")
+		} else {
+			throwsType = throwsTypeAnn
+			end = throwsType.Span().End
 		}
 	}
 

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -697,10 +697,11 @@ func (p *Parser) parseConstructorElem(
 		p.reportError(next.Span, "constructors cannot declare a return type")
 		p.lexer.consume()
 		_ = p.typeAnn()
-		// A `throws` after `->` is also tolerated, but we already errored. A second one
-		// after a clause we already read is left unconsumed, so the first wins.
-		if throwsType == nil {
-			throwsType = p.throwsClause()
+		// A `throws` after `->` is also tolerated, but we already errored. It is consumed
+		// either way, so the body still parses when the source wrote a clause on both
+		// sides of the arrow; the first clause is the one that survives.
+		if second := p.throwsClause(); throwsType == nil {
+			throwsType = second
 		}
 		next = p.lexer.peek()
 	}

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -557,7 +557,6 @@ func (p *Parser) fnExpr(start ast.Location, async bool) ast.Expr {
 	p.expect(CloseParen, ConsumeOnMatch)
 
 	var returnType ast.TypeAnn
-	var throwsType ast.TypeAnn
 	token := p.lexer.peek()
 	if token.Type == Arrow {
 		p.lexer.consume()
@@ -569,19 +568,7 @@ func (p *Parser) fnExpr(start ast.Location, async bool) ast.Expr {
 		returnType = typeAnn
 	}
 
-	// The throws clause is parsed outside the arrow branch, so a function that lets its
-	// return type be inferred can still declare what it raises: `fn () throws string
-	// { … }`. Methods, getters, and constructors already parse the two independently.
-	token = p.lexer.peek()
-	if token.Type == Throws {
-		p.lexer.consume()
-		throwsTypeAnn := p.typeAnn()
-		if throwsTypeAnn == nil {
-			p.reportError(token.Span, "Expected type annotation after 'throws'")
-		} else {
-			throwsType = throwsTypeAnn
-		}
-	}
+	throwsType := p.throwsClause()
 
 	body := p.block()
 	end := body.Span.End

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -567,17 +567,19 @@ func (p *Parser) fnExpr(start ast.Location, async bool) ast.Expr {
 			return nil
 		}
 		returnType = typeAnn
+	}
 
-		// Check for throws clause after return type
-		token = p.lexer.peek()
-		if token.Type == Throws {
-			p.lexer.consume()
-			throwsTypeAnn := p.typeAnn()
-			if throwsTypeAnn == nil {
-				p.reportError(token.Span, "Expected type annotation after 'throws'")
-			} else {
-				throwsType = throwsTypeAnn
-			}
+	// The throws clause is parsed outside the arrow branch, so a function that lets its
+	// return type be inferred can still declare what it raises: `fn () throws string
+	// { … }`. Methods, getters, and constructors already parse the two independently.
+	token = p.lexer.peek()
+	if token.Type == Throws {
+		p.lexer.consume()
+		throwsTypeAnn := p.typeAnn()
+		if throwsTypeAnn == nil {
+			p.reportError(token.Span, "Expected type annotation after 'throws'")
+		} else {
+			throwsType = throwsTypeAnn
 		}
 	}
 

--- a/internal/parser/expr_test.go
+++ b/internal/parser/expr_test.go
@@ -114,6 +114,9 @@ func TestParseExprNoErrors(t *testing.T) {
 		"FuncExprWithThrows": {
 			input: "fn (a, b) -> number throws Error { a + b }",
 		},
+		"FuncExprWithThrowsAndNoReturnType": {
+			input: "fn (a, b) throws Error { a + b }",
+		},
 		"FuncExprReturnIfElse": {
 			input: `fn (value: string) { return if value != "" { value } else { "value is empty" } }`,
 		},

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -43,6 +43,13 @@ func TestParseModuleNoErrors(t *testing.T) {
 				}
 			`,
 		},
+		"FuncDeclWithThrowsAndNoReturnType": {
+			input: `
+				fn divide(a, b) throws DivisionByZeroError {
+					return a / b
+				}
+			`,
+		},
 		"AsyncFuncDecls": {
 			input: `
 				async fn fetchData(url: string) -> Promise<string> {

--- a/internal/parser/throws_test.go
+++ b/internal/parser/throws_test.go
@@ -64,3 +64,12 @@ func TestParseThrowsClauseMissingType(t *testing.T) {
 		require.Equal(t, "1:18-1:24: Expected type annotation after 'throws'", errs[0])
 	})
 }
+
+// A constructor accepts `throws` on either side of the `->` it may not declare. Writing
+// one on each side is a single error, the return type, and the body still parses: the
+// second clause is consumed and discarded, and the first is the one that survives.
+func TestParseThrowsClauseOnBothSidesOfConstructorArrow(t *testing.T) {
+	require.Equal(t,
+		[]string{"1:47-1:49: constructors cannot declare a return type"},
+		parseThrowsSrc(t, `class C { constructor(mut self) throws string -> number throws boolean { } }`))
+}

--- a/internal/parser/throws_test.go
+++ b/internal/parser/throws_test.go
@@ -1,0 +1,66 @@
+package parser
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// parseThrowsSrc parses one in-memory module and returns its errors, rendered with spans.
+func parseThrowsSrc(t *testing.T, src string) []string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, errs := ParseLibFiles(ctx, []*ast.Source{{ID: 0, Path: "input.esc", Contents: src}})
+	out := make([]string, len(errs))
+	for i, e := range errs {
+		out[i] = e.String()
+	}
+	return out
+}
+
+// Every signature form that can carry a `throws` clause parses one, independently of
+// whether it also writes a `-> R` return annotation. The clause routes through one
+// helper, so a form that parses it at all parses it the same way.
+func TestParseThrowsClauseOnEverySignatureForm(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"FnDeclWithReturnType", `fn f() -> number throws string { return 1 }`},
+		{"FnDeclWithoutReturnType", `fn f() throws string { throw "x" }`},
+		{"FnExprWithoutReturnType", `val f = fn () throws string { throw "x" }`},
+		{"DeclareFn", `declare fn f() -> number throws string`},
+		{"Method", `class C { m(self) -> number throws string { throw "x" } }`},
+		{"Getter", `class C { v: number, get x(self) -> number throws string { return self.v } }`},
+		{"Setter", `class C { v: number, set x(mut self, v: number) throws string { self.v = v } }`},
+		{"Constructor", `class C { constructor(mut self) throws string { throw "x" } }`},
+		{"FuncTypeAnn", `type F = fn(x: number) -> number throws string`},
+		{"ObjectMethodSignature", `type T = {parse(self) -> number throws SyntaxError}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Empty(t, parseThrowsSrc(t, test.src))
+		})
+	}
+}
+
+// A `throws` with no type after it is one error, and the rest of the signature still
+// parses. The `{` case is the one that matters: handing the block to the type parser
+// would read it as an object type and consume the function body, so the clause has to
+// end before it.
+func TestParseThrowsClauseMissingType(t *testing.T) {
+	t.Run("FollowedByABody", func(t *testing.T) {
+		require.Equal(t,
+			[]string{"1:8-1:14: Expected type annotation after 'throws'"},
+			parseThrowsSrc(t, `fn f() throws { return 1 }`))
+	})
+	t.Run("FollowedByTheNextDeclaration", func(t *testing.T) {
+		errs := parseThrowsSrc(t, "fn f() -> number throws\nval y = 1")
+		require.NotEmpty(t, errs)
+		require.Equal(t, "1:18-1:24: Expected type annotation after 'throws'", errs[0])
+	})
+}

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -957,14 +957,25 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		p.expect(Arrow, ConsumeOnMatch)
 
 		retType := p.typeAnnRequired()
+		endSpan := retType.Span()
+
+		// A method, getter, or setter signature inside an object type declares what it
+		// raises the same way a standalone function type does: `{run(): number throws
+		// string}`.
+		var throwsType ast.TypeAnn
+		if p.lexer.peek().Type == Throws {
+			p.lexer.consume()
+			throwsType = p.typeAnnRequired()
+			endSpan = throwsType.Span()
+		}
 
 		fnTypeAnn := ast.NewFuncTypeAnn(
 			lifetimeParams,
 			typeParams,
 			params,
 			retType,
-			nil, // TODO: support throws clause
-			ast.MergeSpans(token.Span, retType.Span()),
+			throwsType,
+			ast.MergeSpans(token.Span, endSpan),
 		)
 
 		// nolint: exhaustive

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -44,12 +44,21 @@ func (p *Parser) typeAnnRequired() ast.TypeAnn {
 // that lets its return type be inferred can still declare what it raises, as in
 // `fn f() throws string { … }`. A `throws` with no type after it is reported and yields
 // nil, so the caller keeps the rest of the signature.
+//
+// An `{` after `throws` is the function's body, not the start of an object type, so the
+// clause ends before it. Handing the block to typeAnn instead would parse `fn f() throws
+// { return 1 }` as a function raising the object type `{ return 1 }`, consuming the body
+// and leaving the caller to fail on whatever follows.
 func (p *Parser) throwsClause() ast.TypeAnn {
 	token := p.lexer.peek()
 	if token.Type != Throws {
 		return nil
 	}
 	p.lexer.consume()
+	if p.lexer.peek().Type == OpenBrace {
+		p.reportError(token.Span, "Expected type annotation after 'throws'")
+		return nil
+	}
 	throwsType := p.typeAnn()
 	if throwsType == nil {
 		p.reportError(token.Span, "Expected type annotation after 'throws'")

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -39,6 +39,24 @@ func (p *Parser) typeAnnRequired() ast.TypeAnn {
 	return typeAnn
 }
 
+// throwsClause parses an optional `throws T` clause and returns T, or nil when the next
+// token is not `throws`. It is independent of the `-> R` return annotation, so a function
+// that lets its return type be inferred can still declare what it raises, as in
+// `fn f() throws string { … }`. A `throws` with no type after it is reported and yields
+// nil, so the caller keeps the rest of the signature.
+func (p *Parser) throwsClause() ast.TypeAnn {
+	token := p.lexer.peek()
+	if token.Type != Throws {
+		return nil
+	}
+	p.lexer.consume()
+	throwsType := p.typeAnn()
+	if throwsType == nil {
+		p.reportError(token.Span, "Expected type annotation after 'throws'")
+	}
+	return throwsType
+}
+
 func (p *Parser) typeAnn() ast.TypeAnn {
 	typeAnns := NewStack[ast.TypeAnn]()
 	ops := NewStack[*TypeAnnOp]()
@@ -960,12 +978,10 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		endSpan := retType.Span()
 
 		// A method, getter, or setter signature inside an object type declares what it
-		// raises the same way a standalone function type does: `{run(): number throws
-		// string}`.
-		var throwsType ast.TypeAnn
-		if p.lexer.peek().Type == Throws {
-			p.lexer.consume()
-			throwsType = p.typeAnnRequired()
+		// raises the same way a standalone function type does, as in
+		// `{parse(self) -> number throws SyntaxError}`.
+		throwsType := p.throwsClause()
+		if throwsType != nil {
 			endSpan = throwsType.Span()
 		}
 

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -51,6 +51,12 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 		"FuncWithTypeParams": {
 			input: "fn<T: number, U: string>(x: T, y: U) -> boolean",
 		},
+		"FuncWithThrows": {
+			input: "fn(x: number) -> boolean throws Error",
+		},
+		"ObjectMethodWithThrows": {
+			input: "{parse(self) -> number throws SyntaxError}",
+		},
 		"UnionType": {
 			input: "A | B | C",
 		},

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -436,28 +436,44 @@ func (p *Printer) printMethodSig(sig *ast.FuncSig, recv *ast.MethodReceiver) {
 		}
 	}
 	p.writeString(")")
-	if sig.Return != nil {
-		p.writeString(" -> ")
-		p.printTypeAnn(sig.Return)
-	}
-	p.printThrowsClause(sig.Throws)
+	p.printReturnAndThrows(sig.Return, sig.Throws)
 }
 
-// printThrowsClause emits ` throws T` after a signature's return type, or nothing when
-// the function raises nothing. Both spellings of that count: an absent clause, and an
+// printReturnAndThrows emits ` -> R` followed by any `throws T` clause. Every signature
+// form routes through it, so a function, method, getter, setter, and function type
+// annotation all render the pair the same way. A nil ret emits no arrow, which is the
+// `fn f() throws string { … }` form that lets its return type be inferred.
+//
+// A clause is emitted for neither spelling of "raises nothing": an absent clause, and an
 // explicit `throws never`, which names the empty set of raised values and carries no more
-// information than writing no clause at all. Every signature form routes through here so
-// a method, getter, setter, function, and function type annotation all render the clause
-// the same way.
-func (p *Printer) printThrowsClause(throws ast.TypeAnn) {
-	if throws == nil {
-		return
-	}
+// information than writing no clause at all.
+//
+// `-> R` is greedy, so a function-typed return is parenthesized once a clause follows it,
+// or the clause reads as the INNER function's. A function that returns a non-throwing
+// function and itself raises `string` prints `fn () -> (fn () -> number) throws string`.
+// Drop those parens and it is indistinguishable from a function that returns one raising
+// `string`, which is what re-reading it would give. soltype's printFuncBody parenthesizes
+// the coalesced form for the same reason.
+func (p *Printer) printReturnAndThrows(ret ast.TypeAnn, throws ast.TypeAnn) {
+	clause := throws
 	if _, isNever := throws.(*ast.NeverTypeAnn); isNever {
-		return
+		clause = nil
 	}
-	p.writeString(" throws ")
-	p.printTypeAnn(throws)
+	if ret != nil {
+		p.writeString(" -> ")
+		_, retIsFunc := ret.(*ast.FuncTypeAnn)
+		if retIsFunc && clause != nil {
+			p.writeString("(")
+			p.printTypeAnn(ret)
+			p.writeString(")")
+		} else {
+			p.printTypeAnn(ret)
+		}
+	}
+	if clause != nil {
+		p.writeString(" throws ")
+		p.printTypeAnn(clause)
+	}
 }
 
 // printDecorators emits each decorator on its own line, preserving
@@ -1055,12 +1071,7 @@ func (p *Printer) printFuncSig(sig *ast.FuncSig) {
 	}
 	p.writeString(")")
 
-	if sig.Return != nil {
-		p.writeString(" -> ")
-		p.printTypeAnn(sig.Return)
-	}
-
-	p.printThrowsClause(sig.Throws)
+	p.printReturnAndThrows(sig.Return, sig.Throws)
 }
 
 func (p *Printer) printBlock(block *ast.Block) {
@@ -1341,15 +1352,12 @@ func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
 			}
 		}
 		p.writeString(")")
-		p.writeString(" -> ")
-		p.printTypeAnn(e.Fn.Return)
-		p.printThrowsClause(e.Fn.Throws)
+		p.printReturnAndThrows(e.Fn.Return, e.Fn.Throws)
 	case *ast.GetterTypeAnn:
 		p.writeString("get ")
 		p.printObjKey(e.Name)
-		p.writeString("(self) -> ")
-		p.printTypeAnn(e.Fn.Return)
-		p.printThrowsClause(e.Fn.Throws)
+		p.writeString("(self)")
+		p.printReturnAndThrows(e.Fn.Return, e.Fn.Throws)
 	case *ast.SetterTypeAnn:
 		p.writeString("set ")
 		p.printObjKey(e.Name)
@@ -1363,9 +1371,7 @@ func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
 		}
 		p.writeString(")")
 		// Setters require -> void in Escalier syntax
-		p.writeString(" -> ")
-		p.printTypeAnn(e.Fn.Return)
-		p.printThrowsClause(e.Fn.Throws)
+		p.printReturnAndThrows(e.Fn.Return, e.Fn.Throws)
 	case *ast.PropertyTypeAnn:
 		if e.Readonly {
 			p.writeString("readonly ")
@@ -1569,10 +1575,7 @@ func (p *Printer) printFuncTypeAnn(typ *ast.FuncTypeAnn) {
 	}
 	p.writeString(")")
 
-	p.writeString(" -> ")
-	p.printTypeAnn(typ.Return)
-
-	p.printThrowsClause(typ.Throws)
+	p.printReturnAndThrows(typ.Return, typ.Throws)
 }
 
 func (p *Printer) printTemplateLitTypeAnn(typ *ast.TemplateLitTypeAnn) {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -440,10 +440,24 @@ func (p *Printer) printMethodSig(sig *ast.FuncSig, recv *ast.MethodReceiver) {
 		p.writeString(" -> ")
 		p.printTypeAnn(sig.Return)
 	}
-	if sig.Throws != nil {
-		p.writeString(" throws ")
-		p.printTypeAnn(sig.Throws)
+	p.printThrowsClause(sig.Throws)
+}
+
+// printThrowsClause emits ` throws T` after a signature's return type, or nothing when
+// the function raises nothing. Both spellings of that count: an absent clause, and an
+// explicit `throws never`, which names the empty set of raised values and carries no more
+// information than writing no clause at all. Every signature form routes through here so
+// a method, getter, setter, function, and function type annotation all render the clause
+// the same way.
+func (p *Printer) printThrowsClause(throws ast.TypeAnn) {
+	if throws == nil {
+		return
 	}
+	if _, isNever := throws.(*ast.NeverTypeAnn); isNever {
+		return
+	}
+	p.writeString(" throws ")
+	p.printTypeAnn(throws)
 }
 
 // printDecorators emits each decorator on its own line, preserving
@@ -1046,10 +1060,7 @@ func (p *Printer) printFuncSig(sig *ast.FuncSig) {
 		p.printTypeAnn(sig.Return)
 	}
 
-	if sig.Throws != nil {
-		p.writeString(" throws ")
-		p.printTypeAnn(sig.Throws)
-	}
+	p.printThrowsClause(sig.Throws)
 }
 
 func (p *Printer) printBlock(block *ast.Block) {
@@ -1332,15 +1343,13 @@ func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
 		p.writeString(")")
 		p.writeString(" -> ")
 		p.printTypeAnn(e.Fn.Return)
-		if e.Fn.Throws != nil {
-			p.writeString(" throws ")
-			p.printTypeAnn(e.Fn.Throws)
-		}
+		p.printThrowsClause(e.Fn.Throws)
 	case *ast.GetterTypeAnn:
 		p.writeString("get ")
 		p.printObjKey(e.Name)
 		p.writeString("(self) -> ")
 		p.printTypeAnn(e.Fn.Return)
+		p.printThrowsClause(e.Fn.Throws)
 	case *ast.SetterTypeAnn:
 		p.writeString("set ")
 		p.printObjKey(e.Name)
@@ -1356,6 +1365,7 @@ func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
 		// Setters require -> void in Escalier syntax
 		p.writeString(" -> ")
 		p.printTypeAnn(e.Fn.Return)
+		p.printThrowsClause(e.Fn.Throws)
 	case *ast.PropertyTypeAnn:
 		if e.Readonly {
 			p.writeString("readonly ")
@@ -1562,12 +1572,7 @@ func (p *Printer) printFuncTypeAnn(typ *ast.FuncTypeAnn) {
 	p.writeString(" -> ")
 	p.printTypeAnn(typ.Return)
 
-	if typ.Throws != nil {
-		if _, isNever := typ.Throws.(*ast.NeverTypeAnn); !isNever {
-			p.writeString(" throws ")
-			p.printTypeAnn(typ.Throws)
-		}
-	}
+	p.printThrowsClause(typ.Throws)
 }
 
 func (p *Printer) printTemplateLitTypeAnn(typ *ast.TemplateLitTypeAnn) {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -439,21 +439,11 @@ func (p *Printer) printMethodSig(sig *ast.FuncSig, recv *ast.MethodReceiver) {
 	p.printReturnAndThrows(sig.Return, sig.Throws)
 }
 
-// printReturnAndThrows emits ` -> R` followed by any `throws T` clause. Every signature
-// form routes through it, so a function, method, getter, setter, and function type
-// annotation all render the pair the same way. A nil ret emits no arrow, which is the
-// `fn f() throws string { … }` form that lets its return type be inferred.
-//
-// A clause is emitted for neither spelling of "raises nothing": an absent clause, and an
-// explicit `throws never`, which names the empty set of raised values and carries no more
-// information than writing no clause at all.
-//
-// `-> R` is greedy, so a function-typed return is parenthesized once a clause follows it,
-// or the clause reads as the INNER function's. A function that returns a non-throwing
-// function and itself raises `string` prints `fn () -> (fn () -> number) throws string`.
-// Drop those parens and it is indistinguishable from a function that returns one raising
-// `string`, which is what re-reading it would give. soltype's printFuncBody parenthesizes
-// the coalesced form for the same reason.
+// printReturnAndThrows emits ` -> R` followed by any `throws T` clause, so every signature
+// form renders the pair alike. A nil ret emits no arrow, and neither a nil nor a `never`
+// throws emits a clause. `-> R` is greedy, so a function-typed return is parenthesized
+// once a clause follows it — `fn () -> (fn () -> number) throws string` — or the clause
+// re-reads as the inner function's. soltype's printFuncBody does the same.
 func (p *Printer) printReturnAndThrows(ret ast.TypeAnn, throws ast.TypeAnn) {
 	clause := throws
 	if _, isNever := throws.(*ast.NeverTypeAnn); isNever {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1861,3 +1861,35 @@ func TestPrintImportStmt(t *testing.T) {
 // 		})
 // 	}
 // }
+
+// A `throws` clause round-trips on every signature form that can carry one. The object
+// getter and setter forms print it through the same helper the method form uses, so a
+// type annotation that declares a raising accessor reprints with its clause intact.
+func TestPrintThrowsClause(t *testing.T) {
+	opts := DefaultOptions()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"function type", "fn(x: number) -> number throws string"},
+		{"object method", "{m(self) -> number throws SyntaxError}"},
+		{"object getter", "{get g(self) -> number throws string}"},
+		{"object setter", "{set s(mut self, v: number) -> undefined throws string}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Print(parseTypeAnn(t, tt.input), opts)
+			require.NoError(t, err)
+			require.Contains(t, result, "throws")
+		})
+	}
+
+	// An explicit `throws never` names the empty set of raised values, so it carries no
+	// more information than writing no clause at all and prints as no clause.
+	t.Run("throws never prints nothing", func(t *testing.T) {
+		result, err := Print(parseTypeAnn(t, "fn(x: number) -> number throws never"), opts)
+		require.NoError(t, err)
+		require.Equal(t, "fn (x: number) -> number", result)
+	})
+}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1862,34 +1862,78 @@ func TestPrintImportStmt(t *testing.T) {
 // 	}
 // }
 
-// A `throws` clause round-trips on every signature form that can carry one. The object
-// getter and setter forms print it through the same helper the method form uses, so a
-// type annotation that declares a raising accessor reprints with its clause intact.
+// A `throws` clause round-trips on every signature form that can carry one. Each form
+// prints the return type and the clause through one helper, so a type annotation that
+// declares a raising method or accessor reprints with its clause intact.
+//
+// A function-typed return is parenthesized when a clause follows it. `-> R` is greedy, so
+// the last two cases below are distinct types that would print alike without the parens,
+// and both would re-read as the inner-throws one.
 func TestPrintThrowsClause(t *testing.T) {
 	opts := DefaultOptions()
 
 	tests := []struct {
 		name  string
 		input string
+		want  string
 	}{
-		{"function type", "fn(x: number) -> number throws string"},
-		{"object method", "{m(self) -> number throws SyntaxError}"},
-		{"object getter", "{get g(self) -> number throws string}"},
-		{"object setter", "{set s(mut self, v: number) -> undefined throws string}"},
+		{
+			name:  "function type",
+			input: "fn(x: number) -> number throws string",
+			want:  "fn (x: number) -> number throws string",
+		},
+		{
+			name:  "object method",
+			input: "{m(self) -> number throws SyntaxError}",
+			want:  "{\n    m() -> number throws SyntaxError\n}",
+		},
+		{
+			name:  "object getter",
+			input: "{get g(self) -> number throws string}",
+			want:  "{\n    get g(self) -> number throws string\n}",
+		},
+		{
+			name:  "object setter",
+			input: "{set s(mut self, v: number) -> undefined throws string}",
+			want:  "{\n    set s(mut self, v: number) -> undefined throws string\n}",
+		},
+		{
+			// An explicit `throws never` names the empty set of raised values, so it
+			// carries no more information than writing no clause at all.
+			name:  "throws never prints no clause",
+			input: "fn(x: number) -> number throws never",
+			want:  "fn (x: number) -> number",
+		},
+		{
+			// The OUTER function raises `string` and returns a non-throwing function.
+			name:  "fn-typed return with an outer clause is parenthesized",
+			input: "fn(x: number) -> (fn() -> number) throws string",
+			want:  "fn (x: number) -> (fn () -> number) throws string",
+		},
+		{
+			// The INNER function raises `string`, so the return needs no parens.
+			name:  "fn-typed return whose own clause it is stays bare",
+			input: "fn(x: number) -> fn() -> number throws string",
+			want:  "fn (x: number) -> fn () -> number throws string",
+		},
+		{
+			// With no clause to bound, a function-typed return is never parenthesized.
+			name:  "fn-typed return with no clause stays bare",
+			input: "fn(x: number) -> fn() -> number",
+			want:  "fn (x: number) -> fn () -> number",
+		},
+		{
+			// `throws` terminates the return type, so a union return needs no parens.
+			name:  "union return with a clause stays bare",
+			input: "fn(x: number) -> number | string throws string",
+			want:  "fn (x: number) -> number | string throws string",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := Print(parseTypeAnn(t, tt.input), opts)
 			require.NoError(t, err)
-			require.Contains(t, result, "throws")
+			require.Equal(t, tt.want, result)
 		})
 	}
-
-	// An explicit `throws never` names the empty set of raised values, so it carries no
-	// more information than writing no clause at all and prints as no clause.
-	t.Run("throws never prints nothing", func(t *testing.T) {
-		result, err := Print(parseTypeAnn(t, "fn(x: number) -> number throws never"), opts)
-		require.NoError(t, err)
-		require.Equal(t, "fn (x: number) -> number", result)
-	})
 }

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1062,20 +1062,27 @@ func (p *namedPrinter) printFuncBody(t *FuncType) string {
 	if t.Inexact {
 		ps = append(ps, "...")
 	}
-	tail := "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
 	// A `throws T` clause renders after the return type, matching the surface syntax. A
 	// function that raises nothing resolves to `never` and renders no clause, so
 	// `fn () -> number` stays the common form. That covers a coalesced throws variable
 	// nothing reached as well as a FuncType minted with no clause at all.
-	//
-	// The clause is last, and the enclosing form supplies whatever delimiter follows it,
-	// so the thrown type prints with no minimum precedence. This matches the return type,
-	// which is greedy for the same reason. A whole function nested in a union is already
-	// parenthesized by typePrec's precFunc.
-	if throws := t.ThrowsOrNever(); !isNever(throws) {
-		tail += " throws " + p.printType(throws)
+	throws := t.ThrowsOrNever()
+	if isNever(throws) {
+		return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
 	}
-	return tail
+	// `-> R` is greedy, so a function-typed return has to be parenthesized once a clause
+	// follows it, or the clause reads as the INNER function's. A function that returns a
+	// non-throwing function and itself raises `string` renders
+	// `fn () -> (fn () -> number) throws string`. Drop those parens and it is
+	// indistinguishable from a function that returns one raising `string`, which re-reads
+	// as the second type. precUnion is the minimum that bounds a function type and nothing
+	// else, since precFunc is the only precedence below it.
+	//
+	// The thrown type itself needs no minimum. The clause is last, and the enclosing form
+	// supplies whatever delimiter follows it, so nothing can bind across its right edge.
+	// A whole function nested in a union is already parenthesized by typePrec's precFunc.
+	return "(" + strings.Join(ps, ", ") + ") -> " + p.printTypeMinPrec(t.Ret, precUnion) +
+		" throws " + p.printType(throws)
 }
 
 // isNever reports whether t is the `never` type.

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1063,27 +1063,23 @@ func (p *namedPrinter) printFuncBody(t *FuncType) string {
 		ps = append(ps, "...")
 	}
 	tail := "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
-	// A `throws T` clause renders after the return type, matching the surface syntax.
-	// A function that raises nothing carries either a nil Throws or `never`, and neither
-	// renders a clause, so `fn () -> number` stays the common form.
-	if !isNeverThrows(t.Throws) {
-		// The clause is last, and the enclosing form supplies whatever delimiter follows it,
-		// so the thrown type prints with no minimum precedence. This matches the return
-		// type, which is greedy for the same reason. A whole function nested in a union is
-		// already parenthesized by typePrec's precFunc.
-		tail += " throws " + p.printType(t.Throws)
+	// A `throws T` clause renders after the return type, matching the surface syntax. A
+	// function that raises nothing resolves to `never` and renders no clause, so
+	// `fn () -> number` stays the common form. That covers a coalesced throws variable
+	// nothing reached as well as a FuncType minted with no clause at all.
+	//
+	// The clause is last, and the enclosing form supplies whatever delimiter follows it,
+	// so the thrown type prints with no minimum precedence. This matches the return type,
+	// which is greedy for the same reason. A whole function nested in a union is already
+	// parenthesized by typePrec's precFunc.
+	if throws := t.ThrowsOrNever(); !isNever(throws) {
+		tail += " throws " + p.printType(throws)
 	}
 	return tail
 }
 
-// isNeverThrows reports whether t names the empty set of raised values, so a function
-// carrying it needs no `throws` clause. Both spellings count: nil is the shorthand a
-// FuncType minted without a clause carries, and NeverType is what an explicit `throws
-// never` and a coalesced throws variable with no lower bounds produce.
-func isNeverThrows(t Type) bool {
-	if t == nil {
-		return true
-	}
+// isNever reports whether t is the `never` type.
+func isNever(t Type) bool {
 	_, never := t.(*NeverType)
 	return never
 }

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -427,6 +427,9 @@ func freeTypeVars(t Type) []*TypeVarType {
 				walk(p.Type)
 			}
 			walk(t.Ret)
+			if t.Throws != nil {
+				walk(t.Throws)
+			}
 		case *TupleType:
 			for _, e := range t.Elems {
 				walk(e)
@@ -1059,7 +1062,30 @@ func (p *namedPrinter) printFuncBody(t *FuncType) string {
 	if t.Inexact {
 		ps = append(ps, "...")
 	}
-	return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
+	tail := "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
+	// A `throws T` clause renders after the return type, matching the surface syntax.
+	// A function that raises nothing carries either a nil Throws or `never`, and neither
+	// renders a clause, so `fn () -> number` stays the common form.
+	if !isNeverThrows(t.Throws) {
+		// The clause is last, and the enclosing form supplies whatever delimiter follows it,
+		// so the thrown type prints with no minimum precedence. This matches the return
+		// type, which is greedy for the same reason. A whole function nested in a union is
+		// already parenthesized by typePrec's precFunc.
+		tail += " throws " + p.printType(t.Throws)
+	}
+	return tail
+}
+
+// isNeverThrows reports whether t names the empty set of raised values, so a function
+// carrying it needs no `throws` clause. Both spellings count: nil is the shorthand a
+// FuncType minted without a clause carries, and NeverType is what an explicit `throws
+// never` and a coalesced throws variable with no lower bounds produce.
+func isNeverThrows(t Type) bool {
+	if t == nil {
+		return true
+	}
+	_, never := t.(*NeverType)
+	return never
 }
 
 // nameTypeParams registers each type parameter's binding variable under its source name

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1070,17 +1070,11 @@ func (p *namedPrinter) printFuncBody(t *FuncType) string {
 	if isNever(throws) {
 		return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
 	}
-	// `-> R` is greedy, so a function-typed return has to be parenthesized once a clause
-	// follows it, or the clause reads as the INNER function's. A function that returns a
-	// non-throwing function and itself raises `string` renders
-	// `fn () -> (fn () -> number) throws string`. Drop those parens and it is
-	// indistinguishable from a function that returns one raising `string`, which re-reads
-	// as the second type. precUnion is the minimum that bounds a function type and nothing
-	// else, since precFunc is the only precedence below it.
-	//
-	// The thrown type itself needs no minimum. The clause is last, and the enclosing form
-	// supplies whatever delimiter follows it, so nothing can bind across its right edge.
-	// A whole function nested in a union is already parenthesized by typePrec's precFunc.
+	// `-> R` is greedy, so a function-typed return is parenthesized once a clause follows
+	// it — `fn () -> (fn () -> number) throws string` — or the clause re-reads as the inner
+	// function's. precUnion bounds a function type and nothing else, precFunc being the
+	// only precedence below it. The clause itself needs no minimum: it is last, so nothing
+	// can bind across its right edge.
 	return "(" + strings.Join(ps, ", ") + ") -> " + p.printTypeMinPrec(t.Ret, precUnion) +
 		" throws " + p.printType(throws)
 }

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -140,6 +140,25 @@ func TestPrintRoundTrips(t *testing.T) {
 		},
 		{"fn with never throws renders no clause", &FuncType{Ret: numP(), Throws: &NeverType{}}, "fn () -> number"},
 		{
+			// `-> R` is greedy, so a function-typed return is parenthesized once a clause
+			// follows it. Without the parens this and the next case would render alike and
+			// re-read as the next one.
+			"fn-typed return with throws parenthesizes the return",
+			&FuncType{Ret: &FuncType{Ret: numP()}, Throws: strP()},
+			"fn () -> (fn () -> number) throws string",
+		},
+		{
+			"fn-typed return whose own throws is the clause needs no parens",
+			&FuncType{Ret: &FuncType{Ret: numP(), Throws: strP()}},
+			"fn () -> fn () -> number throws string",
+		},
+		{
+			// `throws` terminates the return type, so a union return needs no parens.
+			"union return with throws stays bare",
+			&FuncType{Ret: &UnionType{Types: []Type{numP(), strP()}}, Throws: strP()},
+			"fn () -> number | string throws string",
+		},
+		{
 			// A throwing function nested in a union is parenthesized by its own precedence,
 			// so the clause cannot run on into the sibling member.
 			"throwing fn inside a union",

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -125,6 +125,28 @@ func TestPrintRoundTrips(t *testing.T) {
 			"fn (a: number, ...rest: string) -> boolean",
 		},
 
+		// A throws clause renders after the return type. A function that raises nothing
+		// spells that either as a nil Throws or as `never`, and neither renders a clause.
+		{"fn with throws", &FuncType{Ret: numP(), Throws: strP()}, "fn () -> number throws string"},
+		{
+			"fn with throws and params",
+			&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: numP(), Throws: strP()},
+			"fn (x: number) -> number throws string",
+		},
+		{
+			"fn throwing a union",
+			&FuncType{Ret: numP(), Throws: &UnionType{Types: []Type{numP(), strP()}}},
+			"fn () -> number throws number | string",
+		},
+		{"fn with never throws renders no clause", &FuncType{Ret: numP(), Throws: &NeverType{}}, "fn () -> number"},
+		{
+			// A throwing function nested in a union is parenthesized by its own precedence,
+			// so the clause cannot run on into the sibling member.
+			"throwing fn inside a union",
+			&UnionType{Types: []Type{&FuncType{Ret: numP(), Throws: strP()}, boolP()}},
+			"(fn () -> number throws string) | boolean",
+		},
+
 		// Unions and intersections.
 		{"union pair", &UnionType{Types: []Type{numP(), strP()}}, "number | string"},
 		{"union triple", &UnionType{Types: []Type{numP(), strP(), boolP()}}, "number | string | boolean"},

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -231,7 +231,7 @@ type FuncParam struct {
 // that throws more. A nil Throws means the function raises nothing and reads as `never`,
 // the bottom of the lattice, so the zero value is non-throwing and every FuncType minted
 // without thinking about exceptions is correct. `never` written out explicitly means the
-// same thing, and the solver's throwsOf collapses the two before comparing them.
+// same thing, and ThrowsOrNever collapses the two so no reader has to tell them apart.
 type FuncType struct {
 	SelfParam *FuncParam // nil ⇒ static method or plain function; non-nil ⇒ instance method
 	Params    []*FuncParam
@@ -244,6 +244,17 @@ type FuncType struct {
 	// LifetimeParams are the function's quantified lifetime parameters, the twin of TypeParams;
 	// LevelOf skips them too, though a body lifetime still counts through its RefType.
 	LifetimeParams []*LifetimeParam
+}
+
+// ThrowsOrNever returns the type a call to t may raise, resolving the nil shorthand to
+// the `never` it stands for. Every reader of the throws position goes through it, so a
+// function written with no clause and one written `throws never` behave identically in
+// subtyping, equality, ordering, and printing, and no caller has to test for nil.
+func (t *FuncType) ThrowsOrNever() Type {
+	if t.Throws == nil {
+		return &NeverType{}
+	}
+	return t.Throws
 }
 
 // TypeParam is one quantified type parameter, shared by FuncType.TypeParams for

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -230,13 +230,9 @@ type FuncType struct {
 	SelfParam *FuncParam // nil ⇒ static method or plain function; non-nil ⇒ instance method
 	Params    []*FuncParam
 	Ret       Type
-	// Throws is the type a call to the function may raise, the twin of Ret for the
-	// exceptional exit. It is covariant, so a function that raises a narrower set is a
-	// subtype of one that raises a wider set. Nil means the function raises nothing and
-	// reads as `never`, the bottom of the lattice, so the zero value is non-throwing and
-	// a FuncType minted without thinking about exceptions is correct. An explicit
-	// `never` means the same thing, and ThrowsOrNever collapses the two so no reader
-	// has to tell them apart.
+	// Throws is the type a call may raise, the twin of Ret for the exceptional exit and
+	// covariant like it. Nil reads as `never`, so the zero value is non-throwing;
+	// ThrowsOrNever collapses nil and an explicit `never` so no reader tells them apart.
 	Throws  Type
 	Inexact bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
 	// TypeParams are the function's own quantified type parameters; nil is monomorphic and
@@ -247,10 +243,8 @@ type FuncType struct {
 	LifetimeParams []*LifetimeParam
 }
 
-// ThrowsOrNever returns the type a call to t may raise, resolving the nil shorthand to
-// the `never` it stands for. Every reader of the throws position goes through it, so a
-// function written with no clause and one written `throws never` behave identically in
-// subtyping, equality, ordering, and printing, and no caller has to test for nil.
+// ThrowsOrNever returns the type a call to t may raise, resolving the nil shorthand to the
+// `never` it stands for, so no reader of the throws position has to test for nil.
 func (t *FuncType) ThrowsOrNever() Type {
 	if t.Throws == nil {
 		return &NeverType{}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -226,10 +226,17 @@ type FuncParam struct {
 // is `&mut Self`. The printer reads that shape back to the shorthand, and the
 // receiver's borrow and lifetime flow through the visitor the same way a
 // parameter's do. Pattern names the receiver, always the `self` identifier.
+// Throws is the type a call to the function may raise, the twin of Ret for the
+// exceptional exit. It is covariant, so a function that throws less is a subtype of one
+// that throws more. A nil Throws means the function raises nothing and reads as `never`,
+// the bottom of the lattice, so the zero value is non-throwing and every FuncType minted
+// without thinking about exceptions is correct. `never` written out explicitly means the
+// same thing, and the solver's throwsOf collapses the two before comparing them.
 type FuncType struct {
 	SelfParam *FuncParam // nil ⇒ static method or plain function; non-nil ⇒ instance method
 	Params    []*FuncParam
 	Ret       Type
+	Throws    Type // nil ⇒ raises nothing, equivalent to `never`
 	Inexact   bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
 	// TypeParams are the function's own quantified type parameters; nil is monomorphic and
 	// a class-level parameter is captured, not listed. LevelOf skips them, being minted deeper.
@@ -1112,7 +1119,11 @@ func LevelOf(t Type) int {
 		for _, p := range t.Params {
 			m = max(m, LevelOf(p.Type))
 		}
-		return max(m, LevelOf(t.Ret))
+		m = max(m, LevelOf(t.Ret))
+		if t.Throws != nil {
+			m = max(m, LevelOf(t.Throws))
+		}
+		return m
 	case *TupleType:
 		m := 0
 		for _, e := range t.Elems {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -226,18 +226,19 @@ type FuncParam struct {
 // is `&mut Self`. The printer reads that shape back to the shorthand, and the
 // receiver's borrow and lifetime flow through the visitor the same way a
 // parameter's do. Pattern names the receiver, always the `self` identifier.
-// Throws is the type a call to the function may raise, the twin of Ret for the
-// exceptional exit. It is covariant, so a function that throws less is a subtype of one
-// that throws more. A nil Throws means the function raises nothing and reads as `never`,
-// the bottom of the lattice, so the zero value is non-throwing and every FuncType minted
-// without thinking about exceptions is correct. `never` written out explicitly means the
-// same thing, and ThrowsOrNever collapses the two so no reader has to tell them apart.
 type FuncType struct {
 	SelfParam *FuncParam // nil ⇒ static method or plain function; non-nil ⇒ instance method
 	Params    []*FuncParam
 	Ret       Type
-	Throws    Type // nil ⇒ raises nothing, equivalent to `never`
-	Inexact   bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
+	// Throws is the type a call to the function may raise, the twin of Ret for the
+	// exceptional exit. It is covariant, so a function that raises a narrower set is a
+	// subtype of one that raises a wider set. Nil means the function raises nothing and
+	// reads as `never`, the bottom of the lattice, so the zero value is non-throwing and
+	// a FuncType minted without thinking about exceptions is correct. An explicit
+	// `never` means the same thing, and ThrowsOrNever collapses the two so no reader
+	// has to tell them apart.
+	Throws  Type
+	Inexact bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
 	// TypeParams are the function's own quantified type parameters; nil is monomorphic and
 	// a class-level parameter is captured, not listed. LevelOf skips them, being minted deeper.
 	TypeParams []*TypeParam

--- a/internal/soltype/type_test.go
+++ b/internal/soltype/type_test.go
@@ -56,6 +56,23 @@ func TestLevelOf(t *testing.T) {
 			want: 0,
 		},
 		{
+			name: "function: the throws type counts too",
+			ty: &FuncType{
+				Params: []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: num}},
+				Ret:    num,
+				Throws: v5,
+			},
+			want: 5,
+		},
+		{
+			name: "function: a nil throws contributes nothing",
+			ty: &FuncType{
+				Params: []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: v2}},
+				Ret:    num,
+			},
+			want: 2,
+		},
+		{
 			name: "tuple: max over elements",
 			ty:   &TupleType{Elems: []Type{num, v2, v5}},
 			want: 5,

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -99,13 +99,19 @@ func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 	self, selfChanged := acceptSelfParam(cur.SelfParam, v, pol) // receiver contravariant
 	params, changed := acceptParams(cur.Params, v, pol)         // params contravariant
 	ret := cur.Ret.Accept(v, pol)                               // return covariant
+	// The throws type is the exceptional exit, so it walks at the same polarity as the
+	// return. A nil Throws is the `never` shorthand and has nothing to walk.
+	throws := cur.Throws
+	if throws != nil {
+		throws = throws.Accept(v, pol)
+	}
 	out := cur
-	if tpChanged || selfChanged || changed || ret != cur.Ret {
+	if tpChanged || selfChanged || changed || ret != cur.Ret || throws != cur.Throws {
 		// LifetimeParams carry through unchanged here, because Accept never walks a
 		// lifetime. A lifetime-aware visitor freshens them in its EnterType, replacing
 		// the whole FuncType before this rebuild, so cur already holds the freshened
 		// params.
-		out = &FuncType{SelfParam: self, Params: params, Ret: ret, Inexact: cur.Inexact, TypeParams: tparams, LifetimeParams: cur.LifetimeParams}
+		out = &FuncType{SelfParam: self, Params: params, Ret: ret, Throws: throws, Inexact: cur.Inexact, TypeParams: tparams, LifetimeParams: cur.LifetimeParams}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -123,6 +123,35 @@ func TestAcceptCopyOnWrite(t *testing.T) {
 	require.True(t, got.Inexact, "the FuncType keeps its Inexact marker")
 }
 
+// The throws type walks at the same polarity as the return, since both describe an exit
+// the function produces, and a rewrite of it forces a fresh parent the same way a
+// rewritten return does. A nil Throws is the `never` shorthand with nothing to walk.
+func TestAcceptFuncThrows(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	b := &TypeVarType{ID: 2}
+
+	// fn (x: a) -> num throws b, walked from Positive.
+	fn := &FuncType{
+		Params: []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: a}},
+		Ret:    num,
+		Throws: b,
+	}
+	r := &recorder{seen: map[Type]Polarity{}}
+	fn.Accept(r, Positive)
+	require.Equal(t, Negative, r.seen[a], "a parameter is contravariant")
+	require.Equal(t, Positive, r.seen[b], "the throws type is covariant, like the return")
+
+	got := fn.Accept(&replaceVar{target: b, repl: str}, Positive).(*FuncType)
+	require.NotSame(t, fn, got, "a changed throws forces a new parent")
+	require.Same(t, str, got.Throws, "the changed throws took the replacement")
+	require.Same(t, num, got.Ret, "the unchanged return keeps its pointer")
+
+	noThrows := &FuncType{Ret: num}
+	require.Same(t, noThrows, noThrows.Accept(identityVisitor{}, Positive), "a nil throws walks nothing")
+}
+
 // recordEntered logs every node EnterType reaches, replacing target with repl and
 // SKIPPING its children — so a skipped subtree is never entered.
 type recordEntered struct {

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -579,6 +579,7 @@ func strippedMethodSig(sig *soltype.FuncType) *soltype.FuncType {
 	return &soltype.FuncType{
 		Params:         sig.Params,
 		Ret:            sig.Ret,
+		Throws:         sig.Throws,
 		Inexact:        sig.Inexact,
 		TypeParams:     sig.TypeParams,
 		LifetimeParams: sig.LifetimeParams,

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1246,7 +1246,12 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 				return false
 			}
 		}
-		return equalTypeWith(a.Ret, b.Ret, ctx)
+		if !equalTypeWith(a.Ret, b.Ret, ctx) {
+			return false
+		}
+		// throwsOf reads both sides through the nil-is-never collapse, so a function
+		// written with no clause equals one written `throws never`.
+		return equalTypeWith(throwsOf(a), throwsOf(b), ctx)
 	case *soltype.TupleType:
 		b, ok := b.(*soltype.TupleType)
 		// Inexact flags must be equal — an open tuple never equals a closed one,

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1249,9 +1249,9 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		if !equalTypeWith(a.Ret, b.Ret, ctx) {
 			return false
 		}
-		// throwsOf reads both sides through the nil-is-never collapse, so a function
+		// ThrowsOrNever reads both sides through the nil-is-never collapse, so a function
 		// written with no clause equals one written `throws never`.
-		return equalTypeWith(throwsOf(a), throwsOf(b), ctx)
+		return equalTypeWith(a.ThrowsOrNever(), b.ThrowsOrNever(), ctx)
 	case *soltype.TupleType:
 		b, ok := b.(*soltype.TupleType)
 		// Inexact flags must be equal — an open tuple never equals a closed one,

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -671,7 +671,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			// function that raises a narrower set may stand in for one that raises a wider
 			// set. A non-throwing sub carries `never`, which constrain short-circuits, so a
 			// function with no clause satisfies every super.
-			return append(errs, c.constrain(throwsOf(sub), throwsOf(sup), seen, false)...)
+			return append(errs, c.constrain(sub.ThrowsOrNever(), sup.ThrowsOrNever(), seen, false)...)
 		}
 	case *soltype.TupleType:
 		if tupleHasSpread(sub) || tupleHasSpread(super) {
@@ -1409,17 +1409,6 @@ func callableView(ft *soltype.FuncType) *soltype.FuncType {
 		TypeParams:     ft.TypeParams,
 		LifetimeParams: ft.LifetimeParams,
 	}
-}
-
-// throwsOf returns the type ft raises, collapsing the nil shorthand to the `never` it
-// stands for so a comparison never has to test for nil. constrain, equalType, and
-// compareType all read a function's throws through it, so a function written with no
-// clause and one written `throws never` behave identically everywhere.
-func throwsOf(ft *soltype.FuncType) soltype.Type {
-	if ft.Throws == nil {
-		return &soltype.NeverType{}
-	}
-	return ft.Throws
 }
 
 // skolemizeFuncBinder replaces ft's own type parameters with fresh skolems, so a term checked

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1411,6 +1411,12 @@ func callableView(ft *soltype.FuncType) *soltype.FuncType {
 	}
 }
 
+// isNeverType reports whether t is `never`, the bottom of the subtype lattice.
+func isNeverType(t soltype.Type) bool {
+	_, never := t.(*soltype.NeverType)
+	return never
+}
+
 // skolemizeFuncBinder replaces ft's own type parameters with fresh skolems, so a term checked
 // against ft as a supertype must satisfy it for every instantiation. Each parameter's declared
 // bound becomes its skolem's Upper, seeded first so a bound naming a sibling reaches it. For

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -666,7 +666,12 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 					errs = append(errs, c.constrain(unknownT, sub.Params[i].Type, seen, false)...)
 				}
 			}
-			return append(errs, c.constrain(sub.Ret, sup.Ret, seen, false)...) // covariant
+			errs = append(errs, c.constrain(sub.Ret, sup.Ret, seen, false)...) // covariant
+			// The throws clause is the exceptional exit, covariant like the return: a
+			// function that raises a narrower set may stand in for one that raises a wider
+			// set. A non-throwing sub carries `never`, which constrain short-circuits, so a
+			// function with no clause satisfies every super.
+			return append(errs, c.constrain(throwsOf(sub), throwsOf(sup), seen, false)...)
 		}
 	case *soltype.TupleType:
 		if tupleHasSpread(sub) || tupleHasSpread(super) {
@@ -1399,10 +1404,22 @@ func callableView(ft *soltype.FuncType) *soltype.FuncType {
 	return &soltype.FuncType{
 		Params:         ft.Params,
 		Ret:            ft.Ret,
+		Throws:         ft.Throws,
 		Inexact:        ft.Inexact,
 		TypeParams:     ft.TypeParams,
 		LifetimeParams: ft.LifetimeParams,
 	}
+}
+
+// throwsOf returns the type ft raises, collapsing the nil shorthand to the `never` it
+// stands for so a comparison never has to test for nil. constrain, equalType, and
+// compareType all read a function's throws through it, so a function written with no
+// clause and one written `throws never` behave identically everywhere.
+func throwsOf(ft *soltype.FuncType) soltype.Type {
+	if ft.Throws == nil {
+		return &soltype.NeverType{}
+	}
+	return ft.Throws
 }
 
 // skolemizeFuncBinder replaces ft's own type parameters with fresh skolems, so a term checked
@@ -1460,6 +1477,13 @@ func substFuncBinder(ft *soltype.FuncType, sub *typeSubst) *soltype.FuncType {
 		cp.Params[i] = &np
 	}
 	cp.Ret = ft.Ret.Accept(sub, soltype.Positive)
+	// The throws type is substituted at the same polarity as the return, so a `throws E`
+	// clause binds to the same fresh variable or skolem the parameter positions got. Miss
+	// this and `fn <E>(g: fn () -> R throws E) -> R throws E` would leave its own clause
+	// naming the unsubstituted binder, disconnected from the argument's throws.
+	if ft.Throws != nil {
+		cp.Throws = ft.Throws.Accept(sub, soltype.Positive)
+	}
 	if ft.SelfParam != nil {
 		ns := *ft.SelfParam
 		ns.Type = ft.SelfParam.Type.Accept(sub, soltype.Negative)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -667,10 +667,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				}
 			}
 			errs = append(errs, c.constrain(sub.Ret, sup.Ret, seen, false)...) // covariant
-			// The throws clause is the exceptional exit, covariant like the return: a
-			// function that raises a narrower set may stand in for one that raises a wider
-			// set. A non-throwing sub carries `never`, which constrain short-circuits, so a
-			// function with no clause satisfies every super.
+			// The throws clause is covariant like the return. A non-throwing sub carries
+			// `never`, which constrain short-circuits, so no clause satisfies every super.
 			return append(errs, c.constrain(sub.ThrowsOrNever(), sup.ThrowsOrNever(), seen, false)...)
 		}
 	case *soltype.TupleType:
@@ -1472,10 +1470,8 @@ func substFuncBinder(ft *soltype.FuncType, sub *typeSubst) *soltype.FuncType {
 		cp.Params[i] = &np
 	}
 	cp.Ret = ft.Ret.Accept(sub, soltype.Positive)
-	// The throws type is substituted at the same polarity as the return, so a `throws E`
-	// clause binds to the same fresh variable or skolem the parameter positions got. Miss
-	// this and `fn <E>(g: fn () -> R throws E) -> R throws E` would leave its own clause
-	// naming the unsubstituted binder, disconnected from the argument's throws.
+	// Substituted at the return's polarity, so a `throws E` clause binds to the same fresh
+	// variable or skolem the parameters got rather than naming the unsubstituted binder.
 	if ft.Throws != nil {
 		cp.Throws = ft.Throws.Accept(sub, soltype.Positive)
 	}

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1527,6 +1527,51 @@ func (e *UnusedLifetimeParamError) Message() string {
 	return "lifetime parameter '" + e.Name + " is declared but never used"
 }
 
+// UnusedThrowsClauseError fires when a signature declares `throws T` but no `throw` and no
+// call in the body can raise anything. The program is well-typed, since the body's `never`
+// is below every declared type, but the clause obliges every caller to handle an exception
+// that cannot occur. Ann is the clause the source wrote, which carries the blame span.
+//
+// It is the exceptional twin of UnusedLifetimeParamError: a declaration the body never
+// uses, reported as a warning because a signature may be deliberately conservative.
+// `throws _` never reaches here, since a wildcard asks for inference rather than declaring
+// anything.
+type UnusedThrowsClauseError struct {
+	Ann      ast.TypeAnn
+	Declared soltype.Type
+}
+
+func (*UnusedThrowsClauseError) isSolverError()        {}
+func (e *UnusedThrowsClauseError) Span() ast.Span      { return e.Ann.Span() }
+func (e *UnusedThrowsClauseError) Related() []ast.Span { return nil }
+func (e *UnusedThrowsClauseError) IsWarning() bool     { return true }
+func (e *UnusedThrowsClauseError) Message() string {
+	return "the body raises nothing, so the declared `throws " + soltype.Print(e.Declared) +
+		"` is unreachable; drop the clause"
+}
+
+// UnreachableReturnAnnotationError fires when a signature declares `-> R` but every path
+// through the body leaves along the exceptional edge, so the body's return type is `never`
+// and no caller can observe an R. The program is well-typed, since `never` is below every
+// declared type. Ann is the annotation the source wrote, which carries the blame span.
+//
+// It is a warning rather than an error because a not-yet-implemented stub is written this
+// way, `fn f() -> number { throw "todo" }`, and because a signature may be dictated by an
+// interface the body cannot narrow.
+type UnreachableReturnAnnotationError struct {
+	Ann      ast.TypeAnn
+	Declared soltype.Type
+}
+
+func (*UnreachableReturnAnnotationError) isSolverError()        {}
+func (e *UnreachableReturnAnnotationError) Span() ast.Span      { return e.Ann.Span() }
+func (e *UnreachableReturnAnnotationError) Related() []ast.Span { return nil }
+func (e *UnreachableReturnAnnotationError) IsWarning() bool     { return true }
+func (e *UnreachableReturnAnnotationError) Message() string {
+	return "every path through the body throws, so the declared return type `" +
+		soltype.Print(e.Declared) + "` is unreachable; the body returns `never`"
+}
+
 // AmbiguousUnionCommitWarning fires when a value matches more than one member of a union-super
 // trial, so the committed choice is not evident from the source. For `5 <: (T | number)` number
 // commits, yet T would also match by pinning to 5. It is a warning rather than an error, since

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -135,9 +135,9 @@ type funcCtx struct {
 	// every returned value is uniquely owned, so the join of the returns is too.
 	returnExprs []ast.Expr
 
-	// throws is the single type every exceptional exit of this body is constrained
-	// against, the exceptional twin of the joined return type. A `throw e` constrains e's
-	// type into it, and a call constrains the callee's throws into it by putting it in the
+	// throws is this body's exceptional SINK: the single type every exceptional exit is
+	// constrained against, the twin of the joined return type. A `throw e` constrains e's
+	// type into it. A call constrains the callee's throws into it by putting it in the
 	// synthesized call shape's own Throws slot, where constrain's covariant throws rule
 	// finds it. Routing both through one sink rather than through a list of collected
 	// types is what lets a call contribute without the walk having to resolve the callee
@@ -146,15 +146,27 @@ type funcCtx struct {
 	// When the signature declares `throws T`, inferFunc seeds the sink with T before the
 	// body is walked, so each throw and each call checks against the declared type at its
 	// own site and blames it there. Seeding also keeps a declared type parameter from
-	// picking up a vacuous bound: were the body instead constrained into a separate
-	// variable and that variable then into `T`, the two would bound each other and
+	// picking up a vacuous bound. The alternative is to constrain the body into a separate
+	// variable and that variable into `T`, which leaves the two bounding each other, so
 	// `fn <E>(g: fn () -> number throws E) -> number throws E` would render its own sink
 	// as a second quantifier.
 	//
 	// With no clause the sink is a variable throwsSink mints on first use, so a body that
-	// neither throws nor calls anything allocates nothing. A variable that gained no lower
-	// bound means nothing reached it, and inferredThrows reports that as no throws at all
-	// rather than a variable standing for `never`.
+	// neither throws nor calls anything leaves this nil and the function raises nothing.
+	// inferFunc reads it back as the function's Throws once the body is walked, which
+	// mirrors the return type: the join variable becomes FuncType.Ret whether or not
+	// anything flowed into it. A sink nothing reached coalesces to `never` and renders no
+	// clause.
+	//
+	// Emptiness is deliberately not tested by looking at the sink's own lower bounds.
+	// constrain records a variable-to-variable edge on one endpoint only, so a generic
+	// callee's `throws E` leaves the sink's lower bounds empty while E carries the sink as
+	// an upper bound. Coalescing reads that edge back through its mirrored view, and a
+	// lower-bounds test would not, so it would drop the throws the caller inherits.
+	//
+	// A minted-but-unreached sink is also what makes minting safe under a discardable
+	// probe: the mint itself is not journaled, but the bounds a trial appends to it are,
+	// so a discarded trial leaves a sink indistinguishable from none.
 	throws soltype.Type
 
 	// written records the widened type stored into a receiver variable's field by a
@@ -321,37 +333,18 @@ func (c *checker) inScript() bool {
 
 // throwsSink returns the type this body's exceptional exits are constrained against,
 // minting a fresh variable at lvl when the signature declared no `throws` clause and
-// nothing has needed the sink yet. A `throw` or a call at module top level has no
-// enclosing function to raise out of, so it gets a fresh variable that nothing reads:
-// the thrown type is still checked, it just propagates nowhere. Recording a module
-// initializer's throws needs somewhere on the module to put them, which no milestone has
-// designed yet.
+// nothing has needed the sink yet.
+//
+// A `throw` or a call at module top level has no enclosing function to raise out of, so
+// it gets a fresh variable that nothing reads. The thrown type is still checked there;
+// it simply propagates nowhere. Recording a module initializer's throws needs somewhere
+// on the module to put them, which no milestone has designed yet.
 func (c *checker) throwsSink(lvl int) soltype.Type {
 	if c.fn == nil {
 		return c.freshAt(lvl)
 	}
 	if c.fn.throws == nil {
 		c.fn.throws = c.freshAt(lvl)
-	}
-	return c.fn.throws
-}
-
-// inferredThrows returns the sink the current body's exceptional exits were constrained
-// against, or nil when the body has no exceptional exit at all — no `throw` and no call
-// ever asked for the sink, so none was minted. This mirrors the return type, where the
-// join variable becomes FuncType.Ret whether or not anything flowed into it: a sink that
-// nothing reached coalesces to `never` and renders no clause.
-//
-// Emptiness is deliberately NOT tested by looking at the sink's lower bounds. constrain
-// records a variable-to-variable edge on one endpoint only, so a generic callee's
-// `throws E` leaves the sink's own lower bounds empty while E carries the sink as an
-// upper bound. Coalescing reads that edge back through its mirrored view; a lower-bounds
-// test here would not, and would drop the throws the caller inherits.
-//
-// Call it before popFuncCtx restores the outer context.
-func (c *checker) inferredThrows() soltype.Type {
-	if c.fn == nil {
-		return nil
 	}
 	return c.fn.throws
 }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -143,30 +143,29 @@ type funcCtx struct {
 	// types is what lets a call contribute without the walk having to resolve the callee
 	// first.
 	//
-	// When the signature declares `throws T`, inferFunc seeds the sink with T before the
-	// body is walked, so each throw and each call checks against the declared type at its
-	// own site and blames it there. Seeding also keeps a declared type parameter from
-	// picking up a vacuous bound. The alternative is to constrain the body into a separate
-	// variable and that variable into `T`, which leaves the two bounding each other, so
+	// inferFunc seeds the sink from the signature before the body is walked, so each throw
+	// and each call is checked against it at its own site and blamed there. A signature
+	// with no clause seeds `never`, which is how omitting the clause declares that the
+	// function raises nothing; `throws T` seeds T, and `throws _` seeds a fresh variable
+	// the body's exits flow into.
+	//
+	// Seeding also keeps a declared type parameter from picking up a vacuous bound. The
+	// alternative is to constrain the body into a separate variable and that variable into
+	// `T`, which leaves the two bounding each other, so
 	// `fn <E>(g: fn () -> number throws E) -> number throws E` would render its own sink
 	// as a second quantifier.
 	//
-	// With no clause the sink is a variable throwsSink mints on first use, so a body that
-	// neither throws nor calls anything leaves this nil and the function raises nothing.
-	// inferFunc reads it back as the function's Throws once the body is walked, which
-	// mirrors the return type: the join variable becomes FuncType.Ret whether or not
-	// anything flowed into it. A sink nothing reached coalesces to `never` and renders no
-	// clause.
+	// inferFunc reads the sink back as the function's Throws once the body is walked,
+	// which mirrors the return type: the join variable becomes FuncType.Ret whether or not
+	// anything flowed into it. A `throws _` sink nothing reached coalesces to `never` and
+	// renders no clause.
 	//
-	// Emptiness is deliberately not tested by looking at the sink's own lower bounds.
-	// constrain records a variable-to-variable edge on one endpoint only, so a generic
-	// callee's `throws E` leaves the sink's lower bounds empty while E carries the sink as
-	// an upper bound. Coalescing reads that edge back through its mirrored view, and a
-	// lower-bounds test would not, so it would drop the throws the caller inherits.
+	// A body with no signature to seed from leaves this nil until throwsSink mints a
+	// variable on first use. Only a script's top level is in that position, since it has
+	// nowhere to write a clause.
 	//
-	// A minted-but-unreached sink is also what makes minting safe under a discardable
-	// probe: the mint itself is not journaled, but the bounds a trial appends to it are,
-	// so a discarded trial leaves a sink indistinguishable from none.
+	// Minting is safe under a discardable probe: the mint itself is not journaled, but the
+	// bounds a trial appends to it are, so a discarded trial leaves a sink nothing reached.
 	throws soltype.Type
 	// lvl is the level this body is walked at, recorded so throwsSink mints the sink
 	// there rather than wherever the first exceptional exit happens to sit. A `val`
@@ -340,14 +339,16 @@ func (c *checker) inScript() bool {
 	return c.fn != nil && c.fn.node == nil
 }
 
-// throwsSink returns the type this body's exceptional exits are constrained against,
-// minting a fresh variable at lvl when the signature declared no `throws` clause and
-// nothing has needed the sink yet.
+// throwsSink returns the type this body's exceptional exits are constrained against.
+// inferFunc seeds it from the signature, so a function body always has one before its
+// first exceptional exit is walked, and the mint below fires only for a body with no
+// signature: a script's top level, which has nowhere to write a clause and so infers
+// what it raises rather than being held to `never`.
 //
-// A `throw` or a call at module top level has no enclosing function to raise out of, so
-// it gets a fresh variable that nothing reads. The thrown type is still checked there;
-// it simply propagates nowhere. Recording a module initializer's throws needs somewhere
-// on the module to put them, which no milestone has designed yet.
+// A `throw` or a call at module top level has no enclosing function to raise out of at
+// all, so it gets a fresh variable that nothing reads. The thrown type is still checked
+// there; it simply propagates nowhere. Recording a module initializer's throws needs
+// somewhere on the module to put them, which no milestone has designed yet.
 func (c *checker) throwsSink(lvl int) soltype.Type {
 	if c.fn == nil {
 		return c.freshAt(lvl)

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -168,6 +168,15 @@ type funcCtx struct {
 	// probe: the mint itself is not journaled, but the bounds a trial appends to it are,
 	// so a discarded trial leaves a sink indistinguishable from none.
 	throws soltype.Type
+	// lvl is the level this body is walked at, recorded so throwsSink mints the sink
+	// there rather than wherever the first exceptional exit happens to sit. A `val`
+	// initializer is typed one level deeper, so a sink minted at the first exit's own
+	// level would land inner to the body when that exit is a call inside an
+	// initializer. A later exit at the body's own level would then extrude it, wiring
+	// the extruded proxy back to the original in both directions, and the cycle renders
+	// the function's throws as a μ-knot: `fn g() { val x = a()  a()  return x }`
+	// reports `throws μX0.(string | X0)` instead of `throws string`.
+	lvl int
 
 	// written records the widened type stored into a receiver variable's field by a
 	// field-write `recv.prop = source` (M4 C3), keyed by the receiver var's ID and
@@ -316,9 +325,9 @@ type funcCtx struct {
 // after walking the body. Push/pop is straight-line, not deferred: the caller needs
 // popFuncCtx's returned return-points as a value, and the walk reports errors rather
 // than panicking, so there is no unwind to guard against.
-func (c *checker) pushFuncCtx(async bool, node ast.Node) *funcCtx {
+func (c *checker) pushFuncCtx(async bool, node ast.Node, lvl int) *funcCtx {
 	saved := c.fn
-	c.fn = &funcCtx{async: async, node: node, written: map[fieldKey]soltype.Type{}}
+	c.fn = &funcCtx{async: async, node: node, lvl: lvl, written: map[fieldKey]soltype.Type{}}
 	return saved
 }
 
@@ -344,7 +353,7 @@ func (c *checker) throwsSink(lvl int) soltype.Type {
 		return c.freshAt(lvl)
 	}
 	if c.fn.throws == nil {
-		c.fn.throws = c.freshAt(lvl)
+		c.fn.throws = c.freshAt(c.fn.lvl)
 	}
 	return c.fn.throws
 }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -167,6 +167,14 @@ type funcCtx struct {
 	// Minting is safe under a discardable probe: the mint itself is not journaled, but the
 	// bounds a trial appends to it are, so a discarded trial leaves a sink nothing reached.
 	throws soltype.Type
+	// raised records whether any exceptional exit in this body can actually raise, which a
+	// declared sink cannot answer on its own: constraining into a concrete `throws string`
+	// leaves no trace on it. inferFunc reads it to warn about a clause the body never uses.
+	//
+	// A `throw` sets it unconditionally. A call sets it unless the callee is resolved and
+	// provably non-throwing, so a callee whose own throws is still an unsolved variable
+	// counts as raising. Erring that way costs a missed warning rather than a false one.
+	raised bool
 	// lvl is the level this body is walked at, recorded so throwsSink mints the sink
 	// there rather than wherever the first exceptional exit happens to sit. A `val`
 	// initializer is typed one level deeper, so a sink minted at the first exit's own
@@ -357,6 +365,15 @@ func (c *checker) throwsSink(lvl int) soltype.Type {
 		c.fn.throws = c.freshAt(c.fn.lvl)
 	}
 	return c.fn.throws
+}
+
+// markRaised records that the body being walked has an exceptional exit that can raise.
+// inferFunc reads the flag to warn about a `throws` clause the body never uses. It is a
+// no-op at module top level, where there is no clause to be unused.
+func (c *checker) markRaised() {
+	if c.fn != nil {
+		c.fn.raised = true
+	}
 }
 
 // popFuncCtx restores the previous function context (the pointer pushFuncCtx

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -135,54 +135,19 @@ type funcCtx struct {
 	// every returned value is uniquely owned, so the join of the returns is too.
 	returnExprs []ast.Expr
 
-	// throws is this body's exceptional SINK: the single type every exceptional exit is
-	// constrained against, the twin of the joined return type. A `throw e` constrains e's
-	// type into it. A call constrains the callee's throws into it by putting it in the
-	// synthesized call shape's own Throws slot, where constrain's covariant throws rule
-	// finds it. Routing both through one sink rather than through a list of collected
-	// types is what lets a call contribute without the walk having to resolve the callee
-	// first.
-	//
-	// inferFunc seeds the sink from the signature before the body is walked, so each throw
-	// and each call is checked against it at its own site and blamed there. A signature
-	// with no clause seeds `never`, which is how omitting the clause declares that the
-	// function raises nothing; `throws T` seeds T, and `throws _` seeds a fresh variable
-	// the body's exits flow into.
-	//
-	// Seeding also keeps a declared type parameter from picking up a vacuous bound. The
-	// alternative is to constrain the body into a separate variable and that variable into
-	// `T`, which leaves the two bounding each other, so
-	// `fn <E>(g: fn () -> number throws E) -> number throws E` would render its own sink
-	// as a second quantifier.
-	//
-	// inferFunc reads the sink back as the function's Throws once the body is walked,
-	// which mirrors the return type: the join variable becomes FuncType.Ret whether or not
-	// anything flowed into it. A `throws _` sink nothing reached coalesces to `never` and
-	// renders no clause.
-	//
-	// A body with no signature to seed from leaves this nil until throwsSink mints a
-	// variable on first use. Only a script's top level is in that position, since it has
-	// nowhere to write a clause.
-	//
-	// Minting is safe under a discardable probe: the mint itself is not journaled, but the
-	// bounds a trial appends to it are, so a discarded trial leaves a sink nothing reached.
+	// throws is this body's exceptional SINK: the single type every `throw` and every call
+	// is constrained against, the twin of the joined return type. inferFunc seeds it from
+	// the signature before the body is walked — `never` for no clause, T for `throws T`, a
+	// fresh variable for `throws _` — so each exit is blamed at its own site, and reads it
+	// back as the function's Throws. Only a script's top level has no signature to seed it.
 	throws soltype.Type
-	// raised records whether any exceptional exit in this body can actually raise, which a
-	// declared sink cannot answer on its own: constraining into a concrete `throws string`
-	// leaves no trace on it. inferFunc reads it to warn about a clause the body never uses.
-	//
-	// A `throw` sets it unconditionally. A call sets it unless the callee is resolved and
-	// provably non-throwing, so a callee whose own throws is still an unsolved variable
-	// counts as raising. Erring that way costs a missed warning rather than a false one.
+	// raised records whether any exceptional exit can actually raise, which a concrete
+	// declared sink cannot answer since constraining into it leaves no trace. A `throw`
+	// sets it; a call sets it unless the callee is resolved and provably non-throwing.
 	raised bool
-	// lvl is the level this body is walked at, recorded so throwsSink mints the sink
-	// there rather than wherever the first exceptional exit happens to sit. A `val`
-	// initializer is typed one level deeper, so a sink minted at the first exit's own
-	// level would land inner to the body when that exit is a call inside an
-	// initializer. A later exit at the body's own level would then extrude it, wiring
-	// the extruded proxy back to the original in both directions, and the cycle renders
-	// the function's throws as a μ-knot: `fn g() { val x = a()  a()  return x }`
-	// reports `throws μX0.(string | X0)` instead of `throws string`.
+	// lvl is the level this body is walked at, so throwsSink mints the sink there rather
+	// than inside a `val` initializer, which is typed one level deeper. A sink minted deep
+	// gets extruded by a later exit, and the resulting cycle renders as a μ-knot.
 	lvl int
 
 	// written records the widened type stored into a receiver variable's field by a
@@ -348,15 +313,8 @@ func (c *checker) inScript() bool {
 }
 
 // throwsSink returns the type this body's exceptional exits are constrained against.
-// inferFunc seeds it from the signature, so a function body always has one before its
-// first exceptional exit is walked, and the mint below fires only for a body with no
-// signature: a script's top level, which has nowhere to write a clause and so infers
-// what it raises rather than being held to `never`.
-//
-// A `throw` or a call at module top level has no enclosing function to raise out of at
-// all, so it gets a fresh variable that nothing reads. The thrown type is still checked
-// there; it simply propagates nowhere. Recording a module initializer's throws needs
-// somewhere on the module to put them, which no milestone has designed yet.
+// inferFunc seeds it from the signature, so the mint below fires only where there is no
+// signature to seed from: a script's top level, and a `throw` or call at module top level.
 func (c *checker) throwsSink(lvl int) soltype.Type {
 	if c.fn == nil {
 		return c.freshAt(lvl)

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -135,6 +135,28 @@ type funcCtx struct {
 	// every returned value is uniquely owned, so the join of the returns is too.
 	returnExprs []ast.Expr
 
+	// throws is the single type every exceptional exit of this body is constrained
+	// against, the exceptional twin of the joined return type. A `throw e` constrains e's
+	// type into it, and a call constrains the callee's throws into it by putting it in the
+	// synthesized call shape's own Throws slot, where constrain's covariant throws rule
+	// finds it. Routing both through one sink rather than through a list of collected
+	// types is what lets a call contribute without the walk having to resolve the callee
+	// first.
+	//
+	// When the signature declares `throws T`, inferFunc seeds the sink with T before the
+	// body is walked, so each throw and each call checks against the declared type at its
+	// own site and blames it there. Seeding also keeps a declared type parameter from
+	// picking up a vacuous bound: were the body instead constrained into a separate
+	// variable and that variable then into `T`, the two would bound each other and
+	// `fn <E>(g: fn () -> number throws E) -> number throws E` would render its own sink
+	// as a second quantifier.
+	//
+	// With no clause the sink is a variable throwsSink mints on first use, so a body that
+	// neither throws nor calls anything allocates nothing. A variable that gained no lower
+	// bound means nothing reached it, and inferredThrows reports that as no throws at all
+	// rather than a variable standing for `never`.
+	throws soltype.Type
+
 	// written records the widened type stored into a receiver variable's field by a
 	// field-write `recv.prop = source` (M4 C3), keyed by the receiver var's ID and
 	// the property name. A later read of the same field returns this concrete type
@@ -295,6 +317,43 @@ func (c *checker) pushFuncCtx(async bool, node ast.Node) *funcCtx {
 // such as a local enum declaration.
 func (c *checker) inScript() bool {
 	return c.fn != nil && c.fn.node == nil
+}
+
+// throwsSink returns the type this body's exceptional exits are constrained against,
+// minting a fresh variable at lvl when the signature declared no `throws` clause and
+// nothing has needed the sink yet. A `throw` or a call at module top level has no
+// enclosing function to raise out of, so it gets a fresh variable that nothing reads:
+// the thrown type is still checked, it just propagates nowhere. Recording a module
+// initializer's throws needs somewhere on the module to put them, which no milestone has
+// designed yet.
+func (c *checker) throwsSink(lvl int) soltype.Type {
+	if c.fn == nil {
+		return c.freshAt(lvl)
+	}
+	if c.fn.throws == nil {
+		c.fn.throws = c.freshAt(lvl)
+	}
+	return c.fn.throws
+}
+
+// inferredThrows returns the sink the current body's exceptional exits were constrained
+// against, or nil when the body has no exceptional exit at all — no `throw` and no call
+// ever asked for the sink, so none was minted. This mirrors the return type, where the
+// join variable becomes FuncType.Ret whether or not anything flowed into it: a sink that
+// nothing reached coalesces to `never` and renders no clause.
+//
+// Emptiness is deliberately NOT tested by looking at the sink's lower bounds. constrain
+// records a variable-to-variable edge on one endpoint only, so a generic callee's
+// `throws E` leaves the sink's own lower bounds empty while E carries the sink as an
+// upper bound. Coalescing reads that edge back through its mirrored view; a lower-bounds
+// test here would not, and would drop the throws the caller inherits.
+//
+// Call it before popFuncCtx restores the outer context.
+func (c *checker) inferredThrows() soltype.Type {
+	if c.fn == nil {
+		return nil
+	}
+	return c.fn.throws
 }
 
 // popFuncCtx restores the previous function context (the pointer pushFuncCtx
@@ -480,6 +539,8 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 		return c.inferMatch(scope, lvl, e)
 	case *ast.BorrowExpr:
 		return c.inferBorrow(scope, lvl, e)
+	case *ast.ThrowExpr:
+		return c.inferThrow(scope, lvl, e)
 	case *ast.BinaryExpr:
 		// PR8 handles the ASSIGNMENT op only (`a = expr`); every other binary
 		// operator (+, ==, &&, ++, …) needs the operator-scheme walk over the prelude

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -467,12 +467,8 @@ func (c *checker) buildMemberSigs(
 				continue
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
+			c.reportAccessorThrows(elem.Fn, elem, "getter")
 			stub := c.memberSigStub(lvl, elem.Fn)
-			// A getter projects to the type its read yields, so `soltype.GetterElem` holds a
-			// bare Type and has nowhere to record a `throws` clause the source wrote. A
-			// throwing getter therefore reads as non-throwing. Recording it would first
-			// require deciding what a property read that can raise means at the access site,
-			// which no milestone has designed. A setter's write has the same gap.
 			getter := &soltype.GetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Type: stub.Ret}
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, getter)
@@ -486,6 +482,7 @@ func (c *checker) buildMemberSigs(
 				continue
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
+			c.reportAccessorThrows(elem.Fn, elem, "setter")
 			// A well-formed setter declares exactly one value parameter beyond `self` — the
 			// value being assigned. Report a paramless or multi-parameter setter, then still
 			// build the elem from the first value parameter, or `unknown` when there is none,
@@ -534,6 +531,19 @@ func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Throws: ft.Throws, Inexact: ft.Inexact}
 	}
 	c.constrain(node, callable(bodyFt), callable(stub))
+}
+
+// reportAccessorThrows rejects a `throws` clause on a getter or setter. An accessor
+// projects to the type its read yields or its write accepts, so `soltype.GetterElem` and
+// `soltype.SetterElem` hold a bare Type with nowhere to put the clause. Accepting it and
+// dropping it would let a raising accessor read as non-throwing, which is worse than
+// refusing it, so the clause is reported here rather than silently discarded. Supporting
+// it means first deciding what a property read or write that can raise means at the
+// access site, which no milestone has designed. kind names the accessor in the message.
+func (c *checker) reportAccessorThrows(fn *ast.FuncExpr, blame ast.Node, kind string) {
+	if fn.Throws != nil {
+		c.reportUnsupportedFeature(blame, "throws clause on a "+kind)
+	}
 }
 
 // memberSigStub builds a member's signature stub: one fresh var per value parameter,

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -533,13 +533,9 @@ func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 	c.constrain(node, callable(bodyFt), callable(stub))
 }
 
-// reportAccessorThrows rejects a `throws` clause on a getter or setter. An accessor
-// projects to the type its read yields or its write accepts, so `soltype.GetterElem` and
-// `soltype.SetterElem` hold a bare Type with nowhere to put the clause. Accepting it and
-// dropping it would let a raising accessor read as non-throwing, which is worse than
-// refusing it, so the clause is reported here rather than silently discarded. Supporting
-// it means first deciding what a property read or write that can raise means at the
-// access site, which no milestone has designed. kind names the accessor in the message.
+// reportAccessorThrows rejects a `throws` clause on a getter or setter. Neither element
+// holds more than a bare Type, and dropping the clause would let a raising accessor read
+// as non-throwing. kind names the accessor in the message.
 func (c *checker) reportAccessorThrows(fn *ast.FuncExpr, blame ast.Node, kind string) {
 	if fn.Throws != nil {
 		c.reportUnsupportedFeature(blame, "throws clause on a "+kind)

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -468,6 +468,11 @@ func (c *checker) buildMemberSigs(
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
 			stub := c.memberSigStub(lvl, elem.Fn)
+			// A getter projects to the type its read yields, so `soltype.GetterElem` holds a
+			// bare Type and has nowhere to record a `throws` clause the source wrote. A
+			// throwing getter therefore reads as non-throwing. Recording it would first
+			// require deciding what a property read that can raise means at the access site,
+			// which no milestone has designed. A setter's write has the same gap.
 			getter := &soltype.GetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Type: stub.Ret}
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, getter)
@@ -532,9 +537,10 @@ func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 }
 
 // memberSigStub builds a member's signature stub: one fresh var per value parameter,
-// preserving arity, parameter names, and optionality, plus a fresh return var and a
-// fresh throws var. A sibling call reads the stub before the body pass runs, so the
-// throws var is what lets a method that raises reach its callers within the same class.
+// preserving arity, parameter names, and optionality, plus a fresh return var and a fresh
+// throws var. A sibling call reads the stub before the body pass installs the real
+// signature, so the throws var is what carries a raising method's throws to a caller
+// inside the same class.
 func (c *checker) memberSigStub(lvl int, fn *ast.FuncExpr) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(fn.Params))
 	for i, p := range fn.Params {

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -526,13 +526,15 @@ func (c *checker) inferMemberBodies(scope *Scope, lvl int, body *soltype.ObjectT
 // stub); SelfParam lives on the element and is not compared here.
 func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 	callable := func(ft *soltype.FuncType) *soltype.FuncType {
-		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Inexact: ft.Inexact}
+		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Throws: ft.Throws, Inexact: ft.Inexact}
 	}
 	c.constrain(node, callable(bodyFt), callable(stub))
 }
 
 // memberSigStub builds a member's signature stub: one fresh var per value parameter,
-// preserving arity, parameter names, and optionality, plus a fresh return var.
+// preserving arity, parameter names, and optionality, plus a fresh return var and a
+// fresh throws var. A sibling call reads the stub before the body pass runs, so the
+// throws var is what lets a method that raises reach its callers within the same class.
 func (c *checker) memberSigStub(lvl int, fn *ast.FuncExpr) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(fn.Params))
 	for i, p := range fn.Params {
@@ -549,7 +551,12 @@ func (c *checker) memberSigStub(lvl int, fn *ast.FuncExpr) *soltype.FuncType {
 			Optional: p.Optional,
 		}
 	}
-	return &soltype.FuncType{Params: params, Ret: c.freshAt(lvl), Inexact: fn.FuncSig.Inexact}
+	return &soltype.FuncType{
+		Params:  params,
+		Ret:     c.freshAt(lvl),
+		Throws:  c.freshAt(lvl),
+		Inexact: fn.FuncSig.Inexact,
+	}
 }
 
 // targetBody selects the static or instance body for a member.

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -74,7 +74,7 @@ func (c *checker) walkConstructorBody(scope *Scope, lvl int, self *soltype.Class
 	c.checkConstructorInit(body, ctor)
 	// A constructor returns a fresh instance, not the void its statement body falls off
 	// to, so override the inferred return with the instance type.
-	return &soltype.FuncType{Params: ft.Params, Ret: self, Inexact: ft.Inexact}
+	return &soltype.FuncType{Params: ft.Params, Ret: self, Throws: ft.Throws, Inexact: ft.Inexact}
 }
 
 // checkConstructorInit runs definite-assignment analysis over an explicit

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -320,6 +320,11 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 
 	var ret soltype.Type = &soltype.Void{}
 	var retExprs []ast.Expr
+	// bodyDiverges records that every path through the body left along the exceptional
+	// edge, and raised that some exceptional exit can actually raise. Both are read after
+	// the walk to warn about a signature the body cannot deliver on.
+	bodyDiverges := false
+	raised := false
 	// throws is what a caller sees on the exceptional edge. A bodyless `declare fn` has
 	// only its clause. A body-carrying function reads the sink back once the body is
 	// walked, which is the declared type when there was a clause and the inferred variable
@@ -354,6 +359,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		c.checkUseAfterMoves()
 		retExprs = c.fn.returnExprs
 		throws = c.fn.throws
+		raised = c.fn.raised
 		collected := c.popFuncCtx(saved)
 		// A body with no `return` that always leaves along the exceptional edge reaches
 		// no normal exit, so it produces `never`, not the `void` a fall-through body
@@ -361,9 +367,17 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// `void <: number`.
 		if len(collected) == 0 && blockDiverges(body) {
 			ret = &soltype.NeverType{}
+			bodyDiverges = true
 		} else {
 			ret = c.joinReturnPoints(node, lvl, collected)
 		}
+	}
+	// A declared `throws T` the body never uses obliges every caller to handle an
+	// exception that cannot occur, so warn and point at the clause. `throws _` asks for
+	// inference rather than declaring anything, and a bodyless `declare fn` has no body to
+	// measure against, so neither reaches here.
+	if hasBody && !raised && sig.Throws != nil && !isWildcardAnn(sig.Throws) {
+		c.report(&UnusedThrowsClauseError{Ann: sig.Throws, Declared: throws})
 	}
 	// Return-annotation handling diverges by async-ness.
 	//
@@ -397,6 +411,12 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			// would raise a spurious `void <: T`).
 			if hasBody {
 				c.constrainReturnAgainstAnnotation(node, retExprs, ret, annT) // body <: declared return
+				// No caller can observe an annotated return the body never reaches, so warn
+				// and point at the annotation. A body that diverges into `never` on purpose
+				// writes `-> never`, which is what it delivers and so is not flagged.
+				if bodyDiverges && !isNeverType(annT) {
+					c.report(&UnreachableReturnAnnotationError{Ann: sig.Return, Declared: annT})
+				}
 			}
 			ret = annT
 		} else if !hasBody {
@@ -1278,6 +1298,12 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// carries `never`, which constrain short-circuits, so an ordinary call records
 	// nothing.
 	callShape := &soltype.FuncType{Params: demand, Ret: res, Throws: c.throwsSink(lvl)}
+	// A resolved callee that declares nothing raises nothing, so it leaves the enclosing
+	// clause unused. Any other callee counts as raising, since its throws may still be an
+	// unsolved variable at this point.
+	if fn, ok := resolveFunc(callee); !ok || !isNeverType(fn.ThrowsOrNever()) {
+		c.markRaised()
+	}
 	// Record the synthesized call-shape against the CallExpr so a FuncArityMismatchError
 	// — now only from a DEFERRED callee's too-few (or a callback-arity failure), since
 	// concrete arity faults are owned by the lints above — resolves its blame to the call.
@@ -2428,6 +2454,7 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Type {
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	c.constrain(e, arg, c.throwsSink(lvl))
+	c.markRaised()
 	t := &soltype.NeverType{}
 	c.recordType(e, t)
 	return t

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -297,11 +297,11 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 
 	// A `throws T` clause is resolved before the body is walked, because it is the sink
 	// every `throw` and every call in the body checks against. Resolving it up front is
-	// what makes a mismatch blame the throw or the call rather than the whole function,
-	// and it is why the declared type reaches the function's Throws whether or not the
-	// body raises anything. `throws _` puts a fresh variable there instead, so the clause
-	// asks for inference rather than fixing a type. An unsupported clause was already
-	// reported by resolveTypeAnn and recovers as no clause at all.
+	// what makes a mismatch blame the throw or the call rather than the whole function.
+	// It is also why the declared type reaches the function's Throws whether or not the
+	// body raises anything. Writing `throws _` puts a fresh variable there instead, so
+	// the clause asks for inference rather than fixing a type. An unsupported clause was
+	// already reported by resolveTypeAnn and recovers as no clause at all.
 	var declaredThrows soltype.Type
 	if sig.Throws != nil {
 		if annT, ok := c.resolveTypeAnn(declScope, sig.Throws, lvl); ok {
@@ -311,9 +311,10 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 
 	var ret soltype.Type = &soltype.Void{}
 	var retExprs []ast.Expr
-	// throws is what a caller sees on the exceptional edge: the declared type when the
-	// signature has a clause, otherwise whatever the body's exits reached. Nil means the
-	// function raises nothing.
+	// throws is what a caller sees on the exceptional edge. A bodyless `declare fn` has
+	// only its clause. A body-carrying function reads the sink back once the body is
+	// walked, which is the declared type when there was a clause and the inferred variable
+	// when there was not. Nil means the function raises nothing.
 	throws := declaredThrows
 	hasBody := body != nil
 	if hasBody {
@@ -343,9 +344,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// it reads this body's move and use state off c.fn.
 		c.checkUseAfterMoves()
 		retExprs = c.fn.returnExprs
-		if throws == nil {
-			throws = c.inferredThrows()
-		}
+		throws = c.fn.throws
 		collected := c.popFuncCtx(saved)
 		// A body with no `return` that always leaves along the exceptional edge reaches
 		// no normal exit, so it produces `never`, not the `void` a fall-through body
@@ -377,7 +376,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	//
 	// Throws is untouched by either arm. An `async fn` that throws really rejects its
 	// promise rather than raising to its caller, so the thrown type belongs in the
-	// promise's rejection slot, and `soltype.PromiseType` carries only a fulfilment type.
+	// promise's rejection slot. `soltype.PromiseType` carries only a fulfilment type.
 	// Until it carries a rejection type too, an async function keeps what it raises on
 	// its own Throws, which is the information the body supplied.
 	if sig.Async {
@@ -1264,11 +1263,11 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// required(callee) <= N <= upper(callee). If callShape were INEXACT instead,
 	// its accept-set would widen to [N, ∞), demanding upper(callee) = ∞ and thus
 	// rejecting every call to a fixed-arity (exact) function.
-	// The shape's Throws slot is the enclosing body's throws variable, so constrain's
-	// covariant throws rule records whatever the callee raises as a lower bound of it and
-	// the exception propagates to this body's own `throws` clause. A non-throwing callee
+	// The shape's Throws slot is the enclosing body's throws sink, so constrain's
+	// covariant throws rule records whatever the callee raises into that sink and the
+	// exception propagates to this body's own `throws` clause. A non-throwing callee
 	// carries `never`, which constrain short-circuits, so an ordinary call records
-	// nothing and the variable stays empty.
+	// nothing.
 	callShape := &soltype.FuncType{Params: demand, Ret: res, Throws: c.throwsSink(lvl)}
 	// Record the synthesized call-shape against the CallExpr so a FuncArityMismatchError
 	// — now only from a DEFERRED callee's too-few (or a callback-arity failure), since
@@ -2414,9 +2413,9 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 
 // inferThrow types `throw e`. The thrown value's type is constrained into the enclosing
 // body's throws sink, so it reaches the function's `throws` clause the way a `return`
-// reaches its return type. The expression itself is `never`: control
-// leaves along the exceptional edge, so `throw` yields no value and composes anywhere a
-// value is expected, as in `return if ok { v } else { throw Error("no value") }`.
+// reaches its return type. The expression itself is `never`, because control leaves
+// along the exceptional edge and no value is produced. That lets a `throw` sit anywhere
+// a value is expected, as in `return if ok { v } else { throw Error("no value") }`.
 func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Type {
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	c.constrain(e, arg, c.throwsSink(lvl))
@@ -2431,12 +2430,12 @@ func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Ty
 // branch as a lower bound, so the result coalesces to the union of the branches
 // that can actually produce a value.
 //
-// Diverging branches contribute `never`: a branch that always exits before its tail,
+// Diverging branches contribute `never`. A branch that always exits before its tail,
 // through a trailing `return` or `throw`, can never be the path that yields the if's
-// value, so it drops out of the branch union entirely rather than leaking its
-// operand. `val x = if c { return 1 } else { "y" }` is `"y"`, not `1 | "y"`, and
-// when both branches diverge the if's value coalesces to `never`. blockDiverges
-// decides which branches those are.
+// value, so it drops out of the branch union rather than leaking its operand.
+// `val x = if c { return 1 } else { "y" }` is `"y"`, not `1 | "y"`, and when both
+// branches diverge the if's value coalesces to `never`. blockDiverges decides which
+// branches those are.
 //
 // Block return-point interaction: any ReturnStmt inside either branch is still
 // collected on the enclosing function's funcCtx by inferStmt — independent of the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -295,15 +295,24 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		}
 	}
 
-	// A `throws T` clause is resolved before the body is walked, because it is the sink
-	// every `throw` and every call in the body checks against. Resolving it up front is
-	// what makes a mismatch blame the throw or the call rather than the whole function.
-	// It is also why the declared type reaches the function's Throws whether or not the
-	// body raises anything. Writing `throws _` puts a fresh variable there instead, so
-	// the clause asks for inference rather than fixing a type. An unsupported clause was
-	// already reported by resolveTypeAnn and recovers as no clause at all.
-	var declaredThrows soltype.Type
+	// The `throws` clause is resolved before the body is walked, because it is the sink
+	// every `throw` and every call in the body is checked against. Resolving it up front
+	// is what makes a mismatch blame the throw or the call rather than the whole
+	// function, and it is why the declared type reaches the function's Throws whether or
+	// not the body raises anything.
+	//
+	// Writing NO clause is itself a declaration: the function raises nothing. The sink is
+	// `never`, so a `throw` in the body or a call to a throwing callee is rejected at its
+	// own site, and a function is non-throwing only by omitting the clause rather than by
+	// writing `throws never`. Writing `throws _` opts back into inference by putting a
+	// fresh variable there for the body's exits to flow into.
+	//
+	// An unsupported clause recovers to a fresh variable rather than to `never`, after
+	// resolveTypeAnn has reported it. Recovering to the strictest type would re-report
+	// every exceptional exit on top of the one real diagnostic.
+	var declaredThrows soltype.Type = &soltype.NeverType{}
 	if sig.Throws != nil {
+		declaredThrows = c.freshAt(lvl)
 		if annT, ok := c.resolveTypeAnn(declScope, sig.Throws, lvl); ok {
 			declaredThrows = annT
 		}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -295,21 +295,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		}
 	}
 
-	// The `throws` clause is resolved before the body is walked, because it is the sink
-	// every `throw` and every call in the body is checked against. Resolving it up front
-	// is what makes a mismatch blame the throw or the call rather than the whole
-	// function, and it is why the declared type reaches the function's Throws whether or
-	// not the body raises anything.
-	//
-	// Writing NO clause is itself a declaration: the function raises nothing. The sink is
-	// `never`, so a `throw` in the body or a call to a throwing callee is rejected at its
-	// own site, and a function is non-throwing only by omitting the clause rather than by
-	// writing `throws never`. Writing `throws _` opts back into inference by putting a
-	// fresh variable there for the body's exits to flow into.
-	//
-	// An unsupported clause recovers to a fresh variable rather than to `never`, after
-	// resolveTypeAnn has reported it. Recovering to the strictest type would re-report
-	// every exceptional exit on top of the one real diagnostic.
+	// The clause is the sink every throw and call is checked against, so it resolves
+	// before the body: `never` for no clause, which is how omitting it declares that the
+	// function raises nothing; T for `throws T`; a fresh var for `throws _` or a bad one.
 	var declaredThrows soltype.Type = &soltype.NeverType{}
 	if sig.Throws != nil {
 		declaredThrows = c.freshAt(lvl)
@@ -397,11 +385,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// there is no body, since a synthetic Void would falsely signal "returns
 	// nothing").
 	//
-	// Throws is untouched by either arm. An `async fn` that throws really rejects its
-	// promise rather than raising to its caller, so the thrown type belongs in the
-	// promise's rejection slot. `soltype.PromiseType` carries only a fulfilment type.
-	// Until it carries a rejection type too, an async function keeps what it raises on
-	// its own Throws, which is the information the body supplied.
+	// Throws is untouched by either arm. An `async fn` rejects its promise rather than
+	// raising, so what it throws belongs in a rejection slot `soltype.PromiseType` does not
+	// yet have; until it does, an async function keeps it on its own Throws. See PR10c.
 	if sig.Async {
 		ret = c.asyncReturn(declScope, node, sig.Return, ret, hasBody, lvl)
 	} else if sig.Return != nil {
@@ -1292,11 +1278,8 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// required(callee) <= N <= upper(callee). If callShape were INEXACT instead,
 	// its accept-set would widen to [N, ∞), demanding upper(callee) = ∞ and thus
 	// rejecting every call to a fixed-arity (exact) function.
-	// The shape's Throws slot is the enclosing body's throws sink, so constrain's
-	// covariant throws rule records whatever the callee raises into that sink and the
-	// exception propagates to this body's own `throws` clause. A non-throwing callee
-	// carries `never`, which constrain short-circuits, so an ordinary call records
-	// nothing.
+	// The shape's Throws slot is this body's sink, so constrain's covariant throws rule
+	// records what the callee raises into it. A non-throwing `never` records nothing.
 	callShape := &soltype.FuncType{Params: demand, Ret: res, Throws: c.throwsSink(lvl)}
 	// A resolved callee that declares nothing raises nothing, so it leaves the enclosing
 	// clause unused. Any other callee counts as raising, since its throws may still be an
@@ -2446,11 +2429,9 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	return res
 }
 
-// inferThrow types `throw e`. The thrown value's type is constrained into the enclosing
-// body's throws sink, so it reaches the function's `throws` clause the way a `return`
-// reaches its return type. The expression itself is `never`, because control leaves
-// along the exceptional edge and no value is produced. That lets a `throw` sit anywhere
-// a value is expected, as in `return if ok { v } else { throw Error("no value") }`.
+// inferThrow types `throw e`. The thrown type is constrained into the enclosing body's
+// throws sink, the way a `return` reaches the return type. The expression is `never`, so
+// a `throw` sits where a value is expected: `return if ok { v } else { throw E("x") }`.
 func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Type {
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	c.constrain(e, arg, c.throwsSink(lvl))

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2430,8 +2430,8 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 }
 
 // inferThrow types `throw e`. The thrown type is constrained into the enclosing body's
-// throws sink, the way a `return` reaches the return type. The expression is `never`, so
-// a `throw` sits where a value is expected: `return if ok { v } else { throw E("x") }`.
+// throws sink, the way a `return` reaches the return type. It is `never`, so a `throw`
+// sits where a value is expected: `return if ok { v } else { throw Error("no value") }`.
 func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Type {
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	c.constrain(e, arg, c.throwsSink(lvl))

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2436,6 +2436,8 @@ func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Ty
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	c.constrain(e, arg, c.throwsSink(lvl))
 	c.markRaised()
+	// Recorded but given no provenance: every `&NeverType{}` shares one address, and Prov
+	// is pointer-keyed, so a second throw would trip recordProv's guard. Info is node-keyed.
 	t := &soltype.NeverType{}
 	c.recordType(e, t)
 	return t

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -321,7 +321,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// PR3: open a fresh function context so every ReturnStmt encountered while
 		// walking the body lands in our own returns list (a nested fn inside this
 		// body opens its own context, so its returns never leak out here).
-		saved := c.pushFuncCtx(sig.Async, node)
+		saved := c.pushFuncCtx(sig.Async, node, lvl)
 		c.fn.throws = declaredThrows
 		// M4 G1: run the liveness pre-pass before walking the body so mutability
 		// transitions are checked. It renames the body's variable nodes (writing the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -295,14 +295,33 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		}
 	}
 
+	// A `throws T` clause is resolved before the body is walked, because it is the sink
+	// every `throw` and every call in the body checks against. Resolving it up front is
+	// what makes a mismatch blame the throw or the call rather than the whole function,
+	// and it is why the declared type reaches the function's Throws whether or not the
+	// body raises anything. `throws _` puts a fresh variable there instead, so the clause
+	// asks for inference rather than fixing a type. An unsupported clause was already
+	// reported by resolveTypeAnn and recovers as no clause at all.
+	var declaredThrows soltype.Type
+	if sig.Throws != nil {
+		if annT, ok := c.resolveTypeAnn(declScope, sig.Throws, lvl); ok {
+			declaredThrows = annT
+		}
+	}
+
 	var ret soltype.Type = &soltype.Void{}
 	var retExprs []ast.Expr
+	// throws is what a caller sees on the exceptional edge: the declared type when the
+	// signature has a clause, otherwise whatever the body's exits reached. Nil means the
+	// function raises nothing.
+	throws := declaredThrows
 	hasBody := body != nil
 	if hasBody {
 		// PR3: open a fresh function context so every ReturnStmt encountered while
 		// walking the body lands in our own returns list (a nested fn inside this
 		// body opens its own context, so its returns never leak out here).
 		saved := c.pushFuncCtx(sig.Async, node)
+		c.fn.throws = declaredThrows
 		// M4 G1: run the liveness pre-pass before walking the body so mutability
 		// transitions are checked. It renames the body's variable nodes (writing the
 		// VarIDs DetermineAliasSource and the alias tracker read) and seeds the
@@ -324,7 +343,19 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// it reads this body's move and use state off c.fn.
 		c.checkUseAfterMoves()
 		retExprs = c.fn.returnExprs
-		ret = c.joinReturnPoints(node, lvl, c.popFuncCtx(saved))
+		if throws == nil {
+			throws = c.inferredThrows()
+		}
+		collected := c.popFuncCtx(saved)
+		// A body with no `return` that always leaves along the exceptional edge reaches
+		// no normal exit, so it produces `never`, not the `void` a fall-through body
+		// produces. Without this `fn f() -> number { throw Error("no") }` would report
+		// `void <: number`.
+		if len(collected) == 0 && blockDiverges(body) {
+			ret = &soltype.NeverType{}
+		} else {
+			ret = c.joinReturnPoints(node, lvl, collected)
+		}
 	}
 	// Return-annotation handling diverges by async-ness.
 	//
@@ -343,6 +374,12 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// resolveTypeAnn; recover by keeping the inferred body type (or unknown when
 	// there is no body, since a synthetic Void would falsely signal "returns
 	// nothing").
+	//
+	// Throws is untouched by either arm. An `async fn` that throws really rejects its
+	// promise rather than raising to its caller, so the thrown type belongs in the
+	// promise's rejection slot, and `soltype.PromiseType` carries only a fulfilment type.
+	// Until it carries a rejection type too, an async function keeps what it raises on
+	// its own Throws, which is the information the body supplied.
 	if sig.Async {
 		ret = c.asyncReturn(declScope, node, sig.Return, ret, hasBody, lvl)
 	} else if sig.Return != nil {
@@ -363,7 +400,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// inexact — it tolerates extra args when used as a callback (#677 §4.1), accept
 	// [required, ∞). Note exactness governs callback subtyping, not direct calls: an
 	// inexact value still rejects extras at a visible call site (the inferCall lint).
-	ft := &soltype.FuncType{Params: params, Ret: ret, Inexact: sig.Inexact, TypeParams: typeParams}
+	ft := &soltype.FuncType{Params: params, Ret: ret, Throws: throws, Inexact: sig.Inexact, TypeParams: typeParams}
 	// Record the function's own type against its node so a function flowing into a
 	// non-function requirement blames the function, and FuncArityMismatchError can
 	// carry a "defined here" related span. (For a named callee this raw FuncType is
@@ -1227,7 +1264,12 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// required(callee) <= N <= upper(callee). If callShape were INEXACT instead,
 	// its accept-set would widen to [N, ∞), demanding upper(callee) = ∞ and thus
 	// rejecting every call to a fixed-arity (exact) function.
-	callShape := &soltype.FuncType{Params: demand, Ret: res}
+	// The shape's Throws slot is the enclosing body's throws variable, so constrain's
+	// covariant throws rule records whatever the callee raises as a lower bound of it and
+	// the exception propagates to this body's own `throws` clause. A non-throwing callee
+	// carries `never`, which constrain short-circuits, so an ordinary call records
+	// nothing and the variable stays empty.
+	callShape := &soltype.FuncType{Params: demand, Ret: res, Throws: c.throwsSink(lvl)}
 	// Record the synthesized call-shape against the CallExpr so a FuncArityMismatchError
 	// — now only from a DEFERRED callee's too-few (or a callback-arity failure), since
 	// concrete arity faults are owned by the lints above — resolves its blame to the call.
@@ -2370,18 +2412,31 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	return res
 }
 
+// inferThrow types `throw e`. The thrown value's type is constrained into the enclosing
+// body's throws sink, so it reaches the function's `throws` clause the way a `return`
+// reaches its return type. The expression itself is `never`: control
+// leaves along the exceptional edge, so `throw` yields no value and composes anywhere a
+// value is expected, as in `return if ok { v } else { throw Error("no value") }`.
+func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Type {
+	arg := c.inferExpr(scope, lvl, e.Arg)
+	c.constrain(e, arg, c.throwsSink(lvl))
+	t := &soltype.NeverType{}
+	c.recordType(e, t)
+	return t
+}
+
 // inferIfElse types `if cond { cons } else { alt }`. The condition is
 // constrained `<: boolean`; each branch is typed (an empty / missing else
 // contributes Void); the result is a fresh join var with each NON-DIVERGING
 // branch as a lower bound, so the result coalesces to the union of the branches
 // that can actually produce a value.
 //
-// Diverging branches contribute `never`: a branch that always exits before its
-// tail (today a trailing `return`; `throw` / `-> never` calls join this set once
-// they land — see blockDiverges) can never be the path that yields the if's
+// Diverging branches contribute `never`: a branch that always exits before its tail,
+// through a trailing `return` or `throw`, can never be the path that yields the if's
 // value, so it drops out of the branch union entirely rather than leaking its
 // operand. `val x = if c { return 1 } else { "y" }` is `"y"`, not `1 | "y"`, and
-// when both branches diverge the if's value coalesces to `never`.
+// when both branches diverge the if's value coalesces to `never`. blockDiverges
+// decides which branches those are.
 //
 // Block return-point interaction: any ReturnStmt inside either branch is still
 // collected on the enclosing function's funcCtx by inferStmt — independent of the
@@ -3023,11 +3078,10 @@ func stmtDiverges(s ast.Stmt) bool {
 // problem of collecting every `return` regardless of position.
 //
 // MatchExpr is walked by inferMatch in M4 E2, so its arm reflects real source. A
-// match diverges when every arm body does. ThrowExpr and DoExpr are not yet walked
-// by the solver, which reports them unsupported, so those arms are unreachable from
-// real source today. They are kept in place so a form's divergence is already
-// recognised the moment its inferExpr case lands, matching the checker rather than
-// re-discovering divergence later. The checker's
+// match diverges when every arm body does. DoExpr is not walked by the solver, which
+// reports it unsupported, so that arm is unreachable from real source. It is kept in
+// place so the form's divergence is already recognised the moment its inferExpr case
+// lands, matching the checker rather than re-discovering divergence later. The checker's
 // CallExpr `-> never` arm is deliberately omitted: the solver represents a call's
 // result as an unresolved variable mid-walk (bounds lists, not a single prunable
 // Instance), so "this call returns never" is a coalescing-time fact — revisit when

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -280,14 +280,14 @@ func TestInferGenericFuncAnnotationChecksBoundedParam(t *testing.T) {
 	})
 }
 
-// A throws clause reports the documented unsupported feature and recovers
-// function-shaped.
-func TestInferThrowsFuncAnnotationReportsUnsupported(t *testing.T) {
+// A throws clause in a function type annotation resolves to the declared type and
+// renders back after the return type. The annotated function raises nothing, and a
+// non-throwing body satisfies a throwing annotation because throws is covariant and the
+// body's `never` is the bottom of the lattice.
+func TestInferThrowsFuncAnnotation(t *testing.T) {
 	values, _, errs := inferSource(t, `val f: fn(x: number) -> number throws boolean = fn (x) { return x }`)
-	require.Len(t, errs, 1)
-	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
-	require.Equal(t, "1:8-1:46: Unsupported: throws clause in function type annotation", msgWithSpan(errs[0]))
-	require.Equal(t, "fn (x: number) -> number", values["f"])
+	require.Empty(t, errs)
+	require.Equal(t, "fn (x: number) -> number throws boolean", values["f"])
 }
 
 // A lifetime parameter in a function type annotation resolves against its declared

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -293,7 +293,7 @@ func TestInferBlockReturnStmt(t *testing.T) {
 	c := newChecker()
 	// A return is only legal inside a function body, so push a func context the way
 	// inferFunc does — otherwise the walk (correctly) reports ReturnOutsideFunction.
-	saved := c.pushFuncCtx(false, nil)
+	saved := c.pushFuncCtx(false, nil, 0)
 	// { return 5 }
 	got, diverges := c.inferBlock(NewScope(), 0, block(returnStmt(numExpr(5))))
 	c.popFuncCtx(saved)

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -1,0 +1,219 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A function's `throws` type is inferred from its body when the signature declares no
+// clause, the way its return type is inferred from its `return` statements. Each case
+// renders the binding named `f` and expects no error.
+func TestInferThrowsFromBody(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "SingleThrow",
+			src:  `fn f() { throw "boom" }`,
+			want: `fn () -> never throws "boom"`,
+		},
+		{
+			// Two throws on different paths union, the same join the return points take.
+			name: "ThrowsOnBothBranches",
+			src:  `fn f(c: boolean) { if c { throw "a" } else { throw 5 } }`,
+			want: `fn (c: boolean) -> never throws 5 | "a"`,
+		},
+		{
+			// The `else` branch diverges, so it drops out of the value union and only the
+			// `then` branch reaches the return.
+			name: "ThrowOnOnePathOnly",
+			src:  `fn f(c: boolean) { if c { return 1 } else { throw "x" } }`,
+			want: `fn (c: boolean) -> 1 throws "x"`,
+		},
+		{
+			// `throw` is `never`, so it composes where a value is expected and contributes
+			// nothing to the union of the branches.
+			name: "ThrowInValuePosition",
+			src:  `fn f(c: boolean) { return if c { 1 } else { throw "x" } }`,
+			want: `fn (c: boolean) -> 1 throws "x"`,
+		},
+		{
+			// A body with no exceptional exit renders no clause at all.
+			name: "NoThrowRendersNoClause",
+			src:  `fn f() { return 1 }`,
+			want: `fn () -> 1`,
+		},
+		{
+			// A nested function owns its own throws sink, so `g`'s throw stays on `g`.
+			name: "NestedFunctionThrowsDoNotLeak",
+			src: `
+				fn f() {
+					val g = fn () { throw "inner" }
+					return 1
+				}
+			`,
+			want: `fn () -> 1`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, test.src)
+			require.Empty(t, errs)
+			require.Equal(t, test.want, values["f"])
+		})
+	}
+}
+
+// A `throws T` clause fixes what the function raises: the declared type is what a caller
+// sees, and each `throw` in the body is checked against it at its own site.
+func TestInferThrowsClause(t *testing.T) {
+	t.Run("ClauseWidensTheThrownLiteral", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f() throws string { throw "boom" }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> never throws string", values["f"])
+	})
+	t.Run("ClauseWithoutReturnAnnotation", func(t *testing.T) {
+		// The clause parses on its own, with no `-> R` in front of it.
+		values, _, errs := inferSource(t, `fn f(x: number) throws string { throw "boom" }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn (x: number) -> never throws string", values["f"])
+	})
+	t.Run("ClauseAfterReturnAnnotation", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f() -> number throws string { return 1 }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> number throws string", values["f"])
+	})
+	t.Run("ThrownValueMustSatisfyTheClause", func(t *testing.T) {
+		_, _, errs := inferSource(t, `fn f() throws number { throw "boom" }`)
+		require.Len(t, errs, 1)
+		require.Equal(t, `1:30-1:36: cannot constrain "boom" <: number`, msgWithSpan(errs[0]))
+	})
+	t.Run("WildcardClauseInfers", func(t *testing.T) {
+		// `throws _` mints a fresh variable the body's throws flow into, so the clause asks
+		// for inference rather than fixing a type.
+		values, _, errs := inferSource(t, `fn f() throws _ { throw "boom" }`)
+		require.Empty(t, errs)
+		require.Equal(t, `fn () -> never throws "boom"`, values["f"])
+	})
+	t.Run("ClauseWithNoThrowingBodyStillShows", func(t *testing.T) {
+		// The declared type is what a caller sees, whether or not the body raises anything.
+		values, _, errs := inferSource(t, `fn f() -> number throws string { return 1 }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> number throws string", values["f"])
+	})
+}
+
+// A body with no `return` that always leaves along the exceptional edge reaches no
+// normal exit, so its return type is `never` and it satisfies any return annotation.
+func TestInferThrowsDivergingBody(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() -> number { throw "x" }`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn () -> number throws "x"`, values["f"])
+}
+
+// A call raises whatever its callee declares, so the callee's throws reaches the
+// caller's own clause exactly as a `throw` in the caller's body would.
+func TestInferThrowsPropagateThroughCalls(t *testing.T) {
+	t.Run("CallerInheritsCalleeThrows", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn f() throws string { throw "boom" }
+			fn g() { f() }
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> void throws string", values["g"])
+	})
+	t.Run("CallToNonThrowingCalleeAddsNothing", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn f() -> number { return 1 }
+			fn g() { return f() }
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> number", values["g"])
+	})
+	t.Run("CalleeThrowsCheckedAgainstCallerClause", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f() throws string { throw "boom" }
+			fn g() throws number { f() }
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "3:27-3:30: cannot constrain string <: number", msgWithSpan(errs[0]))
+	})
+	t.Run("CallThroughAParameter", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f(cb: fn() -> number throws string) { return cb() }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn (cb: fn () -> number throws string) -> number throws string", values["f"])
+	})
+}
+
+// Throws is covariant, so a function that raises a narrower set stands in for one that
+// raises a wider set. A function with no clause raises `never`, the bottom of the
+// lattice, so it satisfies every throwing annotation and no non-throwing annotation
+// accepts a throwing function.
+func TestInferThrowsSubtyping(t *testing.T) {
+	t.Run("NonThrowingSatisfiesThrowingAnnotation", func(t *testing.T) {
+		values, _, errs := inferSource(t, `val f: fn(x: number) -> number throws string = fn (x) { return x }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn (x: number) -> number throws string", values["f"])
+	})
+	t.Run("NarrowerThrowsSatisfiesWider", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn narrow() throws string { throw "boom" }
+			val f: fn() -> never throws string | number = narrow
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> never throws number | string", values["f"])
+	})
+	t.Run("ThrowingFailsNonThrowingAnnotation", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn thrower() throws string { throw "boom" }
+			val f: fn() -> never = thrower
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "3:27-3:34: cannot constrain string <: never", msgWithSpan(errs[0]))
+	})
+	t.Run("WiderThrowsFailsNarrowerAnnotation", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn wide() throws string | number { throw "boom" }
+			val f: fn() -> never throws string = wide
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "3:41-3:45: cannot constrain number <: string", msgWithSpan(errs[0]))
+	})
+}
+
+// A `throws E` clause naming a quantified type parameter needs no machinery of its own:
+// generalization quantifies `E` from the parameter's throws position, a call binds it to
+// the argument's throws, and the result flows out through the caller's own clause.
+func TestInferThrowsPolymorphism(t *testing.T) {
+	t.Run("ParameterThrowsReachesTheReturnClause", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f<E>(g: fn() -> number throws E) -> number throws E { return g() }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn <E>(g: fn () -> number throws E) -> number throws E", values["f"])
+	})
+	t.Run("CallBindsTheThrowsParameter", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn f<E>(g: fn() -> number throws E) -> number throws E { return g() }
+			fn h() { return f(fn () -> number throws string { throw "x" }) }
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> number throws string", values["h"])
+	})
+}
+
+// A method declares and infers throws the same way a standalone function does, and a
+// call through the receiver raises what the method declares.
+func TestInferThrowsOnMethods(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Parser {
+			text: string,
+			constructor(mut self, text: string) { self.text = text },
+			parse(self) -> number throws string { throw "bad input" },
+		}
+		fn run(p: Parser) { return p.parse() }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Parser) -> number throws string", values["run"])
+}

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -151,11 +151,11 @@ func TestInferThrowsFromBodyUnderAWildcardClause(t *testing.T) {
 		},
 		{
 			// A body with no `return` that always leaves along the exceptional edge
-			// reaches no normal exit, so its return type is `never` and it satisfies any
-			// return annotation.
+			// reaches no normal exit, so its return type is `never`. Annotating it
+			// `-> never` says exactly that, so nothing is over-declared.
 			name: "DivergingBodyReturnsNever",
-			src:  `fn f() -> number throws _ { throw "x" }`,
-			want: `fn () -> number throws "x"`,
+			src:  `fn f() -> never throws _ { throw "x" }`,
+			want: `fn () -> never throws "x"`,
 		},
 	})
 }
@@ -176,9 +176,10 @@ func TestInferThrowsClause(t *testing.T) {
 			want: "fn (x: number) -> never throws string",
 		},
 		{
+			// One path returns and the other throws, so both declarations are delivered.
 			name: "ClauseAfterReturnAnnotation",
-			src:  `fn f() -> number throws string { return 1 }`,
-			want: "fn () -> number throws string",
+			src:  `fn f(c: boolean) -> number throws string { if c { return 1 } else { throw "x" } }`,
+			want: "fn (c: boolean) -> number throws string",
 		},
 		{
 			// `throws _` mints a fresh variable the body's throws flow into, so the clause
@@ -186,13 +187,6 @@ func TestInferThrowsClause(t *testing.T) {
 			name: "WildcardClauseInfers",
 			src:  `fn f() throws _ { throw "boom" }`,
 			want: `fn () -> never throws "boom"`,
-		},
-		{
-			// The declared type is what a caller sees, whether or not the body raises
-			// anything.
-			name: "ClauseWithNoThrowingBodyStillShows",
-			src:  `fn f() -> number throws string { return 1 }`,
-			want: "fn () -> number throws string",
 		},
 	})
 	runThrowsErrCases(t, []throwsErrCase{
@@ -299,13 +293,13 @@ func TestInferThrowsPropagateThroughCalls(t *testing.T) {
 // Both callers are asserted from one source, so this stays outside the shared table.
 func TestInferThrowsThroughOverloadResolution(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn a(x: number) -> number throws string { throw "boom" }
+		fn a(x: number) -> never throws string { throw "boom" }
 		fn a(x: string) -> string { return x }
 		fn callsThrowingArm() throws _ { return a(1) }
 		fn callsQuietArm() { return a("s") }
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn () -> number throws string", values["callsThrowingArm"])
+	require.Equal(t, "fn () -> never throws string", values["callsThrowingArm"])
 	require.Equal(t, "fn () -> string", values["callsQuietArm"])
 }
 
@@ -363,7 +357,7 @@ func TestInferThrowsPolymorphism(t *testing.T) {
 			name: "CallBindsTheThrowsParameter",
 			src: `
 				fn f<E>(g: fn() -> number throws E) -> number throws E { return g() }
-				fn h() throws _ { return f(fn () -> number throws string { throw "x" }) }
+				fn h() throws _ { return f(fn () -> never throws string { throw "x" }) }
 			`,
 			binding: "h",
 			want:    "fn () -> number throws string",
@@ -394,11 +388,11 @@ func TestInferThrowsOnClassMembers(t *testing.T) {
 				class Parser {
 					text: string,
 					constructor(mut self, text: string) { self.text = text },
-					parse(self) -> number throws string { throw "bad input" },
+					parse(self) -> never throws string { throw "bad input" },
 				}
 				fn f(p: Parser) throws _ { return p.parse() }
 			`,
-			want: "fn (p: Parser) -> number throws string",
+			want: "fn (p: Parser) -> never throws string",
 		},
 		{
 			name: "ConstructorThrowsRidesOnTheClassValue",
@@ -427,18 +421,94 @@ func TestInferThrowsAnnotationRecovery(t *testing.T) {
 		{
 			// `void` stands in for any annotation resolveTypeAnn does not support.
 			name:     "UnsupportedAnnotationDoesNotCascade",
-			src:      `val f: fn() -> number throws void = fn () -> number throws _ { throw "x" }`,
+			src:      `val f: fn() -> number throws void = fn () -> never throws _ { throw "x" }`,
 			wantErrs: []string{"1:30-1:34: Unsupported: VoidTypeAnn"},
 		},
 		{
-			name:     "GetterClauseIsRejected",
-			src:      `class C { v: number, get x(self) -> number throws string { return self.v } }`,
-			wantErrs: []string{"1:22-1:75: Unsupported: throws clause on a getter"},
+			// The clause draws two diagnostics: it is unsupported on an accessor at all,
+			// and the body raises nothing so it would read as unused even where it is
+			// supported. Both say to drop it.
+			name: "GetterClauseIsRejected",
+			src:  `class C { v: number, get x(self) -> number throws string { return self.v } }`,
+			wantErrs: []string{
+				"1:22-1:75: Unsupported: throws clause on a getter",
+				"1:51-1:57: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
+			},
 		},
 		{
-			name:     "SetterClauseIsRejected",
-			src:      `class C { v: number, set x(mut self, v: number) throws string { self.v = v } }`,
-			wantErrs: []string{"1:22-1:77: Unsupported: throws clause on a setter"},
+			name: "SetterClauseIsRejected",
+			src:  `class C { v: number, set x(mut self, v: number) throws string { self.v = v } }`,
+			wantErrs: []string{
+				"1:22-1:77: Unsupported: throws clause on a setter",
+				"1:56-1:62: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
+			},
+		},
+	})
+}
+
+// A signature can declare something its body never delivers. Both directions are sound,
+// since `never` sits below every type, so neither is an error — but neither is useful
+// either, and each is reported as a warning naming the declaration to drop.
+func TestInferThrowsOverDeclaredSignature(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// The body reaches no exceptional exit, so the clause obliges every caller to
+			// handle an exception that cannot occur.
+			name: "ClauseNoExceptionalExitReaches",
+			src:  `fn f() -> number throws string { return 1 }`,
+			wantErrs: []string{
+				"1:25-1:31: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
+			},
+		},
+		{
+			// The body reaches no normal exit, so no caller can observe a `number`.
+			name: "ReturnAnnotationNoNormalExitReaches",
+			src:  `fn f() -> number throws _ { throw "x" }`,
+			wantErrs: []string{
+				"1:11-1:17: every path through the body throws, so the declared return type `number` is unreachable; the body returns `never`",
+			},
+		},
+		{
+			// The two checks are independent. Here the clause IS used, since the body
+			// throws into it, so only the unreachable return is reported.
+			name: "OnlyTheReturnIsOverDeclared",
+			src:  `fn f() -> number throws string { throw "x" }`,
+			wantErrs: []string{
+				"1:11-1:17: every path through the body throws, so the declared return type `number` is unreachable; the body returns `never`",
+			},
+		},
+	})
+
+	// Neither warning fires where the body delivers what the signature declares. These
+	// are the shapes the warnings must stay quiet on, so a correct signature is never
+	// nagged.
+	runThrowsCases(t, []throwsCase{
+		{
+			// `-> never` says what a diverging body actually delivers.
+			name: "NeverAnnotationOnADivergingBody",
+			src:  `fn f() -> never throws _ { throw "x" }`,
+			want: `fn () -> never throws "x"`,
+		},
+		{
+			// One path returns and the other throws, so both declarations are reachable.
+			name: "MixedReturnAndThrowPaths",
+			src:  `fn f(c: boolean) -> number throws string { if c { return 1 } else { throw "x" } }`,
+			want: "fn (c: boolean) -> number throws string",
+		},
+		{
+			// A clause satisfied by a call rather than by a `throw` still counts as used.
+			name: "ClauseUsedByACall",
+			src: `
+				fn a() throws string { throw "boom" }
+				fn f() throws string { a() }
+			`,
+			want: "fn () -> void throws string",
+		},
+		{
+			// A bodyless `declare fn` has no body to measure either declaration against.
+			name: "BodylessDeclareFnIsNotMeasured",
+			src:  `declare fn f() -> number throws string`,
+			want: "fn () -> number throws string",
 		},
 	})
 }

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -6,15 +6,56 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// throwsCase is one accept case: src infers with no error, and the top-level binding
+// named by `binding` renders as `want`. An empty binding names `f`, the name most cases
+// declare, so only a case that inspects another binding spells one out.
+type throwsCase struct {
+	name    string
+	src     string
+	binding string
+	want    string
+}
+
+// throwsErrCase is one reject case: src reports exactly the diagnostics in wantErrs, each
+// rendered with its span. The full message is asserted, not a substring.
+type throwsErrCase struct {
+	name     string
+	src      string
+	wantErrs []string
+}
+
+func runThrowsCases(t *testing.T, tests []throwsCase) {
+	t.Helper()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			binding := test.binding
+			if binding == "" {
+				binding = "f"
+			}
+			values, _, errs := inferSource(t, test.src)
+			require.Empty(t, errs)
+			require.Equal(t, test.want, values[binding])
+		})
+	}
+}
+
+func runThrowsErrCases(t *testing.T, tests []throwsErrCase) {
+	t.Helper()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Len(t, errs, len(test.wantErrs))
+			for i, want := range test.wantErrs {
+				require.Equal(t, want, msgWithSpan(errs[i]))
+			}
+		})
+	}
+}
+
 // A function's `throws` type is inferred from its body when the signature declares no
-// clause, the way its return type is inferred from its `return` statements. Each case
-// renders the binding named `f` and expects no error.
+// clause, the way its return type is inferred from its `return` statements.
 func TestInferThrowsFromBody(t *testing.T) {
-	tests := []struct {
-		name string
-		src  string
-		want string
-	}{
+	runThrowsCases(t, []throwsCase{
 		{
 			name: "SingleThrow",
 			src:  `fn f() { throw "boom" }`,
@@ -57,149 +98,164 @@ func TestInferThrowsFromBody(t *testing.T) {
 			`,
 			want: `fn () -> 1`,
 		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			values, _, errs := inferSource(t, test.src)
-			require.Empty(t, errs)
-			require.Equal(t, test.want, values["f"])
-		})
-	}
+		{
+			// A body with no `return` that always leaves along the exceptional edge
+			// reaches no normal exit, so its return type is `never` and it satisfies any
+			// return annotation.
+			name: "DivergingBodyReturnsNever",
+			src:  `fn f() -> number { throw "x" }`,
+			want: `fn () -> number throws "x"`,
+		},
+	})
 }
 
 // A `throws T` clause fixes what the function raises: the declared type is what a caller
 // sees, and each `throw` in the body is checked against it at its own site.
 func TestInferThrowsClause(t *testing.T) {
-	t.Run("ClauseWidensTheThrownLiteral", func(t *testing.T) {
-		values, _, errs := inferSource(t, `fn f() throws string { throw "boom" }`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> never throws string", values["f"])
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "ClauseWidensTheThrownLiteral",
+			src:  `fn f() throws string { throw "boom" }`,
+			want: "fn () -> never throws string",
+		},
+		{
+			// The clause parses on its own, with no `-> R` in front of it.
+			name: "ClauseWithoutReturnAnnotation",
+			src:  `fn f(x: number) throws string { throw "boom" }`,
+			want: "fn (x: number) -> never throws string",
+		},
+		{
+			name: "ClauseAfterReturnAnnotation",
+			src:  `fn f() -> number throws string { return 1 }`,
+			want: "fn () -> number throws string",
+		},
+		{
+			// `throws _` mints a fresh variable the body's throws flow into, so the clause
+			// asks for inference rather than fixing a type.
+			name: "WildcardClauseInfers",
+			src:  `fn f() throws _ { throw "boom" }`,
+			want: `fn () -> never throws "boom"`,
+		},
+		{
+			// The declared type is what a caller sees, whether or not the body raises
+			// anything.
+			name: "ClauseWithNoThrowingBodyStillShows",
+			src:  `fn f() -> number throws string { return 1 }`,
+			want: "fn () -> number throws string",
+		},
 	})
-	t.Run("ClauseWithoutReturnAnnotation", func(t *testing.T) {
-		// The clause parses on its own, with no `-> R` in front of it.
-		values, _, errs := inferSource(t, `fn f(x: number) throws string { throw "boom" }`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn (x: number) -> never throws string", values["f"])
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name:     "ThrownValueMustSatisfyTheClause",
+			src:      `fn f() throws number { throw "boom" }`,
+			wantErrs: []string{`1:30-1:36: cannot constrain "boom" <: number`},
+		},
 	})
-	t.Run("ClauseAfterReturnAnnotation", func(t *testing.T) {
-		values, _, errs := inferSource(t, `fn f() -> number throws string { return 1 }`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> number throws string", values["f"])
-	})
-	t.Run("ThrownValueMustSatisfyTheClause", func(t *testing.T) {
-		_, _, errs := inferSource(t, `fn f() throws number { throw "boom" }`)
-		require.Len(t, errs, 1)
-		require.Equal(t, `1:30-1:36: cannot constrain "boom" <: number`, msgWithSpan(errs[0]))
-	})
-	t.Run("WildcardClauseInfers", func(t *testing.T) {
-		// `throws _` mints a fresh variable the body's throws flow into, so the clause asks
-		// for inference rather than fixing a type.
-		values, _, errs := inferSource(t, `fn f() throws _ { throw "boom" }`)
-		require.Empty(t, errs)
-		require.Equal(t, `fn () -> never throws "boom"`, values["f"])
-	})
-	t.Run("ClauseWithNoThrowingBodyStillShows", func(t *testing.T) {
-		// The declared type is what a caller sees, whether or not the body raises anything.
-		values, _, errs := inferSource(t, `fn f() -> number throws string { return 1 }`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> number throws string", values["f"])
-	})
-}
-
-// A body with no `return` that always leaves along the exceptional edge reaches no
-// normal exit, so its return type is `never` and it satisfies any return annotation.
-func TestInferThrowsDivergingBody(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f() -> number { throw "x" }`)
-	require.Empty(t, errs)
-	require.Equal(t, `fn () -> number throws "x"`, values["f"])
 }
 
 // A call raises whatever its callee declares, so the callee's throws reaches the
 // caller's own clause exactly as a `throw` in the caller's body would.
 func TestInferThrowsPropagateThroughCalls(t *testing.T) {
-	t.Run("CallerInheritsCalleeThrows", func(t *testing.T) {
-		values, _, errs := inferSource(t, `
-			fn f() throws string { throw "boom" }
-			fn g() { f() }
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> void throws string", values["g"])
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "CallerInheritsCalleeThrows",
+			src: `
+				fn f() throws string { throw "boom" }
+				fn g() { f() }
+			`,
+			binding: "g",
+			want:    "fn () -> void throws string",
+		},
+		{
+			name: "CallToNonThrowingCalleeAddsNothing",
+			src: `
+				fn f() -> number { return 1 }
+				fn g() { return f() }
+			`,
+			binding: "g",
+			want:    "fn () -> number",
+		},
+		{
+			name:    "CallThroughAParameter",
+			src:     `fn f(cb: fn() -> number throws string) { return cb() }`,
+			binding: "f",
+			want:    "fn (cb: fn () -> number throws string) -> number throws string",
+		},
+		{
+			name: "ThrowsPropagateThroughACallChain",
+			src: `
+				fn a() throws string { throw "boom" }
+				fn b() { a() }
+				fn c() { b() }
+			`,
+			binding: "c",
+			want:    "fn () -> void throws string",
+		},
+		{
+			// `inner` raises, but `outer` only builds and returns it, so `outer` raises
+			// nothing.
+			name: "ClosureKeepsItsOwnThrows",
+			src: `
+				fn a() throws string { throw "boom" }
+				fn outer() {
+					val inner = fn () { a() }
+					return inner
+				}
+			`,
+			binding: "outer",
+			want:    "fn () -> fn () -> void throws string",
+		},
+		{
+			name: "BodylessDeclareFnDeclaresThrows",
+			src: `
+				declare fn a() -> number throws string
+				fn f() { return a() }
+			`,
+			want: "fn () -> number throws string",
+		},
+		{
+			// The sink is minted at the body's own level, not at the level of whichever
+			// exceptional exit reaches it first. A `val` initializer is typed one level
+			// deeper, so a sink minted there would be inner to the body and the later
+			// bare call would extrude it, wiring the proxy back to the original in both
+			// directions. The cycle used to render as `throws μX0.(string | X0)`.
+			name: "SinkMintedInAValInitializerStaysAtTheBodyLevel",
+			src: `
+				fn a() throws string { throw "boom" }
+				fn f() {
+					val x = a()
+					a()
+					return x
+				}
+			`,
+			want: "fn () -> never throws string",
+		},
 	})
-	t.Run("CallToNonThrowingCalleeAddsNothing", func(t *testing.T) {
-		values, _, errs := inferSource(t, `
-			fn f() -> number { return 1 }
-			fn g() { return f() }
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> number", values["g"])
-	})
-	t.Run("CalleeThrowsCheckedAgainstCallerClause", func(t *testing.T) {
-		_, _, errs := inferSource(t, `
-			fn f() throws string { throw "boom" }
-			fn g() throws number { f() }
-		`)
-		require.Len(t, errs, 1)
-		require.Equal(t, "3:27-3:30: cannot constrain string <: number", msgWithSpan(errs[0]))
-	})
-	t.Run("CallThroughAParameter", func(t *testing.T) {
-		values, _, errs := inferSource(t, `fn f(cb: fn() -> number throws string) { return cb() }`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn (cb: fn () -> number throws string) -> number throws string", values["f"])
-	})
-	t.Run("ThrowsPropagateThroughACallChain", func(t *testing.T) {
-		values, _, errs := inferSource(t, `
-			fn a() throws string { throw "boom" }
-			fn b() { a() }
-			fn c() { b() }
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> void throws string", values["c"])
-	})
-	t.Run("ClosureKeepsItsOwnThrows", func(t *testing.T) {
-		// `inner` raises, but `outer` only builds and returns it, so `outer` raises nothing.
-		values, _, errs := inferSource(t, `
-			fn a() throws string { throw "boom" }
-			fn outer() {
-				val inner = fn () { a() }
-				return inner
-			}
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> fn () -> void throws string", values["outer"])
-	})
-	t.Run("BodylessDeclareFnDeclaresThrows", func(t *testing.T) {
-		values, _, errs := inferSource(t, `
-			declare fn a() -> number throws string
-			fn f() { return a() }
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> number throws string", values["f"])
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name: "CalleeThrowsCheckedAgainstCallerClause",
+			src: `
+				fn f() throws string { throw "boom" }
+				fn g() throws number { f() }
+			`,
+			wantErrs: []string{"3:28-3:31: cannot constrain string <: number"},
+		},
 	})
 }
 
 // Overload resolution picks one arm, so only that arm's throws reaches the caller. A set
 // whose other arms raise contributes nothing to a call that matched a non-throwing one.
+// Both callers are asserted from one source, so this stays outside the shared table.
 func TestInferThrowsThroughOverloadResolution(t *testing.T) {
-	src := `
+	values, _, errs := inferSource(t, `
 		fn a(x: number) -> number throws string { throw "boom" }
 		fn a(x: string) -> string { return x }
 		fn callsThrowingArm() { return a(1) }
 		fn callsQuietArm() { return a("s") }
-	`
-	values, _, errs := inferSource(t, src)
+	`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn () -> number throws string", values["callsThrowingArm"])
 	require.Equal(t, "fn () -> string", values["callsQuietArm"])
-}
-
-// A `throws E` clause is an output position, so a body that pins `E` to a concrete type
-// over-promises exactly as a body pinning a declared return type does.
-func TestInferThrowsTypeParamMustBeProducible(t *testing.T) {
-	_, _, errs := inferSource(t, `fn f<E>() throws E { throw "boom" }`)
-	require.Len(t, errs, 1)
-	require.Equal(t,
-		"1:1-1:36: the body forces type parameter `E` to `\"boom\"`, so it cannot stand for an arbitrary type",
-		msgWithSpan(errs[0]))
 }
 
 // Throws is covariant, so a function that raises a narrower set stands in for one that
@@ -207,34 +263,38 @@ func TestInferThrowsTypeParamMustBeProducible(t *testing.T) {
 // lattice, so it satisfies every throwing annotation and no non-throwing annotation
 // accepts a throwing function.
 func TestInferThrowsSubtyping(t *testing.T) {
-	t.Run("NonThrowingSatisfiesThrowingAnnotation", func(t *testing.T) {
-		values, _, errs := inferSource(t, `val f: fn(x: number) -> number throws string = fn (x) { return x }`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn (x: number) -> number throws string", values["f"])
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "NonThrowingSatisfiesThrowingAnnotation",
+			src:  `val f: fn(x: number) -> number throws string = fn (x) { return x }`,
+			want: "fn (x: number) -> number throws string",
+		},
+		{
+			name: "NarrowerThrowsSatisfiesWider",
+			src: `
+				fn narrow() throws string { throw "boom" }
+				val f: fn() -> never throws string | number = narrow
+			`,
+			want: "fn () -> never throws number | string",
+		},
 	})
-	t.Run("NarrowerThrowsSatisfiesWider", func(t *testing.T) {
-		values, _, errs := inferSource(t, `
-			fn narrow() throws string { throw "boom" }
-			val f: fn() -> never throws string | number = narrow
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> never throws number | string", values["f"])
-	})
-	t.Run("ThrowingFailsNonThrowingAnnotation", func(t *testing.T) {
-		_, _, errs := inferSource(t, `
-			fn thrower() throws string { throw "boom" }
-			val f: fn() -> never = thrower
-		`)
-		require.Len(t, errs, 1)
-		require.Equal(t, "3:27-3:34: cannot constrain string <: never", msgWithSpan(errs[0]))
-	})
-	t.Run("WiderThrowsFailsNarrowerAnnotation", func(t *testing.T) {
-		_, _, errs := inferSource(t, `
-			fn wide() throws string | number { throw "boom" }
-			val f: fn() -> never throws string = wide
-		`)
-		require.Len(t, errs, 1)
-		require.Equal(t, "3:41-3:45: cannot constrain number <: string", msgWithSpan(errs[0]))
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name: "ThrowingFailsNonThrowingAnnotation",
+			src: `
+				fn thrower() throws string { throw "boom" }
+				val f: fn() -> never = thrower
+			`,
+			wantErrs: []string{"3:28-3:35: cannot constrain string <: never"},
+		},
+		{
+			name: "WiderThrowsFailsNarrowerAnnotation",
+			src: `
+				fn wide() throws string | number { throw "boom" }
+				val f: fn() -> never throws string = wide
+			`,
+			wantErrs: []string{"3:42-3:46: cannot constrain number <: string"},
+		},
 	})
 }
 
@@ -242,58 +302,92 @@ func TestInferThrowsSubtyping(t *testing.T) {
 // generalization quantifies `E` from the parameter's throws position, a call binds it to
 // the argument's throws, and the result flows out through the caller's own clause.
 func TestInferThrowsPolymorphism(t *testing.T) {
-	t.Run("ParameterThrowsReachesTheReturnClause", func(t *testing.T) {
-		values, _, errs := inferSource(t, `fn f<E>(g: fn() -> number throws E) -> number throws E { return g() }`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn <E>(g: fn () -> number throws E) -> number throws E", values["f"])
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "ParameterThrowsReachesTheReturnClause",
+			src:  `fn f<E>(g: fn() -> number throws E) -> number throws E { return g() }`,
+			want: "fn <E>(g: fn () -> number throws E) -> number throws E",
+		},
+		{
+			name: "CallBindsTheThrowsParameter",
+			src: `
+				fn f<E>(g: fn() -> number throws E) -> number throws E { return g() }
+				fn h() { return f(fn () -> number throws string { throw "x" }) }
+			`,
+			binding: "h",
+			want:    "fn () -> number throws string",
+		},
 	})
-	t.Run("CallBindsTheThrowsParameter", func(t *testing.T) {
-		values, _, errs := inferSource(t, `
-			fn f<E>(g: fn() -> number throws E) -> number throws E { return g() }
-			fn h() { return f(fn () -> number throws string { throw "x" }) }
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn () -> number throws string", values["h"])
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// A `throws E` clause is an output position, so a body that pins `E` to a
+			// concrete type over-promises exactly as a body pinning a declared return
+			// type does.
+			name: "TypeParamMustBeProducible",
+			src:  `fn f<E>() throws E { throw "boom" }`,
+			wantErrs: []string{
+				"1:1-1:36: the body forces type parameter `E` to `\"boom\"`, so it cannot stand for an arbitrary type",
+			},
+		},
 	})
 }
 
-// A method declares and infers throws the same way a standalone function does, and a
-// call through the receiver raises what the method declares.
-func TestInferThrowsOnMethods(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		class Parser {
-			text: string,
-			constructor(mut self, text: string) { self.text = text },
-			parse(self) -> number throws string { throw "bad input" },
-		}
-		fn run(p: Parser) { return p.parse() }
-	`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn (p: Parser) -> number throws string", values["run"])
+// A method and a constructor declare and infer throws the same way a standalone function
+// does, and a call through the receiver or through the class value raises what they
+// declare. A constructor's clause rides on the callable signature the class name binds.
+func TestInferThrowsOnClassMembers(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "MethodThrowsReachesItsCaller",
+			src: `
+				class Parser {
+					text: string,
+					constructor(mut self, text: string) { self.text = text },
+					parse(self) -> number throws string { throw "bad input" },
+				}
+				fn f(p: Parser) { return p.parse() }
+			`,
+			want: "fn (p: Parser) -> number throws string",
+		},
+		{
+			name: "ConstructorThrowsRidesOnTheClassValue",
+			src: `
+				class Counter {
+					n: number,
+					constructor(mut self, n: number) throws string { throw "bad count" },
+				}
+				fn f(n: number) { return Counter(n) }
+			`,
+			want: "fn (n: number) -> Counter throws string",
+		},
+	})
 }
 
 // An unsupported `throws` annotation recovers to a fresh variable, matching the parameter
 // and return positions. Recovering to nil would read as `never`, so every value flowing
 // into the annotation would be re-reported for raising something on top of the one real
-// error. `void` stands in here for any annotation resolveTypeAnn does not support.
-func TestInferThrowsUnsupportedAnnotationDoesNotCascade(t *testing.T) {
-	_, _, errs := inferSource(t, `val f: fn() -> number throws void = fn () -> number { throw "x" }`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "1:30-1:34: Unsupported: VoidTypeAnn", msgWithSpan(errs[0]))
-}
-
+// error.
+//
 // A getter or setter projects to the type its read yields or its write accepts, and
-// neither element has anywhere to record a `throws` clause. The clause is rejected rather
-// than dropped, so a raising accessor cannot read as non-throwing.
-func TestInferThrowsOnAccessorIsRejected(t *testing.T) {
-	t.Run("Getter", func(t *testing.T) {
-		_, _, errs := inferSource(t, `class C { v: number, get x(self) -> number throws string { return self.v } }`)
-		require.Len(t, errs, 1)
-		require.Equal(t, "1:22-1:75: Unsupported: throws clause on a getter", msgWithSpan(errs[0]))
-	})
-	t.Run("Setter", func(t *testing.T) {
-		_, _, errs := inferSource(t, `class C { v: number, set x(mut self, v: number) throws string { self.v = v } }`)
-		require.Len(t, errs, 1)
-		require.Equal(t, "1:22-1:77: Unsupported: throws clause on a setter", msgWithSpan(errs[0]))
+// neither element has anywhere to record a clause, so the clause is rejected rather than
+// dropped. A raising accessor cannot read as non-throwing.
+func TestInferThrowsAnnotationRecovery(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// `void` stands in for any annotation resolveTypeAnn does not support.
+			name:     "UnsupportedAnnotationDoesNotCascade",
+			src:      `val f: fn() -> number throws void = fn () -> number { throw "x" }`,
+			wantErrs: []string{"1:30-1:34: Unsupported: VoidTypeAnn"},
+		},
+		{
+			name:     "GetterClauseIsRejected",
+			src:      `class C { v: number, get x(self) -> number throws string { return self.v } }`,
+			wantErrs: []string{"1:22-1:75: Unsupported: throws clause on a getter"},
+		},
+		{
+			name:     "SetterClauseIsRejected",
+			src:      `class C { v: number, set x(mut self, v: number) throws string { self.v = v } }`,
+			wantErrs: []string{"1:22-1:77: Unsupported: throws clause on a setter"},
+		},
 	})
 }

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -52,47 +52,98 @@ func runThrowsErrCases(t *testing.T, tests []throwsErrCase) {
 	}
 }
 
-// A function's `throws` type is inferred from its body when the signature declares no
-// clause, the way its return type is inferred from its `return` statements.
-func TestInferThrowsFromBody(t *testing.T) {
+// Omitting the `throws` clause declares that a function raises nothing, so a body that
+// does raise is rejected at the site that raises rather than at the whole function. This
+// mirrors the old checker, where inferFuncSig gives a clause-less signature `never`.
+// Writing `throws never` is not how a non-throwing function is spelled; omitting the
+// clause is.
+func TestInferThrowsRequiresAClause(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name:     "ThrowInAClauselessFunction",
+			src:      `fn f() { throw "boom" }`,
+			wantErrs: []string{`1:16-1:22: cannot constrain "boom" <: never`},
+		},
+		{
+			name: "CallToAThrowingCalleeFromAClauselessCaller",
+			src: `
+				fn a() throws string { throw "boom" }
+				fn f() { a() }
+			`,
+			wantErrs: []string{"3:14-3:17: cannot constrain string <: never"},
+		},
+		{
+			name:     "ThrowInAClauselessFunctionExpression",
+			src:      `val f = fn () { throw "x" }`,
+			wantErrs: []string{`1:23-1:26: cannot constrain "x" <: never`},
+		},
+		{
+			name:     "ThrowInAClauselessMethod",
+			src:      `class C { m(self) { throw "x" } }`,
+			wantErrs: []string{`1:27-1:30: cannot constrain "x" <: never`},
+		},
+		{
+			// A clause on the ANNOTATION does not reach an un-annotated function
+			// expression: the lambda's own signature has no clause, so its sink is
+			// `never` and its throw is rejected before the annotation is consulted. The
+			// old checker behaves the same way, since inferFuncSig reads only the
+			// signature. Writing `fn () throws _ { … }` is how the lambda opts in.
+			name:     "AnnotationClauseDoesNotReachAnUnannotatedLambda",
+			src:      `val f: fn() -> never throws string = fn () { throw "x" }`,
+			wantErrs: []string{`1:52-1:55: cannot constrain "x" <: never`},
+		},
+	})
+}
+
+// `throws _` opts into inference: the clause mints a fresh variable that the body's
+// exceptional exits flow into, so the function's throws is read off the body the way its
+// return type is read off its `return` statements.
+func TestInferThrowsFromBodyUnderAWildcardClause(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
 			name: "SingleThrow",
-			src:  `fn f() { throw "boom" }`,
+			src:  `fn f() throws _ { throw "boom" }`,
 			want: `fn () -> never throws "boom"`,
 		},
 		{
 			// Two throws on different paths union, the same join the return points take.
 			name: "ThrowsOnBothBranches",
-			src:  `fn f(c: boolean) { if c { throw "a" } else { throw 5 } }`,
+			src:  `fn f(c: boolean) throws _ { if c { throw "a" } else { throw 5 } }`,
 			want: `fn (c: boolean) -> never throws 5 | "a"`,
 		},
 		{
 			// The `else` branch diverges, so it drops out of the value union and only the
 			// `then` branch reaches the return.
 			name: "ThrowOnOnePathOnly",
-			src:  `fn f(c: boolean) { if c { return 1 } else { throw "x" } }`,
+			src:  `fn f(c: boolean) throws _ { if c { return 1 } else { throw "x" } }`,
 			want: `fn (c: boolean) -> 1 throws "x"`,
 		},
 		{
 			// `throw` is `never`, so it composes where a value is expected and contributes
 			// nothing to the union of the branches.
 			name: "ThrowInValuePosition",
-			src:  `fn f(c: boolean) { return if c { 1 } else { throw "x" } }`,
+			src:  `fn f(c: boolean) throws _ { return if c { 1 } else { throw "x" } }`,
 			want: `fn (c: boolean) -> 1 throws "x"`,
 		},
 		{
-			// A body with no exceptional exit renders no clause at all.
+			// A body with no exceptional exit renders no clause at all, clause or no.
 			name: "NoThrowRendersNoClause",
 			src:  `fn f() { return 1 }`,
 			want: `fn () -> 1`,
 		},
 		{
-			// A nested function owns its own throws sink, so `g`'s throw stays on `g`.
+			// A wildcard clause nothing reached is still no clause.
+			name: "UnreachedWildcardRendersNoClause",
+			src:  `fn f() throws _ { return 1 }`,
+			want: `fn () -> 1`,
+		},
+		{
+			// A nested function owns its own throws sink, so `g`'s throw stays on `g` and
+			// the enclosing `f` needs no clause of its own.
 			name: "NestedFunctionThrowsDoNotLeak",
 			src: `
 				fn f() {
-					val g = fn () { throw "inner" }
+					val g = fn () throws _ { throw "inner" }
 					return 1
 				}
 			`,
@@ -103,7 +154,7 @@ func TestInferThrowsFromBody(t *testing.T) {
 			// reaches no normal exit, so its return type is `never` and it satisfies any
 			// return annotation.
 			name: "DivergingBodyReturnsNever",
-			src:  `fn f() -> number { throw "x" }`,
+			src:  `fn f() -> number throws _ { throw "x" }`,
 			want: `fn () -> number throws "x"`,
 		},
 	})
@@ -161,7 +212,7 @@ func TestInferThrowsPropagateThroughCalls(t *testing.T) {
 			name: "CallerInheritsCalleeThrows",
 			src: `
 				fn f() throws string { throw "boom" }
-				fn g() { f() }
+				fn g() throws _ { f() }
 			`,
 			binding: "g",
 			want:    "fn () -> void throws string",
@@ -177,7 +228,7 @@ func TestInferThrowsPropagateThroughCalls(t *testing.T) {
 		},
 		{
 			name:    "CallThroughAParameter",
-			src:     `fn f(cb: fn() -> number throws string) { return cb() }`,
+			src:     `fn f(cb: fn() -> number throws string) throws _ { return cb() }`,
 			binding: "f",
 			want:    "fn (cb: fn () -> number throws string) -> number throws string",
 		},
@@ -185,8 +236,8 @@ func TestInferThrowsPropagateThroughCalls(t *testing.T) {
 			name: "ThrowsPropagateThroughACallChain",
 			src: `
 				fn a() throws string { throw "boom" }
-				fn b() { a() }
-				fn c() { b() }
+				fn b() throws _ { a() }
+				fn c() throws _ { b() }
 			`,
 			binding: "c",
 			want:    "fn () -> void throws string",
@@ -198,7 +249,7 @@ func TestInferThrowsPropagateThroughCalls(t *testing.T) {
 			src: `
 				fn a() throws string { throw "boom" }
 				fn outer() {
-					val inner = fn () { a() }
+					val inner = fn () throws _ { a() }
 					return inner
 				}
 			`,
@@ -209,7 +260,7 @@ func TestInferThrowsPropagateThroughCalls(t *testing.T) {
 			name: "BodylessDeclareFnDeclaresThrows",
 			src: `
 				declare fn a() -> number throws string
-				fn f() { return a() }
+				fn f() throws _ { return a() }
 			`,
 			want: "fn () -> number throws string",
 		},
@@ -222,7 +273,7 @@ func TestInferThrowsPropagateThroughCalls(t *testing.T) {
 			name: "SinkMintedInAValInitializerStaysAtTheBodyLevel",
 			src: `
 				fn a() throws string { throw "boom" }
-				fn f() {
+				fn f() throws _ {
 					val x = a()
 					a()
 					return x
@@ -250,7 +301,7 @@ func TestInferThrowsThroughOverloadResolution(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn a(x: number) -> number throws string { throw "boom" }
 		fn a(x: string) -> string { return x }
-		fn callsThrowingArm() { return a(1) }
+		fn callsThrowingArm() throws _ { return a(1) }
 		fn callsQuietArm() { return a("s") }
 	`)
 	require.Empty(t, errs)
@@ -312,7 +363,7 @@ func TestInferThrowsPolymorphism(t *testing.T) {
 			name: "CallBindsTheThrowsParameter",
 			src: `
 				fn f<E>(g: fn() -> number throws E) -> number throws E { return g() }
-				fn h() { return f(fn () -> number throws string { throw "x" }) }
+				fn h() throws _ { return f(fn () -> number throws string { throw "x" }) }
 			`,
 			binding: "h",
 			want:    "fn () -> number throws string",
@@ -345,7 +396,7 @@ func TestInferThrowsOnClassMembers(t *testing.T) {
 					constructor(mut self, text: string) { self.text = text },
 					parse(self) -> number throws string { throw "bad input" },
 				}
-				fn f(p: Parser) { return p.parse() }
+				fn f(p: Parser) throws _ { return p.parse() }
 			`,
 			want: "fn (p: Parser) -> number throws string",
 		},
@@ -356,7 +407,7 @@ func TestInferThrowsOnClassMembers(t *testing.T) {
 					n: number,
 					constructor(mut self, n: number) throws string { throw "bad count" },
 				}
-				fn f(n: number) { return Counter(n) }
+				fn f(n: number) throws _ { return Counter(n) }
 			`,
 			want: "fn (n: number) -> Counter throws string",
 		},
@@ -376,7 +427,7 @@ func TestInferThrowsAnnotationRecovery(t *testing.T) {
 		{
 			// `void` stands in for any annotation resolveTypeAnn does not support.
 			name:     "UnsupportedAnnotationDoesNotCascade",
-			src:      `val f: fn() -> number throws void = fn () -> number { throw "x" }`,
+			src:      `val f: fn() -> number throws void = fn () -> number throws _ { throw "x" }`,
 			wantErrs: []string{"1:30-1:34: Unsupported: VoidTypeAnn"},
 		},
 		{

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -146,6 +146,60 @@ func TestInferThrowsPropagateThroughCalls(t *testing.T) {
 		require.Empty(t, errs)
 		require.Equal(t, "fn (cb: fn () -> number throws string) -> number throws string", values["f"])
 	})
+	t.Run("ThrowsPropagateThroughACallChain", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn a() throws string { throw "boom" }
+			fn b() { a() }
+			fn c() { b() }
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> void throws string", values["c"])
+	})
+	t.Run("ClosureKeepsItsOwnThrows", func(t *testing.T) {
+		// `inner` raises, but `outer` only builds and returns it, so `outer` raises nothing.
+		values, _, errs := inferSource(t, `
+			fn a() throws string { throw "boom" }
+			fn outer() {
+				val inner = fn () { a() }
+				return inner
+			}
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> fn () -> void throws string", values["outer"])
+	})
+	t.Run("BodylessDeclareFnDeclaresThrows", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			declare fn a() -> number throws string
+			fn f() { return a() }
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> number throws string", values["f"])
+	})
+}
+
+// Overload resolution picks one arm, so only that arm's throws reaches the caller. A set
+// whose other arms raise contributes nothing to a call that matched a non-throwing one.
+func TestInferThrowsThroughOverloadResolution(t *testing.T) {
+	src := `
+		fn a(x: number) -> number throws string { throw "boom" }
+		fn a(x: string) -> string { return x }
+		fn callsThrowingArm() { return a(1) }
+		fn callsQuietArm() { return a("s") }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> number throws string", values["callsThrowingArm"])
+	require.Equal(t, "fn () -> string", values["callsQuietArm"])
+}
+
+// A `throws E` clause is an output position, so a body that pins `E` to a concrete type
+// over-promises exactly as a body pinning a declared return type does.
+func TestInferThrowsTypeParamMustBeProducible(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f<E>() throws E { throw "boom" }`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"1:1-1:36: the body forces type parameter `E` to `\"boom\"`, so it cannot stand for an arbitrary type",
+		msgWithSpan(errs[0]))
 }
 
 // Throws is covariant, so a function that raises a narrower set stands in for one that

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -271,3 +271,29 @@ func TestInferThrowsOnMethods(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, "fn (p: Parser) -> number throws string", values["run"])
 }
+
+// An unsupported `throws` annotation recovers to a fresh variable, matching the parameter
+// and return positions. Recovering to nil would read as `never`, so every value flowing
+// into the annotation would be re-reported for raising something on top of the one real
+// error. `void` stands in here for any annotation resolveTypeAnn does not support.
+func TestInferThrowsUnsupportedAnnotationDoesNotCascade(t *testing.T) {
+	_, _, errs := inferSource(t, `val f: fn() -> number throws void = fn () -> number { throw "x" }`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "1:30-1:34: Unsupported: VoidTypeAnn", msgWithSpan(errs[0]))
+}
+
+// A getter or setter projects to the type its read yields or its write accepts, and
+// neither element has anywhere to record a `throws` clause. The clause is rejected rather
+// than dropped, so a raising accessor cannot read as non-throwing.
+func TestInferThrowsOnAccessorIsRejected(t *testing.T) {
+	t.Run("Getter", func(t *testing.T) {
+		_, _, errs := inferSource(t, `class C { v: number, get x(self) -> number throws string { return self.v } }`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "1:22-1:75: Unsupported: throws clause on a getter", msgWithSpan(errs[0]))
+	})
+	t.Run("Setter", func(t *testing.T) {
+		_, _, errs := inferSource(t, `class C { v: number, set x(mut self, v: number) throws string { self.v = v } }`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "1:22-1:77: Unsupported: throws clause on a setter", msgWithSpan(errs[0]))
+	})
+}

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -524,7 +524,7 @@ func TestInferKeyofUnionWithUnreadableMember(t *testing.T) {
 				fn f<T>(k: keyof ({a: number, x: string} | {b: number, x: string} | T)) {}
 				val r = f("a")
 			`,
-			wantErr: `cannot constrain "a" <: keyof t10 | object | object`,
+			wantErr: `cannot constrain "a" <: keyof t11 | object | object`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -439,9 +439,9 @@ func compareSameKind(a, b soltype.Type) int {
 		if c := compareType(a.Ret, b.Ret); c != 0 {
 			return c
 		}
-		// throwsOf reads both sides through the nil-is-never collapse, so two functions
+		// ThrowsOrNever reads both sides through the nil-is-never collapse, so two functions
 		// differing only in whether the clause was written compare equal here.
-		return compareType(throwsOf(a), throwsOf(b))
+		return compareType(a.ThrowsOrNever(), b.ThrowsOrNever())
 	case *soltype.UnionType:
 		b := b.(*soltype.UnionType)
 		if a.Inexact != b.Inexact {

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -436,7 +436,12 @@ func compareSameKind(a, b soltype.Type) int {
 				return c
 			}
 		}
-		return compareType(a.Ret, b.Ret)
+		if c := compareType(a.Ret, b.Ret); c != 0 {
+			return c
+		}
+		// throwsOf reads both sides through the nil-is-never collapse, so two functions
+		// differing only in whether the clause was written compare equal here.
+		return compareType(throwsOf(a), throwsOf(b))
 	case *soltype.UnionType:
 		b := b.(*soltype.UnionType)
 		if a.Inexact != b.Inexact {

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -61,6 +61,13 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 			// tryOverloadArm runs the error-returning engine, so a warning the winning arm
 			// accepted with never reached c.errs. Blame it at the call so the winner's survive.
 			c.blameConstraintErrors(call, diags)
+			// Only the winning arm's throws reaches the caller, so a set whose other arms
+			// raise contributes nothing here. Resolution never builds a call shape for
+			// constrain to read, so the exceptional edge is wired by hand instead, the way
+			// inferCall's shape wires it.
+			if inst.Throws != nil {
+				c.constrain(call, inst.Throws, c.throwsSink(lvl))
+			}
 			return inst.Ret
 		}
 	}

--- a/internal/solver/script.go
+++ b/internal/solver/script.go
@@ -47,7 +47,7 @@ func InferScript(script *ast.Script) (*Scope, *Info, []SolverError) {
 	// child is the outer scope the pre-pass resolves names against. There is no
 	// enclosing context to restore, so the returned previous one is discarded.
 	scriptBody := &ast.Block{Stmts: script.Stmts, Span: script.Span()}
-	c.pushFuncCtx(false, nil)
+	c.pushFuncCtx(false, nil, 0)
 	c.runLivenessPrePass(scope, nil, nil, scriptBody)
 
 	// Walk the body through inferBlock, the same source-order statement walker a

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -834,6 +834,14 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 	return t, true
 }
 
+// isWildcardAnn reports whether ta is the `_` inference placeholder. A signature position
+// written `_` asks to be inferred rather than declaring a type, so a check that faults an
+// over-declared signature has nothing to fault there.
+func isWildcardAnn(ta ast.TypeAnn) bool {
+	_, wildcard := ta.(*ast.WildcardTypeAnn)
+	return wildcard
+}
+
 // mirrorParamPat structurally mirrors a function-type-annotation parameter pattern
 // into its soltype.Pat for rendering. A shape with no soltype counterpart is dropped.
 func (c *checker) mirrorParamPat(pat ast.Pat) soltype.Pat {

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -814,10 +814,16 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 	}
 
 	// An absent `throws` clause leaves Throws nil, which reads as `never`: the annotation
-	// promises the function raises nothing. An unsupported clause recovers the same way,
-	// after resolveTypeAnn has reported it.
+	// promises the function raises nothing.
+	//
+	// An unsupported clause recovers to a fresh var instead, matching the parameter and
+	// return positions above. Recovering to nil would read as `never`, the strictest type
+	// there is, so every value flowing into the annotation would be re-reported for
+	// raising something. A fresh var constrains nothing, leaving the one diagnostic
+	// resolveTypeAnn already recorded.
 	var throws soltype.Type
 	if ta.Throws != nil {
+		throws = c.freshAt(lvl)
 		if t, ok := c.resolveTypeAnn(annScope, ta.Throws, lvl); ok {
 			throws = t
 		}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -813,14 +813,9 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 		}
 	}
 
-	// An absent `throws` clause leaves Throws nil, which reads as `never`: the annotation
-	// promises the function raises nothing.
-	//
-	// An unsupported clause recovers to a fresh var instead, matching the parameter and
-	// return positions above. Recovering to nil would read as `never`, the strictest type
-	// there is, so every value flowing into the annotation would be re-reported for
-	// raising something. A fresh var constrains nothing, leaving the one diagnostic
-	// resolveTypeAnn already recorded.
+	// An absent clause leaves Throws nil, which reads as `never`: the annotation promises
+	// the function raises nothing. An unsupported clause recovers to a fresh var instead,
+	// matching the parameter and return positions, so it is not re-reported at every use.
 	var throws soltype.Type
 	if ta.Throws != nil {
 		throws = c.freshAt(lvl)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -753,9 +753,6 @@ func (c *checker) typeofMember(recv soltype.Type, name string) (soltype.Type, bo
 // `<T>` list resolves through resolveTypeParams into a child scope, so a parameter, return,
 // or union member that names `T` reads the annotation's own quantified var.
 func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int) (soltype.Type, bool) {
-	if ta.Throws != nil {
-		c.reportUnsupportedFeature(ta, "throws clause in function type annotation")
-	}
 	// A function type annotation is its own quantifier scope, so give it its own
 	// named-lifetime map the way inferFunc does for a function body. Without this a
 	// nested `fn<'a: 'static>(…)` annotation would resolve `'a` to the enclosing
@@ -816,7 +813,17 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 		}
 	}
 
-	t := &soltype.FuncType{Params: params, Ret: ret, Inexact: ta.Inexact, TypeParams: typeParams}
+	// An absent `throws` clause leaves Throws nil, which reads as `never`: the annotation
+	// promises the function raises nothing. An unsupported clause recovers the same way,
+	// after resolveTypeAnn has reported it.
+	var throws soltype.Type
+	if ta.Throws != nil {
+		if t, ok := c.resolveTypeAnn(annScope, ta.Throws, lvl); ok {
+			throws = t
+		}
+	}
+
+	t := &soltype.FuncType{Params: params, Ret: ret, Throws: throws, Inexact: ta.Inexact, TypeParams: typeParams}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/type_param_producible.go
+++ b/internal/solver/type_param_producible.go
@@ -35,11 +35,17 @@ func (c *checker) checkTypeParamsProducible(node ast.Node, ft *soltype.FuncType)
 }
 
 // outputTypeVars collects the inference vars in an OUTPUT position of a signature, walking
-// the return covariantly and each parameter contravariantly. It skips the TypeParams
-// binder list, which FuncType.Accept would otherwise visit at the call polarity.
+// the return and the throws covariantly and each parameter contravariantly. A `throws E`
+// clause is an output the same way the return is, since the function hands the caller an E
+// along the exceptional edge. So `fn f<E>() throws E { throw "x" }` over-promises exactly
+// as `fn make<T>() -> T { return 5 }` does. It skips the TypeParams binder list, which
+// FuncType.Accept would otherwise visit at the call polarity.
 func outputTypeVars(ft *soltype.FuncType) set.Set[*soltype.TypeVarType] {
 	pv := &polarityVarVisitor{out: set.NewSet[*soltype.TypeVarType]()}
 	ft.Ret.Accept(pv, soltype.Positive)
+	if ft.Throws != nil {
+		ft.Throws.Accept(pv, soltype.Positive)
+	}
 	if ft.SelfParam != nil {
 		ft.SelfParam.Type.Accept(pv, soltype.Negative)
 	}

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -689,8 +689,12 @@ Orthogonal to the evaluator. Touches only `FuncType` and the function-inference
 walk.
 
 **Data structures.** `soltype.FuncType` gains a `Throws Type` field
-([soltype/type.go:201](../../internal/soltype/type.go)), parallel to `Ret`,
-defaulting to `never` (⊥) when the source has no `throws` clause.
+([soltype/type.go:201](../../internal/soltype/type.go)), parallel to `Ret`. A nil
+Throws reads as `never` (⊥), so a FuncType minted without thinking about exceptions
+raises nothing. A source function with no `throws` clause infers its throws from its
+body rather than being pinned to `never`, matching
+[06_error_handling.md](../../docs/06_error_handling.md), where `fn foo() { throw
+FooError() }` is "inferred as `fn() -> undefined throws FooError | ...`".
 
 **Algorithms.**
 - **Constraint engine, parallel arms** — the function arm in `constrain` recurses
@@ -702,11 +706,20 @@ defaulting to `never` (⊥) when the source has no `throws` clause.
 - **Throws polymorphism** falls out of M3's let-generalization with no special
   handling — `E` in `<E>(f: () -> T throws E) -> T throws E` is just another
   quantified variable.
-- **Open design question to resolve in this PR:** how `try`/`catch` narrows the
-  inferred throws of the body. The conservative starting point is the two-variable
-  encoding `body_throws <: surrounding_throws ∪ caught_throws`, which fits the
-  existing lattice. Integration with the checker's narrowing semantics is the
-  actual question to settle before implementation.
+- **How `try`/`catch` narrows the body's throws — settled.** The body carries one
+  **throws sink**, the type every `throw` and every call is constrained into. A
+  signature that writes `throws T` makes `T` the sink directly, so each exceptional
+  exit is checked at its own site; a signature with no clause gets a fresh variable
+  and the coalesced sink becomes the inferred clause. A `try` block then needs no new
+  lattice machinery: it pushes a nested sink, and the enclosing sink receives only the
+  part the `catch` arms leave unhandled. That is the two-variable encoding
+  `body_throws <: surrounding_throws ∪ caught_throws` with the union realized by the
+  arms' patterns rather than by a second variable.
+
+  The nested sink is not built here, because the solver has no `try`/`catch` walk to
+  push it: `TryCatchExpr` reaches `inferExpr`'s default arm and reports the node
+  unsupported. Building the sink with no caller would be dead code, so it lands with
+  the walk. The `funcCtx.throws` field is the single place that walk pushes and pops.
 
 **Depends on** M3 only (the function machinery, landed). Independent of the whole
 operator track — can start immediately.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -133,23 +133,31 @@ spike work rather than inventing it:
 
 ## PR-by-PR breakdown
 
-Twenty-three PRs across five tracks. Track A builds the evaluator and the core
+Twenty-five PRs across five tracks. Track A builds the evaluator and the core
 operators in dependency order. Track B adds spread and template-literal
 operators, which hang off the backbone but are independent of each other. Track C
-adds exactness propagation and the recursion static-check. Track D is the two
-function-signature effects, which touch `FuncType` and not the evaluator at all,
-so it runs fully in parallel with A–C. Track E is the capstone verification and the
-one follow-on it turned up.
+adds exactness propagation and the recursion static-check. Track D is the
+function-signature effects and the exception machinery around them, which touch
+`FuncType` and not the evaluator at all, so it runs fully in parallel with A–C.
+Track E is the capstone verification and the follow-ons it turned up.
 
 The two heaviest concerns — the evaluator backbone and the conditional/`infer`
 matcher — are each split in two so no single PR carries both a new representation
 and a new algorithm: PR1a/PR1b and PR3a/PR3b below.
 
-Sixteen of the twenty-three were planned up front. PR9c through PR9f were added to Track C
+Sixteen of the twenty-five were planned up front. PR9c through PR9f were added to Track C
 after PR9b's review, which turned up one soundness question, one wrong answer, and one
 representation the milestone assumed exists. They are described together in "the
 recursion-safety follow-on group" below. PR14 through PR16 were added to Track E after
 PR13, which found four utilities inexpressible and identified what each waits on.
+
+PR10b and PR10c were added to Track D after PR10, which settled how `try`/`catch` narrows
+a body's throws but could not build it: the solver has no `try`/`catch` walk at all, so
+the design had no caller. PR10b is that walk. PR10c then moves an `async fn`'s throws off
+its own signature and into the promise it returns, which is where a rejection belongs and
+which needs PR10b's `try` to be catchable. Both were assumed by
+[01-milestones.md](01-milestones.md) — its M9 accept list calls for "a `try`/`catch` test
+for the body-narrowing rule" — without a PR to build them.
 
 ### PR1a — Residual-node representation + inert plumbing
 
@@ -737,11 +745,135 @@ is the exceptional twin of `UnusedLifetimeParamError`.
 
   The nested sink is not built here, because the solver has no `try`/`catch` walk to
   push it: `TryCatchExpr` reaches `inferExpr`'s default arm and reports the node
-  unsupported. Building the sink with no caller would be dead code, so it lands with
-  the walk. The `funcCtx.throws` field is the single place that walk pushes and pops.
+  unsupported. Building the sink with no caller would be dead code, so it lands in
+  PR10b. The `funcCtx.throws` field is the single place that walk pushes and pops.
 
 **Depends on** M3 only (the function machinery, landed). Independent of the whole
 operator track — can start immediately.
+
+### PR10b — `try`/`catch`
+
+The walk PR10's design was written against. It is what lets a caller HANDLE an
+exception rather than re-declare it, so it is the other half of the checked-exception
+story: with no clause meaning `never`, a `try` is the only way a clause-less function
+can call a throwing one.
+
+`ast.TryCatchExpr` ([ast/expr.go](../../internal/ast/expr.go)) is already parsed and
+visitable, carrying a `Try` block and a `Catch []*MatchCase`. The solver never walks
+it — `inferExpr`'s default arm reports the node unsupported — so nothing about
+try/catch exists below the AST.
+
+**Data structures.** None new in `soltype`. The nested sink is a save/restore of
+`funcCtx.throws` around the try block, the same shape `pushFuncCtx` uses for a whole
+body, so a `try` inside a `try` nests for free.
+
+**Algorithms.**
+- **The nested sink.** Save `funcCtx.throws`, install a fresh variable, walk the `Try`
+  block, then restore. What the fresh variable collected is the union the catch arms
+  match against, and it is the value the docs render as the caught binding's type.
+- **Catch arms reuse the match machinery.** The arms are `[]*ast.MatchCase`, so
+  `inferMatch` ([infer_expr.go](../../internal/solver/infer_expr.go)) is the template
+  arm for arm: a child scope per arm, `bindPattern` over the caught union,
+  `narrowMatchArm` to drop members a structural pattern cannot destructure, a boolean
+  guard, and `inferBlockOrExpr` for the body. The try/catch's own value is the join of
+  the try block's tail value and each non-diverging arm body, exactly as `inferMatch`
+  joins its arms.
+- **Automatic rethrow rather than an exhaustiveness error.** The arms need not cover
+  the caught union. Per [06_error_handling.md](../../docs/06_error_handling.md), "if
+  there is no catch-all, the compiler will automatically re-throw the unhandled error",
+  so an uncovered member is constrained into the ENCLOSING sink instead of being
+  reported. `unionMemberCovered` and `isCatchAll`
+  ([infer_expr.go](../../internal/solver/infer_expr.go)) already decide coverage per
+  member for `checkMatchExhaustive`; this reads the same relation the other way, keeping
+  one definition of "this pattern covers this member". A catch-all therefore
+  contributes nothing to the enclosing sink, which is what makes a clause-less caller
+  legal.
+- **The caught union is inexact.** The docs are explicit that a caught error is always
+  an open union — `FooError | ...` — because any function can throw something the type
+  system did not predict. `soltype.UnionType` already carries `Inexact`, so the caught
+  binding sets it. The open tail is itself an uncovered remainder, so a `try` without a
+  catch-all always rethrows something, however many members its arms name. Only a
+  catch-all closes the union, which is the same rule `checkMatchExhaustive` applies to
+  an inexact scrutinee, reached here through the rethrow instead of a diagnostic.
+- **A diverging try/catch.** `exprDiverges` ([infer_expr.go](../../internal/solver/infer_expr.go))
+  gains an arm: the form diverges when the try block and every arm body do, the same
+  AND-fold `MatchExpr` uses.
+
+**Wiring.** An `inferExpr` arm for `*ast.TryCatchExpr`.
+
+**Not in scope: `finally`.** The parser's grammar comment reads `'try' block ('catch'
+matchCase (',' matchCase)*)? ('finally' block)?`, but `tryExpr`
+([parser/expr.go](../../internal/parser/expr.go)) never parses the clause and
+`ast.TryCatchExpr` has no field to hold it. `finally` affects control flow rather than
+the throws lattice, so it is a parser/AST addition first; it belongs with whatever
+milestone adds the field, not here.
+
+**Accept.** A `try` with a catch-all lets a clause-less caller call a throwing function
+with no diagnostic. A `try` with no catch-all propagates the uncovered members, plus the
+inexact tail, to the enclosing clause. The caught binding renders as an inexact union.
+A `try` nested in another `try`'s block sends its own uncovered remainder to the outer
+arms rather than to the function's clause.
+
+**Depends on** PR10 (the sink it pushes and pops) and M4 E2 (the pattern and
+exhaustiveness machinery, landed). Independent of the whole operator track.
+
+### PR10c — `Promise<T, E>` and async rejection
+
+An `async fn` that throws rejects its promise; it does not raise to its caller. PR10
+records what such a function raises on its own `FuncType.Throws` because
+`soltype.PromiseType` is `struct{ Inner Type }`
+([soltype/type.go:650](../../internal/soltype/type.go)) with nowhere else to put it.
+That is the wrong place: a caller that never awaits the promise cannot observe the
+rejection, and one that does should be the site that has to handle it.
+
+The two-parameter promise is not new to Escalier. `internal/interop` already augments
+TypeScript's `Promise<T>` to `Promise<T, E>` through `PromiseVisitor`
+([interop/decl.go](../../internal/interop/decl.go)) and emits it back as `Promise<T>`
+for `.d.ts` compatibility, and
+[stdlib_types/requirements.md](../stdlib_types/requirements.md) §"Promise<T, E> Usage"
+specifies the surface. This PR is the `soltype` half of that existing design.
+
+**Data structures.** `soltype.PromiseType` gains an `Err Type` field, nil reading as
+`never` exactly as `FuncType.Throws` does, so a promise that cannot reject is the zero
+value and `Promise<T>` stays the rendered form. It is covariant, like `Inner`. The
+visitor, `LevelOf`, the printer, `equalType`, and `compareType` each grow the arm
+`Throws` grew in PR10.
+
+**Algorithms.**
+- **An async body's throws becomes the promise's rejection type.** `inferFunc`'s async
+  arm ([infer_expr.go](../../internal/solver/infer_expr.go)) moves the body's sink into
+  the wrapped `PromiseType.Err` and leaves the function's own `Throws` at `never`,
+  since calling an async function raises nothing — it returns a promise.
+- **A clause on an `async fn` names the rejection, not what a call raises.** The
+  signature is still where the body's exits are checked, so PR10's rules carry over
+  unchanged: no clause means the body may not throw at all, `throws E` fixes the
+  rejection type, and `throws _` infers it. Only the destination moves, from the
+  function's own `Throws` to the promise's `Err`. So `async fn f() throws string { … }`
+  reads `fn () -> Promise<T, string>`, and an async body that throws with no clause is
+  rejected exactly as a sync one is.
+- **`await` is an exceptional exit.** `inferAwait` constrains the awaited promise's
+  `Err` into the enclosing body's throws sink, so awaiting a rejecting promise needs a
+  clause or a `try` the same way a throwing call does. This is the join with PR10b: a
+  `try` around an `await` catches the rejection, which is the pattern
+  [06_error_handling.md](../../docs/06_error_handling.md)'s `fetchJSON` example is
+  built on.
+- **The annotation surface.** `resolveTypeAnn`'s Promise arm reads a second type
+  argument when written, so `Promise<number, FetchError>` resolves, and a
+  single-argument `Promise<T>` leaves `Err` nil.
+- **Async generators.** `AsyncGenerator<…>` is the same question one level out and
+  rides on whatever PR11 lands for `Generator`.
+
+**Accept.** `async fn f() throws _ { throw "x" }` renders `fn () -> Promise<never, "x">`
+with no `throws` clause of its own, and the same body without the clause is rejected at
+the `throw`. A caller that only holds the promise needs no clause. A caller that awaits
+it needs `throws "x"` or a `try` around the `await`. The `fetchJSON` example from
+[06_error_handling.md](../../docs/06_error_handling.md) type-checks, including its catch
+arms narrowing the rejection union.
+
+**Depends on** PR10 (the covariant-effect arms this copies), PR10b (the `try` that
+catches an awaited rejection), and M7.5 (the real `Promise` from the stdlib, which is
+where the second parameter has to survive ingestion). Relates to PR11 for
+`AsyncGenerator` and PR12 for `Awaited<T>`, neither of which it blocks.
 
 ### PR11 — Generators (`gen fn` / `yield e` / `yield from g`)
 
@@ -1161,8 +1293,10 @@ or a single function-signature effect, sized comparably to a typical M4/M6 PR.
 Mapped types (PR4) and object spread (PR5) are the next-largest — the fiddly
 modifier/`as`-remapping semantics and the Flow optional-field union rule
 respectively — but each is one self-contained operator and stays within the M4/M6
-band. PR10 and PR11 touch only `FuncType` and never the evaluator, so they carry
-no operator-track review burden. PR13 is verification-heavy but low-risk; if the
+band. PR10, PR10c, and PR11 touch only `FuncType` and `PromiseType`, never the
+evaluator, so they carry no operator-track review burden. PR10b is the largest of
+Track D: it is a new expression walk rather than a field plus parallel arms, sized
+like `inferMatch`, whose arm loop it reuses. PR13 is verification-heavy but low-risk; if the
 utility corpus balloons it splits cleanly by category (mapped-based,
 conditional-based, template-based).
 
@@ -1211,7 +1345,7 @@ unmarked PR has not been built yet.
 
 ```
 M7   (type aliases: alias node + generics + scope-driven TypeRef)  ──► PR1a
-M7.5 (library type resolution: real stdlib types, import-only)     ──► PR11, PR12
+M7.5 (library type resolution: real stdlib types, import-only)     ──► PR10c, PR11, PR12
 
 PR1a ✅ #914 (residual-node representation + inert plumbing)
  └─► PR1b ✅ #915 (evaluator backbone + keyof reduction)
@@ -1234,6 +1368,8 @@ PR9e ✅ #943 (μ-knot representation)       ── needs M3 only; owed from M3,
  └─► PR9f (regular-tree normalization)     ── also needs PR9b
 
 PR10 (throws clause)                       ── needs M3 only; parallel to everything
+ ├─► PR10b (try/catch)                     ── also needs M4 E2 (pattern machinery)
+ │    └─► PR10c (Promise<T, E> + async rejection)  ── also needs M7.5
  └─► PR11 (generators)                     ── also needs M7.5 (+PR3b/PR12 for the async-gen accept case)
 
 PR13 (TS utility-type suite)               ── needs PR2, PR3b, PR4, PR7, PR12
@@ -1249,7 +1385,8 @@ to intersect the members' key sets, and #937 capped total alias expansion with a
 monotonic budget. #938 added the `{[K: Keys]: Value}` index-signature shorthand to
 PR4's mapped types.
 
-Everything still open is PR8, PR9d, PR9f, PR10, PR11, PR13, PR14, PR15, and PR16. PR8 is partly
+Everything still open is PR8, PR9d, PR9f, PR10, PR10b, PR10c, PR11, PR13, PR14, PR15,
+and PR16. PR8 is partly
 seeded — #922 threads an object's exactness through `keyof` — but the rest of the
 operators and the `Exact` / `Inexact` intrinsics are untouched.
 
@@ -1279,6 +1416,9 @@ graph TD
     PR9f["PR9f (regular-tree normalization)"]
     M3["M3 (let-generalization + coalescing)"]
     PR10["PR10 (throws clause)"]
+    PR10b["PR10b (try/catch)"]
+    PR10c["PR10c (Promise<T, E> + async rejection)"]
+    M4E2["M4 E2 (pattern matching)"]
     PR11["PR11 (generators)"]
     PR12["PR12 ✅ #952 (Awaited<T>)"]
     PR13["PR13 (TS utility-type suite)"]
@@ -1287,8 +1427,10 @@ graph TD
     PR16["PR16 (null + undefined + NonNullable<T>)"]
 
     M7 -.-> PR1a
+    M75 -.-> PR10c
     M75 -.-> PR11
     M75 -.-> PR12
+    M4E2 -.-> PR10b
     M3 -.-> PR9e
 
     PR1a --> PR1b
@@ -1318,7 +1460,9 @@ graph TD
     PR6 --> PR8
     PR7 --> PR8
     PR7 --> PR13
+    PR10 --> PR10b
     PR10 --> PR11
+    PR10b --> PR10c
     PR11 --> PR13
     PR12 --> PR13
     PR13 --> PR14
@@ -1360,7 +1504,11 @@ graph TD
   and unblocks PR9f; then PR9d, which fixes a wrong answer PR9b introduced; PR9f last,
   and only if a real library type needs it.
 - **Track D** — PR10 (throws) has no operator dependency and can start on day one
-  alongside PR1a; PR11 (generators) follows PR10.
+  alongside PR1a. PR10b (try/catch) and PR11 (generators) both follow PR10 and are
+  independent of each other, so they can be built concurrently. PR10c (Promise<T, E>)
+  is the track's only join, waiting on PR10b and M7.5. Suggested order: PR10b next,
+  since a clause-less function cannot call a throwing one without it, then PR11 and
+  PR10c as M7.5 allows.
 - **Track E** — PR13 is the final join, waiting on PR2, PR3b, PR4, PR7, PR12. PR14 and
   PR15 follow it in that order, closing the gaps PR13 found that the operator track can
   close on its own. PR15's `InstanceType<C>` half is separable from PR14 and could run

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -691,10 +691,18 @@ walk.
 **Data structures.** `soltype.FuncType` gains a `Throws Type` field
 ([soltype/type.go:201](../../internal/soltype/type.go)), parallel to `Ret`. A nil
 Throws reads as `never` (⊥), so a FuncType minted without thinking about exceptions
-raises nothing. A source function with no `throws` clause infers its throws from its
-body rather than being pinned to `never`, matching
-[06_error_handling.md](../../docs/06_error_handling.md), where `fn foo() { throw
-FooError() }` is "inferred as `fn() -> undefined throws FooError | ...`".
+raises nothing.
+
+Omitting the clause is how a source function declares that it raises nothing, matching
+the old checker's `inferFuncSig`, which gives a clause-less signature `never`. A body
+that raises anyway is rejected at the `throw` or the call, so `throws never` is never
+the way to spell a non-throwing function. `throws _` opts into inference and is what a
+function whose raised type should come from its body writes.
+
+This contradicts [06_error_handling.md](../../docs/06_error_handling.md), which shows
+`fn foo() { throw FooError() }` as "inferred as `fn() -> undefined throws FooError |
+...`" and whose `try`/`catch` examples call clause-less functions that raise. The doc
+needs revising to match, which is tracked separately from this PR.
 
 **Algorithms.**
 - **Constraint engine, parallel arms** — the function arm in `constrain` recurses
@@ -707,14 +715,18 @@ FooError() }` is "inferred as `fn() -> undefined throws FooError | ...`".
   handling — `E` in `<E>(f: () -> T throws E) -> T throws E` is just another
   quantified variable.
 - **How `try`/`catch` narrows the body's throws — settled.** The body carries one
-  **throws sink**, the type every `throw` and every call is constrained into. A
-  signature that writes `throws T` makes `T` the sink directly, so each exceptional
-  exit is checked at its own site; a signature with no clause gets a fresh variable
-  and the coalesced sink becomes the inferred clause. A `try` block then needs no new
-  lattice machinery: it pushes a nested sink, and the enclosing sink receives only the
-  part the `catch` arms leave unhandled. That is the two-variable encoding
-  `body_throws <: surrounding_throws ∪ caught_throws` with the union realized by the
-  arms' patterns rather than by a second variable.
+  **throws sink**, the type every `throw` and every call is constrained into. The
+  signature seeds it: `throws T` makes `T` the sink directly, no clause makes it
+  `never`, and `throws _` makes it a fresh variable whose coalesced value becomes the
+  inferred clause. Each exceptional exit is therefore checked at its own site. A `try`
+  block then needs no new lattice machinery: it pushes a nested sink, and the enclosing
+  sink receives only the part the `catch` arms leave unhandled. That is the
+  two-variable encoding `body_throws <: surrounding_throws ∪ caught_throws` with the
+  union realized by the arms' patterns rather than by a second variable.
+
+  The nested sink is also what makes a clause-less function usable once `try`/`catch`
+  lands: a call wrapped in a `try` whose arms are exhaustive contributes nothing to the
+  enclosing `never` sink, so the caller needs no clause of its own.
 
   The nested sink is not built here, because the solver has no `try`/`catch` walk to
   push it: `TryCatchExpr` reaches `inferExpr`'s default arm and reports the node

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -704,6 +704,13 @@ This contradicts [06_error_handling.md](../../docs/06_error_handling.md), which 
 ...`" and whose `try`/`catch` examples call clause-less functions that raise. The doc
 needs revising to match, which is tracked separately from this PR.
 
+A signature can also declare more than its body delivers, in either direction, since
+`never` sits below every type. Both are warnings rather than errors, because a
+conservative signature and a not-yet-implemented stub are each written that way:
+`UnusedThrowsClauseError` for a clause no exceptional exit reaches, and
+`UnreachableReturnAnnotationError` for a `-> R` on a body that always throws. The first
+is the exceptional twin of `UnusedLifetimeParamError`.
+
 **Algorithms.**
 - **Constraint engine, parallel arms** — the function arm in `constrain` recurses
   `l.Throws <: r.Throws` (covariant); `extrude` recurses into `Throws` with the


### PR DESCRIPTION
Adds support for the `throws` clause on function signatures, enabling declaration and inference of exception types that functions may raise.

**Summary**

Functions can now declare what they raise with a `throws T` clause, independent of the return type annotation. When no clause is present, the throws type is inferred from the function body. The throws type is covariant, so a function raising a narrower set of exceptions satisfies an annotation expecting a wider set.

**Key changes**

- **Parser** (`internal/parser/`): Added `throwsClause()` helper to parse optional `throws T` on all signature forms (function declarations, expressions, methods, getters, setters, constructors, and function type annotations). The clause parses independently of `-> R`, allowing `fn f() throws string { … }` without a return annotation.

- **Type system** (`internal/soltype/`): `FuncType` gains a `Throws` field parallel to `Ret`. A nil `Throws` reads as `never` (the bottom type), so functions raise nothing by default. Added `ThrowsOrNever()` helper to normalize the two representations.

- **Type inference** (`internal/solver/infer_expr.go`): Functions resolve their declared `throws` clause before walking the body, making it the sink every `throw` statement and call checks against. This routes blame to the throw or call site rather than the whole function. Bodies with no declared clause infer their throws from the body's exceptional exits. A body that always diverges (only throws, never returns) produces `never` as its return type.

- **Constraint checking** (`internal/solver/constrain.go`): Added covariant throws rule to function subtyping. A function throwing a narrower set satisfies one expecting a wider set.

- **Overload resolution** (`internal/solver/overload.go`): Only the selected overload's throws reaches the caller, so a call to a non-throwing arm of an overloaded set contributes no exceptions.

- **Accessor validation** (`internal/solver/infer_class.go`): Getters and setters cannot declare a `throws` clause, since they project to property types with no room for exception information. The clause is rejected rather than silently dropped.

- **Printer** (`internal/printer/printer.go`): Added `printThrowsClause()` to emit ` throws T` after return types. An explicit `throws never` renders as no clause, matching the nil representation.

- **Tests**: Comprehensive test coverage in `internal/solver/infer_throws_test.go` and `internal/parser/throws_test.go` covering inference, declaration, propagation through calls, overload resolution, polymorphism, and error cases.

**Implementation details**

The throws type flows through the type system the same way the return type does. A declared clause fixes what callers see and what the body is checked against. An inferred clause (when no declaration exists) collects the union of all exceptional exits. Polymorphic functions with `throws E` where `E` is a type parameter work through the existing let-generalization machinery with no special handling.

https://claude.ai/code/session_01T5YGRG8rq8R4ySc7yr8QbH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `throws` clauses on functions, methods, constructors, function types, and object methods.
  * Infers thrown types from function bodies and propagates them through calls, overloads, generics, and nested functions.
  * Supports type checking, subtyping, and rendering of thrown types; omitted clauses remain equivalent to `throws never`.

* **Bug Fixes**
  * Improved handling of missing or unsupported `throws` annotations with clearer diagnostics.
  * Preserved thrown-type information during inference and signature processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->