### PR TITLE
printer: render a class, alias, or enum binding under its source type-parameter names

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -652,38 +652,34 @@ func (p *namedPrinter) bindTypeParam(v *TypeVarType, base string) string {
 
 // bindTypeParams registers each type parameter's binding variable under its source name, so
 // a use of the parameter renders as that name rather than the raw t{ID} debug form. A
-// parameter with no source name is left unregistered and falls back to t{ID}. The names stay
-// in scope for the rest of the render; scopeTypeParams is the form that releases them.
-func (p *namedPrinter) bindTypeParams(tps []*TypeParam) {
+// parameter with no source name is left unregistered and falls back to t{ID}.
+//
+// It returns the surface names it bound. A caller whose parameters go out of scope partway
+// through the render hands them to releaseNames at that point; one whose parameters stay in
+// scope for the whole render discards them.
+func (p *namedPrinter) bindTypeParams(tps []*TypeParam) []string {
+	if len(tps) == 0 {
+		return nil
+	}
+	bound := make([]string, 0, len(tps))
 	for _, tp := range tps {
 		if tp.Name != "" {
-			p.bindTypeParam(tp.Var, tp.Name)
+			bound = append(bound, p.bindTypeParam(tp.Var, tp.Name))
 		}
 	}
+	return bound
 }
 
-// scopeTypeParams binds tps like bindTypeParams and returns a function that releases their
-// names for the next signature to reuse. A signature's parameters are in scope only inside
-// it, so two overload arms each written `<T>` both render `T`. A `<T>` nested inside an
-// enclosing `<T>` is still renamed, because the enclosing binder holds its name across the
-// whole nested signature.
+// releaseNames frees each name for a later binder to reuse. A signature's parameters are in
+// scope only inside it, so releasing them on the way out is what lets two overload arms each
+// written `<T>` both render `T`. A `<T>` nested inside an enclosing `<T>` is still renamed,
+// because the enclosing binder holds its name across the whole nested signature.
 //
 // The variable-to-name bindings themselves are left in place, so a variable that escaped its
 // binder still renders under the name its declaration gave it.
-func (p *namedPrinter) scopeTypeParams(tps []*TypeParam) func() {
-	if len(tps) == 0 {
-		return func() {}
-	}
-	claimed := make([]string, 0, len(tps))
-	for _, tp := range tps {
-		if tp.Name != "" {
-			claimed = append(claimed, p.bindTypeParam(tp.Var, tp.Name))
-		}
-	}
-	return func() {
-		for _, name := range claimed {
-			p.claimed.Remove(name)
-		}
+func (p *namedPrinter) releaseNames(names []string) {
+	for _, name := range names {
+		p.claimed.Remove(name)
 	}
 }
 
@@ -1210,8 +1206,8 @@ func (p *namedPrinter) printSelfReceiver(sp *FuncParam) string {
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	// The signature's own type parameters are in scope only inside it, so their names are
 	// released on the way out and a sibling signature is free to reuse them.
-	unbind := p.scopeTypeParams(t.TypeParams)
-	defer unbind()
+	scoped := p.bindTypeParams(t.TypeParams)
+	defer p.releaseNames(scoped)
 	p.nameLifetimeParams(t.LifetimeParams)
 	binders := append(p.typeParamBinders(t.TypeParams), p.lifetimeParamBinders(t.LifetimeParams)...)
 	prefix := ""
@@ -1280,9 +1276,8 @@ func isNever(t Type) bool {
 // constraint, `U = D` for a default, or `U: T = D` for both — without the surrounding
 // `<>`. The constraint is the parameter variable's upper bound. A variable with several
 // upper bounds renders them joined by ` & `. The parameters must be bound first, through
-// bindTypeParams or scopeTypeParams. Each binder then renders under its own name, and a
-// binder whose constraint or default names a sibling parameter renders that name too.
-// Callers that build a
+// bindTypeParams. Each binder then renders under its own name, and a binder whose constraint
+// or default names a sibling parameter renders that name too. Callers that build a
 // combined quantifier prefix, such as PrintAsSchemeWith, join these with the scheme's
 // free variables and lifetimes into one list.
 func (p *namedPrinter) typeParamBinders(tps []*TypeParam) []string {

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -174,8 +174,8 @@ func PrintAsScheme(t Type) string {
 // A class, alias, or enum keeps its type parameters in the checker's registry rather than
 // in the type it binds, so the type carries the parameter's variable and nothing else.
 // `class Node<T> {value: T}` binds the type Node<t0>, which Print renders with the raw
-// `t{ID}` debug form. Passing the class's parameters here renders it Node<T>. A variable no
-// entry of declared names keeps that `t{ID}` form, the fallback Print applies to every
+// `t{ID}` debug form. Passing the class's parameters here renders it Node<T>. A variable that
+// declared does not list keeps the `t{ID}` form, the fallback Print applies to every
 // variable.
 func PrintWithParams(t Type, declared []*TypeParam) string {
 	p := &namedPrinter{}
@@ -202,8 +202,8 @@ func PrintWithParams(t Type, declared []*TypeParam) string {
 // accepts renders under its source name and leads the quantifier prefix in declaration
 // order, ahead of the generated names. `class Pair<K, V>` whose constructor takes v before
 // k therefore renders `<K, V> {new (v: V, k: K) -> Pair<K, V>}` rather than a binder list
-// permuted by first appearance. Pass nil when there is no such declaration, which is every
-// function: a FuncType carries its own parameters and names them itself.
+// permuted by first appearance. Pass nil when there is no such declaration. That is every
+// function, since a FuncType carries its own parameters and names them itself.
 func PrintAsSchemeWith(
 	t Type,
 	isParam func(*TypeVarType) bool,
@@ -213,8 +213,7 @@ func PrintAsSchemeWith(
 	p := &namedPrinter{}
 	// A function's own type parameters claim their source names before anything else, so a
 	// generated T0 skips a name the source itself wrote. `fn <T0>` beside a free scheme
-	// variable renders `fn <T1, T0>`, with each binder naming one variable. The FuncType arm
-	// below reads these names back rather than binding them a second time.
+	// variable renders `fn <T1, T0>`, with each binder naming one variable.
 	if ft, ok := t.(*FuncType); ok {
 		p.bindTypeParams(ft.TypeParams)
 	}
@@ -233,7 +232,7 @@ func PrintAsSchemeWith(
 			continue
 		}
 		if _, bound := p.names[tp.Var]; bound {
-			continue // two parameters sharing one variable name it once
+			continue // one variable gets one binder, however many parameters point at it
 		}
 		labels = append(labels, p.bindTypeParam(tp.Var, tp.Name))
 	}
@@ -616,24 +615,25 @@ type namedPrinter struct {
 	// the nesting of the node being rendered, counted from 0 at the root.
 	maxDepth int
 	depth    int
-	// claimed holds every surface name currently bound to a type parameter in this render,
-	// across both alphabets — a source name such as `K` and a generated `T0`. A binder
-	// consults it so two parameters visible at once never render under one name. A
-	// signature's own parameters are unbound once it is rendered, so two sibling signatures
+	// claimed holds every surface name a type parameter in scope at this point renders
+	// under, across both alphabets — a source name such as `K` and a generated `T0`. A new
+	// binder consults it so two parameters in scope at once never share one name. A
+	// signature releases its own parameters' names on the way out, so two sibling signatures
 	// each written `<T>` both render `T`.
 	claimed set.Set[string]
 }
 
-// nameTaken reports whether a type parameter visible at this point already renders under
+// nameTaken reports whether a type parameter in scope at this point already renders under
 // name. Reading a nil set is safe, so plain Print needs no initialization.
 func (p *namedPrinter) nameTaken(name string) bool {
 	return p.claimed.Contains(name)
 }
 
-// bindTypeParam registers v under name for the rest of this render and returns the name it
-// was bound to. base is used as written when it is free. When another parameter already holds
-// it, a numeric suffix disambiguates: a method written `<T>` inside a class written `<T>`
-// renders its own parameter as `T_2`, so the two stay distinct wherever both are visible.
+// bindTypeParam registers v under a surface name derived from base and returns that name.
+// base is used as written when no parameter in scope holds it. When one does, a numeric
+// suffix disambiguates. A method written `<T>` inside a class written `<T>` renders its own
+// parameter as `T_2`, so the two read as different types everywhere in the method, which is
+// the whole region where both are in scope.
 func (p *namedPrinter) bindTypeParam(v *TypeVarType, base string) string {
 	if p.names == nil {
 		p.names = map[*TypeVarType]string{}
@@ -642,7 +642,7 @@ func (p *namedPrinter) bindTypeParam(v *TypeVarType, base string) string {
 		p.claimed = set.NewSet[string]()
 	}
 	name := base
-	for n := 2; p.claimed.Contains(name); n++ {
+	for n := 2; p.nameTaken(name); n++ {
 		name = base + "_" + strconv.Itoa(n)
 	}
 	p.claimed.Add(name)
@@ -652,8 +652,8 @@ func (p *namedPrinter) bindTypeParam(v *TypeVarType, base string) string {
 
 // bindTypeParams registers each type parameter's binding variable under its source name, so
 // a use of the parameter renders as that name rather than the raw t{ID} debug form. A
-// parameter with no source name is left unregistered and falls back to t{ID}. The bindings
-// last for the rest of the render; scopeTypeParams is the form that undoes them.
+// parameter with no source name is left unregistered and falls back to t{ID}. The names stay
+// in scope for the rest of the render; scopeTypeParams is the form that releases them.
 func (p *namedPrinter) bindTypeParams(tps []*TypeParam) {
 	for _, tp := range tps {
 		if tp.Name != "" {
@@ -662,39 +662,27 @@ func (p *namedPrinter) bindTypeParams(tps []*TypeParam) {
 	}
 }
 
-// scopeTypeParams binds tps for the duration of one signature and returns a function that
-// unbinds them. A signature's parameters are visible only inside it, so unbinding them frees
-// their names for the next signature: two overload arms each written `<T>` both render `T`,
-// while a `<T>` nested inside an enclosing `<T>` is still renamed by bindTypeParam.
+// scopeTypeParams binds tps like bindTypeParams and returns a function that releases their
+// names for the next signature to reuse. A signature's parameters are in scope only inside
+// it, so two overload arms each written `<T>` both render `T`. A `<T>` nested inside an
+// enclosing `<T>` is still renamed, because the enclosing binder holds its name across the
+// whole nested signature.
+//
+// The variable-to-name bindings themselves are left in place, so a variable that escaped its
+// binder still renders under the name its declaration gave it.
 func (p *namedPrinter) scopeTypeParams(tps []*TypeParam) func() {
 	if len(tps) == 0 {
 		return func() {}
 	}
-	type binding struct {
-		v     *TypeVarType
-		name  string
-		bound bool
-	}
-	restore := make([]binding, 0, len(tps))
 	claimed := make([]string, 0, len(tps))
 	for _, tp := range tps {
-		if tp.Name == "" {
-			continue
+		if tp.Name != "" {
+			claimed = append(claimed, p.bindTypeParam(tp.Var, tp.Name))
 		}
-		prev, bound := p.names[tp.Var]
-		restore = append(restore, binding{v: tp.Var, name: prev, bound: bound})
-		claimed = append(claimed, p.bindTypeParam(tp.Var, tp.Name))
 	}
 	return func() {
 		for _, name := range claimed {
 			p.claimed.Remove(name)
-		}
-		for _, b := range restore {
-			if b.bound {
-				p.names[b.v] = b.name
-				continue
-			}
-			delete(p.names, b.v)
 		}
 	}
 }
@@ -1220,8 +1208,8 @@ func (p *namedPrinter) printSelfReceiver(sp *FuncParam) string {
 // entry (`fn (x: T, ...) -> R`) so the exactness it carries round-trips to surface
 // syntax. An exact function with no receiver renders with no marker.
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
-	// The signature's own type parameters are visible only inside it, so they are unbound
-	// again on the way out and a sibling signature is free to reuse their names.
+	// The signature's own type parameters are in scope only inside it, so their names are
+	// released on the way out and a sibling signature is free to reuse them.
 	unbind := p.scopeTypeParams(t.TypeParams)
 	defer unbind()
 	p.nameLifetimeParams(t.LifetimeParams)
@@ -1292,8 +1280,9 @@ func isNever(t Type) bool {
 // constraint, `U = D` for a default, or `U: T = D` for both — without the surrounding
 // `<>`. The constraint is the parameter variable's upper bound. A variable with several
 // upper bounds renders them joined by ` & `. The parameters must be bound first, through
-// bindTypeParams or scopeTypeParams, so each binder renders under its own name and a binder
-// that references another parameter renders under that one's. Callers that build a
+// bindTypeParams or scopeTypeParams. Each binder then renders under its own name, and a
+// binder whose constraint or default names a sibling parameter renders that name too.
+// Callers that build a
 // combined quantifier prefix, such as PrintAsSchemeWith, join these with the scheme's
 // free variables and lifetimes into one list.
 func (p *namedPrinter) typeParamBinders(tps []*TypeParam) []string {
@@ -1493,4 +1482,3 @@ func printLit(lit Lit) string {
 	}
 	panic(fmt.Sprintf("printLit: unhandled Lit %T", lit))
 }
-

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -165,7 +165,22 @@ func PrintElided(t Type, maxDepth int) string {
 // PrintAsSchemeWith, which the solver's renderScheme does. Use renderScheme, not
 // PrintAsScheme, to display a solver scheme that may carry borrow lifetimes.
 func PrintAsScheme(t Type) string {
-	return PrintAsSchemeWith(t, func(*TypeVarType) bool { return true }, nil)
+	return PrintAsSchemeWith(t, func(*TypeVarType) bool { return true }, nil, nil)
+}
+
+// PrintWithParams renders a type like Print, naming each variable in declared under the
+// source name its declaration wrote.
+//
+// A class, alias, or enum keeps its type parameters in the checker's registry rather than
+// in the type it binds, so the type carries the parameter's variable and nothing else.
+// `class Node<T> {value: T}` binds the type Node<t0>, which Print renders with the raw
+// `t{ID}` debug form. Passing the class's parameters here renders it Node<T>. A variable no
+// entry of declared names keeps that `t{ID}` form, the fallback Print applies to every
+// variable.
+func PrintWithParams(t Type, declared []*TypeParam) string {
+	p := &namedPrinter{}
+	p.bindTypeParams(declared)
+	return p.printType(t)
 }
 
 // PrintAsSchemeWith renders a generalized type, naming ONLY the free variables
@@ -180,16 +195,62 @@ func PrintAsScheme(t Type) string {
 // bounded below by two borrows renders as `<'a: 'c, 'b: 'c, 'c>`, where 'a and 'b
 // each carry the bound {'c}. A nil map draws no bounds, so a caller that does not
 // solve lifetime bounds renders bare names.
-func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*LifetimeVar][]*LifetimeVar) string {
-	names := map[*TypeVarType]string{}
-	var labels []string
+//
+// declared carries the source type parameters of the declaration t stands for, in
+// declaration order. A class, alias, or enum keeps them in the checker's registry rather
+// than in the type, so the caller must hand them over. Each one whose variable isParam
+// accepts renders under its source name and leads the quantifier prefix in declaration
+// order, ahead of the generated names. `class Pair<K, V>` whose constructor takes v before
+// k therefore renders `<K, V> {new (v: V, k: K) -> Pair<K, V>}` rather than a binder list
+// permuted by first appearance. Pass nil when there is no such declaration, which is every
+// function: a FuncType carries its own parameters and names them itself.
+func PrintAsSchemeWith(
+	t Type,
+	isParam func(*TypeVarType) bool,
+	ltBounds map[*LifetimeVar][]*LifetimeVar,
+	declared []*TypeParam,
+) string {
+	p := &namedPrinter{}
+	// A function's own type parameters claim their source names before anything else, so a
+	// generated T0 skips a name the source itself wrote. `fn <T0>` beside a free scheme
+	// variable renders `fn <T1, T0>`, with each binder naming one variable. The FuncType arm
+	// below reads these names back rather than binding them a second time.
+	if ft, ok := t.(*FuncType); ok {
+		p.bindTypeParams(ft.TypeParams)
+	}
+	// The free variables the caller is willing to quantify, in first-appearance print order.
+	// Anything isParam rejects is left unnamed and renders as t{ID}.
+	var params []*TypeVarType
 	for _, v := range freeTypeVars(t) {
-		if !isParam(v) {
-			continue // non-parameter free var → left unnamed → renders as t{ID}
+		if isParam(v) {
+			params = append(params, v)
 		}
-		name := typeParamName(len(labels))
-		names[v] = name
-		labels = append(labels, name)
+	}
+	quantified := set.FromSlice(params)
+	var labels []string
+	for _, tp := range declared {
+		if tp.Name == "" || !quantified.Contains(tp.Var) {
+			continue
+		}
+		if _, bound := p.names[tp.Var]; bound {
+			continue // two parameters sharing one variable name it once
+		}
+		labels = append(labels, p.bindTypeParam(tp.Var, tp.Name))
+	}
+	// Every remaining quantified variable takes a generated T0, T1, … in first-appearance
+	// order, skipping any name a source parameter already claims.
+	next := 0
+	for _, v := range params {
+		if _, bound := p.names[v]; bound {
+			continue
+		}
+		name := typeParamName(next)
+		for p.nameTaken(name) {
+			next++
+			name = typeParamName(next)
+		}
+		next++
+		labels = append(labels, p.bindTypeParam(v, name))
 	}
 	// Borrow lifetimes left in the coalesced type by D4's coalesceLifetimes are all
 	// nameable. A connect-nothing one was already elided; a param lifetime and a kept
@@ -201,17 +262,17 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*Li
 	// A function's own lifetime parameters keep their source names in the prefix, and a
 	// free lifetime gets a generated name from the same 'a, 'b, … alphabet, so a generated
 	// name must skip any source name a parameter already claims. Without this a captured
-	// 'a and a declared 'a would both render as 'a. The type-parameter path never collides
-	// because generated T0, T1 and source names like U are disjoint alphabets.
+	// 'a and a declared 'a would both render as 'a. The type-parameter loop above skips a
+	// claimed name the same way.
 	reserved := ownLifetimeParamNames(t)
-	next := 0
+	nextLt := 0
 	for i, lv := range ltVars {
-		name := lifetimeParamName(next)
+		name := lifetimeParamName(nextLt)
 		for reserved.Contains(name) {
-			next++
-			name = lifetimeParamName(next)
+			nextLt++
+			name = lifetimeParamName(nextLt)
 		}
-		next++
+		nextLt++
 		ltNames[lv] = name
 		ltIndex[lv] = i
 	}
@@ -220,7 +281,7 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*Li
 		// keeps a leaked variable visible as t{ID}.
 		return Print(t)
 	}
-	p := &namedPrinter{names: names, ltNames: ltNames}
+	p.ltNames = ltNames
 	switch t.(type) {
 	case *ClassType, *AliasType:
 		// A class instance or alias reference already displays its parameters inline in its
@@ -240,8 +301,9 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*Li
 		// method that also captures a scheme variable renders `fn <T0, U, 'a>(...)` rather
 		// than adjacent groups. A function's own lifetime params are excluded from ltLabels
 		// by freeLifetimeVars, so they are named and rendered here from their declared
-		// bounds. printFuncBody omits the prefix so the own parameters are not repeated.
-		p.nameTypeParams(ft.TypeParams)
+		// bounds. printFuncBody omits the prefix so the own parameters are not repeated. The
+		// own TYPE parameters were bound at the top of this function, so typeParamBinders
+		// reads their names back rather than binding them a second time.
 		p.nameLifetimeParams(ft.LifetimeParams)
 		binders := append([]string{}, labels...)
 		binders = append(binders, p.typeParamBinders(ft.TypeParams)...)
@@ -554,6 +616,87 @@ type namedPrinter struct {
 	// the nesting of the node being rendered, counted from 0 at the root.
 	maxDepth int
 	depth    int
+	// claimed holds every surface name currently bound to a type parameter in this render,
+	// across both alphabets — a source name such as `K` and a generated `T0`. A binder
+	// consults it so two parameters visible at once never render under one name. A
+	// signature's own parameters are unbound once it is rendered, so two sibling signatures
+	// each written `<T>` both render `T`.
+	claimed set.Set[string]
+}
+
+// nameTaken reports whether a type parameter visible at this point already renders under
+// name. Reading a nil set is safe, so plain Print needs no initialization.
+func (p *namedPrinter) nameTaken(name string) bool {
+	return p.claimed.Contains(name)
+}
+
+// bindTypeParam registers v under name for the rest of this render and returns the name it
+// was bound to. base is used as written when it is free. When another parameter already holds
+// it, a numeric suffix disambiguates: a method written `<T>` inside a class written `<T>`
+// renders its own parameter as `T_2`, so the two stay distinct wherever both are visible.
+func (p *namedPrinter) bindTypeParam(v *TypeVarType, base string) string {
+	if p.names == nil {
+		p.names = map[*TypeVarType]string{}
+	}
+	if p.claimed == nil {
+		p.claimed = set.NewSet[string]()
+	}
+	name := base
+	for n := 2; p.claimed.Contains(name); n++ {
+		name = base + "_" + strconv.Itoa(n)
+	}
+	p.claimed.Add(name)
+	p.names[v] = name
+	return name
+}
+
+// bindTypeParams registers each type parameter's binding variable under its source name, so
+// a use of the parameter renders as that name rather than the raw t{ID} debug form. A
+// parameter with no source name is left unregistered and falls back to t{ID}. The bindings
+// last for the rest of the render; scopeTypeParams is the form that undoes them.
+func (p *namedPrinter) bindTypeParams(tps []*TypeParam) {
+	for _, tp := range tps {
+		if tp.Name != "" {
+			p.bindTypeParam(tp.Var, tp.Name)
+		}
+	}
+}
+
+// scopeTypeParams binds tps for the duration of one signature and returns a function that
+// unbinds them. A signature's parameters are visible only inside it, so unbinding them frees
+// their names for the next signature: two overload arms each written `<T>` both render `T`,
+// while a `<T>` nested inside an enclosing `<T>` is still renamed by bindTypeParam.
+func (p *namedPrinter) scopeTypeParams(tps []*TypeParam) func() {
+	if len(tps) == 0 {
+		return func() {}
+	}
+	type binding struct {
+		v     *TypeVarType
+		name  string
+		bound bool
+	}
+	restore := make([]binding, 0, len(tps))
+	claimed := make([]string, 0, len(tps))
+	for _, tp := range tps {
+		if tp.Name == "" {
+			continue
+		}
+		prev, bound := p.names[tp.Var]
+		restore = append(restore, binding{v: tp.Var, name: prev, bound: bound})
+		claimed = append(claimed, p.bindTypeParam(tp.Var, tp.Name))
+	}
+	return func() {
+		for _, name := range claimed {
+			p.claimed.Remove(name)
+		}
+		for _, b := range restore {
+			if b.bound {
+				p.names[b.v] = b.name
+				continue
+			}
+			delete(p.names, b.v)
+		}
+	}
 }
 
 // printLifetime renders a lifetime in Escalier surface syntax: 'static for the
@@ -1077,7 +1220,10 @@ func (p *namedPrinter) printSelfReceiver(sp *FuncParam) string {
 // entry (`fn (x: T, ...) -> R`) so the exactness it carries round-trips to surface
 // syntax. An exact function with no receiver renders with no marker.
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
-	p.nameTypeParams(t.TypeParams)
+	// The signature's own type parameters are visible only inside it, so they are unbound
+	// again on the way out and a sibling signature is free to reuse their names.
+	unbind := p.scopeTypeParams(t.TypeParams)
+	defer unbind()
 	p.nameLifetimeParams(t.LifetimeParams)
 	binders := append(p.typeParamBinders(t.TypeParams), p.lifetimeParamBinders(t.LifetimeParams)...)
 	prefix := ""
@@ -1142,30 +1288,12 @@ func isNever(t Type) bool {
 	return never
 }
 
-// nameTypeParams registers each type parameter's binding variable under its source name
-// in the printer's name map, so a use of the parameter inside the params, return,
-// constraints, or defaults renders as that name rather than the raw t{ID} debug form. It
-// allocates the map lazily, since plain Print starts with none. A parameter with no
-// source name is left unregistered and falls back to t{ID}.
-func (p *namedPrinter) nameTypeParams(tps []*TypeParam) {
-	if len(tps) == 0 {
-		return
-	}
-	if p.names == nil {
-		p.names = map[*TypeVarType]string{}
-	}
-	for _, tp := range tps {
-		if tp.Name != "" {
-			p.names[tp.Var] = tp.Name
-		}
-	}
-}
-
 // typeParamBinders renders each type parameter as a binder string — `U`, `U: T` for a
 // constraint, `U = D` for a default, or `U: T = D` for both — without the surrounding
 // `<>`. The constraint is the parameter variable's upper bound. A variable with several
-// upper bounds renders them joined by ` & `. nameTypeParams must run first so a binder
-// that references another parameter renders under its name. Callers that build a
+// upper bounds renders them joined by ` & `. The parameters must be bound first, through
+// bindTypeParams or scopeTypeParams, so each binder renders under its own name and a binder
+// that references another parameter renders under that one's. Callers that build a
 // combined quantifier prefix, such as PrintAsSchemeWith, join these with the scheme's
 // free variables and lifetimes into one list.
 func (p *namedPrinter) typeParamBinders(tps []*TypeParam) []string {
@@ -1365,3 +1493,4 @@ func printLit(lit Lit) string {
 	}
 	panic(fmt.Sprintf("printLit: unhandled Lit %T", lit))
 }
+

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -174,8 +174,8 @@ func PrintAsScheme(t Type) string {
 // A class, alias, or enum keeps its type parameters in the checker's registry rather than
 // in the type it binds, so the type carries the parameter's variable and nothing else.
 // `class Node<T> {value: T}` binds the type Node<t0>, which Print renders with the raw
-// `t{ID}` debug form. Passing the class's parameters here renders it Node<T>. A variable that
-// declared does not list keeps the `t{ID}` form, the fallback Print applies to every
+// `t{ID}` debug form. Passing the class's parameters here renders it Node<T>. A variable no
+// entry of `declared` points at keeps the `t{ID}` form, the fallback Print applies to every
 // variable.
 func PrintWithParams(t Type, declared []*TypeParam) string {
 	p := &namedPrinter{}

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -673,6 +673,19 @@ func TestPrintScheme(t *testing.T) {
 		require.Equal(t, "fn <T0, U>(x: U, y: T0) -> [U, T0]", PrintAsScheme(ty))
 	})
 
+	t.Run("a generated name skips a source name from the same alphabet", func(t *testing.T) {
+		t0 := &TypeVarType{ID: 10, Level: 2}   // a parameter the source wrote as T0
+		free := &TypeVarType{ID: 20, Level: 1} // a captured scheme variable
+		// fn <T0>(x: T0, y: free) -> [T0, free]: naming free T0 as well would put two binders
+		// under one name, so the generated alphabet skips to T1.
+		ty := &FuncType{
+			TypeParams: []*TypeParam{{Name: "T0", Var: t0}},
+			Params:     []*FuncParam{identP("x", t0), identP("y", free)},
+			Ret:        &TupleType{Elems: []Type{t0, free}},
+		}
+		require.Equal(t, "fn <T1, T0>(x: T0, y: T1) -> [T0, T1]", PrintAsScheme(ty))
+	})
+
 	t.Run("distinct vars are named by first appearance", func(t *testing.T) {
 		a := &TypeVarType{ID: 1, Level: 1}
 		b := &TypeVarType{ID: 2, Level: 1}
@@ -745,8 +758,145 @@ func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
 		Params: []*FuncParam{identP("x", param)},
 		Ret:    &TupleType{Elems: []Type{param, leaked}},
 	}
-	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 }, nil)
+	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 }, nil, nil)
 	require.Equal(t, "fn <T0>(x: T0) -> [T0, t99]", got)
+}
+
+// A class, alias, or enum keeps its type parameters outside the type it binds, so
+// PrintAsSchemeWith renders them under their source names only when the caller passes them as
+// declared. The cases below build the shape a class VALUE binding takes: an object holding
+// the constructor, whose free variables are the class's own parameters.
+//
+// quantified is the predicate renderScheme uses for a generalized binding — a variable
+// deeper than the binding's level is one generalization quantified.
+func TestPrintSchemeDeclaredNames(t *testing.T) {
+	quantified := func(v *TypeVarType) bool { return v.Level > 1 }
+
+	t.Run("a class parameter renders under its source name", func(t *testing.T) {
+		// class Node<T> { value: T, tail: Node<T> }
+		tv := &TypeVarType{ID: 0, Level: 2}
+		node := &ClassType{Name: "Node", TypeArgs: []Type{tv}}
+		obj := ctorObj(&FuncType{
+			Params: []*FuncParam{identP("value", tv), identP("tail", node)},
+			Ret:    node,
+		})
+		got := PrintAsSchemeWith(obj, quantified, nil, []*TypeParam{{Name: "T", Var: tv}})
+		require.Equal(t, "<T> {new (value: T, tail: Node<T>) -> Node<T>}", got)
+	})
+
+	t.Run("binders follow declaration order, not first appearance", func(t *testing.T) {
+		// class Pair<K, V> { …, constructor(mut self, v: V, k: K) { … } }. The constructor
+		// takes v first, so first appearance would order the binders V, K.
+		k := &TypeVarType{ID: 0, Level: 2}
+		v := &TypeVarType{ID: 1, Level: 2}
+		pair := &ClassType{Name: "Pair", TypeArgs: []Type{k, v}}
+		obj := ctorObj(&FuncType{
+			Params: []*FuncParam{identP("v", v), identP("k", k)},
+			Ret:    pair,
+		})
+		got := PrintAsSchemeWith(obj, quantified, nil,
+			[]*TypeParam{{Name: "K", Var: k}, {Name: "V", Var: v}})
+		require.Equal(t, "<K, V> {new (v: V, k: K) -> Pair<K, V>}", got)
+	})
+
+	t.Run("a generated name skips one the source already wrote", func(t *testing.T) {
+		// class C<T0> declares the name the generated alphabet starts at, so the undeclared
+		// variable beside it takes T1.
+		declared := &TypeVarType{ID: 0, Level: 2}
+		extra := &TypeVarType{ID: 1, Level: 2}
+		obj := ctorObj(&FuncType{
+			Params: []*FuncParam{identP("a", declared), identP("b", extra)},
+			Ret:    &ClassType{Name: "C", TypeArgs: []Type{declared}},
+		})
+		got := PrintAsSchemeWith(obj, quantified, nil, []*TypeParam{{Name: "T0", Var: declared}})
+		require.Equal(t, "<T0, T1> {new (a: T0, b: T1) -> C<T0>}", got)
+	})
+
+	t.Run("a variable the predicate rejects keeps the leak anchor", func(t *testing.T) {
+		// A source name does not mask a variable coalescing failed to inline: leaked is
+		// declared, but the predicate rejects it, so it renders as t99 rather than as E.
+		tv := &TypeVarType{ID: 0, Level: 2}
+		leaked := &TypeVarType{ID: 99, Level: 0}
+		obj := ctorObj(&FuncType{
+			Params: []*FuncParam{identP("a", tv), identP("b", leaked)},
+			Ret:    &ClassType{Name: "C", TypeArgs: []Type{tv}},
+		})
+		got := PrintAsSchemeWith(obj, quantified, nil,
+			[]*TypeParam{{Name: "T", Var: tv}, {Name: "E", Var: leaked}})
+		require.Equal(t, "<T> {new (a: T, b: t99) -> C<T>}", got)
+	})
+
+	t.Run("a method parameter shadowing the class's stays distinct", func(t *testing.T) {
+		// class Shadow<T> { v: T, m<T>(x: T) -> T }. The class's T holds the source name, so
+		// the method's own parameter renders under a suffixed one and the two never collide.
+		outer := &TypeVarType{ID: 0, Level: 2}
+		inner := &TypeVarType{ID: 1, Level: 3}
+		obj := &ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "v", Type: outer},
+			&MethodElem{Name: "m", Signatures: []*FuncType{{
+				TypeParams: []*TypeParam{{Name: "T", Var: inner}},
+				Params:     []*FuncParam{identP("x", inner)},
+				Ret:        outer,
+			}}},
+		}}
+		got := PrintAsSchemeWith(obj, quantified, nil, []*TypeParam{{Name: "T", Var: outer}})
+		require.Equal(t, "<T> {v: T, m<T_2>(x: T_2) -> T}", got)
+	})
+}
+
+// A signature's own type parameters are visible only inside it, so two sibling signatures
+// each written `<T>` both render T. Without that scoping the second would be renamed to avoid
+// the first, which shares no scope with it.
+func TestPrintSiblingSignaturesReuseOneName(t *testing.T) {
+	a := &TypeVarType{ID: 1, Level: 2}
+	b := &TypeVarType{ID: 2, Level: 2}
+	obj := &ObjectType{Elems: []ObjTypeElem{&MethodElem{Name: "m", Signatures: []*FuncType{
+		{TypeParams: []*TypeParam{{Name: "T", Var: a}}, Params: []*FuncParam{identP("x", a)}, Ret: a},
+		{TypeParams: []*TypeParam{{Name: "T", Var: b}}, Params: []*FuncParam{identP("y", b)}, Ret: b},
+	}}}}
+	require.Equal(t, "{m<T>(x: T) -> T; m<T>(y: T) -> T}", Print(obj))
+}
+
+// PrintWithParams is the plain-Print path for a TYPE binding, which carries no quantifier
+// prefix to hang names on. `class Node<T>` binds the type Node<t0>; handing over the class's
+// parameters renders it Node<T>.
+func TestPrintWithParams(t *testing.T) {
+	tv := &TypeVarType{ID: 0, Level: 2}
+	declared := []*TypeParam{{Name: "T", Var: tv}}
+
+	t.Run("a class instance names its argument", func(t *testing.T) {
+		got := PrintWithParams(&ClassType{Name: "Node", TypeArgs: []Type{tv}}, declared)
+		require.Equal(t, "Node<T>", got)
+	})
+
+	t.Run("an alias body names the variable it holds", func(t *testing.T) {
+		// The rendered form of `type Alias<T> = {v: T}`, whose binding shows the body rather
+		// than the opaque alias name.
+		body := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "v", Type: tv}}}
+		require.Equal(t, "{v: T}", PrintWithParams(body, declared))
+	})
+
+	t.Run("an enum names its variants' arguments", func(t *testing.T) {
+		// The rendered form of `enum Opt<T> { Some(v: T), None }`, whose binding is the union
+		// of the variant handles.
+		body := &UnionType{Types: []Type{
+			&ClassType{Name: "Opt.Some", TypeArgs: []Type{tv}, Variant: true},
+			&ClassType{Name: "Opt.None", TypeArgs: []Type{tv}, Variant: true},
+		}}
+		require.Equal(t, "Opt.Some<T> | Opt.None<T>", PrintWithParams(body, declared))
+	})
+
+	t.Run("an undeclared variable keeps the raw debug form", func(t *testing.T) {
+		other := &TypeVarType{ID: 42, Level: 2}
+		got := PrintWithParams(&ClassType{Name: "Node", TypeArgs: []Type{other}}, declared)
+		require.Equal(t, "Node<t42>", got)
+	})
+}
+
+// ctorObj wraps a constructor signature in the object a class value binds to, the
+// `{new (…) -> C}` shape classValue builds in internal/solver.
+func ctorObj(fn *FuncType) *ObjectType {
+	return &ObjectType{Elems: []ObjTypeElem{&ConstructorElem{Fn: fn}}}
 }
 
 // PrintElided renders a type like Print but stops at maxDepth, standing in ElisionMark for every

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -767,8 +767,8 @@ func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
 // declared. The cases below build the shape a class VALUE binding takes: an object holding
 // the constructor, whose free variables are the class's own parameters.
 //
-// quantified is the predicate renderScheme uses for a generalized binding — a variable
-// deeper than the binding's level is one generalization quantified.
+// quantified is the predicate renderScheme uses for a generalized binding: a variable minted
+// deeper than the binding's own level is one that generalization quantified.
 func TestPrintSchemeDeclaredNames(t *testing.T) {
 	quantified := func(v *TypeVarType) bool { return v.Level > 1 }
 
@@ -813,7 +813,7 @@ func TestPrintSchemeDeclaredNames(t *testing.T) {
 	})
 
 	t.Run("a variable the predicate rejects keeps the leak anchor", func(t *testing.T) {
-		// A source name does not mask a variable coalescing failed to inline: leaked is
+		// A source name does not mask a variable that coalescing failed to inline. leaked is
 		// declared, but the predicate rejects it, so it renders as t99 rather than as E.
 		tv := &TypeVarType{ID: 0, Level: 2}
 		leaked := &TypeVarType{ID: 99, Level: 0}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -602,9 +602,8 @@ func schemeType(s TypeScheme) soltype.Type {
 // spurious type parameter. A MonoScheme coalesces to a var-free type, so plain
 // PrintAsScheme suffices.
 //
-// It names no parameter from the source, so a class value binding's parameters come out
-// positional. renderSchemeWithParams is the form that renders them under the names the
-// declaration wrote.
+// It passes the printer no source names, so a class value binding's parameters render
+// positionally. renderSchemeWithParams renders them under the names the declaration wrote.
 func renderScheme(s TypeScheme) string {
 	return renderSchemeWithParams(s, nil)
 }
@@ -613,8 +612,8 @@ func renderScheme(s TypeScheme) string {
 // type parameters the scheme's declaration wrote. declared is the class's, alias's, or
 // enum's own parameters, which live in the Context registry rather than in the type, so a
 // caller reads them from there and hands them over. Pass nil for a binding with no such
-// declaration, which is every function: a FuncType carries its own parameters and names them
-// itself.
+// declaration. That is every function, since a FuncType carries its own parameters and names
+// them itself.
 func renderSchemeWithParams(s TypeScheme, declared []*soltype.TypeParam) string {
 	switch sc := s.(type) {
 	case *MonoScheme:
@@ -637,12 +636,6 @@ func (c *checker) renderValueBinding(s TypeScheme) string {
 	return renderSchemeWithParams(s, c.declaredTypeParams(schemeType(s)))
 }
 
-// renderTypeBinding renders a type binding under the source type-parameter names of the
-// declaration it came from, so `class Node<T>` binds a type that renders `Node<T>`.
-func (c *checker) renderTypeBinding(t soltype.Type) string {
-	return soltype.PrintWithParams(t, c.declaredTypeParams(t))
-}
-
 // declaredTypeParams returns the type parameters written by the declaration a display type
 // stands for, or nil when it stands for none. A class, alias, or enum keeps its parameters
 // in the Context registry rather than in the type, so the printer cannot reach them from the
@@ -663,9 +656,14 @@ func (c *checker) declaredTypeParams(t soltype.Type) []*soltype.TypeParam {
 		}
 	case *soltype.ObjectType:
 		for _, elem := range t.Elems {
-			if ctor, ok := elem.(*soltype.ConstructorElem); ok {
-				return c.declaredTypeParams(ctor.Fn.Ret)
+			ctor, isCtor := elem.(*soltype.ConstructorElem)
+			if !isCtor {
+				continue
 			}
+			if cls, isClass := ctor.Fn.Ret.(*soltype.ClassType); isClass {
+				return c.declaredTypeParams(cls)
+			}
+			return nil
 		}
 	}
 	return nil

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -603,37 +603,47 @@ func schemeType(s TypeScheme) soltype.Type {
 // PrintAsScheme suffices.
 //
 // It passes the printer no source names, so a class value binding's parameters render
-// positionally. renderSchemeWithParams renders them under the names the declaration wrote.
+// positionally. renderSchemeWith renders them under the names the declaration wrote.
 func renderScheme(s TypeScheme) string {
-	return renderSchemeWithParams(s, nil)
+	return renderSchemeWith(s, nil)
 }
 
-// renderSchemeWithParams renders a scheme like renderScheme, under the source names of the
-// type parameters the scheme's declaration wrote. declared is the class's, alias's, or
-// enum's own parameters, which live in the Context registry rather than in the type, so a
-// caller reads them from there and hands them over. Pass nil for a binding with no such
-// declaration. That is every function, since a FuncType carries its own parameters and names
-// them itself.
-func renderSchemeWithParams(s TypeScheme, declared []*soltype.TypeParam) string {
+// renderSchemeWith renders a scheme like renderScheme, under the source names of the type
+// parameters the scheme's declaration wrote. A class, alias, or enum keeps those parameters
+// in the Context registry rather than in the type, so declaredFor looks them up from the
+// scheme's display type. It is called with that type once it is derived, since the lookup
+// reads the class or alias the type names. Pass nil to name nothing from the source, which
+// is right for every function: a FuncType carries its own parameters and names them itself.
+func renderSchemeWith(s TypeScheme, declaredFor func(soltype.Type) []*soltype.TypeParam) string {
+	var t soltype.Type
+	// A MonoScheme coalesces to a var-free type, so every free variable left in it is a
+	// parameter. A PolyScheme names only the variables generalization quantified — those with
+	// Level > sc.Level, the exact retention criterion coalesceScheme uses — so a variable that
+	// escaped coalescing renders as the raw t{ID} debug form instead of being disguised as a
+	// spurious type parameter.
+	var isParam func(*soltype.TypeVarType) bool
 	switch sc := s.(type) {
 	case *MonoScheme:
-		t := coalesce(sc.Ty, soltype.Positive)
-		return soltype.PrintAsSchemeWith(t, func(*soltype.TypeVarType) bool { return true },
-			displayLtBounds(t, soltype.Positive), declared)
+		t = coalesce(sc.Ty, soltype.Positive)
+		isParam = func(*soltype.TypeVarType) bool { return true }
 	case *PolyScheme:
-		t := sc.display()
-		return soltype.PrintAsSchemeWith(t, func(v *soltype.TypeVarType) bool {
-			return v.Level > sc.Level
-		}, displayLtBounds(t, soltype.Positive), declared)
+		t = sc.display()
+		isParam = func(v *soltype.TypeVarType) bool { return v.Level > sc.Level }
+	default:
+		panic(fmt.Sprintf("renderScheme: unknown TypeScheme %T", s))
 	}
-	panic(fmt.Sprintf("renderScheme: unknown TypeScheme %T", s))
+	var declared []*soltype.TypeParam
+	if declaredFor != nil {
+		declared = declaredFor(t)
+	}
+	return soltype.PrintAsSchemeWith(t, isParam, displayLtBounds(t, soltype.Positive), declared)
 }
 
 // renderValueBinding renders a value binding's scheme under the source type-parameter names
 // of the declaration it came from, so `class Node<T> {value: T}` binds a value that renders
 // `<T> {new (value: T) -> Node<T>}`.
 func (c *checker) renderValueBinding(s TypeScheme) string {
-	return renderSchemeWithParams(s, c.declaredTypeParams(schemeType(s)))
+	return renderSchemeWith(s, c.declaredTypeParams)
 }
 
 // declaredTypeParams returns the type parameters written by the declaration a display type
@@ -648,11 +658,11 @@ func (c *checker) declaredTypeParams(t soltype.Type) []*soltype.TypeParam {
 	switch t := t.(type) {
 	case *soltype.ClassType:
 		if def, ok := c.ctx.classDef(t.Name); ok {
-			return def.TypeParams
+			return paramsForArgs(def.TypeParams, t.TypeArgs)
 		}
 	case *soltype.AliasType:
 		if def, ok := c.ctx.aliasDef(t.Name); ok {
-			return def.TypeParams
+			return paramsForArgs(def.TypeParams, t.TypeArgs)
 		}
 	case *soltype.ObjectType:
 		for _, elem := range t.Elems {
@@ -667,6 +677,36 @@ func (c *checker) declaredTypeParams(t soltype.Type) []*soltype.TypeParam {
 		}
 	}
 	return nil
+}
+
+// paramsForArgs returns tps with each parameter's variable replaced by the variable a
+// reference passes in that argument position. The printer names a variable by identity, and a
+// binding that holds an instantiated copy of a class value carries freshened variables rather
+// than the declaration's own. Reading the name off the argument position covers both:
+// `class Box<T> {value: T}` and a later `val Alias = Box` each render
+// `<T> {new (value: T) -> Box<T>}`, where matching on the declaration's variable would leave
+// the second positional.
+//
+// A position holding something other than a variable keeps the parameter as declared, so
+// `Box<5>` names nothing. So does a reference whose argument count does not match the
+// declaration's, which covers the argument-less handle an alias binds: `type Alias<T> = {v: T}`
+// renders its body under the declared variables.
+func paramsForArgs(tps []*soltype.TypeParam, args []soltype.Type) []*soltype.TypeParam {
+	if len(args) != len(tps) {
+		return tps
+	}
+	out := make([]*soltype.TypeParam, len(tps))
+	for i, tp := range tps {
+		v, isVar := args[i].(*soltype.TypeVarType)
+		if !isVar || v == tp.Var {
+			out[i] = tp
+			continue
+		}
+		cp := *tp
+		cp.Var = v
+		out[i] = &cp
+	}
+	return out
 }
 
 // hasEqualBounds reports whether v's lower and upper bound sets are non-empty and

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -630,7 +630,7 @@ func renderSchemeWith(s TypeScheme, declaredFor func(soltype.Type) []*soltype.Ty
 		t = sc.display()
 		isParam = func(v *soltype.TypeVarType) bool { return v.Level > sc.Level }
 	default:
-		panic(fmt.Sprintf("renderScheme: unknown TypeScheme %T", s))
+		panic(fmt.Sprintf("renderSchemeWith: unknown TypeScheme %T", s))
 	}
 	var declared []*soltype.TypeParam
 	if declaredFor != nil {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -601,19 +601,74 @@ func schemeType(s TypeScheme) soltype.Type {
 // not inlined) renders as the raw t{ID} debug form instead of being disguised as a
 // spurious type parameter. A MonoScheme coalesces to a var-free type, so plain
 // PrintAsScheme suffices.
+//
+// It names no parameter from the source, so a class value binding's parameters come out
+// positional. renderSchemeWithParams is the form that renders them under the names the
+// declaration wrote.
 func renderScheme(s TypeScheme) string {
+	return renderSchemeWithParams(s, nil)
+}
+
+// renderSchemeWithParams renders a scheme like renderScheme, under the source names of the
+// type parameters the scheme's declaration wrote. declared is the class's, alias's, or
+// enum's own parameters, which live in the Context registry rather than in the type, so a
+// caller reads them from there and hands them over. Pass nil for a binding with no such
+// declaration, which is every function: a FuncType carries its own parameters and names them
+// itself.
+func renderSchemeWithParams(s TypeScheme, declared []*soltype.TypeParam) string {
 	switch sc := s.(type) {
 	case *MonoScheme:
 		t := coalesce(sc.Ty, soltype.Positive)
 		return soltype.PrintAsSchemeWith(t, func(*soltype.TypeVarType) bool { return true },
-			displayLtBounds(t, soltype.Positive))
+			displayLtBounds(t, soltype.Positive), declared)
 	case *PolyScheme:
 		t := sc.display()
 		return soltype.PrintAsSchemeWith(t, func(v *soltype.TypeVarType) bool {
 			return v.Level > sc.Level
-		}, displayLtBounds(t, soltype.Positive))
+		}, displayLtBounds(t, soltype.Positive), declared)
 	}
 	panic(fmt.Sprintf("renderScheme: unknown TypeScheme %T", s))
+}
+
+// renderValueBinding renders a value binding's scheme under the source type-parameter names
+// of the declaration it came from, so `class Node<T> {value: T}` binds a value that renders
+// `<T> {new (value: T) -> Node<T>}`.
+func (c *checker) renderValueBinding(s TypeScheme) string {
+	return renderSchemeWithParams(s, c.declaredTypeParams(schemeType(s)))
+}
+
+// renderTypeBinding renders a type binding under the source type-parameter names of the
+// declaration it came from, so `class Node<T>` binds a type that renders `Node<T>`.
+func (c *checker) renderTypeBinding(t soltype.Type) string {
+	return soltype.PrintWithParams(t, c.declaredTypeParams(t))
+}
+
+// declaredTypeParams returns the type parameters written by the declaration a display type
+// stands for, or nil when it stands for none. A class, alias, or enum keeps its parameters
+// in the Context registry rather than in the type, so the printer cannot reach them from the
+// type alone and a caller reads them from here.
+//
+// A class VALUE binding is an object holding the constructor, whose return is the class's own
+// handle, so the class is reached through that return: `class Node<T>` binds the value
+// `{new (value: T) -> Node<T>}` and its parameters are found under Node.
+func (c *checker) declaredTypeParams(t soltype.Type) []*soltype.TypeParam {
+	switch t := t.(type) {
+	case *soltype.ClassType:
+		if def, ok := c.ctx.classDef(t.Name); ok {
+			return def.TypeParams
+		}
+	case *soltype.AliasType:
+		if def, ok := c.ctx.aliasDef(t.Name); ok {
+			return def.TypeParams
+		}
+	case *soltype.ObjectType:
+		for _, elem := range t.Elems {
+			if ctor, ok := elem.(*soltype.ConstructorElem); ok {
+				return c.declaredTypeParams(ctor.Fn.Ret)
+			}
+		}
+	}
+	return nil
 }
 
 // hasEqualBounds reports whether v's lower and upper bound sets are non-empty and

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -220,7 +220,7 @@ func TestInferClassGeneric(t *testing.T) {
 				val v = b.value
 			`,
 			wantValues: map[string]string{
-				"Box": "<T0> {new (value: T0) -> Box<T0>}",
+				"Box": "<T> {new (value: T) -> Box<T>}",
 				"b":   "Box<5>",
 				"v":   "5",
 			},
@@ -967,7 +967,7 @@ func TestInferClassGenericSubGenericSuper(t *testing.T) {
 		val g = d.tag
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "<T0> {new (tag: T0) -> Dog<T0>}", values["Dog"])
+	require.Equal(t, "<D> {new (tag: D) -> Dog<D>}", values["Dog"])
 	require.Equal(t, `Dog<"bone">`, values["d"])
 	require.Equal(t, `"bone"`, values["f"])
 	require.Equal(t, `"bone"`, values["g"])
@@ -1007,7 +1007,7 @@ func TestInferClassGenericMemberParam(t *testing.T) {
 		val b = Box(5)
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "<T0> {new (v: T0) -> Box<T0>}", values["Box"])
+	require.Equal(t, "<T> {new (v: T) -> Box<T>}", values["Box"])
 	require.Equal(t, "Box<5>", values["b"])
 }
 

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -71,23 +71,29 @@ func inferModule(module *ast.Module) (values, types map[string]string, errs []So
 			values[name] = soltype.Print(&soltype.IntersectionType{Types: arms})
 			continue
 		}
-		// PR1: an ordinary binding holds exactly one scheme; renderScheme adds the
-		// <T0, …> quantifier prefix when generalization left type parameters behind.
-		values[name] = renderScheme(b.Schemes[0])
+		// PR1: an ordinary binding holds exactly one scheme; renderValueBinding adds the
+		// quantifier prefix when generalization left type parameters behind, naming each
+		// one the declaration wrote under its source name.
+		values[name] = c.renderValueBinding(b.Schemes[0])
 	}
 	// A type-alias binding renders as its definition body, not its opaque name, so a test
 	// asserts the structure the alias stands for. `type Point = {x: number}` shows
 	// `{x: number}`, not `Point`. Every other type binding, including a nominal class,
 	// renders as itself.
+	//
+	// The alias's own type parameters are read off the handle before the body replaces it,
+	// since the body carries their variables but not their names: `type Alias<T> = {v: T}`
+	// shows `{v: T}`.
 	types = make(map[string]string, len(scope.types))
 	for name, b := range scope.types {
 		ty := b.Type
+		params := c.declaredTypeParams(ty)
 		if alias, ok := ty.(*soltype.AliasType); ok {
 			if def, ok := c.ctx.aliasDef(alias.Name); ok {
 				ty = def.Body
 			}
 		}
-		types[name] = soltype.Print(ty)
+		types[name] = soltype.PrintWithParams(ty, params)
 	}
 	return values, types, c.errs
 }

--- a/internal/solver/print_test.go
+++ b/internal/solver/print_test.go
@@ -22,3 +22,68 @@ func TestMultiBoundRenders(t *testing.T) {
 	got := soltype.Print(coalesce(a, soltype.Positive))
 	require.Equal(t, "number | string", got)
 }
+
+// A class, alias, or enum keeps its type parameters in the Context registry rather than in
+// the type it binds, so a binding renders them under the names the source wrote only when the
+// registry is consulted. These cover both binding sorts end to end, from Escalier source
+// through inference to the rendered string.
+func TestBindingsRenderSourceTypeParamNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		wantValues map[string]string
+		wantTypes  map[string]string
+	}{
+		{
+			name:       "ClassNamesItsOwnParameter",
+			src:        `class Node<T> { value: T, tail: Node<T> }`,
+			wantValues: map[string]string{"Node": "<T> {new (value: T, tail: Node<T>) -> Node<T>}"},
+			wantTypes:  map[string]string{"Node": "Node<T>"},
+		},
+		{
+			// The constructor takes v before k, so first appearance would order the binders
+			// V, K. The prefix follows the `<K, V>` clause the declaration wrote instead.
+			name: "ClassBindersFollowDeclarationOrder",
+			src: `
+				class Pair<K, V> {
+					k: K,
+					v: V,
+					constructor(mut self, v: V, k: K) {
+						self.v = v
+						self.k = k
+					},
+				}
+			`,
+			wantValues: map[string]string{"Pair": "<K, V> {new (v: V, k: K) -> Pair<K, V>}"},
+			wantTypes:  map[string]string{"Pair": "Pair<K, V>"},
+		},
+		{
+			name:       "AliasNamesItsOwnParameter",
+			src:        `type Alias<T> = {v: T}`,
+			wantValues: map[string]string{},
+			wantTypes:  map[string]string{"Alias": "{v: T}"},
+		},
+		{
+			name:       "EnumNamesItsOwnParameter",
+			src:        `enum Opt<T> { Some(v: T), None }`,
+			wantValues: map[string]string{},
+			wantTypes:  map[string]string{"Opt": "Opt.Some<T> | Opt.None<T>"},
+		},
+		{
+			// The regression guard on the path that already names its parameters: a FuncType
+			// carries its own TypeParams, so the printer reads the names off the type.
+			name:       "FunctionKeepsItsOwnParameter",
+			src:        `fn identity<T>(x: T) -> T { return x }`,
+			wantValues: map[string]string{"identity": "fn <T>(x: T) -> T"},
+			wantTypes:  map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, types, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantValues, values)
+			require.Equal(t, tt.wantTypes, types)
+		})
+	}
+}

--- a/internal/solver/print_test.go
+++ b/internal/solver/print_test.go
@@ -77,6 +77,21 @@ func TestBindingsRenderSourceTypeParamNames(t *testing.T) {
 			wantValues: map[string]string{"identity": "fn <T>(x: T) -> T"},
 			wantTypes:  map[string]string{},
 		},
+		{
+			// Binding the class value again instantiates it, which freshens the variable
+			// standing for T. The name is read off the argument position rather than matched
+			// on the declaration's own variable, so both bindings render alike.
+			name: "AnInstantiatedClassValueKeepsTheName",
+			src: `
+				class Box<T> { value: T }
+				val Alias = Box
+			`,
+			wantValues: map[string]string{
+				"Box":   "<T> {new (value: T) -> Box<T>}",
+				"Alias": "<T> {new (value: T) -> Box<T>}",
+			},
+			wantTypes: map[string]string{"Box": "Box<T>"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/solver/type_args_test.go
+++ b/internal/solver/type_args_test.go
@@ -524,7 +524,7 @@ func TestMutuallyRecursiveGenericClassesResolve(t *testing.T) {
 		class Tail<T> { node: Node<T> }
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "<T0> {new (value: T0, tail: Tail<T0>) -> Node<T0>}", values["Node"])
+	require.Equal(t, "<T> {new (value: T, tail: Tail<T>) -> Node<T>}", values["Node"])
 }
 
 // TestClassArityAcrossMixedComponent covers a dep_graph component holding both sorts of key. A


### PR DESCRIPTION
Fixes #999

A generic function renders its type parameters under the names the source wrote, because a `FuncType` carries its own `TypeParams` and the printer seeds each variable's name from them. A class, alias, or enum keeps its parameters in the checker's registry instead, so nothing in the type it binds carries a name. `class Node<T>` bound a value rendering `<T0> {new (value: T0, tail: Node<T0>) -> Node<T0>}` and a type rendering `Node<t0>`.

Both printing paths now take the declaration's parameters from the caller.

| | before | after |
|---|---|---|
| `class Node<T>` value | `<T0> {new (value: T0, tail: Node<T0>) -> Node<T0>}` | `<T> {new (value: T, tail: Node<T>) -> Node<T>}` |
| `class Node<T>` type | `Node<t0>` | `Node<T>` |
| `class Pair<K, V>` value | `<T0, T1> {new (v: T0, k: T1) -> Pair<T1, T0>}` | `<K, V> {new (v: V, k: K) -> Pair<K, V>}` |
| `type Alias<T> = {v: T}` | `{v: t0}` | `{v: T}` |
| `enum Opt<T>` | `Opt.Some<t0> \| Opt.None<t0>` | `Opt.Some<T> \| Opt.None<T>` |

## The printer

`PrintAsSchemeWith` gains a `declared []*TypeParam` argument. Those parameters lead the quantifier prefix in **declaration order**, ahead of the generated names, so `class Pair<K, V>` whose constructor takes `v` before `k` renders a binder list matching the `<K, V>` clause rather than one permuted by first appearance.

`PrintWithParams` is a new plain-`Print` entry point for the type-binding path, which carries no prefix to hang names on.

Naming goes through `bindTypeParam`, which tracks every name in scope. Two collisions arise now that source names and generated names share one alphabet:

- A generated `T0, T1, …` skips any name a source parameter claims, so a declaration that writes `T0` itself keeps it. This mirrors what `ownLifetimeParamNames` already does on the lifetime side.
- A signature releases its own parameters' names on the way out, so two overload arms each written `<T>` both render `T`, while a `<T>` nested inside an enclosing `<T>` renders `T_2` and the two stay distinct.

The leak anchor is preserved: a variable `isParam` rejects still renders `t{ID}` even when `declared` names it, so a variable that failed to coalesce is not disguised as a declared parameter.

## The solver

`declaredTypeParams` reads the parameters back out of the `Context` registry, reaching a class through its constructor's return type for a value binding. `paramsForArgs` reads each name off the matching argument position of the class or alias reference rather than matching on the declaration's own variable, so a binding holding an instantiated copy of a class value keeps the names: `val Alias = Box` renders the same as `Box` itself. `renderSchemeWith` threads the lookup into the scheme printer, deriving the display type once.

## Not settled here

The issue's open display question about `class Box<T: string>` rendering its bound inline (`v: T & string`) rather than as a `<T: string>` binder is unchanged — the issue says that is a separate decision.

## Testing

New table-driven end-to-end cases in `internal/solver/print_test.go` cover every item in the issue's test plan, plus `internal/soltype/print_test.go` unit cases for declaration order, the generated-name collision on both the class and function paths, the leak anchor, method-over-class shadowing, and sibling signatures reusing one name. Four existing assertions in `infer_class_test.go` / `type_args_test.go` moved from `T0` to the source names. `go test ./...` passes with no snapshot or fixture drift.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RBhKrvikZ9HY9LDaFUm8a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Preserved source-declared type-parameter names and declaration order in inferred type displays.
  * Improved handling of nested and shadowed type parameters to avoid naming conflicts.
  * Added clearer rendering for generic classes, aliases, enums, functions, and instantiated class values.
* **Bug Fixes**
  * Prevented generated type-parameter names from leaking into displayed inferred types.
  * Improved reuse of nonconflicting names across sibling function signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->