### PR TITLE
Support manual generator advancement via next() method

### DIFF
--- a/internal/solver/generator.go
+++ b/internal/solver/generator.go
@@ -6,14 +6,12 @@ import (
 )
 
 // generatorMember resolves a member read off a generator receiver against the member list
-// generatorBody builds. It is the GeneratorType twin of projectedMember, which does the same
-// for a class instance.
+// generatorBody builds. It is the GeneratorType twin of projectedMember.
 //
-// Like projectedMember it reports a miss here rather than letting it fall through to the
-// structural `{name: fieldVar}` requirement in valueProp. That requirement constrains the
-// receiver `<: object`, and constrain has no rule taking a generator to an object. A miss
-// left to fall through would therefore surface as `cannot constrain Generator <: object`
-// rather than naming the member that does not exist.
+// Like projectedMember it reports a miss here. Falling through to the structural
+// `{name: fieldVar}` requirement in valueProp would constrain the receiver `<: object`, and
+// constrain has no rule taking a generator to an object, so an unknown member would surface as
+// `cannot constrain Generator <: object` instead of being named.
 func (c *checker) generatorMember(lvl int, blame, provNode ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
 	g, ok := generatorCarrier(c.ctx, carrier)
 	if !ok {
@@ -22,11 +20,10 @@ func (c *checker) generatorMember(lvl int, blame, provNode ast.Node, name string
 	body := c.generatorBody(g)
 	member, found := body.ReadMember(name)
 	if !found {
-		// MissingPropertyError blames the variable standing in the requirement's property
-		// slot, so mint one against provNode, the property identifier. The diagnostic then
-		// points at `.done` in `it.done` rather than at the whole access, matching where the
-		// structural field-requirement path in valueProp puts the same message. The variable
-		// carries no bounds and goes nowhere else.
+		// MissingPropertyError blames the variable in the requirement's property slot, so mint
+		// one against provNode, the property identifier. The diagnostic then points at `.done`
+		// in `it.done` rather than at the whole access, matching valueProp's structural path.
+		// The variable carries no bounds and goes nowhere else.
 		missing := c.freshAt(lvl)
 		c.recordProv(missing, provNode, MemberAccess)
 		err := &MissingPropertyError{Sub: body, Super: propReq(name, missing, false), Name: name}
@@ -37,20 +34,15 @@ func (c *checker) generatorMember(lvl int, blame, provNode ast.Node, name string
 	return c.memberValue(lvl, blame, member), true
 }
 
-// generatorCarrier reads the generator a member access on t goes through.
-//
-// A receiver often stands for more than one generator. `val it = g()` types `it` as the call's
-// fresh result var, and a single call to a polymorphic generator leaves that var with two
-// lower bounds differing only in their fresh slot variables. Branching, as in `val it = if b
-// { g() } else { h() }`, leaves one bound per branch. joinGenerators folds whatever the
-// receiver stands for into the one generator every part has to satisfy, so all of these read
-// their members off a single type.
+// generatorCarrier reads the generator a member access on t goes through, folding the several a
+// receiver may stand for into one. A single call to a polymorphic generator leaves two lower
+// bounds differing only in their fresh slot variables, and `if b { g() } else { h() }` leaves
+// one bound per branch.
 //
 // A receiver standing for anything besides generators is declined, so `if b { g() } else { 5 }`
 // keeps the structural field-requirement path, where the non-generator part is rejected. A var
-// with no lower bound at all is declined too, since nothing yet says it holds a generator. That
-// is what an unannotated parameter is, so `fn f(it) { it.next() }` still infers the structural
-// receiver `{next: fn () -> T0}`.
+// with no lower bound is declined too, since nothing yet says it holds a generator. That is what
+// an unannotated parameter is, so `fn f(it) { it.next() }` still infers `{next: fn () -> T0}`.
 func generatorCarrier(c *Context, t soltype.Type) (*soltype.GeneratorType, bool) {
 	parts, ok := generatorParts(t)
 	if !ok || len(parts) == 0 {
@@ -60,8 +52,8 @@ func generatorCarrier(c *Context, t soltype.Type) (*soltype.GeneratorType, bool)
 }
 
 // generatorParts collects the generators a receiver stands for, reporting false as soon as it
-// stands for anything else. A borrow is already peeled off by readCarrier before the receiver
-// reaches here, so `mut Generator<…>` arrives as the bare generator.
+// stands for anything else. readCarrier peels a borrow first, so `mut Generator<…>` arrives
+// here bare.
 func generatorParts(t soltype.Type) ([]*soltype.GeneratorType, bool) {
 	switch t := t.(type) {
 	case *soltype.GeneratorType:
@@ -95,15 +87,11 @@ func generatorParts(t soltype.Type) ([]*soltype.GeneratorType, bool) {
 	return nil, false
 }
 
-// joinGenerators folds several generators into the one a member read goes through, the least
-// generator every input is a subtype of. Yield, Ret, and Throws are covariant, so the join
-// unions each of them. Next is contravariant, being the value a caller sends in, so the join
-// intersects it instead. A value the caller sends has to be acceptable to every generator the
-// receiver may hold. A single input is returned unchanged, which is the path an ordinary
-// `val it = g()` takes.
-//
-// A sync and an async generator are unrelated under subtyping, so a receiver mixing the two
-// has no join and is declined.
+// joinGenerators folds several generators into the least generator every input is a subtype of.
+// Yield, Ret, and Throws are covariant, so the join unions each. Next is contravariant, being
+// the value a caller sends in, so the join intersects it: what the caller sends has to be
+// acceptable to every generator the receiver may hold. A sync and an async generator are
+// unrelated under subtyping, so a receiver mixing the two is declined.
 func joinGenerators(c *Context, gs []*soltype.GeneratorType) (*soltype.GeneratorType, bool) {
 	if len(gs) == 1 {
 		return gs[0], true
@@ -129,32 +117,27 @@ func joinGenerators(c *Context, gs []*soltype.GeneratorType) (*soltype.Generator
 }
 
 // generatorBody builds the members a generator exposes to a caller driving it by hand. It
-// carries `next` alone. The `return` and `throw` methods, which finish a generator early,
-// need no new machinery beyond what next uses here and are not declared yet.
+// carries `next` alone. The `return` and `throw` methods, which finish a generator early, are
+// not declared yet and need no machinery beyond what `next` uses here.
 func (c *checker) generatorBody(g *soltype.GeneratorType) *soltype.ObjectType {
 	return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{c.generatorNext(g)}}
 }
 
 // generatorNext declares the `next` method that advances g, as an overload set of up to two
-// arms. N below is g's Next slot, the type a `yield` expression in the body evaluates to and so
-// the value a caller sends back in. iterationResult builds the shared result type.
+// arms over the result iterationResult builds. N is g's Next slot, the value a caller sends in.
 //
-//	next() -> {value: Y, done: false} | {value: R, done: true}
-//	next(value: N) -> {value: Y, done: false} | {value: R, done: true}
+//	next() -> IteratorResult<Y, R>
+//	next(value: N) -> IteratorResult<Y, R>
 //
-// Both arms carry g's raise, so a caller that drives a generator by hand handles what its
-// body throws the way an iterating caller does.
+// Both arms carry g's raise, so driving a generator by hand handles what its body throws the way
+// iterating it does.
 //
-// The no-argument arm is offered only when `undefined` is assignable to N. Omitting the
-// argument sends `undefined` at runtime, so an unconditional no-argument arm would let a body
-// that reads its sent value as a string receive `undefined` instead. An inferred N is
-// `unknown`, which accepts `undefined`, so the argumentless call stays available for every
-// generator that does not declare a narrower N. A generator that declares one, such as
-// `Generator<number, string, string>`, offers only the one-argument arm, and a bare
-// `it.next()` on it is reported as a call missing an argument.
-//
-// Declaring the parameter optional, `next(value?: N)`, would not close that hole, because an
-// optional parameter lets `undefined` arrive for exactly the same reason.
+// The no-argument arm is offered only when `undefined` is assignable to N, since omitting the
+// argument sends `undefined` at runtime. An inferred N is `unknown` and accepts it. A declared
+// narrow one such as `Generator<number, string, string>` does not, so that generator offers only
+// the one-argument arm and a bare `it.next()` on it is reported as missing an argument. Making
+// the parameter optional, `next(value?: N)`, would not close the hole, because an optional
+// parameter lets `undefined` arrive for the same reason.
 func (c *checker) generatorNext(g *soltype.GeneratorType) *soltype.MethodElem {
 	result := c.iterationResult(g)
 	sigs := make([]*soltype.FuncType, 0, 2)
@@ -169,15 +152,13 @@ func (c *checker) generatorNext(g *soltype.GeneratorType) *soltype.MethodElem {
 
 // advanceSig builds one signature of a method that advances g and evaluates to result.
 //
-// A sync generator runs its body during the call, so the call is where the body's raise
-// escapes. The signature's Throws is therefore g's own raise slot, and constrain's covariant
-// throws rule records it into the calling body's sink. A nil slot is the shorthand for
-// `never`, so a generator that cannot raise contributes nothing.
+// A sync generator runs its body during the call, so the call is where the body's raise escapes.
+// The signature's Throws is g's raise slot, which constrain's covariant throws rule records into
+// the calling body's sink. A nil slot is the `never` shorthand and contributes nothing.
 //
-// An async generator returns a promise instead, and its body's raise surfaces as that
-// promise's rejection. Putting the slot in the promise's Err rather than on the signature
-// means `it.next()` alone raises nothing and `await it.next()` is what reaches the awaiting
-// body's sink.
+// An async generator returns a promise, and its body's raise surfaces as that promise's
+// rejection. Carrying the slot in the promise's Err rather than on the signature means
+// `it.next()` alone raises nothing and `await it.next()` reaches the awaiting body's sink.
 func advanceSig(g *soltype.GeneratorType, result soltype.Type, params []*soltype.FuncParam) *soltype.FuncType {
 	if g.Async {
 		return &soltype.FuncType{Params: params, Ret: &soltype.PromiseType{Inner: result, Err: g.Throws}}
@@ -186,26 +167,20 @@ func advanceSig(g *soltype.GeneratorType, result soltype.Type, params []*soltype
 }
 
 // iterationResult builds the type an advance of g evaluates to, a reference to one of the
-// built-in iterator-result aliases at g's Yield and Ret slots. registerIteratorResultAliases in
-// prelude.go holds the three alias bodies, so the shape lives in one place and a caller may
-// annotate against it by name.
+// built-in iterator-result aliases registerIteratorResultAliases defines in prelude.go.
 //
-// An advance either produces a yielded value or reports that the generator finished with its
-// return value, and `IteratorResult<Y, R>` is the union of one arm per outcome, tagged by
-// `done`. Naming the two arms keeps Y and R distinct. `gen fn g() { yield 1 return "done" }`
-// advances to `IteratorResult<1, "done">`, where one flat `{value: Y | R, done: boolean}` object
-// would merge both into `1 | "done"` and lose which value belongs to which outcome. Reducing a
-// result to one arm by testing its `done` needs narrowing on a literal-tagged union, which does
-// not reduce this union yet, so today a bare `r.value` reads the join of both arms.
+// An advance either yields a value or reports the generator finished, and `IteratorResult<Y, R>`
+// is one arm per outcome tagged by `done`. Two arms keep Y and R distinct, where one flat
+// `{value: Y | R, done: boolean}` object would merge them. Reducing a result to one arm by
+// testing its `done` needs narrowing on a literal-tagged union, which does not reduce this union
+// yet, so a bare `r.value` reads the join of both arms.
 //
-// A generator that cannot reach one outcome names that outcome's arm alone rather than the
-// union, which is a strictly more precise result and one an annotation can be written against.
-// `gen fn g() { yield 1 throw "boom" }` has `never` in Ret, so it never finishes normally and
-// advances to `IteratorYieldResult<1>`. A generator that only ever finishes has `never` in Yield
-// and advances to `IteratorReturnResult<R>`. One that can do neither advances to `never`.
+// A generator that cannot reach an outcome names the reachable arm alone, which is more precise
+// and still annotatable. `gen fn g() { yield 1 throw "boom" }` has `never` in Ret and advances
+// to `IteratorYieldResult<1>`; one that only finishes advances to `IteratorReturnResult<R>`.
 //
-// Every reference is interned, since a member access mints one per read and constrain keys its
-// cycle cache on pointer identity.
+// References are interned, since a member access mints one per read and constrain keys its cycle
+// cache on pointer identity.
 func (c *checker) iterationResult(g *soltype.GeneratorType) soltype.Type {
 	yields, returns := !isNeverType(g.Yield), !isNeverType(g.Ret)
 	switch {
@@ -225,23 +200,20 @@ func (c *checker) iterationResultRef(name string, args ...soltype.Type) soltype.
 }
 
 // acceptsUndefined reports whether `undefined` is assignable to t without narrowing t, the
-// question that decides whether generatorNext offers its no-argument arm. The trial runs under
-// a throwaway probe, so t picks up no bound from being asked.
+// question that decides whether generatorNext offers its no-argument arm. The trial runs under a
+// throwaway probe, so t picks up no bound from being asked.
 //
-// A trial that succeeds only by recording a bound does not count as accepting. Such a trial
-// says t is a variable the constraint would WIDEN to admit `undefined`, not a type that already
-// admits it, and the probe throws that widening away. A declared type parameter is the case
-// that matters. For `fn drive<T>(it: Generator<number, string, T>) { it.next() }`, T has to
-// stand for any type its caller picks, so sending `undefined` is exactly what the gate exists
-// to reject. Reading the trial's success alone would offer the no-argument arm there and let
-// `drive(g())`, for a `g` whose body reads its sent value as a string, send `undefined` into
-// that body.
+// A trial that succeeds only by recording a bound does not count as accepting: it says t is a
+// variable the constraint would WIDEN to admit `undefined`, not one that already admits it. A
+// declared type parameter is the case that matters. In
+// `fn drive<T>(it: Generator<number, string, T>) { it.next() }`, T stands for whatever the caller
+// picks, so reading the trial's success alone would offer the no-argument arm and let
+// `drive(g())` send `undefined` into a `g` whose body reads its sent value as a string.
 //
-// A declared parameter's var is an ordinary bounded inference var, and nothing at an access
-// site tells the two apart — checkTypeParamsProducible decides that afterwards from the bounds
-// the whole body recorded. So the mutation test also declines an ordinary unsolved variable,
-// which costs `Generator<1, undefined, _>` whose body never reads its sent value the
-// argumentless call. Writing that slot as `unknown` restores it.
+// Nothing at an access site tells a declared parameter's var from an ordinary unsolved one, since
+// checkTypeParamsProducible decides that afterwards from the bounds the whole body recorded. So
+// the mutation test declines both, costing `Generator<1, undefined, _>` whose body never reads
+// its sent value the argumentless call. Writing that slot as `unknown` restores it.
 func (c *checker) acceptsUndefined(t soltype.Type) bool {
 	ok, mutated := c.ctx.trialMutatesBounds(&soltype.UndefinedType{}, t, newSeenPairs(), false)
 	return ok && !mutated

--- a/internal/solver/generator.go
+++ b/internal/solver/generator.go
@@ -136,11 +136,11 @@ func (c *checker) generatorBody(g *soltype.GeneratorType) *soltype.ObjectType {
 }
 
 // generatorNext declares the `next` method that advances g, as an overload set of up to two
-// arms. Y, R, and N below are g's Yield, Ret, and Next slots. N is the type a `yield`
-// expression in the body evaluates to, the value a caller sends back in.
+// arms. N below is g's Next slot, the type a `yield` expression in the body evaluates to and so
+// the value a caller sends back in. iterationResult builds the shared result type.
 //
-//	next() -> {value: Y | R, done: boolean}
-//	next(value: N) -> {value: Y | R, done: boolean}
+//	next() -> {value: Y, done: false} | {value: R, done: true}
+//	next(value: N) -> {value: Y, done: false} | {value: R, done: true}
 //
 // Both arms carry g's raise, so a caller that drives a generator by hand handles what its
 // body throws the way an iterating caller does.
@@ -185,19 +185,46 @@ func advanceSig(g *soltype.GeneratorType, result soltype.Type, params []*soltype
 	return &soltype.FuncType{Params: params, Ret: result, Throws: g.Throws}
 }
 
-// iterationResult builds the object an advance of g evaluates to, `{value: Y | R, done:
-// boolean}`. It stands in for the standard library's `IteratorResult<Y, R>`, one of the
-// opaque prelude placeholders until library type ingestion lands. A running generator reports
-// the type it yields and a finished one the type it returns, so the value slot is the union
-// of both.
+// iterationResult builds the type an advance of g evaluates to. It stands in for the standard
+// library's `IteratorResult<Y, R>`, one of the opaque prelude placeholders until library type
+// ingestion lands.
 //
-// The precise form is the discriminated union `{value: Y, done: false} | {value: R, done:
-// true}`, which lets a reader recover Y alone after testing `done`. This wider object is a
-// supertype of it, so reading a result through it is sound but coarser.
+// An advance either produces a yielded value or reports that the generator finished with its
+// return value, so the result is a union of one arm per outcome, tagged by `done`:
+//
+//	{value: Y, done: false} | {value: R, done: true}
+//
+// Two arms keep Y and R distinct. `gen fn g() { yield 1 return "done" }` advances to
+// `{value: 1, done: false} | {value: "done", done: true}`, where a single
+// `{value: Y | R, done: boolean}` object would flatten both into `1 | "done"` and lose which
+// value belongs to which outcome. Reducing a result to one arm by testing its `done` needs
+// narrowing on a literal-tagged union, which does not reduce this union yet, so today a bare
+// `r.value` reads the join of both arms.
+//
+// An arm is dropped when its value type is the `never` no value inhabits. A generator that
+// always throws has `never` in Ret, so `gen fn g() { yield 1 throw "boom" }` advances to
+// `{value: 1, done: false}` alone rather than carrying an unreachable finished arm.
+//
+// The `done` slot is required in both arms, where TypeScript writes the yield arm's as
+// `done?: false`. An optional tag lets a hand-written iterator omit the field. Every generator
+// sets it, and a required tag is what a narrowing rule can read to pick an arm.
 func (c *checker) iterationResult(g *soltype.GeneratorType) soltype.Type {
+	arms := make([]soltype.Type, 0, 2)
+	if !isNeverType(g.Yield) {
+		arms = append(arms, iterationResultArm(g.Yield, false))
+	}
+	if !isNeverType(g.Ret) {
+		arms = append(arms, iterationResultArm(g.Ret, true))
+	}
+	return newUnion(c.ctx, arms, false)
+}
+
+// iterationResultArm builds one arm of the iteration-result union: the yielded-value arm when
+// done is false, and the finished arm carrying the generator's return value when it is true.
+func iterationResultArm(value soltype.Type, done bool) *soltype.ObjectType {
 	return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
-		&soltype.PropertyElem{Name: "value", Type: newUnion(c.ctx, []soltype.Type{g.Yield, g.Ret}, false)},
-		&soltype.PropertyElem{Name: "done", Type: &soltype.PrimType{Prim: soltype.BoolPrim}},
+		&soltype.PropertyElem{Name: "value", Type: value},
+		&soltype.PropertyElem{Name: "done", Type: &soltype.LitType{Lit: &soltype.BoolLit{Value: done}}},
 	}}
 }
 

--- a/internal/solver/generator.go
+++ b/internal/solver/generator.go
@@ -185,47 +185,43 @@ func advanceSig(g *soltype.GeneratorType, result soltype.Type, params []*soltype
 	return &soltype.FuncType{Params: params, Ret: result, Throws: g.Throws}
 }
 
-// iterationResult builds the type an advance of g evaluates to. It stands in for the standard
-// library's `IteratorResult<Y, R>`, one of the opaque prelude placeholders until library type
-// ingestion lands.
+// iterationResult builds the type an advance of g evaluates to, a reference to one of the
+// built-in iterator-result aliases at g's Yield and Ret slots. registerIteratorResultAliases in
+// prelude.go holds the three alias bodies, so the shape lives in one place and a caller may
+// annotate against it by name.
 //
 // An advance either produces a yielded value or reports that the generator finished with its
-// return value, so the result is a union of one arm per outcome, tagged by `done`:
+// return value, and `IteratorResult<Y, R>` is the union of one arm per outcome, tagged by
+// `done`. Naming the two arms keeps Y and R distinct. `gen fn g() { yield 1 return "done" }`
+// advances to `IteratorResult<1, "done">`, where one flat `{value: Y | R, done: boolean}` object
+// would merge both into `1 | "done"` and lose which value belongs to which outcome. Reducing a
+// result to one arm by testing its `done` needs narrowing on a literal-tagged union, which does
+// not reduce this union yet, so today a bare `r.value` reads the join of both arms.
 //
-//	{value: Y, done: false} | {value: R, done: true}
+// A generator that cannot reach one outcome names that outcome's arm alone rather than the
+// union, which is a strictly more precise result and one an annotation can be written against.
+// `gen fn g() { yield 1 throw "boom" }` has `never` in Ret, so it never finishes normally and
+// advances to `IteratorYieldResult<1>`. A generator that only ever finishes has `never` in Yield
+// and advances to `IteratorReturnResult<R>`. One that can do neither advances to `never`.
 //
-// Two arms keep Y and R distinct. `gen fn g() { yield 1 return "done" }` advances to
-// `{value: 1, done: false} | {value: "done", done: true}`, where a single
-// `{value: Y | R, done: boolean}` object would flatten both into `1 | "done"` and lose which
-// value belongs to which outcome. Reducing a result to one arm by testing its `done` needs
-// narrowing on a literal-tagged union, which does not reduce this union yet, so today a bare
-// `r.value` reads the join of both arms.
-//
-// An arm is dropped when its value type is the `never` no value inhabits. A generator that
-// always throws has `never` in Ret, so `gen fn g() { yield 1 throw "boom" }` advances to
-// `{value: 1, done: false}` alone rather than carrying an unreachable finished arm.
-//
-// The `done` slot is required in both arms, where TypeScript writes the yield arm's as
-// `done?: false`. An optional tag lets a hand-written iterator omit the field. Every generator
-// sets it, and a required tag is what a narrowing rule can read to pick an arm.
+// Every reference is interned, since a member access mints one per read and constrain keys its
+// cycle cache on pointer identity.
 func (c *checker) iterationResult(g *soltype.GeneratorType) soltype.Type {
-	arms := make([]soltype.Type, 0, 2)
-	if !isNeverType(g.Yield) {
-		arms = append(arms, iterationResultArm(g.Yield, false))
+	yields, returns := !isNeverType(g.Yield), !isNeverType(g.Ret)
+	switch {
+	case yields && returns:
+		return c.iterationResultRef(iteratorResultName, g.Yield, g.Ret)
+	case yields:
+		return c.iterationResultRef(iteratorYieldResultName, g.Yield)
+	case returns:
+		return c.iterationResultRef(iteratorReturnResultName, g.Ret)
 	}
-	if !isNeverType(g.Ret) {
-		arms = append(arms, iterationResultArm(g.Ret, true))
-	}
-	return newUnion(c.ctx, arms, false)
+	return &soltype.NeverType{}
 }
 
-// iterationResultArm builds one arm of the iteration-result union: the yielded-value arm when
-// done is false, and the finished arm carrying the generator's return value when it is true.
-func iterationResultArm(value soltype.Type, done bool) *soltype.ObjectType {
-	return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
-		&soltype.PropertyElem{Name: "value", Type: value},
-		&soltype.PropertyElem{Name: "done", Type: &soltype.LitType{Lit: &soltype.BoolLit{Value: done}}},
-	}}
+// iterationResultRef builds an interned reference to one of the iterator-result aliases.
+func (c *checker) iterationResultRef(name string, args ...soltype.Type) soltype.Type {
+	return c.ctx.internAlias(&soltype.AliasType{Name: name, TypeArgs: args})
 }
 
 // acceptsUndefined reports whether `undefined` is assignable to t without narrowing t, the

--- a/internal/solver/generator.go
+++ b/internal/solver/generator.go
@@ -1,0 +1,144 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// generatorMember resolves a member read off a generator receiver against the member list
+// generatorBody builds. It is the GeneratorType twin of projectedMember, which does the same
+// for a class instance.
+//
+// Like projectedMember it reports a miss here rather than letting it fall through to the
+// structural `{name: fieldVar}` requirement in valueProp. That requirement constrains the
+// receiver `<: object`, and constrain has no rule taking a generator to an object, so a miss
+// left to fall through would surface as `cannot constrain Generator <: object` instead of
+// naming the member that does not exist.
+func (c *checker) generatorMember(lvl int, blame, provNode ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
+	g, ok := generatorCarrier(carrier)
+	if !ok {
+		return pathResult{}, false
+	}
+	body := c.generatorBody(g)
+	member, found := body.ReadMember(name)
+	if !found {
+		// MissingPropertyError blames the variable standing in the requirement's property
+		// slot, so mint one against provNode, the property identifier. The diagnostic then
+		// points at `.done` in `it.done` rather than at the whole access, matching where the
+		// structural field-requirement path in valueProp puts the same message. The variable
+		// carries no bounds and goes nowhere else.
+		missing := c.freshAt(lvl)
+		c.recordProv(missing, provNode, MemberAccess)
+		err := &MissingPropertyError{Sub: body, Super: propReq(name, missing, false), Name: name}
+		err.prov, err.site = c.prov, blame
+		c.errs = append(c.errs, err)
+		return pathResult{value: &soltype.ErrorType{}}, true
+	}
+	return c.memberValue(lvl, blame, member), true
+}
+
+// generatorCarrier reads the generator type a receiver denotes: the type itself, or the
+// single generator among an unresolved var's lower bounds. `val it = g()` types `it` as the
+// call's fresh result var, so the var arm is what an ordinary `it.next()` goes through. It
+// mirrors classCarrier and objectCarrier, and like them it declines a var whose bounds
+// disagree, since there is no one member list to read in that case.
+func generatorCarrier(t soltype.Type) (*soltype.GeneratorType, bool) {
+	switch t := t.(type) {
+	case *soltype.GeneratorType:
+		return t, true
+	case *soltype.TypeVarType:
+		var found *soltype.GeneratorType
+		for _, lb := range t.LowerBounds {
+			g, ok := lb.(*soltype.GeneratorType)
+			if !ok {
+				continue
+			}
+			if found != nil && !equalType(found, g) {
+				return nil, false
+			}
+			found = g
+		}
+		if found != nil {
+			return found, true
+		}
+	}
+	return nil, false
+}
+
+// generatorBody builds the members a generator exposes to a caller driving it by hand. It
+// carries `next` alone. The `return` and `throw` methods, which finish a generator early,
+// need no new machinery beyond what next uses here and are not declared yet.
+func (c *checker) generatorBody(g *soltype.GeneratorType) *soltype.ObjectType {
+	return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{c.generatorNext(g)}}
+}
+
+// generatorNext declares the `next` method that advances g, as an overload set of up to two
+// arms. Both return the iteration result and both carry g's raise, so a caller that drives a
+// generator by hand handles what its body throws the way an iterating caller does.
+//
+//	next() -> {value: Y | R, done: boolean}
+//	next(value: N) -> {value: Y | R, done: boolean}
+//
+// The no-argument arm is offered only when `undefined` is assignable to N, the type a `yield`
+// expression in the body evaluates to. Omitting the argument sends `undefined` at runtime, so
+// an unconditional no-argument arm would let a body that reads its sent value as a string
+// receive `undefined` instead. An inferred N is `unknown`, which accepts `undefined`, so the
+// argumentless call stays available for every generator that does not declare a narrower N.
+// A generator that declares one, such as `Generator<number, string, string>`, offers only the
+// one-argument arm, and a bare `it.next()` on it is reported as a call missing an argument.
+//
+// Note that declaring the parameter optional, `next(value?: N)`, would not close that hole:
+// an optional parameter lets `undefined` arrive for exactly the same reason.
+func (c *checker) generatorNext(g *soltype.GeneratorType) *soltype.MethodElem {
+	result := c.iterationResult(g)
+	sigs := make([]*soltype.FuncType, 0, 2)
+	if c.acceptsUndefined(g.Next) {
+		sigs = append(sigs, advanceSig(g, result, nil))
+	}
+	sigs = append(sigs, advanceSig(g, result, []*soltype.FuncParam{
+		{Pattern: &soltype.IdentPat{Name: "value"}, Type: g.Next},
+	}))
+	return &soltype.MethodElem{Name: "next", Signatures: sigs}
+}
+
+// advanceSig builds one signature of a method that advances g and evaluates to result.
+//
+// A sync generator runs its body during the call, so the call is where the body's raise
+// escapes: the signature's Throws is g's own raise slot, and constrain's covariant throws
+// rule records it into the calling body's sink. A nil slot is the shorthand for `never`, so a
+// generator that cannot raise contributes nothing.
+//
+// An async generator returns a promise instead, and its body's raise surfaces as that
+// promise's rejection. Putting the slot in the promise's Err rather than on the signature
+// means `it.next()` alone raises nothing and `await it.next()` is what reaches the awaiting
+// body's sink.
+func advanceSig(g *soltype.GeneratorType, result soltype.Type, params []*soltype.FuncParam) *soltype.FuncType {
+	if g.Async {
+		return &soltype.FuncType{Params: params, Ret: &soltype.PromiseType{Inner: result, Err: g.Throws}}
+	}
+	return &soltype.FuncType{Params: params, Ret: result, Throws: g.Throws}
+}
+
+// iterationResult builds the object an advance of g evaluates to, `{value: Y | R, done:
+// boolean}`. It stands in for the standard library's `IteratorResult<Y, R>`, which is still
+// one of the opaque prelude placeholders until library type ingestion lands. A running
+// generator reports the type it yields and a finished one the type it returns, so the value
+// slot is the union of both.
+//
+// The precise form is the discriminated union `{value: Y, done: false} | {value: R, done:
+// true}`, which lets a reader recover Y alone after testing `done`. This wider object is a
+// supertype of it, so reading a result through it is sound but coarser.
+func (c *checker) iterationResult(g *soltype.GeneratorType) soltype.Type {
+	return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.PropertyElem{Name: "value", Type: newUnion(c.ctx, []soltype.Type{g.Yield, g.Ret}, false)},
+		&soltype.PropertyElem{Name: "done", Type: &soltype.PrimType{Prim: soltype.BoolPrim}},
+	}}
+}
+
+// acceptsUndefined reports whether `undefined` is assignable to t, the question that decides
+// whether generatorNext offers its no-argument arm. The trial runs under a throwaway probe,
+// so a t that is still an unsolved variable picks up no bound from being asked.
+func (c *checker) acceptsUndefined(t soltype.Type) bool {
+	ok, _ := c.ctx.trialMutatesBounds(&soltype.UndefinedType{}, t, newSeenPairs(), false)
+	return ok
+}

--- a/internal/solver/generator.go
+++ b/internal/solver/generator.go
@@ -11,9 +11,9 @@ import (
 //
 // Like projectedMember it reports a miss here rather than letting it fall through to the
 // structural `{name: fieldVar}` requirement in valueProp. That requirement constrains the
-// receiver `<: object`, and constrain has no rule taking a generator to an object, so a miss
-// left to fall through would surface as `cannot constrain Generator <: object` instead of
-// naming the member that does not exist.
+// receiver `<: object`, and constrain has no rule taking a generator to an object. A miss
+// left to fall through would therefore surface as `cannot constrain Generator <: object`
+// rather than naming the member that does not exist.
 func (c *checker) generatorMember(lvl int, blame, provNode ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
 	g, ok := generatorCarrier(carrier)
 	if !ok {
@@ -73,22 +73,25 @@ func (c *checker) generatorBody(g *soltype.GeneratorType) *soltype.ObjectType {
 }
 
 // generatorNext declares the `next` method that advances g, as an overload set of up to two
-// arms. Both return the iteration result and both carry g's raise, so a caller that drives a
-// generator by hand handles what its body throws the way an iterating caller does.
+// arms. Y, R, and N below are g's Yield, Ret, and Next slots. N is the type a `yield`
+// expression in the body evaluates to, the value a caller sends back in.
 //
 //	next() -> {value: Y | R, done: boolean}
 //	next(value: N) -> {value: Y | R, done: boolean}
 //
-// The no-argument arm is offered only when `undefined` is assignable to N, the type a `yield`
-// expression in the body evaluates to. Omitting the argument sends `undefined` at runtime, so
-// an unconditional no-argument arm would let a body that reads its sent value as a string
-// receive `undefined` instead. An inferred N is `unknown`, which accepts `undefined`, so the
-// argumentless call stays available for every generator that does not declare a narrower N.
-// A generator that declares one, such as `Generator<number, string, string>`, offers only the
-// one-argument arm, and a bare `it.next()` on it is reported as a call missing an argument.
+// Both arms carry g's raise, so a caller that drives a generator by hand handles what its
+// body throws the way an iterating caller does.
 //
-// Note that declaring the parameter optional, `next(value?: N)`, would not close that hole:
-// an optional parameter lets `undefined` arrive for exactly the same reason.
+// The no-argument arm is offered only when `undefined` is assignable to N. Omitting the
+// argument sends `undefined` at runtime, so an unconditional no-argument arm would let a body
+// that reads its sent value as a string receive `undefined` instead. An inferred N is
+// `unknown`, which accepts `undefined`, so the argumentless call stays available for every
+// generator that does not declare a narrower N. A generator that declares one, such as
+// `Generator<number, string, string>`, offers only the one-argument arm, and a bare
+// `it.next()` on it is reported as a call missing an argument.
+//
+// Declaring the parameter optional, `next(value?: N)`, would not close that hole, because an
+// optional parameter lets `undefined` arrive for exactly the same reason.
 func (c *checker) generatorNext(g *soltype.GeneratorType) *soltype.MethodElem {
 	result := c.iterationResult(g)
 	sigs := make([]*soltype.FuncType, 0, 2)
@@ -104,9 +107,9 @@ func (c *checker) generatorNext(g *soltype.GeneratorType) *soltype.MethodElem {
 // advanceSig builds one signature of a method that advances g and evaluates to result.
 //
 // A sync generator runs its body during the call, so the call is where the body's raise
-// escapes: the signature's Throws is g's own raise slot, and constrain's covariant throws
-// rule records it into the calling body's sink. A nil slot is the shorthand for `never`, so a
-// generator that cannot raise contributes nothing.
+// escapes. The signature's Throws is therefore g's own raise slot, and constrain's covariant
+// throws rule records it into the calling body's sink. A nil slot is the shorthand for
+// `never`, so a generator that cannot raise contributes nothing.
 //
 // An async generator returns a promise instead, and its body's raise surfaces as that
 // promise's rejection. Putting the slot in the promise's Err rather than on the signature
@@ -120,10 +123,10 @@ func advanceSig(g *soltype.GeneratorType, result soltype.Type, params []*soltype
 }
 
 // iterationResult builds the object an advance of g evaluates to, `{value: Y | R, done:
-// boolean}`. It stands in for the standard library's `IteratorResult<Y, R>`, which is still
-// one of the opaque prelude placeholders until library type ingestion lands. A running
-// generator reports the type it yields and a finished one the type it returns, so the value
-// slot is the union of both.
+// boolean}`. It stands in for the standard library's `IteratorResult<Y, R>`, one of the
+// opaque prelude placeholders until library type ingestion lands. A running generator reports
+// the type it yields and a finished one the type it returns, so the value slot is the union
+// of both.
 //
 // The precise form is the discriminated union `{value: Y, done: false} | {value: R, done:
 // true}`, which lets a reader recover Y alone after testing `done`. This wider object is a

--- a/internal/solver/generator.go
+++ b/internal/solver/generator.go
@@ -76,11 +76,22 @@ func generatorParts(t soltype.Type) ([]*soltype.GeneratorType, bool) {
 				// what the receiver holds. readCarrier drops the same bound.
 				continue
 			}
-			g, ok := lb.(*soltype.GeneratorType)
-			if !ok {
+			switch lb.(type) {
+			case *soltype.GeneratorType, *soltype.UnionType:
+				// One bound may itself hold several generators. Calling a function whose
+				// return type is `Generator<1, …> | Generator<2, …>` lowers that union into
+				// the call's result var as a single union-valued bound, so flatten it rather
+				// than reading the bound as one generator. The recursion goes one level: the
+				// union arm above matches only a direct GeneratorType per member, and
+				// newUnion leaves no union nested inside a union.
+				members, ok := generatorParts(lb)
+				if !ok {
+					return nil, false
+				}
+				parts = append(parts, members...)
+			default:
 				return nil, false
 			}
-			parts = append(parts, g)
 		}
 		return parts, true
 	}

--- a/internal/solver/generator.go
+++ b/internal/solver/generator.go
@@ -15,7 +15,7 @@ import (
 // left to fall through would therefore surface as `cannot constrain Generator <: object`
 // rather than naming the member that does not exist.
 func (c *checker) generatorMember(lvl int, blame, provNode ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
-	g, ok := generatorCarrier(carrier)
+	g, ok := generatorCarrier(c.ctx, carrier)
 	if !ok {
 		return pathResult{}, false
 	}
@@ -37,32 +37,95 @@ func (c *checker) generatorMember(lvl int, blame, provNode ast.Node, name string
 	return c.memberValue(lvl, blame, member), true
 }
 
-// generatorCarrier reads the generator type a receiver denotes: the type itself, or the
-// single generator among an unresolved var's lower bounds. `val it = g()` types `it` as the
-// call's fresh result var, so the var arm is what an ordinary `it.next()` goes through. It
-// mirrors classCarrier and objectCarrier, and like them it declines a var whose bounds
-// disagree, since there is no one member list to read in that case.
-func generatorCarrier(t soltype.Type) (*soltype.GeneratorType, bool) {
+// generatorCarrier reads the generator a member access on t goes through.
+//
+// A receiver often stands for more than one generator. `val it = g()` types `it` as the call's
+// fresh result var, and a single call to a polymorphic generator leaves that var with two
+// lower bounds differing only in their fresh slot variables. Branching, as in `val it = if b
+// { g() } else { h() }`, leaves one bound per branch. joinGenerators folds whatever the
+// receiver stands for into the one generator every part has to satisfy, so all of these read
+// their members off a single type.
+//
+// A receiver standing for anything besides generators is declined, so `if b { g() } else { 5 }`
+// keeps the structural field-requirement path, where the non-generator part is rejected. A var
+// with no lower bound at all is declined too, since nothing yet says it holds a generator. That
+// is what an unannotated parameter is, so `fn f(it) { it.next() }` still infers the structural
+// receiver `{next: fn () -> T0}`.
+func generatorCarrier(c *Context, t soltype.Type) (*soltype.GeneratorType, bool) {
+	parts, ok := generatorParts(t)
+	if !ok || len(parts) == 0 {
+		return nil, false
+	}
+	return joinGenerators(c, parts)
+}
+
+// generatorParts collects the generators a receiver stands for, reporting false as soon as it
+// stands for anything else. A borrow is already peeled off by readCarrier before the receiver
+// reaches here, so `mut Generator<…>` arrives as the bare generator.
+func generatorParts(t soltype.Type) ([]*soltype.GeneratorType, bool) {
 	switch t := t.(type) {
 	case *soltype.GeneratorType:
-		return t, true
-	case *soltype.TypeVarType:
-		var found *soltype.GeneratorType
-		for _, lb := range t.LowerBounds {
-			g, ok := lb.(*soltype.GeneratorType)
+		return []*soltype.GeneratorType{t}, true
+	case *soltype.UnionType:
+		parts := make([]*soltype.GeneratorType, 0, len(t.Types))
+		for _, member := range t.Types {
+			g, ok := member.(*soltype.GeneratorType)
 			if !ok {
-				continue
-			}
-			if found != nil && !equalType(found, g) {
 				return nil, false
 			}
-			found = g
+			parts = append(parts, g)
 		}
-		if found != nil {
-			return found, true
+		return parts, true
+	case *soltype.TypeVarType:
+		parts := make([]*soltype.GeneratorType, 0, len(t.LowerBounds))
+		for _, lb := range t.LowerBounds {
+			if lb == soltype.Type(t) {
+				// A vacuous `v <: v` self-edge constrains nothing, so it says nothing about
+				// what the receiver holds. readCarrier drops the same bound.
+				continue
+			}
+			g, ok := lb.(*soltype.GeneratorType)
+			if !ok {
+				return nil, false
+			}
+			parts = append(parts, g)
 		}
+		return parts, true
 	}
 	return nil, false
+}
+
+// joinGenerators folds several generators into the one a member read goes through, the least
+// generator every input is a subtype of. Yield, Ret, and Throws are covariant, so the join
+// unions each of them. Next is contravariant, being the value a caller sends in, so the join
+// intersects it instead. A value the caller sends has to be acceptable to every generator the
+// receiver may hold. A single input is returned unchanged, which is the path an ordinary
+// `val it = g()` takes.
+//
+// A sync and an async generator are unrelated under subtyping, so a receiver mixing the two
+// has no join and is declined.
+func joinGenerators(c *Context, gs []*soltype.GeneratorType) (*soltype.GeneratorType, bool) {
+	if len(gs) == 1 {
+		return gs[0], true
+	}
+	yields := make([]soltype.Type, len(gs))
+	rets := make([]soltype.Type, len(gs))
+	nexts := make([]soltype.Type, len(gs))
+	throws := make([]soltype.Type, len(gs))
+	for i, g := range gs {
+		if g.Async != gs[0].Async {
+			return nil, false
+		}
+		yields[i], rets[i], nexts[i] = g.Yield, g.Ret, g.Next
+		throws[i] = g.ThrowsOrNever()
+	}
+	return &soltype.GeneratorType{
+		Yield:  newUnion(c, yields, false),
+		Ret:    newUnion(c, rets, false),
+		Next:   newIntersection(c, nexts),
+		Throws: newUnion(c, throws, false),
+		Async:  gs[0].Async,
+	}, true
 }
 
 // generatorBody builds the members a generator exposes to a caller driving it by hand. It
@@ -138,10 +201,25 @@ func (c *checker) iterationResult(g *soltype.GeneratorType) soltype.Type {
 	}}
 }
 
-// acceptsUndefined reports whether `undefined` is assignable to t, the question that decides
-// whether generatorNext offers its no-argument arm. The trial runs under a throwaway probe,
-// so a t that is still an unsolved variable picks up no bound from being asked.
+// acceptsUndefined reports whether `undefined` is assignable to t without narrowing t, the
+// question that decides whether generatorNext offers its no-argument arm. The trial runs under
+// a throwaway probe, so t picks up no bound from being asked.
+//
+// A trial that succeeds only by recording a bound does not count as accepting. Such a trial
+// says t is a variable the constraint would WIDEN to admit `undefined`, not a type that already
+// admits it, and the probe throws that widening away. A declared type parameter is the case
+// that matters. For `fn drive<T>(it: Generator<number, string, T>) { it.next() }`, T has to
+// stand for any type its caller picks, so sending `undefined` is exactly what the gate exists
+// to reject. Reading the trial's success alone would offer the no-argument arm there and let
+// `drive(g())`, for a `g` whose body reads its sent value as a string, send `undefined` into
+// that body.
+//
+// A declared parameter's var is an ordinary bounded inference var, and nothing at an access
+// site tells the two apart — checkTypeParamsProducible decides that afterwards from the bounds
+// the whole body recorded. So the mutation test also declines an ordinary unsolved variable,
+// which costs `Generator<1, undefined, _>` whose body never reads its sent value the
+// argumentless call. Writing that slot as `unknown` restores it.
 func (c *checker) acceptsUndefined(t soltype.Type) bool {
-	ok, _ := c.ctx.trialMutatesBounds(&soltype.UndefinedType{}, t, newSeenPairs(), false)
-	return ok
+	ok, mutated := c.ctx.trialMutatesBounds(&soltype.UndefinedType{}, t, newSeenPairs(), false)
+	return ok && !mutated
 }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -439,9 +439,13 @@ func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
 }
 
 // newChecker returns a checker with a fresh Context, an empty Info table, and an
-// empty Prov side table.
+// empty Prov side table. The Context's alias registry starts seeded with the built-in
+// iterator-result aliases, which the prelude scope binds by name and a generator's `next`
+// method returns.
 func newChecker() *checker {
-	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}, varIDCounter: 1}
+	c := &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}, varIDCounter: 1}
+	registerIteratorResultAliases(c.ctx)
+	return c
 }
 
 // freshAt allocates a fresh inference variable at the given level. Provenance for

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2481,6 +2481,13 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	if res, ok := c.objectMember(lvl, blame, name, recvCarrier); ok {
 		return res
 	}
+	// A generator receiver resolves through its own member list, which carries the `next`
+	// method a caller advances it with. The structural path below cannot serve it: constrain
+	// has no rule taking a generator to an object, so the field requirement it builds would
+	// fail on the receiver rather than read a member.
+	if res, ok := c.generatorMember(lvl, blame, provNode, name, recvCarrier); ok {
+		return res
+	}
 	// A union receiver reaches the structural requirement below, whose result is joined
 	// per member inside constrain by constrainUnionFieldRead. That join runs with no
 	// access to the enclosing throws sink, so the getters it may read through are

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2482,9 +2482,9 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 		return res
 	}
 	// A generator receiver resolves through its own member list, which carries the `next`
-	// method a caller advances it with. The structural path below cannot serve it: constrain
-	// has no rule taking a generator to an object, so the field requirement it builds would
-	// fail on the receiver rather than read a member.
+	// method a caller advances it with. The structural path below cannot serve it. constrain
+	// has no rule taking a generator to an object, so the field requirement that path builds
+	// would fail on the receiver rather than read a member.
 	if res, ok := c.generatorMember(lvl, blame, provNode, name, recvCarrier); ok {
 		return res
 	}

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -614,6 +614,39 @@ func TestInferGenNext(t *testing.T) {
 			`,
 			want: `fn () -> {value: 1 | undefined, done: boolean}`,
 		},
+		{
+			// Two calls to one generator leave the receiver holding two lower bounds that
+			// differ only in their fresh slot variables, so the member read goes through
+			// their join rather than declining for want of a single bound.
+			name: "NextOnTwoCallsOfOneGenerator",
+			src: `
+				gen fn g() { yield 1 }
+				fn f(b: boolean) { val it = if b { g() } else { g() } return it.next() }
+			`,
+			want: `fn (b: boolean) -> {value: 1 | undefined, done: boolean}`,
+		},
+		{
+			// A receiver holding two different generators advances through their join, so
+			// the result reports what either may yield.
+			name: "NextOnAJoinOfTwoGenerators",
+			src: `
+				gen fn g() { yield 1 }
+				gen fn h() { yield "a" }
+				fn f(b: boolean) { val it = if b { g() } else { h() } return it.next() }
+			`,
+			want: `fn (b: boolean) -> {value: 1 | "a" | undefined, done: boolean}`,
+		},
+		{
+			// The join's raise is the union of what either generator raises, so a caller
+			// that advances it needs a clause covering both.
+			name: "NextOnAJoinCarriesEitherRaise",
+			src: `
+				gen fn g() { yield 1 throw "boom" }
+				gen fn h() { yield "a" throw 5 }
+				fn f(b: boolean) throws _ { val it = if b { g() } else { h() } return it.next() }
+			`,
+			want: `fn (b: boolean) -> {value: 1 | "a", done: boolean} throws 5 | "boom"`,
+		},
 	})
 	runGenErrCases(t, []genErrCase{
 		{
@@ -628,6 +661,17 @@ func TestInferGenNext(t *testing.T) {
 			wantErrs: []string{`3:34-3:43: Not enough arguments: expected at least 1, but got 0`},
 		},
 		{
+			// A declared send type has to stand for whatever a caller picks, so omitting the
+			// argument is rejected there too. `undefined` is assignable to the parameter's var
+			// only by narrowing it, which is not the same as the parameter already admitting
+			// `undefined`.
+			name: "ArgumentlessNextRejectedOnADeclaredSendTypeParam",
+			src: `
+				fn drive<T>(it: Generator<number, string, T>) { return it.next() }
+			`,
+			wantErrs: []string{`2:60-2:69: Not enough arguments: expected at least 1, but got 0`},
+		},
+		{
 			// A generator carries `next` and nothing else, so any other member names the
 			// missing property rather than failing on the receiver.
 			name: "UnknownGeneratorMember",
@@ -636,6 +680,35 @@ func TestInferGenNext(t *testing.T) {
 				fn f() { val it = g() return it.done }
 			`,
 			wantErrs: []string{`3:37-3:41: object is missing property: done`},
+		},
+		{
+			// A receiver that may hold something other than a generator is not advanced
+			// through the generator member list, so the non-generator part is still rejected
+			// rather than silently accepted.
+			name: "NextOnAReceiverThatMayNotBeAGenerator",
+			src: `
+				gen fn g() { yield 1 }
+				fn f(b: boolean) { val it = if b { g() } else { 5 } return it.next() }
+			`,
+			wantErrs: []string{
+				`3:64-3:71: cannot constrain Generator<t8, undefined, unknown> <: object`,
+				`3:64-3:71: cannot constrain 5 <: object`,
+			},
+		},
+		{
+			// A call no arm accepts is still an exceptional exit, since nothing shows it
+			// cannot raise. The no-match error stands alone rather than being joined by an
+			// unused-clause warning against the clause the call needs.
+			name: "NoMatchingNextArmReportsOnlyTheNoMatch",
+			src: `
+				gen fn g() { yield 1 throw "boom" }
+				fn f() throws string { val it = g() return it.next(1, 2) }
+			`,
+			wantErrs: []string{
+				"3:48-3:61: No matching overload for this call\n" +
+					`  fn () -> {value: 1, done: boolean} throws "boom"` + "\n" +
+					`  fn (value: unknown) -> {value: 1, done: boolean} throws "boom"`,
+			},
 		},
 	})
 }

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -510,7 +510,7 @@ func TestInferGenRaises(t *testing.T) {
 				gen fn g() { yield 1 throw "boom" }
 				fn f() throws _ { val it = g() return it.next() }
 			`,
-			want: `fn () -> {value: 1, done: boolean} throws "boom"`,
+			want: `fn () -> {value: 1, done: false} throws "boom"`,
 		},
 		{
 			// An async generator's advance returns a promise that rejects with what the
@@ -520,7 +520,7 @@ func TestInferGenRaises(t *testing.T) {
 				async gen fn g() { yield 1 throw "boom" }
 				async fn f() { val it = g() return await it.next() }
 			`,
-			want: `fn () -> Promise<{value: 1, done: boolean}, "boom">`,
+			want: `fn () -> Promise<{value: 1, done: false}, "boom">`,
 		},
 		{
 			// The promise is what carries the rejection, so calling `next` without awaiting
@@ -530,7 +530,7 @@ func TestInferGenRaises(t *testing.T) {
 				async gen fn g() { yield 1 throw "boom" }
 				fn f() { val it = g() return it.next() }
 			`,
-			want: `fn () -> Promise<{value: 1, done: boolean}, "boom">`,
+			want: `fn () -> Promise<{value: 1, done: false}, "boom">`,
 		},
 	})
 	runGenErrCases(t, []genErrCase{
@@ -576,14 +576,35 @@ func TestInferGenRaises(t *testing.T) {
 func TestInferGenNext(t *testing.T) {
 	runGenCases(t, []genCase{
 		{
-			// Advancing reports either the type the body yields or the type it returns, so
-			// the value slot is the union of both.
-			name: "NextResultUnionsYieldAndReturn",
+			// Advancing either produces a yielded value or reports the generator finished
+			// with its return value, so the result is one arm per outcome tagged by `done`.
+			// The two arms keep the yield type and the return type distinct.
+			name: "NextResultTagsYieldAndReturnApart",
 			src: `
 				gen fn g() { yield 1 return "done" }
 				fn f() { val it = g() return it.next() }
 			`,
-			want: `fn () -> {value: 1 | "done", done: boolean}`,
+			want: `fn () -> {value: 1, done: false} | {value: "done", done: true}`,
+		},
+		{
+			// A generator that always throws never finishes normally, so `never` in its Ret
+			// slot drops the finished arm rather than carrying one no value inhabits.
+			name: "NextResultDropsAnUninhabitedArm",
+			src: `
+				gen fn g() { yield 1 throw "boom" }
+				fn f() throws _ { val it = g() return it.next() }
+			`,
+			want: `fn () -> {value: 1, done: false} throws "boom"`,
+		},
+		{
+			// Reading `value` off the result reaches both arms, since reducing the union to
+			// one arm by testing its `done` needs narrowing on a literal-tagged union.
+			name: "ReadingValueOffTheResultJoinsBothArms",
+			src: `
+				gen fn g() { yield 1 return "done" }
+				fn f() { val r = g().next() return r.value }
+			`,
+			want: `fn () -> 1 | "done"`,
 		},
 		{
 			// The sent value is what a `yield` expression in the body evaluates to, so the
@@ -593,7 +614,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn g() -> Generator<number, string, string> { yield 1 return "x" }
 				fn f() { val it = g() return it.next("a") }
 			`,
-			want: `fn () -> {value: number | string, done: boolean}`,
+			want: `fn () -> {value: number, done: false} | {value: string, done: true}`,
 		},
 		{
 			// An inferred Next slot is `unknown`, which accepts `undefined`, so the
@@ -603,7 +624,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn g() { yield 1 }
 				fn f() { val it = g() return it.next() }
 			`,
-			want: `fn () -> {value: 1 | undefined, done: boolean}`,
+			want: `fn () -> {value: 1, done: false} | {value: undefined, done: true}`,
 		},
 		{
 			// A generator obtained without an intervening binding advances the same way.
@@ -612,7 +633,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn g() { yield 1 }
 				fn f() { return g().next() }
 			`,
-			want: `fn () -> {value: 1 | undefined, done: boolean}`,
+			want: `fn () -> {value: 1, done: false} | {value: undefined, done: true}`,
 		},
 		{
 			// Two calls to one generator leave the receiver holding two lower bounds that
@@ -623,7 +644,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn g() { yield 1 }
 				fn f(b: boolean) { val it = if b { g() } else { g() } return it.next() }
 			`,
-			want: `fn (b: boolean) -> {value: 1 | undefined, done: boolean}`,
+			want: `fn (b: boolean) -> {value: 1, done: false} | {value: undefined, done: true}`,
 		},
 		{
 			// A receiver holding two different generators advances through their join, so
@@ -634,7 +655,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn h() { yield "a" }
 				fn f(b: boolean) { val it = if b { g() } else { h() } return it.next() }
 			`,
-			want: `fn (b: boolean) -> {value: 1 | "a" | undefined, done: boolean}`,
+			want: `fn (b: boolean) -> {value: 1 | "a", done: false} | {value: undefined, done: true}`,
 		},
 		{
 			// The join's raise is the union of what either generator raises, so a caller
@@ -645,7 +666,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn h() { yield "a" throw 5 }
 				fn f(b: boolean) throws _ { val it = if b { g() } else { h() } return it.next() }
 			`,
-			want: `fn (b: boolean) -> {value: 1 | "a", done: boolean} throws 5 | "boom"`,
+			want: `fn (b: boolean) -> {value: 1 | "a", done: false} throws 5 | "boom"`,
 		},
 	})
 	runGenErrCases(t, []genErrCase{
@@ -706,8 +727,8 @@ func TestInferGenNext(t *testing.T) {
 			`,
 			wantErrs: []string{
 				"3:48-3:61: No matching overload for this call\n" +
-					`  fn () -> {value: 1, done: boolean} throws "boom"` + "\n" +
-					`  fn (value: unknown) -> {value: 1, done: boolean} throws "boom"`,
+					`  fn () -> {value: 1, done: false} throws "boom"` + "\n" +
+					`  fn (value: unknown) -> {value: 1, done: false} throws "boom"`,
 			},
 		},
 	})

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -502,6 +502,36 @@ func TestInferGenRaises(t *testing.T) {
 			`,
 			want: `fn () -> Generator<1, undefined, unknown, "boom">`,
 		},
+		{
+			// Calling `next` advances the generator by hand, the third way to advance one,
+			// so it carries the raise the way iterating and delegating do.
+			name: "AdvancingWithNextCarriesTheRaiseToTheCaller",
+			src: `
+				gen fn g() { yield 1 throw "boom" }
+				fn f() throws _ { val it = g() return it.next() }
+			`,
+			want: `fn () -> {value: 1, done: boolean} throws "boom"`,
+		},
+		{
+			// An async generator's advance returns a promise that rejects with what the
+			// body raises, so the raise reaches whoever awaits the result.
+			name: "AwaitingNextCarriesTheRaiseAsARejection",
+			src: `
+				async gen fn g() { yield 1 throw "boom" }
+				async fn f() { val it = g() return await it.next() }
+			`,
+			want: `fn () -> Promise<{value: 1, done: boolean}, "boom">`,
+		},
+		{
+			// The promise is what carries the rejection, so calling `next` without awaiting
+			// it raises nothing into the calling body.
+			name: "CallingNextOnAnAsyncGeneratorRaisesNothing",
+			src: `
+				async gen fn g() { yield 1 throw "boom" }
+				fn f() { val it = g() return it.next() }
+			`,
+			want: `fn () -> Promise<{value: 1, done: boolean}, "boom">`,
+		},
 	})
 	runGenErrCases(t, []genErrCase{
 		{
@@ -526,6 +556,86 @@ func TestInferGenRaises(t *testing.T) {
 				fn f() { for x in g() { } }
 			`,
 			wantErrs: []string{`3:23-3:26: cannot constrain "boom" <: never`},
+		},
+		{
+			// A clause-less caller that advances a raising generator by hand is asked to
+			// handle it too, so `next` is not a hole the other two advance paths close.
+			name: "AdvancingWithoutAClauseRejected",
+			src: `
+				gen fn g() { yield 1 throw "boom" }
+				fn f() { val it = g() return it.next() }
+			`,
+			wantErrs: []string{`3:34-3:43: cannot constrain "boom" <: never`},
+		},
+	})
+}
+
+// A caller advances a generator by hand through `next`. It is declared as an overload set
+// of two arms, one taking the sent value and one omitting it, and the argumentless arm is
+// offered only when omitting the argument is sound.
+func TestInferGenNext(t *testing.T) {
+	runGenCases(t, []genCase{
+		{
+			// Advancing reports either the type the body yields or the type it returns, so
+			// the value slot is the union of both.
+			name: "NextResultUnionsYieldAndReturn",
+			src: `
+				gen fn g() { yield 1 return "done" }
+				fn f() { val it = g() return it.next() }
+			`,
+			want: `fn () -> {value: 1 | "done", done: boolean}`,
+		},
+		{
+			// The sent value is what a `yield` expression in the body evaluates to, so the
+			// one-argument arm takes the generator's Next slot.
+			name: "NextAcceptsTheSentValue",
+			src: `
+				gen fn g() -> Generator<number, string, string> { yield 1 return "x" }
+				fn f() { val it = g() return it.next("a") }
+			`,
+			want: `fn () -> {value: number | string, done: boolean}`,
+		},
+		{
+			// An inferred Next slot is `unknown`, which accepts `undefined`, so the
+			// argumentless arm stays available for a generator that declares no send type.
+			name: "ArgumentlessNextOnAnInferredSendType",
+			src: `
+				gen fn g() { yield 1 }
+				fn f() { val it = g() return it.next() }
+			`,
+			want: `fn () -> {value: 1 | undefined, done: boolean}`,
+		},
+		{
+			// A generator obtained without an intervening binding advances the same way.
+			name: "NextOnACallResult",
+			src: `
+				gen fn g() { yield 1 }
+				fn f() { return g().next() }
+			`,
+			want: `fn () -> {value: 1 | undefined, done: boolean}`,
+		},
+	})
+	runGenErrCases(t, []genErrCase{
+		{
+			// Omitting the argument sends `undefined` at runtime, so a generator whose body
+			// reads its sent value as a string does not offer the argumentless arm. Leaving
+			// it available would let that body receive `undefined`.
+			name: "ArgumentlessNextRejectedOnANarrowSendType",
+			src: `
+				gen fn g() -> Generator<number, string, string> { yield 1 return "x" }
+				fn f() { val it = g() return it.next() }
+			`,
+			wantErrs: []string{`3:34-3:43: Not enough arguments: expected at least 1, but got 0`},
+		},
+		{
+			// A generator carries `next` and nothing else, so any other member names the
+			// missing property rather than failing on the receiver.
+			name: "UnknownGeneratorMember",
+			src: `
+				gen fn g() { yield 1 }
+				fn f() { val it = g() return it.done }
+			`,
+			wantErrs: []string{`3:37-3:41: object is missing property: done`},
 		},
 	})
 }

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -689,6 +689,37 @@ func TestInferGenNext(t *testing.T) {
 			`,
 			want: `fn (b: boolean) -> IteratorYieldResult<1 | "a"> throws 5 | "boom"`,
 		},
+		{
+			// A callee whose return type is a union of generators lowers that union into the
+			// call's result var as one union-valued lower bound, rather than one bound per
+			// generator the way branching does. The bound is flattened so the receiver joins
+			// the same way.
+			name: "NextOnAUnionValuedLowerBound",
+			src: `
+				declare fn mk() -> Generator<1, undefined, unknown> | Generator<2, undefined, unknown>
+				fn f() { return mk().next() }
+			`,
+			want: `fn () -> IteratorResult<1 | 2, undefined>`,
+		},
+		{
+			// A generator that never yields only ever finishes, so it advances to the
+			// finished arm alone. Only an annotation reaches this: a `gen fn` whose body has
+			// no `yield` is already rejected for being an empty generator.
+			name: "NextResultNamesTheReturnArmAlone",
+			src: `
+				fn f(it: Generator<never, string, unknown>) { return it.next() }
+			`,
+			want: `fn (it: Generator<never, string, unknown>) -> IteratorReturnResult<string>`,
+		},
+		{
+			// A generator that can neither yield nor finish produces no result at all, so
+			// advancing it evaluates to `never`.
+			name: "NextResultIsNeverWhenNeitherOutcomeIsReachable",
+			src: `
+				fn f(it: Generator<never, never, unknown>) { return it.next() }
+			`,
+			want: `fn (it: Generator<never, never, unknown>) -> never`,
+		},
 	})
 	runGenErrCases(t, []genErrCase{
 		{

--- a/internal/solver/infer_gen_test.go
+++ b/internal/solver/infer_gen_test.go
@@ -510,7 +510,7 @@ func TestInferGenRaises(t *testing.T) {
 				gen fn g() { yield 1 throw "boom" }
 				fn f() throws _ { val it = g() return it.next() }
 			`,
-			want: `fn () -> {value: 1, done: false} throws "boom"`,
+			want: `fn () -> IteratorYieldResult<1> throws "boom"`,
 		},
 		{
 			// An async generator's advance returns a promise that rejects with what the
@@ -520,7 +520,7 @@ func TestInferGenRaises(t *testing.T) {
 				async gen fn g() { yield 1 throw "boom" }
 				async fn f() { val it = g() return await it.next() }
 			`,
-			want: `fn () -> Promise<{value: 1, done: false}, "boom">`,
+			want: `fn () -> Promise<IteratorYieldResult<1>, "boom">`,
 		},
 		{
 			// The promise is what carries the rejection, so calling `next` without awaiting
@@ -530,7 +530,7 @@ func TestInferGenRaises(t *testing.T) {
 				async gen fn g() { yield 1 throw "boom" }
 				fn f() { val it = g() return it.next() }
 			`,
-			want: `fn () -> Promise<{value: 1, done: false}, "boom">`,
+			want: `fn () -> Promise<IteratorYieldResult<1>, "boom">`,
 		},
 	})
 	runGenErrCases(t, []genErrCase{
@@ -577,24 +577,45 @@ func TestInferGenNext(t *testing.T) {
 	runGenCases(t, []genCase{
 		{
 			// Advancing either produces a yielded value or reports the generator finished
-			// with its return value, so the result is one arm per outcome tagged by `done`.
-			// The two arms keep the yield type and the return type distinct.
-			name: "NextResultTagsYieldAndReturnApart",
+			// with its return value, and IteratorResult is the union of one arm per outcome
+			// tagged by `done`. Naming the two arms keeps the yield type and the return type
+			// distinct.
+			name: "NextResultNamesIteratorResult",
 			src: `
 				gen fn g() { yield 1 return "done" }
 				fn f() { val it = g() return it.next() }
 			`,
-			want: `fn () -> {value: 1, done: false} | {value: "done", done: true}`,
+			want: `fn () -> IteratorResult<1, "done">`,
 		},
 		{
 			// A generator that always throws never finishes normally, so `never` in its Ret
-			// slot drops the finished arm rather than carrying one no value inhabits.
-			name: "NextResultDropsAnUninhabitedArm",
+			// slot names the yielded-value arm alone rather than a union whose finished arm
+			// no value inhabits.
+			name: "NextResultNamesTheYieldArmAlone",
 			src: `
 				gen fn g() { yield 1 throw "boom" }
 				fn f() throws _ { val it = g() return it.next() }
 			`,
-			want: `fn () -> {value: 1, done: false} throws "boom"`,
+			want: `fn () -> IteratorYieldResult<1> throws "boom"`,
+		},
+		{
+			// A caller may annotate against the result by name, since `next` returns a
+			// reference to the same built-in alias a source-level annotation resolves to.
+			name: "NextResultSatisfiesAnAnnotationNamingIt",
+			src: `
+				gen fn g() { yield 1 return "done" }
+				fn f() { val r: IteratorResult<1, "done"> = g().next() return r }
+			`,
+			want: `fn () -> IteratorResult<1, "done">`,
+		},
+		{
+			// `done` is optional on the yielded-value arm, matching the standard library, so
+			// an iterator written by hand may omit it while yielding.
+			name: "YieldArmAcceptsAResultWithoutDone",
+			src: `
+				fn f() { val r: IteratorYieldResult<5> = {value: 5} return r }
+			`,
+			want: `fn () -> IteratorYieldResult<5>`,
 		},
 		{
 			// Reading `value` off the result reaches both arms, since reducing the union to
@@ -614,7 +635,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn g() -> Generator<number, string, string> { yield 1 return "x" }
 				fn f() { val it = g() return it.next("a") }
 			`,
-			want: `fn () -> {value: number, done: false} | {value: string, done: true}`,
+			want: `fn () -> IteratorResult<number, string>`,
 		},
 		{
 			// An inferred Next slot is `unknown`, which accepts `undefined`, so the
@@ -624,7 +645,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn g() { yield 1 }
 				fn f() { val it = g() return it.next() }
 			`,
-			want: `fn () -> {value: 1, done: false} | {value: undefined, done: true}`,
+			want: `fn () -> IteratorResult<1, undefined>`,
 		},
 		{
 			// A generator obtained without an intervening binding advances the same way.
@@ -633,7 +654,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn g() { yield 1 }
 				fn f() { return g().next() }
 			`,
-			want: `fn () -> {value: 1, done: false} | {value: undefined, done: true}`,
+			want: `fn () -> IteratorResult<1, undefined>`,
 		},
 		{
 			// Two calls to one generator leave the receiver holding two lower bounds that
@@ -644,7 +665,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn g() { yield 1 }
 				fn f(b: boolean) { val it = if b { g() } else { g() } return it.next() }
 			`,
-			want: `fn (b: boolean) -> {value: 1, done: false} | {value: undefined, done: true}`,
+			want: `fn (b: boolean) -> IteratorResult<1, undefined>`,
 		},
 		{
 			// A receiver holding two different generators advances through their join, so
@@ -655,7 +676,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn h() { yield "a" }
 				fn f(b: boolean) { val it = if b { g() } else { h() } return it.next() }
 			`,
-			want: `fn (b: boolean) -> {value: 1 | "a", done: false} | {value: undefined, done: true}`,
+			want: `fn (b: boolean) -> IteratorResult<1 | "a", undefined>`,
 		},
 		{
 			// The join's raise is the union of what either generator raises, so a caller
@@ -666,7 +687,7 @@ func TestInferGenNext(t *testing.T) {
 				gen fn h() { yield "a" throw 5 }
 				fn f(b: boolean) throws _ { val it = if b { g() } else { h() } return it.next() }
 			`,
-			want: `fn (b: boolean) -> {value: 1 | "a", done: false} throws 5 | "boom"`,
+			want: `fn (b: boolean) -> IteratorYieldResult<1 | "a"> throws 5 | "boom"`,
 		},
 	})
 	runGenErrCases(t, []genErrCase{
@@ -691,6 +712,16 @@ func TestInferGenNext(t *testing.T) {
 				fn drive<T>(it: Generator<number, string, T>) { return it.next() }
 			`,
 			wantErrs: []string{`2:60-2:69: Not enough arguments: expected at least 1, but got 0`},
+		},
+		{
+			// IteratorResult takes both its arguments, where TypeScript defaults the second
+			// to `any`. Escalier has no `any`, so a reference supplying one is an arity
+			// mismatch rather than a silent widening.
+			name: "IteratorResultRequiresBothArguments",
+			src: `
+				fn f(r: IteratorResult<1>) { return r }
+			`,
+			wantErrs: []string{"2:13-2:30: type alias `IteratorResult` expects 2 type arguments but got 1"},
 		},
 		{
 			// A generator carries `next` and nothing else, so any other member names the
@@ -727,8 +758,8 @@ func TestInferGenNext(t *testing.T) {
 			`,
 			wantErrs: []string{
 				"3:48-3:61: No matching overload for this call\n" +
-					`  fn () -> {value: 1, done: false} throws "boom"` + "\n" +
-					`  fn (value: unknown) -> {value: 1, done: false} throws "boom"`,
+					`  fn () -> IteratorYieldResult<1> throws "boom"` + "\n" +
+					`  fn (value: unknown) -> IteratorYieldResult<1> throws "boom"`,
 			},
 		},
 	})

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -67,6 +67,13 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 			// inferCall's shape wires it.
 			if inst.Throws != nil {
 				c.constrain(call, inst.Throws, c.throwsSink(lvl))
+				// The call counts as an exceptional exit unless the winner declares it raises
+				// nothing, so an enclosing `throws` clause this call needs is not warned about
+				// as unused. An unsolved throws variable counts as raising, the same reading
+				// inferCall gives an unresolved callee.
+				if !isNeverType(inst.ThrowsOrNever()) {
+					c.markRaised()
+				}
 			}
 			return inst.Ret
 		}

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -78,6 +78,10 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 			return inst.Ret
 		}
 	}
+	// No arm accepted the call, so nothing here shows it cannot raise. Count it as an
+	// exceptional exit, the reading inferCall gives a callee it cannot resolve, so the no-match
+	// error is not joined by a spurious unused-clause warning against a clause the call needs.
+	c.markRaised()
 	return c.report(&NoMatchingOverloadError{Call: call, Candidates: b.Schemes})
 }
 

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -41,6 +41,7 @@ func NewPrelude() *Scope {
 	s := NewScope()
 	addOperatorBindings(s)
 	addStdlibTypePlaceholders(s)
+	addIteratorResultAliases(s)
 	return s
 }
 
@@ -104,7 +105,6 @@ var stdlibTypePlaceholders = []string{
 	"AsyncIterable",
 	"Generator",
 	"AsyncGenerator",
-	"IteratorResult",
 }
 
 // addStdlibTypePlaceholders seeds each stdlib type name as an opaque unknown
@@ -114,4 +114,86 @@ func addStdlibTypePlaceholders(s *Scope) {
 	for _, name := range stdlibTypePlaceholders {
 		s.defineType(name, TypeBinding{Type: &soltype.UnknownType{}})
 	}
+}
+
+// The three names an advance of a generator resolves through. They are real aliases rather
+// than opaque `unknown` stubs, so `it.next()` reads as `IteratorResult<1, "done">` and a
+// caller may annotate against the arms by name.
+const (
+	iteratorResultName       = "IteratorResult"
+	iteratorYieldResultName  = "IteratorYieldResult"
+	iteratorReturnResultName = "IteratorReturnResult"
+)
+
+// addIteratorResultAliases binds each of the three names to the AliasType handle a reference
+// resolves to. The handle carries only the name, so it holds no inference variable and is safe
+// in the process-wide prelude scope. registerIteratorResultAliases puts the bodies those names
+// expand to on each run's Context, which is where the alias registry lives.
+func addIteratorResultAliases(s *Scope) {
+	for _, name := range []string{iteratorResultName, iteratorYieldResultName, iteratorReturnResultName} {
+		s.defineType(name, TypeBinding{Type: &soltype.AliasType{Name: name}})
+	}
+}
+
+// registerIteratorResultAliases registers the bodies of the three iterator-result aliases on
+// ctx, mirroring the standard library:
+//
+//	type IteratorYieldResult<TYield>   = {done?: false, value: TYield}
+//	type IteratorReturnResult<TReturn> = {done: true, value: TReturn}
+//	type IteratorResult<T, TReturn>    = IteratorYieldResult<T> | IteratorReturnResult<TReturn>
+//
+// TReturn has no default, where TypeScript defaults it to `any`. Escalier has no `any`, and
+// every site that mints an iterator result knows the generator's return type, so both
+// arguments are required.
+//
+// The registry is per-Context and the prelude scope is shared across runs, so the bodies are
+// rebuilt here rather than once at prelude construction. That also keeps each run's parameter
+// vars its own, so nothing a run does to them can reach another.
+func registerIteratorResultAliases(ctx *Context) {
+	yield := builtinTypeParam("TYield", -1)
+	ctx.registerAlias(iteratorYieldResultName, &AliasDef{
+		TypeParams: []*soltype.TypeParam{yield},
+		Body: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			// `done` is optional on this arm alone, matching the standard library. An
+			// iterator written by hand may omit it while yielding, and `{value: 5}` has to
+			// satisfy the arm for that to type-check.
+			&soltype.PropertyElem{Name: "done", Type: doneTag(false), Optional: true},
+			&soltype.PropertyElem{Name: "value", Type: yield.Var},
+		}},
+	})
+
+	ret := builtinTypeParam("TReturn", -1)
+	ctx.registerAlias(iteratorReturnResultName, &AliasDef{
+		TypeParams: []*soltype.TypeParam{ret},
+		Body: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.PropertyElem{Name: "done", Type: doneTag(true)},
+			&soltype.PropertyElem{Name: "value", Type: ret.Var},
+		}},
+	})
+
+	t, tReturn := builtinTypeParam("T", -1), builtinTypeParam("TReturn", -2)
+	ctx.registerAlias(iteratorResultName, &AliasDef{
+		TypeParams: []*soltype.TypeParam{t, tReturn},
+		Body: newUnion(ctx, []soltype.Type{
+			&soltype.AliasType{Name: iteratorYieldResultName, TypeArgs: []soltype.Type{t.Var}},
+			&soltype.AliasType{Name: iteratorReturnResultName, TypeArgs: []soltype.Type{tReturn.Var}},
+		}, false),
+	})
+}
+
+// doneTag builds the boolean literal one arm of IteratorResult tags itself with, `false` on the
+// yielded-value arm and `true` on the finished one.
+func doneTag(done bool) soltype.Type {
+	return &soltype.LitType{Lit: &soltype.BoolLit{Value: done}}
+}
+
+// builtinTypeParam mints one parameter of a built-in alias. Name is what a diagnostic about the
+// alias shows, so it matches the standard library's spelling of that parameter. id is negative
+// to keep it outside the run's own var-ID space, and it need only tell this alias's parameters
+// apart, because expandAlias substitutes a parameter var by POINTER identity and never by ID.
+// Drawing from Context.freshVar instead would shift the ID of every variable a run mints
+// afterwards, renaming the `t{ID}` forms diagnostics and tests read, to distinguish variables
+// that cannot collide in the first place.
+func builtinTypeParam(name string, id int) *soltype.TypeParam {
+	return &soltype.TypeParam{Name: name, Var: &soltype.TypeVarType{ID: id}}
 }

--- a/internal/solver/prelude_test.go
+++ b/internal/solver/prelude_test.go
@@ -41,12 +41,67 @@ func TestPreludeStdlibTypePlaceholders(t *testing.T) {
 	s := NewPrelude()
 	for _, name := range []string{
 		"Promise", "Iterable", "AsyncIterable",
-		"Generator", "AsyncGenerator", "IteratorResult",
+		"Generator", "AsyncGenerator",
 	} {
 		t.Run(name, func(t *testing.T) {
 			b, ok := s.GetType(name)
 			require.True(t, ok, "stdlib type %q should resolve to a placeholder", name)
 			require.IsType(t, &soltype.UnknownType{}, b.Type)
+		})
+	}
+}
+
+// The three iterator-result names bind to real aliases rather than opaque placeholders, so a
+// reference resolves to a handle the alias registry expands. The prelude scope holds only the
+// handle; newChecker seeds the bodies on each run's Context.
+//
+// Each case expands a reference at concrete arguments rather than printing the stored body,
+// since that is the form every consumer sees. A body printed directly renders its parameters as
+// the raw `t{ID}` debug form, the parameters being inference vars that expansion substitutes
+// away.
+func TestPreludeIteratorResultAliases(t *testing.T) {
+	s := NewPrelude()
+	ctx := &Context{}
+	registerIteratorResultAliases(ctx)
+	tests := []struct {
+		name string
+		args []soltype.Type
+		want string
+	}{
+		{
+			name: "IteratorYieldResult",
+			args: []soltype.Type{&soltype.PrimType{Prim: soltype.NumPrim}},
+			want: `{done?: false, value: number}`,
+		},
+		{
+			name: "IteratorReturnResult",
+			args: []soltype.Type{&soltype.PrimType{Prim: soltype.StrPrim}},
+			want: `{done: true, value: string}`,
+		},
+		{
+			name: "IteratorResult",
+			args: []soltype.Type{
+				&soltype.PrimType{Prim: soltype.NumPrim},
+				&soltype.PrimType{Prim: soltype.StrPrim},
+			},
+			want: `IteratorYieldResult<number> | IteratorReturnResult<string>`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, ok := s.GetType(test.name)
+			require.True(t, ok, "iterator-result type %q should resolve", test.name)
+			ref, isAlias := b.Type.(*soltype.AliasType)
+			require.True(t, isAlias, "%q should bind to an alias handle", test.name)
+			require.Equal(t, test.name, ref.Name)
+			require.Empty(t, ref.TypeArgs, "the prelude handle carries no arguments")
+
+			def, registered := ctx.aliasDef(test.name)
+			require.True(t, registered, "%q should be registered on the Context", test.name)
+			require.Len(t, def.TypeParams, len(test.args))
+
+			expanded := ctx.expandAlias(&soltype.AliasType{Name: test.name, TypeArgs: test.args})
+			require.Equal(t, test.want, soltype.Print(expanded))
 		})
 	}
 }


### PR DESCRIPTION
Adds support for advancing generators by hand through the `next()` method, complementing the existing iteration and delegation paths. This allows callers to drive a generator step-by-step and properly handles exception propagation.

**Key changes:**

- Added `generatorMember()` to resolve member access on generator receivers, mirroring the existing `objectMember()` and `projectedMember()` patterns. Reports missing members with proper diagnostics rather than falling through to structural constraints.
- Added `generatorCarrier()` to extract a `GeneratorType` from a receiver, handling both direct generator types and unresolved variables with generator lower bounds.
- Added `generatorBody()` to build the member list a generator exposes, currently carrying only the `next` method.
- Added `generatorNext()` to declare the `next` method as an overload set of up to two signatures: one taking the sent value and one omitting it. The argumentless arm is offered only when `undefined` is assignable to the generator's `Next` slot, preventing unsound calls on generators with narrower send types.
- Added `advanceSig()` to build individual `next` signatures, properly threading the generator's `Throws` slot into the signature for sync generators or into the returned promise's rejection type for async generators.
- Added `iterationResult()` to build the `{value: Y | R, done: boolean}` object type that `next()` returns, unioning the generator's yield and return types.
- Added `acceptsUndefined()` to check whether a type accepts `undefined`, used to decide whether the argumentless `next()` arm is sound.
- Integrated `generatorMember()` into `valueProp()` so member access on generators routes through the new path.
- Updated `resolveOverload()` to mark the throws sink as raised when a call's throws type is not `never`, ensuring that enclosing `throws` clauses are not warned about as unused when the call can raise.

**Test coverage:**

Added comprehensive tests covering `next()` behavior: result type unions, sent value handling, argumentless arm availability based on send type, and proper error reporting for missing members and unsound calls.

https://claude.ai/code/session_01U3mwBqZb9VCr2eBHwdALbz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved generator type inference, including yielded values, return values, sent values, and synchronous or asynchronous behavior.
  * Added support for generator `next()` calls with optional arguments and precise iterator result types.
  * Added built-in iterator result type aliases for yield, return, and combined results.
  * Improved handling of generator member access, compatible generator combinations, and error reporting.

* **Bug Fixes**
  * Calls now correctly propagate potential errors from matching or unmatched overloads.
  * Added clearer diagnostics for invalid generator members, arguments, annotations, and receiver types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->