### PR TITLE
UCS IR (1/5) — the compact AST-fragment renderer

### DIFF
--- a/internal/solver/ucs/doc.go
+++ b/internal/solver/ucs/doc.go
@@ -1,0 +1,11 @@
+// Package ucs holds the conditional-normalization IR that Escalier's rich
+// conditional surface lowers into. The three surface forms are `match`, `if val`,
+// and `val … else`. The pipeline follows "The Ultimate Conditional Syntax" by Cheng
+// and Parreaux, OOPSLA 2024, which the package is named after. See
+// planning/ucs/implementation_plan.md.
+//
+// The package is pure IR with no behavior of its own. It imports internal/ast for
+// the surface nodes it points back at. It never imports internal/solver or
+// internal/soltype, so the typing walk can import it and a future internal/codegen
+// consumer can too, with no cycle either way.
+package ucs

--- a/internal/solver/ucs/helpers_test.go
+++ b/internal/solver/ucs/helpers_test.go
@@ -1,0 +1,62 @@
+package ucs
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+func ident(name string) *ast.IdentExpr {
+	return ast.NewIdent(name, ast.Span{})
+}
+
+func num(value float64) ast.Expr {
+	return ast.NewLitExpr(ast.NewNumber(value, ast.Span{}))
+}
+
+func str(value string) ast.Expr {
+	return ast.NewLitExpr(ast.NewString(value, ast.Span{}))
+}
+
+func shorthandElem(key string) ast.ObjPatElem {
+	return ast.NewObjShorthandPat(ast.NewIdentifier(key, ast.Span{}), false, nil, nil, ast.Span{})
+}
+
+// objPat builds an object pattern of shorthand keys, the `{x, y}` form.
+func objPat(keys ...string) *ast.ObjectPat {
+	elems := make([]ast.ObjPatElem, len(keys))
+	for i, key := range keys {
+		elems[i] = shorthandElem(key)
+	}
+	return ast.NewObjectPat(elems, ast.Span{})
+}
+
+func identPat(name string) *ast.IdentPat {
+	return ast.NewIdentPat(name, false, nil, nil, ast.Span{})
+}
+
+func wildcardPat() *ast.WildcardPat {
+	return ast.NewWildcardPat(ast.Span{})
+}
+
+func numPat(value float64) *ast.LitPat {
+	return ast.NewLitPat(ast.NewNumber(value, ast.Span{}), ast.Span{})
+}
+
+func keyValueElem(key string, value ast.Pat) ast.ObjPatElem {
+	return ast.NewObjKeyValuePat(ast.NewIdentifier(key, ast.Span{}), value, ast.Span{})
+}
+
+func objRestElem(name string) ast.ObjPatElem {
+	return ast.NewObjRestPat(identPat(name), ast.Span{})
+}
+
+// blockBody wraps a single expression statement as a block arm body, the shape an
+// `if val` consequent takes.
+func blockBody(e ast.Expr) ast.BlockOrExpr {
+	block := &ast.Block{Stmts: []ast.Stmt{ast.NewExprStmt(e, ast.Span{})}}
+	return ast.BlockOrExpr{Block: block}
+}
+
+// exprBody wraps a bare expression as an arm body.
+func exprBody(e ast.Expr) ast.BlockOrExpr {
+	return ast.BlockOrExpr{Expr: e}
+}

--- a/internal/solver/ucs/print_ast.go
+++ b/internal/solver/ucs/print_ast.go
@@ -1,0 +1,315 @@
+package ucs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+// This file renders the AST fragments the IR points at into the compact one-line
+// forms the IR printer embeds. Those fragments are patterns, guard conditions, arm
+// bodies, and the match target. The renderer is deliberately small and lossy rather
+// than a second copy of internal/printer. Importing internal/printer would pull the
+// parser into the solver's dependency graph, and what matters in an IR snapshot is
+// the shape of the splits. A form this renderer does not spell out prints as its
+// node kind in angle brackets, for example `<FuncExpr>`.
+
+// exprString renders an expression on one line.
+func exprString(e ast.Expr) string {
+	switch e := e.(type) {
+	case nil:
+		return "<nil>"
+	case *ast.IdentExpr:
+		return e.Name
+	case *ast.LiteralExpr:
+		return litString(e.Lit)
+	case *ast.MemberExpr:
+		return groupedExprString(e.Object) + "." + e.Prop.Name
+	case *ast.IndexExpr:
+		return groupedExprString(e.Object) + "[" + exprString(e.Index) + "]"
+	case *ast.CallExpr:
+		args := make([]string, len(e.Args))
+		for i, arg := range e.Args {
+			args[i] = exprString(arg)
+		}
+		return groupedExprString(e.Callee) + "(" + strings.Join(args, ", ") + ")"
+	case *ast.TupleExpr:
+		elems := make([]string, len(e.Elems))
+		for i, elem := range e.Elems {
+			elems[i] = exprString(elem)
+		}
+		return "[" + strings.Join(elems, ", ") + "]"
+	case *ast.BinaryExpr:
+		return groupedExprString(e.Left) + " " + string(e.Op) + " " + groupedExprString(e.Right)
+	case *ast.UnaryExpr:
+		return unaryOpString(e.Op) + groupedExprString(e.Arg)
+	default:
+		return nodeKind(e)
+	}
+}
+
+// groupedExprString renders a subexpression whose grouping the surrounding syntax
+// does not already make clear, parenthesizing it when it is an operator expression.
+// The renderer prints no precedence-aware parentheses of its own, so without this a
+// nested operator reads as though it sat at the outer level.
+//
+// Two guards that test different things would otherwise share one rendering, since
+// `!(x > y)` and `(!x) > y` both flatten to `!x > y`. A receiver is worse than
+// ambiguous: `(a + b).c` flattens to `a + b.c`, which names a different expression
+// than the one the IR holds.
+//
+// Callers pass only the positions that need it. An argument list, an index, and a
+// tuple element are already delimited by their brackets, so those stay ungrouped.
+func groupedExprString(e ast.Expr) string {
+	switch e.(type) {
+	case *ast.BinaryExpr, *ast.UnaryExpr:
+		return "(" + exprString(e) + ")"
+	default:
+		return exprString(e)
+	}
+}
+
+// unaryOpString renders a unary operator's source spelling.
+func unaryOpString(op ast.UnaryOp) string {
+	switch op {
+	case ast.UnaryPlus:
+		return "+"
+	case ast.UnaryMinus:
+		return "-"
+	case ast.LogicalNot:
+		return "!"
+	default:
+		return "?"
+	}
+}
+
+// litString renders a literal's source spelling.
+func litString(lit ast.Lit) string {
+	switch l := lit.(type) {
+	case nil:
+		return "<nil>"
+	case *ast.BoolLit:
+		return strconv.FormatBool(l.Value)
+	case *ast.NumLit:
+		return strconv.FormatFloat(l.Value, 'g', -1, 64)
+	case *ast.StrLit:
+		return strconv.Quote(l.Value)
+	case *ast.RegexLit:
+		return l.Value
+	case *ast.BigIntLit:
+		return l.Value.String() + "n"
+	case *ast.NullLit:
+		return "null"
+	case *ast.UndefinedLit:
+		return "undefined"
+	default:
+		return nodeKind(lit)
+	}
+}
+
+// patString renders a pattern on one line, matching the source spelling closely
+// enough that a core split's `pat …` reads like the arm the user wrote.
+func patString(p ast.Pat) string {
+	switch p := p.(type) {
+	case nil:
+		return "<nil>"
+	case *ast.IdentPat:
+		return leafPatString(p.Mutable, p.Name, p.TypeAnn, p.Default)
+	case *ast.WildcardPat:
+		return "_"
+	case *ast.LitPat:
+		return litString(p.Lit)
+	case *ast.TuplePat:
+		elems := make([]string, len(p.Elems))
+		for i, elem := range p.Elems {
+			elems[i] = patString(elem)
+		}
+		return "[" + strings.Join(elems, ", ") + "]"
+	case *ast.ObjectPat:
+		return objPatString(p)
+	case *ast.ExtractorPat:
+		args := make([]string, len(p.Args))
+		for i, arg := range p.Args {
+			args[i] = patString(arg)
+		}
+		return ast.QualIdentToString(p.Name) + "(" + strings.Join(args, ", ") + ")"
+	case *ast.InstancePat:
+		return ast.QualIdentToString(p.ClassName) + " " + objPatString(p.Object)
+	case *ast.RestPat:
+		return "..." + patString(p.Pattern)
+	default:
+		return nodeKind(p)
+	}
+}
+
+// objPatString renders an object pattern's braces and elements.
+func objPatString(p *ast.ObjectPat) string {
+	if p == nil {
+		return "{}"
+	}
+	elems := make([]string, 0, len(p.Elems))
+	for _, elem := range p.Elems {
+		switch e := elem.(type) {
+		case *ast.ObjKeyValuePat:
+			elems = append(elems, e.Key.Name+": "+patString(e.Value))
+		case *ast.ObjShorthandPat:
+			elems = append(elems, leafPatString(e.Mutable, e.Key.Name, e.TypeAnn, e.Default))
+		case *ast.ObjRestPat:
+			elems = append(elems, "..."+patString(e.Pattern))
+		default:
+			elems = append(elems, nodeKind(elem))
+		}
+	}
+	return "{" + strings.Join(elems, ", ") + "}"
+}
+
+// leafPatString renders a binding leaf, which is either an `IdentPat` or the
+// shorthand element of an object pattern. Both can carry a `mut` prefix, a type
+// annotation, and a default, and all three are rendered. The default is the one that
+// changes matching. It makes the field optional, so `{x = 0}` and `{x}` match
+// different values and must not share a snapshot.
+func leafPatString(mutable bool, name string, typeAnn ast.TypeAnn, dflt ast.Expr) string {
+	var b strings.Builder
+	if mutable {
+		b.WriteString("mut ")
+	}
+	b.WriteString(name)
+	if typeAnn != nil {
+		b.WriteString(": " + typeAnnString(typeAnn))
+	}
+	if dflt != nil {
+		b.WriteString(" = " + exprString(dflt))
+	}
+	return b.String()
+}
+
+// typeAnnString renders a type annotation on one line. It spells out the forms that
+// show up on a pattern leaf and falls back to the node kind for the rest, which is
+// enough to keep two arms that differ only in their annotation distinguishable.
+func typeAnnString(t ast.TypeAnn) string {
+	switch t := t.(type) {
+	case nil:
+		return "<nil>"
+	case *ast.NumberTypeAnn:
+		return "number"
+	case *ast.StringTypeAnn:
+		return "string"
+	case *ast.BooleanTypeAnn:
+		return "boolean"
+	case *ast.BigintTypeAnn:
+		return "bigint"
+	case *ast.SymbolTypeAnn:
+		return "symbol"
+	case *ast.AnyTypeAnn:
+		return "any"
+	case *ast.UnknownTypeAnn:
+		return "unknown"
+	case *ast.NeverTypeAnn:
+		return "never"
+	case *ast.WildcardTypeAnn:
+		return "_"
+	case *ast.LitTypeAnn:
+		return litString(t.Lit)
+	case *ast.TypeRefTypeAnn:
+		name := ast.QualIdentToString(t.Name)
+		if len(t.TypeArgs) == 0 {
+			return name
+		}
+		args := make([]string, len(t.TypeArgs))
+		for i, arg := range t.TypeArgs {
+			args[i] = typeAnnString(arg)
+		}
+		return name + "<" + strings.Join(args, ", ") + ">"
+	case *ast.TupleTypeAnn:
+		elems := make([]string, 0, len(t.Elems)+1)
+		for _, elem := range t.Elems {
+			elems = append(elems, typeAnnString(elem))
+		}
+		if t.Inexact {
+			elems = append(elems, "...")
+		}
+		return "[" + strings.Join(elems, ", ") + "]"
+	case *ast.UnionTypeAnn:
+		if t.Inexact {
+			return joinTypeAnns(t.Types, " | ") + " | ..."
+		}
+		return joinTypeAnns(t.Types, " | ")
+	case *ast.IntersectionTypeAnn:
+		parts := make([]string, len(t.Types))
+		for i, member := range t.Types {
+			parts[i] = groupedTypeAnnString(member)
+		}
+		return strings.Join(parts, " & ")
+	default:
+		return nodeKind(t)
+	}
+}
+
+// groupedTypeAnnString renders a member of an intersection, parenthesizing a union.
+// `&` binds tighter than `|` in the surface syntax, so a bare union member would
+// reassociate: `(number | string) & boolean` and `number | (string & boolean)` both
+// flatten to `number | string & boolean`, which names the second of the two. An
+// intersection nested in a union needs no parentheses, because the tighter operator
+// already groups the way the tree does.
+func groupedTypeAnnString(t ast.TypeAnn) string {
+	if _, ok := t.(*ast.UnionTypeAnn); ok {
+		return "(" + typeAnnString(t) + ")"
+	}
+	return typeAnnString(t)
+}
+
+func joinTypeAnns(anns []ast.TypeAnn, sep string) string {
+	parts := make([]string, len(anns))
+	for i, ann := range anns {
+		parts[i] = typeAnnString(ann)
+	}
+	return strings.Join(parts, sep)
+}
+
+// bodyString renders an arm body on one line. A body written as a bare expression
+// renders as that expression; a block renders its statements inside braces, so two
+// blocks that differ stay distinguishable in a snapshot.
+func bodyString(b ast.BlockOrExpr) string {
+	if b.Expr != nil {
+		return exprString(b.Expr)
+	}
+	if b.Block != nil {
+		stmts := make([]string, len(b.Block.Stmts))
+		for i, stmt := range b.Block.Stmts {
+			stmts[i] = stmtString(stmt)
+		}
+		return "{ " + strings.Join(stmts, "; ") + " }"
+	}
+	return "<empty>"
+}
+
+// stmtString renders a statement on one line.
+func stmtString(s ast.Stmt) string {
+	switch s := s.(type) {
+	case nil:
+		return "<nil>"
+	case *ast.ExprStmt:
+		return exprString(s.Expr)
+	case *ast.ReturnStmt:
+		if s.Expr == nil {
+			return "return"
+		}
+		return "return " + exprString(s.Expr)
+	default:
+		return nodeKind(s)
+	}
+}
+
+// nodeKind renders a value's concrete type as `<TypeName>`, the placeholder every
+// renderer here falls back to for a form it does not spell out. A `*ast.FuncExpr`
+// renders as `<FuncExpr>`. The pointer marker and the package qualifier are dropped,
+// so a ucs type renders the same way an ast type does.
+func nodeKind(n any) string {
+	name := strings.TrimPrefix(fmt.Sprintf("%T", n), "*")
+	if dot := strings.LastIndex(name, "."); dot >= 0 {
+		name = name[dot+1:]
+	}
+	return "<" + name + ">"
+}

--- a/internal/solver/ucs/print_ast_render_test.go
+++ b/internal/solver/ucs/print_ast_render_test.go
@@ -1,0 +1,245 @@
+package ucs
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests here walk each renderer's arms. A snapshot in a later IR test is only as
+// trustworthy as the fragment rendering underneath it, so every form this file
+// spells out gets a case, and every form it does not gets a `<NodeKind>` case that
+// pins the fallback.
+
+func TestLitString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   ast.Lit
+		want string
+	}{
+		{"true", ast.NewBoolean(true, ast.Span{}), "true"},
+		{"false", ast.NewBoolean(false, ast.Span{}), "false"},
+		{"integral number", ast.NewNumber(1, ast.Span{}), "1"},
+		{"fractional number", ast.NewNumber(1.5, ast.Span{}), "1.5"},
+		{"string", ast.NewString("hi", ast.Span{}), `"hi"`},
+		{
+			// A quoted string keeps its escapes, so two literals that differ only in
+			// escaping stay distinguishable.
+			"string with a quote",
+			ast.NewString(`a"b`, ast.Span{}),
+			`"a\"b"`,
+		},
+		{"regex", ast.NewRegex("/ab+/", ast.Span{}), "/ab+/"},
+		{"bigint", ast.NewBigInt(*big.NewInt(42), ast.Span{}), "42n"},
+		{"null", ast.NewNull(ast.Span{}), "null"},
+		{"undefined", ast.NewUndefined(ast.Span{}), "undefined"},
+		{"nil", nil, "<nil>"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, litString(test.in))
+		})
+	}
+}
+
+func TestUnaryOpString(t *testing.T) {
+	require.Equal(t, "+", unaryOpString(ast.UnaryPlus))
+	require.Equal(t, "-", unaryOpString(ast.UnaryMinus))
+	require.Equal(t, "!", unaryOpString(ast.LogicalNot))
+	// An operator the renderer does not know still prints something.
+	require.Equal(t, "?", unaryOpString(ast.UnaryOp(99)))
+}
+
+func TestExprStringRendersEachForm(t *testing.T) {
+	a := ident("a")
+
+	tests := []struct {
+		name string
+		in   ast.Expr
+		want string
+	}{
+		{"identifier", a, "a"},
+		{"literal", num(2), "2"},
+		{"member", ast.NewMember(a, ast.NewIdentifier("b", ast.Span{}), false, ast.Span{}), "a.b"},
+		{"index", ast.NewIndex(a, num(0), false, ast.Span{}), "a[0]"},
+		{"call with no args", ast.NewCall(a, nil, false, ast.Span{}), "a()"},
+		{"call with args", ast.NewCall(a, []ast.Expr{num(1), num(2)}, false, ast.Span{}), "a(1, 2)"},
+		{"empty tuple", ast.NewArray(nil, ast.Span{}), "[]"},
+		{"tuple", ast.NewArray([]ast.Expr{num(1), a}, ast.Span{}), "[1, a]"},
+		{"nil", nil, "<nil>"},
+		{"unrendered form", ast.NewDo(ast.Block{}, ast.Span{}), "<DoExpr>"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, exprString(test.in))
+		})
+	}
+}
+
+func TestPatStringRendersEachForm(t *testing.T) {
+	qual := func(name string) ast.QualIdent { return ast.NewIdentifier(name, ast.Span{}) }
+
+	tests := []struct {
+		name string
+		in   ast.Pat
+		want string
+	}{
+		{"identifier", identPat("a"), "a"},
+		{"mutable identifier", ast.NewIdentPat("a", true, nil, nil, ast.Span{}), "mut a"},
+		{"wildcard", wildcardPat(), "_"},
+		{"literal", numPat(1), "1"},
+		{"empty tuple", ast.NewTuplePat(nil, ast.Span{}), "[]"},
+		{"tuple", ast.NewTuplePat([]ast.Pat{identPat("a"), wildcardPat()}, ast.Span{}), "[a, _]"},
+		{"tuple with a rest", ast.NewTuplePat([]ast.Pat{
+			identPat("first"), ast.NewRestPat(identPat("rest"), ast.Span{}),
+		}, ast.Span{}), "[first, ...rest]"},
+		{"empty object", ast.NewObjectPat(nil, ast.Span{}), "{}"},
+		{"object shorthand", objPat("x", "y"), "{x, y}"},
+		{"object key-value", ast.NewObjectPat([]ast.ObjPatElem{
+			keyValueElem("x", identPat("a")),
+		}, ast.Span{}), "{x: a}"},
+		{"object rest", ast.NewObjectPat([]ast.ObjPatElem{
+			shorthandElem("x"), objRestElem("rest"),
+		}, ast.Span{}), "{x, ...rest}"},
+		{
+			"extractor",
+			ast.NewExtractorPat(qual("Ok"), []ast.Pat{identPat("v")}, ast.Span{}),
+			"Ok(v)",
+		},
+		{
+			"nullary extractor",
+			ast.NewExtractorPat(qual("None"), nil, ast.Span{}),
+			"None()",
+		},
+		{
+			"instance",
+			ast.NewInstancePat(qual("Point"), objPat("x", "y"), ast.Span{}),
+			"Point {x, y}",
+		},
+		{"nil", nil, "<nil>"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, patString(test.in))
+		})
+	}
+}
+
+// A nil *ast.ObjectPat renders `{}` rather than panicking, which keeps an instance
+// pattern printable when its object half is missing.
+func TestObjPatStringToleratesANilPattern(t *testing.T) {
+	require.Equal(t, "{}", objPatString(nil))
+}
+
+func TestTypeAnnStringRendersEachForm(t *testing.T) {
+	number := &ast.NumberTypeAnn{}
+	str := &ast.StringTypeAnn{}
+
+	tests := []struct {
+		name string
+		in   ast.TypeAnn
+		want string
+	}{
+		{"number", number, "number"},
+		{"string", str, "string"},
+		{"boolean", &ast.BooleanTypeAnn{}, "boolean"},
+		{"bigint", &ast.BigintTypeAnn{}, "bigint"},
+		{"symbol", &ast.SymbolTypeAnn{}, "symbol"},
+		{"any", &ast.AnyTypeAnn{}, "any"},
+		{"unknown", &ast.UnknownTypeAnn{}, "unknown"},
+		{"never", &ast.NeverTypeAnn{}, "never"},
+		{"wildcard", &ast.WildcardTypeAnn{}, "_"},
+		{"literal", ast.NewLitTypeAnn(ast.NewNumber(1, ast.Span{}), ast.Span{}), "1"},
+		{
+			"type reference",
+			&ast.TypeRefTypeAnn{Name: ast.NewIdentifier("Point", ast.Span{})},
+			"Point",
+		},
+		{
+			"generic type reference",
+			&ast.TypeRefTypeAnn{
+				Name:     ast.NewIdentifier("Map", ast.Span{}),
+				TypeArgs: []ast.TypeAnn{str, number},
+			},
+			"Map<string, number>",
+		},
+		{"empty tuple", &ast.TupleTypeAnn{}, "[]"},
+		{"tuple", &ast.TupleTypeAnn{Elems: []ast.TypeAnn{number, str}}, "[number, string]"},
+		{
+			"inexact tuple",
+			&ast.TupleTypeAnn{Elems: []ast.TypeAnn{number}, Inexact: true},
+			"[number, ...]",
+		},
+		{"union", &ast.UnionTypeAnn{Types: []ast.TypeAnn{number, str}}, "number | string"},
+		{
+			"inexact union",
+			&ast.UnionTypeAnn{Types: []ast.TypeAnn{number}, Inexact: true},
+			"number | ...",
+		},
+		{
+			"intersection",
+			&ast.IntersectionTypeAnn{Types: []ast.TypeAnn{number, str}},
+			"number & string",
+		},
+		{"nil", nil, "<nil>"},
+		{"unrendered form", &ast.KeyOfTypeAnn{}, "<KeyOfTypeAnn>"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, typeAnnString(test.in))
+		})
+	}
+}
+
+func TestBodyStringAndStmtString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   ast.BlockOrExpr
+		want string
+	}{
+		{"bare expression", exprBody(num(1)), "1"},
+		{"block with one statement", blockBody(num(1)), "{ 1 }"},
+		{
+			"block with several statements",
+			ast.BlockOrExpr{Block: &ast.Block{Stmts: []ast.Stmt{
+				ast.NewExprStmt(num(1), ast.Span{}),
+				ast.NewReturnStmt(num(2), ast.Span{}),
+			}}},
+			"{ 1; return 2 }",
+		},
+		{
+			"bare return",
+			ast.BlockOrExpr{Block: &ast.Block{Stmts: []ast.Stmt{
+				ast.NewReturnStmt(nil, ast.Span{}),
+			}}},
+			"{ return }",
+		},
+		{"empty block", ast.BlockOrExpr{Block: &ast.Block{}}, "{  }"},
+		{
+			// Neither half set is what an arm with no body looks like, which the
+			// renderer names rather than crashing on.
+			"neither expression nor block",
+			ast.BlockOrExpr{},
+			"<empty>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, bodyString(test.in))
+		})
+	}
+}
+
+// A statement form the renderer does not spell out prints as its node kind, and a nil
+// statement prints `<nil>` rather than panicking.
+func TestStmtStringFallbacks(t *testing.T) {
+	require.Equal(t, "<nil>", stmtString(nil))
+	require.Equal(t, "<DeclStmt>", stmtString(&ast.DeclStmt{}))
+}

--- a/internal/solver/ucs/print_ast_test.go
+++ b/internal/solver/ucs/print_ast_test.go
@@ -1,0 +1,217 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// An operand that is itself an operator expression is parenthesized. Without that,
+// `!(x > y)` and `(!x) > y` both render `!x > y`, so two guards that test different
+// things would be indistinguishable in a snapshot.
+func TestExprStringParenthesizesOperatorOperands(t *testing.T) {
+	x, y := ident("x"), ident("y")
+	notGreater := ast.NewUnary(ast.LogicalNot, ast.NewBinary(x, y, ast.GreaterThan, ast.Span{}), ast.Span{})
+	greaterOfNot := ast.NewBinary(ast.NewUnary(ast.LogicalNot, x, ast.Span{}), y, ast.GreaterThan, ast.Span{})
+
+	tests := []struct {
+		name string
+		in   ast.Expr
+		want string
+	}{
+		{"negated comparison", notGreater, "!(x > y)"},
+		{"comparison of a negation", greaterOfNot, "(!x) > y"},
+		{
+			"right-nested conjunction",
+			ast.NewBinary(x, ast.NewBinary(y, ident("z"), ast.LogicalAnd, ast.Span{}), ast.LogicalOr, ast.Span{}),
+			"x || (y && z)",
+		},
+		{
+			"left-nested disjunction",
+			ast.NewBinary(ast.NewBinary(x, y, ast.LogicalOr, ast.Span{}), ident("z"), ast.LogicalAnd, ast.Span{}),
+			"(x || y) && z",
+		},
+		{
+			// A plain operand needs no parentheses, so the common guard stays readable.
+			"simple operands",
+			ast.NewBinary(x, y, ast.GreaterThan, ast.Span{}),
+			"x > y",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, exprString(test.in))
+		})
+	}
+}
+
+// A binding leaf renders its `mut` prefix, its type annotation, and its default. The
+// default is what makes a field optional, so dropping it would let `{x = 0}` and
+// `{x}` render alike even though they match different values.
+func TestPatStringRendersLeafExtras(t *testing.T) {
+	numberAnn := &ast.NumberTypeAnn{}
+	stringAnn := &ast.StringTypeAnn{}
+
+	tests := []struct {
+		name string
+		in   ast.Pat
+		want string
+	}{
+		{"plain shorthand", objPat("x"), "{x}"},
+		{
+			"shorthand with a default",
+			ast.NewObjectPat([]ast.ObjPatElem{
+				ast.NewObjShorthandPat(ast.NewIdentifier("x", ast.Span{}), false, nil, num(0), ast.Span{}),
+			}, ast.Span{}),
+			"{x = 0}",
+		},
+		{
+			"shorthand with an annotation",
+			ast.NewObjectPat([]ast.ObjPatElem{
+				ast.NewObjShorthandPat(ast.NewIdentifier("x", ast.Span{}), false, numberAnn, nil, ast.Span{}),
+			}, ast.Span{}),
+			"{x: number}",
+		},
+		{
+			"mutable shorthand with both",
+			ast.NewObjectPat([]ast.ObjPatElem{
+				ast.NewObjShorthandPat(ast.NewIdentifier("x", ast.Span{}), true, numberAnn, num(0), ast.Span{}),
+			}, ast.Span{}),
+			"{mut x: number = 0}",
+		},
+		{
+			"ident leaf with both",
+			ast.NewIdentPat("a", false, stringAnn, str("hi"), ast.Span{}),
+			`a: string = "hi"`,
+		},
+		{
+			"tuple element with a default",
+			ast.NewTuplePat([]ast.Pat{ast.NewIdentPat("a", false, nil, num(1), ast.Span{})}, ast.Span{}),
+			"[a = 1]",
+		},
+		{
+			// An annotation this renderer does not spell out still shows its presence.
+			"unrendered annotation",
+			ast.NewIdentPat("a", false, &ast.KeyOfTypeAnn{}, nil, ast.Span{}),
+			"a: <KeyOfTypeAnn>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, patString(test.in))
+		})
+	}
+}
+
+// A form the compact renderer does not spell out prints as its node kind, so an
+// unrecognized body still leaves the surrounding IR readable.
+func TestBodyStringFallsBackToTheNodeKind(t *testing.T) {
+	require.Equal(t, "<DoExpr>", bodyString(ast.BlockOrExpr{Expr: ast.NewDo(ast.Block{}, ast.Span{})}))
+}
+
+// A receiver that is an operator expression keeps its parentheses. Without them
+// `(a + b).c` flattens to `a + b.c`, which names a different expression, and
+// `(-a).c` flattens to `-a.c`, which negates the field rather than the object.
+func TestExprStringParenthesizesOperatorReceivers(t *testing.T) {
+	a, b, c := ident("a"), ident("b"), ident("c")
+	sum := ast.NewBinary(a, b, ast.Plus, ast.Span{})
+	negated := ast.NewUnary(ast.UnaryMinus, a, ast.Span{})
+	prop := ast.NewIdentifier("c", ast.Span{})
+
+	tests := []struct {
+		name string
+		in   ast.Expr
+		want string
+	}{
+		{
+			"member of a sum",
+			ast.NewMember(sum, prop, false, ast.Span{}),
+			"(a + b).c",
+		},
+		{
+			"member of a negation",
+			ast.NewMember(negated, prop, false, ast.Span{}),
+			"(-a).c",
+		},
+		{
+			"index of a sum",
+			ast.NewIndex(sum, c, false, ast.Span{}),
+			"(a + b)[c]",
+		},
+		{
+			"call of a sum",
+			ast.NewCall(sum, []ast.Expr{c}, false, ast.Span{}),
+			"(a + b)(c)",
+		},
+		{
+			// A plain receiver needs no parentheses, so the common member access
+			// stays readable.
+			"member of an identifier",
+			ast.NewMember(a, prop, false, ast.Span{}),
+			"a.c",
+		},
+		{
+			// Brackets already delimit an argument, an index, and a tuple element, so
+			// an operator in those positions stays bare.
+			"delimited positions stay bare",
+			ast.NewCall(a, []ast.Expr{sum}, false, ast.Span{}),
+			"a(a + b)",
+		},
+		{
+			"index expression stays bare",
+			ast.NewIndex(a, sum, false, ast.Span{}),
+			"a[a + b]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, exprString(test.in))
+		})
+	}
+}
+
+// A union inside an intersection keeps its parentheses. `&` binds tighter than `|`,
+// so without them the two nestings below both render `number | string & boolean` and
+// an annotation on a pattern leaf would not distinguish them.
+func TestTypeAnnStringParenthesizesANestedUnion(t *testing.T) {
+	number := &ast.NumberTypeAnn{}
+	str := &ast.StringTypeAnn{}
+	boolean := &ast.BooleanTypeAnn{}
+	union := func(types ...ast.TypeAnn) ast.TypeAnn { return &ast.UnionTypeAnn{Types: types} }
+	isect := func(types ...ast.TypeAnn) ast.TypeAnn { return &ast.IntersectionTypeAnn{Types: types} }
+
+	tests := []struct {
+		name string
+		in   ast.TypeAnn
+		want string
+	}{
+		{
+			"union inside an intersection",
+			isect(union(number, str), boolean),
+			"(number | string) & boolean",
+		},
+		{
+			// The tighter operator already groups the way the tree does.
+			"intersection inside a union",
+			union(number, isect(str, boolean)),
+			"number | string & boolean",
+		},
+		{"plain intersection", isect(number, str), "number & string"},
+		{"plain union", union(number, str), "number | string"},
+		{
+			"inexact union inside an intersection",
+			isect(&ast.UnionTypeAnn{Types: []ast.TypeAnn{number}, Inexact: true}, boolean),
+			"(number | ...) & boolean",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, typeAnnString(test.in))
+		})
+	}
+}


### PR DESCRIPTION
Refs #1020.

First of five stacked PRs adding `internal/solver/ucs`, the IR that Escalier's `match`, `if val`, and `val … else` lower into. The package is pure IR wired into nothing, so no behavior changes.

**The stack**

1. **This PR** — the compact AST-fragment renderer
2. #1031 — provenance and scrutinees
3. #1032 — the leaves and the desugared-core ADT
4. #1033 — tag tests and the normalized form
5. #1034 — the IR printer and the worked-example snapshots

Each builds on the one before, compiles alone, and passes `go test ./...` alone. Merge in order.

## Review posture: this one is scaffolding

Worth saying up front — **this PR is temporary, and #1040 deletes all of it.** `internal/printer` already renders every form here, and better. It cannot be used yet only because it emits multi-line output with its own indentation, which collides with the IR's nesting, and because it returns an error rather than a placeholder for a nil or unsupported node. #1040 tracks giving the printer a compact mode and deleting this file.

It was split out of #1031 for exactly that reason: it was 55% of that PR's diff and it is the half that does not survive. Review here can be lighter than on the four PRs that follow, which are the durable design.

## What's here

An IR snapshot embeds the AST fragments the IR points at — patterns, guard conditions, arm bodies, and the match target. This renders those as compact one-line text. The renderer is deliberately lossy; a form it does not spell out prints as its node kind in angle brackets.

Three details matter for the snapshots later in the stack:

- **Operands and receivers are parenthesized.** Without it, `!(x > y)` and `(!x) > y` both render `!x > y`, and `(a + b).c` flattens to `a + b.c` — a different expression from the one the IR holds. Arguments, indices, and tuple elements stay bare, since their brackets already delimit them.
- **A union nested in an intersection is parenthesized.** `&` binds tighter than `|`, so `(number | string) & boolean` and `number | (string & boolean)` would otherwise collide. An intersection inside a union needs nothing.
- **A binding leaf renders its type annotation and its default.** The default makes a field optional, so `{x = 0}` and `{x}` match different values and must not render alike.

The first two are the same defects `internal/printer` and `internal/codegen/printer.go` still have, tracked in #1039 and #1038. In codegen they are live miscompilations.

## Testing

`go test ./...` is green. 99 tests, 97.7% statement coverage — every renderer arm has a case and every fallback has one.

Part of the Ultimate Conditional Syntax IR plan, #884. Refs #882.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLgZYqkty4zyoMzoQyRMSK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing the conditional-normalization intermediate representation and supported syntax forms.

* **Tests**
  * Added comprehensive coverage for rendering expressions, literals, patterns, types, statements, and bodies.
  * Added checks for operator precedence, grouping, nested structures, nil values, and unsupported syntax fallbacks.

* **Developer Experience**
  * Added compact source-like rendering for intermediate representation snapshots, improving readability during diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->