### PR TITLE
Implement try/catch expression type inference

### DIFF
--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -564,6 +564,20 @@ func exprAlwaysExits(expr ast.Expr) bool {
 			}
 		}
 		return true
+	case *ast.TryCatchExpr:
+		// Control falls out of a try/catch unless every way through it leaves: the
+		// try block must exit, and so must every catch arm body reachable when it
+		// raises. Same AND-fold as MatchExpr above. A `try` with no arms is just
+		// its block.
+		if !blockAlwaysExits(&e.Try) {
+			return false
+		}
+		for _, arm := range e.Catch {
+			if !blockOrExprAlwaysExits(arm.Body) {
+				return false
+			}
+		}
+		return true
 	case *ast.DoExpr:
 		return blockAlwaysExits(&e.Body)
 	case *ast.CallExpr:

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -567,8 +567,8 @@ func exprAlwaysExits(expr ast.Expr) bool {
 	case *ast.TryCatchExpr:
 		// Control falls out of a try/catch unless every way through it leaves: the
 		// try block must exit, and so must every catch arm body reachable when it
-		// raises. Same AND-fold as MatchExpr above. A `try` with no arms is just
-		// its block.
+		// raises. Same AND-fold as MatchExpr above. An arm-less `try` is just its
+		// block, which is what the empty fold yields.
 		if !blockAlwaysExits(&e.Try) {
 			return false
 		}

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -3848,3 +3848,33 @@
     span: 1:1-1:33,
 }
 ---
+
+[TestParseExprErrorHandling/TryCatchEmptyMissingClosingBrace - 1]
+&ast.TryCatchExpr{
+    Try: ast.Block{
+        Stmts: []ast.Stmt{
+            &ast.ExprStmt{
+                Expr: &ast.CallExpr{
+                    Callee: &ast.IdentExpr{
+                        Name: "operation",
+                        span: 1:7-1:16,
+                    },
+                    span: 1:7-1:18,
+                },
+                span: 1:7-1:18,
+            },
+        },
+        Span: 1:5-1:20,
+    },
+    span: 1:1-1:20,
+}
+---
+
+[TestParseExprErrorHandling/TryCatchEmptyMissingClosingBrace - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: 1:28-1:28,
+        Message: "Expected } but got ",
+    },
+}
+---

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -1142,11 +1142,11 @@ func (p *Parser) tryExpr() ast.Expr {
 	tryBlock := p.block()
 
 	var catchCases []*ast.MatchCase
-	// catchEnd is the end of the catch clause's closing brace, set only when a real brace
+	// `catchEnd` is the end of the catch clause's closing brace, set only when a real brace
 	// closed the clause. It is the span end for a well-formed `catch { }` holding no cases,
 	// so the empty braces fall inside the node rather than outside it. A recovery path that
-	// never reached a brace leaves it nil, which keeps a malformed clause's span on the try
-	// block rather than on wherever recovery happened to stop.
+	// never reached a brace leaves it nil, which keeps a malformed clause's span on the
+	// `try` block rather than on wherever recovery happened to stop.
 	var catchEnd *ast.Location
 
 	token := p.lexer.peek()

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -1142,6 +1142,12 @@ func (p *Parser) tryExpr() ast.Expr {
 	tryBlock := p.block()
 
 	var catchCases []*ast.MatchCase
+	// catchEnd is the end of the catch clause's closing brace, set only when a real brace
+	// closed the clause. It is the span end for a well-formed `catch { }` holding no cases,
+	// so the empty braces fall inside the node rather than outside it. A recovery path that
+	// never reached a brace leaves it nil, which keeps a malformed clause's span on the try
+	// block rather than on wherever recovery happened to stop.
+	var catchEnd *ast.Location
 
 	token := p.lexer.peek()
 
@@ -1177,11 +1183,16 @@ func (p *Parser) tryExpr() ast.Expr {
 			}
 		}
 
+		if p.lexer.peek().Type == CloseBrace {
+			closeEnd := p.lexer.peek().Span.End
+			catchEnd = &closeEnd
+		}
 		p.expect(CloseBrace, AlwaysConsume)
 	}
 
 	var end ast.Location
-	if len(catchCases) > 0 {
+	switch {
+	case len(catchCases) > 0:
 		// Find the end of the last catch case
 		lastCase := catchCases[len(catchCases)-1]
 		if lastCase.Body.Block != nil {
@@ -1191,7 +1202,9 @@ func (p *Parser) tryExpr() ast.Expr {
 		} else {
 			end = lastCase.Pattern.Span().End
 		}
-	} else {
+	case catchEnd != nil:
+		end = *catchEnd
+	default:
 		end = tryBlock.Span.End
 	}
 

--- a/internal/parser/expr_test.go
+++ b/internal/parser/expr_test.go
@@ -398,6 +398,11 @@ func TestParseExprErrorHandling(t *testing.T) {
 		"TryCatchMissingClosingBrace": {
 			input: "try { operation() } catch { error => error",
 		},
+		// No case supplies a span end and no closing brace was reached, so the node ends at
+		// the try block. This is the recovery path `catchEnd` deliberately leaves nil.
+		"TryCatchEmptyMissingClosingBrace": {
+			input: "try { operation() } catch {",
+		},
 		"TryCatchMissingPattern": {
 			input: "try { operation() } catch { => \"error\" }",
 		},

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1032,6 +1032,28 @@ type MissingCatchArmError struct {
 	Try *ast.TryCatchExpr
 }
 
+// UnhandledRethrowError fires when the part of a caught union the catch arms leave
+// uncovered cannot reach the enclosing throws sink. `rethrowUnhandled` returns early on a
+// catch-all, so this error only ever describes a `try` without one.
+//
+// It replaces the errors the constraint engine would raise for the same failure, for two
+// reasons. Blame is the first. An engine error resolves per-operand blame through Prov, and
+// a rethrown member's Prov entry is the `throw` inside the try block — but that `throw` is
+// caught. What fails is the re-raise, which happens at the try/catch.
+//
+// Count is the second. The engine reports the open tail and each uncovered member
+// separately, and the tail fails whenever the sink is closed at all, so a member error
+// never adds an independently actionable fact. Adding a catch-all resolves every one of
+// them together, and naming the members does not change that remedy.
+//
+// It is a bridge error born in `rethrowUnhandled` with the try/catch node in hand, so it
+// self-blames the whole form through `Span` and carries no related node.
+type UnhandledRethrowError struct {
+	Try      *ast.TryCatchExpr
+	Rethrown soltype.Type
+	Sink     soltype.Type
+}
+
 // MixedOwnershipError fires when an inferred union or intersection has a borrowed
 // member beside an owned one, such as `{x: number} | &{y: number}`, which has no
 // single owned-or-borrowed verdict. It blames the inference join where it forms.
@@ -1061,7 +1083,8 @@ func (*NotIterableError) isSolverError()                    {}
 func (*ReturnOutsideFunctionError) isSolverError()          {}
 func (*AsyncReturnNotPromiseError) isSolverError()          {}
 func (*NonExhaustiveMatchError) isSolverError()             {}
-func (*MissingCatchArmError) isSolverError()             {}
+func (*MissingCatchArmError) isSolverError()                {}
+func (*UnhandledRethrowError) isSolverError()               {}
 func (*MixedOwnershipError) isSolverError()                 {}
 func (*MutLeafThroughSharedBorrowError) isSolverError()     {}
 func (*MissingSelfReceiverError) isSolverError()            {}
@@ -1485,8 +1508,15 @@ func (e *NonExhaustiveMatchError) Message() string {
 	return "match is not exhaustive; add a catch-all branch"
 }
 
-func (e *MissingCatchArmError) Span() ast.Span      { return e.Try.Span() }
-func (e *MissingCatchArmError) Related() []ast.Span { return nil }
+func (e *MissingCatchArmError) Span() ast.Span       { return e.Try.Span() }
+func (e *MissingCatchArmError) Related() []ast.Span  { return nil }
+func (e *UnhandledRethrowError) Span() ast.Span      { return e.Try.Span() }
+func (e *UnhandledRethrowError) Related() []ast.Span { return nil }
+func (e *UnhandledRethrowError) Message() string {
+	return "the catch arms leave " + soltype.Print(e.Rethrown) + " uncovered, so it is rethrown, and the enclosing `throws " +
+		soltype.Print(e.Sink) + "` does not admit it. Add a catch-all arm; only a catch-all closes a caught union's open tail"
+}
+
 func (e *MissingCatchArmError) Message() string {
 	return "a `try` with no catch arms catches nothing; drop the `try` and keep its block, or add at least one catch arm"
 }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1036,15 +1036,11 @@ type MissingCatchArmError struct {
 // uncovered cannot reach the enclosing throws sink. `rethrowUnhandled` returns early on a
 // catch-all, so this error only ever describes a `try` without one.
 //
-// It replaces the errors the constraint engine would raise for the same failure, for two
-// reasons. Blame is the first. An engine error resolves per-operand blame through Prov, and
-// a rethrown member's Prov entry is the `throw` inside the try block — but that `throw` is
-// caught. What fails is the re-raise, which happens at the try/catch.
-//
-// Count is the second. The engine reports the open tail and each uncovered member
-// separately, and the tail fails whenever the sink is closed at all, so a member error
-// never adds an independently actionable fact. Adding a catch-all resolves every one of
-// them together, and naming the members does not change that remedy.
+// It replaces the errors the constraint engine would raise for the same failure. An engine
+// error resolves per-operand blame through Prov, and a rethrown member's Prov entry is the
+// `throw` inside the try block. Blaming that `throw` would be wrong, because the `try`
+// caught it. What fails is the re-raise, which happens at the try/catch, so one error
+// blamed there reports the escape once at the site it escapes from.
 //
 // It is a bridge error born in `rethrowUnhandled` with the try/catch node in hand, so it
 // self-blames the whole form through `Span` and carries no related node.
@@ -1514,7 +1510,7 @@ func (e *UnhandledRethrowError) Span() ast.Span      { return e.Try.Span() }
 func (e *UnhandledRethrowError) Related() []ast.Span { return nil }
 func (e *UnhandledRethrowError) Message() string {
 	return "the catch arms leave " + soltype.Print(e.Rethrown) + " uncovered, so it is rethrown, and the enclosing `throws " +
-		soltype.Print(e.Sink) + "` does not admit it. Add a catch-all arm; only a catch-all closes a caught union's open tail"
+		soltype.Print(e.Sink) + "` does not admit it. Cover it with a catch arm, or widen the enclosing clause"
 }
 
 func (e *MissingCatchArmError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1017,6 +1017,17 @@ type NonExhaustiveMatchError struct {
 	Match *ast.MatchExpr
 }
 
+// MissingCatchClauseError fires when a `try` block carries no `catch` arms. A `try` is
+// the construct that HANDLES an exception, and arms are the only thing that handles one,
+// so a `try` without them changes nothing about the block it wraps. Writing the block on
+// its own says the same thing more directly.
+//
+// It is a bridge error born in inferTryCatch with the try/catch node in hand, so it
+// self-blames the whole form through Span and carries no related node.
+type MissingCatchClauseError struct {
+	Try *ast.TryCatchExpr
+}
+
 // MixedOwnershipError fires when an inferred union or intersection has a borrowed
 // member beside an owned one, such as `{x: number} | &{y: number}`, which has no
 // single owned-or-borrowed verdict. It blames the inference join where it forms.
@@ -1046,6 +1057,7 @@ func (*NotIterableError) isSolverError()                    {}
 func (*ReturnOutsideFunctionError) isSolverError()          {}
 func (*AsyncReturnNotPromiseError) isSolverError()          {}
 func (*NonExhaustiveMatchError) isSolverError()             {}
+func (*MissingCatchClauseError) isSolverError()             {}
 func (*MixedOwnershipError) isSolverError()                 {}
 func (*MutLeafThroughSharedBorrowError) isSolverError()     {}
 func (*MissingSelfReceiverError) isSolverError()            {}
@@ -1467,6 +1479,12 @@ func (e *NonExhaustiveMatchError) Span() ast.Span      { return e.Match.Span() }
 func (e *NonExhaustiveMatchError) Related() []ast.Span { return nil }
 func (e *NonExhaustiveMatchError) Message() string {
 	return "match is not exhaustive; add a catch-all branch"
+}
+
+func (e *MissingCatchClauseError) Span() ast.Span      { return e.Try.Span() }
+func (e *MissingCatchClauseError) Related() []ast.Span { return nil }
+func (e *MissingCatchClauseError) Message() string {
+	return "`try` needs a `catch` clause; without one it handles nothing, so drop the `try` and keep the block"
 }
 
 // MutLeafThroughSharedBorrowError fires when a destructuring pattern marks a leaf

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1017,14 +1017,18 @@ type NonExhaustiveMatchError struct {
 	Match *ast.MatchExpr
 }
 
-// MissingCatchClauseError fires when a `try` block carries no `catch` arms. A `try` is
-// the construct that HANDLES an exception, and arms are the only thing that handles one,
-// so a `try` without them changes nothing about the block it wraps. Writing the block on
-// its own says the same thing more directly.
+// MissingCatchArmError fires when a `try` carries no catch arms. The arms are what handle
+// an exception, so a `try` without them changes nothing about the block it wraps. Writing
+// the block on its own says the same thing more directly.
+//
+// An omitted `catch` and a written-but-empty `catch { }` both land here, since
+// ast.TryCatchExpr records only the arms and both leave that slice empty. One message
+// covers them because the fix is the same either way: write an arm. Saying "add a `catch`
+// clause" would tell the author of `catch { }` to add what they already wrote.
 //
 // It is a bridge error born in inferTryCatch with the try/catch node in hand, so it
 // self-blames the whole form through Span and carries no related node.
-type MissingCatchClauseError struct {
+type MissingCatchArmError struct {
 	Try *ast.TryCatchExpr
 }
 
@@ -1057,7 +1061,7 @@ func (*NotIterableError) isSolverError()                    {}
 func (*ReturnOutsideFunctionError) isSolverError()          {}
 func (*AsyncReturnNotPromiseError) isSolverError()          {}
 func (*NonExhaustiveMatchError) isSolverError()             {}
-func (*MissingCatchClauseError) isSolverError()             {}
+func (*MissingCatchArmError) isSolverError()             {}
 func (*MixedOwnershipError) isSolverError()                 {}
 func (*MutLeafThroughSharedBorrowError) isSolverError()     {}
 func (*MissingSelfReceiverError) isSolverError()            {}
@@ -1481,10 +1485,10 @@ func (e *NonExhaustiveMatchError) Message() string {
 	return "match is not exhaustive; add a catch-all branch"
 }
 
-func (e *MissingCatchClauseError) Span() ast.Span      { return e.Try.Span() }
-func (e *MissingCatchClauseError) Related() []ast.Span { return nil }
-func (e *MissingCatchClauseError) Message() string {
-	return "`try` needs a `catch` clause; without one it handles nothing, so drop the `try` and keep the block"
+func (e *MissingCatchArmError) Span() ast.Span      { return e.Try.Span() }
+func (e *MissingCatchArmError) Related() []ast.Span { return nil }
+func (e *MissingCatchArmError) Message() string {
+	return "`try` needs at least one catch arm; with none it handles nothing, so drop the `try` and keep the block"
 }
 
 // MutLeafThroughSharedBorrowError fires when a destructuring pattern marks a leaf

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1017,17 +1017,17 @@ type NonExhaustiveMatchError struct {
 	Match *ast.MatchExpr
 }
 
-// MissingCatchArmError fires when a `try` carries no catch arms. The arms are what handle
-// an exception, so a `try` without them changes nothing about the block it wraps. Writing
-// the block on its own says the same thing more directly.
+// MissingCatchArmError fires when a `try` carries no catch arms. The arms are what catch
+// an exception, so a `try` without them changes nothing about the block it wraps. Either
+// resolution is fine. Dropping the `try` keeps the block saying what it already says, and
+// adding an arm makes the `try` do something.
 //
 // An omitted `catch` and a written-but-empty `catch { }` both land here, since
-// ast.TryCatchExpr records only the arms and both leave that slice empty. One message
-// covers them because the fix is the same either way: write an arm. Saying "add a `catch`
-// clause" would tell the author of `catch { }` to add what they already wrote.
+// `ast.TryCatchExpr` records only the arms and both leave that slice empty. One message
+// covers them, because both ways out apply whichever form was written.
 //
-// It is a bridge error born in inferTryCatch with the try/catch node in hand, so it
-// self-blames the whole form through Span and carries no related node.
+// It is a bridge error born in `inferTryCatch` with the try/catch node in hand, so it
+// self-blames the whole form through `Span` and carries no related node.
 type MissingCatchArmError struct {
 	Try *ast.TryCatchExpr
 }
@@ -1488,7 +1488,7 @@ func (e *NonExhaustiveMatchError) Message() string {
 func (e *MissingCatchArmError) Span() ast.Span      { return e.Try.Span() }
 func (e *MissingCatchArmError) Related() []ast.Span { return nil }
 func (e *MissingCatchArmError) Message() string {
-	return "`try` needs at least one catch arm; with none it handles nothing, so drop the `try` and keep the block"
+	return "a `try` with no catch arms catches nothing; drop the `try` and keep its block, or add at least one catch arm"
 }
 
 // MutLeafThroughSharedBorrowError fires when a destructuring pattern marks a leaf

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -325,6 +325,18 @@ func (c *checker) throwsSink(lvl int) soltype.Type {
 	return c.fn.throws
 }
 
+// freshThrowsSink mints a sink at the level throwsSink mints at, the enclosing body's own
+// level rather than the level the current expression is typed at. inferTryCatch installs
+// the result for the duration of a try block. A sink minted one level deeper, inside a
+// `val` initializer, gets extruded by a later exceptional exit, and the resulting cycle
+// renders as a μ-knot. lvl is the fallback where there is no body to read a level from.
+func (c *checker) freshThrowsSink(lvl int) *soltype.TypeVarType {
+	if c.fn != nil {
+		return c.freshAt(c.fn.lvl)
+	}
+	return c.freshAt(lvl)
+}
+
 // markRaised records that the body being walked has an exceptional exit that can raise.
 // inferFunc reads the flag to warn about a `throws` clause the body never uses. It is a
 // no-op at module top level, where there is no clause to be unused.
@@ -519,6 +531,8 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 		return c.inferBorrow(scope, lvl, e)
 	case *ast.ThrowExpr:
 		return c.inferThrow(scope, lvl, e)
+	case *ast.TryCatchExpr:
+		return c.inferTryCatch(scope, lvl, e)
 	case *ast.BinaryExpr:
 		// PR8 handles the ASSIGNMENT op only (`a = expr`); every other binary
 		// operator (+, ==, &&, ++, …) needs the operator-scheme walk over the prelude

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -328,7 +328,7 @@ func (c *checker) throwsSink(lvl int) soltype.Type {
 // freshThrowsSink mints a sink at the level throwsSink mints at, the enclosing body's own
 // level rather than the level the current expression is typed at. inferTryCatch installs
 // the result for the duration of a try block. A sink minted one level deeper, inside a
-// `val` initializer, gets extruded by a later exceptional exit, and the resulting cycle
+// `val` initializer, gets extruded by a later exceptional exit. The resulting cycle then
 // renders as a μ-knot. lvl is the fallback where there is no body to read a level from.
 func (c *checker) freshThrowsSink(lvl int) *soltype.TypeVarType {
 	if c.fn != nil {

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -36,6 +36,18 @@ type checker struct {
 	// returns collection (a return inside an inner fn never escapes to the outer).
 	fn *funcCtx
 
+	// topThrows is the throws sink for a `try` block written at module top level, where
+	// there is no funcCtx to hold one. inferTryCatch installs it for the duration of the
+	// block and clears it afterwards, so it is nil everywhere else. throwsSink reads it
+	// only when fn is nil, which keeps a function body's sink on its own funcCtx and a
+	// nested function inside a top-level `try` collecting into its own signature rather
+	// than into the enclosing block's.
+	//
+	// Outside a `try` it stays nil and a top-level `throw` reaches a throwaway variable, so
+	// module top level checks no exceptions of its own. There is no signature there to
+	// declare a clause on and none to check a raise against.
+	topThrows soltype.Type
+
 	// debugProv, when set, makes recordProv panic on a conflicting overwrite (the
 	// same type pointer recorded against a *different* node) — turning the
 	// implicit "every minted type is a unique pointer" invariant into an enforced
@@ -315,14 +327,37 @@ func (c *checker) inScript() bool {
 // throwsSink returns the type this body's exceptional exits are constrained against.
 // inferFunc seeds it from the signature, so the mint below fires only where there is no
 // signature to seed from: a script's top level, and a `throw` or call at module top level.
+//
+// A `try` at module top level installs topThrows, which is the only sink available with no
+// funcCtx to hold one. Outside such a block topThrows is nil and each exit reaches a
+// throwaway variable, so module top level checks no exceptions of its own.
 func (c *checker) throwsSink(lvl int) soltype.Type {
 	if c.fn == nil {
+		if c.topThrows != nil {
+			return c.topThrows
+		}
 		return c.freshAt(lvl)
 	}
 	if c.fn.throws == nil {
 		c.fn.throws = c.freshAt(c.fn.lvl)
 	}
 	return c.fn.throws
+}
+
+// installThrowsSink puts sink in place as the sink throwsSink returns and hands back the
+// one it replaced, so a caller can restore that afterwards. It writes to funcCtx.throws
+// inside a body and to topThrows outside one, matching where throwsSink reads from. A nil
+// sink restores the unminted state, which is what both fields hold before a body's first
+// exceptional exit.
+func (c *checker) installThrowsSink(sink soltype.Type) soltype.Type {
+	if c.fn == nil {
+		saved := c.topThrows
+		c.topThrows = sink
+		return saved
+	}
+	saved := c.fn.throws
+	c.fn.throws = sink
+	return saved
 }
 
 // freshThrowsSink mints a sink at the level throwsSink mints at, the enclosing body's own

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2689,10 +2689,13 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 // The form's value is the join of the try block's tail value and each non-diverging arm
 // body, the same branch-join inferMatch builds from its arms.
 func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) soltype.Type {
-	// With no `catch` clause nothing inspects the error, so there is nothing to bind and
-	// nothing to narrow. Walking the block against the enclosing sink directly lets its
-	// throws reach the function's clause exactly as they would without the `try`.
+	// A `try` needs arms to be worth writing, since the arms are what handle an exception.
+	// With none there is nothing to bind and nothing to narrow, so the form is rejected and
+	// the block recovers as if it had been written on its own: it walks against the
+	// enclosing sink, and its throws reach the function's clause unchanged. That keeps the
+	// missing clause to one diagnostic instead of cascading a rethrow through it.
 	if len(e.Catch) == 0 {
+		c.report(&MissingCatchClauseError{Try: e})
 		t, _ := c.inferBlock(scope.Child(), lvl, &e.Try)
 		c.recordType(e, t)
 		return t
@@ -2765,9 +2768,10 @@ func (c *checker) walkTryBlock(scope *Scope, lvl int, b *ast.Block, sink soltype
 }
 
 // caughtType returns the type a catch arm's pattern binds against: what the try block
-// raised, reopened with a trailing `...`. The tail is there because any call can raise
-// something no signature predicted, so a caught error is never a closed set. That is the
-// `FooError | ...` docs/06_error_handling.md renders for a caught binding.
+// raised, reopened with a trailing `...`. The tail is there because a `throws` clause is a
+// floor rather than a ceiling. Any call can raise something its signature did not name, so
+// the members collected from the block are the part of a caught error the type system can
+// see, not the whole of it.
 //
 // A block with no known exceptional exit yields `unknown`, which is the tail standing on
 // its own. An inexact union with no members carries no value, so there would be nothing to
@@ -2782,9 +2786,9 @@ func (c *checker) caughtType(collected soltype.Type) soltype.Type {
 
 // rethrowUnhandled constrains the part of the caught union no arm covers into the
 // enclosing throws sink, so a `try` narrows what its function raises rather than swallowing
-// it. This is the automatic rethrow docs/06_error_handling.md specifies in place of an
-// exhaustiveness diagnostic: "if there is no catch-all, the compiler will automatically
-// re-throw the unhandled error".
+// it. A value that matches no arm is re-raised at runtime, so the enclosing clause is where
+// it lands. That is why uncovered members draw a rethrow rather than the non-exhaustiveness
+// diagnostic the equivalent `match` would draw.
 //
 // Coverage is decided by isCatchAll and unionMemberCovered, the same two relations
 // checkMatchExhaustive reads, so one definition of "this pattern covers this member" serves
@@ -3277,8 +3281,9 @@ func exprDiverges(e ast.Expr) bool {
 	case *ast.TryCatchExpr:
 		// Control falls out of a try/catch unless every way through it leaves: the try
 		// block must diverge, and so must every arm body reachable when it raises. The
-		// arms are folded with the same AND that MatchExpr uses. A `try` with no arms is
-		// just its block.
+		// arms are folded with the same AND that MatchExpr uses. An arm-less `try` is
+		// rejected by inferTryCatch and recovers as its block alone, which is what the
+		// empty fold yields here.
 		if !blockDiverges(&e.Try) {
 			return false
 		}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2711,6 +2711,9 @@ func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) solt
 	// the try block's tail alongside the arm bodies. A diverging branch produces no value
 	// and is left out of both the join and the check.
 	var branches []soltype.Type
+	// This call is what fills `collected`. Nothing assigns to it: walkTryBlock installs it as
+	// the sink throwsSink returns, so each `throw` and each call inside the block constrains
+	// into it and records a lower bound.
 	tryT, tryDiverges := c.walkTryBlock(scope, lvl, &e.Try, collected)
 	if !tryDiverges {
 		c.constrain(e, tryT, res)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2693,9 +2693,10 @@ func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) solt
 	// With none there is nothing to bind and nothing to narrow, so the form is rejected and
 	// the block recovers as if it had been written on its own: it walks against the
 	// enclosing sink, and its throws reach the function's clause unchanged. That keeps the
-	// missing clause to one diagnostic instead of cascading a rethrow through it.
+	// missing arms to one diagnostic instead of cascading a rethrow through them. An
+	// omitted `catch` and a written `catch { }` both arrive here with an empty slice.
 	if len(e.Catch) == 0 {
-		c.report(&MissingCatchClauseError{Try: e})
+		c.report(&MissingCatchArmError{Try: e})
 		t, _ := c.inferBlock(scope.Child(), lvl, &e.Try)
 		c.recordType(e, t)
 		return t
@@ -2743,27 +2744,30 @@ func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) solt
 	return res
 }
 
-// walkTryBlock walks a try block with sink installed as the enclosing body's throws sink,
-// then puts the previous sink back. The swap is the save/restore shape pushFuncCtx uses
-// for a whole function body, so a `try` inside another `try`'s block nests for free and
-// sends its own leftovers to the outer arms.
+// walkTryBlock walks a try block with sink installed as the throws sink its exceptional
+// exits reach, then puts the previous sink back. The swap is the save/restore shape
+// pushFuncCtx uses for a whole function body, so a `try` inside another `try`'s block nests
+// for free and sends its own leftovers to the outer arms. installThrowsSink picks the field
+// to swap, so a top-level `try` collects into the checker's module-level sink and one in a
+// body collects into that body's funcCtx.
 //
 // funcCtx.raised is saved and cleared alongside the sink. The flag records whether the
 // enclosing body has an exceptional exit its own clause must cover. An exit the catch arms
 // handle is not one, so the flag starts clear for the block, and rethrowUnhandled sets it
 // again only when something is left over. That way a clause reached solely through a fully
-// handled `try` still reports as unused.
-//
-// At module top level there is no funcCtx to swap, so the block walks against the
-// throwaway sink throwsSink mints there and nothing is collected.
+// handled `try` still reports as unused. Module top level has no clause to measure, so the
+// flag has nothing to track there and markRaised is already a no-op.
 func (c *checker) walkTryBlock(scope *Scope, lvl int, b *ast.Block, sink soltype.Type) (soltype.Type, bool) {
-	if c.fn == nil {
-		return c.inferBlock(scope.Child(), lvl, b)
+	savedThrows := c.installThrowsSink(sink)
+	savedRaised := false
+	if c.fn != nil {
+		savedRaised, c.fn.raised = c.fn.raised, false
 	}
-	savedThrows, savedRaised := c.fn.throws, c.fn.raised
-	c.fn.throws, c.fn.raised = sink, false
 	t, diverges := c.inferBlock(scope.Child(), lvl, b)
-	c.fn.throws, c.fn.raised = savedThrows, savedRaised
+	c.installThrowsSink(savedThrows)
+	if c.fn != nil {
+		c.fn.raised = savedRaised
+	}
 	return t, diverges
 }
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2800,9 +2800,10 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 		rethrown = newUnion(c.ctx, uncovered, false)
 	}
 	if isNeverType(rethrown) {
-		// Every member an arm could name is covered, so nothing known escapes and the
-		// enclosing clause is left alone. This is what lets a caller with no clause wrap a
-		// throwing call once it has handled what that call declares.
+		// Every member an arm could name is covered. Codegen still emits a runtime rethrow
+		// for a value that matches no arm, but such a value came from the open tail, so no
+		// signature named its type. Recording it would mean widening the clause to
+		// `unknown` to state what is already true of every clause.
 		return
 	}
 	// The engine runs directly rather than through c.constrain, so its errors are dropped

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2653,25 +2653,12 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 }
 
 // inferMatchArms types each arm of a `match` or of a `try`'s catch clause, constrains every
-// non-diverging body into res, and returns those bodies so the caller can check them for
-// uniform ownership. Both forms hold `[]*ast.MatchCase` and join their arms the same way, so
-// the walk is shared rather than restated.
-//
-// shape is the coalesced scrutinee the narrowing reads union members from. scrutinee is what
-// an arm binds against when no narrowing applies, so its var identity and borrow survive
-// there. inferMatch passes a snapshot and the original; inferTryCatch passes its caught type
-// for both, since that is already concrete. node is blamed for each body's join.
-//
-// Each arm binds its pattern's leaves in a fresh child scope, so a name bound by one arm is
-// invisible to the next. bindPattern peels the scrutinee's borrow for the member-lookup
-// requirements but reapplies the binding mode to each leaf, so a leaf of a `&mut` scrutinee
-// binds as a `&mut` borrow, just as `val` destructuring does. A missing field or a wrong
-// tuple arity surfaces there too.
-//
-// A structural pattern over a union scrutinee binds against only the members whose shape it
-// matches, so an arm may destructure one variant and leave the rest to later arms.
-// narrowMatchArm drops the members `arm.Pattern` cannot destructure. Every other pattern
-// binds against the whole scrutinee.
+// non-diverging body into res, and returns those bodies for the caller's ownership check.
+// Each arm binds in a fresh child scope, so a name one arm binds is invisible to the next,
+// and node is blamed for each body's join. shape is the coalesced scrutinee narrowMatchArm
+// reads union members from. scrutinee is what an arm binds against when no narrowing
+// applies, so a var's identity and borrow survive there. inferMatch passes a snapshot and
+// the original, inferTryCatch one already-concrete type for both.
 func (c *checker) inferMatchArms(
 	scope *Scope, lvl int, node ast.Node, arms []*ast.MatchCase, shape, scrutinee, res soltype.Type,
 ) []soltype.Type {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2798,8 +2798,13 @@ func (c *checker) caughtType(collected soltype.Type) soltype.Type {
 // checkMatchExhaustive reads, so one definition of "this pattern covers this member" serves
 // both walks. A guarded arm can always fail its guard, so it covers nothing.
 //
-// The caught union's open tail is uncovered as well, and only a catch-all closes it. So a
-// catch-all is what lets a function with no `throws` clause wrap a call to a throwing one.
+// Only the uncovered MEMBERS are rethrown. The caught union's open tail is not, even
+// though no arm short of a catch-all covers it, because every throws type is already open.
+// A clause is a floor rather than a ceiling: any call can raise something its signature did
+// not name, whatever that signature says. Carrying the tail into the enclosing clause would
+// re-state that global fact once per `try` and, since only `unknown` can hold it, would
+// erase every named type the clause had. So the tail is left where it is observable, on the
+// caught binding a catch arm matches, and the clause records what is known to escape.
 //
 // A rethrow the enclosing sink cannot accept is one UnhandledRethrowError blamed on the
 // try/catch, since the re-raise happens there rather than at the `throw` the block caught.
@@ -2809,7 +2814,10 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 			return
 		}
 	}
-	rethrown := caught
+	// A non-union `caught` carries no named member to rethrow. It is `unknown`, the bare
+	// open tail caughtType renders for a block that raises nothing known, or the ErrorType
+	// recovery placeholder. Neither leaves anything for the enclosing clause to record.
+	var rethrown soltype.Type = &soltype.NeverType{}
 	if u, isUnion := caught.(*soltype.UnionType); isUnion {
 		uncovered := make([]soltype.Type, 0, len(u.Types))
 		for _, m := range u.Types {
@@ -2817,13 +2825,13 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 				uncovered = append(uncovered, m)
 			}
 		}
-		rethrown = newUnion(c.ctx, uncovered, true)
-		if isNeverType(rethrown) {
-			// Every listed member is covered, so only the open tail is left over. `unknown`
-			// is how caughtType spells that same tail-only case, since the inexactness flag
-			// has no carrier once the members are gone.
-			rethrown = &soltype.UnknownType{}
-		}
+		rethrown = newUnion(c.ctx, uncovered, false)
+	}
+	if isNeverType(rethrown) {
+		// Every member an arm could name is covered, so nothing known escapes and the
+		// enclosing clause is left alone. This is what lets a caller with no clause wrap a
+		// throwing call once it has handled what that call declares.
+		return
 	}
 	// The engine runs directly rather than through c.constrain, so its errors are dropped
 	// in favour of one UnhandledRethrowError blamed here. A member's Prov entry is the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2679,6 +2679,139 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	return res
 }
 
+// inferTryCatch types `try { … } catch { pat => body, … }`. The try block is walked
+// against a nested throws sink, a fresh variable installed in place of the enclosing
+// body's, so every `throw` and every call inside the block records into that variable
+// rather than into the function's own clause. The catch arms then match against what the
+// nested sink collected, the way `match` arms match a scrutinee, and rethrowUnhandled
+// sends whatever they leave over to the enclosing sink.
+//
+// The form's value is the join of the try block's tail value and each non-diverging arm
+// body, the same branch-join inferMatch builds from its arms.
+func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) soltype.Type {
+	// With no `catch` clause nothing inspects the error, so there is no caught binding to
+	// bind and nothing to narrow. Walking the block against the enclosing sink directly
+	// lets its throws reach the function's clause exactly as they would without the `try`.
+	if len(e.Catch) == 0 {
+		t, _ := c.inferBlock(scope.Child(), lvl, &e.Try)
+		c.recordType(e, t)
+		return t
+	}
+
+	res := c.freshAt(lvl)
+	c.recordProv(res, e, TryCatchBranch)
+	// The enclosing sink is read before the nested one is installed, so the rethrow below
+	// reaches the clause of the function this `try` sits in.
+	enclosing := c.throwsSink(lvl)
+	collected := c.freshThrowsSink(lvl)
+	c.recordProv(collected, e, CaughtThrows)
+
+	tryT, tryDiverges := c.walkTryBlock(scope, lvl, &e.Try, collected)
+	if !tryDiverges {
+		c.constrain(e, tryT, res)
+	}
+
+	caught := c.caughtType(collected)
+	var armBodies []soltype.Type
+	for _, arm := range e.Catch {
+		// Each arm binds its pattern's leaves in a fresh child scope, and a structural
+		// pattern binds against only the caught members whose shape it matches. Both are
+		// what inferMatch does with a match arm; the caught type is this walk's scrutinee.
+		armScope := scope.Child()
+		armScrut := narrowMatchArm(caught, caught, arm.Pattern)
+		c.bindPattern(armScope, lvl, arm.Pattern, armScrut, nil)
+		if arm.Guard != nil {
+			guard := c.inferExpr(armScope, lvl, arm.Guard)
+			c.constrain(arm.Guard, guard, &soltype.PrimType{Prim: soltype.BoolPrim})
+		}
+		bodyT, diverges := c.inferBlockOrExpr(armScope, lvl, &arm.Body)
+		if !diverges {
+			c.constrain(e, bodyT, res)
+			armBodies = append(armBodies, bodyT)
+		}
+	}
+	c.checkUniformOwnership(e, armBodies)
+	c.rethrowUnhandled(scope, e, caught, enclosing)
+	c.recordType(e, res)
+	return res
+}
+
+// walkTryBlock walks a try block with sink installed as the enclosing body's throws sink,
+// then puts the previous sink back. The swap is the save/restore shape pushFuncCtx uses
+// for a whole function body, so a `try` inside another `try`'s block nests for free and
+// sends its own leftovers to the outer arms.
+//
+// funcCtx.raised is saved and cleared alongside the sink. The flag records whether the
+// enclosing body has an exceptional exit its own clause has to cover, and an exit the
+// catch arms handle does not. rethrowUnhandled sets it again when something is left over,
+// so a clause reached only through a fully handled `try` still reports as unused.
+//
+// At module top level there is no funcCtx to swap, so the block walks against the
+// throwaway sink throwsSink mints there and nothing is collected.
+func (c *checker) walkTryBlock(scope *Scope, lvl int, b *ast.Block, sink soltype.Type) (soltype.Type, bool) {
+	if c.fn == nil {
+		return c.inferBlock(scope.Child(), lvl, b)
+	}
+	savedThrows, savedRaised := c.fn.throws, c.fn.raised
+	c.fn.throws, c.fn.raised = sink, false
+	t, diverges := c.inferBlock(scope.Child(), lvl, b)
+	c.fn.throws, c.fn.raised = savedThrows, savedRaised
+	return t, diverges
+}
+
+// caughtType returns the type a catch arm's pattern binds against: what the try block
+// raised, reopened with a trailing `...`. The tail is there because any call can raise
+// something no signature predicted, so a caught error is never a closed set — the docs
+// render one as `FooError | ...`. A block with no known exceptional exit yields `unknown`,
+// which is that tail standing on its own, since an inexact union with no members carries
+// no value to bind.
+func (c *checker) caughtType(collected soltype.Type) soltype.Type {
+	shape := coalesce(collected, soltype.Positive)
+	if isNeverType(shape) {
+		return &soltype.UnknownType{}
+	}
+	return newUnion(c.ctx, []soltype.Type{shape}, true)
+}
+
+// rethrowUnhandled constrains the part of the caught union no arm covers into the
+// enclosing throws sink, so a `try` narrows what its function raises rather than swallowing
+// it. This is the automatic rethrow docs/06_error_handling.md specifies in place of an
+// exhaustiveness diagnostic: "if there is no catch-all, the compiler will automatically
+// re-throw the unhandled error".
+//
+// Coverage is decided by isCatchAll and unionMemberCovered, the same two relations
+// checkMatchExhaustive reads, so one definition of "this pattern covers this member" serves
+// both walks. A guarded arm can always fail its guard, so it covers nothing.
+//
+// The caught union's open tail is uncovered as well, and only a catch-all closes it. That
+// is what makes a catch-all the thing that lets a function with no `throws` clause wrap a
+// throwing call.
+func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, enclosing soltype.Type) {
+	for _, arm := range e.Catch {
+		if arm.Guard == nil && isCatchAll(arm.Pattern) {
+			return
+		}
+	}
+	rethrown := caught
+	if u, isUnion := caught.(*soltype.UnionType); isUnion {
+		uncovered := make([]soltype.Type, 0, len(u.Types))
+		for _, m := range u.Types {
+			if !c.unionMemberCovered(scope, m, e.Catch) {
+				uncovered = append(uncovered, m)
+			}
+		}
+		rethrown = newUnion(c.ctx, uncovered, true)
+		if isNeverType(rethrown) {
+			// Every listed member is covered and only the open tail is left over. It is
+			// spelled `unknown` for the same reason caughtType spells an empty catch that
+			// way: the inexactness flag has no carrier without members.
+			rethrown = &soltype.UnknownType{}
+		}
+	}
+	c.constrain(e, rethrown, enclosing)
+	c.markRaised()
+}
+
 // checkMatchExhaustive reports a NonExhaustiveMatchError when no arm covers every
 // value the coalesced scrutinee can take, dispatching on its union or object/tuple shape.
 func (c *checker) checkMatchExhaustive(scope *Scope, e *ast.MatchExpr, scrutinee soltype.Type) {
@@ -3130,6 +3263,20 @@ func exprDiverges(e ast.Expr) bool {
 			return false
 		}
 		for _, arm := range e.Cases {
+			if !blockOrExprDiverges(&arm.Body) {
+				return false
+			}
+		}
+		return true
+	case *ast.TryCatchExpr:
+		// Control falls out of a try/catch unless every way through it leaves: the try
+		// block must diverge, and so must every arm body reachable when it raises. The
+		// arms are folded with the same AND that MatchExpr uses. A `try` with no arms is
+		// just its block.
+		if !blockDiverges(&e.Try) {
+			return false
+		}
+		for _, arm := range e.Catch {
 			if !blockOrExprDiverges(&arm.Body) {
 				return false
 			}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2788,8 +2788,15 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 	if u, isUnion := caught.(*soltype.UnionType); isUnion {
 		uncovered := make([]soltype.Type, 0, len(u.Types))
 		for _, m := range u.Types {
-			if !c.unionMemberCovered(scope, m, e.Catch) {
-				uncovered = append(uncovered, m)
+			// A transparent alias member, an enum handle or a `type` reference, carries the
+			// alias rather than the type it stands for. unionMemberCovered has no arm for
+			// one, so an unexpanded alias reads as uncovered however many arms name its
+			// members, and `type Err = "a" | "b"` would behave unlike the union spelled
+			// inline. checkMatchExhaustive expands for the same reason.
+			for _, part := range unionParts(c.expandAliasChain(m)) {
+				if !c.unionMemberCovered(scope, part, e.Catch) {
+					uncovered = append(uncovered, part)
+				}
 			}
 		}
 		rethrown = newUnion(c.ctx, uncovered, false)
@@ -2811,25 +2818,38 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 	c.markRaised()
 }
 
+// expandAliasChain follows a chain of transparent aliases to the type it stands for, so a
+// caller decides against that type rather than against the alias handle. A seen-set of names
+// breaks a degenerate cycle such as `type A = A`. A non-alias is returned unchanged.
+func (c *checker) expandAliasChain(t soltype.Type) soltype.Type {
+	seen := set.NewSet[string]()
+	for {
+		at, ok := t.(*soltype.AliasType)
+		if !ok || seen.Contains(at.Name) {
+			return t
+		}
+		seen.Add(at.Name)
+		t = c.ctx.expandAlias(at)
+	}
+}
+
+// unionParts returns a union's members, or the type itself as a one-element slice. It lets a
+// caller iterate members without branching on whether it holds a union.
+func unionParts(t soltype.Type) []soltype.Type {
+	if u, ok := t.(*soltype.UnionType); ok {
+		return u.Types
+	}
+	return []soltype.Type{t}
+}
+
 // checkMatchExhaustive reports a NonExhaustiveMatchError when no arm covers every
 // value the coalesced scrutinee can take, dispatching on its union or object/tuple shape.
 func (c *checker) checkMatchExhaustive(scope *Scope, e *ast.MatchExpr, scrutinee soltype.Type) {
-	carrier := soltype.CarrierOf(scrutinee)
 	// A transparent alias scrutinee, an enum handle or a user `type` reference, carries the
 	// alias rather than the type it stands for. Expand it to that type before dispatching, the
 	// same unfold constrain performs, so `match c { Color.RGB(..) => .., Color.Hex(..) => .. }`
-	// over `val c: Color` covers the variant union without a default arm. The loop follows a
-	// chain of aliases to the underlying union or shape, and a seen-set of names breaks a
-	// degenerate alias cycle.
-	seenAliases := set.NewSet[string]()
-	for {
-		at, ok := carrier.(*soltype.AliasType)
-		if !ok || seenAliases.Contains(at.Name) {
-			break
-		}
-		seenAliases.Add(at.Name)
-		carrier = c.ctx.expandAlias(at)
-	}
+	// over `val c: Color` covers the variant union without a default arm.
+	carrier := c.expandAliasChain(soltype.CarrierOf(scrutinee))
 	if u, ok := carrier.(*soltype.UnionType); ok {
 		if !c.unionMatchExhaustive(scope, e, u) {
 			c.report(&NonExhaustiveMatchError{Match: e})

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2645,19 +2645,40 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	}
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, MatchBranch)
-	var armBodies []soltype.Type
-	for _, arm := range e.Cases {
-		// Each arm binds its pattern's leaves in a fresh child scope so a name bound
-		// by one arm is invisible to the next. bindPattern peels the scrutinee's borrow
-		// for the member-lookup requirements but reapplies the binding mode to each
-		// leaf, so a leaf of a `&mut` scrutinee binds as a `&mut` borrow, just as `val`
-		// destructuring does. A missing field or wrong tuple arity surfaces here too.
+	armBodies := c.inferMatchArms(scope, lvl, e, e.Cases, matchShape, scrutinee, res)
+	c.checkUniformOwnership(e, armBodies)
+	c.checkMatchExhaustive(scope, e, matchShape)
+	c.recordType(e, res)
+	return res
+}
+
+// inferMatchArms types each arm of a `match` or of a `try`'s catch clause, constrains every
+// non-diverging body into res, and returns those bodies so the caller can check them for
+// uniform ownership. Both forms hold `[]*ast.MatchCase` and join their arms the same way, so
+// the walk is shared rather than restated.
+//
+// shape is the coalesced scrutinee the narrowing reads union members from. scrutinee is what
+// an arm binds against when no narrowing applies, so its var identity and borrow survive
+// there. inferMatch passes a snapshot and the original; inferTryCatch passes its caught type
+// for both, since that is already concrete. node is blamed for each body's join.
+//
+// Each arm binds its pattern's leaves in a fresh child scope, so a name bound by one arm is
+// invisible to the next. bindPattern peels the scrutinee's borrow for the member-lookup
+// requirements but reapplies the binding mode to each leaf, so a leaf of a `&mut` scrutinee
+// binds as a `&mut` borrow, just as `val` destructuring does. A missing field or a wrong
+// tuple arity surfaces there too.
+//
+// A structural pattern over a union scrutinee binds against only the members whose shape it
+// matches, so an arm may destructure one variant and leave the rest to later arms.
+// narrowMatchArm drops the members `arm.Pattern` cannot destructure. Every other pattern
+// binds against the whole scrutinee.
+func (c *checker) inferMatchArms(
+	scope *Scope, lvl int, node ast.Node, arms []*ast.MatchCase, shape, scrutinee, res soltype.Type,
+) []soltype.Type {
+	var bodies []soltype.Type
+	for _, arm := range arms {
 		armScope := scope.Child()
-		// A structural pattern over a union scrutinee binds against only the members
-		// whose shape it matches, so a match arm may destructure one variant while
-		// leaving the rest for later arms. narrowMatchArm drops the members `arm.Pattern`
-		// cannot destructure. Every other pattern binds against the whole scrutinee.
-		armScrut := narrowMatchArm(matchShape, scrutinee, arm.Pattern)
+		armScrut := narrowMatchArm(shape, scrutinee, arm.Pattern)
 		c.bindPattern(armScope, lvl, arm.Pattern, armScrut, nil)
 		if arm.Guard != nil {
 			// A guard is an ordinary boolean condition over the arm's bindings. As in
@@ -2669,14 +2690,11 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 		}
 		bodyT, diverges := c.inferBlockOrExpr(armScope, lvl, &arm.Body)
 		if !diverges {
-			c.constrain(e, bodyT, res)
-			armBodies = append(armBodies, bodyT)
+			c.constrain(node, bodyT, res)
+			bodies = append(bodies, bodyT)
 		}
 	}
-	c.checkUniformOwnership(e, armBodies)
-	c.checkMatchExhaustive(scope, e, matchShape)
-	c.recordType(e, res)
-	return res
+	return bodies
 }
 
 // inferTryCatch types `try { … } catch { pat => body, … }`. The try block is walked
@@ -2720,24 +2738,11 @@ func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) solt
 		branches = append(branches, tryT)
 	}
 
+	// The caught type is this walk's scrutinee, and the arms are typed exactly as a `match`
+	// expression's are. It is already concrete, so it serves as both the narrowing shape and
+	// the bind target.
 	caught := c.caughtType(collected)
-	for _, arm := range e.Catch {
-		// Each arm binds its pattern's leaves in a fresh child scope, and a structural
-		// pattern binds against only the caught members whose shape it matches. Both are
-		// what inferMatch does with a match arm. The caught type is this walk's scrutinee.
-		armScope := scope.Child()
-		armScrut := narrowMatchArm(caught, caught, arm.Pattern)
-		c.bindPattern(armScope, lvl, arm.Pattern, armScrut, nil)
-		if arm.Guard != nil {
-			guard := c.inferExpr(armScope, lvl, arm.Guard)
-			c.constrain(arm.Guard, guard, &soltype.PrimType{Prim: soltype.BoolPrim})
-		}
-		bodyT, diverges := c.inferBlockOrExpr(armScope, lvl, &arm.Body)
-		if !diverges {
-			c.constrain(e, bodyT, res)
-			branches = append(branches, bodyT)
-		}
-	}
+	branches = append(branches, c.inferMatchArms(scope, lvl, e, e.Catch, caught, caught, res)...)
 	c.checkUniformOwnership(e, branches)
 	c.rethrowUnhandled(scope, e, caught, enclosing)
 	c.recordType(e, res)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2800,6 +2800,9 @@ func (c *checker) caughtType(collected soltype.Type) soltype.Type {
 //
 // The caught union's open tail is uncovered as well, and only a catch-all closes it. So a
 // catch-all is what lets a function with no `throws` clause wrap a call to a throwing one.
+//
+// A rethrow the enclosing sink cannot accept is one UnhandledRethrowError blamed on the
+// try/catch, since the re-raise happens there rather than at the `throw` the block caught.
 func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, enclosing soltype.Type) {
 	for _, arm := range e.Catch {
 		if arm.Guard == nil && isCatchAll(arm.Pattern) {
@@ -2822,7 +2825,13 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 			rethrown = &soltype.UnknownType{}
 		}
 	}
-	c.constrain(e, rethrown, enclosing)
+	// The engine runs directly rather than through c.constrain, so its errors are dropped
+	// in favour of one UnhandledRethrowError blamed here. A member's Prov entry is the
+	// `throw` that produced it inside the block, and blaming that `throw` would be wrong:
+	// the `try` caught it. What fails is the re-raise, which happens at this node.
+	if errs := c.ctx.Constrain(rethrown, enclosing); len(errs) > 0 {
+		c.report(&UnhandledRethrowError{Try: e, Rethrown: rethrown, Sink: enclosing})
+	}
 	c.markRaised()
 }
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2680,18 +2680,18 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 }
 
 // inferTryCatch types `try { … } catch { pat => body, … }`. The try block is walked
-// against a nested throws sink, a fresh variable installed in place of the enclosing
-// body's, so every `throw` and every call inside the block records into that variable
-// rather than into the function's own clause. The catch arms then match against what the
-// nested sink collected, the way `match` arms match a scrutinee, and rethrowUnhandled
-// sends whatever they leave over to the enclosing sink.
+// against a nested throws sink, a fresh variable installed over the enclosing body's. Every
+// `throw` and every call inside the block therefore records into that variable rather than
+// into the function's own clause. The catch arms match against what the variable collected,
+// the way `match` arms match a scrutinee. rethrowUnhandled then sends whatever the arms
+// leave over to the enclosing sink.
 //
 // The form's value is the join of the try block's tail value and each non-diverging arm
 // body, the same branch-join inferMatch builds from its arms.
 func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) soltype.Type {
-	// With no `catch` clause nothing inspects the error, so there is no caught binding to
-	// bind and nothing to narrow. Walking the block against the enclosing sink directly
-	// lets its throws reach the function's clause exactly as they would without the `try`.
+	// With no `catch` clause nothing inspects the error, so there is nothing to bind and
+	// nothing to narrow. Walking the block against the enclosing sink directly lets its
+	// throws reach the function's clause exactly as they would without the `try`.
 	if len(e.Catch) == 0 {
 		t, _ := c.inferBlock(scope.Child(), lvl, &e.Try)
 		c.recordType(e, t)
@@ -2706,17 +2706,21 @@ func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) solt
 	collected := c.freshThrowsSink(lvl)
 	c.recordProv(collected, e, CaughtThrows)
 
+	// branches collects every value the form can produce, so the ownership check below sees
+	// the try block's tail alongside the arm bodies. A diverging branch produces no value
+	// and is left out of both the join and the check.
+	var branches []soltype.Type
 	tryT, tryDiverges := c.walkTryBlock(scope, lvl, &e.Try, collected)
 	if !tryDiverges {
 		c.constrain(e, tryT, res)
+		branches = append(branches, tryT)
 	}
 
 	caught := c.caughtType(collected)
-	var armBodies []soltype.Type
 	for _, arm := range e.Catch {
 		// Each arm binds its pattern's leaves in a fresh child scope, and a structural
 		// pattern binds against only the caught members whose shape it matches. Both are
-		// what inferMatch does with a match arm; the caught type is this walk's scrutinee.
+		// what inferMatch does with a match arm. The caught type is this walk's scrutinee.
 		armScope := scope.Child()
 		armScrut := narrowMatchArm(caught, caught, arm.Pattern)
 		c.bindPattern(armScope, lvl, arm.Pattern, armScrut, nil)
@@ -2727,10 +2731,10 @@ func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) solt
 		bodyT, diverges := c.inferBlockOrExpr(armScope, lvl, &arm.Body)
 		if !diverges {
 			c.constrain(e, bodyT, res)
-			armBodies = append(armBodies, bodyT)
+			branches = append(branches, bodyT)
 		}
 	}
-	c.checkUniformOwnership(e, armBodies)
+	c.checkUniformOwnership(e, branches)
 	c.rethrowUnhandled(scope, e, caught, enclosing)
 	c.recordType(e, res)
 	return res
@@ -2742,9 +2746,10 @@ func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) solt
 // sends its own leftovers to the outer arms.
 //
 // funcCtx.raised is saved and cleared alongside the sink. The flag records whether the
-// enclosing body has an exceptional exit its own clause has to cover, and an exit the
-// catch arms handle does not. rethrowUnhandled sets it again when something is left over,
-// so a clause reached only through a fully handled `try` still reports as unused.
+// enclosing body has an exceptional exit its own clause must cover. An exit the catch arms
+// handle is not one, so the flag starts clear for the block, and rethrowUnhandled sets it
+// again only when something is left over. That way a clause reached solely through a fully
+// handled `try` still reports as unused.
 //
 // At module top level there is no funcCtx to swap, so the block walks against the
 // throwaway sink throwsSink mints there and nothing is collected.
@@ -2761,10 +2766,12 @@ func (c *checker) walkTryBlock(scope *Scope, lvl int, b *ast.Block, sink soltype
 
 // caughtType returns the type a catch arm's pattern binds against: what the try block
 // raised, reopened with a trailing `...`. The tail is there because any call can raise
-// something no signature predicted, so a caught error is never a closed set — the docs
-// render one as `FooError | ...`. A block with no known exceptional exit yields `unknown`,
-// which is that tail standing on its own, since an inexact union with no members carries
-// no value to bind.
+// something no signature predicted, so a caught error is never a closed set. That is the
+// `FooError | ...` docs/06_error_handling.md renders for a caught binding.
+//
+// A block with no known exceptional exit yields `unknown`, which is the tail standing on
+// its own. An inexact union with no members carries no value, so there would be nothing to
+// bind against.
 func (c *checker) caughtType(collected soltype.Type) soltype.Type {
 	shape := coalesce(collected, soltype.Positive)
 	if isNeverType(shape) {
@@ -2783,9 +2790,8 @@ func (c *checker) caughtType(collected soltype.Type) soltype.Type {
 // checkMatchExhaustive reads, so one definition of "this pattern covers this member" serves
 // both walks. A guarded arm can always fail its guard, so it covers nothing.
 //
-// The caught union's open tail is uncovered as well, and only a catch-all closes it. That
-// is what makes a catch-all the thing that lets a function with no `throws` clause wrap a
-// throwing call.
+// The caught union's open tail is uncovered as well, and only a catch-all closes it. So a
+// catch-all is what lets a function with no `throws` clause wrap a call to a throwing one.
 func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, enclosing soltype.Type) {
 	for _, arm := range e.Catch {
 		if arm.Guard == nil && isCatchAll(arm.Pattern) {
@@ -2802,9 +2808,9 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 		}
 		rethrown = newUnion(c.ctx, uncovered, true)
 		if isNeverType(rethrown) {
-			// Every listed member is covered and only the open tail is left over. It is
-			// spelled `unknown` for the same reason caughtType spells an empty catch that
-			// way: the inexactness flag has no carrier without members.
+			// Every listed member is covered, so only the open tail is left over. `unknown`
+			// is how caughtType spells that same tail-only case, since the inexactness flag
+			// has no carrier once the members are gone.
 			rethrown = &soltype.UnknownType{}
 		}
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2689,12 +2689,9 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 // The form's value is the join of the try block's tail value and each non-diverging arm
 // body, the same branch-join inferMatch builds from its arms.
 func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) soltype.Type {
-	// A `try` needs arms to be worth writing, since the arms are what handle an exception.
-	// With none there is nothing to bind and nothing to narrow, so the form is rejected and
-	// the block recovers as if it had been written on its own: it walks against the
-	// enclosing sink, and its throws reach the function's clause unchanged. That keeps the
-	// missing arms to one diagnostic instead of cascading a rethrow through them. An
-	// omitted `catch` and a written `catch { }` both arrive here with an empty slice.
+	// A `try` with no arms catches nothing, so it is rejected and the block recovers as if
+	// written on its own. Its throws reach the enclosing clause unchanged, which keeps the
+	// fault to one diagnostic. An omitted `catch` and a written `catch { }` both land here.
 	if len(e.Catch) == 0 {
 		c.report(&MissingCatchArmError{Try: e})
 		t, _ := c.inferBlock(scope.Child(), lvl, &e.Try)
@@ -2744,19 +2741,11 @@ func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) solt
 	return res
 }
 
-// walkTryBlock walks a try block with sink installed as the throws sink its exceptional
-// exits reach, then puts the previous sink back. The swap is the save/restore shape
-// pushFuncCtx uses for a whole function body, so a `try` inside another `try`'s block nests
-// for free and sends its own leftovers to the outer arms. installThrowsSink picks the field
-// to swap, so a top-level `try` collects into the checker's module-level sink and one in a
-// body collects into that body's funcCtx.
-//
-// funcCtx.raised is saved and cleared alongside the sink. The flag records whether the
-// enclosing body has an exceptional exit its own clause must cover. An exit the catch arms
-// handle is not one, so the flag starts clear for the block, and rethrowUnhandled sets it
-// again only when something is left over. That way a clause reached solely through a fully
-// handled `try` still reports as unused. Module top level has no clause to measure, so the
-// flag has nothing to track there and markRaised is already a no-op.
+// walkTryBlock walks a try block against sink, then restores the sink it replaced, so a
+// `try` nested in another sends its own leftovers to the outer arms. installThrowsSink
+// picks the field, so a top-level `try` collects into the checker and one in a body into
+// that body's funcCtx. funcCtx.raised is cleared alongside, and rethrowUnhandled sets it
+// again only when something escapes, so a fully covered `try` leaves a clause unused.
 func (c *checker) walkTryBlock(scope *Scope, lvl int, b *ast.Block, sink soltype.Type) (soltype.Type, bool) {
 	savedThrows := c.installThrowsSink(sink)
 	savedRaised := false
@@ -2772,14 +2761,10 @@ func (c *checker) walkTryBlock(scope *Scope, lvl int, b *ast.Block, sink soltype
 }
 
 // caughtType returns the type a catch arm's pattern binds against: what the try block
-// raised, reopened with a trailing `...`. The tail is there because a `throws` clause is a
-// floor rather than a ceiling. Any call can raise something its signature did not name, so
-// the members collected from the block are the part of a caught error the type system can
-// see, not the whole of it.
-//
-// A block with no known exceptional exit yields `unknown`, which is the tail standing on
-// its own. An inexact union with no members carries no value, so there would be nothing to
-// bind against.
+// raised, reopened with a trailing `...`. The tail is there because a clause is a floor
+// rather than a ceiling, so a call can raise something its signature did not name. A block
+// with no known exceptional exit yields `unknown`, the tail on its own, since an inexact
+// union with no members carries no value to bind against.
 func (c *checker) caughtType(collected soltype.Type) soltype.Type {
 	shape := coalesce(collected, soltype.Positive)
 	if isNeverType(shape) {
@@ -2788,26 +2773,13 @@ func (c *checker) caughtType(collected soltype.Type) soltype.Type {
 	return newUnion(c.ctx, []soltype.Type{shape}, true)
 }
 
-// rethrowUnhandled constrains the part of the caught union no arm covers into the
-// enclosing throws sink, so a `try` narrows what its function raises rather than swallowing
-// it. A value that matches no arm is re-raised at runtime, so the enclosing clause is where
-// it lands. That is why uncovered members draw a rethrow rather than the non-exhaustiveness
-// diagnostic the equivalent `match` would draw.
-//
-// Coverage is decided by isCatchAll and unionMemberCovered, the same two relations
-// checkMatchExhaustive reads, so one definition of "this pattern covers this member" serves
-// both walks. A guarded arm can always fail its guard, so it covers nothing.
-//
-// Only the uncovered MEMBERS are rethrown. The caught union's open tail is not, even
-// though no arm short of a catch-all covers it, because every throws type is already open.
-// A clause is a floor rather than a ceiling: any call can raise something its signature did
-// not name, whatever that signature says. Carrying the tail into the enclosing clause would
-// re-state that global fact once per `try` and, since only `unknown` can hold it, would
-// erase every named type the clause had. So the tail is left where it is observable, on the
-// caught binding a catch arm matches, and the clause records what is known to escape.
-//
-// A rethrow the enclosing sink cannot accept is one UnhandledRethrowError blamed on the
-// try/catch, since the re-raise happens there rather than at the `throw` the block caught.
+// rethrowUnhandled sends the part of the caught union no arm covers into the enclosing
+// throws sink. A value matching no arm is re-raised at runtime, so uncovered members draw a
+// rethrow rather than the non-exhaustiveness error the equivalent `match` would draw.
+// Coverage comes from isCatchAll and unionMemberCovered, so it agrees with
+// checkMatchExhaustive, and a guarded arm can fail its guard and covers nothing. Only the
+// MEMBERS are rethrown: every throws type is open already, and only `unknown` could carry
+// the tail, so adding it would erase the named types the clause had.
 func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, enclosing soltype.Type) {
 	for _, arm := range e.Catch {
 		if arm.Guard == nil && isCatchAll(arm.Pattern) {
@@ -3300,11 +3272,8 @@ func exprDiverges(e ast.Expr) bool {
 		}
 		return true
 	case *ast.TryCatchExpr:
-		// Control falls out of a try/catch unless every way through it leaves: the try
-		// block must diverge, and so must every arm body reachable when it raises. The
-		// arms are folded with the same AND that MatchExpr uses. An arm-less `try` is
-		// rejected by inferTryCatch and recovers as its block alone, which is what the
-		// empty fold yields here.
+		// Control falls out unless every way through leaves, so the try block and every arm
+		// body must diverge. Same AND-fold as MatchExpr. An arm-less `try` is just its block.
 		if !blockDiverges(&e.Try) {
 			return false
 		}

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -394,3 +394,58 @@ func TestInferTryCatchLeavesAnUnusedClauseUnused(t *testing.T) {
 		msgWithSpan(errs[0]))
 	require.Equal(t, "fn () -> void throws string", values["f"])
 }
+
+// Coverage is decided against the type an alias stands for, not against the alias handle. A
+// transparent alias, an enum handle or a user `type` reference, carries the alias rather than
+// its underlying union, and unionMemberCovered has no arm for one. Without expanding first, an
+// aliased error type would read as uncovered however many arms name its members, so naming a
+// union would behave unlike spelling it inline.
+func TestInferTryCatchExpandsAliasedErrorTypes(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			// The control: the same union written inline, which never needed expanding.
+			name: "InlineUnionIsCovered",
+			src: `
+				fn a() throws "a" | "b" { throw "a" }
+				fn f() { try { a() } catch { "a" => 0, "b" => 1 } }
+			`,
+			want: "fn () -> void",
+		},
+		{
+			// The same union behind a name has to reach the same verdict.
+			name: "AliasedUnionIsCovered",
+			src: `
+				type Err = "a" | "b"
+				fn a() throws Err { throw "a" }
+				fn f() { try { a() } catch { "a" => 0, "b" => 1 } }
+			`,
+			want: "fn () -> void",
+		},
+		{
+			// An enum registers as a transparent alias over its variant union, so its
+			// variants are covered by extractor patterns the same way.
+			name: "EnumVariantsAreCovered",
+			src: `
+				enum Color { Red, Green }
+				fn a() throws Color { throw Color.Red() }
+				fn f() { try { a() } catch { Color.Red => 0, Color.Green => 1 } }
+			`,
+			want: "fn () -> void",
+		},
+	})
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// Expanding does not make coverage lax. A member left unnamed is still rethrown,
+			// and it is named by the type it expands to rather than by the alias.
+			name: "AnUnnamedMemberOfAnAliasIsStillRethrown",
+			src: `
+				type Err = "a" | "b"
+				fn a() throws Err { throw "a" }
+				fn f() { try { a() } catch { "a" => 0 } }
+			`,
+			wantErrs: []string{
+				"4:14-4:42: the catch arms leave \"b\" uncovered, so it is rethrown, and the enclosing `throws never` does not admit it. Cover it with a catch arm, or widen the enclosing clause",
+			},
+		},
+	})
+}

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -121,19 +121,34 @@ func TestInferTryCatchRethrowsWhatTheArmsLeave(t *testing.T) {
 	})
 	runThrowsErrCases(t, []throwsErrCase{
 		{
-			// A clause-less function raises `never`, which is closed, so both the rethrown
-			// member and the open tail are rejected against it.
+			// A clause-less function raises `never`, which is closed, so the rethrow has
+			// nowhere to land. The blame is the try/catch, not the `throw "boom"` inside the
+			// block: that `throw` IS caught, and what fails is the re-raise past the arms.
+			// One diagnostic covers it, since only a catch-all resolves either half.
 			name: "RethrowNeedsAClause",
 			src:  `fn f() { try { throw "boom" } catch { 5 => 0 } }`,
 			wantErrs: []string{
-				`1:10-1:45: cannot constrain "boom" | ... <: never`,
-				`1:22-1:28: cannot constrain "boom" <: never`,
+				"1:10-1:45: the catch arms leave \"boom\" | ... uncovered, so it is rethrown, and the enclosing `throws never` does not admit it. Add a catch-all arm; only a catch-all closes a caught union's open tail",
 			},
 		},
 		{
-			name:     "TheBareTailNeedsAClauseToo",
-			src:      `fn f() { try { throw "boom" } catch { "boom" => 0 } }`,
-			wantErrs: []string{"1:10-1:50: cannot constrain unknown <: never"},
+			// Covering the one named member leaves the open tail, spelled `unknown`, and it
+			// is rethrown on its own.
+			name: "TheBareTailNeedsAClauseToo",
+			src:  `fn f() { try { throw "boom" } catch { "boom" => 0 } }`,
+			wantErrs: []string{
+				"1:10-1:50: the catch arms leave unknown uncovered, so it is rethrown, and the enclosing `throws never` does not admit it. Add a catch-all arm; only a catch-all closes a caught union's open tail",
+			},
+		},
+		{
+			// A member the enclosing clause does admit passes through, so only the tail is
+			// left to reject. The clause being narrower than `unknown` is what fails, and a
+			// catch-all is still the remedy.
+			name: "ANarrowClauseStillCannotCarryTheTail",
+			src:  `fn f(c: boolean) throws string { try { if c { throw "a" } else { throw "b" } } catch { "a" => 0 } }`,
+			wantErrs: []string{
+				"1:34-1:96: the catch arms leave \"b\" | ... uncovered, so it is rethrown, and the enclosing `throws string` does not admit it. Add a catch-all arm; only a catch-all closes a caught union's open tail",
+			},
 		},
 	})
 }

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -138,29 +138,44 @@ func TestInferTryCatchRethrowsWhatTheArmsLeave(t *testing.T) {
 	})
 }
 
-// The catch arms are what handle an exception, so a `try` without them handles nothing and
+// noArmsMsg is the MissingCatchArmError message, shared by every case below so the span is
+// the only thing each one spells out.
+const noArmsMsg = "a `try` with no catch arms catches nothing; drop the `try` and keep its block, or add at least one catch arm"
+
+// The catch arms are what catch an exception, so a `try` without them catches nothing and
 // is rejected. The block recovers as if written on its own, which keeps the missing arms
 // to a single diagnostic: its throws reach the enclosing sink unchanged, with no caught
 // binding and no open tail added on top.
+//
+// The blame span is where the two spellings differ. An omitted `catch` has nothing past the
+// try block to point at, so the node ends there. A written `catch` ends at its closing
+// brace, so the empty braces fall inside the blame and it lands where the arm goes.
 func TestInferTryWithoutCatchArmsIsRejected(t *testing.T) {
 	runThrowsErrCases(t, []throwsErrCase{
 		{
-			name: "OmittedCatchIsRejected",
-			src:  `fn f() throws string { try { throw "boom" } }`,
-			wantErrs: []string{
-				"1:24-1:44: `try` needs at least one catch arm; with none it handles nothing, so drop the `try` and keep the block",
-			},
+			name:     "OmittedCatchIsRejected",
+			src:      `fn f() throws string { try { throw "boom" } }`,
+			wantErrs: []string{"1:24-1:44: " + noArmsMsg},
 		},
 		{
-			// A written `catch { }` reaches the same diagnostic, since ast.TryCatchExpr
-			// records only the arms and both forms leave that slice empty. The message asks
-			// for an arm rather than for a `catch` clause, so it stays true here, and the
-			// span covers the empty braces so the blame lands where the arm goes.
-			name: "WrittenButEmptyCatchIsRejected",
-			src:  `fn f() throws string { try { throw "boom" } catch { } }`,
-			wantErrs: []string{
-				"1:24-1:54: `try` needs at least one catch arm; with none it handles nothing, so drop the `try` and keep the block",
-			},
+			// A written `catch { }` reaches the same diagnostic, since `ast.TryCatchExpr`
+			// records only the arms and both spellings leave that slice empty. The message
+			// names both ways out, so it stays true whichever was written.
+			name:     "WrittenButEmptyCatchIsRejected",
+			src:      `fn f() throws string { try { throw "boom" } catch { } }`,
+			wantErrs: []string{"1:24-1:54: " + noArmsMsg},
+		},
+		{
+			// The parser skips comments while looking for cases, so a comment between the
+			// braces still leaves no arms, and the closing brace on line 4 still ends the
+			// node.
+			name: "ACommentIsNotAnArm",
+			src: `fn f() throws string {
+	try { throw "boom" } catch {
+		// an arm goes here
+	}
+}`,
+			wantErrs: []string{"2:2-4:3: " + noArmsMsg},
 		},
 		{
 			// The block's `throw` is checked against the enclosing clause exactly as it
@@ -169,7 +184,7 @@ func TestInferTryWithoutCatchArmsIsRejected(t *testing.T) {
 			name: "TheBlockStillReachesTheEnclosingClause",
 			src:  `fn f() { try { throw "boom" } }`,
 			wantErrs: []string{
-				"1:10-1:30: `try` needs at least one catch arm; with none it handles nothing, so drop the `try` and keep the block",
+				"1:10-1:30: " + noArmsMsg,
 				`1:22-1:28: cannot constrain "boom" <: never`,
 			},
 		},
@@ -180,38 +195,52 @@ func TestInferTryWithoutCatchArmsIsRejected(t *testing.T) {
 // checker's module-level one instead. Without that the block collects nothing and every
 // caught binding reads `unknown`.
 func TestInferTryCatchAtModuleTopLevel(t *testing.T) {
-	t.Run("CaughtBindingCollectsTheBlocksThrows", func(t *testing.T) {
-		values, _, errs := inferSource(t, `val caught = try { throw "fail" } catch { msg => msg }`)
-		require.Empty(t, errs)
-		require.Equal(t, `"fail" | ...`, values["caught"])
-	})
-
-	t.Run("TheSinkDoesNotLeakBetweenDecls", func(t *testing.T) {
-		// The install is undone when the block finishes, so a later `try` over a quiet
-		// block collects nothing rather than inheriting the earlier block's throws.
-		values, _, errs := inferSource(t, `
-			val a = try { throw "one" } catch { e => e }
-			val b = try { val q = 1 } catch { e => e }
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, `"one" | ...`, values["a"])
-		require.Equal(t, "unknown", values["b"])
-	})
-
-	t.Run("ANestedFunctionKeepsItsOwnSink", func(t *testing.T) {
-		// throwsSink reads the module-level sink only when there is no funcCtx, so a
-		// function declared inside the block collects into its own signature. The block
-		// diverges, so the binding is the caught type alone, and `"inner"` is absent from
-		// it while the block's own `"outer"` is there.
-		values, _, errs := inferSource(t, `
-			val caught = try {
-				val g = fn () throws _ { throw "inner" }
-				throw "outer"
-			} catch { e => e }
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, `"outer" | ...`, values["caught"])
-	})
+	tests := []struct {
+		name string
+		src  string
+		// want maps a top-level binding's name to its rendered type. A case naming two
+		// bindings asserts a relationship between them that one binding cannot show.
+		want map[string]string
+	}{
+		{
+			name: "CaughtBindingCollectsTheBlocksThrows",
+			src:  `val caught = try { throw "fail" } catch { msg => msg }`,
+			want: map[string]string{"caught": `"fail" | ...`},
+		},
+		{
+			// The install is undone when the block finishes, so a later `try` over a quiet
+			// block collects nothing rather than inheriting the earlier block's throws.
+			name: "TheSinkDoesNotLeakBetweenDecls",
+			src: `
+				val a = try { throw "one" } catch { e => e }
+				val b = try { val q = 1 } catch { e => e }
+			`,
+			want: map[string]string{"a": `"one" | ...`, "b": "unknown"},
+		},
+		{
+			// throwsSink reads the module-level sink only when there is no funcCtx, so a
+			// function declared inside the block collects into its own signature. The block
+			// diverges, so the binding is the caught type alone, and `"inner"` is absent
+			// from it while the block's own `"outer"` is there.
+			name: "ANestedFunctionKeepsItsOwnSink",
+			src: `
+				val caught = try {
+					val g = fn () throws _ { throw "inner" }
+					throw "outer"
+				} catch { e => e }
+			`,
+			want: map[string]string{"caught": `"outer" | ...`},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, test.src)
+			require.Empty(t, errs)
+			for name, want := range test.want {
+				require.Equal(t, want, values[name])
+			}
+		})
+	}
 }
 
 // A `try` inside another `try`'s block installs its own sink over the outer one, so the

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -138,21 +138,29 @@ func TestInferTryCatchRethrowsWhatTheArmsLeave(t *testing.T) {
 	})
 }
 
-// A `try` with no `catch` clause inspects nothing, so it is transparent: the block's
-// throws reach the enclosing clause unchanged, with no caught binding and no open tail.
-func TestInferTryWithoutCatchIsTransparent(t *testing.T) {
-	runThrowsCases(t, []throwsCase{
-		{
-			name: "ThrowsPassThroughUnwidened",
-			src:  `fn f() throws string { try { throw "boom" } }`,
-			want: "fn () -> never throws string",
-		},
-	})
+// The catch arms are what handle an exception, so a `try` without them handles nothing and
+// is rejected. The block recovers as if written on its own, which keeps the missing clause
+// to a single diagnostic: its throws reach the enclosing sink unchanged, with no caught
+// binding and no open tail added on top.
+func TestInferTryWithoutCatchIsRejected(t *testing.T) {
 	runThrowsErrCases(t, []throwsErrCase{
 		{
-			name:     "AClauselessFunctionIsStillRejected",
-			src:      `fn f() { try { throw "boom" } }`,
-			wantErrs: []string{`1:22-1:28: cannot constrain "boom" <: never`},
+			name: "ArmlessTryIsRejected",
+			src:  `fn f() throws string { try { throw "boom" } }`,
+			wantErrs: []string{
+				"1:24-1:44: `try` needs a `catch` clause; without one it handles nothing, so drop the `try` and keep the block",
+			},
+		},
+		{
+			// The block's `throw` is checked against the enclosing clause exactly as it
+			// would be with no `try` around it, so the missing clause is the only extra
+			// diagnostic.
+			name: "TheBlockStillReachesTheEnclosingClause",
+			src:  `fn f() { try { throw "boom" } }`,
+			wantErrs: []string{
+				"1:10-1:30: `try` needs a `catch` clause; without one it handles nothing, so drop the `try` and keep the block",
+				`1:22-1:28: cannot constrain "boom" <: never`,
+			},
 		},
 	})
 }

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -281,8 +281,8 @@ func TestInferTryCatchValue(t *testing.T) {
 }
 
 // A fully handled `try` leaves the enclosing clause unreached, so the unused-clause warning
-// PR10 added still fires. The nested sink is what makes that visible: the body's exceptional
-// exits were all consumed inside the `try`.
+// still fires. The nested sink is what makes that visible: every exceptional exit the body
+// has was consumed inside the `try`.
 func TestInferTryCatchLeavesAnUnusedClauseUnused(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f() throws string { try { throw "boom" } catch { e => 0 } }`)
 	require.Len(t, errs, 1)

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -139,29 +139,78 @@ func TestInferTryCatchRethrowsWhatTheArmsLeave(t *testing.T) {
 }
 
 // The catch arms are what handle an exception, so a `try` without them handles nothing and
-// is rejected. The block recovers as if written on its own, which keeps the missing clause
+// is rejected. The block recovers as if written on its own, which keeps the missing arms
 // to a single diagnostic: its throws reach the enclosing sink unchanged, with no caught
 // binding and no open tail added on top.
-func TestInferTryWithoutCatchIsRejected(t *testing.T) {
+func TestInferTryWithoutCatchArmsIsRejected(t *testing.T) {
 	runThrowsErrCases(t, []throwsErrCase{
 		{
-			name: "ArmlessTryIsRejected",
+			name: "OmittedCatchIsRejected",
 			src:  `fn f() throws string { try { throw "boom" } }`,
 			wantErrs: []string{
-				"1:24-1:44: `try` needs a `catch` clause; without one it handles nothing, so drop the `try` and keep the block",
+				"1:24-1:44: `try` needs at least one catch arm; with none it handles nothing, so drop the `try` and keep the block",
+			},
+		},
+		{
+			// A written `catch { }` reaches the same diagnostic, since ast.TryCatchExpr
+			// records only the arms and both forms leave that slice empty. The message asks
+			// for an arm rather than for a `catch` clause, so it stays true here, and the
+			// span covers the empty braces so the blame lands where the arm goes.
+			name: "WrittenButEmptyCatchIsRejected",
+			src:  `fn f() throws string { try { throw "boom" } catch { } }`,
+			wantErrs: []string{
+				"1:24-1:54: `try` needs at least one catch arm; with none it handles nothing, so drop the `try` and keep the block",
 			},
 		},
 		{
 			// The block's `throw` is checked against the enclosing clause exactly as it
-			// would be with no `try` around it, so the missing clause is the only extra
+			// would be with no `try` around it, so the missing arms are the only extra
 			// diagnostic.
 			name: "TheBlockStillReachesTheEnclosingClause",
 			src:  `fn f() { try { throw "boom" } }`,
 			wantErrs: []string{
-				"1:10-1:30: `try` needs a `catch` clause; without one it handles nothing, so drop the `try` and keep the block",
+				"1:10-1:30: `try` needs at least one catch arm; with none it handles nothing, so drop the `try` and keep the block",
 				`1:22-1:28: cannot constrain "boom" <: never`,
 			},
 		},
+	})
+}
+
+// A `try` at module top level has no funcCtx to hold its nested sink, so it installs the
+// checker's module-level one instead. Without that the block collects nothing and every
+// caught binding reads `unknown`.
+func TestInferTryCatchAtModuleTopLevel(t *testing.T) {
+	t.Run("CaughtBindingCollectsTheBlocksThrows", func(t *testing.T) {
+		values, _, errs := inferSource(t, `val caught = try { throw "fail" } catch { msg => msg }`)
+		require.Empty(t, errs)
+		require.Equal(t, `"fail" | ...`, values["caught"])
+	})
+
+	t.Run("TheSinkDoesNotLeakBetweenDecls", func(t *testing.T) {
+		// The install is undone when the block finishes, so a later `try` over a quiet
+		// block collects nothing rather than inheriting the earlier block's throws.
+		values, _, errs := inferSource(t, `
+			val a = try { throw "one" } catch { e => e }
+			val b = try { val q = 1 } catch { e => e }
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, `"one" | ...`, values["a"])
+		require.Equal(t, "unknown", values["b"])
+	})
+
+	t.Run("ANestedFunctionKeepsItsOwnSink", func(t *testing.T) {
+		// throwsSink reads the module-level sink only when there is no funcCtx, so a
+		// function declared inside the block collects into its own signature. The block
+		// diverges, so the binding is the caught type alone, and `"inner"` is absent from
+		// it while the block's own `"outer"` is there.
+		values, _, errs := inferSource(t, `
+			val caught = try {
+				val g = fn () throws _ { throw "inner" }
+				throw "outer"
+			} catch { e => e }
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, `"outer" | ...`, values["caught"])
 	})
 }
 

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -1,0 +1,293 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A `try` block collects what it raises into a sink of its own, so an exception the catch
+// arms handle never reaches the enclosing function's clause. A catch-all handles the whole
+// caught union, tail included, which is what lets a function with no `throws` clause wrap a
+// call to a throwing one.
+func TestInferTryCatchHandlesWithACatchAll(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "CatchAllLetsAClauselessFunctionThrow",
+			src:  `fn f() { try { throw "boom" } catch { e => 0 } }`,
+			want: "fn () -> void",
+		},
+		{
+			name: "CatchAllLetsAClauselessFunctionCallAThrowingCallee",
+			src: `
+				fn a() throws string { throw "boom" }
+				fn f() { try { a() } catch { e => 0 } }
+			`,
+			want: "fn () -> void",
+		},
+		{
+			// A catch arm body is walked against the enclosing sink, not the nested one, so
+			// an exception it raises propagates the way any other exit does.
+			name: "AnArmBodyRaisesIntoTheEnclosingClause",
+			src:  `fn f() throws _ { try { throw "boom" } catch { e => throw 5 } }`,
+			want: "fn () -> never throws 5",
+		},
+	})
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// The arm's own `throw` has no clause to reach, so it is rejected at the throw
+			// exactly as it would be outside a `try`.
+			name:     "AnArmBodyStillNeedsAClause",
+			src:      `fn f() { try { throw "boom" } catch { e => throw 5 } }`,
+			wantErrs: []string{"1:50-1:51: cannot constrain 5 <: never"},
+		},
+	})
+}
+
+// The caught union is open. Any call can raise something no signature predicted, so the
+// members the try block is known to raise are only the part the type system can name.
+func TestInferTryCatchBindsAnInexactUnion(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			// The arm returns the caught binding, so the function's return type is the
+			// caught type.
+			name: "CaughtBindingCarriesAnOpenTail",
+			src:  `fn f() { try { throw "boom" } catch { e => { return e } } }`,
+			want: `fn () -> "boom" | ...`,
+		},
+		{
+			name: "CaughtBindingUnionsEveryRaisedType",
+			src: `
+				fn f(c: boolean) {
+					try {
+						if c { throw "boom" } else { throw 5 }
+					} catch {
+						e => { return e }
+					}
+				}
+			`,
+			want: `fn (c: boolean) -> 5 | "boom" | ...`,
+		},
+		{
+			// A block with no known exceptional exit still binds something, since the tail
+			// is what remains. `unknown` is that tail on its own.
+			name: "CaughtBindingOfAQuietBlockIsUnknown",
+			src: `
+				fn f() {
+					try {
+						val x = 1
+					} catch {
+						e => { return e }
+					}
+				}
+			`,
+			want: "fn () -> unknown",
+		},
+	})
+}
+
+// Without a catch-all the arms leave part of the caught union unhandled, and the compiler
+// rethrows it rather than reporting the arms non-exhaustive. What reaches the enclosing
+// clause is the members no arm covers, plus the open tail.
+func TestInferTryCatchRethrowsWhatTheArmsLeave(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "UncoveredMemberReachesTheClause",
+			src: `
+				fn f(c: boolean) throws _ {
+					try {
+						if c { throw "boom" } else { throw 5 }
+					} catch {
+						5 => 0
+					}
+				}
+			`,
+			want: `fn (c: boolean) -> void throws "boom" | ...`,
+		},
+		{
+			// Covering every named member leaves only the tail, so the clause is `unknown`.
+			// Nothing short of a catch-all closes an open union.
+			name: "CoveringEveryMemberStillLeavesTheTail",
+			src:  `fn f() throws _ { try { throw "boom" } catch { "boom" => 0 } }`,
+			want: "fn () -> void throws unknown",
+		},
+		{
+			// A guarded arm can always fail its guard, so it covers nothing and its member
+			// is rethrown alongside the tail.
+			name: "AGuardedArmCoversNothing",
+			src:  `fn f() throws _ { try { throw "boom" } catch { "boom" if true => 0 } }`,
+			want: `fn () -> void throws "boom" | ...`,
+		},
+	})
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// A clause-less function raises `never`, which is closed, so both the rethrown
+			// member and the open tail are rejected against it.
+			name: "RethrowNeedsAClause",
+			src:  `fn f() { try { throw "boom" } catch { 5 => 0 } }`,
+			wantErrs: []string{
+				`1:10-1:45: cannot constrain "boom" | ... <: never`,
+				`1:22-1:28: cannot constrain "boom" <: never`,
+			},
+		},
+		{
+			name:     "TheBareTailNeedsAClauseToo",
+			src:      `fn f() { try { throw "boom" } catch { "boom" => 0 } }`,
+			wantErrs: []string{"1:10-1:50: cannot constrain unknown <: never"},
+		},
+	})
+}
+
+// A `try` with no `catch` clause inspects nothing, so it is transparent: the block's
+// throws reach the enclosing clause unchanged, with no caught binding and no open tail.
+func TestInferTryWithoutCatchIsTransparent(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "ThrowsPassThroughUnwidened",
+			src:  `fn f() throws string { try { throw "boom" } }`,
+			want: "fn () -> never throws string",
+		},
+	})
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name:     "AClauselessFunctionIsStillRejected",
+			src:      `fn f() { try { throw "boom" } }`,
+			wantErrs: []string{`1:22-1:28: cannot constrain "boom" <: never`},
+		},
+	})
+}
+
+// A `try` inside another `try`'s block installs its own sink over the outer one, so the
+// inner form's leftovers reach the OUTER arms rather than the function's clause.
+func TestInferTryCatchNests(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "InnerRemainderReachesTheOuterArms",
+			src: `
+				fn f(c: boolean) {
+					try {
+						try {
+							if c { throw "boom" } else { throw 5 }
+						} catch {
+							5 => 0
+						}
+					} catch {
+						e => { return e }
+					}
+				}
+			`,
+			want: `fn (c: boolean) -> "boom" | ...`,
+		},
+		{
+			// The outer catch-all closes what the inner form left over, so the function
+			// still needs no clause.
+			name: "AnOuterCatchAllAbsorbsTheInnerRemainder",
+			src: `
+				fn f() {
+					try {
+						try { throw "boom" } catch { 5 => 0 }
+					} catch {
+						e => 1
+					}
+				}
+			`,
+			want: "fn () -> void",
+		},
+		{
+			// A nested function owns its own throws sink, so a `try` in the enclosing body
+			// never collects what the inner function raises.
+			name: "ANestedFunctionsThrowsAreNotCaught",
+			src: `
+				fn f() {
+					try {
+						val g = fn () throws _ { throw "inner" }
+						val y = 1
+					} catch {
+						e => 0
+					}
+				}
+			`,
+			want: "fn () -> void",
+		},
+		{
+			// The nested sink is minted at the enclosing body's level, not at the deeper
+			// level a `val` initializer is typed at. A sink minted deep would be extruded by
+			// a later exceptional exit, and the resulting cycle would render as a μ-knot.
+			name: "SinkInAValInitializerStaysAtTheBodyLevel",
+			src: `
+				fn a() throws string { throw "boom" }
+				fn f() throws _ {
+					val x = try { a() } catch { 5 => 0 }
+					return x
+				}
+			`,
+			want: "fn () -> 0 throws string | ...",
+		},
+	})
+}
+
+// A class-shaped catch arm covers the member whose class it names and leaves the rest.
+// Coverage is decided by the same relation `match` exhaustiveness reads, so an instance
+// pattern covers a nominal member exactly as it does in a `match`.
+func TestInferTryCatchOverClassErrors(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "AnUnnamedClassMemberIsRethrown",
+			src: `
+				class FooError { msg: string, constructor(mut self, msg: string) { self.msg = msg } }
+				class BarError { msg: string, constructor(mut self, msg: string) { self.msg = msg } }
+				fn a() throws FooError | BarError { throw FooError("x") }
+				fn f() throws _ { try { a() } catch { FooError{msg} => msg } }
+			`,
+			want: "fn () -> void throws BarError | ...",
+		},
+		{
+			// The arm binds the narrowed member, so `msg` is the named class's field rather
+			// than a property read against the whole caught union.
+			name: "AnArmDestructuresTheMemberItNames",
+			src: `
+				class FooError { msg: string, constructor(mut self, msg: string) { self.msg = msg } }
+				class BarError { code: number, constructor(mut self, code: number) { self.code = code } }
+				fn a() throws FooError | BarError { throw FooError("x") }
+				fn f() { try { a() } catch { FooError{msg} => { return msg }, e => { return 0 } } }
+			`,
+			want: "fn () -> string | 0",
+		},
+	})
+}
+
+// The form's value is the join of the try block's tail value and each non-diverging arm
+// body, the same branch join `match` builds from its arms.
+func TestInferTryCatchValue(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "ValueJoinsTheBlockAndTheArms",
+			src:  `fn f() { return try { 1 } catch { e => 2 } }`,
+			want: "fn () -> 1 | 2",
+		},
+		{
+			// A diverging arm contributes nothing, so only the block's value survives.
+			name: "ADivergingArmDropsOutOfTheJoin",
+			src:  `fn f() throws _ { return try { 1 } catch { e => throw 5 } }`,
+			want: "fn () -> 1 throws 5",
+		},
+		{
+			// Every path leaves, so the form diverges and the body reaches no normal exit.
+			name: "EveryPathDivergingMakesTheFormDiverge",
+			src:  `fn f() -> never throws _ { try { throw "boom" } catch { e => throw 5 } }`,
+			want: "fn () -> never throws 5",
+		},
+	})
+}
+
+// A fully handled `try` leaves the enclosing clause unreached, so the unused-clause warning
+// PR10 added still fires. The nested sink is what makes that visible: the body's exceptional
+// exits were all consumed inside the `try`.
+func TestInferTryCatchLeavesAnUnusedClauseUnused(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() throws string { try { throw "boom" } catch { e => 0 } }`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"1:15-1:21: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
+		msgWithSpan(errs[0]))
+	require.Equal(t, "fn () -> void throws string", values["f"])
+}

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 // A `try` block collects what it raises into a sink of its own, so an exception the catch
-// arms handle never reaches the enclosing function's clause. A catch-all handles the whole
-// caught union, tail included, which is what lets a function with no `throws` clause wrap a
-// call to a throwing one.
+// arms cover never reaches the enclosing function's clause. A catch-all covers every member
+// at once, so it always leaves the clause untouched, whatever the block raises. Naming each
+// member individually does the same job where the block's throws are known, which
+// TestInferTryCatchRethrowsWhatTheArmsLeave covers.
 func TestInferTryCatchHandlesWithACatchAll(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
@@ -46,6 +47,10 @@ func TestInferTryCatchHandlesWithACatchAll(t *testing.T) {
 
 // The caught union is open. Any call can raise something no signature predicted, so the
 // members the try block is known to raise are only the part the type system can name.
+//
+// This is the one place the tail is rendered. A rethrow drops it, since a throws clause is
+// open already and would gain nothing from carrying it, but a catch arm matches an actual
+// value and has to reckon with one the block did not predict.
 func TestInferTryCatchBindsAnInexactUnion(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
@@ -88,7 +93,14 @@ func TestInferTryCatchBindsAnInexactUnion(t *testing.T) {
 
 // Without a catch-all the arms leave part of the caught union unhandled, and the compiler
 // rethrows it rather than reporting the arms non-exhaustive. What reaches the enclosing
-// clause is the members no arm covers, plus the open tail.
+// clause is the members no arm covers.
+//
+// The caught union's open tail is NOT among them, even though no arm short of a catch-all
+// covers it. Every throws type is already open, since any call can raise something its
+// signature did not name, so carrying the tail into the clause would re-state that once per
+// `try` and, since only `unknown` can hold it, erase every named type the clause had. The
+// tail stays where it is observable, on the caught binding, which
+// TestInferTryCatchBindsAnInexactUnion covers.
 func TestInferTryCatchRethrowsWhatTheArmsLeave(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
@@ -102,52 +114,42 @@ func TestInferTryCatchRethrowsWhatTheArmsLeave(t *testing.T) {
 					}
 				}
 			`,
-			want: `fn (c: boolean) -> void throws "boom" | ...`,
+			want: `fn (c: boolean) -> void throws "boom"`,
 		},
 		{
-			// Covering every named member leaves only the tail, so the clause is `unknown`.
-			// Nothing short of a catch-all closes an open union.
-			name: "CoveringEveryMemberStillLeavesTheTail",
-			src:  `fn f() throws _ { try { throw "boom" } catch { "boom" => 0 } }`,
-			want: "fn () -> void throws unknown",
+			// Nothing known escapes, so the clause is untouched and a caller with no clause
+			// of its own is legal. This is the point of covering the members a callee
+			// declares: the handling is what removes the obligation.
+			name: "CoveringEveryKnownMemberLeavesNoClause",
+			src:  `fn f() { try { throw "boom" } catch { "boom" => 0 } }`,
+			want: "fn () -> void",
 		},
 		{
 			// A guarded arm can always fail its guard, so it covers nothing and its member
-			// is rethrown alongside the tail.
+			// is rethrown.
 			name: "AGuardedArmCoversNothing",
 			src:  `fn f() throws _ { try { throw "boom" } catch { "boom" if true => 0 } }`,
-			want: `fn () -> void throws "boom" | ...`,
+			want: `fn () -> void throws "boom"`,
 		},
 	})
 	runThrowsErrCases(t, []throwsErrCase{
 		{
-			// A clause-less function raises `never`, which is closed, so the rethrow has
-			// nowhere to land. The blame is the try/catch, not the `throw "boom"` inside the
-			// block: that `throw` IS caught, and what fails is the re-raise past the arms.
-			// One diagnostic covers it, since only a catch-all resolves either half.
+			// A clause-less function raises `never`, so an uncovered member has nowhere to
+			// land. The blame is the try/catch, not the `throw "boom"` inside the block:
+			// that `throw` IS caught, and what fails is the re-raise past the arms.
 			name: "RethrowNeedsAClause",
 			src:  `fn f() { try { throw "boom" } catch { 5 => 0 } }`,
 			wantErrs: []string{
-				"1:10-1:45: the catch arms leave \"boom\" | ... uncovered, so it is rethrown, and the enclosing `throws never` does not admit it. Add a catch-all arm; only a catch-all closes a caught union's open tail",
+				"1:10-1:45: the catch arms leave \"boom\" uncovered, so it is rethrown, and the enclosing `throws never` does not admit it. Cover it with a catch arm, or widen the enclosing clause",
 			},
 		},
 		{
-			// Covering the one named member leaves the open tail, spelled `unknown`, and it
-			// is rethrown on its own.
-			name: "TheBareTailNeedsAClauseToo",
-			src:  `fn f() { try { throw "boom" } catch { "boom" => 0 } }`,
+			// A clause narrower than what escapes fails the same way. Only the uncovered
+			// member is named, so the diagnostic points at the one type to account for.
+			name: "RethrowMustSatisfyANarrowClause",
+			src:  `fn f(c: boolean) throws string { try { if c { throw "a" } else { throw 5 } } catch { "a" => 0 } }`,
 			wantErrs: []string{
-				"1:10-1:50: the catch arms leave unknown uncovered, so it is rethrown, and the enclosing `throws never` does not admit it. Add a catch-all arm; only a catch-all closes a caught union's open tail",
-			},
-		},
-		{
-			// A member the enclosing clause does admit passes through, so only the tail is
-			// left to reject. The clause being narrower than `unknown` is what fails, and a
-			// catch-all is still the remedy.
-			name: "ANarrowClauseStillCannotCarryTheTail",
-			src:  `fn f(c: boolean) throws string { try { if c { throw "a" } else { throw "b" } } catch { "a" => 0 } }`,
-			wantErrs: []string{
-				"1:34-1:96: the catch arms leave \"b\" | ... uncovered, so it is rethrown, and the enclosing `throws string` does not admit it. Add a catch-all arm; only a catch-all closes a caught union's open tail",
+				"1:34-1:94: the catch arms leave 5 uncovered, so it is rethrown, and the enclosing `throws string` does not admit it. Cover it with a catch arm, or widen the enclosing clause",
 			},
 		},
 	})
@@ -322,7 +324,7 @@ func TestInferTryCatchNests(t *testing.T) {
 					return x
 				}
 			`,
-			want: "fn () -> 0 throws string | ...",
+			want: "fn () -> 0 throws string",
 		},
 	})
 }
@@ -340,7 +342,7 @@ func TestInferTryCatchOverClassErrors(t *testing.T) {
 				fn a() throws FooError | BarError { throw FooError("x") }
 				fn f() throws _ { try { a() } catch { FooError{msg} => msg } }
 			`,
-			want: "fn () -> void throws BarError | ...",
+			want: "fn () -> void throws BarError",
 		},
 		{
 			// The arm binds the narrowed member, so `msg` is the named class's field rather

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -65,6 +65,8 @@ const (
 	IfElseBranch                            // a fresh branch-join var from inferIfElse (the union of cons / alt)
 	MatchBranch                             // a fresh branch-join var from inferMatch (the union of every arm body)
 	IfValBranch                             // a fresh branch-join var from inferIfVal (the union of cons / alt)
+	TryCatchBranch                          // a fresh branch-join var from inferTryCatch (the union of the try block's value and every catch arm body)
+	CaughtThrows                            // a fresh nested throws sink from inferTryCatch (what the try block raises, before the catch arms narrow it)
 	ValElseBranch                           // a fresh branch-join var from inferValElse (the union of the matched init and a non-diverging else's fallback)
 	BorrowExprOrigin                        // a RefType minted by inferBorrow from a `&p` / `&mut p` expression
 	OwnedMutConstruction                    // an owned-mutable RefType minted for `val mut q = {…}` from a fresh literal

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,8 @@ importers:
 
   fixtures/bin_only: {}
 
+  fixtures/class_field_name_collision: {}
+
   fixtures/class_with_computed_members: {}
 
   fixtures/class_with_fluent_mutating_methods: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,6 @@ importers:
 
   fixtures/bin_only: {}
 
-  fixtures/class_field_name_collision: {}
-
   fixtures/class_with_computed_members: {}
 
   fixtures/class_with_fluent_mutating_methods: {}


### PR DESCRIPTION
Adds type inference and checking for try/catch expressions, allowing functions to handle exceptions selectively without declaring a `throws` clause for unhandled cases.

A `try` block is walked against a nested throws sink, isolating its exceptions from the enclosing function's clause. Catch arms match against the collected exceptions like `match` arms against a scrutinee, with coverage determined by the same exhaustiveness rules. Unhandled exceptions are rethrown to the enclosing sink, so a `try` narrows what a function raises rather than swallowing it entirely. A catch-all arm closes the open tail of the caught union, enabling a clauseless function to wrap a throwing callee.

Key changes:
- `inferTryCatch` types the expression by installing a nested throws sink for the block, binding catch patterns against the collected exceptions, and rethrowing uncovered members
- `walkTryBlock` swaps the throws sink for the duration of the block, then restores it, enabling nested `try` blocks to send their leftovers to outer arms
- `caughtType` builds the type catch patterns bind against: the collected exceptions reopened with a trailing `...` to account for unknown runtime exceptions
- `rethrowUnhandled` constrains uncovered members and the open tail into the enclosing sink, using the same coverage logic as `match` exhaustiveness checking
- `installThrowsSink` and `freshThrowsSink` manage sink swapping for both function bodies and module-level `try` blocks
- `MissingCatchArmError` reports when a `try` carries no catch arms, since they are required to handle exceptions
- Parser updates track the catch clause's closing brace location so empty `catch { }` spans correctly
- Control flow analysis (`exprDiverges`, `exprAlwaysExits`) treats `try/catch` like `match`: it diverges only if the block and every arm body diverge

A `try` at module top level installs its sink in `topThrows` since there is no function context to hold one. Nested functions inside a top-level `try` collect into their own signatures rather than the enclosing block's, and the sink is cleared after the block finishes so later declarations don't inherit earlier throws.

https://claude.ai/code/session_01HpSmkqXyyuNLt4Zeq3xWaG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inferring `try`/`catch` expressions, including caught, rethrown, and joined values.
  * Added validation requiring at least one catch arm.
  * Added support for exception handling at module level and within nested scopes.
  * Improved divergence analysis for `try`/`catch` control flow.

* **Bug Fixes**
  * Improved source spans and diagnostics for malformed or incomplete catch clauses.

* **Tests**
  * Added comprehensive coverage for catching, rethrowing, nesting, divergence, and diagnostic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->