### PR TITLE
Resolve a field write to a setter in the solver

### DIFF
--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -533,8 +533,9 @@ func TestObjectMemberGetterSetterSameName(t *testing.T) {
 // ReadMember and WriteMember resolve a name by access direction rather than declaration
 // order: a read takes the getter half of an accessor pair and a write takes the setter
 // half, regardless of which half the class body declares first. On a name carried by a
-// single element of any kind, both return that element, so they stand in for Member
-// everywhere.
+// single element of any kind, both return that element, so a directional caller never
+// needs Member's declaration-order result. A caller that only asks whether the name is
+// present at all still uses Member.
 func TestObjectReadWriteMember(t *testing.T) {
 	getter := &GetterElem{Name: "x", Type: numP()}
 	setter := &SetterElem{Name: "x", Param: strP()}

--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -532,8 +532,9 @@ func TestObjectMemberGetterSetterSameName(t *testing.T) {
 
 // ReadMember and WriteMember resolve a name by access direction rather than declaration
 // order: a read takes the getter half of an accessor pair and a write takes the setter
-// half, whichever comes first. On a name carried by a single element of any kind, both
-// return that element, so they stand in for Member everywhere.
+// half, regardless of which half the class body declares first. On a name carried by a
+// single element of any kind, both return that element, so they stand in for Member
+// everywhere.
 func TestObjectReadWriteMember(t *testing.T) {
 	getter := &GetterElem{Name: "x", Type: numP()}
 	setter := &SetterElem{Name: "x", Param: strP()}

--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -515,8 +515,8 @@ func TestObjectMember(t *testing.T) {
 // A getter and a setter may legitimately share a name. Member returns the first in
 // declaration order and cannot reach the second, so it is insufficient on its own to
 // resolve read-versus-write member access, where obj.x reads the getter and obj.x = v
-// writes the setter. A caller that needs both sides scans Elems by name AND kind
-// rather than relying on Member. This pins the first-declared-wins behavior.
+// writes the setter. ReadMember and WriteMember, covered below, are the two lookups that
+// choose by direction. This pins Member's first-declared-wins behavior.
 func TestObjectMemberGetterSetterSameName(t *testing.T) {
 	getter := &GetterElem{Name: "x", Type: numP()}
 	setter := &SetterElem{Name: "x", Param: strP()}
@@ -528,6 +528,85 @@ func TestObjectMemberGetterSetterSameName(t *testing.T) {
 	got, ok = (&ObjectType{Elems: []ObjTypeElem{setter, getter}}).Member("x")
 	require.True(t, ok)
 	require.Same(t, setter, got, "declaration order decides which of the two Member returns")
+}
+
+// ReadMember and WriteMember resolve a name by access direction rather than declaration
+// order: a read takes the getter half of an accessor pair and a write takes the setter
+// half, whichever comes first. On a name carried by a single element of any kind, both
+// return that element, so they stand in for Member everywhere.
+func TestObjectReadWriteMember(t *testing.T) {
+	getter := &GetterElem{Name: "x", Type: numP()}
+	setter := &SetterElem{Name: "x", Param: strP()}
+	prop := &PropertyElem{Name: "p", Type: numP()}
+	m := method("m", &FuncType{Ret: numP()})
+
+	tests := []struct {
+		name      string
+		elems     []ObjTypeElem
+		lookup    string
+		wantRead  ObjTypeElem
+		wantWrite ObjTypeElem
+	}{
+		{
+			name:      "pair with the getter first",
+			elems:     []ObjTypeElem{getter, setter},
+			lookup:    "x",
+			wantRead:  getter,
+			wantWrite: setter,
+		},
+		{
+			name:      "pair with the setter first",
+			elems:     []ObjTypeElem{setter, getter},
+			lookup:    "x",
+			wantRead:  getter,
+			wantWrite: setter,
+		},
+		{
+			name:      "getter alone",
+			elems:     []ObjTypeElem{getter},
+			lookup:    "x",
+			wantRead:  getter,
+			wantWrite: getter,
+		},
+		{
+			name:      "setter alone",
+			elems:     []ObjTypeElem{setter},
+			lookup:    "x",
+			wantRead:  setter,
+			wantWrite: setter,
+		},
+		{
+			name:      "property",
+			elems:     []ObjTypeElem{prop, getter, setter},
+			lookup:    "p",
+			wantRead:  prop,
+			wantWrite: prop,
+		},
+		{
+			name:      "method",
+			elems:     []ObjTypeElem{m},
+			lookup:    "m",
+			wantRead:  m,
+			wantWrite: m,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &ObjectType{Elems: tt.elems}
+			gotRead, ok := obj.ReadMember(tt.lookup)
+			require.True(t, ok)
+			require.Same(t, tt.wantRead, gotRead)
+			gotWrite, ok := obj.WriteMember(tt.lookup)
+			require.True(t, ok)
+			require.Same(t, tt.wantWrite, gotWrite)
+		})
+	}
+
+	obj := &ObjectType{Elems: []ObjTypeElem{getter, setter}}
+	_, ok := obj.ReadMember("missing")
+	require.False(t, ok, "an absent name reports not present to a read")
+	_, ok = obj.WriteMember("missing")
+	require.False(t, ok, "an absent name reports not present to a write")
 }
 
 // ObjElemName reads the name off any element kind.

--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -532,10 +532,16 @@ func TestObjectMemberGetterSetterSameName(t *testing.T) {
 
 // ReadMember and WriteMember resolve a name by access direction rather than declaration
 // order: a read takes the getter half of an accessor pair and a write takes the setter
-// half, regardless of which half the class body declares first. On a name carried by a
-// single element of any kind, both return that element, so a directional caller never
-// needs Member's declaration-order result. A caller that only asks whether the name is
-// present at all still uses Member.
+// half, regardless of which half the class body declares first. A caller that only asks
+// whether the name is present at all still uses Member.
+//
+// The direction is a tie-break between two elements sharing a name, not a filter on what
+// the access may reach. A name carried by one element resolves to that element in both
+// directions, whatever its kind. So a setter-only name resolves through ReadMember, and a
+// getter-only name through WriteMember. Neither says the access is legal. Both are what
+// let the caller tell an ABSENT name from one that is present but exposes no half in the
+// direction wanted, which is the difference between `object is missing property: x` and
+// the pointed `Property 'x' is write-only` / `is read-only`.
 func TestObjectReadWriteMember(t *testing.T) {
 	getter := &GetterElem{Name: "x", Type: numP()}
 	setter := &SetterElem{Name: "x", Param: strP()}
@@ -564,6 +570,8 @@ func TestObjectReadWriteMember(t *testing.T) {
 			wantWrite: setter,
 		},
 		{
+			// Resolved in both directions. The write direction reaching the getter is what
+			// lets writeAccessor report the pointed read-only error.
 			name:      "getter alone",
 			elems:     []ObjTypeElem{getter},
 			lookup:    "x",
@@ -571,6 +579,8 @@ func TestObjectReadWriteMember(t *testing.T) {
 			wantWrite: getter,
 		},
 		{
+			// The mirror: the read direction reaching the setter is what lets memberValue
+			// report the pointed write-only error.
 			name:      "setter alone",
 			elems:     []ObjTypeElem{setter},
 			lookup:    "x",
@@ -578,6 +588,10 @@ func TestObjectReadWriteMember(t *testing.T) {
 			wantWrite: setter,
 		},
 		{
+			// A name carried by no accessor half at all resolves to its own element in both
+			// directions. Without that fallback the two lookups would return only their
+			// preferred accessor kind, and every ordinary field and method access would
+			// resolve to nothing.
 			name:      "property",
 			elems:     []ObjTypeElem{prop, getter, setter},
 			lookup:    "p",

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -566,6 +566,50 @@ func (o *ObjectType) Member(name string) (ObjTypeElem, bool) {
 	return nil, false
 }
 
+// ReadMember returns the member a READ of name resolves to. When a getter and a
+// setter share the name, the getter is the half a read wants, so it wins over
+// declaration order. `class C { set x(mut self, n: number) {…}, get x(self) -> number
+// {…} }` read through `c.x` therefore yields the getter's `number` rather than the
+// setter Member would return. Every other member kind resolves the same as Member.
+func (o *ObjectType) ReadMember(name string) (ObjTypeElem, bool) {
+	return o.preferredMember(name, func(e ObjTypeElem) bool {
+		_, ok := e.(*GetterElem)
+		return ok
+	})
+}
+
+// WriteMember returns the member a WRITE of name resolves to, the mirror of
+// ReadMember. When a getter and a setter share the name, the setter is the half a
+// write wants. `class C { get x(self) -> number {…}, set x(mut self, n: number) {…} }`
+// written through `c.x = 5` therefore checks 5 against the setter's parameter rather
+// than against the getter Member would return.
+func (o *ObjectType) WriteMember(name string) (ObjTypeElem, bool) {
+	return o.preferredMember(name, func(e ObjTypeElem) bool {
+		_, ok := e.(*SetterElem)
+		return ok
+	})
+}
+
+// preferredMember returns the first element named name that satisfies preferred, or
+// the first element named name at all when none does. It is the shared scan behind
+// ReadMember and WriteMember, which differ only in which half of a getter/setter pair
+// they prefer.
+func (o *ObjectType) preferredMember(name string, preferred func(ObjTypeElem) bool) (ObjTypeElem, bool) {
+	var first ObjTypeElem
+	for _, e := range o.Elems {
+		if ObjElemName(e) != name {
+			continue
+		}
+		if preferred(e) {
+			return e, true
+		}
+		if first == nil {
+			first = e
+		}
+	}
+	return first, first != nil
+}
+
 // Constructor returns the object's constructor call signature and whether it carries
 // one. A class value carries exactly one ConstructorElem, so this is the lookup a call
 // site and the nominal-value constrain rule use to reach the constructor without a

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -571,6 +571,11 @@ func (o *ObjectType) Member(name string) (ObjTypeElem, bool) {
 // declaration order. `class C { set x(mut self, n: number) {…}, get x(self) -> number
 // {…} }` read through `c.x` therefore yields the getter's `number` rather than the
 // setter Member would return. Every other member kind resolves the same as Member.
+//
+// A setter-only name still resolves HERE, to the setter. This is not a claim that the
+// member is readable. It is what lets a caller tell a name that is absent from one that
+// is present but exposes no read, so `memberValue` can report `Property 'x' is
+// write-only` instead of the generic missing-property error a not-found would produce.
 func (o *ObjectType) ReadMember(name string) (ObjTypeElem, bool) {
 	return o.preferredMember(name, func(e ObjTypeElem) bool {
 		_, ok := e.(*GetterElem)
@@ -583,6 +588,10 @@ func (o *ObjectType) ReadMember(name string) (ObjTypeElem, bool) {
 // write wants. `class C { get x(self) -> number {…}, set x(mut self, n: number) {…} }`
 // written through `c.x = 5` therefore checks 5 against the setter's parameter rather
 // than against the getter Member would return.
+//
+// A getter-only name resolves here to the getter, the mirror of ReadMember resolving a
+// setter-only name. That is what lets `writeAccessor` report `Property 'x' is read-only`
+// rather than the generic missing-property error a not-found would produce.
 func (o *ObjectType) WriteMember(name string) (ObjTypeElem, bool) {
 	return o.preferredMember(name, func(e ObjTypeElem) bool {
 		_, ok := e.(*SetterElem)
@@ -594,6 +603,12 @@ func (o *ObjectType) WriteMember(name string) (ObjTypeElem, bool) {
 // the first element named name at all when none does. It is the shared scan behind
 // ReadMember and WriteMember, which differ only in which half of a getter/setter pair
 // they prefer.
+//
+// The preference is a tie-break between two elements sharing a name, not a filter. Both
+// callers pass a predicate matching a single accessor kind, so without the fallback
+// ReadMember would return only getters and every property and method read would resolve
+// to nothing. The fallback is therefore what carries the ordinary members, and returning
+// the opposite accessor half for an accessor-only name follows from the same rule.
 func (o *ObjectType) preferredMember(name string, preferred func(ObjTypeElem) bool) (ObjTypeElem, bool) {
 	var first ObjTypeElem
 	for _, e := range o.Elems {

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -475,7 +475,7 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 	if !ok || def.Body == nil {
 		return pathResult{}, false
 	}
-	member, found := c.projectedClassMember(ct, name, readLookup, set.NewSet[string]())
+	member, found := c.projectedClassMember(ct, name, (*soltype.ObjectType).ReadMember, set.NewSet[string]())
 	if !found {
 		// The miss is rare, so project the whole body here to render the diagnostic at
 		// the instance's arguments rather than the declared type parameters.
@@ -501,7 +501,7 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 // bounding the walk on a cyclic hierarchy the same way constrainNominalWalk does.
 //
 // lookup selects which half of a getter/setter pair the access wants. A read passes
-// readLookup and a write passes writeLookup.
+// ObjectType.ReadMember and a write passes ObjectType.WriteMember.
 func (c *checker) projectedClassMember(ct *soltype.ClassType, name string, lookup memberLookup, visited set.Set[string]) (soltype.ObjTypeElem, bool) {
 	def, ok := c.ctx.classDef(ct.Name)
 	if !ok || def.Body == nil {
@@ -526,15 +526,10 @@ func (c *checker) projectedClassMember(ct *soltype.ClassType, name string, looku
 	return nil, false
 }
 
-// memberLookup selects one named member off a class body or class value. The two
-// implementations are readLookup and writeLookup, which differ only in which half of a
+// memberLookup selects one named member off a class body. The two implementations are
+// ObjectType.ReadMember and ObjectType.WriteMember, which differ only in which half of a
 // getter/setter pair they return.
 type memberLookup func(*soltype.ObjectType, string) (soltype.ObjTypeElem, bool)
-
-var (
-	readLookup  memberLookup = (*soltype.ObjectType).ReadMember
-	writeLookup memberLookup = (*soltype.ObjectType).WriteMember
-)
 
 // classBodyMember resolves a method, getter, or setter read off a class-body ObjectType —
 // the object `self` binds to inside a method or constructor body (M5 B3). It returns
@@ -673,10 +668,11 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 //  2. a class body, the object `self` binds to inside a method or constructor
 //  3. a class value, the receiver of a static write such as `C.x = 5`
 //
-// It returns the resolved element only when it is a getter or a setter, since those are
-// the two kinds the structural write requirement cannot see. A plain field, a method, and
-// a name no receiver carries all return ok=false, leaving the caller on the structural
-// path that already types them.
+// Each shape is looked up with the setter half of a getter/setter pair preferred. It
+// returns the resolved element only when it is a getter or a setter, since those are the
+// two kinds the structural write requirement cannot see. A plain field, a method, and a
+// name no receiver carries all return ok=false, leaving the caller on the structural path
+// that already types them.
 func (c *checker) writeAccessor(name string, carrier soltype.Type) (soltype.ObjTypeElem, bool) {
 	member, found := c.writeMember(name, carrier)
 	if !found {
@@ -689,13 +685,12 @@ func (c *checker) writeAccessor(name string, carrier soltype.Type) (soltype.ObjT
 	return nil, false
 }
 
-// writeMember looks name up on carrier with the setter half of a getter/setter pair
-// preferred, trying the class instance, class body, and class value shapes in turn. It
-// returns found=false for any other receiver, so a plain object stays on the structural
-// write-requirement path.
+// writeMember looks name up on carrier's class instance, class body, or class value,
+// whichever it resolves as, preferring the setter half of a getter/setter pair. It returns
+// found=false for any other receiver.
 func (c *checker) writeMember(name string, carrier soltype.Type) (soltype.ObjTypeElem, bool) {
 	if ct, ok := classCarrier(carrier); ok {
-		return c.projectedClassMember(ct, name, writeLookup, set.NewSet[string]())
+		return c.projectedClassMember(ct, name, (*soltype.ObjectType).WriteMember, set.NewSet[string]())
 	}
 	if obj, ok := carrier.(*soltype.ObjectType); ok {
 		return obj.WriteMember(name)
@@ -730,10 +725,10 @@ func strippedMethodSig(sig *soltype.FuncType) *soltype.FuncType {
 //   - `mut self` receiver   → plain `self` member: ok, mutable downgrades to shared
 //   - plain `self` receiver → plain `self` member: ok
 //
-// recv is the un-stripped receiver, so it carries the accessor's own mutability. The
-// receiver is rebuilt as `Self` in that mutability, so the diagnostic reads `immutable C
-// <: mutable C`. A nil self, which a static member or a property has, is a no-op, as is a
-// receiver that is not a class instance.
+// recv is the un-stripped receiver, so it still carries the mutability the access has to
+// lend. The receiver is rebuilt as `Self` in that mutability, so the diagnostic reads
+// `immutable C <: mutable C`. A nil self, which a static member and a property both have,
+// is a no-op, as is a receiver that is not a class instance.
 func (c *checker) checkReceiverMut(blame ast.Node, recv soltype.Type, self *soltype.FuncParam) {
 	if self == nil {
 		return

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -668,11 +668,21 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 //  2. a class body, the object `self` binds to inside a method or constructor
 //  3. a class value, the receiver of a static write such as `C.x = 5`
 //
-// Each shape is looked up with the setter half of a getter/setter pair preferred. It
-// returns the resolved element only when it is a getter or a setter, since those are the
-// two kinds the structural write requirement cannot see. A plain field, a method, and a
-// name no receiver carries all return ok=false, leaving the caller on the structural path
-// that already types them.
+// Each shape is looked up with the setter half of a getter/setter pair preferred. The
+// returned ok is a ROUTING answer — whether the write belongs to inferAccessorAssign
+// rather than to the structural requirement — not a claim that the write is legal. The
+// two accessor kinds answer it for different reasons:
+//
+//   - a setter is the member the write actually calls;
+//   - a getter is a write that has no setter to call, and only inferAccessorAssign knows
+//     to say so. Left to the structural path it reads as `object is missing property: x`,
+//     since that path matches a PropertyElem and finds none.
+//
+// A plain field, a method, and a name no receiver carries all return ok=false. A field
+// write in particular MUST fall through, since the structural path is where the readonly
+// check, the owned-mutable upgrade, the `written` record, and the alias and field-store
+// edges live. This is the write-side counterpart of classBodyMember returning ok=false for
+// a PropertyElem.
 func (c *checker) writeAccessor(name string, carrier soltype.Type) (soltype.ObjTypeElem, bool) {
 	member, found := c.writeMember(name, carrier)
 	if !found {

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -475,7 +475,7 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 	if !ok || def.Body == nil {
 		return pathResult{}, false
 	}
-	member, found := c.projectedClassMember(ct, name, set.NewSet[string]())
+	member, found := c.projectedClassMember(ct, name, readLookup, set.NewSet[string]())
 	if !found {
 		// The miss is rare, so project the whole body here to render the diagnostic at
 		// the instance's arguments rather than the declared type parameters.
@@ -499,7 +499,10 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 // Animal<T>` accessed at Dog<string> walks Animal<string>, and an inherited member typed
 // `T` projects to `string`. visited holds the class names already on the current chain,
 // bounding the walk on a cyclic hierarchy the same way constrainNominalWalk does.
-func (c *checker) projectedClassMember(ct *soltype.ClassType, name string, visited set.Set[string]) (soltype.ObjTypeElem, bool) {
+//
+// lookup selects which half of a getter/setter pair the access wants. A read passes
+// readLookup and a write passes writeLookup.
+func (c *checker) projectedClassMember(ct *soltype.ClassType, name string, lookup memberLookup, visited set.Set[string]) (soltype.ObjTypeElem, bool) {
 	def, ok := c.ctx.classDef(ct.Name)
 	if !ok || def.Body == nil {
 		return nil, false
@@ -507,7 +510,7 @@ func (c *checker) projectedClassMember(ct *soltype.ClassType, name string, visit
 	// Member names are invariant under substitution, so look the member up on the
 	// unprojected body and project only the one accessed, rather than rebuilding the
 	// whole body per access.
-	if member, found := def.Body.Member(name); found {
+	if member, found := lookup(def.Body, name); found {
 		return c.projectClassMember(def, ct, member), true
 	}
 	if visited.Contains(ct.Name) {
@@ -516,12 +519,22 @@ func (c *checker) projectedClassMember(ct *soltype.ClassType, name string, visit
 	visited.Add(ct.Name)
 	for _, superType := range def.Supers {
 		superInstance := substituteSuperArgs(def, ct, superType)
-		if member, found := c.projectedClassMember(superInstance, name, visited); found {
+		if member, found := c.projectedClassMember(superInstance, name, lookup, visited); found {
 			return member, true
 		}
 	}
 	return nil, false
 }
+
+// memberLookup selects one named member off a class body or class value. The two
+// implementations are readLookup and writeLookup, which differ only in which half of a
+// getter/setter pair they return.
+type memberLookup func(*soltype.ObjectType, string) (soltype.ObjTypeElem, bool)
+
+var (
+	readLookup  memberLookup = (*soltype.ObjectType).ReadMember
+	writeLookup memberLookup = (*soltype.ObjectType).WriteMember
+)
 
 // classBodyMember resolves a method, getter, or setter read off a class-body ObjectType —
 // the object `self` binds to inside a method or constructor body (M5 B3). It returns
@@ -553,14 +566,14 @@ func (c *checker) classBodyMember(lvl int, blame ast.Node, name string, recv, ca
 	if !ok {
 		return pathResult{}, false
 	}
-	member, found := obj.Member(name)
+	member, found := obj.ReadMember(name)
 	if !found {
 		return pathResult{}, false
 	}
 	if _, isProp := member.(*soltype.PropertyElem); isProp {
 		return pathResult{}, false
 	}
-	c.checkMethodReceiver(blame, recv, member)
+	c.checkReceiverMut(blame, recv, memberSelfParam(member))
 	return c.memberValue(lvl, blame, member), true
 }
 
@@ -652,6 +665,47 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 	return pathResult{value: out}
 }
 
+// writeAccessor resolves the accessor a field write `recv.prop = …` targets. It is the
+// write-side twin of the three read interceptions valueProp runs, covering the same three
+// receiver shapes:
+//
+//  1. a class instance, whose member is looked up on the projected class body
+//  2. a class body, the object `self` binds to inside a method or constructor
+//  3. a class value, the receiver of a static write such as `C.x = 5`
+//
+// It returns the resolved element only when it is a getter or a setter, since those are
+// the two kinds the structural write requirement cannot see. A plain field, a method, and
+// a name no receiver carries all return ok=false, leaving the caller on the structural
+// path that already types them.
+func (c *checker) writeAccessor(name string, carrier soltype.Type) (soltype.ObjTypeElem, bool) {
+	member, found := c.writeMember(name, carrier)
+	if !found {
+		return nil, false
+	}
+	switch member.(type) {
+	case *soltype.SetterElem, *soltype.GetterElem:
+		return member, true
+	}
+	return nil, false
+}
+
+// writeMember looks name up on carrier with the setter half of a getter/setter pair
+// preferred, trying the class instance, class body, and class value shapes in turn. It
+// returns found=false for any other receiver, so a plain object stays on the structural
+// write-requirement path.
+func (c *checker) writeMember(name string, carrier soltype.Type) (soltype.ObjTypeElem, bool) {
+	if ct, ok := classCarrier(carrier); ok {
+		return c.projectedClassMember(ct, name, writeLookup, set.NewSet[string]())
+	}
+	if obj, ok := carrier.(*soltype.ObjectType); ok {
+		return obj.WriteMember(name)
+	}
+	if obj, ok := classValueCarrier(carrier); ok {
+		return obj.WriteMember(name)
+	}
+	return nil, false
+}
+
 // strippedMethodSig returns a method signature as a plain callable, its SelfParam
 // dropped, since `p.m` binds the receiver and returns a function of the remaining
 // parameters. The receiver's own ownership is checked separately at member access as a
@@ -667,20 +721,20 @@ func strippedMethodSig(sig *soltype.FuncType) *soltype.FuncType {
 	}
 }
 
-// checkMethodReceiver rejects a `mut self` member reached from a plain-`self` body, which
-// holds only a shared borrow to lend. It constrains the enclosing `self` against the accessed
-// member's declared `self`. The four pairings:
+// checkReceiverMut rejects a `mut self` member reached through a receiver that holds only
+// a shared borrow to lend. It constrains the accessing receiver recv against the accessed
+// member's own declared `self`, which the caller passes as self. The four pairings:
 //
-//   - plain `self` body → `mut self` member: rejected, a shared borrow has no mut to lend
-//   - `mut self` body   → `mut self` member: ok
-//   - `mut self` body   → plain `self` member: ok, mutable downgrades to shared
-//   - plain `self` body → plain `self` member: ok
+//   - plain `self` receiver → `mut self` member: rejected, a shared borrow has no mut to lend
+//   - `mut self` receiver   → `mut self` member: ok
+//   - `mut self` receiver   → plain `self` member: ok, mutable downgrades to shared
+//   - plain `self` receiver → plain `self` member: ok
 //
-// It fires only inside a body, where the un-stripped `self` binding recv carries the caller's
-// mutability. The receiver is rebuilt as `Self` in that mutability, so the diagnostic reads
-// `immutable C <: mutable C`. A no-op for a static member, a property, or a non-class receiver.
-func (c *checker) checkMethodReceiver(blame ast.Node, recv soltype.Type, member soltype.ObjTypeElem) {
-	self := memberSelfParam(member)
+// recv is the un-stripped receiver, so it carries the accessor's own mutability. The
+// receiver is rebuilt as `Self` in that mutability, so the diagnostic reads `immutable C
+// <: mutable C`. A nil self, which a static member or a property has, is a no-op, as is a
+// receiver that is not a class instance.
+func (c *checker) checkReceiverMut(blame ast.Node, recv soltype.Type, self *soltype.FuncParam) {
 	if self == nil {
 		return
 	}
@@ -735,7 +789,7 @@ func (c *checker) classValueMember(lvl int, blame ast.Node, name string, carrier
 	if !ok {
 		return pathResult{}, false
 	}
-	member, found := obj.Member(name)
+	member, found := obj.ReadMember(name)
 	if !found {
 		return pathResult{}, false
 	}

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -660,34 +660,19 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 	return pathResult{value: out}
 }
 
-// writeAccessor resolves the accessor a field write `recv.prop = …` targets. It is the
-// write-side twin of the three read interceptions valueProp runs, covering the same three
-// receiver shapes:
-//
-//  1. a class instance, whose member is looked up on the projected class body
-//  2. a class body, the object `self` binds to inside a method or constructor
-//  3. a class value, the receiver of a static write such as `C.x = 5`
-//
-// Each shape is looked up with the setter half of a getter/setter pair preferred. The
-// returned ok is a ROUTING answer — whether the write belongs to inferAccessorAssign
-// rather than to the structural requirement — not a claim that the write is legal. The
-// two accessor kinds answer it for different reasons:
-//
-//   - a setter is the member the write actually calls;
-//   - a getter is a write that has no setter to call, and only inferAccessorAssign knows
-//     to say so. Left to the structural path it reads as `object is missing property: x`,
-//     since that path matches a PropertyElem and finds none.
-//
-// A plain field, a method, and a name no receiver carries all return ok=false. A field
-// write in particular MUST fall through, since the structural path is where the readonly
-// check, the owned-mutable upgrade, the `written` record, and the alias and field-store
-// edges live. This is the write-side counterpart of classBodyMember returning ok=false for
-// a PropertyElem.
+// writeAccessor resolves the accessor a field write `recv.prop = …` targets, across the
+// same three receiver shapes valueProp intercepts for a read: a class instance, a class
+// body reached through `self`, and a class value. The returned ok routes the write to
+// inferAccessorAssign. Every other member kind returns ok=false, so a field write keeps the
+// structural path, where the readonly check, the `written` record, and the borrow edges live.
 func (c *checker) writeAccessor(name string, carrier soltype.Type) (soltype.ObjTypeElem, bool) {
 	member, found := c.writeMember(name, carrier)
 	if !found {
 		return nil, false
 	}
+	// A setter is the member the write calls. A getter is routed here too, since it has no
+	// setter to call and only inferAccessorAssign knows to report that. The structural path
+	// matches a PropertyElem, finds none, and would blame a missing property instead.
 	switch member.(type) {
 	case *soltype.SetterElem, *soltype.GetterElem:
 		return member, true
@@ -755,20 +740,36 @@ func (c *checker) checkReceiverMut(blame ast.Node, recv soltype.Type, self *solt
 }
 
 // lendsMut reports whether recv has mutable access to lend: a `mut` borrow directly, or a
-// binding var carrying one among its lower bounds. The look-through matches classCarrier's,
-// since a `mut` borrow that reaches a receiver position through a call result or a branch
-// join arrives as a variable with the borrow among its lower bounds rather than as a bare
-// RefType. `g(c).x = 5`, where `g` returns `mut C`, is one such receiver.
+// binding var whose lower bounds are all `mut` borrows. The look-through matches
+// classCarrier's, since a `mut` borrow that reaches a receiver position through a call
+// result or a branch join arrives as a variable with the borrow among its lower bounds
+// rather than as a bare RefType. `g(c).x = 5`, where `g` returns `mut C`, is one such
+// receiver.
+//
+// EVERY lower bound must be mutable, since each is a value the receiver may actually hold
+// at run time. A join of `mut C` and `C` lends no mutable access, because the branch taken
+// may be the immutable one. Reporting mutable off a single bound would accept a `mut self`
+// setter write the structural field-write path rejects on the same receiver.
 func lendsMut(recv soltype.Type) bool {
 	switch recv := recv.(type) {
 	case *soltype.RefType:
 		return recv.Mut
 	case *soltype.TypeVarType:
+		sawBound := false
 		for _, lb := range recv.LowerBounds {
-			if r, ok := lb.(*soltype.RefType); ok && r.Mut {
-				return true
+			if lb == soltype.Type(recv) {
+				// A vacuous `v <: v` self-edge constrains nothing, the same edge readCarrier
+				// drops. It names no value the receiver holds, so it neither grants nor
+				// withholds mutable access.
+				continue
 			}
+			r, ok := lb.(*soltype.RefType)
+			if !ok || !r.Mut {
+				return false
+			}
+			sawBound = true
 		}
+		return sawBound
 	}
 	return false
 }

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -738,10 +738,29 @@ func (c *checker) checkReceiverMut(blame ast.Node, recv soltype.Type, self *solt
 		return
 	}
 	recvT := soltype.Type(inner)
-	if r, ok := recv.(*soltype.RefType); ok && r.Mut {
+	if lendsMut(recv) {
 		recvT = soltype.NewRef(true, nil, inner)
 	}
 	c.constrain(blame, recvT, self.Type)
+}
+
+// lendsMut reports whether recv has mutable access to lend: a `mut` borrow directly, or a
+// binding var carrying one among its lower bounds. The look-through matches classCarrier's,
+// since a `mut` borrow that reaches a receiver position through a call result or a branch
+// join arrives as a variable with the borrow among its lower bounds rather than as a bare
+// RefType. `g(c).x = 5`, where `g` returns `mut C`, is one such receiver.
+func lendsMut(recv soltype.Type) bool {
+	switch recv := recv.(type) {
+	case *soltype.RefType:
+		return recv.Mut
+	case *soltype.TypeVarType:
+		for _, lb := range recv.LowerBounds {
+			if r, ok := lb.(*soltype.RefType); ok && r.Mut {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // memberSelfParam returns the `self` receiver of a readable member, a method or getter, or

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1488,7 +1488,7 @@ func (c *Context) readCarrierObject(carrier soltype.Type) (*soltype.ObjectType, 
 // as undefined at runtime. An absent or setter-only member has hasValue false, so a property
 // readable on no member surfaces as a missing-property error rather than bare undefined.
 func memberReadContribution(obj *soltype.ObjectType, name string) (read soltype.Type, hasValue, mayUndef bool) {
-	member, found := obj.Member(name)
+	member, found := obj.ReadMember(name)
 	if !found {
 		return nil, false, true
 	}
@@ -1565,9 +1565,18 @@ func (c *Context) constrainIntoIndexSignature(sub, sup *soltype.ObjectType, supe
 // against the sub's same-named member by variance: a method by its receiver-stripped
 // callable signature (first arm; overload dispatch is E1), a getter covariantly, a setter
 // contravariantly. A missing or wrong-kind member fails.
+//
+// A setter requirement resolves the sub's setter half and every other requirement its
+// getter half, so a sub carrying an accessor pair satisfies both requirements whichever
+// half it declares first. A method requirement is unaffected, since no name is carried by
+// both a method and an accessor.
 func (c *Context) constrainObjMember(superElem soltype.ObjTypeElem, sub, sup *soltype.ObjectType, seen *seenPairs, mutCtx bool) []SolverError {
 	name := soltype.ObjElemName(superElem)
-	subElem, ok := sub.Member(name)
+	var lookup memberLookup = (*soltype.ObjectType).ReadMember
+	if _, isSetter := superElem.(*soltype.SetterElem); isSetter {
+		lookup = (*soltype.ObjectType).WriteMember
+	}
+	subElem, ok := lookup(sub, name)
 	if !ok {
 		return []SolverError{&MissingPropertyError{Sub: sub, Super: sup, Name: name}}
 	}

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1090,6 +1090,7 @@ func (*DuplicateConstructorSignatureError) isSolverError()  {}
 func (*FieldInitializerNotAllowedError) isSolverError()     {}
 func (*SubclassConstructorRequiredError) isSolverError()    {}
 func (*WriteOnlyPropertyError) isSolverError()              {}
+func (*ReadOnlyPropertyError) isSolverError()               {}
 func (*SetterArityError) isSolverError()                    {}
 func (*RecursiveMethodAnnotationError) isSolverError()      {}
 func (*FieldNotInitializedError) isSolverError()            {}
@@ -1150,6 +1151,20 @@ func (e *WriteOnlyPropertyError) Span() ast.Span      { return e.Site.Span() }
 func (e *WriteOnlyPropertyError) Related() []ast.Span { return nil }
 func (e *WriteOnlyPropertyError) Message() string {
 	return "Property '" + e.Name + "' is write-only; it has a setter but no getter or field to read."
+}
+
+// ReadOnlyPropertyError fires when a getter-only member is written, as in `c.value = 5`
+// where `value` is declared only with `get value(...)`. A getter defines a read, not a
+// writable location. It is the write-side mirror of WriteOnlyPropertyError.
+type ReadOnlyPropertyError struct {
+	Name string
+	Site ast.Node
+}
+
+func (e *ReadOnlyPropertyError) Span() ast.Span      { return e.Site.Span() }
+func (e *ReadOnlyPropertyError) Related() []ast.Span { return nil }
+func (e *ReadOnlyPropertyError) Message() string {
+	return "Property '" + e.Name + "' is read-only; it has a getter but no setter or field to write."
 }
 
 // InstancePatternNotClassError fires when the name in an instance pattern `Name { ... }`

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1092,6 +1092,7 @@ func (*SubclassConstructorRequiredError) isSolverError()    {}
 func (*WriteOnlyPropertyError) isSolverError()              {}
 func (*ReadOnlyPropertyError) isSolverError()               {}
 func (*SetterArityError) isSolverError()                    {}
+func (*SetterReceiverError) isSolverError()                 {}
 func (*RecursiveMethodAnnotationError) isSolverError()      {}
 func (*FieldNotInitializedError) isSolverError()            {}
 func (*ReadBeforeInitError) isSolverError()                 {}
@@ -1468,6 +1469,21 @@ func (e *SetterArityError) Span() ast.Span      { return e.Elem.Span() }
 func (e *SetterArityError) Related() []ast.Span { return nil }
 func (e *SetterArityError) Message() string {
 	return "Setter '" + e.Name + "' must declare exactly one value parameter; found " + strconv.Itoa(e.Count) + "."
+}
+
+// SetterReceiverError fires when an instance setter declares a receiver other than `mut
+// self`. Writing through a setter mutates the instance, so a plain `self` or a shared
+// `&self` receiver holds no mutable access to do it with. A static setter has no instance
+// to mutate and declares no receiver, so it never reaches this.
+type SetterReceiverError struct {
+	Name string
+	Elem *ast.SetterElem
+}
+
+func (e *SetterReceiverError) Span() ast.Span      { return e.Elem.Span() }
+func (e *SetterReceiverError) Related() []ast.Span { return nil }
+func (e *SetterReceiverError) Message() string {
+	return "Setter '" + e.Name + "' must declare a `mut self` receiver; writing through it mutates the instance."
 }
 
 // RecursiveMethodAnnotationError fires when a group of mutually recursive methods

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -488,6 +488,14 @@ func (c *checker) buildMemberSigs(
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
 			c.reportAccessorThrows(elem.Fn, elem, "setter")
+			// An instance setter mutates the instance, so it must hold mutable access to it.
+			// Report a plain `self` or shared `&self` receiver here, then keep the declared
+			// receiver on the elem so a write through it draws only this one diagnostic. An
+			// absent receiver is checkSelfReceiver's to report, and a static setter has no
+			// instance to mutate.
+			if elem.Receiver != nil && !elem.Receiver.Mut {
+				c.report(&SetterReceiverError{Name: name, Elem: elem})
+			}
 			// A well-formed setter declares exactly one value parameter beyond `self` — the
 			// value being assigned. Report a paramless or multi-parameter setter, then still
 			// build the elem from the first value parameter, or `unknown` when there is none,

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1476,6 +1476,16 @@ func TestInferClassErrors(t *testing.T) {
 			want: "Setter 'value' must declare exactly one value parameter; found 2.",
 		},
 		{
+			name: "SetterPlainSelfReceiver",
+			src: `
+				class C {
+					v: number,
+					set value(self, x: number) { },
+				}
+			`,
+			want: "Setter 'value' must declare a `mut self` receiver; writing through it mutates the instance.",
+		},
+		{
 			name: "MultipleConstructors",
 			src: `class C {
 				constructor(mut self) {},

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1700,6 +1700,15 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		return voidT
 	}
 	recv := c.inferWriteReceiver(scope, lvl, m.Object)
+	// A write whose receiver carries an accessor under this name is a setter call, not a
+	// field store, so it never reaches the structural requirement below. The structural
+	// requirement is a one-property object whose element is a PropertyElem, and
+	// constrain's object arm resolves the sub side with ObjectType.Prop, which matches
+	// only a PropertyElem. An accessor of the same name would therefore read as a missing
+	// property.
+	if accessor, ok := c.writeAccessor(m.Prop.Name, readCarrier(recv)); ok {
+		return c.inferAccessorAssign(e, m, recv, source, accessor, assignStmt)
+	}
 	w := widen(source)
 	// An owned-mutable field takes the immutable→mutable upgrade through the same shared
 	// helper as the other value-flow sites, so the field write stays consistent with them:
@@ -1764,6 +1773,66 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	}
 	// The assignment evaluates to the value just stored. recordType overwrites the
 	// `void` recovery type inferAssign recorded on e before dispatching here.
+	c.recordType(e, w)
+	return w
+}
+
+// inferAccessorAssign types a write `recv.prop = source` whose receiver carries an
+// accessor named prop. A setter accepts the write and a getter-only member rejects it.
+//
+// A setter write is a call, not a store, so it checks what a call checks. The source is
+// constrained against the setter's declared parameter, which sits in write position and
+// so is read contravariantly. The receiver is constrained against the setter's own `self`,
+// which rejects a write through an immutable receiver to a `mut self` setter. An owned
+// source passed to an owned parameter is consumed, the same move a call argument makes.
+//
+// Nothing is recorded in `written`. That map is the read-after-write shortcut for a
+// field's storage cell, and a setter has no cell — `self.v = n` inside the setter body
+// stores to whatever field the setter chooses, and a later `recv.prop` must run the getter
+// rather than return the value just passed in.
+//
+// A write to a getter-only member has no setter to call and is reported. This is the
+// mirror of the WriteOnlyPropertyError memberValue reports for reading a setter-only
+// member.
+//
+// The write is not an exceptional exit, so it constrains nothing into the enclosing body's
+// throws sink. A setter cannot raise: reportAccessorThrows rejects a `throws` clause on an
+// accessor, and SetterElem carries no throws for a raise to flow through. Lifting that
+// restriction is escalier-lang/escalier#972.
+func (c *checker) inferAccessorAssign(
+	e *ast.BinaryExpr,
+	m *ast.MemberExpr,
+	recv soltype.Type,
+	source soltype.Type,
+	accessor soltype.ObjTypeElem,
+	assignStmt ast.Stmt,
+) soltype.Type {
+	setter, ok := accessor.(*soltype.SetterElem)
+	if !ok {
+		out := c.report(&ReadOnlyPropertyError{Name: m.Prop.Name, Site: e})
+		c.recordType(e, out)
+		return out
+	}
+	c.checkReceiverMut(e.Left, recv, setter.SelfParam)
+	errsBefore := len(c.errs)
+	c.constrain(e.Right, source, setter.Param)
+	// A concretely owned parameter takes the value out of this frame, so the source
+	// binding is consumed and a later use of it is a use-after-move. This mirrors
+	// consumeCallArgs, since a setter write is a call on the argument side. The move
+	// records against the assignment's statement, resolved from assignStmt rather than
+	// c.fn.currentStmt, which inferring the receiver and source may have overwritten with
+	// an inner branch statement. A rejected write records no move.
+	if c.fn != nil && len(c.errs) == errsBefore && isConcreteOwned(setter.Param) {
+		if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
+			c.consumeOwned(e.Right, source, e.Right, ref)
+			c.recordEscapeSite(e.Right, ref)
+		}
+	}
+	// The assignment evaluates to the value just written, widened the way a field write
+	// widens it, so `val b = (c.x = 5)` reads `number` whether `x` is a field or a setter.
+	// recordType overwrites the `void` recovery type inferAssign recorded on e before
+	// dispatching here.
+	w := widen(source)
 	c.recordType(e, w)
 	return w
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1700,12 +1700,9 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		return voidT
 	}
 	recv := c.inferWriteReceiver(scope, lvl, m.Object)
-	// A write whose receiver carries an accessor under this name resolves to that accessor
-	// rather than to a field, so it never reaches the structural requirement below. That
-	// requirement is a one-property object whose element is a PropertyElem, and
-	// constrain's object arm resolves the sub side with ObjectType.Prop, which matches
-	// only a PropertyElem. An accessor of the same name would therefore read as a missing
-	// property.
+	// An accessor named prop resolves here rather than through the structural requirement
+	// below, whose element is a PropertyElem. constrain's object arm matches the sub side
+	// with ObjectType.Prop, so an accessor would read there as a missing property.
 	if accessor, ok := c.writeAccessor(m.Prop.Name, readCarrier(recv)); ok {
 		return c.inferAccessorAssign(e, m, recv, source, accessor, assignStmt)
 	}
@@ -1777,27 +1774,11 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	return w
 }
 
-// inferAccessorAssign types a write `recv.prop = source` whose receiver carries an
-// accessor named prop. A setter accepts the write and a getter-only member rejects it.
-//
-// A setter write is a call, not a store, so it checks what a call checks. The source is
-// constrained against the setter's declared parameter, which sits in write position and
-// so is read contravariantly. The receiver is constrained against the setter's own `self`,
-// which rejects a write through an immutable receiver to a `mut self` setter. An owned
-// source passed to an owned parameter is consumed, the same move a call argument makes.
-//
-// Nothing is recorded in `written`, the read-after-write map that hands a later read of a
-// field the value the last write stored. A setter has no such storage cell. Its body
-// stores to whatever field it chooses, so a later `recv.prop` has to run the getter
-// instead of returning the value just passed in.
-//
-// A write to a getter-only member has no setter to call and is reported. This mirrors the
-// WriteOnlyPropertyError memberValue reports for reading a setter-only member.
-//
-// The write is not an exceptional exit, so it constrains nothing into the enclosing body's
-// throws sink. A setter cannot raise at all. reportAccessorThrows rejects a `throws`
-// clause on an accessor, and SetterElem carries no throws slot for a raise to flow
-// through. Lifting that restriction is escalier-lang/escalier#972.
+// inferAccessorAssign types a write `recv.prop = source` that resolved to an accessor. A
+// getter-only member is reported, having no setter to call. A setter write is a call, not
+// a store: it checks the source against the setter's parameter and the receiver against
+// its `self`. It records nothing in `written`, since a setter has no cell a later read
+// could shortcut to, and nothing in the throws sink, since a setter cannot raise until #972.
 func (c *checker) inferAccessorAssign(
 	e *ast.BinaryExpr,
 	m *ast.MemberExpr,

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1700,8 +1700,8 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		return voidT
 	}
 	recv := c.inferWriteReceiver(scope, lvl, m.Object)
-	// A write whose receiver carries an accessor under this name is a setter call, not a
-	// field store, so it never reaches the structural requirement below. The structural
+	// A write whose receiver carries an accessor under this name resolves to that accessor
+	// rather than to a field, so it never reaches the structural requirement below. That
 	// requirement is a one-property object whose element is a PropertyElem, and
 	// constrain's object arm resolves the sub side with ObjectType.Prop, which matches
 	// only a PropertyElem. An accessor of the same name would therefore read as a missing
@@ -1786,19 +1786,18 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 // which rejects a write through an immutable receiver to a `mut self` setter. An owned
 // source passed to an owned parameter is consumed, the same move a call argument makes.
 //
-// Nothing is recorded in `written`. That map is the read-after-write shortcut for a
-// field's storage cell, and a setter has no cell — `self.v = n` inside the setter body
-// stores to whatever field the setter chooses, and a later `recv.prop` must run the getter
-// rather than return the value just passed in.
+// Nothing is recorded in `written`, the read-after-write map that hands a later read of a
+// field the value the last write stored. A setter has no such storage cell. Its body
+// stores to whatever field it chooses, so a later `recv.prop` has to run the getter
+// instead of returning the value just passed in.
 //
-// A write to a getter-only member has no setter to call and is reported. This is the
-// mirror of the WriteOnlyPropertyError memberValue reports for reading a setter-only
-// member.
+// A write to a getter-only member has no setter to call and is reported. This mirrors the
+// WriteOnlyPropertyError memberValue reports for reading a setter-only member.
 //
 // The write is not an exceptional exit, so it constrains nothing into the enclosing body's
-// throws sink. A setter cannot raise: reportAccessorThrows rejects a `throws` clause on an
-// accessor, and SetterElem carries no throws for a raise to flow through. Lifting that
-// restriction is escalier-lang/escalier#972.
+// throws sink. A setter cannot raise at all. reportAccessorThrows rejects a `throws`
+// clause on an accessor, and SetterElem carries no throws slot for a raise to flow
+// through. Lifting that restriction is escalier-lang/escalier#972.
 func (c *checker) inferAccessorAssign(
 	e *ast.BinaryExpr,
 	m *ast.MemberExpr,
@@ -1813,8 +1812,8 @@ func (c *checker) inferAccessorAssign(
 		c.recordType(e, out)
 		return out
 	}
-	c.checkReceiverMut(e.Left, recv, setter.SelfParam)
 	errsBefore := len(c.errs)
+	c.checkReceiverMut(e.Left, recv, setter.SelfParam)
 	c.constrain(e.Right, source, setter.Param)
 	// A concretely owned parameter takes the value out of this frame, so the source
 	// binding is consumed and a later use of it is a use-after-move. This mirrors

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -275,11 +275,15 @@ func TestInferMemberAssignSetter(t *testing.T) {
 			want: []string{"3:18-3:21: cannot constrain immutable C <: mutable C"},
 		},
 		{
-			name: "plain self setter accepts an immutable receiver",
+			// A setter mutates the instance, so a plain `self` receiver is rejected at the
+			// declaration. The write itself draws nothing further, since the elem keeps the
+			// declared receiver and the diagnostic belongs to the declaration.
+			name: "plain self setter is rejected at its declaration",
 			src: `
 				class C { set x(self, n: number) { } }
 				fn f(c: C) { c.x = 5 }
 			`,
+			want: []string{"2:15-2:41: Setter 'x' must declare a `mut self` receiver; writing through it mutates the instance."},
 		},
 		{
 			name: "mut self setter reached from a plain self body",

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -243,3 +243,169 @@ func TestInferMemberAssignClassReceiver(t *testing.T) {
 		})
 	}
 }
+
+// A field write whose receiver carries a setter under the written name is a setter call,
+// not a field store. It never mints the structural one-property requirement, which
+// resolves the sub side with ObjectType.Prop and so matches only a PropertyElem. The
+// source is checked against the setter's declared parameter and the receiver against the
+// setter's own `self`.
+func TestInferMemberAssignSetter(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "self receiver inside a mut self method",
+			src:  `class C { v: number, set x(mut self, n: number) { self.v = n }, m(mut self) { self.x = 5 } }`,
+		},
+		{
+			name: "mut instance receiver",
+			src: `
+				class C { v: number, set x(mut self, n: number) { self.v = n } }
+				fn f(c: mut C) { c.x = 5 }
+			`,
+		},
+		{
+			name: "immutable instance receiver has no mut to lend",
+			src: `
+				class C { v: number, set x(mut self, n: number) { self.v = n } }
+				fn f(c: C) { c.x = 5 }
+			`,
+			want: []string{"3:18-3:21: cannot constrain immutable C <: mutable C"},
+		},
+		{
+			name: "plain self setter accepts an immutable receiver",
+			src: `
+				class C { set x(self, n: number) { } }
+				fn f(c: C) { c.x = 5 }
+			`,
+		},
+		{
+			name: "mut self setter reached from a plain self body",
+			src:  `class C { v: number, set x(mut self, n: number) { self.v = n }, m(self) { self.x = 5 } }`,
+			want: []string{"1:75-1:81: cannot constrain immutable C <: mutable C"},
+		},
+		{
+			name: "value is checked against the setter parameter",
+			src: `
+				class C { v: number, set x(mut self, n: number) { self.v = n } }
+				fn f(c: mut C) { c.x = "hi" }
+			`,
+			want: []string{`3:28-3:32: cannot constrain "hi" <: number`},
+		},
+		{
+			name: "inherited setter resolves through a subclass instance",
+			src: `
+				class C { v: number, set x(mut self, n: number) { self.v = n } }
+				class D extends C { constructor(mut self) { } }
+				fn f(d: mut D) { d.x = 5 }
+			`,
+		},
+		{
+			name: "static setter",
+			src: `
+				class C { static set x(n: number) { } }
+				fn f() { C.x = 5 }
+			`,
+		},
+		{
+			name: "static setter rejects a wrongly-typed value",
+			src: `
+				class C { static set x(n: number) { } }
+				fn f() { C.x = "hi" }
+			`,
+			want: []string{`3:20-3:24: cannot constrain "hi" <: number`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// A getter and a setter that share a name resolve by direction rather than by declaration
+// order: a write takes the setter and a read takes the getter, whichever half comes first
+// in the class body. ObjectType.WriteMember and ObjectType.ReadMember are the two lookups
+// that make that choice.
+func TestInferMemberAssignAccessorPair(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "setter declared first",
+			src: `
+				class C {
+					v: number,
+					set x(mut self, n: number) { self.v = n },
+					get x(self) -> number { return self.v },
+				}
+				fn f(c: mut C) -> number {
+					c.x = 5
+					return c.x
+				}
+			`,
+		},
+		{
+			name: "getter declared first",
+			src: `
+				class C {
+					v: number,
+					get x(self) -> number { return self.v },
+					set x(mut self, n: number) { self.v = n },
+				}
+				fn f(c: mut C) -> number {
+					c.x = 5
+					return c.x
+				}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Empty(t, messagesWithSpan(errs))
+		})
+	}
+}
+
+// A write to a getter-only member has no setter to call. It reports ReadOnlyPropertyError,
+// the mirror of the WriteOnlyPropertyError a read of a setter-only member reports.
+func TestInferMemberAssignGetterOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "instance receiver",
+			src: `
+				class C { v: number, get x(self) -> number { return self.v } }
+				fn f(c: mut C) { c.x = 5 }
+			`,
+			want: []string{"3:22-3:29: Property 'x' is read-only; it has a getter but no setter or field to write."},
+		},
+		{
+			name: "self receiver",
+			src:  `class C { v: number, get x(self) -> number { return self.v }, m(mut self) { self.x = 5 } }`,
+			want: []string{"1:77-1:87: Property 'x' is read-only; it has a getter but no setter or field to write."},
+		},
+		{
+			name: "static receiver",
+			src: `
+				class C { static get x() -> number { return 1 } }
+				fn f() { C.x = 5 }
+			`,
+			want: []string{"3:14-3:21: Property 'x' is read-only; it has a getter but no setter or field to write."},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -482,6 +482,19 @@ func TestInferMemberAssignSetterIndirectReceiver(t *testing.T) {
 			`,
 		},
 		{
+			// Every value the receiver may hold has to lend mutable access. A join with an
+			// immutable branch does not, since that branch may be the one taken, so it is
+			// rejected exactly as the structural field-write path rejects it.
+			name: "branch join with one immutable arm",
+			src: `
+				class C { v: number, set x(mut self, n: number) { self.v = n } }
+				fn f(a: mut C, b: C, cond: boolean) { val r = if (cond) { a } else { b }
+					r.x = 5
+				}
+			`,
+			want: []string{"4:6-4:9: cannot constrain immutable C <: mutable C"},
+		},
+		{
 			name: "immutable call result",
 			src: `
 				class C { v: number, set x(mut self, n: number) { self.v = n } }

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -246,9 +246,9 @@ func TestInferMemberAssignClassReceiver(t *testing.T) {
 
 // A field write whose receiver carries a setter under the written name is a setter call,
 // not a field store. It never mints the structural one-property requirement, which
-// resolves the sub side with ObjectType.Prop and so matches only a PropertyElem. The
-// source is checked against the setter's declared parameter and the receiver against the
-// setter's own `self`.
+// constrain's object arm resolves with ObjectType.Prop and so cannot match a SetterElem.
+// The source is checked against the setter's declared parameter and the receiver against
+// the setter's own `self`.
 func TestInferMemberAssignSetter(t *testing.T) {
 	tests := []struct {
 		name string
@@ -301,6 +301,24 @@ func TestInferMemberAssignSetter(t *testing.T) {
 				class D extends C { constructor(mut self) { } }
 				fn f(d: mut D) { d.x = 5 }
 			`,
+		},
+		{
+			name: "setter write inside the class's own constructor",
+			src: `
+				class C {
+					v: number,
+					constructor(mut self) { self.v = 0 self.x = 5 },
+					set x(mut self, n: number) { self.v = n },
+				}
+			`,
+		},
+		{
+			name: "generic setter parameter projects the instance argument",
+			src: `
+				class Box<T> { v: T, set x(mut self, n: T) { self.v = n } }
+				fn f(b: mut Box<number>) { b.x = "hi" }
+			`,
+			want: []string{`3:38-3:42: cannot constrain "hi" <: number`},
 		},
 		{
 			name: "static setter",
@@ -408,4 +426,25 @@ func TestInferMemberAssignGetterOnly(t *testing.T) {
 			require.Equal(t, tt.want, messagesWithSpan(errs))
 		})
 	}
+}
+
+// A setter write evaluates to the value just written, widened the way a field write
+// widens it, so a caller reads `number` whether `x` is a field or a setter. Nothing is
+// recorded in `written`, so a later read of the same name runs the getter rather than
+// returning the value just passed in.
+func TestInferMemberAssignSetterValue(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class C {
+			v: number,
+			get x(self) -> string { return "s" },
+			set x(mut self, n: number) { self.v = n },
+		}
+		fn written(c: mut C) { return (c.x = 5) }
+		fn readBack(c: mut C) { c.x = 5
+			return c.x
+		}
+	`)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t, "fn (c: mut C) -> number", values["written"])
+	require.Equal(t, "fn (c: mut C) -> string", values["readBack"])
 }

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -448,3 +448,49 @@ func TestInferMemberAssignSetterValue(t *testing.T) {
 	require.Equal(t, "fn (c: mut C) -> number", values["written"])
 	require.Equal(t, "fn (c: mut C) -> string", values["readBack"])
 }
+
+// A `mut` borrow reaches a receiver position through a call result or a branch join as a
+// variable carrying the borrow among its lower bounds, not as a bare RefType. The setter
+// write looks through that variable for the receiver's mutability, so it accepts the same
+// receivers a field write and a `mut self` method call accept. An immutable receiver is
+// still rejected.
+func TestInferMemberAssignSetterIndirectReceiver(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "call result",
+			src: `
+				class C { v: number, set x(mut self, n: number) { self.v = n } }
+				declare fn g(c: mut C) -> mut C
+				fn f(c: mut C) { g(c).x = 5 }
+			`,
+		},
+		{
+			name: "branch join",
+			src: `
+				class C { v: number, set x(mut self, n: number) { self.v = n } }
+				fn f(a: mut C, b: mut C, cond: boolean) { val r = if (cond) { a } else { b }
+					r.x = 5
+				}
+			`,
+		},
+		{
+			name: "immutable call result",
+			src: `
+				class C { v: number, set x(mut self, n: number) { self.v = n } }
+				declare fn g(c: C) -> C
+				fn f(c: C) { g(c).x = 5 }
+			`,
+			want: []string{"4:18-4:24: cannot constrain immutable C <: mutable C"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -771,6 +771,22 @@ func TestInferMemberClassUnionSetterOnlyReadsUndefined(t *testing.T) {
 	require.Equal(t, "fn (p: A | B) -> string | undefined", values["f"])
 }
 
+// A union member carrying both halves of an accessor pair contributes its GETTER to the
+// read join, whichever half the class body declares first. Here `A` declares `set v` before
+// `get v`, so a lookup that took declaration order would treat `v` as write-only on `A` and
+// fold `undefined` into the join.
+func TestInferMemberClassUnionAccessorPairReadsGetter(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class A { _v: number, set v(mut self, x: string) { }, get v(self) -> string { return "a" } }
+		class B { v: string }
+		fn f(p: A | B) {
+			return p.v
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: A | B) -> string", values["f"])
+}
+
 // A setter-only member is not readable, so a member exposed only as a setter across every
 // union member yields no readable value. With no member to read, the access is a
 // missing-property error rather than binding as bare undefined (#886).

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1107,6 +1107,23 @@ func TestInferIndexNamedTypeStaysSymbolic(t *testing.T) {
 			wantSymbolic: `Point["x"]`,
 			wantExpanded: "number",
 		},
+		{
+			// An indexed access reads the class body, so a key carried by both halves of an
+			// accessor pair selects the getter's type whichever half the body declares first.
+			// Here `set x` comes before `get x`, and the access still reduces to the getter's
+			// `number` rather than reporting the key as write-only.
+			name: "ClassAccessorPair",
+			src: `
+				class C {
+					v: number,
+					set x(mut self, n: number) { self.v = n },
+					get x(self) -> number { return self.v },
+				}
+				type Result = C["x"]
+			`,
+			wantSymbolic: `C["x"]`,
+			wantExpanded: "number",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #982

A write `recv.prop = v` never reached a setter. `inferMemberAssign` minted a structural one-property requirement whose element is a `PropertyElem`, and constrain's object arm resolves the sub side with `ObjectType.Prop`, which matches only a `PropertyElem`. A `SetterElem` of that name therefore read as a missing property, and every setter write was rejected.

## The write-side resolution

`inferMemberAssign` now resolves the write against the receiver before minting the requirement, the twin of the three read interceptions `valueProp` runs. It covers the same three receiver shapes: a class instance, a class body reached through `self`, and a class value for a static write.

A `SetterElem` routes to the new `inferAccessorAssign`. A setter write is a call, not a store, so it checks what a call checks. The source is constrained against `setter.Param` and the receiver against `setter.SelfParam`, and an owned source passed to an owned parameter is consumed the way a call argument is. Nothing is recorded in `written`, so a later read of the same name runs the getter rather than returning the value just passed in.

A `GetterElem` reports the new `ReadOnlyPropertyError`, the mirror of the `WriteOnlyPropertyError` `memberValue` already reports for reading a setter-only member.

## Resolving accessor pairs by direction

`ObjectType` gains `ReadMember` and `WriteMember`. When a getter and a setter share a name they return the half the access direction wants, so neither is hidden by the other's declaration order. `Member` keeps its first-declared-wins behavior for callers that only ask whether a name is present.

Every directional lookup moved onto the new pair. Beyond the read path in `classes.go`, that includes two sites that were order-dependent before this change:

- `memberReadContribution` — a class declaring `set x` before `get x` read as write-only through a union, so `fn f(u: C | D) -> number { return u.x }` reported `cannot constrain undefined <: number`.
- `constrainObjMember` — a getter requirement resolved against whichever half the sub declared first.

`indexObject`'s presence check keeps `Member`, since asking whether a name exists is direction-independent. The indexed access itself reads through `memberReadContribution`, so `C["x"]` now reduces for a setter-first pair.

## Receiver mutability

`checkMethodReceiver` became `checkReceiverMut`, taking the member's `self` parameter directly so the write path can pass a setter's receiver without pulling setters into `memberSelfParam`, which the read path uses and where a setter is already a write-only error.

It also recognized a mutable receiver only as a literal `RefType`. A `mut` borrow arriving through a call result or a branch join reaches the receiver position as a variable carrying the borrow among its lower bounds, so `g(c).x = 5` was rejected as immutable while `g(c).v = 5` and `g(c).m()` were fine. `lendsMut` looks through the variable, the same look-through `classCarrier` already uses to find the setter.

## Not included

Point 4 of the issue, carrying the setter's throws to the write site, is not implementable yet. It depends on `SetterElem.Throws` from #972, which is still open — neither that field nor `raiseAccessorThrows` exists on `main`. A setter cannot raise at all today, since `reportAccessorThrows` rejects a `throws` clause on an accessor, so the write is not an exceptional exit. `inferAccessorAssign` carries a comment saying so and pointing at #972.

## Testing

`go test ./...` passes. New coverage: setter writes through `self`, a `mut` instance, an immutable instance, a plain-`self` setter, a subclass instance, a static receiver, the class's own constructor, a generic setter parameter projected to the instance argument, and indirect receivers from a call result and a branch join; getter-only writes on all three receiver shapes; accessor-pair resolution in both declaration orders for a member write, a union read, and an indexed access; and unit coverage of `ReadMember`/`WriteMember` across every element kind.

One thing checked and deliberately left alone: a nested write `o.p.x = 5` through `o: mut {p: C}` is rejected on receiver mutability, identically to what a plain field write does there. That is a pre-existing deep-mut gap for class-typed fields, not something this change introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H89sMMgdSNGG2vhSibCh23

---
_Generated by [Claude Code](https://claude.ai/code/session_01H89sMMgdSNGG2vhSibCh23)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for getter and setter accessors, including inherited and static members.
  * Member reads now prefer getters, while writes prefer setters.
  * Setter assignments validate mutability and value compatibility.

* **Bug Fixes**
  * Added clear diagnostics when attempting to write to getter-only properties.
  * Corrected accessor resolution for unions and indexed property access.
  * Improved handling of accessor pairs regardless of declaration order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->