### PR TITLE
UCS IR (3/5) — the leaves and the desugared-core ADT

### DIFF
--- a/internal/solver/ucs/core.go
+++ b/internal/solver/ucs/core.go
@@ -1,0 +1,75 @@
+package ucs
+
+import "github.com/escalier-lang/escalier/internal/ast"
+
+// Core is a term of the desugared core, the small language every conditional
+// surface form lowers into. The core still carries whole source patterns.
+// Flattening them into one-tag-level splits is what normalization does.
+type Core interface {
+	Term
+	isCore()
+}
+
+func (*CoreSplit) isCore() {}
+func (*CoreGuard) isCore() {}
+func (*CoreBind) isCore()  {}
+
+// CoreSplit tests a scrutinee against an ordered list of branches. Order is source
+// order, and the first branch whose pattern matches wins, so the core preserves the
+// surface's first-match semantics directly.
+type CoreSplit struct {
+	Scrutinee *Scrutinee
+	Branches  []*CoreBranch
+	// Else is the fallthrough taken when no branch matches. An `if val` and a
+	// `val … else` always set it, since both write an `else` path. A `match` leaves
+	// it nil, because a catch-all arm is an ordinary branch in the core and only
+	// normalization moves it into the default tail. A nil Else prints as no `else`
+	// clause at all.
+	Else Core
+	Origin
+}
+
+// CoreBranch is one arm of a core split. It keeps the arm's source pattern whole,
+// nesting included.
+type CoreBranch struct {
+	// Pattern is the arm's pattern exactly as the user wrote it.
+	Pattern ast.Pat
+	// Cont is what runs once Pattern matches. A guarded arm puts a CoreGuard here so
+	// the guard reads the bindings the pattern introduced.
+	Cont Core
+	// Arm is the surface arm this branch came from. It survives the merging and
+	// flattening that normalization does, so a diagnostic blames the arm the user
+	// typed. Origin.Node can point at a synthesized node after those rewrites; Arm
+	// never does.
+	Arm Spanned
+	Origin
+}
+
+// CoreGuard tests a boolean condition after its branch's bindings are in scope, so
+// the condition can read them. In `{x, y} if x > y => x` the guard sees `x` and `y`.
+//
+// A core guard has no failure continuation. A failed guard falls through to the
+// remaining branches of the enclosing split in source order, which the ordered
+// branch list already expresses. Normalization makes that continuation explicit as
+// NormGuard.Default.
+type CoreGuard struct {
+	Cond ast.Expr
+	Cont Core
+	Origin
+}
+
+// CoreBind names an intermediate value so later stages see every binding the same
+// way, whether the user wrote it or the desugarer introduced it.
+type CoreBind struct {
+	// Name is the bound identifier.
+	Name string
+	// Pat is the pattern leaf the name came from, which the solver binds through so
+	// the leaf keeps its annotation and its borrow mode. It is nil for a name the
+	// desugarer invented, which has no pattern leaf behind it.
+	Pat ast.Pat
+	// Source is the value the name binds to.
+	Source *Scrutinee
+	// Cont is what runs with Name in scope.
+	Cont Core
+	Origin
+}

--- a/internal/solver/ucs/core_test.go
+++ b/internal/solver/ucs/core_test.go
@@ -25,8 +25,8 @@ func TestCoreNodesCarryProvenance(t *testing.T) {
 }
 
 // TestCoreSplitKeepsSourceOrder locks the core's first-match semantics. Branch order
-// is source order, and normalization in PR3 is what rewrites it into tests that
-// never backtrack.
+// is source order, and the first branch whose pattern matches wins. Removing the
+// backtracking that implies is normalization's job, not the core's.
 func TestCoreSplitKeepsSourceOrder(t *testing.T) {
 	origin := At(OriginMatchArm, arm(span(1, 1, 8)))
 	scrutinee := NewRoot(ident("p"), origin)

--- a/internal/solver/ucs/core_test.go
+++ b/internal/solver/ucs/core_test.go
@@ -1,0 +1,53 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoreNodesCarryProvenance(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(2, 5, 18)))
+	scrutinee := NewRoot(ident("p"), origin)
+
+	terms := map[string]Term{
+		"CoreSplit":  &CoreSplit{Scrutinee: scrutinee, Origin: origin},
+		"CoreBranch": &CoreBranch{Pattern: wildcardPat(), Origin: origin},
+		"CoreGuard":  &CoreGuard{Cond: ident("g"), Origin: origin},
+		"CoreBind":   &CoreBind{Name: "x", Source: scrutinee, Origin: origin},
+	}
+
+	for name, term := range terms {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, origin, term.Prov())
+		})
+	}
+}
+
+// TestCoreSplitKeepsSourceOrder locks the core's first-match semantics. Branch order
+// is source order, and normalization in PR3 is what rewrites it into tests that
+// never backtrack.
+func TestCoreSplitKeepsSourceOrder(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(1, 1, 8)))
+	scrutinee := NewRoot(ident("p"), origin)
+
+	first := &CoreBranch{Pattern: identPat("a"), Cont: &BodyLeaf{Body: exprBody(num(1))}, Origin: origin}
+	second := &CoreBranch{Pattern: wildcardPat(), Cont: &BodyLeaf{Body: exprBody(num(2))}, Origin: origin}
+	split := &CoreSplit{Scrutinee: scrutinee, Branches: []*CoreBranch{first, second}, Origin: origin}
+
+	require.Equal(t, []*CoreBranch{first, second}, split.Branches)
+	// A `match` leaves Else nil, since a catch-all arm is an ordinary branch here.
+	require.Nil(t, split.Else)
+}
+
+// TestCoreBranchKeepsItsPatternWhole is the property that separates the core from the
+// normalized form. A core branch holds the arm's pattern with its nesting intact, so
+// no tag-level flattening has happened yet.
+func TestCoreBranchKeepsItsPatternWhole(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(1, 1, 8)))
+	pattern := objPat("x", "y")
+	branch := &CoreBranch{Pattern: pattern, Origin: origin}
+
+	require.Same(t, pattern, branch.Pattern)
+	require.Equal(t, "{x, y}", patString(branch.Pattern))
+}

--- a/internal/solver/ucs/doc.go
+++ b/internal/solver/ucs/doc.go
@@ -9,6 +9,11 @@
 // pipeline can point back at what the user typed. A Scrutinee names the value a test
 // examines, either a match target or a projection out of one.
 //
+// The desugared core is what the surface lowers into directly. A CoreSplit tests a
+// scrutinee against an ordered list of branches, a CoreBind names an intermediate
+// value, a CoreGuard tests a boolean over a branch's bindings, and a leaf ends a
+// branch. A core branch keeps its arm's source pattern whole, nesting and all.
+//
 // The package is pure IR with no behavior of its own. It imports internal/ast for
 // the surface nodes it points back at and internal/set for key sets. It never
 // imports internal/solver or internal/soltype, so the typing walk can import it and

--- a/internal/solver/ucs/leaf.go
+++ b/internal/solver/ucs/leaf.go
@@ -1,0 +1,63 @@
+package ucs
+
+import "github.com/escalier-lang/escalier/internal/ast"
+
+// The three leaf types end a branch of the core.
+func (*BodyLeaf) isCore()     {}
+func (*EscapeLeaf) isCore()   {}
+func (*FallbackLeaf) isCore() {}
+
+// BodyLeaf ends a branch with the body the user wrote for it: a `match` arm's body,
+// or the consequent or `else` of an `if val`. Its bindings are scoped to Body and do
+// not escape.
+type BodyLeaf struct {
+	// Body is the arm body. BodySpan reads the span a diagnostic about the body
+	// blames, which is narrower than the arm span Origin.Node carries.
+	Body ast.BlockOrExpr
+	// Arm is the surface arm this leaf came from. It survives the merging and
+	// flattening that normalization does to the splits above it, so a message such
+	// as "unreachable arm" blames the arm the user typed rather than a rewritten
+	// node. Origin.Node can point at a synthesized node after those rewrites; Arm
+	// never does.
+	Arm Spanned
+	Origin
+}
+
+// EscapeLeaf ends the success path of a `val pat = init else { … }` declaration. It
+// carries no body, because the declaration's bindings escape into the enclosing
+// block and the rest of that block is the continuation. Modelling the escape as its
+// own leaf is what keeps the typing walk from looking for a body that a
+// `val … else` never has.
+type EscapeLeaf struct {
+	// Arm is the surface `val` declaration this leaf came from. See BodyLeaf.Arm for
+	// why the back-reference is kept separate from Origin.
+	Arm Spanned
+	Origin
+}
+
+// BodySpan returns the span of an arm body, and false when the body holds neither an
+// expression nor a block. A body written as a bare expression spans that expression;
+// a block spans its braces. A leaf's Origin points at the whole surface arm, so a
+// diagnostic that should underline only the body reads its span from here.
+func BodySpan(b ast.BlockOrExpr) (ast.Span, bool) {
+	if b.Expr != nil {
+		return b.Expr.Span(), true
+	}
+	if b.Block != nil {
+		return b.Block.Span, true
+	}
+	return ast.Span{}, false
+}
+
+// FallbackLeaf ends the `else` path of a `val pat = init else { … }` declaration.
+// The `else` either diverges or evaluates to a fallback value. It is a distinct leaf
+// from BodyLeaf so the coverage check does not count it as an arm that covers the
+// scrutinee. It runs precisely when the pattern failed to match.
+type FallbackLeaf struct {
+	// Body is the `else` block. BodySpan reads its span.
+	Body ast.BlockOrExpr
+	// Arm is the surface `val` declaration this leaf came from. See BodyLeaf.Arm for
+	// why the back-reference is kept separate from Origin.
+	Arm Spanned
+	Origin
+}

--- a/internal/solver/ucs/leaf_test.go
+++ b/internal/solver/ucs/leaf_test.go
@@ -1,0 +1,54 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLeavesEndACoreTerm checks that all three leaf types terminate a core branch.
+// PR3 adds the normalized form and extends this to cover both.
+func TestLeavesEndACoreTerm(t *testing.T) {
+	leaves := []any{
+		&BodyLeaf{Body: exprBody(num(1))},
+		&EscapeLeaf{},
+		&FallbackLeaf{Body: exprBody(num(0))},
+	}
+
+	for _, leaf := range leaves {
+		require.Implements(t, (*Core)(nil), leaf)
+	}
+}
+
+func TestBodySpan(t *testing.T) {
+	exprSpan := span(2, 14, 19)
+	blockSpan := span(3, 1, 12)
+
+	found, ok := BodySpan(ast.BlockOrExpr{Expr: ast.NewIdent("x", exprSpan)})
+	require.True(t, ok)
+	require.Equal(t, exprSpan, found)
+
+	found, ok = BodySpan(ast.BlockOrExpr{Block: &ast.Block{Span: blockSpan}})
+	require.True(t, ok)
+	require.Equal(t, blockSpan, found)
+
+	_, ok = BodySpan(ast.BlockOrExpr{})
+	require.False(t, ok)
+}
+
+func TestLeavesCarryProvenance(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(2, 5, 18)))
+
+	terms := map[string]Term{
+		"BodyLeaf":     &BodyLeaf{Body: exprBody(num(1)), Origin: origin},
+		"EscapeLeaf":   &EscapeLeaf{Origin: origin},
+		"FallbackLeaf": &FallbackLeaf{Body: exprBody(num(0)), Origin: origin},
+	}
+
+	for name, term := range terms {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, origin, term.Prov())
+		})
+	}
+}

--- a/internal/solver/ucs/leaf_test.go
+++ b/internal/solver/ucs/leaf_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLeavesEndACoreTerm checks that all three leaf types terminate a core branch.
-// PR3 adds the normalized form and extends this to cover both.
+// TestLeavesEndACoreTerm checks that all three leaf types terminate a core branch,
+// which is what lets a split's continuation be a leaf as readily as another split.
 func TestLeavesEndACoreTerm(t *testing.T) {
 	leaves := []any{
 		&BodyLeaf{Body: exprBody(num(1))},


### PR DESCRIPTION
Refs #1020.

Third of five stacked PRs adding `internal/solver/ucs`. Still pure IR wired into nothing.

**Stacked on #1031.** Review that one first; this PR's diff is against it.

## What's here

**`Core`** is the desugared core, the small language every conditional surface form lowers into directly.

- `CoreSplit` tests a scrutinee against an ordered list of branches.
- `CoreBind` names an intermediate value, so later stages see every binding the same way whether the user wrote it or the desugarer introduced it.
- `CoreGuard` tests a boolean after its branch's bindings are in scope.

Two things make the core the core rather than the normalized form. A `CoreBranch` holds its arm's source pattern whole, nesting included, so `Line { start: {x, y} }` is still one pattern rather than a chain of tag-level tests. Branch order is source order and first match wins, so the core preserves the surface's semantics directly and leaves backtracking removal to normalization in #1033.

A `CoreGuard` has no failure continuation for the same reason. A failed guard falls through to the remaining branches of the enclosing split, which the ordered branch list already expresses. The normalized form's `NormGuard` makes that continuation explicit.

**The three leaves** end a branch:

- `BodyLeaf` carries the body the user wrote.
- `EscapeLeaf` ends the success path of a `val pat = init else { … }`. It carries no body, because the declaration's bindings escape into the enclosing block and the rest of that block is the continuation. Modelling that as its own leaf keeps the typing walk from looking for a body a `val … else` never has.
- `FallbackLeaf` ends the `else` path. It stays distinct from `BodyLeaf` so the coverage check does not count it as an arm that covers the scrutinee.

`BodySpan` reads the span of an arm body. A leaf's `Origin` points at the whole surface arm, so a diagnostic that should underline only the body reads its narrower span from here.

## Reviewer notes

The leaves implement `Core` here and gain `Norm` in #1033. Normalization rewrites the splits around a leaf and leaves the leaf itself alone, which is why there is one set of leaves rather than a parallel pair.

## Testing

`go test ./...` is green. 146 tests in the package, 13 new: core-node provenance, source-order preservation, whole-pattern retention on a branch, leaf `Core` membership, and `BodySpan` across its three cases.

Part of the Ultimate Conditional Syntax IR plan, #884. Refs #882.