### PR TITLE
Add `new (…) -> T` constructor signature support in object type annotations

### DIFF
--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -2556,3 +2556,47 @@
     span: 1:1-1:43,
 }
 ---
+
+[TestParseTypeAnnErrorHandling/ConstructorSignatureMissingReturnType - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.ConstructorTypeAnn{
+            Fn: &ast.FuncTypeAnn{
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "x",
+                            span: 1:7-1:8,
+                        },
+                        TypeAnn: &ast.NumberTypeAnn{
+                            span: 1:10-1:16,
+                        },
+                    },
+                },
+                Return: &ast.ErrorTypeAnn{
+                    span: 1:18-1:18,
+                },
+                span: 1:2-1:18,
+            },
+        },
+    },
+    span: 1:1-1:18,
+}
+---
+
+[TestParseTypeAnnErrorHandling/ConstructorSignatureMissingReturnType - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: 1:17-1:18,
+        Message: "Expected -> but got }",
+    },
+    &parser.Error{
+        Span: 1:18-1:18,
+        Message: "expected a type annotation",
+    },
+    &parser.Error{
+        Span: 1:18-1:18,
+        Message: "Expected } but got ",
+    },
+}
+---

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -2390,3 +2390,169 @@
     span: 1:1-1:38,
 }
 ---
+
+[TestParseTypeAnnNoErrors/ObjectConstructorSignatureWithTypeParams - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.ConstructorTypeAnn{
+            Fn: &ast.FuncTypeAnn{
+                TypeParams: []*ast.TypeParam{
+                    &ast.TypeParam{
+                        Name: "T",
+                    },
+                },
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "x",
+                            span: 1:10-1:11,
+                        },
+                        TypeAnn: &ast.TypeRefTypeAnn{
+                            Name: &ast.Ident{
+                                Name: "T",
+                                span: 1:13-1:14,
+                            },
+                            span: 1:13-1:14,
+                        },
+                    },
+                },
+                Return: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "Box",
+                        span: 1:19-1:22,
+                    },
+                    TypeArgs: []ast.TypeAnn{
+                        &ast.TypeRefTypeAnn{
+                            Name: &ast.Ident{
+                                Name: "T",
+                                span: 1:23-1:24,
+                            },
+                            span: 1:23-1:24,
+                        },
+                    },
+                    span: 1:19-1:25,
+                },
+                span: 1:2-1:25,
+            },
+        },
+    },
+    span: 1:1-1:26,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectConstructorSignature - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.ConstructorTypeAnn{
+            Fn: &ast.FuncTypeAnn{
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "x",
+                            span: 1:7-1:8,
+                        },
+                        TypeAnn: &ast.NumberTypeAnn{
+                            span: 1:10-1:16,
+                        },
+                    },
+                },
+                Return: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "Point",
+                        span: 1:21-1:26,
+                    },
+                    span: 1:21-1:26,
+                },
+                span: 1:2-1:26,
+            },
+        },
+    },
+    span: 1:1-1:27,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectConstructorSignatureBesideProperty - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.ConstructorTypeAnn{
+            Fn: &ast.FuncTypeAnn{
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "x",
+                            span: 1:7-1:8,
+                        },
+                        TypeAnn: &ast.NumberTypeAnn{
+                            span: 1:10-1:16,
+                        },
+                    },
+                },
+                Return: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "Point",
+                        span: 1:21-1:26,
+                    },
+                    span: 1:21-1:26,
+                },
+                span: 1:2-1:26,
+            },
+        },
+        &ast.PropertyTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "origin",
+                span: 1:28-1:34,
+            },
+            Value: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "Point",
+                    span: 1:36-1:41,
+                },
+                span: 1:36-1:41,
+            },
+        },
+    },
+    span: 1:1-1:42,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectConstructorSignatureWithRestParam - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.ConstructorTypeAnn{
+            Fn: &ast.FuncTypeAnn{
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.RestPat{
+                            Pattern: &ast.IdentPat{
+                                Name: "args",
+                                span: 1:10-1:14,
+                            },
+                            span: 1:7-1:14,
+                        },
+                        TypeAnn: &ast.TupleTypeAnn{
+                            Elems: []ast.TypeAnn{
+                                &ast.NumberTypeAnn{
+                                    span: 1:17-1:23,
+                                },
+                                &ast.StringTypeAnn{
+                                    span: 1:25-1:31,
+                                },
+                            },
+                            span: 1:16-1:32,
+                        },
+                    },
+                },
+                Return: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "Point",
+                        span: 1:37-1:42,
+                    },
+                    span: 1:37-1:42,
+                },
+                span: 1:2-1:42,
+            },
+        },
+    },
+    span: 1:1-1:43,
+}
+---

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -229,6 +229,47 @@ loop:
 	return result
 }
 
+// funcTypeAnnTail parses a function signature once its leading keyword has been consumed:
+// optional lifetime and type parameters, the parameter list with its `...` inexact marker,
+// the `-> R` return, and an optional `throws` clause. The `fn` type annotation and the
+// `new (…) -> T` member of an object type share it, so a constructor signature accepts
+// everything a function type annotation does. keyword is the token that introduced the
+// signature and anchors the resulting span.
+func (p *Parser) funcTypeAnnTail(keyword *Token) *ast.FuncTypeAnn {
+	lifetimeParams, typeParams := p.maybeLifetimeAndTypeParams(false)
+
+	p.expect(OpenParen, AlwaysConsume)
+
+	funcParams, inexact := p.parseFuncParams()
+
+	p.expect(CloseParen, AlwaysConsume)
+
+	p.expect(Arrow, AlwaysConsume)
+
+	retType := p.typeAnnRequired()
+
+	endSpan := retType.Span()
+
+	// Parse optional throws clause
+	var throwsType ast.TypeAnn
+	if p.lexer.peek().Type == Throws {
+		p.lexer.consume() // consume 'throws'
+		throwsType = p.typeAnnRequired()
+		endSpan = throwsType.Span()
+	}
+
+	fnAnn := ast.NewFuncTypeAnn(
+		lifetimeParams,
+		typeParams,
+		funcParams,
+		retType,
+		throwsType,
+		ast.NewSpan(keyword.Span.Start, endSpan.End, p.lexer.source.ID),
+	)
+	fnAnn.Inexact = inexact
+	return fnAnn
+}
+
 func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 	token := p.lexer.peek()
 
@@ -356,38 +397,7 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 			)
 		case Fn:
 			p.lexer.consume()
-			lifetimeParams, typeParams := p.maybeLifetimeAndTypeParams(false)
-
-			p.expect(OpenParen, AlwaysConsume)
-
-			funcParams, inexact := p.parseFuncParams()
-
-			p.expect(CloseParen, AlwaysConsume)
-
-			p.expect(Arrow, AlwaysConsume)
-
-			retType := p.typeAnnRequired()
-
-			endSpan := retType.Span()
-
-			// Parse optional throws clause
-			var throwsType ast.TypeAnn
-			if p.lexer.peek().Type == Throws {
-				p.lexer.consume() // consume 'throws'
-				throwsType = p.typeAnnRequired()
-				endSpan = throwsType.Span()
-			}
-
-			fnAnn := ast.NewFuncTypeAnn(
-				lifetimeParams,
-				typeParams,
-				funcParams,
-				retType,
-				throwsType,
-				ast.NewSpan(token.Span.Start, endSpan.End, p.lexer.source.ID),
-			)
-			fnAnn.Inexact = inexact
-			typeAnn = fnAnn
+			typeAnn = p.funcTypeAnnTail(token)
 		case If: // conditional type
 			p.lexer.consume() // consume 'if'
 			checkType := p.typeAnnRequired()
@@ -841,6 +851,15 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		}
 		span := ast.MergeSpans(token.Span, value.Span())
 		return ast.NewRestSpreadTypeAnn(value, span)
+	}
+
+	// A `new (x: number) -> T` construct signature. `new` is a keyword, so it can never be
+	// an object key and the arm needs no lookahead past it. The signature parses through the
+	// same tail the `fn` annotation uses, which gives it type parameters, an inexact marker,
+	// and a `throws` clause for free.
+	if token.Type == New {
+		p.lexer.consume() // consume 'new'
+		return &ast.ConstructorTypeAnn{Fn: p.funcTypeAnnTail(token)}
 	}
 
 	mod := ""

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -308,6 +308,9 @@ func TestParseTypeAnnErrorHandling(t *testing.T) {
 		"PropertyMissingType": {
 			input: "{x: }",
 		},
+		"ConstructorSignatureMissingReturnType": {
+			input: "{new (x: number)}",
+		},
 		"ConditionalTypeMissingElse": {
 			input: "if A : B { C } else {",
 		},

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -240,6 +240,18 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 		"ObjectInexactOnly": {
 			input: "{...}",
 		},
+		"ObjectConstructorSignature": {
+			input: "{new (x: number) -> Point}",
+		},
+		"ObjectConstructorSignatureWithRestParam": {
+			input: "{new (...args: [number, string]) -> Point}",
+		},
+		"ObjectConstructorSignatureWithTypeParams": {
+			input: "{new <T>(x: T) -> Box<T>}",
+		},
+		"ObjectConstructorSignatureBesideProperty": {
+			input: "{new (x: number) -> Point, origin: Point}",
+		},
 		"UnionOfFunctions": {
 			input: "(fn (x: number) -> string) | (fn (x: string) -> number)",
 		},

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1323,7 +1323,7 @@ func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
 		p.printFuncTypeAnn(e.Fn)
 	case *ast.ConstructorTypeAnn:
 		p.writeString("new")
-		p.printFuncTypeAnn(e.Fn)
+		p.printFuncTypeAnnTail(e.Fn)
 	case *ast.MethodTypeAnn:
 		p.printObjKey(e.Name)
 		p.printGenericParams(e.Fn.LifetimeParams, e.Fn.TypeParams)
@@ -1542,6 +1542,13 @@ func (p *Printer) printLifetimeAnn(lt ast.LifetimeAnnNode) {
 
 func (p *Printer) printFuncTypeAnn(typ *ast.FuncTypeAnn) {
 	p.writeString("fn")
+	p.printFuncTypeAnnTail(typ)
+}
+
+// printFuncTypeAnnTail renders a function signature after its leading keyword: the generic
+// parameters, the parameter list, the return, and any `throws` clause. The `fn` annotation
+// and an object type's `new (…) -> T` member share it, mirroring the parser's split.
+func (p *Printer) printFuncTypeAnnTail(typ *ast.FuncTypeAnn) {
 	p.printGenericParams(typ.LifetimeParams, typ.TypeParams)
 	p.writeString(" (")
 	for i, param := range typ.Params {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -781,6 +781,44 @@ func TestPrintTypeAnnotations(t *testing.T) {
 	}
 }
 
+// A `new (…) -> T` member of an object type annotation round-trips through the printer. It shares
+// its signature rendering with the `fn` annotation, so type parameters, an inexact parameter list,
+// and a `throws` clause all come along, and only the leading keyword differs.
+func TestPrintConstructorTypeAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"constructor", "{new (x: number) -> Point}", "{\n    new (x: number) -> Point\n}"},
+		{"no params", "{new () -> Point}", "{\n    new () -> Point\n}"},
+		{"type params", "{new <T>(x: T) -> Box<T>}", "{\n    new<T> (x: T) -> Box<T>\n}"},
+		{"rest param", "{new (...args: [number, string]) -> Point}", "{\n    new (...args: [number, string]) -> Point\n}"},
+		{"throws", "{new (x: number) -> Point throws RangeError}", "{\n    new (x: number) -> Point throws RangeError\n}"},
+		{
+			"beside a property",
+			"{new (x: number) -> Point, origin: Point}",
+			"{\n    new (x: number) -> Point,\n    origin: Point\n}",
+		},
+	}
+
+	opts := DefaultOptions()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typeAnn := parseTypeAnn(t, tt.input)
+			result, err := Print(typeAnn, opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+
+			// Re-parsing the rendered form and printing it again must land on the same text,
+			// which is what makes the output a form the source could have been written in.
+			reprinted, err := Print(parseTypeAnn(t, result), opts)
+			require.NoError(t, err)
+			require.Equal(t, result, reprinted)
+		})
+	}
+}
+
 func TestPrintBorrowTypeAnnotations(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -808,15 +808,20 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			return append(errs, c.constrain(sub.ThrowsOrNever(), sup.ThrowsOrNever(), seen, false)...)
 		}
 		// A bare function fills an object target whose only member is a construct signature.
-		// classValue binds a class with no statics to its constructor FuncType and one with
-		// statics to an object carrying a ConstructorElem, so `typeof Point` renders
-		// `fn (x: number) -> Point` for the first and `{new (x: number) -> Point, origin: number}`
-		// for the second. This rule is what makes `InstanceType<typeof Point>` match either
-		// shape. Its cost is that an ordinary function also satisfies the target, since nothing
-		// in a FuncType says whether the value behind it is constructible.
+		// classValue gives a class with no statics its bare constructor FuncType and one with
+		// statics an object carrying a ConstructorElem. So for
 		//
-		// A target carrying anything besides the signature demands statics the bare function
-		// cannot supply, so it stays on the object-against-object arm and fails there.
+		//	class Point { x: number, constructor(mut self, x: number) { self.x = x } }
+		//
+		// `typeof Point` renders `fn (x: number) -> Point`, while the same class with a
+		// `static origin: Point` renders `{new (x: number) -> Point, origin: Point}`. This rule
+		// is what lets one `{new (…) -> R, ...}` target accept both, which is how
+		// `InstanceType<typeof C>` reads either class's instance. Its cost is that an ordinary
+		// function satisfies such a target too, since nothing in a FuncType says whether the
+		// value behind it is constructible.
+		//
+		// A target carrying another member alongside the signature demands something a bare
+		// function cannot supply. It stays on the object-against-object arm and fails there.
 		if sup, ok := super.(*soltype.ObjectType); ok && len(sup.Elems) == 1 {
 			if supCtor, has := sup.Constructor(); has {
 				return c.constrain(sub, supCtor.Fn, seen, mutCtx)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -816,9 +816,14 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		// `typeof Point` renders `fn (x: number) -> Point`, while the same class with a
 		// `static origin: Point` renders `{new (x: number) -> Point, origin: Point}`. This rule
 		// is what lets one `{new (…) -> R, ...}` target accept both, which is how
-		// `InstanceType<typeof C>` reads either class's instance. Its cost is that an ordinary
-		// function satisfies such a target too, since nothing in a FuncType says whether the
-		// value behind it is constructible.
+		// `InstanceType<typeof C>` reads either class's instance.
+		//
+		// Its cost is that an ordinary function satisfies such a target too, since nothing in a
+		// FuncType records whether the value behind it is constructible. So
+		// `InstanceType<fn (x: number) -> {a: number}>` reduces to `{a: number}` where
+		// TypeScript reduces the same application to `never`. Separating the two needs either a
+		// constructor marker on FuncType or a class value that is always an object, and the
+		// second rewrites every rendered class-value type.
 		//
 		// A target carrying another member alongside the signature demands something a bare
 		// function cannot supply. It stays on the object-against-object arm and fails there.

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -807,39 +807,12 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			// `never`, which constrain short-circuits, so no clause satisfies every super.
 			return append(errs, c.constrain(sub.ThrowsOrNever(), sup.ThrowsOrNever(), seen, false)...)
 		}
-		// A bare function fills an object target whose only member is a construct signature.
-		// classValue gives a class with no statics its bare constructor FuncType and one with
-		// statics an object carrying a ConstructorElem. So for
-		//
-		//	class Point { x: number, constructor(mut self, x: number) { self.x = x } }
-		//
-		// `typeof Point` renders `fn (x: number) -> Point`, while the same class with a
-		// `static origin: Point` renders `{new (x: number) -> Point, origin: Point}`. This rule
-		// is what lets one `{new (…) -> R, ...}` target accept both, which is how
-		// `InstanceType<typeof C>` reads either class's instance.
-		//
-		// The return has to be a nominal class instance, because a FuncType records nothing
-		// about whether the value behind it is constructible and a bare function would
-		// otherwise fill the target on its signature alone. Both constructor paths set
-		// `Ret: self` — see synthesizeConstructor and walkConstructorBody in
-		// infer_class_ctor.go — so every class value passes and
-		// `InstanceType<fn (x: number) -> {a: number}>` reduces to `never`, matching
-		// TypeScript.
-		//
-		// What the test admits that TypeScript rejects is a factory,
-		// `fn make(x: number) -> Point`, whose return is a class instance it did not
-		// construct. Rejecting that one too needs a constructor marker carried on FuncType,
-		// or a class value that is always an object so this arm goes away entirely.
-		//
-		// A target carrying another member alongside the signature demands something a bare
-		// function cannot supply. It stays on the object-against-object arm and fails there.
-		if sup, ok := super.(*soltype.ObjectType); ok && len(sup.Elems) == 1 {
-			if _, retIsClass := sub.Ret.(*soltype.ClassType); retIsClass {
-				if supCtor, has := sup.Constructor(); has {
-					return c.constrain(sub, supCtor.Fn, seen, mutCtx)
-				}
-			}
-		}
+		// A function never fills an object target that names a construct signature. classValue
+		// binds every class value to an object carrying a ConstructorElem, so a constructor
+		// reaches such a target through the object-against-object arm below and a bare function
+		// has no way in. That is what makes `InstanceType<fn (x: number) -> {a: number}>` reduce
+		// to `never`, matching TypeScript, while `InstanceType<typeof Point>` still reads the
+		// instance off the class value.
 	case *soltype.TupleType:
 		if tupleHasSpread(sub) || tupleHasSpread(super) {
 			// One side carries an unreduced `...P` spread the pre-switch could not ground: a spread

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -818,18 +818,26 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		// is what lets one `{new (…) -> R, ...}` target accept both, which is how
 		// `InstanceType<typeof C>` reads either class's instance.
 		//
-		// Its cost is that an ordinary function satisfies such a target too, since nothing in a
-		// FuncType records whether the value behind it is constructible. So
-		// `InstanceType<fn (x: number) -> {a: number}>` reduces to `{a: number}` where
-		// TypeScript reduces the same application to `never`. Separating the two needs either a
-		// constructor marker on FuncType or a class value that is always an object, and the
-		// second rewrites every rendered class-value type.
+		// The return has to be a nominal class instance, because a FuncType records nothing
+		// about whether the value behind it is constructible and a bare function would
+		// otherwise fill the target on its signature alone. Both constructor paths set
+		// `Ret: self` — see synthesizeConstructor and walkConstructorBody in
+		// infer_class_ctor.go — so every class value passes and
+		// `InstanceType<fn (x: number) -> {a: number}>` reduces to `never`, matching
+		// TypeScript.
+		//
+		// What the test admits that TypeScript rejects is a factory,
+		// `fn make(x: number) -> Point`, whose return is a class instance it did not
+		// construct. Rejecting that one too needs a constructor marker carried on FuncType,
+		// or a class value that is always an object so this arm goes away entirely.
 		//
 		// A target carrying another member alongside the signature demands something a bare
 		// function cannot supply. It stays on the object-against-object arm and fails there.
 		if sup, ok := super.(*soltype.ObjectType); ok && len(sup.Elems) == 1 {
-			if supCtor, has := sup.Constructor(); has {
-				return c.constrain(sub, supCtor.Fn, seen, mutCtx)
+			if _, retIsClass := sub.Ret.(*soltype.ClassType); retIsClass {
+				if supCtor, has := sup.Constructor(); has {
+					return c.constrain(sub, supCtor.Fn, seen, mutCtx)
+				}
 			}
 		}
 	case *soltype.TupleType:

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -807,6 +807,21 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			// `never`, which constrain short-circuits, so no clause satisfies every super.
 			return append(errs, c.constrain(sub.ThrowsOrNever(), sup.ThrowsOrNever(), seen, false)...)
 		}
+		// A bare function fills an object target whose only member is a construct signature.
+		// classValue binds a class with no statics to its constructor FuncType and one with
+		// statics to an object carrying a ConstructorElem, so `typeof Point` renders
+		// `fn (x: number) -> Point` for the first and `{new (x: number) -> Point, origin: number}`
+		// for the second. This rule is what makes `InstanceType<typeof Point>` match either
+		// shape. Its cost is that an ordinary function also satisfies the target, since nothing
+		// in a FuncType says whether the value behind it is constructible.
+		//
+		// A target carrying anything besides the signature demands statics the bare function
+		// cannot supply, so it stays on the object-against-object arm and fails there.
+		if sup, ok := super.(*soltype.ObjectType); ok && len(sup.Elems) == 1 {
+			if supCtor, has := sup.Constructor(); has {
+				return c.constrain(sub, supCtor.Fn, seen, mutCtx)
+			}
+		}
 	case *soltype.TupleType:
 		if tupleHasSpread(sub) || tupleHasSpread(super) {
 			// One side carries an unreduced `...P` spread the pre-switch could not ground: a spread

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1343,9 +1343,9 @@ func (e *MultipleConstructorsError) Message() string {
 
 // DuplicateConstructorSignatureError fires on the second and any later `new (…) -> T` member
 // in one object type annotation. soltype.ObjectType.Constructor() returns at most one
-// construct signature and constrain checks a constructor requirement against that one, so a
-// second signature has nowhere to live and would be dropped without a diagnostic. The extra
-// member carries the blame span.
+// construct signature, and constrain checks a constructor requirement against that one. A
+// second signature therefore has nowhere to live, and reporting it is what keeps it from
+// being dropped in silence. The extra member carries the blame span.
 type DuplicateConstructorSignatureError struct {
 	Ctor *ast.ConstructorTypeAnn
 }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1051,6 +1051,7 @@ func (*MutLeafThroughSharedBorrowError) isSolverError()     {}
 func (*MissingSelfReceiverError) isSolverError()            {}
 func (*MethodOverloadReceiverMismatchError) isSolverError() {}
 func (*MultipleConstructorsError) isSolverError()           {}
+func (*DuplicateConstructorSignatureError) isSolverError()  {}
 func (*FieldInitializerNotAllowedError) isSolverError()     {}
 func (*SubclassConstructorRequiredError) isSolverError()    {}
 func (*WriteOnlyPropertyError) isSolverError()              {}
@@ -1338,6 +1339,21 @@ func (e *MultipleConstructorsError) Span() ast.Span      { return e.Ctor.Span() 
 func (e *MultipleConstructorsError) Related() []ast.Span { return nil }
 func (e *MultipleConstructorsError) Message() string {
 	return "Multiple constructors per class are not yet supported."
+}
+
+// DuplicateConstructorSignatureError fires on the second and any later `new (…) -> T` member
+// in one object type annotation. soltype.ObjectType.Constructor() returns at most one
+// construct signature and constrain checks a constructor requirement against that one, so a
+// second signature has nowhere to live and would be dropped without a diagnostic. The extra
+// member carries the blame span.
+type DuplicateConstructorSignatureError struct {
+	Ctor *ast.ConstructorTypeAnn
+}
+
+func (e *DuplicateConstructorSignatureError) Span() ast.Span      { return e.Ctor.Fn.Span() }
+func (e *DuplicateConstructorSignatureError) Related() []ast.Span { return nil }
+func (e *DuplicateConstructorSignatureError) Message() string {
+	return "An object type may declare at most one `new` signature."
 }
 
 // FieldInitializerNotAllowedError fires when an instance field declares a `= expr`

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -13,9 +13,8 @@ import (
 
 // inferClassDecl types a class declaration (M5 B1). It returns the class's value type
 // for the SCC driver to constrain into the value binding var and generalize, along with
-// the decl's provenance. The value is the bare constructor FuncType for a class with no
-// statics, or a ctor-plus-static object for one with static members (see classValue). It
-// has two side effects. It registers
+// the decl's provenance. The value is an object carrying the constructor as a ConstructorElem
+// plus any static members (see classValue). It has two side effects. It registers
 // the instance TypeBinding in scope, so the class name resolves as a type. It registers
 // the ClassDef in the nominal registry, so member lookup and the nominal constrain rule
 // can read the projected body.
@@ -140,13 +139,16 @@ func (c *checker) bindScriptClass(scope *Scope, lvl int, decl *ast.ClassDecl) {
 	})
 }
 
-// classValue produces the RAW value type a class name binds to. A class with no statics
-// binds its bare constructor FuncType; one with statics binds an exact object holding a
-// ConstructorElem plus the static members, so `Point(…)` constructs and `Point.origin` reads.
+// classValue produces the RAW value type a class name binds to: an exact object holding a
+// ConstructorElem plus whatever static members the class declares, so `Point(…)` constructs and
+// `Point.origin` reads. A class with no statics binds an object carrying the signature alone, so
+// `typeof Point` is `{new (x: number) -> Point}` rather than the bare `fn (x: number) -> Point`.
+//
+// One shape for every class is what lets a `{new (…) -> R, ...}` target accept any class value
+// through constrain's ordinary object-against-object arm. A statics-free class bound to its bare
+// constructor function would need an arm of its own, and that arm could not tell a constructor
+// from an ordinary function, since a FuncType records nothing about constructibility.
 func (c *checker) classValue(ctorType soltype.Type, static *soltype.ObjectType) soltype.Type {
-	if len(static.Elems) == 0 {
-		return ctorType
-	}
 	// inferConstructor always returns a FuncType, so anything else is a wiring bug.
 	// Fail loudly rather than drop the statics by returning the bare ctorType.
 	ctorFn, ok := ctorType.(*soltype.FuncType)

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -39,7 +39,7 @@ func TestInferClassBasic(t *testing.T) {
 					y: number,
 				}
 			`,
-			wantValues: map[string]string{"Point": "fn (x: number, y: number) -> Point"},
+			wantValues: map[string]string{"Point": "{new (x: number, y: number) -> Point}"},
 			wantTypes:  map[string]string{"Point": "Point"},
 		},
 		{
@@ -53,7 +53,7 @@ func TestInferClassBasic(t *testing.T) {
 				val px = p.x
 			`,
 			wantValues: map[string]string{
-				"Point": "fn (x: number, y: number) -> Point",
+				"Point": "{new (x: number, y: number) -> Point}",
 				"p":     "Point",
 				"px":    "number",
 			},
@@ -86,7 +86,7 @@ func TestInferClassBasic(t *testing.T) {
 				val px = p.x
 			`,
 			wantValues: map[string]string{
-				"Point": "fn (x: number, y: number) -> Point",
+				"Point": "{new (x: number, y: number) -> Point}",
 				"p":     "Point",
 				"px":    "number",
 			},
@@ -125,10 +125,10 @@ func TestInferClassBasic(t *testing.T) {
 	}
 }
 
-// TestInferClassStatic covers the callable class value with static members. The value
-// binds a ctor-plus-static object rather than a bare constructor function, so
-// construction still resolves through the constructor call signature, a static field
-// reads its declared type, and a static method reads and calls through the same value.
+// TestInferClassStatic covers the callable class value with static members. The statics sit
+// alongside the construct signature in the same object, so construction still resolves through
+// the signature, a static field reads its declared type, and a static method reads and calls
+// through the same value.
 func TestInferClassStatic(t *testing.T) {
 	src := `
 		class Vec {
@@ -151,10 +151,11 @@ func TestInferClassStatic(t *testing.T) {
 	}, map[string]string{"Vec": "Vec"})
 }
 
-// A class with no static members keeps binding its bare constructor function, so the
-// single-callable-element object is minted only for the class values that need it.
-// Construction and field access are unaffected.
-func TestInferClassNoStaticStaysFunction(t *testing.T) {
+// A class with no static members binds an object carrying its construct signature alone, the
+// same shape a class with statics binds. One shape for every class value is what lets a
+// `{new (…) -> R, ...}` target accept any of them through ordinary object subtyping.
+// Construction and field access read through the signature either way.
+func TestInferClassNoStaticsBindsSignatureOnlyObject(t *testing.T) {
 	src := `
 		class Point {
 			x: number,
@@ -163,7 +164,7 @@ func TestInferClassNoStaticStaysFunction(t *testing.T) {
 		val p = Point(1, 2)
 	`
 	classValues(t, src, map[string]string{
-		"Point": "fn (x: number, y: number) -> Point",
+		"Point": "{new (x: number, y: number) -> Point}",
 		"p":     "Point",
 	}, nil)
 }
@@ -218,7 +219,7 @@ func TestInferClassGeneric(t *testing.T) {
 				val v = b.value
 			`,
 			wantValues: map[string]string{
-				"Box": "fn <T0>(value: T0) -> Box<T0>",
+				"Box": "<T0> {new (value: T0) -> Box<T0>}",
 				"b":   "Box<5>",
 				"v":   "5",
 			},
@@ -522,8 +523,8 @@ func TestInferClassMutualRecursion(t *testing.T) {
 				class B { a: A }
 			`,
 			wantValues: map[string]string{
-				"A": "fn (b: B) -> A",
-				"B": "fn (a: A) -> B",
+				"A": "{new (b: B) -> A}",
+				"B": "{new (a: A) -> B}",
 			},
 			wantTypes: map[string]string{"A": "A", "B": "B"},
 		},
@@ -531,7 +532,7 @@ func TestInferClassMutualRecursion(t *testing.T) {
 			// A self-referential field resolves to the class being declared.
 			name:       "SelfReferentialField",
 			src:        `class Node { next: Node }`,
-			wantValues: map[string]string{"Node": "fn (next: Node) -> Node"},
+			wantValues: map[string]string{"Node": "{new (next: Node) -> Node}"},
 			wantTypes:  map[string]string{"Node": "Node"},
 		},
 		{
@@ -549,8 +550,8 @@ func TestInferClassMutualRecursion(t *testing.T) {
 				}
 			`,
 			wantValues: map[string]string{
-				"A": "fn (b: B) -> A",
-				"B": "fn (a: A) -> B",
+				"A": "{new (b: B) -> A}",
+				"B": "{new (a: A) -> B}",
 			},
 			wantTypes: map[string]string{"A": "A", "B": "B"},
 		},
@@ -564,9 +565,9 @@ func TestInferClassMutualRecursion(t *testing.T) {
 				class C { a: A }
 			`,
 			wantValues: map[string]string{
-				"A": "fn (b: B) -> A",
-				"B": "fn (c: C) -> B",
-				"C": "fn (a: A) -> C",
+				"A": "{new (b: B) -> A}",
+				"B": "{new (c: C) -> B}",
+				"C": "{new (a: A) -> C}",
 			},
 			wantTypes: map[string]string{"A": "A", "B": "B", "C": "C"},
 		},
@@ -630,7 +631,7 @@ func TestInferClassMethodRecursion(t *testing.T) {
 					loop(self, k: number) -> number { return self.loop(k) },
 				}
 			`,
-			wantValues: map[string]string{"C": "fn (n: number) -> C"},
+			wantValues: map[string]string{"C": "{new (n: number) -> C}"},
 		},
 		{
 			// A mutually recursive pair with annotated returns type-checks; each call
@@ -643,7 +644,7 @@ func TestInferClassMethodRecursion(t *testing.T) {
 					pong(self, k: number) -> number { return self.ping(k) },
 				}
 			`,
-			wantValues: map[string]string{"C": "fn (n: number) -> C"},
+			wantValues: map[string]string{"C": "{new (n: number) -> C}"},
 		},
 		{
 			// A method reads a getter of the same class through self; the getter's value
@@ -671,7 +672,7 @@ func TestInferClassMethodRecursion(t *testing.T) {
 					update(mut self) -> number { return self.helper() },
 				}
 			`,
-			wantValues: map[string]string{"C": "fn (n: number) -> C"},
+			wantValues: map[string]string{"C": "{new (n: number) -> C}"},
 		},
 		{
 			// A destructuring method parameter is handled: the stub carries arity only, so
@@ -965,7 +966,7 @@ func TestInferClassGenericSubGenericSuper(t *testing.T) {
 		val g = d.tag
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <T0>(tag: T0) -> Dog<T0>", values["Dog"])
+	require.Equal(t, "<T0> {new (tag: T0) -> Dog<T0>}", values["Dog"])
 	require.Equal(t, `Dog<"bone">`, values["d"])
 	require.Equal(t, `"bone"`, values["f"])
 	require.Equal(t, `"bone"`, values["g"])
@@ -1005,7 +1006,7 @@ func TestInferClassGenericMemberParam(t *testing.T) {
 		val b = Box(5)
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <T0>(v: T0) -> Box<T0>", values["Box"])
+	require.Equal(t, "<T0> {new (v: T0) -> Box<T0>}", values["Box"])
 	require.Equal(t, "Box<5>", values["b"])
 }
 
@@ -1567,8 +1568,8 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 			// Each constructor is synthesized from its OWN class body, so the two bodies
 			// never merged on a shared "Point" registry entry. Both render bare.
 			wantValues: map[string]string{
-				"geometry.Point": "fn (x: number) -> Point",
-				"shape.Point":    "fn (label: string) -> Point",
+				"geometry.Point": "{new (x: number) -> Point}",
+				"shape.Point":    "{new (label: string) -> Point}",
 			},
 			wantTypes: map[string]string{
 				"geometry.Point": "Point",
@@ -1590,8 +1591,8 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 			// The bare `Point` in Line's field resolves to the sibling geometry.Point
 			// through the class's own namespace, not to any other namespace's Point.
 			wantValues: map[string]string{
-				"geometry.Line":  "fn (start: Point) -> Line",
-				"geometry.Point": "fn (x: number) -> Point",
+				"geometry.Line":  "{new (start: Point) -> Line}",
+				"geometry.Point": "{new (x: number) -> Point}",
 			},
 			wantTypes: map[string]string{
 				"geometry.Line":  "Line",
@@ -1615,8 +1616,8 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 			// The qualified `geometry.Point` reference from the shape namespace resolves
 			// to the geometry class's registered type binding.
 			wantValues: map[string]string{
-				"shape.Line":     "fn (start: Point) -> Line",
-				"geometry.Point": "fn (x: number) -> Point",
+				"shape.Line":     "{new (start: Point) -> Line}",
+				"geometry.Point": "{new (x: number) -> Point}",
 			},
 			wantTypes: map[string]string{
 				"shape.Line":     "Line",
@@ -1634,7 +1635,7 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 			},
 			// A root-namespace class keeps its bare name as the qualified key, so nothing
 			// changes for the common single-namespace case.
-			wantValues: map[string]string{"Point": "fn (x: number) -> Point"},
+			wantValues: map[string]string{"Point": "{new (x: number) -> Point}"},
 			wantTypes:  map[string]string{"Point": "Point"},
 		},
 		{
@@ -1658,8 +1659,8 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 			// resolves through the shared handle with no placeholder leak. Each field
 			// renders the peer under its bare name.
 			wantValues: map[string]string{
-				"foo.A": "fn (peer: B) -> A",
-				"bar.B": "fn (peer: A) -> B",
+				"foo.A": "{new (peer: B) -> A}",
+				"bar.B": "{new (peer: A) -> B}",
 			},
 			wantTypes: map[string]string{
 				"foo.A": "A",

--- a/internal/solver/infer_ctor_ann_test.go
+++ b/internal/solver/infer_ctor_ann_test.go
@@ -160,10 +160,9 @@ func TestInferKeyofConstructorCarryingObject(t *testing.T) {
 }
 
 // A class value fills an object annotation that names a construct signature, which is what
-// `InstanceType<typeof C>` relies on. classValue gives a class with no statics its bare
-// constructor FuncType, so the sub is a function rather than an object, and constrain's
-// constructor-only rule is what accepts it. A class with statics is already an object carrying a
-// ConstructorElem, and it needs an inexact target since its statics are extra members.
+// `InstanceType<typeof C>` relies on. Both cases go through the same object-against-object arm,
+// since classValue gives every class an object carrying a ConstructorElem. The class with
+// statics needs an inexact target, because its statics are extra members against an exact one.
 func TestInferClassValueSatisfiesConstructorAnnotation(t *testing.T) {
 	tests := []struct {
 		name string
@@ -199,16 +198,27 @@ func TestInferClassValueSatisfiesConstructorAnnotation(t *testing.T) {
 	}
 }
 
-// The constructor-only rule fires only when the signature is the target's whole member list. A
-// target that also names a static demands a member a bare function cannot supply, so it stays on
-// the object-against-object arm and reports the miss there.
-func TestInferBareFunctionMissesConstructorTargetWithStatics(t *testing.T) {
+// A target that names a static the class does not declare reports the missing member, since a
+// class value is an object and this is ordinary object subtyping.
+func TestInferClassValueMissesConstructorTargetWithStatics(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		class Point {
 			x: number,
 			constructor(mut self, x: number) { self.x = x },
 		}
 		val ctor: {new (x: number) -> Point, origin: Point} = Point
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "object is missing property: origin", errs[0].Message())
+}
+
+// A plain function never fills a target that names a construct signature. Only a class value
+// carries a ConstructorElem, and a FuncType records nothing about constructibility, so accepting
+// one here would make every function a constructor.
+func TestInferPlainFunctionMissesConstructorTarget(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn make(x: number) -> {a: number} { return {a: x} }
+		val ctor: {new (x: number) -> {a: number}} = make
 	`)
 	require.Len(t, errs, 1)
 	require.Equal(t, "cannot constrain function <: object", errs[0].Message())

--- a/internal/solver/infer_ctor_ann_test.go
+++ b/internal/solver/infer_ctor_ann_test.go
@@ -9,9 +9,10 @@ import (
 
 // --- M9 PR15: `new (…) -> T` members in object type annotations ---
 
-// A `new (…) -> T` member resolves to the same ConstructorElem a class value carries, so the
-// annotation round-trips through the soltype printer as the source wrote it. The signature accepts
-// everything a `fn` annotation does, since both parse and resolve through the same path.
+// A `new (…) -> T` member resolves to the same ConstructorElem a class value carries, and the
+// soltype printer renders it back as `new (…) -> T`. The signature accepts everything a `fn`
+// annotation does, since both parse and resolve through the same path. The BesideProperty case
+// shows the one way the rendering departs from the source, which the next test explains.
 func TestInferConstructorTypeAnnRoundTrip(t *testing.T) {
 	tests := []struct {
 		name string
@@ -58,6 +59,19 @@ func TestInferConstructorTypeAnnGeneric(t *testing.T) {
 	nodes, _, errs := inferTypeNodes(t, `type Result = {new <T>(x: T) -> {a: T}}`)
 	require.Empty(t, errs)
 	require.Equal(t, "{new <T>(x: T) -> {a: T}}", soltype.Print(nodes["Result"]))
+}
+
+// A type named inside a construct signature is a dependency of the enclosing alias, so the
+// declaration order in the source does not matter. ObjectTypeAnn.Accept already walks a
+// ConstructorTypeAnn's signature, which is what puts the reference in the dependency graph.
+func TestInferConstructorTypeAnnForwardReference(t *testing.T) {
+	nodes, _, errs := inferTypeNodes(t, `
+		type Result = {new (x: Arg) -> Made}
+		type Arg = number
+		type Made = {a: number}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "{new (x: Arg) -> Made}", soltype.Print(nodes["Result"]))
 }
 
 // soltype.ObjectType.Constructor() returns at most one construct signature and constrain checks a

--- a/internal/solver/infer_ctor_ann_test.go
+++ b/internal/solver/infer_ctor_ann_test.go
@@ -100,6 +100,36 @@ func TestInferConstructorTypeAnnWithSpread(t *testing.T) {
 		soltype.Print(expandResidual(ctx, nodes["Result"])))
 }
 
+// The spread merge folds two operands together under the member they overlap on. A construct
+// signature is unnamed and a property key may itself be the empty string, so both would answer
+// `""` if the merge keyed on the name alone. They are distinct members, so an object carrying
+// both keeps both, in either written order.
+func TestInferConstructorTypeAnnAndEmptyStringKeyBothSurvive(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			"SignatureFirst",
+			`type Result = {new () -> number, "": string, ...Base}`,
+			`{new () -> number, "": string, q: number}`,
+		},
+		{
+			"PropertyFirst",
+			`type Result = {"": string, new () -> number, ...Base}`,
+			`{"": string, new () -> number, q: number}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, "type Base = {q: number}\n"+tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
 // keyofObject projects property, getter, and setter names. A construct signature is unnamed, so it
 // contributes no key at all rather than an empty-string one, and `keyof {new (…) -> T, origin: N}`
 // is just `"origin"`. A signature-only object has an empty key set, which is `never`.

--- a/internal/solver/infer_ctor_ann_test.go
+++ b/internal/solver/infer_ctor_ann_test.go
@@ -1,0 +1,171 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- M9 PR15: `new (…) -> T` members in object type annotations ---
+
+// A `new (…) -> T` member resolves to the same ConstructorElem a class value carries, so the
+// annotation round-trips through the soltype printer as the source wrote it. The signature accepts
+// everything a `fn` annotation does, since both parse and resolve through the same path.
+func TestInferConstructorTypeAnnRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"OneParam", `type Result = {new (x: number) -> {a: number}}`, "{new (x: number) -> {a: number}}"},
+		{"NoParams", `type Result = {new () -> {a: number}}`, "{new () -> {a: number}}"},
+		{
+			"BesideProperty",
+			`type Result = {new (x: number) -> {a: number}, origin: number}`,
+			"{origin: number, new (x: number) -> {a: number}}",
+		},
+		{
+			"RestParam",
+			`type Result = {new (...args: [number, string]) -> {a: number}}`,
+			"{new (...args: [number, string]) -> {a: number}}",
+		},
+		{
+			"Throws",
+			`type Result = {new (x: number) -> {a: number} throws string}`,
+			"{new (x: number) -> {a: number} throws string}",
+		},
+		{
+			"Inexact",
+			`type Result = {new (x: number) -> {a: number}, ...}`,
+			"{new (x: number) -> {a: number}, ...}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, _, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(nodes["Result"]))
+		})
+	}
+}
+
+// A construct signature is unnamed, so the dedup builder has no key to file it under and appends
+// it after the properties. That ordering is why BesideProperty above renders the signature last
+// while the source wrote it first. A generic signature keeps its own type parameters, which the
+// enclosing annotation does not bind.
+func TestInferConstructorTypeAnnGeneric(t *testing.T) {
+	nodes, _, errs := inferTypeNodes(t, `type Result = {new <T>(x: T) -> {a: T}}`)
+	require.Empty(t, errs)
+	require.Equal(t, "{new <T>(x: T) -> {a: T}}", soltype.Print(nodes["Result"]))
+}
+
+// soltype.ObjectType.Constructor() returns at most one construct signature and constrain checks a
+// requirement against that one, so a second `new` member is reported rather than dropped in
+// silence. The object still carries the first signature, so the annotation stays usable.
+func TestInferDuplicateConstructorTypeAnnRejected(t *testing.T) {
+	nodes, _, errs := inferTypeNodes(t, `
+		type Result = {new (x: number) -> {a: number}, new (y: string) -> {a: number}}
+	`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &DuplicateConstructorSignatureError{}, errs[0])
+	require.Equal(t, "An object type may declare at most one `new` signature.", errs[0].Message())
+	require.Equal(t, "{new (x: number) -> {a: number}}", soltype.Print(nodes["Result"]))
+}
+
+// A `...A` spread puts the object on the ordered path, where a construct signature keeps its
+// source position rather than being appended. The spread's operand grounds here, so the member
+// list merges and the signature survives the merge.
+func TestInferConstructorTypeAnnWithSpread(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Base = {origin: number}
+		type Result = {new (x: number) -> {a: number}, ...Base}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "{new (x: number) -> {a: number}, origin: number}",
+		soltype.Print(expandResidual(ctx, nodes["Result"])))
+}
+
+// keyofObject projects property, getter, and setter names. A construct signature is unnamed, so it
+// contributes no key at all rather than an empty-string one, and `keyof {new (…) -> T, origin: N}`
+// is just `"origin"`. A signature-only object has an empty key set, which is `never`.
+func TestInferKeyofConstructorCarryingObject(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			"SignatureIsSkipped",
+			`type Result = keyof {new (x: number) -> {a: number}, origin: number}`,
+			`"origin"`,
+		},
+		{
+			"SignatureOnlyHasNoKeys",
+			`type Result = keyof {new (x: number) -> {a: number}}`,
+			"never",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A class value fills an object annotation that names a construct signature, which is what
+// `InstanceType<typeof C>` relies on. classValue gives a class with no statics its bare
+// constructor FuncType, so the sub is a function rather than an object, and constrain's
+// constructor-only rule is what accepts it. A class with statics is already an object carrying a
+// ConstructorElem, and it needs an inexact target since its statics are extra members.
+func TestInferClassValueSatisfiesConstructorAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			"NoStatics",
+			`
+				class Point {
+					x: number,
+					constructor(mut self, x: number) { self.x = x },
+				}
+				val ctor: {new (x: number) -> Point} = Point
+			`,
+		},
+		{
+			"WithStatics",
+			`
+				class Counter {
+					n: number,
+					static zero: number = 0,
+					constructor(mut self, n: number) { self.n = n },
+				}
+				val ctor: {new (n: number) -> Counter, ...} = Counter
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+		})
+	}
+}
+
+// The constructor-only rule fires only when the signature is the target's whole member list. A
+// target that also names a static demands a member a bare function cannot supply, so it stays on
+// the object-against-object arm and reports the miss there.
+func TestInferBareFunctionMissesConstructorTargetWithStatics(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class Point {
+			x: number,
+			constructor(mut self, x: number) { self.x = x },
+		}
+		val ctor: {new (x: number) -> Point, origin: Point} = Point
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain function <: object", errs[0].Message())
+}

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -138,7 +138,7 @@ func TestInferEnumClassMutuallyRecursive(t *testing.T) {
 		val treeCtor = Tree.Branch
 		val kids = node.left
 	`, map[string]string{
-		"Node":     "fn (left: Tree, right: Tree) -> Node",
+		"Node":     "{new (left: Tree, right: Tree) -> Node}",
 		"node":     "Node",
 		"branch":   "Tree",
 		"treeCtor": "fn (node: Node) -> Tree",

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1419,9 +1419,9 @@ func funcIntersectionArms(t soltype.Type) ([]*soltype.FuncType, bool) {
 // bound yet) — the caller skips return recovery. PR1 bindings have at most one
 // func lower bound; overload sets (PR6) resolve through resolveOverload, not here.
 //
-// A class value with static members is an object carrying its constructor as a
-// ConstructorElem rather than a bare FuncType, so a call `Point(1, 2)` recovers the
-// constructor signature through that element. An inline object callee yields it directly.
+// A class value is an object carrying its constructor as a ConstructorElem rather than a
+// bare FuncType, so a call `Point(1, 2)` recovers the constructor signature through that
+// element. An inline object callee yields it directly.
 // A binding var yields it through an object lower bound, the same look-through the
 // FuncType arm runs for a named function.
 func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -459,17 +459,17 @@ func (c *checker) resolveQualClassType(scope *Scope, qi ast.QualIdent) (*soltype
 	return ct, isClass
 }
 
-// ctorSignature resolves a value to its constructor signature in one of three shapes: a bare
-// FuncType, a class value object's ConstructorElem, or either of those reached through a
-// binding var's lower bounds. The var case is the common one, since a class value is a
-// pre-bound var during its own inference component with the constructor recorded as a lower
-// bound.
+// ctorSignature resolves a value to its constructor signature in one of three shapes: a class
+// value object's ConstructorElem, a bare FuncType, or either of those reached through a binding
+// var's lower bounds. The var case is the common one, since a class value is a pre-bound var
+// during its own inference component with the constructor recorded as a lower bound.
 //
-// For `class Point { x: number, y: number }` the value `Point` resolves mid-inference to a
-// var whose lower bound is `fn (x: number, y: number) -> Point`, and ctorSignature looks
-// through the var to that FuncType. A class that also declares static members instead binds
-// an ObjectType carrying a ConstructorElem, so the ObjectType arm returns its Constructor().Fn.
-// A var with two conflicting constructor lower bounds is ambiguous and left unresolved.
+// For `class Point { x: number, y: number }` the value `Point` resolves mid-inference to a var
+// whose lower bound is `{new (x: number, y: number) -> Point}`, and ctorSignature looks through
+// the var to that object, returning its Constructor().Fn. Every class value has that shape,
+// statics or not. The bare-FuncType arm is what an extractor pattern naming a plain function
+// resolves through. A var with two conflicting constructor lower bounds is ambiguous and left
+// unresolved.
 func ctorSignature(t soltype.Type) (*soltype.FuncType, bool) {
 	switch t := t.(type) {
 	case *soltype.FuncType:

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -104,7 +104,7 @@ func TestInferScriptClass(t *testing.T) {
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, "Point", types["Point"])
-	require.Equal(t, "fn (x: number, y: number) -> Point", values["Point"])
+	require.Equal(t, "{new (x: number, y: number) -> Point}", values["Point"])
 	require.Equal(t, "Point", values["p"])
 	require.Equal(t, "number", values["px"])
 	require.Equal(t, "number", values["d"])

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -202,24 +202,21 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	}
 	unsupported := false
 	sawCtor := false
-	// resolveCtor lowers one `new (…) -> T` member, reporting a second one in the same
-	// annotation rather than emitting it. soltype.ObjectType.Constructor() returns at most one
-	// construct signature and constrain checks a requirement against that one, so a second
-	// would be dropped without a diagnostic.
+	// resolveCtor lowers one `new (…) -> T` member to a ConstructorElem. An object type carries
+	// at most one construct signature, so a second is reported through
+	// DuplicateConstructorSignatureError instead of being emitted.
 	resolveCtor := func(ctor *ast.ConstructorTypeAnn) soltype.ObjTypeElem {
 		if sawCtor {
 			c.report(&DuplicateConstructorSignatureError{Ctor: ctor})
 			return nil
 		}
 		sawCtor = true
-		fn, ok := c.resolveFuncTypeAnn(scope, ctor.Fn, lvl)
-		if !ok {
-			return nil
-		}
-		// resolveFuncTypeAnn returns a FuncType for every signature it resolves, so anything
-		// else is a wiring bug rather than a source error.
-		fnType, ok := fn.(*soltype.FuncType)
-		if !ok {
+		// resolveFuncTypeAnn recovers every unsupported part of a signature to a fresh var, so
+		// it always yields a FuncType and its ok result is always true. Anything else is a
+		// wiring bug rather than a source error, so fail loudly instead of dropping the member.
+		fn, _ := c.resolveFuncTypeAnn(scope, ctor.Fn, lvl)
+		fnType, isFunc := fn.(*soltype.FuncType)
+		if !isFunc {
 			panic(fmt.Sprintf("resolveObjectTypeAnn: `new` signature resolved to %T, not *soltype.FuncType", fn))
 		}
 		return &soltype.ConstructorElem{Fn: fnType}
@@ -233,9 +230,10 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 		b := newObjElemBuilder(len(ta.Elems))
 		var ctors []soltype.ObjTypeElem
 		for _, elem := range ta.Elems {
-			// A construct signature is unnamed, so it has no key for the builder to dedup on
-			// and is collected separately. Its position among the properties carries no
-			// meaning, so appending the two groups keeps the member set the source wrote.
+			// A construct signature is unnamed, so the key-dedup builder has no key to file it
+			// under. Collect it separately and append it after the properties. Its position
+			// among them carries no meaning, since every reader reaches it through
+			// ObjectType.Constructor() rather than by index.
 			if ctor, ok := elem.(*ast.ConstructorTypeAnn); ok {
 				if resolved := resolveCtor(ctor); resolved != nil {
 					ctors = append(ctors, resolved)
@@ -281,7 +279,7 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 		}
 	}
 	if unsupported {
-		c.reportUnsupportedFeature(ta, "object type member other than a property or spread")
+		c.reportUnsupportedFeature(ta, "object type member other than a property, spread, mapped member, or `new` signature")
 	}
 	t := &soltype.ObjectType{Elems: elems, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"fmt"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -171,8 +173,10 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 // to a PropertyElem; a `...A` spread resolves to a SpreadElem, so `{...A, x: T}` is an
 // ObjectType carrying a spread element — the object twin of a spread-carrying tuple. The
 // evaluator merges the spread once its operand grounds; until then the object stays a
-// residual that prints the way the source wrote it. Method/getter/setter members (M5) and
-// mapped/index signatures (M9) are not yet part of an object annotation and report an
+// residual that prints the way the source wrote it. A `new (…) -> T` member resolves to a
+// ConstructorElem, the same construct signature a class value carries, which is what lets
+// `InstanceType<C>` and `ConstructorParameters<C>` match a written object type. Method,
+// getter, and setter members are not yet part of an object annotation and report an
 // unsupported feature, with the object still built from the members that do resolve.
 //
 // A spread-free object dedups duplicate keys last-wins-first-position, keeping property
@@ -197,6 +201,29 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 		}
 	}
 	unsupported := false
+	sawCtor := false
+	// resolveCtor lowers one `new (…) -> T` member, reporting a second one in the same
+	// annotation rather than emitting it. soltype.ObjectType.Constructor() returns at most one
+	// construct signature and constrain checks a requirement against that one, so a second
+	// would be dropped without a diagnostic.
+	resolveCtor := func(ctor *ast.ConstructorTypeAnn) soltype.ObjTypeElem {
+		if sawCtor {
+			c.report(&DuplicateConstructorSignatureError{Ctor: ctor})
+			return nil
+		}
+		sawCtor = true
+		fn, ok := c.resolveFuncTypeAnn(scope, ctor.Fn, lvl)
+		if !ok {
+			return nil
+		}
+		// resolveFuncTypeAnn returns a FuncType for every signature it resolves, so anything
+		// else is a wiring bug rather than a source error.
+		fnType, ok := fn.(*soltype.FuncType)
+		if !ok {
+			panic(fmt.Sprintf("resolveObjectTypeAnn: `new` signature resolved to %T, not *soltype.FuncType", fn))
+		}
+		return &soltype.ConstructorElem{Fn: fnType}
+	}
 	var elems []soltype.ObjTypeElem
 	// The two paths differ only in when duplicate keys collapse. A residual-free object is never
 	// reduced later, so its duplicates must collapse here to the unique-key shape Prop and equalType
@@ -204,7 +231,17 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	// once its spreads and mapped members ground.
 	if !hasResidual {
 		b := newObjElemBuilder(len(ta.Elems))
+		var ctors []soltype.ObjTypeElem
 		for _, elem := range ta.Elems {
+			// A construct signature is unnamed, so it has no key for the builder to dedup on
+			// and is collected separately. Its position among the properties carries no
+			// meaning, so appending the two groups keeps the member set the source wrote.
+			if ctor, ok := elem.(*ast.ConstructorTypeAnn); ok {
+				if resolved := resolveCtor(ctor); resolved != nil {
+					ctors = append(ctors, resolved)
+				}
+				continue
+			}
 			prop, ok := elem.(*ast.PropertyTypeAnn)
 			if !ok {
 				unsupported = true
@@ -216,7 +253,7 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			}
 			b.add(name, ft, prop.Optional, prop.Readonly)
 		}
-		elems = b.elems
+		elems = append(b.elems, ctors...)
 	} else {
 		for _, elem := range ta.Elems {
 			switch elem := elem.(type) {
@@ -234,6 +271,10 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 				elems = append(elems, &soltype.SpreadElem{Type: src})
 			case *ast.MappedTypeAnn:
 				elems = append(elems, c.resolveMappedElem(scope, elem, lvl))
+			case *ast.ConstructorTypeAnn:
+				if resolved := resolveCtor(elem); resolved != nil {
+					elems = append(elems, resolved)
+				}
 			default:
 				unsupported = true
 			}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"unicode"
@@ -650,19 +651,52 @@ func mergeSpreadOperands(operandElems [][]soltype.ObjTypeElem) []soltype.ObjType
 	return out
 }
 
-// mergeKey identifies the member two spread operands overlap on. A construct signature is
-// unnamed, so keying the merge on ObjElemName alone would fold it together with a property
-// literally named `""`, dropping whichever the merge visited first. ctor separates the two, so
-// `{new () -> number, "": string, ...B}` keeps both members, and two construct signatures still
-// collapse to the rightmost one.
+// mergeKey identifies the member two spread operands overlap on. Two members merge only when
+// their keys are equal.
+//
+// A named member — a property, method, getter, or setter — keys on its name, and they all share
+// one kind so that a getter and a property of the same name still merge with the rightmost
+// winning. A member with no name keys on its kind alone, since it has no name to distinguish it
+// by and no sibling of another kind it could be confused with.
+//
+// The kind is what separates the two groups, not an empty name, because a property key may
+// itself be the literal empty string. Keying every member on ObjElemName alone folded
+// `{new () -> number, "": string}` into one member and dropped whichever the merge reached
+// first, since ObjElemName answers `""` for both.
 type mergeKey struct {
-	name string
-	ctor bool
+	kind objElemKind
+	name string // meaningful only for kindNamed; an unnamed member leaves it empty
 }
 
+// objElemKind is the part of a mergeKey that says which group of members an element belongs to.
+// mergeKeyOf switches over every ObjTypeElem variant and panics on one it does not name, so a
+// new element kind has to state whether it merges by name or stands alone rather than silently
+// sharing another kind's key. The call signature escalier-lang/escalier#992 adds is the next
+// such kind, and it stands alone.
+type objElemKind uint8
+
+const (
+	kindNamed objElemKind = iota
+	kindConstructor
+	kindMapped
+	kindSpread
+)
+
 func mergeKeyOf(elem soltype.ObjTypeElem) mergeKey {
-	_, isCtor := elem.(*soltype.ConstructorElem)
-	return mergeKey{name: soltype.ObjElemName(elem), ctor: isCtor}
+	switch elem.(type) {
+	case *soltype.PropertyElem, *soltype.MethodElem, *soltype.GetterElem, *soltype.SetterElem:
+		return mergeKey{kind: kindNamed, name: soltype.ObjElemName(elem)}
+	case *soltype.ConstructorElem:
+		return mergeKey{kind: kindConstructor}
+	case *soltype.MappedElem:
+		// A mapped member and a spread each stand for a group of members the evaluator has not
+		// computed yet, so neither reaches a merge: reduceObject expands both into field groups
+		// before it merges, and bails out when one cannot ground.
+		return mergeKey{kind: kindMapped}
+	case *soltype.SpreadElem:
+		return mergeKey{kind: kindSpread}
+	}
+	panic(fmt.Sprintf("mergeKeyOf: unhandled ObjTypeElem %T", elem))
 }
 
 // mergeSpreadElem combines an earlier object member with a later one of the same name under Flow's

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -635,19 +635,34 @@ func mergeSpreadOperands(operandElems [][]soltype.ObjTypeElem) []soltype.ObjType
 		total += len(elems)
 	}
 	out := make([]soltype.ObjTypeElem, 0, total)
-	pos := make(map[string]int, total)
+	pos := make(map[mergeKey]int, total)
 	for _, elems := range operandElems {
 		for _, elem := range elems {
-			name := soltype.ObjElemName(elem)
-			if i, seen := pos[name]; seen {
+			key := mergeKeyOf(elem)
+			if i, seen := pos[key]; seen {
 				out[i] = mergeSpreadElem(out[i], elem)
 				continue
 			}
-			pos[name] = len(out)
+			pos[key] = len(out)
 			out = append(out, elem)
 		}
 	}
 	return out
+}
+
+// mergeKey identifies the member two spread operands overlap on. A construct signature is
+// unnamed, so keying the merge on ObjElemName alone would fold it together with a property
+// literally named `""`, dropping whichever the merge visited first. ctor separates the two, so
+// `{new () -> number, "": string, ...B}` keeps both members, and two construct signatures still
+// collapse to the rightmost one.
+type mergeKey struct {
+	name string
+	ctor bool
+}
+
+func mergeKeyOf(elem soltype.ObjTypeElem) mergeKey {
+	_, isCtor := elem.(*soltype.ConstructorElem)
+	return mergeKey{name: soltype.ObjElemName(elem), ctor: isCtor}
 }
 
 // mergeSpreadElem combines an earlier object member with a later one of the same name under Flow's

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -946,6 +946,27 @@ func TestUtilityTypeInstanceType(t *testing.T) {
 	})
 }
 
+// An ordinary function matches both constructor patterns, where TypeScript reduces each
+// application to `never`. This is the cost of the rule that lets a bare function fill a
+// constructor-only object target, which is itself what makes `InstanceType<typeof C>` work for a
+// class with no statics — classValue binds such a class to its bare constructor function, so
+// nothing distinguishes it from a function that is not a constructor. These cases pin the
+// divergence so a later change that separates the two shows up here.
+func TestUtilityTypeConstructorUtilitiesAcceptOrdinaryFunction(t *testing.T) {
+	runUtilityReductions(t, []utilityReduction{
+		{
+			name:         "InstanceTypeReadsTheReturn",
+			src:          `type Result = InstanceType<fn (x: number) -> {a: number}>`,
+			wantExpanded: "{a: number}",
+		},
+		{
+			name:         "ConstructorParametersReadsTheParams",
+			src:          `type Result = ConstructorParameters<fn (x: number) -> {a: number}>`,
+			wantExpanded: "[number]",
+		},
+	})
+}
+
 // A class value is what `typeof C` names, and `InstanceType<typeof C>` reads its instance off
 // the construct signature. classValue gives a class with no statics its bare constructor
 // FuncType and one with statics an object carrying a ConstructorElem, so the two render

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -946,11 +946,9 @@ func TestUtilityTypeInstanceType(t *testing.T) {
 	})
 }
 
-// A function whose return is not a nominal class instance is not a constructor, so both
-// utilities reduce to `never` over one, matching TypeScript. A bare function can fill a
-// constructor-only target at all only because classValue binds a class with no statics to its
-// bare constructor function; requiring a class return is what keeps that allowance from reaching
-// every function.
+// A function is not a constructor, so both utilities reduce to `never` over one, matching
+// TypeScript. Matching runs through the ConstructorElem a class value carries, and a FuncType
+// has none.
 func TestUtilityTypeConstructorUtilitiesRejectOrdinaryFunction(t *testing.T) {
 	runUtilityReductions(t, []utilityReduction{
 		{
@@ -966,11 +964,10 @@ func TestUtilityTypeConstructorUtilitiesRejectOrdinaryFunction(t *testing.T) {
 	})
 }
 
-// A factory function returning a class instance still matches, where TypeScript gives `never`.
-// The test is the return type, and a factory's return is indistinguishable from a constructor's,
-// so this is what a marker-free rule admits. It is pinned so a later change that carries
-// constructibility on FuncType shows up here.
-func TestUtilityTypeConstructorUtilitiesAcceptClassReturningFactory(t *testing.T) {
+// A factory returning a class instance is not a constructor either, so it reduces to `never`
+// like any other function. Nothing about its return makes it match, since matching goes through
+// the ConstructorElem only a class value carries.
+func TestUtilityTypeConstructorUtilitiesRejectClassReturningFactory(t *testing.T) {
 	runUtilityReductions(t, []utilityReduction{
 		{
 			name: "InstanceTypeOfFactory",
@@ -982,17 +979,16 @@ func TestUtilityTypeConstructorUtilitiesAcceptClassReturningFactory(t *testing.T
 				fn make(x: number) -> Point { return Point(x) }
 				type Result = InstanceType<typeof make>
 			`,
-			wantExpanded: "Point",
+			wantExpanded: "never",
 		},
 	})
 }
 
 // A class value is what `typeof C` names, and `InstanceType<typeof C>` reads its instance off
-// the construct signature. classValue gives a class with no statics its bare constructor
-// FuncType and one with statics an object carrying a ConstructorElem, so the two render
-// differently — `fn (x: number) -> Point` against `{new (x: number) -> Counter, zero: Counter}`.
-// constrain's rule that a bare function fills a constructor-only object target is what makes one
-// pattern match both.
+// the construct signature. Every class value is an object carrying a ConstructorElem, so the two
+// differ only in what sits beside the signature — `{new (x: number) -> Point}` against
+// `{new (n: number) -> Counter, zero: number}`. One pattern matches both because its trailing
+// `...` tolerates the statics.
 func TestUtilityTypeInstanceTypeOfClass(t *testing.T) {
 	runUtilityReductions(t, []utilityReduction{
 		{

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -1016,3 +1016,66 @@ func TestUtilityTypeInstanceTypeOfClass(t *testing.T) {
 		},
 	})
 }
+
+// `ConstructorParameters<typeof C>` captures a class's constructor parameter list as a tuple,
+// the other half of what a class value's construct signature carries. A synthesized constructor
+// takes one parameter per required instance field in declaration order, so a class with no
+// `constructor` block still has a parameter list to capture, and an optional field is omitted
+// from it. The tuple is what `new`-ing the class through a stored argument list would need.
+func TestUtilityTypeConstructorParametersOfClass(t *testing.T) {
+	runUtilityReductions(t, []utilityReduction{
+		{
+			name: "ExplicitConstructor",
+			src: `
+				class Point {
+					x: number,
+					y: string,
+					constructor(mut self, x: number, y: string) {
+						self.x = x
+						self.y = y
+					},
+				}
+				type Result = ConstructorParameters<typeof Point>
+			`,
+			wantExpanded: "[number, string]",
+		},
+		{
+			// The statics sit beside the signature rather than in it, so they do not reach
+			// the captured list.
+			name: "ClassWithStatics",
+			src: `
+				class Counter {
+					n: number,
+					static zero: number = 0,
+					constructor(mut self, n: number) { self.n = n },
+				}
+				type Result = ConstructorParameters<typeof Counter>
+			`,
+			wantExpanded: "[number]",
+		},
+		{
+			// No `constructor` block, so synthesizeConstructor builds the signature from the
+			// required instance fields in declaration order. `tag` is optional and omitted.
+			name: "SynthesizedConstructor",
+			src: `
+				class Pair {
+					a: number,
+					b: string,
+					tag?: boolean,
+				}
+				type Result = ConstructorParameters<typeof Pair>
+			`,
+			wantExpanded: "[number, string]",
+		},
+		{
+			name: "NoParameters",
+			src: `
+				class Empty {
+					constructor(mut self) {},
+				}
+				type Result = ConstructorParameters<typeof Empty>
+			`,
+			wantExpanded: "[]",
+		},
+	})
+}

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -946,23 +946,43 @@ func TestUtilityTypeInstanceType(t *testing.T) {
 	})
 }
 
-// An ordinary function matches both constructor patterns, where TypeScript reduces each
-// application to `never`. This is the cost of the rule that lets a bare function fill a
-// constructor-only object target, which is itself what makes `InstanceType<typeof C>` work for a
-// class with no statics — classValue binds such a class to its bare constructor function, so
-// nothing distinguishes it from a function that is not a constructor. These cases pin the
-// divergence so a later change that separates the two shows up here.
-func TestUtilityTypeConstructorUtilitiesAcceptOrdinaryFunction(t *testing.T) {
+// A function whose return is not a nominal class instance is not a constructor, so both
+// utilities reduce to `never` over one, matching TypeScript. A bare function can fill a
+// constructor-only target at all only because classValue binds a class with no statics to its
+// bare constructor function; requiring a class return is what keeps that allowance from reaching
+// every function.
+func TestUtilityTypeConstructorUtilitiesRejectOrdinaryFunction(t *testing.T) {
 	runUtilityReductions(t, []utilityReduction{
 		{
-			name:         "InstanceTypeReadsTheReturn",
+			name:         "InstanceTypeOfPlainFunction",
 			src:          `type Result = InstanceType<fn (x: number) -> {a: number}>`,
-			wantExpanded: "{a: number}",
+			wantExpanded: "never",
 		},
 		{
-			name:         "ConstructorParametersReadsTheParams",
+			name:         "ConstructorParametersOfPlainFunction",
 			src:          `type Result = ConstructorParameters<fn (x: number) -> {a: number}>`,
-			wantExpanded: "[number]",
+			wantExpanded: "never",
+		},
+	})
+}
+
+// A factory function returning a class instance still matches, where TypeScript gives `never`.
+// The test is the return type, and a factory's return is indistinguishable from a constructor's,
+// so this is what a marker-free rule admits. It is pinned so a later change that carries
+// constructibility on FuncType shows up here.
+func TestUtilityTypeConstructorUtilitiesAcceptClassReturningFactory(t *testing.T) {
+	runUtilityReductions(t, []utilityReduction{
+		{
+			name: "InstanceTypeOfFactory",
+			src: `
+				class Point {
+					x: number,
+					constructor(mut self, x: number) { self.x = x },
+				}
+				fn make(x: number) -> Point { return Point(x) }
+				type Result = InstanceType<typeof make>
+			`,
+			wantExpanded: "Point",
 		},
 	})
 }

--- a/internal/solver/utility_types_test.go
+++ b/internal/solver/utility_types_test.go
@@ -58,8 +58,11 @@ import (
 // naked type parameter, so it distributes over the argument and decides each member alone, which
 // is machinery the conditional evaluator already carries.
 //
-// `ConstructorParameters<C>` and `InstanceType<C>` are the two utilities the suite cannot express
-// yet. Each has a disabled test at the end of this file naming what it waits on.
+// `ConstructorParameters<C>` and `InstanceType<C>` each match a `new (…) -> T` member, the
+// construct signature TypeScript writes as the standalone type `new (…) => T`. Escalier has no
+// standalone form, so the pattern is an object type carrying one member. Both patterns end in `...`
+// because an object type is exact by default and a class value with static members carries them
+// alongside its signature, so an exact pattern would reject it as extra properties.
 //
 // Two declarations at the end are not TypeScript utilities. `EventName<K>` is a template-literal
 // type that builds a handler name from an event name. `Point` is the sample object several tests
@@ -76,6 +79,8 @@ const utilityTypeDecls = `
 	type ReturnType<F: fn (...args: Array<_>) -> _> = if F : fn (...args: Array<_>) -> infer R { R } else { never }
 	type Parameters<F: fn (...args: Array<_>) -> _> = if F : fn (...args: infer P) -> _ { P } else { never }
 	type NonNullable<T> = if T : null | undefined { never } else { T }
+	type ConstructorParameters<C> = if C : {new (...args: infer P) -> unknown, ...} { P } else { never }
+	type InstanceType<C> = if C : {new (...args: Array<_>) -> infer R, ...} { R } else { never }
 	type Awaited<T> = if T : Promise<infer U> { Awaited<U> } else { T }
 	type EventName<K> = ` + "`on${Capitalize<K>}`" + `
 	type Point = {x: number, y: string}
@@ -891,60 +896,86 @@ func TestUtilityTypeNonNullable(t *testing.T) {
 	})
 }
 
-// DISABLED until M9 PR15, which adds a `new (…)` member to object type annotations.
-// `ConstructorParameters<C>` matches a constructor signature, and `objTypeAnnElemInner` has no arm
-// for `new`, so `{new (...args: infer P) -> unknown}` fails to parse. The rest parameter and the
-// tuple capture the pattern needs are both in place, so the annotation surface is the only piece
-// missing.
-//
-// Re-enable by removing the comment wrapper and adding
-//
-//	type ConstructorParameters<C> = if C : {new (...args: infer P) -> unknown} { P } else { never }
-//
-// to utilityTypeDecls.
+// `ConstructorParameters<C>` captures a construct signature's parameter list as a tuple. Its
+// pattern writes the list as one rest parameter, so it matches a constructor of any arity, the
+// same way `Parameters<F>` matches a function of any arity.
 func TestUtilityTypeConstructorParameters(t *testing.T) {
-	/*
-		runUtilityReductions(t, []utilityReduction{
-			{
-				name:         "ConstructorParameterList",
-				src:          `type Result = ConstructorParameters<{new (x: number) -> {a: number}}>`,
-				wantExpanded: "[number]",
-			},
-			{
-				name:         "NonConstructor",
-				src:          `type Result = ConstructorParameters<number>`,
-				wantExpanded: "never",
-			},
-		})
-	*/
+	runUtilityReductions(t, []utilityReduction{
+		{
+			name:         "ConstructorParameterList",
+			src:          `type Result = ConstructorParameters<{new (x: number) -> {a: number}}>`,
+			wantExpanded: "[number]",
+		},
+		{
+			name:         "TwoParameters",
+			src:          `type Result = ConstructorParameters<{new (x: number, y: string) -> {a: number}}>`,
+			wantExpanded: "[number, string]",
+		},
+		{
+			name:         "NoParameters",
+			src:          `type Result = ConstructorParameters<{new () -> {a: number}}>`,
+			wantExpanded: "[]",
+		},
+		{
+			name:         "NonConstructor",
+			src:          `type Result = ConstructorParameters<number>`,
+			wantExpanded: "never",
+		},
+	})
 }
 
-// DISABLED until M9 PR15, which adds a `new (…)` member to object type annotations.
-// `InstanceType<C>` reads the return type off a constructor signature, and `objTypeAnnElemInner`
-// has no arm for `new`, so `{new (…) -> infer R}` fails to parse. The representation is not what is
-// missing. The printer already renders the form, as internal/solver/infer_class_test.go shows a
-// class's static side printing `{new (x: number, y: number) -> Vec, …}`.
-//
-// Re-enable by removing the comment wrapper and adding
-//
-//	type InstanceType<C> = if C : {new (a: never) -> infer R} { R } else { never }
-//
-// to utilityTypeDecls. The pattern is written for a one-parameter constructor because a `new (…)`
-// member has no annotation surface at all; once it has one, a rest parameter in that position reads
-// any arity the way `ReturnType<F>` does.
+// `InstanceType<C>` reads the return type off a construct signature, which is the instance a
+// `new` call produces.
 func TestUtilityTypeInstanceType(t *testing.T) {
-	/*
-		runUtilityReductions(t, []utilityReduction{
-			{
-				name:         "ConstructorReturn",
-				src:          `type Result = InstanceType<{new (x: number) -> {a: number}}>`,
-				wantExpanded: "{a: number}",
-			},
-			{
-				name:         "NonConstructor",
-				src:          `type Result = InstanceType<number>`,
-				wantExpanded: "never",
-			},
-		})
-	*/
+	runUtilityReductions(t, []utilityReduction{
+		{
+			name:         "ConstructorReturn",
+			src:          `type Result = InstanceType<{new (x: number) -> {a: number}}>`,
+			wantExpanded: "{a: number}",
+		},
+		{
+			name:         "NoParameters",
+			src:          `type Result = InstanceType<{new () -> {a: number}}>`,
+			wantExpanded: "{a: number}",
+		},
+		{
+			name:         "NonConstructor",
+			src:          `type Result = InstanceType<number>`,
+			wantExpanded: "never",
+		},
+	})
+}
+
+// A class value is what `typeof C` names, and `InstanceType<typeof C>` reads its instance off
+// the construct signature. classValue gives a class with no statics its bare constructor
+// FuncType and one with statics an object carrying a ConstructorElem, so the two render
+// differently — `fn (x: number) -> Point` against `{new (x: number) -> Counter, zero: Counter}`.
+// constrain's rule that a bare function fills a constructor-only object target is what makes one
+// pattern match both.
+func TestUtilityTypeInstanceTypeOfClass(t *testing.T) {
+	runUtilityReductions(t, []utilityReduction{
+		{
+			name: "ClassWithoutStatics",
+			src: `
+				class Point {
+					x: number,
+					constructor(mut self, x: number) { self.x = x },
+				}
+				type Result = InstanceType<typeof Point>
+			`,
+			wantExpanded: "Point",
+		},
+		{
+			name: "ClassWithStatics",
+			src: `
+				class Counter {
+					n: number,
+					static zero: number = 0,
+					constructor(mut self, n: number) { self.n = n },
+				}
+				type Result = InstanceType<typeof Counter>
+			`,
+			wantExpanded: "Counter",
+		},
+	})
 }


### PR DESCRIPTION
Adds support for writing constructor signatures as members of object type annotations, enabling patterns like `{new (x: number) -> Point}` and utility types like `InstanceType<C>` and `ConstructorParameters<C>`.

**Key changes:**

- **Parser**: Added `funcTypeAnnTail` to extract the shared signature parsing logic between `fn` type annotations and the new `new (…) -> T` constructor member syntax. Constructor signatures accept the same parameters, type parameters, inexact markers, and `throws` clauses as function annotations.

- **AST & Printer**: Added `ConstructorTypeAnn` AST node and updated the printer to render constructor signatures. The printer's `printFuncTypeAnnTail` method handles the signature portion while the `new` keyword is printed separately.

- **Type solver**: Updated `resolveObjectTypeAnn` to lower `ConstructorTypeAnn` to a `ConstructorElem`, the same representation a class value carries. Added `DuplicateConstructorSignatureError` to reject multiple `new` members in one object type, since `soltype.ObjectType.Constructor()` returns at most one signature.

- **Constraint checking**: Added a rule allowing a bare function to fill an object target whose only member is a construct signature. This enables `InstanceType<typeof C>` to work for both classes with and without static members, since `classValue` represents a class without statics as a bare `FuncType` and one with statics as an object carrying a `ConstructorElem`.

- **Spread merging**: Updated `mergeSpreadOperands` to use a `mergeKey` struct that distinguishes construct signatures from properties with empty-string keys, preventing the two from collapsing together during spread merges.

- **Utility types**: Enabled `ConstructorParameters<C>` and `InstanceType<C>` by adding their definitions to the utility type declarations and re-enabling their tests.

**Implementation notes:**

Constructor signatures are unnamed members, so they are appended after named properties in the dedup builder and keep their source position when merged through spreads. A construct signature contributes no key to `keyof` projections, so `keyof {new (…) -> T}` yields `never`.

https://claude.ai/code/session_012ysLjkxxEeUJbVQgoDjgv5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for constructor signatures (`new (...) -> T`) in object type annotations.
  * Constructor signatures now support generics, rest parameters, return types, and `throws` clauses.
  * Bare function types can satisfy object types containing only a constructor signature.
  * Enabled constructor utility types, including `ConstructorParameters` and `InstanceType`.

* **Bug Fixes**
  * Added diagnostics for duplicate constructor signatures.
  * Improved object spread handling when constructors coexist with empty-string properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->