### PR TITLE
Warn about unused and unreachable type parameters

### DIFF
--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -357,17 +357,23 @@ const (
 // here means subtyping, not the outliving ':' of a LifetimeParam bound. A
 // binder is a type or a lifetime, never both, so the two never mix on one
 // binder and the checker picks the relation from the binder's sort. Variance is
-// the optional `in`/`out`/`in out` declaration-site modifier.
+// the optional `in`/`out`/`in out` declaration-site modifier. span covers the
+// whole binder, from the variance modifier or the name through the end of a
+// constraint or default, so a diagnostic about the parameter can point at the
+// declaration that introduced it.
 type TypeParam struct {
 	Name       string
 	Constraint TypeAnn
 	Default    TypeAnn
 	Variance   VarianceModifier
+	span       Span
 }
 
-func NewTypeParam(name string, constraint, defaultType TypeAnn) TypeParam {
-	return TypeParam{Name: name, Constraint: constraint, Default: defaultType}
+func NewTypeParam(name string, constraint, defaultType TypeAnn, span Span) TypeParam {
+	return TypeParam{Name: name, Constraint: constraint, Default: defaultType, span: span}
 }
+
+func (t *TypeParam) Span() Span { return t.span }
 
 type FuncSig struct {
 	LifetimeParams []*LifetimeParam // optional, e.g. <'a, 'b: 'a>

--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -358,9 +358,9 @@ const (
 // binder is a type or a lifetime, never both, so the two never mix on one
 // binder and the checker picks the relation from the binder's sort. Variance is
 // the optional `in`/`out`/`in out` declaration-site modifier. span covers the
-// whole binder, from the variance modifier or the name through the end of a
-// constraint or default, so a diagnostic about the parameter can point at the
-// declaration that introduced it.
+// whole binder. It runs from the variance modifier or the name through the end
+// of a constraint or default, so a diagnostic about the parameter can point at
+// the declaration that introduced it.
 type TypeParam struct {
 	Name       string
 	Constraint TypeAnn

--- a/internal/interop/__snapshots__/helper_test.snap
+++ b/internal/interop/__snapshots__/helper_test.snap
@@ -610,6 +610,7 @@
     TypeParams: []*ast.TypeParam{
         &ast.TypeParam{
             Name: "T",
+            span: 1:2-1:3,
         },
     },
     Params: []*ast.Param{
@@ -646,6 +647,7 @@
             Constraint: &ast.StringTypeAnn{
                 span: 1:12-1:18,
             },
+            span: 1:2-1:18,
         },
     },
     Params: []*ast.Param{
@@ -1480,12 +1482,14 @@
             Constraint: &ast.StringTypeAnn{
                 span: 1:12-1:18,
             },
+            span: 1:2-1:18,
         },
         &ast.TypeParam{
             Name: "U",
             Constraint: &ast.NumberTypeAnn{
                 span: 1:30-1:36,
             },
+            span: 1:20-1:36,
         },
     },
     Params: []*ast.Param{
@@ -1864,6 +1868,7 @@
             TypeParams: []*ast.TypeParam{
                 &ast.TypeParam{
                     Name: "T",
+                    span: 1:26-1:27,
                 },
             },
             Params: []*ast.Param{

--- a/internal/interop/decl.go
+++ b/internal/interop/decl.go
@@ -295,11 +295,10 @@ func convertInterfaceDecl(di *dts_parser.InterfaceDecl) (ast.Decl, error) {
 	}
 
 	if di.Name.Name == "PromiseLike" || di.Name.Name == "Promise" {
-		errorTypeParam := ast.NewTypeParam(
-			"E",
-			nil,
-			ast.NewAnyTypeAnn(ast.NewSpan(ast.Location{Line: 0, Column: 0}, ast.Location{Line: 0, Column: 0}, 0)),
-		)
+		// The rejection parameter is synthesized rather than read from the `.d.ts`, so it
+		// borrows the declaration's own span.
+		synthSpan := ast.NewSpan(ast.Location{Line: 0, Column: 0}, ast.Location{Line: 0, Column: 0}, 0)
+		errorTypeParam := ast.NewTypeParam("E", nil, ast.NewAnyTypeAnn(synthSpan), di.Span())
 		typeParams = append(typeParams, &errorTypeParam)
 		visitor := &PromiseVisitor{
 			ast.DefaultVisitor{},

--- a/internal/interop/helper.go
+++ b/internal/interop/helper.go
@@ -53,7 +53,7 @@ func convertTypeParam(tp *dts_parser.TypeParam) (*ast.TypeParam, error) {
 		}
 	}
 
-	typeParam := ast.NewTypeParam(tp.Name.Name, constraint, defaultType)
+	typeParam := ast.NewTypeParam(tp.Name.Name, constraint, defaultType, tp.Span())
 	return &typeParam, nil
 }
 

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -3197,6 +3197,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:5-1:6,
             },
         },
         Params: []*ast.Param{
@@ -3244,9 +3245,11 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "A",
+                span: 1:5-1:6,
             },
             &ast.TypeParam{
                 Name: "B",
+                span: 1:8-1:9,
             },
         },
         Params: []*ast.Param{

--- a/internal/parser/__snapshots__/lifetime_test.snap
+++ b/internal/parser/__snapshots__/lifetime_test.snap
@@ -192,6 +192,7 @@
             TypeParams: []*ast.TypeParam{
                 &ast.TypeParam{
                     Name: "T",
+                    span: 1:17-1:18,
                 },
             },
             Params: []*ast.Param{
@@ -1614,6 +1615,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:23-1:24,
             },
         },
         TypeAnn: &ast.TupleTypeAnn{
@@ -1671,6 +1673,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:14-1:15,
             },
         },
         TypeAnn: &ast.RefTypeAnn{

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -905,6 +905,7 @@
             TypeParams: []*ast.TypeParam{
                 &ast.TypeParam{
                     Name: "T",
+                    span: 2:17-2:18,
                 },
             },
             Params: []*ast.Param{
@@ -1016,6 +1017,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 2:16-2:17,
             },
         },
         Elems: []ast.EnumElem{
@@ -1065,9 +1067,11 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 2:24-2:25,
             },
             &ast.TypeParam{
                 Name: "E",
+                span: 2:27-2:28,
             },
         },
         Elems: []ast.EnumElem{
@@ -2170,6 +2174,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 2:15-2:16,
             },
         },
         Extends: &ast.TypeRefTypeAnn{
@@ -2451,6 +2456,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 2:19-2:20,
             },
         },
         Extends: []*ast.TypeRefTypeAnn{
@@ -2600,9 +2606,11 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 2:19-2:20,
             },
             &ast.TypeParam{
                 Name: "U",
+                span: 2:22-2:23,
             },
         },
         Extends: []*ast.TypeRefTypeAnn{
@@ -3535,6 +3543,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 2:15-2:16,
             },
         },
         Body: []ast.ClassElem{
@@ -3558,6 +3567,7 @@
                         TypeParams: []*ast.TypeParam{
                             &ast.TypeParam{
                                 Name: "U",
+                                span: 4:18-4:19,
                             },
                         },
                         Params: []*ast.Param{
@@ -4273,6 +4283,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 2:22-2:23,
             },
         },
         Extends: &ast.TypeRefTypeAnn{
@@ -4723,6 +4734,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 2:18-2:19,
             },
         },
         Implements: []*ast.TypeRefTypeAnn{
@@ -5199,6 +5211,7 @@
                 TypeParams: []*ast.TypeParam{
                     &ast.TypeParam{
                         Name: "T",
+                        span: 26:25-26:26,
                     },
                 },
                 Body: []ast.ClassElem{

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -879,12 +879,14 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:13-1:14,
             },
             &ast.TypeParam{
                 Name: "U",
                 Constraint: &ast.StringTypeAnn{
                     span: 1:19-1:25,
                 },
+                span: 1:16-1:25,
             },
         },
         TypeAnn: &ast.ObjectTypeAnn{
@@ -934,6 +936,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:13-1:14,
             },
         },
         TypeAnn: &ast.TypeRefTypeAnn{
@@ -971,6 +974,7 @@
                 Constraint: &ast.NumberTypeAnn{
                     span: 1:16-1:22,
                 },
+                span: 1:13-1:22,
             },
             &ast.TypeParam{
                 Name: "U",
@@ -980,6 +984,7 @@
                 Default: &ast.StringTypeAnn{
                     span: 1:36-1:42,
                 },
+                span: 1:24-1:42,
             },
         },
         TypeAnn: &ast.UnionTypeAnn{
@@ -1226,6 +1231,7 @@
                         TypeParams: []*ast.TypeParam{
                             &ast.TypeParam{
                                 Name: "T",
+                                span: 1:30-1:31,
                             },
                         },
                         Params: []*ast.Param{
@@ -1285,6 +1291,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:11-1:12,
             },
         },
         Body: []ast.ClassElem{
@@ -1418,6 +1425,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:14-1:15,
             },
         },
         Body: []ast.ClassElem{
@@ -1445,6 +1453,7 @@
                         TypeParams: []*ast.TypeParam{
                             &ast.TypeParam{
                                 Name: "U",
+                                span: 3:9-3:10,
                             },
                         },
                         Params: []*ast.Param{
@@ -1564,6 +1573,7 @@
                 Default: &ast.StringTypeAnn{
                     span: 1:25-1:31,
                 },
+                span: 1:16-1:31,
             },
         },
         Body: []ast.ClassElem{
@@ -1601,12 +1611,14 @@
                 Constraint: &ast.NumberTypeAnn{
                     span: 1:15-1:21,
                 },
+                span: 1:12-1:21,
             },
             &ast.TypeParam{
                 Name: "U",
                 Constraint: &ast.StringTypeAnn{
                     span: 1:26-1:32,
                 },
+                span: 1:23-1:32,
             },
         },
         Body: []ast.ClassElem{
@@ -1663,6 +1675,7 @@
                         TypeParams: []*ast.TypeParam{
                             &ast.TypeParam{
                                 Name: "T",
+                                span: 1:30-1:31,
                             },
                         },
                         Params: []*ast.Param{
@@ -3274,9 +3287,11 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:16-1:17,
             },
             &ast.TypeParam{
                 Name: "U",
+                span: 1:19-1:20,
             },
         },
         TypeAnn: &ast.ObjectTypeAnn{
@@ -3363,6 +3378,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:15-1:16,
             },
         },
         TypeAnn: &ast.ObjectTypeAnn{
@@ -4344,6 +4360,7 @@
             &ast.TypeParam{
                 Name: "T",
                 Variance: 3,
+                span: 1:12-1:20,
             },
         },
         Body: []ast.ClassElem{
@@ -4382,6 +4399,7 @@
                     span: 1:18-1:24,
                 },
                 Variance: 1,
+                span: 1:11-1:24,
             },
         },
         Body: []ast.ClassElem{
@@ -4417,6 +4435,7 @@
             &ast.TypeParam{
                 Name: "T",
                 Variance: 2,
+                span: 1:16-1:20,
             },
         },
         Body: []ast.ClassElem{
@@ -4471,6 +4490,7 @@
             &ast.TypeParam{
                 Name: "T",
                 Variance: 1,
+                span: 1:11-1:16,
             },
         },
         Body: []ast.ClassElem{
@@ -4505,6 +4525,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:8-1:12,
             },
         },
         Elems: []ast.EnumElem{
@@ -4542,6 +4563,7 @@
             TypeParams: []*ast.TypeParam{
                 &ast.TypeParam{
                     Name: "T",
+                    span: 1:6-1:11,
                 },
             },
             Params: []*ast.Param{
@@ -4595,6 +4617,7 @@
         TypeParams: []*ast.TypeParam{
             &ast.TypeParam{
                 Name: "T",
+                span: 1:10-1:15,
             },
         },
         TypeAnn: &ast.ObjectTypeAnn{

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -2401,6 +2401,7 @@
                 TypeParams: []*ast.TypeParam{
                     &ast.TypeParam{
                         Name: "T",
+                        span: 1:7-1:8,
                     },
                 },
                 Params: []*ast.Param{
@@ -2615,6 +2616,7 @@
                 TypeParams: []*ast.TypeParam{
                     &ast.TypeParam{
                         Name: "T",
+                        span: 1:4-1:5,
                     },
                 },
                 Params: []*ast.Param{

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -77,12 +77,14 @@
             Constraint: &ast.NumberTypeAnn{
                 span: 1:7-1:13,
             },
+            span: 1:4-1:13,
         },
         &ast.TypeParam{
             Name: "U",
             Constraint: &ast.StringTypeAnn{
                 span: 1:18-1:24,
             },
+            span: 1:15-1:24,
         },
     },
     Params: []*ast.Param{

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -1060,6 +1060,9 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 
 func (p *Parser) typeParam(allowVariance bool) *ast.TypeParam {
 	variance, varianceSpan := p.parseVarianceModifier()
+	// A written modifier precedes the name, so it is where the binder starts. Record
+	// that before the rejection below drops the modifier.
+	wroteVariance := variance != ast.VarianceNone
 	if variance != ast.VarianceNone && !allowVariance {
 		// A variance modifier is meaningful only on a class or interface type parameter,
 		// where it is checked against the inferred variance. Anywhere else — a function,
@@ -1081,20 +1084,32 @@ func (p *Parser) typeParam(allowVariance bool) *ast.TypeParam {
 	p.lexer.consume() // consume identifier
 	name := token.Value
 
+	start := token.Span.Start
+	if wroteVariance {
+		start = varianceSpan.Start
+	}
+	end := token.Span.End
+
 	var constraint ast.TypeAnn
 	var default_ ast.TypeAnn
 
 	if p.lexer.peek().Type == Colon {
 		p.lexer.consume() // consume ':'
 		constraint = p.typeAnnRequired()
+		if constraint != nil {
+			end = constraint.Span().End
+		}
 	}
 
 	if p.lexer.peek().Type == Equal {
 		p.lexer.consume() // consume '='
 		default_ = p.typeAnnRequired()
+		if default_ != nil {
+			end = default_.Span().End
+		}
 	}
 
-	typeParam := ast.NewTypeParam(name, constraint, default_)
+	typeParam := ast.NewTypeParam(name, constraint, default_, ast.NewSpan(start, end, p.lexer.source.ID))
 	typeParam.Variance = variance
 	return &typeParam
 }

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -100,10 +100,11 @@ type aliasShell struct {
 	// def is the registered AliasDef preBindAlias inserted with a nil Body; inferAliasBody
 	// fills its Body once every sibling identity in the component is bound.
 	def *AliasDef
-	// bodyResolved is false when inferAliasBody recovered from a missing or unsupported
-	// annotation, which leaves the def's Body a fresh var that mentions no type parameter.
-	// reportPhantomParams reads it so a recovered body does not warn about every parameter.
-	bodyResolved bool
+	// bodyClean is true when inferAliasBody resolved the whole annotation with no
+	// diagnostic, the errorWindow rule applied to an alias. `type M<T> = {f(x: T) -> T}`
+	// drops the unsupported method and with it every occurrence of T, so reportPhantomParams
+	// reads this before warning that T is unused.
+	bodyClean bool
 }
 
 // preBindAlias resolves an alias's type parameters, registers a shell AliasDef whose Body
@@ -206,17 +207,18 @@ func (c *checker) inferAliasBody(sh *aliasShell) {
 
 	// A nil TypeAnn is parser error recovery for `type Foo =`, already reported. Bind a
 	// fresh var and skip resolveTypeAnn, since a nil annotation has no span to report on.
+	quiet := c.errorWindow()
 	var body soltype.Type = c.freshAt(sh.lvl)
 	if sh.decl.TypeAnn != nil {
 		if resolved, ok := c.resolveTypeAnn(sh.declScope, sh.decl.TypeAnn, sh.lvl); ok {
 			body = resolved
-			sh.bodyResolved = true
 		}
 		// An unsupported body reported its own error. Keep the fresh var so a reference
 		// resolves rather than cascading an unbound-name error, matching the Promise-wrapper
 		// recovery in resolveTypeAnn.
 	}
 	sh.def.Body = body
+	sh.bodyClean = sh.decl.TypeAnn != nil && quiet()
 }
 
 // buildAliasInstance resolves a use-site reference to a registered alias into an AliasType

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -100,11 +100,16 @@ type aliasShell struct {
 	// def is the registered AliasDef preBindAlias inserted with a nil Body; inferAliasBody
 	// fills its Body once every sibling identity in the component is bound.
 	def *AliasDef
-	// bodyClean is true when inferAliasBody resolved the whole annotation with no
-	// diagnostic, the errorWindow rule applied to an alias. `type M<T> = {f(x: T) -> T}`
-	// drops the unsupported method and with it every occurrence of T, so reportPhantomParams
-	// reads this before warning that T is unused.
-	bodyClean bool
+	// paramsClean is true when preBindAlias resolved the alias's `<…>` list with no
+	// diagnostic. A bound or default that fails to resolve is left nil, taking the
+	// occurrences it held with it, so `type Foo<T, U: Nope<T>> = number` keeps no record
+	// that U's bound wrote T.
+	paramsClean bool
+	// declClean is paramsClean and the same answer for the body, the errorWindow rule
+	// applied to an alias. `type M<T> = {f(x: T) -> T}` drops the unsupported method and
+	// with it every occurrence of T, so reportPhantomParams reads this before warning that
+	// T is unused.
+	declClean bool
 }
 
 // preBindAlias resolves an alias's type parameters, registers a shell AliasDef whose Body
@@ -114,6 +119,8 @@ type aliasShell struct {
 // body is still being walked. expandAlias only runs at subtyping time, after every body in
 // the component is filled, so the nil Body is never read during pre-binding.
 func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns string) *aliasShell {
+	quiet := c.errorWindow()
+
 	// The four intrinsic string operators — Uppercase, Lowercase, Capitalize, Uncapitalize — are
 	// built-in type operators, not aliases a user may shadow. Reject a `type Uppercase<T> = …`
 	// declaration and skip binding it, so a `Uppercase<…>` reference resolves to the built-in
@@ -168,7 +175,16 @@ func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns str
 	})
 	c.recordType(decl.Name, t)
 
-	return &aliasShell{decl: decl, ns: ns, lvl: lvl, qname: qname, declScope: declScope, namedLts: aliasNamedLts, def: def}
+	return &aliasShell{
+		decl:        decl,
+		ns:          ns,
+		lvl:         lvl,
+		qname:       qname,
+		declScope:   declScope,
+		namedLts:    aliasNamedLts,
+		def:         def,
+		paramsClean: quiet(),
+	}
 }
 
 // resolveAliasLifetimeParams mints one lifetime variable per `<'a, ...>` parameter through
@@ -218,7 +234,7 @@ func (c *checker) inferAliasBody(sh *aliasShell) {
 		// recovery in resolveTypeAnn.
 	}
 	sh.def.Body = body
-	sh.bodyClean = sh.decl.TypeAnn != nil && quiet()
+	sh.declClean = sh.paramsClean && sh.decl.TypeAnn != nil && quiet()
 }
 
 // buildAliasInstance resolves a use-site reference to a registered alias into an AliasType

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -100,6 +100,10 @@ type aliasShell struct {
 	// def is the registered AliasDef preBindAlias inserted with a nil Body; inferAliasBody
 	// fills its Body once every sibling identity in the component is bound.
 	def *AliasDef
+	// bodyResolved is false when inferAliasBody recovered from a missing or unsupported
+	// annotation, which leaves the def's Body a fresh var that mentions no type parameter.
+	// reportPhantomParams reads it so a recovered body does not warn about every parameter.
+	bodyResolved bool
 }
 
 // preBindAlias resolves an alias's type parameters, registers a shell AliasDef whose Body
@@ -206,6 +210,7 @@ func (c *checker) inferAliasBody(sh *aliasShell) {
 	if sh.decl.TypeAnn != nil {
 		if resolved, ok := c.resolveTypeAnn(sh.declScope, sh.decl.TypeAnn, sh.lvl); ok {
 			body = resolved
+			sh.bodyResolved = true
 		}
 		// An unsupported body reported its own error. Keep the fresh var so a reference
 		// resolves rather than cascading an unbound-name error, matching the Promise-wrapper

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -334,7 +334,7 @@ func TestUnsupportedAnnotationRecovers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tt.src)
 			require.Len(t, errs, 1)
-			require.Equal(t, "Unsupported: TypeRefTypeAnn", errs[0].Message())
+			require.Equal(t, "cannot find type `Foo`", errs[0].Message())
 			require.Equal(t, tt.want, values)
 		})
 	}

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1769,8 +1769,8 @@ func (e *UnusedLifetimeParamError) Message() string {
 // UnusedLifetimeParamError and is likewise always a warning. Name is the declared name,
 // and Param is the binder, which carries the blame span.
 //
-// A leading underscore quiets it, so `type Ignore<_T> = number` reports nothing. That is
-// the way to keep a binder a work in progress means to fill in.
+// A leading underscore quiets it, so `type Ignore<_T> = number` reports nothing. Write a
+// binder that way to keep one the source has not filled in yet.
 type UnusedTypeParamError struct {
 	Name  string
 	Param *ast.TypeParam
@@ -1814,9 +1814,9 @@ func (e *UnreachableTypeParamError) Message() string {
 }
 
 // instantiation renders a reference to the alias with the unreachable parameter filled by
-// arg and every other parameter left under its own name, which is what makes the two
-// renderings differ in exactly the one position the warning is about. `type Pair<T, U>`
-// with U unreachable gives `Pair<T, number>`.
+// arg and every other parameter left under its own name. The two renderings the message
+// pairs then differ in exactly the position the warning is about. `type Pair<T, U>` with U
+// unreachable gives `Pair<T, number>`.
 func (e *UnreachableTypeParamError) instantiation(arg string) string {
 	args := slices.Clone(e.Params)
 	args[e.Index] = arg

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1763,9 +1763,11 @@ func (e *UnusedLifetimeParamError) Message() string {
 	return "lifetime parameter '" + e.Name + " is declared but never used"
 }
 
-// UnusedTypeParamError fires when a type alias declares a `<T>` binder that its body does
-// not mention, and that no sibling parameter's bound or default mentions either. The
-// program is well-typed; the binder is dead weight. It is the type-sort twin of
+// UnusedTypeParamError fires when a type alias, a class, or an enum declares a `<T>` binder
+// that nothing in the declaration mentions, and that no sibling parameter's bound or default
+// mentions either. What counts as the declaration differs by sort — an alias's body, a
+// class's members and supers, an enum's variant parameters — and the conclusion does not.
+// The program is well-typed; the binder is dead weight. It is the type-sort twin of
 // UnusedLifetimeParamError and is likewise always a warning. Name is the declared name,
 // and Param is the binder, which carries the blame span.
 //

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -1760,6 +1761,66 @@ func (e *UnusedLifetimeParamError) Related() []ast.Span { return nil }
 func (e *UnusedLifetimeParamError) IsWarning() bool     { return true }
 func (e *UnusedLifetimeParamError) Message() string {
 	return "lifetime parameter '" + e.Name + " is declared but never used"
+}
+
+// UnusedTypeParamError fires when a type alias declares a `<T>` binder that its body does
+// not mention, and that no sibling parameter's bound or default mentions either. The
+// program is well-typed; the binder is dead weight. It is the type-sort twin of
+// UnusedLifetimeParamError and is likewise always a warning. Name is the declared name,
+// and Param is the binder, which carries the blame span.
+//
+// A leading underscore quiets it, so `type Ignore<_T> = number` reports nothing. That is
+// the way to keep a binder a work in progress means to fill in.
+type UnusedTypeParamError struct {
+	Name  string
+	Param *ast.TypeParam
+}
+
+func (*UnusedTypeParamError) isSolverError()        {}
+func (e *UnusedTypeParamError) Span() ast.Span      { return e.Param.Span() }
+func (e *UnusedTypeParamError) Related() []ast.Span { return nil }
+func (e *UnusedTypeParamError) IsWarning() bool     { return true }
+func (e *UnusedTypeParamError) Message() string {
+	return "type parameter " + e.Name + " is declared but never used"
+}
+
+// UnreachableTypeParamError fires when a type alias's body mentions a `<T>` binder, but no
+// argument passed to it can appear in the type an instantiation denotes. Every instantiation
+// of the alias is then one type, so a caller who writes an argument there says nothing by
+// writing it. `type Deep<T> = {a: Deep<{b: T}>}` pushes its payload one unfolding deeper
+// forever, and `Deep<number>` and `Deep<string>` are both `{a: {a: …}}`.
+//
+// It is a warning for the same reason UnusedTypeParamError is. The program checks either
+// way, and a leading underscore quiets it.
+//
+// Alias is the alias's qualified name and Params are its parameter names in declaration
+// order, both used to render the two instantiations the message names. Index is the
+// unreachable parameter's position, and Param is its binder, which carries the blame span.
+type UnreachableTypeParamError struct {
+	Alias  string
+	Params []string
+	Index  int
+	Param  *ast.TypeParam
+}
+
+func (*UnreachableTypeParamError) isSolverError()        {}
+func (e *UnreachableTypeParamError) Span() ast.Span      { return e.Param.Span() }
+func (e *UnreachableTypeParamError) Related() []ast.Span { return nil }
+func (e *UnreachableTypeParamError) IsWarning() bool     { return true }
+func (e *UnreachableTypeParamError) Message() string {
+	return "no argument passed to type parameter " + e.Params[e.Index] +
+		" can appear in the type, so " + e.instantiation("number") + " and " +
+		e.instantiation("string") + " are the same type"
+}
+
+// instantiation renders a reference to the alias with the unreachable parameter filled by
+// arg and every other parameter left under its own name, which is what makes the two
+// renderings differ in exactly the one position the warning is about. `type Pair<T, U>`
+// with U unreachable gives `Pair<T, number>`.
+func (e *UnreachableTypeParamError) instantiation(arg string) string {
+	args := slices.Clone(e.Params)
+	args[e.Index] = arg
+	return e.Alias + "<" + strings.Join(args, ", ") + ">"
 }
 
 // UnusedThrowsClauseError fires when a signature declares `throws T` but no `throw` and no

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1225,10 +1225,27 @@ func (e *ExtractorPatternArityError) Message() string {
 type TypeDeclKind string
 
 const (
-	AliasDeclKind TypeDeclKind = "type alias"
-	ClassDeclKind TypeDeclKind = "class"
-	EnumDeclKind  TypeDeclKind = "enum"
+	AliasDeclKind   TypeDeclKind = "type alias"
+	ClassDeclKind   TypeDeclKind = "class"
+	EnumDeclKind    TypeDeclKind = "enum"
+	BuiltinDeclKind TypeDeclKind = "built-in type"
 )
+
+// UnknownTypeError fires on a type reference whose name resolves to no declaration: no alias,
+// class, enum, or type parameter in scope, and none of the built-in names. It names what the
+// source wrote, qualified as written, so `Foo.Bar` reports under that whole path rather than
+// under either half.
+type UnknownTypeError struct {
+	Ref  *ast.TypeRefTypeAnn
+	Name string
+}
+
+func (*UnknownTypeError) isSolverError()        {}
+func (e *UnknownTypeError) Span() ast.Span      { return e.Ref.Span() }
+func (e *UnknownTypeError) Related() []ast.Span { return nil }
+func (e *UnknownTypeError) Message() string {
+	return "cannot find type `" + e.Name + "`"
+}
 
 // TypeArgArityMismatchError fires when a generic reference `Name<…>` supplies fewer than the
 // required number of type arguments or more than the total parameter count. A trailing
@@ -1244,11 +1261,21 @@ type TypeArgArityMismatchError struct {
 	Got      int
 }
 
+// pluralArguments agrees the noun with the count an arity message states, so a declaration
+// taking one parameter reads "1 type argument" rather than "1 type arguments".
+func pluralArguments(n int) string {
+	if n == 1 {
+		return "argument"
+	}
+	return "arguments"
+}
+
 func (e *TypeArgArityMismatchError) Span() ast.Span      { return e.Ref.Span() }
 func (e *TypeArgArityMismatchError) Related() []ast.Span { return nil }
 func (e *TypeArgArityMismatchError) Message() string {
 	if e.Required == e.Total {
-		return fmt.Sprintf("%s `%s` expects %d type arguments but got %d", e.Kind, e.Name, e.Total, e.Got)
+		return fmt.Sprintf("%s `%s` expects %d type %s but got %d",
+			e.Kind, e.Name, e.Total, pluralArguments(e.Total), e.Got)
 	}
 	return fmt.Sprintf("%s `%s` expects between %d and %d type arguments but got %d", e.Kind, e.Name, e.Required, e.Total, e.Got)
 }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -511,8 +511,8 @@ func (c *checker) report(e SolverError) soltype.Type {
 	return &soltype.ErrorType{}
 }
 
-// errorWindow records how many diagnostics have been reported and returns a predicate
-// answering whether any more arrived since. A caller warns only when it holds.
+// errorWindow records how many diagnostics have been reported and returns a predicate that
+// holds while none have been added since. A caller warns only when it still holds.
 //
 // The warnings about a declaration's type parameters read it. Recovery drops the subtree it
 // could not resolve, so a parameter written only there leaves no occurrence in what is

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -120,6 +120,11 @@ type checker struct {
 type classShell struct {
 	declScope  *Scope
 	typeParams []*soltype.TypeParam
+	// paramsClean records that the parameters resolved with no diagnostic. The module SCC
+	// pre-pass resolves them, so a bad bound or default is reported before inferClassDecl
+	// opens its own window and only this carries that news forward. A parameter whose
+	// binder was rejected has lost the occurrences it wrote, so it would read as unused.
+	paramsClean bool
 }
 
 // deferredArgBound is one `arg <: bound` comparison checkTypeArgBounds postponed until

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -511,6 +511,20 @@ func (c *checker) report(e SolverError) soltype.Type {
 	return &soltype.ErrorType{}
 }
 
+// errorWindow records how many diagnostics have been reported and returns a predicate
+// answering whether any more arrived since. A caller warns only when it holds.
+//
+// The warnings about a declaration's type parameters read it. Recovery drops the subtree it
+// could not resolve, so a parameter written only there leaves no occurrence in what is
+// stored. `class B<T> extends T {}` reports that T does not name a class and then keeps no
+// super, which would leave T reading as declared and never used. A declaration that already
+// carries a diagnostic is left alone rather than given a second one derived from the gap the
+// first one left.
+func (c *checker) errorWindow() func() bool {
+	before := len(c.errs)
+	return func() bool { return len(c.errs) == before }
+}
+
 // reportUnsupported records an UnsupportedNodeError for an AST node whose kind is
 // outside the M2 subset. The node self-blames: both the span and the rendered kind
 // (astKind) come from it. When the unsupported thing is a child carried by its

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -135,7 +135,8 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 //
 // A method's `self` receiver is dropped, since every method names the class in it and
 // counting that would make each parameter look used. stripSelfReceiver is the same helper
-// variance inference uses for the same reason.
+// variance inference uses for the same reason. Every other position of a member's signature
+// counts, `throws` included, because AcceptObjElem walks the whole of it.
 func classDeclOccurrences(def *ClassDef, ctor soltype.Type, v soltype.TypeVisitor) {
 	for _, obj := range []*soltype.ObjectType{def.Body, def.Static} {
 		if obj == nil {
@@ -146,13 +147,20 @@ func classDeclOccurrences(def *ClassDef, ctor soltype.Type, v soltype.TypeVisito
 		}
 	}
 	// The constructor is the class's value binding rather than a Static member, so a
-	// parameter written only in `constructor(v: T)` is reached here and nowhere else. Only
-	// its parameters are walked. Its return is the class's own handle, minted with every
-	// type-parameter var as an argument, so walking that would mark them all.
+	// parameter written only in `constructor(v: T) throws E` is reached here and nowhere
+	// else. Walking a copy rather than its fields one by one is what keeps every position
+	// FuncType.Accept covers — parameters, `throws`, and the constructor's own type-parameter
+	// bounds — counted the way a method's are.
+	//
+	// Two positions are cleared first. The receiver is dropped for the reason
+	// stripSelfReceiver drops a method's. The return is the class's own handle, minted with
+	// every type-parameter var as an argument, so walking it would mark them all; `never`
+	// stands in because it is a leaf that names nothing.
 	if fn, ok := ctor.(*soltype.FuncType); ok {
-		for _, param := range fn.Params {
-			param.Type.Accept(v, soltype.Positive)
-		}
+		bare := *fn
+		bare.SelfParam = nil
+		bare.Ret = &soltype.NeverType{}
+		bare.Accept(v, soltype.Positive)
 	}
 	for _, super := range def.Supers {
 		super.Accept(v, soltype.Positive)

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -42,6 +42,10 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	c.classNamespace = ns
 	defer func() { c.classNamespace = prevNS }()
 
+	// The window opens before the parameters resolve, so a diagnostic drawn by a bound or a
+	// default suppresses the unused warning the same way one drawn by the body does.
+	quiet := c.errorWindow()
+
 	// The class's type parameters and the scope its body resolves in, taken from the module
 	// SCC pre-pass when there was one and resolved here when there was not.
 	declScope, typeParams := c.classDeclScope(scope, lvl, decl)
@@ -115,7 +119,47 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// sits under.
 	def.Variance, def.MutVariance = c.inferVariance(def, decl)
 
+	if quiet() {
+		c.reportUnusedTypeParams(typeParams, decl.TypeParams, func(v soltype.TypeVisitor) {
+			classDeclOccurrences(def, ctorType, v)
+		})
+	}
+
 	return c.classValue(ctorType, static), &ast.NodeProvenance{Node: decl}, true
+}
+
+// classDeclOccurrences visits every type a class declaration writes, so a walker over it
+// sees each position that could name one of the class's type parameters. That is the
+// instance and static members, the constructor's signature, and the `extends` and
+// `implements` targets.
+//
+// A method's `self` receiver is dropped, since every method names the class in it and
+// counting that would make each parameter look used. stripSelfReceiver is the same helper
+// variance inference uses for the same reason.
+func classDeclOccurrences(def *ClassDef, ctor soltype.Type, v soltype.TypeVisitor) {
+	for _, obj := range []*soltype.ObjectType{def.Body, def.Static} {
+		if obj == nil {
+			continue
+		}
+		for _, elem := range obj.Elems {
+			soltype.AcceptObjElem(stripSelfReceiver(elem), v, soltype.Positive)
+		}
+	}
+	// The constructor is the class's value binding rather than a Static member, so a
+	// parameter written only in `constructor(v: T)` is reached here and nowhere else. Only
+	// its parameters are walked. Its return is the class's own handle, minted with every
+	// type-parameter var as an argument, so walking that would mark them all.
+	if fn, ok := ctor.(*soltype.FuncType); ok {
+		for _, param := range fn.Params {
+			param.Type.Accept(v, soltype.Positive)
+		}
+	}
+	for _, super := range def.Supers {
+		super.Accept(v, soltype.Positive)
+	}
+	for _, iface := range def.Implements {
+		iface.Accept(v, soltype.Positive)
+	}
 }
 
 // bindScriptClass infers a class declared at a script's top level (bin/) and binds its

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -42,12 +42,15 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	c.classNamespace = ns
 	defer func() { c.classNamespace = prevNS }()
 
-	// The window opens before the parameters resolve, so a diagnostic drawn by a bound or a
-	// default suppresses the unused warning the same way one drawn by the body does.
+	// This window covers the body. A class in an SCC component resolved its parameters in the
+	// module pre-pass, before this point, so a diagnostic drawn by a bound or a default is
+	// carried on the shell instead and both are consulted before the unused warning is
+	// reported.
 	quiet := c.errorWindow()
 
 	// The class's type parameters and the scope its body resolves in, taken from the module
 	// SCC pre-pass when there was one and resolved here when there was not.
+	paramsClean := c.classParamsClean(decl)
 	declScope, typeParams := c.classDeclScope(scope, lvl, decl)
 
 	// The instance's nominal identity and its heavy ClassDef. getOrCreateClass returns
@@ -119,7 +122,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// sits under.
 	def.Variance, def.MutVariance = c.inferVariance(def, decl)
 
-	if quiet() {
+	if quiet() && paramsClean {
 		c.reportUnusedTypeParams(typeParams, decl.TypeParams, func(v soltype.TypeVisitor) {
 			classDeclOccurrences(def, ctorType, v)
 		})
@@ -269,6 +272,16 @@ func (c *checker) classDeclScope(scope *Scope, lvl int, decl *ast.ClassDecl) (*S
 	return declScope, c.resolveTypeParams(declScope, lvl, decl.TypeParams)
 }
 
+// classParamsClean reports whether the module pre-pass resolved this class's type parameters
+// with no diagnostic. A class the pre-pass never saw resolves them inside inferClassDecl, where
+// that function's own window covers them, so it counts as clean here.
+func (c *checker) classParamsClean(decl *ast.ClassDecl) bool {
+	if sh, ok := c.classShells[decl]; ok {
+		return sh.paramsClean
+	}
+	return true
+}
+
 // preBindClassTypeParams resolves a class's type parameters and stores them on its ClassDef.
 // The module SCC pre-pass runs it over every class in a type-key component after every
 // identity in that component is registered, so a bound naming a sibling resolves.
@@ -283,6 +296,7 @@ func (c *checker) preBindClassTypeParams(scope *Scope, lvl int, decl *ast.ClassD
 	c.classNamespace = ns
 	defer func() { c.classNamespace = prevNS }()
 
+	quiet := c.errorWindow()
 	declScope := scope
 	var typeParams []*soltype.TypeParam
 	if len(decl.TypeParams) > 0 {
@@ -292,7 +306,7 @@ func (c *checker) preBindClassTypeParams(scope *Scope, lvl int, decl *ast.ClassD
 	if c.classShells == nil {
 		c.classShells = map[*ast.ClassDecl]*classShell{}
 	}
-	c.classShells[decl] = &classShell{declScope: declScope, typeParams: typeParams}
+	c.classShells[decl] = &classShell{declScope: declScope, typeParams: typeParams, paramsClean: quiet()}
 
 	if def, ok := c.ctx.classDef(qualifyClassName(ns, decl)); ok {
 		def.TypeParams = typeParams

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -123,31 +123,33 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	def.Variance, def.MutVariance = c.inferVariance(def, decl)
 
 	if quiet() && paramsClean {
-		c.reportUnusedTypeParams(typeParams, decl.TypeParams, func(v soltype.TypeVisitor) {
-			classDeclOccurrences(def, ctorType, v)
-		})
+		c.reportUnusedTypeParams(typeParams, decl.TypeParams, classDeclTypes(def, ctorType))
 	}
 
 	return c.classValue(ctorType, static), &ast.NodeProvenance{Node: decl}, true
 }
 
-// classDeclOccurrences visits every type a class declaration writes, so a walker over it
-// sees each position that could name one of the class's type parameters. That is the
-// instance and static members, the constructor's signature, and the `extends` and
-// `implements` targets.
+// classDeclTypes returns every type a class declaration writes, so a walk over them covers each
+// position that could name one of the class's type parameters. That is the instance and static
+// members, the constructor's signature, and the `extends` and `implements` targets.
 //
-// A method's `self` receiver is dropped, since every method names the class in it and
-// counting that would make each parameter look used. stripSelfReceiver is the same helper
-// variance inference uses for the same reason. Every other position of a member's signature
-// counts, `throws` included, because AcceptObjElem walks the whole of it.
-func classDeclOccurrences(def *ClassDef, ctor soltype.Type, v soltype.TypeVisitor) {
+// A method's `self` receiver is dropped, since every method names the class in it and counting
+// that would make each parameter look used. stripSelfReceiver is the same helper variance
+// inference uses for the same reason. Every other position of a member's signature counts,
+// `throws` included, since walking the object that holds them descends into the whole of each.
+func classDeclTypes(def *ClassDef, ctor soltype.Type) []soltype.Type {
+	var out []soltype.Type
+	// The stripped members are handed back inside an object rather than one by one, so the
+	// caller walks a type and the visitor's own member traversal reaches each position.
 	for _, obj := range []*soltype.ObjectType{def.Body, def.Static} {
 		if obj == nil {
 			continue
 		}
-		for _, elem := range obj.Elems {
-			soltype.AcceptObjElem(stripSelfReceiver(elem), v, soltype.Positive)
+		stripped := make([]soltype.ObjTypeElem, len(obj.Elems))
+		for i, elem := range obj.Elems {
+			stripped[i] = stripSelfReceiver(elem)
 		}
+		out = append(out, &soltype.ObjectType{Elems: stripped})
 	}
 	// The constructor is the class's value binding rather than a Static member, so a
 	// parameter written only in `constructor(v: T) throws E` is reached here and nowhere
@@ -163,14 +165,17 @@ func classDeclOccurrences(def *ClassDef, ctor soltype.Type, v soltype.TypeVisito
 		bare := *fn
 		bare.SelfParam = nil
 		bare.Ret = &soltype.NeverType{}
-		bare.Accept(v, soltype.Positive)
+		out = append(out, &bare)
 	}
+	// Appended one at a time, since Go does not spread a slice of a concrete type into a
+	// slice of the interface it satisfies.
 	for _, super := range def.Supers {
-		super.Accept(v, soltype.Positive)
+		out = append(out, super)
 	}
 	for _, iface := range def.Implements {
-		iface.Accept(v, soltype.Positive)
+		out = append(out, iface)
 	}
+	return out
 }
 
 // bindScriptClass infers a class declared at a script's top level (bin/) and binds its

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -259,7 +259,7 @@ func TestInferClassGeneric(t *testing.T) {
 
 // TestInferClassCrossParamBounds covers B4: a type-parameter bound may reference any sibling
 // parameter — forward, mutual, or through a generic class. Each case resolves its
-// cross-parameter references without reporting `Unsupported: TypeRefTypeAnn`, because the
+// cross-parameter references without reporting `an unknown-type error`, because the
 // shared resolveTypeParams declares every parameter in scope before resolving any bound, so a
 // bound reading a later-declared sibling finds it already in scope. A default is restricted
 // where a bound is not; TestTypeParamDefaultForwardRef covers that.
@@ -996,7 +996,7 @@ func TestInferClassNonGenericSubGenericSuper(t *testing.T) {
 // TestInferClassGenericMemberParam covers a generic class whose constructor and method both
 // take a parameter typed by the class type parameter. Resolving `v: T` and `next: T`
 // routes through the general resolveTypeAnn path, which now consults the class type scope,
-// so neither reports `Unsupported: TypeRefTypeAnn` and the class infers generic in `T`.
+// so neither reports `an unknown-type error` and the class infers generic in `T`.
 func TestInferClassGenericMemberParam(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		class Box<T> {
@@ -1015,7 +1015,7 @@ func TestInferClassGenericMemberParam(t *testing.T) {
 // outside a class body — a top-level `val` type and a function parameter. resolveTypeAnn
 // consults the enclosing scope wherever it runs, so a bare `Point` or a generic instance
 // `Box<number>` resolves through the same path a class body uses, rather than reporting
-// `Unsupported: TypeRefTypeAnn`.
+// `an unknown-type error`.
 func TestInferClassNameInAnnotation(t *testing.T) {
 	t.Run("bare class name in a val annotation", func(t *testing.T) {
 		values, _, errs := inferSource(t, `
@@ -1531,7 +1531,7 @@ func TestInferClassErrors(t *testing.T) {
 					constructor(mut self) {}
 				}
 			`,
-			want: "Unsupported: TypeRefTypeAnn",
+			want: "cannot find type `Bogus`",
 		},
 	}
 
@@ -2048,8 +2048,8 @@ func TestInferClassMethodTypeParamsGated(t *testing.T) {
 			`,
 			want: []string{
 				"Unsupported: TypeParam",
-				"Unsupported: TypeRefTypeAnn",
-				"Unsupported: TypeRefTypeAnn",
+				"cannot find type `T`",
+				"cannot find type `T`",
 			},
 		},
 		{
@@ -2062,8 +2062,8 @@ func TestInferClassMethodTypeParamsGated(t *testing.T) {
 			`,
 			want: []string{
 				"Unsupported: TypeParam",
-				"Unsupported: TypeRefTypeAnn",
-				"Unsupported: TypeRefTypeAnn",
+				"cannot find type `T`",
+				"cannot find type `T`",
 			},
 		},
 		{

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -51,8 +51,16 @@ type enumShell struct {
 	// scope is the scope the enum is declared in — where its type binding and namespace
 	// live. declScope is scope, or a child holding a generic enum's type parameters, and
 	// is where variant parameters resolve.
-	scope        *Scope
-	declScope    *Scope
+	scope     *Scope
+	declScope *Scope
+	// typeParams are the enum's own `<T>` binders, resolved by preBindEnum. inferEnumBody
+	// reads them to warn about one no variant mentions.
+	typeParams []*soltype.TypeParam
+	// preBindClean is false when preBindEnum dropped an element it could not read, which is
+	// an enum spread. inferEnumBody reads it alongside its own errorWindow, since a dropped
+	// element takes any type parameter it wrote with it.
+	preBindClean bool
+
 	variants     []*ast.EnumVariant
 	variantTypes []soltype.Type
 	enumType     soltype.Type
@@ -64,6 +72,8 @@ type enumShell struct {
 // front is what lets a sibling enum, or the enum itself, resolve this name while its own
 // body is still being walked.
 func (c *checker) preBindEnum(scope *Scope, lvl int, decl *ast.EnumDecl, ns string) *enumShell {
+	quiet := c.errorWindow()
+
 	// An enum-body type reference resolves against the enum's own namespace first, the
 	// same qualified-first resolution a class body uses. Save and restore around the walk.
 	prevNS := c.classNamespace
@@ -142,6 +152,8 @@ func (c *checker) preBindEnum(scope *Scope, lvl int, decl *ast.EnumDecl, ns stri
 		lvl:          lvl,
 		scope:        scope,
 		declScope:    declScope,
+		typeParams:   typeParams,
+		preBindClean: quiet(),
 		variants:     variants,
 		variantTypes: variantTypes,
 		enumType:     enumType,
@@ -153,14 +165,24 @@ func (c *checker) preBindEnum(scope *Scope, lvl int, decl *ast.EnumDecl, ns stri
 // binds the constructor namespace. It runs after every enum in the recursive group is
 // pre-bound, so a cross-enum parameter reference resolves.
 func (c *checker) inferEnumBody(sh *enumShell) {
+	quiet := c.errorWindow()
+
 	prevNS := c.classNamespace
 	c.classNamespace = sh.ns
 	defer func() { c.classNamespace = prevNS }()
 
 	nsValues := map[string]ValueBinding{}
 	nsTypes := map[string]TypeBinding{}
+	// Each variant's resolved parameter types, which are the only place an enum's own type
+	// parameter can be written. A constructor's return is the enum handle carrying every
+	// type-parameter var, and each variant handle carries them too, so neither says
+	// anything about which ones a variant actually names.
+	var declared []soltype.Type
 	for i, variant := range sh.variants {
 		ctor := c.variantConstructor(sh.declScope, sh.lvl, variant, sh.enumType)
+		for _, param := range ctor.Params {
+			declared = append(declared, param.Type)
+		}
 		nsValues[variant.Name.Name] = ValueBinding{
 			Schemes: []TypeScheme{c.generalize(ctor, sh.lvl-1)},
 			Sources: []provenance.Provenance{&ast.NodeProvenance{Node: variant}},
@@ -175,6 +197,15 @@ func (c *checker) inferEnumBody(sh *enumShell) {
 		Values: nsValues,
 		Types:  nsTypes,
 		Nested: map[string]*Namespace{},
+	})
+
+	if !sh.preBindClean || !quiet() {
+		return
+	}
+	c.reportUnusedTypeParams(sh.typeParams, sh.decl.TypeParams, func(v soltype.TypeVisitor) {
+		for _, t := range declared {
+			t.Accept(v, soltype.Positive)
+		}
 	})
 }
 

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -202,11 +202,7 @@ func (c *checker) inferEnumBody(sh *enumShell) {
 	if !sh.preBindClean || !quiet() {
 		return
 	}
-	c.reportUnusedTypeParams(sh.typeParams, sh.decl.TypeParams, func(v soltype.TypeVisitor) {
-		for _, t := range declared {
-			t.Accept(v, soltype.Positive)
-		}
-	})
+	c.reportUnusedTypeParams(sh.typeParams, sh.decl.TypeParams, declared)
 }
 
 // variantConstructor builds one enum variant's constructor: a function taking the

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -175,7 +175,7 @@ func TestInferFuncExprDestructuringParam(t *testing.T) {
 func TestInferFuncExprGenericResolves(t *testing.T) {
 	c := newChecker()
 	// fn <T>(x: T) -> T { return x }
-	tp := ast.NewTypeParam("T", nil, nil)
+	tp := ast.NewTypeParam("T", nil, nil, testSpan())
 	tRef := func() ast.TypeAnn { return ast.NewRefTypeAnn(ast.NewIdentifier("T", testSpan()), nil, testSpan()) }
 	e := ast.NewFuncExpr(nil, []*ast.TypeParam{&tp}, []*ast.Param{param("x", tRef())}, tRef(),
 		nil, false, block(returnStmt(identExpr("x"))), testSpan())

--- a/internal/solver/infer_generic_func_test.go
+++ b/internal/solver/infer_generic_func_test.go
@@ -198,8 +198,8 @@ func TestInferGenericMethodStillGated(t *testing.T) {
 	// unsupported because the parameter was never declared in scope.
 	require.Equal(t, []string{
 		"Unsupported: TypeParam",
-		"Unsupported: TypeRefTypeAnn",
-		"Unsupported: TypeRefTypeAnn",
+		"cannot find type `T`",
+		"cannot find type `T`",
 	}, msgs)
 }
 

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2084,8 +2084,8 @@ func TestInferCondInferConstraint(t *testing.T) {
 func TestInferCondCaptureNotInScopeInElse(t *testing.T) {
 	_, _, errs := inferSource(t, `type Result = if [number] : [infer U] { U } else { U }`)
 	require.Len(t, errs, 1)
-	require.IsType(t, &UnsupportedNodeError{}, errs[0])
-	require.Equal(t, "Unsupported: TypeRefTypeAnn", errs[0].Message())
+	require.IsType(t, &UnknownTypeError{}, errs[0])
+	require.Equal(t, "cannot find type `U`", errs[0].Message())
 }
 
 // An alias whose Then branch re-instantiates itself with a capture terminates and resolves, one
@@ -2164,7 +2164,7 @@ func TestInferCondNestedCaptureShadowsOuter(t *testing.T) {
 func TestInferCondUnresolvedCheckIsNotDistributive(t *testing.T) {
 	nodes, _, errs := inferTypeNodes(t, `type Result = if Bogus : string { number } else { boolean }`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported: TypeRefTypeAnn", errs[0].Message())
+	require.Equal(t, "cannot find type `Bogus`", errs[0].Message())
 	cond, ok := nodes["Result"].(*soltype.CondType)
 	require.True(t, ok)
 	require.False(t, cond.Distribute)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -298,6 +298,7 @@ func (c *checker) inferComponent(
 	// they leave on each AliasDef.
 	c.checkProductive(aliasShells)
 	markPhantomParams(aliasShells)
+	c.reportPhantomParams(aliasShells)
 	// The deferred bound comparisons run last, after the marks are in place. Each one goes
 	// through constrain, which interns an alias operand's canonical identity, and internAlias
 	// drops the arguments of phantom parameters when it renders that key. Interning a reference

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/graph"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -203,43 +204,20 @@ func (w *phantomWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Typ
 // sibling-mention rule is what excludes them.
 func (c *checker) reportPhantomParams(shells []*aliasShell) {
 	for _, sh := range shells {
-		if !sh.bodyResolved || sh.def.NotProductive {
-			// Two shapes report nothing. A recovered body is a fresh var that mentions no
-			// parameter, so every parameter would read as unused. An alias checkProductive
-			// rejected denotes no type at all, so no parameter can be unreachable in it. Both
-			// already carry a diagnostic that a warning would only pile onto.
+		if !sh.bodyClean || sh.def.NotProductive {
+			// Two shapes report nothing. A body that drew a diagnostic is a partial record of
+			// what the source wrote, so a parameter it dropped would read as unused. An alias
+			// checkProductive rejected denotes no type at all, so no parameter can be
+			// unreachable in it. Both already carry a diagnostic to act on.
 			continue
 		}
 		params := sh.def.TypeParams
 		if len(params) == 0 {
 			continue
 		}
-		slots := map[*soltype.TypeVarType]int{}
-		for i, p := range params {
-			if p.Var != nil {
-				slots[p.Var] = i
-			}
-		}
-		inBody := make([]bool, len(params))
-		markOccurrences(slots, sh.def.Body, inBody)
-
-		inSibling := make([]bool, len(params))
-		mentions := make([]bool, len(params))
-		for j, p := range params {
-			clear(mentions)
-			for _, t := range []soltype.Type{p.Constraint, p.Default} {
-				if t != nil {
-					markOccurrences(slots, t, mentions)
-				}
-			}
-			// An F-bound `<T: Foo<T>>` finds T on its own binder. A parameter does not use
-			// itself, so drop that occurrence before folding the rest in.
-			mentions[j] = false
-			for i, occurs := range mentions {
-				inSibling[i] = inSibling[i] || occurs
-			}
-		}
-
+		inBody, inSibling := typeParamMentions(params, func(v soltype.TypeVisitor) {
+			sh.def.Body.Accept(v, soltype.Positive)
+		})
 		for i, p := range params {
 			if strings.HasPrefix(p.Name, "_") || inSibling[i] {
 				continue
@@ -265,10 +243,74 @@ func (c *checker) reportPhantomParams(shells []*aliasShell) {
 	}
 }
 
-// markOccurrences sets found[i] for each of the alias's own type parameters whose var occurs
-// anywhere in t, leaving the entries it does not reach alone so a caller may fold several
-// types into one slice. slots maps each parameter's var to its position, and found is one
-// entry per parameter. The stored body and bounds hold those vars symbolically, so an
+// reportUnusedTypeParams warns about each type parameter of a class or enum that the
+// declaration never mentions, the unused tier of the alias warning applied to the two
+// nominal sorts. walkBody visits every type the declaration writes, and decls are the
+// binders the warnings blame, one per entry of params.
+//
+// Only the unused tier extends here. A nominal handle carries its arguments into its
+// identity and constrain compares them position by position, so an argument to a parameter
+// the body does write is observable however deep the recursion drives it. `class Nest<T>
+// {deeper: Nest<{b: T}>}` reports a mismatch between `Nest<number>` and `Nest<string>`
+// where the alias of the same shape settles them as one type. Unreachability is a property
+// of a transparent alias, and there is no nominal counterpart to warn about.
+func (c *checker) reportUnusedTypeParams(
+	params []*soltype.TypeParam,
+	decls []*ast.TypeParam,
+	walkBody func(soltype.TypeVisitor),
+) {
+	if len(params) == 0 || len(decls) < len(params) {
+		return
+	}
+	mentioned, inSibling := typeParamMentions(params, walkBody)
+	for i, p := range params {
+		if strings.HasPrefix(p.Name, "_") || mentioned[i] || inSibling[i] {
+			continue
+		}
+		c.report(&UnusedTypeParamError{Name: p.Name, Param: decls[i]})
+	}
+}
+
+// typeParamMentions reports where each of a declaration's type parameters occurs. inBody is
+// true for a parameter whose var walkBody reaches, and inSibling is true for one that occurs
+// in another parameter's bound or default. A parameter's own binder does not count, so the T
+// an F-bound `<T: Foo<T>>` writes in its own bound is not a use of T.
+//
+// The two answers stay separate because they carry different weight. A parameter no body
+// mentions is unused whatever its bound says, while a parameter a sibling's bound or default
+// mentions is doing work the body cannot show. `type Foo<T, U: T> = {x: U}` writes T nowhere
+// in its body, and T still decides which arguments U accepts.
+func typeParamMentions(params []*soltype.TypeParam, walkBody func(soltype.TypeVisitor)) (inBody, inSibling []bool) {
+	slots := map[*soltype.TypeVarType]int{}
+	for i, p := range params {
+		if p.Var != nil {
+			slots[p.Var] = i
+		}
+	}
+	inBody = make([]bool, len(params))
+	walkBody(&paramOccurrenceWalker{slots: slots, found: inBody})
+
+	inSibling = make([]bool, len(params))
+	onBinder := make([]bool, len(params))
+	for j, p := range params {
+		clear(onBinder)
+		for _, t := range []soltype.Type{p.Constraint, p.Default} {
+			if t != nil {
+				markOccurrences(slots, t, onBinder)
+			}
+		}
+		onBinder[j] = false
+		for i, occurs := range onBinder {
+			inSibling[i] = inSibling[i] || occurs
+		}
+	}
+	return inBody, inSibling
+}
+
+// markOccurrences sets found[i] for each of the declaration's own type parameters whose var
+// occurs anywhere in t, leaving the entries it does not reach alone so a caller may fold
+// several types into one slice. slots maps each parameter's var to its position, and found is
+// one entry per parameter. A stored body and bound hold those vars symbolically, so an
 // occurrence is found by pointer identity.
 //
 // Position and reachability play no part, unlike in the phantom marks. `type Deep<T> =

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/escalier-lang/escalier/internal/graph"
 	"github.com/escalier-lang/escalier/internal/set"
@@ -181,6 +182,118 @@ func (w *phantomWalker) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 }
 
 func (w *phantomWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// reportPhantomParams warns about each alias type parameter a caller gains nothing by
+// writing an argument for. It runs beside markPhantomParams, after every body in the
+// dep_graph component is resolved, so the marks it reads are final.
+//
+// A parameter is *mentioned* when its var occurs in the alias body, in a sibling
+// parameter's bound, or in a sibling parameter's default. Its own bound does not count,
+// since the `number` of `<T: number>` constrains T rather than using it. A parameter no
+// position mentions is unused. One the body mentions is unreachable when it is also marked
+// phantom, which means no argument passed to it lands in the type an instantiation denotes.
+//
+// The marks alone cannot answer this. markPhantomParams asks whether an argument reaches
+// the denoted type through the parameter's own slot, and two shapes come back phantom while
+// the parameter is still doing work. `type Foo<T, U: T> = {x: U}` marks T phantom, and T
+// bounds U. `type Pair<T, U = T> = {b: U}` marks T phantom, and `Pair<number>` denotes
+// `{b: number}`. Erasing T is right in both, since the argument reaches the denoted type
+// through U's slot rather than T's, and warning about either would be a false positive. The
+// sibling-mention rule is what excludes them.
+func (c *checker) reportPhantomParams(shells []*aliasShell) {
+	for _, sh := range shells {
+		if !sh.bodyResolved || sh.def.NotProductive {
+			// A recovered body is a fresh var that mentions no parameter, and an alias
+			// checkProductive rejected names no type for a parameter to be unreachable in.
+			// Either way the source already has a diagnostic, and a warning about the
+			// parameters would only pile onto it.
+			continue
+		}
+		params := sh.def.TypeParams
+		if len(params) == 0 {
+			continue
+		}
+		slots := map[*soltype.TypeVarType]int{}
+		for i, p := range params {
+			if p.Var != nil {
+				slots[p.Var] = i
+			}
+		}
+		inBody := paramOccurrences(slots, len(params), sh.def.Body)
+		inSibling := make([]bool, len(params))
+		for j, p := range params {
+			for _, t := range []soltype.Type{p.Constraint, p.Default} {
+				if t == nil {
+					continue
+				}
+				for i, occurs := range paramOccurrences(slots, len(params), t) {
+					// An F-bound `<T: Foo<T>>` finds T in its own bound, which the mentioned
+					// rule does not count.
+					if occurs && i != j {
+						inSibling[i] = true
+					}
+				}
+			}
+		}
+
+		names := make([]string, len(params))
+		for i, p := range params {
+			names[i] = p.Name
+		}
+		for i, p := range params {
+			if strings.HasPrefix(p.Name, "_") || inSibling[i] {
+				continue
+			}
+			decl := sh.decl.TypeParams[i]
+			if !inBody[i] {
+				c.report(&UnusedTypeParamError{Name: p.Name, Param: decl})
+				continue
+			}
+			if i < len(sh.def.PhantomParams) && sh.def.PhantomParams[i] {
+				c.report(&UnreachableTypeParamError{
+					Alias:  sh.qname,
+					Params: names,
+					Index:  i,
+					Param:  decl,
+				})
+			}
+		}
+	}
+}
+
+// paramOccurrences reports, for each of the alias's own type parameters, whether its var
+// occurs anywhere in t. count is the parameter list's length, and slots maps each
+// parameter's var to its position. The stored body and bounds hold those vars symbolically,
+// so an occurrence is found by pointer identity.
+//
+// Position and reachability play no part, unlike in the phantom marks. `type Deep<T> =
+// {a: Deep<{b: T}>}` mentions T, even though no argument passed to T reaches the type Deep
+// denotes.
+func paramOccurrences(slots map[*soltype.TypeVarType]int, count int, t soltype.Type) []bool {
+	w := &paramOccurrenceWalker{slots: slots, found: make([]bool, count)}
+	t.Accept(w, soltype.Positive)
+	return w.found
+}
+
+// paramOccurrenceWalker records which of a fixed set of type variables a type mentions. It
+// rewrites nothing, so every node it visits comes back unchanged. A TypeVarType is a leaf to
+// the visitor, so reaching one records it without descending into the bounds solving has
+// accumulated on it.
+type paramOccurrenceWalker struct {
+	slots map[*soltype.TypeVarType]int
+	found []bool
+}
+
+func (w *paramOccurrenceWalker) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if tv, ok := t.(*soltype.TypeVarType); ok {
+		if i, own := w.slots[tv]; own && i < len(w.found) {
+			w.found[i] = true
+		}
+	}
+	return soltype.EnterResult{}
+}
+
+func (w *paramOccurrenceWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // erasePhantomArgs drops from every alias reference in t the arguments its phantom parameters
 // receive, nested ones included, so internAlias renders two references differing only there to one

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -202,6 +202,15 @@ func (w *phantomWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Typ
 // `{b: number}`. Erasing T is right in both, since the argument reaches the denoted type
 // through U's slot rather than T's, and warning about either would be a false positive. The
 // sibling-mention rule is what excludes them.
+//
+// A leading underscore suppresses the unused tier alone. It is the author saying a parameter
+// they never wrote is deliberate, which settles a warning about their own declaration. The
+// unreachable tier warns about something a caller hits instead: two instantiations that look
+// different denote one type. Renaming the parameter does not reach that caller, who never
+// sees the name, and does not make the arguments differ. There is also nothing the rename
+// could be preserving, since a transparent alias erases the parameter outright — that is what
+// makes it unreachable. The nominal sorts, where a phantom parameter would be load-bearing,
+// keep their arguments observable and never reach this tier at all.
 func (c *checker) reportPhantomParams(shells []*aliasShell) {
 	for _, sh := range shells {
 		if !sh.declClean || sh.def.NotProductive {
@@ -219,12 +228,16 @@ func (c *checker) reportPhantomParams(shells []*aliasShell) {
 			sh.def.Body.Accept(v, soltype.Positive)
 		})
 		for i, p := range params {
-			if strings.HasPrefix(p.Name, "_") || inSibling[i] {
+			if inSibling[i] {
 				continue
 			}
 			decl := sh.decl.TypeParams[i]
 			if !inBody[i] {
-				c.report(&UnusedTypeParamError{Name: p.Name, Param: decl})
+				// A leading underscore marks a parameter the author left unused on purpose,
+				// so it suppresses this tier the way `_x` does for an unused binding.
+				if !strings.HasPrefix(p.Name, "_") {
+					c.report(&UnusedTypeParamError{Name: p.Name, Param: decl})
+				}
 				continue
 			}
 			if i < len(sh.def.PhantomParams) && sh.def.PhantomParams[i] {

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -204,7 +204,7 @@ func (w *phantomWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Typ
 // sibling-mention rule is what excludes them.
 func (c *checker) reportPhantomParams(shells []*aliasShell) {
 	for _, sh := range shells {
-		if !sh.bodyClean || sh.def.NotProductive {
+		if !sh.declClean || sh.def.NotProductive {
 			// Two shapes report nothing. A body that drew a diagnostic is a partial record of
 			// what the source wrote, so a parameter it dropped would read as unused. An alias
 			// checkProductive rejected denotes no type at all, so no parameter can be

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -184,33 +184,10 @@ func (w *phantomWalker) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 
 func (w *phantomWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
-// reportPhantomParams warns about each alias type parameter whose argument a caller gains
-// nothing by writing. It runs beside markPhantomParams, after every body in the dep_graph
-// component is resolved, so the marks it reads are final.
-//
-// A parameter is *mentioned* when its var occurs in the alias body, in a sibling
-// parameter's bound, or in a sibling parameter's default. Its own bound does not count,
-// since the `number` of `<T: number>` constrains T rather than using it. A parameter no
-// position mentions is unused. A parameter the body mentions is unreachable when it is also
-// marked phantom, which means no argument passed to it lands in the type an instantiation
-// denotes.
-//
-// The marks alone cannot answer this. markPhantomParams asks whether an argument reaches
-// the denoted type through the parameter's own slot, and two shapes come back phantom while
-// the parameter is still doing work. `type Foo<T, U: T> = {x: U}` marks T phantom, and T
-// bounds U. `type Pair<T, U = T> = {b: U}` marks T phantom, and `Pair<number>` denotes
-// `{b: number}`. Erasing T is right in both, since the argument reaches the denoted type
-// through U's slot rather than T's, and warning about either would be a false positive. The
-// sibling-mention rule is what excludes them.
-//
-// A leading underscore suppresses the unused tier alone. It is the author saying a parameter
-// they never wrote is deliberate, which settles a warning about their own declaration. The
-// unreachable tier warns about something a caller hits instead: two instantiations that look
-// different denote one type. Renaming the parameter does not reach that caller, who never
-// sees the name, and does not make the arguments differ. There is also nothing the rename
-// could be preserving, since a transparent alias erases the parameter outright — that is what
-// makes it unreachable. The nominal sorts, where a phantom parameter would be load-bearing,
-// keep their arguments observable and never reach this tier at all.
+// reportPhantomParams warns about each alias type parameter a caller gains nothing by passing
+// an argument to: one the declaration never mentions, and one it does mention that no argument
+// can reach. It runs after every body in the dep_graph component is resolved, so the phantom
+// marks it reads are final.
 func (c *checker) reportPhantomParams(shells []*aliasShell) {
 	for _, sh := range shells {
 		if !sh.declClean || sh.def.NotProductive {
@@ -228,6 +205,10 @@ func (c *checker) reportPhantomParams(shells []*aliasShell) {
 			sh.def.Body.Accept(v, soltype.Positive)
 		})
 		for i, p := range params {
+			// A parameter a sibling's bound or default mentions is doing work the body cannot
+			// show, so `type Foo<T, U: T> = {x: U}` warns about neither. markPhantomParams
+			// still marks T phantom, since the argument reaches the denoted type through U's
+			// slot rather than T's.
 			if inSibling[i] {
 				continue
 			}
@@ -256,17 +237,10 @@ func (c *checker) reportPhantomParams(shells []*aliasShell) {
 	}
 }
 
-// reportUnusedTypeParams warns about each type parameter of a class or enum that the
-// declaration never mentions, the unused tier of the alias warning applied to the two
-// nominal sorts. walkBody visits every type the declaration writes, and decls are the
-// binders the warnings blame, one per entry of params.
-//
-// Only the unused tier extends here. A nominal handle carries its arguments into its
-// identity and constrain compares them position by position, so an argument to a parameter
-// the body does write is observable however deep the recursion drives it. `class Nest<T>
-// {deeper: Nest<{b: T}>}` reports a mismatch between `Nest<number>` and `Nest<string>`
-// where the alias of the same shape settles them as one type. Unreachability is a property
-// of a transparent alias, and there is no nominal counterpart to warn about.
+// reportUnusedTypeParams warns about each type parameter of a class or enum the declaration
+// never mentions. walkBody visits every type the declaration writes, and decls are the binders
+// the warnings blame. Only the unused tier applies to the nominal sorts, whose arguments stay
+// observable through recursion, so no parameter of one is ever unreachable.
 func (c *checker) reportUnusedTypeParams(
 	params []*soltype.TypeParam,
 	decls []*ast.TypeParam,
@@ -284,15 +258,9 @@ func (c *checker) reportUnusedTypeParams(
 	}
 }
 
-// typeParamMentions reports where each of a declaration's type parameters occurs. inBody is
-// true for a parameter whose var walkBody reaches, and inSibling is true for one that occurs
-// in another parameter's bound or default. A parameter's own binder does not count, so the T
-// an F-bound `<T: Foo<T>>` writes in its own bound is not a use of T.
-//
-// The two answers stay separate because they carry different weight. A parameter no body
-// mentions is unused whatever its bound says, while a parameter a sibling's bound or default
-// mentions is doing work the body cannot show. `type Foo<T, U: T> = {x: U}` writes T nowhere
-// in its body, and T still decides which arguments U accepts.
+// typeParamMentions reports where each of a declaration's type parameters occurs: inBody for one
+// walkBody reaches, inSibling for one another parameter's bound or default writes. A parameter's
+// own bound does not count, so the T an F-bound `<T: Foo<T>>` writes is not a use of T.
 func typeParamMentions(params []*soltype.TypeParam, walkBody func(soltype.TypeVisitor)) (inBody, inSibling []bool) {
 	slots := map[*soltype.TypeVarType]int{}
 	for i, p := range params {
@@ -320,23 +288,16 @@ func typeParamMentions(params []*soltype.TypeParam, walkBody func(soltype.TypeVi
 	return inBody, inSibling
 }
 
-// markOccurrences sets found[i] for each of the declaration's own type parameters whose var
-// occurs anywhere in t, leaving the entries it does not reach alone so a caller may fold
-// several types into one slice. slots maps each parameter's var to its position, and found is
-// one entry per parameter. A stored body and bound hold those vars symbolically, so an
-// occurrence is found by pointer identity.
-//
-// Position and reachability play no part, unlike in the phantom marks. `type Deep<T> =
-// {a: Deep<{b: T}>}` mentions T, even though no argument passed to T reaches the type Deep
-// denotes.
+// markOccurrences sets found[i] for each type parameter whose var occurs anywhere in t, leaving
+// the entries it does not reach alone so a caller may fold several types into one slice. slots
+// maps each parameter's var to its position. Position and reachability play no part here, unlike
+// in the phantom marks.
 func markOccurrences(slots map[*soltype.TypeVarType]int, t soltype.Type, found []bool) {
 	t.Accept(&paramOccurrenceWalker{slots: slots, found: found}, soltype.Positive)
 }
 
 // paramOccurrenceWalker records which of a fixed set of type variables a type mentions. It
-// rewrites nothing, so every node it visits comes back unchanged. A TypeVarType is a leaf to
-// the visitor, so reaching one records it without descending into the bounds solving has
-// accumulated on it.
+// rewrites nothing, so every node it visits comes back unchanged.
 type paramOccurrenceWalker struct {
 	slots map[*soltype.TypeVarType]int
 	found []bool

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -183,15 +183,16 @@ func (w *phantomWalker) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 
 func (w *phantomWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
-// reportPhantomParams warns about each alias type parameter a caller gains nothing by
-// writing an argument for. It runs beside markPhantomParams, after every body in the
-// dep_graph component is resolved, so the marks it reads are final.
+// reportPhantomParams warns about each alias type parameter whose argument a caller gains
+// nothing by writing. It runs beside markPhantomParams, after every body in the dep_graph
+// component is resolved, so the marks it reads are final.
 //
 // A parameter is *mentioned* when its var occurs in the alias body, in a sibling
 // parameter's bound, or in a sibling parameter's default. Its own bound does not count,
 // since the `number` of `<T: number>` constrains T rather than using it. A parameter no
-// position mentions is unused. One the body mentions is unreachable when it is also marked
-// phantom, which means no argument passed to it lands in the type an instantiation denotes.
+// position mentions is unused. A parameter the body mentions is unreachable when it is also
+// marked phantom, which means no argument passed to it lands in the type an instantiation
+// denotes.
 //
 // The marks alone cannot answer this. markPhantomParams asks whether an argument reaches
 // the denoted type through the parameter's own slot, and two shapes come back phantom while
@@ -203,10 +204,10 @@ func (w *phantomWalker) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Typ
 func (c *checker) reportPhantomParams(shells []*aliasShell) {
 	for _, sh := range shells {
 		if !sh.bodyResolved || sh.def.NotProductive {
-			// A recovered body is a fresh var that mentions no parameter, and an alias
-			// checkProductive rejected names no type for a parameter to be unreachable in.
-			// Either way the source already has a diagnostic, and a warning about the
-			// parameters would only pile onto it.
+			// Two shapes report nothing. A recovered body is a fresh var that mentions no
+			// parameter, so every parameter would read as unused. An alias checkProductive
+			// rejected denotes no type at all, so no parameter can be unreachable in it. Both
+			// already carry a diagnostic that a warning would only pile onto.
 			continue
 		}
 		params := sh.def.TypeParams
@@ -219,27 +220,26 @@ func (c *checker) reportPhantomParams(shells []*aliasShell) {
 				slots[p.Var] = i
 			}
 		}
-		inBody := paramOccurrences(slots, len(params), sh.def.Body)
+		inBody := make([]bool, len(params))
+		markOccurrences(slots, sh.def.Body, inBody)
+
 		inSibling := make([]bool, len(params))
+		mentions := make([]bool, len(params))
 		for j, p := range params {
+			clear(mentions)
 			for _, t := range []soltype.Type{p.Constraint, p.Default} {
-				if t == nil {
-					continue
+				if t != nil {
+					markOccurrences(slots, t, mentions)
 				}
-				for i, occurs := range paramOccurrences(slots, len(params), t) {
-					// An F-bound `<T: Foo<T>>` finds T in its own bound, which the mentioned
-					// rule does not count.
-					if occurs && i != j {
-						inSibling[i] = true
-					}
-				}
+			}
+			// An F-bound `<T: Foo<T>>` finds T on its own binder. A parameter does not use
+			// itself, so drop that occurrence before folding the rest in.
+			mentions[j] = false
+			for i, occurs := range mentions {
+				inSibling[i] = inSibling[i] || occurs
 			}
 		}
 
-		names := make([]string, len(params))
-		for i, p := range params {
-			names[i] = p.Name
-		}
 		for i, p := range params {
 			if strings.HasPrefix(p.Name, "_") || inSibling[i] {
 				continue
@@ -250,6 +250,10 @@ func (c *checker) reportPhantomParams(shells []*aliasShell) {
 				continue
 			}
 			if i < len(sh.def.PhantomParams) && sh.def.PhantomParams[i] {
+				names := make([]string, len(params))
+				for k, q := range params {
+					names[k] = q.Name
+				}
 				c.report(&UnreachableTypeParamError{
 					Alias:  sh.qname,
 					Params: names,
@@ -261,18 +265,17 @@ func (c *checker) reportPhantomParams(shells []*aliasShell) {
 	}
 }
 
-// paramOccurrences reports, for each of the alias's own type parameters, whether its var
-// occurs anywhere in t. count is the parameter list's length, and slots maps each
-// parameter's var to its position. The stored body and bounds hold those vars symbolically,
-// so an occurrence is found by pointer identity.
+// markOccurrences sets found[i] for each of the alias's own type parameters whose var occurs
+// anywhere in t, leaving the entries it does not reach alone so a caller may fold several
+// types into one slice. slots maps each parameter's var to its position, and found is one
+// entry per parameter. The stored body and bounds hold those vars symbolically, so an
+// occurrence is found by pointer identity.
 //
 // Position and reachability play no part, unlike in the phantom marks. `type Deep<T> =
 // {a: Deep<{b: T}>}` mentions T, even though no argument passed to T reaches the type Deep
 // denotes.
-func paramOccurrences(slots map[*soltype.TypeVarType]int, count int, t soltype.Type) []bool {
-	w := &paramOccurrenceWalker{slots: slots, found: make([]bool, count)}
-	t.Accept(w, soltype.Positive)
-	return w.found
+func markOccurrences(slots map[*soltype.TypeVarType]int, t soltype.Type, found []bool) {
+	t.Accept(&paramOccurrenceWalker{slots: slots, found: found}, soltype.Positive)
 }
 
 // paramOccurrenceWalker records which of a fixed set of type variables a type mentions. It
@@ -286,7 +289,7 @@ type paramOccurrenceWalker struct {
 
 func (w *paramOccurrenceWalker) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
 	if tv, ok := t.(*soltype.TypeVarType); ok {
-		if i, own := w.slots[tv]; own && i < len(w.found) {
+		if i, own := w.slots[tv]; own {
 			w.found[i] = true
 		}
 	}

--- a/internal/solver/phantom.go
+++ b/internal/solver/phantom.go
@@ -201,9 +201,7 @@ func (c *checker) reportPhantomParams(shells []*aliasShell) {
 		if len(params) == 0 {
 			continue
 		}
-		inBody, inSibling := typeParamMentions(params, func(v soltype.TypeVisitor) {
-			sh.def.Body.Accept(v, soltype.Positive)
-		})
+		inBody, inSibling := typeParamMentions(params, []soltype.Type{sh.def.Body})
 		for i, p := range params {
 			// A parameter a sibling's bound or default mentions is doing work the body cannot
 			// show, so `type Foo<T, U: T> = {x: U}` warns about neither. markPhantomParams
@@ -238,18 +236,18 @@ func (c *checker) reportPhantomParams(shells []*aliasShell) {
 }
 
 // reportUnusedTypeParams warns about each type parameter of a class or enum the declaration
-// never mentions. walkBody visits every type the declaration writes, and decls are the binders
-// the warnings blame. Only the unused tier applies to the nominal sorts, whose arguments stay
+// never mentions. body is every type the declaration writes, and decls are the binders the
+// warnings blame. Only the unused tier applies to the nominal sorts, whose arguments stay
 // observable through recursion, so no parameter of one is ever unreachable.
 func (c *checker) reportUnusedTypeParams(
 	params []*soltype.TypeParam,
 	decls []*ast.TypeParam,
-	walkBody func(soltype.TypeVisitor),
+	body []soltype.Type,
 ) {
 	if len(params) == 0 || len(decls) < len(params) {
 		return
 	}
-	mentioned, inSibling := typeParamMentions(params, walkBody)
+	mentioned, inSibling := typeParamMentions(params, body)
 	for i, p := range params {
 		if strings.HasPrefix(p.Name, "_") || mentioned[i] || inSibling[i] {
 			continue
@@ -259,9 +257,9 @@ func (c *checker) reportUnusedTypeParams(
 }
 
 // typeParamMentions reports where each of a declaration's type parameters occurs: inBody for one
-// walkBody reaches, inSibling for one another parameter's bound or default writes. A parameter's
+// the body writes, inSibling for one another parameter's bound or default writes. A parameter's
 // own bound does not count, so the T an F-bound `<T: Foo<T>>` writes is not a use of T.
-func typeParamMentions(params []*soltype.TypeParam, walkBody func(soltype.TypeVisitor)) (inBody, inSibling []bool) {
+func typeParamMentions(params []*soltype.TypeParam, body []soltype.Type) (inBody, inSibling []bool) {
 	slots := map[*soltype.TypeVarType]int{}
 	for i, p := range params {
 		if p.Var != nil {
@@ -269,17 +267,13 @@ func typeParamMentions(params []*soltype.TypeParam, walkBody func(soltype.TypeVi
 		}
 	}
 	inBody = make([]bool, len(params))
-	walkBody(&paramOccurrenceWalker{slots: slots, found: inBody})
+	occurrences(slots, body, inBody)
 
 	inSibling = make([]bool, len(params))
 	onBinder := make([]bool, len(params))
 	for j, p := range params {
 		clear(onBinder)
-		for _, t := range []soltype.Type{p.Constraint, p.Default} {
-			if t != nil {
-				markOccurrences(slots, t, onBinder)
-			}
-		}
+		occurrences(slots, []soltype.Type{p.Constraint, p.Default}, onBinder)
 		onBinder[j] = false
 		for i, occurs := range onBinder {
 			inSibling[i] = inSibling[i] || occurs
@@ -288,12 +282,18 @@ func typeParamMentions(params []*soltype.TypeParam, walkBody func(soltype.TypeVi
 	return inBody, inSibling
 }
 
-// markOccurrences sets found[i] for each type parameter whose var occurs anywhere in t, leaving
-// the entries it does not reach alone so a caller may fold several types into one slice. slots
-// maps each parameter's var to its position. Position and reachability play no part here, unlike
+// occurrences sets found[i] for each type parameter whose var occurs anywhere in types, leaving
+// the entries it does not reach alone so a caller may fold several walks into one slice. slots
+// maps each parameter's var to its position, and a nil type is skipped so a caller can pass an
+// absent bound or default straight through. Position and reachability play no part here, unlike
 // in the phantom marks.
-func markOccurrences(slots map[*soltype.TypeVarType]int, t soltype.Type, found []bool) {
-	t.Accept(&paramOccurrenceWalker{slots: slots, found: found}, soltype.Positive)
+func occurrences(slots map[*soltype.TypeVarType]int, types []soltype.Type, found []bool) {
+	w := &paramOccurrenceWalker{slots: slots, found: found}
+	for _, t := range types {
+		if t != nil {
+			t.Accept(w, soltype.Positive)
+		}
+	}
 }
 
 // paramOccurrenceWalker records which of a fixed set of type variables a type mentions. It

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -289,6 +289,14 @@ func TestInferUnusedTypeParamOnClassAndEnum(t *testing.T) {
 			`,
 		},
 		{
+			// So is an `implements` type argument, the only position T occupies here.
+			name: "ClassImplementsWritesTheParameter",
+			src: `
+				class Marker<T> { m: T }
+				class Tag<T> implements Marker<T> { constructor(mut self) {} }
+			`,
+		},
+		{
 			// So is a constructor parameter, which lives on the class's value binding rather
 			// than in either member object.
 			name: "ClassConstructorWritesTheParameter",
@@ -365,6 +373,20 @@ func TestInferUnusedTypeParamSkipsARecoveredDeclaration(t *testing.T) {
 			name: "AliasBodyWithAnUnresolvableReference",
 			src:  `type Foo<T> = number | Nope<T>`,
 			want: []string{"1:24-1:31: Unsupported: TypeRefTypeAnn"},
+		},
+		{
+			// A bound that fails to resolve is left nil, so the T it wrote is lost along with
+			// U's own reason to exist. The parameter list resolves before the body, so both
+			// warnings would land had preBindAlias not opened its own window.
+			name: "AliasParameterWithAnUnresolvableBound",
+			src:  `type Foo<T, U: Nope<T>> = number`,
+			want: []string{"1:16-1:23: Unsupported: TypeRefTypeAnn"},
+		},
+		{
+			// The same for a default, which is the other position resolveTypeParams fills.
+			name: "AliasParameterWithAnUnresolvableDefault",
+			src:  `type Bar<T, U = Nope<T>> = {x: U}`,
+			want: []string{"1:17-1:24: Unsupported: TypeRefTypeAnn"},
 		},
 		{
 			// A type parameter does not name a class, so the extends edge is dropped and the

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -398,6 +398,23 @@ func TestInferUnusedTypeParamSkipsARecoveredDeclaration(t *testing.T) {
 			want: []string{"1:17-1:24: cannot find type `Nope`"},
 		},
 		{
+			// A class resolves its parameters in the module pre-pass, before inferClassDecl
+			// opens its window, so the rejected default's news reaches the warning through the
+			// shell rather than through that window. U is left with no default to be used at.
+			name: "ClassParameterWithAForwardDefault",
+			src:  `class Bad<T = U, U = number> { x: T, constructor(mut self) { self.x = 0 } }`,
+			want: []string{
+				"1:15-1:16: the default for type parameter `T` cannot reference `U`, " +
+					"which is declared after it",
+			},
+		},
+		{
+			// The same for a bound, the other position the pre-pass resolves.
+			name: "ClassParameterWithAnUnresolvableBound",
+			src:  `class Bad<T: Nope> { x: number, constructor(mut self) { self.x = 0 } }`,
+			want: []string{"1:14-1:18: cannot find type `Nope`"},
+		},
+		{
 			// A type parameter does not name a class, so the extends edge is dropped and the
 			// only occurrence of T goes with it.
 			name: "ClassExtendingATypeParameter",

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -361,14 +361,12 @@ func TestInferUnusedTypeParamSkipsARecoveredDeclaration(t *testing.T) {
 		want []string
 	}{
 		{
-			// resolveObjectTypeAnn lowers no method member, so it skips this one and returns
-			// the empty object the rest of the annotation amounts to. The body resolves, and
-			// the only occurrence of T is what went missing.
-			name: "AliasBodyWithAnUnsupportedMember",
-			src:  `type M<T> = {f(x: T) -> T}`,
-			want: []string{
-				"1:13-1:27: Unsupported: object type member other than a property or spread",
-			},
+			// resolveObjectTypeAnn recovers a property whose value did not resolve to a fresh
+			// var and keeps the object shape, so the body resolves to `{a: t}` and the only
+			// occurrence of T is what went missing.
+			name: "AliasBodyWithARecoveredPropertyValue",
+			src:  `type M<T> = {a: Nope<T>}`,
+			want: []string{"1:17-1:24: Unsupported: TypeRefTypeAnn"},
 		},
 		{
 			// The union member recovers to a fresh var, so the body is `t | number` and the T

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -361,7 +361,9 @@ func TestInferUnusedTypeParamSkipsARecoveredDeclaration(t *testing.T) {
 		want []string
 	}{
 		{
-			// The method is not a supported object-type member, so the whole body is dropped.
+			// resolveObjectTypeAnn lowers no method member, so it skips this one and returns
+			// the empty object the rest of the annotation amounts to. The body resolves, and
+			// the only occurrence of T is what went missing.
 			name: "AliasBodyWithAnUnsupportedMember",
 			src:  `type M<T> = {f(x: T) -> T}`,
 			want: []string{
@@ -369,7 +371,8 @@ func TestInferUnusedTypeParamSkipsARecoveredDeclaration(t *testing.T) {
 			},
 		},
 		{
-			// The union member fails to resolve, so the annotation reports and recovers.
+			// The union member recovers to a fresh var, so the body is `t | number` and the T
+			// that member wrote is gone.
 			name: "AliasBodyWithAnUnresolvableReference",
 			src:  `type Foo<T> = number | Nope<T>`,
 			want: []string{"1:24-1:31: Unsupported: TypeRefTypeAnn"},

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -289,6 +289,22 @@ func TestInferUnusedTypeParamOnClassAndEnum(t *testing.T) {
 			`,
 		},
 		{
+			// So is a constructor parameter, which lives on the class's value binding rather
+			// than in either member object.
+			name: "ClassConstructorWritesTheParameter",
+			src:  `class Take<T> { x: number, constructor(mut self, v: T) { self.x = 1 } }`,
+		},
+		{
+			// So is a constructor's `throws` clause. Every caller of the constructor has to
+			// handle what it declares, so the parameter naming it is doing work.
+			name: "ClassConstructorThrowsTheParameter",
+			src: `
+				declare fn boom() throws number
+				class Boom<E> { x: number, constructor(mut self) throws E { self.x = 1
+			boom() } }
+			`,
+		},
+		{
 			// A sibling's bound is a use, the same exemption the alias tier makes.
 			name: "ClassParameterBoundsASibling",
 			src:  `class Pair<T, U: T> { x: U }`,

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -137,6 +137,19 @@ func TestInferPhantomParamWarns(t *testing.T) {
 			},
 		},
 		{
+			// A leading underscore does not reach this tier. It says the author meant to leave a
+			// parameter unwritten, which answers the unused warning about their own declaration.
+			// This warning is about a caller who writes two instantiations that denote one type,
+			// and the name the parameter was given is neither visible to them nor able to make
+			// the arguments differ.
+			name: "UnreachableParameterIsStillWarnedWhenUnderscored",
+			src:  `type Deep<_T> = {a: Deep<{b: _T}>}`,
+			want: []string{
+				"1:11-1:13: no argument passed to type parameter _T can appear in the type, so " +
+					"Deep<number> and Deep<string> are the same type",
+			},
+		},
+		{
 			// The rendered instantiations differ in the unreachable slot alone. U is written at
 			// `here`, so it stays under its own name on both sides.
 			name: "OtherParametersStayNamedInTheMessage",
@@ -160,8 +173,8 @@ func TestInferPhantomParamWarns(t *testing.T) {
 // An alias parameter that carries weight draws no warning, whatever the phantom marks say. The
 // marks answer whether an argument reaches the denoted type through the parameter's own slot, so a
 // parameter that bounds a sibling or supplies a sibling's default is marked phantom while still
-// deciding what an instantiation denotes. A leading underscore quiets both tiers, which is how a
-// binder left to fill in later is written.
+// deciding what an instantiation denotes. A leading underscore quiets the unused tier, which is how
+// a binder left to fill in later is written; it does not reach the unreachable tier.
 func TestInferPhantomParamStaysSilent(t *testing.T) {
 	tests := []struct {
 		name string
@@ -188,11 +201,6 @@ func TestInferPhantomParamStaysSilent(t *testing.T) {
 			// The escape hatch on the unused tier.
 			name: "UnusedParameterIsUnderscored",
 			src:  `type Ignore<_T> = number`,
-		},
-		{
-			// The escape hatch on the unreachable tier.
-			name: "UnreachableParameterIsUnderscored",
-			src:  `type Deep<_T> = {a: Deep<{b: _T}>}`,
 		},
 	}
 	for _, test := range tests {

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -231,3 +231,139 @@ func TestInferPhantomArgumentSurvivesInTheRenderedType(t *testing.T) {
 	require.Equal(t, "Deep<string>", values["d"])
 	require.Equal(t, "fn (p: Deep<number>) -> Deep<number>", values["f"])
 }
+
+// The unused tier reaches a class and an enum as well as an alias, since a parameter no
+// position of the declaration writes is dead weight whatever sort declares it.
+//
+// The unreachable tier stays with aliases. A class and an enum variant are nominal, so
+// constrain compares a handle's arguments position by position and an argument to a
+// parameter the body does write stays observable. `class Nest<T> {deeper: Nest<{b: T}>}`
+// reports a mismatch between `Nest<number>` and `Nest<string>` where the alias of that
+// shape settles them as one type.
+func TestInferUnusedTypeParamOnClassAndEnum(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			// No member, no super, and no constructor parameter writes T.
+			name: "ClassParameterOccursNowhere",
+			src:  `class Box<T> { x: number }`,
+			want: []string{"1:11-1:12: type parameter T is declared but never used"},
+		},
+		{
+			// One parameter of several. U is the field's type, so only T is reported.
+			name: "ClassOneParameterOfSeveralOccursNowhere",
+			src:  `class Two<T, U> { x: U }`,
+			want: []string{"1:11-1:12: type parameter T is declared but never used"},
+		},
+		{
+			// No variant carries a parameter at all.
+			name: "EnumParameterOccursNowhere",
+			src:  `enum Opt<T> { A }`,
+			want: []string{"1:10-1:11: type parameter T is declared but never used"},
+		},
+		{
+			// A variant writes U, so only T is reported.
+			name: "EnumOneParameterOfSeveralOccursNowhere",
+			src:  `enum Two<T, U> { A(v: U) }`,
+			want: []string{"1:10-1:11: type parameter T is declared but never used"},
+		},
+		{
+			// A field's type is a use.
+			name: "ClassFieldWritesTheParameter",
+			src:  `class Box<T> { x: T }`,
+		},
+		{
+			// So is a method parameter, which the `self` receiver alone would not be.
+			name: "ClassMethodWritesTheParameter",
+			src:  `class Hold<T> { put(self, v: T) -> number { return 1 } }`,
+		},
+		{
+			// So is a superclass type argument.
+			name: "ClassSuperWritesTheParameter",
+			src: `
+				class Base<T> { x: T }
+				class Sub<T> extends Base<T> { constructor(mut self) {} }
+			`,
+		},
+		{
+			// A sibling's bound is a use, the same exemption the alias tier makes.
+			name: "ClassParameterBoundsASibling",
+			src:  `class Pair<T, U: T> { x: U }`,
+		},
+		{
+			// As is a sibling's default.
+			name: "ClassParameterSuppliesASiblingsDefault",
+			src:  `class Def<T, U = T> { x: U }`,
+		},
+		{
+			// A variant parameter is a use.
+			name: "EnumVariantWritesTheParameter",
+			src:  `enum Opt<T> { A(v: T) }`,
+		},
+		{
+			name: "ClassParameterIsUnderscored",
+			src:  `class Box<_T> { x: number }`,
+		},
+		{
+			name: "EnumParameterIsUnderscored",
+			src:  `enum Opt<_T> { A }`,
+		},
+		{
+			// The class body drove the recursion, so T is written and the nominal comparison
+			// keeps every argument to it observable. Nothing is reported.
+			name: "ClassRecursionThroughAGrowingArgument",
+			src:  `class Nest<T> { deeper: Nest<{b: T}> }`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Equal(t, test.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// A declaration that already drew a diagnostic reports no unused warning. Recovery drops
+// the subtree it could not resolve, so a parameter written only there leaves no occurrence
+// behind and would read as unused. Each case writes its parameter exactly once, inside the
+// part that is dropped.
+func TestInferUnusedTypeParamSkipsARecoveredDeclaration(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			// The method is not a supported object-type member, so the whole body is dropped.
+			name: "AliasBodyWithAnUnsupportedMember",
+			src:  `type M<T> = {f(x: T) -> T}`,
+			want: []string{
+				"1:13-1:27: Unsupported: object type member other than a property or spread",
+			},
+		},
+		{
+			// The union member fails to resolve, so the annotation reports and recovers.
+			name: "AliasBodyWithAnUnresolvableReference",
+			src:  `type Foo<T> = number | Nope<T>`,
+			want: []string{"1:24-1:31: Unsupported: TypeRefTypeAnn"},
+		},
+		{
+			// A type parameter does not name a class, so the extends edge is dropped and the
+			// only occurrence of T goes with it.
+			name: "ClassExtendingATypeParameter",
+			src:  `class B<T> extends T { constructor(mut self) {} }`,
+			want: []string{
+				"1:20-1:21: `T` does not name a class and cannot be extended or implemented.",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Equal(t, test.want, messagesWithSpan(errs))
+		})
+	}
+}

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -374,14 +374,14 @@ func TestInferUnusedTypeParamSkipsARecoveredDeclaration(t *testing.T) {
 			// occurrence of T is what went missing.
 			name: "AliasBodyWithARecoveredPropertyValue",
 			src:  `type M<T> = {a: Nope<T>}`,
-			want: []string{"1:17-1:24: Unsupported: TypeRefTypeAnn"},
+			want: []string{"1:17-1:24: cannot find type `Nope`"},
 		},
 		{
 			// The union member recovers to a fresh var, so the body is `t | number` and the T
 			// that member wrote is gone.
 			name: "AliasBodyWithAnUnresolvableReference",
 			src:  `type Foo<T> = number | Nope<T>`,
-			want: []string{"1:24-1:31: Unsupported: TypeRefTypeAnn"},
+			want: []string{"1:24-1:31: cannot find type `Nope`"},
 		},
 		{
 			// A bound that fails to resolve is left nil, so the T it wrote is lost along with
@@ -389,13 +389,13 @@ func TestInferUnusedTypeParamSkipsARecoveredDeclaration(t *testing.T) {
 			// warnings would land had preBindAlias not opened its own window.
 			name: "AliasParameterWithAnUnresolvableBound",
 			src:  `type Foo<T, U: Nope<T>> = number`,
-			want: []string{"1:16-1:23: Unsupported: TypeRefTypeAnn"},
+			want: []string{"1:16-1:23: cannot find type `Nope`"},
 		},
 		{
 			// The same for a default, which is the other position resolveTypeParams fills.
 			name: "AliasParameterWithAnUnresolvableDefault",
 			src:  `type Bar<T, U = Nope<T>> = {x: U}`,
-			want: []string{"1:17-1:24: Unsupported: TypeRefTypeAnn"},
+			want: []string{"1:17-1:24: cannot find type `Nope`"},
 		},
 		{
 			// A type parameter does not name a class, so the extends edge is dropped and the

--- a/internal/solver/phantom_test.go
+++ b/internal/solver/phantom_test.go
@@ -9,10 +9,20 @@ import (
 // A phantom parameter's argument cannot appear in the type an instantiation denotes, so two
 // instantiations that differ only in those arguments are one type and check against each other in
 // both directions. Each case below names a different reason the argument never lands in that type.
+//
+// want holds the warnings reportPhantomParams draws for the same aliases. Both halves read the same
+// marks, so a case that compares equal here is a case that warns.
 func TestInferPhantomArgumentsCompareEqual(t *testing.T) {
+	// The warning `type Deep<T> = {a: Deep<{b: T}>}` draws, shared by the cases that declare it on
+	// the source's second line.
+	deepIsPhantom := []string{
+		"2:15-2:16: no argument passed to type parameter T can appear in the type, so " +
+			"Deep<number> and Deep<string> are the same type",
+	}
 	tests := []struct {
 		name string
 		src  string
+		want []string
 	}{
 		{
 			// The recursive reference hands `{b: T}` to the next unfolding, so the payload is always
@@ -24,6 +34,7 @@ func TestInferPhantomArgumentsCompareEqual(t *testing.T) {
 				declare fn make() -> Deep<number>
 				val d: Deep<string> = make()
 			`,
+			want: deepIsPhantom,
 		},
 		{
 			// The same pair the other way round, since the erasure is a property of the identity
@@ -34,6 +45,7 @@ func TestInferPhantomArgumentsCompareEqual(t *testing.T) {
 				declare fn make() -> Deep<string>
 				val d: Deep<number> = make()
 			`,
+			want: deepIsPhantom,
 		},
 		{
 			// Mutual recursion. P's parameter reaches only Q's parameter and Q's reaches only P's, so
@@ -46,6 +58,12 @@ func TestInferPhantomArgumentsCompareEqual(t *testing.T) {
 				declare fn make() -> P<number>
 				val d: P<string> = make()
 			`,
+			want: []string{
+				"3:12-3:13: no argument passed to type parameter U can appear in the type, so " +
+					"Q<number> and Q<string> are the same type",
+				"2:12-2:13: no argument passed to type parameter T can appear in the type, so " +
+					"P<number> and P<string> are the same type",
+			},
 		},
 		{
 			// A parameter the body never mentions. `Ignore<T>` denotes `number` whatever T is, so no
@@ -56,6 +74,7 @@ func TestInferPhantomArgumentsCompareEqual(t *testing.T) {
 				declare fn make() -> Ignore<number>
 				val d: Ignore<string> = make()
 			`,
+			want: []string{"2:17-2:18: type parameter T is declared but never used"},
 		},
 		{
 			// The erasure reaches a nested reference, so a relevant parameter carrying a phantom
@@ -67,6 +86,113 @@ func TestInferPhantomArgumentsCompareEqual(t *testing.T) {
 				declare fn make() -> Hold<Deep<number>>
 				val d: Hold<Deep<string>> = make()
 			`,
+			want: deepIsPhantom,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Equal(t, test.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// An alias parameter a caller gains nothing by writing an argument for draws a warning. The two
+// tiers differ in why the argument says nothing. An unused parameter occurs nowhere, and an
+// unreachable one occurs in the body but only at positions the type an instantiation denotes never
+// reaches.
+func TestInferPhantomParamWarns(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			// The degenerate case. `Ignore<T>` denotes `number` whatever the argument is.
+			name: "ParameterOccursNowhere",
+			src:  `type Ignore<T> = number`,
+			want: []string{"1:13-1:14: type parameter T is declared but never used"},
+		},
+		{
+			// One parameter of several. U is written at `b`, so only T is reported.
+			name: "OneParameterOfSeveralOccursNowhere",
+			src:  `type Half<T, U> = {b: U}`,
+			want: []string{"1:11-1:12: type parameter T is declared but never used"},
+		},
+		{
+			// A parameter's own bound is not a use of it, so an F-bound leaves the parameter
+			// unused when the body does not write it.
+			name: "ParameterOccursOnlyInItsOwnBound",
+			src:  `type Rec<T: {a: T}> = number`,
+			want: []string{"1:10-1:19: type parameter T is declared but never used"},
+		},
+		{
+			// The recursive reference hands `{b: T}` to the next unfolding forever, so T occurs in
+			// the body and no argument passed to it lands in the type Deep denotes.
+			name: "ParameterOccursOnlyAtAnUnreachablePosition",
+			src:  `type Deep<T> = {a: Deep<{b: T}>}`,
+			want: []string{
+				"1:11-1:12: no argument passed to type parameter T can appear in the type, so " +
+					"Deep<number> and Deep<string> are the same type",
+			},
+		},
+		{
+			// The rendered instantiations differ in the unreachable slot alone. U is written at
+			// `here`, so it stays under its own name on both sides.
+			name: "OtherParametersStayNamedInTheMessage",
+			src:  `type Slot<T, U> = {here: U, deeper: Slot<{b: T}, U>}`,
+			want: []string{
+				"1:11-1:12: no argument passed to type parameter T can appear in the type, so " +
+					"Slot<number, U> and Slot<string, U> are the same type",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Equal(t, test.want, messagesWithSpan(errs))
+			require.Len(t, errs, 1)
+			require.True(t, isWarning(errs[0]))
+		})
+	}
+}
+
+// An alias parameter that carries weight draws no warning, whatever the phantom marks say. The
+// marks answer whether an argument reaches the denoted type through the parameter's own slot, so a
+// parameter that bounds a sibling or supplies a sibling's default is marked phantom while still
+// deciding what an instantiation denotes. A leading underscore quiets both tiers, which is how a
+// binder left to fill in later is written.
+func TestInferPhantomParamStaysSilent(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			// The ordinary generic alias. T lands at `head`, inside the object the alias denotes.
+			name: "ParameterReachesTheDenotedType",
+			src:  `type List<T> = {head: T}`,
+		},
+		{
+			// T is marked phantom, since no argument reaches the denoted type through T's slot.
+			// It bounds U, so `Foo<number, 1>` and `Foo<string, 1>` differ in what they accept.
+			name: "ParameterBoundsASibling",
+			src:  `type Foo<T, U: T> = {x: U}`,
+		},
+		{
+			// T is marked phantom for the same reason and supplies U's default, so `Pair<number>`
+			// denotes `{b: number}` and `Pair<string>` denotes `{b: string}`.
+			name: "ParameterSuppliesASiblingsDefault",
+			src:  `type Pair<T, U = T> = {b: U}`,
+		},
+		{
+			// The escape hatch on the unused tier.
+			name: "UnusedParameterIsUnderscored",
+			src:  `type Ignore<_T> = number`,
+		},
+		{
+			// The escape hatch on the unreachable tier.
+			name: "UnreachableParameterIsUnderscored",
+			src:  `type Deep<_T> = {a: Deep<{b: _T}>}`,
 		},
 	}
 	for _, test := range tests {
@@ -98,7 +224,10 @@ func TestInferPhantomArgumentSurvivesInTheRenderedType(t *testing.T) {
 		val d: Deep<string> = make()
 		fn f(p: Deep<number>) -> Deep<number> { return p }
 	`)
-	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t, []string{
+		"2:13-2:14: no argument passed to type parameter T can appear in the type, so " +
+			"Deep<number> and Deep<string> are the same type",
+	}, messagesWithSpan(errs))
 	require.Equal(t, "Deep<string>", values["d"])
 	require.Equal(t, "fn (p: Deep<number>) -> Deep<number>", values["f"])
 }

--- a/internal/solver/productivity_test.go
+++ b/internal/solver/productivity_test.go
@@ -235,8 +235,8 @@ func TestCheckProductiveRejects(t *testing.T) {
 // one type, and subtyping is reflexive, so the canonical identity settles it with no unfolding at
 // all. Each case reaches that identity by a different route: one directly, one through the object
 // the alias emits.
-// The unreachable-parameter warning `Deep` draws is what makes the identity settle, so it is the
-// only diagnostic either case expects.
+// `Deep`'s parameter is unreachable, which is what lets the canonical identity settle the
+// constraint, so the warning it draws is the only diagnostic either case expects.
 func TestInferNonRegularAliasChecks(t *testing.T) {
 	deepIsPhantom := []string{
 		"2:15-2:16: no argument passed to type parameter T can appear in the type, so " +

--- a/internal/solver/productivity_test.go
+++ b/internal/solver/productivity_test.go
@@ -10,10 +10,16 @@ import (
 // checkProductive accepts an alias whose every recursion emits a level of structure. Each case names
 // a shape whose laps build an infinite tree, so the alias denotes a type even when no finite
 // expansion of it exists.
+//
+// want holds the diagnostics the source draws, which for an accepted alias are only the
+// phantom-parameter warnings reportPhantomParams emits. A recursion that hands its parameter
+// straight to the next lap is productive and still leaves that parameter unreachable, so the two
+// checks are independent and a case may trip one without the other.
 func TestCheckProductiveAccepts(t *testing.T) {
 	tests := []struct {
 		name string
 		src  string
+		want []string
 	}{
 		{
 			// The canonical productive recursion. Each lap emits one `{head, tail}` object.
@@ -49,6 +55,10 @@ func TestCheckProductiveAccepts(t *testing.T) {
 			// whether the alias denotes a type. TypeScript accepts this shape too.
 			name: "GrowingArgumentUnderObject",
 			src:  `type Deep<T> = {a: Deep<{b: T}>}`,
+			want: []string{
+				"1:11-1:12: no argument passed to type parameter T can appear in the type, so " +
+					"Deep<number> and Deep<string> are the same type",
+			},
 		},
 		{
 			// The recursive reference sits under an object even though a union sits above it, so the
@@ -85,12 +95,18 @@ func TestCheckProductiveAccepts(t *testing.T) {
 				type A<T> = {b?: B<T>}
 				type B<T> = {a?: A<T>}
 			`,
+			want: []string{
+				"3:12-3:13: no argument passed to type parameter T can appear in the type, so " +
+					"B<number> and B<string> are the same type",
+				"2:12-2:13: no argument passed to type parameter T can appear in the type, so " +
+					"A<number> and A<string> are the same type",
+			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, test.src)
-			require.Empty(t, messagesWithSpan(errs))
+			require.Equal(t, test.want, messagesWithSpan(errs))
 		})
 	}
 }
@@ -219,7 +235,13 @@ func TestCheckProductiveRejects(t *testing.T) {
 // one type, and subtyping is reflexive, so the canonical identity settles it with no unfolding at
 // all. Each case reaches that identity by a different route: one directly, one through the object
 // the alias emits.
+// The unreachable-parameter warning `Deep` draws is what makes the identity settle, so it is the
+// only diagnostic either case expects.
 func TestInferNonRegularAliasChecks(t *testing.T) {
+	deepIsPhantom := []string{
+		"2:15-2:16: no argument passed to type parameter T can appear in the type, so " +
+			"Deep<number> and Deep<string> are the same type",
+	}
 	tests := []struct {
 		name string
 		src  string
@@ -244,7 +266,7 @@ func TestInferNonRegularAliasChecks(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, test.src)
-			require.Empty(t, messagesWithSpan(errs))
+			require.Equal(t, deepIsPhantom, messagesWithSpan(errs))
 		})
 	}
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -117,7 +117,19 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		if t, ok := c.resolveExactnessIntrinsic(scope, ta, lvl); ok {
 			return t, true
 		}
-		return c.reportUnsupported(ta), false
+		// Nothing claimed the name. Either it names no declaration at all, or it names one of
+		// the two built-in stubs above with an argument count neither accepts. Those stubs take
+		// exactly one, and a user-defined Promise or Array would have resolved through the scope
+		// before reaching here, so the name here is the built-in.
+		name := ast.QualIdentToString(ta.Name)
+		if name == "Promise" || name == "Array" {
+			c.report(&TypeArgArityMismatchError{
+				Ref: ta, Kind: BuiltinDeclKind, Name: name,
+				Required: 1, Total: 1, Got: len(ta.TypeArgs),
+			})
+			return &soltype.NeverType{}, false
+		}
+		return c.report(&UnknownTypeError{Ref: ta, Name: name}), false
 	case *ast.ObjectTypeAnn:
 		return c.resolveObjectTypeAnn(scope, ta, lvl)
 	case *ast.TupleTypeAnn:
@@ -662,10 +674,10 @@ func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int)
 	}
 
 	t := &soltype.CondType{
-		Check:      check,
-		Extends:    extends,
-		Then:       then,
-		Else:       els,
+		Check:   check,
+		Extends: extends,
+		Then:    then,
+		Else:    els,
 		// A Check the resolver could not resolve recovered to a fresh var, which is the same kind
 		// nakedTypeParamCheck accepts, so the flag is decided only when the written Check actually
 		// resolved. Otherwise a bare unresolvable name would be read as a type parameter.

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -495,7 +495,7 @@ func TestClassArityAcrossRemainingRefForms(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, test.src)
 			require.Len(t, errs, 1)
-			require.Equal(t, "class `Box` expects 1 type arguments but got 0", errs[0].Message())
+			require.Equal(t, "class `Box` expects 1 type argument but got 0", errs[0].Message())
 		})
 	}
 }
@@ -563,7 +563,7 @@ func TestClassArityAcrossMixedComponent(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			values, _, errs := inferSource(t, test.src)
 			require.Len(t, errs, 1)
-			require.Equal(t, "class `A` expects 1 type arguments but got 0", errs[0].Message())
+			require.Equal(t, "class `A` expects 1 type argument but got 0", errs[0].Message())
 			require.Equal(t, "{new (x: number, a: A<unknown>) -> B}", values["B"])
 		})
 	}

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -26,7 +26,7 @@ func TestTypeArgArityAtReference(t *testing.T) {
 				class Box<T> { value: T }
 				declare fn f() -> Box<number, string>
 			`,
-			want: []string{"class `Box` expects 1 type arguments but got 2"},
+			want: []string{"class `Box` expects 1 type argument but got 2"},
 		},
 		{
 			name: "ClassTooFewArgs",
@@ -44,7 +44,7 @@ func TestTypeArgArityAtReference(t *testing.T) {
 				class Box<T> { value: T }
 				declare fn f() -> Box
 			`,
-			want: []string{"class `Box` expects 1 type arguments but got 0"},
+			want: []string{"class `Box` expects 1 type argument but got 0"},
 		},
 		{
 			name: "ClassTooManyArgsWithDefault",
@@ -70,7 +70,7 @@ func TestTypeArgArityAtReference(t *testing.T) {
 				enum Opt<T> { Some(value: T), None }
 				declare fn f() -> Opt<number, string>
 			`,
-			want: []string{"enum `Opt` expects 1 type arguments but got 2"},
+			want: []string{"enum `Opt` expects 1 type argument but got 2"},
 		},
 		{
 			name: "NonGenericEnumWithArgs",
@@ -86,7 +86,7 @@ func TestTypeArgArityAtReference(t *testing.T) {
 				type Box<T> = {value: T}
 				declare fn f() -> Box<number, string>
 			`,
-			want: []string{"type alias `Box` expects 1 type arguments but got 2"},
+			want: []string{"type alias `Box` expects 1 type argument but got 2"},
 		},
 		// A reference that names the declaration it sits inside is checked like any other, so
 		// a self-referential class body has to write its own arguments.
@@ -95,7 +95,7 @@ func TestTypeArgArityAtReference(t *testing.T) {
 			src: `
 				class Node<T> { value: T, next: Node }
 			`,
-			want: []string{"class `Node` expects 1 type arguments but got 0"},
+			want: []string{"class `Node` expects 1 type argument but got 0"},
 		},
 		{
 			name: "ClassSelfReferenceWithArgAccepted",
@@ -250,8 +250,8 @@ func TestSurplusTypeArgIsResolved(t *testing.T) {
 				declare fn f() -> Box<number, Nonexistent>
 			`,
 			want: []string{
-				"class `Box` expects 1 type arguments but got 2",
-				"Unsupported: TypeRefTypeAnn",
+				"class `Box` expects 1 type argument but got 2",
+				"cannot find type `Nonexistent`",
 			},
 		},
 		{
@@ -262,7 +262,7 @@ func TestSurplusTypeArgIsResolved(t *testing.T) {
 			`,
 			want: []string{
 				"class `Point` expects 0 type arguments but got 1",
-				"Unsupported: TypeRefTypeAnn",
+				"cannot find type `Nonexistent`",
 			},
 		},
 		{
@@ -272,8 +272,8 @@ func TestSurplusTypeArgIsResolved(t *testing.T) {
 				declare fn f() -> Box<number, Nonexistent>
 			`,
 			want: []string{
-				"type alias `Box` expects 1 type arguments but got 2",
-				"Unsupported: TypeRefTypeAnn",
+				"type alias `Box` expects 1 type argument but got 2",
+				"cannot find type `Nonexistent`",
 			},
 		},
 	}
@@ -387,7 +387,7 @@ func TestClassArityCheckedFromOtherDeclarations(t *testing.T) {
 				class A { b: B }
 				class B<T> { v: T }
 			`,
-			want: "class `B` expects 1 type arguments but got 0",
+			want: "class `B` expects 1 type argument but got 0",
 		},
 		{
 			name: "FromClassBodyTooMany",
@@ -395,7 +395,7 @@ func TestClassArityCheckedFromOtherDeclarations(t *testing.T) {
 				class A { b: B<number, string> }
 				class B<T> { v: T }
 			`,
-			want: "class `B` expects 1 type arguments but got 2",
+			want: "class `B` expects 1 type argument but got 2",
 		},
 		{
 			name: "FromAliasBody",
@@ -403,7 +403,7 @@ func TestClassArityCheckedFromOtherDeclarations(t *testing.T) {
 				class B<T> { v: T }
 				type A = {b: B}
 			`,
-			want: "class `B` expects 1 type arguments but got 0",
+			want: "class `B` expects 1 type argument but got 0",
 		},
 		{
 			name: "FromEnumVariantParam",
@@ -411,7 +411,7 @@ func TestClassArityCheckedFromOtherDeclarations(t *testing.T) {
 				class B<T> { v: T }
 				enum A { X(b: B) }
 			`,
-			want: "class `B` expects 1 type arguments but got 0",
+			want: "class `B` expects 1 type argument but got 0",
 		},
 	}
 	for _, tt := range tests {
@@ -435,7 +435,7 @@ func TestClassArityRecoveryKeepsDeclarationVarOut(t *testing.T) {
 	`
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
-	require.Equal(t, "class `B` expects 1 type arguments but got 0", errs[0].Message())
+	require.Equal(t, "class `B` expects 1 type argument but got 0", errs[0].Message())
 	require.Equal(t, "{new (b: B<unknown>) -> A}", values["A"])
 }
 

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -1602,17 +1602,33 @@ left is a parameter left unused mid-edit, which a warning should not obstruct. A
 underscore, `type Ignore<_T> = number`, is the cheap convention and the recommended answer.
 Settle it in this PR rather than shipping the warning with no way to quiet it.
 
-**Scope.** Aliases only, since `PhantomParams` exists only for them, and an enum comes along
-free because it registers as a transparent alias. A class declares type parameters through
-the same `resolveTypeParams` and would warn the same way, but nothing computes reachability
-for a class body. The unused tier needs no reachability and extends to classes cheaply; the
-unreachable tier does not, and is deliberately left out rather than half-built.
+**Scope.** The unreachable tier is aliases only, since `PhantomParams` exists only for them.
+That is not a gap in what a class or an enum gets checked, it is a property those sorts do
+not have. A nominal handle carries its arguments into its identity and `constrain` compares
+them position by position, so an argument to a parameter the body does write stays
+observable however deep the recursion drives it. `class Nest<T> {deeper: Nest<{b: T}>}`
+reports a mismatch between `Nest<number>` and `Nest<string>` where the alias of that shape
+settles them as one type. Unreachability is a property of a transparent alias.
 
-**Accept.** `type Ignore<T> = number` warns that T is never used. `type Deep<T> =
-{a: Deep<{b: T}>}` warns that no argument to T can appear in the type, and the message names
-`Deep<number>` and `Deep<string>` as the same type. `type Foo<T, U: T> = {x: U}`,
-`type Pair<T, U = T> = {b: U}`, and `type List<T> = {head: T}` warn about nothing. Both
-diagnostics are warnings, so no program that checks today stops checking.
+The unused tier needs no reachability and covers all three sorts. A class reports from
+`inferClassDecl` over its members, its constructor's parameters, and its `extends` and
+`implements` targets, with a method's `self` receiver dropped the way variance inference
+drops it. An enum reports from `inferEnumBody` over its variants' parameters, which is the
+only place an enum's own parameter can be written — the variant handles and the constructor
+returns carry every parameter var mechanically.
+
+A declaration that already drew a diagnostic reports nothing. Recovery drops the subtree it
+could not resolve, so a parameter written only there leaves no occurrence behind and would
+read as unused. `type M<T> = {f(x: T) -> T}` drops the unsupported method, and
+`class B<T> extends T {}` drops the super it rejected. A `checker.errorWindow` around each
+declaration's inference is what each of the three sorts consults.
+
+**Accept.** `type Ignore<T> = number`, `class Box<T> {x: number}`, and `enum Opt<T> {A}` warn
+that T is never used. `type Deep<T> = {a: Deep<{b: T}>}` warns that no argument to T can
+appear in the type, and the message names `Deep<number>` and `Deep<string>` as the same type.
+`type Foo<T, U: T> = {x: U}`, `type Pair<T, U = T> = {b: U}`, `type List<T> = {head: T}`, and
+`class Nest<T> {deeper: Nest<{b: T}>}` warn about nothing. Both diagnostics are warnings, so
+no program that checks today stops checking.
 
 **Depends on** PR9d for the marks and for `phantom.go`, where the pass belongs. Independent of
 PR17–PR19 and of the operator track.


### PR DESCRIPTION
Adds warnings for type parameters that provide no value to callers. Two tiers of warnings cover different scenarios:

**Unused tier** (applies to aliases, classes, and enums): A type parameter declared but never mentioned in the declaration body, its sibling parameters' bounds, or its sibling parameters' defaults. `type Ignore<T> = number` warns that T is declared but never used.

**Unreachable tier** (aliases only): A type parameter mentioned in the body but marked phantom, meaning no argument passed to it can appear in the type an instantiation denotes. `type Deep<T> = {a: Deep<{b: T}>}` warns that Deep<number> and Deep<string> are the same type, so writing different arguments to T is pointless. This tier does not apply to classes and enums because their nominal semantics make arguments observable even through recursive references.

Both warnings are suppressible by prefixing the parameter name with an underscore (`_T`), allowing developers to mark parameters left to fill in later without obstruction.

**Key changes:**
- `reportPhantomParams` in `phantom.go` warns about unreachable alias parameters by checking phantom marks against parameter mentions in the body and sibling bounds/defaults
- `reportUnusedTypeParams` in `phantom.go` warns about unused parameters on any declaration type
- `typeParamMentions` and `paramOccurrenceWalker` track which parameters are mentioned in bodies and sibling constraints
- `classDeclOccurrences` visits all positions in a class declaration where type parameters can be written (members, constructor, extends, implements)
- Enum unused-parameter checking added to `inferEnumBody`
- `TypeParam.span` now covers the full parameter declaration (from variance modifier or name through constraint/default end) to support precise error reporting
- `aliasShell.bodyClean` and `enumShell.preBindClean` track whether a declaration's body resolved cleanly, suppressing warnings when recovery dropped parts of the declaration
- `errorWindow` helper prevents duplicate diagnostics when recovery has already reported an error

Both diagnostics are warnings, so existing code that checks today continues to check.

https://claude.ai/code/session_01BNS4VQpsxKNdW1CHVMHy7i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings for unused type parameters in aliases, classes, and enums.
  * Added warnings for type parameters that cannot affect transparent alias results.
  * Warnings include precise source locations and can be suppressed by prefixing parameters with an underscore.

* **Bug Fixes**
  * Improved handling of type-parameter spans across variance modifiers, constraints, and defaults.
  * Avoided reporting misleading warnings when declarations already contain inference errors.

* **Tests**
  * Expanded coverage for recursive aliases, recovered declarations, inheritance, enum variants, and warning suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->