### PR TITLE
M9 PR11 (2/4) — `soltype.GeneratorType` and its parallel arms

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -509,6 +509,10 @@ func freeTypeVars(t Type) []*TypeVarType {
 			if t.Err != nil {
 				walk(t.Err)
 			}
+		case *GeneratorType:
+			walk(t.Yield)
+			walk(t.Ret)
+			walk(t.Next)
 		case *ArrayType:
 			walk(t.Elem)
 		case *RefType:
@@ -827,6 +831,8 @@ func (p *namedPrinter) printType(t Type) string {
 			return "Promise<" + p.printType(t.Inner) + ", " + p.printType(t.Err) + ">"
 		}
 		return "Promise<" + p.printType(t.Inner) + ">"
+	case *GeneratorType:
+		return t.Name() + "<" + p.printType(t.Yield) + ", " + p.printType(t.Ret) + ", " + p.printType(t.Next) + ">"
 	case *ArrayType:
 		return "Array<" + p.printType(t.Elem) + ">"
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -1382,9 +1382,9 @@ func LevelOf(t Type) int {
 		// freshen it, the same reason the FuncType arm folds in its Throws.
 		return max(LevelOf(t.Inner), throwsLevel(t.Err))
 	case *GeneratorType:
-		// A generator's level is the max over its three slots, so an out-of-level yield,
-		// return, or next type lifts the level and the freshener/extruder prune descends
-		// into all three, the three-child analogue of the PromiseType arm.
+		// A generator's level is the max over its three slots, so an out-of-level `Yield`,
+		// `Ret`, or `Next` lifts the level and the freshener/extruder prune descends into
+		// all three, the three-child analogue of the PromiseType arm.
 		return max(max(LevelOf(t.Yield), LevelOf(t.Ret)), LevelOf(t.Next))
 	case *ArrayType:
 		// An array's level is its element's, the same single-child rule PromiseType follows.

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -776,6 +776,31 @@ func (t *PromiseType) Rejects() bool {
 	return t.Err != nil && !isNever(t.Err)
 }
 
+// GeneratorType is the external face of a `gen fn`: calling one returns a generator
+// object rather than the body's value. It is a dedicated concrete for the reason
+// PromiseType is: one stdlib generic the milestone needs typed ahead of library
+// ingestion in M7.5. Yield is the union of the types the body's `yield` expressions
+// produce, Ret is the body's return type, and Next is the type a `yield` expression
+// evaluates to, the value a caller passes back in through `next(v)`. Yield and Ret
+// are covariant; Next is contravariant, since it is an input the way a parameter is.
+// Async distinguishes an `async gen fn`'s AsyncGenerator from a sync Generator; the
+// two are unrelated under subtyping. All three type fields are always non-nil.
+type GeneratorType struct {
+	Yield Type
+	Ret   Type
+	Next  Type
+	Async bool
+}
+
+// Name returns the stdlib name t renders under, `Generator` or `AsyncGenerator`,
+// so the printer and diagnostics spell the async split the same way.
+func (t *GeneratorType) Name() string {
+	if t.Async {
+		return "AsyncGenerator"
+	}
+	return "Generator"
+}
+
 // ArrayType is a homogeneous sequence of Elem, written `Array<T>`. It is a dedicated concrete
 // for the reason PromiseType is: one stdlib generic the milestone needs typed ahead of library
 // ingestion. It exists to give a rest parameter an element type, the arity-and-element pair a
@@ -1229,6 +1254,7 @@ func (*TupleType) isType()           {}
 func (*ObjectType) isType()          {}
 func (*RefType) isType()             {}
 func (*PromiseType) isType()         {}
+func (*GeneratorType) isType()       {}
 func (*ArrayType) isType()           {}
 func (*Void) isType()                {}
 func (*NullType) isType()            {}
@@ -1355,6 +1381,11 @@ func LevelOf(t Type) int {
 		// out-of-level Err lifts the level and the freshener/extruder prune descends to
 		// freshen it, the same reason the FuncType arm folds in its Throws.
 		return max(LevelOf(t.Inner), throwsLevel(t.Err))
+	case *GeneratorType:
+		// A generator's level is the max over its three slots, so an out-of-level yield,
+		// return, or next type lifts the level and the freshener/extruder prune descends
+		// into all three, the three-child analogue of the PromiseType arm.
+		return max(max(LevelOf(t.Yield), LevelOf(t.Ret)), LevelOf(t.Next))
 	case *ArrayType:
 		// An array's level is its element's, the same single-child rule PromiseType follows.
 		return LevelOf(t.Elem)

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -192,6 +192,22 @@ func (t *PromiseType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *GeneratorType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	yield := cur.Yield.Accept(v, pol)      // covariant, what the generator produces
+	ret := cur.Ret.Accept(v, pol)          // covariant, like a function's return
+	next := cur.Next.Accept(v, pol.Flip()) // contravariant, the value next(v) sends in
+	out := cur
+	if yield != cur.Yield || ret != cur.Ret || next != cur.Next {
+		out = &GeneratorType{Yield: yield, Ret: ret, Next: next, Async: cur.Async}
+	}
+	return v.ExitType(out, pol)
+}
+
 func (t *KeyofType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -200,7 +200,7 @@ func (t *GeneratorType) Accept(v TypeVisitor, pol Polarity) Type {
 	cur := descendReplacement(t, e)
 	yield := cur.Yield.Accept(v, pol)      // covariant, what the generator produces
 	ret := cur.Ret.Accept(v, pol)          // covariant, like a function's return
-	next := cur.Next.Accept(v, pol.Flip()) // contravariant, the value next(v) sends in
+	next := cur.Next.Accept(v, pol.Flip()) // contravariant, the value `next(v)` sends in
 	out := cur
 	if yield != cur.Yield || ret != cur.Ret || next != cur.Next {
 		out = &GeneratorType{Yield: yield, Ret: ret, Next: next, Async: cur.Async}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1336,6 +1336,12 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// differing only in whether the rejection slot was written compare equal here.
 		return ok && equalTypeWith(a.Inner, b.Inner, ctx) &&
 			equalTypeWith(a.ErrOrNever(), b.ErrOrNever(), ctx)
+	case *soltype.GeneratorType:
+		b, ok := b.(*soltype.GeneratorType)
+		return ok && a.Async == b.Async &&
+			equalTypeWith(a.Yield, b.Yield, ctx) &&
+			equalTypeWith(a.Ret, b.Ret, ctx) &&
+			equalTypeWith(a.Next, b.Next, ctx)
 	case *soltype.RefType:
 		b, ok := b.(*soltype.RefType)
 		// Mut must match — a mutable borrow never equals an immutable one — and the

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1129,7 +1129,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		}
 	case *soltype.GeneratorType:
 		// Yield and Ret are covariant, what the generator hands out; Next is
-		// contravariant, the value a caller sends back in through next(v), so the
+		// contravariant, the value a caller sends back in through `next(v)`, so the
 		// constraint reverses like a function parameter's. A sync Generator and an
 		// AsyncGenerator are unrelated, so an async mismatch falls through to the
 		// generic CannotConstrainError below, as an unrelated concrete pair does.

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1127,6 +1127,19 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			// which constrain short-circuits, so it satisfies every super.
 			return append(errs, c.constrain(sub.ErrOrNever(), sup.ErrOrNever(), seen, false)...)
 		}
+	case *soltype.GeneratorType:
+		// Yield and Ret are covariant, what the generator hands out; Next is
+		// contravariant, the value a caller sends back in through next(v), so the
+		// constraint reverses like a function parameter's. A sync Generator and an
+		// AsyncGenerator are unrelated, so an async mismatch falls through to the
+		// generic CannotConstrainError below, as an unrelated concrete pair does.
+		// Each slot is its own annotation context, so the deep-mut flag resets.
+		if sup, ok := super.(*soltype.GeneratorType); ok && sub.Async == sup.Async {
+			errs := c.constrain(sub.Yield, sup.Yield, seen, false)
+			errs = append(errs, c.constrain(sub.Ret, sup.Ret, seen, false)...)
+			errs = append(errs, c.constrain(sup.Next, sub.Next, seen, false)...)
+			return errs
+		}
 	case *soltype.RefType:
 		// THE GATE (M4 C2): the single RefType <: RefType rule. The mut-driven inner
 		// invariance is the highest-risk encoding in the migration — see the M4 plan.

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2495,6 +2495,10 @@ func describe(t soltype.Type) string {
 			return "Promise<" + describe(t.Inner) + ", " + describe(t.Err) + ">"
 		}
 		return "Promise<" + describe(t.Inner) + ">"
+	case *soltype.GeneratorType:
+		// Structural like the Promise arm, so a rejected constraint names the slot
+		// types: `Generator<number, void, never>`.
+		return t.Name() + "<" + describe(t.Yield) + ", " + describe(t.Ret) + ", " + describe(t.Next) + ">"
 	case *soltype.KeyofType:
 		// A `keyof` residual renders structurally, recursing like the Promise arm, so a
 		// rejected constraint names it `keyof <operand>` rather than the default `?`. The

--- a/internal/solver/infer_generator_type_test.go
+++ b/internal/solver/infer_generator_type_test.go
@@ -42,7 +42,7 @@ func TestResolveGeneratorAnnotation(t *testing.T) {
 }
 
 // Yield and Ret are covariant, being what the generator hands out. Next is
-// contravariant, being the value a caller sends back in through next(v), so a generator
+// contravariant, being the value a caller sends back in through `next(v)`, so a generator
 // accepting a wider input satisfies a requirement for a narrower one.
 func TestGeneratorVariance(t *testing.T) {
 	accepts := []struct {

--- a/internal/solver/infer_generator_type_test.go
+++ b/internal/solver/infer_generator_type_test.go
@@ -1,0 +1,115 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A generator annotation resolves to the soltype concrete and renders back in the form
+// it was written, so `Generator<Y, R, N>` and `AsyncGenerator<Y, R, N>` round-trip. No
+// inference produces one yet — a `gen fn` body is walked in a later change — so these
+// reach the type through annotations alone.
+func TestResolveGeneratorAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "SyncGeneratorParam",
+			src:  `fn f(g: Generator<number, string, never>) { return g }`,
+			want: `fn (g: Generator<number, string, never>) -> Generator<number, string, never>`,
+		},
+		{
+			name: "AsyncGeneratorParam",
+			src:  `fn f(g: AsyncGenerator<number, string, never>) { return g }`,
+			want: `fn (g: AsyncGenerator<number, string, never>) -> AsyncGenerator<number, string, never>`,
+		},
+		{
+			name: "DeclaredReturn",
+			src:  `declare fn f() -> Generator<1 | 2, undefined, never>`,
+			want: `fn () -> Generator<1 | 2, undefined, never>`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, test.src)
+			require.Empty(t, errs)
+			require.Equal(t, test.want, values["f"])
+		})
+	}
+}
+
+// Yield and Ret are covariant, being what the generator hands out. Next is
+// contravariant, being the value a caller sends back in through next(v), so a generator
+// accepting a wider input satisfies a requirement for a narrower one.
+func TestGeneratorVariance(t *testing.T) {
+	accepts := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "CovariantYieldAndRet",
+			src: `
+				declare fn g() -> Generator<1, "r", never>
+				val f: fn () -> Generator<number, string, never> = g
+			`,
+		},
+		{
+			name: "ContravariantNext",
+			src: `
+				declare fn g() -> Generator<number, string, unknown>
+				val f: fn () -> Generator<number, string, number> = g
+			`,
+		},
+	}
+	for _, test := range accepts {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Empty(t, errs)
+		})
+	}
+
+	rejects := []struct {
+		name     string
+		src      string
+		wantErrs []string
+	}{
+		{
+			name: "YieldIsNotContravariant",
+			src: `
+				declare fn g() -> Generator<number, string, never>
+				val f: fn () -> Generator<1, string, never> = g
+			`,
+			wantErrs: []string{"3:51-3:52: cannot constrain number <: 1"},
+		},
+		{
+			name: "NextIsNotCovariant",
+			src: `
+				declare fn g() -> Generator<number, string, number>
+				val f: fn () -> Generator<number, string, unknown> = g
+			`,
+			wantErrs: []string{"3:58-3:59: cannot constrain unknown <: number"},
+		},
+		{
+			// A sync generator and an async one are unrelated: neither is a subtype of
+			// the other whatever their slots hold.
+			name: "SyncIsNotAsync",
+			src: `
+				declare fn g() -> Generator<number, string, never>
+				val f: fn () -> AsyncGenerator<number, string, never> = g
+			`,
+			wantErrs: []string{"3:61-3:62: cannot constrain Generator<number, string, never> <: AsyncGenerator<number, string, never>"},
+		},
+	}
+	for _, test := range rejects {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Len(t, errs, len(test.wantErrs))
+			for i, want := range test.wantErrs {
+				require.Equal(t, want, msgWithSpan(errs[i]))
+			}
+		})
+	}
+}

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -429,6 +429,18 @@ func compareSameKind(a, b soltype.Type) int {
 		// ErrOrNever reads both sides through the nil-is-never collapse, so two promises
 		// differing only in whether the rejection slot was written compare equal here.
 		return compareType(a.ErrOrNever(), b.ErrOrNever())
+	case *soltype.GeneratorType:
+		b := b.(*soltype.GeneratorType)
+		if a.Async != b.Async {
+			return boolOrder(a.Async) - boolOrder(b.Async)
+		}
+		if c := compareType(a.Yield, b.Yield); c != 0 {
+			return c
+		}
+		if c := compareType(a.Ret, b.Ret); c != 0 {
+			return c
+		}
+		return compareType(a.Next, b.Next)
 	case *soltype.ArrayType:
 		return compareType(a.Elem, b.(*soltype.ArrayType).Elem)
 	case *soltype.FuncType:
@@ -648,20 +660,22 @@ func typeKindOrder(t soltype.Type) int {
 		return 8
 	case *soltype.PromiseType:
 		return 9
-	case *soltype.ArrayType:
+	case *soltype.GeneratorType:
 		return 10
-	case *soltype.FuncType:
+	case *soltype.ArrayType:
 		return 11
-	case *soltype.UnionType:
+	case *soltype.FuncType:
 		return 12
-	case *soltype.IntersectionType:
+	case *soltype.UnionType:
 		return 13
-	case *soltype.NullType:
+	case *soltype.IntersectionType:
 		return 14
-	case *soltype.Void:
+	case *soltype.NullType:
 		return 15
-	case *soltype.UndefinedType:
+	case *soltype.Void:
 		return 16
+	case *soltype.UndefinedType:
+		return 17
 	}
-	return 17
+	return 18
 }

--- a/internal/solver/productivity.go
+++ b/internal/solver/productivity.go
@@ -206,8 +206,8 @@ func (v *unguardedRefCollector) ExitType(t soltype.Type, _ soltype.Polarity) sol
 // component out of their operand instead of wrapping it, so a lap through one emits nothing either.
 func guardsEveryOperand(t soltype.Type) bool {
 	switch t.(type) {
-	case *soltype.FuncType, *soltype.RefType, *soltype.PromiseType, *soltype.ArrayType,
-		*soltype.TemplateLitType, *soltype.ClassType, *soltype.AliasType:
+	case *soltype.FuncType, *soltype.RefType, *soltype.PromiseType, *soltype.GeneratorType,
+		*soltype.ArrayType, *soltype.TemplateLitType, *soltype.ClassType, *soltype.AliasType:
 		return true
 	default:
 		return false

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -102,6 +102,31 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 			c.recordProv(t, ta, AnnotationType)
 			return t, true
 		}
+		// The built-in Generator<Y, R, N> and AsyncGenerator<Y, R, N>, the external face of a
+		// `gen fn` / `async gen fn`. Like Promise they resolve here only when no user binding
+		// shadows the prelude placeholder, and a lifetime annotation is rejected rather than
+		// silently dropped. All three arguments are required: Y is what the body yields, R what
+		// it returns, and N what a `yield` expression evaluates to.
+		if name := ast.QualIdentToString(ta.Name); (name == "Generator" || name == "AsyncGenerator") && len(ta.TypeArgs) == 3 {
+			if len(ta.LifetimeArgs) > 0 || ta.Lifetime != nil {
+				return c.reportUnsupportedFeature(ta, "lifetime annotation on "+name), false
+			}
+			slots := make([]soltype.Type, 3)
+			for i, arg := range ta.TypeArgs {
+				slot, ok := c.resolveTypeAnn(scope, arg, lvl)
+				if !ok {
+					// Recover the slot to a fresh var and keep the Generator wrapper, for the
+					// reason the Promise arm above gives: the wrapper itself is supported, and
+					// a fresh var is cascade-safe where `never` or `unknown` would provoke a
+					// second failure.
+					slot = c.freshAt(lvl)
+				}
+				slots[i] = slot
+			}
+			t := &soltype.GeneratorType{Yield: slots[0], Ret: slots[1], Next: slots[2], Async: name == "AsyncGenerator"}
+			c.recordProv(t, ta, AnnotationType)
+			return t, true
+		}
 		// The built-in Array<T>, the element-typed sequence a rest parameter binds its trailing
 		// arguments into. It is minimal by design: it carries the element type and nothing else, so
 		// `xs.length` and `xs[0]` do not resolve. A local `Array` shadows the stub today, since

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1733,7 +1733,7 @@ func (e *typeEvaluator) reduceExactness(kind soltype.ExactnessKind, operand solt
 		return op
 	case *soltype.PrimType, *soltype.LitType, *soltype.NeverType, *soltype.UnknownType,
 		*soltype.Void, *soltype.NullType, *soltype.UndefinedType, *soltype.PromiseType,
-		*soltype.ArrayType, *soltype.ErrorType:
+		*soltype.GeneratorType, *soltype.ArrayType, *soltype.ErrorType:
 		return reduced
 	}
 	return &soltype.ExactnessType{Kind: kind, Operand: reduced}


### PR DESCRIPTION
Second of four stacked PRs implementing **PR11** of [planning/simple_sub/m9-implementation-plan.md](planning/simple_sub/m9-implementation-plan.md) — generators. This one adds the type representation and threads it through the solver, with nothing yet producing one.

**Stacked on #1002** — review that first; this PR's diff is against it, not `main`.

The stack, in order:

1. #1002 — `gen fn` syntax, codegen, checker marker
2. **this PR** — `soltype.GeneratorType` and its parallel arms
3. yield inference and the external generator face
4. `yield from` delegation and generator iteration

## What lands

`soltype.GeneratorType` is the external face of a generator function, carried as a dedicated concrete for the reason `PromiseType` is: one stdlib generic the milestone needs typed ahead of M7.5's library ingestion.

- `Yield` is what the body produces, `Ret` what it returns, and `Next` what a `yield` expression evaluates to — the value a caller sends back in through `next(v)`.
- `Yield` and `Ret` are covariant. `Next` is contravariant, being an input the way a parameter is.
- `Async` distinguishes an `AsyncGenerator` from a `Generator`; the two are unrelated under subtyping.

The node reaches every site the analogous `PromiseType` and `ArrayType` concretes do: the visitor, `LevelOf`, the printer, `freeTypeVars`, `describe`, `equalTypeWith`, `constrain`, `compareType` and `typeKindOrder`, `reduceExactness`, and productivity's guard set. `resolveTypeAnn` resolves `Generator<Y, R, N>` and `AsyncGenerator<Y, R, N>` alongside the built-in `Promise` and `Array`, rejecting a lifetime annotation and recovering an unresolvable slot to a fresh variable rather than collapsing the wrapper.

The `typeKindOrder` renumbering shifts the kinds after `PromiseType` by one and preserves their relative order, so canonical union rendering is unchanged.

## Splitting this from the inference

This follows the milestone's own PR1a/PR1b precedent of landing a representation before the algorithm that produces it. Nothing constructs a `GeneratorType` in this PR — walking a `gen fn` body is PR 3 of the stack — so the tests reach the type through annotations. That keeps the variance encoding and the plumbing reviewable on their own, without the inference changes in the same diff.

## Testing

`internal/solver/infer_generator_type_test.go` covers annotation round-tripping for both the sync and async forms, and the variance of all three slots in both directions, including a sync generator failing against an async requirement. `go test ./...` passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfnxBqoHTKYakb748NAP4V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for synchronous and asynchronous generator types.
  - Added `Generator<Yield, Return, Next>` and `AsyncGenerator<Yield, Return, Next>` type annotations.
  - Generator types now support type inference, nested type handling, and clear diagnostic messages.

- **Bug Fixes**
  - Improved compatibility checks for generator yield, return, and next-input types.
  - Correctly rejects mismatches between synchronous and asynchronous generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->