### PR TITLE
UCS IR (4/5) — tag tests and the normalized form

### DIFF
--- a/internal/solver/ucs/doc.go
+++ b/internal/solver/ucs/doc.go
@@ -14,6 +14,14 @@
 // value, a CoreGuard tests a boolean over a branch's bindings, and a leaf ends a
 // branch. A core branch keeps its arm's source pattern whole, nesting and all.
 //
+// The normalized form is a backtracking-free rewrite of the core. Every NormSplit
+// tests exactly one tag-level of one scrutinee. A tag-level is the outermost tag a
+// pattern names and nothing under it, so `Line { start: {x, y} }` contributes the
+// `Line` tag alone. A nested sub-pattern becomes a projected sub-scrutinee with a
+// split of its own, and a failed test falls to the split's default tail instead of
+// retrying an earlier branch. The typing walk, the coverage check, and a later
+// codegen consumer all read this form.
+//
 // The package is pure IR with no behavior of its own. It imports internal/ast for
 // the surface nodes it points back at and internal/set for key sets. It never
 // imports internal/solver or internal/soltype, so the typing walk can import it and

--- a/internal/solver/ucs/doc.go
+++ b/internal/solver/ucs/doc.go
@@ -18,9 +18,9 @@
 // tests exactly one tag-level of one scrutinee. A tag-level is the outermost tag a
 // pattern names and nothing under it, so `Line { start: {x, y} }` contributes the
 // `Line` tag alone. A nested sub-pattern becomes a projected sub-scrutinee with a
-// split of its own, and a failed test falls to the split's default tail instead of
-// retrying an earlier branch. The typing walk, the coverage check, and a later
-// codegen consumer all read this form.
+// split of its own. When no branch's test matches, control falls to that split's
+// default tail rather than retrying a branch above it. The typing walk, the coverage
+// check, and a later codegen consumer will all read this form.
 //
 // The package is pure IR with no behavior of its own. It imports internal/ast for
 // the surface nodes it points back at and internal/set for key sets. It never

--- a/internal/solver/ucs/helpers_test.go
+++ b/internal/solver/ucs/helpers_test.go
@@ -77,3 +77,12 @@ func blockBody(e ast.Expr) ast.BlockOrExpr {
 func exprBody(e ast.Expr) ast.BlockOrExpr {
 	return ast.BlockOrExpr{Expr: e}
 }
+
+// keys builds the required-field list of an object test.
+func keys(names ...string) []ObjectKey {
+	out := make([]ObjectKey, len(names))
+	for i, name := range names {
+		out[i] = ObjectKey{Name: name}
+	}
+	return out
+}

--- a/internal/solver/ucs/leaf.go
+++ b/internal/solver/ucs/leaf.go
@@ -2,8 +2,8 @@ package ucs
 
 import "github.com/escalier-lang/escalier/internal/ast"
 
-// The three leaf types end a branch of either IR, so each implements both Core and
-// Norm. Normalization rewrites the splits around a leaf and leaves the leaf itself
+// The three leaf types end a branch of either IR, so each implements both `Core` and
+// `Norm`. Normalization rewrites the splits around a leaf and leaves the leaf itself
 // alone, so there is one set of leaves rather than a parallel pair.
 func (*BodyLeaf) isCore()     {}
 func (*BodyLeaf) isNorm()     {}

--- a/internal/solver/ucs/leaf.go
+++ b/internal/solver/ucs/leaf.go
@@ -2,10 +2,15 @@ package ucs
 
 import "github.com/escalier-lang/escalier/internal/ast"
 
-// The three leaf types end a branch of the core.
+// The three leaf types end a branch of either IR, so each implements both Core and
+// Norm. Normalization rewrites the splits around a leaf and leaves the leaf itself
+// alone, so there is one set of leaves rather than a parallel pair.
 func (*BodyLeaf) isCore()     {}
+func (*BodyLeaf) isNorm()     {}
 func (*EscapeLeaf) isCore()   {}
+func (*EscapeLeaf) isNorm()   {}
 func (*FallbackLeaf) isCore() {}
+func (*FallbackLeaf) isNorm() {}
 
 // BodyLeaf ends a branch with the body the user wrote for it: a `match` arm's body,
 // or the consequent or `else` of an `if val`. Its bindings are scoped to Body and do

--- a/internal/solver/ucs/leaf_test.go
+++ b/internal/solver/ucs/leaf_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLeavesEndACoreTerm checks that all three leaf types terminate a core branch,
-// which is what lets a split's continuation be a leaf as readily as another split.
-func TestLeavesEndACoreTerm(t *testing.T) {
+// TestLeavesBelongToBothForms checks that the three leaf types terminate a core term
+// and a normalized term alike, which is why there is one set of leaves rather than a
+// parallel pair.
+func TestLeavesBelongToBothForms(t *testing.T) {
 	leaves := []any{
 		&BodyLeaf{Body: exprBody(num(1))},
 		&EscapeLeaf{},
@@ -18,6 +19,7 @@ func TestLeavesEndACoreTerm(t *testing.T) {
 
 	for _, leaf := range leaves {
 		require.Implements(t, (*Core)(nil), leaf)
+		require.Implements(t, (*Norm)(nil), leaf)
 	}
 }
 

--- a/internal/solver/ucs/norm.go
+++ b/internal/solver/ucs/norm.go
@@ -1,0 +1,79 @@
+package ucs
+
+import "github.com/escalier-lang/escalier/internal/ast"
+
+// Norm is a term of the normalized form, the backtracking-free rewrite of the core.
+// Every split tests one tag-level of one scrutinee and hands its sub-scrutinees to
+// inner splits, so a consumer reasons about one tag-level at a time instead of
+// walking a deep shape. A failed test falls to the enclosing split's default tail and
+// never retries an earlier branch.
+type Norm interface {
+	Term
+	isNorm()
+}
+
+func (*NormSplit) isNorm() {}
+func (*NormGuard) isNorm() {}
+func (*NormBind) isNorm()  {}
+
+// NormSplit tests one tag-level of one scrutinee. Branches that tested the same
+// scrutinee against different tags in the core are merged into one split here, so
+// each scrutinee is visited once.
+type NormSplit struct {
+	Scrutinee *Scrutinee
+	Branches  []*NormBranch
+	// Default is where control goes when no branch's test matches. A nil Default
+	// means no branch covers the remaining values, which the printer renders `✗`. A
+	// catch-all arm and an `else` both land here.
+	Default Norm
+	Origin
+}
+
+// NormBranch is one branch of a normalized split: a single tag test and what runs
+// when it matches.
+type NormBranch struct {
+	Test Test
+	// Cont is what runs once Test matches. Bindings the branch introduces are
+	// NormBind nodes at the head of Cont, and a guarded arm puts a NormGuard after
+	// them so the guard reads those bindings.
+	Cont Norm
+	// Arm is the surface arm this branch came from. It survives merging and
+	// flattening, so a diagnostic blames the arm the user typed. Origin.Node can
+	// point at a synthesized node after those rewrites; Arm never does.
+	Arm Spanned
+	Origin
+}
+
+// NormGuard tests a boolean condition over the bindings its branch introduced.
+// Unlike CoreGuard it names where a failed test continues, which is what removes the
+// backtracking. Control moves to Default rather than retrying the branches above it.
+//
+// Default is the continuation the branch would have fallen through to in source
+// order. For a two-arm match it is the enclosing split's tail, which is why a
+// guarded branch covers nothing for exhaustiveness. Its continuation can always
+// reach a later arm.
+type NormGuard struct {
+	Cond    ast.Expr
+	Cont    Norm
+	Default Norm
+	Origin
+}
+
+// NormBind names a value projected out of a scrutinee, which is how a normalized
+// branch introduces the leaves its pattern bound. In `Point { x, y }` the branch
+// tests the `Point` tag and then binds `x` and `y` from the projections `p.x` and
+// `p.y`.
+type NormBind struct {
+	// Name is the bound identifier.
+	Name string
+	// Pat is the pattern leaf the name came from, which the solver binds through so
+	// the leaf keeps its annotation and its borrow mode. It is nil for a name the
+	// desugarer invented, which has no pattern leaf behind it.
+	Pat ast.Pat
+	// Source is the projection the name binds to. Sibling binds under one branch
+	// share their parent *Scrutinee, so the parent is evaluated once.
+	Source *Scrutinee
+	// Cont is what runs with Name in scope.
+	Cont Norm
+	Origin
+}

--- a/internal/solver/ucs/norm_test.go
+++ b/internal/solver/ucs/norm_test.go
@@ -1,0 +1,77 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormNodesCarryProvenance(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(2, 5, 18)))
+	scrutinee := NewRoot(ident("p"), origin)
+
+	terms := map[string]Term{
+		"NormSplit":  &NormSplit{Scrutinee: scrutinee, Origin: origin},
+		"NormBranch": &NormBranch{Test: &LitTest{Lit: ast.NewNumber(1, ast.Span{})}, Origin: origin},
+		"NormGuard":  &NormGuard{Cond: ident("g"), Origin: origin},
+		"NormBind":   &NormBind{Name: "x", Source: scrutinee, Origin: origin},
+	}
+
+	for name, term := range terms {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, origin, term.Prov())
+		})
+	}
+}
+
+// TestNormBranchTestsOneTagLevel is the property that separates the normalized form
+// from the core. Where a core branch holds `Line { start: {x, y} }` whole, a
+// normalized branch tests the `Line` tag alone and hands the nested shape to an inner
+// split over a projected sub-scrutinee.
+func TestNormBranchTestsOneTagLevel(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(1, 1, 8)))
+	line := NewRoot(ident("l"), origin)
+	start := line.Project(FieldStep{Name: "start"}, origin)
+
+	inner := &NormSplit{
+		Scrutinee: start,
+		Branches: []*NormBranch{{
+			Test:   &ObjectTest{Keys: keys("x", "y")},
+			Cont:   &BodyLeaf{Body: exprBody(num(1))},
+			Origin: origin,
+		}},
+		Origin: origin,
+	}
+	outer := &NormSplit{
+		Scrutinee: line,
+		Branches: []*NormBranch{{
+			Test:   &ClassTest{Name: ast.NewIdentifier("Line", ast.Span{})},
+			Cont:   inner,
+			Origin: origin,
+		}},
+		Origin: origin,
+	}
+
+	require.Equal(t, "Line", testString(outer.Branches[0].Test))
+	require.Equal(t, "{x, y}", testString(inner.Branches[0].Test))
+	require.Equal(t, "l.start", inner.Scrutinee.String())
+	// Sharing the parent pointer is what keeps `l` evaluated once.
+	require.Same(t, outer.Scrutinee, inner.Scrutinee.Parent)
+}
+
+// TestNormGuardNamesItsFailureContinuation is what removes the backtracking. A
+// CoreGuard has no Default and relies on the enclosing split's branch order; a
+// NormGuard states where a failed test goes.
+func TestNormGuardNamesItsFailureContinuation(t *testing.T) {
+	origin := At(OriginGuard, arm(span(1, 1, 8)))
+	fallthru := &BodyLeaf{Body: exprBody(num(2)), Origin: origin}
+	guard := &NormGuard{
+		Cond:    ident("g"),
+		Cont:    &BodyLeaf{Body: exprBody(num(1)), Origin: origin},
+		Default: fallthru,
+		Origin:  origin,
+	}
+
+	require.Same(t, fallthru, guard.Default)
+}

--- a/internal/solver/ucs/tags_test.go
+++ b/internal/solver/ucs/tags_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExactnessString(t *testing.T) {
-	require.Equal(t, "exact", Exact.String())
-	require.Equal(t, "inexact prefix", InexactPrefix.String())
-	require.Equal(t, "unknown exactness", Exactness(99).String())
+func TestRestKindString(t *testing.T) {
+	require.Equal(t, "no rest", NoRest.String())
+	require.Equal(t, "trailing rest", TrailingRest.String())
+	require.Equal(t, "unknown rest kind", RestKind(99).String())
 }
 
 func TestTagTests(t *testing.T) {
@@ -30,16 +30,16 @@ func TestTagTests(t *testing.T) {
 		},
 		{
 			// `{x, ...rest}` tests an object with at least an `x` field.
-			"inexact object shape",
-			&ObjectTest{Keys: keys("x"), Exactness: InexactPrefix},
+			"object with a trailing rest",
+			&ObjectTest{Keys: keys("x"), Rest: TrailingRest},
 			"{x, ...}",
 		},
 		{"empty tuple", &TupleTest{}, "[]"},
 		{"tuple shape", &TupleTest{Len: 2}, "[_, _]"},
 		{
 			// `[first, ...rest]` tests a tuple at least one element long.
-			"inexact tuple shape",
-			&TupleTest{Len: 1, Exactness: InexactPrefix},
+			"tuple with a trailing rest",
+			&TupleTest{Len: 1, Rest: TrailingRest},
 			"[_, ...]",
 		},
 		{"number literal", &LitTest{Lit: ast.NewNumber(1, ast.Span{})}, "1"},

--- a/internal/solver/ucs/tags_test.go
+++ b/internal/solver/ucs/tags_test.go
@@ -1,0 +1,66 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExactnessString(t *testing.T) {
+	require.Equal(t, "exact", Exact.String())
+	require.Equal(t, "inexact prefix", InexactPrefix.String())
+	require.Equal(t, "unknown exactness", Exactness(99).String())
+}
+
+func TestTagTests(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Test
+		want string
+	}{
+		{"empty object", &ObjectTest{}, "{}"},
+		{"object shape", &ObjectTest{Keys: keys("x", "y")}, "{x, y}"},
+		{
+			// A destructuring default makes the field optional, so `{x = 0}` matches a
+			// value with no `x` at all and must not test for one.
+			"optional key from a default",
+			&ObjectTest{Keys: []ObjectKey{{Name: "x", Optional: true}, {Name: "y"}}},
+			"{x?, y}",
+		},
+		{
+			// `{x, ...rest}` tests an object with at least an `x` field.
+			"inexact object shape",
+			&ObjectTest{Keys: keys("x"), Exactness: InexactPrefix},
+			"{x, ...}",
+		},
+		{"empty tuple", &TupleTest{}, "[]"},
+		{"tuple shape", &TupleTest{Len: 2}, "[_, _]"},
+		{
+			// `[first, ...rest]` tests a tuple at least one element long.
+			"inexact tuple shape",
+			&TupleTest{Len: 1, Exactness: InexactPrefix},
+			"[_, ...]",
+		},
+		{"number literal", &LitTest{Lit: ast.NewNumber(1, ast.Span{})}, "1"},
+		{"string literal", &LitTest{Lit: ast.NewString("one", ast.Span{})}, `"one"`},
+		{"class tag", &ClassTest{Name: ast.NewIdentifier("Point", ast.Span{})}, "Point"},
+		{
+			"extractor tag",
+			&ExtractorTest{Name: ast.NewIdentifier("Ok", ast.Span{}), Arity: 1},
+			"Ok(_)",
+		},
+		{
+			"nullary extractor tag",
+			&ExtractorTest{Name: ast.NewIdentifier("None", ast.Span{})},
+			"None()",
+		},
+		{"nil test", nil, "<nil>"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, testString(test.in))
+		})
+	}
+}

--- a/internal/solver/ucs/test.go
+++ b/internal/solver/ucs/test.go
@@ -6,40 +6,45 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 )
 
-// Exactness records whether a rest pattern relaxed a structural test. `[first]` and
-// `{x}` name a fixed shape, while `[first, ...rest]` and `{x, ...rest}` name only a
-// prefix of one.
+// RestKind records whether the source pattern wrote a rest element. `[first]` and
+// `{x}` did not; `[first, ...rest]` and `{x, ...rest}` did.
 //
 // It is a marker on the structural tests rather than a test of its own, because a
 // rest pattern contributes no tag. All it does is relax the shape the enclosing
 // object or tuple pattern already names. The value a rest pattern binds is named
 // elsewhere, by a SuffixStep or a RemainderStep on the projection path.
 //
-// Exactness describes the pattern, not the constraint the solver derives from it.
-// Leaf binding runs through bindPattern, whose object requirement is inexact for
-// every object pattern. Its propReq helper builds `{name: t, ...}`, "the receiver has
-// at least this field", so a plain `{x, y}` arm already matches a value carrying
-// extra fields. A consumer that wants an Exact test to reject those extra fields
-// decides that for itself.
-type Exactness int
+// The marker is a fact about the pattern's syntax, not a claim about what the test
+// accepts, and the two do not line up. Leaf binding runs through bindPattern, whose
+// object requirement is inexact for every object pattern: its propReq helper builds
+// `{name: t, ...}`, "the receiver has at least this field". So a plain `{x, y}` arm
+// already matches a value carrying extra fields, and NoRest does not mean the derived
+// constraint rejects them. A consumer that wants extra fields rejected decides that
+// for itself.
+//
+// Naming the syntax also keeps this apart from soltype's exactness, which is a real
+// property of a type. There, ObjectType.Inexact and the `Exact<T>` and `Inexact<T>`
+// intrinsics do govern what a value satisfies.
+type RestKind int
 
 const (
-	// Exact is the shape a pattern with no rest element names.
-	Exact Exactness = iota
-	// InexactPrefix is the relaxed shape a rest element leaves: at least the fixed
-	// prefix the pattern names, with anything past it unconstrained.
-	InexactPrefix
+	// NoRest marks a pattern that named every element or field it matches.
+	NoRest RestKind = iota
+	// TrailingRest marks a pattern whose last element is a rest, so the fixed part
+	// the pattern names is a prefix and anything past it is unconstrained. Only a
+	// trailing rest is expressible; see SuffixStep for why an interior one is not.
+	TrailingRest
 )
 
-// String renders the exactness as the phrase used in a diagnostic.
-func (e Exactness) String() string {
-	switch e {
-	case Exact:
-		return "exact"
-	case InexactPrefix:
-		return "inexact prefix"
+// String renders the marker as the phrase used in a diagnostic.
+func (r RestKind) String() string {
+	switch r {
+	case NoRest:
+		return "no rest"
+	case TrailingRest:
+		return "trailing rest"
 	default:
-		return "unknown exactness"
+		return "unknown rest kind"
 	}
 }
 
@@ -72,18 +77,18 @@ type ObjectKey struct {
 // named at this level, in source order. A field's own sub-pattern is not part of the
 // test. It becomes a split over the projected field.
 type ObjectTest struct {
-	Keys      []ObjectKey
-	Exactness Exactness
+	Keys []ObjectKey
+	Rest RestKind
 }
 
 // TupleTest matches a structural tuple shape of Len elements. An element's
 // sub-pattern is not part of the test. It becomes a split over the projected
-// element. Under InexactPrefix, Len counts only the fixed prefix a tuple rest pattern
+// element. Under TrailingRest, Len counts only the fixed prefix a tuple rest pattern
 // leaves, so `[first, ...rest]` has Len 1. See SuffixStep for why only a trailing
 // rest is expressible.
 type TupleTest struct {
-	Len       int
-	Exactness Exactness
+	Len  int
+	Rest RestKind
 }
 
 // LitTest matches a literal value, the `1` of `match n { 1 => … }`.
@@ -126,7 +131,7 @@ func testString(t Test) string {
 				parts = append(parts, key.Name)
 			}
 		}
-		if t.Exactness == InexactPrefix {
+		if t.Rest == TrailingRest {
 			parts = append(parts, "...")
 		}
 		return "{" + strings.Join(parts, ", ") + "}"
@@ -135,7 +140,7 @@ func testString(t Test) string {
 		for range t.Len {
 			parts = append(parts, "_")
 		}
-		if t.Exactness == InexactPrefix {
+		if t.Rest == TrailingRest {
 			parts = append(parts, "...")
 		}
 		return "[" + strings.Join(parts, ", ") + "]"

--- a/internal/solver/ucs/test.go
+++ b/internal/solver/ucs/test.go
@@ -1,0 +1,155 @@
+package ucs
+
+import (
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+// Exactness records whether a rest pattern relaxed a structural test. `[first]` and
+// `{x}` name a fixed shape, while `[first, ...rest]` and `{x, ...rest}` name only a
+// prefix of one.
+//
+// It is a marker on the structural tests rather than a test of its own, because a
+// rest pattern contributes no tag. All it does is relax the shape the enclosing
+// object or tuple pattern already names. The value a rest pattern binds is named
+// elsewhere, by a SuffixStep or a RemainderStep on the projection path.
+//
+// Exactness describes the pattern, not the constraint the solver derives from it.
+// Leaf binding runs through bindPattern, whose object requirement is inexact for
+// every object pattern. Its propReq helper builds `{name: t, ...}`, "the receiver has
+// at least this field", so a plain `{x, y}` arm already matches a value carrying
+// extra fields. A consumer that wants an Exact test to reject those extra fields
+// decides that for itself.
+type Exactness int
+
+const (
+	// Exact is the shape a pattern with no rest element names.
+	Exact Exactness = iota
+	// InexactPrefix is the relaxed shape a rest element leaves: at least the fixed
+	// prefix the pattern names, with anything past it unconstrained.
+	InexactPrefix
+)
+
+// String renders the exactness as the phrase used in a diagnostic.
+func (e Exactness) String() string {
+	switch e {
+	case Exact:
+		return "exact"
+	case InexactPrefix:
+		return "inexact prefix"
+	default:
+		return "unknown exactness"
+	}
+}
+
+// Test is the tag one branch of a normalized split tests its scrutinee against. A
+// test covers exactly one tag-level and never a nested shape. A sub-pattern becomes
+// a projected sub-scrutinee with a split of its own, which is what makes the
+// normalized form backtracking-free.
+//
+// A split is agnostic to which kind its test is, so structural shapes, literals,
+// nominal class tags, and extractor tags all flow through one mechanism.
+type Test interface{ isTest() }
+
+func (*ObjectTest) isTest()    {}
+func (*TupleTest) isTest()     {}
+func (*LitTest) isTest()       {}
+func (*ClassTest) isTest()     {}
+func (*ExtractorTest) isTest() {}
+
+// ObjectKey is one field an object test names.
+type ObjectKey struct {
+	Name string
+	// Optional marks a field the pattern matches without, which a destructuring
+	// default produces. `{x = 0}` binds `x` to 0 when the field is absent, so a test
+	// that demanded `x` would send the value to the wrong branch. bindPattern already
+	// passes `e.Default != nil` through to propReq for exactly this reason.
+	Optional bool
+}
+
+// ObjectTest matches a structural object shape. Keys are the fields the pattern
+// named at this level, in source order. A field's own sub-pattern is not part of the
+// test. It becomes a split over the projected field.
+type ObjectTest struct {
+	Keys      []ObjectKey
+	Exactness Exactness
+}
+
+// TupleTest matches a structural tuple shape of Len elements. An element's
+// sub-pattern is not part of the test. It becomes a split over the projected
+// element. Under InexactPrefix, Len counts only the fixed prefix a tuple rest pattern
+// leaves, so `[first, ...rest]` has Len 1. See SuffixStep for why only a trailing
+// rest is expressible.
+type TupleTest struct {
+	Len       int
+	Exactness Exactness
+}
+
+// LitTest matches a literal value, the `1` of `match n { 1 => … }`.
+type LitTest struct{ Lit ast.Lit }
+
+// ClassTest matches a nominal class tag, the `Point` of an instance pattern
+// `Point { x, y }`. The pattern's fields are not part of the test; each becomes a
+// projected sub-scrutinee, the same flattening a structural object gets.
+type ClassTest struct{ Name ast.QualIdent }
+
+// ExtractorTest matches an extractor tag, the `Ok` of `Ok(v)`. Arity is how many
+// positional values the pattern takes from the extractor, each reached by an
+// ExtractStep.
+type ExtractorTest struct {
+	Name  ast.QualIdent
+	Arity int
+}
+
+// String renders the tag test.
+func (t *ObjectTest) String() string    { return testString(t) }
+func (t *TupleTest) String() string     { return testString(t) }
+func (t *LitTest) String() string       { return testString(t) }
+func (t *ClassTest) String() string     { return testString(t) }
+func (t *ExtractorTest) String() string { return testString(t) }
+
+// testString renders a branch's tag test. A structural test relaxed by a rest
+// pattern renders a trailing `...`, matching how an inexact type prints.
+func testString(t Test) string {
+	switch t := t.(type) {
+	case nil:
+		return "<nil>"
+	case *ObjectTest:
+		parts := make([]string, 0, len(t.Keys)+1)
+		for _, key := range t.Keys {
+			// A trailing `?` marks a key the test tolerates being absent, matching how
+			// an optional property prints in a type.
+			if key.Optional {
+				parts = append(parts, key.Name+"?")
+			} else {
+				parts = append(parts, key.Name)
+			}
+		}
+		if t.Exactness == InexactPrefix {
+			parts = append(parts, "...")
+		}
+		return "{" + strings.Join(parts, ", ") + "}"
+	case *TupleTest:
+		parts := make([]string, 0, t.Len+1)
+		for range t.Len {
+			parts = append(parts, "_")
+		}
+		if t.Exactness == InexactPrefix {
+			parts = append(parts, "...")
+		}
+		return "[" + strings.Join(parts, ", ") + "]"
+	case *LitTest:
+		return litString(t.Lit)
+	case *ClassTest:
+		return ast.QualIdentToString(t.Name)
+	case *ExtractorTest:
+		args := make([]string, t.Arity)
+		for i := range args {
+			args[i] = "_"
+		}
+		return ast.QualIdentToString(t.Name) + "(" + strings.Join(args, ", ") + ")"
+	default:
+		return nodeKind(t)
+	}
+}

--- a/planning/ucs/implementation_plan.md
+++ b/planning/ucs/implementation_plan.md
@@ -486,11 +486,11 @@ into nothing.
   `else` path is a divergence or a fallback value, kept distinct from a covering
   arm so PR7 and PR8 do not treat it as one.
 - Enumerate the branch-test kinds as a sum: a structural object or tuple shape, a
-  literal, a nominal class tag for an instance pattern, an extractor tag, and an
-  inexact-prefix marker a rest pattern sets. A projection path segment must be able
-  to name a field, a tuple index, a positional value an extractor yields, a tuple
-  suffix for a tuple rest, and an object remainder excluding a key set for an object
-  rest.
+  literal, a nominal class tag for an instance pattern, an extractor tag, and a
+  marker recording whether the pattern wrote a rest element. A projection path
+  segment must be able to name a field, a tuple index, a positional value an
+  extractor yields, a tuple suffix for a tuple rest, and an object remainder
+  excluding a key set for an object rest.
   M9 has shipped the types the last two resolve to — tuple spread and an
   `Omit`-style mapped type — and PR0 wires their `bindPattern` cases, so the IR
   names both projections and PR5 onward bind them for real.


### PR DESCRIPTION
Refs #1020.

Fourth of five stacked PRs adding `internal/solver/ucs`. Still pure IR wired into nothing.

**Stacked on #1032.** Review that one first; this PR's diff is against it.

## What's here

**`Test`** is the sum of tag tests a normalized branch can perform: structural object and tuple shapes, a literal, a nominal class tag, and an extractor tag.

**`Norm`** is the backtracking-free rewrite of the core. Every `NormSplit` tests exactly one tag-level of one scrutinee, where a tag-level is the outermost tag a pattern names and nothing under it. A core branch holding `Line { start: {x, y} }` becomes a branch testing the `Line` tag alone, handing the nested shape to an inner split over the projected sub-scrutinee `l.start`. Sibling projections share their parent pointer, so `l` is still evaluated once.

`NormGuard` is what removes the backtracking. A `CoreGuard` has no failure continuation and relies on the enclosing split's branch order. A `NormGuard` names `Default`, the continuation the branch would have fallen through to in source order. That is also why a guarded branch covers nothing for exhaustiveness — its continuation can always reach a later arm. A `NormSplit` with a nil `Default` is one no branch fully covers.

## Two things worth a close read

**`RestKind` records syntax, not semantics.** It says whether the source pattern wrote a rest element — `NoRest` for `{x, y}`, `TrailingRest` for `{x, ...rest}` — and deliberately makes no claim about what the test accepts. Those two do not line up. `bindPattern`'s `propReq` helper builds `{name: t, ...}`, "the receiver has at least this field", for every object pattern, so a plain `{x, y}` arm already matches a value carrying extra fields. `NoRest` does not mean the derived constraint rejects them; a consumer that wants them rejected decides that for itself.

This field was called `Exactness`, with `Exact` and `InexactPrefix`, until a review of this stack. The problem was not vagueness but collision: `soltype` already has exactness, and there it is a real property of a type — `ObjectType.Inexact`, `TupleType.Inexact`, `UnionType.Inexact`, and the `Exact<T>` and `Inexact<T>` intrinsics specified in `planning/exact-types/`. Those genuinely govern what a value satisfies. Reading `ucs.Exact` as "the derived constraint is closed" was a reasonable inference and a wrong one. Naming a fact about source text instead cannot drift from what the solver derives, which is the way the old name failed. `soltype`'s exactness is untouched by this PR.

`TrailingRest` also carries the limitation `SuffixStep` documents: only a trailing rest is expressible. The parser accepts `[first, ...mid, last]`, which no `SuffixStep` names and which `bindPattern` also mishandles, so a lowering pass must reject that form rather than silently drop the elements after the rest. The constant leaves room for an interior rest if that is ever supported.

**`ObjectKey` carries an `Optional` flag** rather than being a bare name. A destructuring default makes a field optional — `bindPattern` passes `e.Default != nil` to `propReq` — so a test that demanded `x` would send `{x = 0}` to the wrong branch. It renders `{x?, y}`.

## Reviewer notes

The three leaves gain `Norm` alongside the `Core` they got in #1032. That is the only change to an existing source file beyond the package doc.

## Testing

`go test ./...` is green. 175 tests in the package, 22 new: norm-node provenance, one-tag-level splitting with a shared parent scrutinee, a guard naming its failure continuation, `RestKind` rendering, and every tag test's rendering including the optional-key and trailing-rest cases.

Part of the Ultimate Conditional Syntax IR plan, #884. Refs #882.