### PR TITLE
Prove regular types with μ-knots instead of searching for them

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -357,7 +357,7 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen *seenPairs) (soltype.Typ
 		// finite μ-knot and the comparison closes on the knot instead. See regular.go.
 		//
 		// The knot stands in only once this alias is already being unfolded further up the path, which
-		// is where a cycle can be. constrainUnfoldingAlias explains what waiting buys.
+		// is where a cycle can be. pushUnfoldingAlias explains what waiting buys.
 		if c.unfoldingAliases[t.Name] > 0 {
 			if knot := c.muKnotFor(t); knot != nil {
 				return knot, nil, true
@@ -479,9 +479,10 @@ func (c *Context) constrainUnwrapped(sub, super soltype.Type, seen *seenPairs, m
 	return errs
 }
 
-// constrainUnfoldingAlias records that an alias operand is being unfolded for the duration of the
-// constraint that unfolding produced, and clears the record on the way back up. Only an alias
-// operand is recorded; every other operand runs body with no bookkeeping at all.
+// pushUnfoldingAlias records that ref is being unfolded, and popUnfoldingAlias clears the record.
+// A caller brackets the constraint its unfolding produced between the two, so the record describes
+// the current path. They are the alias twin of constrainUnwrapped's own depth count, and a caller
+// with an operand that is not an alias reference skips them entirely.
 //
 // evalTypeOperator reads the record to decide whether to hand constrain the alias's μ-knot in place
 // of its expansion. Substituting a knot at the first unfolding would work too, but it would put the
@@ -490,20 +491,19 @@ func (c *Context) constrainUnwrapped(sub, super soltype.Type, seen *seenPairs, m
 // `μX0.{a: "c", b: X0}` where it used to infer `H<{c: {c: number}}>`. A knot is only ever needed to
 // close a cycle, and a cycle takes at least two unfoldings, so waiting for the second one keeps the
 // alias name on everything the first one produces.
-func (c *Context) constrainUnfoldingAlias(operand soltype.Type, body func() []SolverError) []SolverError {
-	ref, isAlias := operand.(*soltype.AliasType)
-	if !isAlias {
-		return body()
-	}
+func (c *Context) pushUnfoldingAlias(ref *soltype.AliasType) {
 	if c.unfoldingAliases == nil {
 		c.unfoldingAliases = map[string]int{}
 	}
 	c.unfoldingAliases[ref.Name]++
-	errs := body()
+}
+
+// popUnfoldingAlias drops one unfolding of ref, removing the entry once the last one is done so the
+// map holds only the aliases the current path is inside.
+func (c *Context) popUnfoldingAlias(ref *soltype.AliasType) {
 	if c.unfoldingAliases[ref.Name]--; c.unfoldingAliases[ref.Name] == 0 {
 		delete(c.unfoldingAliases, ref.Name)
 	}
-	return errs
 }
 
 // constrain asserts sub <: super. mutCtx (PR 14) is the deep-mut context flag: true
@@ -639,9 +639,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			if c.unwrapDepth >= maxUnwrapDepth {
 				return []SolverError{&ExpansionLimitError{Sub: sub, Super: super}}
 			}
-			return c.constrainUnfoldingAlias(sub, func() []SolverError {
-				return c.constrainUnwrapped(evaluated, super, seen, mutCtx)
-			})
+			if ref, isAlias := sub.(*soltype.AliasType); isAlias {
+				c.pushUnfoldingAlias(ref)
+				defer c.popUnfoldingAlias(ref)
+			}
+			return c.constrainUnwrapped(evaluated, super, seen, mutCtx)
 		}
 	}
 	if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
@@ -652,9 +654,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			if c.unwrapDepth >= maxUnwrapDepth {
 				return []SolverError{&ExpansionLimitError{Sub: sub, Super: super}}
 			}
-			return c.constrainUnfoldingAlias(super, func() []SolverError {
-				return c.constrainUnwrapped(sub, evaluated, seen, mutCtx)
-			})
+			if ref, isAlias := super.(*soltype.AliasType); isAlias {
+				c.pushUnfoldingAlias(ref)
+				defer c.popUnfoldingAlias(ref)
+			}
+			return c.constrainUnwrapped(sub, evaluated, seen, mutCtx)
 		}
 	}
 

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -372,10 +372,32 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen *seenPairs) (soltype.Typ
 		*soltype.TemplateLitType, *soltype.StringIntrinsicType, *soltype.ExactnessType:
 		return c.reduceResidual(t, seen)
 	case *soltype.TupleType:
+		// A plain tuple is handled structurally, not as a transparent operator. Only a residual
+		// tuple is reduced here, the positional twin of the ObjectType arm below. A tuple is
+		// residual when it carries a `...P` element whose operand may still splice.
 		if !tupleHasSpread(t) {
 			return nil, nil, false
 		}
-		return c.reduceResidual(t, seen)
+		e := newTypeEvaluator(c, seen)
+		reduced := e.reduce(t)
+		// A rest element whose operand grounds splices into the enclosing tuple, leaving a
+		// spread-free tuple. One that stays a rest element is inert, so leave it for the structural
+		// switch. The check is on the root rather than reduceResidual's containsResidualOp: a
+		// spliced tuple grounds even when one of its elements is itself a residual, which reduces
+		// where that element is compared. `[...[keyof {c: number}], boolean]` splices to
+		// `[keyof {c: number}, boolean]`, and the `keyof` reduces to `"c"` at the position it lands
+		// in. Reading the whole tree instead would call that tuple inert and compare it structurally
+		// against the value, which rejects a constraint that holds.
+		if tup, ok := reduced.(*soltype.TupleType); ok && hasRestSpread(tup.Elems) {
+			// A diagnostic still surfaces from a tuple that stayed residual, the same allowance the
+			// object arm makes. The caller returns on a non-empty errs without reading the reduced
+			// type.
+			if len(e.errs) == 0 {
+				return nil, nil, false
+			}
+			return reduced, e.errs, true
+		}
+		return reduced, e.errs, true
 	case *soltype.ObjectType:
 		// A plain object is handled structurally, not as a transparent operator. Only a residual
 		// object is reduced here, the object twin of the TupleType arm. An object is residual when it
@@ -412,6 +434,10 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen *seenPairs) (soltype.Typ
 // that would re-expand without bound. The errs carry any diagnostic the reduction produced. seen is
 // the enclosing constraint's cycle-detection set, handed to the evaluator so a conditional's branch
 // probe closes a recursive alias through the same guard.
+//
+// It serves the operators whose value is a single node, where a residual anywhere in the result
+// means the operator itself did not settle. The object and tuple arms do not use it, since either
+// one grounds while still carrying a residual in a member or an element.
 func (c *Context) reduceResidual(t soltype.Type, seen *seenPairs) (soltype.Type, []SolverError, bool) {
 	e := newTypeEvaluator(c, seen)
 	reduced := e.reduce(t)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -351,6 +351,13 @@ func (c *Context) peelTransparent(t soltype.Type) soltype.Type {
 func (c *Context) evalTypeOperator(t soltype.Type, seen *seenPairs) (soltype.Type, []SolverError, bool) {
 	switch t := t.(type) {
 	case *soltype.AliasType:
+		// An alias whose recursion grows its own argument reaches a fresh instantiation every lap, so
+		// unfolding it hands the seen-set a pair no earlier lap reached and nothing closes the
+		// comparison. When the tree it denotes is regular all the same, muKnotFor names that tree as a
+		// finite μ-knot and the comparison closes on the knot instead. See regular.go.
+		if knot := c.muKnotFor(t, seen); knot != nil {
+			return knot, nil, true
+		}
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
 		return t.Ty, nil, true

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -355,8 +355,13 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen *seenPairs) (soltype.Typ
 		// unfolding it hands the seen-set a pair no earlier lap reached and nothing closes the
 		// comparison. When the tree it denotes is regular all the same, muKnotFor names that tree as a
 		// finite μ-knot and the comparison closes on the knot instead. See regular.go.
-		if knot := c.muKnotFor(t, seen); knot != nil {
-			return knot, nil, true
+		//
+		// The knot stands in only once this alias is already being unfolded further up the path, which
+		// is where a cycle can be. constrainUnfoldingAlias explains what waiting buys.
+		if c.unfoldingAliases[t.Name] > 0 {
+			if knot := c.muKnotFor(t); knot != nil {
+				return knot, nil, true
+			}
 		}
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
@@ -445,6 +450,33 @@ func (c *Context) constrainUnwrapped(sub, super soltype.Type, seen *seenPairs, m
 	c.unwrapDepth++
 	errs := c.constrain(sub, super, seen, mutCtx)
 	c.unwrapDepth--
+	return errs
+}
+
+// constrainUnfoldingAlias records that an alias operand is being unfolded for the duration of the
+// constraint that unfolding produced, and clears the record on the way back up. Only an alias
+// operand is recorded; every other operand runs body with no bookkeeping at all.
+//
+// evalTypeOperator reads the record to decide whether to hand constrain the alias's μ-knot in place
+// of its expansion. Substituting a knot at the first unfolding would work too, but it would put the
+// knot everywhere the expansion goes, including the value types a member read pulls out and records
+// as a bound. `mk().b` over `type H<T> = {a: keyof T, b: H<{c: T}>}` would then infer
+// `μX0.{a: "c", b: X0}` where it used to infer `H<{c: {c: number}}>`. A knot is only ever needed to
+// close a cycle, and a cycle takes at least two unfoldings, so waiting for the second one keeps the
+// alias name on everything the first one produces.
+func (c *Context) constrainUnfoldingAlias(operand soltype.Type, body func() []SolverError) []SolverError {
+	ref, isAlias := operand.(*soltype.AliasType)
+	if !isAlias {
+		return body()
+	}
+	if c.unfoldingAliases == nil {
+		c.unfoldingAliases = map[string]int{}
+	}
+	c.unfoldingAliases[ref.Name]++
+	errs := body()
+	if c.unfoldingAliases[ref.Name]--; c.unfoldingAliases[ref.Name] == 0 {
+		delete(c.unfoldingAliases, ref.Name)
+	}
 	return errs
 }
 
@@ -581,7 +613,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			if c.unwrapDepth >= maxUnwrapDepth {
 				return []SolverError{&ExpansionLimitError{Sub: sub, Super: super}}
 			}
-			return c.constrainUnwrapped(evaluated, super, seen, mutCtx)
+			return c.constrainUnfoldingAlias(sub, func() []SolverError {
+				return c.constrainUnwrapped(evaluated, super, seen, mutCtx)
+			})
 		}
 	}
 	if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
@@ -592,7 +626,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			if c.unwrapDepth >= maxUnwrapDepth {
 				return []SolverError{&ExpansionLimitError{Sub: sub, Super: super}}
 			}
-			return c.constrainUnwrapped(sub, evaluated, seen, mutCtx)
+			return c.constrainUnfoldingAlias(super, func() []SolverError {
+				return c.constrainUnwrapped(sub, evaluated, seen, mutCtx)
+			})
 		}
 	}
 

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -67,6 +67,24 @@ type Context struct {
 	// so a stale entry cannot make a constraint wrong.
 	aliasInterns map[string]*soltype.AliasType
 
+	// uniformKnots memoizes, per alias name, the μ-knot the regular-tree check proves for the
+	// instantiations one level into that alias's recursion, or a zero entry when it proves none.
+	// Nearly every alias memoizes the zero entry, so a reference pays one map lookup and nothing
+	// more. The map lives for the whole run: the check reads only an alias's registered definition,
+	// which no constraint and no discarded probe changes. See regular.go.
+	uniformKnots map[string]*uniformKnot
+
+	// knotting is true while a level of some alias's unfolding is being walked for the regular-tree
+	// check. That walk reduces the level's residual operators, and a reduction can re-enter
+	// constrain, which would ask for a knot again and start a second walk inside the first. The flag
+	// makes the inner ask fall back to the plain expansion instead. See regular.go.
+	knotting bool
+
+	// muBinderCount numbers the μ-variables the regular-tree check has minted, so two aliases whose
+	// knots are composed into one type carry distinct binders. coalesce numbers its own binders per
+	// walk instead, since the knots one walk produces are numbered together.
+	muBinderCount int
+
 	// unwrapDepth counts the type operators constrain has evaluated along the constraint path it
 	// is currently on, so an unwrap that never bottoms out is cut off at maxUnwrapDepth. constrain
 	// increments it around each recursive call it makes on an evaluated operator and restores it
@@ -200,6 +218,14 @@ func (c *Context) freshSkolem(name string) *soltype.SkolemType {
 	s := &soltype.SkolemType{ID: c.varCounter, Name: name}
 	c.varCounter++
 	return s
+}
+
+// freshMuBinder mints the next μ-variable for a knot the regular-tree check proves, naming it under
+// the same X0, X1, … convention coalesce's binders follow.
+func (c *Context) freshMuBinder() *soltype.RecursiveVarType {
+	v := &soltype.RecursiveVarType{ID: c.muBinderCount, Name: muBinderName(c.muBinderCount)}
+	c.muBinderCount++
+	return v
 }
 
 // freshInferDecl mints the declaration one `infer U` clause introduces, carrying the source name for

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -74,6 +74,13 @@ type Context struct {
 	// which no constraint and no discarded probe changes. See regular.go.
 	uniformKnots map[string]*uniformKnot
 
+	// unfoldingAliases counts, per alias name, how many constraints on the current path are running
+	// on that alias's expansion. evalTypeOperator reads it to hand constrain an alias's μ-knot only
+	// on the second unfolding, where a cycle can be, rather than on the first. Entries are added and
+	// removed by constrainUnfoldingAlias around the constraint each unfolding produces, so the map
+	// describes the current path rather than the whole run.
+	unfoldingAliases map[string]int
+
 	// knotting is true while a level of some alias's unfolding is being walked for the regular-tree
 	// check. That walk reduces the level's residual operators, and a reduction can re-enter
 	// constrain, which would ask for a knot again and start a second walk inside the first. The flag

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1480,6 +1480,70 @@ func TestInferTupleSpreadConstraint(t *testing.T) {
 	}
 }
 
+// A spliced tuple grounds even when one of its elements is still a residual. constrain decides that
+// from the root of the reduced tuple rather than from the whole tree, so an element that reduces at
+// the position it lands in does not make the enclosing tuple inert. An inert tuple would be compared
+// structurally against the value, rejecting a constraint that holds.
+//
+// Each case here reaches a residual through a different route: a `keyof` element the splice carries
+// in, a splice nested inside another splice, and a recursive tuple alias whose own body spreads
+// itself. The last case is why the root check matters most, since such an alias always has a `...L`
+// one level down and would never ground under a whole-tree reading.
+func TestInferTupleSpreadGroundsWithResidualElements(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			// The splice carries in a `keyof` that reduces to `"c"` where it lands.
+			name: "KeyofElement",
+			src: `
+				type P = {c: number}
+				val r: [...[keyof P], boolean] = ["c", true]
+			`,
+		},
+		{
+			// The operand is itself a spliced tuple, so the reduced result holds a nested one.
+			name: "NestedSplice",
+			src: `
+				type Inner = [number]
+				val r: [...[...Inner, string]] = [1, "a"]
+			`,
+		},
+		{
+			// A recursive tuple alias. Its spliced form always names itself one level down, so a
+			// whole-tree check never lets it ground. No finite value inhabits `L`, so the constraint
+			// runs between two types rather than from a literal.
+			name: "RecursiveTupleAlias",
+			src: `
+				type L = [number, [...L]]
+				declare fn mk() -> [...L]
+				fn use() -> [number, [...L]] { return mk() }
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Empty(t, Messages(errs))
+		})
+	}
+}
+
+// A rest element whose operand never grounds keeps the tuple inert, which is what the root check
+// must still report. A type parameter has no tuple to splice, so `[...T, number]` stays residual and
+// the value is rejected against it rather than against some spliced form. The operand renders as the
+// var the call instantiated `T` to rather than as `T` itself, since the rejection happens at the
+// call site.
+func TestInferTupleSpreadOverTypeParamStaysInert(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f<T>(x: [...T, number]) -> number { return 1 }
+		val r = f([1])
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain tuple <: [...t7, number]", errs[0].Message())
+}
+
 // A `mut` spread operand `[...mut P]` is rejected at the annotation site the same way a positional
 // `[mut X]` element is: the enclosing tuple decides mutability, so an owned-mutable operand nested
 // in it is misleading. The annotation reports MutFieldError and recovers to the bare operand, which

--- a/internal/solver/recursive_test.go
+++ b/internal/solver/recursive_test.go
@@ -31,6 +31,11 @@ func muKnot(id int, name string, body func(ref *soltype.RecursiveVarType) soltyp
 // The one unrolled level in front of each knot is a monomorphic-recursion artifact. Each call site
 // instantiates its own return variable, so the outer shape comes from the call and the knot from the
 // variable the body's recursive call flows through.
+//
+// Every source here puts nothing between the recursive call and the value the body builds, so none
+// of these functions returns when called. The types are right all the same, since no finite value
+// inhabits a knot with no base case, and what is being pinned is the rendering rather than a program
+// anyone runs. TestInferGuardedRecursionRendersMuKnot covers the shapes that do return.
 func TestInferRecursiveRendersMuKnot(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -66,6 +71,120 @@ func TestInferRecursiveRendersMuKnot(t *testing.T) {
 			`,
 			binding: "ping",
 			want:    "fn () -> {p: μX0.{q: {p: X0}}}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, Messages(errs))
+			require.Equal(t, tt.want, values[tt.binding])
+		})
+	}
+}
+
+// TestInferGuardedRecursionRendersMuKnot covers the recursive shapes a program actually runs.
+//
+// Every case in TestInferRecursiveRendersMuKnot puts nothing between the recursive call and the
+// value the body builds, so calling one of those functions never returns. Their knots are still the
+// right types, since no finite value inhabits `μX0.{next: X0}` either, but nobody writes such a
+// function to call it.
+//
+// A guarded recursion does return. Two guards appear in ordinary code. A branch with a base case
+// stops the recursion on some input, and the knot then binds the union of the two arms, so the
+// terminator sits inside the μ form rather than beside it. A lambda defers the recursive call until
+// something forces it, and the knot then closes through that lambda's return type.
+//
+// The rendering is what these pin. Without a μ form each recursive position collapses to the
+// polarity identity, so a linked list inferred from a builder reads `{head: number, tail: never}`
+// and says nothing about the list.
+func TestInferGuardedRecursionRendersMuKnot(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		binding string
+		want    string
+	}{
+		{
+			// A list builder with a base case, the canonical guarded shape. The knot binds the whole
+			// union, so one form covers both the terminated tail and the recursive one.
+			name: "list built by a recursion with a base case",
+			src: `
+				declare fn done(n: number) -> boolean
+				declare fn dec(n: number) -> number
+				fn count(n: number) {
+					return if done(n) { {head: n, tail: undefined} } else { {head: n, tail: count(dec(n))} }
+				}
+			`,
+			binding: "count",
+			want:    "fn (n: number) -> μX0.({head: number, tail: undefined} | {head: number, tail: X0})",
+		},
+		{
+			// The branching twin of the list: the recursive position sits in a tuple element, and the
+			// base case supplies the empty tuple.
+			name: "tree built by a recursion with a base case",
+			src: `
+				declare fn leaf(n: number) -> boolean
+				declare fn half(n: number) -> number
+				fn tree(n: number) {
+					return if leaf(n) { {value: n, kids: []} } else { {value: n, kids: [tree(half(n))]} }
+				}
+			`,
+			binding: "tree",
+			want:    "fn (n: number) -> μX0.({value: number, kids: []} | {value: number, kids: [X0]})",
+		},
+		{
+			// A lazy stream. The recursive call sits under a thunk, so the value is finite until
+			// something calls `rest`, and the knot closes through that thunk's return type.
+			name: "lazy stream behind a thunk",
+			src: `
+				declare fn inc(n: number) -> number
+				fn stream(n: number) { return {value: n, rest: fn () { return stream(inc(n)) }} }
+			`,
+			binding: "stream",
+			want:    "fn (n: number) -> {value: number, rest: fn () -> μX0.{value: number, rest: fn () -> X0}}",
+		},
+		{
+			// The JS iterator protocol, which combines both guards: the recursive call is behind the
+			// `next` thunk, and the `done: true` arm terminates the walk.
+			name: "iterator protocol",
+			src: `
+				declare fn more(n: number) -> boolean
+				declare fn inc(n: number) -> number
+				fn iter(n: number) {
+					return {next: fn () {
+						return if more(n) { {done: false, value: n, rest: iter(inc(n))} } else { {done: true} }
+					}}
+				}
+			`,
+			binding: "iter",
+			want: "fn (n: number) -> {next: fn () -> μX0.({done: true} | " +
+				"{done: false, value: number, rest: {next: fn () -> X0}})}",
+		},
+		{
+			// A fluent API whose chaining methods return the builder again. Every method is a lambda,
+			// so nothing recurses until a caller chains.
+			name: "fluent builder returning itself",
+			src: `
+				fn emitter() {
+					return {on: fn (name: string) { return emitter() }, emit: fn (name: string) { return 1 }}
+				}
+			`,
+			binding: "emitter",
+			want: "fn () -> {on: fn (name: string) -> μX0.{on: fn (name: string) -> X0, " +
+				"emit: fn (name: string) -> 1}, emit: fn (name: string) -> 1}",
+		},
+		{
+			// Mutual recursion between two bindings, the shape an AST walk takes. The knot closes one
+			// lap out at whichever binding is being rendered, and the base case rides inside it.
+			name: "mutually recursive AST builders",
+			src: `
+				declare fn atEnd() -> boolean
+				fn expr() { return {kind: "call", arg: if atEnd() { undefined } else { stmt() }} }
+				fn stmt() { return {kind: "stmt", inner: expr()} }
+			`,
+			binding: "expr",
+			want: `fn () -> {kind: "call", arg: μX0.({kind: "stmt", inner: {kind: "call", arg: X0}} ` +
+				`| undefined)}`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/regular.go
+++ b/internal/solver/regular.go
@@ -293,11 +293,12 @@ func (r *levelReducer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type
 }
 
 // unreducedOp reports whether a node still stands for a value reduction has to work out. It is
-// isResidualOp widened by the object-spread case: isResidualOp's object arm counts only an unsettled
-// mapped member, since constrain compares a spread-carrying object structurally rather than as an
-// operator, while a knot's body has to be the object the spread merges to.
+// isResidualOp widened by the two spread cases. isResidualOp's object arm counts only an unsettled
+// mapped member and its tuple arm counts none, since constrain compares a spread-carrying object or
+// tuple structurally rather than as an operator. A knot's body instead has to be the object or tuple
+// the spread merges to, so both are reduced here.
 func unreducedOp(t soltype.Type) bool {
-	return isResidualOp(t) || objectIsResidual(t)
+	return isResidualOp(t) || objectIsResidual(t) || tupleHasSpread(t)
 }
 
 // containsUnreducedOp reports whether any node in t is one reduction did not finish with. A shape

--- a/internal/solver/regular.go
+++ b/internal/solver/regular.go
@@ -182,7 +182,12 @@ func (c *Context) probeUniformKnot(name string, def *AliasDef) *uniformKnot {
 		if containsUnreducedOp(next) {
 			// An operator survived the reduction with the recursive reference already abstracted away
 			// beneath it. `type Sp<T> = {a: keyof T, b: {...Sp<{c: T}>}}` abstracts to
-			// `{a: "c", b: {...X0}}`, a spread of a bare μ-variable, which stands for no object.
+			// `{a: "c", b: {...X0}}`. A knot does exist for such an alias, since spreading one operand
+			// into an otherwise empty object yields that operand, so declining is incompleteness
+			// rather than a shape no knot fits. What forces it is that reduction has no rule for
+			// grounding a spread whose operand is a μ-variable: the residual spread would reach
+			// constrain and be compared structurally against a real object, failing a comparison that
+			// should hold. Declining leaves the alias on the plain expansion instead.
 			return none
 		}
 		if !sameInstantiations(below, applyPatterns(patterns, skolems, pattern.TypeArgs)) {

--- a/internal/solver/regular.go
+++ b/internal/solver/regular.go
@@ -79,7 +79,13 @@ type uniformKnot struct {
 // muKnotFor returns the μ-knot a reference denotes, or nil when the reference is not one the
 // regular-tree check settles. evalTypeOperator calls it in place of expandAlias, so a settled
 // reference reaches constrain as a knot to unfold rather than as an alias to expand again.
-func (c *Context) muKnotFor(ref *soltype.AliasType, seen *seenPairs) *soltype.RecursiveType {
+//
+// The level is reduced under a fresh seen-set rather than the enclosing constraint's. A conditional
+// decides its branch by re-entering constrain, which can close on a pair the enclosing derivation
+// assumed, so sharing that set would let the surrounding constraint decide whether this reference
+// is admitted as the knot. The probe that proved the knot also used a fresh set, so this is what
+// makes the two shapes comparable.
+func (c *Context) muKnotFor(ref *soltype.AliasType) *soltype.RecursiveType {
 	if c.knotting {
 		// A level's own reduction re-entered constrain, which asks again for the alias being
 		// expanded. Answering it would start a second level walk inside the first and recur without
@@ -92,8 +98,8 @@ func (c *Context) muKnotFor(ref *soltype.AliasType, seen *seenPairs) *soltype.Re
 	}
 	c.knotting = true
 	defer func() { c.knotting = false }()
-	body, _, ok := c.knotLevel(ref, u.knot.Binder, seen)
-	if !ok || soltype.PrintQualified(body) != u.shape {
+	body, _, ok := c.knotLevel(ref, u.knot.Binder)
+	if !ok || containsUnreducedOp(body) || soltype.PrintQualified(body) != u.shape {
 		// This reference sits above the level at which the argument stopped mattering, so its own
 		// body is not the knot's. Expanding it normally walks one lap closer, and the reference the
 		// lap emits is asked again.
@@ -150,7 +156,7 @@ func (c *Context) probeUniformKnot(name string, def *AliasDef) *uniformKnot {
 	binder := c.freshMuBinder()
 
 	// The references the alias's own body emits are the argument patterns g_1 … g_m.
-	_, patterns, ok := c.knotLevel(probe, binder, newSeenPairs())
+	_, patterns, ok := c.knotLevel(probe, binder)
 	if !ok || len(patterns) == 0 {
 		return none
 	}
@@ -167,10 +173,16 @@ func (c *Context) probeUniformKnot(name string, def *AliasDef) *uniformKnot {
 	var shape string
 	var body soltype.Type
 	for _, pattern := range patterns {
-		next, below, ok := c.knotLevel(pattern, binder, newSeenPairs())
+		next, below, ok := c.knotLevel(pattern, binder)
 		if !ok || mentionsAnySkolem(next, probeIDs) {
 			// Condition 1: the argument still reaches the emitted body, so this alias's instantiations
 			// denote different trees and none of them has a finite knot the probe can name.
+			return none
+		}
+		if containsUnreducedOp(next) {
+			// An operator survived the reduction with the recursive reference already abstracted away
+			// beneath it. `type Sp<T> = {a: keyof T, b: {...Sp<{c: T}>}}` abstracts to
+			// `{a: "c", b: {...X0}}`, a spread of a bare μ-variable, which stands for no object.
 			return none
 		}
 		if !sameInstantiations(below, applyPatterns(patterns, skolems, pattern.TypeArgs)) {
@@ -189,40 +201,70 @@ func (c *Context) probeUniformKnot(name string, def *AliasDef) *uniformKnot {
 			return none
 		}
 	}
+	if emitsNoStructure(body, binder) {
+		return none
+	}
 	return &uniformKnot{knot: &soltype.RecursiveType{Binder: binder, Body: body}, shape: shape}
 }
 
-// knotLevel expands one alias reference and returns the μ-body that level emits, together with the
-// references back to the same alias that the body carried before they were abstracted away. It
-// reports ok=false for a reference whose definition has no resolved body.
+// emitsNoStructure reports whether a candidate knot body puts no type constructor between the knot
+// and its own binder. `μX0.X0` is that shape, and so is `μX0.Id<X0>` over `type Id<X> = X`, since a
+// transparent alias unfolds to whatever it was handed. Such a knot has no unfolding that mentions a
+// type, so constrain would close on it against any super at all and accept vacuously. coalesce's tie
+// carries the same guard for the knots it mints.
 //
-// It runs two walks. The first reduces every residual operator the substitution left behind, so a
+// A bare alias reference is rejected without asking what it expands to. A knot whose whole body is
+// one reference emits nothing of its own either way, and the referenced alias is asked for its own
+// knot at its own reference.
+func emitsNoStructure(body soltype.Type, binder *soltype.RecursiveVarType) bool {
+	if body == soltype.Type(binder) {
+		return true
+	}
+	_, bare := body.(*soltype.AliasType)
+	return bare
+}
+
+// knotLevel expands one alias reference and returns the μ-body that level emits, together with the
+// references back to the same alias that the body carried before they were abstracted away.
+//
+// It runs two walks. The first reduces every operator the substitution left behind, so a
 // `keyof {c: number}` becomes the `"c"` it stands for and two levels that denote one type render
 // alike. The second replaces each remaining reference back to the alias with the knot's binder. The
 // order matters: an operator can have a reference to the alias as its own operand, as the
 // `Grow<{a: T}>[K]` of `type Grow<T> = {[K]: Grow<{a: T}>[K] for K in keyof T}` does. Abstracting
 // first would hand that operator a bare μ-variable to read a member out of, which is not a type any
 // reduction rule is written for.
-func (c *Context) knotLevel(ref *soltype.AliasType, binder *soltype.RecursiveVarType, seen *seenPairs) (soltype.Type, []*soltype.AliasType, bool) {
+//
+// It reports ok=false in three cases, each one saying that what came back is not the node this level
+// emits:
+//
+//   - the reference's definition has no resolved body, so the expansion is the ErrorType sentinel;
+//   - an expansion budget cut the reduction off, so the result is a truncation. Rendering one is
+//     expensive as well as meaningless, since a truncation can be arbitrarily large;
+//   - the reduction reported a diagnostic, such as a member read off a key the object does not
+//     carry. The plain expansion surfaces that diagnostic at the constraint site, and this walk
+//     discards the errors it collects, so declining is what keeps the report from being swallowed.
+//
+// A shape that still carries an operator is not rejected here, since the probe's first walk is over
+// the alias's own parameters and its shape is expected to hold one. Every caller that uses a shape
+// as a knot body screens it with containsUnreducedOp instead.
+func (c *Context) knotLevel(ref *soltype.AliasType, binder *soltype.RecursiveVarType) (soltype.Type, []*soltype.AliasType, bool) {
 	expanded := c.expandAlias(ref)
 	if _, unresolved := expanded.(*soltype.ErrorType); unresolved {
 		return nil, nil, false
 	}
-	r := &levelReducer{eval: newTypeEvaluator(c, seen), name: ref.Name}
+	r := &levelReducer{eval: newTypeEvaluator(c, newSeenPairs()), name: ref.Name}
 	reduced := expanded.Accept(r, soltype.Positive)
-	if r.eval.truncated {
-		// An expansion budget cut the reduction off, so what came back is not the node this level
-		// emits. Reading a shape off it would compare one truncation against another, and a
-		// truncation can be arbitrarily large, so rendering it is expensive as well as meaningless.
+	if r.eval.truncated || len(r.eval.errs) > 0 {
 		return nil, nil, false
 	}
 	a := &recursiveRefAbstractor{name: ref.Name, binder: binder}
 	return reduced.Accept(a, soltype.Positive), a.found, true
 }
 
-// levelReducer reduces every residual operator in one level of an alias's unfolding. It leaves a
-// reference back to the alias itself in place, and does not walk that reference's arguments, since
-// those are the growing payload the knot abstracts away.
+// levelReducer reduces every operator in one level of an alias's unfolding. It leaves a reference
+// back to the alias itself in place, and does not walk that reference's arguments, since those are
+// the growing payload the knot abstracts away.
 type levelReducer struct {
 	eval *typeEvaluator
 	name string
@@ -239,11 +281,42 @@ func (r *levelReducer) EnterType(t soltype.Type, _ soltype.Polarity) soltype.Ent
 // form. The evaluator is shared across the walk, which gives one expansion budget to the whole level
 // rather than one per node.
 func (r *levelReducer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
-	if !isResidualOp(t) {
+	if !unreducedOp(t) {
 		return t
 	}
 	return r.eval.reduce(t)
 }
+
+// unreducedOp reports whether a node still stands for a value reduction has to work out. It is
+// isResidualOp widened by the object-spread case: isResidualOp's object arm counts only an unsettled
+// mapped member, since constrain compares a spread-carrying object structurally rather than as an
+// operator, while a knot's body has to be the object the spread merges to.
+func unreducedOp(t soltype.Type) bool {
+	return isResidualOp(t) || objectIsResidual(t)
+}
+
+// containsUnreducedOp reports whether any node in t is one reduction did not finish with. A shape
+// carrying one is not the node its level emits, so no knot can be read off it.
+func containsUnreducedOp(t soltype.Type) bool {
+	f := &unreducedOpFinder{}
+	t.Accept(f, soltype.Positive)
+	return f.found
+}
+
+type unreducedOpFinder struct{ found bool }
+
+func (f *unreducedOpFinder) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if f.found {
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	if unreducedOp(t) {
+		f.found = true
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (f *unreducedOpFinder) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // recursiveRefAbstractor replaces each reference back to the walked alias with the knot's binder and
 // records the references it replaced, in traversal order. probeUniformKnot reads the alias's

--- a/internal/solver/regular.go
+++ b/internal/solver/regular.go
@@ -1,0 +1,354 @@
+package solver
+
+import (
+	"slices"
+
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// A type is regular when it has finitely many distinct subtrees. Every regular type is denoted
+// exactly by a finite μ-knot, and constrain compares two knots by unfolding them under its
+// coinductive seen-set. Nothing builds a knot for a recursive alias, though. The alias name serves
+// as the μ-variable and unfolding ties the knot, which works as long as the unfolding comes back to
+// an instantiation it already visited.
+//
+// `type List<T> = {head: T, tail?: List<T>}` does come back. `List<number>` unfolds to a body that
+// names `List<number>` again, and the seen-set closes on the repeated pair. An alias whose recursion
+// grows its own argument never comes back:
+//
+//	type H<T> = {a: keyof T, b: H<{c: T}>}
+//
+// `H<number>` unfolds to `{a: never, b: H<{c: number}>}`, then to `{a: "c", b: H<{c: {c: number}}>}`,
+// and the argument gains a level every lap, so no pair ever repeats. The tree is regular all the
+// same. `keyof {c: X}` is `"c"` whatever X is, so every lap below the first emits `{a: "c", b: …}`
+// and the whole tree has two distinct subtrees. muKnotFor finds that knot, and evalTypeOperator
+// hands constrain `μX0.{a: "c", b: X0}` in place of the `H<{c: number}>` reference.
+//
+// # What proves a knot
+//
+// The proof rests on one observation. Expand the alias with a rigid skolem in place of its type
+// argument and reduce. If the skolem is nowhere in the result, the reduction never read the
+// argument, so it produces that one body for every argument and one symbolic expansion settles
+// infinitely many instantiations at once.
+//
+// Write `A<T>` for the alias and `g` for the argument its recursive reference passes, so `H`'s `g`
+// maps `T` to `{c: T}`. The probe runs the check one level into the recursion rather than at the
+// alias's own parameters, since `H`'s first level does read `T`. It expands `A<g(S)>` for a fresh
+// skolem `S` and asks two things of the result:
+//
+//  1. Its shape — the body with every reference back to `A` abstracted to the μ-binder — holds no
+//     skolem. Every `A<g(σ)>` therefore has that one shape, whatever σ is.
+//  2. Its recursive reference passes `g(g(S))`, so the state below `A<g(σ)>` is `A<g(g(σ))>`, which
+//     is again of the form `A<g(·)>`.
+//
+// Together those close the family `{A<g(σ)> : σ}` under the successor relation and give every member
+// of it the same shape Σ. All of them are therefore the same tree, and that tree is `μX.Σ`.
+//
+// An alias with several recursive references, or with several type parameters, is handled the same
+// way with `g` ranging over one argument pattern per reference. Condition 1 is asked of each
+// pattern's expansion and every shape must agree, and condition 2 asks that the references below
+// `A<g_i(S)>` pass exactly the patterns `g_1(g_i(S)), …, g_m(g_i(S))`.
+//
+// # What is left to the budgets
+//
+// The check is sound and incomplete. It proves a knot for an alias whose argument stops mattering at
+// a bounded depth, and it proves nothing for one whose argument keeps mattering forever.
+// `type Nest<T> = {here: T, deeper: Nest<{b: T}>}` reads `T` at every level, so its probe shape holds
+// the skolem and no knot is found. That alias denotes a genuinely non-regular tree, which no finite
+// knot can represent, and maxExpandDepth, maxExpandKeyChars, and maxUnwrapDepth remain the backstop
+// for it. checkProductive's own doc comment describes the same split between what is decidable here
+// and what a budget has to cut off.
+
+// uniformKnot is one alias's memoized answer from muKnotFor: the μ-knot every instantiation one
+// level into its recursion denotes, and that knot's body rendered under PrintQualified. An alias
+// whose probe failed any of the conditions above memoizes a zero value, whose nil knot reads as "no
+// knot found" at every reference to it.
+//
+// The knot is shared rather than rebuilt per reference, so the constraint between two references to
+// one alias keys on a single pointer and constrain's seen-set closes on it.
+type uniformKnot struct {
+	knot *soltype.RecursiveType
+	// shape is PrintQualified(knot.Body). A reference is admitted as this knot only when its own
+	// expansion renders identically. That test is what keeps a reference a lap above the knot from
+	// being tied to it. `H<number>` emits `{a: never, b: …}` at its own level, which is not the
+	// `{a: "c", b: …}` every level below it emits.
+	shape string
+}
+
+// muKnotFor returns the μ-knot a reference denotes, or nil when the reference is not one the
+// regular-tree check settles. evalTypeOperator calls it in place of expandAlias, so a settled
+// reference reaches constrain as a knot to unfold rather than as an alias to expand again.
+func (c *Context) muKnotFor(ref *soltype.AliasType, seen *seenPairs) *soltype.RecursiveType {
+	if c.knotting {
+		// A level's own reduction re-entered constrain, which asks again for the alias being
+		// expanded. Answering it would start a second level walk inside the first and recur without
+		// bound, so the inner ask falls back to the plain expansion.
+		return nil
+	}
+	u := c.uniformKnotOf(ref.Name)
+	if u.knot == nil {
+		return nil
+	}
+	c.knotting = true
+	defer func() { c.knotting = false }()
+	body, _, ok := c.knotLevel(ref, u.knot.Binder, seen)
+	if !ok || soltype.PrintQualified(body) != u.shape {
+		// This reference sits above the level at which the argument stopped mattering, so its own
+		// body is not the knot's. Expanding it normally walks one lap closer, and the reference the
+		// lap emits is asked again.
+		return nil
+	}
+	return u.knot
+}
+
+// uniformKnotOf memoizes probeUniformKnot per alias. The zero value doubles as the in-progress
+// marker: a reduction inside the probe can re-enter constrain, which asks for the same alias again,
+// and reading the marker declines that inner ask rather than restarting the probe.
+//
+// An alias whose body has not been resolved yet is answered without being memoized. Its expansion is
+// the ErrorType sentinel, which no knot can be read off, and memoizing that would pin the answer for
+// a definition that is about to be filled in.
+func (c *Context) uniformKnotOf(name string) *uniformKnot {
+	if u, done := c.uniformKnots[name]; done {
+		return u
+	}
+	def, registered := c.aliasDef(name)
+	if !registered || def.Body == nil {
+		return &uniformKnot{}
+	}
+	if c.uniformKnots == nil {
+		c.uniformKnots = map[string]*uniformKnot{}
+	}
+	c.uniformKnots[name] = &uniformKnot{}
+	outer := c.knotting
+	c.knotting = true
+	defer func() { c.knotting = outer }()
+	u := c.probeUniformKnot(name, def)
+	c.uniformKnots[name] = u
+	return u
+}
+
+// probeUniformKnot runs the two-condition check this file's doc comment describes and returns the
+// knot it proves, or a zero uniformKnot when it proves none.
+func (c *Context) probeUniformKnot(name string, def *AliasDef) *uniformKnot {
+	none := &uniformKnot{}
+	if def.NotProductive || len(def.TypeParams) == 0 {
+		// A non-generic alias has no argument to grow, so its instantiations repeat and the seen-set
+		// already closes on them. A rejected definition names no type to normalize.
+		return none
+	}
+
+	skolems := make([]soltype.Type, len(def.TypeParams))
+	probeIDs := set.NewSet[int]()
+	for i, p := range def.TypeParams {
+		s := c.freshSkolem(p.Name)
+		skolems[i] = s
+		probeIDs.Add(s.ID)
+	}
+	probe := &soltype.AliasType{Name: name, TypeArgs: skolems}
+	binder := c.freshMuBinder()
+
+	// The references the alias's own body emits are the argument patterns g_1 … g_m.
+	_, patterns, ok := c.knotLevel(probe, binder, newSeenPairs())
+	if !ok || len(patterns) == 0 {
+		return none
+	}
+	probeKey := soltype.PrintQualified(probe)
+	if !slices.ContainsFunc(patterns, func(p *soltype.AliasType) bool {
+		return soltype.PrintQualified(p) != probeKey
+	}) {
+		// Every reference passes the alias's own arguments straight through, so the instantiation
+		// repeats on the next lap and constrain's seen-set closes on it with no knot. Declining here
+		// keeps such an alias rendering and comparing the way it does without this check.
+		return none
+	}
+
+	var shape string
+	var body soltype.Type
+	for _, pattern := range patterns {
+		next, below, ok := c.knotLevel(pattern, binder, newSeenPairs())
+		if !ok || mentionsAnySkolem(next, probeIDs) {
+			// Condition 1: the argument still reaches the emitted body, so this alias's instantiations
+			// denote different trees and none of them has a finite knot the probe can name.
+			return none
+		}
+		if !sameInstantiations(below, applyPatterns(patterns, skolems, pattern.TypeArgs)) {
+			// Condition 2: the references below this one pass something other than the alias's own
+			// patterns applied again, so the family the probe closed over is not closed after all.
+			return none
+		}
+		rendered := soltype.PrintQualified(next)
+		if body == nil {
+			body, shape = next, rendered
+			continue
+		}
+		if rendered != shape {
+			// Two patterns emit different bodies, so the tree below this alias depends on which
+			// reference was taken and one knot cannot stand for both.
+			return none
+		}
+	}
+	return &uniformKnot{knot: &soltype.RecursiveType{Binder: binder, Body: body}, shape: shape}
+}
+
+// knotLevel expands one alias reference and returns the μ-body that level emits, together with the
+// references back to the same alias that the body carried before they were abstracted away. It
+// reports ok=false for a reference whose definition has no resolved body.
+//
+// It runs two walks. The first reduces every residual operator the substitution left behind, so a
+// `keyof {c: number}` becomes the `"c"` it stands for and two levels that denote one type render
+// alike. The second replaces each remaining reference back to the alias with the knot's binder. The
+// order matters: an operator can have a reference to the alias as its own operand, as the
+// `Grow<{a: T}>[K]` of `type Grow<T> = {[K]: Grow<{a: T}>[K] for K in keyof T}` does. Abstracting
+// first would hand that operator a bare μ-variable to read a member out of, which is not a type any
+// reduction rule is written for.
+func (c *Context) knotLevel(ref *soltype.AliasType, binder *soltype.RecursiveVarType, seen *seenPairs) (soltype.Type, []*soltype.AliasType, bool) {
+	expanded := c.expandAlias(ref)
+	if _, unresolved := expanded.(*soltype.ErrorType); unresolved {
+		return nil, nil, false
+	}
+	r := &levelReducer{eval: newTypeEvaluator(c, seen), name: ref.Name}
+	reduced := expanded.Accept(r, soltype.Positive)
+	if r.eval.truncated {
+		// An expansion budget cut the reduction off, so what came back is not the node this level
+		// emits. Reading a shape off it would compare one truncation against another, and a
+		// truncation can be arbitrarily large, so rendering it is expensive as well as meaningless.
+		return nil, nil, false
+	}
+	a := &recursiveRefAbstractor{name: ref.Name, binder: binder}
+	return reduced.Accept(a, soltype.Positive), a.found, true
+}
+
+// levelReducer reduces every residual operator in one level of an alias's unfolding. It leaves a
+// reference back to the alias itself in place, and does not walk that reference's arguments, since
+// those are the growing payload the knot abstracts away.
+type levelReducer struct {
+	eval *typeEvaluator
+	name string
+}
+
+func (r *levelReducer) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if ref, ok := t.(*soltype.AliasType); ok && ref.Name == r.name {
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+// ExitType reduces bottom-up, so an operator whose operand is itself an operator reads the reduced
+// form. The evaluator is shared across the walk, which gives one expansion budget to the whole level
+// rather than one per node.
+func (r *levelReducer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
+	if !isResidualOp(t) {
+		return t
+	}
+	return r.eval.reduce(t)
+}
+
+// recursiveRefAbstractor replaces each reference back to the walked alias with the knot's binder and
+// records the references it replaced, in traversal order. probeUniformKnot reads the alias's
+// argument patterns off that record.
+type recursiveRefAbstractor struct {
+	name   string
+	binder *soltype.RecursiveVarType
+	found  []*soltype.AliasType
+}
+
+// EnterType takes over at a reference back to the walked alias. Skipping its children is what keeps
+// the walk out of the growing argument.
+func (a *recursiveRefAbstractor) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	ref, ok := t.(*soltype.AliasType)
+	if !ok || ref.Name != a.name {
+		return soltype.EnterResult{}
+	}
+	a.found = append(a.found, ref)
+	return soltype.EnterResult{Type: a.binder, SkipChildren: true}
+}
+
+func (a *recursiveRefAbstractor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// applyPatterns substitutes args for the probe skolems in each of the alias's own argument patterns,
+// yielding the references that must sit one level below a state whose arguments are args. It is the
+// `g_1(g_i(S)), …, g_m(g_i(S))` of condition 2.
+func applyPatterns(patterns []*soltype.AliasType, skolems []soltype.Type, args []soltype.Type) []*soltype.AliasType {
+	subst := map[int]soltype.Type{}
+	for i, s := range skolems {
+		if sk, ok := s.(*soltype.SkolemType); ok && i < len(args) {
+			subst[sk.ID] = args[i]
+		}
+	}
+	out := make([]*soltype.AliasType, 0, len(patterns))
+	for _, p := range patterns {
+		applied, ok := p.Accept(&skolemSubst{subst: subst}, soltype.Positive).(*soltype.AliasType)
+		if !ok {
+			continue
+		}
+		out = append(out, applied)
+	}
+	return out
+}
+
+// sameInstantiations reports whether two reference lists name the same multiset of instantiations,
+// compared by their rendered form. Order is not required to match, since a reduction may emit the
+// references of one level in a different order than the level above.
+func sameInstantiations(got, want []*soltype.AliasType) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	render := func(refs []*soltype.AliasType) []string {
+		out := make([]string, len(refs))
+		for i, r := range refs {
+			out[i] = soltype.PrintQualified(r)
+		}
+		slices.Sort(out)
+		return out
+	}
+	return slices.Equal(render(got), render(want))
+}
+
+// skolemSubst replaces the probe skolems by the types a concrete state passes in their place.
+type skolemSubst struct {
+	subst map[int]soltype.Type
+}
+
+func (s *skolemSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	sk, ok := t.(*soltype.SkolemType)
+	if !ok {
+		return soltype.EnterResult{}
+	}
+	if replacement, found := s.subst[sk.ID]; found {
+		return soltype.EnterResult{Type: replacement, SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (s *skolemSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// mentionsAnySkolem reports whether t holds any of the probe's skolems, which is what says the
+// reduction read the alias's argument instead of producing the same body for every argument.
+func mentionsAnySkolem(t soltype.Type, ids set.Set[int]) bool {
+	f := &skolemFinder{ids: ids}
+	t.Accept(f, soltype.Positive)
+	return f.found
+}
+
+// skolemFinder is the read-only walking visitor behind mentionsAnySkolem. It rewrites nothing, and
+// prunes once it has seen one of the ids, since one occurrence is enough — the same shape
+// soltype's typeVarSeeker uses.
+type skolemFinder struct {
+	ids   set.Set[int]
+	found bool
+}
+
+func (f *skolemFinder) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if f.found {
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	if sk, ok := t.(*soltype.SkolemType); ok && f.ids.Contains(sk.ID) {
+		f.found = true
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (f *skolemFinder) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }

--- a/internal/solver/regular.go
+++ b/internal/solver/regular.go
@@ -19,11 +19,13 @@ import (
 //
 //	type H<T> = {a: keyof T, b: H<{c: T}>}
 //
-// `H<number>` unfolds to `{a: never, b: H<{c: number}>}`, then to `{a: "c", b: H<{c: {c: number}}>}`,
-// and the argument gains a level every lap, so no pair ever repeats. The tree is regular all the
-// same. `keyof {c: X}` is `"c"` whatever X is, so every lap below the first emits `{a: "c", b: …}`
-// and the whole tree has two distinct subtrees. muKnotFor finds that knot, and evalTypeOperator
-// hands constrain `μX0.{a: "c", b: X0}` in place of the `H<{c: number}>` reference.
+// `H<number>` unfolds to `{a: never, b: H<{c: number}>}`. The reference that leaves behind unfolds
+// in turn to `{a: "c", b: H<{c: {c: number}}>}`, so two unfoldings of `H<number>` reach
+// `{a: never, b: {a: "c", b: H<{c: {c: number}}>}}`. The argument gains a level every lap, so no
+// pair ever repeats. The tree is regular all the same. `keyof {c: X}` is `"c"` whatever X is, so
+// every lap below the first emits `{a: "c", b: …}` and the whole tree has two distinct subtrees.
+// muKnotFor finds that knot, and evalTypeOperator hands constrain `μX0.{a: "c", b: X0}` in place of
+// the `H<{c: number}>` reference.
 //
 // # What proves a knot
 //

--- a/internal/solver/regular.go
+++ b/internal/solver/regular.go
@@ -240,19 +240,24 @@ func emitsNoStructure(body soltype.Type, binder *soltype.RecursiveVarType) bool 
 // first would hand that operator a bare μ-variable to read a member out of, which is not a type any
 // reduction rule is written for.
 //
-// It reports ok=false in three cases, each one saying that what came back is not the node this level
+// It reports ok=false in two cases, each one saying that what came back is not the node this level
 // emits:
 //
 //   - the reference's definition has no resolved body, so the expansion is the ErrorType sentinel;
 //   - an expansion budget cut the reduction off, so the result is a truncation. Rendering one is
-//     expensive as well as meaningless, since a truncation can be arbitrarily large;
-//   - the reduction reported a diagnostic, such as a member read off a key the object does not
-//     carry. The plain expansion surfaces that diagnostic at the constraint site, and this walk
-//     discards the errors it collects, so declining is what keeps the report from being swallowed.
+//     expensive as well as meaningless, since a truncation can be arbitrarily large.
 //
-// A shape that still carries an operator is not rejected here, since the probe's first walk is over
-// the alias's own parameters and its shape is expected to hold one. Every caller that uses a shape
-// as a knot body screens it with containsUnreducedOp instead.
+// A reduction that reports a diagnostic is not one of them. Such a reduction already substituted the
+// ErrorType sentinel for the member it could not work out, so the level it emits is a real node with
+// `error` at that position, and `error` absorbs at every constraint site. The diagnostic itself is
+// carried by the plain expansion, which every reference runs before this walk is consulted, so the
+// errors collected here are discarded rather than reported twice. `{x: number}["z"]` inside an alias
+// body therefore yields the knot `μX0.{…, e: error, …}` and one report, not a knot-less comparison
+// that runs to the unwrap budget.
+//
+// A shape that still carries an operator is not rejected here either, since the probe's first walk is
+// over the alias's own parameters and its shape is expected to hold one. Every caller that uses a
+// shape as a knot body screens it with containsUnreducedOp instead.
 func (c *Context) knotLevel(ref *soltype.AliasType, binder *soltype.RecursiveVarType) (soltype.Type, []*soltype.AliasType, bool) {
 	expanded := c.expandAlias(ref)
 	if _, unresolved := expanded.(*soltype.ErrorType); unresolved {
@@ -260,7 +265,7 @@ func (c *Context) knotLevel(ref *soltype.AliasType, binder *soltype.RecursiveVar
 	}
 	r := &levelReducer{eval: newTypeEvaluator(c, newSeenPairs()), name: ref.Name}
 	reduced := expanded.Accept(r, soltype.Positive)
-	if r.eval.truncated || len(r.eval.errs) > 0 {
+	if r.eval.truncated {
 		return nil, nil, false
 	}
 	a := &recursiveRefAbstractor{name: ref.Name, binder: binder}

--- a/internal/solver/regular_test.go
+++ b/internal/solver/regular_test.go
@@ -251,6 +251,10 @@ func TestMuKnotForDeclinesUnproductiveAlias(t *testing.T) {
 // `node` returns a knot because its recursive call makes its own return variable's lower bound
 // mention it, which is the shape coalesce renders as a μ form. The one unrolled level in front of the
 // knot is the monomorphic-recursion artifact TestInferRecursiveRendersMuKnot describes.
+//
+// The recursion is unguarded, so calling `node` never returns. That is forced rather than careless:
+// `H` has no base case, so no finite value inhabits `H<{c: number}>` and only an infinite value can
+// be checked against it. TestInferGuardedRecursionRendersMuKnot carries the terminating shapes.
 func TestConstrainRegularAliasClosesOnItsKnot(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		type H<T> = {a: keyof T, b: H<{c: T}>}

--- a/internal/solver/regular_test.go
+++ b/internal/solver/regular_test.go
@@ -1,0 +1,226 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// probeKnot infers src, reads the alias reference bound to `Probe`, and returns the μ-knot the
+// regular-tree check proves for it, or the empty string when it proves none. Every case below
+// declares the aliases under test and names the one reference it asks about as `Probe`.
+func probeKnot(t *testing.T, src string) string {
+	t.Helper()
+	nodes, ctx, errs := inferTypeNodes(t, src)
+	require.Empty(t, Messages(errs))
+	ref, ok := nodes["Probe"].(*soltype.AliasType)
+	require.True(t, ok, "Probe must bind an alias reference, got %T", nodes["Probe"])
+	knot := ctx.muKnotFor(ref, newSeenPairs())
+	if knot == nil {
+		return ""
+	}
+	return soltype.Print(knot)
+}
+
+// The regular-tree check settles an alias reference whose unfolding emits one shape from that
+// reference down, and declines every other. Each case names its reference `Probe` and states the
+// μ-knot the check proves, or the empty string for a reference the check leaves to the plain
+// expansion.
+func TestMuKnotForSettlesRegularAlias(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// The headline shape. `keyof {c: X}` is `"c"` whatever X is, so the argument stops
+			// reaching the emitted body one level in and every level below the first is `{a: "c", …}`.
+			name: "argument stops reaching the body one level in",
+			src: `
+				type H<T> = {a: keyof T, b: H<{c: T}>}
+				type Probe = H<{c: number}>
+			`,
+			want: `μX0.{a: "c", b: X0}`,
+		},
+		{
+			// The same alias one lap higher. `keyof number` is `never` rather than `"c"`, so this
+			// reference emits a body the levels below it do not, and no knot stands for it. Expanding
+			// it normally walks one lap closer, and the reference that lap emits is settled above.
+			name: "the lap above the knot is not the knot",
+			src: `
+				type H<T> = {a: keyof T, b: H<{c: T}>}
+				type Probe = H<number>
+			`,
+			want: "",
+		},
+		{
+			// The parameter never reaches the emitted body at all, so the knot is already tied at the
+			// reference the source wrote. markPhantomParams reaches the same conclusion about this
+			// alias from its declaration alone, and settles `Deep<number> <: Deep<string>` by making
+			// the two references intern to one identity.
+			name: "parameter never reaches the body",
+			src: `
+				type Deep<T> = {a: Deep<{b: T}>}
+				type Probe = Deep<number>
+			`,
+			want: "μX0.{a: X0}",
+		},
+		{
+			// Two recursive references growing the argument the same way emit one body, so one binder
+			// stands for both positions.
+			name: "two references growing the argument alike",
+			src: `
+				type Fork<T> = {a: keyof T, l: Fork<{c: T}>, r: Fork<{c: T}>}
+				type Probe = Fork<{c: number}>
+			`,
+			want: `μX0.{a: "c", l: X0, r: X0}`,
+		},
+		{
+			// Two recursive references growing the argument differently emit different bodies, so
+			// which reference a level was reached through decides the tree below it and one knot
+			// cannot stand for both.
+			name: "two references growing the argument differently",
+			src: `
+				type Split<T> = {a: keyof T, l: Split<{c: T}>, r: Split<{d: T}>}
+				type Probe = Split<{c: number}>
+			`,
+			want: "",
+		},
+		{
+			// Each parameter grows independently, and neither reaches the emitted body past the first
+			// level, so the pair of them settles the same way one does.
+			name: "two parameters, both stopping",
+			src: `
+				type Pair<T, U> = {a: keyof T, b: keyof U, rest: Pair<{x: T}, {y: U}>}
+				type Probe = Pair<{x: number}, {y: string}>
+			`,
+			want: `μX0.{a: "x", b: "y", rest: X0}`,
+		},
+		{
+			// The parameter reaches the emitted body at every level, so the instantiations denote
+			// different trees and none of them is regular. maxUnwrapDepth stays the backstop for this
+			// shape — see TestConstrainNonRegularAliasStillReachesTheBudget.
+			name: "parameter keeps reaching the body",
+			src: `
+				type Nest<T> = {here: T, deeper: Nest<{b: T}>}
+				type Probe = Nest<number>
+			`,
+			want: "",
+		},
+		{
+			// The recursion passes its argument through unchanged, so the instantiation repeats and
+			// constrain's seen-set closes on it with no knot. Declining here is what keeps the
+			// ordinary recursive alias comparing and rendering the way it does without this check.
+			name: "recursion repeats its instantiation",
+			src: `
+				type List<T> = {head: T, tail?: List<T>}
+				type Probe = List<number>
+			`,
+			want: "",
+		},
+		{
+			// A non-generic alias has no argument to grow, so its instantiation repeats for the same
+			// reason.
+			name: "no type parameter to grow",
+			src: `
+				type Cycle = {next: Cycle}
+				type Probe = Cycle
+			`,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, probeKnot(t, tt.src))
+		})
+	}
+}
+
+// A lap of this alias's recursion emits no structure, so checkProductive rejects it at its
+// declaration and it names no type to normalize. It sits outside the table above because that
+// rejection is a diagnostic, and every case in the table infers cleanly.
+func TestMuKnotForDeclinesUnproductiveAlias(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Grow<T> = Grow<{a: T}>
+		type Probe = Grow<number>
+	`)
+	require.Equal(t, []string{notProductiveMsg("2:8-2:12", "Grow")}, messagesWithSpan(errs))
+	ref, ok := nodes["Probe"].(*soltype.AliasType)
+	require.True(t, ok, "Probe must bind an alias reference, got %T", nodes["Probe"])
+	require.Nil(t, ctx.muKnotFor(ref, newSeenPairs()))
+}
+
+// A value whose own type is a μ-knot checks against a regular alias whose instantiations never
+// repeat. Both sides reach constrain as knots, so its seen-set closes on the second lap. Without the
+// normalization the alias side would grow its argument forever and the comparison would be cut off
+// with an ExpansionLimitError.
+//
+// `node` returns a knot because its recursive call makes its own return variable's lower bound
+// mention it, which is the shape coalesce renders as a μ form. The one unrolled level in front of the
+// knot is the monomorphic-recursion artifact TestInferRecursiveRendersMuKnot describes.
+func TestConstrainRegularAliasClosesOnItsKnot(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		type H<T> = {a: keyof T, b: H<{c: T}>}
+		fn node() { return {a: "c", b: node()} }
+		fn use() -> H<{c: number}> { return node() }
+	`)
+	require.Empty(t, Messages(errs))
+	require.Equal(t, `fn () -> {a: "c", b: μX0.{a: "c", b: X0}}`, values["node"])
+	require.Equal(t, "fn () -> H<{c: number}>", values["use"])
+}
+
+// The reference one lap above the knot checks too. Its own level emits `keyof number`, which is
+// `never`, so the value has to supply a `never` there; the knot settles every level below it. The
+// mismatch on the first field is what proves the level was compared rather than skipped.
+func TestConstrainRegularAliasChecksTheLapAboveTheKnot(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type H<T> = {a: keyof T, b: H<{c: T}>}
+		fn node() { return {a: "c", b: node()} }
+		fn use() -> H<number> { return node() }
+	`)
+	require.Equal(t, []string{`4:3-4:42: cannot constrain "c" <: never`}, messagesWithSpan(errs))
+}
+
+// Normalizing does not make the comparison blind: a value that disagrees with the knot's body is
+// still rejected, and once rather than once per level.
+func TestConstrainRegularAliasStillReportsAMismatch(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type H<T> = {a: keyof T, b: H<{c: T}>}
+		fn node() { return {a: "wrong", b: node()} }
+		fn use() -> H<{c: number}> { return node() }
+	`)
+	require.Equal(t, []string{`4:3-4:47: cannot constrain "wrong" <: "c"`}, messagesWithSpan(errs))
+}
+
+// Two instantiations of a regular alias whose argument stops reaching its emitted body denote one
+// tree, so the comparison between them succeeds. `keyof {c: X}` is `"c"` for both, and neither the
+// `number` nor the `string` appears anywhere in the tree either side denotes. Both normalize to the
+// memoized knot, so the second lap of the comparison asks the pair the first lap already assumed and
+// the seen-set closes on it. Without the normalization neither side would ever repeat an
+// instantiation and the comparison would be cut off at maxUnwrapDepth.
+func TestConstrainRegularAliasInstantiationsAgree(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Chain<T> = {a: keyof T, b: Chain<{c: T}>}
+		declare fn make() -> Chain<{c: number}>
+		fn use() -> Chain<{c: string}> { return make() }
+	`)
+	require.Empty(t, Messages(errs))
+}
+
+// An alias whose parameter reaches its emitted body at every level denotes a genuinely non-regular
+// tree, which no finite knot represents. The check proves nothing for it and maxUnwrapDepth cuts the
+// comparison off, the same outcome as before the check existed.
+func TestConstrainNonRegularAliasStillReachesTheBudget(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Nest<T> = {here: T, deeper: Nest<{b: T}>}
+		declare fn make() -> Nest<number>
+		fn use() -> Nest<string> { return make() }
+	`)
+	require.Equal(t, []string{
+		"4:3-4:45: cannot constrain number <: string",
+		"4:3-4:45: comparing two instantiations of `Nest` reached the limit of 200 type-operator " +
+			"expansions and was cut off; either the two sides recurse without ever repeating a pair " +
+			"the check can close on, or their alias chains run deeper than the limit unfolds",
+	}, messagesWithSpan(errs))
+}

--- a/internal/solver/regular_test.go
+++ b/internal/solver/regular_test.go
@@ -16,7 +16,7 @@ func probeKnot(t *testing.T, src string) string {
 	require.Empty(t, Messages(errs))
 	ref, ok := nodes["Probe"].(*soltype.AliasType)
 	require.True(t, ok, "Probe must bind an alias reference, got %T", nodes["Probe"])
-	knot := ctx.muKnotFor(ref, newSeenPairs())
+	knot := ctx.muKnotFor(ref)
 	if knot == nil {
 		return ""
 	}
@@ -129,6 +129,48 @@ func TestMuKnotForSettlesRegularAlias(t *testing.T) {
 			`,
 			want: "",
 		},
+		{
+			// The recursive reference is a spread's operand, so abstracting it would leave `{...X0}`,
+			// a spread of a bare μ-variable, which stands for no object. Reduction cannot merge the
+			// spread either, since grounding its operand is the very expansion the knot abstracts
+			// away. The comparison falls back to the budget, which is where it sat before this check
+			// existed.
+			name: "recursive reference under an object spread",
+			src: `
+				type Sp<T> = {a: keyof T, b: {...Sp<{c: T}>}}
+				type Probe = Sp<{c: number}>
+			`,
+			want: "",
+		},
+		{
+			// The positional twin: a rest spread leaves `[...X0]`.
+			name: "recursive reference under a tuple spread",
+			src: `
+				type Tp<T> = [keyof T, [...Tp<{c: T}>]]
+				type Probe = Tp<{c: number}>
+			`,
+			want: "",
+		},
+		{
+			// Nothing stands between the knot and its own binder, so `μX0.X0` would unfold to itself
+			// and close against any super at all. coalesce's tie carries the same guard.
+			name: "knot body would be the bare binder",
+			src: `
+				type Bare<T> = [Bare<{a: T}>][0]
+				type Probe = Bare<number>
+			`,
+			want: "",
+		},
+		{
+			// The same degeneracy behind a transparent alias, which unfolds to whatever it was handed.
+			name: "knot body would be a bare alias reference",
+			src: `
+				type Id<X> = X
+				type Wrapped<T> = Id<Wrapped<{a: T}>>
+				type Probe = Wrapped<number>
+			`,
+			want: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -148,11 +190,12 @@ func TestMuKnotForDeclinesUnproductiveAlias(t *testing.T) {
 	require.Equal(t, []string{notProductiveMsg("2:8-2:12", "Grow")}, messagesWithSpan(errs))
 	ref, ok := nodes["Probe"].(*soltype.AliasType)
 	require.True(t, ok, "Probe must bind an alias reference, got %T", nodes["Probe"])
-	require.Nil(t, ctx.muKnotFor(ref, newSeenPairs()))
+	require.Nil(t, ctx.muKnotFor(ref))
 }
 
 // A value whose own type is a μ-knot checks against a regular alias whose instantiations never
-// repeat. Both sides reach constrain as knots, so its seen-set closes on the second lap. Without the
+// repeat. The first unfolding runs on the alias's expansion, and the second hands constrain the
+// knot, so both sides are knots from there down and the seen-set closes on them. Without the
 // normalization the alias side would grow its argument forever and the comparison would be cut off
 // with an ExpansionLimitError.
 //
@@ -183,22 +226,29 @@ func TestConstrainRegularAliasChecksTheLapAboveTheKnot(t *testing.T) {
 }
 
 // Normalizing does not make the comparison blind: a value that disagrees with the knot's body is
-// still rejected, and once rather than once per level.
+// still rejected. The mismatch is reported twice, once for each unfolding the comparison makes. The
+// first unfolding runs on the alias's expansion and the second on the knot, since evalTypeOperator
+// waits for the second before substituting one. Without the normalization the same source reports
+// the mismatch once per lap until maxUnwrapDepth cuts the walk off, roughly two hundred times, and
+// then adds two ExpansionLimitErrors on top.
 func TestConstrainRegularAliasStillReportsAMismatch(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		type H<T> = {a: keyof T, b: H<{c: T}>}
 		fn node() { return {a: "wrong", b: node()} }
 		fn use() -> H<{c: number}> { return node() }
 	`)
-	require.Equal(t, []string{`4:3-4:47: cannot constrain "wrong" <: "c"`}, messagesWithSpan(errs))
+	require.Equal(t, []string{
+		`4:3-4:47: cannot constrain "wrong" <: "c"`,
+		`4:3-4:47: cannot constrain "wrong" <: "c"`,
+	}, messagesWithSpan(errs))
 }
 
 // Two instantiations of a regular alias whose argument stops reaching its emitted body denote one
 // tree, so the comparison between them succeeds. `keyof {c: X}` is `"c"` for both, and neither the
-// `number` nor the `string` appears anywhere in the tree either side denotes. Both normalize to the
-// memoized knot, so the second lap of the comparison asks the pair the first lap already assumed and
-// the seen-set closes on it. Without the normalization neither side would ever repeat an
-// instantiation and the comparison would be cut off at maxUnwrapDepth.
+// `number` nor the `string` appears anywhere in the tree either side denotes. Both sides normalize
+// to the one memoized knot on their second unfolding, so the lap after that asks a pair an earlier
+// lap already assumed and the seen-set closes on it. Without the normalization neither side would
+// ever repeat an instantiation and the comparison would be cut off at maxUnwrapDepth.
 func TestConstrainRegularAliasInstantiationsAgree(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		type Chain<T> = {a: keyof T, b: Chain<{c: T}>}
@@ -223,4 +273,40 @@ func TestConstrainNonRegularAliasStillReachesTheBudget(t *testing.T) {
 			"expansions and was cut off; either the two sides recurse without ever repeating a pair " +
 			"the check can close on, or their alias chains run deeper than the limit unfolds",
 	}, messagesWithSpan(errs))
+}
+
+// A reduction diagnostic inside an alias's body still surfaces. The level walk that decides whether
+// a reference is the knot discards the errors it collects, so a level whose reduction reported one
+// is declined outright and the plain expansion carries the report to the constraint site. Declining
+// every level leaves this comparison with no knot at all, so the budget cuts it off the way it did
+// before the check existed. Reporting the malformed member is what matters; the two cut-off
+// diagnostics are the pre-existing outcome for an alias no knot settles.
+func TestConstrainRegularAliasKeepsAReductionDiagnostic(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type H<T> = {a: keyof T, e: {x: number}["z"], b: H<{c: T}>}
+		fn node() { return {a: "c", e: 1, b: node()} }
+		fn use() -> H<{c: number}> { return node() }
+	`)
+	require.Equal(t, []string{
+		`4:3-4:47: object {x: number} has no property "z"`,
+		"4:3-4:47: comparing \"c\" with keyof object reached the limit of 200 type-operator " +
+			"expansions and was cut off; either the two sides recurse without ever repeating a pair " +
+			"the check can close on, or their alias chains run deeper than the limit unfolds",
+		"4:3-4:47: comparing object with H reached the limit of 200 type-operator expansions and " +
+			"was cut off; either the two sides recurse without ever repeating a pair the check can " +
+			"close on, or their alias chains run deeper than the limit unfolds",
+	}, messagesWithSpan(errs))
+}
+
+// A member read off a regular alias keeps the alias name on the type it yields. evalTypeOperator
+// waits for the second unfolding before substituting a knot, and a member read makes only the first,
+// so the value it pulls out is recorded as the alias reference the expansion emitted.
+func TestMemberReadOnRegularAliasKeepsTheAliasName(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		type H<T> = {a: keyof T, b: H<{c: T}>}
+		declare fn mk() -> H<{c: number}>
+		fn field() { return mk().b }
+	`)
+	require.Empty(t, Messages(errs))
+	require.Equal(t, "fn () -> H<{c: {c: number}}>", values["field"])
 }

--- a/internal/solver/regular_test.go
+++ b/internal/solver/regular_test.go
@@ -146,14 +146,38 @@ func TestMuKnotForSettlesRegularAlias(t *testing.T) {
 		},
 		{
 			// The positional twin, declined for the same reason and with the same knot going begging.
-			// A rest spread leaves `[...X0]`, and `[...X]` over a tuple is X, so `Tp<{c: number}>` is
-			// `μX0.["c", X0]`.
+			// `[...X]` over a tuple is X, so `Tp<{c: number}>` is `μX0.["c", X0]`. Proving that knot
+			// would buy nothing on its own: `[...Tp<…>]` fails to check against a real tuple whether or
+			// not a knot exists, since the first unfolding runs on the plain expansion and reduction
+			// cannot ground that spread either.
 			name: "recursive reference under a tuple spread",
 			src: `
 				type Tp<T> = [keyof T, [...Tp<{c: T}>]]
 				type Probe = Tp<{c: number}>
 			`,
 			want: "",
+		},
+		{
+			// A spread of a NON-recursive operand does merge, so the level emits the tuple the splice
+			// yields and the knot is proven over that. This is the positional twin of the object shape
+			// above, and it reads its elements through the same widening in unreducedOp.
+			name: "tuple spreads a non-recursive operand",
+			src: `
+				type Pair = [number, string]
+				type WT<T> = [keyof T, ...Pair, WT<{c: T}>]
+				type Probe = WT<{c: number}>
+			`,
+			want: `μX0.["c", number, string, X0]`,
+		},
+		{
+			// The object twin of the case above, for the pair to be read together.
+			name: "object spreads a non-recursive operand",
+			src: `
+				type Base = {tag: string}
+				type WO<T> = {a: keyof T, ...Base, b: WO<{c: T}>}
+				type Probe = WO<{c: number}>
+			`,
+			want: `μX0.{a: "c", tag: string, b: X0}`,
 		},
 		{
 			// Nothing stands between the knot and its own binder, so `μX0.X0` would unfold to itself
@@ -313,4 +337,19 @@ func TestMemberReadOnRegularAliasKeepsTheAliasName(t *testing.T) {
 	`)
 	require.Empty(t, Messages(errs))
 	require.Equal(t, "fn () -> H<{c: {c: number}}>", values["field"])
+}
+
+// A tuple alias that splices a non-recursive operand every lap checks against another of its own
+// instantiations. Both denote one tree, since `keyof {c: X}` is `"c"` whatever X is and the spliced
+// elements are fixed. Reducing the splice is what makes the level a plain tuple the knot can be read
+// off; without it the level keeps a `...Pair` element, no knot is proven, and the comparison is cut
+// off at maxUnwrapDepth.
+func TestConstrainRegularTupleAliasSplicesItsSpread(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Pair = [number, string]
+		type WT<T> = [keyof T, ...Pair, WT<{c: T}>]
+		declare fn mk() -> WT<{c: number}>
+		fn use() -> WT<{c: {c: number}}> { return mk() }
+	`)
+	require.Empty(t, Messages(errs))
 }

--- a/internal/solver/regular_test.go
+++ b/internal/solver/regular_test.go
@@ -303,27 +303,28 @@ func TestConstrainNonRegularAliasStillReachesTheBudget(t *testing.T) {
 	}, messagesWithSpan(errs))
 }
 
-// A reduction diagnostic inside an alias's body still surfaces. The level walk that decides whether
-// a reference is the knot discards the errors it collects, so a level whose reduction reported one
-// is declined outright and the plain expansion carries the report to the constraint site. Declining
-// every level leaves this comparison with no knot at all, so the budget cuts it off the way it did
-// before the check existed. Reporting the malformed member is what matters; the two cut-off
-// diagnostics are the pre-existing outcome for an alias no knot settles.
+// A malformed member inside an alias body reports once and does not stop the alias being normalized.
+// Reduction substitutes the ErrorType sentinel for `{x: number}["z"]`, so the level the alias emits
+// is a real node carrying `error` at that position and the knot is proven over it. The diagnostic
+// comes from the plain expansion, which runs before any knot is substituted, and `error` absorbs
+// everywhere below, so nothing derived from it cascades.
 func TestConstrainRegularAliasKeepsAReductionDiagnostic(t *testing.T) {
+	nodes, ctx, _ := inferTypeNodes(t, `
+		type H<T> = {a: keyof T, e: {x: number}["z"], b: H<{c: T}>}
+		type Probe = H<{c: number}>
+	`)
+	ref, ok := nodes["Probe"].(*soltype.AliasType)
+	require.True(t, ok, "Probe must bind an alias reference, got %T", nodes["Probe"])
+	knot := ctx.muKnotFor(ref)
+	require.NotNil(t, knot)
+	require.Equal(t, `μX0.{a: "c", e: error, b: X0}`, soltype.Print(knot))
+
 	_, _, errs := inferSource(t, `
 		type H<T> = {a: keyof T, e: {x: number}["z"], b: H<{c: T}>}
 		fn node() { return {a: "c", e: 1, b: node()} }
 		fn use() -> H<{c: number}> { return node() }
 	`)
-	require.Equal(t, []string{
-		`4:3-4:47: object {x: number} has no property "z"`,
-		"4:3-4:47: comparing \"c\" with keyof object reached the limit of 200 type-operator " +
-			"expansions and was cut off; either the two sides recurse without ever repeating a pair " +
-			"the check can close on, or their alias chains run deeper than the limit unfolds",
-		"4:3-4:47: comparing object with H reached the limit of 200 type-operator expansions and " +
-			"was cut off; either the two sides recurse without ever repeating a pair the check can " +
-			"close on, or their alias chains run deeper than the limit unfolds",
-	}, messagesWithSpan(errs))
+	require.Equal(t, []string{`4:3-4:47: object {x: number} has no property "z"`}, messagesWithSpan(errs))
 }
 
 // A member read off a regular alias keeps the alias name on the type it yields. evalTypeOperator

--- a/internal/solver/regular_test.go
+++ b/internal/solver/regular_test.go
@@ -10,10 +10,18 @@ import (
 // probeKnot infers src, reads the alias reference bound to `Probe`, and returns the μ-knot the
 // regular-tree check proves for it, or the empty string when it proves none. Every case below
 // declares the aliases under test and names the one reference it asks about as `Probe`.
-func probeKnot(t *testing.T, src string) string {
+//
+// wantDiags is what the declarations themselves report, which is empty for most cases. An alias
+// whose recursion carries its parameter only inside its own reference has a phantom parameter, and
+// the unused-type-parameter check warns about it at the declaration.
+func probeKnot(t *testing.T, src string, wantDiags []string) string {
 	t.Helper()
 	nodes, ctx, errs := inferTypeNodes(t, src)
-	require.Empty(t, Messages(errs))
+	if len(wantDiags) == 0 {
+		require.Empty(t, Messages(errs))
+	} else {
+		require.Equal(t, wantDiags, messagesWithSpan(errs))
+	}
 	ref, ok := nodes["Probe"].(*soltype.AliasType)
 	require.True(t, ok, "Probe must bind an alias reference, got %T", nodes["Probe"])
 	knot := ctx.muKnotFor(ref)
@@ -29,9 +37,10 @@ func probeKnot(t *testing.T, src string) string {
 // expansion.
 func TestMuKnotForSettlesRegularAlias(t *testing.T) {
 	tests := []struct {
-		name string
-		src  string
-		want string
+		name      string
+		src       string
+		want      string
+		wantDiags []string
 	}{
 		{
 			// The headline shape. `keyof {c: X}` is `"c"` whatever X is, so the argument stops
@@ -65,6 +74,10 @@ func TestMuKnotForSettlesRegularAlias(t *testing.T) {
 				type Probe = Deep<number>
 			`,
 			want: "μX0.{a: X0}",
+			wantDiags: []string{
+				"2:15-2:16: no argument passed to type parameter T can appear in the type, so " +
+					"Deep<number> and Deep<string> are the same type",
+			},
 		},
 		{
 			// Two recursive references growing the argument the same way emit one body, so one binder
@@ -188,6 +201,10 @@ func TestMuKnotForSettlesRegularAlias(t *testing.T) {
 				type Probe = Bare<number>
 			`,
 			want: "",
+			wantDiags: []string{
+				"2:15-2:16: no argument passed to type parameter T can appear in the type, so " +
+					"Bare<number> and Bare<string> are the same type",
+			},
 		},
 		{
 			// The same degeneracy behind a transparent alias, which unfolds to whatever it was handed.
@@ -198,11 +215,15 @@ func TestMuKnotForSettlesRegularAlias(t *testing.T) {
 				type Probe = Wrapped<number>
 			`,
 			want: "",
+			wantDiags: []string{
+				"3:18-3:19: no argument passed to type parameter T can appear in the type, so " +
+					"Wrapped<number> and Wrapped<string> are the same type",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, probeKnot(t, tt.src))
+			require.Equal(t, tt.want, probeKnot(t, tt.src, tt.wantDiags))
 		})
 	}
 }

--- a/internal/solver/regular_test.go
+++ b/internal/solver/regular_test.go
@@ -130,11 +130,13 @@ func TestMuKnotForSettlesRegularAlias(t *testing.T) {
 			want: "",
 		},
 		{
-			// The recursive reference is a spread's operand, so abstracting it would leave `{...X0}`,
-			// a spread of a bare μ-variable, which stands for no object. Reduction cannot merge the
-			// spread either, since grounding its operand is the very expansion the knot abstracts
-			// away. The comparison falls back to the budget, which is where it sat before this check
-			// existed.
+			// The recursive reference is a spread's operand, so abstracting it leaves `{...X0}`. This
+			// alias does have a knot, `μX0.{a: "c", b: X0}`, since spreading one operand into an
+			// otherwise empty object yields that operand. The check declines it anyway, because
+			// reduction has no rule for grounding a spread whose operand is a μ-variable, and the
+			// residual spread would reach constrain and fail a comparison against a real object that
+			// should hold. The comparison falls back to the budget, which is where it sat before this
+			// check existed.
 			name: "recursive reference under an object spread",
 			src: `
 				type Sp<T> = {a: keyof T, b: {...Sp<{c: T}>}}
@@ -143,7 +145,9 @@ func TestMuKnotForSettlesRegularAlias(t *testing.T) {
 			want: "",
 		},
 		{
-			// The positional twin: a rest spread leaves `[...X0]`.
+			// The positional twin, declined for the same reason and with the same knot going begging.
+			// A rest spread leaves `[...X0]`, and `[...X]` over a tuple is X, so `Tp<{c: number}>` is
+			// `μX0.["c", X0]`.
 			name: "recursive reference under a tuple spread",
 			src: `
 				type Tp<T> = [keyof T, [...Tp<{c: T}>]]

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -112,6 +112,12 @@ type typeEvaluator struct {
 	// structurally-equal instances of a recursive alias close through constrain's seen-set. The
 	// value solve seeds it fresh at each constraint site, and the test expander passes an empty set.
 	seen *seenPairs
+	// truncated records that a budget stopped an expansion, so the result is the operator over an
+	// unexpanded alias rather than the value it stands for. Reduction is designed to leave such a
+	// result symbolic and carry on, which is why nothing on the checking path reads this. The
+	// regular-tree check does: a level whose reduction was cut off is not the node the alias emits,
+	// so no knot can be read off it. See regular.go.
+	truncated bool
 	// errs collects the diagnostics a reduction produces. `keyof` reduction is total and adds
 	// none; indexed-access reduction records an UnknownObjectKeyError or a
 	// TupleIndexOutOfRangeError when a ground access resolves to no member. constrain reads
@@ -1104,6 +1110,7 @@ func (e *typeEvaluator) expandAliasGuarded(op *soltype.AliasType, fallback func(
 		return fallback(op)
 	}
 	if e.depth <= 0 || e.keyChars <= 0 {
+		e.truncated = true
 		return fallback(op)
 	}
 	key := soltype.PrintQualified(op)

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -718,9 +718,8 @@ at least two unfoldings, so waiting for the second keeps the alias name on every
 first produces. The cost is one duplicated diagnostic when a value disagrees with the
 knot's body, once for each of the two unfoldings.
 
-Three shapes are declined that the argument-independence proof alone would admit. A level
-whose reduction reported a diagnostic is declined, so the plain expansion carries that
-report to the constraint site rather than the knot swallowing it. A shape still carrying an
+Two shapes are declined that the argument-independence proof alone would admit. A shape
+still carrying an
 operator is declined, since a recursive reference standing as a spread's operand abstracts
 to `{...X0}`, which reduction has no rule for grounding. Such an alias does have a knot, so
 that one is incompleteness rather than a shape no knot fits. And a knot body

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -722,7 +722,8 @@ Three shapes are declined that the argument-independence proof alone would admit
 whose reduction reported a diagnostic is declined, so the plain expansion carries that
 report to the constraint site rather than the knot swallowing it. A shape still carrying an
 operator is declined, since a recursive reference standing as a spread's operand abstracts
-to `{...X0}`, a spread of a bare μ-variable, which stands for no object. And a knot body
+to `{...X0}`, which reduction has no rule for grounding. Such an alias does have a knot, so
+that one is incompleteness rather than a shape no knot fits. And a knot body
 that puts no type constructor between the knot and its own binder is declined, since
 `μX0.X0` unfolds to itself and would close against any super at all — the guard
 `coalesce`'s `tie` already carries for the knots it mints.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -678,18 +678,54 @@ it actually is. That is the normalization Amadio–Cardelli presupposes: their a
 decides subtyping for types already presented as finite μ-terms, and nothing in the
 compiler currently produces one for this shape.
 
-**Data structures.** None new. PR9e's node is where a found knot goes.
+**Data structures.** None new in `soltype`; PR9e's node is where a found knot goes. The
+`Context` gains a per-alias memo of the knot the check proves, keyed by alias name.
 
-**Algorithms.** Expand one level, abstract the recursive positions to placeholders, and
-look for an earlier emitted node with the same abstracted shape. A candidate must be
-confirmed by partition refinement rather than by a structural hash, since a hash
-collapses `{a: X}` and `{a: Y}` for unrelated `X` and `Y`.
+**Algorithms.** The PR was scoped around finding a candidate by abstracted shape and
+confirming it by partition refinement over the nodes emitted so far. That confirmation
+does not survive contact with the problem. Partition refinement decides bisimilarity on a
+*finite* state set, and the states here are instantiations, of which a growing alias has
+infinitely many. Refining over the finite prefix already emitted means treating the
+unexpanded frontier optimistically, which merges two levels that a later level would have
+split, so a knot could be tied for a type that is not regular at all.
+
+What replaces it is a proof, not a search. Expand the alias with a rigid skolem in place
+of its argument and reduce. If the skolem is nowhere in the result, the reduction never
+read the argument, so it produces that one body for *every* argument. Write `A<T>` for the
+alias and `g` for the argument its recursive reference passes, so `H`'s `g` maps `T` to
+`{c: T}`. The check expands `A<g(S)>` for a fresh skolem `S` and asks two things of it:
+
+1. its shape — the body with every reference back to `A` abstracted to the μ-binder —
+   holds no skolem, so every `A<g(σ)>` has that one shape;
+2. its recursive reference passes `g(g(S))`, so the state below `A<g(σ)>` is again of the
+   form `A<g(·)>`.
+
+Together those close the family `{A<g(σ)> : σ}` under the successor relation and give
+every member one shape Σ, so all of them are the same tree and that tree is `μX.Σ`. The
+answer is memoized per alias, and a reference is admitted as that knot when its own level
+renders the same Σ. `H<number>` is not admitted, since its own level emits
+`{a: never, …}`; the `H<{c: number}>` its expansion yields is.
+
+An alias with several recursive references, or several type parameters, runs the same
+check with `g` ranging over one argument pattern per reference.
+
+The abstracted shape is still what candidates are compared by, so the "structural hash"
+half of the original scoping survives. It is the confirmation that changed, from a
+fixed point over a partial graph to a single argument-independence proof.
 
 **Accept.** `H<number>` reduces to a finite μ form, and a value checks against it.
+`Chain<{c: number}> <: Chain<{c: string}>` succeeds for
+`type Chain<T> = {a: keyof T, b: Chain<{c: T}>}`, since neither argument appears anywhere
+in the tree either side denotes, where before it was cut off at `maxUnwrapDepth`.
 
-The walk converges only when the tree really is regular, so `maxExpandDepth`,
-`maxExpandKeyChars`, and `maxUnwrapDepth` all stay as the backstop for the non-regular
-residue — the same reservation [03-references.md](03-references.md) makes. PR9d already
+The check is sound and incomplete: it proves a knot for an alias whose argument stops
+mattering at a bounded depth, and nothing for one whose argument keeps mattering forever.
+`type Nest<T> = {here: T, deeper: Nest<{b: T}>}` reads `T` at every level, so its probe
+shape holds the skolem. That alias denotes a genuinely non-regular tree, and
+`maxExpandDepth`, `maxExpandKeyChars`, and `maxUnwrapDepth` all stay as the backstop for
+it — the same reservation [03-references.md](03-references.md) makes. A level whose own
+reduction one of those budgets cut off is not the node the alias emits, so the check
+declines it rather than reading a shape off a truncation. PR9d already
 covers the phantom-parameter shapes, so this PR's marginal class is aliases whose
 parameter genuinely reaches the tree at a bounded depth. Those exist but are contrived,
 which is why it sits last: worth building when a real library type demands it, not

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -709,6 +709,24 @@ renders the same Σ. `H<number>` is not admitted, since its own level emits
 An alias with several recursive references, or several type parameters, runs the same
 check with `g` ranging over one argument pattern per reference.
 
+The knot stands in only once the alias is already being unfolded further up the constraint
+path. Substituting at the first unfolding works for termination, but it puts the knot
+everywhere the expansion goes, including the value types a member read pulls out and
+records as a bound, so `mk().b` over `H` would infer `μX0.{a: "c", b: X0}` where it infers
+`H<{c: {c: number}}>` today. A knot is only ever needed to close a cycle, and a cycle takes
+at least two unfoldings, so waiting for the second keeps the alias name on everything the
+first produces. The cost is one duplicated diagnostic when a value disagrees with the
+knot's body, once for each of the two unfoldings.
+
+Three shapes are declined that the argument-independence proof alone would admit. A level
+whose reduction reported a diagnostic is declined, so the plain expansion carries that
+report to the constraint site rather than the knot swallowing it. A shape still carrying an
+operator is declined, since a recursive reference standing as a spread's operand abstracts
+to `{...X0}`, a spread of a bare μ-variable, which stands for no object. And a knot body
+that puts no type constructor between the knot and its own binder is declined, since
+`μX0.X0` unfolds to itself and would close against any super at all — the guard
+`coalesce`'s `tie` already carries for the knots it mints.
+
 The abstracted shape is still what candidates are compared by, so the "structural hash"
 half of the original scoping survives. It is the confirmation that changed, from a
 fixed point over a partial graph to a single argument-independence proof.


### PR DESCRIPTION
Adds a proof-based algorithm to detect when a recursive alias denotes a regular type (one with finitely many distinct subtrees) and represent it as a finite μ-knot. This lets the constraint solver close cycles on regular aliases without hitting expansion budgets.

**Summary**

When a recursive alias grows its argument at each level (like `type H<T> = {a: keyof T, b: H<{c: T}>}`), unfolding it produces a fresh instantiation every lap, so the constraint solver's seen-set never closes and the comparison runs until hitting `maxUnwrapDepth`. The new code detects when such an alias denotes a regular tree by proving two conditions: (1) expanding the alias with a fresh skolem in place of its argument produces a body where the skolem never appears, and (2) the recursive references below that expansion pass the same argument patterns again. When both hold, every instantiation of the alias denotes the same tree, which is represented as a μ-knot and memoized per alias.

**Key changes**

- `internal/solver/regular.go` (new): Implements the regularity check via `probeUniformKnot`, which expands an alias with a skolem argument and validates the two conditions. Helper functions walk the expansion to reduce operators, abstract recursive references, and check for skolem mentions. The memoized knot is retrieved by `muKnotFor` and used in place of further expansion.

- `internal/solver/context.go`: Adds three fields to track knot memoization and the current unfolding path: `uniformKnots` (per-alias knot memo), `unfoldingAliases` (depth counter for each alias on the current constraint path), and `knotting` (flag to prevent re-entrance during the regularity check).

- `internal/solver/constrain.go`: Integrates the knot into constraint solving. `evalTypeOperator` substitutes a knot for an alias expansion when the alias is already being unfolded further up the path (second unfolding or deeper). `constrainUnfoldingAlias` wraps constraint bodies to track which aliases are being unfolded, ensuring knots are only substituted after the first unfolding so member reads and other first-level operations still see the alias name.

- `internal/solver/regular_test.go` (new): Comprehensive test suite covering regular aliases (argument stops reaching the body, multiple parameters, multiple references), non-regular aliases (argument keeps reaching the body), degenerate cases (bare binder, transparent alias), and integration tests showing the knot closes cycles and still reports mismatches.

**Implementation notes**

The knot is substituted only on the second unfolding of an alias, not the first. This keeps the alias name on types that member reads pull out (so `mk().b` infers `H<{c: {c: number}}>` rather than the knot), since a knot is only needed to close a cycle and cycles require at least two unfoldings. The trade-off is that mismatches between a value and the knot's body are reported twice, once per unfolding, rather than once per lap as before.

Three shapes are rejected even when the argument-independence proof would admit them: reductions that report diagnostics (so the plain expansion carries the error), shapes still carrying operators (since a recursive reference under a spread abstracts to `{...X0}`, which is invalid), and knot bodies with no type constructor between the binder and itself (since `μX0.X0` would close against any super).

https://claude.ai/code/session_01SdyX7LBxarnH5pudRmC78H