### PR TITLE
Enforce ordering rule on type parameter defaults

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1068,6 +1068,7 @@ func (*ReservedTypeNameError) isSolverError()               {}
 func (*RestParamNotLastError) isSolverError()               {}
 func (*RestParamNeedsTypeError) isSolverError()             {}
 func (*OptionalRestParamError) isSolverError()              {}
+func (*TypeParamDefaultForwardRefError) isSolverError()     {}
 func (*NotProductiveAliasError) isSolverError()             {}
 func (*ExpansionLimitError) isSolverError()                 {}
 
@@ -1255,6 +1256,27 @@ func (e *OptionalRestParamError) Span() ast.Span      { return e.Param.Span() }
 func (e *OptionalRestParamError) Related() []ast.Span { return nil }
 func (e *OptionalRestParamError) Message() string {
 	return "a rest parameter cannot be marked optional"
+}
+
+// TypeParamDefaultForwardRefError fires when a type parameter's default names the parameter
+// itself or one declared after it, as `type Loop<T = T>` and `type Pair<T = U, U = number>` do.
+// A reference that omits a trailing argument fills it from that parameter's default,
+// substituting the arguments before it. A default is usable only when every parameter it names
+// already has an argument by then, which means only an earlier one. Ref is the offending
+// reference, Param the parameter whose default holds it, and Target the parameter it reaches.
+type TypeParamDefaultForwardRefError struct {
+	Ref    *ast.TypeRefTypeAnn
+	Param  string
+	Target string
+}
+
+func (e *TypeParamDefaultForwardRefError) Span() ast.Span      { return e.Ref.Span() }
+func (e *TypeParamDefaultForwardRefError) Related() []ast.Span { return nil }
+func (e *TypeParamDefaultForwardRefError) Message() string {
+	if e.Param == e.Target {
+		return fmt.Sprintf("the default for type parameter `%s` cannot reference `%s` itself", e.Param, e.Target)
+	}
+	return fmt.Sprintf("the default for type parameter `%s` cannot reference `%s`, which is declared after it", e.Param, e.Target)
 }
 
 // NotProductiveAliasError fires when a recursive type alias reaches itself with no type constructor

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -255,17 +255,17 @@ func TestInferClassGeneric(t *testing.T) {
 	}
 }
 
-// TestInferClassCrossParamBounds covers B4: a type-parameter bound or default may
-// reference any sibling parameter — forward, mutual, or through a generic class. Each case
-// resolves its cross-parameter references without reporting `Unsupported: TypeRefTypeAnn`,
-// because the shared resolveTypeParams declares every parameter in scope before resolving
-// any bound, so a bound reading a later-declared sibling finds it already in scope.
+// TestInferClassCrossParamBounds covers B4: a type-parameter bound may reference any sibling
+// parameter — forward, mutual, or through a generic class. Each case resolves its
+// cross-parameter references without reporting `Unsupported: TypeRefTypeAnn`, because the
+// shared resolveTypeParams declares every parameter in scope before resolving any bound, so a
+// bound reading a later-declared sibling finds it already in scope. A default is restricted
+// where a bound is not; TestTypeParamDefaultForwardRef covers that.
 func TestInferClassCrossParamBounds(t *testing.T) {
 	srcs := map[string]string{
 		"ForwardConstraint": `class C<T: U, U> { value: T }`,
 		"MutualConstraint":  `class C<T: U, U: T> { value: T }`,
-		"ForwardDefault":    `class C<T = U, U> { value: T }`,
-		"MutualDefault":     `class C<T = U, U = T> { value: T }`,
+		"EarlierDefault":    `class C<T, U = T> { value: U }`,
 		// The referenced class Cmp is declared before Foo so its instance type is in scope
 		// when Foo's bounds resolve. Resolving `Cmp<U>` / `Cmp<T>` combines the two-pass
 		// sibling visibility with generic-class-reference resolution. Robust ordering

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -2,22 +2,26 @@ package solver
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
 // resolveTypeParams resolves a `<…>` type-parameter list to soltype TypeParams in two
-// passes, so a bound or default may reference any sibling parameter regardless of order.
-// Pass 1 mints one fresh var per parameter and declares its name in scope. Pass 2 resolves
-// each parameter's constraint into its var's upper bound and its default, reading names
-// against the scope that now holds every sibling.
+// passes, so a bound may reference any sibling parameter regardless of order. Pass 1 mints
+// one fresh var per parameter and declares its name in scope. Pass 2 resolves each
+// parameter's constraint into its var's upper bound and its default, reading names against
+// the scope that now holds every sibling.
 //
 // Declaring every parameter before reading any bound is what lets a forward reference
-// `<T: U, U>`, a mutual cycle `<T: U, U: T>`, an F-bound `<T: Foo<T>>`, a mutual F-bound
-// `<T: Cmp<U>, U: Cmp<T>>`, and a defaulting reference `<T = U, U>` all resolve. A single
-// declare-and-resolve pass leaves a later-declared sibling undeclared when its bound is
-// read, so the reference falls through to general type-ref resolution and reports
-// `Unsupported: TypeRefTypeAnn`. Because every sibling is in scope up front, a true mutual
-// cycle resolves that a topological sort of the parameters cannot order.
+// `<T: U, U>`, a mutual cycle `<T: U, U: T>`, an F-bound `<T: Foo<T>>`, and a mutual F-bound
+// `<T: Cmp<U>, U: Cmp<T>>` all resolve. A single declare-and-resolve pass leaves a
+// later-declared sibling undeclared when its bound is read, so the reference falls through to
+// general type-ref resolution and reports `Unsupported: TypeRefTypeAnn`. Because every sibling
+// is in scope up front, a true mutual cycle resolves that a topological sort of the parameters
+// cannot order.
+//
+// A default is restricted where a bound is not. It may name only an earlier parameter. See
+// reportDefaultForwardRef for why, and for what a rejected default leaves behind.
 //
 // The result stays in declaration order, so instantiation substitutes type arguments
 // positionally. The class and, once generic-function inference lands, the function and
@@ -43,11 +47,92 @@ func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypePar
 				out[i].Constraint = ct
 			}
 		}
-		if p.Default != nil {
+		if p.Default != nil && !c.reportDefaultForwardRef(params, i) {
 			if dt, ok := c.resolveTypeAnn(scope, p.Default, lvl); ok {
 				out[i].Default = dt
 			}
 		}
 	}
 	return out
+}
+
+// reportDefaultForwardRef reports the first reference params[i]'s default makes to a parameter
+// it may not name, meaning params[i] itself or one declared after it. It returns whether it
+// reported.
+//
+// A reference that omits a trailing argument fills it from that parameter's default,
+// substituting the arguments before it. buildAliasInstance does exactly that for the `U = T`
+// of `type Pair<T, U = T>`. Only a parameter earlier in the list has an argument by then, so
+// only an earlier one is replaced by that substitution.
+//
+// A later or self reference is left untouched, so it stays the declaration's own var, and
+// every reference to the type shares that one var. In `type Pair<T = U, U = number> = {a: T, b: U}`,
+// `T`'s default resolves to `U`'s var, so admitting it would let `val q: Pair = {a: "s", b: 3}`
+// widen a second `val p: Pair = {a: 1, b: 2}` to `Pair<1 | "s", number>`. Rejecting the default
+// keeps that var out of every instance.
+//
+// The caller drops a rejected default, which leaves the parameter required, so a reference
+// that omits it reports an arity mismatch naming the omission.
+//
+// The restriction covers the default position alone. A bound may name any sibling, since
+// `<T: U, U: T>` is a legal mutual F-bound and `<T: Foo<T>>` names the parameter being
+// declared. Neither is substituted positionally, so neither needs the ordering a default does.
+func (c *checker) reportDefaultForwardRef(params []*ast.TypeParam, i int) bool {
+	forbidden := set.NewSet[string]()
+	for _, p := range params[i:] {
+		forbidden.Add(p.Name)
+	}
+	scan := typeParamRefScan{bound: set.NewSet[string]()}
+	params[i].Default.Accept(&scan)
+	for _, ref := range scan.refs {
+		name := ast.QualIdentToString(ref.Name)
+		if !forbidden.Contains(name) || scan.bound.Contains(name) {
+			continue
+		}
+		c.report(&TypeParamDefaultForwardRefError{Ref: ref, Param: params[i].Name, Target: name})
+		return true
+	}
+	return false
+}
+
+// typeParamRefScan walks a type annotation and records both the names it reads and the names
+// it binds, so a caller can tell a reference to an enclosing `<…>` parameter from one a nested
+// binder introduced.
+//
+// refs holds every `Name` and `Name<…>` reference in traversal order, so a caller reports the
+// leftmost offending one. bound holds the name each binder inside the annotation introduces.
+// There are three such binders: a nested `fn <U>(…)` quantifier, a mapped type's key binder
+// written `K` in `{[K: Keys]: V}`, and a conditional's `infer U`. A reference to one of those
+// reads the binder's own name rather than an enclosing parameter's.
+//
+// bound covers the whole annotation rather than each binder's own region, which errs toward
+// silence. In `{a: fn <U>(x: U) -> U, b: U}` the `b: U` reads an enclosing `U`, and the scan
+// suppresses it along with the two inside the nested quantifier.
+type typeParamRefScan struct {
+	ast.DefaultVisitor
+	refs  []*ast.TypeRefTypeAnn
+	bound set.Set[string]
+}
+
+func (v *typeParamRefScan) EnterTypeAnn(t ast.TypeAnn) bool {
+	switch n := t.(type) {
+	case *ast.TypeRefTypeAnn:
+		v.refs = append(v.refs, n)
+	case *ast.FuncTypeAnn:
+		for _, tp := range n.TypeParams {
+			v.bound.Add(tp.Name)
+		}
+	case *ast.ObjectTypeAnn:
+		// A mapped type is an object element rather than a type annotation of its own, so the
+		// walk reaches its key constraint, name, and value without entering the mapped node.
+		// Read its key binder off the element here.
+		for _, elem := range n.Elems {
+			if mapped, ok := elem.(*ast.MappedTypeAnn); ok {
+				v.bound.Add(mapped.TypeParam.Name)
+			}
+		}
+	case *ast.InferTypeAnn:
+		v.bound.Add(n.Name)
+	}
+	return true
 }

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -47,13 +47,17 @@ func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypePar
 	return out
 }
 
-// reportDefaultForwardRef reports the first reference params[i]'s default makes to a parameter it
-// may not name, params[i] itself or one declared after it, and returns whether it reported. A
-// reference fills an omitted argument from the default with the earlier arguments substituted in,
-// as buildAliasInstance does for the `U = T` of `type Pair<T, U = T>`. A later or self reference
-// has nothing to substitute, so it stays the declaration's own var, shared by every reference to
-// the type. A rejected default is dropped, which leaves the parameter required. Neither instance
+// reportDefaultForwardRef reports each parameter params[i]'s default names that it may not,
+// params[i] itself or one declared after it, and returns whether it reported. A reference fills an
+// omitted argument from the default with the earlier arguments substituted in, as
+// buildAliasInstance does for the `U = T` of `type Pair<T, U = T>`. A later or self reference has
+// nothing to substitute, so it stays the declaration's own var, shared by every reference to the
+// type. A rejected default is dropped, which leaves the parameter required. Neither instance
 // builder reports the follow-on arity error in every case, which PR18's shared helper settles.
+//
+// One report per offending name, blaming its leftmost reference. Naming each one lets a default
+// that reaches two later parameters be fixed in a single pass, while a name written twice reports
+// once, since both references need the same fix.
 func (c *checker) reportDefaultForwardRef(params []*ast.TypeParam, i int) bool {
 	forbidden := set.NewSet[string]()
 	for _, p := range params[i:] {
@@ -61,15 +65,16 @@ func (c *checker) reportDefaultForwardRef(params []*ast.TypeParam, i int) bool {
 	}
 	var scan typeParamRefScan
 	params[i].Default.Accept(&scan)
+	reported := set.NewSet[string]()
 	for _, ref := range scan.free {
 		name := ast.QualIdentToString(ref.Name)
-		if !forbidden.Contains(name) {
+		if !forbidden.Contains(name) || reported.Contains(name) {
 			continue
 		}
+		reported.Add(name)
 		c.report(&TypeParamDefaultForwardRefError{Ref: ref, Param: params[i].Name, Target: name})
-		return true
 	}
-	return false
+	return reported.Len() > 0
 }
 
 // typeParamRefScan collects a type annotation's free references, the `Name` and `Name<…>`

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -6,51 +6,62 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// resolveTypeParams resolves a `<…>` type-parameter list to soltype TypeParams in two
-// passes, so a bound may reference any sibling parameter regardless of order. Pass 1 mints
-// one fresh var per parameter and declares its name in scope. Pass 2 resolves each
-// parameter's constraint into its var's upper bound and its default, reading names against
-// the scope that now holds every sibling.
+// resolveTypeParams resolves a `<…>` type-parameter list to soltype TypeParams in three
+// passes. Pass 1 mints one fresh var per parameter. Pass 2 resolves each parameter's default
+// and then declares that parameter's name, so a default reads only the siblings before it.
+// Pass 3 resolves each constraint into its var's upper bound, against the scope that by then
+// holds every sibling.
 //
-// Declaring every parameter before reading any bound is what lets a forward reference
-// `<T: U, U>`, a mutual cycle `<T: U, U: T>`, an F-bound `<T: Foo<T>>`, and a mutual F-bound
-// `<T: Cmp<U>, U: Cmp<T>>` all resolve. A single declare-and-resolve pass leaves a
-// later-declared sibling undeclared when its bound is read, so the reference falls through to
-// general type-ref resolution and reports `Unsupported: TypeRefTypeAnn`. Because every sibling
-// is in scope up front, a true mutual cycle resolves that a topological sort of the parameters
-// cannot order.
+// A default and a bound need opposite visibility, which is why they sit in separate passes.
 //
-// A default is restricted where a bound is not. It may name only an earlier parameter. See
-// reportDefaultForwardRef for why, and for what a rejected default leaves behind.
+// A bound may name any sibling. Declaring every parameter before reading any bound is what
+// lets a forward reference `<T: U, U>`, a mutual cycle `<T: U, U: T>`, an F-bound
+// `<T: Foo<T>>`, and a mutual F-bound `<T: Cmp<U>, U: Cmp<T>>` all resolve. Resolving a bound
+// under a scope that holds only the earlier siblings would leave a later-declared name
+// undeclared, so the reference would fall through to general type-ref resolution and report
+// `Unsupported: TypeRefTypeAnn`. Because every sibling is in scope by pass 3, a true mutual
+// cycle resolves that a topological sort of the parameters cannot order.
+//
+// A default may name only an earlier sibling, since instantiation substitutes a default
+// positionally. reportDefaultForwardRef reports a default that names a later sibling or
+// itself, and the caller then skips resolving it, so that check is what a user sees. Growing
+// the scope one parameter at a time is the backstop underneath it: a later sibling's name is
+// not in scope when the default resolves, so its var cannot reach an instance even if the
+// check's idea of where a binder's region ends ever drifts from resolveTypeAnn's. See
+// reportDefaultForwardRef for the rest of the rule.
 //
 // The result stays in declaration order, so instantiation substitutes type arguments
 // positionally. The class and, once generic-function inference lands, the function and
 // method paths both route their `<…>` lists through here so bound resolution never forks.
 func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypeParam) []*soltype.TypeParam {
 	out := make([]*soltype.TypeParam, len(params))
-	// Pass 1: mint each parameter's var and declare its name, so a bound in pass 2 may
-	// reference any sibling — earlier, later, itself, or mutually.
+	// Pass 1: mint each parameter's var. Nothing is declared yet, so pass 2 controls which
+	// siblings each default can see.
 	for i, p := range params {
-		v := c.freshAt(lvl)
-		scope.defineType(p.Name, TypeBinding{Type: v})
-		out[i] = &soltype.TypeParam{Name: p.Name, Var: v}
+		out[i] = &soltype.TypeParam{Name: p.Name, Var: c.freshAt(lvl)}
 	}
-	// Pass 2: resolve each constraint into its var's upper bound and each default, now that
-	// every sibling name is in scope.
+	// Pass 2: resolve each default under the names declared so far, then declare this
+	// parameter. A default naming a later sibling or itself finds the name undeclared.
 	for i, p := range params {
-		if p.Constraint != nil {
-			if ct, ok := c.resolveTypeAnn(scope, p.Constraint, lvl); ok {
-				c.ctx.addUpperBound(out[i].Var, ct)
-				// Keep the declared constraint where later solving cannot overwrite it. The
-				// var's upper-bound list grows as constraints flow in, so a reader that wants
-				// what the source wrote reads this field instead.
-				out[i].Constraint = ct
-			}
-		}
 		if p.Default != nil && !c.reportDefaultForwardRef(params, i) {
 			if dt, ok := c.resolveTypeAnn(scope, p.Default, lvl); ok {
 				out[i].Default = dt
 			}
+		}
+		scope.defineType(p.Name, TypeBinding{Type: out[i].Var})
+	}
+	// Pass 3: resolve each constraint into its var's upper bound, now that every sibling name
+	// is in scope.
+	for i, p := range params {
+		if p.Constraint == nil {
+			continue
+		}
+		if ct, ok := c.resolveTypeAnn(scope, p.Constraint, lvl); ok {
+			c.ctx.addUpperBound(out[i].Var, ct)
+			// Keep the declared constraint where later solving cannot overwrite it. The var's
+			// upper-bound list grows as constraints flow in, so a reader that wants what the
+			// source wrote reads this field instead.
+			out[i].Constraint = ct
 		}
 	}
 	return out
@@ -71,8 +82,16 @@ func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypePar
 // widen a second `val p: Pair = {a: 1, b: 2}` to `Pair<1 | "s", number>`. Rejecting the default
 // keeps that var out of every instance.
 //
-// The caller drops a rejected default, which leaves the parameter required, so a reference
-// that omits it reports an arity mismatch naming the omission.
+// The caller drops a rejected default rather than replacing it, so the parameter becomes
+// required. Whether omitting that argument then reports a second diagnostic is up to the
+// instance builder, and neither builder reports it in every case today. buildAliasInstance
+// counts its required arguments as the number of parameters carrying no default, with no
+// regard for where those parameters sit. Writing `Tri<string>` against
+// `type Tri<T = number, U = V, V = number>` passes that count, so the omitted `U` becomes a
+// fresh var with only the ordering error reported. An arity mismatch is reported when no
+// defaulted parameter precedes the rejected one. buildClassInstance checks no arity at all.
+// PR18 of planning/simple_sub/m9-implementation-plan.md factors both builders into one
+// helper, which is where a positional count belongs.
 //
 // The restriction covers the default position alone. A bound may name any sibling, since
 // `<T: U, U: T>` is a legal mutual F-bound and `<T: Foo<T>>` names the parameter being
@@ -82,11 +101,11 @@ func (c *checker) reportDefaultForwardRef(params []*ast.TypeParam, i int) bool {
 	for _, p := range params[i:] {
 		forbidden.Add(p.Name)
 	}
-	scan := typeParamRefScan{bound: set.NewSet[string]()}
+	var scan typeParamRefScan
 	params[i].Default.Accept(&scan)
-	for _, ref := range scan.refs {
+	for _, ref := range scan.free {
 		name := ast.QualIdentToString(ref.Name)
-		if !forbidden.Contains(name) || scan.bound.Contains(name) {
+		if !forbidden.Contains(name) {
 			continue
 		}
 		c.report(&TypeParamDefaultForwardRefError{Ref: ref, Param: params[i].Name, Target: name})
@@ -95,44 +114,91 @@ func (c *checker) reportDefaultForwardRef(params []*ast.TypeParam, i int) bool {
 	return false
 }
 
-// typeParamRefScan walks a type annotation and records both the names it reads and the names
-// it binds, so a caller can tell a reference to an enclosing `<…>` parameter from one a nested
-// binder introduced.
+// typeParamRefScan walks a type annotation and collects the references that read a name from
+// outside it, so a caller can tell a reference to an enclosing `<…>` parameter from one a
+// binder written inside the annotation introduces.
 //
-// refs holds every `Name` and `Name<…>` reference in traversal order, so a caller reports the
-// leftmost offending one. bound holds the name each binder inside the annotation introduces.
-// There are three such binders: a nested `fn <U>(…)` quantifier, a mapped type's key binder
-// written `K` in `{[K: Keys]: V}`, and a conditional's `infer U`. A reference to one of those
-// reads the binder's own name rather than an enclosing parameter's.
+// free holds those references in traversal order, so a caller reports the leftmost offending
+// one. A reference whose name an enclosing binder declares is left out, since it reads that
+// binder's name rather than a `<…>` parameter's. Three binders can appear inside an
+// annotation, and the scan tracks the region each one covers:
 //
-// bound covers the whole annotation rather than each binder's own region, which errs toward
-// silence. In `{a: fn <U>(x: U) -> U, b: U}` the `b: U` reads an enclosing `U`, and the scan
-// suppresses it along with the two inside the nested quantifier.
+//   - A `fn <U>(…)` quantifier covers the whole function annotation.
+//   - A mapped type's key binder, the `K` of `{[K: Keys]: V}`, covers the object annotation
+//     that holds it. That is wider than the binder's own region by the key constraint and any
+//     sibling element, so `{[K: Keys]: V, other: K}` reads `other: K` as the key binder.
+//   - An `infer U` clause covers the Extends and Then operands of the conditional whose
+//     Extends declares it, matching where resolveCondTypeAnn declares the name. The same name
+//     in the Else operand is a free reference.
+//
+// scopes holds one name set per region the walk is currently inside, innermost last.
 type typeParamRefScan struct {
 	ast.DefaultVisitor
-	refs  []*ast.TypeRefTypeAnn
-	bound set.Set[string]
+	scopes []set.Set[string]
+	free   []*ast.TypeRefTypeAnn
 }
 
 func (v *typeParamRefScan) EnterTypeAnn(t ast.TypeAnn) bool {
 	switch n := t.(type) {
 	case *ast.TypeRefTypeAnn:
-		v.refs = append(v.refs, n)
-	case *ast.FuncTypeAnn:
-		for _, tp := range n.TypeParams {
-			v.bound.Add(tp.Name)
+		if !v.shadowed(ast.QualIdentToString(n.Name)) {
+			v.free = append(v.free, n)
 		}
+	case *ast.FuncTypeAnn:
+		names := set.NewSet[string]()
+		for _, tp := range n.TypeParams {
+			names.Add(tp.Name)
+		}
+		v.push(names)
 	case *ast.ObjectTypeAnn:
 		// A mapped type is an object element rather than a type annotation of its own, so the
 		// walk reaches its key constraint, name, and value without entering the mapped node.
-		// Read its key binder off the element here.
+		// Read the key binder off the element here and scope it to the object annotation.
+		names := set.NewSet[string]()
 		for _, elem := range n.Elems {
 			if mapped, ok := elem.(*ast.MappedTypeAnn); ok {
-				v.bound.Add(mapped.TypeParam.Name)
+				names.Add(mapped.TypeParam.Name)
 			}
 		}
-	case *ast.InferTypeAnn:
-		v.bound.Add(n.Name)
+		v.push(names)
+	case *ast.CondTypeAnn:
+		// The four operands are walked here rather than by the shared descent, since an
+		// `infer U` clause covers only two of them. Check reads no capture, and a capture
+		// named again in Else is a free reference.
+		n.Check.Accept(v)
+		v.push(set.FromSlice(inferAnnNames(n.Extends)))
+		n.Extends.Accept(v)
+		n.Then.Accept(v)
+		v.pop()
+		n.Else.Accept(v)
+		return false
 	}
 	return true
+}
+
+// ExitTypeAnn closes the region opened on entering a function or object annotation. A
+// conditional pops its own region inside EnterTypeAnn, since it drives its operands itself.
+func (v *typeParamRefScan) ExitTypeAnn(t ast.TypeAnn) {
+	switch t.(type) {
+	case *ast.FuncTypeAnn, *ast.ObjectTypeAnn:
+		v.pop()
+	}
+}
+
+func (v *typeParamRefScan) push(names set.Set[string]) {
+	v.scopes = append(v.scopes, names)
+}
+
+func (v *typeParamRefScan) pop() {
+	v.scopes = v.scopes[:len(v.scopes)-1]
+}
+
+// shadowed reports whether any region the walk is inside declares name.
+func (v *typeParamRefScan) shadowed(name string) bool {
+	for _, names := range v.scopes {
+		if names.Contains(name) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -6,33 +6,13 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// resolveTypeParams resolves a `<…>` type-parameter list to soltype TypeParams in three
-// passes. Pass 1 mints one fresh var per parameter. Pass 2 resolves each parameter's default
-// and then declares that parameter's name, so a default reads only the siblings before it.
-// Pass 3 resolves each constraint into its var's upper bound, against the scope that by then
-// holds every sibling.
-//
-// A default and a bound need opposite visibility, which is why they sit in separate passes.
-//
-// A bound may name any sibling. Declaring every parameter before reading any bound is what
-// lets a forward reference `<T: U, U>`, a mutual cycle `<T: U, U: T>`, an F-bound
-// `<T: Foo<T>>`, and a mutual F-bound `<T: Cmp<U>, U: Cmp<T>>` all resolve. Resolving a bound
-// under a scope that holds only the earlier siblings would leave a later-declared name
-// undeclared, so the reference would fall through to general type-ref resolution and report
-// `Unsupported: TypeRefTypeAnn`. Because every sibling is in scope by pass 3, a true mutual
-// cycle resolves that a topological sort of the parameters cannot order.
-//
-// A default may name only an earlier sibling, since instantiation substitutes a default
-// positionally. reportDefaultForwardRef reports a default that names a later sibling or
-// itself, and the caller then skips resolving it, so that check is what a user sees. Growing
-// the scope one parameter at a time is the backstop underneath it: a later sibling's name is
-// not in scope when the default resolves, so its var cannot reach an instance even if the
-// check's idea of where a binder's region ends ever drifts from resolveTypeAnn's. See
-// reportDefaultForwardRef for the rest of the rule.
-//
-// The result stays in declaration order, so instantiation substitutes type arguments
-// positionally. The class and, once generic-function inference lands, the function and
-// method paths both route their `<…>` lists through here so bound resolution never forks.
+// resolveTypeParams resolves a `<…>` type-parameter list to soltype TypeParams in three passes,
+// since a default and a bound need opposite visibility. Pass 1 mints one fresh var per parameter.
+// Pass 2 resolves each parameter's default and then declares that parameter, so a default reads
+// only the earlier siblings, the ones instantiation can substitute for it. Pass 3 resolves each
+// constraint into its var's upper bound against the full list, so a forward `<T: U, U>`, a mutual
+// `<T: U, U: T>`, and an F-bound `<T: Foo<T>>` all resolve. The result stays in declaration order,
+// and the alias, class, enum, and function-annotation paths all route through here.
 func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypeParam) []*soltype.TypeParam {
 	out := make([]*soltype.TypeParam, len(params))
 	// Pass 1: mint each parameter's var. Nothing is declared yet, so pass 2 controls which
@@ -67,35 +47,13 @@ func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypePar
 	return out
 }
 
-// reportDefaultForwardRef reports the first reference params[i]'s default makes to a parameter
-// it may not name, meaning params[i] itself or one declared after it. It returns whether it
-// reported.
-//
-// A reference that omits a trailing argument fills it from that parameter's default,
-// substituting the arguments before it. buildAliasInstance does exactly that for the `U = T`
-// of `type Pair<T, U = T>`. Only a parameter earlier in the list has an argument by then, so
-// only an earlier one is replaced by that substitution.
-//
-// A later or self reference is left untouched, so it stays the declaration's own var, and
-// every reference to the type shares that one var. In `type Pair<T = U, U = number> = {a: T, b: U}`,
-// `T`'s default resolves to `U`'s var, so admitting it would let `val q: Pair = {a: "s", b: 3}`
-// widen a second `val p: Pair = {a: 1, b: 2}` to `Pair<1 | "s", number>`. Rejecting the default
-// keeps that var out of every instance.
-//
-// The caller drops a rejected default rather than replacing it, so the parameter becomes
-// required. Whether omitting that argument then reports a second diagnostic is up to the
-// instance builder, and neither builder reports it in every case today. buildAliasInstance
-// counts its required arguments as the number of parameters carrying no default, with no
-// regard for where those parameters sit. Writing `Tri<string>` against
-// `type Tri<T = number, U = V, V = number>` passes that count, so the omitted `U` becomes a
-// fresh var with only the ordering error reported. An arity mismatch is reported when no
-// defaulted parameter precedes the rejected one. buildClassInstance checks no arity at all.
-// PR18 of planning/simple_sub/m9-implementation-plan.md factors both builders into one
-// helper, which is where a positional count belongs.
-//
-// The restriction covers the default position alone. A bound may name any sibling, since
-// `<T: U, U: T>` is a legal mutual F-bound and `<T: Foo<T>>` names the parameter being
-// declared. Neither is substituted positionally, so neither needs the ordering a default does.
+// reportDefaultForwardRef reports the first reference params[i]'s default makes to a parameter it
+// may not name, params[i] itself or one declared after it, and returns whether it reported. A
+// reference fills an omitted argument from the default with the earlier arguments substituted in,
+// as buildAliasInstance does for the `U = T` of `type Pair<T, U = T>`. A later or self reference
+// has nothing to substitute, so it stays the declaration's own var, shared by every reference to
+// the type. A rejected default is dropped, which leaves the parameter required. Neither instance
+// builder reports the follow-on arity error in every case, which PR18's shared helper settles.
 func (c *checker) reportDefaultForwardRef(params []*ast.TypeParam, i int) bool {
 	forbidden := set.NewSet[string]()
 	for _, p := range params[i:] {
@@ -114,28 +72,15 @@ func (c *checker) reportDefaultForwardRef(params []*ast.TypeParam, i int) bool {
 	return false
 }
 
-// typeParamRefScan walks a type annotation and collects the references that read a name from
-// outside it, so a caller can tell a reference to an enclosing `<…>` parameter from one a
-// binder written inside the annotation introduces.
-//
-// free holds those references in traversal order, so a caller reports the leftmost offending
-// one. A reference whose name an enclosing binder declares is left out, since it reads that
-// binder's name rather than a `<…>` parameter's. Three binders can appear inside an
-// annotation, and the scan tracks the region each one covers:
-//
-//   - A `fn <U>(…)` quantifier covers the whole function annotation.
-//   - A mapped type's key binder, the `K` of `{[K: Keys]: V}`, covers the object annotation
-//     that holds it. That is wider than the binder's own region by the key constraint and any
-//     sibling element, so `{[K: Keys]: V, other: K}` reads `other: K` as the key binder.
-//   - An `infer U` clause covers the Extends and Then operands of the conditional whose
-//     Extends declares it, matching where resolveCondTypeAnn declares the name. The same name
-//     in the Else operand is a free reference.
-//
-// scopes holds one name set per region the walk is currently inside, innermost last.
+// typeParamRefScan collects a type annotation's free references, the `Name` and `Name<…>`
+// references that no binder written inside the annotation declares. It tracks the region each
+// binder covers: a `fn <U>(…)` quantifier covers its function annotation, a mapped key covers the
+// object annotation holding it, and an `infer U` covers its conditional's Extends and Then
+// operands, matching where resolveCondTypeAnn declares the name.
 type typeParamRefScan struct {
 	ast.DefaultVisitor
-	scopes []set.Set[string]
-	free   []*ast.TypeRefTypeAnn
+	scopes []set.Set[string]     // one name set per region the walk is inside, innermost last
+	free   []*ast.TypeRefTypeAnn // in traversal order, so a caller reports the leftmost
 }
 
 func (v *typeParamRefScan) EnterTypeAnn(t ast.TypeAnn) bool {

--- a/internal/solver/type_params_test.go
+++ b/internal/solver/type_params_test.go
@@ -105,6 +105,27 @@ func TestTypeParamDefaultForwardRef(t *testing.T) {
 				type Pick<T = if [number] : [infer U] { U } else { never }, U = string> = {a: T, b: U}
 			`,
 		},
+		// A default that reaches two later parameters names both, so one pass over the reported
+		// errors is enough to fix it.
+		{
+			name: "TwoLaterParamsBothReported",
+			src: `
+				type Bad<T = {a: U, b: V}, U = number, V = string> = {t: T, u: U, v: V}
+			`,
+			want: []string{
+				"the default for type parameter `T` cannot reference `U`, which is declared after it",
+				"the default for type parameter `T` cannot reference `V`, which is declared after it",
+			},
+		},
+		// One name written twice needs one fix, so it reports once, blaming its leftmost
+		// reference.
+		{
+			name: "RepeatedLaterParamReportedOnce",
+			src: `
+				type Bad<T = {a: U, b: U}, U = number> = {t: T, u: U}
+			`,
+			want: []string{"the default for type parameter `T` cannot reference `U`, which is declared after it"},
+		},
 		// A binder covers its own region and no more. The mapped key `U` is nested inside the
 		// `m` property, so the `b: U` beside it reads the later sibling parameter and is
 		// reported even though the same name is bound elsewhere in the default.

--- a/internal/solver/type_params_test.go
+++ b/internal/solver/type_params_test.go
@@ -1,0 +1,149 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTypeParamDefaultForwardRef covers the ordering rule on a type parameter's default. It
+// may name only a parameter declared before it. A reference that omits a trailing argument
+// fills it from that parameter's default, substituting the arguments before it, so a default
+// naming a later parameter or itself has nothing to substitute and would carry the
+// declaration's own var into the instance.
+//
+// The rule reaches every `<…>` list, since the alias, class, enum, and function-annotation
+// paths all resolve their parameters through resolveTypeParams. It covers the default
+// position alone, so a bound naming a later sibling still resolves.
+func TestTypeParamDefaultForwardRef(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "AliasLaterParam",
+			src: `
+				type Pair<T = U, U = number> = {a: T, b: U}
+				val p: Pair<string, number> = {a: "s", b: 1}
+			`,
+			want: []string{"the default for type parameter `T` cannot reference `U`, which is declared after it"},
+		},
+		{
+			name: "AliasSelf",
+			src: `
+				type Loop<T = T> = {v: T}
+				val l: Loop<number> = {v: 1}
+			`,
+			want: []string{"the default for type parameter `T` cannot reference `T` itself"},
+		},
+		// The reference is nested inside a type argument rather than written bare, so the
+		// scan has to reach it through the annotation rather than read the default's head.
+		{
+			name: "AliasNestedInTypeArgument",
+			src: `
+				type Box<X> = {v: X}
+				type Wrap<T = Box<U>, U = number> = {a: T, b: U}
+				val w: Wrap<Box<number>, number> = {a: {v: 1}, b: 2}
+			`,
+			want: []string{"the default for type parameter `T` cannot reference `U`, which is declared after it"},
+		},
+		{
+			name: "ClassLaterParam",
+			src:  `class C<T = U, U = number> { value: T }`,
+			want: []string{"the default for type parameter `T` cannot reference `U`, which is declared after it"},
+		},
+		{
+			name: "EnumLaterParam",
+			src:  `enum Opt<T = U, U = number> { Some(T), None }`,
+			want: []string{"the default for type parameter `T` cannot reference `U`, which is declared after it"},
+		},
+		{
+			name: "FuncAnnotationLaterParam",
+			src:  `val f: fn<T = U, U = number>(x: T) -> T = fn (x) { return x }`,
+			want: []string{"the default for type parameter `T` cannot reference `U`, which is declared after it"},
+		},
+		// A default naming an earlier parameter is what the rule allows, since that
+		// parameter's argument is already resolved when the default fills the later slot.
+		{
+			name: "AliasEarlierParamAccepted",
+			src: `
+				type Pair<T = number, U = T> = {a: T, b: U}
+				val p: Pair = {a: 1, b: 2}
+			`,
+		},
+		// A bound is not substituted positionally, so a mutual F-bound keeps resolving.
+		{
+			name: "MutualBoundAccepted",
+			src: `
+				type Pair<T: U, U: T> = {a: T, b: U}
+				val p: Pair<number, number> = {a: 1, b: 2}
+			`,
+		},
+		// The nested `fn <U>(…)` quantifier declares its own `U`, so the `U` inside it reads
+		// that binder rather than the later sibling parameter.
+		{
+			name: "NestedQuantifierShadowsAccepted",
+			src: `
+				type Holder<T = fn<U>(x: U) -> U, U = number> = {a: T, b: U}
+				val h: Holder<fn<X>(x: X) -> X, number> = {a: fn (x) { return x }, b: 1}
+			`,
+		},
+		// A mapped type's `[U: "a"]` key is its own binder, so the `U` the value position
+		// reads is that key rather than the later sibling parameter.
+		{
+			name: "MappedKeyShadowsAccepted",
+			src: `
+				type Named<T = {[U: "a"]: U}, U = number> = {a: T, b: U}
+			`,
+		},
+		// An `infer U` clause binds `U` for the conditional's Then branch, so the `U` that
+		// branch reads is the capture rather than the later sibling parameter.
+		{
+			name: "InferClauseShadowsAccepted",
+			src: `
+				type Pick<T = if [number] : [infer U] { U } else { never }, U = string> = {a: T, b: U}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, len(tt.want))
+			for i, want := range tt.want {
+				require.Equal(t, want, errs[i].Message())
+			}
+		})
+	}
+}
+
+// TestTypeParamDefaultForwardRefLeavesParamRequired checks the recovery. A rejected default is
+// dropped rather than replaced, which leaves that parameter required, so a reference that omits
+// it reports the arity mismatch that names the omission alongside the ordering error. `U` keeps
+// its own `= number` default, so the range the arity message states starts at one rather than
+// two.
+func TestTypeParamDefaultForwardRefLeavesParamRequired(t *testing.T) {
+	src := `
+		type Pair<T = U, U = number> = {a: T, b: U}
+		val p: Pair = {a: 1, b: 2}
+	`
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 2)
+	require.Equal(t, "the default for type parameter `T` cannot reference `U`, which is declared after it", errs[0].Message())
+	require.Equal(t, "type alias `Pair` expects between 1 and 2 type arguments but got 0", errs[1].Message())
+}
+
+// TestTypeParamDefaultIsPerReference checks that a default filled at one reference does not
+// reach another. `U = T` substitutes the argument that reference wrote for `T`, so `p` and `q`
+// each carry their own second argument instead of sharing one var declared on the alias.
+func TestTypeParamDefaultIsPerReference(t *testing.T) {
+	src := `
+		type Pair<T, U = T> = {a: T, b: U}
+		val p: Pair<number> = {a: 1, b: 2}
+		val q: Pair<string> = {a: "s", b: "t"}
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "Pair<number, number>", values["p"])
+	require.Equal(t, "Pair<string, string>", values["q"])
+}

--- a/internal/solver/type_params_test.go
+++ b/internal/solver/type_params_test.go
@@ -105,6 +105,25 @@ func TestTypeParamDefaultForwardRef(t *testing.T) {
 				type Pick<T = if [number] : [infer U] { U } else { never }, U = string> = {a: T, b: U}
 			`,
 		},
+		// A binder covers its own region and no more. The mapped key `U` is nested inside the
+		// `m` property, so the `b: U` beside it reads the later sibling parameter and is
+		// reported even though the same name is bound elsewhere in the default.
+		{
+			name: "MappedKeyDoesNotShadowSibling",
+			src: `
+				type Bad<T = {m: {[U: "a"]: number}, b: U}, U = unknown> = {t: T, u: U}
+			`,
+			want: []string{"the default for type parameter `T` cannot reference `U`, which is declared after it"},
+		},
+		// An `infer U` capture does not reach the Else branch, matching where
+		// resolveCondTypeAnn declares the name, so the `U` there reads the later sibling.
+		{
+			name: "InferClauseDoesNotShadowElseBranch",
+			src: `
+				type Bad<T = if [number] : [infer U] { number } else { U }, U = unknown> = {t: T, u: U}
+			`,
+			want: []string{"the default for type parameter `T` cannot reference `U`, which is declared after it"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -119,9 +138,10 @@ func TestTypeParamDefaultForwardRef(t *testing.T) {
 
 // TestTypeParamDefaultForwardRefLeavesParamRequired checks the recovery. A rejected default is
 // dropped rather than replaced, which leaves that parameter required, so a reference that omits
-// it reports the arity mismatch that names the omission alongside the ordering error. `U` keeps
-// its own `= number` default, so the range the arity message states starts at one rather than
-// two.
+// it reports an arity mismatch alongside the ordering error. `T` is the first parameter, so no
+// defaulted parameter sits before it and buildAliasInstance's count catches the omission. `U`
+// keeps its own `= number` default, so the range the arity message states starts at one rather
+// than two.
 func TestTypeParamDefaultForwardRefLeavesParamRequired(t *testing.T) {
 	src := `
 		type Pair<T = U, U = number> = {a: T, b: U}


### PR DESCRIPTION
A type parameter's default may now reference only earlier siblings, not later ones or itself. This prevents defaults from carrying a parameter's own var into instances when the default is substituted positionally.

**Changes:**

- Split `resolveTypeParams` into three passes: Pass 1 mints each parameter's var, Pass 2 resolves defaults (growing scope one parameter at a time), and Pass 3 resolves bounds (with all siblings in scope). This gives defaults and bounds opposite visibility: a default sees only earlier siblings, while a bound may reference any sibling.

- Added `reportDefaultForwardRef` to detect and report defaults that reference a parameter itself or one declared after it. The check walks the default's AST to find free references (those not shadowed by nested binders like `fn <U>`, mapped-type keys, or `infer` clauses) and reports the leftmost offending one.

- Added `typeParamRefScan` visitor to collect free references in a type annotation, tracking nested binder regions (function quantifiers, mapped-type keys, conditional `infer` clauses) so shadowed names are excluded.

- Added `TypeParamDefaultForwardRefError` to report the violation with a clear message distinguishing self-reference from forward reference to a later sibling.

- Updated `TestInferClassCrossParamBounds` to reflect that defaults are now restricted while bounds remain unrestricted. Removed forward and mutual default test cases; added an earlier-default case that is accepted.

- Added comprehensive test suite `TestTypeParamDefaultForwardRef` covering the rule across aliases, classes, enums, and function annotations, including nested references and shadowing by nested binders. Added `TestTypeParamDefaultForwardRefLeavesParamRequired` to verify recovery (rejected default leaves parameter required). Added `TestTypeParamDefaultIsPerReference` to confirm defaults are substituted per-reference, not shared across instances.

The restriction applies to all `<…>` lists (aliases, classes, enums, function annotations) since they all route through `resolveTypeParams`.

https://claude.ai/code/session_0184LNirKmxfXkYXFJHV3XgZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostics for type-parameter defaults that reference themselves or parameters declared later.
  * Earlier type parameters can be referenced in defaults, while invalid forward references are rejected.
  * Improved handling of nested type scopes and conditional annotations.

* **Bug Fixes**
  * Invalid defaults are omitted correctly, preserving required-parameter validation.
  * Default substitutions are now handled independently for each reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->