### PR TITLE
UCS IR (5/5) — the IR printer and the worked-example snapshots

### DIFF
--- a/internal/solver/ucs/helpers_test.go
+++ b/internal/solver/ucs/helpers_test.go
@@ -86,3 +86,8 @@ func keys(names ...string) []ObjectKey {
 	}
 	return out
 }
+
+// matchCase builds a surface arm for a branch to point back at.
+func matchCase(pattern ast.Pat, guard ast.Expr, body ast.Expr, s ast.Span) *ast.MatchCase {
+	return ast.NewMatchCase(pattern, guard, exprBody(body), s)
+}

--- a/internal/solver/ucs/print.go
+++ b/internal/solver/ucs/print.go
@@ -1,0 +1,237 @@
+package ucs
+
+import "strings"
+
+// PrintOptions configures how Print renders a term.
+type PrintOptions struct {
+	// Indent is the string one nesting level adds. Print substitutes two spaces when
+	// it is empty.
+	Indent string
+	// ShowOrigins appends each node's Origin tag, written `[match arm]` or
+	// `[synthetic if val]`. It is off by default so a shape snapshot stays readable.
+	// A test that asserts provenance turns it on.
+	ShowOrigins bool
+	// ShowArms appends the surface arm each branch and leaf points back at, written
+	// `arm=1:5-1:14` from the arm's span, or `arm=none` when the node carries no
+	// back-reference. A test that asserts a merged or flattened split still blames
+	// the arm the user typed turns it on.
+	ShowArms bool
+}
+
+// DefaultPrintOptions renders shape alone, with two-space indentation.
+func DefaultPrintOptions() PrintOptions {
+	return PrintOptions{Indent: "  "}
+}
+
+// Print renders a core or normalized term. The output is for snapshot tests and
+// debugging. Nothing parses it back, so its shape is free to change with the IR.
+func Print(t Term, opts PrintOptions) string {
+	if opts.Indent == "" {
+		opts.Indent = "  "
+	}
+	p := &printer{opts: opts}
+	p.term(t)
+	return p.sb.String()
+}
+
+func (n *CoreSplit) String() string    { return Print(n, DefaultPrintOptions()) }
+func (n *CoreBranch) String() string   { return Print(n, DefaultPrintOptions()) }
+func (n *CoreGuard) String() string    { return Print(n, DefaultPrintOptions()) }
+func (n *CoreBind) String() string     { return Print(n, DefaultPrintOptions()) }
+func (n *NormSplit) String() string    { return Print(n, DefaultPrintOptions()) }
+func (n *NormBranch) String() string   { return Print(n, DefaultPrintOptions()) }
+func (n *NormGuard) String() string    { return Print(n, DefaultPrintOptions()) }
+func (n *NormBind) String() string     { return Print(n, DefaultPrintOptions()) }
+func (n *BodyLeaf) String() string     { return Print(n, DefaultPrintOptions()) }
+func (n *EscapeLeaf) String() string   { return Print(n, DefaultPrintOptions()) }
+func (n *FallbackLeaf) String() string { return Print(n, DefaultPrintOptions()) }
+
+// String renders the scrutinee's projection path, for example `l.start.x`.
+// printer accumulates the rendered term. indent counts nesting levels, not
+// characters; newline expands it through opts.Indent.
+type printer struct {
+	sb     strings.Builder
+	opts   PrintOptions
+	indent int
+}
+
+func (p *printer) write(s string) { p.sb.WriteString(s) }
+
+func (p *printer) newline() {
+	p.sb.WriteString("\n")
+	p.sb.WriteString(strings.Repeat(p.opts.Indent, p.indent))
+}
+
+// term dispatches on which IR the node belongs to. The leaf types belong to both, so
+// the Core arm claims them. Both arms render a leaf the same way, so which arm wins
+// does not change the output.
+func (p *printer) term(t Term) {
+	switch n := t.(type) {
+	case Core:
+		p.core(n)
+	case Norm:
+		p.norm(n)
+	case *CoreBranch:
+		p.coreBranch(n)
+	case *NormBranch:
+		p.normBranch(n)
+	case *Scrutinee:
+		p.write(scrutineeString(n))
+	default:
+		p.write(nodeKind(t))
+	}
+}
+
+// branches writes the braced, indented body of a split or a normalized guard. write
+// renders the entry at index i. A body with no entries collapses to `{}` so an
+// unreachable split does not spend two lines saying nothing.
+func (p *printer) branches(count int, write func(i int)) {
+	if count == 0 {
+		p.write(" {}")
+		return
+	}
+	p.write(" {")
+	p.indent++
+	for i := range count {
+		p.newline()
+		write(i)
+	}
+	p.indent--
+	p.newline()
+	p.write("}")
+}
+
+func (p *printer) core(n Core) {
+	switch n := n.(type) {
+	case *CoreSplit:
+		p.write("split " + scrutineeString(n.Scrutinee) + p.originTag(n.Origin))
+		p.branches(len(n.Branches), func(i int) { p.coreBranch(n.Branches[i]) })
+		if n.Else != nil {
+			p.write(" else ")
+			p.core(n.Else)
+		}
+	case *CoreGuard:
+		p.write("guard (" + exprString(n.Cond) + ")" + p.originTag(n.Origin) + " => ")
+		p.core(n.Cont)
+	case *CoreBind:
+		// coreBinds writes the whole bind clause, so it must run before the
+		// continuation it returns is written.
+		cont := p.coreBinds(n)
+		p.core(cont)
+	default:
+		p.leaf(n)
+	}
+}
+
+func (p *printer) coreBranch(b *CoreBranch) {
+	p.write("pat " + patString(b.Pattern) + p.originTag(b.Origin) + p.armTag(b.Arm) + " => ")
+	p.core(b.Cont)
+}
+
+// coreBinds renders a run of consecutive binds as one `bind a = …, b = …;` clause
+// and returns what follows the run, so a branch that introduces several leaves
+// stays on one line.
+func (p *printer) coreBinds(n *CoreBind) Core {
+	p.write("bind ")
+	for i := 0; ; i++ {
+		if i > 0 {
+			p.write(", ")
+		}
+		p.write(n.Name + " = " + scrutineeString(n.Source) + p.originTag(n.Origin))
+		next, ok := n.Cont.(*CoreBind)
+		if !ok {
+			break
+		}
+		n = next
+	}
+	p.write("; ")
+	return n.Cont
+}
+
+func (p *printer) norm(n Norm) {
+	switch n := n.(type) {
+	case *NormSplit:
+		p.write("split " + scrutineeString(n.Scrutinee) + p.originTag(n.Origin))
+		p.branches(len(n.Branches), func(i int) { p.normBranch(n.Branches[i]) })
+		p.write(" default ")
+		p.norm(n.Default)
+	case *NormGuard:
+		p.write("guard (" + exprString(n.Cond) + ")" + p.originTag(n.Origin))
+		p.branches(1, func(int) { p.norm(n.Cont) })
+		p.write(" default ")
+		p.norm(n.Default)
+	case *NormBind:
+		// normBinds writes the whole bind clause, so it must run before the
+		// continuation it returns is written.
+		cont := p.normBinds(n)
+		p.norm(cont)
+	default:
+		p.leaf(n)
+	}
+}
+
+func (p *printer) normBranch(b *NormBranch) {
+	p.write(testString(b.Test) + p.originTag(b.Origin) + p.armTag(b.Arm) + " => ")
+	p.norm(b.Cont)
+}
+
+// normBinds renders a run of consecutive binds as one clause, the same way
+// coreBinds does, and returns what follows the run.
+func (p *printer) normBinds(n *NormBind) Norm {
+	p.write("bind ")
+	for i := 0; ; i++ {
+		if i > 0 {
+			p.write(", ")
+		}
+		p.write(n.Name + " = " + scrutineeString(n.Source) + p.originTag(n.Origin))
+		next, ok := n.Cont.(*NormBind)
+		if !ok {
+			break
+		}
+		n = next
+	}
+	p.write("; ")
+	return n.Cont
+}
+
+// leaf renders a terminal of either IR. A nil term is a split tail with no covering
+// continuation, written `✗`.
+func (p *printer) leaf(t Term) {
+	switch n := t.(type) {
+	case nil:
+		p.write("✗")
+	case *BodyLeaf:
+		p.write("leaf " + bodyString(n.Body) + p.originTag(n.Origin) + p.armTag(n.Arm))
+	case *EscapeLeaf:
+		p.write("escape" + p.originTag(n.Origin) + p.armTag(n.Arm))
+	case *FallbackLeaf:
+		p.write("fallback " + bodyString(n.Body) + p.originTag(n.Origin) + p.armTag(n.Arm))
+	default:
+		p.write(nodeKind(t))
+	}
+}
+
+// originTag renders a node's provenance, or nothing when the caller did not ask for
+// it.
+func (p *printer) originTag(o Origin) string {
+	if !p.opts.ShowOrigins {
+		return ""
+	}
+	if o.Synthetic {
+		return " [synthetic " + o.Kind.String() + "]"
+	}
+	return " [" + o.Kind.String() + "]"
+}
+
+// armTag renders a branch's or leaf's surface-arm back-reference as the arm's span,
+// or nothing when the caller did not ask for it.
+func (p *printer) armTag(arm Spanned) string {
+	if !p.opts.ShowArms {
+		return ""
+	}
+	s, ok := SpanOf(arm)
+	if !ok {
+		return " arm=none"
+	}
+	return " arm=" + s.String()
+}

--- a/internal/solver/ucs/print.go
+++ b/internal/solver/ucs/print.go
@@ -46,9 +46,8 @@ func (n *BodyLeaf) String() string     { return Print(n, DefaultPrintOptions()) 
 func (n *EscapeLeaf) String() string   { return Print(n, DefaultPrintOptions()) }
 func (n *FallbackLeaf) String() string { return Print(n, DefaultPrintOptions()) }
 
-// String renders the scrutinee's projection path, for example `l.start.x`.
 // printer accumulates the rendered term. indent counts nesting levels, not
-// characters; newline expands it through opts.Indent.
+// characters. newline expands indent through opts.Indent.
 type printer struct {
 	sb     strings.Builder
 	opts   PrintOptions

--- a/internal/solver/ucs/print_test.go
+++ b/internal/solver/ucs/print_test.go
@@ -12,9 +12,9 @@ import (
 
 // The tests below hand-build IR for the worked examples in
 // planning/ucs/implementation_plan.md, then lock the printer's rendering with an
-// inline snapshot. Nothing here calls a desugarer or a normalizer, because neither
-// exists yet. These snapshots are the shapes their output is checked against once
-// they do.
+// inline snapshot. They construct each term directly rather than running a desugarer
+// or a normalizer over source, so a snapshot pins the printer's output for a shape
+// the test states outright.
 
 // In a literal match the catch-all arm is still an ordinary branch of the core.
 // Only normalization moves it into the default tail.
@@ -518,6 +518,9 @@ func TestPrintDefaultsIndentWhenEmpty(t *testing.T) {
 		Origin: origin,
 	}
 
+	// String() renders through DefaultPrintOptions, so it is the reference the
+	// substitution has to reproduce. It is the expected value; the empty-Indent
+	// call is what this test exercises.
 	require.Equal(t, norm.String(), Print(norm, PrintOptions{}))
 }
 

--- a/internal/solver/ucs/print_test.go
+++ b/internal/solver/ucs/print_test.go
@@ -1,6 +1,7 @@
 package ucs
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/ast"
@@ -539,4 +540,111 @@ func TestPrintUnrenderedExpressionFallsBackToItsKind(t *testing.T) {
 	leaf := &BodyLeaf{Body: armCase.Body, Arm: armCase, Origin: At(OriginMatchArm, armCase)}
 
 	require.Equal(t, "leaf <DoExpr>", leaf.String())
+}
+
+// A core branch can bind the leaves its pattern introduced, the same way a
+// normalized branch does. A run of consecutive binds folds onto one `bind` clause so
+// a branch that names several fields stays on one line, and the guard after the run
+// reads what the run bound.
+func TestPrintCoreBindRun(t *testing.T) {
+	guardCond := ast.NewBinary(ident("x"), ident("y"), ast.GreaterThan, ast.Span{})
+	armCase := matchCase(objPat("x", "y"), guardCond, ident("x"), span(2, 5, 30))
+	target := ident("p")
+	origin := At(OriginMatchArm, armCase)
+	root := NewRoot(target, origin)
+
+	core := &CoreSplit{
+		Scrutinee: root,
+		Branches: []*CoreBranch{{
+			Pattern: armCase.Pattern,
+			Cont: &CoreBind{
+				Name:   "x",
+				Source: root.Project(FieldStep{Name: "x"}, origin),
+				Cont: &CoreBind{
+					Name:   "y",
+					Source: root.Project(FieldStep{Name: "y"}, origin),
+					Cont: &CoreGuard{
+						Cond:   guardCond,
+						Cont:   &BodyLeaf{Body: armCase.Body, Arm: armCase, Origin: origin},
+						Origin: At(OriginGuard, guardCond),
+					},
+					Origin: origin,
+				},
+				Origin: origin,
+			},
+			Arm:    armCase,
+			Origin: origin,
+		}},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, core.String(), snaps.Inline(`split p {
+  pat {x, y} => bind x = p.x, y = p.y; guard (x > y) => leaf x
+}`))
+}
+
+// Every node renders through String(), so a failing require.Equal on any of them
+// prints the term rather than a struct address.
+func TestStringOnEveryNode(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(1, 1, 8)))
+	root := NewRoot(ident("p"), origin)
+	leaf := &BodyLeaf{Body: exprBody(num(1)), Arm: nil, Origin: origin}
+
+	tests := []struct {
+		name string
+		in   fmt.Stringer
+		want string
+	}{
+		{"CoreSplit", &CoreSplit{Scrutinee: root, Origin: origin}, "split p {}"},
+		{
+			"CoreBranch",
+			&CoreBranch{Pattern: wildcardPat(), Cont: leaf, Origin: origin},
+			"pat _ => leaf 1",
+		},
+		{
+			"CoreGuard",
+			&CoreGuard{Cond: ident("g"), Cont: leaf, Origin: origin},
+			"guard (g) => leaf 1",
+		},
+		{
+			"CoreBind",
+			&CoreBind{Name: "x", Source: root, Cont: leaf, Origin: origin},
+			"bind x = p; leaf 1",
+		},
+		{"NormSplit", &NormSplit{Scrutinee: root, Origin: origin}, "split p {} default ✗"},
+		{
+			"NormBranch",
+			&NormBranch{Test: &LitTest{Lit: ast.NewNumber(1, ast.Span{})}, Cont: leaf, Origin: origin},
+			"1 => leaf 1",
+		},
+		{
+			"NormGuard",
+			&NormGuard{Cond: ident("g"), Cont: leaf, Origin: origin},
+			"guard (g) {\n  leaf 1\n} default ✗",
+		},
+		{
+			"NormBind",
+			&NormBind{Name: "x", Source: root, Cont: leaf, Origin: origin},
+			"bind x = p; leaf 1",
+		},
+		{"BodyLeaf", leaf, "leaf 1"},
+		{"EscapeLeaf", &EscapeLeaf{Origin: origin}, "escape"},
+		{"FallbackLeaf", &FallbackLeaf{Body: exprBody(num(0)), Origin: origin}, "fallback 0"},
+		{"Scrutinee", root, "p"},
+		{"ObjectTest", &ObjectTest{Keys: keys("x")}, "{x}"},
+		{"TupleTest", &TupleTest{Len: 1}, "[_]"},
+		{"LitTest", &LitTest{Lit: ast.NewNumber(1, ast.Span{})}, "1"},
+		{"ClassTest", &ClassTest{Name: ast.NewIdentifier("Point", ast.Span{})}, "Point"},
+		{
+			"ExtractorTest",
+			&ExtractorTest{Name: ast.NewIdentifier("Ok", ast.Span{}), Arity: 1},
+			"Ok(_)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, test.in.String())
+		})
+	}
 }

--- a/internal/solver/ucs/print_test.go
+++ b/internal/solver/ucs/print_test.go
@@ -1,0 +1,542 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests below hand-build IR for the worked examples in
+// planning/ucs/implementation_plan.md, then lock the printer's rendering with an
+// inline snapshot. Nothing here calls a desugarer or a normalizer, because neither
+// exists yet. These snapshots are the shapes their output is checked against once
+// they do.
+
+// In a literal match the catch-all arm is still an ordinary branch of the core.
+// Only normalization moves it into the default tail.
+func TestPrintCoreLiteralMatch(t *testing.T) {
+	one := matchCase(numPat(1), nil, str("one"), span(2, 5, 18))
+	other := matchCase(wildcardPat(), nil, str("other"), span(3, 5, 20))
+	target := ident("n")
+	expr := ast.NewMatch(target, []*ast.MatchCase{one, other}, span(1, 1, 40))
+	origin := At(OriginMatchArm, expr)
+
+	core := &CoreSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*CoreBranch{
+			{
+				Pattern: one.Pattern,
+				Cont:    &BodyLeaf{Body: one.Body, Arm: one, Origin: At(OriginMatchArm, one)},
+				Arm:     one,
+				Origin:  At(OriginMatchArm, one),
+			},
+			{
+				Pattern: other.Pattern,
+				Cont:    &BodyLeaf{Body: other.Body, Arm: other, Origin: At(OriginMatchArm, other)},
+				Arm:     other,
+				Origin:  At(OriginMatchArm, other),
+			},
+		},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, core.String(), snaps.Inline(`split n {
+  pat 1 => leaf "one"
+  pat _ => leaf "other"
+}`))
+}
+
+// A nested pattern stays one deep shape in the core. Normalization is what flattens
+// it into successive one-tag-level splits.
+func TestPrintCoreNestedPattern(t *testing.T) {
+	pattern := ast.NewInstancePat(
+		ast.NewIdentifier("Line", ast.Span{}),
+		ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("start", objPat("x", "y"))}, ast.Span{}),
+		ast.Span{},
+	)
+	body := ast.NewArray([]ast.Expr{ident("x"), ident("y")}, ast.Span{})
+	line := matchCase(pattern, nil, body, span(2, 5, 40))
+	target := ident("l")
+	expr := ast.NewMatch(target, []*ast.MatchCase{line}, span(1, 1, 50))
+	origin := At(OriginMatchArm, expr)
+
+	core := &CoreSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*CoreBranch{{
+			Pattern: line.Pattern,
+			Cont:    &BodyLeaf{Body: line.Body, Arm: line, Origin: At(OriginMatchArm, line)},
+			Arm:     line,
+			Origin:  At(OriginMatchArm, line),
+		}},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, core.String(), snaps.Inline(`split l {
+  pat Line {start: {x, y}} => leaf [x, y]
+}`))
+}
+
+// A guard becomes a node inside its branch, after the bindings the pattern
+// introduces, so the condition can read `x` and `y`. A core guard names no failure
+// continuation. The branches after it already express where a failed guard goes.
+func TestPrintCoreGuardedArm(t *testing.T) {
+	guardCond := ast.NewBinary(ident("x"), ident("y"), ast.GreaterThan, ast.Span{})
+	guarded := matchCase(objPat("x", "y"), guardCond, ident("x"), span(2, 5, 30))
+	fallthroughArm := matchCase(wildcardPat(), nil, num(0), span(3, 5, 16))
+	target := ident("p")
+	expr := ast.NewMatch(target, []*ast.MatchCase{guarded, fallthroughArm}, span(1, 1, 50))
+	origin := At(OriginMatchArm, expr)
+
+	core := &CoreSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*CoreBranch{
+			{
+				Pattern: guarded.Pattern,
+				Cont: &CoreGuard{
+					Cond:   guardCond,
+					Cont:   &BodyLeaf{Body: guarded.Body, Arm: guarded, Origin: At(OriginMatchArm, guarded)},
+					Origin: At(OriginGuard, guardCond),
+				},
+				Arm:    guarded,
+				Origin: At(OriginMatchArm, guarded),
+			},
+			{
+				Pattern: fallthroughArm.Pattern,
+				Cont:    &BodyLeaf{Body: fallthroughArm.Body, Arm: fallthroughArm, Origin: At(OriginMatchArm, fallthroughArm)},
+				Arm:     fallthroughArm,
+				Origin:  At(OriginMatchArm, fallthroughArm),
+			},
+		},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, core.String(), snaps.Inline(`split p {
+  pat {x, y} => guard (x > y) => leaf x
+  pat _ => leaf 0
+}`))
+}
+
+// `if val {x, y} = p { cons } else { alt }` lowers to the same two-branch split a
+// two-arm match produces. The `else` is the split's fallthrough rather than a branch.
+func TestPrintCoreIfVal(t *testing.T) {
+	target := ident("p")
+	cons := ast.Block{Stmts: []ast.Stmt{ast.NewExprStmt(ident("cons"), ast.Span{})}}
+	alt := blockBody(ident("alt"))
+	expr := ast.NewIfVal(objPat("x", "y"), target, cons, &alt, span(1, 1, 45))
+	origin := At(OriginIfVal, expr)
+
+	core := &CoreSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*CoreBranch{{
+			Pattern: expr.Pattern,
+			Cont:    &BodyLeaf{Body: ast.BlockOrExpr{Block: &cons}, Arm: expr, Origin: origin},
+			Arm:     expr,
+			Origin:  origin,
+		}},
+		Else:   &BodyLeaf{Body: alt, Arm: expr, Origin: origin},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, core.String(), snaps.Inline(`split p {
+  pat {x, y} => leaf { cons }
+} else leaf { alt }`))
+}
+
+// `val {x, y} = p else { return }` lowers to the same split, but its success path
+// carries no body. The bindings escape into the enclosing block, and the `else`
+// diverges rather than covering the scrutinee.
+func TestPrintCoreValElse(t *testing.T) {
+	target := ident("p")
+	decl := ast.NewVarDecl(ast.ValKind, objPat("x", "y"), nil, target, false, false, span(1, 1, 35))
+	decl.Else = &ast.Block{Stmts: []ast.Stmt{ast.NewReturnStmt(nil, ast.Span{})}}
+	origin := At(OriginValElse, decl)
+
+	core := &CoreSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*CoreBranch{{
+			Pattern: decl.Pattern,
+			Cont:    &EscapeLeaf{Arm: decl, Origin: origin},
+			Arm:     decl,
+			Origin:  origin,
+		}},
+		Else: &FallbackLeaf{
+			Body:   ast.BlockOrExpr{Block: decl.Else},
+			Arm:    decl,
+			Origin: origin,
+		},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, core.String(), snaps.Inline(`split p {
+  pat {x, y} => escape
+} else fallback { return }`))
+}
+
+// In the normalized literal match the catch-all arm has become the default tail.
+func TestPrintNormLiteralMatch(t *testing.T) {
+	one := matchCase(numPat(1), nil, str("one"), span(2, 5, 18))
+	other := matchCase(wildcardPat(), nil, str("other"), span(3, 5, 20))
+	target := ident("n")
+	expr := ast.NewMatch(target, []*ast.MatchCase{one, other}, span(1, 1, 40))
+	origin := At(OriginMatchArm, expr)
+
+	norm := &NormSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*NormBranch{{
+			Test:   &LitTest{Lit: ast.NewNumber(1, ast.Span{})},
+			Cont:   &BodyLeaf{Body: one.Body, Arm: one, Origin: At(OriginMatchArm, one)},
+			Arm:    one,
+			Origin: At(OriginMatchArm, one),
+		}},
+		Default: &BodyLeaf{Body: other.Body, Arm: other, Origin: At(OriginMatchArm, other)},
+		Origin:  origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, norm.String(), snaps.Inline(`split n {
+  1 => leaf "one"
+} default leaf "other"`))
+}
+
+// Flattening `match l { Line { start: {x, y} } => [x, y] }` gives a split on `l`
+// and then a split on the projected `l.start`, so no split sees more than one
+// tag-level. Each tail is `✗` because no arm covers the remaining values.
+func TestPrintNormNestedPattern(t *testing.T) {
+	pattern := ast.NewInstancePat(
+		ast.NewIdentifier("Line", ast.Span{}),
+		ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("start", objPat("x", "y"))}, ast.Span{}),
+		ast.Span{},
+	)
+	body := ast.NewArray([]ast.Expr{ident("x"), ident("y")}, ast.Span{})
+	line := matchCase(pattern, nil, body, span(2, 5, 40))
+	target := ident("l")
+	expr := ast.NewMatch(target, []*ast.MatchCase{line}, span(1, 1, 50))
+	origin := At(OriginMatchArm, expr)
+	armOrigin := At(OriginMatchArm, line)
+
+	root := NewRoot(target, origin)
+	start := root.Project(FieldStep{Name: "start"}, armOrigin)
+
+	norm := &NormSplit{
+		Scrutinee: root,
+		Branches: []*NormBranch{{
+			Test: &ClassTest{Name: ast.NewIdentifier("Line", ast.Span{})},
+			Cont: &NormSplit{
+				Scrutinee: start,
+				Branches: []*NormBranch{{
+					Test: &ObjectTest{Keys: keys("x", "y")},
+					Cont: &NormBind{
+						Name:   "x",
+						Source: start.Project(FieldStep{Name: "x"}, armOrigin),
+						Cont: &NormBind{
+							Name:   "y",
+							Source: start.Project(FieldStep{Name: "y"}, armOrigin),
+							Cont:   &BodyLeaf{Body: line.Body, Arm: line, Origin: armOrigin},
+							Origin: armOrigin,
+						},
+						Origin: armOrigin,
+					},
+					Arm:    line,
+					Origin: armOrigin,
+				}},
+				Origin: armOrigin,
+			},
+			Arm:    line,
+			Origin: armOrigin,
+		}},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, norm.String(), snaps.Inline(`split l {
+  Line => split l.start {
+    {x, y} => bind x = l.start.x, y = l.start.y; leaf [x, y]
+  } default ✗
+} default ✗`))
+}
+
+// An extractor pattern tests an extractor tag and reaches its arguments as
+// positional results, so `Ok(v)` binds `v` from `r.0`.
+func TestPrintNormExtractorPattern(t *testing.T) {
+	okPat := ast.NewExtractorPat(ast.NewIdentifier("Ok", ast.Span{}), []ast.Pat{identPat("v")}, ast.Span{})
+	errPat := ast.NewExtractorPat(ast.NewIdentifier("Err", ast.Span{}), []ast.Pat{wildcardPat()}, ast.Span{})
+	okArm := matchCase(okPat, nil, ident("v"), span(2, 5, 16))
+	errArm := matchCase(errPat, nil, num(0), span(3, 5, 16))
+	target := ident("r")
+	expr := ast.NewMatch(target, []*ast.MatchCase{okArm, errArm}, span(1, 1, 40))
+	origin := At(OriginMatchArm, expr)
+	okOrigin := At(OriginMatchArm, okArm)
+	errOrigin := At(OriginMatchArm, errArm)
+
+	root := NewRoot(target, origin)
+
+	norm := &NormSplit{
+		Scrutinee: root,
+		Branches: []*NormBranch{
+			{
+				Test: &ExtractorTest{Name: ast.NewIdentifier("Ok", ast.Span{}), Arity: 1},
+				Cont: &NormBind{
+					Name:   "v",
+					Pat:    identPat("v"),
+					Source: root.Project(ExtractStep{Index: 0}, okOrigin),
+					Cont:   &BodyLeaf{Body: okArm.Body, Arm: okArm, Origin: okOrigin},
+					Origin: okOrigin,
+				},
+				Arm:    okArm,
+				Origin: okOrigin,
+			},
+			{
+				Test:   &ExtractorTest{Name: ast.NewIdentifier("Err", ast.Span{}), Arity: 1},
+				Cont:   &BodyLeaf{Body: errArm.Body, Arm: errArm, Origin: errOrigin},
+				Arm:    errArm,
+				Origin: errOrigin,
+			},
+		},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, norm.String(), snaps.Inline(`split r {
+  Ok(_) => bind v = r.#0; leaf v
+  Err(_) => leaf 0
+} default ✗`))
+}
+
+// A tuple rest relaxes its split to an inexact prefix and binds the suffix past that
+// prefix, so `[first, ...rest]` binds `first` from `xs.0` and `rest` from `xs[1..]`.
+func TestPrintNormTupleRest(t *testing.T) {
+	pattern := ast.NewTuplePat([]ast.Pat{identPat("first"), ast.NewRestPat(identPat("rest"), ast.Span{})}, ast.Span{})
+	armCase := matchCase(pattern, nil, ident("first"), span(2, 5, 30))
+	target := ident("xs")
+	expr := ast.NewMatch(target, []*ast.MatchCase{armCase}, span(1, 1, 40))
+	origin := At(OriginMatchArm, expr)
+	armOrigin := At(OriginMatchArm, armCase)
+
+	root := NewRoot(target, origin)
+
+	norm := &NormSplit{
+		Scrutinee: root,
+		Branches: []*NormBranch{{
+			Test: &TupleTest{Len: 1, Rest: TrailingRest},
+			Cont: &NormBind{
+				Name:   "first",
+				Source: root.Project(IndexStep{Index: 0}, armOrigin),
+				Cont: &NormBind{
+					Name:   "rest",
+					Source: root.Project(SuffixStep{From: 1}, armOrigin),
+					Cont:   &BodyLeaf{Body: armCase.Body, Arm: armCase, Origin: armOrigin},
+					Origin: armOrigin,
+				},
+				Origin: armOrigin,
+			},
+			Arm:    armCase,
+			Origin: armOrigin,
+		}},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, norm.String(), snaps.Inline(`split xs {
+  [_, ...] => bind first = xs.0, rest = xs[1..]; leaf first
+} default ✗`))
+}
+
+// An object rest has no positional slice, so `{x, ...rest}` binds `rest` from the
+// scrutinee with the keys named here removed.
+func TestPrintNormObjectRest(t *testing.T) {
+	pattern := ast.NewObjectPat([]ast.ObjPatElem{shorthandElem("x"), objRestElem("rest")}, ast.Span{})
+	armCase := matchCase(pattern, nil, ident("rest"), span(2, 5, 28))
+	target := ident("p")
+	expr := ast.NewMatch(target, []*ast.MatchCase{armCase}, span(1, 1, 40))
+	origin := At(OriginMatchArm, expr)
+	armOrigin := At(OriginMatchArm, armCase)
+
+	root := NewRoot(target, origin)
+
+	norm := &NormSplit{
+		Scrutinee: root,
+		Branches: []*NormBranch{{
+			Test: &ObjectTest{Keys: keys("x"), Rest: TrailingRest},
+			Cont: &NormBind{
+				Name:   "x",
+				Source: root.Project(FieldStep{Name: "x"}, armOrigin),
+				Cont: &NormBind{
+					Name:   "rest",
+					Source: root.Project(RemainderStep{Exclude: set.FromSlice([]string{"x"})}, armOrigin),
+					Cont:   &BodyLeaf{Body: armCase.Body, Arm: armCase, Origin: armOrigin},
+					Origin: armOrigin,
+				},
+				Origin: armOrigin,
+			},
+			Arm:    armCase,
+			Origin: armOrigin,
+		}},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, norm.String(), snaps.Inline(`split p {
+  {x, ...} => bind x = p.x, rest = p \ {x}; leaf rest
+} default ✗`))
+}
+
+// A normalized guard names where a failed test continues, which is the fallthrough
+// the branch would have taken in source order. Here that is the split's own tail, so
+// the later unguarded arm stays reachable.
+func TestPrintNormGuardedArm(t *testing.T) {
+	guardCond := ast.NewBinary(ident("x"), ident("y"), ast.GreaterThan, ast.Span{})
+	guarded := matchCase(objPat("x", "y"), guardCond, ident("x"), span(2, 5, 30))
+	fallthroughArm := matchCase(wildcardPat(), nil, num(0), span(3, 5, 16))
+	target := ident("p")
+	expr := ast.NewMatch(target, []*ast.MatchCase{guarded, fallthroughArm}, span(1, 1, 50))
+	origin := At(OriginMatchArm, expr)
+	guardedOrigin := At(OriginMatchArm, guarded)
+
+	root := NewRoot(target, origin)
+	tail := &BodyLeaf{
+		Body:   fallthroughArm.Body,
+		Arm:    fallthroughArm,
+		Origin: At(OriginMatchArm, fallthroughArm),
+	}
+
+	norm := &NormSplit{
+		Scrutinee: root,
+		Branches: []*NormBranch{{
+			Test: &ObjectTest{Keys: keys("x", "y")},
+			Cont: &NormBind{
+				Name:   "x",
+				Source: root.Project(FieldStep{Name: "x"}, guardedOrigin),
+				Cont: &NormBind{
+					Name:   "y",
+					Source: root.Project(FieldStep{Name: "y"}, guardedOrigin),
+					Cont: &NormGuard{
+						Cond:    guardCond,
+						Cont:    &BodyLeaf{Body: guarded.Body, Arm: guarded, Origin: guardedOrigin},
+						Default: tail,
+						Origin:  At(OriginGuard, guardCond),
+					},
+					Origin: guardedOrigin,
+				},
+				Origin: guardedOrigin,
+			},
+			Arm:    guarded,
+			Origin: guardedOrigin,
+		}},
+		Default: tail,
+		Origin:  origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, norm.String(), snaps.Inline(`split p {
+  {x, y} => bind x = p.x, y = p.y; guard (x > y) {
+    leaf x
+  } default leaf 0
+} default leaf 0`))
+}
+
+// A split with no branches collapses to `{}`, and a missing tail renders `✗`.
+func TestPrintNormEmptySplit(t *testing.T) {
+	origin := Invented(OriginMatchArm)
+	norm := &NormSplit{Scrutinee: NewRoot(ident("p"), origin), Origin: origin}
+
+	snaps.MatchInlineSnapshot(t, norm.String(), snaps.Inline(`split p {} default ✗`))
+}
+
+// ShowOrigins turns on the provenance tag a diagnostic keys its wording off. The
+// invented fallthrough is marked synthetic so a message never anchors a span the
+// user cannot see.
+func TestPrintShowsOriginTags(t *testing.T) {
+	target := ident("p")
+	cons := ast.Block{Stmts: []ast.Stmt{ast.NewExprStmt(ident("cons"), ast.Span{})}}
+	expr := ast.NewIfVal(objPat("x", "y"), target, cons, nil, span(1, 1, 32))
+	origin := At(OriginIfVal, expr)
+	invented := Invented(OriginIfVal)
+
+	core := &CoreSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*CoreBranch{{
+			Pattern: expr.Pattern,
+			Cont:    &BodyLeaf{Body: ast.BlockOrExpr{Block: &cons}, Arm: expr, Origin: origin},
+			Arm:     expr,
+			Origin:  origin,
+		}},
+		Else:   &BodyLeaf{Body: exprBody(ast.NewLitExpr(ast.NewUndefined(ast.Span{}))), Origin: invented},
+		Origin: origin,
+	}
+
+	opts := DefaultPrintOptions()
+	opts.ShowOrigins = true
+	snaps.MatchInlineSnapshot(t, Print(core, opts), snaps.Inline(`split p [if val] {
+  pat {x, y} [if val] => leaf { cons } [if val]
+} else leaf undefined [synthetic if val]`))
+}
+
+// ShowArms turns on the surface-arm back-reference, rendered as the arm's span. The
+// synthetic fallthrough points at no arm, so it renders `arm=none`.
+func TestPrintShowsArmBackReferences(t *testing.T) {
+	one := matchCase(numPat(1), nil, str("one"), span(2, 5, 18))
+	target := ident("n")
+	expr := ast.NewMatch(target, []*ast.MatchCase{one}, span(1, 1, 30))
+	origin := At(OriginMatchArm, expr)
+
+	norm := &NormSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*NormBranch{{
+			Test:   &LitTest{Lit: ast.NewNumber(1, ast.Span{})},
+			Cont:   &BodyLeaf{Body: one.Body, Arm: one, Origin: At(OriginMatchArm, one)},
+			Arm:    one,
+			Origin: At(OriginMatchArm, one),
+		}},
+		Default: &BodyLeaf{
+			Body:   exprBody(ast.NewLitExpr(ast.NewUndefined(ast.Span{}))),
+			Origin: Invented(OriginMatchArm),
+		},
+		Origin: origin,
+	}
+
+	opts := DefaultPrintOptions()
+	opts.ShowArms = true
+	snaps.MatchInlineSnapshot(t, Print(norm, opts), snaps.Inline(`split n {
+  1 arm=2:5-2:18 => leaf "one" arm=2:5-2:18
+} default leaf undefined arm=none`))
+}
+
+// An empty Indent falls back to two spaces, so a zero-value PrintOptions still
+// renders nested splits readably.
+func TestPrintDefaultsIndentWhenEmpty(t *testing.T) {
+	one := matchCase(numPat(1), nil, str("one"), span(2, 5, 18))
+	target := ident("n")
+	expr := ast.NewMatch(target, []*ast.MatchCase{one}, span(1, 1, 30))
+	origin := At(OriginMatchArm, expr)
+
+	norm := &NormSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*NormBranch{{
+			Test:   &LitTest{Lit: ast.NewNumber(1, ast.Span{})},
+			Cont:   &BodyLeaf{Body: one.Body, Arm: one, Origin: At(OriginMatchArm, one)},
+			Arm:    one,
+			Origin: At(OriginMatchArm, one),
+		}},
+		Origin: origin,
+	}
+
+	require.Equal(t, norm.String(), Print(norm, PrintOptions{}))
+}
+
+// A typed-nil arm renders `arm=none` instead of panicking, so a lowering bug shows up
+// as a printable IR rather than a crash inside the printer.
+func TestPrintToleratesATypedNilArm(t *testing.T) {
+	var typedNil *ast.MatchCase
+	leaf := &BodyLeaf{Body: exprBody(num(1)), Arm: typedNil, Origin: Invented(OriginMatchArm)}
+
+	opts := DefaultPrintOptions()
+	opts.ShowArms = true
+	require.Equal(t, "leaf 1 arm=none", Print(leaf, opts))
+}
+
+// A form the compact AST renderer does not spell out prints as its node kind, so an
+// unrecognized body still leaves the surrounding split readable.
+func TestPrintUnrenderedExpressionFallsBackToItsKind(t *testing.T) {
+	body := ast.NewDo(ast.Block{}, ast.Span{})
+	armCase := matchCase(wildcardPat(), nil, body, span(2, 5, 20))
+	leaf := &BodyLeaf{Body: armCase.Body, Arm: armCase, Origin: At(OriginMatchArm, armCase)}
+
+	require.Equal(t, "leaf <DoExpr>", leaf.String())
+}


### PR DESCRIPTION
Fixes #1020.

Last of five stacked PRs adding `internal/solver/ucs`. Still pure IR wired into nothing.

**Stacked on #1033.** Review that one first; this PR's diff is against it.

## What's here

**`Print`** renders a core or normalized term as indented text. The output exists for snapshot tests and debugging. Nothing parses it back, so its shape is free to change with the IR. Every node type also gets a `String()` so a failing assertion prints something readable.

**`PrintOptions`** keeps provenance out of the default rendering. A shape snapshot stays readable without it. A test that asserts provenance turns on `ShowOrigins` for `[match arm]` tags, or `ShowArms` for `arm=1:5-1:14` back-references. A node with no back-reference renders `arm=none` rather than panicking, so a lowering bug shows up as a printable IR instead of a crash inside the printer.

A run of consecutive binds folds onto one indent level. `bind x = p.x` followed by `bind y = p.y` renders as two lines rather than a staircase, which keeps a branch that binds several fields readable:

```
split p {
  pat {x, y} => bind x = p.x, y = p.y; guard (x > y) => leaf x
}
```

## The snapshots

This is where most of the diff sits, and it reads fast. The tests cover the thirteen worked examples from `planning/ucs/implementation_plan.md`, in both forms where the plan gives both — a literal match, a nested pattern, a guarded arm, `if val`, `val … else`, an extractor pattern, a tuple rest, and an object rest.

Nothing here calls a desugarer or a normalizer, because neither exists yet. These are the shapes their output gets checked against once they land.

## Testing

`go test ./...` is green. 204 tests in the package, 97.2% coverage. Snapshots were written by `UPDATE_SNAPS=true` and reviewed by hand.

Part of the Ultimate Conditional Syntax IR plan, #884. Refs #882.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable rendering for match trees and normalized terms.
  * Added optional indentation, origin details, and arm references to rendered output.
  * Added readable string representations for supported match-tree elements.
  * Added compact handling for empty branches, nested structures, bindings, and unsupported expressions.

* **Tests**
  * Added comprehensive coverage for literal, nested, guarded, extractor, tuple-rest, object-rest, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->