### PR TITLE
M9 PR11 (5/5) — Track what a generator raises in its type

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -513,6 +513,9 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Yield)
 			walk(t.Ret)
 			walk(t.Next)
+			if t.Throws != nil {
+				walk(t.Throws)
+			}
 		case *ArrayType:
 			walk(t.Elem)
 		case *RefType:
@@ -832,7 +835,14 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *GeneratorType:
-		return t.Name() + "<" + p.printType(t.Yield) + ", " + p.printType(t.Ret) + ", " + p.printType(t.Next) + ">"
+		// A generator that can raise renders its raise type as a fourth argument,
+		// `Generator<Y, R, N, E>`, the same shape `Promise<T, E>` takes. One that cannot
+		// resolves its Throws to `never` and renders three arguments.
+		slots := p.printType(t.Yield) + ", " + p.printType(t.Ret) + ", " + p.printType(t.Next)
+		if t.Raises() {
+			slots += ", " + p.printType(t.Throws)
+		}
+		return t.Name() + "<" + slots + ">"
 	case *ArrayType:
 		return "Array<" + p.printType(t.Elem) + ">"
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -784,12 +784,34 @@ func (t *PromiseType) Rejects() bool {
 // evaluates to, the value a caller passes back in through `next(v)`. Yield and Ret
 // are covariant; Next is contravariant, since it is an input the way a parameter is.
 // Async distinguishes an `async gen fn`'s AsyncGenerator from a sync Generator; the
-// two are unrelated under subtyping. All three type fields are always non-nil.
+// two are unrelated under subtyping. Yield, Ret, and Next are always non-nil.
+//
+// Throws is what advancing the generator may raise, the twin of PromiseType.Err. A
+// generator body does not run at the call, so what it raises surfaces at `next(v)`
+// rather than to whoever obtained the generator. Like Err it is covariant and a nil
+// Throws is shorthand for `never`, so a generator that cannot raise is the zero value
+// and renders as the three-argument `Generator<Y, R, N>`.
 type GeneratorType struct {
-	Yield Type
-	Ret   Type
-	Next  Type
-	Async bool
+	Yield  Type
+	Ret    Type
+	Next   Type
+	Throws Type
+	Async  bool
+}
+
+// ThrowsOrNever returns the type advancing t may raise, resolving the nil shorthand to
+// the `never` it stands for, so callers compare one canonical value.
+func (t *GeneratorType) ThrowsOrNever() Type {
+	if t.Throws == nil {
+		return &NeverType{}
+	}
+	return t.Throws
+}
+
+// Raises reports whether advancing t can raise, which is what decides whether the
+// rendered form carries its fourth argument.
+func (t *GeneratorType) Raises() bool {
+	return t.Throws != nil && !isNever(t.Throws)
 }
 
 // Name returns the stdlib name t renders under, `Generator` or `AsyncGenerator`,
@@ -1382,10 +1404,13 @@ func LevelOf(t Type) int {
 		// freshen it, the same reason the FuncType arm folds in its Throws.
 		return max(LevelOf(t.Inner), throwsLevel(t.Err))
 	case *GeneratorType:
-		// A generator's level is the max over its three slots, so an out-of-level `Yield`,
-		// `Ret`, or `Next` lifts the level and the freshener/extruder prune descends into
-		// all three, the three-child analogue of the PromiseType arm.
-		return max(max(LevelOf(t.Yield), LevelOf(t.Ret)), LevelOf(t.Next))
+		// A generator's level is the max over its slots, so an out-of-level `Yield`, `Ret`,
+		// `Next`, or `Throws` lifts the level and the freshener/extruder prune descends into
+		// all of them, the same reason the PromiseType arm folds in its `Err`.
+		return max(
+			max(LevelOf(t.Yield), LevelOf(t.Ret)),
+			max(LevelOf(t.Next), throwsLevel(t.Throws)),
+		)
 	case *ArrayType:
 		// An array's level is its element's, the same single-child rule PromiseType follows.
 		return LevelOf(t.Elem)

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -201,9 +201,15 @@ func (t *GeneratorType) Accept(v TypeVisitor, pol Polarity) Type {
 	yield := cur.Yield.Accept(v, pol)      // covariant, what the generator produces
 	ret := cur.Ret.Accept(v, pol)          // covariant, like a function's return
 	next := cur.Next.Accept(v, pol.Flip()) // contravariant, the value `next(v)` sends in
+	// The raise is an exit, so it walks at the same polarity as the return. A nil Throws
+	// is the `never` shorthand and has nothing to walk.
+	throws := cur.Throws
+	if throws != nil {
+		throws = throws.Accept(v, pol)
+	}
 	out := cur
-	if yield != cur.Yield || ret != cur.Ret || next != cur.Next {
-		out = &GeneratorType{Yield: yield, Ret: ret, Next: next, Async: cur.Async}
+	if yield != cur.Yield || ret != cur.Ret || next != cur.Next || throws != cur.Throws {
+		out = &GeneratorType{Yield: yield, Ret: ret, Next: next, Throws: throws, Async: cur.Async}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1338,10 +1338,13 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 			equalTypeWith(a.ErrOrNever(), b.ErrOrNever(), ctx)
 	case *soltype.GeneratorType:
 		b, ok := b.(*soltype.GeneratorType)
+		// ThrowsOrNever reads both sides through the nil-is-never collapse, so two
+		// generators differing only in whether the raise slot was written compare equal.
 		return ok && a.Async == b.Async &&
 			equalTypeWith(a.Yield, b.Yield, ctx) &&
 			equalTypeWith(a.Ret, b.Ret, ctx) &&
-			equalTypeWith(a.Next, b.Next, ctx)
+			equalTypeWith(a.Next, b.Next, ctx) &&
+			equalTypeWith(a.ThrowsOrNever(), b.ThrowsOrNever(), ctx)
 	case *soltype.RefType:
 		b, ok := b.(*soltype.RefType)
 		// Mut must match — a mutable borrow never equals an immutable one — and the

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1138,6 +1138,10 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			errs := c.constrain(sub.Yield, sup.Yield, seen, false)
 			errs = append(errs, c.constrain(sub.Ret, sup.Ret, seen, false)...)
 			errs = append(errs, c.constrain(sup.Next, sub.Next, seen, false)...)
+			// The raise is covariant, like the return. ThrowsOrNever reads both sides
+			// through the nil-is-never collapse, so a generator that cannot raise
+			// satisfies one that declares a raise type.
+			errs = append(errs, c.constrain(sub.ThrowsOrNever(), sup.ThrowsOrNever(), seen, false)...)
 			return errs
 		}
 	case *soltype.RefType:

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1923,6 +1923,34 @@ func (e *UnusedThrowsClauseError) Message() string {
 		"` is unreachable; drop the clause"
 }
 
+// GenThrowsClauseError fires when a `gen fn` writes a `throws` clause. A generator does
+// not raise at the call: obtaining one runs no body code, so what the body raises
+// surfaces at `next(v)` and belongs on the generator the function returns. The return
+// annotation's fourth argument is the surface that declares it.
+//
+// It is the generator twin of AsyncThrowsClauseError and a WALK rejection like it: born
+// in inferFunc with the clause and function nodes in hand, so it self-blames from the
+// clause's span and relates the function via Related(). The raise type is still read from
+// the annotation or inferred from the body, so one diagnostic covers the fault.
+type GenThrowsClauseError struct {
+	Throws ast.TypeAnn // the clause's annotation (blame span)
+	Fn     ast.Node    // the enclosing generator function, surfaced via Related()
+}
+
+func (*GenThrowsClauseError) isSolverError() {}
+func (e *GenThrowsClauseError) Span() ast.Span {
+	return e.Throws.Span()
+}
+func (e *GenThrowsClauseError) Related() []ast.Span {
+	if e.Fn == nil {
+		return nil
+	}
+	return []ast.Span{e.Fn.Span()}
+}
+func (e *GenThrowsClauseError) Message() string {
+	return "generator function cannot have a throws clause; declare the raise type in the return type as Generator<..., E>"
+}
+
 // GeneratorWithoutYieldError fires when a `gen fn` body contains no `yield` and no
 // `yield from`. The program is well-typed — the function returns a generator whose Yield
 // slot is `never` — but that generator finishes on the first `next()` without ever
@@ -2590,8 +2618,13 @@ func describe(t soltype.Type) string {
 		return "Promise<" + describe(t.Inner) + ">"
 	case *soltype.GeneratorType:
 		// Structural like the Promise arm, so a rejected constraint names the slot
-		// types: `Generator<number, void, never>`.
-		return t.Name() + "<" + describe(t.Yield) + ", " + describe(t.Ret) + ", " + describe(t.Next) + ">"
+		// types: `Generator<number, void, never>`. The raise type joins them only when
+		// the generator can raise, matching the printer.
+		slots := describe(t.Yield) + ", " + describe(t.Ret) + ", " + describe(t.Next)
+		if t.Raises() {
+			slots += ", " + describe(t.Throws)
+		}
+		return t.Name() + "<" + slots + ">"
 	case *soltype.KeyofType:
 		// A `keyof` residual renders structurally, recursing like the Promise arm, so a
 		// rejected constraint names it `keyof <operand>` rather than the default `?`. The

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -336,9 +336,22 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// A generator's yield sink and `next` resolve before the body for the reason the
 	// throws clause does, so each `yield` is checked at its own site. The return
 	// annotation on a `gen fn` names the external Generator, and its slots seed the sinks.
+	//
+	// A generator cannot raise at the call either: its body's raises surface at `next(v)`,
+	// so the annotation's E is the only surface that declares them and a `throws` clause is
+	// rejected, exactly as on an `async fn`. A written E seeds the sink; otherwise the sink
+	// is left to be inferred and lands in the wrapped generator's Throws.
 	var gen *genSinks
 	if sig.Gen {
 		gen = c.resolveGenSinks(declScope, node, sig, lvl)
+		if sig.Throws != nil && !sig.Async {
+			c.report(&GenThrowsClauseError{Throws: sig.Throws, Fn: node})
+		}
+		if gen.ann != nil && gen.ann.Raises() {
+			declaredThrows = gen.ann.Throws
+		} else {
+			declaredThrows = nil
+		}
 	}
 
 	var ret soltype.Type = &soltype.Void{}
@@ -444,14 +457,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// A generator takes its own arm ahead of the async one: an `async gen fn` faces
 	// callers as an AsyncGenerator, not a Promise, so the async wrap never applies.
 	//
-	// It keeps its body's raises on its own Throws, which over-approximates: advancing
-	// the generator is what raises, so a caller that only obtains one is asked to handle
-	// an exception it cannot yet observe. An `async fn` moves its raises into the
-	// promise's rejection slot just below, and a generator has no such slot. Keeping the
-	// raise here errs safe, since dropping it would let the raise escape a clause-less
-	// caller that iterates. Giving GeneratorType a rejection slot is the real fix.
+	// It also moves the body's raises, the way the async arm moves them into the promise.
+	// Obtaining a generator runs no body code, so what the body raises belongs on the
+	// generator it returns rather than on the signature, and the function's own Throws
+	// stays `never`. Iterating or delegating is what advances it, and those sites read the
+	// slot back into their enclosing sink.
 	if sig.Gen {
-		ret = c.genReturn(node, gen, retExprs, ret, hasBody)
+		ret = c.genReturn(node, gen, retExprs, ret, throws, hasBody)
+		throws = nil
 	} else if sig.Async {
 		// The async arm also moves the body's throws. An `async fn` rejects its promise
 		// rather than raising, so the body's throws become the promise's Err and the
@@ -997,9 +1010,10 @@ func (c *checker) resolveGenSinks(scope *Scope, node ast.Node, sig ast.FuncSig, 
 // genReturn computes a `gen fn`'s external return type, always a generator, since
 // calling one returns a generator object rather than the body's value. A matching
 // annotation IS that type, with the body's return constrained against its `Ret` slot.
-// Otherwise the inferred pieces are wrapped. A bodyless `declare gen fn` wraps
-// `unknown` rather than the synthetic Void, which would signal that it returns nothing.
-func (c *checker) genReturn(node ast.Node, gs *genSinks, retExprs []ast.Expr, bodyType soltype.Type, hasBody bool) soltype.Type {
+// Otherwise the inferred pieces are wrapped, with what the body raises going in the
+// generator's Throws. A bodyless `declare gen fn` wraps `unknown` rather than the
+// synthetic Void, which would signal that it returns nothing.
+func (c *checker) genReturn(node ast.Node, gs *genSinks, retExprs []ast.Expr, bodyType, throws soltype.Type, hasBody bool) soltype.Type {
 	if gs.ann != nil {
 		if hasBody {
 			c.constrainReturnAgainstAnnotation(node, retExprs, bodyType, gs.ann.Ret) // body <: declared Ret
@@ -1009,13 +1023,16 @@ func (c *checker) genReturn(node ast.Node, gs *genSinks, retExprs []ast.Expr, bo
 	if !hasBody {
 		bodyType = &soltype.UnknownType{}
 	}
-	return c.wrapGenerator(node, gs, bodyType)
+	return c.wrapGenerator(node, gs, bodyType, throws)
 }
 
-// wrapGenerator mints the external `Generator<Y, R, N>` face of a generator function
-// and records its provenance (GeneratorWrap) against the function node.
-func (c *checker) wrapGenerator(node ast.Node, gs *genSinks, bodyType soltype.Type) soltype.Type {
-	wrapped := &soltype.GeneratorType{Yield: gs.yields, Ret: bodyType, Next: gs.next, Async: gs.async}
+// wrapGenerator mints the external generator face of a generator function and records
+// its provenance (GeneratorWrap) against the function node. A nil throws leaves the
+// Throws slot nil, the shorthand for a generator that cannot raise.
+func (c *checker) wrapGenerator(node ast.Node, gs *genSinks, bodyType, throws soltype.Type) soltype.Type {
+	wrapped := &soltype.GeneratorType{
+		Yield: gs.yields, Ret: bodyType, Next: gs.next, Throws: throws, Async: gs.async,
+	}
 	c.recordProv(wrapped, node, GeneratorWrap)
 	return wrapped
 }
@@ -2766,6 +2783,9 @@ func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Ty
 			return t
 		}
 		arg := c.inferExpr(scope, lvl, e.Value)
+		// Delegating advances the delegate, so what it raises reaches this body's sink
+		// exactly as iterating it would.
+		c.constrainIterationRaise(e.Value, arg, lvl)
 		elem, res, ok := c.delegateElemType(arg)
 		if !ok {
 			// A delegate with no structure is the recursive case: `gen fn f() { yield from

--- a/internal/solver/infer_for_in.go
+++ b/internal/solver/infer_for_in.go
@@ -42,6 +42,10 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 	}
 
 	iterable := c.inferExpr(scope, lvl, s.Iterable)
+	// A loop advances what it iterates, so a generator's raise surfaces here rather than
+	// where the generator was obtained. Constrain it into the enclosing sink, the way a
+	// throwing call does, so iterating one needs a clause or a `try`.
+	c.constrainIterationRaise(s.Iterable, iterable, lvl)
 	elem, ok := c.iterableElemType(s.IsAwait, iterable)
 	if !ok {
 		// An iterable that already failed to infer is the ErrorType recovery
@@ -81,6 +85,49 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 	c.bindPattern(bodyScope, lvl, s.Pattern, elem, nil)
 	c.inferBlock(bodyScope, lvl, &s.Body)
 	return &soltype.Void{}
+}
+
+// constrainIterationRaise sends what advancing t may raise into the enclosing throws
+// sink. Only a generator carries a raise type today, and a union of them raises whatever
+// any branch does, so the walk mirrors the element-type walk. Anything else contributes
+// nothing. It marks the body as raising for the same reason a throwing call does, so an
+// unused-clause warning is not drawn against a clause this loop uses.
+func (c *checker) constrainIterationRaise(site ast.Expr, t soltype.Type, lvl int) {
+	raise, ok := c.iterationRaise(t)
+	if !ok {
+		return
+	}
+	c.constrain(site, raise, c.throwsSink(lvl))
+	c.markRaised()
+}
+
+// iterationRaise returns what advancing t may raise, and whether anything can. A borrow
+// is peeled and an inference variable coalesced first, the same normalization the
+// element-type walk applies.
+func (c *checker) iterationRaise(t soltype.Type) (soltype.Type, bool) {
+	t = soltype.CarrierOf(t)
+	if _, isVar := t.(*soltype.TypeVarType); isVar {
+		t = soltype.CarrierOf(coalesce(t, soltype.Positive))
+	}
+	switch t := t.(type) {
+	case *soltype.GeneratorType:
+		if !t.Raises() {
+			return nil, false
+		}
+		return t.Throws, true
+	case *soltype.UnionType:
+		raises := make([]soltype.Type, 0, len(t.Types))
+		for _, branch := range t.Types {
+			if r, ok := c.iterationRaise(branch); ok {
+				raises = append(raises, r)
+			}
+		}
+		if len(raises) == 0 {
+			return nil, false
+		}
+		return newUnion(c.ctx, raises, false), true
+	}
+	return nil, false
 }
 
 // iterableElemType resolves the element type T yielded by iterating a value of

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -364,42 +364,86 @@ func TestInferGenReturnAnnotationShape(t *testing.T) {
 	})
 }
 
-// The throws sink is untouched by generator-ness: a clause-less gen fn raises nothing,
-// so a throw in its body is rejected at the throw, exactly as in a plain function, and a
-// declared clause reaches the generator's own type.
-//
-// A generator carries its body's raises on its own signature, which over-approximates:
-// advancing the generator is what raises, so a caller that only obtains it is asked to
-// handle an exception it cannot yet observe. An `async fn` moves its raises into the
-// promise's rejection slot, and a generator has no such slot to move them into. Keeping
-// them on the signature errs in the safe direction — dropping them instead would let the
-// raise escape a clause-less caller that iterates.
-func TestInferGenThrowsStillChecked(t *testing.T) {
-	runGenErrCases(t, []genErrCase{
+// A generator does not raise at the call: obtaining one runs no body code, so what the
+// body raises lands in the generator's Throws slot and the function's own throws stays
+// `never`. Advancing it is what raises, so iterating or delegating reads the slot back
+// into the enclosing sink. This mirrors how an `async fn` moves its raises onto the
+// promise it returns.
+func TestInferGenRaises(t *testing.T) {
+	runGenCases(t, []genCase{
 		{
-			name:     "ThrowInAClauselessGenFn",
-			src:      `gen fn f() { yield 1 throw "boom" }`,
-			wantErrs: []string{`1:28-1:34: cannot constrain "boom" <: never`},
+			// With no annotation the raise is inferred into the slot, the way an
+			// annotation-less `async fn` infers its rejection.
+			name: "RaiseInferredIntoTheSlot",
+			src:  `gen fn f() { yield 1 throw "boom" }`,
+			want: `fn () -> Generator<1, never, never, "boom">`,
 		},
 		{
-			// Iterating a throwing generator is a `.next()` driver, so the raise must
-			// reach the enclosing clause. The over-approximation on the signature is
-			// what carries it there today.
-			name: "IteratingAThrowingGeneratorNeedsAClause",
+			// A written fourth argument seeds the sink, so each `throw` is checked
+			// against it and the annotation is presented as the external type.
+			name: "RaiseDeclaredInTheAnnotation",
+			src:  `gen fn f() -> Generator<1, never, never, "boom"> { yield 1 throw "boom" }`,
+			want: `fn () -> Generator<1, never, never, "boom">`,
+		},
+		{
+			// A generator that cannot raise leaves the slot at `never` and renders three
+			// arguments, the same suppression `Promise<T>` gets.
+			name: "NonRaisingGeneratorRendersThreeArgs",
+			src:  `gen fn f() { yield 1 }`,
+			want: `fn () -> Generator<1, void, never>`,
+		},
+		{
+			// Obtaining a generator runs none of its body, so a clause-less caller needs
+			// no clause of its own.
+			name: "ObtainingAGeneratorRaisesNothing",
 			src: `
-				gen fn g() throws "boom" { yield 1 throw "boom" }
+				gen fn g() { yield 1 throw "boom" }
+				fn f() { val it = g() }
+			`,
+			want: `fn () -> void`,
+		},
+		{
+			// Iterating advances the generator, so the raise reaches the caller's clause.
+			name: "IteratingCarriesTheRaiseToTheCaller",
+			src: `
+				gen fn g() { yield 1 throw "boom" }
+				fn f() throws _ { for x in g() { } }
+			`,
+			want: `fn () -> void throws "boom"`,
+		},
+		{
+			// Delegating advances the delegate, so it carries the raise the same way.
+			name: "DelegatingCarriesTheRaiseToTheDelegator",
+			src: `
+				gen fn g() { yield 1 throw "boom" }
+				gen fn f() { yield from g() }
+			`,
+			want: `fn () -> Generator<1, void, never, "boom">`,
+		},
+	})
+	runGenErrCases(t, []genErrCase{
+		{
+			// The raise type belongs in the return annotation, so a `throws` clause on a
+			// generator is rejected the way one on an `async fn` is.
+			name:     "ThrowsClauseRejected",
+			src:      `gen fn f() throws _ { yield 1 throw "boom" }`,
+			wantErrs: []string{"1:19-1:20: generator function cannot have a throws clause; declare the raise type in the return type as Generator<..., E>"},
+		},
+		{
+			// A declared raise slot is the sink each `throw` is checked against, so a
+			// mismatched raise is blamed at its own site.
+			name:     "ThrowAgainstDeclaredRaiseSlot",
+			src:      `gen fn f() -> Generator<1, never, never, "boom"> { yield 1 throw "other" }`,
+			wantErrs: []string{`1:66-1:73: cannot constrain "other" <: "boom"`},
+		},
+		{
+			// A clause-less caller that iterates a raising generator is asked to handle it.
+			name: "IteratingWithoutAClauseRejected",
+			src: `
+				gen fn g() { yield 1 throw "boom" }
 				fn f() { for x in g() { } }
 			`,
 			wantErrs: []string{`3:23-3:26: cannot constrain "boom" <: never`},
-		},
-	})
-	runGenCases(t, []genCase{
-		{
-			// The body always leaves along the exceptional edge, so its normal return —
-			// the Generator's Ret slot — is `never`.
-			name: "GenFnWithThrowsClause",
-			src:  `gen fn f() throws _ { yield 1 throw "boom" }`,
-			want: `fn () -> Generator<1, never, never> throws "boom"`,
 		},
 	})
 }

--- a/internal/solver/infer_generator_type_test.go
+++ b/internal/solver/infer_generator_type_test.go
@@ -113,3 +113,69 @@ func TestGeneratorVariance(t *testing.T) {
 		})
 	}
 }
+
+// The optional fourth type argument names what advancing the generator may raise. An
+// unwritten one leaves the slot at `never`, so a generator that cannot raise renders
+// three arguments — the same suppression `Promise<T>` gets when it cannot reject.
+func TestResolveGeneratorRaiseAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "RaisingGeneratorKeepsItsFourthArgument",
+			src:  `fn f(g: Generator<number, string, never, boolean>) { return g }`,
+			want: `fn (g: Generator<number, string, never, boolean>) -> Generator<number, string, never, boolean>`,
+		},
+		{
+			// An explicit `never` collapses to the unwritten form, since ThrowsOrNever
+			// reads both through one canonical value.
+			name: "ExplicitNeverRendersAsThreeArguments",
+			src:  `fn f(g: Generator<number, string, never, never>) { return g }`,
+			want: `fn (g: Generator<number, string, never>) -> Generator<number, string, never>`,
+		},
+		{
+			name: "AsyncGeneratorCarriesItToo",
+			src:  `fn f(g: AsyncGenerator<number, string, never, boolean>) { return g }`,
+			want: `fn (g: AsyncGenerator<number, string, never, boolean>) -> AsyncGenerator<number, string, never, boolean>`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, test.src)
+			require.Empty(t, errs)
+			require.Equal(t, test.want, values["f"])
+		})
+	}
+}
+
+// The raise slot is covariant, like Ret: a generator that raises less satisfies one that
+// declares more, and a generator that cannot raise satisfies any declared raise type.
+func TestGeneratorRaiseVariance(t *testing.T) {
+	accepts := []string{
+		`
+			declare fn g() -> Generator<number, string, never, "a">
+			val f: fn () -> Generator<number, string, never, "a" | "b"> = g
+		`,
+		`
+			declare fn g() -> Generator<number, string, never>
+			val f: fn () -> Generator<number, string, never, "a"> = g
+		`,
+	}
+	for i, src := range accepts {
+		t.Run("Accepts"+string(rune('A'+i)), func(t *testing.T) {
+			_, _, errs := inferSource(t, src)
+			require.Empty(t, errs)
+		})
+	}
+
+	t.Run("RaiseIsNotContravariant", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			declare fn g() -> Generator<number, string, never, "a" | "b">
+			val f: fn () -> Generator<number, string, never, "a"> = g
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, `3:60-3:61: cannot constrain "b" <: "a"`, msgWithSpan(errs[0]))
+	})
+}

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -440,7 +440,10 @@ func compareSameKind(a, b soltype.Type) int {
 		if c := compareType(a.Ret, b.Ret); c != 0 {
 			return c
 		}
-		return compareType(a.Next, b.Next)
+		if c := compareType(a.Next, b.Next); c != 0 {
+			return c
+		}
+		return compareType(a.ThrowsOrNever(), b.ThrowsOrNever())
 	case *soltype.ArrayType:
 		return compareType(a.Elem, b.(*soltype.ArrayType).Elem)
 	case *soltype.FuncType:

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -102,16 +102,20 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 			c.recordProv(t, ta, AnnotationType)
 			return t, true
 		}
-		// The built-in Generator<Y, R, N> and AsyncGenerator<Y, R, N>, the external face of a
-		// `gen fn` / `async gen fn`. Like Promise they resolve here only when no user binding
-		// shadows the prelude placeholder, and a lifetime annotation is rejected rather than
-		// silently dropped. All three arguments are required: Y is what the body yields, R what
-		// it returns, and N what a `yield` expression evaluates to.
-		if name := ast.QualIdentToString(ta.Name); (name == "Generator" || name == "AsyncGenerator") && len(ta.TypeArgs) == 3 {
+		// The built-in Generator and AsyncGenerator, the external face of a `gen fn` /
+		// `async gen fn`. Like Promise they resolve here only when no user binding shadows
+		// the prelude placeholder, and a lifetime annotation is rejected rather than silently
+		// dropped. Y is what the body yields, R what it returns, and N what a `yield`
+		// evaluates to; all three are required. The optional fourth argument names what
+		// advancing the generator may raise, `Generator<Y, R, N, E>`, the same shape
+		// `Promise<T, E>` takes. An unwritten one leaves Throws nil, the shorthand for a
+		// generator that cannot raise.
+		if name := ast.QualIdentToString(ta.Name); (name == "Generator" || name == "AsyncGenerator") &&
+			(len(ta.TypeArgs) == 3 || len(ta.TypeArgs) == 4) {
 			if len(ta.LifetimeArgs) > 0 || ta.Lifetime != nil {
 				return c.reportUnsupportedFeature(ta, "lifetime annotation on "+name), false
 			}
-			slots := make([]soltype.Type, 3)
+			slots := make([]soltype.Type, len(ta.TypeArgs))
 			for i, arg := range ta.TypeArgs {
 				slot, ok := c.resolveTypeAnn(scope, arg, lvl)
 				if !ok {
@@ -123,7 +127,14 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 				}
 				slots[i] = slot
 			}
-			t := &soltype.GeneratorType{Yield: slots[0], Ret: slots[1], Next: slots[2], Async: name == "AsyncGenerator"}
+			var throws soltype.Type
+			if len(slots) == 4 {
+				throws = slots[3]
+			}
+			t := &soltype.GeneratorType{
+				Yield: slots[0], Ret: slots[1], Next: slots[2], Throws: throws,
+				Async: name == "AsyncGenerator",
+			}
 			c.recordProv(t, ta, AnnotationType)
 			return t, true
 		}


### PR DESCRIPTION
Fifth of the stacked PRs implementing **PR11** of [planning/simple_sub/m9-implementation-plan.md](planning/simple_sub/m9-implementation-plan.md). This one closes the known gap the earlier four documented, by giving a generator a raise slot the way PR10c (#1000) gave `Promise` a rejection slot.

**Stacked on #1005** — review #1002 through #1005 first; this PR's diff is against #1005, not `main`.

1. #1002 — `gen fn` syntax, codegen, checker marker
2. #1003 — `soltype.GeneratorType` and its parallel arms
3. #1004 — yield inference and the external generator face
4. #1005 — `yield from` delegation and generator iteration
5. **this PR** — the raise slot

## Why this is separate

It touches all three type-carrying PRs at once — the node in #1003, the inference that fills it in #1004, and the iteration and delegation sites that read it in #1005 — so folding it in would re-open each of them after review and blur what each is about. It also stands on its own: everything below it is complete and correct without it, just less precise.

## What lands

`soltype.GeneratorType` gains a `Throws` slot, written as an optional fourth type argument, `Generator<Y, R, N, E>` and `AsyncGenerator<Y, R, N, E>`. This is the same shape `Promise<T, E>` takes, down to the details: `Throws` is covariant, a nil `Throws` is shorthand for `never` via `ThrowsOrNever`, and a generator that cannot raise is the zero value and still renders three arguments. `Raises` decides whether the fourth argument appears, mirroring `Rejects`.

`inferFunc` moves a generator body's raises into that slot and leaves the function's own `Throws` at `never`, exactly as the async arm moves them onto the promise. A `throws` clause on a `gen fn` is rejected with `GenThrowsClauseError`, the twin of `AsyncThrowsClauseError` — the raise type belongs in the return annotation, whose fourth argument seeds the sink when written and is inferred from the body when not.

Iterating and delegating are what advance a generator, so both read the slot back into the enclosing throws sink through one shared helper. That helper distributes over unions, so a union of generators raises whatever any branch does.

## What this fixes

The earlier PRs carried a generator's raises on its own signature, which over-approximated in the safe direction but was wrong in both directions at once:

- **False positive, now gone.** `fn f() { val it = g() }` was asked to handle an exception it could not observe, because obtaining a generator runs no body code.
- **False negative, avoided.** Simply dropping the raise would have let it escape a clause-less caller that iterates. Now `for x in g() { }` over a raising generator reports it, and `fn f() throws _ { for x in g() { } }` infers `throws "boom"`.

A clause-less generator also now *infers* its raise rather than rejecting the `throw`, matching how an annotation-less `async fn` infers its rejection.

## A choice worth confirming

The slot goes on **both** `Generator` and `AsyncGenerator`, not just the async form. They are one node distinguished by a flag, and a sync generator's `next()` raises just as an async one's does — the `IteratingWithoutAClauseRejected` test is the sync case. Restricting it to the async form would leave the sync side with the imprecision this removes.

## Testing

`TestInferGenRaises` covers the inferred and declared slot, the three-argument suppression, obtaining versus iterating versus delegating, the rejected clause, and a mismatched raise blamed at its own `throw`. `TestResolveGeneratorRaiseAnnotation` covers the annotation surface including an explicit `never` collapsing to the short form, and `TestGeneratorRaiseVariance` covers covariance in both directions. `go test ./...` passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfnxBqoHTKYakb748NAP4V)_