### PR TITLE
Check class type arguments against their parameter bounds (M9 PR19)

### DIFF
--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -1,8 +1,6 @@
 package solver
 
 import (
-	"slices"
-
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -244,71 +242,8 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 		}
 		return &soltype.AliasType{Name: at.Name, LifetimeArgs: ltArgs}
 	}
-	c.checkAliasArgBounds(params, args, ltParams, ltArgs, ref)
+	c.checkTypeArgBounds(params, args, ltParams, ltArgs, ref)
 	return &soltype.AliasType{Name: at.Name, TypeArgs: args, LifetimeArgs: ltArgs}
-}
-
-// checkAliasArgBounds reports a type argument that does not satisfy its parameter's declared
-// bound, so `type Box<T: string>` rejects `Box<number>`. Arguments are substituted into the
-// bound first, which lets a bound name a sibling as the `B: A` of `type P<A, B: A>` does. The
-// comparison is live rather than a discarded trial, so an argument that is itself a variable
-// carries the bound to its instantiation the way the function and class positions do.
-func (c *checker) checkAliasArgBounds(
-	params []*soltype.TypeParam,
-	args []soltype.Type,
-	ltParams []*soltype.LifetimeParam,
-	ltArgs []soltype.Lifetime,
-	ref *ast.TypeRefTypeAnn,
-) {
-	bounded := func(p *soltype.TypeParam) bool { return p.Constraint != nil }
-	if !slices.ContainsFunc(params, bounded) {
-		// Every parameter is unbounded, so there is nothing to compare and no substitution to
-		// build. This is the common shape for a generic alias.
-		return
-	}
-	subst := newTypeSubst(params, args, ltParams, ltArgs)
-	for i, p := range params {
-		if !bounded(p) {
-			continue
-		}
-		// Read the declared constraint from the parameter rather than from its var's upper
-		// bounds. A `<T: A & B>` bound resolves to one IntersectionType, so this is the whole
-		// of what the source wrote, and it cannot be displaced by a bound solving inferred.
-		bound := p.Constraint.Accept(subst, soltype.Positive)
-		if i >= len(ref.TypeArgs) && bound == p.Constraint && args[i] == p.Default {
-			// This argument came from the parameter's default rather than from the reference, and
-			// substitution changed neither the bound nor the default. Both therefore read here
-			// exactly as they do at the declaration, where resolveTypeParams already compared
-			// them. Repeating the comparison would file one copy of the same diagnostic per
-			// reference. The check still runs whenever substitution moved either side, since then
-			// only the reference knows what the comparison is really between. `<A, B: A = number>`
-			// is the moved-bound case and `<T, U: string = T>` the moved-default case.
-			continue
-		}
-		// Blame the written argument. A trailing argument filled from its parameter's default
-		// has no node of its own, so the blame falls back to the whole reference.
-		var site ast.Node = ref
-		if i < len(ref.TypeArgs) {
-			site = ref.TypeArgs[i]
-		}
-		if c.deferAliasBounds {
-			c.deferredAliasBounds = append(c.deferredAliasBounds, deferredAliasBound{
-				arg: args[i], bound: bound, site: site,
-			})
-			continue
-		}
-		c.constrain(site, args[i], bound)
-	}
-}
-
-// runDeferredAliasBounds replays and clears the checks checkAliasArgBounds queued while the
-// component's bodies were nil, since an unfilled alias argument expands to ErrorType and absorbs.
-func (c *checker) runDeferredAliasBounds() {
-	pending := c.deferredAliasBounds
-	c.deferredAliasBounds = nil
-	for _, p := range pending {
-		c.constrain(p.site, p.arg, p.bound)
-	}
 }
 
 // resolveAliasLifetimeArgs resolves a reference's `<'a, ...>` lifetime arguments and checks

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -96,23 +96,41 @@ type checker struct {
 	// rejected even though the outer Extends is still being walked.
 	inCondExtends bool
 
-	// deferAliasBounds routes checkAliasArgBounds to deferredAliasBounds instead of
-	// constraining on the spot. inferComponent sets it around the enum and alias body
-	// loops, the window in which a sibling alias in the same dep_graph component is bound
-	// but its Body is still nil. Constraining an argument that names such a sibling would
-	// expand it to ErrorType, which absorbs, so `type A = {b: Box<A>}` would accept A
-	// against Box's `string` bound.
-	deferAliasBounds bool
+	// deferArgBounds routes checkTypeArgBounds to deferredArgBounds instead of
+	// constraining on the spot. inferComponent sets it around the class parameter,
+	// enum body, and alias body loops, the window in which a sibling alias in the same
+	// dep_graph component is bound but its Body is still nil. Constraining an argument
+	// that names such a sibling would expand it to ErrorType, which absorbs, so
+	// `type A = {b: Box<A>}` would accept A against Box's `string` bound.
+	deferArgBounds bool
 
-	// deferredAliasBounds holds the comparisons raised during that window, replayed by
-	// runDeferredAliasBounds once every body in the component is filled.
-	deferredAliasBounds []deferredAliasBound
+	// deferredArgBounds holds the comparisons raised during that window, replayed by
+	// runDeferredArgBounds once every body in the component is filled.
+	deferredArgBounds []deferredArgBound
+
+	// classShells holds the type parameters and declaration scope preBindClassTypeParams
+	// resolved for a class, keyed by the declaration inferClassDecl later walks. The module
+	// SCC pre-pass fills it so a class's parameter list, and the defaults and bounds hanging
+	// off it, are final before any body in the component resolves a reference to the class.
+	// inferClassDecl reuses the entry rather than minting a second, unrelated set of
+	// parameter vars. A script has no pre-pass, so its classes are absent here and
+	// inferClassDecl resolves their parameters itself.
+	classShells map[*ast.ClassDecl]*classShell
 }
 
-// deferredAliasBound is one `arg <: bound` comparison checkAliasArgBounds postponed until
+// classShell carries the state preBindClassTypeParams resolved for one class declaration.
+// declScope is the enclosing scope, or a child holding a generic class's type parameters, and
+// is the scope the class body resolves in so a `T` in a field reads the same var the def
+// stores. typeParams is nil for a non-generic class, whose declScope is the enclosing scope.
+type classShell struct {
+	declScope  *Scope
+	typeParams []*soltype.TypeParam
+}
+
+// deferredArgBound is one `arg <: bound` comparison checkTypeArgBounds postponed until
 // the enclosing dep_graph component finished resolving its bodies. site is the node the
 // resulting diagnostic blames, the written type argument where there is one.
-type deferredAliasBound struct {
+type deferredArgBound struct {
 	arg   soltype.Type
 	bound soltype.Type
 	site  ast.Node

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -96,12 +96,11 @@ type checker struct {
 	// rejected even though the outer Extends is still being walked.
 	inCondExtends bool
 
-	// deferArgBounds routes checkTypeArgBounds to deferredArgBounds instead of
-	// constraining on the spot. inferComponent sets it around the class parameter,
-	// enum body, and alias body loops, the window in which a sibling alias in the same
-	// dep_graph component is bound but its Body is still nil. Constraining an argument
-	// that names such a sibling would expand it to ErrorType, which absorbs, so
-	// `type A = {b: Box<A>}` would accept A against Box's `string` bound.
+	// deferArgBounds routes checkTypeArgBounds to deferredArgBounds instead of constraining
+	// on the spot. inferComponent sets it around the class parameter, enum body, and alias
+	// body loops, where a sibling alias is bound but its Body is still nil. Constraining
+	// against one would expand it to ErrorType, which absorbs, so `type A = {b: Box<A>}`
+	// would accept A against Box's `string` bound.
 	deferArgBounds bool
 
 	// deferredArgBounds holds the comparisons raised during that window, replayed by
@@ -109,19 +108,15 @@ type checker struct {
 	deferredArgBounds []deferredArgBound
 
 	// classShells holds the type parameters and declaration scope preBindClassTypeParams
-	// resolved for a class, keyed by the declaration inferClassDecl later walks. The module
-	// SCC pre-pass fills it so a class's parameter list, and the defaults and bounds hanging
-	// off it, are final before any body in the component resolves a reference to the class.
-	// inferClassDecl reuses the entry rather than minting a second, unrelated set of
-	// parameter vars. A script has no pre-pass, so its classes are absent here and
-	// inferClassDecl resolves their parameters itself.
+	// resolved for a class, keyed by its declaration. inferClassDecl reuses the entry rather
+	// than minting a second, unrelated set of parameter vars. A script class has no pre-pass,
+	// so it is absent here and inferClassDecl resolves its own.
 	classShells map[*ast.ClassDecl]*classShell
 }
 
 // classShell carries the state preBindClassTypeParams resolved for one class declaration.
-// declScope is the enclosing scope, or a child holding a generic class's type parameters, and
-// is the scope the class body resolves in so a `T` in a field reads the same var the def
-// stores. typeParams is nil for a non-generic class, whose declScope is the enclosing scope.
+// declScope is where the class body resolves, so a `T` in a field reads the same var the
+// ClassDef stores. A non-generic class has nil typeParams and the enclosing scope.
 type classShell struct {
 	declScope  *Scope
 	typeParams []*soltype.TypeParam

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -42,10 +42,8 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	c.classNamespace = ns
 	defer func() { c.classNamespace = prevNS }()
 
-	// The class's type parameters and the scope its body resolves in. The module SCC
-	// pre-pass resolves these for every class in a type-key component before any body runs,
-	// so a reference from one class to another reads final defaults and bounds. Reuse that
-	// entry when there is one. A script class has no pre-pass, so it resolves its own here.
+	// The class's type parameters and the scope its body resolves in, taken from the module
+	// SCC pre-pass when there was one and resolved here when there was not.
 	declScope, typeParams := c.classDeclScope(scope, lvl, decl)
 
 	// The instance's nominal identity and its heavy ClassDef. getOrCreateClass returns
@@ -205,9 +203,9 @@ func (c *checker) getOrCreateClass(scope *Scope, decl *ast.ClassDecl, ns string)
 }
 
 // classDeclScope returns the scope a class body resolves in and the class's resolved type
-// parameters, reusing whatever preBindClassTypeParams already produced for this declaration. A
-// generic class resolves its parameters into a child scope so the body reads each `T` as the
-// one shared var the ClassDef stores. A non-generic class reuses the enclosing scope.
+// parameters, reusing what preBindClassTypeParams produced for this declaration. A generic
+// class gets a child scope holding its parameters, so the body reads each `T` as the one
+// shared var the ClassDef stores. A non-generic class reuses the enclosing scope.
 func (c *checker) classDeclScope(scope *Scope, lvl int, decl *ast.ClassDecl) (*Scope, []*soltype.TypeParam) {
 	if sh, ok := c.classShells[decl]; ok {
 		return sh.declScope, sh.typeParams
@@ -219,19 +217,15 @@ func (c *checker) classDeclScope(scope *Scope, lvl int, decl *ast.ClassDecl) (*S
 	return declScope, c.resolveTypeParams(declScope, lvl, decl.TypeParams)
 }
 
-// preBindClassTypeParams resolves a pre-bound class's type parameters and stores them on its
-// ClassDef. The module SCC pre-pass runs it over every class in a type-key component after
-// every class, enum, and alias identity in that component is registered, so a bound naming a
-// sibling resolves. inferClassDecl then reuses the recorded parameters and scope instead of
-// minting a second set.
+// preBindClassTypeParams resolves a class's type parameters and stores them on its ClassDef.
+// The module SCC pre-pass runs it over every class in a type-key component after every
+// identity in that component is registered, so a bound naming a sibling resolves.
 //
 // Resolving here rather than at the class's value key is what makes a reference's defaults and
-// bounds readable everywhere. A class body resolves at its value key, while a reference to
-// another class only depends on that class's type key, so at value-key time a referenced
-// class's parameters may not be read yet. ClassDef.Arity covers the count either way, but a
-// default can only be filled and a bound only checked from the resolved parameters. Every
-// class in the module has its parameters resolved by the end of the type-key pass, before the
-// first body runs.
+// bounds readable. A class body resolves at its value key, while a reference to a class depends
+// only on that class's type key, so at value-key time the referenced parameters may not be read
+// yet. ClassDef.Arity covers the count either way, but filling a default and checking a bound
+// both need the resolved parameters.
 func (c *checker) preBindClassTypeParams(scope *Scope, lvl int, decl *ast.ClassDecl, ns string) {
 	prevNS := c.classNamespace
 	c.classNamespace = ns
@@ -334,13 +328,11 @@ func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn, lvl int
 }
 
 // buildClassInstance returns the handle a class reference resolves to, one argument per type
-// parameter, paired by resolveTypeArgs the way an alias's are. The module pre-pass resolves
-// every class's parameters before any body runs, so a reference reached from a body fills an
-// omitted argument from its default and has each argument checked against its parameter's
-// bound. A reference reached earlier — from a sibling's own `<…>` clause while the pre-pass is
-// still walking the component — reads a def whose TypeParams are not filled yet; Arity is
-// registered with the identity, so the count is still checked, and each omitted argument
-// recovers to a fresh var.
+// parameter, paired by resolveTypeArgs the way an alias's are. The pre-pass resolves every
+// class's parameters before any body runs, so a reference from a body fills an omitted argument
+// from its default and has each argument checked against its bound. A reference from a sibling's
+// own `<…>` clause is reached while the pre-pass is still walking, so it reads unfilled
+// TypeParams. Arity still counts it, and an omitted argument recovers to a fresh var.
 func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *ast.TypeRefTypeAnn, lvl int) *soltype.ClassType {
 	var params []*soltype.TypeParam
 	// An unregistered name has no declared count to check against, so take the reference's own
@@ -357,8 +349,8 @@ func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *a
 		// Either way the handle carries no arguments, so return the declaration's own.
 		return ct
 	}
-	// A class reference carries no lifetime arguments today, so the substitution the bound
-	// check builds covers the type sort only.
+	// A class reference carries no lifetime arguments today, so the bound check substitutes
+	// the type sort only.
 	c.checkTypeArgBounds(params, args, nil, nil, ref)
 	return &soltype.ClassType{Name: ct.Name, TypeArgs: args, Final: ct.Final, Variant: ct.Variant}
 }

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -42,15 +42,11 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	c.classNamespace = ns
 	defer func() { c.classNamespace = prevNS }()
 
-	// Resolve the class's type parameters into a child scope so the body resolves the
-	// class's T to one shared var, quantified at the class boundary and freshened per
-	// construction. A non-generic class reuses the enclosing scope.
-	declScope := scope
-	var typeParams []*soltype.TypeParam
-	if len(decl.TypeParams) > 0 {
-		declScope = scope.Child()
-		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
-	}
+	// The class's type parameters and the scope its body resolves in. The module SCC
+	// pre-pass resolves these for every class in a type-key component before any body runs,
+	// so a reference from one class to another reads final defaults and bounds. Reuse that
+	// entry when there is one. A script class has no pre-pass, so it resolves its own here.
+	declScope, typeParams := c.classDeclScope(scope, lvl, decl)
 
 	// The instance's nominal identity and its heavy ClassDef. getOrCreateClass returns
 	// the pair the SCC pre-pass registered for this class — an empty shell it minted
@@ -208,6 +204,55 @@ func (c *checker) getOrCreateClass(scope *Scope, decl *ast.ClassDecl, ns string)
 	return self, def
 }
 
+// classDeclScope returns the scope a class body resolves in and the class's resolved type
+// parameters, reusing whatever preBindClassTypeParams already produced for this declaration. A
+// generic class resolves its parameters into a child scope so the body reads each `T` as the
+// one shared var the ClassDef stores. A non-generic class reuses the enclosing scope.
+func (c *checker) classDeclScope(scope *Scope, lvl int, decl *ast.ClassDecl) (*Scope, []*soltype.TypeParam) {
+	if sh, ok := c.classShells[decl]; ok {
+		return sh.declScope, sh.typeParams
+	}
+	if len(decl.TypeParams) == 0 {
+		return scope, nil
+	}
+	declScope := scope.Child()
+	return declScope, c.resolveTypeParams(declScope, lvl, decl.TypeParams)
+}
+
+// preBindClassTypeParams resolves a pre-bound class's type parameters and stores them on its
+// ClassDef. The module SCC pre-pass runs it over every class in a type-key component after
+// every class, enum, and alias identity in that component is registered, so a bound naming a
+// sibling resolves. inferClassDecl then reuses the recorded parameters and scope instead of
+// minting a second set.
+//
+// Resolving here rather than at the class's value key is what makes a reference's defaults and
+// bounds readable everywhere. A class body resolves at its value key, while a reference to
+// another class only depends on that class's type key, so at value-key time a referenced
+// class's parameters may not be read yet. ClassDef.Arity covers the count either way, but a
+// default can only be filled and a bound only checked from the resolved parameters. Every
+// class in the module has its parameters resolved by the end of the type-key pass, before the
+// first body runs.
+func (c *checker) preBindClassTypeParams(scope *Scope, lvl int, decl *ast.ClassDecl, ns string) {
+	prevNS := c.classNamespace
+	c.classNamespace = ns
+	defer func() { c.classNamespace = prevNS }()
+
+	declScope := scope
+	var typeParams []*soltype.TypeParam
+	if len(decl.TypeParams) > 0 {
+		declScope = scope.Child()
+		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
+	}
+	if c.classShells == nil {
+		c.classShells = map[*ast.ClassDecl]*classShell{}
+	}
+	c.classShells[decl] = &classShell{declScope: declScope, typeParams: typeParams}
+
+	if def, ok := c.ctx.classDef(qualifyClassName(ns, decl)); ok {
+		def.TypeParams = typeParams
+	}
+}
+
 // qualifyClassName returns a class's dep_graph-qualified name — the namespace joined
 // to the local name with a dot, or the bare local name at the root namespace. This is
 // the same `CurrentNamespace + "." + name` rule dep_graph forms binding keys with, so
@@ -289,9 +334,13 @@ func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn, lvl int
 }
 
 // buildClassInstance returns the handle a class reference resolves to, one argument per type
-// parameter, paired by resolveTypeArgs the way an alias's are. Arity is registered with the
-// class's identity but TypeParams lands later, so a reference resolved in between is still
-// counted and recovers an omitted argument to a fresh var instead of filling its default.
+// parameter, paired by resolveTypeArgs the way an alias's are. The module pre-pass resolves
+// every class's parameters before any body runs, so a reference reached from a body fills an
+// omitted argument from its default and has each argument checked against its parameter's
+// bound. A reference reached earlier — from a sibling's own `<…>` clause while the pre-pass is
+// still walking the component — reads a def whose TypeParams are not filled yet; Arity is
+// registered with the identity, so the count is still checked, and each omitted argument
+// recovers to a fresh var.
 func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *ast.TypeRefTypeAnn, lvl int) *soltype.ClassType {
 	var params []*soltype.TypeParam
 	// An unregistered name has no declared count to check against, so take the reference's own
@@ -308,6 +357,9 @@ func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *a
 		// Either way the handle carries no arguments, so return the declaration's own.
 		return ct
 	}
+	// A class reference carries no lifetime arguments today, so the substitution the bound
+	// check builds covers the type sort only.
+	c.checkTypeArgBounds(params, args, nil, nil, ref)
 	return &soltype.ClassType{Name: ct.Name, TypeArgs: args, Final: ct.Final, Variant: ct.Variant}
 }
 

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -137,8 +137,16 @@ type componentBinding struct {
 //  1. give every VALUE binding in the component a fresh var at lvl+1 and define
 //     it in scope BEFORE any body is inferred, so a mutually-recursive reference
 //     resolves through the var;
-//  2. infer each declaration's definition at lvl+1 and constrain it <: its var;
-//  3. rebind each name to the coalesced MONOMORPHIC type of its var.
+//  2. bind every non-value key in the component — each class and enum identity, each
+//     class's type parameters, and each enum and alias body — so a body inferred in
+//     step 3 resolves any type name the component declares;
+//  3. infer each declaration's definition at lvl+1 and constrain it <: its var;
+//  4. rebind each name to the coalesced MONOMORPHIC type of its var.
+//
+// Step 2 runs before step 3 because a component can mix the two sorts. A class member
+// body creates a value dependency, so `type:A` and `value:B` land in one component when
+// A's body calls B and B's field names `A<T>`. Inferring B's body first would leave the
+// name A unbound at the point B reads it.
 //
 // M2 does NOT generalize (M1 ships no schemes): step 3 freezes each binding at
 // its coalesced monomorphic type rather than wrapping it in a PolyScheme. The
@@ -205,6 +213,131 @@ func (c *checker) inferComponent(
 		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{monoScheme(v)}})
 	}
 
+	// Non-value keys such as type aliases are outside the M2 subset. Report each
+	// contributing decl once, skipping any already handled by a value key. A class or
+	// enum contributes both a value and a type key for the same decl, so one of the two
+	// keys is handled here and the other elsewhere.
+	//
+	// A class's type key is left to its value key, which infers the class and registers
+	// both the instance type and the constructor together (M5 B1). Its type key here only
+	// pre-binds the nominal identity for recursion; reporting it as unsupported would
+	// mis-report the class and mark the decl handled, blocking the value key. So a class
+	// type key skips without marking handled and the value key does the work.
+	//
+	// An enum inverts the split (M5 D-Enum): its type key here infers the whole enum — the
+	// union type binding and the variant-constructor namespace — and marks the decl
+	// handled, so its value key becomes a no-op. The enum two-pass below runs first for
+	// exactly that reason.
+	// Pre-bind every nominal identity in this component — each class handle and each enum
+	// union type — before any enum body resolves a variant parameter, so a group of
+	// mutually-recursive classes AND enums resolves each other. A class's variant-holding
+	// enum and an enum's field-holding class land in one type-key SCC component; binding
+	// all their identities first lets `enum Json { Arr(items: JsonArray) }` /
+	// `class JsonArray { head: Json }` each resolve the sibling.
+	//
+	//   - A class is pre-bound to its nominal identity (M5 B2) and left for its value key,
+	//     which infers the body and marks the decl handled. Leaving it unhandled here lets
+	//     the reconciliation pass find it through that key.
+	//   - An enum is pre-bound to its union type (preBindEnum) and marked handled, then
+	//     completed by inferEnumBody once every sibling is bound; its value key is then a
+	//     no-op whose pre-bound value var is retracted in phase 3.
+	var enumShells []*enumShell
+	var aliasShells []*aliasShell
+	var classDecls []*ast.ClassDecl
+	var classNamespaces []string
+	for _, key := range component {
+		if _, isValue := bindings[key]; isValue {
+			continue
+		}
+		for _, d := range g.GetDecls(key) {
+			if handled.Contains(d) {
+				continue
+			}
+			switch decl := d.(type) {
+			case *ast.EnumDecl:
+				enumShells = append(enumShells, c.preBindEnum(scope, inner, decl, g.GetNamespace(key)))
+				handled.Add(d)
+			case *ast.ClassDecl:
+				// A type-key component is the SCC condensation of mutually-recursive classes,
+				// so registering every class's type binding and empty ClassDef here lets a
+				// sibling resolve a forward reference — `class A { b: B }` / `class B { a: A }`.
+				// The returned handle and def are discarded here; inferClassDecl reuses them,
+				// keyed by the same qualified name the shared namespace reconstructs. The
+				// class's type parameters are resolved in the loop below, once every sibling
+				// identity in the component is registered.
+				c.getOrCreateClass(scope, decl, g.GetNamespace(key))
+				classDecls = append(classDecls, decl)
+				classNamespaces = append(classNamespaces, g.GetNamespace(key))
+			case *ast.TypeDecl:
+				// A `type X = Body` alias infers at its type key and is marked handled, so its
+				// value key is a no-op. preBindAlias registers the alias identity and binds its
+				// name; inferAliasBody resolves the body below, once every sibling identity in
+				// the component is bound. Pre-binding the identity first lets a self or mutual
+				// reference — `type List<T> = {tail: List<T> | Null}`, or a mutual `type A =
+				// {b: B}` / `type B = {a: A}` pair — find its target already bound.
+				// preBindAlias returns nil for a reserved built-in name it rejected, which is not
+				// bound and has no body to resolve, so skip appending it.
+				if sh := c.preBindAlias(scope, inner, decl, g.GetNamespace(key)); sh != nil {
+					aliasShells = append(aliasShells, sh)
+				}
+				handled.Add(d)
+			}
+		}
+	}
+	// The loops below run while sibling alias and enum bodies are still nil, so a bound check
+	// inside them is queued rather than run against a half-built sibling. Do not convert this
+	// to a defer, because a check queued after runDeferredArgBounds would never be replayed.
+	c.deferArgBounds = true
+	// Resolve each class's type parameters now that every class, enum, and alias identity in
+	// the component is registered, so a bound naming a sibling resolves. A class body waits
+	// for the class's value key, but the parameter list a reference reads — the defaults it
+	// fills omitted arguments from and the bounds its arguments are checked against — is
+	// final from here on.
+	for i, decl := range classDecls {
+		c.preBindClassTypeParams(scope, inner, decl, classNamespaces[i])
+	}
+	// Every enum body resolves its variant parameters against the fully pre-bound
+	// identities above, so a parameter naming a sibling enum or class resolves.
+	for _, sh := range enumShells {
+		c.inferEnumBody(sh)
+	}
+	// Each alias body resolves after every alias, enum, and class identity in the component
+	// is bound, so a body naming a sibling type — or the alias itself — resolves.
+	for _, sh := range aliasShells {
+		c.inferAliasBody(sh)
+	}
+	c.deferArgBounds = false
+	// Every body in the component is resolved, so the alias reference graph the productivity
+	// check and the phantom-parameter fixed point read is complete. Both run before any
+	// constraint reaches an alias in the component, which is what lets constrain trust the marks
+	// they leave on each AliasDef.
+	c.checkProductive(aliasShells)
+	markPhantomParams(aliasShells)
+	// The deferred bound comparisons run last, after the marks are in place. Each one goes
+	// through constrain, which interns an alias operand's canonical identity, and internAlias
+	// drops the arguments of phantom parameters when it renders that key. Interning a reference
+	// before its alias is marked would key it under its full arguments and keep that
+	// representative for the rest of the run, so the same type could hold two identities.
+	c.runDeferredArgBounds()
+
+	// Report any remaining non-value decl as unsupported. A class was pre-bound above and
+	// is completed at its value key, so skip it rather than mis-reporting it.
+	for _, key := range component {
+		if _, isValue := bindings[key]; isValue {
+			continue
+		}
+		for _, d := range g.GetDecls(key) {
+			if handled.Contains(d) {
+				continue
+			}
+			if _, ok := d.(*ast.ClassDecl); ok {
+				continue
+			}
+			handled.Add(d)
+			c.reportUnsupported(d)
+		}
+	}
+
 	// Phase 2: infer each declaration's definition and constrain it <: its var.
 	for _, key := range component {
 		// Each top-level binding is its own named-lifetime scope, mirroring inferFunc.
@@ -213,7 +346,7 @@ func (c *checker) inferComponent(
 		c.namedLifetimes = nil
 		b, isValue := bindings[key]
 		if !isValue {
-			continue // non-value keys handled below
+			continue // non-value keys handled above
 		}
 		if b.signatureBound {
 			// The schemes are already bound in scope from phase 1, so phase 2 does not
@@ -322,117 +455,6 @@ func (c *checker) inferComponent(
 				Previous: b.primary,
 				Name:     key.Name(),
 			})
-		}
-	}
-
-	// Non-value keys such as type aliases are outside the M2 subset. Report each
-	// contributing decl once, skipping any already handled by a value key. A class or
-	// enum contributes both a value and a type key for the same decl, so one of the two
-	// keys is handled here and the other elsewhere.
-	//
-	// A class's type key is left to its value key, which infers the class and registers
-	// both the instance type and the constructor together (M5 B1). Its type key here only
-	// pre-binds the nominal identity for recursion; reporting it as unsupported would
-	// mis-report the class and mark the decl handled, blocking the value key. So a class
-	// type key skips without marking handled and the value key does the work.
-	//
-	// An enum inverts the split (M5 D-Enum): its type key here infers the whole enum — the
-	// union type binding and the variant-constructor namespace — and marks the decl
-	// handled, so its value key becomes a no-op. The enum two-pass below runs first for
-	// exactly that reason.
-	// Pre-bind every nominal identity in this component — each class handle and each enum
-	// union type — before any enum body resolves a variant parameter, so a group of
-	// mutually-recursive classes AND enums resolves each other. A class's variant-holding
-	// enum and an enum's field-holding class land in one type-key SCC component; binding
-	// all their identities first lets `enum Json { Arr(items: JsonArray) }` /
-	// `class JsonArray { head: Json }` each resolve the sibling.
-	//
-	//   - A class is pre-bound to its nominal identity (M5 B2) and left for its value key,
-	//     which infers the body and marks the decl handled. Leaving it unhandled here lets
-	//     the reconciliation pass find it through that key.
-	//   - An enum is pre-bound to its union type (preBindEnum) and marked handled, then
-	//     completed by inferEnumBody once every sibling is bound; its value key is then a
-	//     no-op whose pre-bound value var is retracted in phase 3.
-	var enumShells []*enumShell
-	var aliasShells []*aliasShell
-	for _, key := range component {
-		if _, isValue := bindings[key]; isValue {
-			continue
-		}
-		for _, d := range g.GetDecls(key) {
-			if handled.Contains(d) {
-				continue
-			}
-			switch decl := d.(type) {
-			case *ast.EnumDecl:
-				enumShells = append(enumShells, c.preBindEnum(scope, inner, decl, g.GetNamespace(key)))
-				handled.Add(d)
-			case *ast.ClassDecl:
-				// A type-key component is the SCC condensation of mutually-recursive classes,
-				// so registering every class's type binding and empty ClassDef here lets a
-				// sibling resolve a forward reference — `class A { b: B }` / `class B { a: A }`.
-				// The returned handle and def are discarded here; inferClassDecl reuses them,
-				// keyed by the same qualified name the shared namespace reconstructs.
-				c.getOrCreateClass(scope, decl, g.GetNamespace(key))
-			case *ast.TypeDecl:
-				// A `type X = Body` alias infers at its type key and is marked handled, so its
-				// value key is a no-op. preBindAlias registers the alias identity and binds its
-				// name; inferAliasBody resolves the body below, once every sibling identity in
-				// the component is bound. Pre-binding the identity first lets a self or mutual
-				// reference — `type List<T> = {tail: List<T> | Null}`, or a mutual `type A =
-				// {b: B}` / `type B = {a: A}` pair — find its target already bound.
-				// preBindAlias returns nil for a reserved built-in name it rejected, which is not
-				// bound and has no body to resolve, so skip appending it.
-				if sh := c.preBindAlias(scope, inner, decl, g.GetNamespace(key)); sh != nil {
-					aliasShells = append(aliasShells, sh)
-				}
-				handled.Add(d)
-			}
-		}
-	}
-	// The two loops below fill bodies that are still nil, so a bound check inside them is queued
-	// rather than run against a half-built sibling. Do not convert this to a defer, because a
-	// check queued after runDeferredAliasBounds would never be replayed.
-	c.deferAliasBounds = true
-	// Every enum body resolves its variant parameters against the fully pre-bound
-	// identities above, so a parameter naming a sibling enum or class resolves.
-	for _, sh := range enumShells {
-		c.inferEnumBody(sh)
-	}
-	// Each alias body resolves after every alias, enum, and class identity in the component
-	// is bound, so a body naming a sibling type — or the alias itself — resolves.
-	for _, sh := range aliasShells {
-		c.inferAliasBody(sh)
-	}
-	c.deferAliasBounds = false
-	// Every body in the component is resolved, so the alias reference graph the productivity
-	// check and the phantom-parameter fixed point read is complete. Both run before any
-	// constraint reaches an alias in the component, which is what lets constrain trust the marks
-	// they leave on each AliasDef.
-	c.checkProductive(aliasShells)
-	markPhantomParams(aliasShells)
-	// The deferred bound comparisons run last, after the marks are in place. Each one goes
-	// through constrain, which interns an alias operand's canonical identity, and internAlias
-	// drops the arguments of phantom parameters when it renders that key. Interning a reference
-	// before its alias is marked would key it under its full arguments and keep that
-	// representative for the rest of the run, so the same type could hold two identities.
-	c.runDeferredAliasBounds()
-
-	// Report any remaining non-value decl as unsupported. A class was pre-bound above and
-	// is completed at its value key, so skip it rather than mis-reporting it.
-	for _, key := range component {
-		if _, isValue := bindings[key]; isValue {
-			continue
-		}
-		for _, d := range g.GetDecls(key) {
-			if handled.Contains(d) {
-				continue
-			}
-			if _, ok := d.(*ast.ClassDecl); ok {
-				continue
-			}
-			handled.Add(d)
-			c.reportUnsupported(d)
 		}
 	}
 

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -213,21 +213,6 @@ func (c *checker) inferComponent(
 		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{monoScheme(v)}})
 	}
 
-	// Non-value keys such as type aliases are outside the M2 subset. Report each
-	// contributing decl once, skipping any already handled by a value key. A class or
-	// enum contributes both a value and a type key for the same decl, so one of the two
-	// keys is handled here and the other elsewhere.
-	//
-	// A class's type key is left to its value key, which infers the class and registers
-	// both the instance type and the constructor together (M5 B1). Its type key here only
-	// pre-binds the nominal identity for recursion; reporting it as unsupported would
-	// mis-report the class and mark the decl handled, blocking the value key. So a class
-	// type key skips without marking handled and the value key does the work.
-	//
-	// An enum inverts the split (M5 D-Enum): its type key here infers the whole enum — the
-	// union type binding and the variant-constructor namespace — and marks the decl
-	// handled, so its value key becomes a no-op. The enum two-pass below runs first for
-	// exactly that reason.
 	// Pre-bind every nominal identity in this component — each class handle and each enum
 	// union type — before any enum body resolves a variant parameter, so a group of
 	// mutually-recursive classes AND enums resolves each other. A class's variant-holding
@@ -320,8 +305,20 @@ func (c *checker) inferComponent(
 	// representative for the rest of the run, so the same type could hold two identities.
 	c.runDeferredArgBounds()
 
-	// Report any remaining non-value decl as unsupported. A class was pre-bound above and
-	// is completed at its value key, so skip it rather than mis-reporting it.
+	// Non-value keys such as type aliases are outside the M2 subset. Report each remaining
+	// contributing decl once as unsupported, skipping any already handled by a value key. A
+	// class or enum contributes both a value and a type key for the same decl, so one of the
+	// two keys is handled here and the other elsewhere.
+	//
+	// A class's type key is left to its value key, which infers the class and registers both
+	// the instance type and the constructor together (M5 B1). Its type key only pre-binds the
+	// nominal identity for recursion; reporting it as unsupported would mis-report the class
+	// and mark the decl handled, blocking the value key. So a class type key skips without
+	// marking handled and the value key does the work.
+	//
+	// An enum inverts the split (M5 D-Enum): its type key infers the whole enum — the union
+	// type binding and the variant-constructor namespace — and marks the decl handled, so its
+	// value key becomes a no-op and nothing of it remains to report here.
 	for _, key := range component {
 		if _, isValue := bindings[key]; isValue {
 			continue

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -439,22 +439,297 @@ func TestClassArityRecoveryKeepsDeclarationVarOut(t *testing.T) {
 	require.Equal(t, "{new (b: B<unknown>) -> A}", values["A"])
 }
 
-// TestClassDefaultUnfilledForUnresolvedSibling pins what the count reaching a reference early
-// does not buy. A class's Arity is registered with its identity, but its resolved TypeParams —
-// and so the defaults hanging off them — land only when that class's own pass runs. `A` is
-// walked before `B`, so the omitted argument has no default to read yet and recovers to a fresh
-// var: `B<unknown>` where the declaration says `B<number>`. No arity error is reported, since
-// omitting an argument for a defaulted parameter is a legal reference.
-//
-// The same reference written in a `fn` annotation does fill the default, which is what
-// TestTypeParamDefaultAtReference covers. Closing the gap needs the check deferred until every
-// class in the component has its parameters, the machinery PR19 adds for bounds.
-func TestClassDefaultUnfilledForUnresolvedSibling(t *testing.T) {
+// TestClassDefaultFilledFromClassBody checks that a reference from one class's body fills an
+// omitted argument from the referenced class's default. The module SCC pre-pass resolves every
+// class's type parameters before any body runs, so `A`'s field annotation reads `B`'s resolved
+// default no matter which declaration the dep graph walks first.
+func TestClassDefaultFilledFromClassBody(t *testing.T) {
 	src := `
 		class B<T = number> { v: T }
 		class A { b: B }
 	`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "{new (b: B<unknown>) -> A}", values["A"])
+	require.Equal(t, "{new (b: B<number>) -> A}", values["A"])
+}
+
+// TestClassArityAcrossRemainingRefForms extends TestClassArityCheckedFromOtherDeclarations to
+// the reference positions it does not cover — an `extends` edge, an `implements` edge, a
+// type-parameter bound, a constructor parameter, and a method return. Every form resolves
+// through buildClassInstance, so each reports the same too-few diagnostic.
+func TestClassArityAcrossRemainingRefForms(t *testing.T) {
+	srcs := map[string]string{
+		"Extends": `
+			class Box<T> { value: T }
+			class Wrapper extends Box {
+				constructor(mut self) {},
+			}
+		`,
+		"Implements": `
+			class Box<T> { value: T }
+			class Wrapper implements Box { value: number }
+		`,
+		"TypeParamBound": `
+			class Box<T> { value: T }
+			class Holder<U: Box> { value: U }
+		`,
+		"ConstructorParam": `
+			class Box<T> { value: T }
+			class Holder {
+				boxed: Box<number>,
+				constructor(mut self, boxed: Box) { self.boxed = boxed },
+			}
+		`,
+		"MethodReturn": `
+			class Box<T> { value: T }
+			class Holder {
+				boxed: Box<number>,
+				unwrap(self) -> Box { return self.boxed },
+			}
+		`,
+	}
+	for name, src := range srcs {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, src)
+			require.Len(t, errs, 1)
+			require.Equal(t, "class `Box` expects 1 type arguments but got 0", errs[0].Message())
+		})
+	}
+}
+
+// TestClassDefaultFilledDeclarationOrderIndependent is TestClassDefaultFilledFromClassBody with
+// the declarations the other way round, so the fill does not depend on which class the dep
+// graph reaches first. The pre-pass resolves every class's parameters before any body runs,
+// which is what makes both orders read the same default.
+func TestClassDefaultFilledDeclarationOrderIndependent(t *testing.T) {
+	src := `
+		class A { b: B }
+		class B<T = number> { v: T }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "{new (b: B<number>) -> A}", values["A"])
+}
+
+// TestMutuallyRecursiveGenericClassesResolve guards the pre-pass against a mutually-recursive
+// group. Each class names the other with a full argument list while the group's parameters
+// resolve, so a pre-pass that read a half-registered sibling would report a spurious mismatch
+// or leak one class's parameter var into the other.
+func TestMutuallyRecursiveGenericClassesResolve(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Node<T> { value: T, tail: Tail<T> }
+		class Tail<T> { node: Node<T> }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "<T0> {new (value: T0, tail: Tail<T0>) -> Node<T0>}", values["Node"])
+}
+
+// TestClassArityAcrossMixedComponent covers a dep_graph component holding both sorts of key. A
+// class member body creates a value dependency, so `class A<T>` whose method calls `B` and
+// `class B` whose field names `A` put A's type key and B's value key in one SCC. Binding every
+// non-value key before the value walk is what lets B's annotation find A registered with its
+// parameters resolved. Inferring B's body first would leave `A` an unbound name, reported as an
+// unresolved reference instead of the arity mismatch it is.
+func TestClassArityAcrossMixedComponent(t *testing.T) {
+	srcs := map[string]string{
+		"GenericClassFirst": `
+			class A<T> {
+				v: T,
+				make(self) -> number { return B(1, A(2)).x },
+			}
+			class B {
+				x: number,
+				a: A,
+			}
+		`,
+		"GenericClassSecond": `
+			class B {
+				x: number,
+				a: A,
+			}
+			class A<T> {
+				v: T,
+				make(self) -> number { return B(1, A(2)).x },
+			}
+		`,
+	}
+	for name, src := range srcs {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, src)
+			require.Len(t, errs, 1)
+			require.Equal(t, "class `A` expects 1 type arguments but got 0", errs[0].Message())
+			require.Equal(t, "{new (x: number, a: A<unknown>) -> B}", values["B"])
+		})
+	}
+}
+
+// TestClassTypeArgBounds covers the bound a generic class declares on a type parameter,
+// `class Box<T: string>`. A reference supplying an argument outside the bound is rejected at
+// the reference, and one inside it is accepted. Every reference form routes through
+// buildClassInstance, so a self-reference in the class's own body is checked the same way an
+// annotation elsewhere is. A bound may name a sibling parameter, so the reference's own
+// arguments are substituted into the bound before the comparison.
+func TestClassTypeArgBounds(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "ArgumentOutsideBound",
+			src: `
+				class Box<T: string> { v: T }
+				fn take(b: Box<number>) -> number { return 1 }
+			`,
+			want: []string{"cannot constrain number <: string"},
+		},
+		{
+			name: "ArgumentInsideBound",
+			src: `
+				class Box<T: string> { v: T }
+				fn take(b: Box<"a">) -> number { return 1 }
+			`,
+		},
+		{
+			name: "UnboundedParamAcceptsAnyArgument",
+			src: `
+				class Box<T> { v: T }
+				fn take(b: Box<number>) -> number { return 1 }
+			`,
+		},
+		{
+			name: "SelfReferenceInFieldChecked",
+			src:  `class Box<T: string> { v: T, other: Box<number> }`,
+			want: []string{"cannot constrain number <: string"},
+		},
+		{
+			name: "SelfReferenceInFieldSatisfied",
+			src:  `class Box<T: string> { v: T, other: Box<"a"> }`,
+		},
+		{
+			name: "ExtendsEdgeChecked",
+			src: `
+				class Box<T: string> { v: T }
+				class Sub extends Box<number> {
+					constructor(mut self) {},
+				}
+			`,
+			want: []string{"cannot constrain number <: string"},
+		},
+		{
+			name: "MethodParamChecked",
+			src: `
+				class Box<T: string> { v: T }
+				class Holder {
+					x: number,
+					take(self, b: Box<number>) -> number { return self.x },
+				}
+			`,
+			want: []string{"cannot constrain number <: string"},
+		},
+		{
+			name: "SiblingBoundViolated",
+			src: `
+				class P<A, B: A> { a: A, b: B }
+				fn take(p: P<string, 1>) -> number { return 1 }
+			`,
+			want: []string{"cannot constrain 1 <: string"},
+		},
+		{
+			name: "SiblingBoundSatisfied",
+			src: `
+				class P<A, B: A> { a: A, b: B }
+				fn take(p: P<number, 1>) -> number { return 1 }
+			`,
+		},
+		{
+			name: "IntersectionBound",
+			src: `
+				class Box<T: string & "a"> { v: T }
+				fn take(b: Box<"b">) -> number { return 1 }
+			`,
+			want: []string{`cannot constrain "b" <: "a"`},
+		},
+		{
+			name: "CrossClassBoundChecked",
+			src: `
+				class Animal { name: string }
+				class Pen<T: Animal> { pet: T }
+				fn take(p: Pen<number>) -> number { return 1 }
+			`,
+			want: []string{"cannot constrain number <: Animal"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			var msgs []string
+			for _, e := range errs {
+				msgs = append(msgs, e.Message())
+			}
+			require.Equal(t, test.want, msgs)
+		})
+	}
+}
+
+// TestClassBoundDefersForUnfilledAliasSibling checks the deferral a class bound check inherits
+// from the alias path. A class reference inside an alias body resolves while a sibling alias's
+// Body is still nil, and a comparison run at that moment would expand the sibling to ErrorType,
+// which absorbs. The queued comparison replays once every body in the component is filled, so
+// the violation still reports.
+func TestClassBoundDefersForUnfilledAliasSibling(t *testing.T) {
+	src := `
+		class Box<T: string> { v: T }
+		type A = {b: Box<number>, other: Other}
+		type Other = {a?: A}
+	`
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain number <: string", errs[0].Message())
+}
+
+// TestClassBoundForwardingFn covers a generic function whose return names the class with the
+// function's own unbounded parameter, `fn g<U>(u: U) -> Box<U>`. The comparison is live rather
+// than a discarded trial, so it leaves Box's bound on U and the call site is where a violation
+// surfaces: the declaration alone is clean, a string call passes, and a number call reports
+// once at the argument.
+func TestClassBoundForwardingFn(t *testing.T) {
+	t.Run("DeclarationAloneClean", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class Box<T: string> { v: T }
+			fn g<U>(u: U) -> Box<U> { return Box(u) }
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("CallInsideBound", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class Box<T: string> { v: T }
+			fn g<U>(u: U) -> Box<U> { return Box(u) }
+			val b = g("a")
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("CallOutsideBound", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class Box<T: string> { v: T }
+			fn g<U>(u: U) -> Box<U> { return Box(u) }
+			val b = g(1)
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain 1 <: string", errs[0].Message())
+	})
+}
+
+// TestClassBoundConstructionNotDoubleReported guards the seam between the two enforcement
+// paths. A construction's argument flows into the parameter var, whose upper bound is the
+// declared constraint, so `Box(1)` against `class Box<T: string>` reports through inference.
+// The reference check covers annotations only, so a construction with no annotation reports
+// exactly once.
+func TestClassBoundConstructionNotDoubleReported(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class Box<T: string> { v: T }
+		val b = Box(1)
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain 1 <: string", errs[0].Message())
 }

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -458,39 +458,42 @@ func TestClassDefaultFilledFromClassBody(t *testing.T) {
 // type-parameter bound, a constructor parameter, and a method return. Every form resolves
 // through buildClassInstance, so each reports the same too-few diagnostic.
 func TestClassArityAcrossRemainingRefForms(t *testing.T) {
-	srcs := map[string]string{
-		"Extends": `
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "Extends", src: `
 			class Box<T> { value: T }
 			class Wrapper extends Box {
 				constructor(mut self) {},
 			}
-		`,
-		"Implements": `
+		`},
+		{name: "Implements", src: `
 			class Box<T> { value: T }
 			class Wrapper implements Box { value: number }
-		`,
-		"TypeParamBound": `
+		`},
+		{name: "TypeParamBound", src: `
 			class Box<T> { value: T }
 			class Holder<U: Box> { value: U }
-		`,
-		"ConstructorParam": `
+		`},
+		{name: "ConstructorParam", src: `
 			class Box<T> { value: T }
 			class Holder {
 				boxed: Box<number>,
 				constructor(mut self, boxed: Box) { self.boxed = boxed },
 			}
-		`,
-		"MethodReturn": `
+		`},
+		{name: "MethodReturn", src: `
 			class Box<T> { value: T }
 			class Holder {
 				boxed: Box<number>,
 				unwrap(self) -> Box { return self.boxed },
 			}
-		`,
+		`},
 	}
-	for name, src := range srcs {
-		t.Run(name, func(t *testing.T) {
-			_, _, errs := inferSource(t, src)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
 			require.Len(t, errs, 1)
 			require.Equal(t, "class `Box` expects 1 type arguments but got 0", errs[0].Message())
 		})
@@ -531,8 +534,11 @@ func TestMutuallyRecursiveGenericClassesResolve(t *testing.T) {
 // parameters resolved. Inferring B's body first would leave `A` an unbound name, reported as an
 // unresolved reference instead of the arity mismatch it is.
 func TestClassArityAcrossMixedComponent(t *testing.T) {
-	srcs := map[string]string{
-		"GenericClassFirst": `
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "GenericClassFirst", src: `
 			class A<T> {
 				v: T,
 				make(self) -> number { return B(1, A(2)).x },
@@ -541,8 +547,8 @@ func TestClassArityAcrossMixedComponent(t *testing.T) {
 				x: number,
 				a: A,
 			}
-		`,
-		"GenericClassSecond": `
+		`},
+		{name: "GenericClassSecond", src: `
 			class B {
 				x: number,
 				a: A,
@@ -551,11 +557,11 @@ func TestClassArityAcrossMixedComponent(t *testing.T) {
 				v: T,
 				make(self) -> number { return B(1, A(2)).x },
 			}
-		`,
+		`},
 	}
-	for name, src := range srcs {
-		t.Run(name, func(t *testing.T) {
-			values, _, errs := inferSource(t, src)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, test.src)
 			require.Len(t, errs, 1)
 			require.Equal(t, "class `A` expects 1 type arguments but got 0", errs[0].Message())
 			require.Equal(t, "{new (x: number, a: A<unknown>) -> B}", values["B"])

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -301,11 +301,10 @@ func (v *typeParamRefScan) shadowed(name string) bool {
 
 // checkTypeArgBounds reports a type argument that does not satisfy its parameter's declared
 // bound, so `class Box<T: string>` and `type Box<T: string>` both reject `Box<number>`. Every
-// generic class, enum, and alias reference routes through here, so the rule reads the same on
-// all three. Arguments are substituted into the bound first, which lets a bound name a sibling
-// as the `B: A` of `<A, B: A>` does. The comparison is live rather than a discarded trial, so
-// an argument that is itself a variable carries the bound to its instantiation the way a
-// function call's does.
+// generic class, enum, and alias reference routes through here. Arguments are substituted into
+// the bound first, which lets a bound name a sibling as the `B: A` of `<A, B: A>` does. The
+// comparison is live rather than a discarded trial, so a variable argument carries the bound to
+// its instantiation.
 func (c *checker) checkTypeArgBounds(
 	params []*soltype.TypeParam,
 	args []soltype.Type,
@@ -329,13 +328,12 @@ func (c *checker) checkTypeArgBounds(
 		// of what the source wrote, and it cannot be displaced by a bound solving inferred.
 		bound := p.Constraint.Accept(subst, soltype.Positive)
 		if i >= len(ref.TypeArgs) && bound == p.Constraint && args[i] == p.Default {
-			// This argument came from the parameter's default rather than from the reference, and
-			// substitution changed neither the bound nor the default. Both therefore read here
-			// exactly as they do at the declaration, where resolveTypeParams already compared
-			// them. Repeating the comparison would file one copy of the same diagnostic per
-			// reference. The check still runs whenever substitution moved either side, since then
-			// only the reference knows what the comparison is really between. `<A, B: A = number>`
-			// is the moved-bound case and `<T, U: string = T>` the moved-default case.
+			// This argument came from the parameter's default, and substitution moved neither the
+			// bound nor the default, so both read here exactly as they do at the declaration where
+			// resolveTypeParams already compared them. Repeating it would file the same diagnostic
+			// once per reference. A moved bound, `<A, B: A = number>`, or a moved default,
+			// `<T, U: string = T>`, is still checked, since only the reference knows what the
+			// comparison is between.
 			continue
 		}
 		// Blame the written argument. A trailing argument filled from its parameter's default

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"slices"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -295,4 +297,69 @@ func (v *typeParamRefScan) shadowed(name string) bool {
 		}
 	}
 	return false
+}
+
+// checkTypeArgBounds reports a type argument that does not satisfy its parameter's declared
+// bound, so `class Box<T: string>` and `type Box<T: string>` both reject `Box<number>`. Every
+// generic class, enum, and alias reference routes through here, so the rule reads the same on
+// all three. Arguments are substituted into the bound first, which lets a bound name a sibling
+// as the `B: A` of `<A, B: A>` does. The comparison is live rather than a discarded trial, so
+// an argument that is itself a variable carries the bound to its instantiation the way a
+// function call's does.
+func (c *checker) checkTypeArgBounds(
+	params []*soltype.TypeParam,
+	args []soltype.Type,
+	ltParams []*soltype.LifetimeParam,
+	ltArgs []soltype.Lifetime,
+	ref *ast.TypeRefTypeAnn,
+) {
+	bounded := func(p *soltype.TypeParam) bool { return p.Constraint != nil }
+	if !slices.ContainsFunc(params, bounded) {
+		// Every parameter is unbounded, so there is nothing to compare and no substitution to
+		// build. This is the common shape for a generic alias.
+		return
+	}
+	subst := newTypeSubst(params, args, ltParams, ltArgs)
+	for i, p := range params {
+		if !bounded(p) {
+			continue
+		}
+		// Read the declared constraint from the parameter rather than from its var's upper
+		// bounds. A `<T: A & B>` bound resolves to one IntersectionType, so this is the whole
+		// of what the source wrote, and it cannot be displaced by a bound solving inferred.
+		bound := p.Constraint.Accept(subst, soltype.Positive)
+		if i >= len(ref.TypeArgs) && bound == p.Constraint && args[i] == p.Default {
+			// This argument came from the parameter's default rather than from the reference, and
+			// substitution changed neither the bound nor the default. Both therefore read here
+			// exactly as they do at the declaration, where resolveTypeParams already compared
+			// them. Repeating the comparison would file one copy of the same diagnostic per
+			// reference. The check still runs whenever substitution moved either side, since then
+			// only the reference knows what the comparison is really between. `<A, B: A = number>`
+			// is the moved-bound case and `<T, U: string = T>` the moved-default case.
+			continue
+		}
+		// Blame the written argument. A trailing argument filled from its parameter's default
+		// has no node of its own, so the blame falls back to the whole reference.
+		var site ast.Node = ref
+		if i < len(ref.TypeArgs) {
+			site = ref.TypeArgs[i]
+		}
+		if c.deferArgBounds {
+			c.deferredArgBounds = append(c.deferredArgBounds, deferredArgBound{
+				arg: args[i], bound: bound, site: site,
+			})
+			continue
+		}
+		c.constrain(site, args[i], bound)
+	}
+}
+
+// runDeferredArgBounds replays and clears the checks checkTypeArgBounds queued while the
+// component's bodies were nil, since an unfilled alias argument expands to ErrorType and absorbs.
+func (c *checker) runDeferredArgBounds() {
+	pending := c.deferredArgBounds
+	c.deferredArgBounds = nil
+	for _, p := range pending {
+		c.constrain(p.site, p.arg, p.bound)
+	}
 }

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -1463,11 +1463,11 @@ class is ordinary, so a reference is regularly resolved before the class it name
 own pass. `getOrCreateClass` therefore reads the counts straight off the declaration's `<…>`
 clause when it registers the identity, which is before any reference can be resolved, and
 `inferClassDecl` fills `TypeParams` later. The count is always available, so every reference is
-checked. The defaults are not, so a reference that omits an argument for a class whose
-parameters have not landed recovers to a fresh var instead of filling the default. That is a
-silent wrong answer — `B<unknown>` where the declaration says `B<number>` — and closing it
-needs the check deferred until every class in the component has its parameters, the machinery
-PR19 adds for bounds.
+checked. The defaults land with the resolved parameters, which PR19's pre-pass makes final for
+every class in a component before any body runs, so a reference that omits an argument fills
+the default no matter which declaration the dep graph reaches first. As shipped in #993, before
+that pre-pass, a reference resolved ahead of the class's own pass recovered the omitted
+argument to a fresh var — `B<unknown>` where the declaration says `B<number>`.
 
 A fresh var rather than the declaration's own var is what keeps the recovery contained. Filling
 `class A { b: B }` against `class B<T>` with `B`'s parameter var would make `A`'s constructor
@@ -1507,27 +1507,40 @@ sibling whose body is not yet filled, and the live rather than discarded compari
 leaves a bound on a caller's variable — so this PR is that machinery reaching a second
 caller, not a second design.
 
-**Algorithms.**
-- Check each argument `buildClassInstance` resolves against its parameter's
-  `TypeParam.Constraint`, substituting the reference's own arguments into the bound first so
-  a bound naming a sibling parameter, `<T, K: keyof T>`, reaches the argument that filled it.
-  PR18's helper is where the pairing happens.
-- **Reuse #956's comparison rather than reimplementing it.** It is live, not a discarded
-  trial, which is what makes a type-variable argument defer to the caller's instantiation
-  instead of silently passing. Factoring the alias check's body into a shared routine over a
-  parameter list and an argument list keeps one answer to that question.
-- **A class in a dep_graph component with an unfilled sibling defers the same way.** A class
-  body resolves after its own pre-binding, so a bound naming a sibling class can reach a
-  registered-but-empty `ClassDef`. Route through the same deferral list #956 added, replayed
-  once the component's bodies are filled.
-- An argument that fails its bound is reported and then kept rather than replaced with a
-  recovery var, so a later diagnostic names the type the source wrote.
+**Data structures.** A `classShell` per class declaration, held on the checker's `classShells`
+map, carrying the resolved type parameters and the scope the class body resolves in.
+`preBindClassTypeParams` fills it during the SCC type-key pass and `inferClassDecl` reuses it
+rather than minting a second set of parameter vars.
 
-**Accept.** `Box<Other>` against `class Box<T: A>` reports a full-message bound error, and
-`Box<B>` for a subclass `B` of `A` passes. `Box(Other())` keeps reporting the
+**Algorithms.**
+- **Resolve every class's type parameters in the SCC type-key pass**, after every identity in
+  the component is registered and before any body runs. A class body resolves at its value
+  key, while a reference to a class depends only on that class's type key, so without the
+  pre-pass a reference regularly reads a def whose `TypeParams` are empty — no defaults to
+  fill and no bounds to check. With it, the parameter list every reference reads is final.
+  This also closes PR18's known gap: an omitted argument fills its default in every
+  declaration order, not only when the referenced class happens to resolve first.
+- **The whole non-value pre-bind block runs before the component's value walk.** A class
+  member body creates a value dependency, so `type:A` and `value:B` share a component when
+  A's body calls B and B's field names `A<T>`; inferring B's body first would read `A` before
+  anything registered it.
+- Check each argument `buildClassInstance` resolves against its parameter's
+  `TypeParam.Constraint` through `checkTypeArgBounds`, #956's alias check moved to
+  type_params.go beside the other shared type-argument helpers and renamed with its deferral
+  plumbing (`deferArgBounds`, `runDeferredArgBounds`), since the queue now holds class
+  comparisons too. The bound is substituted with the reference's own arguments first, so a
+  bound naming a sibling parameter reaches the argument that filled it.
+- The comparison is live, not a discarded trial, which is what makes a type-variable argument
+  defer to the caller's instantiation instead of silently passing.
+- A class reference resolved while a sibling alias's body is still nil routes through the
+  same deferral window the alias check uses, replayed once the component's bodies are filled.
+
+**Accept.** `Box<Other>` against `class Box<T: A>` reports a full-message bound error, and an
+argument inside the bound passes. `Box(Other())` keeps reporting the
 `cannot constrain Other <: A` it reports today, so the inference path and the check path do
 not double-report one mismatch. A forwarding declaration `fn g<U>(u: U) -> Box<U>` defers to
-its call site, matching what #956 settled for the alias position.
+its call site, matching what #956 settled for the alias position. `class B<T = number>`
+referenced bare from a sibling class body infers `B<number>` in either declaration order.
 
 **Depends on** PR18 for the helper and #956 for the comparison. Independent of the operator
 track.
@@ -1708,8 +1721,8 @@ PR13 ✅ #954 (TS utility-type suite)        ── needs PR2, PR3b, PR4, PR7, P
  │    └─► PR15 (new (…) members in obj type anns + ConstructorParameters<C>)
  └─► PR16 ✅ #960 (null + undefined + NonNullable<T>)     ── also needs PR3b
 
-PR17 (default names only an earlier param) ── needs M7 only
- └─► PR18 🔄 #962 (class type-param defaults + arity at a type reference)
+PR17 ✅ #968 (default names only an earlier param) ── needs M7 only
+ └─► PR18 ✅ #993 (class type-param defaults + arity at a type reference)
       └─► PR19 (class type-argument bound checking)  ── also needs #956
 
 PR20 (warn on a phantom type parameter)    ── needs PR9d only
@@ -1722,8 +1735,8 @@ sets, #937 capped total alias expansion with a monotonic budget, #938 added the
 `{[K: Keys]: Value}` index-signature shorthand to PR4's mapped types, and #949 factored
 out the `alphaCtx` bijection that PR9e's knot comparison reuses.
 
-Everything still open is PR9f, PR10b, PR10c, PR11, PR15, and Track F's PR17 through PR20,
-with PR18 already up for review as #962. PR8 landed in two steps: #922 threaded an object's
+Everything still open is PR9f, PR10b, PR10c, PR11, PR15, PR19, and PR20; Track F's PR17
+and PR18 landed as #968 and #993. PR8 landed in two steps: #922 threaded an object's
 exactness through `keyof`, and #953 carried it through the remaining operators and added the
 `Exact` / `Inexact` intrinsics.
 
@@ -1762,8 +1775,8 @@ graph TD
     PR14["PR14 ✅ #961 (rest params in fn type anns + Parameters<F>)"]
     PR15["PR15 (new (…) in obj type anns + ConstructorParameters<C>)"]
     PR16["PR16 ✅ #960 (null + undefined + NonNullable<T>)"]
-    PR17["PR17 (default names only an earlier param)"]
-    PR18["PR18 🔄 #962 (class type-param defaults + arity at a type reference)"]
+    PR17["PR17 ✅ #968 (default names only an earlier param)"]
+    PR18["PR18 ✅ #993 (class type-param defaults + arity at a type reference)"]
     PR19["PR19 (class type-argument bound checking)"]
     PR20["PR20 (warn on a phantom type parameter)"]
 
@@ -1836,7 +1849,8 @@ graph TD
     style PR10 stroke:#2e7d32,stroke-width:4px
     style PR9d stroke:#2e7d32,stroke-width:4px
     style PR14 stroke:#2e7d32,stroke-width:4px
-    style PR18 stroke:#ef6c00,stroke-width:4px,stroke-dasharray:5 3
+    style PR17 stroke:#2e7d32,stroke-width:4px
+    style PR18 stroke:#2e7d32,stroke-width:4px
 ```
 
 ### Parallelism
@@ -1866,10 +1880,9 @@ graph TD
 - **Track F** — a chain, PR17 → PR18 → PR19, and nothing outside it waits on any of the
   three, so it can run start to finish alongside any other track. The order is both the
   dependency order and the value order: PR17 fixes a wrong answer, PR18 fixes a second one
-  and builds the helper, PR19 routes #956's comparison to it. #962 opened PR18 ahead of
-  PR17, so the forward-reference restriction PR17 adds still has to land for the class path
-  to stop filling a default that can leak a declaration var. PR20 is off the chain, waiting
-  only on PR9d, so it can land now that the marks exist.
+  and builds the helper, PR19 routes #956's comparison to it. PR17 landed as #968 and PR18
+  as #993, so PR19 is the chain's remainder with both prerequisites in. PR20 is off the
+  chain, waiting only on PR9d, so it can land now that the marks exist.
 
 The critical path is `M7 → PR1a → PR1b → PR3a → PR3b → PR4 → PR8`, and — for the
 async-generator accept case — `M7 → PR1a → PR1b → PR3b → PR12 → PR13 → PR14 → PR15`.
@@ -1877,7 +1890,6 @@ Both are now down to their tails: the first has landed end to end, and only PR15
 on the second. The follow-on group sits off both: nothing in PR1a–PR16 waits on PR9c–PR9f,
 and nothing waits on Track F.
 
-What is left divides by what it waits on. PR9f, PR10b, PR15, PR17, and PR20 have every
+What is left divides by what it waits on. PR9f, PR10b, PR15, PR19, and PR20 have every
 prerequisite in and can each start now. PR10c and PR11 wait on M7.5, which has not been
-built, and PR10c waits on PR10b besides. PR18 and PR19 are the Track F chain, so PR19 waits
-on #962 landing and PR18 waits on PR17.
+built, and PR10c waits on PR10b besides.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -1463,11 +1463,12 @@ class is ordinary, so a reference is regularly resolved before the class it name
 own pass. `getOrCreateClass` therefore reads the counts straight off the declaration's `<…>`
 clause when it registers the identity, which is before any reference can be resolved, and
 `inferClassDecl` fills `TypeParams` later. The count is always available, so every reference is
-checked. The defaults land with the resolved parameters, which PR19's pre-pass makes final for
-every class in a component before any body runs, so a reference that omits an argument fills
-the default no matter which declaration the dep graph reaches first. As shipped in #993, before
-that pre-pass, a reference resolved ahead of the class's own pass recovered the omitted
-argument to a fresh var — `B<unknown>` where the declaration says `B<number>`.
+checked. The defaults land with the resolved parameters, which the type-key pre-pass makes
+final for every class in a component before any body runs, so no body's reference can reach a
+class whose parameters are unresolved, and a reference that omits an argument fills the
+default no matter which declaration the dep graph reaches first. The one window left open is a
+sibling's own `<…>` clause, which resolves while the pre-pass is still walking the component;
+a reference there recovers an omitted argument to a fresh var.
 
 A fresh var rather than the declaration's own var is what keeps the recovery contained. Filling
 `class A { b: B }` against `class B<T>` with `B`'s parameter var would make `A`'s constructor


### PR DESCRIPTION
Refs #861.

Implements PR19 of `planning/simple_sub/m9-implementation-plan.md`, replacing the abandoned #962 (see that PR for why it was closed rather than rebased onto #993).

## What this does

A generic alias reference compares each type argument against its parameter's declared bound; a class reference did not. `class Box<T: string>` accepted an annotation of `Box<number>` anywhere it appeared, including inside Box's own body. The bound was only enforced when a value was constructed, so annotating was a way around it.

**Bound checking.** #956's `checkAliasArgBounds` moves to `type_params.go` as `checkTypeArgBounds`, beside the other shared type-argument helpers, and `buildClassInstance` now calls it too, so every generic class, enum, and alias reference is held to the same rule. The deferral plumbing is renamed `deferArgBounds` / `runDeferredArgBounds`, since the queue now holds class comparisons as well. The comparison stays live rather than a discarded trial, so a forwarding declaration `fn g<U>(u: U) -> Box<U>` carries Box's bound onto `U` and defers to its call site, matching what #956 settled for the alias position.

**Eager class type-parameter resolution.** The check needs resolved parameters, which a reference could not rely on: a class body resolves at its value key, while a reference to a class depends only on that class's type key, so a reference regularly read a def whose `TypeParams` were still empty. `preBindClassTypeParams` now resolves every class's parameters in the SCC type-key pass, after the component's identities are registered and before any body runs; `inferClassDecl` reuses the recorded parameters and scope through `classShells` instead of minting a second set. `ClassDef.Arity` stays as the count's source — it still covers the shrunk window where a sibling's own `<…>` clause resolves during the pre-pass, and script classes, which have no pre-pass.

This also closes #993's known default-fill gap: `class B<T = number>` referenced bare from a sibling class body infers `B<number>` in either declaration order, where it recovered to `B<unknown>` before. `TestClassDefaultUnfilledForUnresolvedSibling`, which pinned the gap, is rewritten as `TestClassDefaultFilledFromClassBody`.

**Mixed-component ordering.** The whole non-value pre-bind block now runs before the component's value walk. A class member body creates a value dependency, so a class's type key and a sibling's value key can share one SCC; inferring the sibling's body first read the class's name before anything registered it and reported `Unsupported: TypeRefTypeAnn` instead of resolving.

## Test plan

- `TestClassTypeArgBounds` — outside/inside bound, unbounded, self-reference in the class's own body, `extends` edge, method parameter, sibling bound `<A, B: A>`, intersection bound, cross-class bound.
- `TestClassBoundForwardingFn` — the plan's forwarding acceptance: declaration clean, in-bound call passes, out-of-bound call reports once at the argument.
- `TestClassBoundConstructionNotDoubleReported` — construction alone still reports exactly once.
- `TestClassBoundDefersForUnfilledAliasSibling` — a class reference inside an alias body defers and replays.
- `TestClassDefaultFilledFromClassBody` / `TestClassDefaultFilledDeclarationOrderIndependent` — the closed gap, both declaration orders.
- `TestClassArityAcrossRemainingRefForms`, `TestClassArityAcrossMixedComponent`, `TestMutuallyRecursiveGenericClassesResolve`.
- Full suite green: `go test ./...`.

The m9 plan's PR19 section is updated to describe what landed, and Track F's tracking markers reflect #968 and #993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSGsuQbC7wfpqAM8e2ibn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSGsuQbC7wfpqAM8e2ibn6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved generic class resolution across declaration order and mutually recursive definitions.
  * Class type arguments now consistently apply declared defaults and validate parameter bounds.
  * Added support for resolving class references across additional syntax contexts.

* **Bug Fixes**
  * Prevented duplicate bound-related diagnostics.
  * Improved handling of forwarded type arguments and unresolved dependencies.

* **Tests**
  * Added comprehensive coverage for defaults, recursion, bounds, forwarding, and class reference arity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->