### PR TITLE
Implement M9 rest patterns for tuple and object destructuring

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1376,20 +1376,34 @@ func printPat(pat Pat) (string, bool) {
 			parts[i] = s
 		}
 		return "[" + strings.Join(parts, ", ") + "]", true
+	case *RestPat:
+		s, ok := printPat(p.Pattern)
+		if !ok {
+			s = "_"
+		}
+		return "..." + s, true
 	case *ObjectPat:
-		parts := make([]string, len(p.Fields))
-		for i, f := range p.Fields {
+		parts := make([]string, 0, len(p.Fields)+1)
+		for _, f := range p.Fields {
 			// A shorthand `{x}` is a field whose value is the IdentPat `x`, so render
 			// it as the bare key. Any other sub-pattern renders `name: subpat`.
 			if ip, ok := f.Value.(*IdentPat); ok && ip.Name == f.Name {
-				parts[i] = printObjectKeyName(f.Name)
+				parts = append(parts, printObjectKeyName(f.Name))
 				continue
 			}
 			s, ok := printPat(f.Value)
 			if !ok {
 				s = "_"
 			}
-			parts[i] = printObjectKeyName(f.Name) + ": " + s
+			parts = append(parts, printObjectKeyName(f.Name)+": "+s)
+		}
+		// The rest renders last, the position the source must write it at.
+		if p.Rest != nil {
+			s, ok := printPat(p.Rest)
+			if !ok {
+				s = "_"
+			}
+			parts = append(parts, "..."+s)
 		}
 		return "{" + strings.Join(parts, ", ") + "}", true
 	case *ExtractorPat:

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1397,7 +1397,8 @@ func printPat(pat Pat) (string, bool) {
 			}
 			parts = append(parts, printObjectKeyName(f.Name)+": "+s)
 		}
-		// The rest renders last, the position the source must write it at.
+		// A rest renders after the named fields, the only position the source may
+		// write it at.
 		if p.Rest != nil {
 			s, ok := printPat(p.Rest)
 			if !ok {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -129,10 +129,26 @@ type TuplePat struct{ Elems []Pat }
 
 func (*TuplePat) isPat() {}
 
+// RestPat is a `...sub` element of a tuple destructuring pattern, the `...rest` of
+// `[a, ...rest]`. Pattern is the sub-pattern the leftover elements bind through, an
+// IdentPat for the plain `...rest` spelling. It stands as an element of TuplePat.Elems,
+// so it keeps the position the source wrote it at. An object's rest has no position
+// among the named fields, so ObjectPat carries it in a field of its own instead.
+type RestPat struct{ Pattern Pat }
+
+func (*RestPat) isPat() {}
+
 // ObjectPat is an object destructuring pattern (M4 E1). Each field names a
 // property and binds its value through a sub-pattern. A bare `{x}` shorthand is
 // an ObjectPatField whose Value is an IdentPat of the same name.
-type ObjectPat struct{ Fields []*ObjectPatField }
+//
+// Rest is the sub-pattern a `...rest` element binds through, or nil when the pattern
+// wrote none. It binds the properties Fields does not name, so `{x, ...rest}` has one
+// field for x and a Rest of the IdentPat `rest`.
+type ObjectPat struct {
+	Fields []*ObjectPatField
+	Rest   Pat
+}
 
 func (*ObjectPat) isPat() {}
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3678,12 +3678,18 @@ func armCoversShape(p ast.Pat, inexact bool) bool {
 // irrefutablePat reports whether a pattern matches every value of a compatible
 // type, so it can never fail at runtime. A wildcard or identifier binds
 // unconditionally. An object or tuple pattern is irrefutable only when all of its
-// sub-patterns are. A literal pattern can fail, and the constructor patterns deferred
-// to M5 are refutable, so both return false.
+// sub-patterns are. A `...rest` element binds the leftover the pattern's fixed parts
+// leave, which is a value of the compatible type whatever its shape, so it is
+// irrefutable exactly when its own sub-pattern is. Whether the pattern's fixed arity
+// fits the value it is checked against is a separate question, which
+// patternMatchesMemberShape answers. A literal pattern can fail, and the constructor
+// patterns deferred to M5 are refutable, so both return false.
 func irrefutablePat(p ast.Pat) bool {
 	switch p := p.(type) {
 	case *ast.WildcardPat, *ast.IdentPat:
 		return true
+	case *ast.RestPat:
+		return irrefutablePat(p.Pattern)
 	case *ast.TuplePat:
 		for _, e := range p.Elems {
 			if !irrefutablePat(e) {
@@ -3700,8 +3706,11 @@ func irrefutablePat(p ast.Pat) bool {
 				if !irrefutablePat(e.Value) {
 					return false
 				}
+			case *ast.ObjRestPat:
+				if !irrefutablePat(e.Pattern) {
+					return false
+				}
 			default:
-				// ObjRestPat is M9; treat anything else as refutable.
 				return false
 			}
 		}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -285,6 +285,16 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			// whose mismatch blame should point at the pattern.
 			if p.TypeAnn == nil {
 				c.recordProv(pt, p.Pattern, ParamBinding)
+				// A pattern naming a `...rest` binds the properties its fields do not, so
+				// the parameter has to admit an argument that carries them. Policy A would
+				// otherwise close the usage-inferred object to exact, which rejects every
+				// such argument and leaves the rest nothing to bind: `fn f({x, ...rest})`
+				// would infer the parameter `{x: T0}` and reject `f({x: 1, y: 2})` for the
+				// extra y. Marking the var open keeps the folded object inexact, the same
+				// row-polymorphic shape the written `open` marker produces.
+				if v, ok := pt.(*soltype.TypeVarType); ok && objectPatNamesRest(p.Pattern) {
+					v.Open = true
+				}
 			}
 			mirror := c.bindPattern(fnScope, lvl, p.Pattern, pt, paramTypes)
 			params[i] = &soltype.FuncParam{Pattern: mirror, Type: pt, Optional: p.Optional}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3678,12 +3678,12 @@ func armCoversShape(p ast.Pat, inexact bool) bool {
 // irrefutablePat reports whether a pattern matches every value of a compatible
 // type, so it can never fail at runtime. A wildcard or identifier binds
 // unconditionally. An object or tuple pattern is irrefutable only when all of its
-// sub-patterns are. A `...rest` element binds the leftover the pattern's fixed parts
-// leave, which is a value of the compatible type whatever its shape, so it is
+// sub-patterns are. A `...rest` element binds whatever the pattern's fixed parts leave
+// behind. That leftover exists for every value of a compatible type, so a rest is
 // irrefutable exactly when its own sub-pattern is. Whether the pattern's fixed arity
-// fits the value it is checked against is a separate question, which
-// patternMatchesMemberShape answers. A literal pattern can fail, and the constructor
-// patterns deferred to M5 are refutable, so both return false.
+// fits the value at all is a separate question, answered by patternMatchesMemberShape.
+// A literal pattern can fail, and the constructor patterns deferred to M5 are refutable,
+// so both return false.
 func irrefutablePat(p ast.Pat) bool {
 	switch p := p.(type) {
 	case *ast.WildcardPat, *ast.IdentPat:

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -456,25 +456,21 @@ func TestInferMatchTupleUnionDifferentArity(t *testing.T) {
 	require.Equal(t, `fn (b: boolean) -> 1 | "a"`, values["f"])
 }
 
-// DISABLED until M9. A tuple rest pattern `[head, ...tail]` binds the first element and
-// captures the remaining elements as a tuple. It matches any tuple at least as long as its
-// fixed prefix, so a single such arm covers a union of tuples of differing arity and the
-// match is exhaustive. M5 defers the typed rest-tuple binding. bindPatMode reports the
-// `...tail` element unsupported, and irrefutablePat treats a RestPat as refutable, so the
-// arm neither binds nor covers today. Re-enable when M9's typed rest tuples land and assert
-// the exhaustive, empty-error result the commented body records.
+// A tuple rest pattern `[head, ...tail]` binds the first element and captures the
+// remaining elements as a tuple. It matches any tuple at least as long as its fixed
+// prefix, so a single such arm covers a union of tuples of differing arity and the match
+// is exhaustive. `head` binds at each member's first element, so the arm's body joins the
+// two.
 func TestInferMatchTupleRestPattern(t *testing.T) {
-	/*
-		values, _, errs := inferSource(t, `
-			fn f(p: [number, number] | [string]) {
-				return match p {
-					[head, ...tail] => head
-				}
+	values, _, errs := inferSource(t, `
+		fn f(p: [number, number] | [string]) {
+			return match p {
+				[head, ...tail] => head
 			}
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn (p: [number, number] | [string]) -> number | string", values["f"])
-	*/
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: [string] | [number, number]) -> number | string", values["f"])
 }
 
 // An inexact union's open `...` tail survives match-arm narrowing. narrowMatchArm keeps the

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -164,8 +164,7 @@ func TestInferObjectPatternLeafDefault(t *testing.T) {
 }
 
 // A trailing rest element relaxes the tuple requirement to an inexact prefix, so
-// the fixed elements bind without a spurious arity error. The rest element itself is
-// reported unsupported, since typed rest tuples are M9.
+// the fixed elements bind without a spurious arity error.
 func TestInferTuplePatternRestPrefix(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(t: [number, string, boolean]) {
@@ -173,9 +172,312 @@ func TestInferTuplePatternRestPrefix(t *testing.T) {
 			return a
 		}
 	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "3:12-3:19: Unsupported: RestPat", msgWithSpan(errs[0]))
+	require.Empty(t, errs)
 	require.Equal(t, "fn (t: [number, string, boolean]) -> number", values["f"])
+}
+
+// --- M9 rest patterns: a `...rest` element binds the leftover ---
+
+// A tuple rest binds the elements past the fixed prefix, gathered into a tuple, and an
+// object rest binds the properties the pattern's fields do not name. Each case returns
+// the bound rest, so the function's return type is the inferred rest type. The three
+// binding sites — a `val`, a destructuring parameter, and a `match` arm — share
+// bindPattern, so each one is covered here.
+func TestInferRestPatternBinds(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// The suffix of an exact tuple is exact: two elements remain past `a`.
+			name: "TupleValDestructure",
+			src: `
+				fn f(t: [number, string, boolean]) {
+					val [a, ...rest] = t
+					return rest
+				}`,
+			want: "fn (t: [number, string, boolean]) -> [string, boolean]",
+		},
+		{
+			// A destructuring parameter binds the same way and renders its `...rest`
+			// element back into the parameter's pattern.
+			name: "TupleParam",
+			src: `
+				fn f([a, ...rest]: [number, string, boolean]) {
+					return rest
+				}`,
+			want: "fn ([a, ...rest]: [number, string, boolean]) -> [string, boolean]",
+		},
+		{
+			// A `match` arm binds against the same scrutinee a `val` would. The arm is
+			// irrefutable over an exact tuple, so no catch-all is needed.
+			name: "TupleMatchArm",
+			src: `
+				fn f(t: [number, string, boolean]) {
+					return match t {
+						[a, ...rest] => rest
+					}
+				}`,
+			want: "fn (t: [number, string, boolean]) -> [string, boolean]",
+		},
+		{
+			// An inexact scrutinee hands its open `...` tail to the suffix, since the
+			// elements the tail hides are part of the leftover.
+			name: "TupleInexactScrutinee",
+			src: `
+				fn f(t: [number, string, ...]) {
+					val [a, ...rest] = t
+					return rest
+				}`,
+			want: "fn (t: [number, string, ...]) -> [string, ...]",
+		},
+		{
+			// A rest that consumes every remaining element binds the empty tuple.
+			name: "TupleRestBindsEmptySuffix",
+			src: `
+				fn f(t: [number]) {
+					val [a, ...rest] = t
+					return rest
+				}`,
+			want: "fn (t: [number]) -> []",
+		},
+		{
+			// The binding mode propagates into a nested pattern, so an inner rest binds
+			// the inner tuple's suffix.
+			name: "TupleNestedRest",
+			src: `
+				fn f(t: [number, [string, boolean, number]]) {
+					val [a, [b, ...rest]] = t
+					return rest
+				}`,
+			want: "fn (t: [number, [string, boolean, number]]) -> [boolean, number]",
+		},
+		{
+			// The rest's sub-pattern is bound through the same walk as a fixed element,
+			// so `...[b, c]` destructures the suffix in turn.
+			name: "TupleRestSubPatternDestructures",
+			src: `
+				fn f(t: [number, string, boolean]) {
+					val [a, ...[b, c]] = t
+					return [c, b]
+				}`,
+			want: "fn (t: [number, string, boolean]) -> [boolean, string]",
+		},
+		{
+			name: "ObjectValDestructure",
+			src: `
+				fn f(p: {x: number, y: string, z: boolean}) {
+					val {x, ...rest} = p
+					return rest
+				}`,
+			want: "fn (p: {x: number, y: string, z: boolean}) -> {y: string, z: boolean}",
+		},
+		{
+			name: "ObjectParam",
+			src: `
+				fn f({x, ...rest}: {x: number, y: string}) {
+					return rest
+				}`,
+			want: "fn ({x, ...rest}: {x: number, y: string}) -> {y: string}",
+		},
+		{
+			name: "ObjectMatchArm",
+			src: `
+				fn f(p: {x: number, y: string}) {
+					return match p {
+						{x, ...rest} => rest
+					}
+				}`,
+			want: "fn (p: {x: number, y: string}) -> {y: string}",
+		},
+		{
+			// A leftover member carries through untouched, so it keeps the `?` and
+			// `readonly` markers the scrutinee wrote.
+			name: "ObjectRestKeepsMarkers",
+			src: `
+				fn f(p: {x: number, y?: string, readonly z: boolean}) {
+					val {x, ...rest} = p
+					return rest
+				}`,
+			want: "fn (p: {x: number, y?: string, readonly z: boolean}) -> {y?: string, readonly z: boolean}",
+		},
+		{
+			// A key-value field names its key just as a shorthand does, so `{x: a}`
+			// removes x from the leftover even though the leaf is named a.
+			name: "ObjectKeyValueFieldNamesItsKey",
+			src: `
+				fn f(p: {x: number, y: string}) {
+					val {x: a, ...rest} = p
+					return rest
+				}`,
+			want: "fn (p: {x: number, y: string}) -> {y: string}",
+		},
+		{
+			// An inexact scrutinee passes its open `...` tail on, since the properties
+			// the tail hides belong to the leftover too.
+			name: "ObjectInexactScrutinee",
+			src: `
+				fn f(p: {x: number, y: string, ...}) {
+					val {x, ...rest} = p
+					return rest
+				}`,
+			want: "fn (p: {x: number, y: string, ...}) -> {y: string, ...}",
+		},
+		{
+			// A rest that names no leftover property binds the empty object.
+			name: "ObjectRestBindsEmptyLeftover",
+			src: `
+				fn f(p: {x: number}) {
+					val {x, ...rest} = p
+					return rest
+				}`,
+			want: "fn (p: {x: number}) -> {}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// A rest of a borrowed scrutinee is a borrow of the leftover, bounded by the
+// scrutinee's lifetime, the same projection the sibling leaves take. Each case pins the
+// rest against a borrow return annotation, so an owned or wrongly-mutable rest would
+// fail that constraint and acceptance confirms the projection. That is the same
+// technique TestDestructureMutBorrowLeafRendersBorrow uses, and for the same reason: a
+// returned `&mut` leaf does not survive the return-join cleanly enough to assert on its
+// rendered form.
+func TestInferRestPatternBorrowMode(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "MutBorrowTupleRest",
+			src: `
+				fn f(line: &mut [{x: number}, {y: number}, {z: number}]) -> &mut [{y: number}, {z: number}] {
+					val [a, ...rest] = line
+					return rest
+				}`,
+			want: "fn <'a>(line: &'a mut [{x: number}, {y: number}, {z: number}]) -> &'a mut [{y: number}, {z: number}]",
+		},
+		{
+			name: "SharedBorrowTupleRest",
+			src: `
+				fn f(line: &[{x: number}, {y: number}]) -> &[{y: number}] {
+					val [a, ...rest] = line
+					return rest
+				}`,
+			want: "fn <'a>(line: &'a [{x: number}, {y: number}]) -> &'a [{y: number}]",
+		},
+		{
+			name: "MutBorrowObjectRest",
+			src: `
+				fn f(pt: &mut {a: {x: number}, b: {y: number}}) -> &mut {b: {y: number}} {
+					val {a, ...rest} = pt
+					return rest
+				}`,
+			want: "fn <'a>(pt: &'a mut {a: {x: number}, b: {y: number}}) -> &'a mut {b: {y: number}}",
+		},
+		{
+			name: "SharedBorrowObjectRest",
+			src: `
+				fn f(pt: &{a: {x: number}, b: {y: number}}) -> &{b: {y: number}} {
+					val {a, ...rest} = pt
+					return rest
+				}`,
+			want: "fn <'a>(pt: &'a {a: {x: number}, b: {y: number}}) -> &'a {b: {y: number}}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// A `&mut` object rest is a MUTABLE borrow of the leftover, so a write through it
+// succeeds without any `mut` marker on the rest, following the same Rust match
+// ergonomics the sibling leaves follow.
+func TestInferRestPatternMutBorrowAcceptsWrite(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(pt: &mut {a: {x: number}, b: {y: number}}) {
+			val {a, ...rest} = pt
+			rest.b = {y: 5}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (pt: &mut {a: {x: number}, b: {y: number}}) -> undefined", values["f"])
+}
+
+// A scrutinee with no statically known shape leaves the leftover unknowable, so the
+// rest binds "some tuple" or "some object" rather than a definite one. The parameter
+// here is un-annotated, so its shape comes only from the pattern's fixed prefix.
+func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "Tuple",
+			src: `
+				fn f([a, ...rest]) {
+					return rest
+				}`,
+			want: "fn ([a, ...rest]: [unknown, ...]) -> [...]",
+		},
+		{
+			name: "Object",
+			src: `
+				fn f({x, ...rest}) {
+					return rest
+				}`,
+			want: "fn ({x, ...rest}: {x: unknown}) -> {...}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// Only a trailing rest has a suffix to bind. A rest at an earlier position stands for a
+// run of elements whose length nothing pins down, so it is reported and binds nothing.
+// The requirement still relaxes to an inexact prefix, so no arity error is layered on
+// top.
+func TestInferTuplePatternNonTrailingRest(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(t: [number, string, boolean]) {
+			val [...rest, b] = t
+			return b
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "3:9-3:16: Unsupported: RestPat", msgWithSpan(errs[0]))
+}
+
+// A second `...rest` in an object pattern has no leftover of its own: the first already
+// takes every property the fields do not name. It is reported and binds nothing.
+func TestInferObjectPatternSecondRest(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number, y: string}) {
+			val {x, ...rest, ...more} = p
+			return rest
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "3:21-3:28: Unsupported: ObjRestPat", msgWithSpan(errs[0]))
 }
 
 // A closure capturing a destructured leaf resolves the leaf's binding. This

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -555,21 +555,24 @@ func TestInferRestPatternTopLevelDestructure(t *testing.T) {
 	}
 }
 
-// A scrutinee with no statically known shape leaves the leftover unknowable. The rest
-// binds a bare variable with no bound at all, which coalesces to `never` when nothing
-// constrains it. The parameter below is un-annotated, so its shape comes only from the
-// pattern's fixed prefix and the leftover past that prefix is genuinely unknown.
+// A scrutinee with no statically known shape leaves the leftover's CONTENTS unknowable,
+// but not its kind. The rest of a tuple pattern is still some tuple, and the rest of an
+// object pattern still some object, so each binds a variable bounded below by that kind's
+// top: the empty inexact tuple `[...]` and the empty inexact object `{...}`. Every tuple
+// is a subtype of `[...]` and every object of `{...}`, so the bound is the join over every
+// leftover a caller could produce.
 //
-// A bound such as the empty inexact tuple `[...]` would render better but would be a
-// claim the scrutinee does not support. `val [b, c] = rest` would then be rejected for
-// destructuring two elements out of a zero-length tuple, even though a caller passing a
-// three-element tuple makes that destructuring correct. Nothing connects the rest
-// variable to the scrutinee's requirement, so no bound can be both informative and sound
-// here. Annotating the parameter resolves the leftover; see TestInferRestPatternBinds.
+// The bound is what the leftover reads as, not merely how it renders. Without it the
+// variable carries no bound at all and coalesces to `never` in a return position, which
+// claims the function does not return and lets a caller assign the result to anything.
+// `[...]` is also the tightest sound answer. The exact empty tuple `[]` would be wrong,
+// since a caller passing `[1, "x"]` makes the leftover `["x"]`, which is not a subtype of
+// `[]`. Naming the leftover exactly needs the parameter's arity, which only an annotation
+// supplies; see TestInferRestPatternBinds.
 //
-// Two more scrutinees reach the same bare variable, both of them already reported as
-// constraint errors by the requirement the fixed prefix emits. They are covered by
-// TestInferTuplePatternRestFallbackGuards below, which pins the recovery.
+// Two more scrutinees reach the same bounded variable, both already reported as constraint
+// errors by the requirement the fixed prefix emits. TestInferTuplePatternRestFallbackGuards
+// below pins that recovery.
 func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
 	tests := []struct {
 		name string
@@ -582,28 +585,17 @@ func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
 				fn f([a, ...rest]) {
 					return rest
 				}`,
-			want: "fn ([a, ...rest]: [unknown, ...]) -> never",
+			want: "fn ([a, ...rest]: [unknown, ...]) -> [...]",
 		},
 		{
+			// The parameter is inexact because the pattern names a rest. See
+			// TestInferRestPatternParamAdmitsExtraFields.
 			name: "Object",
 			src: `
 				fn f({x, ...rest}) {
 					return rest
 				}`,
-			want: "fn ({x, ...rest}: {x: unknown}) -> never",
-		},
-		{
-			// Destructuring the unknown leftover is accepted rather than rejected against
-			// a bound the scrutinee never justified. The leaves carry no information, so
-			// they read `never`.
-			name: "TupleLeftoverDestructures",
-			src: `
-				fn f(p) {
-					val [a, ...rest] = p
-					val [b, c] = rest
-					return c
-				}`,
-			want: "fn (p: [unknown, ...]) -> never",
+			want: "fn ({x, ...rest}: {x: unknown, ...}) -> {...}",
 		},
 	}
 	for _, tt := range tests {
@@ -613,6 +605,93 @@ func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
 			require.Equal(t, tt.want, values["f"])
 		})
 	}
+}
+
+// The leftover's kind bound is load-bearing at the use site, not just in rendering. A
+// return of the unknown leftover is checked against the caller's expectation instead of
+// passing as `never`, and destructuring more elements out of it than its kind guarantees
+// is rejected. The rejection is correct rather than a limitation: nothing in
+// `fn f(p) { val [a, ...rest] = p }` stops a caller from passing `[1]`, which makes the
+// leftover empty, so `val [b, c] = rest` cannot be justified. Annotating the parameter
+// gives the leftover a length and the same destructuring checks.
+func TestInferRestPatternUnknownLeftoverUses(t *testing.T) {
+	t.Run("returning the leftover is checked against the caller", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f([a, ...rest]) { return rest }
+			val bad: string = f([1, 2])
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "3:22-3:31: cannot constrain tuple <: string", msgWithSpan(errs[0]))
+	})
+
+	t.Run("destructuring past the leftover's guaranteed length is rejected", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(p) {
+				val [a, ...rest] = p
+				val [b, c] = rest
+				return c
+			}
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "4:9-4:15: cannot constrain tuple of length 0 <: tuple of length 2", msgWithSpan(errs[0]))
+	})
+
+	t.Run("reading a field off the leftover is rejected", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(p) {
+				val {x, ...rest} = p
+				return rest.y
+			}
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "4:17-4:18: object is missing property: y", msgWithSpan(errs[0]))
+	})
+
+	t.Run("an annotated scrutinee gives the leftover a length", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn f(p: [number, string, boolean]) {
+				val [a, ...rest] = p
+				val [b, c] = rest
+				return c
+			}
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn (p: [number, string, boolean]) -> boolean", values["f"])
+	})
+}
+
+// An un-annotated parameter whose pattern names a `...rest` stays row-polymorphic, so a
+// caller may pass an object carrying the properties the rest is there to collect. Policy A
+// closes a usage-inferred object to exact, which would reject every such argument and
+// leave the rest nothing to bind, so a rest opts the parameter out of that close the same
+// way the written `open` marker does. A pattern with no rest still closes to exact.
+func TestInferRestPatternParamAdmitsExtraFields(t *testing.T) {
+	t.Run("a rest admits extra fields", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn f({x, ...rest}) { return x }
+			val r = f({x: 1, y: 2})
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn <T0>({x, ...rest}: {x: T0, ...}) -> T0", values["f"])
+	})
+
+	t.Run("no rest still closes to exact", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f({x}) { return x }
+			val r = f({x: 1, y: 2})
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "3:24-3:25: object has extra property: y", msgWithSpan(errs[0]))
+	})
+
+	t.Run("a tuple rest already admits a longer tuple", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn f([a, ...rest]) { return a }
+			val r = f([1, 2, 3])
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn <T0>([a, ...rest]: [T0, ...]) -> T0", values["f"])
+	})
 }
 
 // tupleRestType cuts the suffix out of the scrutinee's element list, so it guards two

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -565,6 +566,10 @@ func TestInferRestPatternTopLevelDestructure(t *testing.T) {
 // three-element tuple makes that destructuring correct. Nothing connects the rest
 // variable to the scrutinee's requirement, so no bound can be both informative and sound
 // here. Annotating the parameter resolves the leftover; see TestInferRestPatternBinds.
+//
+// Two more scrutinees reach the same bare variable, both of them already reported as
+// constraint errors by the requirement the fixed prefix emits. They are covered by
+// TestInferTuplePatternRestFallbackGuards below, which pins the recovery.
 func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
 	tests := []struct {
 		name string
@@ -606,6 +611,57 @@ func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
 			values, _, errs := inferSource(t, tt.src)
 			require.Empty(t, errs)
 			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// tupleRestType cuts the suffix out of the scrutinee's element list, so it guards two
+// shapes where that cut has no meaning and falls back to a bare variable instead.
+//
+//   - A `...P` spread inside the fixed prefix stands for a run of unknown length, so
+//     nothing past it sits at a fixed index.
+//   - A scrutinee shorter than the fixed prefix has no elements left to cut. The guard is
+//     what keeps the slice in range.
+//
+// Neither case is diagnostic-free. The requirement the fixed prefix emits already rejects
+// both, so the bare variable is recovery on an erroring pattern rather than an inferred
+// answer. Each case asserts that single error and confirms the rest still binds a name.
+func TestInferTuplePatternRestFallbackGuards(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// `[a, b, ...rest]` reads b at index 1, which the `...Pair` spread occupies.
+			name: "SpreadInsideFixedPrefix",
+			src: `
+				type Pair = [string, boolean]
+				fn f(t: [number, ...Pair]) {
+					val [a, b, ...rest] = t
+					return rest
+				}`,
+			want: "4:14-4:15: cannot constrain string <: ...Pair",
+		},
+		{
+			// A two-element prefix against a one-element scrutinee leaves nothing to cut.
+			name: "ScrutineeShorterThanFixedPrefix",
+			src: `
+				fn f(t: [number]) {
+					val [a, b, ...rest] = t
+					return rest
+				}`,
+			want: "2:13-2:21: cannot constrain tuple of length 1 <: tuple of length 2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+			// The rest still binds, so `return rest` resolves the name rather than
+			// cascading into an unknown-identifier error on top of the constraint error.
+			require.NotContains(t, values["f"], "error")
 		})
 	}
 }
@@ -659,6 +715,53 @@ func TestInferRestPatternRejectedPositions(t *testing.T) {
 			_, _, errs := inferSource(t, tt.src)
 			require.Len(t, errs, 1)
 			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+		})
+	}
+}
+
+// A function-type annotation mirrors its parameter patterns into soltype so the type
+// reads back the way the source wrote it. A rest element survives that round trip in both
+// the tuple and the object form, and a rest whose sub-pattern has no soltype counterpart
+// still renders its `...` with the wildcard placeholder rather than disappearing. A regex
+// literal is such a sub-pattern: soltype has no LitType for one, so mirrorParamPat
+// returns nil for it.
+func TestMirrorParamPatRestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "TupleRest",
+			src:  `type F = fn ([a, ...rest]: [number, string]) -> number`,
+			want: "fn ([a, ...rest]: [number, string]) -> number",
+		},
+		{
+			name: "ObjectRest",
+			src:  `type F = fn ({x, ...rest}: {x: number, y: string}) -> number`,
+			want: "fn ({x, ...rest}: {x: number, y: string}) -> number",
+		},
+		{
+			name: "ObjectRestDestructures",
+			src:  `type F = fn ({x, ...{y}}: {x: number, y: string}) -> number`,
+			want: "fn ({x, ...{y}}: {x: number, y: string}) -> number",
+		},
+		{
+			name: "TupleRestWithoutMirror",
+			src:  `type F = fn ([a, .../ab/]: [number, string]) -> number`,
+			want: "fn ([a, ..._]: [number, string]) -> number",
+		},
+		{
+			name: "ObjectRestWithoutMirror",
+			src:  `type F = fn ({x, .../ab/}: {x: number, y: string}) -> number`,
+			want: "fn ({x, ..._}: {x: number, y: string}) -> number",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, _, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(nodes["F"]))
 		})
 	}
 }

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -500,9 +500,71 @@ func TestInferRestPatternGroundsScrutinee(t *testing.T) {
 	}
 }
 
-// A scrutinee with no statically known shape leaves the leftover unknowable, so the
-// rest binds "some tuple" or "some object" rather than a definite one. The parameter
-// here is un-annotated, so its shape comes only from the pattern's fixed prefix.
+// A top-level destructuring reads the same leftover a body-level one does. Its
+// initializer is a reference to another module-level binding, which types as that
+// binding's variable rather than as the annotation, so the rest resolves the shape off
+// the variable's bounds. Each case checks the leaf types the module driver recorded.
+func TestInferRestPatternTopLevelDestructure(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			name: "Tuple",
+			src: `
+				val tup: [number, string, boolean] = [1, "a", true]
+				val [a, ...r] = tup`,
+			want: map[string]string{"a": "number", "r": "[string, boolean]"},
+		},
+		{
+			// The rest's own sub-pattern destructures the suffix, so it needs the suffix
+			// resolved rather than a bare variable.
+			name: "TupleRestSubPattern",
+			src: `
+				val tup: [number, string, boolean] = [1, "a", true]
+				val [a, ...[b, c]] = tup`,
+			want: map[string]string{"a": "number", "b": "string", "c": "boolean"},
+		},
+		{
+			name: "Object",
+			src: `
+				val rec: {x: number, y: string} = {x: 1, y: "a"}
+				val {x, ...rest} = rec`,
+			want: map[string]string{"x": "number", "rest": "{y: string}"},
+		},
+		{
+			name: "MatchArm",
+			src: `
+				val tup: [number, string, boolean] = [1, "a", true]
+				val out = match tup {
+					[a, ...rest] => rest
+				}`,
+			want: map[string]string{"out": "[string, boolean]"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			for name, want := range tt.want {
+				require.Equal(t, want, values[name], "binding %s", name)
+			}
+		})
+	}
+}
+
+// A scrutinee with no statically known shape leaves the leftover unknowable. The rest
+// binds a bare variable with no bound at all, which coalesces to `never` when nothing
+// constrains it. The parameter below is un-annotated, so its shape comes only from the
+// pattern's fixed prefix and the leftover past that prefix is genuinely unknown.
+//
+// A bound such as the empty inexact tuple `[...]` would render better but would be a
+// claim the scrutinee does not support. `val [b, c] = rest` would then be rejected for
+// destructuring two elements out of a zero-length tuple, even though a caller passing a
+// three-element tuple makes that destructuring correct. Nothing connects the rest
+// variable to the scrutinee's requirement, so no bound can be both informative and sound
+// here. Annotating the parameter resolves the leftover; see TestInferRestPatternBinds.
 func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
 	tests := []struct {
 		name string
@@ -515,7 +577,7 @@ func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
 				fn f([a, ...rest]) {
 					return rest
 				}`,
-			want: "fn ([a, ...rest]: [unknown, ...]) -> [...]",
+			want: "fn ([a, ...rest]: [unknown, ...]) -> never",
 		},
 		{
 			name: "Object",
@@ -523,7 +585,20 @@ func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
 				fn f({x, ...rest}) {
 					return rest
 				}`,
-			want: "fn ({x, ...rest}: {x: unknown}) -> {...}",
+			want: "fn ({x, ...rest}: {x: unknown}) -> never",
+		},
+		{
+			// Destructuring the unknown leftover is accepted rather than rejected against
+			// a bound the scrutinee never justified. The leaves carry no information, so
+			// they read `never`.
+			name: "TupleLeftoverDestructures",
+			src: `
+				fn f(p) {
+					val [a, ...rest] = p
+					val [b, c] = rest
+					return c
+				}`,
+			want: "fn (p: [unknown, ...]) -> never",
 		},
 	}
 	for _, tt := range tests {
@@ -535,32 +610,57 @@ func TestInferRestPatternUnknownScrutineeShape(t *testing.T) {
 	}
 }
 
-// Only a trailing rest has a suffix to bind. A rest at an earlier position stands for a
-// run of elements whose length nothing pins down, so it is reported and binds nothing.
-// The requirement still relaxes to an inexact prefix, so no arity error is layered on
-// top.
-func TestInferTuplePatternNonTrailingRest(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f(t: [number, string, boolean]) {
-			val [...rest, b] = t
-			return b
-		}
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "3:9-3:16: Unsupported: RestPat", msgWithSpan(errs[0]))
-}
-
-// A second `...rest` in an object pattern has no leftover of its own: the first already
-// takes every property the fields do not name. It is reported and binds nothing.
-func TestInferObjectPatternSecondRest(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f(p: {x: number, y: string}) {
-			val {x, ...rest, ...more} = p
-			return rest
-		}
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "3:21-3:28: Unsupported: ObjRestPat", msgWithSpan(errs[0]))
+// A rest the walk cannot place is reported once and recovered against a fresh variable,
+// so its leaves stay defined and a later reference resolves rather than cascading into an
+// unknown-identifier error. Each case asserts the single reported error and reads a leaf
+// of the rejected rest back.
+func TestInferRestPatternRejectedPositions(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// A tuple rest before another element stands for a run of elements whose
+			// length nothing pins down, so no position after it names a fixed element.
+			name: "TupleNonTrailingRest",
+			src: `
+				fn f(t: [number, string, boolean]) {
+					val [...rest, b] = t
+					return [rest, b]
+				}`,
+			want: "3:11-3:18: Unsupported: RestPat",
+		},
+		{
+			// An object rest must come last, the position JavaScript's own destructuring
+			// requires, even though the leftover itself does not depend on the order.
+			name: "ObjectNonTrailingRest",
+			src: `
+				fn f(p: {x: number, y: string}) {
+					val {...rest, x} = p
+					return rest
+				}`,
+			want: "3:11-3:18: Unsupported: ObjRestPat",
+		},
+		{
+			// A second rest has no leftover of its own, since the first already takes every
+			// property the fields do not name. The non-final one is the rejected one.
+			name: "ObjectSecondRest",
+			src: `
+				fn f(p: {x: number, y: string}) {
+					val {x, ...rest, ...more} = p
+					return [rest, more]
+				}`,
+			want: "3:14-3:21: Unsupported: ObjRestPat",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+		})
+	}
 }
 
 // A closure capturing a destructured leaf resolves the leaf's binding. This

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -430,9 +430,8 @@ func TestInferRestPatternGroundsScrutinee(t *testing.T) {
 		want string
 	}{
 		{
-			// The `...Pair` element sits past the fixed prefix, so it lands in the suffix
-			// as written. The rest binds the spread rather than the elements it stands
-			// for.
+			// A `...P` spread splices before anything is read by index, so the rest binds
+			// the elements the spread stands for rather than the spread itself.
 			name: "TupleSpreadOverAlias",
 			src: `
 				type Pair = [string, boolean]
@@ -440,7 +439,55 @@ func TestInferRestPatternGroundsScrutinee(t *testing.T) {
 					val [a, ...rest] = t
 					return rest
 				}`,
-			want: "fn (t: [number, ...Pair]) -> [...Pair]",
+			want: "fn (t: [number, ...Pair]) -> [string, boolean]",
+		},
+		{
+			// Splicing puts a real element at every index, so a fixed element may sit at a
+			// position the spread contributed. b reads `string` out of `...Pair` and the
+			// rest takes what is left of it.
+			name: "TupleFixedElementInsideSpread",
+			src: `
+				type Pair = [string, boolean]
+				fn f(t: [number, ...Pair]) {
+					val [a, b, ...rest] = t
+					return [a, b, rest]
+				}`,
+			want: "fn (t: [number, ...Pair]) -> [number, string, [boolean]]",
+		},
+		{
+			// A prefix consuming every spliced element leaves the empty tuple.
+			name: "TupleFixedPrefixConsumesSpread",
+			src: `
+				type Pair = [string, boolean]
+				fn f(t: [number, ...Pair]) {
+					val [a, b, c, ...rest] = t
+					return [c, rest]
+				}`,
+			want: "fn (t: [number, ...Pair]) -> [boolean, []]",
+		},
+		{
+			// Splicing recurses, so a spread whose operand itself spreads still resolves.
+			name: "TupleNestedSpreadOverAlias",
+			src: `
+				type Inner = [boolean]
+				type Pair = [string, ...Inner]
+				fn f(t: [number, ...Pair]) {
+					val [a, b, ...rest] = t
+					return rest
+				}`,
+			want: "fn (t: [number, ...Pair]) -> [boolean]",
+		},
+		{
+			// An inexact spread operand splices its known prefix and passes its open tail
+			// to the suffix.
+			name: "TupleInexactSpreadOperand",
+			src: `
+				type Open = [string, ...]
+				fn f(t: [number, ...Open]) {
+					val [a, ...rest] = t
+					return rest
+				}`,
+			want: "fn (t: [number, ...Open]) -> [string, ...]",
 		},
 		{
 			name: "ObjectAliasScrutinee",
@@ -694,34 +741,26 @@ func TestInferRestPatternParamAdmitsExtraFields(t *testing.T) {
 	})
 }
 
-// tupleRestType cuts the suffix out of the scrutinee's element list, so it guards two
-// shapes where that cut has no meaning and falls back to a bare variable instead.
+// tupleRestType cuts the suffix out of the scrutinee's spliced element list, so it falls
+// back to the `[...]`-bounded variable on the two shapes where that cut has no meaning.
 //
-//   - A `...P` spread inside the fixed prefix stands for a run of unknown length, so
-//     nothing past it sits at a fixed index.
 //   - A scrutinee shorter than the fixed prefix has no elements left to cut. The guard is
 //     what keeps the slice in range.
+//   - A tuple whose spread never splices, as a spread over a type parameter does not, is
+//     unreadable by index at all, so groundedTuple reports no shape.
 //
 // Neither case is diagnostic-free. The requirement the fixed prefix emits already rejects
-// both, so the bare variable is recovery on an erroring pattern rather than an inferred
+// both, so the bounded variable is recovery on an erroring pattern rather than an inferred
 // answer. Each case asserts that single error and confirms the rest still binds a name.
+//
+// A spread that DOES splice is not a fallback at all. It contributes real elements at real
+// indices, which TestInferRestPatternGroundsScrutinee covers.
 func TestInferTuplePatternRestFallbackGuards(t *testing.T) {
 	tests := []struct {
 		name string
 		src  string
 		want string
 	}{
-		{
-			// `[a, b, ...rest]` reads b at index 1, which the `...Pair` spread occupies.
-			name: "SpreadInsideFixedPrefix",
-			src: `
-				type Pair = [string, boolean]
-				fn f(t: [number, ...Pair]) {
-					val [a, b, ...rest] = t
-					return rest
-				}`,
-			want: "4:14-4:15: cannot constrain string <: ...Pair",
-		},
 		{
 			// A two-element prefix against a one-element scrutinee leaves nothing to cut.
 			name: "ScrutineeShorterThanFixedPrefix",
@@ -731,6 +770,17 @@ func TestInferTuplePatternRestFallbackGuards(t *testing.T) {
 					return rest
 				}`,
 			want: "2:13-2:21: cannot constrain tuple of length 1 <: tuple of length 2",
+		},
+		{
+			// `...P` over a type parameter never splices, so no position after it is fixed
+			// and the tuple cannot be read by index.
+			name: "SpreadOverTypeParamNeverSplices",
+			src: `
+				fn f<P>(t: [number, ...P]) {
+					val [a, ...rest] = t
+					return rest
+				}`,
+			want: "3:10-3:22: cannot constrain [number, ...t1] <: tuple",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -417,6 +417,89 @@ func TestInferRestPatternMutBorrowAcceptsWrite(t *testing.T) {
 	require.Equal(t, "fn (pt: &mut {a: {x: number}, b: {y: number}}) -> undefined", values["f"])
 }
 
+// A scrutinee the pattern cannot read members off directly still yields a leftover. An
+// object rest grounds its scrutinee through the same groundToObject an object spread's
+// operand uses, so an alias, a class instance, or a mapped type resolves to the members
+// the leftover keeps. A tuple rest instead slices the elements it was given, so a `...P`
+// spread element in the suffix carries through unspliced.
+func TestInferRestPatternGroundsScrutinee(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// The `...Pair` element sits past the fixed prefix, so it lands in the suffix
+			// as written. The rest binds the spread rather than the elements it stands
+			// for.
+			name: "TupleSpreadOverAlias",
+			src: `
+				type Pair = [string, boolean]
+				fn f(t: [number, ...Pair]) {
+					val [a, ...rest] = t
+					return rest
+				}`,
+			want: "fn (t: [number, ...Pair]) -> [...Pair]",
+		},
+		{
+			name: "ObjectAliasScrutinee",
+			src: `
+				type Rec = {x: number, y: string, z: boolean}
+				fn f(p: Rec) {
+					val {x, ...rest} = p
+					return rest
+				}`,
+			want: "fn (p: Rec) -> {y: string, z: boolean}",
+		},
+		{
+			// A class instance grounds to its projected body, which is inexact, so the
+			// leftover keeps the open tail.
+			name: "ObjectClassInstanceScrutinee",
+			src: `
+				class Point {
+					x: number,
+					y: string,
+				}
+				fn f(p: Point) {
+					val {x, ...rest} = p
+					return rest
+				}`,
+			want: "fn (p: Point) -> {y: string, ...}",
+		},
+		{
+			// The scrutinee is a mapped type, which grounds to the members it computes,
+			// so the leftover keeps the `?` marker `Partial` added.
+			name: "ObjectMappedScrutinee",
+			src: `
+				type Point = {x: number, y: string}
+				type Partial<T> = {[K]?: T[K] for K in keyof T}
+				fn f(p: Partial<Point>) {
+					val {x, ...rest} = p
+					return rest
+				}`,
+			want: "fn (p: Partial<Point>) -> {y?: string}",
+		},
+		{
+			// A method member names a key, so it lands in the leftover as a method rather
+			// than flattening into a property.
+			name: "ObjectMethodMemberSurvives",
+			src: `
+				fn f(p: {x: number, m(a: number) -> string}) {
+					val {x, ...rest} = p
+					return rest
+				}`,
+			want: "fn (p: {x: number, m(a: number) -> string}) -> {m(a: number) -> string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
 // A scrutinee with no statically known shape leaves the leftover unknowable, so the
 // rest binds "some tuple" or "some object" rather than a definite one. The parameter
 // here is un-annotated, so its shape comes only from the pattern's fixed prefix.

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -326,12 +326,9 @@ func splitTupleRest(elems []ast.Pat) (fixed []ast.Pat, rest *ast.RestPat, recove
 	return elems, nil, nil
 }
 
-// bindRecoveredElem binds one tuple element the walk could not place at a known index,
-// reached only after a non-trailing `...rest` was reported. It binds against a fresh
-// variable so the leaves stay defined and a later reference resolves instead of cascading
-// into an unknown-identifier error, the same recovery bindInstancePat makes for an
-// unresolved class name. A rest is unwrapped and re-wrapped in the mirror, since
-// bindPatMode's arms reject a bare RestPat.
+// bindRecoveredElem binds a tuple element the walk could not place, reached only after a
+// non-trailing `...rest` was reported. A fresh variable keeps its leaves defined so a later
+// reference does not cascade. A rest is unwrapped, since bindPatMode rejects a bare one.
 func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	if r, isRest := e.(*ast.RestPat); isRest {
 		sub := c.bindPatMode(scope, lvl, r.Pattern, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
@@ -340,25 +337,11 @@ func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeM
 	return c.bindPatMode(scope, lvl, e, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
 }
 
-// tupleRestType resolves what a tuple pattern's trailing `...rest` binds: the scrutinee's
-// elements past the fixed prefix, gathered back into a tuple. `[a, ...rest]` against
-// `[number, string, boolean]` binds rest at `[string, boolean]`. An inexact scrutinee
-// hands its open tail on, so against `[number, string, ...]` rest is `[string, ...]`.
-//
-// prefix is the count of fixed elements before the rest. scrutTup and concreteTup are the
-// spliced shapes restTupleShape picks between. scrutinee is the raw type it falls back to
-// reading a variable's bounds off.
-//
-// With no tuple shape at all, as for an un-annotated parameter, the leftover's contents
-// are unknown but its kind is not: it is still some tuple. The rest then binds a fresh
-// variable bounded below by `[...]`, the tuple lattice's top, which is the join over every
-// leftover a caller could produce. `[]` would be unsound, since a caller's `[1, "x"]`
-// leaves `["x"]`. The bound is load-bearing, not cosmetic: without it the variable
-// coalesces to `never`, which claims the function does not return and lets a caller assign
-// the result to anything.
-//
-// bind is what the rest binds at. restConcrete is what an owned `mut` or borrowed rest
-// inspects to decide whether to wrap, nil for that bounded variable.
+// tupleRestType resolves what a trailing `...rest` binds: the scrutinee's elements past the
+// fixed prefix, re-gathered into a tuple. An inexact scrutinee hands its open tail on. With
+// no tuple shape, as for an un-annotated parameter, the leftover is still SOME tuple, so it
+// binds a variable bounded below by `[...]`. Unbounded it would coalesce to `never`, which
+// lets a caller assign the result to anything. restConcrete drives the borrow wrap.
 func (c *checker) tupleRestType(lvl int, node ast.Node, scrutinee soltype.Type, scrutTup, concreteTup *soltype.TupleType, prefix int) (bind, restConcrete soltype.Type) {
 	tup, ok := c.restTupleShape(scrutinee, scrutTup, concreteTup)
 	if !ok || len(tup.Elems) < prefix {
@@ -373,12 +356,9 @@ func (c *checker) tupleRestType(lvl int, node ast.Node, scrutinee soltype.Type, 
 	return suffix, suffix
 }
 
-// restTupleShape picks the tuple a rest reads its suffix out of. concreteTup carries it at
-// a nested level, where the scrutinee is only the parent's element variable. scrutTup
-// carries it at a top-level destructuring. Both are nil when the initializer references
-// another module-level binding, since that reference types as the binding's variable. That
-// variable is coalesced to the shape its bounds have fixed, so `val [a, ...r] = tup` reads
-// the same suffix at module scope that it reads inside a function.
+// restTupleShape picks the tuple a rest reads its suffix out of: concreteTup at a nested
+// level, scrutTup at a top-level destructuring. Both are nil when the initializer
+// references another module-level binding, whose variable is coalesced to its bound shape.
 func (c *checker) restTupleShape(scrutinee soltype.Type, scrutTup, concreteTup *soltype.TupleType) (*soltype.TupleType, bool) {
 	if concreteTup != nil {
 		return concreteTup, true
@@ -392,14 +372,9 @@ func (c *checker) restTupleShape(scrutinee soltype.Type, scrutTup, concreteTup *
 	return c.groundedTuple(soltype.CarrierOf(coalesce(scrutinee, soltype.Positive)))
 }
 
-// groundedTuple reports t's tuple shape with every `...P` spread spliced into position, so
-// its elements can be read by index. `[number, ...Pair]` over
-// `type Pair = [string, boolean]` grounds to `[number, string, boolean]`, which is what
-// lets `val [a, b, ...rest] = t` read b at `string` and bind rest at `[boolean]`.
-//
-// ok=false when t is not a tuple, and when a spread's operand stays abstract as one over a
-// type parameter does. Such an element stands for a run of unknown length, so no position
-// past it is fixed and the tuple is unreadable by index rather than readable up to it.
+// groundedTuple splices every `...P` spread into position so elements can be read by index,
+// grounding `[number, ...Pair]` over `type Pair = [string, boolean]` to
+// `[number, string, boolean]`. ok=false past an abstract spread, where no position is fixed.
 func (c *checker) groundedTuple(t soltype.Type) (*soltype.TupleType, bool) {
 	tup, ok := t.(*soltype.TupleType)
 	if !ok {
@@ -408,22 +383,12 @@ func (c *checker) groundedTuple(t soltype.Type) (*soltype.TupleType, bool) {
 	return newTypeEvaluator(c.ctx, newSeenPairs()).groundTuple(tup)
 }
 
-// objectRestType resolves what an object pattern's `...rest` binds: the scrutinee's
-// members minus the keys the pattern's fields name. `{x, ...rest}` against
-// `{x: number, y: string}` binds rest at `{y: string}`, the object `Omit<T, "x">` names,
-// read straight off the scrutinee rather than built as a mapped type over it.
-//
-// restObjectShape grounds the members through the same groundToObject an object spread's
-// operand uses, so an alias, a class instance, or a mapped type resolves. Each surviving
-// member carries through untouched, keeping its `?` and `readonly` markers, and a method
-// stays a method. An index signature names no single key, so it survives too. An inexact
-// source passes its open `...` tail on, since the properties it hides are leftover as well.
-//
-// With no ground object shape, as for an un-annotated parameter, the rest binds a fresh
-// variable bounded below by `{...}`, the object twin of tupleRestType's `[...]` fallback.
-// Such a parameter is not left uninformative: inferFunc marks its variable open when the
-// pattern names a rest, so callers may pass the very properties the rest collects. bind and
-// restConcrete follow tupleRestType's contract.
+// objectRestType resolves what an object pattern's `...rest` binds: the scrutinee's members
+// minus the keys its fields name, which is what `Omit<T, K>` names. Each surviving member
+// carries through untouched, so markers and methods survive and an inexact source passes
+// its open tail on. With no ground object shape it binds a variable bounded below by
+// `{...}`, tupleRestType's twin, and inferFunc opens such a parameter so a caller can fill
+// the rest.
 func (c *checker) objectRestType(lvl int, node ast.Node, scrutinee, concrete soltype.Type, named set.Set[string]) (bind, restConcrete soltype.Type) {
 	obj, ok := c.restObjectShape(scrutinee, concrete)
 	if !ok {

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -1,7 +1,10 @@
 package solver
 
 import (
+	"slices"
+
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -149,18 +152,26 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// A trailing `...rest` element makes the pattern match any tuple at least as
 		// long as the fixed prefix, so the requirement becomes an INEXACT tuple over
 		// the fixed elements. Without a rest the requirement stays exact and a wrong
-		// arity is a TupleLengthMismatchError. The rest element itself needs typed
-		// rest tuples, which arrive in M9, so it is reported unsupported and binds
-		// nothing.
+		// arity is a TupleLengthMismatchError. The rest element binds the elements past
+		// that prefix; tupleRestType resolves their type.
 		fixed := make([]ast.Pat, 0, len(p.Elems))
+		var rest *ast.RestPat
 		inexact := false
-		for _, e := range p.Elems {
-			if _, isRest := e.(*ast.RestPat); isRest {
-				inexact = true
-				c.reportUnsupported(e)
+		for i, e := range p.Elems {
+			r, isRest := e.(*ast.RestPat)
+			if !isRest {
+				fixed = append(fixed, e)
 				continue
 			}
-			fixed = append(fixed, e)
+			inexact = true
+			if i == len(p.Elems)-1 {
+				rest = r
+				continue
+			}
+			// Only a trailing rest has a suffix to bind. A rest at any earlier position
+			// stands for a run of elements whose length nothing pins down, so the
+			// positions after it name no fixed element. Report it and bind nothing.
+			c.reportUnsupported(e)
 		}
 		elemTypes := make([]soltype.Type, len(fixed))
 		for i := range fixed {
@@ -186,19 +197,32 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// so only the threaded concrete still carries the element shape a borrowed leaf
 		// must inspect to decide whether to borrow.
 		concreteTup, _ := concrete.(*soltype.TupleType)
-		subs := make([]soltype.Pat, len(fixed))
+		subs := make([]soltype.Pat, 0, len(p.Elems))
 		for i, e := range fixed {
 			var elemConcrete soltype.Type
 			if concreteTup != nil && i < len(concreteTup.Elems) {
 				elemConcrete = concreteTup.Elems[i]
 			}
-			subs[i] = c.bindPatMode(scope, lvl, e, elemTypes[i], elemConcrete, scrutineeMode, leafTypes, emit)
+			subs = append(subs, c.bindPatMode(scope, lvl, e, elemTypes[i], elemConcrete, scrutineeMode, leafTypes, emit))
+		}
+		if rest != nil {
+			// The rest's sub-pattern binds against the suffix the same way a fixed element
+			// binds against its own, so it inherits the scrutinee's borrow through the
+			// shared walk and a nested `[a, ...[b, c]]` destructures the suffix in turn.
+			suffix, suffixConcrete := c.tupleRestType(lvl, rest, concreteTup, len(fixed))
+			sub := c.bindPatMode(scope, lvl, rest.Pattern, suffix, suffixConcrete, scrutineeMode, leafTypes, emit)
+			subs = append(subs, &soltype.RestPat{Pattern: sub})
 		}
 		c.recordType(p, scrutinee)
 		return &soltype.TuplePat{Elems: subs}
 
 	case *ast.ObjectPat:
 		fields := make([]*soltype.ObjectPatField, 0, len(p.Elems))
+		// named collects the keys the pattern's fields bind. A `...rest` element takes
+		// every property outside that set, so it is bound after this loop, once the set
+		// is complete.
+		named := set.NewSet[string]()
+		var rest *ast.ObjRestPat
 		for _, elem := range p.Elems {
 			switch e := elem.(type) {
 			case *ast.ObjShorthandPat:
@@ -209,6 +233,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				t := c.applyLeafExtras(scope, lvl, e, beta, e.TypeAnn, e.Default)
 				t = c.applyBindMode(lvl, e, e.Mutable, t, c.concreteLeaf(fieldConcrete(concrete, e.Key.Name), e.TypeAnn), scrutineeMode)
 				c.bindLeaf(scope, e.Key.Name, t, e, leafTypes, emit)
+				named.Add(e.Key.Name)
 				fields = append(fields, &soltype.ObjectPatField{
 					Name:  e.Key.Name,
 					Value: &soltype.IdentPat{Name: e.Key.Name},
@@ -229,14 +254,31 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 					}
 				}
 				sub := c.bindPatMode(scope, lvl, e.Value, beta, fieldConcrete(concrete, e.Key.Name), scrutineeMode, leafTypes, emit)
+				named.Add(e.Key.Name)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
+			case *ast.ObjRestPat:
+				if rest == nil {
+					rest = e
+				} else {
+					// A second `...rest` has no leftover of its own. The first already takes
+					// every property the fields do not name, so report this one and bind
+					// nothing.
+					c.reportUnsupported(elem)
+				}
 			default:
-				// ObjRestPat (`{...rest}`) needs object rest types, which arrive in M9.
 				c.reportUnsupported(elem)
 			}
 		}
+		var restPat soltype.Pat
+		if rest != nil {
+			// The rest's sub-pattern binds against the leftover object the same way a field
+			// binds against its own type, so it inherits the scrutinee's borrow through the
+			// shared walk.
+			leftover, leftoverConcrete := c.objectRestType(lvl, rest, concrete, named)
+			restPat = c.bindPatMode(scope, lvl, rest.Pattern, leftover, leftoverConcrete, scrutineeMode, leafTypes, emit)
+		}
 		c.recordType(p, scrutinee)
-		return &soltype.ObjectPat{Fields: fields}
+		return &soltype.ObjectPat{Fields: fields, Rest: restPat}
 
 	case *ast.InstancePat:
 		return c.bindInstancePat(scope, lvl, p, scrutinee, concrete, scrutineeMode, leafTypes, emit)
@@ -250,6 +292,77 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		c.reportUnsupported(pat)
 		return &soltype.WildcardPat{}
 	}
+}
+
+// tupleRestType resolves what a tuple pattern's trailing `...rest` binds: the scrutinee's
+// elements past the fixed prefix, gathered back into a tuple. `[a, ...rest]` against
+// `[number, string, boolean]` binds rest at `[string, boolean]`. An inexact scrutinee
+// hands its open tail to the suffix, so `[a, ...rest]` against `[number, string, ...]`
+// binds rest at `[string, ...]`. A `...P` spread element in the suffix carries through
+// unspliced, so the same pattern against `[number, ...P]` binds rest at `[...P]`.
+//
+// concreteTup is the scrutinee's tuple shape when it is statically known, and prefix is
+// the number of fixed elements before the rest. The suffix is readable only when that
+// prefix holds one element per position. A `...P` spread inside it stands for a run of
+// unknown length, so nothing past it sits at a fixed index and the suffix cannot be cut
+// there. A scrutinee whose length is not known that way — an un-annotated parameter, or a
+// union of tuples — falls back to a fresh variable bounded below by the empty inexact
+// tuple, which renders `[...]` and reads as "some tuple".
+//
+// The returned bind is the type the rest binds at. The returned concrete is what an owned
+// `mut` or borrowed rest inspects to decide whether to wrap, and is nil for that fallback
+// variable, matching how a fixed element threads a nil concrete for an unknown shape.
+func (c *checker) tupleRestType(lvl int, node ast.Node, concreteTup *soltype.TupleType, prefix int) (bind, concrete soltype.Type) {
+	if concreteTup != nil && len(concreteTup.Elems) >= prefix && !hasRestSpread(concreteTup.Elems[:prefix]) {
+		suffix := &soltype.TupleType{
+			Elems:   slices.Clone(concreteTup.Elems[prefix:]),
+			Inexact: concreteTup.Inexact,
+		}
+		return suffix, suffix
+	}
+	v := c.freshAt(lvl)
+	c.constrain(node, &soltype.TupleType{Inexact: true}, v)
+	return v, nil
+}
+
+// objectRestType resolves what an object pattern's `...rest` binds: the scrutinee's
+// members minus the keys the pattern's fields name. `{x, ...rest}` against
+// `{x: number, y: string}` binds rest at `{y: string}`. That is the object
+// `Omit<{x: number, y: string}, "x">` names, read straight off the scrutinee rather than
+// built as a mapped type over it.
+//
+// The scrutinee grounds to a concrete object through the same groundToObject an object
+// spread's operand uses, so an alias, a class instance, or a mapped type resolves to the
+// members the leftover keeps. Each surviving member carries through untouched, so it
+// keeps its `?` and `readonly` markers and a method stays a method. An index signature
+// names no single key, so it survives and the leftover still reads a key the fields did
+// not name. An inexact scrutinee passes its open `...` tail on, since the properties that
+// tail hides belong to the leftover too.
+//
+// A scrutinee with no ground object shape, most often an un-annotated parameter's
+// inference variable, leaves the leftover unknowable. The rest then binds a fresh variable
+// bounded below by the empty inexact object, which renders `{...}` and reads as "some
+// object". The returned bind and concrete follow tupleRestType's contract.
+func (c *checker) objectRestType(lvl int, node ast.Node, scrutinee soltype.Type, named set.Set[string]) (bind, concrete soltype.Type) {
+	var obj *soltype.ObjectType
+	ground := false
+	if scrutinee != nil {
+		obj, ground = newTypeEvaluator(c.ctx, newSeenPairs()).groundToObject(scrutinee)
+	}
+	if !ground {
+		v := c.freshAt(lvl)
+		c.constrain(node, &soltype.ObjectType{Inexact: true}, v)
+		return v, nil
+	}
+	elems := make([]soltype.ObjTypeElem, 0, len(obj.Elems))
+	for _, el := range obj.Elems {
+		if named.Contains(soltype.ObjElemName(el)) {
+			continue
+		}
+		elems = append(elems, el)
+	}
+	leftover := &soltype.ObjectType{Elems: elems, Inexact: obj.Inexact}
+	return leftover, leftover
 }
 
 // bindInstancePat types a class-instance pattern `Name { x, y }`: it narrows the scrutinee

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -303,14 +303,15 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 //
 // concreteTup is the scrutinee's tuple shape when it is statically known, and prefix is
 // the number of fixed elements before the rest. The suffix is readable only when that
-// prefix holds one element per position. A `...P` spread inside it stands for a run of
-// unknown length, so nothing past it sits at a fixed index and the suffix cannot be cut
-// there. A scrutinee whose length is not known that way — an un-annotated parameter, or a
-// union of tuples — falls back to a fresh variable bounded below by the empty inexact
-// tuple, which renders `[...]` and reads as "some tuple".
+// prefix holds one element per position. A `...P` spread inside the prefix stands for a
+// run of unknown length, so nothing past it sits at a fixed index and there is no place
+// to cut. Two scrutinees fail that test: an un-annotated parameter, whose shape is still
+// an inference variable, and a union of tuples, which has no single length. Each falls
+// back to a fresh variable bounded below by the empty inexact tuple. That variable
+// renders `[...]` and reads as "some tuple".
 //
 // The returned bind is the type the rest binds at. The returned concrete is what an owned
-// `mut` or borrowed rest inspects to decide whether to wrap, and is nil for that fallback
+// `mut` or borrowed rest inspects to decide whether to wrap. It is nil for that fallback
 // variable, matching how a fixed element threads a nil concrete for an unknown shape.
 func (c *checker) tupleRestType(lvl int, node ast.Node, concreteTup *soltype.TupleType, prefix int) (bind, concrete soltype.Type) {
 	if concreteTup != nil && len(concreteTup.Elems) >= prefix && !hasRestSpread(concreteTup.Elems[:prefix]) {
@@ -331,23 +332,23 @@ func (c *checker) tupleRestType(lvl int, node ast.Node, concreteTup *soltype.Tup
 // `Omit<{x: number, y: string}, "x">` names, read straight off the scrutinee rather than
 // built as a mapped type over it.
 //
-// The scrutinee grounds to a concrete object through the same groundToObject an object
-// spread's operand uses, so an alias, a class instance, or a mapped type resolves to the
-// members the leftover keeps. Each surviving member carries through untouched, so it
-// keeps its `?` and `readonly` markers and a method stays a method. An index signature
-// names no single key, so it survives and the leftover still reads a key the fields did
-// not name. An inexact scrutinee passes its open `...` tail on, since the properties that
-// tail hides belong to the leftover too.
+// source is the scrutinee's shape at this level, and it grounds to a concrete object
+// through the same groundToObject an object spread's operand uses. So an alias, a class
+// instance, or a mapped type resolves to the members the leftover keeps. Each surviving
+// member carries through untouched, so it keeps its `?` and `readonly` markers and a
+// method stays a method. An index signature names no single key, so it survives and the
+// leftover still reads a key the fields did not name. An inexact source passes its open
+// `...` tail on, since the properties that tail hides belong to the leftover too.
 //
-// A scrutinee with no ground object shape, most often an un-annotated parameter's
-// inference variable, leaves the leftover unknowable. The rest then binds a fresh variable
-// bounded below by the empty inexact object, which renders `{...}` and reads as "some
-// object". The returned bind and concrete follow tupleRestType's contract.
-func (c *checker) objectRestType(lvl int, node ast.Node, scrutinee soltype.Type, named set.Set[string]) (bind, concrete soltype.Type) {
+// A source with no ground object shape, most often an un-annotated parameter's inference
+// variable, leaves the leftover unknowable. The rest then binds a fresh variable bounded
+// below by the empty inexact object, which renders `{...}` and reads as "some object".
+// The returned bind and concrete follow tupleRestType's contract.
+func (c *checker) objectRestType(lvl int, node ast.Node, source soltype.Type, named set.Set[string]) (bind, concrete soltype.Type) {
 	var obj *soltype.ObjectType
 	ground := false
-	if scrutinee != nil {
-		obj, ground = newTypeEvaluator(c.ctx, newSeenPairs()).groundToObject(scrutinee)
+	if source != nil {
+		obj, ground = newTypeEvaluator(c.ctx, newSeenPairs()).groundToObject(source)
 	}
 	if !ground {
 		v := c.freshAt(lvl)

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -154,25 +154,16 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// the fixed elements. Without a rest the requirement stays exact and a wrong
 		// arity is a TupleLengthMismatchError. The rest element binds the elements past
 		// that prefix; tupleRestType resolves their type.
-		fixed := make([]ast.Pat, 0, len(p.Elems))
-		var rest *ast.RestPat
-		inexact := false
-		for i, e := range p.Elems {
-			r, isRest := e.(*ast.RestPat)
-			if !isRest {
-				fixed = append(fixed, e)
-				continue
-			}
-			inexact = true
-			if i == len(p.Elems)-1 {
-				rest = r
-				continue
-			}
-			// Only a trailing rest has a suffix to bind. A rest at any earlier position
-			// stands for a run of elements whose length nothing pins down, so the
-			// positions after it name no fixed element. Report it and bind nothing.
-			c.reportUnsupported(e)
+		//
+		// Only a trailing rest has such a suffix. splitTupleRest hands back a
+		// non-trailing one, and every element after it, as recovered. That element is
+		// reported, and the recovered group binds against fresh variables so each leaf
+		// stays defined without pinning it to an index it does not sit at.
+		fixed, rest, recovered := splitTupleRest(p.Elems)
+		if len(recovered) > 0 {
+			c.reportUnsupported(recovered[0])
 		}
+		inexact := rest != nil || len(recovered) > 0
 		elemTypes := make([]soltype.Type, len(fixed))
 		for i := range fixed {
 			elemTypes[i] = c.freshAt(lvl)
@@ -209,9 +200,12 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			// The rest's sub-pattern binds against the suffix the same way a fixed element
 			// binds against its own, so it inherits the scrutinee's borrow through the
 			// shared walk and a nested `[a, ...[b, c]]` destructures the suffix in turn.
-			suffix, suffixConcrete := c.tupleRestType(lvl, rest, concreteTup, len(fixed))
+			suffix, suffixConcrete := c.tupleRestType(lvl, scrutinee, concrete, len(fixed))
 			sub := c.bindPatMode(scope, lvl, rest.Pattern, suffix, suffixConcrete, scrutineeMode, leafTypes, emit)
 			subs = append(subs, &soltype.RestPat{Pattern: sub})
+		}
+		for _, e := range recovered {
+			subs = append(subs, c.bindRecoveredElem(scope, lvl, e, scrutineeMode, leafTypes, emit))
 		}
 		c.recordType(p, scrutinee)
 		return &soltype.TuplePat{Elems: subs}
@@ -223,7 +217,8 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// is complete.
 		named := set.NewSet[string]()
 		var rest *ast.ObjRestPat
-		for _, elem := range p.Elems {
+		var recovered []ast.Pat
+		for i, elem := range p.Elems {
 			switch e := elem.(type) {
 			case *ast.ObjShorthandPat:
 				// A default makes the field optional. `{x = 0}` binds even when x is
@@ -257,13 +252,14 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				named.Add(e.Key.Name)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
 			case *ast.ObjRestPat:
-				if rest == nil {
+				// A rest takes every property the fields do not name, so a pattern admits
+				// exactly one and it must come last, the position JavaScript's own
+				// destructuring requires. Any other rest is reported and recovered.
+				if rest == nil && i == len(p.Elems)-1 {
 					rest = e
 				} else {
-					// A second `...rest` has no leftover of its own. The first already takes
-					// every property the fields do not name, so report this one and bind
-					// nothing.
 					c.reportUnsupported(elem)
+					recovered = append(recovered, e.Pattern)
 				}
 			default:
 				c.reportUnsupported(elem)
@@ -274,8 +270,13 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			// The rest's sub-pattern binds against the leftover object the same way a field
 			// binds against its own type, so it inherits the scrutinee's borrow through the
 			// shared walk.
-			leftover, leftoverConcrete := c.objectRestType(lvl, rest, concrete, named)
+			leftover, leftoverConcrete := c.objectRestType(lvl, scrutinee, concrete, named)
 			restPat = c.bindPatMode(scope, lvl, rest.Pattern, leftover, leftoverConcrete, scrutineeMode, leafTypes, emit)
+		}
+		// A reported rest still binds against a fresh variable, so a later reference to one
+		// of its leaves resolves instead of cascading into an unknown-identifier error.
+		for _, sub := range recovered {
+			c.bindPatMode(scope, lvl, sub, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
 		}
 		c.recordType(p, scrutinee)
 		return &soltype.ObjectPat{Fields: fields, Rest: restPat}
@@ -294,6 +295,41 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 	}
 }
 
+// splitTupleRest splits a tuple pattern's elements at its first `...rest`. fixed holds the
+// elements before it, which bind positionally against the scrutinee. rest is that element
+// when it is the pattern's last, the only position with a suffix to bind. Otherwise
+// recovered holds it and every element after it. None of those sits at a known index,
+// because the rest stands for a run of elements whose length nothing pins down. A pattern
+// with no rest returns every element as fixed.
+func splitTupleRest(elems []ast.Pat) (fixed []ast.Pat, rest *ast.RestPat, recovered []ast.Pat) {
+	for i, e := range elems {
+		r, isRest := e.(*ast.RestPat)
+		if !isRest {
+			continue
+		}
+		if i == len(elems)-1 {
+			return elems[:i], r, nil
+		}
+		return elems[:i], nil, elems[i:]
+	}
+	return elems, nil, nil
+}
+
+// bindRecoveredElem binds one tuple element the walk could not place at a known index,
+// which happens only after a non-trailing `...rest` has already been reported. The element
+// binds against a fresh variable, so its leaves stay defined and a later reference resolves
+// instead of cascading into an unknown-identifier error. That is the same recovery
+// bindInstancePat makes for a name that does not resolve to a class. A rest element is
+// unwrapped first and re-wrapped in the returned mirror, since bindPatMode's own arms
+// reject a bare RestPat.
+func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+	if r, isRest := e.(*ast.RestPat); isRest {
+		sub := c.bindPatMode(scope, lvl, r.Pattern, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
+		return &soltype.RestPat{Pattern: sub}
+	}
+	return c.bindPatMode(scope, lvl, e, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
+}
+
 // tupleRestType resolves what a tuple pattern's trailing `...rest` binds: the scrutinee's
 // elements past the fixed prefix, gathered back into a tuple. `[a, ...rest]` against
 // `[number, string, boolean]` binds rest at `[string, boolean]`. An inexact scrutinee
@@ -301,29 +337,51 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 // binds rest at `[string, ...]`. A `...P` spread element in the suffix carries through
 // unspliced, so the same pattern against `[number, ...P]` binds rest at `[...P]`.
 //
-// concreteTup is the scrutinee's tuple shape when it is statically known, and prefix is
-// the number of fixed elements before the rest. The suffix is readable only when that
-// prefix holds one element per position. A `...P` spread inside the prefix stands for a
-// run of unknown length, so nothing past it sits at a fixed index and there is no place
-// to cut. Two scrutinees fail that test: an un-annotated parameter, whose shape is still
-// an inference variable, and a union of tuples, which has no single length. Each falls
-// back to a fresh variable bounded below by the empty inexact tuple. That variable
-// renders `[...]` and reads as "some tuple".
+// prefix is the number of fixed elements before the rest. concrete is the scrutinee's
+// shape threaded down the walk, and scrutinee is what this level constrains against.
+// restTupleShape reads the tuple out of whichever of the two carries one.
+//
+// The suffix is readable only when the prefix holds one element per position. A `...P`
+// spread inside the prefix stands for a run of unknown length, so nothing past it sits at
+// a fixed index and there is no place to cut. When no tuple shape is available at all, as
+// for an un-annotated parameter, the rest binds a bare fresh variable. Nothing is known
+// about the leftover, so the surrounding uses are left to constrain it, the same way an
+// un-annotated fixed element's variable is filled by its uses.
 //
 // The returned bind is the type the rest binds at. The returned concrete is what an owned
-// `mut` or borrowed rest inspects to decide whether to wrap. It is nil for that fallback
+// `mut` or borrowed rest inspects to decide whether to wrap. It is nil for that bare
 // variable, matching how a fixed element threads a nil concrete for an unknown shape.
-func (c *checker) tupleRestType(lvl int, node ast.Node, concreteTup *soltype.TupleType, prefix int) (bind, concrete soltype.Type) {
-	if concreteTup != nil && len(concreteTup.Elems) >= prefix && !hasRestSpread(concreteTup.Elems[:prefix]) {
-		suffix := &soltype.TupleType{
-			Elems:   slices.Clone(concreteTup.Elems[prefix:]),
-			Inexact: concreteTup.Inexact,
-		}
-		return suffix, suffix
+func (c *checker) tupleRestType(lvl int, scrutinee, concrete soltype.Type, prefix int) (bind, restConcrete soltype.Type) {
+	tup, ok := restTupleShape(scrutinee, concrete)
+	if !ok || len(tup.Elems) < prefix || hasRestSpread(tup.Elems[:prefix]) {
+		return c.freshAt(lvl), nil
 	}
-	v := c.freshAt(lvl)
-	c.constrain(node, &soltype.TupleType{Inexact: true}, v)
-	return v, nil
+	suffix := &soltype.TupleType{
+		Elems:   slices.Clone(tup.Elems[prefix:]),
+		Inexact: tup.Inexact,
+	}
+	return suffix, suffix
+}
+
+// restTupleShape reports the tuple a rest reads its suffix out of. The threaded concrete
+// type carries it at a nested level, where the scrutinee is only the parent's element
+// variable. The scrutinee carries it at a top-level destructuring, where the concrete type
+// is the same tuple. Neither carries it when the initializer is a reference to another
+// module-level binding, since that reference types as the binding's variable; the variable
+// is coalesced to the shape its bounds have fixed so `val [a, ...r] = tup` reads the same
+// suffix at module scope that it reads inside a function.
+func restTupleShape(scrutinee, concrete soltype.Type) (*soltype.TupleType, bool) {
+	if tup, ok := concrete.(*soltype.TupleType); ok {
+		return tup, true
+	}
+	if tup, ok := scrutinee.(*soltype.TupleType); ok {
+		return tup, true
+	}
+	if _, isVar := scrutinee.(*soltype.TypeVarType); !isVar {
+		return nil, false
+	}
+	tup, ok := soltype.CarrierOf(coalesce(scrutinee, soltype.Positive)).(*soltype.TupleType)
+	return tup, ok
 }
 
 // objectRestType resolves what an object pattern's `...rest` binds: the scrutinee's
@@ -332,28 +390,22 @@ func (c *checker) tupleRestType(lvl int, node ast.Node, concreteTup *soltype.Tup
 // `Omit<{x: number, y: string}, "x">` names, read straight off the scrutinee rather than
 // built as a mapped type over it.
 //
-// source is the scrutinee's shape at this level, and it grounds to a concrete object
-// through the same groundToObject an object spread's operand uses. So an alias, a class
-// instance, or a mapped type resolves to the members the leftover keeps. Each surviving
-// member carries through untouched, so it keeps its `?` and `readonly` markers and a
-// method stays a method. An index signature names no single key, so it survives and the
-// leftover still reads a key the fields did not name. An inexact source passes its open
-// `...` tail on, since the properties that tail hides belong to the leftover too.
+// The members come from whichever of concrete and scrutinee grounds to an object, the same
+// two sources restTupleShape reads a tuple out of, and grounding runs through the
+// groundToObject an object spread's operand uses. So an alias, a class instance, or a
+// mapped type resolves to the members the leftover keeps. Each surviving member carries
+// through untouched, so it keeps its `?` and `readonly` markers and a method stays a
+// method. An index signature names no single key, so it survives and the leftover still
+// reads a key the fields did not name. An inexact source passes its open `...` tail on,
+// since the properties that tail hides belong to the leftover too.
 //
-// A source with no ground object shape, most often an un-annotated parameter's inference
-// variable, leaves the leftover unknowable. The rest then binds a fresh variable bounded
-// below by the empty inexact object, which renders `{...}` and reads as "some object".
-// The returned bind and concrete follow tupleRestType's contract.
-func (c *checker) objectRestType(lvl int, node ast.Node, source soltype.Type, named set.Set[string]) (bind, concrete soltype.Type) {
-	var obj *soltype.ObjectType
-	ground := false
-	if source != nil {
-		obj, ground = newTypeEvaluator(c.ctx, newSeenPairs()).groundToObject(source)
-	}
-	if !ground {
-		v := c.freshAt(lvl)
-		c.constrain(node, &soltype.ObjectType{Inexact: true}, v)
-		return v, nil
+// With no ground object shape at all, as for an un-annotated parameter, the rest binds a
+// bare fresh variable and its uses constrain it. The returned bind and concrete follow
+// tupleRestType's contract.
+func (c *checker) objectRestType(lvl int, scrutinee, concrete soltype.Type, named set.Set[string]) (bind, restConcrete soltype.Type) {
+	obj, ok := c.restObjectShape(scrutinee, concrete)
+	if !ok {
+		return c.freshAt(lvl), nil
 	}
 	elems := make([]soltype.ObjTypeElem, 0, len(obj.Elems))
 	for _, el := range obj.Elems {
@@ -364,6 +416,28 @@ func (c *checker) objectRestType(lvl int, node ast.Node, source soltype.Type, na
 	}
 	leftover := &soltype.ObjectType{Elems: elems, Inexact: obj.Inexact}
 	return leftover, leftover
+}
+
+// restObjectShape reports the object a rest reads its leftover members out of, the object
+// twin of restTupleShape. It grounds the threaded concrete type first, then the scrutinee,
+// then the scrutinee coalesced to the shape its bounds have fixed.
+func (c *checker) restObjectShape(scrutinee, concrete soltype.Type) (*soltype.ObjectType, bool) {
+	eval := newTypeEvaluator(c.ctx, newSeenPairs())
+	if concrete != nil {
+		if obj, ok := eval.groundToObject(concrete); ok {
+			return obj, true
+		}
+	}
+	if scrutinee == nil {
+		return nil, false
+	}
+	if obj, ok := eval.groundToObject(scrutinee); ok {
+		return obj, true
+	}
+	if _, isVar := scrutinee.(*soltype.TypeVarType); !isVar {
+		return nil, false
+	}
+	return eval.groundToObject(soltype.CarrierOf(coalesce(scrutinee, soltype.Positive)))
 }
 
 // bindInstancePat types a class-instance pattern `Name { x, y }`: it narrows the scrutinee

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -171,23 +171,29 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// Each αi lowers from the scrutinee's matching element, so a sub-pattern binds
 		// at that element's type.
 		c.constrain(p, scrutinee, &soltype.TupleType{Elems: elemTypes, Inexact: inexact})
+		// Resolve both tuple shapes once, with every `...P` spread spliced into position,
+		// since each read below is by index. `[number, ...Pair]` over
+		// `type Pair = [string, boolean]` splices to `[number, string, boolean]`, so the
+		// element at index 1 is `string` rather than the spread element standing for a
+		// run of them.
+		scrutTup, _ := c.groundedTuple(scrutinee)
+		// Child concrete types come from the threaded concrete tuple, not from the
+		// scrutinee: at a nested level the scrutinee is the parent's element variable,
+		// so only the threaded concrete still carries the element shape a borrowed leaf
+		// must inspect to decide whether to borrow.
+		concreteTup, _ := c.groundedTuple(concrete)
 		// When the scrutinee is a concrete tuple, pin each αi's upper bound to the
 		// matching element. The constraint above gives αi the element only as a lower
 		// bound, which cannot reject a refutable literal sub-pattern of the wrong kind.
 		// The upper bound makes a nested literal flow against the real element type, so
 		// `[a, "hi"]` against `[number, number]` reports the mismatch.
-		if tup, ok := scrutinee.(*soltype.TupleType); ok {
+		if scrutTup != nil {
 			for i := range fixed {
-				if i < len(tup.Elems) {
-					c.constrain(fixed[i], elemTypes[i], tup.Elems[i])
+				if i < len(scrutTup.Elems) {
+					c.constrain(fixed[i], elemTypes[i], scrutTup.Elems[i])
 				}
 			}
 		}
-		// Child concrete types come from the threaded concrete tuple, not from the
-		// scrutinee: at a nested level the scrutinee is the parent's element variable,
-		// so only the threaded concrete still carries the element shape a borrowed leaf
-		// must inspect to decide whether to borrow.
-		concreteTup, _ := concrete.(*soltype.TupleType)
 		subs := make([]soltype.Pat, 0, len(p.Elems))
 		for i, e := range fixed {
 			var elemConcrete soltype.Type
@@ -200,7 +206,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			// The rest's sub-pattern binds against the suffix the same way a fixed element
 			// binds against its own, so it inherits the scrutinee's borrow through the
 			// shared walk and a nested `[a, ...[b, c]]` destructures the suffix in turn.
-			suffix, suffixConcrete := c.tupleRestType(lvl, rest, scrutinee, concrete, len(fixed))
+			suffix, suffixConcrete := c.tupleRestType(lvl, rest, scrutinee, scrutTup, concreteTup, len(fixed))
 			sub := c.bindPatMode(scope, lvl, rest.Pattern, suffix, suffixConcrete, scrutineeMode, leafTypes, emit)
 			subs = append(subs, &soltype.RestPat{Pattern: sub})
 		}
@@ -352,20 +358,20 @@ func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeM
 // elements past the fixed prefix, gathered back into a tuple. `[a, ...rest]` against
 // `[number, string, boolean]` binds rest at `[string, boolean]`. An inexact scrutinee
 // hands its open tail to the suffix, so `[a, ...rest]` against `[number, string, ...]`
-// binds rest at `[string, ...]`. A `...P` spread element in the suffix carries through
-// unspliced, so the same pattern against `[number, ...P]` binds rest at `[...P]`.
+// binds rest at `[string, ...]`. A `...P` spread the caller's shape has already spliced is
+// just more elements, so `[a, b, ...rest]` against `[number, ...Pair]` over
+// `type Pair = [string, boolean]` binds rest at `[boolean]`.
 //
-// prefix is the number of fixed elements before the rest. concrete is the scrutinee's
-// shape threaded down the walk, and scrutinee is what this level constrains against.
-// restTupleShape reads the tuple out of whichever of the two carries one.
+// prefix is the number of fixed elements before the rest. scrutTup and concreteTup are the
+// scrutinee's spliced tuple shape from this level's two sources, either of them nil when
+// that source carries no tuple. scrutinee is the raw type this level constrains against,
+// which restTupleShape falls back to reading a variable's bounds off.
 //
-// The suffix is readable only when the prefix holds one element per position. A `...P`
-// spread inside the prefix stands for a run of unknown length, so nothing past it sits at
-// a fixed index and there is no place to cut. When no tuple shape is available at all, as
-// for an un-annotated parameter, the leftover's contents are unknown but its kind is not:
-// it is still some tuple. The rest binds a fresh variable bounded below by the empty
-// inexact tuple `[...]`, the top of the tuple lattice, so the variable reads as "some
-// tuple" rather than coalescing to `never`.
+// When no tuple shape is available at all, as for an un-annotated parameter or a tuple
+// whose spread never splices, the leftover's contents are unknown but its kind is not: it
+// is still some tuple. The rest binds a fresh variable bounded below by the empty inexact
+// tuple `[...]`, the top of the tuple lattice, so the variable reads as "some tuple"
+// rather than coalescing to `never`.
 //
 // `[...]` is the tightest sound bound. It is the join over every leftover a caller could
 // produce, since every tuple is a subtype of it. The exact empty tuple `[]` would be
@@ -377,9 +383,9 @@ func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeM
 // The returned bind is the type the rest binds at. The returned concrete is what an owned
 // `mut` or borrowed rest inspects to decide whether to wrap. It is nil for that bounded
 // variable, matching how a fixed element threads a nil concrete for an unknown shape.
-func (c *checker) tupleRestType(lvl int, node ast.Node, scrutinee, concrete soltype.Type, prefix int) (bind, restConcrete soltype.Type) {
-	tup, ok := restTupleShape(scrutinee, concrete)
-	if !ok || len(tup.Elems) < prefix || hasRestSpread(tup.Elems[:prefix]) {
+func (c *checker) tupleRestType(lvl int, node ast.Node, scrutinee soltype.Type, scrutTup, concreteTup *soltype.TupleType, prefix int) (bind, restConcrete soltype.Type) {
+	tup, ok := c.restTupleShape(scrutinee, scrutTup, concreteTup)
+	if !ok || len(tup.Elems) < prefix {
 		v := c.freshAt(lvl)
 		c.constrain(node, &soltype.TupleType{Inexact: true}, v)
 		return v, nil
@@ -391,25 +397,43 @@ func (c *checker) tupleRestType(lvl int, node ast.Node, scrutinee, concrete solt
 	return suffix, suffix
 }
 
-// restTupleShape reports the tuple a rest reads its suffix out of. The threaded concrete
-// type carries it at a nested level, where the scrutinee is only the parent's element
-// variable. The scrutinee carries it at a top-level destructuring, where the concrete type
-// is the same tuple. Neither carries it when the initializer is a reference to another
-// module-level binding, since that reference types as the binding's variable; the variable
-// is coalesced to the shape its bounds have fixed so `val [a, ...r] = tup` reads the same
-// suffix at module scope that it reads inside a function.
-func restTupleShape(scrutinee, concrete soltype.Type) (*soltype.TupleType, bool) {
-	if tup, ok := concrete.(*soltype.TupleType); ok {
-		return tup, true
+// restTupleShape reports the tuple a rest reads its suffix out of, given the two spliced
+// shapes the caller already resolved. concreteTup is non-nil at a nested level, where the
+// scrutinee is only the parent's element variable. scrutTup is non-nil at a top-level
+// destructuring, where the concrete type is the same tuple. Both are nil when the
+// initializer is a reference to another module-level binding, since that reference types
+// as the binding's variable; the variable is coalesced to the shape its bounds have fixed,
+// so `val [a, ...r] = tup` reads the same suffix at module scope that it reads inside a
+// function.
+func (c *checker) restTupleShape(scrutinee soltype.Type, scrutTup, concreteTup *soltype.TupleType) (*soltype.TupleType, bool) {
+	if concreteTup != nil {
+		return concreteTup, true
 	}
-	if tup, ok := scrutinee.(*soltype.TupleType); ok {
-		return tup, true
+	if scrutTup != nil {
+		return scrutTup, true
 	}
 	if _, isVar := scrutinee.(*soltype.TypeVarType); !isVar {
 		return nil, false
 	}
-	tup, ok := soltype.CarrierOf(coalesce(scrutinee, soltype.Positive)).(*soltype.TupleType)
-	return tup, ok
+	return c.groundedTuple(soltype.CarrierOf(coalesce(scrutinee, soltype.Positive)))
+}
+
+// groundedTuple reports t's tuple shape with every `...P` spread element spliced into
+// position, so the elements can be read by index. `[number, ...Pair]` over
+// `type Pair = [string, boolean]` grounds to `[number, string, boolean]`, which is what
+// lets `val [a, b, ...rest] = t` read b at `string` and bind rest at `[boolean]`. A tuple
+// carrying no spread grounds to itself.
+//
+// ok=false when t is not a tuple at all, and when a spread's operand stays abstract, as a
+// spread over a type parameter does. Such an element stands for a run of elements whose
+// length nothing pins down, so no position past it is fixed. The whole tuple is then
+// unreadable by index rather than readable up to that element.
+func (c *checker) groundedTuple(t soltype.Type) (*soltype.TupleType, bool) {
+	tup, ok := t.(*soltype.TupleType)
+	if !ok {
+		return nil, false
+	}
+	return newTypeEvaluator(c.ctx, newSeenPairs()).groundTuple(tup)
 }
 
 // objectRestType resolves what an object pattern's `...rest` binds: the scrutinee's

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -152,13 +152,8 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// A trailing `...rest` element makes the pattern match any tuple at least as
 		// long as the fixed prefix, so the requirement becomes an INEXACT tuple over
 		// the fixed elements. Without a rest the requirement stays exact and a wrong
-		// arity is a TupleLengthMismatchError. The rest element binds the elements past
-		// that prefix; tupleRestType resolves their type.
-		//
-		// Only a trailing rest has such a suffix. splitTupleRest hands back a
-		// non-trailing one, and every element after it, as recovered. That element is
-		// reported, and the recovered group binds against fresh variables so each leaf
-		// stays defined without pinning it to an index it does not sit at.
+		// arity is a TupleLengthMismatchError. Only a trailing rest has a suffix to
+		// bind. splitTupleRest returns any other one as recovered.
 		fixed, rest, recovered := splitTupleRest(p.Elems)
 		if len(recovered) > 0 {
 			c.reportUnsupported(recovered[0])
@@ -171,11 +166,8 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// Each αi lowers from the scrutinee's matching element, so a sub-pattern binds
 		// at that element's type.
 		c.constrain(p, scrutinee, &soltype.TupleType{Elems: elemTypes, Inexact: inexact})
-		// Resolve both tuple shapes once, with every `...P` spread spliced into position,
-		// since each read below is by index. `[number, ...Pair]` over
-		// `type Pair = [string, boolean]` splices to `[number, string, boolean]`, so the
-		// element at index 1 is `string` rather than the spread element standing for a
-		// run of them.
+		// Both shapes are spliced once, since every read below is by index. See
+		// groundedTuple.
 		scrutTup, _ := c.groundedTuple(scrutinee)
 		// Child concrete types come from the threaded concrete tuple, not from the
 		// scrutinee: at a nested level the scrutinee is the parent's element variable,
@@ -203,9 +195,9 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			subs = append(subs, c.bindPatMode(scope, lvl, e, elemTypes[i], elemConcrete, scrutineeMode, leafTypes, emit))
 		}
 		if rest != nil {
-			// The rest's sub-pattern binds against the suffix the same way a fixed element
-			// binds against its own, so it inherits the scrutinee's borrow through the
-			// shared walk and a nested `[a, ...[b, c]]` destructures the suffix in turn.
+			// The rest's sub-pattern binds through the same walk a fixed element does, so
+			// it inherits the scrutinee's borrow and `[a, ...[b, c]]` destructures the
+			// suffix in turn.
 			suffix, suffixConcrete := c.tupleRestType(lvl, rest, scrutinee, scrutTup, concreteTup, len(fixed))
 			sub := c.bindPatMode(scope, lvl, rest.Pattern, suffix, suffixConcrete, scrutineeMode, leafTypes, emit)
 			subs = append(subs, &soltype.RestPat{Pattern: sub})
@@ -218,9 +210,8 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 
 	case *ast.ObjectPat:
 		fields := make([]*soltype.ObjectPatField, 0, len(p.Elems))
-		// named collects the keys the pattern's fields bind. A `...rest` element takes
-		// every property outside that set, so it is bound after this loop, once the set
-		// is complete.
+		// A rest takes every property outside named, so it binds after this loop, once
+		// the key set is complete.
 		named := set.NewSet[string]()
 		var rest *ast.ObjRestPat
 		var recovered []ast.Pat
@@ -258,9 +249,8 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				named.Add(e.Key.Name)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
 			case *ast.ObjRestPat:
-				// A rest takes every property the fields do not name, so a pattern admits
-				// exactly one and it must come last, the position JavaScript's own
-				// destructuring requires. Any other rest is reported and recovered.
+				// One rest takes every unnamed property, so a second has nothing left. It
+				// must also come last, the position JavaScript itself requires.
 				if rest == nil && i == len(p.Elems)-1 {
 					rest = e
 				} else {
@@ -273,9 +263,8 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		}
 		var restPat soltype.Pat
 		if rest != nil {
-			// The rest's sub-pattern binds against the leftover object the same way a field
-			// binds against its own type, so it inherits the scrutinee's borrow through the
-			// shared walk.
+			// The rest binds through the same walk a field does, so it inherits the
+			// scrutinee's borrow.
 			leftover, leftoverConcrete := c.objectRestType(lvl, rest, scrutinee, concrete, named)
 			restPat = c.bindPatMode(scope, lvl, rest.Pattern, leftover, leftoverConcrete, scrutineeMode, leafTypes, emit)
 		}
@@ -301,11 +290,10 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 	}
 }
 
-// objectPatNamesRest reports whether a pattern is an object pattern carrying a `...rest`
-// element. Only an object pattern is asked about. A tuple pattern's rest already reaches
-// the parameter's type through the inexact tuple requirement its fixed prefix emits, so
-// `fn f([a, ...rest])` infers the parameter `[unknown, ...]` and accepts a longer tuple
-// without any further marking.
+// objectPatNamesRest reports whether pat is an object pattern carrying a `...rest`. Only
+// an object pattern is asked about: a tuple pattern's rest already reaches the parameter
+// type through the inexact requirement its fixed prefix emits, so `fn f([a, ...rest])`
+// infers `[unknown, ...]` and accepts a longer tuple with no further marking.
 func objectPatNamesRest(pat ast.Pat) bool {
 	obj, ok := pat.(*ast.ObjectPat)
 	if !ok {
@@ -320,11 +308,10 @@ func objectPatNamesRest(pat ast.Pat) bool {
 }
 
 // splitTupleRest splits a tuple pattern's elements at its first `...rest`. fixed holds the
-// elements before it, which bind positionally against the scrutinee. rest is that element
-// when it is the pattern's last, the only position with a suffix to bind. Otherwise
-// recovered holds it and every element after it. None of those sits at a known index,
-// because the rest stands for a run of elements whose length nothing pins down. A pattern
-// with no rest returns every element as fixed.
+// elements before it, which bind positionally. rest is that element when it is the
+// pattern's last, the only position with a suffix to bind. Otherwise recovered holds it
+// and everything after, none of which sits at a known index: the rest stands for a run of
+// elements whose length nothing pins down. A pattern with no rest is all fixed.
 func splitTupleRest(elems []ast.Pat) (fixed []ast.Pat, rest *ast.RestPat, recovered []ast.Pat) {
 	for i, e := range elems {
 		r, isRest := e.(*ast.RestPat)
@@ -340,12 +327,11 @@ func splitTupleRest(elems []ast.Pat) (fixed []ast.Pat, rest *ast.RestPat, recove
 }
 
 // bindRecoveredElem binds one tuple element the walk could not place at a known index,
-// which happens only after a non-trailing `...rest` has already been reported. The element
-// binds against a fresh variable, so its leaves stay defined and a later reference resolves
-// instead of cascading into an unknown-identifier error. That is the same recovery
-// bindInstancePat makes for a name that does not resolve to a class. A rest element is
-// unwrapped first and re-wrapped in the returned mirror, since bindPatMode's own arms
-// reject a bare RestPat.
+// reached only after a non-trailing `...rest` was reported. It binds against a fresh
+// variable so the leaves stay defined and a later reference resolves instead of cascading
+// into an unknown-identifier error, the same recovery bindInstancePat makes for an
+// unresolved class name. A rest is unwrapped and re-wrapped in the mirror, since
+// bindPatMode's arms reject a bare RestPat.
 func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	if r, isRest := e.(*ast.RestPat); isRest {
 		sub := c.bindPatMode(scope, lvl, r.Pattern, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
@@ -357,32 +343,22 @@ func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeM
 // tupleRestType resolves what a tuple pattern's trailing `...rest` binds: the scrutinee's
 // elements past the fixed prefix, gathered back into a tuple. `[a, ...rest]` against
 // `[number, string, boolean]` binds rest at `[string, boolean]`. An inexact scrutinee
-// hands its open tail to the suffix, so `[a, ...rest]` against `[number, string, ...]`
-// binds rest at `[string, ...]`. A `...P` spread the caller's shape has already spliced is
-// just more elements, so `[a, b, ...rest]` against `[number, ...Pair]` over
-// `type Pair = [string, boolean]` binds rest at `[boolean]`.
+// hands its open tail on, so against `[number, string, ...]` rest is `[string, ...]`.
 //
-// prefix is the number of fixed elements before the rest. scrutTup and concreteTup are the
-// scrutinee's spliced tuple shape from this level's two sources, either of them nil when
-// that source carries no tuple. scrutinee is the raw type this level constrains against,
-// which restTupleShape falls back to reading a variable's bounds off.
+// prefix is the count of fixed elements before the rest. scrutTup and concreteTup are the
+// spliced shapes restTupleShape picks between. scrutinee is the raw type it falls back to
+// reading a variable's bounds off.
 //
-// When no tuple shape is available at all, as for an un-annotated parameter or a tuple
-// whose spread never splices, the leftover's contents are unknown but its kind is not: it
-// is still some tuple. The rest binds a fresh variable bounded below by the empty inexact
-// tuple `[...]`, the top of the tuple lattice, so the variable reads as "some tuple"
-// rather than coalescing to `never`.
+// With no tuple shape at all, as for an un-annotated parameter, the leftover's contents
+// are unknown but its kind is not: it is still some tuple. The rest then binds a fresh
+// variable bounded below by `[...]`, the tuple lattice's top, which is the join over every
+// leftover a caller could produce. `[]` would be unsound, since a caller's `[1, "x"]`
+// leaves `["x"]`. The bound is load-bearing, not cosmetic: without it the variable
+// coalesces to `never`, which claims the function does not return and lets a caller assign
+// the result to anything.
 //
-// `[...]` is the tightest sound bound. It is the join over every leftover a caller could
-// produce, since every tuple is a subtype of it. The exact empty tuple `[]` would be
-// wrong: `[a, ...rest]` against a caller's `[1, "x"]` leaves `["x"]`, which is not a
-// subtype of `[]`. The bound is deliberately load-bearing rather than cosmetic. It lets a
-// return of the leftover be checked against the caller's expectation, and it rejects
-// `val [b, c] = rest`, which no argument shape justifies once the length is unknown.
-//
-// The returned bind is the type the rest binds at. The returned concrete is what an owned
-// `mut` or borrowed rest inspects to decide whether to wrap. It is nil for that bounded
-// variable, matching how a fixed element threads a nil concrete for an unknown shape.
+// bind is what the rest binds at. restConcrete is what an owned `mut` or borrowed rest
+// inspects to decide whether to wrap, nil for that bounded variable.
 func (c *checker) tupleRestType(lvl int, node ast.Node, scrutinee soltype.Type, scrutTup, concreteTup *soltype.TupleType, prefix int) (bind, restConcrete soltype.Type) {
 	tup, ok := c.restTupleShape(scrutinee, scrutTup, concreteTup)
 	if !ok || len(tup.Elems) < prefix {
@@ -397,14 +373,12 @@ func (c *checker) tupleRestType(lvl int, node ast.Node, scrutinee soltype.Type, 
 	return suffix, suffix
 }
 
-// restTupleShape reports the tuple a rest reads its suffix out of, given the two spliced
-// shapes the caller already resolved. concreteTup is non-nil at a nested level, where the
-// scrutinee is only the parent's element variable. scrutTup is non-nil at a top-level
-// destructuring, where the concrete type is the same tuple. Both are nil when the
-// initializer is a reference to another module-level binding, since that reference types
-// as the binding's variable; the variable is coalesced to the shape its bounds have fixed,
-// so `val [a, ...r] = tup` reads the same suffix at module scope that it reads inside a
-// function.
+// restTupleShape picks the tuple a rest reads its suffix out of. concreteTup carries it at
+// a nested level, where the scrutinee is only the parent's element variable. scrutTup
+// carries it at a top-level destructuring. Both are nil when the initializer references
+// another module-level binding, since that reference types as the binding's variable. That
+// variable is coalesced to the shape its bounds have fixed, so `val [a, ...r] = tup` reads
+// the same suffix at module scope that it reads inside a function.
 func (c *checker) restTupleShape(scrutinee soltype.Type, scrutTup, concreteTup *soltype.TupleType) (*soltype.TupleType, bool) {
 	if concreteTup != nil {
 		return concreteTup, true
@@ -418,16 +392,14 @@ func (c *checker) restTupleShape(scrutinee soltype.Type, scrutTup, concreteTup *
 	return c.groundedTuple(soltype.CarrierOf(coalesce(scrutinee, soltype.Positive)))
 }
 
-// groundedTuple reports t's tuple shape with every `...P` spread element spliced into
-// position, so the elements can be read by index. `[number, ...Pair]` over
+// groundedTuple reports t's tuple shape with every `...P` spread spliced into position, so
+// its elements can be read by index. `[number, ...Pair]` over
 // `type Pair = [string, boolean]` grounds to `[number, string, boolean]`, which is what
-// lets `val [a, b, ...rest] = t` read b at `string` and bind rest at `[boolean]`. A tuple
-// carrying no spread grounds to itself.
+// lets `val [a, b, ...rest] = t` read b at `string` and bind rest at `[boolean]`.
 //
-// ok=false when t is not a tuple at all, and when a spread's operand stays abstract, as a
-// spread over a type parameter does. Such an element stands for a run of elements whose
-// length nothing pins down, so no position past it is fixed. The whole tuple is then
-// unreadable by index rather than readable up to that element.
+// ok=false when t is not a tuple, and when a spread's operand stays abstract as one over a
+// type parameter does. Such an element stands for a run of unknown length, so no position
+// past it is fixed and the tuple is unreadable by index rather than readable up to it.
 func (c *checker) groundedTuple(t soltype.Type) (*soltype.TupleType, bool) {
 	tup, ok := t.(*soltype.TupleType)
 	if !ok {
@@ -438,28 +410,20 @@ func (c *checker) groundedTuple(t soltype.Type) (*soltype.TupleType, bool) {
 
 // objectRestType resolves what an object pattern's `...rest` binds: the scrutinee's
 // members minus the keys the pattern's fields name. `{x, ...rest}` against
-// `{x: number, y: string}` binds rest at `{y: string}`. That is the object
-// `Omit<{x: number, y: string}, "x">` names, read straight off the scrutinee rather than
-// built as a mapped type over it.
+// `{x: number, y: string}` binds rest at `{y: string}`, the object `Omit<T, "x">` names,
+// read straight off the scrutinee rather than built as a mapped type over it.
 //
-// The members come from whichever of concrete and scrutinee grounds to an object, the same
-// two sources restTupleShape reads a tuple out of, and grounding runs through the
-// groundToObject an object spread's operand uses. So an alias, a class instance, or a
-// mapped type resolves to the members the leftover keeps. Each surviving member carries
-// through untouched, so it keeps its `?` and `readonly` markers and a method stays a
-// method. An index signature names no single key, so it survives and the leftover still
-// reads a key the fields did not name. An inexact source passes its open `...` tail on,
-// since the properties that tail hides belong to the leftover too.
+// restObjectShape grounds the members through the same groundToObject an object spread's
+// operand uses, so an alias, a class instance, or a mapped type resolves. Each surviving
+// member carries through untouched, keeping its `?` and `readonly` markers, and a method
+// stays a method. An index signature names no single key, so it survives too. An inexact
+// source passes its open `...` tail on, since the properties it hides are leftover as well.
 //
-// With no ground object shape at all, as for an un-annotated parameter, the rest binds a
-// fresh variable bounded below by the empty inexact object `{...}`, the object twin of the
-// `[...]` bound tupleRestType falls back to and the top of the object lattice. The
-// returned bind and concrete follow tupleRestType's contract.
-//
-// An un-annotated parameter reaches this fallback but is not left uninformative by it.
-// inferFunc marks such a parameter's variable open when its pattern names a rest, so the
-// parameter stays row-polymorphic and a caller may pass the very properties the rest
-// collects.
+// With no ground object shape, as for an un-annotated parameter, the rest binds a fresh
+// variable bounded below by `{...}`, the object twin of tupleRestType's `[...]` fallback.
+// Such a parameter is not left uninformative: inferFunc marks its variable open when the
+// pattern names a rest, so callers may pass the very properties the rest collects. bind and
+// restConcrete follow tupleRestType's contract.
 func (c *checker) objectRestType(lvl int, node ast.Node, scrutinee, concrete soltype.Type, named set.Set[string]) (bind, restConcrete soltype.Type) {
 	obj, ok := c.restObjectShape(scrutinee, concrete)
 	if !ok {

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -200,7 +200,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			// The rest's sub-pattern binds against the suffix the same way a fixed element
 			// binds against its own, so it inherits the scrutinee's borrow through the
 			// shared walk and a nested `[a, ...[b, c]]` destructures the suffix in turn.
-			suffix, suffixConcrete := c.tupleRestType(lvl, scrutinee, concrete, len(fixed))
+			suffix, suffixConcrete := c.tupleRestType(lvl, rest, scrutinee, concrete, len(fixed))
 			sub := c.bindPatMode(scope, lvl, rest.Pattern, suffix, suffixConcrete, scrutineeMode, leafTypes, emit)
 			subs = append(subs, &soltype.RestPat{Pattern: sub})
 		}
@@ -270,7 +270,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			// The rest's sub-pattern binds against the leftover object the same way a field
 			// binds against its own type, so it inherits the scrutinee's borrow through the
 			// shared walk.
-			leftover, leftoverConcrete := c.objectRestType(lvl, scrutinee, concrete, named)
+			leftover, leftoverConcrete := c.objectRestType(lvl, rest, scrutinee, concrete, named)
 			restPat = c.bindPatMode(scope, lvl, rest.Pattern, leftover, leftoverConcrete, scrutineeMode, leafTypes, emit)
 		}
 		// A reported rest still binds against a fresh variable, so a later reference to one
@@ -293,6 +293,24 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		c.reportUnsupported(pat)
 		return &soltype.WildcardPat{}
 	}
+}
+
+// objectPatNamesRest reports whether a pattern is an object pattern carrying a `...rest`
+// element. Only an object pattern is asked about. A tuple pattern's rest already reaches
+// the parameter's type through the inexact tuple requirement its fixed prefix emits, so
+// `fn f([a, ...rest])` infers the parameter `[unknown, ...]` and accepts a longer tuple
+// without any further marking.
+func objectPatNamesRest(pat ast.Pat) bool {
+	obj, ok := pat.(*ast.ObjectPat)
+	if !ok {
+		return false
+	}
+	for _, elem := range obj.Elems {
+		if _, isRest := elem.(*ast.ObjRestPat); isRest {
+			return true
+		}
+	}
+	return false
 }
 
 // splitTupleRest splits a tuple pattern's elements at its first `...rest`. fixed holds the
@@ -344,17 +362,27 @@ func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeM
 // The suffix is readable only when the prefix holds one element per position. A `...P`
 // spread inside the prefix stands for a run of unknown length, so nothing past it sits at
 // a fixed index and there is no place to cut. When no tuple shape is available at all, as
-// for an un-annotated parameter, the rest binds a bare fresh variable. Nothing is known
-// about the leftover, so the surrounding uses are left to constrain it, the same way an
-// un-annotated fixed element's variable is filled by its uses.
+// for an un-annotated parameter, the leftover's contents are unknown but its kind is not:
+// it is still some tuple. The rest binds a fresh variable bounded below by the empty
+// inexact tuple `[...]`, the top of the tuple lattice, so the variable reads as "some
+// tuple" rather than coalescing to `never`.
+//
+// `[...]` is the tightest sound bound. It is the join over every leftover a caller could
+// produce, since every tuple is a subtype of it. The exact empty tuple `[]` would be
+// wrong: `[a, ...rest]` against a caller's `[1, "x"]` leaves `["x"]`, which is not a
+// subtype of `[]`. The bound is deliberately load-bearing rather than cosmetic. It lets a
+// return of the leftover be checked against the caller's expectation, and it rejects
+// `val [b, c] = rest`, which no argument shape justifies once the length is unknown.
 //
 // The returned bind is the type the rest binds at. The returned concrete is what an owned
-// `mut` or borrowed rest inspects to decide whether to wrap. It is nil for that bare
+// `mut` or borrowed rest inspects to decide whether to wrap. It is nil for that bounded
 // variable, matching how a fixed element threads a nil concrete for an unknown shape.
-func (c *checker) tupleRestType(lvl int, scrutinee, concrete soltype.Type, prefix int) (bind, restConcrete soltype.Type) {
+func (c *checker) tupleRestType(lvl int, node ast.Node, scrutinee, concrete soltype.Type, prefix int) (bind, restConcrete soltype.Type) {
 	tup, ok := restTupleShape(scrutinee, concrete)
 	if !ok || len(tup.Elems) < prefix || hasRestSpread(tup.Elems[:prefix]) {
-		return c.freshAt(lvl), nil
+		v := c.freshAt(lvl)
+		c.constrain(node, &soltype.TupleType{Inexact: true}, v)
+		return v, nil
 	}
 	suffix := &soltype.TupleType{
 		Elems:   slices.Clone(tup.Elems[prefix:]),
@@ -400,12 +428,20 @@ func restTupleShape(scrutinee, concrete soltype.Type) (*soltype.TupleType, bool)
 // since the properties that tail hides belong to the leftover too.
 //
 // With no ground object shape at all, as for an un-annotated parameter, the rest binds a
-// bare fresh variable and its uses constrain it. The returned bind and concrete follow
-// tupleRestType's contract.
-func (c *checker) objectRestType(lvl int, scrutinee, concrete soltype.Type, named set.Set[string]) (bind, restConcrete soltype.Type) {
+// fresh variable bounded below by the empty inexact object `{...}`, the object twin of the
+// `[...]` bound tupleRestType falls back to and the top of the object lattice. The
+// returned bind and concrete follow tupleRestType's contract.
+//
+// An un-annotated parameter reaches this fallback but is not left uninformative by it.
+// inferFunc marks such a parameter's variable open when its pattern names a rest, so the
+// parameter stays row-polymorphic and a caller may pass the very properties the rest
+// collects.
+func (c *checker) objectRestType(lvl int, node ast.Node, scrutinee, concrete soltype.Type, named set.Set[string]) (bind, restConcrete soltype.Type) {
 	obj, ok := c.restObjectShape(scrutinee, concrete)
 	if !ok {
-		return c.freshAt(lvl), nil
+		v := c.freshAt(lvl)
+		c.constrain(node, &soltype.ObjectType{Inexact: true}, v)
+		return v, nil
 	}
 	elems := make([]soltype.ObjTypeElem, 0, len(obj.Elems))
 	for _, el := range obj.Elems {

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -1098,8 +1098,15 @@ func (c *checker) mirrorParamPat(pat ast.Pat) soltype.Pat {
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: c.mirrorParamPat(e.Value)})
 			case *ast.ObjRestPat:
 				// An object's rest has no position among the named fields, so it mirrors
-				// into ObjectPat.Rest rather than into the field list.
+				// into ObjectPat.Rest rather than into the field list. A sub-pattern with
+				// no soltype counterpart mirrors to the wildcard rather than to nil, so
+				// the written `...` still renders. `{x, .../ab/}` reads back `{x, ..._}`,
+				// the same recovery the tuple path's `[a, ..._]` produces, instead of
+				// dropping the rest and reading back `{x}`.
 				rest = c.mirrorParamPat(e.Pattern)
+				if rest == nil {
+					rest = &soltype.WildcardPat{}
+				}
 			}
 		}
 		return &soltype.ObjectPat{Fields: fields, Rest: rest}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -1078,18 +1078,17 @@ func (c *checker) mirrorParamPat(pat ast.Pat) soltype.Pat {
 			return &soltype.LitPat{Lit: lt.Lit}
 		}
 		return nil
+	case *ast.RestPat:
+		return &soltype.RestPat{Pattern: c.mirrorParamPat(p.Pattern)}
 	case *ast.TuplePat:
 		elems := make([]soltype.Pat, 0, len(p.Elems))
 		for _, e := range p.Elems {
-			// soltype.TuplePat has no rest element, so a `...rest` is dropped.
-			if _, isRest := e.(*ast.RestPat); isRest {
-				continue
-			}
 			elems = append(elems, c.mirrorParamPat(e))
 		}
 		return &soltype.TuplePat{Elems: elems}
 	case *ast.ObjectPat:
 		fields := make([]*soltype.ObjectPatField, 0, len(p.Elems))
+		var rest soltype.Pat
 		for _, elem := range p.Elems {
 			switch e := elem.(type) {
 			case *ast.ObjShorthandPat:
@@ -1097,10 +1096,13 @@ func (c *checker) mirrorParamPat(pat ast.Pat) soltype.Pat {
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: &soltype.IdentPat{Name: e.Key.Name}})
 			case *ast.ObjKeyValuePat:
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: c.mirrorParamPat(e.Value)})
+			case *ast.ObjRestPat:
+				// An object's rest has no position among the named fields, so it mirrors
+				// into ObjectPat.Rest rather than into the field list.
+				rest = c.mirrorParamPat(e.Pattern)
 			}
-			// ObjRestPat has no soltype counterpart and is dropped.
 		}
-		return &soltype.ObjectPat{Fields: fields}
+		return &soltype.ObjectPat{Fields: fields, Rest: rest}
 	case *ast.ExtractorPat:
 		args := make([]soltype.Pat, len(p.Args))
 		for i, a := range p.Args {


### PR DESCRIPTION
Implements typed rest patterns (`...rest`) for tuple and object destructuring, completing the M9 milestone feature. Rest patterns now bind the leftover elements or properties that the pattern's fixed parts do not consume.

## Changes

- **Pattern binding**: `bindPatMode` now handles `RestPat` and `ObjRestPat` elements by computing the leftover type and binding the rest's sub-pattern against it. Non-trailing tuple rests and non-final object rests are reported as unsupported and recovered against fresh variables.

- **Tuple rest type inference**: Added `tupleRestType` to compute the suffix of a tuple past the fixed prefix. Handles inexact tuples by passing the open tail through, and spread elements by leaving them unspliced. Returns a fresh variable when the scrutinee shape is unknown.

- **Object rest type inference**: Added `objectRestType` to compute the leftover object by filtering out properties the pattern's fields name. Preserves `?` and `readonly` markers, method members, and index signatures. Passes through the inexact tail when present.

- **Tuple rest splitting**: Added `splitTupleRest` to separate fixed elements from a trailing rest, identifying non-trailing rests for error recovery.

- **Borrow mode propagation**: Rest patterns inherit the scrutinee's borrow mode through the shared walk, so `&mut` rests accept writes and borrowed rests are properly constrained by lifetime.

- **Type printing**: Updated `printPat` to render `RestPat` as `...pattern` and `ObjectPat.Rest` after named fields.

- **Type definitions**: Added `RestPat` struct to represent `...sub` elements in tuple patterns, and added `Rest` field to `ObjectPat` for the object rest sub-pattern.

- **Pattern mirroring**: Updated `mirrorParamPat` to preserve rest elements when rendering parameter patterns back into annotations.

- **Match exhaustiveness**: Re-enabled `TestInferMatchTupleRestPattern` now that rest patterns are fully supported; a single rest arm covers unions of tuples with different arities.

## Test coverage

Added comprehensive test suite covering:
- Rest binding in `val`, parameter, and `match` contexts
- Borrow mode projection for `&` and `&mut` rests
- Nested rest patterns and rest sub-pattern destructuring
- Top-level destructuring with rest
- Unknown scrutinee shapes
- Rejected positions (non-trailing tuple rests, non-final object rests, multiple object rests)
- Grounding through aliases, class instances, and mapped types

https://claude.ai/code/session_01WFKvrubPQkGMjMr3iBz4pf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tuple rest destructuring, including nested patterns and remaining-element bindings.
  - Added object rest destructuring for capturing unspecified properties.
  - Rest patterns now work in variable declarations, function parameters, and match arms.
  - Improved support for type inference, aliases, mutable bindings, and empty or inexact remainder values.

- **Bug Fixes**
  - Preserved rest patterns in function type annotations.
  - Improved pattern rendering and recovery for unsupported rest positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->