### PR TITLE
Check type-argument arity and fill defaults at class and enum references

### DIFF
--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -239,7 +239,7 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 		}
 	}
 	ltArgs := c.resolveAliasLifetimeArgs(ref, kind, ltParams, lvl)
-	args := c.resolveTypeArgs(scope, ref, kind, params, lvl)
+	args := c.resolveTypeArgs(scope, ref, kind, params, arityOfParams(params), lvl)
 	if len(args) == 0 {
 		// A non-generic alias carries no type arguments; any that were supplied are reported
 		// by resolveTypeArgs. Return a handle carrying only the lifetime arguments, or the bare

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -218,14 +218,9 @@ func (c *checker) inferAliasBody(sh *aliasShell) {
 
 // buildAliasInstance resolves a use-site reference to a registered alias into an AliasType
 // carrying one type argument per type parameter and one lifetime argument per lifetime
-// parameter. resolveTypeArgs checks the type-argument count and fills a trailing omitted one
-// from its parameter's default. A lifetime parameter has no default, so its count must match
-// exactly. A mismatch on either sort reports and recovers with fresh arguments, so a
-// downstream reference still resolves.
-//
-// An enum reaches this too, since an enum name binds to an alias whose body is the union of
-// its variant handles. The kind the diagnostics render comes off the AliasDef, so a bad
-// `Color<…>` reference calls `Color` an enum rather than a type alias.
+// parameter. A mismatch on either sort reports and recovers with fresh arguments. An enum
+// reaches this too, since an enum name binds to an alias over its variant union, so the kind
+// the diagnostics render comes off the AliasDef rather than being assumed.
 func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *ast.TypeRefTypeAnn, lvl int) *soltype.AliasType {
 	def, _ := c.ctx.aliasDef(at.Name)
 	var params []*soltype.TypeParam

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -53,6 +53,12 @@ type AliasDef struct {
 	// It is nil for an alias no fixed point ran over, which is an enum's synthesized alias. A
 	// nil slice marks nothing phantom, so every argument stays in the identity key.
 	PhantomParams []bool
+
+	// Enum marks the alias preBindEnum synthesizes for an `enum` declaration, whose body is
+	// the union of the enum's variant handles. A reference to an enum resolves through the
+	// alias path, so this is what lets its arity diagnostics name it an enum. It is false for
+	// an alias a `type` declaration wrote.
+	Enum bool
 }
 
 // expandAlias unfolds an alias reference to its registered AliasDef Body, the shared
@@ -212,66 +218,36 @@ func (c *checker) inferAliasBody(sh *aliasShell) {
 
 // buildAliasInstance resolves a use-site reference to a registered alias into an AliasType
 // carrying one type argument per type parameter and one lifetime argument per lifetime
-// parameter. A trailing type parameter with a default may be omitted, so its argument is
-// filled from the default with the earlier arguments already substituted, letting `type
-// Pair<T, U = T>` resolve `Pair<number>` to `Pair<number, number>`. A lifetime parameter has
-// no default, so its count must match exactly. A mismatch on either sort reports and recovers
-// with fresh arguments, so a downstream reference still resolves.
+// parameter. resolveTypeArgs checks the type-argument count and fills a trailing omitted one
+// from its parameter's default. A lifetime parameter has no default, so its count must match
+// exactly. A mismatch on either sort reports and recovers with fresh arguments, so a
+// downstream reference still resolves.
+//
+// An enum reaches this too, since an enum name binds to an alias whose body is the union of
+// its variant handles. The kind the diagnostics render comes off the AliasDef, so a bad
+// `Color<…>` reference calls `Color` an enum rather than a type alias.
 func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *ast.TypeRefTypeAnn, lvl int) *soltype.AliasType {
 	def, _ := c.ctx.aliasDef(at.Name)
 	var params []*soltype.TypeParam
 	var ltParams []*soltype.LifetimeParam
+	kind := AliasDeclKind
 	if def != nil {
 		params = def.TypeParams
 		ltParams = def.LifetimeParams
-	}
-	ltArgs := c.resolveAliasLifetimeArgs(ref, ltParams, lvl)
-	total := len(params)
-	required := 0
-	for _, p := range params {
-		if p.Default == nil {
-			required++
+		if def.Enum {
+			kind = EnumDeclKind
 		}
 	}
-	got := len(ref.TypeArgs)
-	if got < required || got > total {
-		c.report(&AliasArityMismatchError{
-			Ref:      ref,
-			Name:     ast.QualIdentToString(ref.Name),
-			Required: required,
-			Total:    total,
-			Got:      got,
-		})
-	}
-	if total == 0 {
+	ltArgs := c.resolveAliasLifetimeArgs(ref, kind, ltParams, lvl)
+	args := c.resolveTypeArgs(scope, ref, kind, params, lvl)
+	if len(args) == 0 {
 		// A non-generic alias carries no type arguments; any that were supplied are reported
-		// above. Return a handle carrying only the lifetime arguments, or the bare handle when
-		// there are none, so the alias still resolves under its name.
+		// by resolveTypeArgs. Return a handle carrying only the lifetime arguments, or the bare
+		// handle when there are none, so the alias still resolves under its name.
 		if len(ltArgs) == 0 {
 			return at
 		}
 		return &soltype.AliasType{Name: at.Name, LifetimeArgs: ltArgs}
-	}
-	args := make([]soltype.Type, total)
-	for i := range total {
-		if i < got {
-			if resolved, ok := c.resolveTypeAnn(scope, ref.TypeArgs[i], lvl); ok {
-				args[i] = resolved
-			} else {
-				args[i] = c.freshAt(lvl)
-			}
-			continue
-		}
-		if params[i].Default != nil {
-			// The default may reference an earlier parameter, as `U = T` does, so substitute
-			// the arguments already resolved for parameters before this one.
-			subst := newTypeSubst(params[:i], args[:i], nil, nil)
-			args[i] = params[i].Default.Accept(subst, soltype.Positive)
-		} else {
-			// A required argument was omitted, already reported as an arity mismatch. Recover
-			// to a fresh var so expansion has one argument per parameter.
-			args[i] = c.freshAt(lvl)
-		}
 	}
 	c.checkAliasArgBounds(params, args, ltParams, ltArgs, ref)
 	return &soltype.AliasType{Name: at.Name, TypeArgs: args, LifetimeArgs: ltArgs}
@@ -332,13 +308,14 @@ func (c *checker) runDeferredAliasBounds() {
 
 // resolveAliasLifetimeArgs resolves a reference's `<'a, ...>` lifetime arguments and checks
 // their count against the alias's lifetime parameters, which have no default. A mismatch
-// reports an AliasLifetimeArityMismatchError and recovers with fresh lifetimes.
-func (c *checker) resolveAliasLifetimeArgs(ref *ast.TypeRefTypeAnn, ltParams []*soltype.LifetimeParam, lvl int) []soltype.Lifetime {
+// reports a LifetimeArgArityMismatchError and recovers with fresh lifetimes.
+func (c *checker) resolveAliasLifetimeArgs(ref *ast.TypeRefTypeAnn, kind TypeDeclKind, ltParams []*soltype.LifetimeParam, lvl int) []soltype.Lifetime {
 	total := len(ltParams)
 	got := len(ref.LifetimeArgs)
 	if got != total {
-		c.report(&AliasLifetimeArityMismatchError{
+		c.report(&LifetimeArgArityMismatchError{
 			Ref:      ref,
+			Kind:     kind,
 			Name:     ast.QualIdentToString(ref.Name),
 			Expected: total,
 			Got:      got,

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -344,7 +344,7 @@ func TestInferMutuallyRecursiveTypeAliases(t *testing.T) {
 
 // TestInferGenericTypeAliasArityErrors covers the two out-of-range counts. Supplying more
 // than the total parameter count and fewer than the required count each report a single
-// AliasArityMismatchError, whose message states a range when a default makes a parameter
+// TypeArgArityMismatchError, whose message states a range when a default makes a parameter
 // optional and a single count when every parameter is required.
 func TestInferGenericTypeAliasArityErrors(t *testing.T) {
 	tests := []struct {

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -21,14 +21,13 @@ type ClassDef struct {
 	// nil for a non-generic class.
 	TypeParams []*soltype.TypeParam
 
-	// ParamsResolved separates a class whose TypeParams are nil because it declares none
-	// from one whose TypeParams have not been resolved yet. getOrCreateClass registers a
-	// bare ClassDef during the SCC pre-pass so a forward reference from a sibling in the
-	// same dep_graph component resolves, and inferClassDecl fills the parameters and sets
-	// this when that class's own pass runs. A reference reaching the class in between has
-	// no parameter list to check its written type arguments against, so buildClassInstance
-	// reads this before reporting an arity mismatch.
-	ParamsResolved bool
+	// Arity is how many type arguments a reference to this class may write, read off the
+	// declaration's `<…>` clause when the class's identity is registered. TypeParams lands
+	// later, when the class's own inferClassDecl runs, and a reference resolved in between
+	// still has to be counted — a class body naming a sibling class is the ordinary case,
+	// since a class's members resolve in whatever order the dep graph reaches its
+	// declaration. So the count comes from here and the defaults come from TypeParams.
+	Arity typeParamArity
 
 	// LifetimeParams are the class's quantified lifetime parameters (A3), the lifetime
 	// twin of TypeParams. nil for a class that holds no borrowed data.

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -21,12 +21,9 @@ type ClassDef struct {
 	// nil for a non-generic class.
 	TypeParams []*soltype.TypeParam
 
-	// Arity is how many type arguments a reference to this class may write, read off the
-	// declaration's `<…>` clause when the class's identity is registered. TypeParams lands
-	// later, when the class's own inferClassDecl runs, and a reference resolved in between
-	// still has to be counted — a class body naming a sibling class is the ordinary case,
-	// since a class's members resolve in whatever order the dep graph reaches its
-	// declaration. So the count comes from here and the defaults come from TypeParams.
+	// Arity is how many type arguments a reference may write, read off the declaration's
+	// `<…>` clause when the class's identity is registered. TypeParams lands later, so a
+	// reference resolved in between — a class body naming a sibling — still has a count.
 	Arity typeParamArity
 
 	// LifetimeParams are the class's quantified lifetime parameters (A3), the lifetime

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -21,6 +21,15 @@ type ClassDef struct {
 	// nil for a non-generic class.
 	TypeParams []*soltype.TypeParam
 
+	// ParamsResolved separates a class whose TypeParams are nil because it declares none
+	// from one whose TypeParams have not been resolved yet. getOrCreateClass registers a
+	// bare ClassDef during the SCC pre-pass so a forward reference from a sibling in the
+	// same dep_graph component resolves, and inferClassDecl fills the parameters and sets
+	// this when that class's own pass runs. A reference reaching the class in between has
+	// no parameter list to check its written type arguments against, so buildClassInstance
+	// reads this before reporting an arity mismatch.
+	ParamsResolved bool
+
 	// LifetimeParams are the class's quantified lifetime parameters (A3), the lifetime
 	// twin of TypeParams. nil for a class that holds no borrowed data.
 	LifetimeParams []*soltype.LifetimeParam

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1107,6 +1107,7 @@ func (*RestParamNotLastError) isSolverError()               {}
 func (*RestParamNeedsTypeError) isSolverError()             {}
 func (*OptionalRestParamError) isSolverError()              {}
 func (*TypeParamDefaultForwardRefError) isSolverError()     {}
+func (*TypeParamRequiredAfterDefaultError) isSolverError()  {}
 func (*NotProductiveAliasError) isSolverError()             {}
 func (*ExpansionLimitError) isSolverError()                 {}
 
@@ -1343,6 +1344,24 @@ func (e *TypeParamDefaultForwardRefError) Message() string {
 		return fmt.Sprintf("the default for type parameter `%s` cannot reference `%s` itself", e.Param, e.Target)
 	}
 	return fmt.Sprintf("the default for type parameter `%s` cannot reference `%s`, which is declared after it", e.Param, e.Target)
+}
+
+// TypeParamRequiredAfterDefaultError fires when a type parameter with a default is declared
+// before one without, as `type Pair<T = number, U>` does. Arguments bind positionally, so
+// omitting the argument for `T` would leave `U` reading the argument written for `T`. Every
+// argument up to the last required parameter therefore has to be written, and a default before
+// that point can never be reached. Default is the unusable `= …` annotation, Param the parameter
+// carrying it, and Target the first parameter after it that has none.
+type TypeParamRequiredAfterDefaultError struct {
+	Default ast.TypeAnn
+	Param   string
+	Target  string
+}
+
+func (e *TypeParamRequiredAfterDefaultError) Span() ast.Span      { return e.Default.Span() }
+func (e *TypeParamRequiredAfterDefaultError) Related() []ast.Span { return nil }
+func (e *TypeParamRequiredAfterDefaultError) Message() string {
+	return fmt.Sprintf("the default for type parameter `%s` can never be used, since `%s` is declared after it and has no default", e.Param, e.Target)
 }
 
 // NotProductiveAliasError fires when a recursive type alias reaches itself with no type constructor

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1100,8 +1100,8 @@ func (*MethodCallBeforeInitError) isSolverError()           {}
 func (*InstancePatternNotClassError) isSolverError()        {}
 func (*ExtractorPatternNotCtorError) isSolverError()        {}
 func (*ExtractorPatternArityError) isSolverError()          {}
-func (*AliasArityMismatchError) isSolverError()             {}
-func (*AliasLifetimeArityMismatchError) isSolverError()     {}
+func (*TypeArgArityMismatchError) isSolverError()           {}
+func (*LifetimeArgArityMismatchError) isSolverError()       {}
 func (*ReservedTypeNameError) isSolverError()               {}
 func (*RestParamNotLastError) isSolverError()               {}
 func (*RestParamNeedsTypeError) isSolverError()             {}
@@ -1214,43 +1214,57 @@ func (e *ExtractorPatternArityError) Message() string {
 	return fmt.Sprintf("extractor pattern `%s` expects %d arguments but got %d", e.Name, e.Expected, e.Got)
 }
 
-// AliasArityMismatchError fires when a generic-alias reference `Name<…>` supplies fewer
-// than the required number of type arguments or more than the total parameter count. A
-// trailing parameter with a default is optional, so the valid count is the range from
-// Required to Total, where Required counts the parameters with no default. The message
-// states a single count when every parameter is required and a range when a default makes
-// one optional.
-type AliasArityMismatchError struct {
+// TypeDeclKind names the sort of declaration a type reference resolved to. resolveTypeArgs
+// reports one arity error for all three sorts, and this is the noun that error renders. An
+// enum needs a value of its own because it registers as an alias whose body is the union of
+// its variant handles, so without it a bad `Color<…>` reference would call `Color` a type
+// alias, naming a declaration the source never wrote.
+type TypeDeclKind string
+
+const (
+	AliasDeclKind TypeDeclKind = "type alias"
+	ClassDeclKind TypeDeclKind = "class"
+	EnumDeclKind  TypeDeclKind = "enum"
+)
+
+// TypeArgArityMismatchError fires when a generic reference `Name<…>` supplies fewer than the
+// required number of type arguments or more than the total parameter count. A trailing
+// parameter with a default is optional, so the valid count is the range from Required to
+// Total, where Required counts the parameters with no default. The message states a single
+// count when every parameter is required and a range when a default makes one optional.
+type TypeArgArityMismatchError struct {
 	Ref      *ast.TypeRefTypeAnn
+	Kind     TypeDeclKind
 	Name     string
 	Required int
 	Total    int
 	Got      int
 }
 
-func (e *AliasArityMismatchError) Span() ast.Span      { return e.Ref.Span() }
-func (e *AliasArityMismatchError) Related() []ast.Span { return nil }
-func (e *AliasArityMismatchError) Message() string {
+func (e *TypeArgArityMismatchError) Span() ast.Span      { return e.Ref.Span() }
+func (e *TypeArgArityMismatchError) Related() []ast.Span { return nil }
+func (e *TypeArgArityMismatchError) Message() string {
 	if e.Required == e.Total {
-		return fmt.Sprintf("type alias `%s` expects %d type arguments but got %d", e.Name, e.Total, e.Got)
+		return fmt.Sprintf("%s `%s` expects %d type arguments but got %d", e.Kind, e.Name, e.Total, e.Got)
 	}
-	return fmt.Sprintf("type alias `%s` expects between %d and %d type arguments but got %d", e.Name, e.Required, e.Total, e.Got)
+	return fmt.Sprintf("%s `%s` expects between %d and %d type arguments but got %d", e.Kind, e.Name, e.Required, e.Total, e.Got)
 }
 
-// AliasLifetimeArityMismatchError fires when a generic-alias reference `Name<'a, …>` supplies
-// a number of lifetime arguments that does not match the alias's declared `<'a, …>` clause. A
-// lifetime parameter has no default, so the counts must match exactly.
-type AliasLifetimeArityMismatchError struct {
+// LifetimeArgArityMismatchError fires when a reference `Name<'a, …>` supplies a number of
+// lifetime arguments that does not match the declaration's `<'a, …>` clause. A lifetime
+// parameter has no default, so the counts must match exactly.
+type LifetimeArgArityMismatchError struct {
 	Ref      *ast.TypeRefTypeAnn
+	Kind     TypeDeclKind
 	Name     string
 	Expected int
 	Got      int
 }
 
-func (e *AliasLifetimeArityMismatchError) Span() ast.Span      { return e.Ref.Span() }
-func (e *AliasLifetimeArityMismatchError) Related() []ast.Span { return nil }
-func (e *AliasLifetimeArityMismatchError) Message() string {
-	return fmt.Sprintf("type alias `%s` expects %d lifetime arguments but got %d", e.Name, e.Expected, e.Got)
+func (e *LifetimeArgArityMismatchError) Span() ast.Span      { return e.Ref.Span() }
+func (e *LifetimeArgArityMismatchError) Related() []ast.Span { return nil }
+func (e *LifetimeArgArityMismatchError) Message() string {
+	return fmt.Sprintf("%s `%s` expects %d lifetime arguments but got %d", e.Kind, e.Name, e.Expected, e.Got)
 }
 
 // ReservedTypeNameError fires when a `type` declaration uses the name of a built-in intrinsic

--- a/internal/solver/infer_alias_lifetime_test.go
+++ b/internal/solver/infer_alias_lifetime_test.go
@@ -131,7 +131,7 @@ func TestInferLifetimeGenericAliasIsTransparent(t *testing.T) {
 
 // TestInferLifetimeGenericAliasArityErrors covers the lifetime-argument arity checks. A
 // lifetime parameter has no default, so supplying too many or too few lifetime arguments each
-// report a single AliasLifetimeArityMismatchError, and supplying a lifetime argument to an
+// report a single LifetimeArgArityMismatchError, and supplying a lifetime argument to an
 // alias that declares none is rejected the same way.
 func TestInferLifetimeGenericAliasArityErrors(t *testing.T) {
 	tests := []struct {

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -69,6 +69,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	self.TypeArgs = typeParamVars(typeParams)
 	def.Level = lvl - 1
 	def.TypeParams = typeParams
+	def.ParamsResolved = true
 	def.Variance = make([]Variance, len(typeParams))
 	def.MutVariance = make([]Variance, len(typeParams))
 	body := def.Body
@@ -280,20 +281,35 @@ func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn, lvl int
 	return c.buildClassInstance(scope, ct, ref, lvl)
 }
 
-// buildClassInstance returns the handle a class reference resolves to: the bare class with
-// no type arguments, or a fresh instance carrying the resolved arguments for a generic one
-// like `Animal<D>`. An unresolved argument recovers to a fresh var, keeping arity cascade-safe.
+// buildClassInstance returns the handle a class reference resolves to: the bare class for a
+// non-generic one, or a fresh instance carrying one argument per type parameter for a generic
+// one like `Animal<D>`. The pairing runs through resolveTypeArgs, the same helper the alias
+// path uses, so a class checks its argument count and fills a trailing omitted argument from
+// its parameter's default the way an alias does. An unresolved argument recovers to a fresh
+// var, keeping arity cascade-safe.
 func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *ast.TypeRefTypeAnn, lvl int) *soltype.ClassType {
-	if len(ref.TypeArgs) == 0 {
-		return ct
-	}
-	args := make([]soltype.Type, len(ref.TypeArgs))
-	for i, arg := range ref.TypeArgs {
-		if at, ok := c.resolveTypeAnn(scope, arg, lvl); ok {
-			args[i] = at
-		} else {
-			args[i] = c.freshAt(lvl)
+	var args []soltype.Type
+	if def, ok := c.ctx.classDef(ct.Name); ok && def.ParamsResolved {
+		args = c.resolveTypeArgs(scope, ref, ClassDeclKind, def.TypeParams, lvl)
+	} else {
+		// The class's parameters are not resolved yet, which a reference from a sibling in the
+		// same dep_graph component reaches. There is no parameter list to check the written
+		// arguments against and no default to fill an omitted one from, so resolve exactly what
+		// the reference wrote.
+		args = make([]soltype.Type, len(ref.TypeArgs))
+		for i, arg := range ref.TypeArgs {
+			if at, ok := c.resolveTypeAnn(scope, arg, lvl); ok {
+				args[i] = at
+			} else {
+				args[i] = c.freshAt(lvl)
+			}
 		}
+	}
+	if len(args) == 0 {
+		// The class declares no type parameters and the reference wrote no arguments, or it
+		// wrote some against a non-generic class and resolveTypeArgs already reported them.
+		// Either way the handle carries no arguments, so return the declaration's own.
+		return ct
 	}
 	return &soltype.ClassType{Name: ct.Name, TypeArgs: args, Final: ct.Final, Variant: ct.Variant}
 }
@@ -329,7 +345,7 @@ func (c *checker) lookupClassBinding(scope *Scope, name string) (TypeBinding, bo
 
 // resolveScopedTypeRef resolves a type reference through lookupClassBinding, covering a
 // bare `Point` or `T`, a generic class instance `Box<number>`, and a generic alias
-// instance `List<number>`. An alias binding always resolves here, with its own arity
+// instance `List<number>`. An alias or class binding always resolves here, with its own arity
 // diagnostic. It returns ok=false only when the name is unbound, or has arguments but is
 // neither a class nor an alias. It never routes back through resolveTypeAnn, so
 // resolveTypeAnn's TypeRef arm can fall back to it without recursing.
@@ -345,11 +361,14 @@ func (c *checker) resolveScopedTypeRef(scope *Scope, ref *ast.TypeRefTypeAnn, lv
 	if at, ok := b.Type.(*soltype.AliasType); ok {
 		return c.buildAliasInstance(scope, at, ref, lvl), true
 	}
-	if len(ref.TypeArgs) == 0 {
-		return b.Type, true
-	}
+	// A class reference routes through buildClassInstance whether or not it supplies
+	// arguments, so a generic class referenced bare still reports an arity mismatch and a
+	// defaulted parameter is filled from its default.
 	if ct, ok := b.Type.(*soltype.ClassType); ok {
 		return c.buildClassInstance(scope, ct, ref, lvl), true
+	}
+	if len(ref.TypeArgs) == 0 {
+		return b.Type, true
 	}
 	return nil, false
 }

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -69,7 +69,6 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	self.TypeArgs = typeParamVars(typeParams)
 	def.Level = lvl - 1
 	def.TypeParams = typeParams
-	def.ParamsResolved = true
 	def.Variance = make([]Variance, len(typeParams))
 	def.MutVariance = make([]Variance, len(typeParams))
 	body := def.Body
@@ -188,7 +187,15 @@ func (c *checker) getOrCreateClass(scope *Scope, decl *ast.ClassDecl, ns string)
 		}
 	}
 	self := &soltype.ClassType{Name: qname, Final: decl.Final()}
-	def := &ClassDef{Body: &soltype.ObjectType{}, Static: &soltype.ObjectType{}}
+	// Record how many type arguments a reference may write before anything else. The
+	// parameters themselves resolve when this class's own inferClassDecl runs, which is after
+	// some of the references to it, so the count is read off the declaration's `<…>` clause
+	// here where every reference can reach it.
+	def := &ClassDef{
+		Arity:  arityOfParamDecls(decl.TypeParams),
+		Body:   &soltype.ObjectType{},
+		Static: &soltype.ObjectType{},
+	}
 	c.ctx.registerClass(qname, def)
 	// Register the type binding under the qualified name so a cross-namespace reference
 	// resolves it and a self-referential type in the body resolves to this class rather
@@ -287,24 +294,22 @@ func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn, lvl int
 // path uses, so a class checks its argument count and fills a trailing omitted argument from
 // its parameter's default the way an alias does. An unresolved argument recovers to a fresh
 // var, keeping arity cascade-safe.
+//
+// The count comes from the ClassDef's Arity, which is set when the class's identity is
+// registered, so a reference resolved before that class's own body pass is still checked. The
+// defaults come from its TypeParams, which land in that later pass, so such a reference
+// recovers an omitted argument to a fresh var rather than filling it. That keeps the
+// declaration's own parameter var out of the instance either way.
 func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *ast.TypeRefTypeAnn, lvl int) *soltype.ClassType {
-	var args []soltype.Type
-	if def, ok := c.ctx.classDef(ct.Name); ok && def.ParamsResolved {
-		args = c.resolveTypeArgs(scope, ref, ClassDeclKind, def.TypeParams, lvl)
-	} else {
-		// The class's parameters are not resolved yet, which a reference from a sibling in the
-		// same dep_graph component reaches. There is no parameter list to check the written
-		// arguments against and no default to fill an omitted one from, so resolve exactly what
-		// the reference wrote.
-		args = make([]soltype.Type, len(ref.TypeArgs))
-		for i, arg := range ref.TypeArgs {
-			if at, ok := c.resolveTypeAnn(scope, arg, lvl); ok {
-				args[i] = at
-			} else {
-				args[i] = c.freshAt(lvl)
-			}
-		}
+	var params []*soltype.TypeParam
+	// An unregistered name has no declared count to check against, so take the reference's own
+	// as the expected one and let it through unreported.
+	arity := typeParamArity{Required: len(ref.TypeArgs), Total: len(ref.TypeArgs)}
+	if def, ok := c.ctx.classDef(ct.Name); ok {
+		params = def.TypeParams
+		arity = def.Arity
 	}
+	args := c.resolveTypeArgs(scope, ref, ClassDeclKind, params, arity, lvl)
 	if len(args) == 0 {
 		// The class declares no type parameters and the reference wrote no arguments, or it
 		// wrote some against a non-generic class and resolveTypeArgs already reported them.

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -288,18 +288,10 @@ func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn, lvl int
 	return c.buildClassInstance(scope, ct, ref, lvl)
 }
 
-// buildClassInstance returns the handle a class reference resolves to: the bare class for a
-// non-generic one, or a fresh instance carrying one argument per type parameter for a generic
-// one like `Animal<D>`. The pairing runs through resolveTypeArgs, the same helper the alias
-// path uses, so a class checks its argument count and fills a trailing omitted argument from
-// its parameter's default the way an alias does. An unresolved argument recovers to a fresh
-// var, keeping arity cascade-safe.
-//
-// The count comes from the ClassDef's Arity, which is set when the class's identity is
-// registered, so a reference resolved before that class's own body pass is still checked. The
-// defaults come from its TypeParams, which land in that later pass, so such a reference
-// recovers an omitted argument to a fresh var rather than filling it. That keeps the
-// declaration's own parameter var out of the instance either way.
+// buildClassInstance returns the handle a class reference resolves to, one argument per type
+// parameter, paired by resolveTypeArgs the way an alias's are. Arity is registered with the
+// class's identity but TypeParams lands later, so a reference resolved in between is still
+// counted and recovers an omitted argument to a fresh var instead of filling its default.
 func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *ast.TypeRefTypeAnn, lvl int) *soltype.ClassType {
 	var params []*soltype.TypeParam
 	// An unregistered name has no declared count to check against, so take the reference's own

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -104,13 +104,13 @@ func (c *checker) preBindEnum(scope *Scope, lvl int, decl *ast.EnumDecl, ns stri
 		vname := qname + "." + variant.Name.Name
 		vt := &soltype.ClassType{Name: vname, TypeArgs: typeArgs, Final: true, Variant: true}
 		c.ctx.registerClass(vname, &ClassDef{
-			TypeParams:     typeParams,
-			ParamsResolved: true,
-			Variance:       make([]Variance, len(typeParams)),
-			MutVariance:    make([]Variance, len(typeParams)),
-			Body:           &soltype.ObjectType{},
-			Static:         &soltype.ObjectType{},
-			Level:          lvl - 1,
+			TypeParams:  typeParams,
+			Arity:       arityOfParams(typeParams),
+			Variance:    make([]Variance, len(typeParams)),
+			MutVariance: make([]Variance, len(typeParams)),
+			Body:        &soltype.ObjectType{},
+			Static:      &soltype.ObjectType{},
+			Level:       lvl - 1,
 		})
 		c.recordType(variant.Name, vt)
 		variants = append(variants, variant)

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -104,12 +104,13 @@ func (c *checker) preBindEnum(scope *Scope, lvl int, decl *ast.EnumDecl, ns stri
 		vname := qname + "." + variant.Name.Name
 		vt := &soltype.ClassType{Name: vname, TypeArgs: typeArgs, Final: true, Variant: true}
 		c.ctx.registerClass(vname, &ClassDef{
-			TypeParams:  typeParams,
-			Variance:    make([]Variance, len(typeParams)),
-			MutVariance: make([]Variance, len(typeParams)),
-			Body:        &soltype.ObjectType{},
-			Static:      &soltype.ObjectType{},
-			Level:       lvl - 1,
+			TypeParams:     typeParams,
+			ParamsResolved: true,
+			Variance:       make([]Variance, len(typeParams)),
+			MutVariance:    make([]Variance, len(typeParams)),
+			Body:           &soltype.ObjectType{},
+			Static:         &soltype.ObjectType{},
+			Level:          lvl - 1,
 		})
 		c.recordType(variant.Name, vt)
 		variants = append(variants, variant)
@@ -125,6 +126,7 @@ func (c *checker) preBindEnum(scope *Scope, lvl int, decl *ast.EnumDecl, ns stri
 		TypeParams: typeParams,
 		Body:       &soltype.UnionType{Types: variantTypes},
 		Level:      lvl - 1,
+		Enum:       true,
 	})
 	enumType := soltype.Type(&soltype.AliasType{Name: qname, TypeArgs: typeArgs})
 	scope.defineType(qname, TypeBinding{

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -156,6 +156,72 @@ func TestTypeArgArityAtReference(t *testing.T) {
 	}
 }
 
+// TestSurplusTypeArgIsResolved checks that an argument written past the parameter count is
+// resolved before it is dropped, so a diagnostic inside it still reports. Dropping it unresolved
+// would hide the second problem behind the count, and fixing the count would then surface an
+// error the author had no reason to expect.
+func TestSurplusTypeArgIsResolved(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "OnGenericClass",
+			src: `
+				class Box<T> { v: T }
+				declare fn f() -> Box<number, Nonexistent>
+			`,
+			want: []string{
+				"class `Box` expects 1 type arguments but got 2",
+				"Unsupported: TypeRefTypeAnn",
+			},
+		},
+		{
+			name: "OnNonGenericClass",
+			src: `
+				class Point { x: number }
+				declare fn f() -> Point<Nonexistent>
+			`,
+			want: []string{
+				"class `Point` expects 0 type arguments but got 1",
+				"Unsupported: TypeRefTypeAnn",
+			},
+		},
+		{
+			name: "OnAlias",
+			src: `
+				type Box<T> = {v: T}
+				declare fn f() -> Box<number, Nonexistent>
+			`,
+			want: []string{
+				"type alias `Box` expects 1 type arguments but got 2",
+				"Unsupported: TypeRefTypeAnn",
+			},
+		},
+		{
+			name: "OnEnum",
+			src: `
+				enum Opt<T> { Some(value: T), None }
+				declare fn f() -> Opt<number, Nonexistent>
+			`,
+			want: []string{
+				"enum `Opt` expects 1 type arguments but got 2",
+				"Unsupported: TypeRefTypeAnn",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, len(tt.want))
+			for i, want := range tt.want {
+				require.Equal(t, want, errs[i].Message())
+			}
+		})
+	}
+}
+
 // TestTypeParamDefaultAtReference covers the other half of resolveTypeArgs, filling a trailing
 // omitted argument from its parameter's default. A class and an enum fill theirs the way an
 // alias does, so a bare `Box` against `class Box<T = number>` is `Box<number>` rather than the
@@ -251,18 +317,101 @@ func TestClassTypeParamDefaultIsPerReference(t *testing.T) {
 	require.Equal(t, "fn () -> Pair<string, string>", values["g"])
 }
 
-// TestClassArityUncheckedForUnresolvedSibling pins the one reference the class count does not
-// reach. The SCC pre-pass registers a bare ClassDef for every class in a dep_graph component so
-// a forward reference resolves, and each class's parameters land when its own pass runs. `A` is
-// walked first, so the `B<number, string>` in its body reaches `B` before `B`'s parameter list
-// exists and there is nothing to check the two written arguments against. The reference still
-// resolves, carrying exactly what it wrote.
-func TestClassArityUncheckedForUnresolvedSibling(t *testing.T) {
+// TestClassArityCheckedFromOtherDeclarations checks that the count reaches a reference written
+// anywhere, not only in a `fn` or `val` annotation. A class's members resolve in whatever order
+// the dep graph reaches its declaration, so a class body, an alias body, and an enum variant
+// parameter list all commonly name a class whose own pass has not run yet. The count is read
+// off the declaration's `<…>` clause when the class's identity is registered, which is before
+// any of them, so each reference is checked all the same.
+func TestClassArityCheckedFromOtherDeclarations(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "FromClassBodyOmitted",
+			src: `
+				class B<T> { v: T }
+				class A { b: B }
+			`,
+			want: "class `B` expects 1 type arguments but got 0",
+		},
+		// The declaration order is reversed from the row above, and the diagnostic is the same.
+		{
+			name: "FromClassBodyOmittedReversed",
+			src: `
+				class A { b: B }
+				class B<T> { v: T }
+			`,
+			want: "class `B` expects 1 type arguments but got 0",
+		},
+		{
+			name: "FromClassBodyTooMany",
+			src: `
+				class A { b: B<number, string> }
+				class B<T> { v: T }
+			`,
+			want: "class `B` expects 1 type arguments but got 2",
+		},
+		{
+			name: "FromAliasBody",
+			src: `
+				class B<T> { v: T }
+				type A = {b: B}
+			`,
+			want: "class `B` expects 1 type arguments but got 0",
+		},
+		{
+			name: "FromEnumVariantParam",
+			src: `
+				class B<T> { v: T }
+				enum A { X(b: B) }
+			`,
+			want: "class `B` expects 1 type arguments but got 0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, errs[0].Message())
+		})
+	}
+}
+
+// TestClassArityRecoveryKeepsDeclarationVarOut checks what an omitted class type argument
+// recovers to. `A` declares no type parameters, so its constructor must not be generic. Filling
+// the omitted argument with `B`'s own parameter var would make it one, since that var is
+// quantified at `B`'s boundary and generalizing `A`'s constructor would capture it. A fresh var
+// keeps `A` monomorphic.
+func TestClassArityRecoveryKeepsDeclarationVarOut(t *testing.T) {
 	src := `
-		class A { b: B<number, string> }
-		class B<T> { a: A, v: T }
+		class B<T> { v: T }
+		class A { b: B }
 	`
-	_, types, errs := inferSource(t, src)
+	values, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, "class `B` expects 1 type arguments but got 0", errs[0].Message())
+	require.Equal(t, "fn (b: B<unknown>) -> A", values["A"])
+}
+
+// TestClassDefaultUnfilledForUnresolvedSibling pins what the count reaching a reference early
+// does not buy. A class's Arity is registered with its identity, but its resolved TypeParams —
+// and so the defaults hanging off them — land only when that class's own pass runs. `A` is
+// walked before `B`, so the omitted argument has no default to read yet and recovers to a fresh
+// var: `B<unknown>` where the declaration says `B<number>`. No arity error is reported, since
+// omitting an argument for a defaulted parameter is a legal reference.
+//
+// The same reference written in a `fn` annotation does fill the default, which is what
+// TestTypeParamDefaultAtReference covers. Closing the gap needs the check deferred until every
+// class in the component has its parameters, the machinery PR19 adds for bounds.
+func TestClassDefaultUnfilledForUnresolvedSibling(t *testing.T) {
+	src := `
+		class B<T = number> { v: T }
+		class A { b: B }
+	`
+	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "A", types["A"])
+	require.Equal(t, "fn (b: B<unknown>) -> A", values["A"])
 }

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -1,0 +1,268 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTypeArgArityAtReference covers the argument-count check a reference gets from
+// resolveTypeArgs. An alias, a class, and an enum all route through it, so the three report
+// the same shape of message and differ only in the noun naming the declaration. The valid
+// count is the range from the parameters with no default up to the whole list, so the message
+// states a single count when every parameter is required and a range when a default makes one
+// optional.
+func TestTypeArgArityAtReference(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "ClassTooManyArgs",
+			src: `
+				class Box<T> { value: T }
+				declare fn f() -> Box<number, string>
+			`,
+			want: []string{"class `Box` expects 1 type arguments but got 2"},
+		},
+		{
+			name: "ClassTooFewArgs",
+			src: `
+				class Pair<T, U> { a: T, b: U }
+				declare fn f() -> Pair<number>
+			`,
+			want: []string{"class `Pair` expects 2 type arguments but got 1"},
+		},
+		// A bare reference to a class whose every parameter is required omits them all, so it
+		// is the same out-of-range count as any other short reference.
+		{
+			name: "ClassBareWithRequiredParam",
+			src: `
+				class Box<T> { value: T }
+				declare fn f() -> Box
+			`,
+			want: []string{"class `Box` expects 1 type arguments but got 0"},
+		},
+		{
+			name: "ClassTooManyArgsWithDefault",
+			src: `
+				class Pair<T, U = T> { a: T, b: U }
+				declare fn f() -> Pair<number, string, boolean>
+			`,
+			want: []string{"class `Pair` expects between 1 and 2 type arguments but got 3"},
+		},
+		{
+			name: "NonGenericClassWithArgs",
+			src: `
+				class Point { x: number }
+				declare fn f() -> Point<number>
+			`,
+			want: []string{"class `Point` expects 0 type arguments but got 1"},
+		},
+		// An enum registers as an alias whose body is the union of its variant handles, so its
+		// reference path is the alias one. The message names it an enum all the same.
+		{
+			name: "EnumTooManyArgs",
+			src: `
+				enum Opt<T> { Some(value: T), None }
+				declare fn f() -> Opt<number, string>
+			`,
+			want: []string{"enum `Opt` expects 1 type arguments but got 2"},
+		},
+		{
+			name: "EnumTooFewArgs",
+			src: `
+				enum Both<T, U> { Pair(a: T, b: U) }
+				declare fn f() -> Both<number>
+			`,
+			want: []string{"enum `Both` expects 2 type arguments but got 1"},
+		},
+		{
+			name: "EnumBareWithRequiredParam",
+			src: `
+				enum Opt<T> { Some(value: T), None }
+				declare fn f() -> Opt
+			`,
+			want: []string{"enum `Opt` expects 1 type arguments but got 0"},
+		},
+		{
+			name: "NonGenericEnumWithArgs",
+			src: `
+				enum Color { Red, Green }
+				declare fn f() -> Color<number>
+			`,
+			want: []string{"enum `Color` expects 0 type arguments but got 1"},
+		},
+		{
+			name: "AliasTooManyArgs",
+			src: `
+				type Box<T> = {value: T}
+				declare fn f() -> Box<number, string>
+			`,
+			want: []string{"type alias `Box` expects 1 type arguments but got 2"},
+		},
+		// A reference that names the declaration it sits inside is checked like any other, so
+		// a self-referential class body has to write its own arguments.
+		{
+			name: "ClassSelfReferenceBare",
+			src: `
+				class Node<T> { value: T, next: Node }
+			`,
+			want: []string{"class `Node` expects 1 type arguments but got 0"},
+		},
+		{
+			name: "ClassSelfReferenceWithArgAccepted",
+			src: `
+				class Node<T> { value: T, next: Node<T> }
+			`,
+		},
+		{
+			name: "EnumSelfReferenceBare",
+			src: `
+				enum List<T> { Cons(head: T, tail: List), Nil }
+			`,
+			want: []string{"enum `List` expects 1 type arguments but got 0"},
+		},
+		{
+			name: "EnumSelfReferenceWithArgAccepted",
+			src: `
+				enum List<T> { Cons(head: T, tail: List<T>), Nil }
+			`,
+		},
+		{
+			name: "ClassExactCountAccepted",
+			src: `
+				class Pair<T, U> { a: T, b: U }
+				declare fn f() -> Pair<number, string>
+			`,
+		},
+		{
+			name: "NonGenericClassBareAccepted",
+			src: `
+				class Point { x: number }
+				declare fn f() -> Point
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, len(tt.want))
+			for i, want := range tt.want {
+				require.Equal(t, want, errs[i].Message())
+			}
+		})
+	}
+}
+
+// TestTypeParamDefaultAtReference covers the other half of resolveTypeArgs, filling a trailing
+// omitted argument from its parameter's default. A class and an enum fill theirs the way an
+// alias does, so a bare `Box` against `class Box<T = number>` is `Box<number>` rather than the
+// declaration handle, whose unconstrained parameter var coalesces to `never`.
+func TestTypeParamDefaultAtReference(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "ClassBareFillsDefault",
+			src: `
+				class Box<T = number> { value: T }
+				declare fn f() -> Box
+			`,
+			want: "fn () -> Box<number>",
+		},
+		{
+			name: "ClassPartialFillsTrailingDefault",
+			src: `
+				class Pair<T, U = string> { a: T, b: U }
+				declare fn f() -> Pair<number>
+			`,
+			want: "fn () -> Pair<number, string>",
+		},
+		// A default may name a parameter declared before it, so the argument that filled the
+		// earlier slot is substituted into it.
+		{
+			name: "ClassDefaultNamesEarlierParam",
+			src: `
+				class Pair<T, U = T> { a: T, b: U }
+				declare fn f() -> Pair<number>
+			`,
+			want: "fn () -> Pair<number, number>",
+		},
+		// A parameter carrying both a bound and a default keeps them independent: the default
+		// fills the omitted argument, and the bound still constrains what the constructor takes.
+		{
+			name: "ClassBoundedDefault",
+			src: `
+				class Box<T: number = 5> { value: T }
+				declare fn f() -> Box
+			`,
+			want: "fn () -> Box<5>",
+		},
+		{
+			name: "EnumBareFillsDefault",
+			src: `
+				enum Opt<T = number> { Some(value: T), None }
+				declare fn f() -> Opt
+			`,
+			want: "fn () -> Opt<number>",
+		},
+		{
+			name: "EnumDefaultNamesEarlierParam",
+			src: `
+				enum Both<T, U = T> { Pair(a: T, b: U) }
+				declare fn f() -> Both<number>
+			`,
+			want: "fn () -> Both<number, number>",
+		},
+		{
+			name: "AliasBareFillsDefault",
+			src: `
+				type Box<T = number> = {value: T}
+				declare fn f() -> Box
+			`,
+			want: "fn () -> Box<number>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// TestClassTypeParamDefaultIsPerReference checks that a default filled at one class reference
+// does not reach another. `U = T` substitutes the argument that reference wrote for `T`, so `f`
+// and `g` each carry their own second argument instead of sharing one var declared on the class.
+func TestClassTypeParamDefaultIsPerReference(t *testing.T) {
+	src := `
+		class Pair<T, U = T> { a: T, b: U }
+		declare fn f() -> Pair<number>
+		declare fn g() -> Pair<string>
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> Pair<number, number>", values["f"])
+	require.Equal(t, "fn () -> Pair<string, string>", values["g"])
+}
+
+// TestClassArityUncheckedForUnresolvedSibling pins the one reference the class count does not
+// reach. The SCC pre-pass registers a bare ClassDef for every class in a dep_graph component so
+// a forward reference resolves, and each class's parameters land when its own pass runs. `A` is
+// walked first, so the `B<number, string>` in its body reaches `B` before `B`'s parameter list
+// exists and there is nothing to check the two written arguments against. The reference still
+// resolves, carrying exactly what it wrote.
+func TestClassArityUncheckedForUnresolvedSibling(t *testing.T) {
+	src := `
+		class A { b: B<number, string> }
+		class B<T> { a: A, v: T }
+	`
+	_, types, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "A", types["A"])
+}

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -7,11 +7,13 @@ import (
 )
 
 // TestTypeArgArityAtReference covers the argument-count check a reference gets from
-// resolveTypeArgs. An alias, a class, and an enum all route through it, so the three report
-// the same shape of message and differ only in the noun naming the declaration. The valid
-// count is the range from the parameters with no default up to the whole list, so the message
-// states a single count when every parameter is required and a range when a default makes one
-// optional.
+// resolveTypeArgs. The valid count is the range from the parameters with no default up to the
+// whole list, so the message states a single count when every parameter is required and a range
+// when a default makes one optional.
+//
+// The rows vary the direction of the miscount and the branch of the message, and cover each
+// declaration sort once for the noun it renders. An alias, a class, and an enum all reach the
+// one helper, so a second row for a sort would re-run the same comparison.
 func TestTypeArgArityAtReference(t *testing.T) {
 	tests := []struct {
 		name string
@@ -71,22 +73,6 @@ func TestTypeArgArityAtReference(t *testing.T) {
 			want: []string{"enum `Opt` expects 1 type arguments but got 2"},
 		},
 		{
-			name: "EnumTooFewArgs",
-			src: `
-				enum Both<T, U> { Pair(a: T, b: U) }
-				declare fn f() -> Both<number>
-			`,
-			want: []string{"enum `Both` expects 2 type arguments but got 1"},
-		},
-		{
-			name: "EnumBareWithRequiredParam",
-			src: `
-				enum Opt<T> { Some(value: T), None }
-				declare fn f() -> Opt
-			`,
-			want: []string{"enum `Opt` expects 1 type arguments but got 0"},
-		},
-		{
 			name: "NonGenericEnumWithArgs",
 			src: `
 				enum Color { Red, Green }
@@ -118,30 +104,10 @@ func TestTypeArgArityAtReference(t *testing.T) {
 			`,
 		},
 		{
-			name: "EnumSelfReferenceBare",
-			src: `
-				enum List<T> { Cons(head: T, tail: List), Nil }
-			`,
-			want: []string{"enum `List` expects 1 type arguments but got 0"},
-		},
-		{
-			name: "EnumSelfReferenceWithArgAccepted",
-			src: `
-				enum List<T> { Cons(head: T, tail: List<T>), Nil }
-			`,
-		},
-		{
 			name: "ClassExactCountAccepted",
 			src: `
 				class Pair<T, U> { a: T, b: U }
 				declare fn f() -> Pair<number, string>
-			`,
-		},
-		{
-			name: "NonGenericClassBareAccepted",
-			src: `
-				class Point { x: number }
-				declare fn f() -> Point
 			`,
 		},
 	}
@@ -163,8 +129,11 @@ func TestTypeArgArityAtReference(t *testing.T) {
 // `never`.
 //
 // Two things report. The declaration reports the unreachable default, once per default and on
-// every path that resolves a `<…>` clause. A reference short of the last required parameter
-// reports the count, which runs to that parameter rather than to the first defaulted one.
+// every path that resolves a `<…>` clause — four rows, since each is a separate call into
+// resolveTypeParams. A reference short of the last required parameter reports the count, which
+// runs to that parameter rather than to the first defaulted one. That has two rows rather than
+// three: an alias and an enum share `arityOfParams`, while a class reads the count its
+// declaration registered through `arityOfParamDecls`.
 func TestRequiredTypeParamAfterDefault(t *testing.T) {
 	const unreachable = "the default for type parameter `T` can never be used, " +
 		"since `U` is declared after it and has no default"
@@ -211,14 +180,6 @@ func TestRequiredTypeParamAfterDefault(t *testing.T) {
 				declare fn f() -> Pair<string>
 			`,
 			want: []string{unreachable, "class `Pair` expects 2 type arguments but got 1"},
-		},
-		{
-			name: "EnumReferenceShortOfLastRequired",
-			src: `
-				enum Pair<T = number, U> { Both(a: T, b: U) }
-				declare fn f() -> Pair<string>
-			`,
-			want: []string{unreachable, "enum `Pair` expects 2 type arguments but got 1"},
 		},
 		// The default is kept rather than dropped, so a reference that writes every argument
 		// still resolves against the full parameter list and reports only the declaration.
@@ -272,6 +233,10 @@ func TestRequiredTypeParamAfterDefault(t *testing.T) {
 // resolved before it is dropped, so a diagnostic inside it still reports. Dropping it unresolved
 // would hide the second problem behind the count, and fixing the count would then surface an
 // error the author had no reason to expect.
+//
+// The zero-parameter row is the one that is not a repeat: resolveTypeArgs returns early for a
+// declaration with no parameters, so the resolve has to happen before that return. The alias row
+// guards the same behavior on the path whose logic moved.
 func TestSurplusTypeArgIsResolved(t *testing.T) {
 	tests := []struct {
 		name string
@@ -308,17 +273,6 @@ func TestSurplusTypeArgIsResolved(t *testing.T) {
 			`,
 			want: []string{
 				"type alias `Box` expects 1 type arguments but got 2",
-				"Unsupported: TypeRefTypeAnn",
-			},
-		},
-		{
-			name: "OnEnum",
-			src: `
-				enum Opt<T> { Some(value: T), None }
-				declare fn f() -> Opt<number, Nonexistent>
-			`,
-			want: []string{
-				"enum `Opt` expects 1 type arguments but got 2",
 				"Unsupported: TypeRefTypeAnn",
 			},
 		},
@@ -360,16 +314,6 @@ func TestTypeParamDefaultAtReference(t *testing.T) {
 			`,
 			want: "fn () -> Pair<number, string>",
 		},
-		// A default may name a parameter declared before it, so the argument that filled the
-		// earlier slot is substituted into it.
-		{
-			name: "ClassDefaultNamesEarlierParam",
-			src: `
-				class Pair<T, U = T> { a: T, b: U }
-				declare fn f() -> Pair<number>
-			`,
-			want: "fn () -> Pair<number, number>",
-		},
 		// A parameter carrying both a bound and a default keeps them independent: the default
 		// fills the omitted argument, and the bound still constrains what the constructor takes.
 		{
@@ -389,14 +333,6 @@ func TestTypeParamDefaultAtReference(t *testing.T) {
 			want: "fn () -> Opt<number>",
 		},
 		{
-			name: "EnumDefaultNamesEarlierParam",
-			src: `
-				enum Both<T, U = T> { Pair(a: T, b: U) }
-				declare fn f() -> Both<number>
-			`,
-			want: "fn () -> Both<number, number>",
-		},
-		{
 			name: "AliasBareFillsDefault",
 			src: `
 				type Box<T = number> = {value: T}
@@ -414,9 +350,10 @@ func TestTypeParamDefaultAtReference(t *testing.T) {
 	}
 }
 
-// TestClassTypeParamDefaultIsPerReference checks that a default filled at one class reference
-// does not reach another. `U = T` substitutes the argument that reference wrote for `T`, so `f`
-// and `g` each carry their own second argument instead of sharing one var declared on the class.
+// TestClassTypeParamDefaultIsPerReference covers a default that names an earlier parameter, and
+// checks that the argument filled from it at one reference does not reach another. `U = T`
+// substitutes the argument that reference wrote for `T`, so `f` and `g` each carry their own
+// second argument instead of sharing one var declared on the class.
 func TestClassTypeParamDefaultIsPerReference(t *testing.T) {
 	src := `
 		class Pair<T, U = T> { a: T, b: U }
@@ -441,17 +378,11 @@ func TestClassArityCheckedFromOtherDeclarations(t *testing.T) {
 		src  string
 		want string
 	}{
+		// `B` is declared after the class that names it, and the diagnostic is the same one
+		// TestClassArityRecoveryKeepsDeclarationVarOut gets for the two declared the other way
+		// round, so the count does not depend on which class the dep graph reaches first.
 		{
-			name: "FromClassBodyOmitted",
-			src: `
-				class B<T> { v: T }
-				class A { b: B }
-			`,
-			want: "class `B` expects 1 type arguments but got 0",
-		},
-		// The declaration order is reversed from the row above, and the diagnostic is the same.
-		{
-			name: "FromClassBodyOmittedReversed",
+			name: "FromClassBodyDeclaredLater",
 			src: `
 				class A { b: B }
 				class B<T> { v: T }

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -505,7 +505,7 @@ func TestClassArityRecoveryKeepsDeclarationVarOut(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "class `B` expects 1 type arguments but got 0", errs[0].Message())
-	require.Equal(t, "fn (b: B<unknown>) -> A", values["A"])
+	require.Equal(t, "{new (b: B<unknown>) -> A}", values["A"])
 }
 
 // TestClassDefaultUnfilledForUnresolvedSibling pins what the count reaching a reference early
@@ -525,5 +525,5 @@ func TestClassDefaultUnfilledForUnresolvedSibling(t *testing.T) {
 	`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (b: B<unknown>) -> A", values["A"])
+	require.Equal(t, "{new (b: B<unknown>) -> A}", values["A"])
 }

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -156,6 +156,118 @@ func TestTypeArgArityAtReference(t *testing.T) {
 	}
 }
 
+// TestRequiredTypeParamAfterDefault covers a default declared before a parameter that has none,
+// `<T = number, U>`. Arguments bind positionally, so omitting the argument for `T` would leave
+// `U` reading the one written for `T`. The default can therefore never be reached, and counting
+// it as optional would let `Pair<string>` pass while leaving `U` a fresh var that coalesces to
+// `never`.
+//
+// Two things report. The declaration reports the unreachable default, once per default and on
+// every path that resolves a `<…>` clause. A reference short of the last required parameter
+// reports the count, which runs to that parameter rather than to the first defaulted one.
+func TestRequiredTypeParamAfterDefault(t *testing.T) {
+	const unreachable = "the default for type parameter `T` can never be used, " +
+		"since `U` is declared after it and has no default"
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "AliasDeclaration",
+			src:  `type Pair<T = number, U> = {a: T, b: U}`,
+			want: []string{unreachable},
+		},
+		{
+			name: "ClassDeclaration",
+			src:  `class Pair<T = number, U> { a: T, b: U }`,
+			want: []string{unreachable},
+		},
+		{
+			name: "EnumDeclaration",
+			src:  `enum Pair<T = number, U> { Both(a: T, b: U) }`,
+			want: []string{unreachable},
+		},
+		{
+			name: "FuncAnnotationDeclaration",
+			src:  `declare fn f<T = number, U>(a: T, b: U) -> U`,
+			want: []string{unreachable},
+		},
+		// The count runs to `U`, the last required parameter, so one argument is short of the
+		// range rather than inside it. Without that the reference would pass and `U` would be
+		// synthesized from nothing.
+		{
+			name: "ReferenceShortOfLastRequired",
+			src: `
+				type Pair<T = number, U> = {a: T, b: U}
+				declare fn f() -> Pair<string>
+			`,
+			want: []string{unreachable, "type alias `Pair` expects 2 type arguments but got 1"},
+		},
+		{
+			name: "ClassReferenceShortOfLastRequired",
+			src: `
+				class Pair<T = number, U> { a: T, b: U }
+				declare fn f() -> Pair<string>
+			`,
+			want: []string{unreachable, "class `Pair` expects 2 type arguments but got 1"},
+		},
+		{
+			name: "EnumReferenceShortOfLastRequired",
+			src: `
+				enum Pair<T = number, U> { Both(a: T, b: U) }
+				declare fn f() -> Pair<string>
+			`,
+			want: []string{unreachable, "enum `Pair` expects 2 type arguments but got 1"},
+		},
+		// The default is kept rather than dropped, so a reference that writes every argument
+		// still resolves against the full parameter list and reports only the declaration.
+		{
+			name: "ReferenceWritingEveryArgument",
+			src: `
+				type Pair<T = number, U> = {a: T, b: U}
+				declare fn f() -> Pair<string, boolean>
+			`,
+			want: []string{unreachable},
+		},
+		// Each unreachable default is named, so one pass over the reports fixes the clause. Both
+		// name `V`, the first parameter after them with no default.
+		{
+			name: "TwoUnreachableDefaults",
+			src:  `type Trio<T = number, U = string, V> = {a: T, b: U, c: V}`,
+			want: []string{
+				"the default for type parameter `T` can never be used, since `V` is declared after it and has no default",
+				"the default for type parameter `U` can never be used, since `V` is declared after it and has no default",
+			},
+		},
+		// A default reaching the end of the clause is what the rule allows, since every parameter
+		// from it on can be filled.
+		{
+			name: "TrailingDefaultAccepted",
+			src: `
+				type Pair<T, U = number> = {a: T, b: U}
+				declare fn f() -> Pair<string>
+			`,
+		},
+		{
+			name: "EveryParamDefaultedAccepted",
+			src: `
+				type Pair<T = string, U = number> = {a: T, b: U}
+				declare fn f() -> Pair
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, len(tt.want))
+			for i, want := range tt.want {
+				require.Equal(t, want, errs[i].Message())
+			}
+		})
+	}
+}
+
 // TestSurplusTypeArgIsResolved checks that an argument written past the parameter count is
 // resolved before it is dropped, so a diagnostic inside it still reports. Dropping it unresolved
 // would hide the second problem behind the count, and fixing the count would then surface an

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -14,6 +14,7 @@ import (
 // `<T: U, U: T>`, and an F-bound `<T: Foo<T>>` all resolve. The result stays in declaration order,
 // and the alias, class, enum, and function-annotation paths all route through here.
 func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypeParam) []*soltype.TypeParam {
+	c.reportRequiredAfterDefault(params)
 	out := make([]*soltype.TypeParam, len(params))
 	// Pass 1: mint each parameter's var. Nothing is declared yet, so pass 2 controls which
 	// siblings each default can see.
@@ -60,15 +61,30 @@ type typeParamArity struct {
 	Total    int
 }
 
-// arityOfParams reads the argument-count range off a resolved parameter list.
-func arityOfParams(params []*soltype.TypeParam) typeParamArity {
-	arity := typeParamArity{Total: len(params)}
-	for _, p := range params {
-		if p.Default == nil {
-			arity.Required++
+// requiredArgCount returns how many arguments a reference must write for a parameter list of
+// length total, where hasDefault reports whether the parameter at an index carries one.
+//
+// This is one past the last parameter with no default, NOT the number of parameters that lack
+// one. Arguments bind positionally, so an argument can be omitted only when every parameter
+// from that position on has a default to fill it. A default written before a required
+// parameter, the `T = number` of `<T = number, U>`, can therefore never be omitted, and
+// counting it as optional would let `Pair<string>` pass while leaving `U` a fresh variable that
+// coalesces to `never`. resolveTypeParams reports such a declaration.
+func requiredArgCount(total int, hasDefault func(int) bool) int {
+	for i := total - 1; i >= 0; i-- {
+		if !hasDefault(i) {
+			return i + 1
 		}
 	}
-	return arity
+	return 0
+}
+
+// arityOfParams reads the argument-count range off a resolved parameter list.
+func arityOfParams(params []*soltype.TypeParam) typeParamArity {
+	return typeParamArity{
+		Required: requiredArgCount(len(params), func(i int) bool { return params[i].Default != nil }),
+		Total:    len(params),
+	}
 }
 
 // arityOfParamDecls reads the argument-count range straight off a declaration's `<…>` clause,
@@ -76,13 +92,10 @@ func arityOfParams(params []*soltype.TypeParam) typeParamArity {
 // arityOfParams reads off the resolved list, since a parameter's `= …` clause is what makes it
 // optional and resolving the clause does not change whether it is there.
 func arityOfParamDecls(params []*ast.TypeParam) typeParamArity {
-	arity := typeParamArity{Total: len(params)}
-	for _, p := range params {
-		if p.Default == nil {
-			arity.Required++
-		}
+	return typeParamArity{
+		Required: requiredArgCount(len(params), func(i int) bool { return params[i].Default != nil }),
+		Total:    len(params),
 	}
-	return arity
 }
 
 // resolveTypeArgs pairs the `<…>` type arguments a reference wrote with the parameters of the
@@ -155,6 +168,41 @@ func (c *checker) resolveTypeArgs(
 		}
 	}
 	return args
+}
+
+// reportRequiredAfterDefault reports each default that a later parameter with no default makes
+// unusable, the `T = number` of `<T = number, U>`. Arguments bind positionally, so omitting the
+// argument for `T` would leave `U` reading the argument written for `T`. A reference therefore
+// has to write every argument up to the last required parameter, which is what requiredArgCount
+// computes, and a default before that point can never be reached.
+//
+// One report per such default, blaming the `= …` annotation and naming the first required
+// parameter that follows it. Blaming each default rather than each required parameter names
+// exactly the annotations that have to change, and the fix is to drop the default or to give
+// every parameter after it one.
+//
+// The default is kept rather than dropped, so a reference that does write every argument still
+// resolves against a full parameter list.
+func (c *checker) reportRequiredAfterDefault(params []*ast.TypeParam) {
+	required := requiredArgCount(len(params), func(i int) bool { return params[i].Default != nil })
+	for i, p := range params[:required] {
+		if p.Default == nil {
+			continue
+		}
+		// params[required-1] has no default, so a later one always exists to name.
+		target := params[required-1]
+		for _, later := range params[i+1 : required] {
+			if later.Default == nil {
+				target = later
+				break
+			}
+		}
+		c.report(&TypeParamRequiredAfterDefaultError{
+			Default: p.Default,
+			Param:   p.Name,
+			Target:  target.Name,
+		})
+	}
 }
 
 // reportDefaultForwardRef reports each parameter params[i]'s default names that it may not,

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -59,6 +59,7 @@ type typeParamArity struct {
 // requiredArgCount returns how many arguments a reference must write: one past the last
 // parameter with no default, not the number lacking one. Arguments bind positionally, so a
 // default before a required parameter can never be omitted, which resolveTypeParams reports.
+// hasDefault is a callback because a parameter list reaches this as either sort of TypeParam.
 func requiredArgCount(total int, hasDefault func(int) bool) int {
 	for i := total - 1; i >= 0; i-- {
 		if !hasDefault(i) {
@@ -151,7 +152,7 @@ func (c *checker) resolveTypeArgs(
 // exactly the annotations that have to change. The default is kept rather than dropped, so a
 // reference that does write every argument still resolves against a full parameter list.
 func (c *checker) reportRequiredAfterDefault(params []*ast.TypeParam) {
-	required := requiredArgCount(len(params), func(i int) bool { return params[i].Default != nil })
+	required := arityOfParamDecls(params).Required
 	for i, p := range params[:required] {
 		if p.Default == nil {
 			continue

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -47,13 +47,80 @@ func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypePar
 	return out
 }
 
+// resolveTypeArgs pairs the `<…>` type arguments a reference wrote with the parameters of the
+// declaration it names, and returns one argument per parameter. It is the instantiation twin
+// of resolveTypeParams, and the alias, enum, and class reference paths all route through it,
+// so a defaulted or miscounted reference resolves the same way whichever sort it names.
+//
+// Three things happen here. The written count is checked against the parameter list, where the
+// valid range runs from the parameters with no default up to the whole list. A trailing
+// omitted argument is filled from its parameter's default, with the arguments already resolved
+// substituted in, so the `U = T` of `type Pair<T, U = T>` resolves `Pair<number>` to
+// `Pair<number, number>`. A required argument that the reference omitted, or one whose
+// annotation failed to resolve, recovers to a fresh var, so a downstream reference still has
+// one argument per parameter to substitute.
+//
+// The result is nil for a declaration with no type parameters, and any arguments the reference
+// wrote past the parameter count are reported and then dropped.
+func (c *checker) resolveTypeArgs(
+	scope *Scope,
+	ref *ast.TypeRefTypeAnn,
+	kind TypeDeclKind,
+	params []*soltype.TypeParam,
+	lvl int,
+) []soltype.Type {
+	total := len(params)
+	required := 0
+	for _, p := range params {
+		if p.Default == nil {
+			required++
+		}
+	}
+	got := len(ref.TypeArgs)
+	if got < required || got > total {
+		c.report(&TypeArgArityMismatchError{
+			Ref:      ref,
+			Kind:     kind,
+			Name:     ast.QualIdentToString(ref.Name),
+			Required: required,
+			Total:    total,
+			Got:      got,
+		})
+	}
+	if total == 0 {
+		return nil
+	}
+	args := make([]soltype.Type, total)
+	for i := range total {
+		if i < got {
+			if resolved, ok := c.resolveTypeAnn(scope, ref.TypeArgs[i], lvl); ok {
+				args[i] = resolved
+			} else {
+				args[i] = c.freshAt(lvl)
+			}
+			continue
+		}
+		if params[i].Default != nil {
+			// The default may reference an earlier parameter, as `U = T` does, so substitute
+			// the arguments already resolved for parameters before this one.
+			subst := newTypeSubst(params[:i], args[:i], nil, nil)
+			args[i] = params[i].Default.Accept(subst, soltype.Positive)
+		} else {
+			// A required argument was omitted, already reported as an arity mismatch. Recover
+			// to a fresh var so every parameter has an argument to substitute.
+			args[i] = c.freshAt(lvl)
+		}
+	}
+	return args
+}
+
 // reportDefaultForwardRef reports each parameter params[i]'s default names that it may not,
 // params[i] itself or one declared after it, and returns whether it reported. A reference fills an
 // omitted argument from the default with the earlier arguments substituted in, as
-// buildAliasInstance does for the `U = T` of `type Pair<T, U = T>`. A later or self reference has
+// resolveTypeArgs does for the `U = T` of `type Pair<T, U = T>`. A later or self reference has
 // nothing to substitute, so it stays the declaration's own var, shared by every reference to the
-// type. A rejected default is dropped, which leaves the parameter required. Neither instance
-// builder reports the follow-on arity error in every case, which PR18's shared helper settles.
+// type. A rejected default is dropped, which leaves the parameter required, so a reference that
+// omits it reports an arity mismatch alongside this error.
 //
 // One report per offending name, blaming its leftmost reference. Naming each one lets a default
 // that reaches two later parameters be fixed in a single pass, while a name written twice reports

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -48,28 +48,17 @@ func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypePar
 	return out
 }
 
-// typeParamArity is how many type arguments a reference to a declaration may write. Total is
-// the whole parameter list and Required counts the parameters with no default, so a valid
-// reference writes anywhere from Required to Total arguments.
-//
-// It is carried separately from the resolved parameters because the two become available at
-// different times on the class path. A class's identity is registered before its parameters
-// are resolved, and a reference reaching it in that window still has to be counted, so the
-// arity is read off the declaration's `<…>` clause when the identity is registered.
+// typeParamArity is how many type arguments a reference to a declaration may write, anywhere
+// from Required to Total. It is carried separately from the resolved parameters because a
+// class registers its identity, and so its count, before its parameters resolve.
 type typeParamArity struct {
 	Required int
 	Total    int
 }
 
-// requiredArgCount returns how many arguments a reference must write for a parameter list of
-// length total, where hasDefault reports whether the parameter at an index carries one.
-//
-// This is one past the last parameter with no default, NOT the number of parameters that lack
-// one. Arguments bind positionally, so an argument can be omitted only when every parameter
-// from that position on has a default to fill it. A default written before a required
-// parameter, the `T = number` of `<T = number, U>`, can therefore never be omitted, and
-// counting it as optional would let `Pair<string>` pass while leaving `U` a fresh variable that
-// coalesces to `never`. resolveTypeParams reports such a declaration.
+// requiredArgCount returns how many arguments a reference must write: one past the last
+// parameter with no default, not the number lacking one. Arguments bind positionally, so a
+// default before a required parameter can never be omitted, which resolveTypeParams reports.
 func requiredArgCount(total int, hasDefault func(int) bool) int {
 	for i := total - 1; i >= 0; i-- {
 		if !hasDefault(i) {

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -47,67 +47,110 @@ func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypePar
 	return out
 }
 
+// typeParamArity is how many type arguments a reference to a declaration may write. Total is
+// the whole parameter list and Required counts the parameters with no default, so a valid
+// reference writes anywhere from Required to Total arguments.
+//
+// It is carried separately from the resolved parameters because the two become available at
+// different times on the class path. A class's identity is registered before its parameters
+// are resolved, and a reference reaching it in that window still has to be counted, so the
+// arity is read off the declaration's `<…>` clause when the identity is registered.
+type typeParamArity struct {
+	Required int
+	Total    int
+}
+
+// arityOfParams reads the argument-count range off a resolved parameter list.
+func arityOfParams(params []*soltype.TypeParam) typeParamArity {
+	arity := typeParamArity{Total: len(params)}
+	for _, p := range params {
+		if p.Default == nil {
+			arity.Required++
+		}
+	}
+	return arity
+}
+
+// arityOfParamDecls reads the argument-count range straight off a declaration's `<…>` clause,
+// before the parameters themselves are resolved. It counts the same two numbers
+// arityOfParams reads off the resolved list, since a parameter's `= …` clause is what makes it
+// optional and resolving the clause does not change whether it is there.
+func arityOfParamDecls(params []*ast.TypeParam) typeParamArity {
+	arity := typeParamArity{Total: len(params)}
+	for _, p := range params {
+		if p.Default == nil {
+			arity.Required++
+		}
+	}
+	return arity
+}
+
 // resolveTypeArgs pairs the `<…>` type arguments a reference wrote with the parameters of the
 // declaration it names, and returns one argument per parameter. It is the instantiation twin
 // of resolveTypeParams, and the alias, enum, and class reference paths all route through it,
 // so a defaulted or miscounted reference resolves the same way whichever sort it names.
 //
-// Three things happen here. The written count is checked against the parameter list, where the
-// valid range runs from the parameters with no default up to the whole list. A trailing
-// omitted argument is filled from its parameter's default, with the arguments already resolved
-// substituted in, so the `U = T` of `type Pair<T, U = T>` resolves `Pair<number>` to
-// `Pair<number, number>`. A required argument that the reference omitted, or one whose
-// annotation failed to resolve, recovers to a fresh var, so a downstream reference still has
-// one argument per parameter to substitute.
+// Three things happen here. The written count is checked against arity, and an out-of-range
+// count is reported. Every written argument is resolved, so an unresolvable annotation reports
+// even in a position past the parameter count. An argument the reference omitted is filled
+// from its parameter's default, with the arguments already resolved substituted in, so the
+// `U = T` of `type Pair<T, U = T>` resolves `Pair<number>` to `Pair<number, number>`.
 //
-// The result is nil for a declaration with no type parameters, and any arguments the reference
-// wrote past the parameter count are reported and then dropped.
+// An omitted argument with no default to fill it recovers to a fresh var, and so does one
+// whose annotation failed to resolve, so a downstream reference always has one argument per
+// parameter to substitute and never picks up a var belonging to the declaration.
+//
+// params may be shorter than arity.Total, which is how a class whose parameters are not
+// resolved yet reaches here. Those positions have no default to read, so each one recovers to
+// a fresh var. The result is nil when arity.Total is zero, and any arguments the reference
+// wrote past the parameter count are resolved, reported, and then dropped.
 func (c *checker) resolveTypeArgs(
 	scope *Scope,
 	ref *ast.TypeRefTypeAnn,
 	kind TypeDeclKind,
 	params []*soltype.TypeParam,
+	arity typeParamArity,
 	lvl int,
 ) []soltype.Type {
-	total := len(params)
-	required := 0
-	for _, p := range params {
-		if p.Default == nil {
-			required++
-		}
-	}
 	got := len(ref.TypeArgs)
-	if got < required || got > total {
+	if got < arity.Required || got > arity.Total {
 		c.report(&TypeArgArityMismatchError{
 			Ref:      ref,
 			Kind:     kind,
 			Name:     ast.QualIdentToString(ref.Name),
-			Required: required,
-			Total:    total,
+			Required: arity.Required,
+			Total:    arity.Total,
 			Got:      got,
 		})
 	}
-	if total == 0 {
+	// Resolve every written argument, including any past the parameter count. A surplus
+	// argument is dropped below, but resolving it first is what reports an unresolvable name
+	// inside it rather than swallowing the diagnostic along with the argument.
+	written := make([]soltype.Type, got)
+	for i, arg := range ref.TypeArgs {
+		if resolved, ok := c.resolveTypeAnn(scope, arg, lvl); ok {
+			written[i] = resolved
+		} else {
+			written[i] = c.freshAt(lvl)
+		}
+	}
+	if arity.Total == 0 {
 		return nil
 	}
-	args := make([]soltype.Type, total)
-	for i := range total {
-		if i < got {
-			if resolved, ok := c.resolveTypeAnn(scope, ref.TypeArgs[i], lvl); ok {
-				args[i] = resolved
-			} else {
-				args[i] = c.freshAt(lvl)
-			}
-			continue
-		}
-		if params[i].Default != nil {
+	args := make([]soltype.Type, arity.Total)
+	for i := range arity.Total {
+		switch {
+		case i < got:
+			args[i] = written[i]
+		case i < len(params) && params[i].Default != nil:
 			// The default may reference an earlier parameter, as `U = T` does, so substitute
 			// the arguments already resolved for parameters before this one.
 			subst := newTypeSubst(params[:i], args[:i], nil, nil)
 			args[i] = params[i].Default.Accept(subst, soltype.Positive)
-		} else {
-			// A required argument was omitted, already reported as an arity mismatch. Recover
-			// to a fresh var so every parameter has an argument to substitute.
+		default:
+			// A required argument was omitted, already reported as an arity mismatch, or the
+			// parameter list is not resolved yet so there is no default to read. Recover to a
+			// fresh var so every parameter has an argument to substitute.
 			args[i] = c.freshAt(lvl)
 		}
 	}

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -159,19 +159,11 @@ func (c *checker) resolveTypeArgs(
 	return args
 }
 
-// reportRequiredAfterDefault reports each default that a later parameter with no default makes
-// unusable, the `T = number` of `<T = number, U>`. Arguments bind positionally, so omitting the
-// argument for `T` would leave `U` reading the argument written for `T`. A reference therefore
-// has to write every argument up to the last required parameter, which is what requiredArgCount
-// computes, and a default before that point can never be reached.
-//
-// One report per such default, blaming the `= …` annotation and naming the first required
-// parameter that follows it. Blaming each default rather than each required parameter names
-// exactly the annotations that have to change, and the fix is to drop the default or to give
-// every parameter after it one.
-//
-// The default is kept rather than dropped, so a reference that does write every argument still
-// resolves against a full parameter list.
+// reportRequiredAfterDefault reports each default a later parameter with no default makes
+// unusable, the `T = number` of `<T = number, U>`. One report per such default, blaming the
+// `= …` annotation and naming the first required parameter after it, so the reports name
+// exactly the annotations that have to change. The default is kept rather than dropped, so a
+// reference that does write every argument still resolves against a full parameter list.
 func (c *checker) reportRequiredAfterDefault(params []*ast.TypeParam) {
 	required := requiredArgCount(len(params), func(i int) bool { return params[i].Default != nil })
 	for i, p := range params[:required] {

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -88,24 +88,10 @@ func arityOfParamDecls(params []*ast.TypeParam) typeParamArity {
 }
 
 // resolveTypeArgs pairs the `<…>` type arguments a reference wrote with the parameters of the
-// declaration it names, and returns one argument per parameter. It is the instantiation twin
-// of resolveTypeParams, and the alias, enum, and class reference paths all route through it,
-// so a defaulted or miscounted reference resolves the same way whichever sort it names.
-//
-// Three things happen here. The written count is checked against arity, and an out-of-range
-// count is reported. Every written argument is resolved, so an unresolvable annotation reports
-// even in a position past the parameter count. An argument the reference omitted is filled
-// from its parameter's default, with the arguments already resolved substituted in, so the
-// `U = T` of `type Pair<T, U = T>` resolves `Pair<number>` to `Pair<number, number>`.
-//
-// An omitted argument with no default to fill it recovers to a fresh var, and so does one
-// whose annotation failed to resolve, so a downstream reference always has one argument per
-// parameter to substitute and never picks up a var belonging to the declaration.
-//
-// params may be shorter than arity.Total, which is how a class whose parameters are not
-// resolved yet reaches here. Those positions have no default to read, so each one recovers to
-// a fresh var. The result is nil when arity.Total is zero, and any arguments the reference
-// wrote past the parameter count are resolved, reported, and then dropped.
+// declaration it names, returning one per parameter or nil when there are none. Shared by the
+// alias, enum, and class paths, it reports an out-of-range count, fills an omitted argument
+// from its default, and recovers anything left to a fresh var. A class whose parameters have
+// not resolved yet passes params shorter than arity.Total, so those positions recover too.
 func (c *checker) resolveTypeArgs(
 	scope *Scope,
 	ref *ast.TypeRefTypeAnn,

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -1436,23 +1436,39 @@ resolves exactly the arguments the reference wrote and returns them, so
 `class Box<T = number>` referenced bare as `Box` yields the declaration handle, whose
 unconstrained parameter var coalesces to `never` and renders `Box<never>` rather than
 `Box<number>`. A reference that supplies too many arguments, `Box<number, string>` on a
-one-parameter class, carries the extra one with no diagnostic. An enum needs neither fix:
-`enum Opt<T = number>` referenced bare already infers `Opt<number>` through the alias path.
+one-parameter class, carries the extra one with no diagnostic.
 
-**Data structures.** A `ClassArityMismatchError`, the nominal twin of
-`AliasArityMismatchError`, carrying the same required/total/got triple so the two render
-alike.
+An enum reaches the alias path, since an enum name binds to an alias whose body is the union
+of its variant handles, so `enum Opt<T = number>` referenced bare already infers `Opt<number>`
+and a miscounted `Opt<number, string>` already reports. What it does not get is the right
+noun. The message calls `Opt` a type alias, naming a shell the source never wrote.
+
+**Data structures.** One `TypeArgArityMismatchError` carrying the required/total/got triple
+and a `TypeDeclKind` — `type alias`, `class`, or `enum` — so the three sorts render alike and
+differ only in the noun. `LifetimeArgArityMismatchError` carries the same kind. An `Enum` flag
+on `AliasDef`, set by `preBindEnum`, is what tells an enum's synthesized alias from one a
+`type` declaration wrote. A `ParamsResolved` flag on `ClassDef` separates a class that
+declares no type parameters from one whose parameters have not been resolved yet.
 
 **Algorithms.** Factor the arity check and the default filling out of `buildAliasInstance`
 into one helper over a `[]*soltype.TypeParam` and a reference's written arguments, returning
-one argument per parameter. Both instance builders call it, so an alias and a class resolve a
-defaulted or miscounted reference the same way. The helper is also the one place that pairs a
-written argument with the parameter it fills, which is what PR19 needs.
+one argument per parameter. Both instance builders call it, so an alias, an enum, and a class
+resolve a defaulted or miscounted reference the same way. The helper is also the one place
+that pairs a written argument with the parameter it fills, which is what PR19 needs.
+
+A class reference reaches the helper only once the class's parameters are resolved.
+`getOrCreateClass` registers a bare `ClassDef` during the SCC pre-pass so a forward reference
+from a sibling in the same dep_graph component resolves, and `inferClassDecl` fills the
+parameters when that class's own pass runs. A reference landing in between has no parameter
+list to check against, so it keeps resolving exactly what it wrote and reports nothing. PR19's
+deferral is what closes that window.
 
 **Accept.** `class Box<T = number>` referenced bare infers `Box<number>`.
-`Box<number, string>` on a one-parameter class reports a full-message arity error. Every
-alias and enum arity and default case that passes today still passes, since the shared helper
-is `buildAliasInstance`'s existing logic moved rather than rewritten.
+`Box<number, string>` on a one-parameter class reports a full-message arity error, and so does
+a bare `Box` against `class Box<T>`, matching what an alias reports for the same omission. A
+miscounted enum reference calls its target an enum rather than a type alias. Every alias
+arity and default case that passes today still passes, since the shared helper is
+`buildAliasInstance`'s existing logic moved rather than rewritten.
 
 **Depends on** PR17, so the class path does not inherit the forward-reference leak the moment
 it starts filling defaults. Independent of the operator track.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -1448,7 +1448,8 @@ and a `TypeDeclKind` — `type alias`, `class`, or `enum` — so the three sorts
 differ only in the noun. `LifetimeArgArityMismatchError` carries the same kind. An `Enum` flag
 on `AliasDef`, set by `preBindEnum`, is what tells an enum's synthesized alias from one a
 `type` declaration wrote. An `Arity` field on `ClassDef` holds the class's required and total
-type-parameter counts.
+type-parameter counts. A `TypeParamRequiredAfterDefaultError` reports a default that a later
+parameter without one makes unreachable.
 
 **Algorithms.** Factor the arity check and the default filling out of `buildAliasInstance`
 into one helper over a `[]*soltype.TypeParam` and a reference's written arguments, returning
@@ -1476,14 +1477,24 @@ Every written argument is resolved, including any past the parameter count. A su
 is dropped from the instance, but resolving it first is what reports an unresolvable name
 inside it rather than swallowing that diagnostic along with the argument.
 
+The required count is one past the last parameter with no default, not the number of parameters
+that lack one. Arguments bind positionally, so an argument can be omitted only when every
+parameter from that position on has a default to fill it. Counting `<T = number, U>` as taking
+one argument would let `Pair<string>` pass while leaving `U` a fresh variable that coalesces to
+`never`. `resolveTypeParams` reports the unreachable default at the declaration, on every path
+that resolves a `<…>` clause, and keeps it, so a reference writing every argument still resolves
+against the full list.
+
 **Accept.** `class Box<T = number>` referenced bare infers `Box<number>`.
 `Box<number, string>` on a one-parameter class reports a full-message arity error, and so does
 a bare `Box` against `class Box<T>`, matching what an alias reports for the same omission. The
 same miscount reports from a class body, an alias body, and an enum variant parameter list, not
 only from a `fn` or `val` annotation. A miscounted enum reference calls its target an enum
 rather than a type alias. `Box<number, Nonexistent>` reports the unresolvable name alongside
-the count. Every alias arity and default case that passes today still passes, since the shared
-helper is `buildAliasInstance`'s existing logic moved rather than rewritten.
+the count. `<T = number, U>` reports its unreachable default at the declaration, and a reference
+writing one argument to it reports a count of two rather than passing and synthesizing `U`.
+Every alias arity and default case that passes today still passes, since the shared helper is
+`buildAliasInstance`'s existing logic moved rather than rewritten.
 
 **Depends on** PR17, so the class path does not inherit the forward-reference leak the moment
 it starts filling defaults. Independent of the operator track.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -1447,8 +1447,8 @@ noun. The message calls `Opt` a type alias, naming a shell the source never wrot
 and a `TypeDeclKind` — `type alias`, `class`, or `enum` — so the three sorts render alike and
 differ only in the noun. `LifetimeArgArityMismatchError` carries the same kind. An `Enum` flag
 on `AliasDef`, set by `preBindEnum`, is what tells an enum's synthesized alias from one a
-`type` declaration wrote. A `ParamsResolved` flag on `ClassDef` separates a class that
-declares no type parameters from one whose parameters have not been resolved yet.
+`type` declaration wrote. An `Arity` field on `ClassDef` holds the class's required and total
+type-parameter counts.
 
 **Algorithms.** Factor the arity check and the default filling out of `buildAliasInstance`
 into one helper over a `[]*soltype.TypeParam` and a reference's written arguments, returning
@@ -1456,19 +1456,34 @@ one argument per parameter. Both instance builders call it, so an alias, an enum
 resolve a defaulted or miscounted reference the same way. The helper is also the one place
 that pairs a written argument with the parameter it fills, which is what PR19 needs.
 
-A class reference reaches the helper only once the class's parameters are resolved.
-`getOrCreateClass` registers a bare `ClassDef` during the SCC pre-pass so a forward reference
-from a sibling in the same dep_graph component resolves, and `inferClassDecl` fills the
-parameters when that class's own pass runs. A reference landing in between has no parameter
-list to check against, so it keeps resolving exactly what it wrote and reports nothing. PR19's
-deferral is what closes that window.
+The class path has to split where the two halves of that come from. A class's members resolve
+in whatever order the dep graph reaches its declaration, and a class body naming a sibling
+class is ordinary, so a reference is regularly resolved before the class it names has run its
+own pass. `getOrCreateClass` therefore reads the counts straight off the declaration's `<…>`
+clause when it registers the identity, which is before any reference can be resolved, and
+`inferClassDecl` fills `TypeParams` later. The count is always available, so every reference is
+checked. The defaults are not, so a reference that omits an argument for a class whose
+parameters have not landed recovers to a fresh var instead of filling the default. That is a
+silent wrong answer — `B<unknown>` where the declaration says `B<number>` — and closing it
+needs the check deferred until every class in the component has its parameters, the machinery
+PR19 adds for bounds.
+
+A fresh var rather than the declaration's own var is what keeps the recovery contained. Filling
+`class A { b: B }` against `class B<T>` with `B`'s parameter var would make `A`'s constructor
+generic, since that var is quantified at `B`'s boundary and generalizing `A` would capture it.
+
+Every written argument is resolved, including any past the parameter count. A surplus argument
+is dropped from the instance, but resolving it first is what reports an unresolvable name
+inside it rather than swallowing that diagnostic along with the argument.
 
 **Accept.** `class Box<T = number>` referenced bare infers `Box<number>`.
 `Box<number, string>` on a one-parameter class reports a full-message arity error, and so does
-a bare `Box` against `class Box<T>`, matching what an alias reports for the same omission. A
-miscounted enum reference calls its target an enum rather than a type alias. Every alias
-arity and default case that passes today still passes, since the shared helper is
-`buildAliasInstance`'s existing logic moved rather than rewritten.
+a bare `Box` against `class Box<T>`, matching what an alias reports for the same omission. The
+same miscount reports from a class body, an alias body, and an enum variant parameter list, not
+only from a `fn` or `val` annotation. A miscounted enum reference calls its target an enum
+rather than a type alias. `Box<number, Nonexistent>` reports the unresolvable name alongside
+the count. Every alias arity and default case that passes today still passes, since the shared
+helper is `buildAliasInstance`'s existing logic moved rather than rewritten.
 
 **Depends on** PR17, so the class path does not inherit the forward-reference leak the moment
 it starts filling defaults. Independent of the operator track.


### PR DESCRIPTION
M9 Track F, PR18. Also covers enums, which the plan had assumed needed no work.

Type expressions below are written in prose rather than code spans, because angle brackets do not survive this description field inside backticks.

## The gaps

`buildAliasInstance` checked a reference's argument count against the alias's parameters and filled a trailing omitted argument from its default. `buildClassInstance` did neither.

- Given class Box&lt;T = number&gt;, a bare Box yielded the declaration handle, whose unconstrained parameter var coalesces to `never`, so it rendered Box&lt;never&gt; instead of Box&lt;number&gt;.
- Given class Box&lt;T&gt;, a reference Box&lt;number, string&gt; carried the extra argument with no diagnostic.

An enum reaches the alias path, since an enum name binds to an alias whose body is the union of its variant handles, so its arity and defaults already worked. What it did not get was the right noun — the message called `Opt` a type alias, naming a declaration the source never wrote.

Review turned up two more, both in the shared code this PR introduces.

- The required count was the *number* of parameters lacking a default, which is only right when every default is trailing. Given type Pair&lt;T = number, U&gt;, the count said one, so Pair&lt;string&gt; passed the range check and left `U` a fresh var that coalesced to `never` — silently, on all three paths. The count was wrong on `main` too, since `buildAliasInstance` computed it the same way.
- Arguments written past the parameter count were dropped unresolved, so Box&lt;number, Nonexistent&gt; reported the count and swallowed the unresolvable name.

## The change

`resolveTypeArgs` in `type_params.go` is `buildAliasInstance`'s arity-and-default logic moved out into one helper over a parameter list and a reference's written arguments, returning one argument per parameter. Both instance builders call it, so an alias, an enum, and a class resolve a defaulted or miscounted reference the same way. It is also the one place that pairs a written argument with the parameter it fills, which is what PR19 needs.

The two arity errors collapse into `TypeArgArityMismatchError` and `LifetimeArgArityMismatchError`, each carrying a `TypeDeclKind` — `type alias`, `class`, or `enum`. An `Enum` flag on `AliasDef`, set by `preBindEnum`, tells an enum's synthesized alias from one a `type` declaration wrote.

### Where a class's counts come from

A class's members resolve in whatever order the dep graph reaches its declaration, so a reference from a class body, an alias body, or an enum variant parameter list is regularly resolved before the class it names has run its own pass. `getOrCreateClass` therefore reads the counts into `ClassDef.Arity` off the declaration's parameter clause when it registers the identity, which is before any reference can be resolved, and `inferClassDecl` fills `TypeParams` later. So the count is always available and every reference is checked; the defaults come from `TypeParams` and are not.

An omitted argument recovers to a fresh var rather than the declaration's own. Given class B&lt;T&gt;, filling the bare `B` in `class A { b: B }` with B's parameter var would make A's constructor generic, since that var is quantified at B's boundary and generalizing A would capture it.

### A default has to be trailing

`requiredArgCount` returns one past the last parameter with no default rather than the number of parameters lacking one. Arguments bind positionally, so an argument can be omitted only when every parameter from that position on has a default to fill it. Both arity helpers call it, so the count a class registers off its declaration and the one an alias reads off its resolved parameters stay in step.

The declaration is the real problem, so `reportRequiredAfterDefault` names it there too. It runs at the top of `resolveTypeParams`, the one place the alias, class, enum, and function-annotation paths share, and emits one `TypeParamRequiredAfterDefaultError` per unreachable default, blaming the annotation it sits on:

```
the default for type parameter `T` can never be used, since `U` is declared after it and has no default
```

Unlike `reportDefaultForwardRef`, the default is kept rather than dropped, so a reference that does write every argument still resolves against the full parameter list. The positional count makes the range right without the recovery, so the two are independent.

### Surplus arguments

Every written argument is resolved, including any past the parameter count. A surplus argument is dropped from the instance, but resolving it first is what reports an unresolvable name inside it rather than swallowing that diagnostic along with the argument.

## Known gap

A reference that omits an argument for a class whose parameters have not landed yet cannot fill the default, so it recovers to a fresh var where the declaration names a type. No diagnostic, since omitting an argument for a defaulted parameter is legal. `TestClassDefaultUnfilledForUnresolvedSibling` pins it. Closing it needs the check deferred until every class in the component has its parameters — the machinery PR19 adds for bounds.

## Accept

- A class whose every type parameter has a default, referenced bare, infers those defaults rather than `never`.
- A miscount reports a full-message arity error in both directions, and a bare reference to a class with required parameters is the same out-of-range count an alias already reports for that omission.
- The same miscount reports from a class body, an alias body, and an enum variant parameter list, not only from a `fn` or `val` annotation.
- A miscounted enum reference calls its target an enum rather than a type alias.
- A default declared before a parameter without one is reported at the declaration, on all four paths, and a reference short of the last required parameter reports the count instead of passing and synthesizing that parameter.
- A surplus argument reports the unresolvable name inside it alongside the count.
- Every alias arity and default case that passed before still passes, since the shared helper is `buildAliasInstance`'s existing logic moved rather than rewritten.

## Tests

Eight tests in `internal/solver/type_args_test.go` cover the reference-side count, defaults at a reference, the per-reference independence of a filled default, the count reaching a class body / alias body / enum variant, the fresh-var recovery, the required-after-default rule across all four declaration paths, surplus-argument resolution, and the known gap.

## Notes

- Depends on PR17 (#968, merged), so the class path does not inherit the forward-reference leak the moment it starts filling defaults.
- Supersedes #962, which implements the same plan item on a different branch and conflicts with main after #968 landed. This is a smaller implementation of the same design.
- Rebased on current main. #967 made a class value an object carrying its constructor as a `new` element rather than a bare function type, so two assertions that pin a class value were updated to match.
