### PR TITLE
M9 PR11 (3/4) — Yield inference and the external generator face

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1925,6 +1925,34 @@ func (e *UnusedThrowsClauseError) Message() string {
 		"` is unreachable; drop the clause"
 }
 
+// GeneratorWithoutYieldError fires when a `gen fn` body contains no `yield` and no
+// `yield from`. The program is well-typed — the function returns a generator whose Yield
+// slot is `never` — but that generator finishes on the first `next()` without ever
+// producing a value, so the marker gives the caller nothing and costs them a generator to
+// unwrap. Fn is the function the marker sits on, which carries the blame span.
+//
+// It is the generator twin of UnusedThrowsClauseError: a declaration the body never uses,
+// reported as a warning rather than an error because the signature is still honest about
+// what it returns. Async selects the wording, since an `async gen fn` returns an
+// AsyncGenerator.
+type GeneratorWithoutYieldError struct {
+	Fn    ast.Node
+	Async bool
+}
+
+func (*GeneratorWithoutYieldError) isSolverError()        {}
+func (e *GeneratorWithoutYieldError) Span() ast.Span      { return e.Fn.Span() }
+func (e *GeneratorWithoutYieldError) Related() []ast.Span { return nil }
+func (e *GeneratorWithoutYieldError) IsWarning() bool     { return true }
+func (e *GeneratorWithoutYieldError) Message() string {
+	kind := "Generator"
+	if e.Async {
+		kind = "AsyncGenerator"
+	}
+	return "the body never yields, so this returns an empty " + kind +
+		"; add a `yield` or drop the `gen`"
+}
+
 // UnreachableReturnAnnotationError fires when a signature declares `-> R` but every path
 // through the body leaves along the exceptional edge, so the body's return type is `never`
 // and no caller can observe an R. The program is well-typed, since `never` is below every

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -925,6 +925,38 @@ type AwaitOutsideAsyncError struct {
 	EnclosingFn ast.Node
 }
 
+// YieldOutsideGenError fires when a `yield` or `yield from` expression appears
+// outside the body of a `gen fn`. Like AwaitOutsideAsyncError it is a WALK
+// rejection, not a type-rule failure: the operand is still walked so its own
+// errors surface, and the yield contributes the error placeholder so callers
+// don't cascade. A closure inside a generator body is rejected too, since the
+// closure itself is not a generator.
+//
+// EnclosingFn is the non-generator function the yield sits in, when there is
+// one — the function the user would mark `gen` to fix the error, surfaced via
+// Related(). It is nil when the yield is at module top-level.
+type YieldOutsideGenError struct {
+	Yield       *ast.YieldExpr
+	EnclosingFn ast.Node
+}
+
+// GenReturnNotGeneratorError fires when a `gen fn` declares a return annotation
+// that is not the matching Generator form. A generator function's external type
+// is always `Generator<Y, R, N>` — `AsyncGenerator<Y, R, N>` when the function
+// is also async — so the annotation NAMES that generator; a bare type
+// (`gen fn () -> number`) and a generator of the wrong async-ness are both
+// rejected. Async records the signature's async-ness so the message names the
+// form to write.
+//
+// Like AsyncReturnNotPromiseError it is a WALK rejection: born in inferFunc
+// (resolveGenSinks) with the annotation and function nodes in hand, so it
+// self-blames from the annotation's span and relates the function via Related().
+type GenReturnNotGeneratorError struct {
+	Return ast.TypeAnn // the offending return annotation
+	Fn     ast.Node    // the enclosing gen function, surfaced via Related()
+	Async  bool        // the signature's async-ness, selecting the expected form
+}
+
 // ReturnOutsideFunctionError fires when a `return` statement is reached outside
 // any function body — e.g. inside an `if` that is part of a top-level `val`
 // initializer. Symmetric to AwaitOutsideAsyncError: the walk rejects it rather
@@ -1095,6 +1127,8 @@ func (*NotIterableError) isSolverError()                    {}
 func (*ReturnOutsideFunctionError) isSolverError()          {}
 func (*AsyncReturnNotPromiseError) isSolverError()          {}
 func (*AsyncThrowsClauseError) isSolverError()              {}
+func (*YieldOutsideGenError) isSolverError()                {}
+func (*GenReturnNotGeneratorError) isSolverError()          {}
 func (*NonExhaustiveMatchError) isSolverError()             {}
 func (*MissingCatchArmError) isSolverError()                {}
 func (*UnhandledRethrowError) isSolverError()               {}
@@ -2086,6 +2120,39 @@ func (e *ReturnOutsideFunctionError) Span() ast.Span      { return e.Return.Span
 func (e *ReturnOutsideFunctionError) Related() []ast.Span { return nil }
 func (e *ReturnOutsideFunctionError) Message() string {
 	return "return can only be used inside a function"
+}
+
+func (e *YieldOutsideGenError) Span() ast.Span { return e.Yield.Span() }
+func (e *YieldOutsideGenError) Related() []ast.Span {
+	// Point at the enclosing function (the one to mark `gen`) when there is one;
+	// empty at module top-level, mirroring AwaitOutsideAsyncError.
+	if e.EnclosingFn != nil {
+		return []ast.Span{e.EnclosingFn.Span()}
+	}
+	return nil
+}
+func (e *YieldOutsideGenError) Message() string {
+	if e.Yield.IsDelegate {
+		return "yield from can only be used inside a generator function"
+	}
+	return "yield can only be used inside a generator function"
+}
+
+func (e *GenReturnNotGeneratorError) Span() ast.Span { return e.Return.Span() }
+func (e *GenReturnNotGeneratorError) Related() []ast.Span {
+	// Point at the enclosing gen function (the signature to fix). Guard a nil Fn to
+	// uphold the "never panic on malformed AST" guarantee, even though inferFunc
+	// always supplies the function node.
+	if e.Fn == nil {
+		return nil
+	}
+	return []ast.Span{e.Fn.Span()}
+}
+func (e *GenReturnNotGeneratorError) Message() string {
+	if e.Async {
+		return "async generator function return type must be an AsyncGenerator; write AsyncGenerator<...>"
+	}
+	return "generator function return type must be a Generator; write Generator<...>"
 }
 
 func (e *ForAwaitOutsideAsyncError) Span() ast.Span { return e.Loop.Span() }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -190,6 +190,11 @@ type funcCtx struct {
 	// the annotation, or to `never` when there is none, matching the old checker's
 	// TNext. Nil outside a generator body.
 	yieldNext soltype.Type
+	// yielded records whether the body has a `yield` at all, which the sink cannot
+	// answer on its own: a body that never yields leaves the sink unconstrained, and so
+	// does one that yields `never`. inferFunc reads it to warn about a `gen` marker the
+	// body never uses. It is the generator twin of raised.
+	yielded bool
 	// lvl is the level this body is walked at, so throwsSink mints the sink there rather
 	// than inside a `val` initializer, which is typed one level deeper. A sink minted deep
 	// gets extruded by a later exit, and the resulting cycle renders as a μ-knot.

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -175,6 +175,21 @@ type funcCtx struct {
 	// declared sink cannot answer since constraining into it leaves no trace. A `throw`
 	// sets it; a call sets it unless the callee is resolved and provably non-throwing.
 	raised bool
+	// gen marks the body of a `gen fn`, the only place a `yield` is legal. A nested
+	// non-generator function opens its own funcCtx with gen false, so a yield inside a
+	// closure is rejected even when the closure sits in a generator's body.
+	gen bool
+	// yields is this body's yield SINK: the type every `yield` operand is constrained
+	// against, the generator twin of throws. inferFunc seeds it before the body is
+	// walked — the annotation's Yield slot when the return annotation is a Generator,
+	// a fresh variable otherwise — so each yield is blamed at its own site. Nil outside
+	// a generator body.
+	yields soltype.Type
+	// yieldNext is the type a `yield` expression evaluates to, the generator's Next
+	// slot: the value a caller passes back in through next(v). inferFunc seeds it from
+	// the annotation, or to `never` when there is none, matching the old checker's
+	// TNext. Nil outside a generator body.
+	yieldNext soltype.Type
 	// lvl is the level this body is walked at, so throwsSink mints the sink there rather
 	// than inside a `val` initializer, which is typed one level deeper. A sink minted deep
 	// gets extruded by a later exit, and the resulting cycle renders as a μ-knot.
@@ -598,6 +613,8 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 		return c.inferBorrow(scope, lvl, e)
 	case *ast.ThrowExpr:
 		return c.inferThrow(scope, lvl, e)
+	case *ast.YieldExpr:
+		return c.inferYield(scope, lvl, e)
 	case *ast.TryCatchExpr:
 		return c.inferTryCatch(scope, lvl, e)
 	case *ast.BinaryExpr:

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -176,7 +176,7 @@ type funcCtx struct {
 	// sets it; a call sets it unless the callee is resolved and provably non-throwing.
 	raised bool
 	// gen marks the body of a `gen fn`, the only place a `yield` is legal. A nested
-	// non-generator function opens its own funcCtx with gen false, so a yield inside a
+	// non-generator function opens its own funcCtx with `gen` clear, so a `yield` inside a
 	// closure is rejected even when the closure sits in a generator's body.
 	gen bool
 	// yields is this body's yield SINK: the type every `yield` operand is constrained
@@ -186,7 +186,7 @@ type funcCtx struct {
 	// a generator body.
 	yields soltype.Type
 	// yieldNext is the type a `yield` expression evaluates to, the generator's Next
-	// slot: the value a caller passes back in through next(v). inferFunc seeds it from
+	// slot: the value a caller passes back in through `next(v)`. inferFunc seeds it from
 	// the annotation, or to `never` when there is none, matching the old checker's
 	// TNext. Nil outside a generator body.
 	yieldNext soltype.Type

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -348,6 +348,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// the walk to warn about a signature the body cannot deliver on.
 	bodyDiverges := false
 	raised := false
+	// yielded records whether a generator body actually yields, read after the walk to
+	// warn about a `gen` marker nothing uses.
+	yielded := false
 	// throws is what a caller sees on the exceptional edge. A bodyless `declare fn` has
 	// only its clause. A body-carrying function reads the sink back once the body is
 	// walked, which is the declared type when there was a clause and the inferred variable
@@ -388,6 +391,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		retExprs = c.fn.returnExprs
 		throws = c.fn.throws
 		raised = c.fn.raised
+		yielded = c.fn.yielded
 		collected := c.popFuncCtx(saved)
 		// A body with no `return` that always leaves along the exceptional edge reaches
 		// no normal exit, so it produces `never`, not the `void` a fall-through body
@@ -407,6 +411,13 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// drew an AsyncThrowsClauseError.
 	if hasBody && !raised && sig.Throws != nil && !sig.Async && !isWildcardAnn(sig.Throws) {
 		c.report(&UnusedThrowsClauseError{Ann: sig.Throws, Declared: throws})
+	}
+	// A `gen fn` whose body never yields still returns a generator, but one that finishes
+	// on the first `next()` without producing a value. The marker then buys the caller
+	// nothing and costs them a generator to unwrap, so warn and let them drop it. A
+	// bodyless `declare gen fn` has no body to measure against, so it does not reach here.
+	if hasBody && !yielded && sig.Gen {
+		c.report(&GeneratorWithoutYieldError{Fn: node, Async: sig.Async})
 	}
 	// Return-annotation handling diverges by async-ness.
 	//
@@ -2760,6 +2771,9 @@ func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Ty
 		c.recordType(e, t)
 		return t
 	}
+	// Recorded before the two forms split, so delegating counts as yielding: a body whose
+	// only yield is a `yield from` does produce values, and its `gen` marker is used.
+	c.fn.yielded = true
 	if e.IsDelegate {
 		// `yield from` forwards another iterable's yields into this body's sink, so it
 		// needs the iteration rules rather than the plain-yield rule below. Treating the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2740,7 +2740,8 @@ func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Ty
 // caller passes back in through next(v). A bare `yield` yields `undefined`.
 //
 // `yield from g` is reported as unsupported. It forwards a delegate's yields rather
-// than yielding the delegate itself, which needs the iteration rules.
+// than yielding the delegate itself, which needs the iteration rules. The delegate is
+// still walked first, so its own errors surface alongside the rejection.
 func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Type {
 	if c.fn == nil || !c.fn.gen {
 		if e.Value != nil {
@@ -2764,6 +2765,9 @@ func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Ty
 		// needs the iteration rules rather than the plain-yield rule below. Treating the
 		// delegate as an ordinary yielded value would put the iterable itself in the sink
 		// instead of its elements, so report it until those rules land.
+		if e.Value != nil {
+			c.inferExpr(scope, lvl, e.Value) // surface delegate-side errors anyway
+		}
 		t := c.reportUnsupportedFeature(e, "yield from")
 		c.recordType(e, t)
 		return t

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -333,6 +333,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		}
 	}
 
+	// A generator's yield sink and next type resolve before the body for the reason the
+	// throws clause does: each `yield` is checked at its own site. The return annotation
+	// on a `gen fn` names the external Generator, so its slots seed the sinks.
+	var gen *genSinks
+	if sig.Gen {
+		gen = c.resolveGenSinks(declScope, node, sig, lvl)
+	}
+
 	var ret soltype.Type = &soltype.Void{}
 	var retExprs []ast.Expr
 	// bodyDiverges records that every path through the body left along the exceptional
@@ -352,6 +360,11 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// body opens its own context, so its returns never leak out here).
 		saved := c.pushFuncCtx(sig.Async, node, lvl)
 		c.fn.throws = declaredThrows
+		if gen != nil {
+			c.fn.gen = true
+			c.fn.yields = gen.yields
+			c.fn.yieldNext = gen.next
+		}
 		// M4 G1: run the liveness pre-pass before walking the body so mutability
 		// transitions are checked. It renames the body's variable nodes (writing the
 		// VarIDs DetermineAliasSource and the alias tracker read) and seeds the
@@ -418,10 +431,24 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// there is no body, since a synthetic Void would falsely signal "returns
 	// nothing").
 	//
-	// The async arm also moves the body's throws. An `async fn` rejects its promise
-	// rather than raising, so the body's throws become the promise's Err and the
-	// function's own Throws stays `never`.
-	if sig.Async {
+	// A generator takes its own arm ahead of the async one: an `async gen fn` faces
+	// callers as an AsyncGenerator, not a Promise, so the async wrap never applies to it.
+	//
+	// A generator keeps its body's raises on its own Throws, which over-approximates.
+	// Advancing the generator is what actually raises, so a caller that only obtains one
+	// is asked to handle an exception it cannot yet observe. An `async fn` moves its
+	// raises into the promise's rejection slot just below, and a generator has no such
+	// slot to move them into. Keeping the raise on the signature errs in the safe
+	// direction: dropping it with nothing reading it in the generator's place would let
+	// the raise escape a clause-less caller that iterates, since iteration advances the
+	// generator. Giving GeneratorType a rejection slot, the way PromiseType has one, is
+	// what puts it in the right place.
+	if sig.Gen {
+		ret = c.genReturn(node, gen, retExprs, ret, hasBody)
+	} else if sig.Async {
+		// The async arm also moves the body's throws. An `async fn` rejects its promise
+		// rather than raising, so the body's throws become the promise's Err and the
+		// function's own Throws stays `never`.
 		if asyncPromise != nil {
 			// Only constrain when there IS a body, for the reason the non-async arm
 			// below spells out.
@@ -909,6 +936,90 @@ func sameObjectKeys(a, b *soltype.ObjectType) bool {
 func (c *checker) wrapPromise(node ast.Node, inner, errT soltype.Type) soltype.Type {
 	wrapped := &soltype.PromiseType{Inner: inner, Err: errT}
 	c.recordProv(wrapped, node, PromiseWrap)
+	return wrapped
+}
+
+// genSinks carries the per-body generator state inferFunc seeds before walking a
+// `gen fn`'s body. yields is the sink each `yield` operand is constrained into, the
+// generator twin of the throws sink. next is the type a `yield` expression evaluates
+// to, the value a caller sends back in through next(v). ann is the resolved return
+// annotation when it is a Generator matching the function's async-ness, kept so
+// genReturn can present the annotation as the external type and constrain the body's
+// return against its Ret slot; it is nil when there is no annotation or the
+// annotation was rejected.
+type genSinks struct {
+	yields soltype.Type
+	next   soltype.Type
+	ann    *soltype.GeneratorType
+	// async records the signature's async-ness so wrapGenerator picks Generator or
+	// AsyncGenerator after popFuncCtx has already restored the enclosing context.
+	async bool
+}
+
+// resolveGenSinks seeds a generator body's yield sink and next type from its return
+// annotation, resolved before the body is walked so each `yield` is checked at its
+// own site, the way the throws clause seeds the throws sink.
+//
+// A `gen fn`'s return annotation names the EXTERNAL Generator, not the body's value,
+// so it must be a `Generator<Y, R, N>` — or `AsyncGenerator<Y, R, N>` for an
+// `async gen fn`. A matching annotation seeds the yield sink with its Y slot and the
+// next type with its N slot. Any other annotation is a GenReturnNotGeneratorError;
+// recovery falls back to the no-annotation seeding so the body still checks. With no
+// annotation the yield sink is a fresh variable the yields flow into, inferring Y the
+// way `throws _` infers a clause, and next is `never`, matching the old checker's
+// TNext: a generator driven by a plain `for` loop is never sent a value.
+func (c *checker) resolveGenSinks(scope *Scope, node ast.Node, sig ast.FuncSig, lvl int) *genSinks {
+	gs := &genSinks{yields: c.freshAt(lvl), next: &soltype.NeverType{}, async: sig.Async}
+	if sig.Return == nil {
+		return gs
+	}
+	annT, ok := c.resolveTypeAnn(scope, sig.Return, lvl)
+	if !ok {
+		// Unsupported annotation — already reported by resolveTypeAnn. Keep the
+		// no-annotation seeding.
+		return gs
+	}
+	g, isGen := annT.(*soltype.GeneratorType)
+	if !isGen || g.Async != sig.Async {
+		// A non-Generator annotation, or a Generator whose async-ness contradicts the
+		// signature (`gen fn () -> AsyncGenerator<…>` and the reverse). Reject it, then
+		// recover with the no-annotation seeding so the external face stays
+		// Generator-shaped and callers don't cascade.
+		c.report(&GenReturnNotGeneratorError{Return: sig.Return, Fn: node, Async: sig.Async})
+		return gs
+	}
+	gs.yields = g.Yield
+	gs.next = g.Next
+	gs.ann = g
+	return gs
+}
+
+// genReturn computes a `gen fn`'s external return type, which always faces callers
+// as a Generator: calling a generator function returns a generator object, not the
+// body's value. With a matching annotation the annotation IS the external type — the
+// body's joined return is constrained against its Ret slot, granting the same
+// owned-mutable upgrade an ordinary return annotation grants. Otherwise the inferred
+// pieces are wrapped: the yield sink becomes Y, the body's joined return becomes R,
+// and next is `never`. A bodyless un-annotated `declare gen fn` wraps `unknown` rather
+// than the synthetic Void, which would falsely signal that it returns nothing.
+func (c *checker) genReturn(node ast.Node, gs *genSinks, retExprs []ast.Expr, bodyType soltype.Type, hasBody bool) soltype.Type {
+	if gs.ann != nil {
+		if hasBody {
+			c.constrainReturnAgainstAnnotation(node, retExprs, bodyType, gs.ann.Ret) // body <: declared Ret
+		}
+		return gs.ann
+	}
+	if !hasBody {
+		bodyType = &soltype.UnknownType{}
+	}
+	return c.wrapGenerator(node, gs, bodyType)
+}
+
+// wrapGenerator mints the external `Generator<Y, R, N>` face of a generator function
+// and records its provenance (GeneratorWrap) against the function node.
+func (c *checker) wrapGenerator(node ast.Node, gs *genSinks, bodyType soltype.Type) soltype.Type {
+	wrapped := &soltype.GeneratorType{Yield: gs.yields, Ret: bodyType, Next: gs.next, Async: gs.async}
+	c.recordProv(wrapped, node, GeneratorWrap)
 	return wrapped
 }
 
@@ -2613,6 +2724,59 @@ func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Ty
 	// Recorded but given no provenance: every `&NeverType{}` shares one address, and Prov
 	// is pointer-keyed, so a second throw would trip recordProv's guard. Info is node-keyed.
 	t := &soltype.NeverType{}
+	c.recordType(e, t)
+	return t
+}
+
+// inferYield types `yield e` and `yield from g`. A yield outside a generator body is
+// a WALK rejection symmetric to AwaitOutsideAsyncError: the operand is still walked so
+// its own errors surface, and the enclosing function — the one to mark `gen` — is
+// related. A closure inside a generator opens its own funcCtx with gen false, so a
+// yield inside it is rejected too, matching JavaScript, where an inner function is not
+// a generator.
+//
+// `yield e` constrains the operand into the body's yield sink, the way a `throw`
+// reaches the throws sink, and evaluates to the generator's Next type — the value a
+// caller passes back in through next(v). A bare `yield` yields `undefined`.
+//
+// `yield from g` is reported as unsupported. It forwards a delegate's yields rather
+// than yielding the delegate itself, which needs the iteration rules.
+func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Type {
+	if c.fn == nil || !c.fn.gen {
+		if e.Value != nil {
+			c.inferExpr(scope, lvl, e.Value) // surface operand-side errors anyway
+		}
+		// When the yield sits in a non-generator function, point Related() at that
+		// function — it is the one to mark `gen`. At module top-level there is no
+		// enclosing function, so EnclosingFn stays nil and Related() is empty.
+		var enclosing ast.Node
+		if c.fn != nil {
+			enclosing = c.fn.node
+		}
+		// report returns the ErrorType recovery placeholder, so the rejected yield
+		// never cascades a downstream failure on top of this error.
+		t := c.report(&YieldOutsideGenError{Yield: e, EnclosingFn: enclosing})
+		c.recordType(e, t)
+		return t
+	}
+	if e.IsDelegate {
+		// `yield from` forwards another iterable's yields into this body's sink, so it
+		// needs the iteration rules rather than the plain-yield rule below. Treating the
+		// delegate as an ordinary yielded value would put the iterable itself in the sink
+		// instead of its elements, so report it until those rules land.
+		t := c.reportUnsupportedFeature(e, "yield from")
+		c.recordType(e, t)
+		return t
+	}
+	var val soltype.Type = &soltype.UndefinedType{}
+	if e.Value != nil {
+		val = c.inferExpr(scope, lvl, e.Value)
+	}
+	c.constrain(e, val, c.fn.yields)
+	// Recorded but given no provenance: the Next type is one shared value seeded on the
+	// funcCtx, and Prov is pointer-keyed, so a second yield would trip recordProv's
+	// guard. Info is node-keyed.
+	t := c.fn.yieldNext
 	c.recordType(e, t)
 	return t
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -333,9 +333,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		}
 	}
 
-	// A generator's yield sink and next type resolve before the body for the reason the
-	// throws clause does: each `yield` is checked at its own site. The return annotation
-	// on a `gen fn` names the external Generator, so its slots seed the sinks.
+	// A generator's yield sink and `next` resolve before the body for the reason the
+	// throws clause does, so each `yield` is checked at its own site. The return
+	// annotation on a `gen fn` names the external Generator, and its slots seed the sinks.
 	var gen *genSinks
 	if sig.Gen {
 		gen = c.resolveGenSinks(declScope, node, sig, lvl)
@@ -412,10 +412,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	if hasBody && !raised && sig.Throws != nil && !sig.Async && !isWildcardAnn(sig.Throws) {
 		c.report(&UnusedThrowsClauseError{Ann: sig.Throws, Declared: throws})
 	}
-	// A `gen fn` whose body never yields still returns a generator, but one that finishes
-	// on the first `next()` without producing a value. The marker then buys the caller
-	// nothing and costs them a generator to unwrap, so warn and let them drop it. A
-	// bodyless `declare gen fn` has no body to measure against, so it does not reach here.
+	// A `gen fn` whose body never yields returns a generator that finishes on the first
+	// `next()` without producing a value, so the marker buys the caller nothing and costs
+	// them a generator to unwrap. A bodyless `declare gen fn` has no body to measure.
 	if hasBody && !yielded && sig.Gen {
 		c.report(&GeneratorWithoutYieldError{Fn: node, Async: sig.Async})
 	}
@@ -443,17 +442,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// nothing").
 	//
 	// A generator takes its own arm ahead of the async one: an `async gen fn` faces
-	// callers as an AsyncGenerator, not a Promise, so the async wrap never applies to it.
+	// callers as an AsyncGenerator, not a Promise, so the async wrap never applies.
 	//
-	// A generator keeps its body's raises on its own Throws, which over-approximates.
-	// Advancing the generator is what actually raises, so a caller that only obtains one
-	// is asked to handle an exception it cannot yet observe. An `async fn` moves its
-	// raises into the promise's rejection slot just below, and a generator has no such
-	// slot to move them into. Keeping the raise on the signature errs in the safe
-	// direction: dropping it with nothing reading it in the generator's place would let
-	// the raise escape a clause-less caller that iterates, since iteration advances the
-	// generator. Giving GeneratorType a rejection slot, the way PromiseType has one, is
-	// what puts it in the right place.
+	// It keeps its body's raises on its own Throws, which over-approximates: advancing
+	// the generator is what raises, so a caller that only obtains one is asked to handle
+	// an exception it cannot yet observe. An `async fn` moves its raises into the
+	// promise's rejection slot just below, and a generator has no such slot. Keeping the
+	// raise here errs safe, since dropping it would let the raise escape a clause-less
+	// caller that iterates. Giving GeneratorType a rejection slot is the real fix.
 	if sig.Gen {
 		ret = c.genReturn(node, gen, retExprs, ret, hasBody)
 	} else if sig.Async {
@@ -950,14 +946,11 @@ func (c *checker) wrapPromise(node ast.Node, inner, errT soltype.Type) soltype.T
 	return wrapped
 }
 
-// genSinks carries the per-body generator state inferFunc seeds before walking a
-// `gen fn`'s body. yields is the sink each `yield` operand is constrained into, the
-// generator twin of the throws sink. next is the type a `yield` expression evaluates
-// to, the value a caller sends back in through next(v). ann is the resolved return
-// annotation when it is a Generator matching the function's async-ness, kept so
-// genReturn can present the annotation as the external type and constrain the body's
-// return against its Ret slot; it is nil when there is no annotation or the
-// annotation was rejected.
+// genSinks is the per-body generator state inferFunc seeds before walking a `gen fn`.
+// `yields` is the sink each `yield` operand is constrained into, the twin of the throws
+// sink. `next` is what a `yield` evaluates to, the value a caller sends back in through
+// `next(v)`. `ann` is the return annotation when it is a matching generator, which
+// genReturn presents as the external type; it is nil otherwise.
 type genSinks struct {
 	yields soltype.Type
 	next   soltype.Type
@@ -967,18 +960,14 @@ type genSinks struct {
 	async bool
 }
 
-// resolveGenSinks seeds a generator body's yield sink and next type from its return
-// annotation, resolved before the body is walked so each `yield` is checked at its
-// own site, the way the throws clause seeds the throws sink.
+// resolveGenSinks seeds a generator body's sinks from its return annotation, before the
+// body is walked so each `yield` is checked at its own site.
 //
-// A `gen fn`'s return annotation names the EXTERNAL Generator, not the body's value,
-// so it must be a `Generator<Y, R, N>` — or `AsyncGenerator<Y, R, N>` for an
-// `async gen fn`. A matching annotation seeds the yield sink with its Y slot and the
-// next type with its N slot. Any other annotation is a GenReturnNotGeneratorError;
-// recovery falls back to the no-annotation seeding so the body still checks. With no
-// annotation the yield sink is a fresh variable the yields flow into, inferring Y the
-// way `throws _` infers a clause, and next is `never`, matching the old checker's
-// TNext: a generator driven by a plain `for` loop is never sent a value.
+// The annotation names the EXTERNAL generator, so it must be `Generator<Y, R, N>`, or
+// `AsyncGenerator<Y, R, N>` when the function is async. A matching one seeds the yield
+// sink from Y and `next` from N. Anything else draws a GenReturnNotGeneratorError and
+// falls back to the no-annotation seeding, where the yield sink is a fresh variable the
+// yields flow into and `next` is `never`, matching the old checker's `TNext`.
 func (c *checker) resolveGenSinks(scope *Scope, node ast.Node, sig ast.FuncSig, lvl int) *genSinks {
 	gs := &genSinks{yields: c.freshAt(lvl), next: &soltype.NeverType{}, async: sig.Async}
 	if sig.Return == nil {
@@ -1005,14 +994,11 @@ func (c *checker) resolveGenSinks(scope *Scope, node ast.Node, sig ast.FuncSig, 
 	return gs
 }
 
-// genReturn computes a `gen fn`'s external return type, which always faces callers
-// as a Generator: calling a generator function returns a generator object, not the
-// body's value. With a matching annotation the annotation IS the external type — the
-// body's joined return is constrained against its Ret slot, granting the same
-// owned-mutable upgrade an ordinary return annotation grants. Otherwise the inferred
-// pieces are wrapped: the yield sink becomes Y, the body's joined return becomes R,
-// and next is `never`. A bodyless un-annotated `declare gen fn` wraps `unknown` rather
-// than the synthetic Void, which would falsely signal that it returns nothing.
+// genReturn computes a `gen fn`'s external return type, always a generator, since
+// calling one returns a generator object rather than the body's value. A matching
+// annotation IS that type, with the body's return constrained against its `Ret` slot.
+// Otherwise the inferred pieces are wrapped. A bodyless `declare gen fn` wraps
+// `unknown` rather than the synthetic Void, which would signal that it returns nothing.
 func (c *checker) genReturn(node ast.Node, gs *genSinks, retExprs []ast.Expr, bodyType soltype.Type, hasBody bool) soltype.Type {
 	if gs.ann != nil {
 		if hasBody {
@@ -2739,20 +2725,17 @@ func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Ty
 	return t
 }
 
-// inferYield types `yield e` and `yield from g`. A yield outside a generator body is
-// a WALK rejection symmetric to AwaitOutsideAsyncError: the operand is still walked so
-// its own errors surface, and the enclosing function — the one to mark `gen` — is
-// related. A closure inside a generator opens its own funcCtx with gen false, so a
-// yield inside it is rejected too, matching JavaScript, where an inner function is not
-// a generator.
+// inferYield types `yield e` and `yield from g`. A yield outside a generator body is a
+// WALK rejection symmetric to AwaitOutsideAsyncError: the operand is still walked so its
+// own errors surface, and the enclosing function is related as the one to mark `gen`. A
+// closure opens its own funcCtx with `gen` clear, so a `yield` inside one is rejected
+// even within a generator, matching JavaScript.
 //
-// `yield e` constrains the operand into the body's yield sink, the way a `throw`
-// reaches the throws sink, and evaluates to the generator's Next type — the value a
-// caller passes back in through next(v). A bare `yield` yields `undefined`.
+// `yield e` constrains its operand into the yield sink and evaluates to the `Next` type,
+// the value a caller sends back in through `next(v)`. A bare `yield` yields `undefined`.
 //
-// `yield from g` is reported as unsupported. It forwards a delegate's yields rather
-// than yielding the delegate itself, which needs the iteration rules. The delegate is
-// still walked first, so its own errors surface alongside the rejection.
+// `yield from g` is reported as unsupported, since forwarding a delegate's yields needs
+// the iteration rules. The delegate is still walked, so its own errors surface too.
 func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Type {
 	if c.fn == nil || !c.fn.gen {
 		if e.Value != nil {

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -265,12 +265,23 @@ func TestGeneratorSubtyping(t *testing.T) {
 // `yield from` forwards a delegate's yields rather than yielding the delegate itself,
 // so it needs the iteration rules and is reported until those land. Treating it as a
 // plain yield would put the iterable in the sink instead of its elements.
+//
+// The delegate is still walked before the rejection is reported, so a mistake inside it
+// is diagnosed instead of being swallowed by the rejection.
 func TestInferYieldFromIsUnsupported(t *testing.T) {
 	runGenErrCases(t, []genErrCase{
 		{
 			name:     "DelegationReported",
 			src:      `gen fn f() { yield from [1, 2] }`,
 			wantErrs: []string{"1:14-1:31: Unsupported: yield from"},
+		},
+		{
+			name: "DelegateErrorsStillSurface",
+			src:  `gen fn f() { yield from missing() }`,
+			wantErrs: []string{
+				"1:25-1:32: Unknown identifier: missing",
+				"1:14-1:34: Unsupported: yield from",
+			},
 		},
 	})
 }

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -80,13 +80,6 @@ func TestInferGenExternalGeneratorFace(t *testing.T) {
 			want: `fn () -> Generator<undefined, void, never>`,
 		},
 		{
-			// A generator with no yield at all still faces callers as a Generator; its
-			// unconstrained yield variable coalesces to `never`.
-			name: "NoYield",
-			src:  `gen fn f() { return "done" }`,
-			want: `fn () -> Generator<never, "done", never>`,
-		},
-		{
 			name: "GenFuncExpr",
 			src:  `val f = gen fn () { yield 1 }`,
 			want: `fn () -> Generator<1, void, never>`,
@@ -147,10 +140,14 @@ func TestInferYieldRequiresGenContext(t *testing.T) {
 			wantErrs: []string{"1:10-1:27: yield from can only be used inside a generator function"},
 		},
 		{
+			// The closure opens its own function context with the marker clear, so its
+			// `yield` is rejected. That same scoping means the yield does not count for
+			// the enclosing `gen fn`, which therefore never yields and warns as well.
 			name: "YieldInAClosureInsideAGenBody",
 			src:  `gen fn f() { val g = fn () { yield 1 } }`,
 			wantErrs: []string{
 				"1:30-1:37: yield can only be used inside a generator function",
+				"1:1-1:41: the body never yields, so this returns an empty Generator; add a `yield` or drop the `gen`",
 			},
 		},
 		{
@@ -284,4 +281,53 @@ func TestInferYieldFromIsUnsupported(t *testing.T) {
 			},
 		},
 	})
+}
+
+// A `gen fn` whose body never yields still returns a generator, but one that finishes on
+// the first `next()` without producing a value, so the marker gives the caller nothing.
+// The warning says so while the function still types as the generator it returns — it is
+// well-typed, just pointless, which is why it warns rather than errors.
+func TestInferGenWithoutYieldWarns(t *testing.T) {
+	runGenErrCases(t, []genErrCase{
+		{
+			name:     "SyncGenNeverYields",
+			src:      `gen fn f() { return "done" }`,
+			wantErrs: []string{"1:1-1:29: the body never yields, so this returns an empty Generator; add a `yield` or drop the `gen`"},
+		},
+		{
+			// An `async gen fn` returns an AsyncGenerator, so the message names that form.
+			name:     "AsyncGenNeverYields",
+			src:      `async gen fn f() { return 1 }`,
+			wantErrs: []string{"1:1-1:30: the body never yields, so this returns an empty AsyncGenerator; add a `yield` or drop the `gen`"},
+		},
+		{
+			// A `gen` method is measured the same way, blamed at the member.
+			name:     "GenMethodNeverYields",
+			src:      `class C { gen m(self) { return 1 } }`,
+			wantErrs: []string{"1:11-1:35: the body never yields, so this returns an empty Generator; add a `yield` or drop the `gen`"},
+		},
+	})
+
+	// The warning does not change the type: a yield-less generator still faces callers as
+	// a Generator whose Yield slot coalesces to `never`.
+	values, _, errs := inferSource(t, `gen fn f() { return "done" }`)
+	require.Len(t, errs, 1)
+	require.True(t, isWarning(errs[0]))
+	require.Equal(t, `fn () -> Generator<never, "done", never>`, values["f"])
+
+	// A body that yields reports nothing at all.
+	_, _, yielding := inferSource(t, `gen fn f() { yield 1 }`)
+	require.Empty(t, yielding)
+
+	// Delegating counts as yielding, so a body whose only yield is a `yield from` does not
+	// draw this warning. It still draws the staged unsupported report, since delegation
+	// itself lands later, so the assertion is that the warning is absent rather than that
+	// nothing is reported.
+	_, _, delegating := inferSource(t, `gen fn f() { yield from [1, 2] }`)
+	require.Len(t, delegating, 1)
+	require.Equal(t, "1:14-1:31: Unsupported: yield from", msgWithSpan(delegating[0]))
+
+	// A bodyless `declare gen fn` has no body to measure, so it is never flagged.
+	_, _, declared := inferSource(t, `declare gen fn f() -> Generator<number, undefined, never>`)
+	require.Empty(t, declared)
 }

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -93,7 +93,7 @@ func TestInferGenExternalGeneratorFace(t *testing.T) {
 		},
 		{
 			// The annotation's Next slot is what a `yield` evaluates to, the value a
-			// caller passes back in through next(v).
+			// caller passes back in through `next(v)`.
 			name: "AnnotatedNextTypesTheYield",
 			src: `
 				gen fn f() -> Generator<number, "done", string> {
@@ -225,7 +225,7 @@ func TestInferGenThrowsStillChecked(t *testing.T) {
 }
 
 // Generator subtyping: Yield and Ret are covariant; Next is contravariant, since it is
-// the value a caller sends back in through next(v).
+// the value a caller sends back in through `next(v)`.
 func TestGeneratorSubtyping(t *testing.T) {
 	runGenCases(t, []genCase{
 		{

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -1,0 +1,276 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// genCase is one accept case: src infers with no error, and the top-level binding named
+// by `binding` renders as `want`. An empty binding names `f`, the name most cases
+// declare, so only a case that inspects another binding spells one out.
+type genCase struct {
+	name    string
+	src     string
+	binding string
+	want    string
+}
+
+// genErrCase is one reject case: src reports exactly the diagnostics in wantErrs, each
+// rendered with its span. The full message is asserted, not a substring.
+type genErrCase struct {
+	name     string
+	src      string
+	wantErrs []string
+}
+
+func runGenCases(t *testing.T, tests []genCase) {
+	t.Helper()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			binding := test.binding
+			if binding == "" {
+				binding = "f"
+			}
+			values, _, errs := inferSource(t, test.src)
+			require.Empty(t, errs)
+			require.Equal(t, test.want, values[binding])
+		})
+	}
+}
+
+func runGenErrCases(t *testing.T, tests []genErrCase) {
+	t.Helper()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Len(t, errs, len(test.wantErrs))
+			for i, want := range test.wantErrs {
+				require.Equal(t, want, msgWithSpan(errs[i]))
+			}
+		})
+	}
+}
+
+// A `gen fn` faces callers as a Generator: Y is the union of what the body yields, R is
+// the body's return type, and N is what a `yield` expression evaluates to — `never`
+// unless the annotation says otherwise, since a generator driven by a plain loop is
+// never sent a value.
+func TestInferGenExternalGeneratorFace(t *testing.T) {
+	runGenCases(t, []genCase{
+		{
+			name: "SingleYield",
+			src:  `gen fn f() { yield 1 }`,
+			want: `fn () -> Generator<1, void, never>`,
+		},
+		{
+			name: "TwoYieldsUnion",
+			src:  `gen fn f() { yield 1 yield "a" }`,
+			want: `fn () -> Generator<1 | "a", void, never>`,
+		},
+		{
+			name: "YieldAndReturn",
+			src:  `gen fn f() { yield 1 return "done" }`,
+			want: `fn () -> Generator<1, "done", never>`,
+		},
+		{
+			// A bare `yield` yields `undefined`, matching JavaScript.
+			name: "BareYield",
+			src:  `gen fn f() { yield }`,
+			want: `fn () -> Generator<undefined, void, never>`,
+		},
+		{
+			// A generator with no yield at all still faces callers as a Generator; its
+			// unconstrained yield variable coalesces to `never`.
+			name: "NoYield",
+			src:  `gen fn f() { return "done" }`,
+			want: `fn () -> Generator<never, "done", never>`,
+		},
+		{
+			name: "GenFuncExpr",
+			src:  `val f = gen fn () { yield 1 }`,
+			want: `fn () -> Generator<1, void, never>`,
+		},
+		{
+			// The annotation names the external Generator; the body checks against its
+			// slots and the annotation is presented as the external type.
+			name: "AnnotatedGenerator",
+			src:  `gen fn f() -> Generator<number, string, never> { yield 1 return "done" }`,
+			want: `fn () -> Generator<number, string, never>`,
+		},
+		{
+			// The annotation's Next slot is what a `yield` evaluates to, the value a
+			// caller passes back in through next(v).
+			name: "AnnotatedNextTypesTheYield",
+			src: `
+				gen fn f() -> Generator<number, "done", string> {
+					val x: string = yield 1
+					return "done"
+				}
+			`,
+			want: `fn () -> Generator<number, "done", string>`,
+		},
+	})
+}
+
+// An `async gen fn` faces callers as an AsyncGenerator, not a Promise: the async wrap
+// never applies to a generator, and `await` is legal in its body.
+func TestInferAsyncGen(t *testing.T) {
+	runGenCases(t, []genCase{
+		{
+			name: "AsyncGenIsAsyncGenerator",
+			src:  `async gen fn f() { yield 1 }`,
+			want: `fn () -> AsyncGenerator<1, void, never>`,
+		},
+		{
+			name: "AwaitInsideAsyncGen",
+			src:  `async gen fn f(p: Promise<number>) { yield await p }`,
+			want: `fn (p: Promise<number>) -> AsyncGenerator<number, void, never>`,
+		},
+	})
+}
+
+// A yield outside a generator body is rejected by the walk, not the type rule: the
+// operand is still walked, and the enclosing function — the one to mark `gen` — is
+// related. A closure inside a generator is not itself a generator, so a yield inside
+// one is rejected too.
+func TestInferYieldRequiresGenContext(t *testing.T) {
+	runGenErrCases(t, []genErrCase{
+		{
+			name:     "YieldInAPlainFunction",
+			src:      `fn f() { yield 1 }`,
+			wantErrs: []string{"1:10-1:17: yield can only be used inside a generator function"},
+		},
+		{
+			name:     "YieldFromInAPlainFunction",
+			src:      `fn f() { yield from [1, 2] }`,
+			wantErrs: []string{"1:10-1:27: yield from can only be used inside a generator function"},
+		},
+		{
+			name: "YieldInAClosureInsideAGenBody",
+			src:  `gen fn f() { val g = fn () { yield 1 } }`,
+			wantErrs: []string{
+				"1:30-1:37: yield can only be used inside a generator function",
+			},
+		},
+		{
+			// `gen` is the marker, so a plain method whose body yields is rejected the
+			// way a plain function is. Writing `gen m(self)` is how a method opts in.
+			name:     "YieldInAPlainMethod",
+			src:      `class C { m(self) { yield 1 } }`,
+			wantErrs: []string{"1:21-1:28: yield can only be used inside a generator function"},
+		},
+	})
+}
+
+// A `gen fn`'s return annotation names the external Generator, so a bare type and a
+// generator of the wrong async-ness are both rejected, and the body still checks under
+// the inferred seeding.
+func TestInferGenReturnAnnotationShape(t *testing.T) {
+	runGenErrCases(t, []genErrCase{
+		{
+			name:     "BareAnnotationRejected",
+			src:      `gen fn f() -> number { yield 1 }`,
+			wantErrs: []string{"1:15-1:21: generator function return type must be a Generator; write Generator<...>"},
+		},
+		{
+			name:     "AsyncGeneratorOnSyncGenRejected",
+			src:      `gen fn f() -> AsyncGenerator<number, undefined, never> { yield 1 }`,
+			wantErrs: []string{"1:15-1:55: generator function return type must be a Generator; write Generator<...>"},
+		},
+		{
+			name:     "GeneratorOnAsyncGenRejected",
+			src:      `async gen fn f() -> Generator<number, undefined, never> { yield 1 }`,
+			wantErrs: []string{"1:21-1:56: async generator function return type must be an AsyncGenerator; write AsyncGenerator<...>"},
+		},
+		{
+			// The annotation's Yield slot is the sink each yield is checked against, so a
+			// mismatched yield is blamed at its own site.
+			name:     "YieldAgainstDeclaredYieldSlot",
+			src:      `gen fn f() -> Generator<string, undefined, never> { yield 1 return undefined }`,
+			wantErrs: []string{"1:59-1:60: cannot constrain 1 <: string"},
+		},
+		{
+			name:     "ReturnAgainstDeclaredRetSlot",
+			src:      `gen fn f() -> Generator<number, string, never> { yield 1 return 2 }`,
+			wantErrs: []string{"1:65-1:66: cannot constrain 2 <: string"},
+		},
+	})
+}
+
+// The throws sink is untouched by generator-ness: a clause-less gen fn raises nothing,
+// so a throw in its body is rejected at the throw, exactly as in a plain function, and a
+// declared clause reaches the generator's own type.
+//
+// A generator carries its body's raises on its own signature, which over-approximates:
+// advancing the generator is what raises, so a caller that only obtains it is asked to
+// handle an exception it cannot yet observe. An `async fn` moves its raises into the
+// promise's rejection slot, and a generator has no such slot to move them into. Keeping
+// them on the signature errs in the safe direction — dropping them instead would let the
+// raise escape a clause-less caller that iterates.
+func TestInferGenThrowsStillChecked(t *testing.T) {
+	runGenErrCases(t, []genErrCase{
+		{
+			name:     "ThrowInAClauselessGenFn",
+			src:      `gen fn f() { yield 1 throw "boom" }`,
+			wantErrs: []string{`1:28-1:34: cannot constrain "boom" <: never`},
+		},
+	})
+	runGenCases(t, []genCase{
+		{
+			// The body always leaves along the exceptional edge, so its normal return —
+			// the Generator's Ret slot — is `never`.
+			name: "GenFnWithThrowsClause",
+			src:  `gen fn f() throws _ { yield 1 throw "boom" }`,
+			want: `fn () -> Generator<1, never, never> throws "boom"`,
+		},
+	})
+}
+
+// Generator subtyping: Yield and Ret are covariant; Next is contravariant, since it is
+// the value a caller sends back in through next(v).
+func TestGeneratorSubtyping(t *testing.T) {
+	runGenCases(t, []genCase{
+		{
+			name: "CovariantYieldAndRet",
+			src: `
+				gen fn g() { yield 1 return "done" }
+				val f: fn () -> Generator<number, string, never> = g
+			`,
+			want: `fn () -> Generator<number, string, never>`,
+		},
+	})
+	runGenErrCases(t, []genErrCase{
+		{
+			name: "YieldSlotMismatchAtUse",
+			src: `
+				gen fn g() { yield "a" return true }
+				val h: fn () -> Generator<number, boolean, never> = g
+			`,
+			wantErrs: []string{`3:57-3:58: cannot constrain "a" <: number`},
+		},
+		{
+			name: "SyncGeneratorIsNotAsync",
+			src: `
+				gen fn g() { yield 1 return true }
+				val h: fn () -> AsyncGenerator<number, boolean, never> = g
+			`,
+			// The yield slot renders in describe's raw mid-constrain form, so g's
+			// still-unsolved yield variable shows as `t4`.
+			wantErrs: []string{"3:62-3:63: cannot constrain Generator<t4, true, never> <: AsyncGenerator<number, boolean, never>"},
+		},
+	})
+}
+
+// `yield from` forwards a delegate's yields rather than yielding the delegate itself,
+// so it needs the iteration rules and is reported until those land. Treating it as a
+// plain yield would put the iterable in the sink instead of its elements.
+func TestInferYieldFromIsUnsupported(t *testing.T) {
+	runGenErrCases(t, []genErrCase{
+		{
+			name:     "DelegationReported",
+			src:      `gen fn f() { yield from [1, 2] }`,
+			wantErrs: []string{"1:14-1:31: Unsupported: yield from"},
+		},
+	})
+}

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -61,6 +61,7 @@ const (
 	WildcardAnnotation                      // a fresh var from a `_` type annotation (resolveTypeAnn), the inner the surrounding annotation infers
 	AwaitResult                             // a fresh `await`-result var from inferAwait
 	PromiseWrap                             // a PromiseType minted by wrapping an async function's external return
+	GeneratorWrap                           // a GeneratorType minted by wrapping a gen function's external return
 	ReturnJoin                              // a fresh return-join var from inferFunc (the union of every return point)
 	IfElseBranch                            // a fresh branch-join var from inferIfElse (the union of cons / alt)
 	MatchBranch                             // a fresh branch-join var from inferMatch (the union of every arm body)


### PR DESCRIPTION
Third of four stacked PRs implementing **PR11** of [planning/simple_sub/m9-implementation-plan.md](planning/simple_sub/m9-implementation-plan.md) — generators. This one walks a `gen fn` body and gives it a type.

**Stacked on #1003** — review #1002 and #1003 first; this PR's diff is against #1003, not `main`.

The stack, in order:

1. #1002 — `gen fn` syntax, codegen, checker marker
2. #1003 — `soltype.GeneratorType` and its parallel arms
3. **this PR** — yield inference and the external generator face
4. `yield from` delegation and generator iteration

## What lands

A `gen fn` body carries a **yield sink**, the generator twin of the throws sink PR10 (#963) added. It is seeded before the body is walked — from the return annotation's `Yield` slot when the annotation is a matching generator, from a fresh inference variable otherwise — so each `yield` is checked and blamed at its own site rather than at the whole function. `yield e` constrains its operand into that sink and evaluates to the generator's `Next` type, the value a caller sends back in through `next(v)`. A bare `yield` yields `undefined`.

The external type is always a generator, since calling one returns a generator object rather than the body's value. An `async gen fn` faces callers as an `AsyncGenerator`, so the async `Promise` wrap never applies to it — the generator arm is taken ahead of the async one. A `gen fn` whose return annotation is not the matching generator form is rejected with `GenReturnNotGeneratorError`, and the body still checks under the inferred seeding so callers don't cascade.

A `yield` outside a generator body is a walk rejection symmetric to `AwaitOutsideAsyncError`, relating the enclosing function as the one to mark `gen`. A closure opens its own function context with the marker clear, so a `yield` inside one is rejected even within a generator's body — matching JavaScript, where an inner function is not a generator.

## Known gap

A generator keeps its body's raises on its own signature. Advancing the generator is what actually raises, so a caller that merely obtains one is asked to handle an exception it cannot yet observe. This over-approximates in the safe direction: moving the raise off the signature with nothing reading it in the generator's place let it escape a clause-less caller that iterates. It is the same imprecision an `async fn` carries until PR10c moves a rejection onto its promise, and the Generator analogue of PR10c is what fixes it properly.

## Deferred to PR 4

`yield from` is reported as unsupported here. It forwards a delegate's yields rather than yielding the delegate itself, so it needs the iteration rules; treating it as a plain yield would put the iterable in the sink instead of its elements. A test pins that staged behaviour.

## Design note

The plan lists a `FuncType.Yields` field, but it also specifies the external type as `Generator<Y, R, TNext>`, and the docs' inferred form (`fn(...) -> Generator<number, "done", unknown>`) agrees. There is no `yields` clause in the surface syntax, so a subtyping-relevant `FuncType.Yields` would be unwritable and unprintable. The parallel arms the plan asks for live on `GeneratorType` instead, landed in #1003. `Next` defaults to `never`, matching the old checker's `TNext`, rather than the docs' `unknown`.

## Testing

`internal/solver/infer_gen_test.go` covers the external generator face across single, multiple, bare, and absent yields; annotated generators including the `Next` slot typing a `yield`; async generators including `await` in the body; the walk rejections in plain functions, plain methods, and closures; return-annotation shape errors in both async directions; the throws interaction; and subtyping of inferred generators. `go test ./...` passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfnxBqoHTKYakb748NAP4V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added type inference support for synchronous and asynchronous generator functions.
  * Added validation and inference for yielded values, generator return values, `next` types, `await`, and generator expressions.
  * Added support for generator subtyping and throws checking.

* **Bug Fixes**
  * Added diagnostics for `yield` outside generator functions and invalid generator return annotations.
  * Clearly reports unsupported delegated yields (`yield from`) and async generator errors.

* **Tests**
  * Added comprehensive coverage for generator inference, annotations, errors, and subtyping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->