### PR TITLE
Add method, getter, and setter members to object type annotations

### DIFF
--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -487,7 +487,11 @@ func (t *FuncTypeAnn) Accept(v Visitor) {
 				param.TypeAnn.Accept(v)
 			}
 		}
-		t.Return.Accept(v)
+		// A setter written in an object type annotation returns nothing and so writes no
+		// `-> R`, which is the one signature form that leaves Return nil.
+		if t.Return != nil {
+			t.Return.Accept(v)
+		}
 		if t.Throws != nil {
 			t.Throws.Accept(v)
 		}

--- a/internal/checker/infer_type_ann.go
+++ b/internal/checker/infer_type_ann.go
@@ -342,8 +342,15 @@ func (c *Checker) inferFuncTypeAnn(
 			Optional: param.Optional,
 		}
 	}
-	returnType, returnErrors := c.inferTypeAnn(funcCtx, funcTypeAnn.Return)
-	errors = slices.Concat(errors, returnErrors)
+	// A setter written in an object type annotation returns nothing and so writes no
+	// `-> R`. Every other signature form names its return, so this is the only shape that
+	// reaches here with a nil Return.
+	var returnType type_system.Type = type_system.NewUndefinedType(nil)
+	if funcTypeAnn.Return != nil {
+		var returnErrors []Error
+		returnType, returnErrors = c.inferTypeAnn(funcCtx, funcTypeAnn.Return)
+		errors = slices.Concat(errors, returnErrors)
+	}
 
 	var throwsType type_system.Type
 	if funcTypeAnn.Throws == nil {

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -2600,3 +2600,275 @@
     },
 }
 ---
+
+[TestParseTypeAnnNoErrors/ObjectMethodWithTypeParams - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.MethodTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "f",
+                span: 1:2-1:3,
+            },
+            Fn: &ast.FuncTypeAnn{
+                TypeParams: []*ast.TypeParam{
+                    &ast.TypeParam{
+                        Name: "T",
+                    },
+                },
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "x",
+                            span: 1:7-1:8,
+                        },
+                        TypeAnn: &ast.TypeRefTypeAnn{
+                            Name: &ast.Ident{
+                                Name: "T",
+                                span: 1:10-1:11,
+                            },
+                            span: 1:10-1:11,
+                        },
+                    },
+                },
+                Return: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "T",
+                        span: 1:16-1:17,
+                    },
+                    span: 1:16-1:17,
+                },
+                span: 1:6-1:17,
+            },
+        },
+    },
+    span: 1:1-1:18,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectMethod - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.MethodTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "f",
+                span: 1:2-1:3,
+            },
+            Fn: &ast.FuncTypeAnn{
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "x",
+                            span: 1:4-1:5,
+                        },
+                        TypeAnn: &ast.NumberTypeAnn{
+                            span: 1:7-1:13,
+                        },
+                    },
+                },
+                Return: &ast.StringTypeAnn{
+                    span: 1:18-1:24,
+                },
+                span: 1:3-1:24,
+            },
+        },
+    },
+    span: 1:1-1:25,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectSetter - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.SetterTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "a",
+                span: 1:6-1:7,
+            },
+            Fn: &ast.FuncTypeAnn{
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "v",
+                            span: 1:18-1:19,
+                        },
+                        TypeAnn: &ast.NumberTypeAnn{
+                            span: 1:21-1:27,
+                        },
+                    },
+                },
+                span: 1:7-1:28,
+            },
+            Receiver: &ast.MethodReceiver{
+                Mut: true,
+                Span_: 1:8-1:16,
+            },
+        },
+    },
+    span: 1:1-1:29,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectMethodWithReceiver - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.MethodTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "f",
+                span: 1:2-1:3,
+            },
+            Fn: &ast.FuncTypeAnn{
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "x",
+                            span: 1:14-1:15,
+                        },
+                        TypeAnn: &ast.NumberTypeAnn{
+                            span: 1:17-1:23,
+                        },
+                    },
+                },
+                Return: &ast.StringTypeAnn{
+                    span: 1:28-1:34,
+                },
+                span: 1:3-1:34,
+            },
+            Receiver: &ast.MethodReceiver{
+                Mut: true,
+                Span_: 1:4-1:12,
+            },
+        },
+    },
+    span: 1:1-1:35,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectSetterWithReturnType - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.SetterTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "a",
+                span: 1:6-1:7,
+            },
+            Fn: &ast.FuncTypeAnn{
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "v",
+                            span: 1:18-1:19,
+                        },
+                        TypeAnn: &ast.NumberTypeAnn{
+                            span: 1:21-1:27,
+                        },
+                    },
+                },
+                Return: &ast.LitTypeAnn{
+                    Lit: &ast.UndefinedLit{
+                        span: 1:32-1:41,
+                    },
+                    span: 1:32-1:41,
+                },
+                span: 1:7-1:41,
+            },
+            Receiver: &ast.MethodReceiver{
+                Mut: true,
+                Span_: 1:8-1:16,
+            },
+        },
+    },
+    span: 1:1-1:42,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectGetter - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.GetterTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "a",
+                span: 1:6-1:7,
+            },
+            Fn: &ast.FuncTypeAnn{
+                Return: &ast.NumberTypeAnn{
+                    span: 1:17-1:23,
+                },
+                span: 1:7-1:23,
+            },
+            Receiver: &ast.MethodReceiver{
+                Span_: 1:8-1:12,
+            },
+        },
+    },
+    span: 1:1-1:24,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectGetterWithThrows - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.GetterTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "a",
+                span: 1:6-1:7,
+            },
+            Fn: &ast.FuncTypeAnn{
+                Return: &ast.NumberTypeAnn{
+                    span: 1:17-1:23,
+                },
+                Throws: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "RangeError",
+                        span: 1:31-1:41,
+                    },
+                    span: 1:31-1:41,
+                },
+                span: 1:7-1:41,
+            },
+            Receiver: &ast.MethodReceiver{
+                Span_: 1:8-1:12,
+            },
+        },
+    },
+    span: 1:1-1:42,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectSetterWithThrows - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.SetterTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "a",
+                span: 1:6-1:7,
+            },
+            Fn: &ast.FuncTypeAnn{
+                Params: []*ast.Param{
+                    &ast.Param{
+                        Pattern: &ast.IdentPat{
+                            Name: "v",
+                            span: 1:18-1:19,
+                        },
+                        TypeAnn: &ast.NumberTypeAnn{
+                            span: 1:21-1:27,
+                        },
+                    },
+                },
+                Throws: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "RangeError",
+                        span: 1:36-1:46,
+                    },
+                    span: 1:36-1:46,
+                },
+                span: 1:7-1:46,
+            },
+            Receiver: &ast.MethodReceiver{
+                Mut: true,
+                Span_: 1:8-1:16,
+            },
+        },
+    },
+    span: 1:1-1:47,
+}
+---

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -998,12 +998,20 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		} else if receiver == nil {
 			params = parseDelimSeq(p, CloseParen, Comma, p.param)
 		}
+		closeParen := p.lexer.peek()
 		p.expect(CloseParen, ConsumeOnMatch)
 
-		p.expect(Arrow, ConsumeOnMatch)
-
-		retType := p.typeAnnRequired()
-		endSpan := retType.Span()
+		// A setter returns nothing, so it writes no `-> R`, matching how a setter is
+		// declared in a class body. A method and a getter both name what they yield and
+		// keep the arrow required. Written anyway, `-> R` still parses on a setter, so a
+		// hand-converted `.d.ts` accessor does not have to drop it.
+		var retType ast.TypeAnn
+		endSpan := closeParen.Span
+		if mod != "set" || p.lexer.peek().Type == Arrow {
+			p.expect(Arrow, ConsumeOnMatch)
+			retType = p.typeAnnRequired()
+			endSpan = retType.Span()
+		}
 
 		// A method, getter, or setter signature inside an object type declares what it
 		// raises the same way a standalone function type does, as in

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -252,6 +252,33 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 		"ObjectConstructorSignatureBesideProperty": {
 			input: "{new (x: number) -> Point, origin: Point}",
 		},
+		"ObjectMethod": {
+			input: "{f(x: number) -> string}",
+		},
+		"ObjectMethodWithReceiver": {
+			input: "{f(mut self, x: number) -> string}",
+		},
+		"ObjectMethodWithTypeParams": {
+			input: "{f<T>(x: T) -> T}",
+		},
+		"ObjectGetter": {
+			input: "{get a(self) -> number}",
+		},
+		// A setter yields nothing, so it writes no `-> R`, the way a class body declares one.
+		"ObjectSetter": {
+			input: "{set a(mut self, v: number)}",
+		},
+		// The arrow still parses on a setter, so a hand-converted `.d.ts` accessor keeps it.
+		"ObjectSetterWithReturnType": {
+			input: "{set a(mut self, v: number) -> undefined}",
+		},
+		"ObjectGetterWithThrows": {
+			input: "{get a(self) -> number throws RangeError}",
+		},
+		// The clause follows the parameter list directly when a setter writes no arrow.
+		"ObjectSetterWithThrows": {
+			input: "{set a(mut self, v: number) throws RangeError}",
+		},
 		"UnionOfFunctions": {
 			input: "(fn (x: number) -> string) | (fn (x: string) -> number)",
 		},

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -439,6 +439,52 @@ func (p *Printer) printMethodSig(sig *ast.FuncSig, recv *ast.MethodReceiver) {
 	p.printReturnAndThrows(sig.Return, sig.Throws)
 }
 
+// annMemberReceiver returns the receiver text a method, getter, or setter written in an object
+// type annotation prints, or "" for none. The parser peels `self` / `mut self` off into the
+// elem's Receiver, so it never reaches Fn.Params and has to be printed from there. A lifetime on
+// the receiver is not rendered, matching printMethodSig.
+//
+// fallback is what the member prints when the source wrote no receiver. An accessor passes
+// `self` or `mut self`, since it is an instance member and the `.d.ts` converter builds one with
+// the field nil. A method passes "", since a method annotation is commonly written with no
+// receiver at all.
+func annMemberReceiver(recv *ast.MethodReceiver, fallback string) string {
+	if recv == nil {
+		return fallback
+	}
+	if recv.Mut {
+		return "mut self"
+	}
+	return "self"
+}
+
+// printAnnMemberParams emits the parenthesized parameter list of a member annotation, leading
+// with recv when it is non-empty. It is the member-annotation counterpart of printMethodSig,
+// which takes the FuncSig a class member carries rather than the FuncTypeAnn an annotation does.
+func (p *Printer) printAnnMemberParams(recv string, params []*ast.Param) {
+	p.writeString("(")
+	first := true
+	if recv != "" {
+		p.writeString(recv)
+		first = false
+	}
+	for _, param := range params {
+		if !first {
+			p.writeString(", ")
+		}
+		first = false
+		p.printPattern(param.Pattern)
+		if param.Optional {
+			p.writeString("?")
+		}
+		if param.TypeAnn != nil {
+			p.writeString(": ")
+			p.printTypeAnn(param.TypeAnn)
+		}
+	}
+	p.writeString(")")
+}
+
 // printReturnAndThrows emits ` -> R` followed by any `throws T` clause, so every signature
 // form renders the pair alike. A nil ret emits no arrow, and neither a nil nor a `never`
 // throws emits a clause. `-> R` is greedy, so a function-typed return is parenthesized
@@ -1327,40 +1373,17 @@ func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
 	case *ast.MethodTypeAnn:
 		p.printObjKey(e.Name)
 		p.printGenericParams(e.Fn.LifetimeParams, e.Fn.TypeParams)
-		p.writeString("(")
-		for i, param := range e.Fn.Params {
-			p.printPattern(param.Pattern)
-			if param.Optional {
-				p.writeString("?")
-			}
-			if param.TypeAnn != nil {
-				p.writeString(": ")
-				p.printTypeAnn(param.TypeAnn)
-			}
-			if i < len(e.Fn.Params)-1 {
-				p.writeString(", ")
-			}
-		}
-		p.writeString(")")
+		p.printAnnMemberParams(annMemberReceiver(e.Receiver, ""), e.Fn.Params)
 		p.printReturnAndThrows(e.Fn.Return, e.Fn.Throws)
 	case *ast.GetterTypeAnn:
 		p.writeString("get ")
 		p.printObjKey(e.Name)
-		p.writeString("(self)")
+		p.printAnnMemberParams(annMemberReceiver(e.Receiver, "self"), nil)
 		p.printReturnAndThrows(e.Fn.Return, e.Fn.Throws)
 	case *ast.SetterTypeAnn:
 		p.writeString("set ")
 		p.printObjKey(e.Name)
-		p.writeString("(mut self, ")
-		if len(e.Fn.Params) > 0 {
-			p.printPattern(e.Fn.Params[0].Pattern)
-			if e.Fn.Params[0].TypeAnn != nil {
-				p.writeString(": ")
-				p.printTypeAnn(e.Fn.Params[0].TypeAnn)
-			}
-		}
-		p.writeString(")")
-		// Setters require -> void in Escalier syntax
+		p.printAnnMemberParams(annMemberReceiver(e.Receiver, "mut self"), e.Fn.Params)
 		p.printReturnAndThrows(e.Fn.Return, e.Fn.Throws)
 	case *ast.PropertyTypeAnn:
 		if e.Readonly {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -439,15 +439,11 @@ func (p *Printer) printMethodSig(sig *ast.FuncSig, recv *ast.MethodReceiver) {
 	p.printReturnAndThrows(sig.Return, sig.Throws)
 }
 
-// annMemberReceiver returns the receiver text a method, getter, or setter written in an object
-// type annotation prints, or "" for none. The parser peels `self` / `mut self` off into the
-// elem's Receiver, so it never reaches Fn.Params and has to be printed from there. A lifetime on
-// the receiver is not rendered, matching printMethodSig.
-//
-// fallback is what the member prints when the source wrote no receiver. An accessor passes
-// `self` or `mut self`, since it is an instance member and the `.d.ts` converter builds one with
-// the field nil. A method passes "", since a method annotation is commonly written with no
-// receiver at all.
+// annMemberReceiver returns the receiver text a member annotation prints, or "" for none. The
+// parser stores it on the elem rather than in Fn.Params, and a lifetime on it is not rendered,
+// matching printMethodSig. fallback covers a member that wrote no receiver: an accessor passes
+// `self` or `mut self`, which is what the `.d.ts` converter's output relies on, and a method
+// passes "".
 func annMemberReceiver(recv *ast.MethodReceiver, fallback string) string {
 	if recv == nil {
 		return fallback

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -819,6 +819,52 @@ func TestPrintConstructorTypeAnnotations(t *testing.T) {
 	}
 }
 
+// A method, getter, or setter member of an object type annotation round-trips through the
+// printer. Each shares its signature rendering with the `fn` annotation, so type parameters and a
+// `throws` clause come along on a method. A setter writes no `-> R`, and the printer omits the
+// arrow rather than inventing a return type for it.
+//
+// A written `self` receiver is not covered. The three arms do not route through printMethodSig,
+// which takes a FuncSig rather than the FuncTypeAnn an annotation member carries, so a method
+// drops its receiver and an accessor prints one whether or not the source wrote it. That is
+// escalier-lang/escalier#635's territory and predates these members resolving at all.
+func TestPrintMemberTypeAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"method", "{f(x: number) -> string}", "{\n    f(x: number) -> string\n}"},
+		{"method with type params", "{f<T>(x: T) -> T}", "{\n    f<T>(x: T) -> T\n}"},
+		{"method throws", "{parse(x: string) -> number throws SyntaxError}", "{\n    parse(x: string) -> number throws SyntaxError\n}"},
+		{"getter", "{get a(self) -> number}", "{\n    get a(self) -> number\n}"},
+		{"setter", "{set a(mut self, v: number)}", "{\n    set a(mut self, v: number)\n}"},
+		{"getter throws", "{get a(self) -> number throws RangeError}", "{\n    get a(self) -> number throws RangeError\n}"},
+		{"setter throws", "{set a(mut self, v: number) throws RangeError}", "{\n    set a(mut self, v: number) throws RangeError\n}"},
+		{
+			"beside a property",
+			"{f(x: number) -> string, origin: Point}",
+			"{\n    f(x: number) -> string,\n    origin: Point\n}",
+		},
+	}
+
+	opts := DefaultOptions()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typeAnn := parseTypeAnn(t, tt.input)
+			result, err := Print(typeAnn, opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+
+			// Re-parsing the rendered form and printing it again must land on the same text,
+			// which is what makes the output a form the source could have been written in.
+			reprinted, err := Print(parseTypeAnn(t, result), opts)
+			require.NoError(t, err)
+			require.Equal(t, result, reprinted)
+		})
+	}
+}
+
 func TestPrintBorrowTypeAnnotations(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -824,10 +824,9 @@ func TestPrintConstructorTypeAnnotations(t *testing.T) {
 // `throws` clause come along on a method. A setter writes no `-> R`, and the printer omits the
 // arrow rather than inventing a return type for it.
 //
-// A written `self` receiver is not covered. The three arms do not route through printMethodSig,
-// which takes a FuncSig rather than the FuncTypeAnn an annotation member carries, so a method
-// drops its receiver and an accessor prints one whether or not the source wrote it. That is
-// escalier-lang/escalier#635's territory and predates these members resolving at all.
+// A written receiver is rendered from the elem's Receiver, since the parser peels it off the
+// parameter list. An accessor that writes none still prints one, which is the form the `.d.ts`
+// converter's output relies on.
 func TestPrintMemberTypeAnnotations(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -838,7 +837,12 @@ func TestPrintMemberTypeAnnotations(t *testing.T) {
 		{"method with type params", "{f<T>(x: T) -> T}", "{\n    f<T>(x: T) -> T\n}"},
 		{"method throws", "{parse(x: string) -> number throws SyntaxError}", "{\n    parse(x: string) -> number throws SyntaxError\n}"},
 		{"getter", "{get a(self) -> number}", "{\n    get a(self) -> number\n}"},
+		{"method with receiver", "{f(mut self, x: number) -> string}", "{\n    f(mut self, x: number) -> string\n}"},
 		{"setter", "{set a(mut self, v: number)}", "{\n    set a(mut self, v: number)\n}"},
+		{"setter with plain receiver", "{set a(self, v: number)}", "{\n    set a(self, v: number)\n}"},
+		// An accessor that writes no receiver still prints one, so the rendered form is the
+		// `.d.ts` converter's output rather than a byte-for-byte echo of the source.
+		{"getter without a receiver", "{get a() -> number}", "{\n    get a(self) -> number\n}"},
 		{"getter throws", "{get a(self) -> number throws RangeError}", "{\n    get a(self) -> number throws RangeError\n}"},
 		{"setter throws", "{set a(mut self, v: number) throws RangeError}", "{\n    set a(mut self, v: number) throws RangeError\n}"},
 		{
@@ -1969,7 +1973,7 @@ func TestPrintThrowsClause(t *testing.T) {
 		{
 			name:  "object method",
 			input: "{m(self) -> number throws SyntaxError}",
-			want:  "{\n    m() -> number throws SyntaxError\n}",
+			want:  "{\n    m(self) -> number throws SyntaxError\n}",
 		},
 		{
 			name:  "object getter",

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -819,14 +819,9 @@ func TestPrintConstructorTypeAnnotations(t *testing.T) {
 	}
 }
 
-// A method, getter, or setter member of an object type annotation round-trips through the
-// printer. Each shares its signature rendering with the `fn` annotation, so type parameters and a
-// `throws` clause come along on a method. A setter writes no `-> R`, and the printer omits the
-// arrow rather than inventing a return type for it.
-//
-// A written receiver is rendered from the elem's Receiver, since the parser peels it off the
-// parameter list. An accessor that writes none still prints one, which is the form the `.d.ts`
-// converter's output relies on.
+// A method, getter, or setter member round-trips through the printer: parsing the rendered form
+// and printing it again lands on the same text. A setter writes no return arrow and the printer
+// omits it, and an accessor that writes no receiver still prints one.
 func TestPrintMemberTypeAnnotations(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -488,6 +488,57 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 	return c.memberValue(lvl, blame, member), true
 }
 
+// objectMember resolves a read of a method, getter, or setter carried by a plain object type,
+// the members an object type annotation declares. It is the structural twin of
+// projectedMember, which does the same for a class instance.
+//
+// A PropertyElem deliberately does not resolve here, and neither does a miss. Both fall through
+// to the structural `{name: fieldVar}` requirement in valueProp, which is where the
+// read-after-write record, the borrow edges, the inexact tail, the union join, and
+// MissingPropertyError already live. Only the member kinds that requirement cannot express are
+// intercepted, so this adds a path rather than diverting one.
+func (c *checker) objectMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
+	obj, ok := objectCarrier(carrier)
+	if !ok {
+		return pathResult{}, false
+	}
+	member, found := obj.ReadMember(name)
+	if !found {
+		return pathResult{}, false
+	}
+	if _, isProp := member.(*soltype.PropertyElem); isProp {
+		return pathResult{}, false
+	}
+	return c.memberValue(lvl, blame, member), true
+}
+
+// objectCarrier reads the object type a receiver denotes: the type itself, or the single
+// object among an unresolved var's lower bounds. It mirrors classCarrier and
+// classValueCarrier, and like them it declines a var whose bounds disagree, since there is no
+// one member list to read in that case.
+func objectCarrier(t soltype.Type) (*soltype.ObjectType, bool) {
+	switch t := t.(type) {
+	case *soltype.ObjectType:
+		return t, true
+	case *soltype.TypeVarType:
+		var found *soltype.ObjectType
+		for _, lb := range t.LowerBounds {
+			obj, ok := lb.(*soltype.ObjectType)
+			if !ok {
+				continue
+			}
+			if found != nil && !equalType(found, obj) {
+				return nil, false
+			}
+			found = obj
+		}
+		if found != nil {
+			return found, true
+		}
+	}
+	return nil, false
+}
+
 // projectedClassMember looks name up on ct's class body, then walks the declared
 // `extends` chain when the class does not declare the member itself, so a member
 // inherited from a superclass reads through a subclass instance. It returns the member

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1456,12 +1456,19 @@ func (e *SubclassConstructorRequiredError) Message() string {
 	return "Subclasses must declare an explicit `constructor` block; constructor synthesis is not supported for classes with an `extends` clause."
 }
 
+// spanned is a node that can carry blame without being a whole ast.Node. An
+// object-type-annotation member is one: it has a span, and no Accept, since the visitor
+// walks the annotation rather than descending into its member list.
+type spanned interface{ Span() ast.Span }
+
 // SetterArityError fires when a setter declares other than exactly one value parameter
 // beyond its `self` receiver. A setter's single parameter is the value being assigned,
-// so `set x(self)` and `set x(self, a, b)` are both malformed.
+// so `set x(self)` and `set x(self, a, b)` are both malformed. The rule is the same for a
+// class member and for a setter written in an object type annotation, so Elem is whichever
+// node the source wrote and carries the blame span.
 type SetterArityError struct {
 	Name  string
-	Elem  *ast.SetterElem
+	Elem  spanned
 	Count int // value parameters declared, excluding `self`
 }
 

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1086,6 +1086,7 @@ func (*MutLeafThroughSharedBorrowError) isSolverError()     {}
 func (*MissingSelfReceiverError) isSolverError()            {}
 func (*MethodOverloadReceiverMismatchError) isSolverError() {}
 func (*MultipleConstructorsError) isSolverError()           {}
+func (*DuplicateObjectMemberError) isSolverError()          {}
 func (*DuplicateConstructorSignatureError) isSolverError()  {}
 func (*FieldInitializerNotAllowedError) isSolverError()     {}
 func (*SubclassConstructorRequiredError) isSolverError()    {}
@@ -1412,6 +1413,29 @@ func (e *MultipleConstructorsError) Span() ast.Span      { return e.Ctor.Span() 
 func (e *MultipleConstructorsError) Related() []ast.Span { return nil }
 func (e *MultipleConstructorsError) Message() string {
 	return "Multiple constructors per class are not yet supported."
+}
+
+// DuplicateObjectMemberError fires on the second member of an object type annotation that
+// answers an access an earlier member already answered: two properties of one name, two getters,
+// a property beside a getter or a method, and so on. The later member wins so the object still
+// carries one member per access, and reporting it is what keeps the earlier one from being
+// dropped in silence. The later member carries the blame span.
+//
+// Two methods of one name are not a redeclaration. They are the arms of an overload set, so they
+// merge and no error is reported. A getter and a setter answer different accesses and likewise
+// coexist.
+//
+// A spread reaches none of this. `{...A, a: number}` overrides rather than redeclares, and
+// reduceObject merges it once the spread grounds, so an object written with one stays silent.
+type DuplicateObjectMemberError struct {
+	Name string
+	Elem spanned
+}
+
+func (e *DuplicateObjectMemberError) Span() ast.Span      { return e.Elem.Span() }
+func (e *DuplicateObjectMemberError) Related() []ast.Span { return nil }
+func (e *DuplicateObjectMemberError) Message() string {
+	return "An object type may declare '" + e.Name + "' only once."
 }
 
 // DuplicateConstructorSignatureError fires on the second and any later `new (…) -> T` member

--- a/internal/solver/infer_ctor_ann_test.go
+++ b/internal/solver/infer_ctor_ann_test.go
@@ -24,7 +24,7 @@ func TestInferConstructorTypeAnnRoundTrip(t *testing.T) {
 		{
 			"BesideProperty",
 			`type Result = {new (x: number) -> {a: number}, origin: number}`,
-			"{origin: number, new (x: number) -> {a: number}}",
+			"{new (x: number) -> {a: number}, origin: number}",
 		},
 		{
 			"RestParam",
@@ -51,10 +51,10 @@ func TestInferConstructorTypeAnnRoundTrip(t *testing.T) {
 	}
 }
 
-// A construct signature is unnamed, so the dedup builder has no key to file it under and appends
-// it after the properties. That ordering is why BesideProperty above renders the signature last
-// while the source wrote it first. A generic signature keeps its own type parameters, which the
-// enclosing annotation does not bind.
+// A construct signature is unnamed, so it answers no access the dedup builder keys on and never
+// displaces a member or is displaced by one. It keeps the position the source gave it, which is
+// why BesideProperty above renders it first. A generic signature keeps its own type parameters,
+// which the enclosing annotation does not bind.
 func TestInferConstructorTypeAnnGeneric(t *testing.T) {
 	nodes, _, errs := inferTypeNodes(t, `type Result = {new <T>(x: T) -> {a: T}}`)
 	require.Empty(t, errs)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2069,14 +2069,13 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 // objElemBuilder accumulates object PropertyElems under JavaScript's last-wins,
 // first-position dedup: a repeated key updates the value in place at the key's
 // original position, so property names stay unique — the invariant ObjectType.Prop
-// and equalType rely on ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). Shared by inferObject
-// (object literals) and resolveObjectTypeAnn (object type annotations) so the dedup
-// rule lives in one place.
+// and equalType rely on ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). resolveObjectTypeAnn
+// collects a residual-free annotation's members through it. An object literal merges
+// its own operands in inferObject instead, since a literal's spread is a value.
 //
-// It is NOT recursive: it accumulates the direct properties of ONE object level.
-// Each property's type arrives already built — inferObject computes it with
-// inferExpr, resolveObjectTypeAnn with resolveTypeAnn — so a nested object is built
-// by that caller's recursion before add stores it.
+// It is NOT recursive: it accumulates the direct members of ONE object level. Each
+// member arrives already built, so a nested object is built by the caller's recursion
+// before addElem files it.
 type objElemBuilder struct {
 	elems []soltype.ObjTypeElem
 	pos   map[memberSlot]int // occupied access slot → index in elems
@@ -2110,10 +2109,6 @@ func newObjElemBuilder(capacity int) *objElemBuilder {
 		elems: make([]soltype.ObjTypeElem, 0, capacity),
 		pos:   make(map[memberSlot]int, capacity),
 	}
-}
-
-func (b *objElemBuilder) add(name string, t soltype.Type, optional, readonly bool) bool {
-	return b.addElem(&soltype.PropertyElem{Name: name, Type: t, Optional: optional, Readonly: readonly})
 }
 
 // addElem files a named member under every access it answers, replacing whatever held those

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -2078,24 +2079,111 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 // by that caller's recursion before add stores it.
 type objElemBuilder struct {
 	elems []soltype.ObjTypeElem
-	pos   map[string]int // property name → index in elems
+	pos   map[memberSlot]int // occupied access slot → index in elems
+}
+
+// memberSlot is the access a named member occupies: the name plus whether the member answers a
+// read or a write. Two members collide only when they answer the same access, so a getter and a
+// setter of one name coexist while a second getter replaces the first. A property answers both,
+// so it collides with either half of a pair and displaces both.
+type memberSlot struct {
+	name  string
+	write bool
+}
+
+// memberSlots returns the accesses elem answers, the keys it occupies in the builder.
+func memberSlots(elem soltype.ObjTypeElem) []memberSlot {
+	name := soltype.ObjElemName(elem)
+	switch elem.(type) {
+	case *soltype.PropertyElem:
+		return []memberSlot{{name, false}, {name, true}}
+	case *soltype.MethodElem, *soltype.GetterElem:
+		return []memberSlot{{name, false}}
+	case *soltype.SetterElem:
+		return []memberSlot{{name, true}}
+	}
+	return nil
 }
 
 func newObjElemBuilder(capacity int) *objElemBuilder {
 	return &objElemBuilder{
 		elems: make([]soltype.ObjTypeElem, 0, capacity),
-		pos:   make(map[string]int, capacity),
+		pos:   make(map[memberSlot]int, capacity),
 	}
 }
 
 func (b *objElemBuilder) add(name string, t soltype.Type, optional, readonly bool) {
-	pe := &soltype.PropertyElem{Name: name, Type: t, Optional: optional, Readonly: readonly}
-	if i, dup := b.pos[name]; dup {
-		b.elems[i] = pe // last value wins, first position kept
+	b.addElem(&soltype.PropertyElem{Name: name, Type: t, Optional: optional, Readonly: readonly})
+}
+
+// addElem files a named member under every access it answers, replacing whatever held those
+// accesses before. The last member of a name wins and the first one's position is kept, which is
+// the rule `{a: 1, b: 2, a: 3}` follows to yield `{a: 3, b: 2}` and the unique-key shape
+// ObjectType.Prop and equalType rely on.
+//
+// Two methods of one name are the exception. They are the arms of an overload set rather than a
+// redeclaration, so the later signature joins the earlier element instead of replacing it,
+// matching what a class body builds through appendMethodSig.
+//
+// An unnamed member — a construct signature — occupies no slot and is appended as-is.
+func (b *objElemBuilder) addElem(elem soltype.ObjTypeElem) {
+	slots := memberSlots(elem)
+	if len(slots) == 0 {
+		b.elems = append(b.elems, elem)
 		return
 	}
-	b.pos[name] = len(b.elems)
-	b.elems = append(b.elems, pe)
+	// Collect every position this member displaces. A property answers both accesses, so it can
+	// displace two elements at once — the getter and the setter of a pair.
+	displaced := []int{}
+	for _, slot := range slots {
+		i, held := b.pos[slot]
+		if !held {
+			continue
+		}
+		if incoming, isMethod := elem.(*soltype.MethodElem); isMethod {
+			if existing, wasMethod := b.elems[i].(*soltype.MethodElem); wasMethod {
+				existing.Signatures = append(existing.Signatures, incoming.Signatures...)
+				return
+			}
+		}
+		if !slices.Contains(displaced, i) {
+			displaced = append(displaced, i)
+		}
+	}
+	// The earliest displaced position is the one this member inherits, keeping the first
+	// occurrence's place. Any other displaced element is tombstoned, since removing it here
+	// would shift every index already recorded in pos.
+	at := len(b.elems)
+	if len(displaced) > 0 {
+		at = slices.Min(displaced)
+		for _, i := range displaced {
+			// Release the accesses the displaced member held. One it answered and the
+			// incoming member does not must fall free rather than point at the replacement,
+			// so a getter overriding a property leaves the write open for a later setter.
+			for _, s := range memberSlots(b.elems[i]) {
+				delete(b.pos, s)
+			}
+			b.elems[i] = nil
+		}
+		b.elems[at] = elem
+	} else {
+		b.elems = append(b.elems, elem)
+	}
+	for _, slot := range slots {
+		b.pos[slot] = at
+	}
+}
+
+// result returns the members in first-occurrence order, dropping the tombstones addElem leaves
+// where a later member displaced an earlier one it did not take the position of.
+func (b *objElemBuilder) result() []soltype.ObjTypeElem {
+	out := make([]soltype.ObjTypeElem, 0, len(b.elems))
+	for _, e := range b.elems {
+		if e != nil {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // inferMember types a field read (recv.prop) in value position: it resolves the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2112,8 +2112,8 @@ func newObjElemBuilder(capacity int) *objElemBuilder {
 	}
 }
 
-func (b *objElemBuilder) add(name string, t soltype.Type, optional, readonly bool) {
-	b.addElem(&soltype.PropertyElem{Name: name, Type: t, Optional: optional, Readonly: readonly})
+func (b *objElemBuilder) add(name string, t soltype.Type, optional, readonly bool) bool {
+	return b.addElem(&soltype.PropertyElem{Name: name, Type: t, Optional: optional, Readonly: readonly})
 }
 
 // addElem files a named member under every access it answers, replacing whatever held those
@@ -2126,11 +2126,16 @@ func (b *objElemBuilder) add(name string, t soltype.Type, optional, readonly boo
 // matching what a class body builds through appendMethodSig.
 //
 // An unnamed member — a construct signature — occupies no slot and is appended as-is.
-func (b *objElemBuilder) addElem(elem soltype.ObjTypeElem) {
+//
+// The result reports whether this member displaced an earlier one, which is a redeclaration
+// rather than a first declaration. A caller that treats one as an error reports it and keeps the
+// collapsed list as the recovery. Merging two methods into an overload set is not a
+// displacement, so it reports false.
+func (b *objElemBuilder) addElem(elem soltype.ObjTypeElem) bool {
 	slots := memberSlots(elem)
 	if len(slots) == 0 {
 		b.elems = append(b.elems, elem)
-		return
+		return false
 	}
 	// Collect every position this member displaces. A property answers both accesses, so it can
 	// displace two elements at once — the getter and the setter of a pair.
@@ -2143,7 +2148,7 @@ func (b *objElemBuilder) addElem(elem soltype.ObjTypeElem) {
 		if incoming, isMethod := elem.(*soltype.MethodElem); isMethod {
 			if existing, wasMethod := b.elems[i].(*soltype.MethodElem); wasMethod {
 				existing.Signatures = append(existing.Signatures, incoming.Signatures...)
-				return
+				return false
 			}
 		}
 		if !slices.Contains(displaced, i) {
@@ -2172,6 +2177,7 @@ func (b *objElemBuilder) addElem(elem soltype.ObjTypeElem) {
 	for _, slot := range slots {
 		b.pos[slot] = at
 	}
+	return len(displaced) > 0
 }
 
 // result returns the members in first-occurrence order, dropping the tombstones addElem leaves

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2236,6 +2236,13 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	if res, ok := c.classValueMember(lvl, blame, name, recvCarrier); ok {
 		return res
 	}
+	// A method, getter, or setter carried by a plain object type resolves here, since the
+	// structural path below reads only properties. This is the annotation twin of the class
+	// lookups above: an object type annotation is the one source of such an object, an object
+	// literal having no syntax for these members.
+	if res, ok := c.objectMember(lvl, blame, name, recvCarrier); ok {
+		return res
+	}
 	// A union receiver reaches the structural requirement below, whose result is joined
 	// per member inside constrain by constrainUnionFieldRead. That join runs with no
 	// access to the enclosing throws sink, so the getters it may read through are

--- a/internal/solver/infer_member_ann_test.go
+++ b/internal/solver/infer_member_ann_test.go
@@ -41,7 +41,7 @@ func TestInferMemberTypeAnnRoundTrip(t *testing.T) {
 		{
 			"BesideProperty",
 			`type Result = {f(x: number) -> string, origin: number}`,
-			"{origin: number, f(x: number) -> string}",
+			"{f(x: number) -> string, origin: number}",
 		},
 		{
 			"UnderSpread",
@@ -58,10 +58,9 @@ func TestInferMemberTypeAnnRoundTrip(t *testing.T) {
 	}
 }
 
-// A named member is keyed by kind as well as by name, so it does not file under the property
-// dedup builder and is appended after the properties. That ordering is why BesideProperty above
-// renders the method last while the source wrote it first. A generic method keeps its own type
-// parameters, which the enclosing annotation does not bind.
+// Every member of an annotation goes through one builder, so the object renders in the order the
+// source wrote it whatever kinds it mixes. A generic method keeps its own type parameters, which
+// the enclosing annotation does not bind.
 func TestInferMethodTypeAnnGeneric(t *testing.T) {
 	nodes, _, errs := inferTypeNodes(t, `type Result = {f<T>(x: T) -> T}`)
 	require.Empty(t, messagesWithSpan(errs))
@@ -300,7 +299,7 @@ func TestInferAnnMemberRead(t *testing.T) {
 			want: []string{"3:21-3:29: cannot constrain number <: string"},
 		},
 		{
-			// A read resolves the getter half of a pair, so the setter does not shadow it.
+			// Each call site picks the arm matching its argument type out of the overload set.
 			name: "OverloadResolvesPerCall",
 			src: `
 				declare fn make() -> {f(x: number) -> number, f(x: string) -> string, ...}
@@ -397,9 +396,9 @@ func TestInferAnnAccessorReadRaises(t *testing.T) {
 	}
 }
 
-// A field write resolves the setter half of an annotated object, which writeMember already
-// reached for a plain object type before a read did. The receiver must be mutable, so these bind
-// with `var` through a `mut` return.
+// A field write resolves the setter half of an annotated object through writeMember, which reads
+// a plain object type. The receiver must be mutable, so these bind with `var` through a `mut`
+// return.
 func TestInferAnnSetterWrite(t *testing.T) {
 	tests := []struct {
 		name string
@@ -443,6 +442,68 @@ func TestInferAnnSetterWrite(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tt.src)
 			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// Two members that answer the same access under one name collapse, the last one winning at the
+// first one's position. That is the rule a duplicate property already followed, and it applies
+// whatever kinds collide. Two methods are the exception: they are overload arms rather than a
+// redeclaration, so the second joins the first.
+//
+// A getter and a setter answer different accesses, so a pair coexists. A property answers both,
+// so it displaces either half and both at once.
+func TestInferMemberTypeAnnDeduplicates(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"TwoProperties", `type Result = {a: number, a: string}`, "{a: string}"},
+		{"TwoGetters", `type Result = {get a(self) -> number, get a(self) -> string}`, "{get a() -> string}"},
+		{"TwoSetters", `type Result = {set a(self, v: number), set a(self, v: string)}`, "{set a(value: string)}"},
+		{
+			"GetterThenProperty",
+			`type Result = {get a(self) -> number, a: string}`,
+			"{a: string}",
+		},
+		{
+			"PropertyThenMethod",
+			`type Result = {a: number, a(x: number) -> string}`,
+			"{a(x: number) -> string}",
+		},
+		{
+			// The property answers both accesses, so it displaces the getter and the setter
+			// together and lands at the getter's position.
+			"PropertyDisplacesBothHalves",
+			`type Result = {get a(self) -> number, set a(self, v: number), b: boolean, a: string}`,
+			"{a: string, b: boolean}",
+		},
+		{
+			// The getter takes over the property's read, and the property's write falls free
+			// rather than staying pointed at the getter, so the setter still lands beside it.
+			"GetterThenSetterOverAProperty",
+			`type Result = {a: number, get a(self) -> string, set a(self, v: string)}`,
+			"{get a() -> string, set a(value: string)}",
+		},
+		{
+			// A pair survives, since neither half answers the other's access.
+			"AccessorPairCoexists",
+			`type Result = {get a(self) -> number, set a(self, v: number)}`,
+			"{get a() -> number, set a(value: number)}",
+		},
+		{
+			// The later signature joins the earlier element rather than replacing it.
+			"MethodsAreOverloadArms",
+			`type Result = {f(x: number) -> number, f(x: string) -> string}`,
+			"{f(x: number) -> number; f(x: string) -> string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, _, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, messagesWithSpan(errs))
+			require.Equal(t, tt.want, soltype.Print(nodes["Result"]))
 		})
 	}
 }

--- a/internal/solver/infer_member_ann_test.go
+++ b/internal/solver/infer_member_ann_test.go
@@ -1,0 +1,319 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Method, getter, and setter members in object type annotations ---
+
+// A method, getter, or setter member resolves to the same MethodElem, GetterElem, or SetterElem
+// a class body builds, and the soltype printer renders each back. The signature accepts
+// everything a `fn` annotation does, since both resolve through resolveFuncTypeAnn.
+func TestInferMemberTypeAnnRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"Method", `type Result = {f(x: number) -> string}`, "{f(x: number) -> string}"},
+		{"MethodNoParams", `type Result = {f() -> string}`, "{f() -> string}"},
+		{
+			"MethodThrows",
+			`type Result = {parse(x: string) -> number throws string}`,
+			"{parse(x: string) -> number throws string}",
+		},
+		{
+			"MethodRestParam",
+			`type Result = {f(...args: [number, string]) -> boolean}`,
+			"{f(...args: [number, string]) -> boolean}",
+		},
+		{"Getter", `type Result = {get a(self) -> number}`, "{get a() -> number}"},
+		// A setter returns nothing, so it writes no `-> R`, the way a class body declares one.
+		{"Setter", `type Result = {set a(self, v: number)}`, "{set a(value: number)}"},
+		{
+			"GetterAndSetter",
+			`type Result = {get a(self) -> number, set a(self, v: number)}`,
+			"{get a() -> number, set a(value: number)}",
+		},
+		{
+			"BesideProperty",
+			`type Result = {f(x: number) -> string, origin: number}`,
+			"{origin: number, f(x: number) -> string}",
+		},
+		{
+			"UnderSpread",
+			`type Result = {...{a: number}, f(x: number) -> string}`,
+			"{...{a: number}, f(x: number) -> string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, _, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, messagesWithSpan(errs))
+			require.Equal(t, tt.want, soltype.Print(nodes["Result"]))
+		})
+	}
+}
+
+// A named member is keyed by kind as well as by name, so it does not file under the property
+// dedup builder and is appended after the properties. That ordering is why BesideProperty above
+// renders the method last while the source wrote it first. A generic method keeps its own type
+// parameters, which the enclosing annotation does not bind.
+func TestInferMethodTypeAnnGeneric(t *testing.T) {
+	nodes, _, errs := inferTypeNodes(t, `type Result = {f<T>(x: T) -> T}`)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t, "{f<T>(x: T) -> T}", soltype.Print(nodes["Result"]))
+}
+
+// Two members of one name are the arms of an overload set, matching how a class body collects
+// them, so they merge into one MethodElem rather than leaving two elements under one name.
+func TestInferMethodTypeAnnOverload(t *testing.T) {
+	nodes, _, errs := inferTypeNodes(t, `type Result = {f(x: number) -> number, f(x: string) -> string}`)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t, "{f(x: number) -> number; f(x: string) -> string}", soltype.Print(nodes["Result"]))
+
+	obj, isObj := nodes["Result"].(*soltype.ObjectType)
+	require.True(t, isObj)
+	require.Len(t, obj.Elems, 1)
+	method, isMethod := obj.Elems[0].(*soltype.MethodElem)
+	require.True(t, isMethod)
+	require.Len(t, method.Signatures, 2)
+}
+
+// An annotated object holding a method accepts a class instance declaring the same method. The
+// receiver is what the two sides describe differently — the class method binds `self` and the
+// annotation does not — and subtyping compares through callableView, which drops it.
+//
+// The annotation carries a trailing `...` because the class declares a `count` field the
+// annotation does not name, and an exact object admits no member beyond the ones it lists.
+func TestInferMethodTypeAnnAcceptsAClassInstance(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class Counter {
+			count: number,
+			constructor(mut self) { self.count = 0 },
+			bump(mut self, by: number) -> number { return self.count }
+		}
+		declare fn make() -> Counter
+		val c: {bump(mut self, by: number) -> number, ...} = make()
+	`)
+	require.Empty(t, messagesWithSpan(errs))
+}
+
+// A method's parameters stay contravariant and its return covariant, the same as a bare function
+// type, so a mismatch in either position is reported against the member.
+func TestInferMethodTypeAnnChecksSignatures(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "ReturnMismatch",
+			src: `
+				declare fn make() -> {f(x: number) -> number}
+				val v: {f(x: number) -> string} = make()
+			`,
+			want: []string{"3:39-3:45: cannot constrain number <: string"},
+		},
+		{
+			name: "GetterMismatch",
+			src: `
+				declare fn make() -> {get a(self) -> number}
+				val v: {get a(self) -> string} = make()
+			`,
+			want: []string{"3:38-3:44: cannot constrain number <: string"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// An accessor declares what an access raises through the Throws position GetterElem and
+// SetterElem carry. The annotation and the signature share one nil-means-`never` shorthand, so an
+// absent clause needs no special case: resolveFuncTypeAnn leaves the signature's Throws nil and
+// the element stores that nil unchanged.
+func TestInferAccessorTypeAnnThrowsRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			"Getter",
+			`type Result = {get a(self) -> number throws string}`,
+			"{get a() -> number throws string}",
+		},
+		{
+			"Setter",
+			`type Result = {set a(self, v: number) throws string}`,
+			"{set a(value: number) throws string}",
+		},
+		{
+			"SetterWithReturnType",
+			`type Result = {set a(self, v: number) -> undefined throws string}`,
+			"{set a(value: number) throws string}",
+		},
+		{
+			"Pair",
+			`type Result = {get a(self) -> number throws string, set a(self, v: number) throws boolean}`,
+			"{get a() -> number throws string, set a(value: number) throws boolean}",
+		},
+		{"NoClause", `type Result = {get a(self) -> number}`, "{get a() -> number}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, _, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, messagesWithSpan(errs))
+			require.Equal(t, tt.want, soltype.Print(nodes["Result"]))
+		})
+	}
+}
+
+// An accessor's throws position is covariant, so what an access raises flows out to whoever
+// performs it. A target declaring a wider clause accepts a narrower source, and a target with no
+// clause promises `never` and so accepts none. The class cases are what show the annotation
+// meeting the class-body wiring: a class getter that raises satisfies an annotation declaring the
+// same clause, and fails against one declaring nothing.
+func TestInferAccessorTypeAnnThrowsIsCovariant(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "WiderTargetAccepts",
+			src: `
+				declare fn make() -> {get a(self) -> number throws string}
+				val v: {get a(self) -> number throws string | boolean} = make()
+			`,
+			want: nil,
+		},
+		{
+			name: "NonThrowingTargetRejects",
+			src: `
+				declare fn make() -> {get a(self) -> number throws string}
+				val v: {get a(self) -> number} = make()
+			`,
+			want: []string{"3:38-3:44: cannot constrain string <: never"},
+		},
+		{
+			name: "ClassGetterFits",
+			src: `
+				declare fn boom() -> number throws string
+				class C {
+					get a(self) -> number throws string { return boom() }
+				}
+				declare fn make() -> C
+				val v: {get a(self) -> number throws string, ...} = make()
+			`,
+			want: nil,
+		},
+		{
+			name: "ClassGetterAgainstNonThrowingTarget",
+			src: `
+				declare fn boom() -> number throws string
+				class C {
+					get a(self) -> number throws string { return boom() }
+				}
+				declare fn make() -> C
+				val v: {get a(self) -> number, ...} = make()
+			`,
+			want: []string{"7:43-7:49: cannot constrain string <: never"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// A method or accessor written in an annotation describes a shape and is compared structurally,
+// but it cannot yet be read or called through. valueProp reaches a non-property member only via
+// its three class escape hatches — a class instance, a `self` read inside a class body, and a
+// static read off a class value — and every other receiver falls to the structural
+// `{name: fieldVar}` requirement, which matches a PropertyElem alone.
+//
+// The gap was unreachable before an annotation could express these members, since an object
+// literal rejects method shorthand and no other producer builds a bare ObjectType carrying one.
+// A plain property on the same receiver reads normally, which is what isolates the cause to the
+// member's kind rather than to the annotation.
+func TestInferAnnMemberReadIsNotResolvedYet(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "MethodCall",
+			src: `
+				declare fn make() -> {f(x: number) -> string, ...}
+				val s = make().f(1)
+			`,
+			want: []string{"3:20-3:21: object is missing property: f"},
+		},
+		{
+			name: "GetterRead",
+			src: `
+				declare fn make() -> {get a(self) -> number, ...}
+				val n = make().a
+			`,
+			want: []string{"3:20-3:21: object is missing property: a"},
+		},
+		{
+			name: "PropertyReadStillWorks",
+			src: `
+				declare fn make() -> {a: number, ...}
+				val n = make().a
+			`,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// A setter's one value parameter is the value being assigned, so any other count is reported.
+// The element is still built, from the first parameter or from `unknown` when there is none, so
+// the object carries a member under the name the source wrote. This is the class rule reaching
+// the annotation position, and both report through SetterArityError.
+func TestInferSetterTypeAnnArity(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+		obj  string
+	}{
+		{
+			name: "NoValueParam",
+			src:  `type Result = {set a(self)}`,
+			want: []string{"1:20-1:21: Setter 'a' must declare exactly one value parameter; found 0."},
+			obj:  "{set a(value: unknown)}",
+		},
+		{
+			name: "TwoValueParams",
+			src:  `type Result = {set a(self, v: number, w: string)}`,
+			want: []string{"1:20-1:21: Setter 'a' must declare exactly one value parameter; found 2."},
+			obj:  "{set a(value: number)}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, _, errs := inferTypeNodes(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+			require.Equal(t, tt.obj, soltype.Print(nodes["Result"]))
+		})
+	}
+}

--- a/internal/solver/infer_member_ann_test.go
+++ b/internal/solver/infer_member_ann_test.go
@@ -446,64 +446,99 @@ func TestInferAnnSetterWrite(t *testing.T) {
 	}
 }
 
-// Two members that answer the same access under one name collapse, the last one winning at the
-// first one's position. That is the rule a duplicate property already followed, and it applies
-// whatever kinds collide. Two methods are the exception: they are overload arms rather than a
-// redeclaration, so the second joins the first.
+// Declaring one name twice in an object type annotation is a redeclaration, so the later member
+// is reported. Two members collide when they answer the same access: a property answers a read
+// and a write, a method or getter answers a read, and a setter answers a write. The later one
+// still wins at the first one's position, which keeps the object at one member per access as the
+// recovery.
 //
-// A getter and a setter answer different accesses, so a pair coexists. A property answers both,
-// so it displaces either half and both at once.
+// A getter and a setter answer different accesses, so a pair is not a redeclaration. Two methods
+// are the arms of an overload set, which Escalier supports, so they merge rather than collide.
+// Neither reports.
+//
+// A spread is the other way an earlier member is superseded, and it stays silent — overriding is
+// the point of writing one. The ordered path handles it and reduceObject merges once it grounds.
 func TestInferMemberTypeAnnDeduplicates(t *testing.T) {
 	tests := []struct {
 		name string
 		src  string
-		want string
+		want []string
+		obj  string
 	}{
-		{"TwoProperties", `type Result = {a: number, a: string}`, "{a: string}"},
-		{"TwoGetters", `type Result = {get a(self) -> number, get a(self) -> string}`, "{get a() -> string}"},
-		{"TwoSetters", `type Result = {set a(self, v: number), set a(self, v: string)}`, "{set a(value: string)}"},
 		{
-			"GetterThenProperty",
-			`type Result = {get a(self) -> number, a: string}`,
-			"{a: string}",
+			name: "TwoProperties",
+			src:  `type Result = {a: number, a: string}`,
+			want: []string{"1:27-1:28: An object type may declare 'a' only once."},
+			obj:  "{a: string}",
 		},
 		{
-			"PropertyThenMethod",
-			`type Result = {a: number, a(x: number) -> string}`,
-			"{a(x: number) -> string}",
+			name: "TwoGetters",
+			src:  `type Result = {get a(self) -> number, get a(self) -> string}`,
+			want: []string{"1:43-1:44: An object type may declare 'a' only once."},
+			obj:  "{get a() -> string}",
+		},
+		{
+			name: "TwoSetters",
+			src:  `type Result = {set a(self, v: number), set a(self, v: string)}`,
+			want: []string{"1:44-1:45: An object type may declare 'a' only once."},
+			obj:  "{set a(value: string)}",
+		},
+		{
+			name: "GetterThenProperty",
+			src:  `type Result = {get a(self) -> number, a: string}`,
+			want: []string{"1:39-1:40: An object type may declare 'a' only once."},
+			obj:  "{a: string}",
+		},
+		{
+			name: "PropertyThenMethod",
+			src:  `type Result = {a: number, a(x: number) -> string}`,
+			want: []string{"1:27-1:28: An object type may declare 'a' only once."},
+			obj:  "{a(x: number) -> string}",
 		},
 		{
 			// The property answers both accesses, so it displaces the getter and the setter
-			// together and lands at the getter's position.
-			"PropertyDisplacesBothHalves",
-			`type Result = {get a(self) -> number, set a(self, v: number), b: boolean, a: string}`,
-			"{a: string, b: boolean}",
+			// together and lands at the getter's position. One member is written twice, so one
+			// error is reported however many earlier members it supersedes.
+			name: "PropertyDisplacesBothHalves",
+			src:  `type Result = {get a(self) -> number, set a(self, v: number), b: boolean, a: string}`,
+			want: []string{"1:75-1:76: An object type may declare 'a' only once."},
+			obj:  "{a: string, b: boolean}",
 		},
 		{
-			// The getter takes over the property's read, and the property's write falls free
-			// rather than staying pointed at the getter, so the setter still lands beside it.
-			"GetterThenSetterOverAProperty",
-			`type Result = {a: number, get a(self) -> string, set a(self, v: string)}`,
-			"{get a() -> string, set a(value: string)}",
+			// The getter takes over the property's read and is itself a redeclaration. The
+			// property's write falls free rather than staying pointed at the getter, so the
+			// setter lands beside it and adds no second error.
+			name: "GetterThenSetterOverAProperty",
+			src:  `type Result = {a: number, get a(self) -> string, set a(self, v: string)}`,
+			want: []string{"1:31-1:32: An object type may declare 'a' only once."},
+			obj:  "{get a() -> string, set a(value: string)}",
 		},
 		{
-			// A pair survives, since neither half answers the other's access.
-			"AccessorPairCoexists",
-			`type Result = {get a(self) -> number, set a(self, v: number)}`,
-			"{get a() -> number, set a(value: number)}",
+			name: "AccessorPairCoexists",
+			src:  `type Result = {get a(self) -> number, set a(self, v: number)}`,
+			want: nil,
+			obj:  "{get a() -> number, set a(value: number)}",
 		},
 		{
-			// The later signature joins the earlier element rather than replacing it.
-			"MethodsAreOverloadArms",
-			`type Result = {f(x: number) -> number, f(x: string) -> string}`,
-			"{f(x: number) -> number; f(x: string) -> string}",
+			name: "MethodsAreOverloadArms",
+			src:  `type Result = {f(x: number) -> number, f(x: string) -> string}`,
+			want: nil,
+			obj:  "{f(x: number) -> number; f(x: string) -> string}",
+		},
+		{
+			// A spread supersedes the earlier member without a diagnostic, which is what
+			// separates an override from a redeclaration.
+			name: "SpreadOverrideIsSilent",
+			src:  `type Result = {a: number, ...{a: string}}`,
+			want: nil,
+			obj:  "{a: number, ...{a: string}}",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nodes, _, errs := inferTypeNodes(t, tt.src)
-			require.Empty(t, messagesWithSpan(errs))
-			require.Equal(t, tt.want, soltype.Print(nodes["Result"]))
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+			require.Equal(t, tt.obj, soltype.Print(nodes["Result"]))
 		})
 	}
 }

--- a/internal/solver/infer_member_ann_test.go
+++ b/internal/solver/infer_member_ann_test.go
@@ -236,17 +236,13 @@ func TestInferAccessorTypeAnnThrowsIsCovariant(t *testing.T) {
 	}
 }
 
-// A method or accessor written in an annotation describes a shape and is compared structurally,
-// but it cannot yet be read or called through. valueProp reaches a non-property member only via
-// its three class escape hatches — a class instance, a `self` read inside a class body, and a
-// static read off a class value — and every other receiver falls to the structural
-// `{name: fieldVar}` requirement, which matches a PropertyElem alone.
+// A method, getter, or setter written in an annotation can be read and called through, not only
+// compared. valueProp intercepts these member kinds on a plain object receiver, since the
+// structural `{name: fieldVar}` requirement it otherwise builds matches a PropertyElem alone.
 //
-// The gap was unreachable before an annotation could express these members, since an object
-// literal rejects method shorthand and no other producer builds a bare ObjectType carrying one.
-// A plain property on the same receiver reads normally, which is what isolates the cause to the
-// member's kind rather than to the annotation.
-func TestInferAnnMemberReadIsNotResolvedYet(t *testing.T) {
+// An object type annotation is the only source of such an object, an object literal having no
+// syntax for these members, so this path exists for the members this file adds.
+func TestInferAnnMemberRead(t *testing.T) {
 	tests := []struct {
 		name string
 		src  string
@@ -256,23 +252,189 @@ func TestInferAnnMemberReadIsNotResolvedYet(t *testing.T) {
 			name: "MethodCall",
 			src: `
 				declare fn make() -> {f(x: number) -> string, ...}
-				val s = make().f(1)
+				val s: string = make().f(1)
 			`,
-			want: []string{"3:20-3:21: object is missing property: f"},
+			want: nil,
+		},
+		{
+			// The receiver is a var holding the object rather than the object itself, which is
+			// the shape objectCarrier reads out of a var's lower bounds.
+			name: "MethodCallThroughABinding",
+			src: `
+				declare fn make() -> {f(x: number) -> string, ...}
+				val o = make()
+				val s: string = o.f(1)
+			`,
+			want: nil,
+		},
+		{
+			name: "MethodArgumentIsChecked",
+			src: `
+				declare fn make() -> {f(x: number) -> string, ...}
+				val s = make().f("nope")
+			`,
+			want: []string{`3:22-3:28: cannot constrain "nope" <: number`},
+		},
+		{
+			name: "MethodReturnIsChecked",
+			src: `
+				declare fn make() -> {f(x: number) -> string, ...}
+				val s: number = make().f(1)
+			`,
+			want: []string{"3:21-3:32: cannot constrain string <: number"},
 		},
 		{
 			name: "GetterRead",
 			src: `
 				declare fn make() -> {get a(self) -> number, ...}
-				val n = make().a
+				val n: number = make().a
 			`,
-			want: []string{"3:20-3:21: object is missing property: a"},
+			want: nil,
 		},
 		{
-			name: "PropertyReadStillWorks",
+			name: "GetterReadIsChecked",
+			src: `
+				declare fn make() -> {get a(self) -> number, ...}
+				val n: string = make().a
+			`,
+			want: []string{"3:21-3:29: cannot constrain number <: string"},
+		},
+		{
+			// A read resolves the getter half of a pair, so the setter does not shadow it.
+			name: "OverloadResolvesPerCall",
+			src: `
+				declare fn make() -> {f(x: number) -> number, f(x: string) -> string, ...}
+				val a: number = make().f(1)
+				val b: string = make().f("s")
+			`,
+			want: nil,
+		},
+		{
+			name: "SetterOnlyNameIsWriteOnly",
+			src: `
+				declare fn make() -> {set a(self, v: number), ...}
+				val n = make().a
+			`,
+			want: []string{"3:13-3:21: Property 'a' is write-only; it has a setter but no getter or field to read."},
+		},
+		{
+			// A name the object does not carry keeps the structural path's diagnostic, since
+			// the interception declines a miss rather than reporting one of its own.
+			name: "MissingNameIsStillReported",
+			src: `
+				declare fn make() -> {f(x: number) -> string}
+				val n = make().nope
+			`,
+			want: []string{"3:20-3:24: object is missing property: nope"},
+		},
+		{
+			// A property keeps the structural path, which is what carries the read-after-write
+			// record, the borrow edges, and the union join.
+			name: "PropertyReadIsUnaffected",
 			src: `
 				declare fn make() -> {a: number, ...}
-				val n = make().a
+				val n: number = make().a
+			`,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// Reading through a getter runs its body, so the read is an exceptional exit of the enclosing
+// body the way a call is. Reading a method is not: `o.f` only names the function, and what it
+// raises stays in the signature until it is called. Both rules already held for a class
+// instance, and reach an annotated object once its members resolve.
+func TestInferAnnAccessorReadRaises(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "GetterReadRaisesUndeclared",
+			src: `
+				declare fn make() -> {get a(self) -> number throws string, ...}
+				fn g() -> number { return make().a }
+			`,
+			want: []string{"3:31-3:39: cannot constrain string <: never"},
+		},
+		{
+			name: "GetterReadRaisesDeclared",
+			src: `
+				declare fn make() -> {get a(self) -> number throws string, ...}
+				fn g() -> number throws string { return make().a }
+			`,
+			want: nil,
+		},
+		{
+			name: "MethodReadDoesNotRaise",
+			src: `
+				declare fn make() -> {f() -> number throws string, ...}
+				fn g() -> fn () -> number throws string { return make().f }
+			`,
+			want: nil,
+		},
+		{
+			name: "SetterWriteRaisesUndeclared",
+			src: `
+				declare fn make() -> mut {set a(self, v: number) throws string, ...}
+				fn g() { var o = make() o.a = 5 }
+			`,
+			want: []string{"3:29-3:36: cannot constrain string <: never"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// A field write resolves the setter half of an annotated object, which writeMember already
+// reached for a plain object type before a read did. The receiver must be mutable, so these bind
+// with `var` through a `mut` return.
+func TestInferAnnSetterWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "Write",
+			src: `
+				declare fn make() -> mut {set a(self, v: number), ...}
+				fn g() { var o = make() o.a = 5 }
+			`,
+			want: nil,
+		},
+		{
+			name: "WrittenValueIsChecked",
+			src: `
+				declare fn make() -> mut {set a(self, v: number), ...}
+				fn g() { var o = make() o.a = "nope" }
+			`,
+			want: []string{`3:35-3:41: cannot constrain "nope" <: number`},
+		},
+		{
+			name: "GetterOnlyNameIsReadOnly",
+			src: `
+				declare fn make() -> mut {get a(self) -> number, ...}
+				fn g() { var o = make() o.a = 5 }
+			`,
+			want: []string{"3:29-3:36: Property 'a' is read-only; it has a getter but no setter or field to write."},
+		},
+		{
+			name: "PairWritesThenReads",
+			src: `
+				declare fn make() -> mut {get a(self) -> number, set a(self, v: number), ...}
+				fn g() -> number { var o = make() o.a = 5 return o.a }
 			`,
 			want: nil,
 		},

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -222,6 +222,11 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 		// Every member goes through the one builder, which keeps source order and collapses
 		// members that answer the same access under one name. A construct signature answers
 		// none, so it is appended in place and never displaces anything.
+		//
+		// A collapse here is a redeclaration the source wrote twice, so it is reported. The
+		// collapsed list is the recovery, which keeps the object at one member per access. The
+		// ordered path below stays silent, since a spread overriding an earlier member is the
+		// point of writing one.
 		b := newObjElemBuilder(len(ta.Elems))
 		var members []soltype.ObjTypeElem
 		for _, elem := range ta.Elems {
@@ -234,7 +239,15 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			members = members[:0]
 			if c.addObjectMember(scope, elem, lvl, &members) {
 				for _, m := range members {
-					b.addElem(m)
+					if !b.addElem(m) {
+						continue
+					}
+					// Only a method, getter, or setter reaches here, and each carries a
+					// span. ObjTypeAnnElem does not declare Span, since a callable
+					// signature and a mapped member do not have one.
+					if blame, hasSpan := elem.(spanned); hasSpan {
+						c.report(&DuplicateObjectMemberError{Name: soltype.ObjElemName(m), Elem: blame})
+					}
 				}
 				continue
 			}
@@ -247,7 +260,9 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			if !ok {
 				continue
 			}
-			b.add(name, ft, prop.Optional, prop.Readonly)
+			if b.add(name, ft, prop.Optional, prop.Readonly) {
+				c.report(&DuplicateObjectMemberError{Name: name, Elem: prop})
+			}
 		}
 		elems = b.result()
 	} else {

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -200,96 +200,48 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			hasResidual = true
 		}
 	}
+	// Lowering is uniform across every member kind, so the two paths below differ only in how
+	// they collect what it produces. A residual-free object is never reduced later, so its
+	// members collapse here to the unique-key shape Prop and equalType assume. A residual object
+	// keeps source order for the override merge and collapses in reduceObject once its spreads
+	// and mapped members ground.
+	lowering := &objAnnLowering{c: c, scope: scope, lvl: lvl}
 	unsupported := false
-	sawCtor := false
-	// resolveCtor lowers one `new (…) -> T` member to a ConstructorElem. An object type carries
-	// at most one construct signature, so a second is reported through
-	// DuplicateConstructorSignatureError instead of being emitted.
-	resolveCtor := func(ctor *ast.ConstructorTypeAnn) soltype.ObjTypeElem {
-		if sawCtor {
-			c.report(&DuplicateConstructorSignatureError{Ctor: ctor})
-			return nil
-		}
-		sawCtor = true
-		return &soltype.ConstructorElem{Fn: c.resolveSigTypeAnn(scope, ctor.Fn, lvl)}
-	}
 	var elems []soltype.ObjTypeElem
-	// The two paths differ only in when duplicate keys collapse. A residual-free object is never
-	// reduced later, so its duplicates must collapse here to the unique-key shape Prop and equalType
-	// assume. A residual object keeps source order for the override merge and dedups in reduceObject
-	// once its spreads and mapped members ground.
 	if !hasResidual {
-		// Every member goes through the one builder, which keeps source order and collapses
-		// members that answer the same access under one name. A construct signature answers
-		// none, so it is appended in place and never displaces anything.
-		//
-		// A collapse here is a redeclaration the source wrote twice, so it is reported. The
-		// collapsed list is the recovery, which keeps the object at one member per access. The
-		// ordered path below stays silent, since a spread overriding an earlier member is the
-		// point of writing one.
+		// The builder keeps source order and collapses members that answer the same access
+		// under one name. A collapse is a redeclaration the source wrote twice, so it is
+		// reported, with the collapsed list as the recovery.
 		b := newObjElemBuilder(len(ta.Elems))
-		var members []soltype.ObjTypeElem
 		for _, elem := range ta.Elems {
-			if ctor, ok := elem.(*ast.ConstructorTypeAnn); ok {
-				if resolved := resolveCtor(ctor); resolved != nil {
-					b.addElem(resolved)
-				}
-				continue
-			}
-			members = members[:0]
-			if c.addObjectMember(scope, elem, lvl, &members) {
-				for _, m := range members {
-					if !b.addElem(m) {
-						continue
-					}
-					// Only a method, getter, or setter reaches here, and each carries a
-					// span. ObjTypeAnnElem does not declare Span, since a callable
-					// signature and a mapped member do not have one.
-					if blame, hasSpan := elem.(spanned); hasSpan {
-						c.report(&DuplicateObjectMemberError{Name: soltype.ObjElemName(m), Elem: blame})
-					}
-				}
-				continue
-			}
-			prop, ok := elem.(*ast.PropertyTypeAnn)
+			resolved, ok := lowering.lower(elem)
 			if !ok {
 				unsupported = true
 				continue
 			}
-			name, ft, ok := c.resolveObjectProperty(scope, prop, lvl)
-			if !ok {
+			if resolved == nil || !b.addElem(resolved) {
 				continue
 			}
-			if b.add(name, ft, prop.Optional, prop.Readonly) {
-				c.report(&DuplicateObjectMemberError{Name: name, Elem: prop})
+			// Every member that can displace another carries a span. ObjTypeAnnElem does
+			// not declare Span, since a callable signature and a mapped member have none,
+			// and neither of those reaches the builder.
+			if blame, hasSpan := elem.(spanned); hasSpan {
+				c.report(&DuplicateObjectMemberError{Name: soltype.ObjElemName(resolved), Elem: blame})
 			}
 		}
 		elems = b.result()
 	} else {
+		// Source order is the merge order, so members are appended as written and nothing
+		// collapses here. A spread superseding an earlier member is an override rather than a
+		// redeclaration, which is why this path reports no duplicate.
 		for _, elem := range ta.Elems {
-			switch elem := elem.(type) {
-			case *ast.PropertyTypeAnn:
-				name, ft, ok := c.resolveObjectProperty(scope, elem, lvl)
-				if !ok {
-					continue
-				}
-				elems = append(elems, &soltype.PropertyElem{Name: name, Type: ft, Optional: elem.Optional, Readonly: elem.Readonly})
-			case *ast.RestSpreadTypeAnn:
-				src, ok := c.resolveTypeAnn(scope, elem.Value, lvl)
-				if !ok {
-					src = c.freshAt(lvl)
-				}
-				elems = append(elems, &soltype.SpreadElem{Type: src})
-			case *ast.MappedTypeAnn:
-				elems = append(elems, c.resolveMappedElem(scope, elem, lvl))
-			case *ast.ConstructorTypeAnn:
-				if resolved := resolveCtor(elem); resolved != nil {
-					elems = append(elems, resolved)
-				}
-			default:
-				if !c.addObjectMember(scope, elem, lvl, &elems) {
-					unsupported = true
-				}
+			resolved, ok := lowering.lower(elem)
+			if !ok {
+				unsupported = true
+				continue
+			}
+			if resolved != nil {
+				elems = append(elems, resolved)
 			}
 		}
 	}
@@ -301,60 +253,96 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	return t, true
 }
 
-// addObjectMember lowers a method, getter, or setter member of an object type annotation onto
-// elems and reports whether it recognized the member's kind. A caller passes every element it
-// has not already handled and treats a false result as an unsupported kind. Collapsing two
-// members of one name is the builder's job, so this only ever appends.
+// objAnnLowering lowers the members of one object type annotation. It carries the only state a
+// member needs from its siblings, which is whether a construct signature was already seen: an
+// object type holds at most one, so a second is reported rather than emitted.
+type objAnnLowering struct {
+	c     *checker
+	scope *Scope
+	lvl   int
+	// sawCtor records that a `new (…) -> T` member was already lowered.
+	sawCtor bool
+}
+
+// lower turns one written member into the element it contributes to the object.
 //
-// The written receiver does not reach the lowered element. The parser peels `self` / `mut self`
+// It returns ok=false for a member kind object type annotations do not support, which the caller
+// reports once for the whole annotation rather than once per member. A nil element with ok=true
+// is a supported member contributing nothing, because it already reported an error of its own —
+// a second `new` signature, a key that is not a name, a property whose value did not resolve.
+//
+// Every kind lowers here, including the spread and mapped members that only ever appear on the
+// ordered path. Which path an annotation takes decides how the elements are collected, not how
+// they are built.
+//
+// A written receiver does not reach the lowered element. The parser peels `self` / `mut self`
 // off into the member's Receiver so it never lands in Fn.Params, and subtyping compares a method
 // through callableView, which drops SelfParam. A receiver written here therefore describes the
 // shape without narrowing it, matching how it reads for a class method the annotation is checked
 // against.
-func (c *checker) addObjectMember(scope *Scope, elem ast.ObjTypeAnnElem, lvl int, elems *[]soltype.ObjTypeElem) bool {
+func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bool) {
 	switch elem := elem.(type) {
+	case *ast.PropertyTypeAnn:
+		name, ft, ok := l.c.resolveObjectProperty(l.scope, elem, l.lvl)
+		if !ok {
+			return nil, true
+		}
+		return &soltype.PropertyElem{Name: name, Type: ft, Optional: elem.Optional, Readonly: elem.Readonly}, true
 	case *ast.MethodTypeAnn:
 		name, ok := objKeyName(elem.Name)
 		if !ok {
-			c.reportUnsupported(elem.Name)
-			return true
+			l.c.reportUnsupported(elem.Name)
+			return nil, true
 		}
-		sig := c.resolveSigTypeAnn(scope, elem.Fn, lvl)
-		*elems = append(*elems, &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}})
+		sig := l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)
+		return &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}}, true
 	case *ast.GetterTypeAnn:
 		name, ok := objKeyName(elem.Name)
 		if !ok {
-			c.reportUnsupported(elem.Name)
-			return true
+			l.c.reportUnsupported(elem.Name)
+			return nil, true
 		}
 		// The value read and what reading it raises both come from the one resolved
 		// signature. An absent `throws` clause leaves the signature's Throws nil, and nil is
 		// the `never` shorthand GetterElem uses too, so it carries over with no special case.
-		sig := c.resolveSigTypeAnn(scope, elem.Fn, lvl)
-		*elems = append(*elems, &soltype.GetterElem{Name: name, Type: sig.Ret, Throws: sig.Throws})
+		sig := l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)
+		return &soltype.GetterElem{Name: name, Type: sig.Ret, Throws: sig.Throws}, true
 	case *ast.SetterTypeAnn:
 		name, ok := objKeyName(elem.Name)
 		if !ok {
-			c.reportUnsupported(elem.Name)
-			return true
+			l.c.reportUnsupported(elem.Name)
+			return nil, true
 		}
-		sig := c.resolveSigTypeAnn(scope, elem.Fn, lvl)
+		sig := l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)
 		// A well-formed setter declares exactly one value parameter beyond the receiver, the
 		// value being assigned. Report any other count and then build the element from the
 		// first parameter, or from `unknown` when there is none, so the object still carries a
 		// member under the name the source wrote. This mirrors the class-member recovery.
 		if len(sig.Params) != 1 {
-			c.report(&SetterArityError{Name: name, Elem: elem, Count: len(sig.Params)})
+			l.c.report(&SetterArityError{Name: name, Elem: elem, Count: len(sig.Params)})
 		}
 		var param soltype.Type = &soltype.UnknownType{}
 		if len(sig.Params) > 0 {
 			param = sig.Params[0].Type
 		}
-		*elems = append(*elems, &soltype.SetterElem{Name: name, Param: param, Throws: sig.Throws})
-	default:
-		return false
+		return &soltype.SetterElem{Name: name, Param: param, Throws: sig.Throws}, true
+	case *ast.ConstructorTypeAnn:
+		if l.sawCtor {
+			l.c.report(&DuplicateConstructorSignatureError{Ctor: elem})
+			return nil, true
+		}
+		l.sawCtor = true
+		return &soltype.ConstructorElem{Fn: l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)}, true
+	case *ast.RestSpreadTypeAnn:
+		src, ok := l.c.resolveTypeAnn(l.scope, elem.Value, l.lvl)
+		if !ok {
+			src = l.c.freshAt(l.lvl)
+		}
+		return &soltype.SpreadElem{Type: src}, true
+	case *ast.MappedTypeAnn:
+		return l.c.resolveMappedElem(l.scope, elem, l.lvl), true
 	}
-	return true
+	return nil, false
 }
 
 // resolveSigTypeAnn lowers the `(…) -> R throws E` tail a method, getter, or setter shares with

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -228,16 +228,21 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	// once its spreads and mapped members ground.
 	if !hasResidual {
 		b := newObjElemBuilder(len(ta.Elems))
-		var ctors []soltype.ObjTypeElem
+		// The builder files properties alone, keyed by name. A construct signature has no name
+		// to file under, and a method, getter, or setter is identified by its kind as well as
+		// its name, so none of them go through it. Collect them in source order and append them
+		// after the properties. Position among them carries no meaning, since a reader reaches
+		// a construct signature through ObjectType.Constructor() and a named member by scanning
+		// for the kind it wants.
+		var nonProperties []soltype.ObjTypeElem
 		for _, elem := range ta.Elems {
-			// A construct signature is unnamed, so the key-dedup builder has no key to file it
-			// under. Collect it separately and append it after the properties. Its position
-			// among them carries no meaning, since every reader reaches it through
-			// ObjectType.Constructor() rather than by index.
 			if ctor, ok := elem.(*ast.ConstructorTypeAnn); ok {
 				if resolved := resolveCtor(ctor); resolved != nil {
-					ctors = append(ctors, resolved)
+					nonProperties = append(nonProperties, resolved)
 				}
+				continue
+			}
+			if c.addObjectMember(scope, elem, lvl, &nonProperties) {
 				continue
 			}
 			prop, ok := elem.(*ast.PropertyTypeAnn)
@@ -251,7 +256,7 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			}
 			b.add(name, ft, prop.Optional, prop.Readonly)
 		}
-		elems = append(b.elems, ctors...)
+		elems = append(b.elems, nonProperties...)
 	} else {
 		for _, elem := range ta.Elems {
 			switch elem := elem.(type) {
@@ -274,16 +279,95 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 					elems = append(elems, resolved)
 				}
 			default:
-				unsupported = true
+				if !c.addObjectMember(scope, elem, lvl, &elems) {
+					unsupported = true
+				}
 			}
 		}
 	}
 	if unsupported {
-		c.reportUnsupportedFeature(ta, "object type member other than a property, spread, mapped member, or `new` signature")
+		c.reportUnsupportedFeature(ta, "object type member other than a property, spread, mapped member, `new` signature, method, or accessor")
 	}
 	t := &soltype.ObjectType{Elems: elems, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
+}
+
+// addObjectMember lowers a method, getter, or setter member of an object type annotation onto
+// elems and reports whether it recognized the member's kind. A caller passes every element it
+// has not already handled and treats a false result as an unsupported kind.
+//
+// The written receiver does not reach the lowered element. The parser peels `self` / `mut self`
+// off into the member's Receiver so it never lands in Fn.Params, and subtyping compares a method
+// through callableView, which drops SelfParam. A receiver written here therefore describes the
+// shape without narrowing it, matching how it reads for a class method the annotation is checked
+// against.
+func (c *checker) addObjectMember(scope *Scope, elem ast.ObjTypeAnnElem, lvl int, elems *[]soltype.ObjTypeElem) bool {
+	switch elem := elem.(type) {
+	case *ast.MethodTypeAnn:
+		name, ok := objKeyName(elem.Name)
+		if !ok {
+			c.reportUnsupported(elem.Name)
+			return true
+		}
+		sig := c.resolveSigTypeAnn(scope, elem.Fn, lvl)
+		// Two members of one name are the arms of an overload set, the shape a class body
+		// builds through appendMethodSig. Merging here rather than emitting a second element
+		// keeps one method per name, which is what member lookup and the depth walk expect.
+		for _, existing := range *elems {
+			if m, isMethod := existing.(*soltype.MethodElem); isMethod && m.Name == name {
+				m.Signatures = append(m.Signatures, sig)
+				return true
+			}
+		}
+		*elems = append(*elems, &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}})
+	case *ast.GetterTypeAnn:
+		name, ok := objKeyName(elem.Name)
+		if !ok {
+			c.reportUnsupported(elem.Name)
+			return true
+		}
+		// The value read and what reading it raises both come from the one resolved
+		// signature. An absent `throws` clause leaves the signature's Throws nil, and nil is
+		// the `never` shorthand GetterElem uses too, so it carries over with no special case.
+		sig := c.resolveSigTypeAnn(scope, elem.Fn, lvl)
+		*elems = append(*elems, &soltype.GetterElem{Name: name, Type: sig.Ret, Throws: sig.Throws})
+	case *ast.SetterTypeAnn:
+		name, ok := objKeyName(elem.Name)
+		if !ok {
+			c.reportUnsupported(elem.Name)
+			return true
+		}
+		sig := c.resolveSigTypeAnn(scope, elem.Fn, lvl)
+		// A well-formed setter declares exactly one value parameter beyond the receiver, the
+		// value being assigned. Report any other count and then build the element from the
+		// first parameter, or from `unknown` when there is none, so the object still carries a
+		// member under the name the source wrote. This mirrors the class-member recovery.
+		if len(sig.Params) != 1 {
+			c.report(&SetterArityError{Name: name, Elem: elem, Count: len(sig.Params)})
+		}
+		var param soltype.Type = &soltype.UnknownType{}
+		if len(sig.Params) > 0 {
+			param = sig.Params[0].Type
+		}
+		*elems = append(*elems, &soltype.SetterElem{Name: name, Param: param, Throws: sig.Throws})
+	default:
+		return false
+	}
+	return true
+}
+
+// resolveSigTypeAnn lowers the `(…) -> R throws E` tail a method, getter, or setter shares with
+// a `fn` annotation. resolveFuncTypeAnn recovers every unsupported part of a signature to a
+// fresh var, so it always yields a FuncType and its ok result is always true. Anything else is a
+// wiring bug rather than a source error, so fail loudly instead of dropping the member.
+func (c *checker) resolveSigTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int) *soltype.FuncType {
+	fn, _ := c.resolveFuncTypeAnn(scope, ta, lvl)
+	sig, isFunc := fn.(*soltype.FuncType)
+	if !isFunc {
+		panic(fmt.Sprintf("resolveSigTypeAnn: signature resolved to %T, not *soltype.FuncType", fn))
+	}
+	return sig
 }
 
 // resolveMappedElem lowers a `[K]: V for K in Keys` member to a MappedElem, stored unreduced so the

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -211,15 +211,7 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			return nil
 		}
 		sawCtor = true
-		// resolveFuncTypeAnn recovers every unsupported part of a signature to a fresh var, so
-		// it always yields a FuncType and its ok result is always true. Anything else is a
-		// wiring bug rather than a source error, so fail loudly instead of dropping the member.
-		fn, _ := c.resolveFuncTypeAnn(scope, ctor.Fn, lvl)
-		fnType, isFunc := fn.(*soltype.FuncType)
-		if !isFunc {
-			panic(fmt.Sprintf("resolveObjectTypeAnn: `new` signature resolved to %T, not *soltype.FuncType", fn))
-		}
-		return &soltype.ConstructorElem{Fn: fnType}
+		return &soltype.ConstructorElem{Fn: c.resolveSigTypeAnn(scope, ctor.Fn, lvl)}
 	}
 	var elems []soltype.ObjTypeElem
 	// The two paths differ only in when duplicate keys collapse. A residual-free object is never
@@ -227,22 +219,23 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	// assume. A residual object keeps source order for the override merge and dedups in reduceObject
 	// once its spreads and mapped members ground.
 	if !hasResidual {
+		// Every member goes through the one builder, which keeps source order and collapses
+		// members that answer the same access under one name. A construct signature answers
+		// none, so it is appended in place and never displaces anything.
 		b := newObjElemBuilder(len(ta.Elems))
-		// The builder files properties alone, keyed by name. A construct signature has no name
-		// to file under, and a method, getter, or setter is identified by its kind as well as
-		// its name, so none of them go through it. Collect them in source order and append them
-		// after the properties. Position among them carries no meaning, since a reader reaches
-		// a construct signature through ObjectType.Constructor() and a named member by scanning
-		// for the kind it wants.
-		var nonProperties []soltype.ObjTypeElem
+		var members []soltype.ObjTypeElem
 		for _, elem := range ta.Elems {
 			if ctor, ok := elem.(*ast.ConstructorTypeAnn); ok {
 				if resolved := resolveCtor(ctor); resolved != nil {
-					nonProperties = append(nonProperties, resolved)
+					b.addElem(resolved)
 				}
 				continue
 			}
-			if c.addObjectMember(scope, elem, lvl, &nonProperties) {
+			members = members[:0]
+			if c.addObjectMember(scope, elem, lvl, &members) {
+				for _, m := range members {
+					b.addElem(m)
+				}
 				continue
 			}
 			prop, ok := elem.(*ast.PropertyTypeAnn)
@@ -256,7 +249,7 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			}
 			b.add(name, ft, prop.Optional, prop.Readonly)
 		}
-		elems = append(b.elems, nonProperties...)
+		elems = b.result()
 	} else {
 		for _, elem := range ta.Elems {
 			switch elem := elem.(type) {
@@ -295,7 +288,8 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 
 // addObjectMember lowers a method, getter, or setter member of an object type annotation onto
 // elems and reports whether it recognized the member's kind. A caller passes every element it
-// has not already handled and treats a false result as an unsupported kind.
+// has not already handled and treats a false result as an unsupported kind. Collapsing two
+// members of one name is the builder's job, so this only ever appends.
 //
 // The written receiver does not reach the lowered element. The parser peels `self` / `mut self`
 // off into the member's Receiver so it never lands in Fn.Params, and subtyping compares a method
@@ -311,15 +305,6 @@ func (c *checker) addObjectMember(scope *Scope, elem ast.ObjTypeAnnElem, lvl int
 			return true
 		}
 		sig := c.resolveSigTypeAnn(scope, elem.Fn, lvl)
-		// Two members of one name are the arms of an overload set, the shape a class body
-		// builds through appendMethodSig. Merging here rather than emitting a second element
-		// keeps one method per name, which is what member lookup and the depth walk expect.
-		for _, existing := range *elems {
-			if m, isMethod := existing.(*soltype.MethodElem); isMethod && m.Name == name {
-				m.Signatures = append(m.Signatures, sig)
-				return true
-			}
-		}
 		*elems = append(*elems, &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}})
 	case *ast.GetterTypeAnn:
 		name, ok := objKeyName(elem.Name)


### PR DESCRIPTION
An object type annotation carrying a method reported the whole annotation as an unsupported member and resolved to `{}`, dropping every member it listed:

```escalier
type M = {f(x: number) -> string}
```

The loss was silent and total. A generic alias whose method mentioned the alias's own type parameter dropped that too, so the annotation named a different type than the source wrote rather than failing outright.

Nothing about the feature was missing except the lowering. The parser already produced `MethodTypeAnn`, `GetterTypeAnn`, and `SetterTypeAnn`; `soltype.ObjectType` already carried `MethodElem`, `GetterElem`, and `SetterElem` for class bodies; and `constrain` and `coalesce` already compared them. `resolveObjectTypeAnn` handled only properties, spreads, mapped members, and the `new` signature #967 added.

Rebased onto #981, which gave `GetterElem` and `SetterElem` a `Throws` position.

## Lowering the members

- **`addObjectMember`** lowers all three on both of `resolveObjectTypeAnn`'s paths — the property-dedup path and the residual path a spread or mapped member puts an annotation on. It resolves through the same signature tail the `fn` annotation and the `new` signature use, so type parameters, a rest parameter, and a `throws` clause all come along.
- **Overloads merge.** Two members of one name become the arms of a single `MethodElem`, matching what a class body builds through `appendMethodSig`, rather than leaving two elements under one name.
- **An accessor's `throws` clause fills the `Throws` position** #981 added. The annotation and the signature share one nil-means-`never` shorthand — `resolveFuncTypeAnn` leaves `Throws` nil for an absent clause, which is exactly what `GetterElem`/`SetterElem` read as `never` — so it carries over with no special case.
- **A setter declaring other than one value parameter** reports the `SetterArityError` the class position already reports. Its blame field widens to a span-bearing interface so both node kinds fit, keeping one diagnostic for one rule.
- **A setter writes no return arrow**, matching how a class body declares one, so the parser makes it optional there. That is the only signature form leaving `FuncTypeAnn.Return` nil, so the AST visitor and the old checker's `inferFuncTypeAnn` now handle it. Written anyway, the arrow still parses, so a hand-converted `.d.ts` accessor need not drop it. A `throws` clause follows the parameter list directly when the arrow is absent.

## Resolving a read

Lowering alone left the members comparable but unusable — `make().f(1)` and `make().a` both reported `object is missing property`. `valueProp` reached a non-property member only through its three class escape hatches, namely a class instance, a `self` read inside a class body, and a static read off a class value. Every other receiver fell to the structural `{name: fieldVar}` requirement, which matches a `PropertyElem` alone.

That gap was unreachable until an annotation could express these members, since an object literal rejects method shorthand and nothing else builds a bare `ObjectType` carrying one. The write half already worked — `writeMember` has read a plain object type since #994.

- **`objectMember`** intercepts a method, getter, or setter on a plain object receiver and hands it to `memberValue`, which already strips a method's `SelfParam`, unions an overload set, reports a setter-only read as write-only, and raises a getter's throws into the enclosing sink.
- **`objectCarrier`** reads the object out of a receiver or out of an unresolved var's lower bounds, mirroring `classCarrier` and `classValueCarrier`.
- **A property and a miss both fall through**, so the read-after-write record, the borrow edges, the inexact tail, the union join, and `MissingPropertyError` all stay where they already live. This adds a path rather than diverting one.

Reading a raising getter is now an exceptional exit through an annotated object too, which is what #981 established for a class instance.

## Accessor `throws`, verified

| case | result |
| --- | --- |
| a getter declaring `throws string` | round-trips, `Throws` populated |
| a setter declaring `throws string`, no return arrow | round-trips |
| target raising `string` or `boolean` ← source raising `string` | accepted, covariant |
| target with no clause ← source raising `string` | `cannot constrain string <: never` |
| annotation raising `string` ← class getter raising `string` | accepted |
| reading a raising getter in a non-raising body | `cannot constrain string <: never` |
| writing through a raising setter in a non-raising body | `cannot constrain string <: never` |
| reading a method — the call raises, the read does not | accepted |

## Printer

The AST printer renders a member's written receiver, which it looked for in `Fn.Params` and so never found — the parser peels it off onto the elem. `printAnnMemberParams` is the member-annotation counterpart of `printMethodSig`, which takes the `FuncSig` a class member carries rather than the `FuncTypeAnn` an annotation does. An accessor that writes no receiver still prints one, so the `.d.ts` converter's output is unchanged; a test that pinned the dropped receiver on a method is updated.

## Still out of scope

**Callable call signatures.** `CallableTypeAnn` remains unsupported — a distinct member kind rather than a gap in these three. escalier-lang/escalier#992 tracks it.

## Testing

`go test ./...` passes with no fixture or interop-snapshot changes.

`internal/solver/infer_member_ann_test.go` covers round-tripping each member kind, generic methods, overload merging, signature variance, accessor `throws` round-trip and covariance, setter arity, a class instance checking against an annotated method, reads and calls through every member kind, getter-read and setter-write throws propagation, and setter writes including the read-only and write-only reports. Parser cases cover each form including the arrow-less setter and its `throws` clause, and printer cases cover round-tripping with and without a written receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNS4VQpsxKNdW1CHVMHy7i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Object type annotations now support methods, getters, and setters.
  * Setter signatures may omit the return arrow and type.
  * Object members support receivers, generics, overloads, and `throws` clauses.
  * Methods, getters, and setters can be resolved and invoked through object-typed values.
  * Improved printing preserves receivers and all setter parameters.

* **Bug Fixes**
  * Improved diagnostics and validation for setter arity and malformed signatures.
  * Prevented failures when traversing or inferring function types without return annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->