### PR TITLE
solver: reject a recursive function whose return type has no finite value

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1482,12 +1482,16 @@ func (e *NotProductiveAliasError) Message() string {
 // it.
 //
 // Site is the node the diagnostic points at, a `fn` declaration's name or a whole function
-// expression. Name is what the source called the function, empty for a function expression. Ret is
-// the coalesced return type, rendered in the message so the knot the check read is visible.
+// expression. Name is what the source called the function, empty for a lambda.
+//
+// Fn is the function's coalesced display type. The message renders the whole signature rather than
+// the return alone because the return can hold a quantified type parameter, and naming a `T0`
+// without the `<T0>` binder the signature carries would render a parameter with nothing to tie it
+// to.
 type NonReturningRecursionError struct {
 	Site ast.Node
 	Name string
-	Ret  soltype.Type
+	Fn   soltype.Type
 }
 
 func (*NonReturningRecursionError) isSolverError()        {}
@@ -1499,10 +1503,10 @@ func (e *NonReturningRecursionError) Message() string {
 		subject = "`" + e.Name + "`"
 	}
 	return fmt.Sprintf(
-		"%s returns `%s`, which no finite value inhabits, so a call to it never returns; give the "+
-			"recursion a base case, make the recursive property optional, or defer the recursive call "+
-			"behind a function or a Promise",
-		subject, soltype.Print(e.Ret))
+		"%s has type `%s`, and no finite value inhabits its return type, so a call to it never "+
+			"returns; give the recursion a base case, make the recursive property optional, or defer "+
+			"the recursive call behind a function or a Promise",
+		subject, soltype.PrintAsScheme(e.Fn))
 }
 
 // ExpansionLimitError fires when constrain evaluates more than maxUnwrapDepth type operators along

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1470,6 +1470,41 @@ func (e *NotProductiveAliasError) Message() string {
 		e.Name, through)
 }
 
+// NonReturningRecursionError fires when no finite value has a function's return type, because a
+// μ-knot in it has no base case. `fn cons(x: number) { return {head: x, tail: cons(x)} }` infers
+// `fn (x: number) -> {head: number, tail: μX0.{head: number, tail: X0}}`. Building the `tail` field
+// calls `cons` again before the object literal is finished, and every value of that knot is an
+// infinite chain, so the call recurses until the stack runs out. finitelyInhabited in inhabited.go
+// decides the question and lists what makes a knot terminate.
+//
+// It is the value-level twin of NotProductiveAliasError. That one fires on a recursion that emits no
+// structure at all. This one fires on a recursion that emits structure forever with nothing to stop
+// it.
+//
+// Site is the node the diagnostic points at, a `fn` declaration's name or a whole function
+// expression. Name is what the source called the function, empty for a function expression. Ret is
+// the coalesced return type, rendered in the message so the knot the check read is visible.
+type NonReturningRecursionError struct {
+	Site ast.Node
+	Name string
+	Ret  soltype.Type
+}
+
+func (*NonReturningRecursionError) isSolverError()        {}
+func (e *NonReturningRecursionError) Span() ast.Span      { return e.Site.Span() }
+func (e *NonReturningRecursionError) Related() []ast.Span { return nil }
+func (e *NonReturningRecursionError) Message() string {
+	subject := "this function"
+	if e.Name != "" {
+		subject = "`" + e.Name + "`"
+	}
+	return fmt.Sprintf(
+		"%s returns `%s`, which no finite value inhabits, so a call to it never returns; give the "+
+			"recursion a base case, make the recursive property optional, or defer the recursive call "+
+			"behind a function or a Promise",
+		subject, soltype.Print(e.Ret))
+}
+
 // ExpansionLimitError fires when constrain evaluates more than maxUnwrapDepth type operators along
 // one constraint path. Two shapes reach it. One is a comparison between two different
 // instantiations of a productive but non-regular alias, `Deep<number> <: Deep<string>` for

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -116,9 +116,9 @@ type checker struct {
 
 	// pendingReturns holds every body-carrying function inferFunc has typed since the last
 	// checkCanReturn, each waiting to have its return type checked for a finite inhabitant. The
-	// check is queued rather than run on the spot because a mutually-recursive group closes its
-	// cycle only once every body in it has been walked, so the μ-knot the check reads does not
-	// exist yet when the first body finishes.
+	// check is queued rather than run on the spot because a recursive call resolves through a
+	// binding var that is still unbounded while the body is walked, so the μ-knot the check reads
+	// does not exist yet when inferFunc finishes. checkCanReturn spells the ordering out.
 	pendingReturns []pendingReturn
 
 	// classShells holds the type parameters and declaration scope preBindClassTypeParams

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -107,6 +107,13 @@ type checker struct {
 	// runDeferredArgBounds once every body in the component is filled.
 	deferredArgBounds []deferredArgBound
 
+	// memberName is the name of the class member whose body is about to be walked, set by
+	// inferMemberBodies and consumed by the inferFunc call that walks it. A member reaches
+	// inferFunc as a bare *ast.FuncExpr, which carries no name, so this is how the
+	// non-returning-recursion diagnostic learns what to call it. inferFunc reads and clears it on
+	// entry, so a lambda nested inside a member body is not blamed under the member's name.
+	memberName string
+
 	// pendingReturns holds every body-carrying function inferFunc has typed since the last
 	// checkCanReturn, each waiting to have its return type checked for a finite inhabitant. The
 	// check is queued rather than run on the spot because a mutually-recursive group closes its

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -107,6 +107,13 @@ type checker struct {
 	// runDeferredArgBounds once every body in the component is filled.
 	deferredArgBounds []deferredArgBound
 
+	// pendingReturns holds every body-carrying function inferFunc has typed since the last
+	// checkCanReturn, each waiting to have its return type checked for a finite inhabitant. The
+	// check is queued rather than run on the spot because a mutually-recursive group closes its
+	// cycle only once every body in it has been walked, so the μ-knot the check reads does not
+	// exist yet when the first body finishes.
+	pendingReturns []pendingReturn
+
 	// classShells holds the type parameters and declaration scope preBindClassTypeParams
 	// resolved for a class, keyed by its declaration. inferClassDecl reuses the entry rather
 	// than minting a second, unrelated set of parameter vars. A script class has no pre-pass,

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -554,6 +554,7 @@ func (c *checker) buildFieldSigs(scope *Scope, lvl int, decl *ast.ClassDecl, bod
 // phase; apply installs the fully-inferred signature onto the stored element.
 type pendingMember struct {
 	fn     *ast.FuncExpr
+	name   string // the member's source name, which its own *ast.FuncExpr does not carry
 	recv   *ast.MethodReceiver
 	static bool
 	stub   *soltype.FuncType
@@ -591,7 +592,7 @@ func (c *checker) buildMemberSigs(
 				c.report(&MethodOverloadReceiverMismatchError{Name: name, Elem: elem})
 			}
 			pending = append(pending, pendingMember{
-				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, stub: stub,
+				fn: elem.Fn, name: name, recv: elem.Receiver, static: elem.Static, stub: stub,
 				apply: func(bodyFt *soltype.FuncType) {
 					bodyFt.SelfParam = stub.SelfParam
 					method.Signatures[arm] = bodyFt
@@ -613,7 +614,7 @@ func (c *checker) buildMemberSigs(
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, getter)
 			pending = append(pending, pendingMember{
-				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, stub: stub,
+				fn: elem.Fn, name: name, recv: elem.Receiver, static: elem.Static, stub: stub,
 				apply: func(bodyFt *soltype.FuncType) {
 					getter.Type = bodyFt.Ret
 					getter.Throws = bodyFt.Throws
@@ -654,7 +655,7 @@ func (c *checker) buildMemberSigs(
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, setter)
 			pending = append(pending, pendingMember{
-				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, stub: stub,
+				fn: elem.Fn, name: name, recv: elem.Receiver, static: elem.Static, stub: stub,
 				apply: func(bodyFt *soltype.FuncType) {
 					if len(bodyFt.Params) > 0 {
 						setter.Param = bodyFt.Params[0].Type
@@ -672,6 +673,9 @@ func (c *checker) buildMemberSigs(
 // bound graph, then installs the real signature onto the stored element.
 func (c *checker) inferMemberBodies(scope *Scope, lvl int, body *soltype.ObjectType, pending []pendingMember) {
 	for _, m := range pending {
+		// Hand the member's name to the inferFunc call below, which sees only the member's
+		// *ast.FuncExpr and so cannot recover it. inferFunc takes and clears it.
+		c.memberName = m.name
 		bodyFt := c.inferMemberFunc(scope, lvl, m.fn, m.recv, m.static, body)
 		c.linkMemberSig(m.fn, bodyFt, m.stub)
 		m.apply(bodyFt)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -199,6 +199,11 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	savedNamedLts := c.namedLifetimes
 	c.namedLifetimes = nil
 	defer func() { c.namedLifetimes = savedNamedLts }()
+	// Take the name inferMemberBodies left for this member, and clear it so a lambda nested in
+	// the body walked below is not blamed under the member's name. It is empty for every function
+	// that is not a class member.
+	memberName := c.memberName
+	c.memberName = ""
 	// Report any named lifetime the signature uses without binding it in its own `<…>`
 	// list, and the symmetric unused binder. Run before resolving the params so the scan
 	// reads the written names, not what namedLifetime has since interned.
@@ -519,7 +524,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// waits until the enclosing group's bound graph is complete, since a mutually-recursive knot is
 	// not tied until every body in the group has been walked.
 	if hasBody {
-		c.queueReturnCheck(node, ret)
+		c.queueReturnCheck(node, ft, lvl-1, memberName)
 	}
 	// A body-carrying function must prove every lifetime bound its signature declares,
 	// so its bounds are checked against the inferred relation. A no-body `declare fn` has

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -514,6 +514,13 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// re-minted by coalescing at binding time, so the entry is exact for inline
 	// callees; M3's FromInstantiation makes named-callee blame precise.)
 	c.recordProv(ft, node, FuncInference)
+	// Queue the return type for the finite-inhabitant check. A `declare fn` adopts its annotation
+	// with no body to recurse through, so only a body-carrying function is queued. The check itself
+	// waits until the enclosing group's bound graph is complete, since a mutually-recursive knot is
+	// not tied until every body in the group has been walked.
+	if hasBody {
+		c.queueReturnCheck(node, ret)
+	}
 	// A body-carrying function must prove every lifetime bound its signature declares,
 	// so its bounds are checked against the inferred relation. A no-body `declare fn` has
 	// no body to prove them, so it lowers each declared bound into constrainLt instead.

--- a/internal/solver/inhabited.go
+++ b/internal/solver/inhabited.go
@@ -22,9 +22,9 @@ import (
 //
 // # What lets a value stop
 //
-// finitelyInhabited decides the question by reading the coalesced return type. A μ-knot has a finite
-// value when some path through its body reaches a leaf without reaching the binder. Four shapes
-// provide such a path, and each one appears in ordinary code.
+// finitelyInhabited decides the question by reading the return of the coalesced signature. A μ-knot
+// has a finite value when some path through its body reaches a leaf without reaching the binder.
+// Four shapes provide such a path, and each one appears in ordinary code.
 //
 // A union arm that does not mention the binder is what a base case produces, so
 // `μX0.({head: number, tail: undefined} | {head: number, tail: X0})` stops at the first arm.
@@ -56,36 +56,60 @@ import (
 // checkCanReturn reports every queued function that cannot return, and clears the queue so a later
 // group starts empty. It runs once a whole mutually-recursive group has been walked, since the cycle
 // that ties the knot is not closed while any body in the group is still outstanding.
+//
+// The display type comes from coalesceScheme rather than plain coalesce, and it is built from the
+// WHOLE function type rather than the return alone. coalesceScheme keeps a variable the caller
+// chooses symbolic instead of inlining it to its bounds, and it recognizes such a variable by its
+// occurring in both polarities. Only the parameter list shows the negative occurrence, which is why
+// the return alone is not enough.
+//
+// Both parts are load-bearing. Plain coalesce renders an unannotated parameter as `never` wherever
+// it reaches the return, and the union constructor drops a `never` arm, so this function would lose
+// the base case it plainly has and be rejected:
+//
+//	fn f(x) {
+//	    if cond() { return x }
+//	    return {next: f(x)}
+//	}
+//
+// It displays as `fn <T0>(x: T0) -> T0 | {next: T0}`, and the `T0` arm is what stops the recursion.
 func (c *checker) checkCanReturn() {
 	pending := c.pendingReturns
 	c.pendingReturns = nil
 	for _, p := range pending {
-		ret := coalesce(p.ret, soltype.Positive)
-		if finitelyInhabited(ret) {
+		display, isFunc := coalesceScheme(p.fn, p.genLevel).(*soltype.FuncType)
+		if !isFunc || finitelyInhabited(display.Ret) {
 			continue
 		}
-		c.report(&NonReturningRecursionError{Site: p.site, Name: p.name, Ret: ret})
+		c.report(&NonReturningRecursionError{Site: p.site, Name: p.name, Fn: display})
 	}
 }
 
-// pendingReturn is one function body waiting for checkCanReturn. ret is the return type the
-// function's FuncType carries, still holding inference variables; checkCanReturn coalesces it so the
-// knot the walk reads is the one the finished bound graph implies. site is the node the diagnostic
-// points at. name is what the source called the function, empty for a function expression.
+// pendingReturn is one function body waiting for checkCanReturn.
+//
+// fn is the function's inferred type, still holding inference variables. genLevel is the level the
+// binding this function belongs to generalizes at, so a variable minted above it becomes a
+// quantified type parameter and a caller chooses what it stands for. site is the node the diagnostic
+// points at. name is what the source called the function, empty when no name reached inferFunc.
 type pendingReturn struct {
-	site ast.Node
-	name string
-	ret  soltype.Type
+	site     ast.Node
+	name     string
+	fn       *soltype.FuncType
+	genLevel int
 }
 
 // queueReturnCheck queues one body-carrying function for checkCanReturn. node is the *ast.FuncDecl
-// or *ast.FuncExpr being typed, and ret is the return type its FuncType carries.
+// or *ast.FuncExpr being typed and ft is the type inferFunc built for it.
+//
+// A `fn` declaration is blamed at its name. Every other function reaches inferFunc as a bare
+// *ast.FuncExpr, so a lambda and a class member are blamed over their whole span. memberName is what
+// the class member is called, empty for a lambda and for a `fn` declaration.
 //
 // A queued entry is rolled back with the probe that recorded it, mirroring the errs snapshot
 // openProbe takes. A discarded trial must leave no diagnostic behind, and the queue turns into
 // diagnostics after the trial is over.
-func (c *checker) queueReturnCheck(node ast.Node, ret soltype.Type) {
-	site, name := node, ""
+func (c *checker) queueReturnCheck(node ast.Node, ft *soltype.FuncType, genLevel int, memberName string) {
+	site, name := node, memberName
 	if fd, isDecl := node.(*ast.FuncDecl); isDecl && fd.Name != nil {
 		site, name = fd.Name, fd.Name.Name
 	}
@@ -93,7 +117,8 @@ func (c *checker) queueReturnCheck(node ast.Node, ret soltype.Type) {
 		queueLen := len(c.pendingReturns)
 		probe.onRollback(func() { c.pendingReturns = c.pendingReturns[:queueLen] })
 	}
-	c.pendingReturns = append(c.pendingReturns, pendingReturn{site: site, name: name, ret: ret})
+	c.pendingReturns = append(c.pendingReturns,
+		pendingReturn{site: site, name: name, fn: ft, genLevel: genLevel})
 }
 
 // finitelyInhabited reports whether a finite value has type t. It reads a coalesced type, where a
@@ -106,9 +131,12 @@ func (c *checker) queueReturnCheck(node ast.Node, ret soltype.Type) {
 // the way, which is the one thing that makes this false.
 //
 // Every shape the walk cannot decide reads as inhabited, so an unfamiliar one never produces a
-// diagnostic. `never` is one of those. Nothing has that type, but a function returning it diverges
-// or throws rather than recursing, and `fn todo() -> never throws string { throw "todo" }` is a stub
-// anyone may write. An alias reference is another, since deciding one would mean expanding it.
+// diagnostic. Three reach it through the final arm. A quantified type parameter is one, since the
+// caller chooses what it stands for and may choose something inhabited, which is what makes a
+// parameter reaching the return count as a base case. `never` is another. Nothing has that type, but
+// a function returning it diverges or throws rather than recursing, and
+// `fn todo() -> never throws string { throw "todo" }` is a stub anyone may write. An alias reference
+// is the third, since deciding one would mean expanding it.
 //
 // It is a recursive switch rather than a soltype visitor, which the CLAUDE.md convention would
 // otherwise call for. Each kind folds its operands differently — an object needs every required

--- a/internal/solver/inhabited.go
+++ b/internal/solver/inhabited.go
@@ -54,8 +54,15 @@ import (
 // to nothing, the value-level twin of `type Bad = Bad`, and they want a diagnostic of their own.
 
 // checkCanReturn reports every queued function that cannot return, and clears the queue so a later
-// group starts empty. It runs once a whole mutually-recursive group has been walked, since the cycle
-// that ties the knot is not closed while any body in the group is still outstanding.
+// group starts empty.
+//
+// It cannot run inside inferFunc, because the cycle that ties the knot does not exist yet when a
+// body finishes. A recursive call resolves through the binding var inferComponent pre-bound in phase
+// 1, and that var carries no bounds until phase 2 constrains the finished function type into it,
+// which happens after inferFunc has returned. Coalescing `fn f() { return {next: f()} }` the moment
+// its body is walked yields `fn () -> {next: never}`, with no μ-knot to read. A mutually-recursive
+// group needs the wait for a second reason on top: the cycle also runs through a sibling whose body
+// has not been walked at all.
 //
 // The display type comes from coalesceScheme rather than plain coalesce, and it is built from the
 // WHOLE function type rather than the return alone. coalesceScheme keeps a variable the caller

--- a/internal/solver/inhabited.go
+++ b/internal/solver/inhabited.go
@@ -1,0 +1,194 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// A function returns a value only when some finite value has its return type. Unguarded recursion
+// takes that away. Here is the shape:
+//
+//	fn cons(x: number) { return {head: x, tail: cons(x)} }
+//
+// It infers `fn (x: number) -> {head: number, tail: μX0.{head: number, tail: X0}}`. The type is
+// right, and that is what makes this a diagnostic gap rather than an inference bug. Every value of
+// `μX0.{head: number, tail: X0}` is an infinite chain, so building the `tail` field calls `cons`
+// again and the call overflows the stack instead of returning. There is no version of that program
+// that does something useful.
+//
+// checkCanReturn is the value-level twin of checkProductive in productivity.go. That one rejects a
+// type alias whose recursion emits no structure at all. This one rejects a function whose recursion
+// emits structure forever with nothing to stop it.
+//
+// # What lets a value stop
+//
+// finitelyInhabited decides the question by reading the coalesced return type. A μ-knot has a finite
+// value when some path through its body reaches a leaf without reaching the binder. Four shapes
+// provide such a path, and each one appears in ordinary code.
+//
+// A union arm that does not mention the binder is what a base case produces, so
+// `μX0.({head: number, tail: undefined} | {head: number, tail: X0})` stops at the first arm.
+//
+// An optional property is never built when it is omitted, so `{head: T, tail?: List}` stops at an
+// absent `tail`.
+//
+// A function type holds its body unevaluated, so `{value: number, rest: fn () -> X0}` stops at the
+// thunk and recurses only when a caller forces `rest`.
+//
+// A `Promise` and a generator hold their payload unevaluated for the same reason. An async loop that
+// yields to the event loop each lap is legitimate and must not be rejected:
+//
+//	async fn serve() {
+//	    val req = await accept()
+//	    handle(req)
+//	    return serve()
+//	}
+//
+// That is `fn () -> Promise<μX0.Promise<X0>>`, a real μ-knot and not a hang, since every `await`
+// hands control back to the event loop.
+//
+// # What this does not cover
+//
+// `fn serve() { return serve() }` returns `never` and `fn serve() { serve() }` returns `void`.
+// Neither infers a μ-knot, so neither reaches this check. Both are tight infinite loops that yield
+// to nothing, the value-level twin of `type Bad = Bad`, and they want a diagnostic of their own.
+
+// checkCanReturn reports every queued function that cannot return, and clears the queue so a later
+// group starts empty. It runs once a whole mutually-recursive group has been walked, since the cycle
+// that ties the knot is not closed while any body in the group is still outstanding.
+func (c *checker) checkCanReturn() {
+	pending := c.pendingReturns
+	c.pendingReturns = nil
+	for _, p := range pending {
+		ret := coalesce(p.ret, soltype.Positive)
+		if finitelyInhabited(ret) {
+			continue
+		}
+		c.report(&NonReturningRecursionError{Site: p.site, Name: p.name, Ret: ret})
+	}
+}
+
+// pendingReturn is one function body waiting for checkCanReturn. ret is the return type the
+// function's FuncType carries, still holding inference variables; checkCanReturn coalesces it so the
+// knot the walk reads is the one the finished bound graph implies. site is the node the diagnostic
+// points at. name is what the source called the function, empty for a function expression.
+type pendingReturn struct {
+	site ast.Node
+	name string
+	ret  soltype.Type
+}
+
+// queueReturnCheck queues one body-carrying function for checkCanReturn. node is the *ast.FuncDecl
+// or *ast.FuncExpr being typed, and ret is the return type its FuncType carries.
+//
+// A queued entry is rolled back with the probe that recorded it, mirroring the errs snapshot
+// openProbe takes. A discarded trial must leave no diagnostic behind, and the queue turns into
+// diagnostics after the trial is over.
+func (c *checker) queueReturnCheck(node ast.Node, ret soltype.Type) {
+	site, name := node, ""
+	if fd, isDecl := node.(*ast.FuncDecl); isDecl && fd.Name != nil {
+		site, name = fd.Name, fd.Name.Name
+	}
+	if probe := c.ctx.probe; probe != nil {
+		queueLen := len(c.pendingReturns)
+		probe.onRollback(func() { c.pendingReturns = c.pendingReturns[:queueLen] })
+	}
+	c.pendingReturns = append(c.pendingReturns, pendingReturn{site: site, name: name, ret: ret})
+}
+
+// finitelyInhabited reports whether a finite value has type t. It reads a coalesced type, where a
+// recursive position is a μ-knot rather than a cyclic inference variable, so it descends a finite
+// tree.
+//
+// The walk visits only the positions that building a value has to fill. An object's optional
+// property and a function type's return are skipped, since neither is built while the value around
+// them is. Reaching a μ-binder means the construction came back to the knot with nothing skipped on
+// the way, which is the one thing that makes this false.
+//
+// Every shape the walk cannot decide reads as inhabited, so an unfamiliar one never produces a
+// diagnostic. `never` is one of those. Nothing has that type, but a function returning it diverges
+// or throws rather than recursing, and `fn todo() -> never throws string { throw "todo" }` is a stub
+// anyone may write. An alias reference is another, since deciding one would mean expanding it.
+//
+// It is a recursive switch rather than a soltype visitor, which the CLAUDE.md convention would
+// otherwise call for. Each kind folds its operands differently — an object needs every required
+// member, a union needs one arm — and the enter/exit visitor carries no per-node synthesized value
+// to fold. guardsEveryOperand in productivity.go is the same shape for the same reason.
+func finitelyInhabited(t soltype.Type) bool {
+	switch t := t.(type) {
+	case *soltype.RecursiveVarType:
+		// The construction came back to the knot, so this path builds one more level instead of
+		// finishing.
+		return false
+	case *soltype.RecursiveType:
+		return finitelyInhabited(t.Body)
+	case *soltype.FuncType, *soltype.PromiseType, *soltype.GeneratorType:
+		// A closure, a promise, and a generator each hold their payload unevaluated, so building one
+		// runs none of the code that would produce that payload.
+		return true
+	case *soltype.ArrayType:
+		// The empty array is a finite value of every array type.
+		return true
+	case *soltype.ObjectType:
+		// Only a required property and a spread are read. A method, a getter, a setter, and a
+		// constructor are function-valued, so they defer their bodies the way a property holding a
+		// function type does. A mapped member is a shape the walk does not decide.
+		for _, elem := range t.Elems {
+			switch elem := elem.(type) {
+			case *soltype.PropertyElem:
+				// An omitted optional property is never built, so it cannot force another lap.
+				if !elem.Optional && !finitelyInhabited(elem.Type) {
+					return false
+				}
+			case *soltype.SpreadElem:
+				// A `...A` merges A's own members in at this position, so what A requires this
+				// object requires.
+				if !finitelyInhabited(elem.Type) {
+					return false
+				}
+			}
+		}
+		return true
+	case *soltype.TupleType:
+		// A tuple has a fixed arity, so every position is built.
+		for _, elem := range t.Elems {
+			if !finitelyInhabited(elem) {
+				return false
+			}
+		}
+		return true
+	case *soltype.UnionType:
+		// One arm that finishes is a base case, and the value takes that arm. An empty union is
+		// `never`, which reads as inhabited for the reason above.
+		if len(t.Types) == 0 {
+			return true
+		}
+		for _, member := range t.Types {
+			if finitelyInhabited(member) {
+				return true
+			}
+		}
+		return false
+	case *soltype.IntersectionType:
+		// A value of an intersection is a value of each member at once, so every member must finish.
+		for _, member := range t.Types {
+			if !finitelyInhabited(member) {
+				return false
+			}
+		}
+		return true
+	case *soltype.RefType:
+		// A borrow points at a value someone else built, so it finishes exactly when its pointee
+		// does. No minting site leaves Inner nil, so reading that as inhabited is a guard against a
+		// crash rather than a case with meaning of its own.
+		if t.Inner == nil {
+			return true
+		}
+		return finitelyInhabited(t.Inner)
+	case *soltype.ExactnessType:
+		// The marker sets exactness on its operand and adds no structure of its own.
+		return finitelyInhabited(t.Operand)
+	default:
+		return true
+	}
+}

--- a/internal/solver/inhabited_test.go
+++ b/internal/solver/inhabited_test.go
@@ -225,9 +225,12 @@ func TestNonReturningRecursionAccepts(t *testing.T) {
 // reach the shapes no inference path mints. An object literal never produces an optional property,
 // and no inferred function returns a borrow of a knot, so those two arms are covered here rather
 // than through source.
+//
+// Each case leads with the type it builds, written the way soltype.Print renders it, since a tree of
+// constructor calls is hard to read as a type.
 func TestFinitelyInhabited(t *testing.T) {
-	// selfProp builds `μX0.{<name>: X0}` with the property optional or required, the two readings
-	// the object arm has to tell apart.
+	// selfProp builds `μX0.{<name>: X0}`, or `μX0.{<name>?: X0}` when optional, the two readings the
+	// object arm has to tell apart.
 	selfProp := func(name string, optional bool) soltype.Type {
 		return muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
 			return exactObj(&soltype.PropertyElem{Name: name, Type: ref, Optional: optional})
@@ -239,22 +242,27 @@ func TestFinitelyInhabited(t *testing.T) {
 		want bool
 	}{
 		{
+			// μX0.{tail: X0}
 			name: "a knot whose only property is required has no finite value",
 			t:    selfProp("tail", false),
 			want: false,
 		},
 		{
+			// μX0.{tail?: X0}
 			name: "an optional property lets the value stop",
 			t:    selfProp("tail", true),
 			want: true,
 		},
 		{
+			// {tail: μX0.{tail: X0}}
 			name: "a required property carrying a knot with no base case has no finite value",
 			t:    exactObj(propElem("tail", selfProp("tail", false))),
 			want: false,
 		},
 		{
-			// The base case as a union arm: one arm reaches a leaf without the binder.
+			// μX0.(undefined | {tail: X0})
+			//
+			// The base case as a union arm. The `undefined` arm reaches a leaf without the binder.
 			name: "a union arm without the binder lets the value stop",
 			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
 				return &soltype.UnionType{Types: []soltype.Type{
@@ -265,7 +273,9 @@ func TestFinitelyInhabited(t *testing.T) {
 			want: true,
 		},
 		{
-			// Every arm of the union comes back to the binder, so no arm terminates.
+			// μX0.({head: X0} | {tail: X0})
+			//
+			// Every arm comes back to the binder, so no arm terminates.
 			name: "a union whose every arm reaches the binder has no finite value",
 			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
 				return &soltype.UnionType{Types: []soltype.Type{
@@ -276,6 +286,7 @@ func TestFinitelyInhabited(t *testing.T) {
 			want: false,
 		},
 		{
+			// μX0.{rest: fn () -> X0}
 			name: "a thunk's return is not built with the value around it",
 			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
 				return exactObj(propElem("rest", &soltype.FuncType{Ret: ref}))
@@ -283,6 +294,7 @@ func TestFinitelyInhabited(t *testing.T) {
 			want: true,
 		},
 		{
+			// μX0.Promise<X0>
 			name: "a Promise's payload is not built with the value around it",
 			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
 				return &soltype.PromiseType{Inner: ref}
@@ -290,6 +302,8 @@ func TestFinitelyInhabited(t *testing.T) {
 			want: true,
 		},
 		{
+			// μX0.Array<X0>
+			//
 			// An array type is inhabited by the empty array, so a recursive element type imposes
 			// nothing on the value.
 			name: "an array of the binder is inhabited by the empty array",
@@ -299,6 +313,8 @@ func TestFinitelyInhabited(t *testing.T) {
 			want: true,
 		},
 		{
+			// μX0.[X0]
+			//
 			// A tuple has a fixed arity, so its positions are all built.
 			name: "a one-element tuple of the binder has no finite value",
 			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
@@ -307,13 +323,19 @@ func TestFinitelyInhabited(t *testing.T) {
 			want: false,
 		},
 		{
+			// mut μX0.{tail: X0}
+			//
 			// A borrow points at a value someone else built, so it terminates exactly when its
-			// pointee does.
+			// pointee does. The borrow is owned-mutable because a shared one needs a lifetime that
+			// no hand-built type here carries, and a lifetime-less shared borrow renders as its bare
+			// pointee.
 			name: "a borrow of a knot with no base case has no finite value",
-			t:    &soltype.RefType{Inner: selfProp("tail", false).(*soltype.RecursiveType)},
+			t:    mutRef(selfProp("tail", false).(*soltype.RecursiveType)),
 			want: false,
 		},
 		{
+			// never
+			//
 			// `never` has no values at all, but nothing about it says a recursion runs forever, and
 			// a throwing stub returns it. The predicate reads it as inhabited so such a stub is not
 			// flagged.
@@ -322,12 +344,15 @@ func TestFinitelyInhabited(t *testing.T) {
 			want: true,
 		},
 		{
+			// List
+			//
 			// An alias reference would have to be expanded to be decided, so it reads as inhabited.
 			name: "an alias reference reads as inhabited",
 			t:    &soltype.AliasType{Name: "List"},
 			want: true,
 		},
 		{
+			// {}
 			name: "an object with no members is inhabited",
 			t:    exactObj(),
 			want: true,

--- a/internal/solver/inhabited_test.go
+++ b/internal/solver/inhabited_test.go
@@ -8,18 +8,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nonReturningMsg builds the diagnostic checkCanReturn reports, so a test spells out the return type
+// nonReturningMsg builds the diagnostic checkCanReturn reports, so a test spells out the signature
 // it expects to see rather than the whole sentence around it. span is the blamed range, name is what
-// the source called the function, and ret is the rendered return type. An empty name is a function
-// expression, which the message calls "this function".
-func nonReturningMsg(span, name, ret string) string {
+// the source called the function, and fn is its rendered type. An empty name is a lambda, which the
+// message calls "this function".
+func nonReturningMsg(span, name, fn string) string {
 	subject := "this function"
 	if name != "" {
 		subject = "`" + name + "`"
 	}
-	return fmt.Sprintf("%s: %s returns `%s`, which no finite value inhabits, so a call to it never "+
-		"returns; give the recursion a base case, make the recursive property optional, or defer the "+
-		"recursive call behind a function or a Promise", span, subject, ret)
+	return fmt.Sprintf("%s: %s has type `%s`, and no finite value inhabits its return type, so a "+
+		"call to it never returns; give the recursion a base case, make the recursive property "+
+		"optional, or defer the recursive call behind a function or a Promise", span, subject, fn)
 }
 
 // TestNonReturningRecursionReported pins the diagnostic on the shapes that cannot return. In each
@@ -37,12 +37,12 @@ func TestNonReturningRecursionReported(t *testing.T) {
 			name: "recursion through an object property",
 			src:  `fn cons(x: number) { return {head: x, tail: cons(x)} }`,
 			want: []string{nonReturningMsg("1:4-1:8", "cons",
-				"{head: number, tail: μX0.{head: number, tail: X0}}")},
+				"fn (x: number) -> {head: number, tail: μX0.{head: number, tail: X0}}")},
 		},
 		{
 			name: "recursion through a tuple element",
 			src:  `fn f() { return [f()] }`,
-			want: []string{nonReturningMsg("1:4-1:5", "f", "[μX0.[X0]]")},
+			want: []string{nonReturningMsg("1:4-1:5", "f", "fn () -> [μX0.[X0]]")},
 		},
 		{
 			// Mutual recursion draws one diagnostic per participant. coalesce closes the cycle at
@@ -54,9 +54,9 @@ func TestNonReturningRecursionReported(t *testing.T) {
 			`,
 			want: []string{
 				nonReturningMsg("3:8-3:12", "stmt",
-					`{kind: "exprStmt", inner: μX0.{kind: "call", args: [{kind: "exprStmt", inner: X0}]}}`),
+					`fn () -> {kind: "exprStmt", inner: μX0.{kind: "call", args: [{kind: "exprStmt", inner: X0}]}}`),
 				nonReturningMsg("2:8-2:12", "expr",
-					`{kind: "call", args: [μX0.{kind: "exprStmt", inner: {kind: "call", args: [X0]}}]}`),
+					`fn () -> {kind: "call", args: [μX0.{kind: "exprStmt", inner: {kind: "call", args: [X0]}}]}`),
 			},
 		},
 		{
@@ -68,8 +68,8 @@ func TestNonReturningRecursionReported(t *testing.T) {
 				fn g() { return f() }
 			`,
 			want: []string{
-				nonReturningMsg("2:8-2:9", "f", "{next: μX0.{next: X0}}"),
-				nonReturningMsg("3:8-3:9", "g", "{next: μX0.{next: X0}}"),
+				nonReturningMsg("2:8-2:9", "f", "fn () -> {next: μX0.{next: X0}}"),
+				nonReturningMsg("3:8-3:9", "g", "fn () -> {next: μX0.{next: X0}}"),
 			},
 		},
 		{
@@ -78,7 +78,29 @@ func TestNonReturningRecursionReported(t *testing.T) {
 			// function expression has no name, so the message says "this function".
 			name: "a lambda that cannot return is blamed on the lambda",
 			src:  `fn f() { return {go: fn () { return {next: f().go()} }} }`,
-			want: []string{nonReturningMsg("1:22-1:55", "", "{next: μX0.{next: X0}}")},
+			want: []string{nonReturningMsg("1:22-1:55", "", "fn () -> {next: μX0.{next: X0}}")},
+		},
+		{
+			// A class member reaches inferFunc as a bare *ast.FuncExpr, so its name arrives through
+			// checker.memberName instead of the node. Without that it would read "this function".
+			name: "a method is named in the diagnostic",
+			src: `
+				class Node {
+					grow(self) { return {next: self.grow()} },
+				}
+			`,
+			want: []string{nonReturningMsg("3:6-3:47", "grow", "fn (self) -> {next: μX0.{next: X0}}")},
+		},
+		{
+			// A lambda inside a member body must not inherit the member's name, which is why
+			// inferFunc clears memberName before walking the body.
+			name: "a lambda inside a method keeps no member name",
+			src: `
+				class Node {
+					grow(self) { return {go: fn () { return {next: self.grow().go()} }} },
+				}
+			`,
+			want: []string{nonReturningMsg("3:31-3:72", "", "fn () -> {next: μX0.{next: X0}}")},
 		},
 	}
 	for _, tt := range tests {
@@ -159,6 +181,36 @@ func TestNonReturningRecursionAccepts(t *testing.T) {
 			// rather than recursing. Rejecting it would flag every not-yet-implemented stub.
 			name: "a throwing stub is not a recursion",
 			src:  `fn todo() -> never throws string { throw "todo" }`,
+		},
+		{
+			// The base case is an UNANNOTATED parameter flowing straight to the return, which
+			// displays as `fn <T0>(x: T0) -> T0 | {next: T0}`. Reading the return alone through
+			// plain coalesce would render that arm `never`, the union constructor would drop it,
+			// and the base case would vanish. Annotating `x` gives the arm a concrete type, so
+			// only the unannotated form pins the retention checkCanReturn depends on.
+			name: "an unannotated parameter reaching the return is a base case",
+			src: `
+				declare fn cond() -> boolean
+				fn f(x) {
+					if cond() { return x }
+					return {next: f(x)}
+				}
+			`,
+		},
+		{
+			// The same base case through a class type parameter, which the member walk resolves
+			// rather than generalization.
+			name: "a class type parameter reaching the return is a base case",
+			src: `
+				declare fn cond() -> boolean
+				class Box<T> {
+					v: T,
+					grow(self) {
+						if cond() { return self.v }
+						return {next: self.grow()}
+					},
+				}
+			`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/inhabited_test.go
+++ b/internal/solver/inhabited_test.go
@@ -1,0 +1,289 @@
+package solver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// nonReturningMsg builds the diagnostic checkCanReturn reports, so a test spells out the return type
+// it expects to see rather than the whole sentence around it. span is the blamed range, name is what
+// the source called the function, and ret is the rendered return type. An empty name is a function
+// expression, which the message calls "this function".
+func nonReturningMsg(span, name, ret string) string {
+	subject := "this function"
+	if name != "" {
+		subject = "`" + name + "`"
+	}
+	return fmt.Sprintf("%s: %s returns `%s`, which no finite value inhabits, so a call to it never "+
+		"returns; give the recursion a base case, make the recursive property optional, or defer the "+
+		"recursive call behind a function or a Promise", span, subject, ret)
+}
+
+// TestNonReturningRecursionReported pins the diagnostic on the shapes that cannot return. In each
+// source every path to a leaf of the returned value runs through the recursive call again, so the
+// call overflows the stack instead of producing a value.
+func TestNonReturningRecursionReported(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			// The issue's headline case. Building `tail` calls `cons` again before the object
+			// literal is finished.
+			name: "recursion through an object property",
+			src:  `fn cons(x: number) { return {head: x, tail: cons(x)} }`,
+			want: []string{nonReturningMsg("1:4-1:8", "cons",
+				"{head: number, tail: μX0.{head: number, tail: X0}}")},
+		},
+		{
+			name: "recursion through a tuple element",
+			src:  `fn f() { return [f()] }`,
+			want: []string{nonReturningMsg("1:4-1:5", "f", "[μX0.[X0]]")},
+		},
+		{
+			// Mutual recursion draws one diagnostic per participant. coalesce closes the cycle at
+			// whichever binding is being rendered, so each one sees the knot in its own return type.
+			name: "mutual recursion reports both participants",
+			src: `
+				fn expr() { return {kind: "call", args: [stmt()]} }
+				fn stmt() { return {kind: "exprStmt", inner: expr()} }
+			`,
+			want: []string{
+				nonReturningMsg("3:8-3:12", "stmt",
+					`{kind: "exprStmt", inner: μX0.{kind: "call", args: [{kind: "exprStmt", inner: X0}]}}`),
+				nonReturningMsg("2:8-2:12", "expr",
+					`{kind: "call", args: [μX0.{kind: "exprStmt", inner: {kind: "call", args: [X0]}}]}`),
+			},
+		},
+		{
+			// A caller of a non-returning function cannot return either, and its own return type
+			// carries the same knot, so it draws its own diagnostic beside the one on `f`.
+			name: "a caller of a non-returning function is reported too",
+			src: `
+				fn f() { return {next: f()} }
+				fn g() { return f() }
+			`,
+			want: []string{
+				nonReturningMsg("2:8-2:9", "f", "{next: μX0.{next: X0}}"),
+				nonReturningMsg("3:8-3:9", "g", "{next: μX0.{next: X0}}"),
+			},
+		},
+		{
+			// The blame is per function body, not per binding. `f` itself returns fine, since its
+			// `go` property holds a lambda, and the lambda inside it is what cannot return. A
+			// function expression has no name, so the message says "this function".
+			name: "a lambda that cannot return is blamed on the lambda",
+			src:  `fn f() { return {go: fn () { return {next: f().go()} }} }`,
+			want: []string{nonReturningMsg("1:22-1:55", "", "{next: μX0.{next: X0}}")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// TestNonReturningRecursionAccepts pins the shapes checkCanReturn must leave alone. Each one
+// either returns a finite value or fails to return for a reason this check is not about.
+func TestNonReturningRecursionAccepts(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			// A base case gives one union arm that reaches a leaf without the binder, so the value
+			// stops there.
+			name: "a base case terminates the recursion",
+			src: `
+				declare fn done(n: number) -> boolean
+				declare fn dec(n: number) -> number
+				fn count(n: number) {
+					return if done(n) { {head: n, tail: undefined} } else { {head: n, tail: count(dec(n))} }
+				}
+			`,
+		},
+		{
+			// A thunk's body does not run while the value around it is built, so the stream is
+			// finite until something calls `rest`.
+			name: "a thunk defers the recursive call",
+			src: `
+				declare fn inc(n: number) -> number
+				fn stream(n: number) { return {value: n, rest: fn () { return stream(inc(n)) }} }
+			`,
+		},
+		{
+			// The issue's event-loop case. `serve` is `fn () -> Promise<μX0.Promise<X0>>`, a real
+			// μ-knot, and every `await` hands control back to the event loop, so it is not a hang.
+			name: "a Promise defers the recursive call",
+			src: `
+				declare fn accept() -> Promise<number>
+				declare fn handle(n: number)
+				async fn serve() {
+					val req = await accept()
+					handle(req)
+					return serve()
+				}
+			`,
+		},
+		{
+			// A generator body does not run at the call either, so a `gen fn` that returns itself
+			// yields a value per `next()` rather than recursing while the generator is obtained.
+			name: "a generator defers the recursive call",
+			src: `
+				gen fn walk(n: number) {
+					yield n
+					return walk(n)
+				}
+			`,
+		},
+		{
+			// The related-but-different shape the issue leaves open. This recursion emits no
+			// structure, so no knot forms and the return type is `never` rather than a knot with no
+			// base case. It is a tight infinite loop and wants its own diagnostic.
+			name: "a recursion that emits no structure is out of scope",
+			src:  `fn serve() { return serve() }`,
+		},
+		{
+			// The statement-position twin of the case above, whose return type is `void`.
+			name: "a discarded recursive call is out of scope",
+			src:  `fn serve() { serve() }`,
+		},
+		{
+			// A function that only throws returns `never`, which nothing inhabits, but it diverges
+			// rather than recursing. Rejecting it would flag every not-yet-implemented stub.
+			name: "a throwing stub is not a recursion",
+			src:  `fn todo() -> never throws string { throw "todo" }`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Empty(t, Messages(errs))
+		})
+	}
+}
+
+// TestFinitelyInhabited pins the predicate directly on hand-built types, which is the only way to
+// reach the shapes no inference path mints. An object literal never produces an optional property,
+// and no inferred function returns a borrow of a knot, so those two arms are covered here rather
+// than through source.
+func TestFinitelyInhabited(t *testing.T) {
+	// selfProp builds `μX0.{<name>: X0}` with the property optional or required, the two readings
+	// the object arm has to tell apart.
+	selfProp := func(name string, optional bool) soltype.Type {
+		return muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+			return exactObj(&soltype.PropertyElem{Name: name, Type: ref, Optional: optional})
+		})
+	}
+	tests := []struct {
+		name string
+		t    soltype.Type
+		want bool
+	}{
+		{
+			name: "a knot whose only property is required has no finite value",
+			t:    selfProp("tail", false),
+			want: false,
+		},
+		{
+			name: "an optional property lets the value stop",
+			t:    selfProp("tail", true),
+			want: true,
+		},
+		{
+			name: "a required property carrying a knot with no base case has no finite value",
+			t:    exactObj(propElem("tail", selfProp("tail", false))),
+			want: false,
+		},
+		{
+			// The base case as a union arm: one arm reaches a leaf without the binder.
+			name: "a union arm without the binder lets the value stop",
+			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+				return &soltype.UnionType{Types: []soltype.Type{
+					&soltype.UndefinedType{},
+					exactObj(propElem("tail", ref)),
+				}}
+			}),
+			want: true,
+		},
+		{
+			// Every arm of the union comes back to the binder, so no arm terminates.
+			name: "a union whose every arm reaches the binder has no finite value",
+			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+				return &soltype.UnionType{Types: []soltype.Type{
+					exactObj(propElem("head", ref)),
+					exactObj(propElem("tail", ref)),
+				}}
+			}),
+			want: false,
+		},
+		{
+			name: "a thunk's return is not built with the value around it",
+			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+				return exactObj(propElem("rest", &soltype.FuncType{Ret: ref}))
+			}),
+			want: true,
+		},
+		{
+			name: "a Promise's payload is not built with the value around it",
+			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+				return &soltype.PromiseType{Inner: ref}
+			}),
+			want: true,
+		},
+		{
+			// An array type is inhabited by the empty array, so a recursive element type imposes
+			// nothing on the value.
+			name: "an array of the binder is inhabited by the empty array",
+			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+				return &soltype.ArrayType{Elem: ref}
+			}),
+			want: true,
+		},
+		{
+			// A tuple has a fixed arity, so its positions are all built.
+			name: "a one-element tuple of the binder has no finite value",
+			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+				return &soltype.TupleType{Elems: []soltype.Type{ref}}
+			}),
+			want: false,
+		},
+		{
+			// A borrow points at a value someone else built, so it terminates exactly when its
+			// pointee does.
+			name: "a borrow of a knot with no base case has no finite value",
+			t:    &soltype.RefType{Inner: selfProp("tail", false).(*soltype.RecursiveType)},
+			want: false,
+		},
+		{
+			// `never` has no values at all, but nothing about it says a recursion runs forever, and
+			// a throwing stub returns it. The predicate reads it as inhabited so such a stub is not
+			// flagged.
+			name: "never reads as inhabited",
+			t:    &soltype.NeverType{},
+			want: true,
+		},
+		{
+			// An alias reference would have to be expanded to be decided, so it reads as inhabited.
+			name: "an alias reference reads as inhabited",
+			t:    &soltype.AliasType{Name: "List"},
+			want: true,
+		},
+		{
+			name: "an object with no members is inhabited",
+			t:    exactObj(),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, finitelyInhabited(tt.t))
+		})
+	}
+}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -456,6 +456,11 @@ func (c *checker) inferComponent(
 		}
 	}
 
+	// Every body in the component has been walked, so a cycle running through two of its bindings
+	// is closed and coalescing a return type now yields the μ-knot that cycle implies. Report each
+	// function in the component whose return type no finite value inhabits.
+	c.checkCanReturn()
+
 	// Phase 3: rebind each value name to its coalesced monomorphic type. A binding
 	// whose declarations all failed to produce a definition (missing initializer,
 	// destructuring, unsupported kind) is removed rather than left as a `never`

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -456,9 +456,9 @@ func (c *checker) inferComponent(
 		}
 	}
 
-	// Every body in the component has been walked, so a cycle running through two of its bindings
-	// is closed and coalescing a return type now yields the μ-knot that cycle implies. Report each
-	// function in the component whose return type no finite value inhabits.
+	// Every definition in the component has been constrained into its binding var, which is what
+	// closes a recursive cycle, so coalescing a return type now yields the μ-knot that cycle
+	// implies. Report each function in the component whose return type no finite value inhabits.
 	c.checkCanReturn()
 
 	// Phase 3: rebind each value name to its coalesced monomorphic type. A binding

--- a/internal/solver/recursive_test.go
+++ b/internal/solver/recursive_test.go
@@ -51,25 +51,23 @@ func TestInferRecursiveRendersMuKnot(t *testing.T) {
 			src:      `fn f() { return {next: f()} }`,
 			binding:  "f",
 			want:     "fn () -> {next: μX0.{next: X0}}",
-			wantErrs: []string{nonReturningMsg("1:4-1:5", "f", "{next: μX0.{next: X0}}")},
+			wantErrs: []string{nonReturningMsg("1:4-1:5", "f", "fn () -> {next: μX0.{next: X0}}")},
 		},
 		{
 			name:     "recursion through a tuple element",
 			src:      `fn f() { return [f()] }`,
 			binding:  "f",
 			want:     "fn () -> [μX0.[X0]]",
-			wantErrs: []string{nonReturningMsg("1:4-1:5", "f", "[μX0.[X0]]")},
+			wantErrs: []string{nonReturningMsg("1:4-1:5", "f", "fn () -> [μX0.[X0]]")},
 		},
 		{
-			// The diagnostic reads the MONOMORPHIC coalescing of the return type, where a parameter
-			// var with no lower bound is `never`, so it renders `value: never` where the generalized
-			// display renders the quantified `value: T0`.
-			name:    "knot beside a retained type parameter",
-			src:     `fn f(x) { return {next: f(x), value: x} }`,
-			binding: "f",
-			want:    "fn <T0>(x: T0) -> {next: μX0.{next: X0, value: T0}, value: T0}",
-			wantErrs: []string{nonReturningMsg("1:4-1:5", "f",
-				"{next: μX0.{next: X0, value: never}, value: never}")},
+			// The diagnostic renders the same display type this case pins, quantifier and all, since
+			// checkCanReturn reads the whole signature through coalesceScheme.
+			name:     "knot beside a retained type parameter",
+			src:      `fn f(x) { return {next: f(x), value: x} }`,
+			binding:  "f",
+			want:     "fn <T0>(x: T0) -> {next: μX0.{next: X0, value: T0}, value: T0}",
+			wantErrs: []string{nonReturningMsg("1:4-1:5", "f", "fn <T0>(x: T0) -> {next: μX0.{next: X0, value: T0}, value: T0}")},
 		},
 		{
 			// Mutual recursion runs the same cycle through two bindings, so the knot closes one lap
@@ -83,8 +81,8 @@ func TestInferRecursiveRendersMuKnot(t *testing.T) {
 			binding: "ping",
 			want:    "fn () -> {p: μX0.{q: {p: X0}}}",
 			wantErrs: []string{
-				nonReturningMsg("3:8-3:12", "pong", "{q: μX0.{p: {q: X0}}}"),
-				nonReturningMsg("2:8-2:12", "ping", "{p: μX0.{q: {p: X0}}}"),
+				nonReturningMsg("3:8-3:12", "pong", "fn () -> {q: μX0.{p: {q: X0}}}"),
+				nonReturningMsg("2:8-2:12", "ping", "fn () -> {p: μX0.{q: {p: X0}}}"),
 			},
 		},
 	}
@@ -250,8 +248,8 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 			binding: "h",
 			want:    "fn () -> {next: μX0.{next: X0}}",
 			wantErrs: []string{
-				nonReturningMsg("2:8-2:9", "f", "{next: μX0.{next: X0}}"),
-				nonReturningMsg("3:8-3:9", "h", "{next: μX0.{next: X0}}"),
+				nonReturningMsg("2:8-2:9", "f", "fn () -> {next: μX0.{next: X0}}"),
+				nonReturningMsg("3:8-3:9", "h", "fn () -> {next: μX0.{next: X0}}"),
 			},
 		},
 		{
@@ -262,7 +260,7 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 			`,
 			binding:  "c",
 			want:     "μX0.{next: X0}",
-			wantErrs: []string{nonReturningMsg("2:8-2:9", "f", "{next: μX0.{next: X0}}")},
+			wantErrs: []string{nonReturningMsg("2:8-2:9", "f", "fn () -> {next: μX0.{next: X0}}")},
 		},
 		{
 			name: "a recursive result through a type parameter still renders a knot",
@@ -273,7 +271,7 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 			`,
 			binding:  "d",
 			want:     "{next: μX0.{next: X0}}",
-			wantErrs: []string{nonReturningMsg("2:8-2:9", "f", "{next: μX0.{next: X0}}")},
+			wantErrs: []string{nonReturningMsg("2:8-2:9", "f", "fn () -> {next: μX0.{next: X0}}")},
 		},
 		{
 			// The tuple shape reaches the same reassignment path, so a coalesced knot over a tuple
@@ -290,8 +288,8 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 			binding: "h",
 			want:    "fn () -> [μX0.[X0]]",
 			wantErrs: []string{
-				nonReturningMsg("2:8-2:9", "f", "[μX0.[X0]]"),
-				nonReturningMsg("3:8-3:9", "h", "[μX0.[X0]]"),
+				nonReturningMsg("2:8-2:9", "f", "fn () -> [μX0.[X0]]"),
+				nonReturningMsg("3:8-3:9", "h", "fn () -> [μX0.[X0]]"),
 			},
 		},
 		{
@@ -304,7 +302,7 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 			`,
 			binding:  "inner",
 			want:     "μX0.[X0]",
-			wantErrs: []string{nonReturningMsg("2:8-2:9", "f", "[μX0.[X0]]")},
+			wantErrs: []string{nonReturningMsg("2:8-2:9", "f", "fn () -> [μX0.[X0]]")},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/recursive_test.go
+++ b/internal/solver/recursive_test.go
@@ -35,35 +35,46 @@ func muKnot(id int, name string, body func(ref *soltype.RecursiveVarType) soltyp
 // Every source here puts nothing between the recursive call and the value the body builds, so none
 // of these functions returns when called. The types are right all the same, since no finite value
 // inhabits a knot with no base case, and what is being pinned is the rendering rather than a program
-// anyone runs. TestInferGuardedRecursionRendersMuKnot covers the shapes that do return.
+// anyone runs. checkCanReturn rejects each source for that reason, so every case carries the
+// diagnostic it draws beside the type. TestInferGuardedRecursionRendersMuKnot covers the shapes that
+// do return.
 func TestInferRecursiveRendersMuKnot(t *testing.T) {
 	tests := []struct {
-		name    string
-		src     string
-		binding string
-		want    string
+		name     string
+		src      string
+		binding  string
+		want     string
+		wantErrs []string
 	}{
 		{
-			name:    "recursion through an object property",
-			src:     `fn f() { return {next: f()} }`,
-			binding: "f",
-			want:    "fn () -> {next: μX0.{next: X0}}",
+			name:     "recursion through an object property",
+			src:      `fn f() { return {next: f()} }`,
+			binding:  "f",
+			want:     "fn () -> {next: μX0.{next: X0}}",
+			wantErrs: []string{nonReturningMsg("1:4-1:5", "f", "{next: μX0.{next: X0}}")},
 		},
 		{
-			name:    "recursion through a tuple element",
-			src:     `fn f() { return [f()] }`,
-			binding: "f",
-			want:    "fn () -> [μX0.[X0]]",
+			name:     "recursion through a tuple element",
+			src:      `fn f() { return [f()] }`,
+			binding:  "f",
+			want:     "fn () -> [μX0.[X0]]",
+			wantErrs: []string{nonReturningMsg("1:4-1:5", "f", "[μX0.[X0]]")},
 		},
 		{
+			// The diagnostic reads the MONOMORPHIC coalescing of the return type, where a parameter
+			// var with no lower bound is `never`, so it renders `value: never` where the generalized
+			// display renders the quantified `value: T0`.
 			name:    "knot beside a retained type parameter",
 			src:     `fn f(x) { return {next: f(x), value: x} }`,
 			binding: "f",
 			want:    "fn <T0>(x: T0) -> {next: μX0.{next: X0, value: T0}, value: T0}",
+			wantErrs: []string{nonReturningMsg("1:4-1:5", "f",
+				"{next: μX0.{next: X0, value: never}, value: never}")},
 		},
 		{
 			// Mutual recursion runs the same cycle through two bindings, so the knot closes one lap
-			// out at whichever binding is being rendered.
+			// out at whichever binding is being rendered. Each binding draws its own diagnostic, in
+			// the order the component's bodies were walked.
 			name: "mutual recursion closes the knot one lap out",
 			src: `
 				fn ping() { return {p: pong()} }
@@ -71,12 +82,16 @@ func TestInferRecursiveRendersMuKnot(t *testing.T) {
 			`,
 			binding: "ping",
 			want:    "fn () -> {p: μX0.{q: {p: X0}}}",
+			wantErrs: []string{
+				nonReturningMsg("3:8-3:12", "pong", "{q: μX0.{p: {q: X0}}}"),
+				nonReturningMsg("2:8-2:12", "ping", "{p: μX0.{q: {p: X0}}}"),
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tt.src)
-			require.Empty(t, Messages(errs))
+			require.Equal(t, tt.wantErrs, messagesWithSpan(errs))
 			require.Equal(t, tt.want, values[tt.binding])
 		})
 	}
@@ -210,12 +225,17 @@ func TestInferGuardedRecursionRendersMuKnot(t *testing.T) {
 // Body, not its coalesced display, so no knot exists while the member chain, the destructuring
 // pattern, or the type parameter is being solved. Those cases pin that the recursive shape survives
 // the round trip and still renders as a knot once the resulting binding is displayed.
+//
+// Building a knot needs an unguarded recursion, so every source here also draws checkCanReturn's
+// diagnostic. A case that wraps the knot in a second function draws a second one, since a function
+// that returns what `f` returns cannot return either.
 func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 	tests := []struct {
-		name    string
-		src     string
-		binding string
-		want    string
+		name     string
+		src      string
+		binding  string
+		want     string
+		wantErrs []string
 	}{
 		{
 			name: "reassigning a recursive binding compares two knots",
@@ -229,6 +249,10 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 			`,
 			binding: "h",
 			want:    "fn () -> {next: μX0.{next: X0}}",
+			wantErrs: []string{
+				nonReturningMsg("2:8-2:9", "f", "{next: μX0.{next: X0}}"),
+				nonReturningMsg("3:8-3:9", "h", "{next: μX0.{next: X0}}"),
+			},
 		},
 		{
 			name: "a member chain over a recursive result still renders a knot",
@@ -236,8 +260,9 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 				fn f() { return {next: f()} }
 				val c = f().next.next
 			`,
-			binding: "c",
-			want:    "μX0.{next: X0}",
+			binding:  "c",
+			want:     "μX0.{next: X0}",
+			wantErrs: []string{nonReturningMsg("2:8-2:9", "f", "{next: μX0.{next: X0}}")},
 		},
 		{
 			name: "a recursive result through a type parameter still renders a knot",
@@ -246,8 +271,9 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 				fn id(x) { return x }
 				val d = id(f())
 			`,
-			binding: "d",
-			want:    "{next: μX0.{next: X0}}",
+			binding:  "d",
+			want:     "{next: μX0.{next: X0}}",
+			wantErrs: []string{nonReturningMsg("2:8-2:9", "f", "{next: μX0.{next: X0}}")},
 		},
 		{
 			// The tuple shape reaches the same reassignment path, so a coalesced knot over a tuple
@@ -263,6 +289,10 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 			`,
 			binding: "h",
 			want:    "fn () -> [μX0.[X0]]",
+			wantErrs: []string{
+				nonReturningMsg("2:8-2:9", "f", "[μX0.[X0]]"),
+				nonReturningMsg("3:8-3:9", "h", "[μX0.[X0]]"),
+			},
 		},
 		{
 			// Destructuring is how a recursive tuple is read apart, since a value-level index
@@ -272,14 +302,15 @@ func TestInferRecursiveThroughSourcePaths(t *testing.T) {
 				fn f() { return [f()] }
 				val [inner] = f()
 			`,
-			binding: "inner",
-			want:    "μX0.[X0]",
+			binding:  "inner",
+			want:     "μX0.[X0]",
+			wantErrs: []string{nonReturningMsg("2:8-2:9", "f", "[μX0.[X0]]")},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tt.src)
-			require.Empty(t, Messages(errs))
+			require.Equal(t, tt.wantErrs, messagesWithSpan(errs))
 			require.Equal(t, tt.want, values[tt.binding])
 		})
 	}

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -29,7 +29,7 @@ import (
 // ceiling to coalesce so a guard bypass fails cleanly instead of crashing).
 func TestInferModuleRecursiveRecordTerminates(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f() { return {x: f()} }`)
-	require.Equal(t, []string{nonReturningMsg("1:4-1:5", "f", "{x: μX0.{x: X0}}")}, messagesWithSpan(errs))
+	require.Equal(t, []string{nonReturningMsg("1:4-1:5", "f", "fn () -> {x: μX0.{x: X0}}")}, messagesWithSpan(errs))
 	require.Equal(t, "fn () -> {x: μX0.{x: X0}}", values["f"])
 }
 

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -18,6 +18,10 @@ import (
 // its own return variable, so the outer object comes from the call and the knot from the variable
 // the body's recursive call flows through.
 //
+// The recursion is unguarded, so `f` cannot return and checkCanReturn rejects it. What this test
+// pins is that coalescing TERMINATES on the cyclic graph, which it has to do before any diagnostic
+// can be reported at all.
+//
 // NOTE: a regression that bypasses the `seen` guard stack-overflows here, which
 // is a fatal (uncatchable) crash that takes down the whole package test binary
 // rather than failing this test in isolation. Tracked in
@@ -25,7 +29,7 @@ import (
 // ceiling to coalesce so a guard bypass fails cleanly instead of crashing).
 func TestInferModuleRecursiveRecordTerminates(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f() { return {x: f()} }`)
-	require.Empty(t, errs, "unexpected inference errors")
+	require.Equal(t, []string{nonReturningMsg("1:4-1:5", "f", "{x: μX0.{x: X0}}")}, messagesWithSpan(errs))
 	require.Equal(t, "fn () -> {x: μX0.{x: X0}}", values["f"])
 }
 

--- a/internal/solver/regular_test.go
+++ b/internal/solver/regular_test.go
@@ -261,7 +261,9 @@ func TestConstrainRegularAliasClosesOnItsKnot(t *testing.T) {
 		fn node() { return {a: "c", b: node()} }
 		fn use() -> H<{c: number}> { return node() }
 	`)
-	require.Empty(t, Messages(errs))
+	require.Equal(t,
+		[]string{nonReturningMsg("3:6-3:10", "node", `{a: "c", b: μX0.{a: "c", b: X0}}`)},
+		messagesWithSpan(errs))
 	require.Equal(t, `fn () -> {a: "c", b: μX0.{a: "c", b: X0}}`, values["node"])
 	require.Equal(t, "fn () -> H<{c: number}>", values["use"])
 }
@@ -275,7 +277,10 @@ func TestConstrainRegularAliasChecksTheLapAboveTheKnot(t *testing.T) {
 		fn node() { return {a: "c", b: node()} }
 		fn use() -> H<number> { return node() }
 	`)
-	require.Equal(t, []string{`4:3-4:42: cannot constrain "c" <: never`}, messagesWithSpan(errs))
+	require.Equal(t, []string{
+		nonReturningMsg("3:6-3:10", "node", `{a: "c", b: μX0.{a: "c", b: X0}}`),
+		`4:3-4:42: cannot constrain "c" <: never`,
+	}, messagesWithSpan(errs))
 }
 
 // Normalizing does not make the comparison blind: a value that disagrees with the knot's body is
@@ -291,6 +296,7 @@ func TestConstrainRegularAliasStillReportsAMismatch(t *testing.T) {
 		fn use() -> H<{c: number}> { return node() }
 	`)
 	require.Equal(t, []string{
+		nonReturningMsg("3:6-3:10", "node", `{a: "wrong", b: μX0.{a: "wrong", b: X0}}`),
 		`4:3-4:47: cannot constrain "wrong" <: "c"`,
 		`4:3-4:47: cannot constrain "wrong" <: "c"`,
 	}, messagesWithSpan(errs))
@@ -349,7 +355,10 @@ func TestConstrainRegularAliasKeepsAReductionDiagnostic(t *testing.T) {
 		fn node() { return {a: "c", e: 1, b: node()} }
 		fn use() -> H<{c: number}> { return node() }
 	`)
-	require.Equal(t, []string{`4:3-4:47: object {x: number} has no property "z"`}, messagesWithSpan(errs))
+	require.Equal(t, []string{
+		nonReturningMsg("3:6-3:10", "node", `{a: "c", e: 1, b: μX0.{a: "c", e: 1, b: X0}}`),
+		`4:3-4:47: object {x: number} has no property "z"`,
+	}, messagesWithSpan(errs))
 }
 
 // A member read off a regular alias keeps the alias name on the type it yields. evalTypeOperator

--- a/internal/solver/regular_test.go
+++ b/internal/solver/regular_test.go
@@ -262,7 +262,7 @@ func TestConstrainRegularAliasClosesOnItsKnot(t *testing.T) {
 		fn use() -> H<{c: number}> { return node() }
 	`)
 	require.Equal(t,
-		[]string{nonReturningMsg("3:6-3:10", "node", `{a: "c", b: μX0.{a: "c", b: X0}}`)},
+		[]string{nonReturningMsg("3:6-3:10", "node", `fn () -> {a: "c", b: μX0.{a: "c", b: X0}}`)},
 		messagesWithSpan(errs))
 	require.Equal(t, `fn () -> {a: "c", b: μX0.{a: "c", b: X0}}`, values["node"])
 	require.Equal(t, "fn () -> H<{c: number}>", values["use"])
@@ -278,7 +278,7 @@ func TestConstrainRegularAliasChecksTheLapAboveTheKnot(t *testing.T) {
 		fn use() -> H<number> { return node() }
 	`)
 	require.Equal(t, []string{
-		nonReturningMsg("3:6-3:10", "node", `{a: "c", b: μX0.{a: "c", b: X0}}`),
+		nonReturningMsg("3:6-3:10", "node", `fn () -> {a: "c", b: μX0.{a: "c", b: X0}}`),
 		`4:3-4:42: cannot constrain "c" <: never`,
 	}, messagesWithSpan(errs))
 }
@@ -296,7 +296,7 @@ func TestConstrainRegularAliasStillReportsAMismatch(t *testing.T) {
 		fn use() -> H<{c: number}> { return node() }
 	`)
 	require.Equal(t, []string{
-		nonReturningMsg("3:6-3:10", "node", `{a: "wrong", b: μX0.{a: "wrong", b: X0}}`),
+		nonReturningMsg("3:6-3:10", "node", `fn () -> {a: "wrong", b: μX0.{a: "wrong", b: X0}}`),
 		`4:3-4:47: cannot constrain "wrong" <: "c"`,
 		`4:3-4:47: cannot constrain "wrong" <: "c"`,
 	}, messagesWithSpan(errs))
@@ -356,7 +356,7 @@ func TestConstrainRegularAliasKeepsAReductionDiagnostic(t *testing.T) {
 		fn use() -> H<{c: number}> { return node() }
 	`)
 	require.Equal(t, []string{
-		nonReturningMsg("3:6-3:10", "node", `{a: "c", e: 1, b: μX0.{a: "c", e: 1, b: X0}}`),
+		nonReturningMsg("3:6-3:10", "node", `fn () -> {a: "c", e: 1, b: μX0.{a: "c", e: 1, b: X0}}`),
 		`4:3-4:47: object {x: number} has no property "z"`,
 	}, messagesWithSpan(errs))
 }

--- a/internal/solver/script.go
+++ b/internal/solver/script.go
@@ -61,6 +61,9 @@ func InferScript(script *ast.Script) (*Scope, *Info, []SolverError) {
 	// here too. With the whole body walked, replay the recorded reads against the
 	// consumed lattice to report use-after-move.
 	c.checkUseAfterMoves()
+	// Every function expression the script wrote has been typed, so each one's return type is
+	// final. Report each function whose return type no finite value inhabits.
+	c.checkCanReturn()
 
 	return scope, c.info, c.errs
 }


### PR DESCRIPTION
Fixes #1010

`fn cons(x: number) { return {head: x, tail: cons(x)} }` type-checks today and infers `fn (x: number) -> {head: number, tail: μX0.{head: number, tail: X0}}`. The type is right — no finite value inhabits that knot — but calling `cons` overflows the stack, and there is no version of the program that does something useful. This reports it instead of typing it silently.

It is the value-level twin of `checkProductive`. That one rejects a type alias whose recursion emits no structure at all. This one rejects a function whose recursion emits structure forever with nothing to stop it.

## How it works

`inferFunc` queues each body-carrying function, and `checkCanReturn` drains the queue at the end of `inferComponent`'s phase 2 and at the end of `InferScript`. It waits that long because a mutually-recursive cycle is not closed until every body in the SCC has been walked, so the μ-knot does not exist yet when the first body finishes.

`finitelyInhabited` then asks whether any path through the return type reaches a leaf without reaching a μ-binder. Five things provide one, each of which appears in ordinary code:

- a union arm that does not mention the binder, which is what a base case produces;
- an optional property, so `{head: T, tail?: List}` stops at an absent `tail`;
- a quantified type parameter, since the caller chooses what it stands for;
- the binder under a function type, since a thunk's body does not run while the value around it is built;
- the binder under a `Promise` or a generator, for the same reason.

The `Promise` case is why `async fn serve() { val req = await accept(); handle(req); return serve() }` stays accepted. It is `fn () -> Promise<μX0.Promise<X0>>`, a real μ-knot, and every `await` hands control back to the event loop.

Mutual recursion needs no SCC machinery. `coalesce` closes the cycle at whichever function is being rendered, so each participant sees the knot in its own return type and each draws its own diagnostic. The check is per function *body*, so a lambda that cannot return is blamed on the lambda even when the enclosing function returns fine.

## Reading the whole signature, not just the return

The second commit fixes a false positive found in review. An unannotated parameter reaching the return is a base case, and the first cut erased it:

```
fn f(x) {
    if cond() { return x }
    return {next: f(x)}
}
```

This displays as `fn <T0>(x: T0) -> T0 | {next: T0}` and plainly terminates, but plain `coalesce` renders an unbound parameter var as `never`, the union constructor drops a `never` arm, and the terminating arm vanished. Annotating `x` made the identical source pass.

The check now reads the display through `coalesceScheme`, which keeps such a variable symbolic, and builds it from the whole function type rather than the return alone — the retention rule recognizes a caller-chosen variable by its occurring in both polarities, and only the parameter list carries the negative occurrence. The message renders the full signature for the same reason: a return type holding a quantified `T0` needs the `<T0>` binder beside it.

That commit also names class members in the diagnostic. A method or getter reaches `inferFunc` as a bare `*ast.FuncExpr`, so it was blamed as "this function"; `inferMemberBodies` now hands its name down through `checker.memberName`, which `inferFunc` takes and clears so a lambda nested in the body is not blamed under the member's name.

## Out of scope

`fn serve() { return serve() }` infers `never` and `fn serve() { serve() }` infers `void`. Neither builds a μ-knot, so neither reaches this check. The issue leaves that shape open for its own diagnostic, and both are pinned here as accepted with the reason.

## Testing

`internal/solver/inhabited_test.go` carries three tables: the shapes that draw the diagnostic (including mutual recursion, a lambda, and a method), the shapes that must not (every guard above, plus the out-of-scope loops and a throwing stub), and a unit table over hand-built types for the arms no inference path mints — the optional property and a borrow of a knot.

The existing tests that pinned these shapes as error-free (`recursive_test.go`, `regression_test.go`, `regular_test.go`) now assert the diagnostic. `TestInferGuardedRecursionRendersMuKnot` passes untouched, which is the no-false-positive evidence.

No fixture: the fixture harness runs the old checker in `internal/checker/`, which stack-overflows on these programs (#597, #946).

`go test ./...` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEBELViJSt9LUArE9bJk3z

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEBELViJSt9LUArE9bJk3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added diagnostics for recursive functions that cannot produce a finite return value.
  * Improved detection across direct, mutual, nested, and method recursion.
  * Reports source locations and suggests remedies for non-terminating recursive return types.
  * Preserves valid recursion involving base cases, deferred values, generators, promises, and throwing functions.
* **Tests**
  * Expanded coverage for recursive type inference and finite inhabitation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->