### PR TITLE
M9 PR11 (4/4) — `yield from` delegation and generator iteration

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -977,14 +977,14 @@ type ForAwaitOutsideAsyncError struct {
 	EnclosingFn ast.Node
 }
 
-// NotIterableError fires when the operand of `for (x in xs)` is not iterable, or
-// the operand of `for await (x in xs)` is not async-iterable. M5 resolves the
-// iteration protocol structurally over the types the solver can represent: a
-// tuple yields the union of its elements, and a union of tuples yields the union
-// of their element types. Array<T> and the `[Symbol.iterator]` protocol land in
-// M7, so every other operand is reported here, as is every operand of a
-// `for await` since no async iterable is representable yet. Await selects the
-// message.
+// NotIterableError fires when the operand of `for (x in xs)` or `yield from xs`
+// is not iterable, or the operand of `for await (x in xs)` is not async-iterable.
+// The iteration protocol resolves structurally over the types the solver can
+// represent: a tuple yields the union of its elements, a union of tuples yields
+// the union of their element types, and a generator yields its Yield slot — a
+// sync one under `for` and `yield from`, an AsyncGenerator under `for await`.
+// Array<T> and the `[Symbol.iterator]` protocol land in M7, so every other
+// operand is reported here. Await selects the message.
 type NotIterableError struct {
 	Iterable ast.Expr
 	Type     soltype.Type

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -977,15 +977,12 @@ type ForAwaitOutsideAsyncError struct {
 	EnclosingFn ast.Node
 }
 
-// NotIterableError fires when the operand of `for (x in xs)` or `yield from xs`
-// is not iterable, or the operand of `for await (x in xs)` is not async-iterable.
-// The rules resolve structurally over the types the solver can represent. A tuple
-// is sync-iterable and yields the union of its elements. A union yields the union
-// of what its branches yield, and it fails when any branch is not iterable. `for`
-// and `yield from` read a sync generator's Yield slot and `for await` reads an
-// AsyncGenerator's. `yield from` also accepts an AsyncGenerator delegate inside an
-// `async gen fn` body. Array<T> and the `[Symbol.iterator]` protocol land in M7, so
-// every other operand is reported here. Await selects the message.
+// NotIterableError fires when the operand of `for (x in xs)` or `yield from xs` is not
+// iterable, or the operand of `for await (x in xs)` is not async-iterable. Iterability
+// resolves structurally over a tuple, a union, and a generator. Each of syncElemType,
+// asyncElemType, and delegateElemType states its own rule. Array<T> and the
+// `[Symbol.iterator]` protocol land in M7, so every other operand is reported here.
+// Await selects the message.
 type NotIterableError struct {
 	Iterable ast.Expr
 	Type     soltype.Type

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -979,12 +979,13 @@ type ForAwaitOutsideAsyncError struct {
 
 // NotIterableError fires when the operand of `for (x in xs)` or `yield from xs`
 // is not iterable, or the operand of `for await (x in xs)` is not async-iterable.
-// The iteration protocol resolves structurally over the types the solver can
-// represent: a tuple yields the union of its elements, a union of tuples yields
-// the union of their element types, and a generator yields its Yield slot — a
-// sync one under `for` and `yield from`, an AsyncGenerator under `for await`.
-// Array<T> and the `[Symbol.iterator]` protocol land in M7, so every other
-// operand is reported here. Await selects the message.
+// The rules resolve structurally over the types the solver can represent. A tuple
+// is sync-iterable and yields the union of its elements. A union yields the union
+// of what its branches yield, and it fails when any branch is not iterable. `for`
+// and `yield from` read a sync generator's Yield slot and `for await` reads an
+// AsyncGenerator's. `yield from` also accepts an AsyncGenerator delegate inside an
+// `async gen fn` body. Array<T> and the `[Symbol.iterator]` protocol land in M7, so
+// every other operand is reported here. Await selects the message.
 type NotIterableError struct {
 	Iterable ast.Expr
 	Type     soltype.Type

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2768,13 +2768,11 @@ func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Ty
 		arg := c.inferExpr(scope, lvl, e.Value)
 		elem, res, ok := c.delegateElemType(arg)
 		if !ok {
-			// A delegate with no structure to read is the recursive case: walking
-			// `gen fn f() { yield from f() }` reaches the delegation while f's own return
-			// is still an unsolved variable, so no structural rule can apply. Synthesize
-			// the requirement instead of reading one, the way inferAwait constrains an
-			// awaited operand against `Promise<U>` rather than looking inside it. Yield is
-			// covariant, so the delegate's yields land in this body's sink, and Ret is the
-			// value the delegation produces once the delegate is exhausted.
+			// A delegate with no structure is the recursive case: `gen fn f() { yield from
+			// f() }` reaches the delegation while f's own return is unsolved. State the
+			// requirement instead of reading one, the way inferAwait constrains against
+			// `Promise<U>`. Yield is covariant, so the delegate's yields land in this
+			// body's sink and Ret is what the delegation produces.
 			if c.delegateIsUnsolved(arg) {
 				res := c.freshAt(lvl)
 				req := &soltype.GeneratorType{Yield: c.fn.yields, Ret: res, Next: c.fn.yieldNext, Async: c.fn.async}
@@ -2810,25 +2808,20 @@ func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Ty
 }
 
 // delegateIsUnsolved reports whether a `yield from` delegate is an inference variable
-// the solve has not given a shape to. Such a delegate carries no structure for the
-// iteration rules to read, so the delegation states its requirement as a constraint
-// instead. A delegate that already failed to infer is the ErrorType placeholder rather
-// than a variable, so it is excluded and keeps absorbing.
+// the solve has not shaped, so the delegation must state its requirement rather than
+// read one. A failed delegate is the ErrorType placeholder, not a variable, so it is
+// excluded and keeps absorbing.
 func (c *checker) delegateIsUnsolved(t soltype.Type) bool {
 	_, isVar := soltype.CarrierOf(t).(*soltype.TypeVarType)
 	return isVar
 }
 
-// delegateElemType resolves what a `yield from` delegate hands the delegating
-// generator: the element type its iteration yields, and the value the whole
-// expression evaluates to once the delegate is exhausted. A generator delegate
-// forwards its Yield slot and finishes with its Ret slot. An async generator is a
-// legal delegate only from an async generator body. A union delegate resolves each
-// branch the same way and unions both results, so
-// `Generator<number, string, never> | Generator<boolean, number, never>` yields
-// `number | boolean` and finishes with `string | number`. Any other operand resolves
-// structurally through syncElemType. A tuple's iterator carries no return value, so
-// the expression finishes with `undefined`.
+// delegateElemType resolves what a `yield from` delegate hands back: the element type
+// its iteration yields, and the value the delegation evaluates to once the delegate is
+// exhausted. A generator forwards its Yield and Ret slots, and an async one is a legal
+// delegate only from an async generator body. A union resolves each branch the same way
+// and unions both results. Any other operand goes through syncElemType, where a tuple
+// carries no return value and so finishes with `undefined`.
 func (c *checker) delegateElemType(t soltype.Type) (soltype.Type, soltype.Type, bool) {
 	carrier := soltype.CarrierOf(t)
 	// An inference-variable delegate is coalesced to its structural lower-bound shape,
@@ -2837,13 +2830,11 @@ func (c *checker) delegateElemType(t soltype.Type) (soltype.Type, soltype.Type, 
 		carrier = soltype.CarrierOf(coalesce(carrier, soltype.Positive))
 	}
 	if u, isUnion := carrier.(*soltype.UnionType); isUnion {
-		// syncElemType walks a union too, but it reports only element types. Recursing
-		// through delegateElemType keeps each branch's Ret slot, which is what the
-		// delegation evaluates to, and it lets an async generator branch through under
-		// the same async-body rule a lone async generator delegate gets. A union is a
-		// legal delegate only when every branch is, matching syncElemType. Inexactness
-		// carries to both results because an inexact union has unlisted branches whose
-		// yields and return value are unknown.
+		// syncElemType walks a union too, but reports only element types. Recursing here
+		// keeps each branch's Ret slot and lets an async branch through under the same
+		// async-body rule a lone async delegate gets. A union is a legal delegate only
+		// when every branch is. Inexactness carries to both results, since the unlisted
+		// branches yield and return something unknown.
 		elems := make([]soltype.Type, 0, len(u.Types))
 		rets := make([]soltype.Type, 0, len(u.Types))
 		for _, branch := range u.Types {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2822,16 +2822,39 @@ func (c *checker) delegateIsUnsolved(t soltype.Type) bool {
 // delegateElemType resolves what a `yield from` delegate hands the delegating
 // generator: the element type its iteration yields, and the value the whole
 // expression evaluates to once the delegate is exhausted. A generator delegate
-// forwards its Yield slot and finishes with its Ret slot; an async generator is only
-// iterable from an async generator body. Any other operand resolves structurally
-// through syncElemType — a tuple's iterator carries no return value, so the
-// expression finishes with `undefined`.
+// forwards its Yield slot and finishes with its Ret slot. An async generator is a
+// legal delegate only from an async generator body. A union delegate resolves each
+// branch the same way and unions both results, so
+// `Generator<number, string, never> | Generator<boolean, number, never>` yields
+// `number | boolean` and finishes with `string | number`. Any other operand resolves
+// structurally through syncElemType. A tuple's iterator carries no return value, so
+// the expression finishes with `undefined`.
 func (c *checker) delegateElemType(t soltype.Type) (soltype.Type, soltype.Type, bool) {
 	carrier := soltype.CarrierOf(t)
 	// An inference-variable delegate is coalesced to its structural lower-bound shape,
 	// the same snapshot syncElemType takes before inspecting a variable operand.
 	if _, isVar := carrier.(*soltype.TypeVarType); isVar {
 		carrier = soltype.CarrierOf(coalesce(carrier, soltype.Positive))
+	}
+	if u, isUnion := carrier.(*soltype.UnionType); isUnion {
+		// syncElemType walks a union too, but it reports only element types. Recursing
+		// through delegateElemType keeps each branch's Ret slot, which is what the
+		// delegation evaluates to, and it lets an async generator branch through under
+		// the same async-body rule a lone async generator delegate gets. A union is a
+		// legal delegate only when every branch is, matching syncElemType. Inexactness
+		// carries to both results because an inexact union has unlisted branches whose
+		// yields and return value are unknown.
+		elems := make([]soltype.Type, 0, len(u.Types))
+		rets := make([]soltype.Type, 0, len(u.Types))
+		for _, branch := range u.Types {
+			elem, ret, ok := c.delegateElemType(branch)
+			if !ok {
+				return nil, nil, false
+			}
+			elems = append(elems, elem)
+			rets = append(rets, ret)
+		}
+		return newUnion(c.ctx, elems, u.Inexact), newUnion(c.ctx, rets, u.Inexact), true
 	}
 	if g, isGen := carrier.(*soltype.GeneratorType); isGen {
 		if g.Async && (c.fn == nil || !c.fn.async) {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2734,8 +2734,8 @@ func (c *checker) inferThrow(scope *Scope, lvl int, e *ast.ThrowExpr) soltype.Ty
 // `yield e` constrains its operand into the yield sink and evaluates to the `Next` type,
 // the value a caller sends back in through `next(v)`. A bare `yield` yields `undefined`.
 //
-// `yield from g` is reported as unsupported, since forwarding a delegate's yields needs
-// the iteration rules. The delegate is still walked, so its own errors surface too.
+// `yield from g` forwards the delegate's yields into the sink and evaluates to the
+// delegate's return type, what the delegating generator sees once it is exhausted.
 func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Type {
 	if c.fn == nil || !c.fn.gen {
 		if e.Value != nil {
@@ -2758,16 +2758,43 @@ func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Ty
 	// only yield is a `yield from` does produce values, and its `gen` marker is used.
 	c.fn.yielded = true
 	if e.IsDelegate {
-		// `yield from` forwards another iterable's yields into this body's sink, so it
-		// needs the iteration rules rather than the plain-yield rule below. Treating the
-		// delegate as an ordinary yielded value would put the iterable itself in the sink
-		// instead of its elements, so report it until those rules land.
-		if e.Value != nil {
-			c.inferExpr(scope, lvl, e.Value) // surface delegate-side errors anyway
+		// A `yield from` with no operand is a parse error the parser already reported;
+		// recover with the error placeholder rather than walking nothing.
+		if e.Value == nil {
+			t := &soltype.ErrorType{}
+			c.recordType(e, t)
+			return t
 		}
-		t := c.reportUnsupportedFeature(e, "yield from")
-		c.recordType(e, t)
-		return t
+		arg := c.inferExpr(scope, lvl, e.Value)
+		elem, res, ok := c.delegateElemType(arg)
+		if !ok {
+			// A delegate with no structure to read is the recursive case: walking
+			// `gen fn f() { yield from f() }` reaches the delegation while f's own return
+			// is still an unsolved variable, so no structural rule can apply. Synthesize
+			// the requirement instead of reading one, the way inferAwait constrains an
+			// awaited operand against `Promise<U>` rather than looking inside it. Yield is
+			// covariant, so the delegate's yields land in this body's sink, and Ret is the
+			// value the delegation produces once the delegate is exhausted.
+			if c.delegateIsUnsolved(arg) {
+				res := c.freshAt(lvl)
+				req := &soltype.GeneratorType{Yield: c.fn.yields, Ret: res, Next: c.fn.yieldNext, Async: c.fn.async}
+				c.constrain(e, arg, req)
+				c.recordType(e, res)
+				return res
+			}
+			// A delegate that already failed to infer is the ErrorType recovery
+			// placeholder; it absorbs rather than cascading a second diagnostic, the
+			// same rule inferForIn applies to a broken iterable.
+			var t soltype.Type = &soltype.ErrorType{}
+			if _, brokenDelegate := soltype.CarrierOf(arg).(*soltype.ErrorType); !brokenDelegate {
+				t = c.report(&NotIterableError{Iterable: e.Value, Type: arg, Await: false})
+			}
+			c.recordType(e, t)
+			return t
+		}
+		c.constrain(e, elem, c.fn.yields)
+		c.recordType(e, res)
+		return res
 	}
 	var val soltype.Type = &soltype.UndefinedType{}
 	if e.Value != nil {
@@ -2780,6 +2807,43 @@ func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Ty
 	t := c.fn.yieldNext
 	c.recordType(e, t)
 	return t
+}
+
+// delegateIsUnsolved reports whether a `yield from` delegate is an inference variable
+// the solve has not given a shape to. Such a delegate carries no structure for the
+// iteration rules to read, so the delegation states its requirement as a constraint
+// instead. A delegate that already failed to infer is the ErrorType placeholder rather
+// than a variable, so it is excluded and keeps absorbing.
+func (c *checker) delegateIsUnsolved(t soltype.Type) bool {
+	_, isVar := soltype.CarrierOf(t).(*soltype.TypeVarType)
+	return isVar
+}
+
+// delegateElemType resolves what a `yield from` delegate hands the delegating
+// generator: the element type its iteration yields, and the value the whole
+// expression evaluates to once the delegate is exhausted. A generator delegate
+// forwards its Yield slot and finishes with its Ret slot; an async generator is only
+// iterable from an async generator body. Any other operand resolves structurally
+// through syncElemType — a tuple's iterator carries no return value, so the
+// expression finishes with `undefined`.
+func (c *checker) delegateElemType(t soltype.Type) (soltype.Type, soltype.Type, bool) {
+	carrier := soltype.CarrierOf(t)
+	// An inference-variable delegate is coalesced to its structural lower-bound shape,
+	// the same snapshot syncElemType takes before inspecting a variable operand.
+	if _, isVar := carrier.(*soltype.TypeVarType); isVar {
+		carrier = soltype.CarrierOf(coalesce(carrier, soltype.Positive))
+	}
+	if g, isGen := carrier.(*soltype.GeneratorType); isGen {
+		if g.Async && (c.fn == nil || !c.fn.async) {
+			return nil, nil, false
+		}
+		return g.Yield, g.Ret, true
+	}
+	elem, ok := c.syncElemType(t)
+	if !ok {
+		return nil, nil, false
+	}
+	return elem, &soltype.UndefinedType{}, true
 }
 
 // inferIfElse types `if cond { cons } else { alt }`. The condition is

--- a/internal/solver/infer_for_in.go
+++ b/internal/solver/infer_for_in.go
@@ -86,11 +86,10 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 // iterableElemType resolves the element type T yielded by iterating a value of
 // type t, returning ok=false when t is not iterable in the current sense.
 //
-// For a `for await`, T must come from an AsyncIterable. The one async iterable the
-// solver can represent is an AsyncGenerator, whose Yield slot is its element type;
-// the real AsyncIterable stdlib type and the symbol-keyed protocol land with library
-// ingestion, so every other operand returns false, which is how a sync iterable is
-// rejected by the type rule.
+// For a `for await`, T must come from an AsyncIterable. The only one the solver can
+// represent is an AsyncGenerator, whose Yield slot is its element type. The real stdlib
+// type and the symbol-keyed protocol land with library ingestion, so every other
+// operand returns false.
 //
 // For a sync `for`, the resolution is structural (see syncElemType): a tuple
 // yields the union of its element types, a union yields the union of its
@@ -104,13 +103,10 @@ func (c *checker) iterableElemType(await bool, t soltype.Type) (soltype.Type, bo
 }
 
 // asyncElemType resolves the element type of an asynchronously-iterable value, the
-// `for await` counterpart of syncElemType and structurally the same walk. A borrow is
-// peeled and an inference variable is coalesced to its lower-bound shape first. An
-// async generator yields its Yield slot, and a union yields the union of its branches'
-// element types, failing if any branch is not async-iterable, so a union of async
-// generators binds the loop variable at the union of what they yield. Inexactness
-// carries through the union for the reason syncElemType gives. A sync generator is not
-// an AsyncIterable, and neither is a tuple, so both are rejected here.
+// `for await` counterpart of syncElemType and structurally the same walk. An async
+// generator yields its Yield slot, and a union yields the union of its branches',
+// failing when any branch is not async-iterable. A sync generator is not an
+// AsyncIterable, and neither is a tuple, so both are rejected here.
 func (c *checker) asyncElemType(t soltype.Type) (soltype.Type, bool) {
 	t = soltype.CarrierOf(t)
 	if _, isVar := t.(*soltype.TypeVarType); isVar {
@@ -159,9 +155,8 @@ func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
 	}
 	switch t := t.(type) {
 	case *soltype.GeneratorType:
-		// A sync generator iterates its yields, so `for x in range(0, 10)` binds x at
-		// the Yield slot. An async generator needs a `for await`, whose arm lives in
-		// iterableElemType.
+		// A sync generator iterates its yields. An async one needs a `for await`, whose
+		// arm lives in asyncElemType.
 		if t.Async {
 			return nil, false
 		}

--- a/internal/solver/infer_for_in.go
+++ b/internal/solver/infer_for_in.go
@@ -10,16 +10,17 @@ import (
 // `xs <: Iterable<T>` and a `for await` needs `xs <: AsyncIterable<T>`, binding
 // the loop variable at the element type T. The full protocol resolves T through
 // the iterable's `[Symbol.iterator]()` method, which needs symbol-keyed members
-// and the real Iterable/Iterator stdlib types that both land in M7. Until then M5
-// resolves the element type STRUCTURALLY over the types the solver can
-// represent — a tuple, the solver's stand-in for an array, and a union of
-// tuples — and rejects everything else as non-iterable. See iterableElemType.
+// and the real Iterable/Iterator stdlib types that both land in M7. Until then
+// the element type resolves STRUCTURALLY over the types the solver can
+// represent — a tuple, the solver's stand-in for an array, a union of tuples,
+// and a generator — and everything else is rejected as non-iterable. See
+// iterableElemType.
 //
 // A `for await` outside an `async fn` is a WALK rejection symmetric to
 // AwaitOutsideAsyncError: the iterable and body are still walked so their own
-// errors surface. A `for await` over any structural operand is rejected by the
-// type rule, since no async iterable is representable yet. A sync iterable is not
-// an AsyncIterable.
+// errors surface. A `for await` accepts an AsyncGenerator, the one async iterable
+// the solver can represent, and rejects every other operand by the type rule. A
+// sync iterable is not an AsyncIterable.
 //
 // The loop contributes Void to its enclosing block — a loop is a statement, not a
 // value. The CFG builder already decomposes a ForInStmt into a header, a body
@@ -85,19 +86,54 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 // iterableElemType resolves the element type T yielded by iterating a value of
 // type t, returning ok=false when t is not iterable in the current sense.
 //
-// For a `for await`, T must come from an AsyncIterable. No async iterable is
-// representable in the solver yet — the real AsyncIterable stdlib type and the
-// symbol-keyed protocol land in M7 — so a `for await` over any structural operand
-// returns false, which is how a sync iterable is rejected by the type rule.
+// For a `for await`, T must come from an AsyncIterable. The one async iterable the
+// solver can represent is an AsyncGenerator, whose Yield slot is its element type;
+// the real AsyncIterable stdlib type and the symbol-keyed protocol land with library
+// ingestion, so every other operand returns false, which is how a sync iterable is
+// rejected by the type rule.
 //
 // For a sync `for`, the resolution is structural (see syncElemType): a tuple
 // yields the union of its element types, a union yields the union of its
-// branches' element types, and every other type is not iterable.
+// branches' element types, a sync generator yields its Yield slot, and every
+// other type is not iterable.
 func (c *checker) iterableElemType(await bool, t soltype.Type) (soltype.Type, bool) {
 	if await {
-		return nil, false
+		return c.asyncElemType(t)
 	}
 	return c.syncElemType(t)
+}
+
+// asyncElemType resolves the element type of an asynchronously-iterable value, the
+// `for await` counterpart of syncElemType and structurally the same walk. A borrow is
+// peeled and an inference variable is coalesced to its lower-bound shape first. An
+// async generator yields its Yield slot, and a union yields the union of its branches'
+// element types, failing if any branch is not async-iterable, so a union of async
+// generators binds the loop variable at the union of what they yield. Inexactness
+// carries through the union for the reason syncElemType gives. A sync generator is not
+// an AsyncIterable, and neither is a tuple, so both are rejected here.
+func (c *checker) asyncElemType(t soltype.Type) (soltype.Type, bool) {
+	t = soltype.CarrierOf(t)
+	if _, isVar := t.(*soltype.TypeVarType); isVar {
+		t = soltype.CarrierOf(coalesce(t, soltype.Positive))
+	}
+	switch t := t.(type) {
+	case *soltype.GeneratorType:
+		if !t.Async {
+			return nil, false
+		}
+		return t.Yield, true
+	case *soltype.UnionType:
+		elems := make([]soltype.Type, 0, len(t.Types))
+		for _, branch := range t.Types {
+			e, ok := c.asyncElemType(branch)
+			if !ok {
+				return nil, false
+			}
+			elems = append(elems, e)
+		}
+		return newUnion(c.ctx, elems, t.Inexact), true
+	}
+	return nil, false
 }
 
 // syncElemType resolves the element type of a synchronously-iterable value
@@ -106,9 +142,9 @@ func (c *checker) iterableElemType(await bool, t soltype.Type) (soltype.Type, bo
 // lower-bound shape, the way inferMatch snapshots a variable scrutinee before
 // inspecting it. A tuple yields the union of its elements, so `[1, 2, 3]` yields
 // `1 | 2 | 3` and the empty tuple yields `never`. A union yields the union of its
-// branches' element types, failing if any branch is not iterable. Every other
-// type — a primitive, an object, a class instance without the M7 iterator
-// protocol — is not iterable.
+// branches' element types, failing if any branch is not iterable. A sync
+// generator yields its Yield slot. Every other type — a primitive, an object, a
+// class instance without the M7 iterator protocol — is not iterable.
 //
 // Inexactness carries through. An inexact tuple `[number, ...]` has an open tail
 // of unknown additional elements, and an inexact union `[number] | ...` an open
@@ -122,6 +158,14 @@ func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
 		t = soltype.CarrierOf(coalesce(t, soltype.Positive))
 	}
 	switch t := t.(type) {
+	case *soltype.GeneratorType:
+		// A sync generator iterates its yields, so `for x in range(0, 10)` binds x at
+		// the Yield slot. An async generator needs a `for await`, whose arm lives in
+		// iterableElemType.
+		if t.Async {
+			return nil, false
+		}
+		return t.Yield, true
 	case *soltype.TupleType:
 		return newUnion(c.ctx, t.Elems, t.Inexact), true
 	case *soltype.UnionType:

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -123,6 +123,123 @@ func TestInferAsyncGen(t *testing.T) {
 	})
 }
 
+// `yield from g` forwards the delegate's yields into the enclosing generator and
+// evaluates to the delegate's return type — what the delegating body sees once the
+// delegate is exhausted. A structural iterable like a tuple forwards its element union
+// and finishes with `undefined`.
+func TestInferYieldFrom(t *testing.T) {
+	runGenCases(t, []genCase{
+		{
+			name: "DelegateToTuple",
+			src:  `gen fn f() { yield from [1, 2] }`,
+			want: `fn () -> Generator<1 | 2, void, never>`,
+		},
+		{
+			name: "DelegateToGeneratorForwardsYieldsAndReturns",
+			src: `
+				gen fn g() { yield 1 return "r" }
+				gen fn f() { yield "a" return yield from g() }
+			`,
+			want: `fn () -> Generator<1 | "a", "r", never>`,
+		},
+		{
+			// Tree-walk delegation is the main use of `yield from`, so a generator
+			// delegating to itself has to work. Its own return type is still unsolved at
+			// the delegation, so the rule states a Generator requirement rather than
+			// reading the operand's shape.
+			name: "SelfRecursiveDelegation",
+			src:  `gen fn f() { yield 1 yield from f() }`,
+			want: `fn () -> Generator<1, void, never>`,
+		},
+		{
+			// Two generators delegating to each other reach a fixed point, so both
+			// yield the union across the cycle.
+			name: "MutuallyRecursiveDelegation",
+			src: `
+				gen fn a() { yield 1 yield from b() }
+				gen fn b() { yield "x" yield from a() }
+			`,
+			binding: "a",
+			want:    `fn () -> Generator<1 | "x", void, never>`,
+		},
+	})
+	runGenErrCases(t, []genErrCase{
+		{
+			// The delegate is walked before its shape is read, so an error inside it is
+			// reported at its own site. The ErrorType that walk yields then absorbs, so
+			// the delegation adds no second diagnostic on top.
+			name:     "ABrokenDelegateReportsOnlyItsOwnError",
+			src:      `gen fn f() { yield from missing() }`,
+			wantErrs: []string{"1:25-1:32: Unknown identifier: missing"},
+		},
+	})
+}
+
+// A sync generator is iterable, so a `for` loop binds its variable at the Yield slot;
+// an async generator is iterable only under `for await`.
+func TestInferGenIteration(t *testing.T) {
+	runGenCases(t, []genCase{
+		{
+			name: "ForInOverGenerator",
+			src: `
+				gen fn g() { yield 1 yield 2 }
+				fn f() { for x in g() { return x } }
+			`,
+			want: `fn () -> 1 | 2`,
+		},
+		{
+			name: "ForAwaitOverAsyncGenerator",
+			src: `
+				async gen fn g() { yield 1 }
+				async fn f() { for await x in g() { return x } }
+			`,
+			want: `fn () -> Promise<1>`,
+		},
+		{
+			// A union of async generators is async-iterable, binding the loop variable
+			// at the union of what its branches yield — the same branch-wise walk the
+			// sync path applies to a union of generators.
+			name: "ForAwaitOverAUnionOfAsyncGenerators",
+			src: `
+				async fn f(g: AsyncGenerator<number, undefined, never> | AsyncGenerator<string, undefined, never>) {
+					for await x in g { return x }
+				}
+			`,
+			want: `fn (g: AsyncGenerator<number, undefined, never> | AsyncGenerator<string, undefined, never>) -> Promise<number | string>`,
+		},
+		{
+			name: "ForInOverAUnionOfGenerators",
+			src: `
+				fn f(g: Generator<number, undefined, never> | Generator<string, undefined, never>) {
+					for x in g { return x }
+				}
+			`,
+			want: `fn (g: Generator<number, undefined, never> | Generator<string, undefined, never>) -> number | string`,
+		},
+		{
+			// A class method marked `gen` is a generator the same way a `gen fn` is, so
+			// iterating its result binds at what the body yields.
+			name: "GenMethodOnAClass",
+			src: `
+				class C { gen m(self) { yield 1 } }
+				fn f(c: C) { for x in c.m() { return x } }
+			`,
+			want: `fn (c: C) -> 1`,
+		},
+	})
+	runGenErrCases(t, []genErrCase{
+		{
+			// An async generator has no sync iterator, so a plain `for` rejects it.
+			name: "ForInOverAsyncGeneratorRejected",
+			src: `
+				declare fn g() -> AsyncGenerator<number, undefined, never>
+				fn f(a: AsyncGenerator<number, undefined, never>) { for x in a { } }
+			`,
+			wantErrs: []string{"3:66-3:67: AsyncGenerator<number, undefined, never> is not iterable"},
+		},
+	})
+}
+
 // A yield outside a generator body is rejected by the walk, not the type rule: the
 // operand is still walked, and the enclosing function — the one to mark `gen` — is
 // related. A closure inside a generator is not itself a generator, so a yield inside
@@ -192,6 +309,11 @@ func TestInferGenReturnAnnotationShape(t *testing.T) {
 			src:      `gen fn f() -> Generator<number, string, never> { yield 1 return 2 }`,
 			wantErrs: []string{"1:65-1:66: cannot constrain 2 <: string"},
 		},
+		{
+			name:     "YieldFromNonIterable",
+			src:      `gen fn f() { yield from 5 }`,
+			wantErrs: []string{"1:25-1:26: 5 is not iterable"},
+		},
 	})
 }
 
@@ -211,6 +333,17 @@ func TestInferGenThrowsStillChecked(t *testing.T) {
 			name:     "ThrowInAClauselessGenFn",
 			src:      `gen fn f() { yield 1 throw "boom" }`,
 			wantErrs: []string{`1:28-1:34: cannot constrain "boom" <: never`},
+		},
+		{
+			// Iterating a throwing generator is a `.next()` driver, so the raise must
+			// reach the enclosing clause. The over-approximation on the signature is
+			// what carries it there today.
+			name: "IteratingAThrowingGeneratorNeedsAClause",
+			src: `
+				gen fn g() throws "boom" { yield 1 throw "boom" }
+				fn f() { for x in g() { } }
+			`,
+			wantErrs: []string{`3:23-3:26: cannot constrain "boom" <: never`},
 		},
 	})
 	runGenCases(t, []genCase{
@@ -259,30 +392,6 @@ func TestGeneratorSubtyping(t *testing.T) {
 	})
 }
 
-// `yield from` forwards a delegate's yields rather than yielding the delegate itself,
-// so it needs the iteration rules and is reported until those land. Treating it as a
-// plain yield would put the iterable in the sink instead of its elements.
-//
-// The delegate is still walked before the rejection is reported, so a mistake inside it
-// is diagnosed instead of being swallowed by the rejection.
-func TestInferYieldFromIsUnsupported(t *testing.T) {
-	runGenErrCases(t, []genErrCase{
-		{
-			name:     "DelegationReported",
-			src:      `gen fn f() { yield from [1, 2] }`,
-			wantErrs: []string{"1:14-1:31: Unsupported: yield from"},
-		},
-		{
-			name: "DelegateErrorsStillSurface",
-			src:  `gen fn f() { yield from missing() }`,
-			wantErrs: []string{
-				"1:25-1:32: Unknown identifier: missing",
-				"1:14-1:34: Unsupported: yield from",
-			},
-		},
-	})
-}
-
 // A `gen fn` whose body never yields still returns a generator, but one that finishes on
 // the first `next()` without producing a value, so the marker gives the caller nothing.
 // The warning says so while the function still types as the generator it returns — it is
@@ -320,12 +429,9 @@ func TestInferGenWithoutYieldWarns(t *testing.T) {
 	require.Empty(t, yielding)
 
 	// Delegating counts as yielding, so a body whose only yield is a `yield from` does not
-	// draw this warning. It still draws the staged unsupported report, since delegation
-	// itself lands later, so the assertion is that the warning is absent rather than that
-	// nothing is reported.
+	// draw this warning.
 	_, _, delegating := inferSource(t, `gen fn f() { yield from [1, 2] }`)
-	require.Len(t, delegating, 1)
-	require.Equal(t, "1:14-1:31: Unsupported: yield from", msgWithSpan(delegating[0]))
+	require.Empty(t, delegating)
 
 	// A bodyless `declare gen fn` has no body to measure, so it is never flagged.
 	_, _, declared := inferSource(t, `declare gen fn f() -> Generator<number, undefined, never>`)

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -143,6 +143,41 @@ func TestInferYieldFrom(t *testing.T) {
 			want: `fn () -> Generator<1 | "a", "r", never>`,
 		},
 		{
+			// A union delegate is resolved branch by branch, so the delegation keeps
+			// both halves of each branch. The yields union to `number | boolean` and the
+			// return types union to `string | number`, which is what `return yield from g`
+			// puts in the delegating generator's Ret slot.
+			name: "DelegateToAUnionOfGenerators",
+			src: `
+				gen fn f(g: Generator<number, string, never> | Generator<boolean, number, never>) {
+					return yield from g
+				}
+			`,
+			want: `fn (g: Generator<number, string, never> | Generator<boolean, number, never>) -> Generator<number | boolean, number | string, never>`,
+		},
+		{
+			// A tuple branch carries no return value, so it contributes `undefined` to
+			// the union the delegation evaluates to.
+			name: "DelegateToAUnionOfAGeneratorAndATuple",
+			src: `
+				gen fn f(g: Generator<number, string, never> | [boolean]) {
+					return yield from g
+				}
+			`,
+			want: `fn (g: [boolean] | Generator<number, string, never>) -> Generator<number | boolean, string | undefined, never>`,
+		},
+		{
+			// An async generator is a legal delegate from an async generator body, and a
+			// union of them is too, one branch at a time.
+			name: "AsyncGenDelegatesToAUnionOfAsyncGenerators",
+			src: `
+				async gen fn f(g: AsyncGenerator<number, string, never> | AsyncGenerator<boolean, number, never>) {
+					return yield from g
+				}
+			`,
+			want: `fn (g: AsyncGenerator<number, string, never> | AsyncGenerator<boolean, number, never>) -> AsyncGenerator<number | boolean, number | string, never>`,
+		},
+		{
 			// Tree-walk delegation is the main use of `yield from`, so a generator
 			// delegating to itself has to work. Its own return type is still unsolved at
 			// the delegation, so the rule states a Generator requirement rather than
@@ -171,6 +206,18 @@ func TestInferYieldFrom(t *testing.T) {
 			name:     "ABrokenDelegateReportsOnlyItsOwnError",
 			src:      `gen fn f() { yield from missing() }`,
 			wantErrs: []string{"1:25-1:32: Unknown identifier: missing"},
+		},
+		{
+			// A union delegate is legal only when every branch is. A sync generator body
+			// cannot drive an async generator, so the async branch rejects the whole
+			// union and the error names the union, not the branch.
+			name: "SyncGenDelegatingToAUnionWithAnAsyncBranchRejected",
+			src: `
+				gen fn f(g: Generator<number, string, never> | AsyncGenerator<boolean, number, never>) {
+					return yield from g
+				}
+			`,
+			wantErrs: []string{"3:24-3:25: Generator<number, string, never> | AsyncGenerator<boolean, number, never> is not iterable"},
 		},
 	})
 }


### PR DESCRIPTION
Last of four stacked PRs implementing **PR11** of [planning/simple_sub/m9-implementation-plan.md](planning/simple_sub/m9-implementation-plan.md) — generators. This one makes generators consumable: delegation and iteration.

**Stacked on #1004** — review #1002, #1003, and #1004 first; this PR's diff is against #1004, not `main`.

The stack, in order:

1. #1002 — `gen fn` syntax, codegen, checker marker
2. #1003 — `soltype.GeneratorType` and its parallel arms
3. #1004 — yield inference and the external generator face
4. **this PR** — `yield from` delegation and generator iteration

## What lands

**Delegation.** `yield from g` forwards the delegate's yields into the enclosing generator's sink and evaluates to the delegate's return type, which is what the delegating body sees once the delegate is exhausted. A generator delegate forwards its `Yield` and `Ret` slots; a structural iterable such as a tuple forwards its element union and finishes with `undefined`. This replaces the unsupported report #1004 left in place.

**Recursion.** A delegate with no shape yet states a `Generator` requirement as a constraint rather than reading the operand, the way `inferAwait` constrains an awaited operand against `Promise<U>` instead of inspecting it. That is the recursive case: a generator delegating to itself reaches the delegation before its own return type is solved. Without it, `gen fn f() { yield 1 yield from f() }` reported `t2 is not iterable` and dropped the delegated yields — and tree-walk delegation, the main use of `yield from`, depends on it. Self-recursive and mutually recursive delegation both infer now.

**Iteration.** A sync generator is iterable under `for` and an `AsyncGenerator` under `for await`, each binding the loop variable at its `Yield` slot. Both walks recurse through unions, so a union of generators binds at the union of what its branches yield. `for await` resolves through its own recursive walk rather than a flat carrier check, which is what makes the union case work and keeps it symmetric with the sync path. A sync generator is not an `AsyncIterable` and an async one is not iterable, so each is rejected by the other's loop.

## Testing

New cases cover delegation to a tuple and to a generator, self-recursive and mutually recursive delegation, a non-iterable delegate, iteration of a generator and of a union of generators under both loop forms, a generator method, the cross-rejections between sync and async, and a throwing generator's raise reaching the enclosing clause through iteration. `go test ./...` passes.

## After this lands

The four PRs together are the original #1001, whose branch this stack replaces. With this merged, PR11 is complete.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfnxBqoHTKYakb748NAP4V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `yield from` delegation in generators.
  * Added generator iteration support for `for` and `for await`, including compatible unions.
  * Improved type inference for yielded values and delegated return values.

* **Bug Fixes**
  * Added clear errors for unsupported or non-iterable delegation and iteration cases.

* **Documentation**
  * Updated generator iteration and delegation guidance.
  * Refreshed the M9 implementation plan to reflect generator work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->