### PR TITLE
Implement Promise rejection types (M9 PR10c)

### DIFF
--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -197,42 +197,11 @@ func (c *Checker) inferFuncDecl(ctx Context, decl *ast.FuncDecl) []Error {
 
 	// For declared functions, we don't have a body to infer from
 	if decl.Declare() && (decl.Body == nil || len(decl.Body.Stmts) == 0) {
-		// Phase 11: apply lifetime elision to body-less declarations.
+		// Phase 11: apply lifetime elision to body-less declarations. An ambient
+		// declaration cannot be `async` — the parser rejects the modifier — so its
+		// return annotation is the whole signature, with no Promise to rebuild.
 		elisionErrors := c.ApplyLifetimeElision(funcType)
 		errors = slices.Concat(errors, elisionErrors)
-
-		// For declared async functions, validate that the return type is a Promise
-		if decl.FuncSig.Async {
-			if promiseType, ok := funcType.Return.(*type_system.TypeRefType); ok &&
-				type_system.QualIdentToString(promiseType.Name) == "Promise" {
-				// Good, it's a Promise type. Ensure it has the right structure.
-				if len(promiseType.TypeArgs) == 1 {
-					// Promise<T> should become Promise<T, never>
-					promiseAlias := ctx.Scope.GetTypeAlias("Promise")
-					if promiseAlias != nil {
-						// Update the function type to have Promise<T, never>
-						newPromiseType := type_system.NewTypeRefType(
-							nil, "Promise", promiseAlias, promiseType.TypeArgs[0], type_system.NewNeverType(nil))
-						newPromiseType.Lifetime = promiseType.Lifetime
-						funcType.Return = newPromiseType
-					}
-				} else if len(promiseType.TypeArgs) >= 2 {
-					// Promise<T, E> is already correct
-				} else {
-					// Promise with no args, this shouldn't happen but let's handle it
-					errors = append(errors, &UnimplementedError{
-						message: "Promise type must have at least one type argument",
-						span:    decl.Span(),
-					})
-				}
-			} else {
-				// Declared async function must return a Promise type
-				errors = append(errors, &UnimplementedError{
-					message: "Declared async functions must return a Promise type",
-					span:    decl.Span(),
-				})
-			}
-		}
 	} else if decl.Body != nil {
 		// Allocate call-site maps so body inference and resolveCallSites share them.
 		callSites := make(map[int][]*type_system.FuncType)

--- a/internal/checker/tests/elision_test.go
+++ b/internal/checker/tests/elision_test.go
@@ -76,17 +76,15 @@ func TestLifetimeElision_DeclareFn(t *testing.T) {
 			fnName:       "pick",
 			expectedType: "fn (a: mut {x: number}, b: mut {x: number}) -> mut {x: number}",
 		},
-		"DeclareAsyncFnPreservesLifetimeThroughPromiseNormalization": {
-			// Phase 11: ApplyLifetimeElision attaches a lifetime to the
-			// signature's Return (a `Promise<T>` TypeRefType). The
-			// async-Promise normalization that follows rebuilds the
-			// Return as `Promise<T, never>`; that rebuild must preserve
-			// the elision-applied lifetime rather than dropping it.
+		"PromiseReturnPreservesLifetime": {
+			// ApplyLifetimeElision attaches a lifetime to the signature's
+			// Return, here a `Promise<T>` TypeRefType. Nothing downstream
+			// may drop it while rewriting the Return.
 			input: `
-				declare async fn identity(p: mut {x: number}) -> Promise<mut {x: number}>
+				declare fn identity(p: mut {x: number}) -> Promise<mut {x: number}>
 			`,
 			fnName:       "identity",
-			expectedType: "fn <'a>(p: mut 'a {x: number}) -> 'a Promise<mut {x: number}, never>",
+			expectedType: "fn <'a>(p: mut 'a {x: number}) -> 'a Promise<mut {x: number}>",
 		},
 		"AlreadyAnnotatedNotElided": {
 			// User wrote an explicit `<'a>` clause. Elision must not

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -625,50 +625,6 @@
 }
 ---
 
-[TestParseModuleNoErrors/DeclareAsyncFuncDecl - 1]
-&ast.DeclStmt{
-    Decl: &ast.FuncDecl{
-        Name: &ast.Ident{
-            Name: "fetch",
-            span: 2:22-2:27,
-        },
-        FuncSig: ast.FuncSig{
-            Params: []*ast.Param{
-                &ast.Param{
-                    Pattern: &ast.IdentPat{
-                        Name: "url",
-                        span: 2:28-2:31,
-                    },
-                    TypeAnn: &ast.StringTypeAnn{
-                        span: 2:33-2:39,
-                    },
-                },
-            },
-            Return: &ast.TypeRefTypeAnn{
-                Name: &ast.Ident{
-                    Name: "Promise",
-                    span: 2:44-2:51,
-                },
-                TypeArgs: []ast.TypeAnn{
-                    &ast.TypeRefTypeAnn{
-                        Name: &ast.Ident{
-                            Name: "Response",
-                            span: 2:52-2:60,
-                        },
-                        span: 2:52-2:60,
-                    },
-                },
-                span: 2:44-2:61,
-            },
-            Async: true,
-        },
-        declare: true,
-        span: 2:5-2:61,
-    },
-    span: 2:5-2:61,
-}
----
-
 [TestParseModuleNoErrors/ExportAsyncFuncDecl - 1]
 &ast.DeclStmt{
     Decl: &ast.FuncDecl{

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -246,13 +246,24 @@ func (p *Parser) Decl() ast.Decl {
 		p.reportError(overrideSpan, "'override' requires 'declare'")
 	}
 
+	var asyncSpan ast.Span
 	if token.Type == Async {
 		async = true
+		asyncSpan = token.Span
 		token = p.lexer.next()
 	}
 
 	if async && token.Type != Fn {
 		p.reportError(token.Span, "async can only be used with functions")
+	}
+
+	// `async` describes how a body computes its result, and an ambient declaration has
+	// no body — its return annotation already names the `Promise` callers see. Drop the
+	// modifier after reporting so the declaration types as the `declare fn` the author
+	// meant, rather than wrapping the annotation in a second Promise.
+	if async && declare {
+		p.reportError(asyncSpan, "'async' is not allowed on an ambient declaration")
+		async = false
 	}
 
 	var finalSpan ast.Span

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -76,11 +76,6 @@ func TestParseModuleNoErrors(t *testing.T) {
 				}
 			`,
 		},
-		"DeclareAsyncFuncDecl": {
-			input: `
-				declare async fn fetch(url: string) -> Promise<Response>
-			`,
-		},
 		"DecoratorOnDeclareVal": {
 			input: `
 				@js("Math.PI")
@@ -429,6 +424,14 @@ func TestParseDeclareBlockErrors(t *testing.T) {
 		"ExportOverrideDeclareGlobal": {
 			input:         `export override declare global { }`,
 			expectedError: "'export' is not allowed before 'declare global'",
+		},
+		"DeclareAsyncFn": {
+			input:         `declare async fn fetch(url: string) -> Promise<Response>`,
+			expectedError: "'async' is not allowed on an ambient declaration",
+		},
+		"ExportDeclareAsyncFn": {
+			input:         `export declare async fn fetch(url: string) -> Promise<Response>`,
+			expectedError: "'async' is not allowed on an ambient declaration",
 		},
 		"OverrideWithoutDeclareFn": {
 			input:         `override fn foo() -> number`,

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -506,6 +506,9 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Body)
 		case *PromiseType:
 			walk(t.Inner)
+			if t.Err != nil {
+				walk(t.Err)
+			}
 		case *ArrayType:
 			walk(t.Elem)
 		case *RefType:
@@ -816,6 +819,13 @@ func (p *namedPrinter) printType(t Type) string {
 		// `μX0.{next: X0}` names one binding twice.
 		return t.DisplayName()
 	case *PromiseType:
+		// A promise that can reject renders its rejection type as a second argument,
+		// `Promise<T, E>`. A promise that cannot reject resolves its Err to `never` and
+		// renders the one-argument `Promise<T>`, the same suppression printThrowsClause
+		// applies to a signature that raises nothing.
+		if !isNever(t.ErrOrNever()) {
+			return "Promise<" + p.printType(t.Inner) + ", " + p.printType(t.Err) + ">"
+		}
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *ArrayType:
 		return "Array<" + p.printType(t.Elem) + ">"

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -823,7 +823,7 @@ func (p *namedPrinter) printType(t Type) string {
 		// `Promise<T, E>`. A promise that cannot reject resolves its Err to `never` and
 		// renders the one-argument `Promise<T>`, the same suppression printThrowsClause
 		// applies to a signature that raises nothing.
-		if !isNever(t.ErrOrNever()) {
+		if t.Rejects() {
 			return "Promise<" + p.printType(t.Inner) + ", " + p.printType(t.Err) + ">"
 		}
 		return "Promise<" + p.printType(t.Inner) + ">"

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -175,9 +175,13 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"null atom", &NullType{}, "null"},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
 
-		// Promises (M3).
+		// Promises (M3). A rejecting promise renders its Err as a second argument
+		// (M9 PR10c); a nil or `never` Err is the non-rejecting shorthand and renders
+		// the one-argument form, the same suppression the throws clause gets.
 		{"promise of prim", &PromiseType{Inner: numP()}, "Promise<number>"},
 		{"nested promise", &PromiseType{Inner: &PromiseType{Inner: strP()}}, "Promise<Promise<string>>"},
+		{"rejecting promise", &PromiseType{Inner: numP(), Err: strP()}, "Promise<number, string>"},
+		{"promise with never err renders one argument", &PromiseType{Inner: numP(), Err: &NeverType{}}, "Promise<number>"},
 
 		// Borrows (M4). Ownership and the borrow `&` split on Lt. An owned value has Lt
 		// nil and renders bare, as owned-mutable `mut {x}`. A borrow has Lt set and leads

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -747,7 +747,27 @@ func (*RecursiveType) isRefInner()    {}
 // L <: R) and the `await` rule does NOT recursively flatten (so awaiting
 // `Promise<Promise<T>>` yields `Promise<T>`, matching the milestone's
 // no-auto-flatten contract — flattening is `Awaited<T>`, M9).
-type PromiseType struct{ Inner Type }
+//
+// Err is the type the promise rejects with, the twin of FuncType.Throws for the
+// asynchronous exceptional exit. What an `async fn`'s body throws lands here rather
+// than on the function's own Throws, since a caller observes the rejection only by
+// awaiting the promise. Like Inner it is covariant, and like FuncType.Throws a nil
+// Err is shorthand for `never`; ErrOrNever collapses nil and an explicit `never`
+// so no reader tells them apart. A promise that cannot reject is therefore the
+// zero value and renders as the one-argument `Promise<T>`.
+type PromiseType struct {
+	Inner Type
+	Err   Type
+}
+
+// ErrOrNever returns the type t may reject with, resolving the nil shorthand to the
+// `never` it stands for, so callers compare one canonical value.
+func (t *PromiseType) ErrOrNever() Type {
+	if t.Err == nil {
+		return &NeverType{}
+	}
+	return t.Err
+}
 
 // ArrayType is a homogeneous sequence of Elem, written `Array<T>`. It is a dedicated concrete
 // for the reason PromiseType is: one stdlib generic the milestone needs typed ahead of library
@@ -1324,7 +1344,10 @@ func LevelOf(t Type) int {
 		// level boundary intact: the body's variables are freshened and the binder is left alone.
 		return LevelOf(t.Body)
 	case *PromiseType:
-		return LevelOf(t.Inner)
+		// A promise's level is the max of its payload's and its rejection type's, so an
+		// out-of-level Err lifts the level and the freshener/extruder prune descends to
+		// freshen it, the same reason the FuncType arm folds in its Throws.
+		return max(LevelOf(t.Inner), throwsLevel(t.Err))
 	case *ArrayType:
 		// An array's level is its element's, the same single-child rule PromiseType follows.
 		return LevelOf(t.Elem)
@@ -1412,9 +1435,10 @@ func selfLevel(self *FuncParam) int {
 	return LevelOf(self.Type)
 }
 
-// throwsLevel returns the level of an accessor's throws position, 0 for the nil shorthand
-// that stands for `never`. `never` is a childless leaf at level 0, so the shorthand and an
-// explicit `never` agree without materializing one.
+// throwsLevel returns the level of an exceptional-exit position — an accessor's throws
+// or a promise's Err — 0 for the nil shorthand that stands for `never`. `never` is a
+// childless leaf at level 0, so the shorthand and an explicit `never` agree without
+// materializing one.
 func throwsLevel(throws Type) int {
 	if throws == nil {
 		return 0

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -769,6 +769,13 @@ func (t *PromiseType) ErrOrNever() Type {
 	return t.Err
 }
 
+// Rejects reports whether t can reject: its Err carries something other than the nil
+// shorthand or an explicit `never`. The printer and the solver's raised-tracking both
+// ask this question, so it lives here to keep their answers locked together.
+func (t *PromiseType) Rejects() bool {
+	return t.Err != nil && !isNever(t.Err)
+}
+
 // ArrayType is a homogeneous sequence of Elem, written `Array<T>`. It is a dedicated concrete
 // for the reason PromiseType is: one stdlib generic the milestone needs typed ahead of library
 // ingestion. It exists to give a rest parameter an element type, the arity-and-element pair a

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -179,9 +179,15 @@ func (t *PromiseType) Accept(v TypeVisitor, pol Polarity) Type {
 	}
 	cur := descendReplacement(t, e)
 	inner := cur.Inner.Accept(v, pol) // covariant, no auto-flatten
+	// The rejection type is the asynchronous exceptional exit, so it walks at the same
+	// polarity as the payload. A nil Err is the `never` shorthand and has nothing to walk.
+	errT := cur.Err
+	if errT != nil {
+		errT = errT.Accept(v, pol)
+	}
 	out := cur
-	if inner != cur.Inner {
-		out = &PromiseType{Inner: inner}
+	if inner != cur.Inner || errT != cur.Err {
+		out = &PromiseType{Inner: inner, Err: errT}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -152,6 +152,32 @@ func TestAcceptFuncThrows(t *testing.T) {
 	require.Same(t, noThrows, noThrows.Accept(identityVisitor{}, Positive), "a nil throws walks nothing")
 }
 
+// A promise's rejection type walks at the same polarity as its payload, since both
+// describe an outcome the promise produces, and a rewrite of it forces a fresh parent the
+// same way a rewritten payload does. A nil Err is the `never` shorthand with nothing to
+// walk.
+func TestAcceptPromiseErr(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	b := &TypeVarType{ID: 2}
+
+	// Promise<a, b>, walked from Positive.
+	p := &PromiseType{Inner: a, Err: b}
+	r := &recorder{seen: map[Type]Polarity{}}
+	p.Accept(r, Positive)
+	require.Equal(t, Positive, r.seen[a], "the payload is covariant")
+	require.Equal(t, Positive, r.seen[b], "the rejection type is covariant, like the payload")
+
+	got := p.Accept(&replaceVar{target: b, repl: str}, Positive).(*PromiseType)
+	require.NotSame(t, p, got, "a changed rejection type forces a fresh parent")
+	require.Same(t, str, got.Err, "the changed rejection type took the replacement")
+	require.Same(t, a, got.Inner, "the unchanged payload keeps its pointer")
+
+	noErr := &PromiseType{Inner: num}
+	require.Same(t, noErr, noErr.Accept(identityVisitor{}, Positive), "a nil Err walks nothing")
+}
+
 // recordEntered logs every node EnterType reaches, replacing target with repl and
 // SKIPPING its children — so a skipped subtree is never entered.
 type recordEntered struct {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1332,7 +1332,10 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		return ok && equalTypeWith(a.Elem, b.Elem, ctx)
 	case *soltype.PromiseType:
 		b, ok := b.(*soltype.PromiseType)
-		return ok && equalTypeWith(a.Inner, b.Inner, ctx)
+		// ErrOrNever reads both sides through the nil-is-never collapse, so two promises
+		// differing only in whether the rejection slot was written compare equal here.
+		return ok && equalTypeWith(a.Inner, b.Inner, ctx) &&
+			equalTypeWith(a.ErrOrNever(), b.ErrOrNever(), ctx)
 	case *soltype.RefType:
 		b, ok := b.(*soltype.RefType)
 		// Mut must match — a mutable borrow never equals an immutable one — and the

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1121,7 +1121,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			// concretes (e.g. Promise<L> <: Tuple), fall through to the generic
 			// CannotConstrainError below, matching the function/tuple/record arms.
 			// A promise's payload is its own annotation context, so the flag resets.
-			return c.constrain(sub.Inner, sup.Inner, seen, false)
+			errs := c.constrain(sub.Inner, sup.Inner, seen, false)
+			// The rejection type is covariant like the payload, the same rule the
+			// function arm applies to Throws. A non-rejecting sub carries `never`,
+			// which constrain short-circuits, so it satisfies every super.
+			return append(errs, c.constrain(sub.ErrOrNever(), sup.ErrOrNever(), seen, false)...)
 		}
 	case *soltype.RefType:
 		// THE GATE (M4 C2): the single RefType <: RefType rule. The mut-driven inner

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -966,7 +966,7 @@ type NotIterableError struct {
 // `-> Promise<_>` to let the checker infer the inner from the body.
 //
 // Like AwaitOutsideAsyncError it is a WALK rejection, not a type-rule failure:
-// born in inferFunc (asyncReturn) with the annotation and function nodes in hand,
+// born in inferFunc with the annotation and function nodes in hand,
 // so it self-blames from the annotation's span and relates the function via
 // Related() (the signature the user would fix).
 type AsyncReturnNotPromiseError struct {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2455,9 +2455,13 @@ func describe(t soltype.Type) string {
 	case *soltype.PromiseType:
 		// Rendered STRUCTURALLY (Promise<inner>), unlike the nominal function/tuple/
 		// object above. That is deliberate and consistent with the Union/Intersection
-		// arms below, which also recurse: a Promise's single type argument is compact
+		// arms below, which also recurse: a Promise's type arguments are compact
 		// and informative (`Promise<number>`), whereas a function/tuple/record would
-		// be verbose spelled out, so those stay nominal.
+		// be verbose spelled out, so those stay nominal. A promise that can reject
+		// names its rejection type as a second argument, matching soltype.Print.
+		if !isNeverType(t.ErrOrNever()) {
+			return "Promise<" + describe(t.Inner) + ", " + describe(t.Err) + ">"
+		}
 		return "Promise<" + describe(t.Inner) + ">"
 	case *soltype.KeyofType:
 		// A `keyof` residual renders structurally, recursing like the Promise arm, so a

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2458,8 +2458,11 @@ func describe(t soltype.Type) string {
 		// arms below, which also recurse: a Promise's type arguments are compact
 		// and informative (`Promise<number>`), whereas a function/tuple/record would
 		// be verbose spelled out, so those stay nominal. A promise that can reject
-		// names its rejection type as a second argument, matching soltype.Print.
-		if !isNeverType(t.ErrOrNever()) {
+		// names its rejection type as a second argument, matching soltype.Print — unless
+		// the slot holds a bare unsolved variable. inferAwait's synthesized requirement
+		// carries the body's throws sink there, internal scaffolding that says nothing
+		// about why a constraint failed, so a variable slot keeps the one-argument form.
+		if _, isVar := t.Err.(*soltype.TypeVarType); t.Rejects() && !isVar {
 			return "Promise<" + describe(t.Inner) + ", " + describe(t.Err) + ">"
 		}
 		return "Promise<" + describe(t.Inner) + ">"

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -974,6 +974,21 @@ type AsyncReturnNotPromiseError struct {
 	Fn     ast.Node    // the enclosing async function, surfaced via Related()
 }
 
+// AsyncThrowsClauseError fires when an `async fn` writes a `throws` clause. An async
+// function cannot raise — its body's throws are absorbed by the promise it returns —
+// so the rejection type is declared in the return annotation, `-> Promise<V, E>`,
+// and the clause form belongs to sync functions. Recovery ignores the clause: the
+// rejection is still read from the annotation or inferred from the body, so one
+// diagnostic covers the fault.
+//
+// Like AsyncReturnNotPromiseError it is a WALK rejection: born in inferFunc with the
+// clause and function nodes in hand, so it self-blames from the clause's span and
+// relates the function via Related() (the signature the user would fix).
+type AsyncThrowsClauseError struct {
+	Throws ast.TypeAnn // the clause's annotation (blame span)
+	Fn     ast.Node    // the enclosing async function, surfaced via Related()
+}
+
 // InvalidAssignmentTargetError fires when the left-hand side of an assignment
 // (`a = expr`) is not an assignable place. M3's only assignable target is an
 // IdentExpr resolving to a `var` binding; a literal, call, or any other non-place
@@ -1079,6 +1094,7 @@ func (*ForAwaitOutsideAsyncError) isSolverError()           {}
 func (*NotIterableError) isSolverError()                    {}
 func (*ReturnOutsideFunctionError) isSolverError()          {}
 func (*AsyncReturnNotPromiseError) isSolverError()          {}
+func (*AsyncThrowsClauseError) isSolverError()              {}
 func (*NonExhaustiveMatchError) isSolverError()             {}
 func (*MissingCatchArmError) isSolverError()                {}
 func (*UnhandledRethrowError) isSolverError()               {}
@@ -2106,6 +2122,19 @@ func (e *AsyncReturnNotPromiseError) Related() []ast.Span {
 }
 func (e *AsyncReturnNotPromiseError) Message() string {
 	return "async function return type must be a Promise; write Promise<...> or Promise<_>"
+}
+
+func (e *AsyncThrowsClauseError) Span() ast.Span { return e.Throws.Span() }
+func (e *AsyncThrowsClauseError) Related() []ast.Span {
+	// Point at the enclosing async function (the signature to fix), guarding a nil Fn
+	// the way AsyncReturnNotPromiseError does.
+	if e.Fn == nil {
+		return nil
+	}
+	return []ast.Span{e.Fn.Span()}
+}
+func (e *AsyncThrowsClauseError) Message() string {
+	return "async function cannot have a throws clause; declare the rejection type in the return type as Promise<..., E> or Promise<_, _>"
 }
 
 func (e *CannotConstrainError) Message() string {

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -104,6 +104,15 @@ func TestInferAsyncBareReturnAnnotationRejected(t *testing.T) {
 	require.Equal(t, "fn () -> Promise<5>", values["f"])
 }
 
+// A bodyless declare with a bare annotation recovers by wrapping `unknown` rather
+// than the synthetic Void, since there is no body to read a return from.
+func TestInferAsyncBareReturnAnnotationOnADeclare(t *testing.T) {
+	values, _, errs := inferSource(t, `declare async fn f() -> number`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "1:25-1:31: async function return type must be a Promise; write Promise<...> or Promise<_>", msgWithSpan(errs[0]))
+	require.Equal(t, "fn () -> Promise<unknown>", values["f"])
+}
+
 // The bare-async-return error blames the offending annotation and relates the
 // enclosing function (the signature to fix).
 func TestInferAsyncBareReturnAnnotationBlame(t *testing.T) {

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -170,7 +170,9 @@ func TestInferAwaitOutsideAsyncTopLevelNoRelated(t *testing.T) {
 
 // `await` of a non-Promise concrete fails through constrain — the rule
 // constrain(e <: Promise<U>) lowers `number <: Promise<U>` to a
-// CannotConstrainError because the concrete shapes don't match.
+// CannotConstrainError because the concrete shapes don't match. The requirement's
+// second argument is the clause-less body's rejection sink, still an unsolved
+// variable when the message renders.
 func TestInferAwaitOfNonPromiseFails(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		async fn f(n: number) {
@@ -178,7 +180,7 @@ func TestInferAwaitOfNonPromiseFails(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "3:4-3:11: cannot constrain number <: Promise<t1>", msgWithSpan(errs[0]))
+	require.Equal(t, "3:4-3:11: cannot constrain number <: Promise<t2, t1>", msgWithSpan(errs[0]))
 }
 
 // `await` inside an async fn nested under a non-async outer must still resolve

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -170,9 +170,9 @@ func TestInferAwaitOutsideAsyncTopLevelNoRelated(t *testing.T) {
 
 // `await` of a non-Promise concrete fails through constrain — the rule
 // constrain(e <: Promise<U>) lowers `number <: Promise<U>` to a
-// CannotConstrainError because the concrete shapes don't match. The requirement's
-// second argument is the clause-less body's rejection sink, still an unsolved
-// variable when the message renders.
+// CannotConstrainError because the concrete shapes don't match. The requirement
+// also carries the body's rejection sink in its Err slot, but describe suppresses
+// an unsolved-variable slot, so the message keeps the one-argument form.
 func TestInferAwaitOfNonPromiseFails(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		async fn f(n: number) {
@@ -180,7 +180,7 @@ func TestInferAwaitOfNonPromiseFails(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "3:4-3:11: cannot constrain number <: Promise<t2, t1>", msgWithSpan(errs[0]))
+	require.Equal(t, "3:4-3:11: cannot constrain number <: Promise<t1>", msgWithSpan(errs[0]))
 }
 
 // `await` inside an async fn nested under a non-async outer must still resolve

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -104,15 +104,6 @@ func TestInferAsyncBareReturnAnnotationRejected(t *testing.T) {
 	require.Equal(t, "fn () -> Promise<5>", values["f"])
 }
 
-// A bodyless declare with a bare annotation recovers by wrapping `unknown` rather
-// than the synthetic Void, since there is no body to read a return from.
-func TestInferAsyncBareReturnAnnotationOnADeclare(t *testing.T) {
-	values, _, errs := inferSource(t, `declare async fn f() -> number`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "1:25-1:31: async function return type must be a Promise; write Promise<...> or Promise<_>", msgWithSpan(errs[0]))
-	require.Equal(t, "fn () -> Promise<unknown>", values["f"])
-}
-
 // The bare-async-return error blames the offending annotation and relates the
 // enclosing function (the signature to fix).
 func TestInferAsyncBareReturnAnnotationBlame(t *testing.T) {

--- a/internal/solver/infer_async_throws_test.go
+++ b/internal/solver/infer_async_throws_test.go
@@ -6,15 +6,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// PR10c — async rejection. An `async fn` that throws rejects its promise rather than
-// raising to its caller, so the body's throws becomes the promise's Err and the
-// function's own throws stays `never`. The clause still governs the body's sink exactly
-// as on a sync function; only the destination a caller observes moves.
+// PR10c — async rejection. An `async fn` cannot raise: what its body throws is absorbed
+// by the promise's rejection slot, the E in `-> Promise<V, E>`, and the function's own
+// throws stays `never`. The return annotation's E is the rejection's declaration
+// surface — a written E is what the body's throws are checked against, `Promise<V>`
+// forbids them, and with no annotation the rejection is inferred. A `throws` clause on
+// an `async fn` also names the rejection and is checked against the annotation's E.
 
-// A clause on an `async fn` names the promise's rejection. `throws _` infers it from the
-// body's exceptional exits, `throws E` fixes it, and either way the function's external
-// type carries no throws clause of its own — calling it raises nothing.
-func TestInferAsyncThrowsBecomesRejection(t *testing.T) {
+// A clause-less async body may throw; the throw is absorbed into the promise's inferred
+// or annotated rejection rather than rejected the way a sync body's would be.
+func TestInferAsyncThrowsAbsorbedIntoRejection(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "ClauselessThrowInfersTheRejection",
+			src:  `async fn f() { throw "x" }`,
+			want: `fn () -> Promise<never, "x">`,
+		},
+		{
+			// Two throws on different paths union into the rejection, the same join a
+			// sync `throws _` builds.
+			name: "ThrowsOnBothBranchesUnionIntoTheRejection",
+			src:  `async fn f(c: boolean) { if c { throw "a" } else { throw 5 } }`,
+			want: `fn (c: boolean) -> Promise<never, 5 | "a">`,
+		},
+		{
+			// A written E is the declaration the body's throws are checked against, the
+			// requirements' fetchWithError shape.
+			name: "AnnotatedRejectionSlotAbsorbsTheBodysThrows",
+			src:  `async fn f(c: boolean) -> Promise<number, string> { if c { throw "boom" } return 5 }`,
+			want: `fn (c: boolean) -> Promise<number, string>`,
+		},
+		{
+			name: "NonThrowingBodyLeavesTheRejectionNever",
+			src:  `async fn f() { return 5 }`,
+			want: "fn () -> Promise<5>",
+		},
+	})
+}
+
+// A `throws` clause on an `async fn` names the rejection explicitly: `throws _` infers
+// it, `throws E` fixes it, and either way the function's external type carries no throws
+// clause of its own — calling it raises nothing.
+func TestInferAsyncThrowsClauseNamesTheRejection(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
 			name: "WildcardClauseInfersTheRejection",
@@ -35,24 +68,16 @@ func TestInferAsyncThrowsBecomesRejection(t *testing.T) {
 			want: `fn (c: boolean) -> Promise<5, string>`,
 		},
 		{
-			// Two throws on different paths union into the rejection, the same join a
-			// sync `throws _` builds.
-			name: "ThrowsOnBothBranchesUnionIntoTheRejection",
-			src:  `async fn f(c: boolean) throws _ { if c { throw "a" } else { throw 5 } }`,
-			want: `fn (c: boolean) -> Promise<never, 5 | "a">`,
-		},
-		{
-			// The annotation names the external promise, rejection slot included, and the
-			// inferred sink is constrained into it the way the body's return is
-			// constrained into the payload.
-			name: "AnnotatedRejectionSlotAdmitsTheInferredThrows",
-			src:  `async fn f() -> Promise<never, string> throws _ { throw "boom" }`,
-			want: `fn () -> Promise<never, string>`,
-		},
-		{
-			name: "AnnotatedRejectionSlotAdmitsTheDeclaredClause",
+			// The clause and the annotation's E name the rejection twice, so the clause
+			// is checked against the slot and the annotation stays the external face.
+			name: "DeclaredClauseBesideAnAnnotatedRejectionSlot",
 			src:  `async fn f(c: boolean) -> Promise<number, string> throws string { if c { throw "boom" } return 5 }`,
 			want: `fn (c: boolean) -> Promise<number, string>`,
+		},
+		{
+			name: "WildcardClauseFlowsIntoAnAnnotatedRejectionSlot",
+			src:  `async fn f() -> Promise<never, string> throws _ { throw "boom" }`,
+			want: `fn () -> Promise<never, string>`,
 		},
 	})
 }
@@ -63,7 +88,8 @@ func TestInferAsyncThrowsBecomesRejection(t *testing.T) {
 func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
-			// The caller only holds the promise, so its clause-less signature is fine.
+			// The caller only holds the promise, so its clause-less sync signature is
+			// fine.
 			name: "HoldingThePromiseNeedsNoClause",
 			src: `
 				async fn f() throws string { throw "boom" }
@@ -73,27 +99,28 @@ func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 			want:    "fn () -> void",
 		},
 		{
-			name: "AwaitUnderADeclaredClause",
+			// An awaited rejection is absorbed into the awaiting async fn's own
+			// rejection, the re-raise chain the requirements' processData example is
+			// built on.
+			name: "AwaitedRejectionPropagatesIntoTheCallersRejection",
 			src: `
 				async fn f() throws string { throw "boom" }
-				async fn g() throws string { await f() }
+				async fn g() { await f() }
 			`,
 			binding: "g",
 			want:    "fn () -> Promise<void, string>",
 		},
 		{
-			// The rejection propagates through `throws _` into the awaiting function's
-			// own rejection, the re-raise chain the docs' fetchJSON example is built on.
-			name: "AwaitUnderAWildcardClausePropagatesTheRejection",
+			name: "AwaitedRejectionPropagatesThroughAParameter",
 			src: `
-				async fn g(p: Promise<number, string>) throws _ { return await p }
+				async fn g(p: Promise<number, string>) { return await p }
 			`,
 			binding: "g",
 			want:    "fn (p: Promise<number, string>) -> Promise<number, string>",
 		},
 		{
-			// A `try` around the await catches the rejection, so the clause-less caller
-			// is legal — the join with PR10b.
+			// A `try` around the await catches the rejection, so nothing reaches the
+			// caller's own rejection slot — the join with PR10b.
 			name: "TryAroundAwaitCatchesTheRejection",
 			src: `
 				async fn f() throws string { throw "boom" }
@@ -103,9 +130,7 @@ func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 			want:    "fn () -> Promise<void>",
 		},
 		{
-			// Awaiting a promise whose Err is `never` records nothing, so the enclosing
-			// clause stays untouched.
-			name: "AwaitingANonRejectingPromiseNeedsNoClause",
+			name: "AwaitingANonRejectingPromiseAddsNothing",
 			src: `
 				async fn f() { return 5 }
 				async fn g() { await f() }
@@ -116,28 +141,30 @@ func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 	})
 }
 
-// PR10's rules carry over unchanged: no clause means the body may not throw at all, and
-// an awaited rejection needs a clause or a `try` the same way a throwing call does.
-func TestInferAsyncThrowsStillRequiresAClause(t *testing.T) {
+// `Promise<V>` reads its missing E as `never`, so an annotation without a rejection slot
+// holds the body to raising nothing, the way a clause-less sync signature does.
+func TestInferAsyncThrowsHeldToTheAnnotation(t *testing.T) {
 	runThrowsErrCases(t, []throwsErrCase{
 		{
-			name:     "ThrowInAClauselessAsyncFunction",
-			src:      `async fn f() { throw "x" }`,
-			wantErrs: []string{`1:22-1:25: cannot constrain "x" <: never`},
+			name:     "ThrowUnderAOneArgumentPromiseAnnotation",
+			src:      `async fn f() -> Promise<number> { throw "x" }`,
+			wantErrs: []string{`1:41-1:44: cannot constrain "x" <: never`},
 		},
 		{
-			name: "AwaitingARejectingPromiseInAClauselessAsyncFunction",
+			name: "AwaitUnderAOneArgumentPromiseAnnotation",
 			src: `
 				async fn f() throws string { throw "boom" }
-				async fn g() { await f() }
+				async fn g() -> Promise<number> {
+					await f()
+					return 5
+				}
 			`,
-			wantErrs: []string{"3:20-3:29: cannot constrain string <: never"},
+			wantErrs: []string{"4:6-4:15: cannot constrain string <: never"},
 		},
 		{
-			// A one-argument `Promise<T>` annotation reads its rejection slot as
-			// `never`, so a clause beside it declares a rejection the annotation
-			// cannot deliver. The body raises nothing either, so the clause is
-			// flagged unused as well.
+			// A clause beside a one-argument annotation declares a rejection the
+			// annotation cannot deliver. The body raises nothing either, so the clause
+			// is flagged unused as well.
 			name: "ClauseBesideAOneArgumentPromiseAnnotation",
 			src:  `async fn f() -> Promise<number> throws string { return 5 }`,
 			wantErrs: []string{
@@ -148,13 +175,32 @@ func TestInferAsyncThrowsStillRequiresAClause(t *testing.T) {
 	})
 }
 
-// The fetchJSON shape from docs/06_error_handling.md: an async function that awaits a
-// rejecting promise and raises its own error accumulates both into its rejection, and a
-// caller that names every member in catch arms needs no clause of its own.
+// A non-async function can also produce a `Promise<V, E>`, but it can raise of its own:
+// what its body throws reaches its `throws` clause, separate from the promise's
+// rejection slot.
+func TestInferSyncFunctionReturningARejectingPromise(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "OwnThrowsStaysOnTheClause",
+			src: `
+				fn f(p: Promise<number, "a">, c: boolean) throws "boom" {
+					if c { throw "boom" }
+					return p
+				}
+			`,
+			want: `fn (p: Promise<number, "a">, c: boolean) -> Promise<number, "a"> throws "boom"`,
+		},
+	})
+}
+
+// The fetchJSON shape from docs/06_error_handling.md: a clause-less async function that
+// awaits a rejecting promise and raises its own error accumulates both into its
+// rejection, and a caller that names every member in catch arms needs no rejection of
+// its own.
 func TestInferAsyncFetchJSONExample(t *testing.T) {
 	src := `
 		declare fn fetch(url: string) -> Promise<string, "fetch-error">
-		async fn fetchJSON(url: string, ok: boolean) throws _ {
+		async fn fetchJSON(url: string, ok: boolean) {
 			val res = await fetch(url)
 			if ok {
 				return res

--- a/internal/solver/infer_async_throws_test.go
+++ b/internal/solver/infer_async_throws_test.go
@@ -187,6 +187,18 @@ func TestInferAwaitJoinedRejections(t *testing.T) {
 			binding: "g",
 			want:    "fn (c: boolean, p1: Promise<number, string>, p2: Promise<number>) -> Promise<void, string>",
 		},
+		{
+			// Two members rejecting with different types contribute both, so the
+			// caller's rejection is their union.
+			name: "BranchesRejectingWithDifferentTypesUnion",
+			src: `
+				async fn g(c: boolean, p1: Promise<number, "a">, p2: Promise<number, "b">) {
+					await (if c { p1 } else { p2 })
+				}
+			`,
+			binding: "g",
+			want:    `fn (c: boolean, p1: Promise<number, "a">, p2: Promise<number, "b">) -> Promise<void, "a" | "b">`,
+		},
 	})
 }
 

--- a/internal/solver/infer_async_throws_test.go
+++ b/internal/solver/infer_async_throws_test.go
@@ -104,6 +104,17 @@ func TestInferAsyncThrowsClauseRejected(t *testing.T) {
 	})
 }
 
+// The async-clause error blames the clause's annotation and relates the enclosing
+// function, the signature the user would fix, the way the bare-return error does.
+func TestInferAsyncThrowsClauseBlame(t *testing.T) {
+	src := `async fn f() throws string { throw "boom" }`
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs,
+		"1:21-1:27: async function cannot have a throws clause; declare the rejection type in the return type as Promise<..., E> or Promise<_, _>",
+		"string",
+		`async fn f() throws string { throw "boom" }`)
+}
+
 // Calling an async function raises nothing — it returns a promise — so only awaiting the
 // promise is the exceptional exit. The await constrains the promise's Err into the
 // enclosing body's sink the way a throwing call constrains the callee's throws.

--- a/internal/solver/infer_async_throws_test.go
+++ b/internal/solver/infer_async_throws_test.go
@@ -141,6 +141,51 @@ func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 	})
 }
 
+// The raised flag behind the unused-clause warning tracks awaits the way it tracks
+// calls: an await that provably cannot reject leaves a declared clause unused, and one
+// that may reject counts as using it. A var joining several promises rejects when ANY
+// member does, so the answer must not depend on which bound the join recorded first.
+func TestInferAwaitRaisedTracking(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// The awaited callee cannot reject, so the clause is unreachable — the
+			// async twin of a sync clause over a non-throwing call.
+			name: "AwaitingANonRejectingCalleeLeavesTheClauseUnused",
+			src: `
+				async fn f() { return 5 }
+				async fn g() throws string { await f() }
+			`,
+			wantErrs: []string{
+				"3:25-3:31: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
+			},
+		},
+	})
+	runThrowsCases(t, []throwsCase{
+		{
+			// One branch rejects, so the join may reject and the clause is used —
+			// whichever branch the join recorded first.
+			name: "JoinWithARejectingBranchUsesTheClause",
+			src: `
+				async fn g(c: boolean, p1: Promise<number>, p2: Promise<number, string>) throws string {
+					await (if c { p1 } else { p2 })
+				}
+			`,
+			binding: "g",
+			want:    "fn (c: boolean, p1: Promise<number>, p2: Promise<number, string>) -> Promise<void, string>",
+		},
+		{
+			name: "JoinWithARejectingBranchUsesTheClauseOrderSwapped",
+			src: `
+				async fn g(c: boolean, p1: Promise<number, string>, p2: Promise<number>) throws string {
+					await (if c { p1 } else { p2 })
+				}
+			`,
+			binding: "g",
+			want:    "fn (c: boolean, p1: Promise<number, string>, p2: Promise<number>) -> Promise<void, string>",
+		},
+	})
+}
+
 // `Promise<V>` reads its missing E as `never`, so an annotation without a rejection slot
 // holds the body to raising nothing, the way a clause-less sync signature does.
 func TestInferAsyncThrowsHeldToTheAnnotation(t *testing.T) {

--- a/internal/solver/infer_async_throws_test.go
+++ b/internal/solver/infer_async_throws_test.go
@@ -1,0 +1,209 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// PR10c — async rejection. An `async fn` that throws rejects its promise rather than
+// raising to its caller, so the body's throws becomes the promise's Err and the
+// function's own throws stays `never`. The clause still governs the body's sink exactly
+// as on a sync function; only the destination a caller observes moves.
+
+// A clause on an `async fn` names the promise's rejection. `throws _` infers it from the
+// body's exceptional exits, `throws E` fixes it, and either way the function's external
+// type carries no throws clause of its own — calling it raises nothing.
+func TestInferAsyncThrowsBecomesRejection(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "WildcardClauseInfersTheRejection",
+			src:  `async fn f() throws _ { throw "x" }`,
+			want: `fn () -> Promise<never, "x">`,
+		},
+		{
+			// A wildcard sink nothing reached coalesces to `never`, so the promise
+			// renders its one-argument form — the same collapse an unused sync
+			// `throws _` gets.
+			name: "WildcardClauseNothingReachesCoalescesAway",
+			src:  `async fn f() throws _ { return 5 }`,
+			want: "fn () -> Promise<5>",
+		},
+		{
+			name: "DeclaredClauseFixesTheRejection",
+			src:  `async fn f(c: boolean) throws string { if c { throw "boom" } return 5 }`,
+			want: `fn (c: boolean) -> Promise<5, string>`,
+		},
+		{
+			// Two throws on different paths union into the rejection, the same join a
+			// sync `throws _` builds.
+			name: "ThrowsOnBothBranchesUnionIntoTheRejection",
+			src:  `async fn f(c: boolean) throws _ { if c { throw "a" } else { throw 5 } }`,
+			want: `fn (c: boolean) -> Promise<never, 5 | "a">`,
+		},
+		{
+			// The annotation names the external promise, rejection slot included, and the
+			// inferred sink is constrained into it the way the body's return is
+			// constrained into the payload.
+			name: "AnnotatedRejectionSlotAdmitsTheInferredThrows",
+			src:  `async fn f() -> Promise<never, string> throws _ { throw "boom" }`,
+			want: `fn () -> Promise<never, string>`,
+		},
+		{
+			name: "AnnotatedRejectionSlotAdmitsTheDeclaredClause",
+			src:  `async fn f(c: boolean) -> Promise<number, string> throws string { if c { throw "boom" } return 5 }`,
+			want: `fn (c: boolean) -> Promise<number, string>`,
+		},
+	})
+}
+
+// Calling an async function raises nothing — it returns a promise — so only awaiting the
+// promise is the exceptional exit. The await constrains the promise's Err into the
+// enclosing body's sink the way a throwing call constrains the callee's throws.
+func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			// The caller only holds the promise, so its clause-less signature is fine.
+			name: "HoldingThePromiseNeedsNoClause",
+			src: `
+				async fn f() throws string { throw "boom" }
+				fn g() { val p = f() }
+			`,
+			binding: "g",
+			want:    "fn () -> void",
+		},
+		{
+			name: "AwaitUnderADeclaredClause",
+			src: `
+				async fn f() throws string { throw "boom" }
+				async fn g() throws string { await f() }
+			`,
+			binding: "g",
+			want:    "fn () -> Promise<void, string>",
+		},
+		{
+			// The rejection propagates through `throws _` into the awaiting function's
+			// own rejection, the re-raise chain the docs' fetchJSON example is built on.
+			name: "AwaitUnderAWildcardClausePropagatesTheRejection",
+			src: `
+				async fn g(p: Promise<number, string>) throws _ { return await p }
+			`,
+			binding: "g",
+			want:    "fn (p: Promise<number, string>) -> Promise<number, string>",
+		},
+		{
+			// A `try` around the await catches the rejection, so the clause-less caller
+			// is legal — the join with PR10b.
+			name: "TryAroundAwaitCatchesTheRejection",
+			src: `
+				async fn f() throws string { throw "boom" }
+				async fn g() { try { await f() } catch { e => 0 } }
+			`,
+			binding: "g",
+			want:    "fn () -> Promise<void>",
+		},
+		{
+			// Awaiting a promise whose Err is `never` records nothing, so the enclosing
+			// clause stays untouched.
+			name: "AwaitingANonRejectingPromiseNeedsNoClause",
+			src: `
+				async fn f() { return 5 }
+				async fn g() { await f() }
+			`,
+			binding: "g",
+			want:    "fn () -> Promise<void>",
+		},
+	})
+}
+
+// PR10's rules carry over unchanged: no clause means the body may not throw at all, and
+// an awaited rejection needs a clause or a `try` the same way a throwing call does.
+func TestInferAsyncThrowsStillRequiresAClause(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name:     "ThrowInAClauselessAsyncFunction",
+			src:      `async fn f() { throw "x" }`,
+			wantErrs: []string{`1:22-1:25: cannot constrain "x" <: never`},
+		},
+		{
+			name: "AwaitingARejectingPromiseInAClauselessAsyncFunction",
+			src: `
+				async fn f() throws string { throw "boom" }
+				async fn g() { await f() }
+			`,
+			wantErrs: []string{"3:20-3:29: cannot constrain string <: never"},
+		},
+		{
+			// A one-argument `Promise<T>` annotation reads its rejection slot as
+			// `never`, so a clause beside it declares a rejection the annotation
+			// cannot deliver. The body raises nothing either, so the clause is
+			// flagged unused as well.
+			name: "ClauseBesideAOneArgumentPromiseAnnotation",
+			src:  `async fn f() -> Promise<number> throws string { return 5 }`,
+			wantErrs: []string{
+				"1:40-1:46: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
+				"1:40-1:46: cannot constrain string <: never",
+			},
+		},
+	})
+}
+
+// The fetchJSON shape from docs/06_error_handling.md: an async function that awaits a
+// rejecting promise and raises its own error accumulates both into its rejection, and a
+// caller that names every member in catch arms needs no clause of its own.
+func TestInferAsyncFetchJSONExample(t *testing.T) {
+	src := `
+		declare fn fetch(url: string) -> Promise<string, "fetch-error">
+		async fn fetchJSON(url: string, ok: boolean) throws _ {
+			val res = await fetch(url)
+			if ok {
+				return res
+			}
+			throw "syntax-error"
+		}
+		async fn process(url: string, ok: boolean) {
+			try {
+				return await fetchJSON(url, ok)
+			} catch {
+				"fetch-error" => "",
+				"syntax-error" => "",
+			}
+		}
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		`fn (url: string, ok: boolean) -> Promise<string, "fetch-error" | "syntax-error">`,
+		values["fetchJSON"])
+	require.Equal(t,
+		"fn (url: string, ok: boolean) -> Promise<string>",
+		values["process"])
+}
+
+// A `Promise<T, E>` annotation resolves its second argument into the rejection slot, and
+// the promise arms are covariant in it: a rejecting promise fits a wider rejection slot
+// but not a narrower one.
+func TestInferPromiseErrAnnotationVariance(t *testing.T) {
+	runThrowsCases(t, []throwsCase{
+		{
+			name: "RejectionWidensCovariantly",
+			src: `
+				fn f(p: Promise<number, "a">) -> Promise<number, "a" | "b"> {
+					return p
+				}
+			`,
+			want: `fn (p: Promise<number, "a">) -> Promise<number, "a" | "b">`,
+		},
+	})
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name: "RejectionDoesNotNarrow",
+			src: `
+				fn f(p: Promise<number, "a" | "b">) -> Promise<number, "a"> {
+					return p
+				}
+			`,
+			wantErrs: []string{`2:35-2:38: cannot constrain "b" <: "a"`},
+		},
+	})
+}

--- a/internal/solver/infer_async_throws_test.go
+++ b/internal/solver/infer_async_throws_test.go
@@ -271,6 +271,40 @@ func TestInferAsyncFetchJSONExample(t *testing.T) {
 		values["process"])
 }
 
+// A rejecting promise renders its rejection type in diagnostics and in a canonical
+// union, matching the printer's two-argument form.
+func TestInferPromiseErrRendering(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			// describe names the rejection type when the slot holds a concrete type,
+			// so the mismatch reads as the promise the user wrote.
+			name:     "DiagnosticNamesTheRejectingPromise",
+			src:      `fn f(p: Promise<number, string>) { val x: number = p }`,
+			wantErrs: []string{"1:52-1:53: cannot constrain Promise<number, string> <: number"},
+		},
+		{
+			// A bad second argument reports once and recovers the slot to a fresh var,
+			// keeping the Promise wrapper the way a bad payload does.
+			name:     "BadRejectionArgumentRecoversTheWrapper",
+			src:      `fn f(p: Promise<number, Bogus>) { }`,
+			wantErrs: []string{"1:25-1:30: cannot find type `Bogus`"},
+		},
+	})
+	runThrowsCases(t, []throwsCase{
+		{
+			// Two promises differing only in their rejection stay distinct union
+			// members, so the canonical member order consults the rejection slot.
+			name: "PromisesDifferingOnlyInRejectionStayDistinct",
+			src: `
+				fn f(c: boolean, p1: Promise<number, "a">, p2: Promise<number, "b">) {
+					return if c { p1 } else { p2 }
+				}
+			`,
+			want: `fn (c: boolean, p1: Promise<number, "a">, p2: Promise<number, "b">) -> Promise<number, "a"> | Promise<number, "b">`,
+		},
+	})
+}
+
 // A `Promise<T, E>` annotation resolves its second argument into the rejection slot, and
 // the promise arms are covariant in it: a rejecting promise fits a wider rejection slot
 // but not a narrower one.

--- a/internal/solver/infer_async_throws_test.go
+++ b/internal/solver/infer_async_throws_test.go
@@ -7,11 +7,12 @@ import (
 )
 
 // PR10c — async rejection. An `async fn` cannot raise: what its body throws is absorbed
-// by the promise's rejection slot, the E in `-> Promise<V, E>`, and the function's own
-// throws stays `never`. The return annotation's E is the rejection's declaration
-// surface — a written E is what the body's throws are checked against, `Promise<V>`
-// forbids them, and with no annotation the rejection is inferred. A `throws` clause on
-// an `async fn` also names the rejection and is checked against the annotation's E.
+// by the promise's rejection slot, so its signature is always `-> Promise<V, E>` and
+// the E in that annotation is the rejection's only declaration surface. A written E is
+// what the body's throws are checked against, `Promise<V>` forbids them, `Promise<_, _>`
+// infers both arguments, and with no annotation the whole promise is inferred. The
+// `throws` clause form belongs to sync functions; writing one on an `async fn` is
+// rejected.
 
 // A clause-less async body may throw; the throw is absorbed into the promise's inferred
 // or annotated rejection rather than rejected the way a sync body's would be.
@@ -44,40 +45,61 @@ func TestInferAsyncThrowsAbsorbedIntoRejection(t *testing.T) {
 	})
 }
 
-// A `throws` clause on an `async fn` names the rejection explicitly: `throws _` infers
-// it, `throws E` fixes it, and either way the function's external type carries no throws
-// clause of its own — calling it raises nothing.
-func TestInferAsyncThrowsClauseNamesTheRejection(t *testing.T) {
+// The annotation's two slots each accept the `_` placeholder, so `Promise<_, _>` reads
+// the payload off the body's returns and the rejection off its throws, and a written
+// argument beside a `_` fixes only its own slot.
+func TestInferAsyncRejectionAnnotated(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
-			name: "WildcardClauseInfersTheRejection",
-			src:  `async fn f() throws _ { throw "x" }`,
+			name: "WildcardSlotsInferBoth",
+			src:  `async fn f() -> Promise<_, _> { throw "x" }`,
 			want: `fn () -> Promise<never, "x">`,
 		},
 		{
-			// A wildcard sink nothing reached coalesces to `never`, so the promise
-			// renders its one-argument form — the same collapse an unused sync
-			// `throws _` gets.
-			name: "WildcardClauseNothingReachesCoalescesAway",
-			src:  `async fn f() throws _ { return 5 }`,
+			// A wildcard rejection slot nothing reached coalesces to `never`, so the
+			// promise renders its one-argument form.
+			name: "WildcardSlotsNothingThrownCoalescesAway",
+			src:  `async fn f() -> Promise<_, _> { return 5 }`,
 			want: "fn () -> Promise<5>",
 		},
 		{
-			name: "DeclaredClauseFixesTheRejection",
-			src:  `async fn f(c: boolean) throws string { if c { throw "boom" } return 5 }`,
+			name: "WrittenRejectionBesideAWildcardPayload",
+			src:  `async fn f(c: boolean) -> Promise<_, string> { if c { throw "boom" } return 5 }`,
 			want: `fn (c: boolean) -> Promise<5, string>`,
 		},
 		{
-			// The clause and the annotation's E name the rejection twice, so the clause
-			// is checked against the slot and the annotation stays the external face.
-			name: "DeclaredClauseBesideAnAnnotatedRejectionSlot",
-			src:  `async fn f(c: boolean) -> Promise<number, string> throws string { if c { throw "boom" } return 5 }`,
-			want: `fn (c: boolean) -> Promise<number, string>`,
+			name: "WrittenRejectionWithANeverPayload",
+			src:  `async fn f() -> Promise<never, string> { throw "boom" }`,
+			want: `fn () -> Promise<never, string>`,
+		},
+	})
+}
+
+// A `throws` clause on an `async fn` is rejected: the function cannot raise, so there
+// is no clause to declare. Recovery ignores the clause, so the rejection is still read
+// from the annotation or inferred from the body and one diagnostic covers the fault.
+func TestInferAsyncThrowsClauseRejected(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name: "DeclaredClause",
+			src:  `async fn f() throws string { throw "boom" }`,
+			wantErrs: []string{
+				"1:21-1:27: async function cannot have a throws clause; declare the rejection type in the return type as Promise<..., E> or Promise<_, _>",
+			},
 		},
 		{
-			name: "WildcardClauseFlowsIntoAnAnnotatedRejectionSlot",
-			src:  `async fn f() -> Promise<never, string> throws _ { throw "boom" }`,
-			want: `fn () -> Promise<never, string>`,
+			name: "WildcardClause",
+			src:  `async fn f() throws _ { return 5 }`,
+			wantErrs: []string{
+				"1:21-1:22: async function cannot have a throws clause; declare the rejection type in the return type as Promise<..., E> or Promise<_, _>",
+			},
+		},
+		{
+			name: "ClauseBesideAPromiseAnnotation",
+			src:  `async fn f() -> Promise<number> throws string { return 5 }`,
+			wantErrs: []string{
+				"1:40-1:46: async function cannot have a throws clause; declare the rejection type in the return type as Promise<..., E> or Promise<_, _>",
+			},
 		},
 	})
 }
@@ -90,9 +112,9 @@ func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 		{
 			// The caller only holds the promise, so its clause-less sync signature is
 			// fine.
-			name: "HoldingThePromiseNeedsNoClause",
+			name: "HoldingThePromiseRaisesNothing",
 			src: `
-				async fn f() throws string { throw "boom" }
+				async fn f() { throw "boom" }
 				fn g() { val p = f() }
 			`,
 			binding: "g",
@@ -104,11 +126,11 @@ func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 			// built on.
 			name: "AwaitedRejectionPropagatesIntoTheCallersRejection",
 			src: `
-				async fn f() throws string { throw "boom" }
+				async fn f() { throw "boom" }
 				async fn g() { await f() }
 			`,
 			binding: "g",
-			want:    "fn () -> Promise<void, string>",
+			want:    `fn () -> Promise<void, "boom">`,
 		},
 		{
 			name: "AwaitedRejectionPropagatesThroughAParameter",
@@ -123,7 +145,7 @@ func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 			// caller's own rejection slot — the join with PR10b.
 			name: "TryAroundAwaitCatchesTheRejection",
 			src: `
-				async fn f() throws string { throw "boom" }
+				async fn f() { throw "boom" }
 				async fn g() { try { await f() } catch { e => 0 } }
 			`,
 			binding: "g",
@@ -141,32 +163,14 @@ func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 	})
 }
 
-// The raised flag behind the unused-clause warning tracks awaits the way it tracks
-// calls: an await that provably cannot reject leaves a declared clause unused, and one
-// that may reject counts as using it. A var joining several promises rejects when ANY
-// member does, so the answer must not depend on which bound the join recorded first.
-func TestInferAwaitRaisedTracking(t *testing.T) {
-	runThrowsErrCases(t, []throwsErrCase{
-		{
-			// The awaited callee cannot reject, so the clause is unreachable — the
-			// async twin of a sync clause over a non-throwing call.
-			name: "AwaitingANonRejectingCalleeLeavesTheClauseUnused",
-			src: `
-				async fn f() { return 5 }
-				async fn g() throws string { await f() }
-			`,
-			wantErrs: []string{
-				"3:25-3:31: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
-			},
-		},
-	})
+// A var joining several promises rejects when ANY member does, so an awaited join
+// propagates the rejecting member's Err whichever bound the join recorded first.
+func TestInferAwaitJoinedRejections(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
-			// One branch rejects, so the join may reject and the clause is used —
-			// whichever branch the join recorded first.
-			name: "JoinWithARejectingBranchUsesTheClause",
+			name: "RejectingBranchSecond",
 			src: `
-				async fn g(c: boolean, p1: Promise<number>, p2: Promise<number, string>) throws string {
+				async fn g(c: boolean, p1: Promise<number>, p2: Promise<number, string>) {
 					await (if c { p1 } else { p2 })
 				}
 			`,
@@ -174,9 +178,9 @@ func TestInferAwaitRaisedTracking(t *testing.T) {
 			want:    "fn (c: boolean, p1: Promise<number>, p2: Promise<number, string>) -> Promise<void, string>",
 		},
 		{
-			name: "JoinWithARejectingBranchUsesTheClauseOrderSwapped",
+			name: "RejectingBranchFirst",
 			src: `
-				async fn g(c: boolean, p1: Promise<number, string>, p2: Promise<number>) throws string {
+				async fn g(c: boolean, p1: Promise<number, string>, p2: Promise<number>) {
 					await (if c { p1 } else { p2 })
 				}
 			`,
@@ -198,24 +202,13 @@ func TestInferAsyncThrowsHeldToTheAnnotation(t *testing.T) {
 		{
 			name: "AwaitUnderAOneArgumentPromiseAnnotation",
 			src: `
-				async fn f() throws string { throw "boom" }
+				async fn f() { throw "boom" }
 				async fn g() -> Promise<number> {
 					await f()
 					return 5
 				}
 			`,
-			wantErrs: []string{"4:6-4:15: cannot constrain string <: never"},
-		},
-		{
-			// A clause beside a one-argument annotation declares a rejection the
-			// annotation cannot deliver. The body raises nothing either, so the clause
-			// is flagged unused as well.
-			name: "ClauseBesideAOneArgumentPromiseAnnotation",
-			src:  `async fn f() -> Promise<number> throws string { return 5 }`,
-			wantErrs: []string{
-				"1:40-1:46: the body raises nothing, so the declared `throws string` is unreachable; drop the clause",
-				"1:40-1:46: cannot constrain string <: never",
-			},
+			wantErrs: []string{`4:6-4:15: cannot constrain "boom" <: never`},
 		},
 	})
 }

--- a/internal/solver/infer_async_throws_test.go
+++ b/internal/solver/infer_async_throws_test.go
@@ -174,8 +174,10 @@ func TestInferAsyncRejectionSurfacesAtAwait(t *testing.T) {
 	})
 }
 
-// A var joining several promises rejects when ANY member does, so an awaited join
-// propagates the rejecting member's Err whichever bound the join recorded first.
+// Every rejection an async body can observe accumulates in one sink, so the rejections
+// of several awaited promises union there. They reach it two ways. A single `await` over
+// a joined var rejects when ANY member does, whichever bound the join recorded first.
+// Separate `await` sites each contribute their own promise's Err.
 func TestInferAwaitJoinedRejections(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
@@ -209,6 +211,21 @@ func TestInferAwaitJoinedRejections(t *testing.T) {
 			`,
 			binding: "g",
 			want:    `fn (c: boolean, p1: Promise<number, "a">, p2: Promise<number, "b">) -> Promise<void, "a" | "b">`,
+		},
+		{
+			// Two await sites reach the same sink, so their rejections union there even
+			// though no join brought the promises together. The payloads stay separate,
+			// each binding taking its own promise's value.
+			name: "SeparateAwaitsRejectingWithDifferentTypesUnion",
+			src: `
+				async fn g(p1: Promise<number, "a">, p2: Promise<string, "b">) {
+					val a = await p1
+					val b = await p2
+					return b
+				}
+			`,
+			binding: "g",
+			want:    `fn (p1: Promise<number, "a">, p2: Promise<string, "b">) -> Promise<string, "a" | "b">`,
 		},
 	})
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -907,15 +907,9 @@ func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, annPromise *soltyp
 	if annPromise == nil {
 		// A non-Promise annotation like `-> number` is rejected here; an unresolved one
 		// was already reported. Either way recover as the no-annotation case so the
-		// external face stays Promise-shaped and callers don't cascade. A bodyless fn
-		// has no body to recover from, so wrap unknown rather than the synthetic Void.
-		if ann != nil {
-			if annOK {
-				c.report(&AsyncReturnNotPromiseError{Return: ann, Fn: node})
-			}
-			if !hasBody {
-				bodyType = &soltype.UnknownType{}
-			}
+		// external face stays Promise-shaped and callers don't cascade.
+		if ann != nil && annOK {
+			c.report(&AsyncReturnNotPromiseError{Return: ann, Fn: node})
 		}
 		return c.wrapPromise(node, bodyType, throws)
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -309,23 +309,30 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// An async fn cannot raise — its body's throws are absorbed by the promise's
 	// rejection slot — so the E in a `-> Promise<V, E>` return annotation is the
 	// rejection's declaration surface, and the annotation resolves before the body the
-	// way a clause does. A written E seeds the sink, so the body's throws are checked
-	// against it at each exit; `Promise<V>` reads E as `never` and forbids them. With
-	// no clause and no usable annotation the sink is a fresh variable and the
-	// rejection is inferred, where a sync body would be held to `never`. A written
+	// way a clause does. Whether it resolved to a Promise is decided once, here, and
+	// asyncPromise carries the answer to every later consumer. A written E seeds the
+	// sink, so the body's throws are checked against it at each exit; `Promise<V>`
+	// reads E as `never` and forbids them. With no clause and no usable annotation the
+	// sink is left nil, so the rejection is inferred through throwsSink's lazy mint on
+	// the body's first exceptional exit and a body with none hands the nil shorthand
+	// straight to the wrap, where a sync body would be held to `never`. A written
 	// clause takes precedence and names the rejection directly; the async arm below
 	// checks it against the annotation's E once the body is walked.
 	var asyncAnnT soltype.Type
 	asyncAnnOK := false
+	var asyncPromise *soltype.PromiseType
 	if sig.Async {
 		if sig.Return != nil {
 			asyncAnnT, asyncAnnOK = c.resolveTypeAnn(declScope, sig.Return, lvl)
+			if promise, isPromise := asyncAnnT.(*soltype.PromiseType); asyncAnnOK && isPromise {
+				asyncPromise = promise
+			}
 		}
 		if sig.Throws == nil {
-			if promise, isPromise := asyncAnnT.(*soltype.PromiseType); asyncAnnOK && isPromise {
-				declaredThrows = promise.ErrOrNever()
+			if asyncPromise != nil {
+				declaredThrows = asyncPromise.ErrOrNever()
 			} else {
-				declaredThrows = c.freshAt(lvl)
+				declaredThrows = nil
 			}
 		}
 	}
@@ -414,16 +421,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// function's own Throws stays `never` — calling it returns a promise and raises
 	// nothing.
 	if sig.Async {
-		ret = c.asyncReturn(node, sig.Return, asyncAnnT, asyncAnnOK, ret, throws, hasBody)
+		ret = c.asyncReturn(node, sig.Return, asyncPromise, asyncAnnOK, ret, throws, hasBody)
 		// A written clause beside an annotated Promise names the rejection twice, so
 		// the clause must fit the annotation's slot — `throws _` flows its inferred
 		// union into a written E, and a declared type beside `Promise<V>` is rejected
 		// against the `never` the missing E stands for. Without a clause the sink was
 		// seeded from the annotation itself, so there is nothing left to check.
-		if sig.Throws != nil && asyncAnnOK {
-			if promise, isPromise := asyncAnnT.(*soltype.PromiseType); isPromise {
-				c.constrain(node, throws, promise.ErrOrNever())
-			}
+		if sig.Throws != nil && asyncPromise != nil {
+			c.constrain(node, throws, asyncPromise.ErrOrNever())
 		}
 		throws = nil
 	} else if sig.Return != nil {
@@ -908,39 +913,35 @@ func sameObjectKeys(a, b *soltype.ObjectType) bool {
 // throws is the body's exceptional exit read back from the sink — the annotation's
 // E or the clause's declared type when one was written, or the inferred variable
 // the clause-less form minted — and it becomes the promise's Err. inferFunc has
-// already resolved the return annotation to annT/annOK ahead of the body walk, so
-// the annotation's rejection slot could seed the sink; asyncReturn reads that
-// result rather than resolving again.
-func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, annT soltype.Type, annOK bool, bodyType, throws soltype.Type, hasBody bool) soltype.Type {
-	if ann == nil {
-		return c.wrapPromise(node, bodyType, throws)
-	}
-	if !annOK {
-		// Unsupported annotation — already reported by resolveTypeAnn. Recover as the
-		// no-annotation case would (wrap the inferred body return); a bodyless fn has
-		// no body to recover from, so wrap unknown rather than the synthetic Void.
-		if !hasBody {
-			bodyType = &soltype.UnknownType{}
-		}
-		return c.wrapPromise(node, bodyType, throws)
-	}
-	promise, isPromise := annT.(*soltype.PromiseType)
-	if !isPromise {
-		// A non-Promise annotation on an async fn (`-> number`). Reject it, then
-		// recover exactly like the unsupported-annotation case so the external face
-		// stays Promise-shaped and callers don't cascade.
-		c.report(&AsyncReturnNotPromiseError{Return: ann, Fn: node})
-		if !hasBody {
-			bodyType = &soltype.UnknownType{}
+// already resolved the return annotation and classified it into annPromise ahead
+// of the body walk, so the annotation's rejection slot could seed the sink;
+// asyncReturn reads that result rather than resolving again. annPromise is nil
+// when there is no annotation, when it did not resolve (annOK false, already
+// reported by resolveTypeAnn), and when it resolved to something other than a
+// Promise — only the last of those draws a report here.
+func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, annPromise *soltype.PromiseType, annOK bool, bodyType, throws soltype.Type, hasBody bool) soltype.Type {
+	if annPromise == nil {
+		// A non-Promise annotation on an async fn (`-> number`) is rejected here; an
+		// unresolved one already reported. Either way recover as the no-annotation
+		// case: wrap the inferred body return so the external face stays
+		// Promise-shaped and callers don't cascade. A bodyless fn has no body to
+		// recover from, so wrap unknown rather than the synthetic Void.
+		if ann != nil {
+			if annOK {
+				c.report(&AsyncReturnNotPromiseError{Return: ann, Fn: node})
+			}
+			if !hasBody {
+				bodyType = &soltype.UnknownType{}
+			}
 		}
 		return c.wrapPromise(node, bodyType, throws)
 	}
 	// Constrain the body's (unwrapped) return against the annotation's inner, and
 	// present the annotation as the external type — it already IS the Promise.
 	if hasBody {
-		c.constrain(node, bodyType, promise.Inner) // body <: declared inner
+		c.constrain(node, bodyType, annPromise.Inner) // body <: declared inner
 	}
-	return annT
+	return annPromise
 }
 
 // wrapPromise mints the external `Promise<inner, errT>` face of an async function and
@@ -2626,11 +2627,10 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, AwaitResult)
-	// A resolved operand whose promise declares no rejection leaves the enclosing
-	// clause unused. Any other operand counts as raising, since its Err may still be
-	// an unsolved variable at this point — the same rule inferCall applies to a
-	// callee's throws.
-	if p, ok := resolvePromise(arg); !ok || !isNeverType(p.ErrOrNever()) {
+	// An operand proven unable to reject leaves the enclosing clause unused. Any
+	// other operand counts as raising, since its Err may still be an unsolved
+	// variable at this point — the same rule inferCall applies to a callee's throws.
+	if !awaitedCannotReject(arg) {
 		c.markRaised()
 	}
 	// Synthesize the Promise<U> requirement at this call site. It isn't given its
@@ -2654,22 +2654,30 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	return res
 }
 
-// resolvePromise recovers the concrete PromiseType behind an awaited operand: the
-// promise itself, or a binding var's promise lower bound, the same look-through
-// resolveFunc runs for a callee. It reports false for anything else, in particular a
-// var with no promise bound yet.
-func resolvePromise(t soltype.Type) (*soltype.PromiseType, bool) {
+// awaitedCannotReject reports whether an awaited operand provably cannot reject: it
+// is a promise whose Err is `never`, or a binding var whose EVERY lower bound is one.
+// A var with no bounds, a bound of any other kind, or a rejecting bound all read as
+// "may reject" — the conservative answer that keeps a declared clause counted as
+// used. Every bound is consulted, not just the first, because a var joining a
+// non-rejecting and a rejecting promise rejects, and the bounds' insertion order
+// must not decide the answer.
+func awaitedCannotReject(t soltype.Type) bool {
 	switch t := t.(type) {
 	case *soltype.PromiseType:
-		return t, true
+		return !t.Rejects()
 	case *soltype.TypeVarType:
+		if len(t.LowerBounds) == 0 {
+			return false
+		}
 		for _, lb := range t.LowerBounds {
-			if p, ok := lb.(*soltype.PromiseType); ok {
-				return p, true
+			p, isPromise := lb.(*soltype.PromiseType)
+			if !isPromise || p.Rejects() {
+				return false
 			}
 		}
+		return true
 	}
-	return nil, false
+	return false
 }
 
 // inferThrow types `throw e`. The thrown type is constrained into the enclosing body's

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -402,9 +402,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// So it must itself be a `Promise<…>`; the body returns the unwrapped inner,
 	// constrained `<: inner`, and the annotation is presented as the external type
 	// (no extra wrap). `Promise<_>` is allowed — the `_` resolves to a fresh var the
-	// body flows into, inferring the inner. With no annotation the inferred body
-	// return is wrapped. asyncReturn carries all of this (and the error/recovery
-	// for a bare annotation like `async fn () -> number`).
+	// body flows into, inferring the inner. A bare annotation like
+	// `async fn () -> number` is rejected, and an unresolved one was already reported
+	// by resolveTypeAnn; both recover the way the no-annotation case does, wrapping
+	// the inferred body return so the external face stays Promise-shaped and callers
+	// don't cascade. That wrap is also what an unannotated async fn gets, preserving
+	// M3's no-auto-flatten behavior: a body that already returns a Promise wraps
+	// again, so `async fn (p: Promise<T>) { return await p }` is
+	// `Promise<Promise<T>>`. Awaited<T> is M9.
 	//
 	// Non-async: the annotation governs the return directly — the body is
 	// constrained `<: annotation` and the function returns the annotation (M2's
@@ -417,7 +422,19 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// rather than raising, so the body's throws become the promise's Err and the
 	// function's own Throws stays `never`.
 	if sig.Async {
-		ret = c.asyncReturn(node, sig.Return, asyncPromise, asyncAnnOK, ret, throws, hasBody)
+		if asyncPromise != nil {
+			// Only constrain when there IS a body, for the reason the non-async arm
+			// below spells out.
+			if hasBody {
+				c.constrain(node, ret, asyncPromise.Inner) // body <: declared inner
+			}
+			ret = asyncPromise
+		} else {
+			if sig.Return != nil && asyncAnnOK {
+				c.report(&AsyncReturnNotPromiseError{Return: sig.Return, Fn: node})
+			}
+			ret = c.wrapPromise(node, ret, throws)
+		}
 		throws = nil
 	} else if sig.Return != nil {
 		if annT, ok := c.resolveTypeAnn(declScope, sig.Return, lvl); ok {
@@ -883,42 +900,6 @@ func sameObjectKeys(a, b *soltype.ObjectType) bool {
 		}
 	}
 	return true
-}
-
-// asyncReturn computes an `async fn`'s external return type, which always faces
-// callers as `Promise<T>`. When a return annotation is present it NAMES that
-// external Promise (not the body's value), so it must itself be a `Promise<…>`:
-// the body returns the unwrapped inner, constrained `<: inner`, and the annotation
-// IS the external type — no extra wrap. `Promise<_>` works because `_` resolved to
-// a fresh var the body's return flows into, inferring the inner. A bare annotation
-// (`async fn () -> number`) is an AsyncReturnNotPromiseError; recovery wraps the
-// inferred body return so the external face stays Promise-shaped. With no
-// annotation the inferred body return (bodyType) is wrapped directly — preserving
-// M3's "wrap an inferred return" model and its no-auto-flatten behavior (a body
-// that already returns a Promise still wraps: `async fn (p: Promise<T>) { return
-// await p }` is `Promise<Promise<T>>`; Awaited<T> is M9).
-//
-// throws is the body's exceptional exit read back from the sink; it becomes the
-// promise's Err. inferFunc resolved the return annotation before the body walk so its
-// E could seed that sink, so asyncReturn reads annPromise instead of resolving again.
-// annPromise is nil for no annotation, for one that failed to resolve and was already
-// reported, and for a non-Promise annotation — only the last reports here.
-func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, annPromise *soltype.PromiseType, annOK bool, bodyType, throws soltype.Type, hasBody bool) soltype.Type {
-	if annPromise == nil {
-		// A non-Promise annotation like `-> number` is rejected here; an unresolved one
-		// was already reported. Either way recover as the no-annotation case so the
-		// external face stays Promise-shaped and callers don't cascade.
-		if ann != nil && annOK {
-			c.report(&AsyncReturnNotPromiseError{Return: ann, Fn: node})
-		}
-		return c.wrapPromise(node, bodyType, throws)
-	}
-	// Constrain the body's (unwrapped) return against the annotation's inner, and
-	// present the annotation as the external type — it already IS the Promise.
-	if hasBody {
-		c.constrain(node, bodyType, annPromise.Inner) // body <: declared inner
-	}
-	return annPromise
 }
 
 // wrapPromise mints the external `Promise<inner, errT>` face of an async function and

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -306,6 +306,29 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			declaredThrows = annT
 		}
 	}
+	// An async fn cannot raise — its body's throws are absorbed by the promise's
+	// rejection slot — so the E in a `-> Promise<V, E>` return annotation is the
+	// rejection's declaration surface, and the annotation resolves before the body the
+	// way a clause does. A written E seeds the sink, so the body's throws are checked
+	// against it at each exit; `Promise<V>` reads E as `never` and forbids them. With
+	// no clause and no usable annotation the sink is a fresh variable and the
+	// rejection is inferred, where a sync body would be held to `never`. A written
+	// clause takes precedence and names the rejection directly; the async arm below
+	// checks it against the annotation's E once the body is walked.
+	var asyncAnnT soltype.Type
+	asyncAnnOK := false
+	if sig.Async {
+		if sig.Return != nil {
+			asyncAnnT, asyncAnnOK = c.resolveTypeAnn(declScope, sig.Return, lvl)
+		}
+		if sig.Throws == nil {
+			if promise, isPromise := asyncAnnT.(*soltype.PromiseType); asyncAnnOK && isPromise {
+				declaredThrows = promise.ErrOrNever()
+			} else {
+				declaredThrows = c.freshAt(lvl)
+			}
+		}
+	}
 
 	var ret soltype.Type = &soltype.Void{}
 	var retExprs []ast.Expr
@@ -389,10 +412,19 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// The async arm also moves the body's throws. An `async fn` rejects its promise
 	// rather than raising, so what the body throws becomes the promise's Err and the
 	// function's own Throws stays `never` — calling it returns a promise and raises
-	// nothing. The clause still governs the body's sink exactly as on a sync
-	// function; only the destination a caller observes moves.
+	// nothing.
 	if sig.Async {
-		ret = c.asyncReturn(declScope, node, sig.Return, ret, throws, hasBody, lvl)
+		ret = c.asyncReturn(node, sig.Return, asyncAnnT, asyncAnnOK, ret, throws, hasBody)
+		// A written clause beside an annotated Promise names the rejection twice, so
+		// the clause must fit the annotation's slot — `throws _` flows its inferred
+		// union into a written E, and a declared type beside `Promise<V>` is rejected
+		// against the `never` the missing E stands for. Without a clause the sink was
+		// seeded from the annotation itself, so there is nothing left to check.
+		if sig.Throws != nil && asyncAnnOK {
+			if promise, isPromise := asyncAnnT.(*soltype.PromiseType); isPromise {
+				c.constrain(node, throws, promise.ErrOrNever())
+			}
+		}
 		throws = nil
 	} else if sig.Return != nil {
 		if annT, ok := c.resolveTypeAnn(declScope, sig.Return, lvl); ok {
@@ -873,18 +905,17 @@ func sameObjectKeys(a, b *soltype.ObjectType) bool {
 // that already returns a Promise still wraps: `async fn (p: Promise<T>) { return
 // await p }` is `Promise<Promise<T>>`; Awaited<T> is M9).
 //
-// throws is the body's exceptional exit read back from the sink — the declared
-// clause type, or the inferred variable a `throws _` minted — and it becomes the
-// promise's Err. An annotated Promise already carries its own rejection slot, so
-// throws is constrained `<: Err` the way the body's return is constrained against
-// the inner. A one-argument `Promise<T>` annotation reads Err as `never`, so a
-// clause beside it that declares any rejection is rejected against it.
-func (c *checker) asyncReturn(scope *Scope, node ast.Node, ann ast.TypeAnn, bodyType, throws soltype.Type, hasBody bool, lvl int) soltype.Type {
+// throws is the body's exceptional exit read back from the sink — the annotation's
+// E or the clause's declared type when one was written, or the inferred variable
+// the clause-less form minted — and it becomes the promise's Err. inferFunc has
+// already resolved the return annotation to annT/annOK ahead of the body walk, so
+// the annotation's rejection slot could seed the sink; asyncReturn reads that
+// result rather than resolving again.
+func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, annT soltype.Type, annOK bool, bodyType, throws soltype.Type, hasBody bool) soltype.Type {
 	if ann == nil {
 		return c.wrapPromise(node, bodyType, throws)
 	}
-	annT, ok := c.resolveTypeAnn(scope, ann, lvl)
-	if !ok {
+	if !annOK {
 		// Unsupported annotation — already reported by resolveTypeAnn. Recover as the
 		// no-annotation case would (wrap the inferred body return); a bodyless fn has
 		// no body to recover from, so wrap unknown rather than the synthetic Void.
@@ -909,10 +940,6 @@ func (c *checker) asyncReturn(scope *Scope, node ast.Node, ann ast.TypeAnn, body
 	if hasBody {
 		c.constrain(node, bodyType, promise.Inner) // body <: declared inner
 	}
-	// The body's throws must fit the annotation's rejection slot whether or not there
-	// is a body: a bodyless declare's clause is a declaration to check the same way.
-	// A clause-less body carries `never`, which constrain short-circuits.
-	c.constrain(node, throws, promise.ErrOrNever())
 	return annT
 }
 
@@ -2574,8 +2601,8 @@ func identPatName(pat ast.Pat) (string, bool) {
 // 01-milestones.md §M3). No auto-flatten: U may itself be a Promise, so
 // `await Promise<Promise<T>>` yields `Promise<T>` (Awaited<T> is M9). An await is
 // also an exceptional exit: the requirement's rejection slot is the enclosing
-// body's throws sink, so what the promise rejects with reaches the clause the way
-// a throwing call's throws does (M9 PR10c). `await`
+// body's throws sink, so what the promise rejects with reaches the body's own
+// rejection or clause the way a throwing call's throws does (M9 PR10c). `await`
 // outside an `async` function is rejected by the WALK (this function), not the
 // type rule — the argument is still walked so its own errors surface, and the
 // await contributes a `never` placeholder so a downstream consumer doesn't see a
@@ -2613,9 +2640,9 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	//
 	// The requirement's Err slot is this body's throws sink, so constrain's covariant
 	// rejection rule records what the awaited promise rejects with into it — an await
-	// is an exceptional exit the way a throwing call is, and needs a clause or an
-	// enclosing `try` the same way. A non-rejecting promise carries `never` and
-	// records nothing.
+	// is an exceptional exit the way a throwing call is, absorbed into an async body's
+	// own rejection, caught by an enclosing `try`, or checked against a declared type.
+	// A non-rejecting promise carries `never` and records nothing.
 	//
 	// PR8: a failed argument is the ErrorType recovery placeholder, which absorbs in
 	// constrain, so `<unknown> <: Promise<U>` no longer cascades a spurious second

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -299,25 +299,26 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// The clause is the sink every throw and call is checked against, so it resolves
 	// before the body: `never` for no clause, which is how omitting it declares that the
 	// function raises nothing; T for `throws T`; a fresh var for `throws _` or a bad one.
+	// The clause form belongs to sync functions; the async arm below rejects one.
 	var declaredThrows soltype.Type = &soltype.NeverType{}
-	if sig.Throws != nil {
+	if sig.Throws != nil && !sig.Async {
 		declaredThrows = c.freshAt(lvl)
 		if annT, ok := c.resolveTypeAnn(declScope, sig.Throws, lvl); ok {
 			declaredThrows = annT
 		}
 	}
 	// An async fn cannot raise — its body's throws are absorbed by the promise's
-	// rejection slot — so the E in a `-> Promise<V, E>` return annotation is the
-	// rejection's declaration surface, and the annotation resolves before the body the
-	// way a clause does. Whether it resolved to a Promise is decided once, here, and
-	// asyncPromise carries the answer to every later consumer. A written E seeds the
-	// sink, so the body's throws are checked against it at each exit; `Promise<V>`
-	// reads E as `never` and forbids them. With no clause and no usable annotation the
-	// sink is left nil, so the rejection is inferred through throwsSink's lazy mint on
-	// the body's first exceptional exit and a body with none hands the nil shorthand
-	// straight to the wrap, where a sync body would be held to `never`. A written
-	// clause takes precedence and names the rejection directly; the async arm below
-	// checks it against the annotation's E once the body is walked.
+	// rejection slot — so the E in a `-> Promise<V, E>` return annotation is the ONLY
+	// rejection declaration surface, and the annotation resolves before the body the
+	// way a sync clause does. Whether it resolved to a Promise is decided once, here,
+	// and asyncPromise carries the answer to every later consumer. A written E seeds
+	// the sink, so the body's throws are checked against it at each exit; `Promise<V>`
+	// reads E as `never` and forbids them, and `Promise<_, _>` infers both arguments.
+	// With no usable annotation the sink is left nil, so the rejection is inferred
+	// through throwsSink's lazy mint on the body's first exceptional exit and a body
+	// with none hands the nil shorthand straight to the wrap, where a sync body would
+	// be held to `never`. A written `throws` clause is rejected and then ignored, so
+	// the rejection the recovery infers is the one dropping the clause would produce.
 	var asyncAnnT soltype.Type
 	asyncAnnOK := false
 	var asyncPromise *soltype.PromiseType
@@ -328,12 +329,13 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 				asyncPromise = promise
 			}
 		}
-		if sig.Throws == nil {
-			if asyncPromise != nil {
-				declaredThrows = asyncPromise.ErrOrNever()
-			} else {
-				declaredThrows = nil
-			}
+		if sig.Throws != nil {
+			c.report(&AsyncThrowsClauseError{Throws: sig.Throws, Fn: node})
+		}
+		if asyncPromise != nil {
+			declaredThrows = asyncPromise.ErrOrNever()
+		} else {
+			declaredThrows = nil
 		}
 	}
 
@@ -394,8 +396,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// A declared `throws T` the body never uses obliges every caller to handle an
 	// exception that cannot occur, so warn and point at the clause. `throws _` asks for
 	// inference rather than declaring anything, and a bodyless `declare fn` has no body to
-	// measure against, so neither reaches here.
-	if hasBody && !raised && sig.Throws != nil && !isWildcardAnn(sig.Throws) {
+	// measure against, so neither reaches here. An async fn's clause already drew an
+	// AsyncThrowsClauseError above, so it is not measured either.
+	if hasBody && !raised && sig.Throws != nil && !sig.Async && !isWildcardAnn(sig.Throws) {
 		c.report(&UnusedThrowsClauseError{Ann: sig.Throws, Declared: throws})
 	}
 	// Return-annotation handling diverges by async-ness.
@@ -422,14 +425,6 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// nothing.
 	if sig.Async {
 		ret = c.asyncReturn(node, sig.Return, asyncPromise, asyncAnnOK, ret, throws, hasBody)
-		// A written clause beside an annotated Promise names the rejection twice, so
-		// the clause must fit the annotation's slot — `throws _` flows its inferred
-		// union into a written E, and a declared type beside `Promise<V>` is rejected
-		// against the `never` the missing E stands for. Without a clause the sink was
-		// seeded from the annotation itself, so there is nothing left to check.
-		if sig.Throws != nil && asyncPromise != nil {
-			c.constrain(node, throws, asyncPromise.ErrOrNever())
-		}
 		throws = nil
 	} else if sig.Return != nil {
 		if annT, ok := c.resolveTypeAnn(declScope, sig.Return, lvl); ok {
@@ -911,11 +906,11 @@ func sameObjectKeys(a, b *soltype.ObjectType) bool {
 // await p }` is `Promise<Promise<T>>`; Awaited<T> is M9).
 //
 // throws is the body's exceptional exit read back from the sink — the annotation's
-// E or the clause's declared type when one was written, or the inferred variable
-// the clause-less form minted — and it becomes the promise's Err. inferFunc has
-// already resolved the return annotation and classified it into annPromise ahead
-// of the body walk, so the annotation's rejection slot could seed the sink;
-// asyncReturn reads that result rather than resolving again. annPromise is nil
+// E when one was written, or the inferred variable the annotation-less form
+// minted — and it becomes the promise's Err. inferFunc has already resolved the
+// return annotation and classified it into annPromise ahead of the body walk, so
+// the annotation's rejection slot could seed the sink; asyncReturn reads that
+// result rather than resolving again. annPromise is nil
 // when there is no annotation, when it did not resolve (annOK false, already
 // reported by resolveTypeAnn), and when it resolved to something other than a
 // Promise — only the last of those draws a report here.
@@ -2602,8 +2597,8 @@ func identPatName(pat ast.Pat) (string, bool) {
 // 01-milestones.md §M3). No auto-flatten: U may itself be a Promise, so
 // `await Promise<Promise<T>>` yields `Promise<T>` (Awaited<T> is M9). An await is
 // also an exceptional exit: the requirement's rejection slot is the enclosing
-// body's throws sink, so what the promise rejects with reaches the body's own
-// rejection or clause the way a throwing call's throws does (M9 PR10c). `await`
+// body's throws sink, so what the promise rejects with reaches the enclosing
+// body's own rejection the way a throwing call's throws does (M9 PR10c). `await`
 // outside an `async` function is rejected by the WALK (this function), not the
 // type rule — the argument is still walked so its own errors surface, and the
 // await contributes a `never` placeholder so a downstream consumer doesn't see a
@@ -2627,12 +2622,6 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, AwaitResult)
-	// An operand proven unable to reject leaves the enclosing clause unused. Any
-	// other operand counts as raising, since its Err may still be an unsolved
-	// variable at this point — the same rule inferCall applies to a callee's throws.
-	if !awaitedCannotReject(arg) {
-		c.markRaised()
-	}
 	// Synthesize the Promise<U> requirement at this call site. It isn't given its
 	// own provenance — the operand the user sees blame on is the awaited expression
 	// (`e.Arg`), already recorded by inferExpr; the synthesized Promise wrapper is
@@ -2640,9 +2629,12 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	//
 	// The requirement's Err slot is this body's throws sink, so constrain's covariant
 	// rejection rule records what the awaited promise rejects with into it — an await
-	// is an exceptional exit the way a throwing call is, absorbed into an async body's
-	// own rejection, caught by an enclosing `try`, or checked against a declared type.
-	// A non-rejecting promise carries `never` and records nothing.
+	// is an exceptional exit the way a throwing call is, absorbed into the async
+	// body's own rejection, caught by an enclosing `try`, or checked against the
+	// annotation's E that seeded the sink. A non-rejecting promise carries `never`
+	// and records nothing. No raised flag is tracked here: the unused-clause warning
+	// it would feed measures a `throws` clause, and the async body an await sits in
+	// cannot have one.
 	//
 	// PR8: a failed argument is the ErrorType recovery placeholder, which absorbs in
 	// constrain, so `<unknown> <: Promise<U>` no longer cascades a spurious second
@@ -2652,32 +2644,6 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	c.constrain(e, arg, &soltype.PromiseType{Inner: res, Err: c.throwsSink(lvl)})
 	c.recordType(e, res)
 	return res
-}
-
-// awaitedCannotReject reports whether an awaited operand provably cannot reject: it
-// is a promise whose Err is `never`, or a binding var whose EVERY lower bound is one.
-// A var with no bounds, a bound of any other kind, or a rejecting bound all read as
-// "may reject" — the conservative answer that keeps a declared clause counted as
-// used. Every bound is consulted, not just the first, because a var joining a
-// non-rejecting and a rejecting promise rejects, and the bounds' insertion order
-// must not decide the answer.
-func awaitedCannotReject(t soltype.Type) bool {
-	switch t := t.(type) {
-	case *soltype.PromiseType:
-		return !t.Rejects()
-	case *soltype.TypeVarType:
-		if len(t.LowerBounds) == 0 {
-			return false
-		}
-		for _, lb := range t.LowerBounds {
-			p, isPromise := lb.(*soltype.PromiseType)
-			if !isPromise || p.Rejects() {
-				return false
-			}
-		}
-		return true
-	}
-	return false
 }
 
 // inferThrow types `throw e`. The thrown type is constrained into the enclosing body's

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -940,12 +940,11 @@ func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, annPromise *soltyp
 }
 
 // wrapPromise mints the external `Promise<inner, errT>` face of an async function and
-// records its provenance (PromiseWrap) against the function node. A `never` errT is
-// stored as the nil shorthand so a promise that cannot reject stays the zero value.
+// records its provenance (PromiseWrap) against the function node. errT is the body's
+// throws sink, so it is nil for a body with no exceptional exit and an inference
+// variable otherwise; either way the rejection needs no normalizing here, and every
+// reader collapses nil and an explicit `never` through ErrOrNever.
 func (c *checker) wrapPromise(node ast.Node, inner, errT soltype.Type) soltype.Type {
-	if isNeverType(errT) {
-		errT = nil
-	}
 	wrapped := &soltype.PromiseType{Inner: inner, Err: errT}
 	c.recordProv(wrapped, node, PromiseWrap)
 	return wrapped

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -386,11 +386,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// there is no body, since a synthetic Void would falsely signal "returns
 	// nothing").
 	//
-	// Throws is untouched by either arm. An `async fn` rejects its promise rather than
-	// raising, so what it throws belongs in a rejection slot `soltype.PromiseType` does not
-	// yet have; until it does, an async function keeps it on its own Throws. See PR10c.
+	// The async arm also moves the body's throws. An `async fn` rejects its promise
+	// rather than raising, so what the body throws becomes the promise's Err and the
+	// function's own Throws stays `never` — calling it returns a promise and raises
+	// nothing. The clause still governs the body's sink exactly as on a sync
+	// function; only the destination a caller observes moves.
 	if sig.Async {
-		ret = c.asyncReturn(declScope, node, sig.Return, ret, hasBody, lvl)
+		ret = c.asyncReturn(declScope, node, sig.Return, ret, throws, hasBody, lvl)
+		throws = nil
 	} else if sig.Return != nil {
 		if annT, ok := c.resolveTypeAnn(declScope, sig.Return, lvl); ok {
 			// Only constrain the body when there IS one; a bodyless (declare/ambient)
@@ -869,9 +872,16 @@ func sameObjectKeys(a, b *soltype.ObjectType) bool {
 // M3's "wrap an inferred return" model and its no-auto-flatten behavior (a body
 // that already returns a Promise still wraps: `async fn (p: Promise<T>) { return
 // await p }` is `Promise<Promise<T>>`; Awaited<T> is M9).
-func (c *checker) asyncReturn(scope *Scope, node ast.Node, ann ast.TypeAnn, bodyType soltype.Type, hasBody bool, lvl int) soltype.Type {
+//
+// throws is the body's exceptional exit read back from the sink — the declared
+// clause type, or the inferred variable a `throws _` minted — and it becomes the
+// promise's Err. An annotated Promise already carries its own rejection slot, so
+// throws is constrained `<: Err` the way the body's return is constrained against
+// the inner. A one-argument `Promise<T>` annotation reads Err as `never`, so a
+// clause beside it that declares any rejection is rejected against it.
+func (c *checker) asyncReturn(scope *Scope, node ast.Node, ann ast.TypeAnn, bodyType, throws soltype.Type, hasBody bool, lvl int) soltype.Type {
 	if ann == nil {
-		return c.wrapPromise(node, bodyType)
+		return c.wrapPromise(node, bodyType, throws)
 	}
 	annT, ok := c.resolveTypeAnn(scope, ann, lvl)
 	if !ok {
@@ -881,7 +891,7 @@ func (c *checker) asyncReturn(scope *Scope, node ast.Node, ann ast.TypeAnn, body
 		if !hasBody {
 			bodyType = &soltype.UnknownType{}
 		}
-		return c.wrapPromise(node, bodyType)
+		return c.wrapPromise(node, bodyType, throws)
 	}
 	promise, isPromise := annT.(*soltype.PromiseType)
 	if !isPromise {
@@ -892,20 +902,28 @@ func (c *checker) asyncReturn(scope *Scope, node ast.Node, ann ast.TypeAnn, body
 		if !hasBody {
 			bodyType = &soltype.UnknownType{}
 		}
-		return c.wrapPromise(node, bodyType)
+		return c.wrapPromise(node, bodyType, throws)
 	}
 	// Constrain the body's (unwrapped) return against the annotation's inner, and
 	// present the annotation as the external type — it already IS the Promise.
 	if hasBody {
 		c.constrain(node, bodyType, promise.Inner) // body <: declared inner
 	}
+	// The body's throws must fit the annotation's rejection slot whether or not there
+	// is a body: a bodyless declare's clause is a declaration to check the same way.
+	// A clause-less body carries `never`, which constrain short-circuits.
+	c.constrain(node, throws, promise.ErrOrNever())
 	return annT
 }
 
-// wrapPromise mints the external `Promise<inner>` face of an async function and
-// records its provenance (PromiseWrap) against the function node.
-func (c *checker) wrapPromise(node ast.Node, inner soltype.Type) soltype.Type {
-	wrapped := &soltype.PromiseType{Inner: inner}
+// wrapPromise mints the external `Promise<inner, errT>` face of an async function and
+// records its provenance (PromiseWrap) against the function node. A `never` errT is
+// stored as the nil shorthand so a promise that cannot reject stays the zero value.
+func (c *checker) wrapPromise(node ast.Node, inner, errT soltype.Type) soltype.Type {
+	if isNeverType(errT) {
+		errT = nil
+	}
+	wrapped := &soltype.PromiseType{Inner: inner, Err: errT}
 	c.recordProv(wrapped, node, PromiseWrap)
 	return wrapped
 }
@@ -2554,7 +2572,10 @@ func identPatName(pat ast.Pat) (string, bool) {
 // fresh U, and U is the await's value type — exactly the rule M3's milestone
 // pins ("`await e` requires `e <: Promise<U>` for some `U` and produces `U`",
 // 01-milestones.md §M3). No auto-flatten: U may itself be a Promise, so
-// `await Promise<Promise<T>>` yields `Promise<T>` (Awaited<T> is M9). `await`
+// `await Promise<Promise<T>>` yields `Promise<T>` (Awaited<T> is M9). An await is
+// also an exceptional exit: the requirement's rejection slot is the enclosing
+// body's throws sink, so what the promise rejects with reaches the clause the way
+// a throwing call's throws does (M9 PR10c). `await`
 // outside an `async` function is rejected by the WALK (this function), not the
 // type rule — the argument is still walked so its own errors surface, and the
 // await contributes a `never` placeholder so a downstream consumer doesn't see a
@@ -2578,19 +2599,50 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, AwaitResult)
+	// A resolved operand whose promise declares no rejection leaves the enclosing
+	// clause unused. Any other operand counts as raising, since its Err may still be
+	// an unsolved variable at this point — the same rule inferCall applies to a
+	// callee's throws.
+	if p, ok := resolvePromise(arg); !ok || !isNeverType(p.ErrOrNever()) {
+		c.markRaised()
+	}
 	// Synthesize the Promise<U> requirement at this call site. It isn't given its
 	// own provenance — the operand the user sees blame on is the awaited expression
 	// (`e.Arg`), already recorded by inferExpr; the synthesized Promise wrapper is
 	// internal scaffolding for the constraint, not a user-authored type.
+	//
+	// The requirement's Err slot is this body's throws sink, so constrain's covariant
+	// rejection rule records what the awaited promise rejects with into it — an await
+	// is an exceptional exit the way a throwing call is, and needs a clause or an
+	// enclosing `try` the same way. A non-rejecting promise carries `never` and
+	// records nothing.
 	//
 	// PR8: a failed argument is the ErrorType recovery placeholder, which absorbs in
 	// constrain, so `<unknown> <: Promise<U>` no longer cascades a spurious second
 	// diagnostic — res then stays unbound and coalesces to `never`, the right
 	// recovery for awaiting something broken. The M2-era isRecoveryPlaceholder guard
 	// this site used is gone.
-	c.constrain(e, arg, &soltype.PromiseType{Inner: res})
+	c.constrain(e, arg, &soltype.PromiseType{Inner: res, Err: c.throwsSink(lvl)})
 	c.recordType(e, res)
 	return res
+}
+
+// resolvePromise recovers the concrete PromiseType behind an awaited operand: the
+// promise itself, or a binding var's promise lower bound, the same look-through
+// resolveFunc runs for a callee. It reports false for anything else, in particular a
+// var with no promise bound yet.
+func resolvePromise(t soltype.Type) (*soltype.PromiseType, bool) {
+	switch t := t.(type) {
+	case *soltype.PromiseType:
+		return t, true
+	case *soltype.TypeVarType:
+		for _, lb := range t.LowerBounds {
+			if p, ok := lb.(*soltype.PromiseType); ok {
+				return p, true
+			}
+		}
+	}
+	return nil, false
 }
 
 // inferThrow types `throw e`. The thrown type is constrained into the enclosing body's

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -307,18 +307,12 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			declaredThrows = annT
 		}
 	}
-	// An async fn cannot raise — its body's throws are absorbed by the promise's
-	// rejection slot — so the E in a `-> Promise<V, E>` return annotation is the ONLY
-	// rejection declaration surface, and the annotation resolves before the body the
-	// way a sync clause does. Whether it resolved to a Promise is decided once, here,
-	// and asyncPromise carries the answer to every later consumer. A written E seeds
-	// the sink, so the body's throws are checked against it at each exit; `Promise<V>`
-	// reads E as `never` and forbids them, and `Promise<_, _>` infers both arguments.
-	// With no usable annotation the sink is left nil, so the rejection is inferred
-	// through throwsSink's lazy mint on the body's first exceptional exit and a body
-	// with none hands the nil shorthand straight to the wrap, where a sync body would
-	// be held to `never`. A written `throws` clause is rejected and then ignored, so
-	// the rejection the recovery infers is the one dropping the clause would produce.
+	// An async fn cannot raise: its body's throws become the promise's rejection, so a
+	// `-> Promise<V, E>` return annotation's E is the only surface that declares them.
+	// It resolves before the body the way a sync clause does, and asyncPromise carries
+	// that one classification to every later consumer. A written E seeds the sink and
+	// every exceptional exit is checked against it. A nil sink leaves the rejection to
+	// be inferred, minted lazily by throwsSink. A `throws` clause is rejected here.
 	var asyncAnnT soltype.Type
 	asyncAnnOK := false
 	var asyncPromise *soltype.PromiseType
@@ -396,8 +390,8 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// A declared `throws T` the body never uses obliges every caller to handle an
 	// exception that cannot occur, so warn and point at the clause. `throws _` asks for
 	// inference rather than declaring anything, and a bodyless `declare fn` has no body to
-	// measure against, so neither reaches here. An async fn's clause already drew an
-	// AsyncThrowsClauseError above, so it is not measured either.
+	// measure against, so neither reaches here. Nor does an async clause: it already
+	// drew an AsyncThrowsClauseError.
 	if hasBody && !raised && sig.Throws != nil && !sig.Async && !isWildcardAnn(sig.Throws) {
 		c.report(&UnusedThrowsClauseError{Ann: sig.Throws, Declared: throws})
 	}
@@ -420,9 +414,8 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// nothing").
 	//
 	// The async arm also moves the body's throws. An `async fn` rejects its promise
-	// rather than raising, so what the body throws becomes the promise's Err and the
-	// function's own Throws stays `never` — calling it returns a promise and raises
-	// nothing.
+	// rather than raising, so the body's throws become the promise's Err and the
+	// function's own Throws stays `never`.
 	if sig.Async {
 		ret = c.asyncReturn(node, sig.Return, asyncPromise, asyncAnnOK, ret, throws, hasBody)
 		throws = nil
@@ -905,22 +898,17 @@ func sameObjectKeys(a, b *soltype.ObjectType) bool {
 // that already returns a Promise still wraps: `async fn (p: Promise<T>) { return
 // await p }` is `Promise<Promise<T>>`; Awaited<T> is M9).
 //
-// throws is the body's exceptional exit read back from the sink — the annotation's
-// E when one was written, or the inferred variable the annotation-less form
-// minted — and it becomes the promise's Err. inferFunc has already resolved the
-// return annotation and classified it into annPromise ahead of the body walk, so
-// the annotation's rejection slot could seed the sink; asyncReturn reads that
-// result rather than resolving again. annPromise is nil
-// when there is no annotation, when it did not resolve (annOK false, already
-// reported by resolveTypeAnn), and when it resolved to something other than a
-// Promise — only the last of those draws a report here.
+// throws is the body's exceptional exit read back from the sink; it becomes the
+// promise's Err. inferFunc resolved the return annotation before the body walk so its
+// E could seed that sink, so asyncReturn reads annPromise instead of resolving again.
+// annPromise is nil for no annotation, for one that failed to resolve and was already
+// reported, and for a non-Promise annotation — only the last reports here.
 func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, annPromise *soltype.PromiseType, annOK bool, bodyType, throws soltype.Type, hasBody bool) soltype.Type {
 	if annPromise == nil {
-		// A non-Promise annotation on an async fn (`-> number`) is rejected here; an
-		// unresolved one already reported. Either way recover as the no-annotation
-		// case: wrap the inferred body return so the external face stays
-		// Promise-shaped and callers don't cascade. A bodyless fn has no body to
-		// recover from, so wrap unknown rather than the synthetic Void.
+		// A non-Promise annotation like `-> number` is rejected here; an unresolved one
+		// was already reported. Either way recover as the no-annotation case so the
+		// external face stays Promise-shaped and callers don't cascade. A bodyless fn
+		// has no body to recover from, so wrap unknown rather than the synthetic Void.
 		if ann != nil {
 			if annOK {
 				c.report(&AsyncReturnNotPromiseError{Return: ann, Fn: node})
@@ -941,9 +929,8 @@ func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, annPromise *soltyp
 
 // wrapPromise mints the external `Promise<inner, errT>` face of an async function and
 // records its provenance (PromiseWrap) against the function node. errT is the body's
-// throws sink, so it is nil for a body with no exceptional exit and an inference
-// variable otherwise; either way the rejection needs no normalizing here, and every
-// reader collapses nil and an explicit `never` through ErrOrNever.
+// throws sink — nil when the body has no exceptional exit — and needs no normalizing
+// here, since readers collapse nil and an explicit `never` through ErrOrNever.
 func (c *checker) wrapPromise(node ast.Node, inner, errT soltype.Type) soltype.Type {
 	wrapped := &soltype.PromiseType{Inner: inner, Err: errT}
 	c.recordProv(wrapped, node, PromiseWrap)
@@ -2595,9 +2582,8 @@ func identPatName(pat ast.Pat) (string, bool) {
 // pins ("`await e` requires `e <: Promise<U>` for some `U` and produces `U`",
 // 01-milestones.md §M3). No auto-flatten: U may itself be a Promise, so
 // `await Promise<Promise<T>>` yields `Promise<T>` (Awaited<T> is M9). An await is
-// also an exceptional exit: the requirement's rejection slot is the enclosing
-// body's throws sink, so what the promise rejects with reaches the enclosing
-// body's own rejection the way a throwing call's throws does (M9 PR10c). `await`
+// also an exceptional exit: the requirement's rejection slot is the enclosing body's
+// throws sink, so what the promise rejects with reaches that body's rejection. `await`
 // outside an `async` function is rejected by the WALK (this function), not the
 // type rule — the argument is still walked so its own errors surface, and the
 // await contributes a `never` placeholder so a downstream consumer doesn't see a
@@ -2627,13 +2613,10 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	// internal scaffolding for the constraint, not a user-authored type.
 	//
 	// The requirement's Err slot is this body's throws sink, so constrain's covariant
-	// rejection rule records what the awaited promise rejects with into it — an await
-	// is an exceptional exit the way a throwing call is, absorbed into the async
-	// body's own rejection, caught by an enclosing `try`, or checked against the
-	// annotation's E that seeded the sink. A non-rejecting promise carries `never`
-	// and records nothing. No raised flag is tracked here: the unused-clause warning
-	// it would feed measures a `throws` clause, and the async body an await sits in
-	// cannot have one.
+	// rejection rule records what the awaited promise rejects with into it. A
+	// non-rejecting promise carries `never` and records nothing. No raised flag is
+	// tracked here: it feeds the unused-clause warning, which measures a `throws`
+	// clause, and the async body an await sits in cannot have one.
 	//
 	// PR8: a failed argument is the ErrorType recovery placeholder, which absorbs in
 	// constrain, so `<unknown> <: Promise<U>` no longer cascades a spurious second

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -422,7 +422,13 @@ func compareSameKind(a, b soltype.Type) int {
 		}
 		return compareObjectFields(a, b)
 	case *soltype.PromiseType:
-		return compareType(a.Inner, b.(*soltype.PromiseType).Inner)
+		b := b.(*soltype.PromiseType)
+		if c := compareType(a.Inner, b.Inner); c != 0 {
+			return c
+		}
+		// ErrOrNever reads both sides through the nil-is-never collapse, so two promises
+		// differing only in whether the rejection slot was written compare equal here.
+		return compareType(a.ErrOrNever(), b.ErrOrNever())
 	case *soltype.ArrayType:
 		return compareType(a.Elem, b.(*soltype.ArrayType).Elem)
 	case *soltype.FuncType:

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -182,7 +182,7 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		}
 		// Everywhere else the value flowing in fills it, so `_` is an inference variable at the
 		// current level. `Promise<_>` on an async fn's return relies on this: the body's return
-		// flows into the variable, inferring the inner (asyncReturn).
+		// flows into the variable, inferring the inner.
 		t := c.freshAt(lvl)
 		c.recordProv(t, ta, WildcardAnnotation)
 		return t, true

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -58,7 +58,7 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		// an `async fn () -> Promise<T>` annotation resolves here. Any other name or arity
 		// reports unsupported with a `never` placeholder so the caller can recover by
 		// keeping the inferred type.
-		if ast.QualIdentToString(ta.Name) == "Promise" && len(ta.TypeArgs) == 1 {
+		if ast.QualIdentToString(ta.Name) == "Promise" && (len(ta.TypeArgs) == 1 || len(ta.TypeArgs) == 2) {
 			// A lifetime-annotated Promise (`'a Promise<T>` or `Promise<'a, T>`) is not
 			// supported: M3's PromiseType carries no lifetime, so silently accepting it
 			// would drop the lifetime. Reject it as an unsupported feature rather than
@@ -87,7 +87,18 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 				// `Promise<T0>`) where ErrorType would freeze it to `Promise<error>`.
 				inner = c.freshAt(lvl)
 			}
-			t := &soltype.PromiseType{Inner: inner}
+			// The optional second argument names the rejection type, `Promise<T, E>`. An
+			// unwritten one leaves Err nil, the shorthand for a promise that cannot
+			// reject. A bad second argument recovers to a fresh var for the reason the
+			// payload does above.
+			var errT soltype.Type
+			if len(ta.TypeArgs) == 2 {
+				errT, ok = c.resolveTypeAnn(scope, ta.TypeArgs[1], lvl)
+				if !ok {
+					errT = c.freshAt(lvl)
+				}
+			}
+			t := &soltype.PromiseType{Inner: inner, Err: errT}
 			c.recordProv(t, ta, AnnotationType)
 			return t, true
 		}

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -851,13 +851,16 @@ visitor, `LevelOf`, the printer, `equalType`, and `compareType` each grow the ar
   arm ([infer_expr.go](../../internal/solver/infer_expr.go)) moves the body's sink into
   the wrapped `PromiseType.Err` and leaves the function's own `Throws` at `never`,
   since calling an async function raises nothing — it returns a promise.
-- **A clause on an `async fn` names the rejection, not what a call raises.** The
-  signature is still where the body's exits are checked, so PR10's rules carry over
-  unchanged: no clause means the body may not throw at all, `throws E` fixes the
-  rejection type, and `throws _` infers it. Only the destination moves, from the
-  function's own `Throws` to the promise's `Err`. So `async fn f() throws string { … }`
-  reads `fn () -> Promise<T, string>`, and an async body that throws with no clause is
-  rejected exactly as a sync one is.
+- **The return annotation's E is the rejection's declaration surface.** An async body's
+  throws are absorbed by the promise rather than raised, so the rules PR10 ties to the
+  `throws` clause attach to the E in `-> Promise<V, E>` instead: a written E fixes the
+  rejection type and the body's exits are checked against it, `Promise<V>` reads the
+  missing E as `never` and forbids them, and no annotation infers the rejection the way
+  `throws _` infers a clause. A clause on an `async fn` still names the rejection
+  explicitly — `async fn f() throws string { … }` reads `fn () -> Promise<T, string>` —
+  and beside an annotated E it is checked `<:` that slot. A non-async function returning
+  a `Promise<V, E>` is untouched by all of this: its own throws still reach its own
+  clause, separate from the promise it returns.
 - **`await` is an exceptional exit.** `inferAwait` constrains the awaited promise's
   `Err` into the enclosing body's throws sink, so awaiting a rejecting promise needs a
   clause or a `try` the same way a throwing call does. This is the join with PR10b: a
@@ -870,10 +873,11 @@ visitor, `LevelOf`, the printer, `equalType`, and `compareType` each grow the ar
 - **Async generators.** `AsyncGenerator<…>` is the same question one level out and
   rides on whatever PR11 lands for `Generator`.
 
-**Accept.** `async fn f() throws _ { throw "x" }` renders `fn () -> Promise<never, "x">`
-with no `throws` clause of its own, and the same body without the clause is rejected at
-the `throw`. A caller that only holds the promise needs no clause. A caller that awaits
-it needs `throws "x"` or a `try` around the `await`. The `fetchJSON` example from
+**Accept.** `async fn f() { throw "x" }` renders `fn () -> Promise<never, "x">` with no
+`throws` clause of its own, and the same body under `-> Promise<never>` is rejected at
+the `throw`. A caller that only holds the promise needs no clause. An async caller that
+awaits it absorbs `"x"` into its own rejection, or catches it with a `try` around the
+`await`. The `fetchJSON` example from
 [06_error_handling.md](../../docs/06_error_handling.md) type-checks, including its catch
 arms narrowing the rejection union.
 

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -851,15 +851,15 @@ visitor, `LevelOf`, the printer, `equalType`, and `compareType` each grow the ar
   arm ([infer_expr.go](../../internal/solver/infer_expr.go)) moves the body's sink into
   the wrapped `PromiseType.Err` and leaves the function's own `Throws` at `never`,
   since calling an async function raises nothing — it returns a promise.
-- **The return annotation's E is the rejection's declaration surface.** An async body's
-  throws are absorbed by the promise rather than raised, so the rules PR10 ties to the
-  `throws` clause attach to the E in `-> Promise<V, E>` instead: a written E fixes the
-  rejection type and the body's exits are checked against it, `Promise<V>` reads the
-  missing E as `never` and forbids them, and no annotation infers the rejection the way
-  `throws _` infers a clause. A clause on an `async fn` still names the rejection
-  explicitly — `async fn f() throws string { … }` reads `fn () -> Promise<T, string>` —
-  and beside an annotated E it is checked `<:` that slot. A non-async function returning
-  a `Promise<V, E>` is untouched by all of this: its own throws still reach its own
+- **The return annotation's E is the rejection's only declaration surface.** An async
+  body's throws are absorbed by the promise rather than raised, so the rules PR10 ties
+  to the `throws` clause attach to the E in `-> Promise<V, E>` instead: a written E
+  fixes the rejection type and the body's exits are checked against it, `Promise<V>`
+  reads the missing E as `never` and forbids them, `Promise<_, _>` infers both
+  arguments, and no annotation infers the whole promise. The clause form belongs to
+  sync functions; writing one on an `async fn` draws an AsyncThrowsClauseError pointing
+  at the clause, and recovery ignores it. A non-async function returning a
+  `Promise<V, E>` is untouched by all of this: its own throws still reach its own
   clause, separate from the promise it returns.
 - **`await` is an exceptional exit.** `inferAwait` constrains the awaited promise's
   `Err` into the enclosing body's throws sink, so awaiting a rejecting promise needs a


### PR DESCRIPTION
Implements M9 PR10c. An `async fn` cannot raise: what its body throws is absorbed by the promise it returns, so its own throws stays `never` — calling an async function returns a promise and raises nothing.

**Key changes:**

- **`PromiseType` gains a rejection slot.** `Err` holds the type the promise rejects with, the twin of `FuncType.Throws` for the asynchronous exceptional exit. It is covariant like the payload, and a nil `Err` is shorthand for `never`, so a promise that cannot reject stays the zero value and renders as the one-argument `Promise<T>`. `ErrOrNever()` collapses the nil shorthand and `Rejects()` answers "can this reject" for the printer and the solver alike.

- **The return annotation's `E` is the only rejection declaration surface.** An async function's signature is always `-> Promise<V, E>`. A written `E` is what the body's throws are checked against at each exit, `Promise<V>` reads the missing `E` as `never` and forbids throws entirely, `Promise<_, _>` infers both arguments, and no annotation infers the whole promise.

- **A `throws` clause on an `async fn` is rejected.** The clause form belongs to sync functions, so writing one draws an `AsyncThrowsClauseError` pointing at the clause and naming the annotation to use instead. Recovery ignores the clause, so the rejection is still read from the annotation or inferred from the body and one diagnostic covers the fault. A non-async function returning a `Promise<V, E>` is untouched: its own throws still reach its own `throws` clause, separate from the promise it returns.

- **`await` is an exceptional exit.** `inferAwait` constrains the awaited promise's `Err` into the enclosing body's throws sink, so an awaited rejection is absorbed into the awaiting function's own rejection, or caught by a `try` around the `await`, or checked against the `E` that seeded the sink. Rejections reaching one sink union there, whether from a join of promises at a single `await` or from separate `await` sites.

- **Type-system plumbing.** The visitor, `LevelOf`, the printer, `describe`, `equalTypeWith`, `compareType`, and the `constrain` arm each grow the arm `Throws` grew in PR10, walking `Err` covariantly and reading both spellings of "cannot reject" through `ErrOrNever`. `resolveTypeAnn` accepts an optional second `Promise` type argument.

- **Tests.** `internal/solver/infer_async_throws_test.go` covers absorption into the rejection, the annotation forms including the wildcard slots, the rejected clause and its blame spans, await propagation and unioning, the sync-function contrast, annotation variance, diagnostic rendering, and the `fetchJSON` example from [docs/06_error_handling.md](docs/06_error_handling.md). The PR10c section of the M9 plan is updated to state these rules.

https://claude.ai/code/session_01SC3CmAcz6BBdMppmfASs3R