### PR TITLE
UCS IR (2/5) — provenance and scrutinees

### DIFF
--- a/internal/solver/ucs/doc.go
+++ b/internal/solver/ucs/doc.go
@@ -4,8 +4,13 @@
 // and Parreaux, OOPSLA 2024, which the package is named after. See
 // planning/ucs/implementation_plan.md.
 //
+// Two foundations are shared by everything the package will hold. An Origin records
+// which surface node a term came from, so a diagnostic raised anywhere in the
+// pipeline can point back at what the user typed. A Scrutinee names the value a test
+// examines, either a match target or a projection out of one.
+//
 // The package is pure IR with no behavior of its own. It imports internal/ast for
-// the surface nodes it points back at. It never imports internal/solver or
-// internal/soltype, so the typing walk can import it and a future internal/codegen
-// consumer can too, with no cycle either way.
+// the surface nodes it points back at and internal/set for key sets. It never
+// imports internal/solver or internal/soltype, so the typing walk can import it and
+// a future internal/codegen consumer can too, with no cycle either way.
 package ucs

--- a/internal/solver/ucs/helpers_test.go
+++ b/internal/solver/ucs/helpers_test.go
@@ -4,6 +4,16 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 )
 
+// span builds a single-line span in source 0, so a test that asserts an arm
+// back-reference has a stable, readable rendering.
+func span(line, start, end int) ast.Span {
+	return ast.NewSpan(
+		ast.Location{Line: line, Column: start},
+		ast.Location{Line: line, Column: end},
+		0,
+	)
+}
+
 func ident(name string) *ast.IdentExpr {
 	return ast.NewIdent(name, ast.Span{})
 }
@@ -14,6 +24,13 @@ func num(value float64) ast.Expr {
 
 func str(value string) ast.Expr {
 	return ast.NewLitExpr(ast.NewString(value, ast.Span{}))
+}
+
+// arm builds a `match` arm with the given span and a wildcard pattern, standing in
+// for the surface node a branch or leaf points back at.
+func arm(s ast.Span) *ast.MatchCase {
+	body := ast.BlockOrExpr{Expr: ident("body")}
+	return ast.NewMatchCase(ast.NewWildcardPat(ast.Span{}), nil, body, s)
 }
 
 func shorthandElem(key string) ast.ObjPatElem {

--- a/internal/solver/ucs/origin.go
+++ b/internal/solver/ucs/origin.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 )
 
 // OriginKind names the surface flow-control form a node lowered from. Desugaring
@@ -78,11 +79,6 @@ type Origin struct {
 	Cause *Origin
 }
 
-// maxCauseDepth bounds the cause walk. A chain the constructors build is a few links
-// long, so a longer one means Cause was assigned by hand into a cycle. Diagnostics
-// must stay total, so the walk gives up rather than spinning.
-const maxCauseDepth = 32
-
 // At builds the origin of a node lowered from the surface node n, which is what a
 // diagnostic about the node blames. Pass a real node; a node the desugarer invented
 // gets its origin from Invented instead.
@@ -130,13 +126,29 @@ func (o Origin) SourceSpan() (ast.Span, bool) {
 // lowering, which is wider than the node itself. Underlining the whole `val … else`
 // for its invented tail is the intended behavior: the tail has no text of its own, so
 // the declaration that produced it is the narrowest honest thing to point at.
+//
+// Cause is exported, so a caller can assign a chain that loops back on itself. The
+// walk records the links it follows and stops on one it has already seen, which keeps
+// a diagnostics path total. The set is keyed on the pointer rather than the Origin
+// value, because Origin holds a Spanned whose dynamic type need not be comparable and
+// `==` on two such values panics. It is allocated only once the walk follows a second
+// link, so the common chain of one or two links costs nothing.
 func (o Origin) NearestSpan() (ast.Span, bool) {
-	cur := &o
-	for depth := 0; cur != nil && depth < maxCauseDepth; depth++ {
+	var seen set.Set[*Origin]
+	for cur := &o; cur != nil; cur = cur.Cause {
 		if span, ok := SpanOf(cur.Node); ok {
 			return span, true
 		}
-		cur = cur.Cause
+		if cur.Cause == nil {
+			break
+		}
+		if seen == nil {
+			seen = set.NewSet[*Origin]()
+		}
+		if seen.Contains(cur.Cause) {
+			break
+		}
+		seen.Add(cur.Cause)
 	}
 	return ast.Span{}, false
 }

--- a/internal/solver/ucs/origin.go
+++ b/internal/solver/ucs/origin.go
@@ -1,0 +1,131 @@
+package ucs
+
+import (
+	"reflect"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+// OriginKind names the surface flow-control form a node lowered from. Desugaring
+// erases that distinction — `match`, `if val`, and `val … else` all become a split —
+// so the tag is the only thing left that tells the three apart. A diagnostic reads
+// it to choose its wording. An inexhaustive `match` asks for a catch-all branch,
+// while an `if val` that cannot bind says the pattern may not match.
+type OriginKind int
+
+const (
+	// OriginMatchArm is an arm of a `match` expression.
+	OriginMatchArm OriginKind = iota
+	// OriginIfVal is the pattern branch or the `else` of an `if val` expression.
+	OriginIfVal
+	// OriginValElse is the success path or the `else` of a
+	// `val pat = init else { … }` declaration.
+	OriginValElse
+	// OriginGuard is an arm's `if` guard.
+	OriginGuard
+)
+
+// String renders the kind as the phrase a diagnostic uses to name the construct.
+func (k OriginKind) String() string {
+	switch k {
+	case OriginMatchArm:
+		return "match arm"
+	case OriginIfVal:
+		return "if val"
+	case OriginValElse:
+		return "val else"
+	case OriginGuard:
+		return "guard"
+	default:
+		return "unknown origin"
+	}
+}
+
+// Spanned is what the IR needs from a surface node: the span a diagnostic points
+// at. It is narrower than ast.Node, which also demands an Accept method. The surface
+// node a match arm lowers from is an *ast.MatchCase, and that type carries only a
+// span, because a match arm is visited through its enclosing MatchExpr rather than
+// on its own. Every ast.Node satisfies Spanned, so a caller can store one directly.
+type Spanned interface {
+	Span() ast.Span
+}
+
+// Origin is the diagnostics provenance every core and normalized node carries. It
+// records which surface construct produced the node and which surface node a message
+// about it should blame.
+type Origin struct {
+	// Kind names the surface construct the node lowered from.
+	Kind OriginKind
+	// Node is the surface node a diagnostic anchors its span to. It is nil on a
+	// synthetic node, which has no source span. Read it through SourceSpan rather
+	// than calling Node.Span() directly, so a missing node is a miss instead of a
+	// panic.
+	Node Spanned
+	// Synthetic marks a node the desugarer minted rather than lowered from
+	// something the user wrote, such as a fallthrough tail or an implicit `else`.
+	// Kind still names the construct the node was minted for. A consumer that needs
+	// a span for a synthetic node takes it from the nearest enclosing real node or
+	// emits none, rather than inventing a position the user cannot see.
+	Synthetic bool
+}
+
+// At builds the origin of a node lowered from the surface node n, which is what a
+// diagnostic about the node blames. Pass a real node; a node the desugarer invented
+// gets its origin from Invented instead.
+func At(kind OriginKind, n Spanned) Origin {
+	if isNilSpanned(n) {
+		return Invented(kind)
+	}
+	return Origin{Kind: kind, Node: n}
+}
+
+// Invented builds the origin of a node the desugarer minted with no source of its
+// own. kind names the construct it was minted for.
+func Invented(kind OriginKind) Origin {
+	return Origin{Kind: kind, Synthetic: true}
+}
+
+// Prov returns the origin itself. Every core and normalized node embeds Origin, so
+// this method is what makes those nodes satisfy Term.
+func (o Origin) Prov() Origin { return o }
+
+// SourceSpan returns the span of the surface node the origin blames, and false when
+// there is none. A synthetic node has no span, so a consumer falls back to the
+// nearest enclosing real span or emits nothing rather than inventing a position.
+func (o Origin) SourceSpan() (ast.Span, bool) {
+	return SpanOf(o.Node)
+}
+
+// SpanOf returns n's span, and false when n names no node. It is the nil-safe way to
+// read a Spanned field, including the surface-arm back-reference on a branch or leaf.
+func SpanOf(n Spanned) (ast.Span, bool) {
+	if isNilSpanned(n) {
+		return ast.Span{}, false
+	}
+	return n.Span(), true
+}
+
+// isNilSpanned reports whether n holds no node. A plain `n == nil` catches only an
+// empty interface, so it misses a nil pointer stored in one. A `(*ast.MatchCase)(nil)`
+// assigned to a Spanned field compares non-nil and then panics on Span(). Reflection
+// catches both cases, and every caller is on a diagnostics or printing path where the
+// cost does not matter.
+func isNilSpanned(n Spanned) bool {
+	if n == nil {
+		return true
+	}
+	v := reflect.ValueOf(n)
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
+// Term is any node of either IR: a core term, a normalized term, or a branch of
+// either. Both ADTs' node interfaces embed it, so the printer and diagnostics can
+// read provenance off a node without knowing which form they hold.
+type Term interface {
+	Prov() Origin
+}

--- a/internal/solver/ucs/origin.go
+++ b/internal/solver/ucs/origin.go
@@ -63,11 +63,25 @@ type Origin struct {
 	Node Spanned
 	// Synthetic marks a node the desugarer minted rather than lowered from
 	// something the user wrote, such as a fallthrough tail or an implicit `else`.
-	// Kind still names the construct the node was minted for. A consumer that needs
-	// a span for a synthetic node takes it from the nearest enclosing real node or
-	// emits none, rather than inventing a position the user cannot see.
+	// Kind still names the construct the node was minted for. A synthetic node has
+	// no span of its own, so a consumer reads NearestSpan rather than inventing a
+	// position the user cannot see.
 	Synthetic bool
+	// Cause is the origin this one was minted from, which is what makes a synthetic
+	// node's provenance recoverable from the node alone. Following Cause reaches a
+	// real surface node without walking the enclosing IR, so a diagnostic about an
+	// implicit `else` can blame the `val … else` that produced it.
+	//
+	// It is set only on a synthetic origin, by InventedFrom, and is nil at the end
+	// of the chain. A chain ends either at a real origin, whose Node a message can
+	// blame, or at an Invented origin with no cause, which names no position at all.
+	Cause *Origin
 }
+
+// maxCauseDepth bounds the cause walk. A chain the constructors build is a few links
+// long, so a longer one means Cause was assigned by hand into a cycle. Diagnostics
+// must stay total, so the walk gives up rather than spinning.
+const maxCauseDepth = 32
 
 // At builds the origin of a node lowered from the surface node n, which is what a
 // diagnostic about the node blames. Pass a real node; a node the desugarer invented
@@ -80,20 +94,51 @@ func At(kind OriginKind, n Spanned) Origin {
 }
 
 // Invented builds the origin of a node the desugarer minted with no source of its
-// own. kind names the construct it was minted for.
+// own and nothing to trace it back to. kind names the construct it was minted for.
+// Prefer InventedFrom whenever the caller holds the origin it is minting from, since
+// an origin built here can never yield a span.
 func Invented(kind OriginKind) Origin {
 	return Origin{Kind: kind, Synthetic: true}
+}
+
+// InventedFrom builds the origin of a node the desugarer minted while lowering
+// cause. The node has no source text of its own, so it gets no Node, but cause keeps
+// a real surface node reachable: NearestSpan follows the chain and returns the first
+// span it finds. Lowering the implicit `else` of a `val … else` passes the
+// declaration's origin, so a message about the invented tail blames the declaration.
+func InventedFrom(kind OriginKind, cause Origin) Origin {
+	return Origin{Kind: kind, Synthetic: true, Cause: &cause}
 }
 
 // Prov returns the origin itself. Every core and normalized node embeds Origin, so
 // this method is what makes those nodes satisfy Term.
 func (o Origin) Prov() Origin { return o }
 
-// SourceSpan returns the span of the surface node the origin blames, and false when
-// there is none. A synthetic node has no span, so a consumer falls back to the
-// nearest enclosing real span or emits nothing rather than inventing a position.
+// SourceSpan returns the span of the surface node this origin itself blames, and
+// false when there is none. It does not follow the cause chain, so a synthetic origin
+// always misses. Use it to ask whether the node maps to source text the user wrote;
+// use NearestSpan to get a span to underline.
 func (o Origin) SourceSpan() (ast.Span, bool) {
 	return SpanOf(o.Node)
+}
+
+// NearestSpan returns the span of the closest real surface node this origin can
+// reach, following Cause when the origin is synthetic, and false when the chain
+// reaches its end without one. It is what a diagnostic underlines.
+//
+// The span it returns belongs to the construct the synthetic node was minted while
+// lowering, which is wider than the node itself. Underlining the whole `val … else`
+// for its invented tail is the intended behavior: the tail has no text of its own, so
+// the declaration that produced it is the narrowest honest thing to point at.
+func (o Origin) NearestSpan() (ast.Span, bool) {
+	cur := &o
+	for depth := 0; cur != nil && depth < maxCauseDepth; depth++ {
+		if span, ok := SpanOf(cur.Node); ok {
+			return span, true
+		}
+		cur = cur.Cause
+	}
+	return ast.Span{}, false
 }
 
 // SpanOf returns n's span, and false when n names no node. It is the nil-safe way to

--- a/internal/solver/ucs/origin_test.go
+++ b/internal/solver/ucs/origin_test.go
@@ -152,7 +152,7 @@ func TestNearestSpanOnARealOrigin(t *testing.T) {
 }
 
 // Cause is exported, so a caller can assign a cycle by hand. Diagnostics must stay
-// total, so the walk gives up at maxCauseDepth instead of spinning forever.
+// total, so the walk stops on a link it has already followed instead of spinning.
 func TestNearestSpanToleratesACauseCycle(t *testing.T) {
 	loop := Invented(OriginGuard)
 	loop.Cause = &loop
@@ -169,4 +169,30 @@ func TestNearestSpanToleratesACauseCycle(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("NearestSpan did not terminate on a cyclic cause chain")
 	}
+}
+
+// A long chain still resolves. Nothing bounds the walk by length, so a legitimate
+// chain does not lose its span for being deep — only a repeated link stops it.
+func TestNearestSpanFollowsALongChain(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(7, 2, 30)))
+	for range 200 {
+		origin = InventedFrom(OriginValElse, origin)
+	}
+
+	found, ok := origin.NearestSpan()
+	require.True(t, ok)
+	require.Equal(t, span(7, 2, 30), found)
+}
+
+// Two links sharing one *Origin are a diamond, not a cycle. A walk down a single
+// path visits each link once, so the seen set must not cut the chain short here.
+func TestNearestSpanToleratesASharedCause(t *testing.T) {
+	shared := At(OriginIfVal, arm(span(4, 1, 12)))
+	left := InventedFrom(OriginValElse, shared)
+	right := InventedFrom(OriginGuard, shared)
+	right.Cause = left.Cause // both links now point at the same *Origin
+
+	found, ok := right.NearestSpan()
+	require.True(t, ok)
+	require.Equal(t, span(4, 1, 12), found)
 }

--- a/internal/solver/ucs/origin_test.go
+++ b/internal/solver/ucs/origin_test.go
@@ -2,6 +2,7 @@ package ucs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/stretchr/testify/require"
@@ -90,4 +91,82 @@ func TestScrutineeCarriesProvenance(t *testing.T) {
 	var term Term = NewRoot(ident("p"), origin)
 
 	require.Equal(t, origin, term.Prov())
+}
+
+// TestInventedFromKeepsAProvenanceChain covers the reason Cause exists. A synthetic
+// node carries no span, and the IR has no parent pointers, so without the chain a
+// diagnostic about an invented node could only recover a position by threading the
+// enclosing origin down a walk. Following Cause recovers it from the node alone.
+func TestInventedFromKeepsAProvenanceChain(t *testing.T) {
+	decl := arm(span(3, 1, 40))
+	declOrigin := At(OriginValElse, decl)
+	tail := InventedFrom(OriginValElse, declOrigin)
+
+	require.True(t, tail.Synthetic)
+	require.Nil(t, tail.Node)
+	require.NotNil(t, tail.Cause)
+	require.Equal(t, declOrigin, *tail.Cause)
+
+	// The synthetic node blames nothing itself.
+	_, ok := tail.SourceSpan()
+	require.False(t, ok)
+
+	// Following the chain reaches the declaration that produced it.
+	found, ok := tail.NearestSpan()
+	require.True(t, ok)
+	require.Equal(t, span(3, 1, 40), found)
+}
+
+// A chain several links long still resolves, which is what a tail minted while
+// lowering another minted node produces.
+func TestNearestSpanFollowsSeveralLinks(t *testing.T) {
+	outer := At(OriginMatchArm, arm(span(1, 1, 8)))
+	mid := InventedFrom(OriginGuard, outer)
+	inner := InventedFrom(OriginValElse, mid)
+
+	found, ok := inner.NearestSpan()
+	require.True(t, ok)
+	require.Equal(t, span(1, 1, 8), found)
+	require.Equal(t, OriginValElse, inner.Kind, "the chain carries a span, not the kind")
+}
+
+// A chain that ends at a causeless Invented names no position, rather than inventing
+// one the user cannot see.
+func TestNearestSpanMissesWhenTheChainHasNoRealNode(t *testing.T) {
+	root := Invented(OriginIfVal)
+	derived := InventedFrom(OriginValElse, root)
+
+	_, ok := derived.NearestSpan()
+	require.False(t, ok)
+
+	_, ok = root.NearestSpan()
+	require.False(t, ok)
+}
+
+// NearestSpan on a real origin is its own span, so a caller can read it uniformly
+// without first asking whether the origin is synthetic.
+func TestNearestSpanOnARealOrigin(t *testing.T) {
+	found, ok := At(OriginMatchArm, arm(span(2, 5, 18))).NearestSpan()
+	require.True(t, ok)
+	require.Equal(t, span(2, 5, 18), found)
+}
+
+// Cause is exported, so a caller can assign a cycle by hand. Diagnostics must stay
+// total, so the walk gives up at maxCauseDepth instead of spinning forever.
+func TestNearestSpanToleratesACauseCycle(t *testing.T) {
+	loop := Invented(OriginGuard)
+	loop.Cause = &loop
+
+	done := make(chan bool, 1)
+	go func() {
+		_, ok := loop.NearestSpan()
+		done <- ok
+	}()
+
+	select {
+	case ok := <-done:
+		require.False(t, ok)
+	case <-time.After(5 * time.Second):
+		t.Fatal("NearestSpan did not terminate on a cyclic cause chain")
+	}
 }

--- a/internal/solver/ucs/origin_test.go
+++ b/internal/solver/ucs/origin_test.go
@@ -1,0 +1,93 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtRecordsTheSurfaceNode(t *testing.T) {
+	node := arm(span(3, 5, 20))
+	origin := At(OriginIfVal, node)
+
+	require.Equal(t, OriginIfVal, origin.Kind)
+	require.Same(t, node, origin.Node)
+	require.False(t, origin.Synthetic)
+}
+
+func TestInventedRecordsNoSurfaceNode(t *testing.T) {
+	origin := Invented(OriginValElse)
+
+	require.Equal(t, OriginValElse, origin.Kind)
+	require.Nil(t, origin.Node)
+	require.True(t, origin.Synthetic)
+}
+
+// TestAtWithoutANodeIsSynthetic checks that a missing surface node produces a
+// synthetic origin rather than one that claims a node and panics on read. Both a
+// plain nil and a nil pointer stored in the interface are covered, since only the
+// first is caught by `== nil`.
+func TestAtWithoutANodeIsSynthetic(t *testing.T) {
+	var typedNil *ast.MatchCase
+
+	for name, origin := range map[string]Origin{
+		"untyped nil": At(OriginMatchArm, nil),
+		"typed nil":   At(OriginMatchArm, typedNil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.True(t, origin.Synthetic)
+			require.Nil(t, origin.Node)
+			_, ok := origin.SourceSpan()
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestSourceSpanReadsTheSurfaceNode(t *testing.T) {
+	node := arm(span(4, 3, 21))
+	found, ok := At(OriginMatchArm, node).SourceSpan()
+
+	require.True(t, ok)
+	require.Equal(t, span(4, 3, 21), found)
+}
+
+// TestSpanOfToleratesATypedNil keeps the printer and any diagnostic reader total. A
+// nil *ast.MatchCase stored in a Spanned field compares non-nil, so a plain nil check
+// would let it through and panic inside Span().
+func TestSpanOfToleratesATypedNil(t *testing.T) {
+	var typedNil *ast.MatchCase
+
+	_, ok := SpanOf(typedNil)
+	require.False(t, ok)
+
+	_, ok = SpanOf(nil)
+	require.False(t, ok)
+}
+
+func TestOriginKindString(t *testing.T) {
+	tests := []struct {
+		kind OriginKind
+		want string
+	}{
+		{OriginMatchArm, "match arm"},
+		{OriginIfVal, "if val"},
+		{OriginValElse, "val else"},
+		{OriginGuard, "guard"},
+		{OriginKind(99), "unknown origin"},
+	}
+
+	for _, test := range tests {
+		require.Equal(t, test.want, test.kind.String())
+	}
+}
+
+// TestScrutineeCarriesProvenance checks that a Scrutinee exposes its Origin through
+// Term, the accessor diagnostics read. Each IR node type is checked the same way as
+// it is added.
+func TestScrutineeCarriesProvenance(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(2, 5, 18)))
+	var term Term = NewRoot(ident("p"), origin)
+
+	require.Equal(t, origin, term.Prov())
+}

--- a/internal/solver/ucs/scrutinee.go
+++ b/internal/solver/ucs/scrutinee.go
@@ -1,0 +1,161 @@
+package ucs
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// Scrutinee is the value a split tests. The root scrutinee is the match target the
+// user wrote. Every other scrutinee is a projection out of an enclosing one, such as
+// the field `x` of an object an outer split already matched.
+//
+// A scrutinee is a shared node, not a path each consumer re-derives. An inner split
+// and every bind beneath it hold the same *Scrutinee pointer, so a codegen consumer
+// can evaluate it once into a local and read every projection off that local.
+// Sharing is also what keeps a side-effecting target evaluated exactly once. In
+// `match f() { … }` the root scrutinee is the single `f()` node, so no test or bind
+// re-runs the call.
+type Scrutinee struct {
+	// Target is the match target expression. It is set exactly on a root scrutinee,
+	// where Parent is nil.
+	Target ast.Expr
+	// Parent is the scrutinee this one projects out of. It is nil on a root.
+	Parent *Scrutinee
+	// Step is the projection that reaches this scrutinee from Parent. It is nil on a
+	// root.
+	Step Step
+	// Origin points at the source pattern this projection came from, so a split over
+	// a flattened sub-scrutinee blames the user's nested pattern rather than the
+	// internal path.
+	Origin
+}
+
+// NewRoot builds the scrutinee for a match target expression.
+func NewRoot(target ast.Expr, origin Origin) *Scrutinee {
+	return &Scrutinee{Target: target, Origin: origin}
+}
+
+// Project builds the sub-scrutinee reached by applying step to s. Callers share one
+// result across the inner split and its binds rather than projecting the same step
+// twice, so the projection is evaluated once.
+func (s *Scrutinee) Project(step Step, origin Origin) *Scrutinee {
+	return &Scrutinee{Parent: s, Step: step, Origin: origin}
+}
+
+// IsRoot reports whether s is a match target rather than a projection.
+func (s *Scrutinee) IsRoot() bool { return s.Parent == nil }
+
+// Step is one segment of a projection path: how a sub-scrutinee is reached from the
+// scrutinee that encloses it.
+//
+// Compare two steps with Equal, never with ==. RemainderStep holds a set, which is a
+// map, so == on two Step values panics at runtime with "comparing uncomparable type"
+// the moment either side is a RemainderStep.
+type Step interface {
+	isStep()
+	// Equal reports whether other names the same projection.
+	Equal(other Step) bool
+}
+
+func (FieldStep) isStep()     {}
+func (IndexStep) isStep()     {}
+func (ResultStep) isStep()    {}
+func (SuffixStep) isStep()    {}
+func (RemainderStep) isStep() {}
+
+// FieldStep reaches an object field by name, the `x` of `p.x`.
+type FieldStep struct{ Name string }
+
+func (s FieldStep) Equal(other Step) bool {
+	o, ok := other.(FieldStep)
+	return ok && o.Name == s.Name
+}
+
+// IndexStep reaches a tuple element by position, the `0` of `xs.0`.
+type IndexStep struct{ Index int }
+
+func (s IndexStep) Equal(other Step) bool {
+	o, ok := other.(IndexStep)
+	return ok && o.Index == s.Index
+}
+
+// ResultStep reaches one of the positional values an extractor yields. The `v` of
+// `Ok(v)` is result 0 of the `Ok` extractor. It is a separate step from IndexStep
+// because the solver resolves it through the extractor rather than through tuple
+// indexing, even though both name a position. The printer keeps them apart too, so a
+// path that should go through an extractor cannot pass for a tuple index.
+type ResultStep struct{ Index int }
+
+func (s ResultStep) Equal(other Step) bool {
+	o, ok := other.(ResultStep)
+	return ok && o.Index == s.Index
+}
+
+// SuffixStep reaches the tuple elements past a fixed prefix, which is what `...rest`
+// binds in a tuple pattern. From is the index of the suffix's first element, so
+// `[first, ...rest]` reaches `rest` through SuffixStep{From: 1}.
+//
+// Only a trailing rest is expressible. The suffix a SuffixStep names runs to the end
+// of the tuple, so there is no way to say "and then two more fixed elements". The
+// parser does accept a rest anywhere in a tuple pattern, as in
+// `[first, ...mid, last]`, but nothing downstream supports one. bindPattern's
+// TuplePat case folds every rest element into a single inexact tail the same way. A
+// lowering pass must reject a non-trailing rest rather than emit a SuffixStep that
+// silently drops the elements after it.
+type SuffixStep struct{ From int }
+
+func (s SuffixStep) Equal(other Step) bool {
+	o, ok := other.(SuffixStep)
+	return ok && o.From == s.From
+}
+
+// RemainderStep reaches an object with a set of keys removed, which is what
+// `...rest` binds in an object pattern. Exclude holds exactly the keys the object
+// pattern named at this level, so a key matched only by a deeper nested split still
+// appears in the remainder. In `{x, ...rest}` the step excludes `x` and `rest` binds
+// everything else.
+type RemainderStep struct{ Exclude set.Set[string] }
+
+func (s RemainderStep) Equal(other Step) bool {
+	o, ok := other.(RemainderStep)
+	return ok && o.Exclude.Equals(s.Exclude)
+}
+
+// String renders the scrutinee's projection path.
+func (s *Scrutinee) String() string { return scrutineeString(s) }
+
+// scrutineeString renders a scrutinee's projection path. A root renders its target
+// expression and every projection appends its step, so `l.start.x` reads as the
+// chain of steps that reaches it.
+func scrutineeString(s *Scrutinee) string {
+	if s == nil {
+		return "<nil>"
+	}
+	if s.IsRoot() {
+		return exprString(s.Target)
+	}
+	base := scrutineeString(s.Parent)
+	switch step := s.Step.(type) {
+	case FieldStep:
+		return base + "." + step.Name
+	case IndexStep:
+		return base + "." + strconv.Itoa(step.Index)
+	case ResultStep:
+		// The `#` keeps an extractor result apart from the tuple element `r.0`. The
+		// solver resolves the two through different lookups, so a snapshot must not
+		// let one stand in for the other.
+		return base + ".#" + strconv.Itoa(step.Index)
+	case SuffixStep:
+		return base + "[" + strconv.Itoa(step.From) + "..]"
+	case RemainderStep:
+		keys := step.Exclude.ToSlice()
+		slices.Sort(keys)
+		return base + " \\ {" + strings.Join(keys, ", ") + "}"
+	default:
+		return base + "." + nodeKind(s.Step)
+	}
+}

--- a/internal/solver/ucs/scrutinee.go
+++ b/internal/solver/ucs/scrutinee.go
@@ -63,7 +63,7 @@ type Step interface {
 
 func (FieldStep) isStep()     {}
 func (IndexStep) isStep()     {}
-func (ResultStep) isStep()    {}
+func (ExtractStep) isStep()   {}
 func (SuffixStep) isStep()    {}
 func (RemainderStep) isStep() {}
 
@@ -83,15 +83,15 @@ func (s IndexStep) Equal(other Step) bool {
 	return ok && o.Index == s.Index
 }
 
-// ResultStep reaches one of the positional values an extractor yields. The `v` of
-// `Ok(v)` is result 0 of the `Ok` extractor. It is a separate step from IndexStep
-// because the solver resolves it through the extractor rather than through tuple
-// indexing, even though both name a position. The printer keeps them apart too, so a
-// path that should go through an extractor cannot pass for a tuple index.
-type ResultStep struct{ Index int }
+// ExtractStep reaches one of the positional values an extractor yields. The `v` of
+// `Ok(v)` is extracted value 0 of the `Ok` extractor. It is a separate step from
+// IndexStep because the solver resolves it through the extractor rather than through
+// tuple indexing, even though both name a position. The printer keeps them apart too,
+// so a path that should go through an extractor cannot pass for a tuple index.
+type ExtractStep struct{ Index int }
 
-func (s ResultStep) Equal(other Step) bool {
-	o, ok := other.(ResultStep)
+func (s ExtractStep) Equal(other Step) bool {
+	o, ok := other.(ExtractStep)
 	return ok && o.Index == s.Index
 }
 
@@ -144,8 +144,8 @@ func scrutineeString(s *Scrutinee) string {
 		return base + "." + step.Name
 	case IndexStep:
 		return base + "." + strconv.Itoa(step.Index)
-	case ResultStep:
-		// The `#` keeps an extractor result apart from the tuple element `r.0`. The
+	case ExtractStep:
+		// The `#` keeps an extracted value apart from the tuple element `r.0`. The
 		// solver resolves the two through different lookups, so a snapshot must not
 		// let one stand in for the other.
 		return base + ".#" + strconv.Itoa(step.Index)

--- a/internal/solver/ucs/scrutinee_test.go
+++ b/internal/solver/ucs/scrutinee_test.go
@@ -50,13 +50,13 @@ func TestStepEqual(t *testing.T) {
 		{"different field", FieldStep{Name: "x"}, FieldStep{Name: "y"}, false},
 		{"same index", IndexStep{Index: 1}, IndexStep{Index: 1}, true},
 		{"different index", IndexStep{Index: 0}, IndexStep{Index: 1}, false},
-		{"same result", ResultStep{Index: 0}, ResultStep{Index: 0}, true},
+		{"same extracted value", ExtractStep{Index: 0}, ExtractStep{Index: 0}, true},
 		{
-			// A tuple element and an extractor result resolve through different
+			// A tuple element and an extracted value resolve through different
 			// machinery, so the same position is not the same projection.
-			"index is not a result",
+			"index is not an extracted value",
 			IndexStep{Index: 0},
-			ResultStep{Index: 0},
+			ExtractStep{Index: 0},
 			false,
 		},
 		{"same suffix", SuffixStep{From: 1}, SuffixStep{From: 1}, true},
@@ -125,10 +125,10 @@ func TestScrutineePaths(t *testing.T) {
 			"xs.0",
 		},
 		{
-			// The `v` of `Ok(v)` is the extractor's first positional result. The `#`
+			// The `v` of `Ok(v)` is the extractor's first extracted value. The `#`
 			// keeps it distinct from the tuple element `r.0` above.
-			"extractor result",
-			root("r").Project(ResultStep{Index: 0}, origin),
+			"extracted value",
+			root("r").Project(ExtractStep{Index: 0}, origin),
 			"r.#0",
 		},
 		{

--- a/internal/solver/ucs/scrutinee_test.go
+++ b/internal/solver/ucs/scrutinee_test.go
@@ -1,0 +1,164 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRootIsARootScrutinee(t *testing.T) {
+	target := ident("p")
+	root := NewRoot(target, At(OriginMatchArm, arm(span(1, 1, 8))))
+
+	require.True(t, root.IsRoot())
+	require.Nil(t, root.Parent)
+	require.Nil(t, root.Step)
+	require.Same(t, target, root.Target)
+}
+
+// TestProjectSharesItsParent locks the once-evaluation guarantee. Sibling
+// projections hold the same parent pointer, so a consumer evaluates the parent once
+// and reads both projections off it.
+func TestProjectSharesItsParent(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(1, 1, 8)))
+	root := NewRoot(ident("p"), origin)
+	x := root.Project(FieldStep{Name: "x"}, origin)
+	y := root.Project(FieldStep{Name: "y"}, origin)
+
+	require.False(t, x.IsRoot())
+	require.Same(t, root, x.Parent)
+	require.Same(t, root, y.Parent)
+	require.Nil(t, x.Target)
+	require.Equal(t, FieldStep{Name: "x"}, x.Step)
+	require.Equal(t, "p.x", x.String())
+	require.Equal(t, "p.y", y.String())
+}
+
+// TestStepEqual covers the comparison every consumer must use. `==` on two Step
+// values panics as soon as either is a RemainderStep, since a set is a map, so Equal
+// is the only safe way to ask whether two projections match.
+func TestStepEqual(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  Step
+		right Step
+		want  bool
+	}{
+		{"same field", FieldStep{Name: "x"}, FieldStep{Name: "x"}, true},
+		{"different field", FieldStep{Name: "x"}, FieldStep{Name: "y"}, false},
+		{"same index", IndexStep{Index: 1}, IndexStep{Index: 1}, true},
+		{"different index", IndexStep{Index: 0}, IndexStep{Index: 1}, false},
+		{"same result", ResultStep{Index: 0}, ResultStep{Index: 0}, true},
+		{
+			// A tuple element and an extractor result resolve through different
+			// machinery, so the same position is not the same projection.
+			"index is not a result",
+			IndexStep{Index: 0},
+			ResultStep{Index: 0},
+			false,
+		},
+		{"same suffix", SuffixStep{From: 1}, SuffixStep{From: 1}, true},
+		{"different suffix", SuffixStep{From: 1}, SuffixStep{From: 2}, false},
+		{
+			"same remainder",
+			RemainderStep{Exclude: set.FromSlice([]string{"x", "y"})},
+			RemainderStep{Exclude: set.FromSlice([]string{"y", "x"})},
+			true,
+		},
+		{
+			"different remainder",
+			RemainderStep{Exclude: set.FromSlice([]string{"x"})},
+			RemainderStep{Exclude: set.FromSlice([]string{"x", "y"})},
+			false,
+		},
+		{
+			"remainder is not a field",
+			RemainderStep{Exclude: set.FromSlice([]string{"x"})},
+			FieldStep{Name: "x"},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, test.left.Equal(test.right))
+			require.Equal(t, test.want, test.right.Equal(test.left))
+		})
+	}
+}
+
+func TestScrutineePaths(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(1, 1, 8)))
+	root := func(name string) *Scrutinee { return NewRoot(ident(name), origin) }
+
+	tests := []struct {
+		name string
+		in   *Scrutinee
+		want string
+	}{
+		{
+			"root target",
+			root("p"),
+			"p",
+		},
+		{
+			// A side-effecting target is one shared node, so no test or bind re-runs it.
+			"root call target",
+			NewRoot(ast.NewCall(ident("f"), nil, false, ast.Span{}), origin),
+			"f()",
+		},
+		{
+			"object field",
+			root("p").Project(FieldStep{Name: "x"}, origin),
+			"p.x",
+		},
+		{
+			"nested object field",
+			root("l").Project(FieldStep{Name: "start"}, origin).Project(FieldStep{Name: "x"}, origin),
+			"l.start.x",
+		},
+		{
+			"tuple element",
+			root("xs").Project(IndexStep{Index: 0}, origin),
+			"xs.0",
+		},
+		{
+			// The `v` of `Ok(v)` is the extractor's first positional result. The `#`
+			// keeps it distinct from the tuple element `r.0` above.
+			"extractor result",
+			root("r").Project(ResultStep{Index: 0}, origin),
+			"r.#0",
+		},
+		{
+			// The `rest` of `[first, ...rest]` is the suffix past the fixed prefix.
+			"tuple suffix",
+			root("xs").Project(SuffixStep{From: 1}, origin),
+			"xs[1..]",
+		},
+		{
+			// The `rest` of `{x, ...rest}` is the scrutinee minus the keys named here.
+			"object remainder",
+			root("p").Project(RemainderStep{Exclude: set.FromSlice([]string{"x"})}, origin),
+			`p \ {x}`,
+		},
+		{
+			// Excluded keys render in sorted order so the path is deterministic.
+			"object remainder with several keys",
+			root("p").Project(RemainderStep{Exclude: set.FromSlice([]string{"y", "x"})}, origin),
+			`p \ {x, y}`,
+		},
+		{
+			"nil scrutinee",
+			nil,
+			"<nil>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, test.in.String())
+		})
+	}
+}

--- a/planning/ucs/implementation_plan.md
+++ b/planning/ucs/implementation_plan.md
@@ -486,8 +486,9 @@ into nothing.
 - Enumerate the branch-test kinds as a sum: a structural object or tuple shape, a
   literal, a nominal class tag for an instance pattern, an extractor tag, and an
   inexact-prefix marker a rest pattern sets. A projection path segment must be able
-  to name a field, a tuple index, an extractor's positional result, a tuple suffix
-  for a tuple rest, and an object remainder excluding a key set for an object rest.
+  to name a field, a tuple index, a positional value an extractor yields, a tuple
+  suffix for a tuple rest, and an object remainder excluding a key set for an object
+  rest.
   M9 has shipped the types the last two resolve to — tuple spread and an
   `Omit`-style mapped type — and PR0 wires their `bindPattern` cases, so the IR
   names both projections and PR5 onward bind them for real.

--- a/planning/ucs/implementation_plan.md
+++ b/planning/ucs/implementation_plan.md
@@ -396,9 +396,11 @@ One decision is deferred to M10, not settled here: the **synthesized-node span
 policy**. The desugarer invents nodes with no source — the fallthrough tail, an
 implicit `else` — and a sourcemap must not point at a column the user cannot see.
 The synthetic marker from point 2 above is what M10 keys that policy off: map a
-synthetic node to the nearest enclosing real span, or emit no mapping for it,
-rather than inventing a position. Recording the marker now keeps that choice open
-instead of foreclosing it with a lost span.
+synthetic node to the span its cause chain reaches, or emit no mapping for it,
+rather than inventing a position. `Origin.Cause` records what a synthetic node was
+minted from and `NearestSpan` walks that chain, so the span is recoverable from the
+node alone rather than by threading the enclosing origin down a walk. Recording
+both now keeps the choice open instead of foreclosing it with a lost span.
 
 ## Codegen efficiency
 


### PR DESCRIPTION
Refs #1020.

Second of five stacked PRs adding `internal/solver/ucs`. Still pure IR wired into nothing.

**Stacked on #1041.** Review that one first; this PR's diff is against it.

**Rescoped.** This PR previously carried the AST-fragment renderer too, at 1421 lines. That renderer is now #1041 — it was 55% of the diff and it is scaffolding that #1040 deletes, so separating it lets review attention go where the durable design is. No code changed in the split; the stack tip is byte-identical.

## What's here

The two foundations the term ADTs later in the stack build on.

**`Origin`** records which surface node a term came from, so a diagnostic raised anywhere in the pipeline points back at what the user typed. `OriginKind` names the surface form. `At` attaches a node, `Invented` marks a node the pipeline synthesized.

- `At` with no node returns a synthetic origin. That keeps "`Node` is nil exactly when `Synthetic` is set" true rather than a claim a caller could break.
- `SpanOf` reads a span through the `Spanned` interface and tolerates a nil pointer stored in it. Such a value compares non-nil and would otherwise panic inside `Span()`.
- `Term` is the one accessor every IR node exposes.

**`Scrutinee`** is the value a test examines, either a match target or a projection out of an enclosing scrutinee. Projections are shared nodes rather than paths each consumer re-derives, so a codegen consumer evaluates `f()` in `match f() { … }` exactly once and reads every projection off that one local. Five `Step` kinds name a field, a tuple index, an extractor result, a tuple suffix, and an object remainder.

Steps are compared with `Equal`, never `==`. `RemainderStep` holds a `set.Set[string]`, which is a map, so `==` on two `Step` values panics with "comparing uncomparable type" as soon as either side is a remainder. Same-scrutinee merging at the end of the stack would hit that on the first `{x, ...rest}`.

`Scrutinee.String()` walks the steps to render a projection path, so `l.start.x` reads as the chain that reaches it. It is this PR's only call into the renderer from #1041.

## Testing

`go test ./...` is green. 133 tests in the package, 97.2% coverage. Step equality including the remainder case, projection-path rendering across all five step kinds, origin construction, and typed-nil tolerance.

Part of the Ultimate Conditional Syntax IR plan, #884. Refs #882.