### PR TITLE
Let getters and setters raise, and make a getter read an exceptional exit

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -449,11 +449,17 @@ func freeTypeVars(t Type) []*TypeVarType {
 						walk(e.SelfParam.Type)
 					}
 					walk(e.Type)
+					if e.Throws != nil {
+						walk(e.Throws)
+					}
 				case *SetterElem:
 					if e.SelfParam != nil {
 						walk(e.SelfParam.Type)
 					}
 					walk(e.Param)
+					if e.Throws != nil {
+						walk(e.Throws)
+					}
 				case *ConstructorElem:
 					walk(e.Fn)
 				case *SpreadElem:
@@ -952,13 +958,20 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 		if e.SelfParam != nil {
 			recv = p.printSelfReceiver(e.SelfParam)
 		}
-		return "get " + printObjectKeyName(e.Name) + "(" + recv + ") -> " + p.printType(e.Type)
+		// `-> R` is greedy, so a function-typed return is parenthesized once a clause
+		// follows it, matching how printFuncTail bounds a signature's return.
+		ret := p.printType(e.Type)
+		if clause := p.printThrowsClause(e.ThrowsOrNever()); clause != "" {
+			ret = p.printTypeMinPrec(e.Type, precUnion) + clause
+		}
+		return "get " + printObjectKeyName(e.Name) + "(" + recv + ") -> " + ret
 	case *SetterElem:
 		recv := ""
 		if e.SelfParam != nil {
 			recv = p.printSelfReceiver(e.SelfParam) + ", "
 		}
-		return "set " + printObjectKeyName(e.Name) + "(" + recv + "value: " + p.printType(e.Param) + ")"
+		return "set " + printObjectKeyName(e.Name) + "(" + recv + "value: " + p.printType(e.Param) + ")" +
+			p.printThrowsClause(e.ThrowsOrNever())
 	case *ConstructorElem:
 		// A class value's constructor renders as the unnamed call signature
 		// `new (params) -> ret`.
@@ -1071,21 +1084,29 @@ func (p *namedPrinter) printFuncBody(t *FuncType) string {
 	if t.Inexact {
 		ps = append(ps, "...")
 	}
-	// A `throws T` clause renders after the return type, matching the surface syntax. A
-	// function that raises nothing resolves to `never` and renders no clause, so
-	// `fn () -> number` stays the common form. That covers a coalesced throws variable
-	// nothing reached as well as a FuncType minted with no clause at all.
-	throws := t.ThrowsOrNever()
-	if isNever(throws) {
+	// A `throws T` clause renders after the return type, matching the surface syntax.
+	clause := p.printThrowsClause(t.ThrowsOrNever())
+	if clause == "" {
 		return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
 	}
 	// `-> R` is greedy, so a function-typed return is parenthesized once a clause follows
 	// it — `fn () -> (fn () -> number) throws string` — or the clause re-reads as the inner
 	// function's. precUnion bounds a function type and nothing else, precFunc being the
-	// only precedence below it. The clause itself needs no minimum: it is last, so nothing
-	// can bind across its right edge.
-	return "(" + strings.Join(ps, ", ") + ") -> " + p.printTypeMinPrec(t.Ret, precUnion) +
-		" throws " + p.printType(throws)
+	// only precedence below it.
+	return "(" + strings.Join(ps, ", ") + ") -> " + p.printTypeMinPrec(t.Ret, precUnion) + clause
+}
+
+// printThrowsClause renders a signature's ` throws T` suffix, or the empty string when
+// there is nothing to raise. A member that raises nothing resolves to `never` and renders
+// no clause, so `fn () -> number` and `get x(self) -> number` stay the common forms. That
+// covers a coalesced throws variable nothing reached as well as a signature minted with no
+// clause at all. The clause needs no minimum precedence: it is last, so nothing can bind
+// across its right edge.
+func (p *namedPrinter) printThrowsClause(throws Type) string {
+	if isNever(throws) {
+		return ""
+	}
+	return " throws " + p.printType(throws)
 }
 
 // isNever reports whether t is the `never` type.

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -958,13 +958,14 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 		if e.SelfParam != nil {
 			recv = p.printSelfReceiver(e.SelfParam)
 		}
-		// `-> R` is greedy, so a function-typed return is parenthesized once a clause
-		// follows it, matching how printFuncTail bounds a signature's return.
-		ret := p.printType(e.Type)
-		if clause := p.printThrowsClause(e.ThrowsOrNever()); clause != "" {
-			ret = p.printTypeMinPrec(e.Type, precUnion) + clause
+		clause := p.printThrowsClause(e.ThrowsOrNever())
+		if clause == "" {
+			return "get " + printObjectKeyName(e.Name) + "(" + recv + ") -> " + p.printType(e.Type)
 		}
-		return "get " + printObjectKeyName(e.Name) + "(" + recv + ") -> " + ret
+		// `-> R` is greedy, so a function-typed return is parenthesized once a clause
+		// follows it, the same bound printFuncBody puts on a signature's return.
+		return "get " + printObjectKeyName(e.Name) + "(" + recv + ") -> " +
+			p.printTypeMinPrec(e.Type, precUnion) + clause
 	case *SetterElem:
 		recv := ""
 		if e.SelfParam != nil {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -373,8 +373,8 @@ type SetterElem struct {
 	SelfParam *FuncParam // nil ⇒ static setter; non-nil ⇒ instance setter
 	Param     Type
 	// Throws is the type writing this property may raise. It is covariant even though
-	// Param is contravariant, since what a write raises flows out to the writer just as
-	// what a getter raises flows out to the reader. Nil reads as `never`.
+	// Param is contravariant. What a write raises flows out to the writer, just as what a
+	// getter raises flows out to the reader. Nil reads as `never`.
 	Throws Type
 }
 

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -350,6 +350,18 @@ type GetterElem struct {
 	Name      string
 	SelfParam *FuncParam // nil ⇒ static getter; non-nil ⇒ instance getter
 	Type      Type
+	// Throws is the type reading this property may raise, the twin of FuncType.Throws
+	// and covariant like it. Nil reads as `never`, so the zero value is non-throwing.
+	Throws Type
+}
+
+// ThrowsOrNever returns the type reading e may raise, resolving the nil shorthand to the
+// `never` it stands for, so no reader of the throws position has to test for nil.
+func (e *GetterElem) ThrowsOrNever() Type {
+	if e.Throws == nil {
+		return &NeverType{}
+	}
+	return e.Throws
 }
 
 // SetterElem is a computed write property `set x(self, v: T)`. Param is the value the
@@ -360,6 +372,19 @@ type SetterElem struct {
 	Name      string
 	SelfParam *FuncParam // nil ⇒ static setter; non-nil ⇒ instance setter
 	Param     Type
+	// Throws is the type writing this property may raise. It is covariant even though
+	// Param is contravariant, since what a write raises flows out to the writer just as
+	// what a getter raises flows out to the reader. Nil reads as `never`.
+	Throws Type
+}
+
+// ThrowsOrNever returns the type writing e may raise, resolving the nil shorthand to the
+// `never` it stands for, so no reader of the throws position has to test for nil.
+func (e *SetterElem) ThrowsOrNever() Type {
+	if e.Throws == nil {
+		return &NeverType{}
+	}
+	return e.Throws
 }
 
 // ConstructorElem is the call signature a class value carries. It is the constructor a
@@ -1354,9 +1379,9 @@ func levelOfElem(e ObjTypeElem) int {
 		}
 		return m
 	case *GetterElem:
-		return max(selfLevel(e.SelfParam), LevelOf(e.Type))
+		return max(selfLevel(e.SelfParam), LevelOf(e.Type), throwsLevel(e.Throws))
 	case *SetterElem:
-		return max(selfLevel(e.SelfParam), LevelOf(e.Param))
+		return max(selfLevel(e.SelfParam), LevelOf(e.Param), throwsLevel(e.Throws))
 	case *ConstructorElem:
 		return LevelOf(e.Fn)
 	case *SpreadElem:
@@ -1385,6 +1410,16 @@ func selfLevel(self *FuncParam) int {
 		return 0
 	}
 	return LevelOf(self.Type)
+}
+
+// throwsLevel returns the level of an accessor's throws position, 0 for the nil shorthand
+// that stands for `never`. `never` is a childless leaf at level 0, so the shorthand and an
+// explicit `never` agree without materializing one.
+func throwsLevel(throws Type) int {
+	if throws == nil {
+		return 0
+	}
+	return LevelOf(throws)
 }
 
 // maxMemberLevel returns the highest LevelOf across a Union/Intersection's members,

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -623,8 +623,8 @@ func AcceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 	case *GetterElem:
 		self, selfChanged := acceptSelfParam(e.SelfParam, v, pol) // receiver contravariant
 		rt := e.Type.Accept(v, pol)                               // covariant read
-		// A nil Throws is the `never` shorthand and has nothing to walk, the same
-		// collapse FuncType's visit takes over its own throws position.
+		// A nil Throws is the `never` shorthand and has nothing to walk, the same way
+		// FuncType's visit leaves its own nil throws position alone.
 		throws := e.Throws
 		if throws != nil {
 			throws = throws.Accept(v, pol) // covariant, like the read

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -623,17 +623,27 @@ func AcceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 	case *GetterElem:
 		self, selfChanged := acceptSelfParam(e.SelfParam, v, pol) // receiver contravariant
 		rt := e.Type.Accept(v, pol)                               // covariant read
-		if !selfChanged && rt == e.Type {
+		// A nil Throws is the `never` shorthand and has nothing to walk, the same
+		// collapse FuncType's visit takes over its own throws position.
+		throws := e.Throws
+		if throws != nil {
+			throws = throws.Accept(v, pol) // covariant, like the read
+		}
+		if !selfChanged && rt == e.Type && throws == e.Throws {
 			return e
 		}
-		return &GetterElem{Name: e.Name, SelfParam: self, Type: rt}
+		return &GetterElem{Name: e.Name, SelfParam: self, Type: rt, Throws: throws}
 	case *SetterElem:
 		self, selfChanged := acceptSelfParam(e.SelfParam, v, pol) // receiver contravariant
 		pt := e.Param.Accept(v, pol.Flip())                       // contravariant write
-		if !selfChanged && pt == e.Param {
+		throws := e.Throws
+		if throws != nil {
+			throws = throws.Accept(v, pol) // covariant, unlike the written value
+		}
+		if !selfChanged && pt == e.Param && throws == e.Throws {
 			return e
 		}
-		return &SetterElem{Name: e.Name, SelfParam: self, Param: pt}
+		return &SetterElem{Name: e.Name, SelfParam: self, Param: pt, Throws: throws}
 	case *MethodElem:
 		sigs, changed := acceptSignatures(e.Signatures, v, pol)
 		if !changed {

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -720,27 +720,36 @@ func (c *checker) raiseAccessorThrows(lvl int, blame ast.Node, throws soltype.Ty
 // raiseUnionAccessorThrows records what reading `name` off a union receiver may raise.
 // constrainUnionFieldRead joins the read's VALUE across the union's members from inside
 // constrain, which holds no throws sink. Only the inference walk holds one, so this walks
-// the same members to reach the getters that join reads through. A member carrying
-// `name` as a plain property, a method, or a setter raises nothing on a read and
-// contributes no constraint. A carrier that is not a union is left alone, as is a union
-// member that is neither an object nor a class instance, matching the shapes join accepts.
+// the same members to reach the getters that join reads through. A carrier that is not a
+// union is left alone. A member carrying `name` as a plain property, a method, or a setter
+// raises nothing on a read and contributes no constraint.
+//
+// The scan collects before it raises so that it accepts exactly the receivers the join
+// accepts. The join abandons the whole read once ANY member carries no readable object,
+// falling back to the strict every-member subtyping rule, and then no member's getter runs.
+// `A | undefined` is such a receiver. Raising per member as the scan went would blame that
+// read for a raise it never performs, on top of the errors the fallback already reports.
 func (c *checker) raiseUnionAccessorThrows(lvl int, blame ast.Node, name string, carrier soltype.Type) {
 	u, isUnion := carrier.(*soltype.UnionType)
 	if !isUnion {
 		return
 	}
+	var throws []soltype.Type
 	for _, member := range u.Types {
 		obj, ok := c.ctx.readCarrierObject(soltype.CarrierOf(member))
 		if !ok {
-			continue
+			return
 		}
-		elem, found := obj.Member(name)
+		elem, found := obj.ReadMember(name)
 		if !found {
 			continue
 		}
 		if getter, isGetter := elem.(*soltype.GetterElem); isGetter {
-			c.raiseAccessorThrows(lvl, blame, getter.ThrowsOrNever())
+			throws = append(throws, getter.ThrowsOrNever())
 		}
+	}
+	for _, t := range throws {
+		c.raiseAccessorThrows(lvl, blame, t)
 	}
 }
 

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -703,12 +703,9 @@ func (c *checker) writeMember(name string, carrier soltype.Type) (soltype.ObjTyp
 // raiseAccessorThrows records that an accessor access raises `throws` into the enclosing
 // body's throws sink, the same wiring inferCall gives a call. A body with no clause has a
 // `never` sink, so a raising accessor is rejected at the access site rather than reading as
-// non-throwing to the caller.
-//
-// An accessor declared to raise nothing hands over `never` and is skipped outright, leaving
-// the enclosing `throws` clause counting as unused. Anything else marks the body as raising.
-// That includes a throws position still holding an unsolved variable, which is how inferCall
-// treats an unresolved callee.
+// non-throwing to the caller. A `never` throws is skipped outright, leaving the enclosing
+// clause counting as unused; anything else, an unsolved variable included, marks the body
+// as raising, matching how inferCall treats an unresolved callee.
 func (c *checker) raiseAccessorThrows(lvl int, blame ast.Node, throws soltype.Type) {
 	if isNeverType(throws) {
 		return
@@ -718,17 +715,11 @@ func (c *checker) raiseAccessorThrows(lvl int, blame ast.Node, throws soltype.Ty
 }
 
 // raiseUnionAccessorThrows records what reading `name` off a union receiver may raise.
-// constrainUnionFieldRead joins the read's VALUE across the union's members from inside
-// constrain, which holds no throws sink. Only the inference walk holds one, so this walks
-// the same members to reach the getters that join reads through. A carrier that is not a
-// union is left alone. A member carrying `name` as a plain property, a method, or a setter
-// raises nothing on a read and contributes no constraint.
-//
-// The scan collects before it raises so that it accepts exactly the receivers the join
-// accepts. The join abandons the whole read once ANY member carries no readable object,
-// falling back to the strict every-member subtyping rule, and then no member's getter runs.
-// `A | undefined` is such a receiver. Raising per member as the scan went would blame that
-// read for a raise it never performs, on top of the errors the fallback already reports.
+// constrainUnionFieldRead joins the read's value across the union's members from inside
+// constrain, which holds no throws sink, so this walks the same members to reach the getters
+// that join reads through. Only a getter contributes; a property, method, or setter raises
+// nothing on a read. It collects before it raises because the join abandons the whole read
+// once any member carries no readable object, as `A | undefined` does, and then no getter runs.
 func (c *checker) raiseUnionAccessorThrows(lvl int, blame ast.Node, name string, carrier soltype.Type) {
 	u, isUnion := carrier.(*soltype.UnionType)
 	if !isUnion {

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -638,7 +638,7 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 		out = m.Type
 	case *soltype.GetterElem:
 		// Reading through a getter runs its body, so the read is an exceptional exit of
-		// the enclosing body the way a call is. A method read is not: reading `p.m` only
+		// the enclosing body the way a call is. A method read is not. Reading `p.m` only
 		// names the function, and its throws stays in the signature until it is called.
 		c.raiseAccessorThrows(lvl, blame, m.ThrowsOrNever())
 		out = m.Type
@@ -703,8 +703,12 @@ func (c *checker) writeMember(name string, carrier soltype.Type) (soltype.ObjTyp
 // raiseAccessorThrows records that an accessor access raises `throws` into the enclosing
 // body's throws sink, the same wiring inferCall gives a call. A body with no clause has a
 // `never` sink, so a raising accessor is rejected at the access site rather than reading as
-// non-throwing to the caller. An accessor that raises nothing constrains `never`, which
-// records nothing, and leaves the enclosing `throws` clause counting as unused.
+// non-throwing to the caller.
+//
+// An accessor declared to raise nothing hands over `never` and is skipped outright, leaving
+// the enclosing `throws` clause counting as unused. Anything else marks the body as raising.
+// That includes a throws position still holding an unsolved variable, which is how inferCall
+// treats an unresolved callee.
 func (c *checker) raiseAccessorThrows(lvl int, blame ast.Node, throws soltype.Type) {
 	if isNeverType(throws) {
 		return
@@ -714,15 +718,15 @@ func (c *checker) raiseAccessorThrows(lvl int, blame ast.Node, throws soltype.Ty
 }
 
 // raiseUnionAccessorThrows records what reading `name` off a union receiver may raise.
-// constrainUnionFieldRead joins the read's VALUE across the union's members inside
-// constrain; this walks the same members to reach the getters that join contributes, since
-// only the inference walk holds the enclosing throws sink. A member that carries `name` as
-// a plain property, a method, or a setter raises nothing on a read and contributes no
-// constraint. A carrier that is not a union, or a union member that is neither an object
-// nor a class instance, is left alone, matching the shapes that join accepts.
+// constrainUnionFieldRead joins the read's VALUE across the union's members from inside
+// constrain, which holds no throws sink. Only the inference walk holds one, so this walks
+// the same members to reach the getters that join reads through. A member carrying
+// `name` as a plain property, a method, or a setter raises nothing on a read and
+// contributes no constraint. A carrier that is not a union is left alone, as is a union
+// member that is neither an object nor a class instance, matching the shapes join accepts.
 func (c *checker) raiseUnionAccessorThrows(lvl int, blame ast.Node, name string, carrier soltype.Type) {
-	u, ok := carrier.(*soltype.UnionType)
-	if !ok {
+	u, isUnion := carrier.(*soltype.UnionType)
+	if !isUnion {
 		return
 	}
 	for _, member := range u.Types {
@@ -730,10 +734,12 @@ func (c *checker) raiseUnionAccessorThrows(lvl int, blame ast.Node, name string,
 		if !ok {
 			continue
 		}
-		if getter, ok := obj.Member(name); ok {
-			if g, isGetter := getter.(*soltype.GetterElem); isGetter {
-				c.raiseAccessorThrows(lvl, blame, g.ThrowsOrNever())
-			}
+		elem, found := obj.Member(name)
+		if !found {
+			continue
+		}
+		if getter, isGetter := elem.(*soltype.GetterElem); isGetter {
+			c.raiseAccessorThrows(lvl, blame, getter.ThrowsOrNever())
 		}
 	}
 }

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -278,9 +278,9 @@ func stripSelfReceiver(elem soltype.ObjTypeElem) soltype.ObjTypeElem {
 		}
 		return &soltype.MethodElem{Name: e.Name, Signatures: sigs, Static: e.Static}
 	case *soltype.GetterElem:
-		return &soltype.GetterElem{Name: e.Name, Type: e.Type}
+		return &soltype.GetterElem{Name: e.Name, Type: e.Type, Throws: e.Throws}
 	case *soltype.SetterElem:
-		return &soltype.SetterElem{Name: e.Name, Param: e.Param}
+		return &soltype.SetterElem{Name: e.Name, Param: e.Param, Throws: e.Throws}
 	default:
 		return elem
 	}
@@ -637,6 +637,10 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 	case *soltype.PropertyElem:
 		out = m.Type
 	case *soltype.GetterElem:
+		// Reading through a getter runs its body, so the read is an exceptional exit of
+		// the enclosing body the way a call is. A method read is not: reading `p.m` only
+		// names the function, and its throws stays in the signature until it is called.
+		c.raiseAccessorThrows(lvl, blame, m.ThrowsOrNever())
 		out = m.Type
 	case *soltype.MethodElem:
 		switch len(m.Signatures) {
@@ -694,6 +698,44 @@ func (c *checker) writeMember(name string, carrier soltype.Type) (soltype.ObjTyp
 		return obj.WriteMember(name)
 	}
 	return nil, false
+}
+
+// raiseAccessorThrows records that an accessor access raises `throws` into the enclosing
+// body's throws sink, the same wiring inferCall gives a call. A body with no clause has a
+// `never` sink, so a raising accessor is rejected at the access site rather than reading as
+// non-throwing to the caller. An accessor that raises nothing constrains `never`, which
+// records nothing, and leaves the enclosing `throws` clause counting as unused.
+func (c *checker) raiseAccessorThrows(lvl int, blame ast.Node, throws soltype.Type) {
+	if isNeverType(throws) {
+		return
+	}
+	c.markRaised()
+	c.constrain(blame, throws, c.throwsSink(lvl))
+}
+
+// raiseUnionAccessorThrows records what reading `name` off a union receiver may raise.
+// constrainUnionFieldRead joins the read's VALUE across the union's members inside
+// constrain; this walks the same members to reach the getters that join contributes, since
+// only the inference walk holds the enclosing throws sink. A member that carries `name` as
+// a plain property, a method, or a setter raises nothing on a read and contributes no
+// constraint. A carrier that is not a union, or a union member that is neither an object
+// nor a class instance, is left alone, matching the shapes that join accepts.
+func (c *checker) raiseUnionAccessorThrows(lvl int, blame ast.Node, name string, carrier soltype.Type) {
+	u, ok := carrier.(*soltype.UnionType)
+	if !ok {
+		return
+	}
+	for _, member := range u.Types {
+		obj, ok := c.ctx.readCarrierObject(soltype.CarrierOf(member))
+		if !ok {
+			continue
+		}
+		if getter, ok := obj.Member(name); ok {
+			if g, isGetter := getter.(*soltype.GetterElem); isGetter {
+				c.raiseAccessorThrows(lvl, blame, g.ThrowsOrNever())
+			}
+		}
+	}
 }
 
 // strippedMethodSig returns a method signature as a plain callable, its SelfParam

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1484,11 +1484,15 @@ func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
 		}
 		return true
 	case *soltype.GetterElem:
+		// ThrowsOrNever reads both sides through the nil-is-never collapse, so two getters
+		// differing only in whether the clause was written compare equal.
 		b, ok := b.(*soltype.GetterElem)
-		return ok && equalSelfParam(a.SelfParam, b.SelfParam, ctx) && equalTypeWith(a.Type, b.Type, ctx)
+		return ok && equalSelfParam(a.SelfParam, b.SelfParam, ctx) && equalTypeWith(a.Type, b.Type, ctx) &&
+			equalTypeWith(a.ThrowsOrNever(), b.ThrowsOrNever(), ctx)
 	case *soltype.SetterElem:
 		b, ok := b.(*soltype.SetterElem)
-		return ok && equalSelfParam(a.SelfParam, b.SelfParam, ctx) && equalTypeWith(a.Param, b.Param, ctx)
+		return ok && equalSelfParam(a.SelfParam, b.SelfParam, ctx) && equalTypeWith(a.Param, b.Param, ctx) &&
+			equalTypeWith(a.ThrowsOrNever(), b.ThrowsOrNever(), ctx)
 	case *soltype.ConstructorElem:
 		b, ok := b.(*soltype.ConstructorElem)
 		return ok && equalTypeWith(a.Fn, b.Fn, ctx)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1564,7 +1564,8 @@ func (c *Context) constrainIntoIndexSignature(sub, sup *soltype.ObjectType, supe
 // constrainObjMember checks a method, getter, or setter requirement on an object super
 // against the sub's same-named member by variance: a method by its receiver-stripped
 // callable signature (first arm; overload dispatch is E1), a getter covariantly, a setter
-// contravariantly. A missing or wrong-kind member fails.
+// contravariantly. An accessor's throws position is covariant in both cases. A missing or
+// wrong-kind member fails.
 //
 // A setter requirement resolves the sub's setter half and every other requirement its
 // getter half, so a sub carrying an accessor pair satisfies both requirements whichever
@@ -1591,11 +1592,15 @@ func (c *Context) constrainObjMember(superElem soltype.ObjTypeElem, sub, sup *so
 		return c.constrain(callableView(sm.Signatures[0]), callableView(se.Signatures[0]), seen, mutCtx)
 	case *soltype.GetterElem:
 		if sg, ok := subElem.(*soltype.GetterElem); ok {
-			return c.constrain(sg.Type, se.Type, seen, mutCtx) // covariant read
+			errs := c.constrain(sg.Type, se.Type, seen, mutCtx) // covariant read
+			// What a read raises flows out to the reader, so the throws position is
+			// covariant like the read: the source may raise no more than the target admits.
+			return append(errs, c.constrain(sg.ThrowsOrNever(), se.ThrowsOrNever(), seen, mutCtx)...)
 		}
 	case *soltype.SetterElem:
 		if ss, ok := subElem.(*soltype.SetterElem); ok {
-			return c.constrain(se.Param, ss.Param, seen, mutCtx) // contravariant write
+			errs := c.constrain(se.Param, ss.Param, seen, mutCtx) // contravariant write
+			return append(errs, c.constrain(ss.ThrowsOrNever(), se.ThrowsOrNever(), seen, mutCtx)...)
 		}
 	}
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1594,12 +1594,14 @@ func (c *Context) constrainObjMember(superElem soltype.ObjTypeElem, sub, sup *so
 		if sg, ok := subElem.(*soltype.GetterElem); ok {
 			errs := c.constrain(sg.Type, se.Type, seen, mutCtx) // covariant read
 			// What a read raises flows out to the reader, so the throws position is
-			// covariant like the read: the source may raise no more than the target admits.
+			// covariant like the read. The source may raise no more than the target admits.
 			return append(errs, c.constrain(sg.ThrowsOrNever(), se.ThrowsOrNever(), seen, mutCtx)...)
 		}
 	case *soltype.SetterElem:
 		if ss, ok := subElem.(*soltype.SetterElem); ok {
 			errs := c.constrain(se.Param, ss.Param, seen, mutCtx) // contravariant write
+			// The written value is contravariant, but what the write raises flows out to
+			// the writer, so the throws position stays covariant.
 			return append(errs, c.constrain(ss.ThrowsOrNever(), se.ThrowsOrNever(), seen, mutCtx)...)
 		}
 	}

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -560,9 +560,9 @@ func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 
 // memberSigStub builds a member's signature stub: one fresh var per value parameter,
 // preserving arity, parameter names, and optionality, plus a fresh return var and a fresh
-// throws var. A sibling call reads the stub before the body pass installs the real
-// signature, so the throws var is what carries a raising method's throws to a caller
-// inside the same class.
+// throws var. A sibling access reads the stub before the body pass installs the real
+// signature, so the throws var is what carries a raising member's throws to a call or a
+// getter read inside the same class.
 func (c *checker) memberSigStub(lvl int, fn *ast.FuncExpr) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(fn.Params))
 	for i, p := range fn.Params {
@@ -935,16 +935,16 @@ func (c *checker) freezeClassBody(obj *soltype.ObjectType, keep set.Set[*soltype
 				Name:      e.Name,
 				SelfParam: e.SelfParam,
 				Type:      coalesceKeeping(e.Type, soltype.Positive, keep, flow),
-				// The throws position is covariant, so it coalesces positively even on a
-				// setter, whose written value coalesces negatively.
-				Throws: coalesceThrows(e.Throws, keep, flow),
+				Throws:    coalesceThrows(e.Throws, keep, flow),
 			}
 		case *soltype.SetterElem:
 			obj.Elems[i] = &soltype.SetterElem{
 				Name:      e.Name,
 				SelfParam: e.SelfParam,
 				Param:     coalesceKeeping(e.Param, soltype.Negative, keep, flow),
-				Throws:    coalesceThrows(e.Throws, keep, flow),
+				// A setter's written value coalesces negatively, but what the write raises
+				// flows out to the writer, so its throws position still coalesces positively.
+				Throws: coalesceThrows(e.Throws, keep, flow),
 			}
 		case *soltype.MethodElem:
 			sigs := make([]*soltype.FuncType, len(e.Signatures))

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -472,14 +472,21 @@ func (c *checker) buildMemberSigs(
 				continue
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
-			c.reportAccessorThrows(elem.Fn, elem, "getter")
 			stub := c.memberSigStub(lvl, elem.Fn)
-			getter := &soltype.GetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Type: stub.Ret}
+			getter := &soltype.GetterElem{
+				Name:      name,
+				SelfParam: c.selfParam(elem.Receiver, elem.Static, self),
+				Type:      stub.Ret,
+				Throws:    stub.Throws,
+			}
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, getter)
 			pending = append(pending, pendingMember{
 				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, stub: stub,
-				apply: func(bodyFt *soltype.FuncType) { getter.Type = bodyFt.Ret },
+				apply: func(bodyFt *soltype.FuncType) {
+					getter.Type = bodyFt.Ret
+					getter.Throws = bodyFt.Throws
+				},
 			})
 		case *ast.SetterElem:
 			name, ok := objKeyName(elem.Name)
@@ -487,7 +494,6 @@ func (c *checker) buildMemberSigs(
 				continue
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
-			c.reportAccessorThrows(elem.Fn, elem, "setter")
 			// An instance setter mutates the instance, so it must hold mutable access to it.
 			// Report a plain `self` or shared `&self` receiver here, then keep the declared
 			// receiver on the elem so a write through it draws only this one diagnostic. An
@@ -508,7 +514,12 @@ func (c *checker) buildMemberSigs(
 			if len(stub.Params) > 0 {
 				param = stub.Params[0].Type
 			}
-			setter := &soltype.SetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Param: param}
+			setter := &soltype.SetterElem{
+				Name:      name,
+				SelfParam: c.selfParam(elem.Receiver, elem.Static, self),
+				Param:     param,
+				Throws:    stub.Throws,
+			}
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, setter)
 			pending = append(pending, pendingMember{
@@ -517,6 +528,7 @@ func (c *checker) buildMemberSigs(
 					if len(bodyFt.Params) > 0 {
 						setter.Param = bodyFt.Params[0].Type
 					}
+					setter.Throws = bodyFt.Throws
 				},
 			})
 		}
@@ -544,15 +556,6 @@ func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Throws: ft.Throws, Inexact: ft.Inexact}
 	}
 	c.constrain(node, callable(bodyFt), callable(stub))
-}
-
-// reportAccessorThrows rejects a `throws` clause on a getter or setter. Neither element
-// holds more than a bare Type, and dropping the clause would let a raising accessor read
-// as non-throwing. kind names the accessor in the message.
-func (c *checker) reportAccessorThrows(fn *ast.FuncExpr, blame ast.Node, kind string) {
-	if fn.Throws != nil {
-		c.reportUnsupportedFeature(blame, "throws clause on a "+kind)
-	}
 }
 
 // memberSigStub builds a member's signature stub: one fresh var per value parameter,
@@ -901,6 +904,16 @@ func keptFlowMap(keep set.Set[*soltype.TypeVarType]) map[*soltype.TypeVarType][]
 	return flow
 }
 
+// coalesceThrows coalesces an accessor's throws position, keeping the nil shorthand that
+// stands for `never` rather than materializing a `never` the accessor was never written
+// with. The position is covariant, so it always coalesces positively.
+func coalesceThrows(t soltype.Type, keep set.Set[*soltype.TypeVarType], flow map[*soltype.TypeVarType][]*soltype.TypeVarType) soltype.Type {
+	if t == nil {
+		return nil
+	}
+	return coalesceKeeping(t, soltype.Positive, keep, flow)
+}
+
 // freezeClassBody coalesces each member's type in place so member lookup and the
 // class-vs-object rule read concrete member types rather than the fresh vars a field held
 // before a constructor assignment refined it. Each member is coalesced individually rather
@@ -918,9 +931,21 @@ func (c *checker) freezeClassBody(obj *soltype.ObjectType, keep set.Set[*soltype
 		case *soltype.PropertyElem:
 			obj.Elems[i] = &soltype.PropertyElem{Name: e.Name, Type: coalesceKeeping(e.Type, soltype.Positive, keep, flow), Optional: e.Optional, Readonly: e.Readonly}
 		case *soltype.GetterElem:
-			obj.Elems[i] = &soltype.GetterElem{Name: e.Name, SelfParam: e.SelfParam, Type: coalesceKeeping(e.Type, soltype.Positive, keep, flow)}
+			obj.Elems[i] = &soltype.GetterElem{
+				Name:      e.Name,
+				SelfParam: e.SelfParam,
+				Type:      coalesceKeeping(e.Type, soltype.Positive, keep, flow),
+				// The throws position is covariant, so it coalesces positively even on a
+				// setter, whose written value coalesces negatively.
+				Throws: coalesceThrows(e.Throws, keep, flow),
+			}
 		case *soltype.SetterElem:
-			obj.Elems[i] = &soltype.SetterElem{Name: e.Name, SelfParam: e.SelfParam, Param: coalesceKeeping(e.Param, soltype.Negative, keep, flow)}
+			obj.Elems[i] = &soltype.SetterElem{
+				Name:      e.Name,
+				SelfParam: e.SelfParam,
+				Param:     coalesceKeeping(e.Param, soltype.Negative, keep, flow),
+				Throws:    coalesceThrows(e.Throws, keep, flow),
+			}
 		case *soltype.MethodElem:
 			sigs := make([]*soltype.FuncType, len(e.Signatures))
 			for j, sig := range e.Signatures {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1704,7 +1704,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	// below, whose element is a PropertyElem. constrain's object arm matches the sub side
 	// with ObjectType.Prop, so an accessor would read there as a missing property.
 	if accessor, ok := c.writeAccessor(m.Prop.Name, readCarrier(recv)); ok {
-		return c.inferAccessorAssign(e, m, recv, source, accessor, assignStmt)
+		return c.inferAccessorAssign(lvl, e, m, recv, source, accessor, assignStmt)
 	}
 	w := widen(source)
 	// An owned-mutable field takes the immutable→mutable upgrade through the same shared
@@ -1777,9 +1777,10 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 // inferAccessorAssign types a write `recv.prop = source` that resolved to an accessor. A
 // getter-only member is reported, having no setter to call. A setter write is a call, not
 // a store: it checks the source against the setter's parameter and the receiver against
-// its `self`. It records nothing in `written`, since a setter has no cell a later read
-// could shortcut to, and nothing in the throws sink, since a setter cannot raise until #972.
+// its `self`, and it raises whatever the setter declares. It records nothing in `written`,
+// since a setter has no cell a later read could shortcut to.
 func (c *checker) inferAccessorAssign(
+	lvl int,
 	e *ast.BinaryExpr,
 	m *ast.MemberExpr,
 	recv soltype.Type,
@@ -1793,6 +1794,11 @@ func (c *checker) inferAccessorAssign(
 		c.recordType(e, out)
 		return out
 	}
+	// Writing through a setter runs its body, so the write is an exceptional exit of the
+	// enclosing body exactly as a getter read is. This runs before errsBefore is captured,
+	// so an undeclared raise does not suppress the move the write records below — the two
+	// checks are independent.
+	c.raiseAccessorThrows(lvl, e, setter.ThrowsOrNever())
 	errsBefore := len(c.errs)
 	c.checkReceiverMut(e.Left, recv, setter.SelfParam)
 	c.constrain(e.Right, source, setter.Param)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2230,6 +2230,11 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	if res, ok := c.classValueMember(lvl, blame, name, recvCarrier); ok {
 		return res
 	}
+	// A union receiver reaches the structural requirement below, whose result is joined
+	// per member inside constrain by constrainUnionFieldRead. That join runs with no
+	// access to the enclosing throws sink, so the getters it may read through are
+	// collected here instead, where the sink is in scope.
+	c.raiseUnionAccessorThrows(lvl, blame, name, recvCarrier)
 	fieldVar := c.freshAt(lvl)
 	// The member-requirement record {prop: fieldVar} is deliberately NOT recorded —
 	// MissingPropertyError blames this inner fieldVar, so the record would be a dead

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -149,14 +149,6 @@ func TestInferThrowsFromBodyUnderAWildcardClause(t *testing.T) {
 			`,
 			want: `fn () -> 1`,
 		},
-		{
-			// A body with no `return` that always leaves along the exceptional edge
-			// reaches no normal exit, so its return type is `never`. Annotating it
-			// `-> never` says exactly that, so nothing is over-declared.
-			name: "DivergingBodyReturnsNever",
-			src:  `fn f() -> never throws _ { throw "x" }`,
-			want: `fn () -> never throws "x"`,
-		},
 	})
 }
 
@@ -168,25 +160,6 @@ func TestInferThrowsClause(t *testing.T) {
 			name: "ClauseWidensTheThrownLiteral",
 			src:  `fn f() throws string { throw "boom" }`,
 			want: "fn () -> never throws string",
-		},
-		{
-			// The clause parses on its own, with no `-> R` in front of it.
-			name: "ClauseWithoutReturnAnnotation",
-			src:  `fn f(x: number) throws string { throw "boom" }`,
-			want: "fn (x: number) -> never throws string",
-		},
-		{
-			// One path returns and the other throws, so both declarations are delivered.
-			name: "ClauseAfterReturnAnnotation",
-			src:  `fn f(c: boolean) -> number throws string { if c { return 1 } else { throw "x" } }`,
-			want: "fn (c: boolean) -> number throws string",
-		},
-		{
-			// `throws _` mints a fresh variable the body's throws flow into, so the clause
-			// asks for inference rather than fixing a type.
-			name: "WildcardClauseInfers",
-			src:  `fn f() throws _ { throw "boom" }`,
-			want: `fn () -> never throws "boom"`,
 		},
 	})
 	runThrowsErrCases(t, []throwsErrCase{
@@ -522,12 +495,6 @@ const raisingGetterClass = `
 func TestInferThrowsFromAnAccessor(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
-			// The getter's clause reaches the reader, which redeclares it as its own.
-			name: "GetterClauseReachesTheReader",
-			src:  raisingGetterClass + `fn f(c: C) -> number throws string { return c.x }`,
-			want: "fn (c: C) -> number throws string",
-		},
-		{
 			// `throws _` on the reader infers from the read, so the getter's declared
 			// `string` is what the reader raises.
 			name: "ReaderInfersTheGetterClause",
@@ -547,21 +514,6 @@ func TestInferThrowsFromAnAccessor(t *testing.T) {
 				fn f(c: C) -> number throws _ { return c.x }
 			`,
 			want: `fn (c: C) -> number throws "boom"`,
-		},
-		{
-			// A sibling member reads the getter through `self`, which resolves on the
-			// class body rather than on a projected instance, and raises the same.
-			name: "SelfReadInsideASiblingMethod",
-			src: `
-				class C {
-					v: number,
-					bad: boolean,
-					get x(self) -> number throws string { if self.bad { throw "boom" } return self.v },
-					m(self) -> number throws string { return self.x },
-				}
-				fn f(c: C) -> number throws string { return c.m() }
-			`,
-			want: "fn (c: C) -> number throws string",
 		},
 		{
 			// A static getter is read off the class VALUE, a third resolution path.
@@ -685,18 +637,6 @@ func TestInferThrowsRejectsAnUndeclaredAccessorRaise(t *testing.T) {
 				}
 			`,
 			wantErrs: []string{"6:33-6:39: cannot constrain string <: never"},
-		},
-		{
-			// Only one member of the union reads through a raising getter. The other
-			// carries `x` as a plain field, which raises nothing, so the single raise
-			// still has to be declared.
-			name: "UnionReceiverReadFromAClauselessCaller",
-			src: `
-				class A { bad: boolean, get x(self) -> number throws string { if self.bad { throw "a" } return 1 } }
-				class B { x: number }
-				fn f(c: A | B) -> number { return c.x }
-			`,
-			wantErrs: []string{"4:39-4:42: cannot constrain string <: never"},
 		},
 	})
 }
@@ -894,12 +834,6 @@ const raisingSetterClass = `
 // the setter half of the throws position is reachable from source.
 func TestInferThrowsThroughASetterWrite(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
-		{
-			// The setter's clause reaches the writer, which redeclares it as its own.
-			name: "SetterClauseReachesTheWriter",
-			src:  raisingSetterClass + `fn f(c: mut C) throws string { c.x = 5 }`,
-			want: "fn (c: mut C) -> void throws string",
-		},
 		{
 			// `throws _` on the writer infers from the write.
 			name: "WriterInfersTheSetterClause",

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -412,10 +412,6 @@ func TestInferThrowsOnClassMembers(t *testing.T) {
 // and return positions. Recovering to nil would read as `never`, so every value flowing
 // into the annotation would be re-reported for raising something on top of the one real
 // error.
-//
-// A getter or setter projects to the type its read yields or its write accepts, and
-// neither element has anywhere to record a clause, so the clause is rejected rather than
-// dropped. A raising accessor cannot read as non-throwing.
 func TestInferThrowsAnnotationRecovery(t *testing.T) {
 	runThrowsErrCases(t, []throwsErrCase{
 		{
@@ -423,25 +419,6 @@ func TestInferThrowsAnnotationRecovery(t *testing.T) {
 			name:     "UnsupportedAnnotationDoesNotCascade",
 			src:      `val f: fn() -> number throws void = fn () -> never throws _ { throw "x" }`,
 			wantErrs: []string{"1:30-1:34: Unsupported: VoidTypeAnn"},
-		},
-		{
-			// The clause draws two diagnostics: it is unsupported on an accessor at all,
-			// and the body raises nothing so it would read as unused even where it is
-			// supported. Both say to drop it.
-			name: "GetterClauseIsRejected",
-			src:  `class C { v: number, get x(self) -> number throws string { return self.v } }`,
-			wantErrs: []string{
-				"1:22-1:75: Unsupported: throws clause on a getter",
-				"1:51-1:57: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
-			},
-		},
-		{
-			name: "SetterClauseIsRejected",
-			src:  `class C { v: number, set x(mut self, v: number) throws string { self.v = v } }`,
-			wantErrs: []string{
-				"1:22-1:77: Unsupported: throws clause on a setter",
-				"1:56-1:62: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
-			},
 		},
 	})
 }
@@ -458,6 +435,22 @@ func TestInferThrowsOverDeclaredSignature(t *testing.T) {
 			src:  `fn f() -> number throws string { return 1 }`,
 			wantErrs: []string{
 				"1:25-1:31: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
+			},
+		},
+		{
+			// An accessor reads its clause the way a method does, so a getter that raises
+			// nothing draws the same warning a clause-less-body function draws.
+			name: "GetterClauseNoExceptionalExitReaches",
+			src:  `class C { v: number, get x(self) -> number throws string { return self.v } }`,
+			wantErrs: []string{
+				"1:51-1:57: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
+			},
+		},
+		{
+			name: "SetterClauseNoExceptionalExitReaches",
+			src:  `class C { v: number, set x(mut self, v: number) throws string { self.v = v } }`,
+			wantErrs: []string{
+				"1:56-1:62: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
 			},
 		},
 		{
@@ -509,6 +502,200 @@ func TestInferThrowsOverDeclaredSignature(t *testing.T) {
 			name: "BodylessDeclareFnIsNotMeasured",
 			src:  `declare fn f() -> number throws string`,
 			want: "fn () -> number throws string",
+		},
+	})
+}
+
+// A getter and a setter each declare what they raise, the same way a method does, and a
+// getter's clause reaches whoever reads the property. Reading through a getter runs its
+// body, so the read is an exceptional exit of the enclosing body just as a call is.
+func TestInferThrowsFromAnAccessor(t *testing.T) {
+	// raisingGetter declares `get x` on a class that both returns and raises, so neither
+	// over-declaration warning fires and the cases below measure only the throws flow.
+	const raisingGetter = `
+		class C {
+			v: number,
+			bad: boolean,
+			get x(self) -> number throws string { if self.bad { throw "boom" } return self.v },
+		}
+	`
+	runThrowsCases(t, []throwsCase{
+		{
+			// The getter's clause reaches the reader, which redeclares it as its own.
+			name: "GetterClauseReachesTheReader",
+			src:  raisingGetter + `fn f(c: C) -> number throws string { return c.x }`,
+			want: "fn (c: C) -> number throws string",
+		},
+		{
+			// `throws _` on the reader infers from the read, so the getter's declared
+			// `string` is what the reader raises.
+			name: "ReaderInfersTheGetterClause",
+			src:  raisingGetter + `fn f(c: C) -> number throws _ { return c.x }`,
+			want: "fn (c: C) -> number throws string",
+		},
+		{
+			// `throws _` on the GETTER infers from its body, so the reader sees the
+			// literal type the body throws rather than a declared widening of it.
+			name: "GetterInfersItsOwnClauseFromItsBody",
+			src: `
+				class C {
+					v: number,
+					bad: boolean,
+					get x(self) -> number throws _ { if self.bad { throw "boom" } return self.v },
+				}
+				fn f(c: C) -> number throws _ { return c.x }
+			`,
+			want: `fn (c: C) -> number throws "boom"`,
+		},
+		{
+			// A sibling member reads the getter through `self`, which resolves on the
+			// class body rather than on a projected instance, and raises the same.
+			name: "SelfReadInsideASiblingMethod",
+			src: `
+				class C {
+					v: number,
+					bad: boolean,
+					get x(self) -> number throws string { if self.bad { throw "boom" } return self.v },
+					m(self) -> number throws string { return self.x },
+				}
+				fn f(c: C) -> number throws string { return c.m() }
+			`,
+			want: "fn (c: C) -> number throws string",
+		},
+		{
+			// A static getter is read off the class VALUE, a third resolution path.
+			name: "StaticGetterRead",
+			src: `
+				class C {
+					bad: boolean,
+					static get x() -> number throws string { if true { throw "boom" } return 1 },
+				}
+				fn f() -> number throws string { return C.x }
+			`,
+			want: "fn () -> number throws string",
+		},
+		{
+			// A class value renders both accessors' clauses, so a raising accessor is
+			// visible in the type rather than reading as non-throwing.
+			name:    "StaticAccessorsRenderTheirClause",
+			binding: "C",
+			src: `
+				class C {
+					static get g() -> number throws string { if true { throw "g" } return 1 },
+					static set s(v: number) throws string { if true { throw "s" } },
+				}
+			`,
+			want: "{new () -> C, get g() -> number throws string, set s(value: number) throws string}",
+		},
+		{
+			// A getter on a generic class projects its return to the instance's argument
+			// while its clause, which names no class parameter, carries through unchanged.
+			name: "GenericClassGetter",
+			src: `
+				class Box<T> {
+					v: T,
+					bad: boolean,
+					get item(self) -> T throws string { if self.bad { throw "boom" } return self.v },
+				}
+				fn f(b: Box<number>) -> number throws string { return b.item }
+			`,
+			want: "fn (b: Box<number>) -> number throws string",
+		},
+		{
+			// A union receiver reads through one getter per member, so the reader raises
+			// the union of what they declare.
+			name: "UnionReceiverJoinsEveryMemberGetter",
+			src: `
+				class A { bad: boolean, get x(self) -> number throws string { if self.bad { throw "a" } return 1 } }
+				class B { bad: boolean, get x(self) -> number throws number { if self.bad { throw 2 } return 1 } }
+				fn f(c: A | B) -> number throws _ { return c.x }
+			`,
+			want: "fn (c: A | B) -> number throws number | string",
+		},
+		{
+			// Reading a METHOD only names the function; its throws stays in the signature
+			// until the method is called, so a clause-less reader is fine.
+			name: "MethodValueReadIsNotAnExceptionalExit",
+			src: `
+				class C { m(self) throws string { throw "boom" } }
+				fn f(c: C) { val g = c.m }
+			`,
+			want: "fn (c: C) -> void",
+		},
+		{
+			// An accessor that handles everything internally raises nothing, so it needs
+			// no clause and its readers need none either.
+			name: "GetterHandlingItsCalleeInternallyRaisesNothing",
+			src: `
+				fn a() throws string { throw "boom" }
+				class C { get x(self) -> number { return try { a() } catch { e => 0 } } }
+				fn f(c: C) -> number { return c.x }
+			`,
+			want: "fn (c: C) -> number",
+		},
+	})
+}
+
+// An accessor with no `throws` clause raises nothing, so every exceptional exit in its
+// body is rejected at its own site, and a read of a raising getter is rejected inside a
+// reader that declares no clause of its own.
+func TestInferThrowsRejectsAnUndeclaredAccessorRaise(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name:     "ThrowInAClauselessGetter",
+			src:      `class C { v: number, get x(self) { throw "boom" } }`,
+			wantErrs: []string{`1:42-1:48: cannot constrain "boom" <: never`},
+		},
+		{
+			name:     "ThrowInAClauselessSetter",
+			src:      `class C { v: number, set x(mut self, v: number) { throw "boom" } }`,
+			wantErrs: []string{`1:57-1:63: cannot constrain "boom" <: never`},
+		},
+		{
+			name: "CallToAThrowingCalleeFromAClauselessGetter",
+			src: `
+				fn a() throws string { throw "boom" }
+				class C { v: number, get x(self) -> number { return a() } }
+			`,
+			wantErrs: []string{"3:57-3:60: cannot constrain string <: never"},
+		},
+		{
+			// The read is the exceptional exit, so the diagnostic blames the access
+			// rather than the getter's own body, which declared its raise correctly.
+			name: "ReadOfARaisingGetterFromAClauselessCaller",
+			src: `
+				class C {
+					v: number,
+					bad: boolean,
+					get x(self) -> number throws string { if self.bad { throw "boom" } return self.v },
+				}
+				fn f(c: C) -> number { return c.x }
+			`,
+			wantErrs: []string{"7:35-7:38: cannot constrain string <: never"},
+		},
+		{
+			name: "SelfReadOfARaisingGetterFromAClauselessMethod",
+			src: `
+				class C {
+					v: number,
+					bad: boolean,
+					get x(self) -> number throws string { if self.bad { throw "boom" } return self.v },
+					m(self) -> number { return self.x },
+				}
+			`,
+			wantErrs: []string{"6:33-6:39: cannot constrain string <: never"},
+		},
+		{
+			// Only one member of the union reads through a raising getter. The other
+			// carries `x` as a plain field, which raises nothing, so the single raise
+			// still has to be declared.
+			name: "UnionReceiverReadFromAClauselessCaller",
+			src: `
+				class A { bad: boolean, get x(self) -> number throws string { if self.bad { throw "a" } return 1 } }
+				class B { x: number }
+				fn f(c: A | B) -> number { return c.x }
+			`,
+			wantErrs: []string{"4:39-4:42: cannot constrain string <: never"},
 		},
 	})
 }

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -506,31 +506,32 @@ func TestInferThrowsOverDeclaredSignature(t *testing.T) {
 	})
 }
 
+// raisingGetterClass declares `get x` on a class that both returns and raises, so neither
+// over-declaration warning fires and a case appending to it measures only the throws flow.
+const raisingGetterClass = `
+	class C {
+		v: number,
+		bad: boolean,
+		get x(self) -> number throws string { if self.bad { throw "boom" } return self.v },
+	}
+`
+
 // A getter and a setter each declare what they raise, the same way a method does, and a
 // getter's clause reaches whoever reads the property. Reading through a getter runs its
 // body, so the read is an exceptional exit of the enclosing body just as a call is.
 func TestInferThrowsFromAnAccessor(t *testing.T) {
-	// raisingGetter declares `get x` on a class that both returns and raises, so neither
-	// over-declaration warning fires and the cases below measure only the throws flow.
-	const raisingGetter = `
-		class C {
-			v: number,
-			bad: boolean,
-			get x(self) -> number throws string { if self.bad { throw "boom" } return self.v },
-		}
-	`
 	runThrowsCases(t, []throwsCase{
 		{
 			// The getter's clause reaches the reader, which redeclares it as its own.
 			name: "GetterClauseReachesTheReader",
-			src:  raisingGetter + `fn f(c: C) -> number throws string { return c.x }`,
+			src:  raisingGetterClass + `fn f(c: C) -> number throws string { return c.x }`,
 			want: "fn (c: C) -> number throws string",
 		},
 		{
 			// `throws _` on the reader infers from the read, so the getter's declared
 			// `string` is what the reader raises.
 			name: "ReaderInfersTheGetterClause",
-			src:  raisingGetter + `fn f(c: C) -> number throws _ { return c.x }`,
+			src:  raisingGetterClass + `fn f(c: C) -> number throws _ { return c.x }`,
 			want: "fn (c: C) -> number throws string",
 		},
 		{
@@ -748,6 +749,146 @@ func TestInferThrowsAccessorReadResolution(t *testing.T) {
 				"3:47-3:50: cannot constrain undefined <: object",
 				"3:49-3:50: object is missing property: x",
 			},
+		},
+	})
+}
+
+// A raise that enters a body through a getter read is an ordinary exceptional exit from
+// there on. It unions with the body's other exits, rides out through the enclosing
+// signature to that function's own callers, and is handled by a `try` the same way a
+// `throw` or a call is. These cases exercise the code that USES a raising accessor rather
+// than the accessor's own declaration.
+func TestInferThrowsThroughAGetterRead(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			// A catch-all covers whatever the block raises, so the read leaves the
+			// enclosing clause untouched and `f` needs none.
+			name: "CatchAllAroundTheReadClearsTheClause",
+			src:  raisingGetterClass + `fn f(c: C) { try { return c.x } catch { e => 0 } }`,
+			want: "fn (c: C) -> number",
+		},
+		{
+			// The arm names the literal the getter's body throws, but the getter DECLARES
+			// `string`, which is what the read raises. `string` outlives the arm, so it is
+			// rethrown and reaches the clause.
+			name: "NamedArmLeavesTheDeclaredRaiseToRethrow",
+			src: raisingGetterClass + `
+				fn f(c: C) throws _ { try { val n = c.x } catch { "boom" => 0 } }
+			`,
+			want: "fn (c: C) -> void throws string",
+		},
+		{
+			// `g` picks the raise up from the read and `f` picks it up from the call to
+			// `g`, so it travels two frames on the ordinary call rule.
+			name: "RaiseTravelsOnThroughTheCallerOfTheReader",
+			src: raisingGetterClass + `
+				fn g(c: C) -> number throws _ { return c.x }
+				fn f(c: C) -> number throws _ { return g(c) }
+			`,
+			want: "fn (c: C) -> number throws string",
+		},
+		{
+			// Two reads on the same path union their raises, the same join two calls take.
+			name: "TwoGetterReadsUnionTheirRaises",
+			src: `
+				class C {
+					bad: boolean,
+					get a(self) -> number throws string { if self.bad { throw "a" } return 1 },
+					get b(self) -> number throws number { if self.bad { throw 2 } return 1 },
+				}
+				fn f(c: C) -> number throws _ {
+					val p = c.a
+					return c.b
+				}
+			`,
+			want: "fn (c: C) -> number throws number | string",
+		},
+		{
+			// A read on one path and a `throw` on the other union, so a getter raise sits
+			// in the same clause as a literal the body throws itself.
+			name: "GetterRaiseJoinsAThrowOnAnotherPath",
+			src:  raisingGetterClass + `fn f(c: C, t: boolean) -> number throws _ { if t { throw 5 } return c.x }`,
+			want: "fn (c: C, t: boolean) -> number throws string | 5",
+		},
+		{
+			// A getter reading another getter is a consumer like any other, so the outer
+			// one has to declare what the inner read raises.
+			name: "GetterReadingAnotherClassGetter",
+			src: raisingGetterClass + `
+				class D {
+					inner: C,
+					get y(self) -> number throws string { return self.inner.x },
+				}
+				fn f(d: D) -> number throws _ { return d.y }
+			`,
+			want: "fn (d: D) -> number throws string",
+		},
+		{
+			// A method reads the getter through `self` and carries the raise into its own
+			// signature, so calling the method raises it at the call site.
+			name: "MethodReadingAGetterCarriesTheRaiseToItsCaller",
+			src: `
+				class C {
+					bad: boolean,
+					get x(self) -> number throws string { if self.bad { throw "boom" } return 1 },
+					m(self) -> number throws _ { return self.x },
+				}
+				fn f(c: C) -> number throws _ { return c.m() }
+			`,
+			want: "fn (c: C) -> number throws string",
+		},
+		{
+			// The constant-string bracket form reads the same getter `c.x` does, so it is
+			// the same exceptional exit.
+			name: "ConstantStringIndexReadRaisesTheSame",
+			src:  raisingGetterClass + `fn f(c: C) -> number throws _ { return c["x"] }`,
+			want: "fn (c: C) -> number throws string",
+		},
+		{
+			// The read sits inside a nested function, which owns its own throws sink, so
+			// the raise stays on the lambda and the enclosing `f` needs no clause.
+			name: "ReadInsideANestedLambdaDoesNotLeakOut",
+			src:  raisingGetterClass + `fn f(c: C) { val g = fn () -> number throws _ { return c.x } }`,
+			want: "fn (c: C) -> void",
+		},
+		{
+			// A setter's clause admits what its own body raises. No write site resolves to
+			// a setter yet, so this is where a setter clause is used today.
+			name:    "SetterBodyRaisesIntoItsOwnClause",
+			binding: "C",
+			src: `
+				class C {
+					v: number,
+					bad: boolean,
+					set x(mut self, n: number) throws string { if self.bad { throw "neg" } self.v = n },
+				}
+			`,
+			want: "fn (v: number, bad: boolean) -> C",
+		},
+	})
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// The arm covers the literal but not the declared `string`, so the leftover is
+			// rethrown into a clause-less function.
+			name: "PartialCatchAroundTheReadStillNeedsAClause",
+			src: raisingGetterClass + `
+				fn f(c: C) { try { val n = c.x } catch { "boom" => 0 } }
+			`,
+			wantErrs: []string{
+				"8:18-8:57: the catch arms leave string uncovered, so it is rethrown, and the enclosing `throws never` does not admit it. Cover it with a catch arm, or widen the enclosing clause",
+			},
+		},
+		{
+			// The outer getter reads the inner one and declares nothing, so the read is
+			// rejected at its own site the way it would be in a plain function.
+			name: "OuterGetterReadingARaisingGetterNeedsItsOwnClause",
+			src: raisingGetterClass + `
+				class D {
+					inner: C,
+					get y(self) -> number { return self.inner.x },
+				}
+			`,
+			wantErrs: []string{"10:37-10:49: cannot constrain string <: never"},
 		},
 	})
 }

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -851,20 +851,6 @@ func TestInferThrowsThroughAGetterRead(t *testing.T) {
 			src:  raisingGetterClass + `fn f(c: C) { val g = fn () -> number throws _ { return c.x } }`,
 			want: "fn (c: C) -> void",
 		},
-		{
-			// A setter's clause admits what its own body raises. No write site resolves to
-			// a setter yet, so this is where a setter clause is used today.
-			name:    "SetterBodyRaisesIntoItsOwnClause",
-			binding: "C",
-			src: `
-				class C {
-					v: number,
-					bad: boolean,
-					set x(mut self, n: number) throws string { if self.bad { throw "neg" } self.v = n },
-				}
-			`,
-			want: "fn (v: number, bad: boolean) -> C",
-		},
 	})
 	runThrowsErrCases(t, []throwsErrCase{
 		{
@@ -889,6 +875,97 @@ func TestInferThrowsThroughAGetterRead(t *testing.T) {
 				}
 			`,
 			wantErrs: []string{"10:37-10:49: cannot constrain string <: never"},
+		},
+	})
+}
+
+// raisingSetterClass declares `set x` on a class whose setter both stores and raises, the
+// write-side twin of raisingGetterClass.
+const raisingSetterClass = `
+	class C {
+		v: number,
+		bad: boolean,
+		set x(mut self, n: number) throws string { if self.bad { throw "boom" } self.v = n },
+	}
+`
+
+// Writing through a setter runs its body, so the write is an exceptional exit of the
+// enclosing body exactly as a getter read is. A write resolves to a setter as of #982, so
+// the setter half of the throws position is reachable from source.
+func TestInferThrowsThroughASetterWrite(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			// The setter's clause reaches the writer, which redeclares it as its own.
+			name: "SetterClauseReachesTheWriter",
+			src:  raisingSetterClass + `fn f(c: mut C) throws string { c.x = 5 }`,
+			want: "fn (c: mut C) -> void throws string",
+		},
+		{
+			// `throws _` on the writer infers from the write.
+			name: "WriterInfersTheSetterClause",
+			src:  raisingSetterClass + `fn f(c: mut C) throws _ { c.x = 5 }`,
+			want: "fn (c: mut C) -> void throws string",
+		},
+		{
+			// A catch-all around the write covers it, so the writer needs no clause.
+			name: "CatchAllAroundTheWriteClearsTheClause",
+			src:  raisingSetterClass + `fn f(c: mut C) { try { c.x = 5 } catch { e => 0 } }`,
+			want: "fn (c: mut C) -> void",
+		},
+		{
+			// A method writes through `self` and carries the raise into its own signature,
+			// so calling the method raises it at the call site.
+			name: "MethodWritingThroughSelfCarriesTheRaiseToItsCaller",
+			src: `
+				class C {
+					v: number,
+					bad: boolean,
+					set x(mut self, n: number) throws string { if self.bad { throw "boom" } self.v = n },
+					m(mut self) throws _ { self.x = 5 },
+				}
+				fn f(c: mut C) throws _ { c.m() }
+			`,
+			want: "fn (c: mut C) -> void throws string",
+		},
+		{
+			// A setter that raises nothing leaves the writer's clause untouched, the same
+			// way a non-throwing callee adds nothing at a call site.
+			name: "NonThrowingSetterWriteAddsNothing",
+			src: `
+				class C { v: number, set x(mut self, n: number) { self.v = n } }
+				fn f(c: mut C) { c.x = 5 }
+			`,
+			want: "fn (c: mut C) -> void",
+		},
+		{
+			// A plain field write is not an accessor call and raises nothing.
+			name: "PlainFieldWriteIsNotAnExceptionalExit",
+			src: `
+				class C { v: number }
+				fn f(c: mut C) { c.v = 5 }
+			`,
+			want: "fn (c: mut C) -> void",
+		},
+	})
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// The write is the exceptional exit, so the diagnostic blames the assignment
+			// rather than the setter's own body, which declared its raise correctly.
+			name:     "WriteThroughARaisingSetterFromAClauselessWriter",
+			src:      raisingSetterClass + `fn f(c: mut C) { c.x = 5 }`,
+			wantErrs: []string{"7:18-7:25: cannot constrain string <: never"},
+		},
+		{
+			name: "SelfWriteThroughARaisingSetterFromAClauselessMethod",
+			src: `
+				class C {
+					v: number,
+					bad: boolean,
+					set x(mut self, n: number) throws string { if self.bad { throw "boom" } self.v = n },
+					m(mut self) { self.x = 5 },
+				}
+			`,
+			wantErrs: []string{"6:20-6:30: cannot constrain string <: never"},
 		},
 	})
 }

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -699,3 +699,55 @@ func TestInferThrowsRejectsAnUndeclaredAccessorRaise(t *testing.T) {
 		},
 	})
 }
+
+// A read resolves an accessor pair to its getter whichever half is declared first, and a
+// union receiver raises only where the read actually joins through its members.
+func TestInferThrowsAccessorReadResolution(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// `set x` precedes `get x`, so a declaration-order lookup would resolve the
+			// read to the setter and report it write-only, dropping the getter's raise.
+			name: "SetterDeclaredBeforeGetterStillReadsTheGetter",
+			src: `
+				class A {
+					v: number,
+					bad: boolean,
+					set x(mut self, n: number) { self.v = n },
+					get x(self) -> number throws string { if self.bad { throw "a" } return self.v },
+				}
+				fn f(c: A) -> number { return c.x }
+			`,
+			wantErrs: []string{"8:35-8:38: cannot constrain string <: never"},
+		},
+		{
+			// The same pair reached through a union, where the read joins per member.
+			name: "SetterDeclaredBeforeGetterUnderAUnionReceiver",
+			src: `
+				class A {
+					v: number,
+					bad: boolean,
+					set x(mut self, n: number) { self.v = n },
+					get x(self) -> number throws string { if self.bad { throw "a" } return self.v },
+				}
+				class B { x: number }
+				fn f(c: A | B) -> number { return c.x }
+			`,
+			wantErrs: []string{"9:39-9:42: cannot constrain string <: never"},
+		},
+		{
+			// `undefined` carries no readable object, so the join abandons the read
+			// entirely and falls back to strict every-member subtyping. No getter runs,
+			// so the two rejections below are the whole story — the getter's `string`
+			// must not be reported as an undeclared raise on top of them.
+			name: "UnionMemberWithNoReadableObjectRaisesNothing",
+			src: `
+				class A { bad: boolean, get x(self) -> number throws string { if self.bad { throw "a" } return 1 } }
+				fn f(c: A | undefined) -> number { return c.x }
+			`,
+			wantErrs: []string{
+				"3:47-3:50: cannot constrain undefined <: object",
+				"3:49-3:50: object is missing property: x",
+			},
+		},
+	})
+}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -580,18 +580,18 @@ func (e *typeEvaluator) reduceElem(el soltype.ObjTypeElem) soltype.ObjTypeElem {
 	case *soltype.PropertyElem:
 		return &soltype.PropertyElem{Name: el.Name, Type: e.reduce(el.Type), Optional: el.Optional, Readonly: el.Readonly}
 	case *soltype.GetterElem:
-		return &soltype.GetterElem{Name: el.Name, SelfParam: el.SelfParam, Type: e.reduce(el.Type), Throws: e.reduceOptional(el.Throws)}
+		return &soltype.GetterElem{Name: el.Name, SelfParam: el.SelfParam, Type: e.reduce(el.Type), Throws: e.reduceThrows(el.Throws)}
 	case *soltype.SetterElem:
-		return &soltype.SetterElem{Name: el.Name, SelfParam: el.SelfParam, Param: e.reduce(el.Param), Throws: e.reduceOptional(el.Throws)}
+		return &soltype.SetterElem{Name: el.Name, SelfParam: el.SelfParam, Param: e.reduce(el.Param), Throws: e.reduceThrows(el.Throws)}
 	default:
 		return el
 	}
 }
 
-// reduceOptional reduces a member's throws position, whose nil shorthand stands for `never`.
-// Preserving nil keeps the shorthand rather than materializing a `never` an accessor was
-// never written with.
-func (e *typeEvaluator) reduceOptional(t soltype.Type) soltype.Type {
+// reduceThrows reduces an accessor's throws position, whose nil shorthand stands for
+// `never`. Preserving nil keeps the shorthand rather than materializing a `never` the
+// accessor was never written with.
+func (e *typeEvaluator) reduceThrows(t soltype.Type) soltype.Type {
 	if t == nil {
 		return nil
 	}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -572,20 +572,30 @@ func (e *typeEvaluator) reduceObject(t *soltype.ObjectType) soltype.Type {
 
 // reduceElem reduces the value types inside one non-spread object member, the object analogue of the
 // `e.reduce(el)` reduceTuple runs on each non-spread tuple element. A property, getter, or setter
-// carries a value type that may itself be an operator such as `keyof X`, so its type is reduced. A
-// method or constructor carries only function types, which reduce leaves untouched, so it passes
-// through unchanged.
+// carries a value type that may itself be an operator such as `keyof X`, so its type is reduced. An
+// accessor's throws position reduces alongside that value type. A method or constructor carries only
+// function types, which reduce leaves untouched, so it passes through unchanged.
 func (e *typeEvaluator) reduceElem(el soltype.ObjTypeElem) soltype.ObjTypeElem {
 	switch el := el.(type) {
 	case *soltype.PropertyElem:
 		return &soltype.PropertyElem{Name: el.Name, Type: e.reduce(el.Type), Optional: el.Optional, Readonly: el.Readonly}
 	case *soltype.GetterElem:
-		return &soltype.GetterElem{Name: el.Name, SelfParam: el.SelfParam, Type: e.reduce(el.Type)}
+		return &soltype.GetterElem{Name: el.Name, SelfParam: el.SelfParam, Type: e.reduce(el.Type), Throws: e.reduceOptional(el.Throws)}
 	case *soltype.SetterElem:
-		return &soltype.SetterElem{Name: el.Name, SelfParam: el.SelfParam, Param: e.reduce(el.Param)}
+		return &soltype.SetterElem{Name: el.Name, SelfParam: el.SelfParam, Param: e.reduce(el.Param), Throws: e.reduceOptional(el.Throws)}
 	default:
 		return el
 	}
+}
+
+// reduceOptional reduces a member's throws position, whose nil shorthand stands for `never`.
+// Preserving nil keeps the shorthand rather than materializing a `never` an accessor was
+// never written with.
+func (e *typeEvaluator) reduceOptional(t soltype.Type) soltype.Type {
+	if t == nil {
+		return nil
+	}
+	return e.reduce(t)
 }
 
 // groundObjectOperand reduces a `...A` spread operand toward the concrete object whose fields it


### PR DESCRIPTION
Fixes #972

A `throws` clause on an accessor was rejected, and with no clause the body's sink is seeded `never`, so any raise was rejected at its own site. A raising accessor was not merely undeclarable but inexpressible. JS getters raise routinely, so this was real friction.

## What changed

**1. A `Throws` position on `GetterElem` and `SetterElem`** ([soltype/type.go](https://github.com/escalier-lang/escalier/blob/claude/github-issue-972-r5nitd/internal/soltype/type.go)), nil reading as `never` through `ThrowsOrNever`, the twin of `FuncType.Throws`. It is covariant on both — including the setter, whose written value is contravariant but whose raise flows out to the writer. Parallel arms landed in `constrainObjMember`, `AcceptObjElem` (so `extrude` and the freshener come free), `levelOfElem`, the printer's `freeTypeVars` walk and `printObjElem`, `equalObjElem`, `freezeClassBody`, `stripSelfReceiver`, and `reduceElem`.

**2. The `reportAccessorThrows` rejection is gone.** `buildMemberSigs` seeds the accessor element from the signature stub's throws var and installs the body's throws on apply. `inferMemberFunc` already routes through `inferFunc`, so the clause seeds the body's sink with no extra wiring — `throws _` inference and `UnusedThrowsClauseError` both fall out automatically, as the issue predicted.

**3. A getter read is an exceptional exit.** `memberValue` constrains the getter's throws into the enclosing body's sink and marks the body as raising, covering the three sites that resolve an accessor during the walk: a class instance, a `self` read inside a class body, and a static read off a class value.

**4. A setter write is an exceptional exit.** `inferAccessorAssign` does the same on the write side. It records the setter's throws into the sink before it captures `errsBefore`, so an undeclared raise does not suppress the move the write records — the two checks are independent.

## The open question

The issue asked whether the read requirement grows a throws position or accessor throws are collected post-solve. Neither turned out to be needed. Every accessor reachable resolves **during the walk**, where the sink is in scope. The one exception is a union receiver, whose read is joined by `constrainUnionFieldRead` from inside `constrain`, which holds no sink — so `valueProp` walks the union's members up front instead.

A receiver still holding an inference variable at the read site never resolves to a getter at all. `fn f(c) { c.x }` against a class carrying a getter fails with `cannot constrain class C <: exact object`, so there is nothing to decide eagerly and no laundering hole to close.

## Rebased onto the accessor-write work

This branch was written before #986 and #994 landed, and the two of them changed what is reachable from source:

- **#994 (fixes #982)** makes a write resolve to a setter. That closes item 4 above, which the original version of this PR had to defer as unreachable — a setter could declare a clause but nothing consumed it. It also lands `ObjectType.ReadMember`/`WriteMember`, a generalization of the `ReadMember` this branch had added for reads alone; the rebase drops mine in favour of the shared `preferredMember` scan.
- **#986 (fixes #870, #983)** makes a plain field write through a `mut` class-instance receiver work at all, which is what `c.v = 5` needed.

The one remaining accessor gap is a *union* receiver write. `writeAccessor` resolves only a class instance, a class body, or a class value, so `fn f(c: mut A | mut B) { c.x = 5 }` is rejected with `object is missing property: x` rather than reaching either setter. Nothing is silently dropped there — the write fails outright, so there is no unsound path — but it means the write side has no union counterpart to `raiseUnionAccessorThrows`. Left alone as #994's scope, not this PR's.

Two sub-bullets from the issue's item 3 remain genuinely unreachable, each verified rather than assumed:

- `val {x} = recv` never reads through a getter — `object is missing property: x`
- `{...recv}` over a class instance is rejected — `cannot spread t9 into an object`

Both pick up the wiring above once they resolve.

## Two bugs found in review

**A read resolves an accessor pair to its getter.** `ObjectType.Member` returns the first same-named element in declaration order, so a class writing `set x` before `get x` resolved a *read* to the setter: a direct read reported the property write-only, and the union read dropped the getter's throws, letting a raising getter reach a clause-less caller unreported. Now handled by `ReadMember`, which #994 generalized to both directions.

**A union read raises only where the join happens.** `raiseUnionAccessorThrows` raised per member as it scanned, while `constrainUnionFieldRead` abandons the whole join once any member carries no readable object. Reading off `A | undefined` blamed the read for a raise it never performs, on top of the errors the strict fallback already reports. The scan now collects first and raises only once every member resolves.

## Testing

`go test ./...` passes. Four new table-driven test functions in `infer_throws_test.go`:

- `TestInferThrowsFromAnAccessor` — 9 accept cases: the clause reaching the reader, wildcard inference on either side, a `self` read, a static read, a class value rendering both accessors' clauses, a generic class, the union join, a method-value read staying non-raising, and try/catch swallowing.
- `TestInferThrowsRejectsAnUndeclaredAccessorRaise` — 6 reject cases.
- `TestInferThrowsThroughAGetterRead` — 11 cases on the code that *uses* a raising getter: a catch-all clearing the clause, a named arm leaving the declared type to rethrow, the raise crossing two frames, two reads unioning, a read joining a `throw` on another path, a getter reading another class's getter, a method carrying the raise from a `self` read, the constant-string index form, and a read inside a nested lambda staying on the lambda.
- `TestInferThrowsThroughASetterWrite` — the write-side twin, 6 accept and 2 reject cases, including a non-throwing setter and a plain field write both adding nothing.
- `TestInferThrowsAccessorReadResolution` — the two review regressions.

The two cases that pinned the old rejection moved into `TestInferThrowsOverDeclaredSignature`, where they now assert only the unused-clause warning.

Worth knowing: the fixture harness runs the old checker — `internal/compiler` does not reference `solver` — so fixtures do not cover any of this. The solver package tests are the only level that exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9WLEVYi811sRW6BMLXA2F