### PR TITLE
Add desugaring for match, if val, and val else constructs

### DIFF
--- a/internal/solver/ucs/desugar.go
+++ b/internal/solver/ucs/desugar.go
@@ -1,0 +1,141 @@
+package ucs
+
+import "github.com/escalier-lang/escalier/internal/ast"
+
+// This file lowers the three conditional surface forms into the desugared core.
+// `match`, `if val`, and `val … else` all become a CoreSplit over one root
+// scrutinee, which is what lets one downstream walk replace the three hand-written
+// paths in internal/solver.
+//
+// Lowering points at the surface nodes rather than copying them. A branch holds the
+// arm's own ast.Pat, a leaf holds the arm's own ast.BlockOrExpr, and the root
+// scrutinee holds the target expression the user wrote. Sharing those nodes is what
+// keeps a side-effecting target evaluated once and lets a consumer read a pattern's
+// annotations straight off the surface.
+//
+// Desugaring mints no CoreBind. A core branch keeps its arm's pattern whole, so
+// every name the arm binds is still inside that pattern and nothing needs an
+// intermediate name here. The binds a later stage reads, such as `bind x = p.x` for
+// each leaf of `{x, y}`, come from normalization, which is what flattens a pattern
+// into projections. CoreBind is the node to reach for when a surface form names a
+// value ahead of its split.
+
+// DesugarMatch lowers a `match` expression into a core split. Each arm becomes one
+// branch that keeps the arm's pattern whole, and a guarded arm puts a CoreGuard
+// between its branch and its body so the condition reads the names the pattern
+// bound.
+//
+// The split's Else stays nil. A `match` writes no fallthrough clause, and a
+// catch-all arm is an ordinary branch in the core. Moving that arm into a default
+// tail is normalization's job.
+func DesugarMatch(e *ast.MatchExpr) *CoreSplit {
+	origin := At(OriginMatchArm, e)
+	branches := make([]*CoreBranch, len(e.Cases))
+	for i, matchCase := range e.Cases {
+		branches[i] = desugarMatchCase(matchCase)
+	}
+	return &CoreSplit{
+		Scrutinee: NewRoot(e.Target, origin),
+		Branches:  branches,
+		Origin:    origin,
+	}
+}
+
+// desugarMatchCase lowers one `match` arm into a branch. It takes an *ast.MatchCase
+// rather than a whole expression, so the catch clauses of a `TryCatchExpr`, which
+// the AST also stores as []*ast.MatchCase, can lower through the same path once the
+// solver types them.
+func desugarMatchCase(matchCase *ast.MatchCase) *CoreBranch {
+	origin := At(OriginMatchArm, matchCase)
+	var cont Core = &BodyLeaf{Body: matchCase.Body, Arm: matchCase, Origin: origin}
+	if matchCase.Guard != nil {
+		// The guard sits below the branch, so it runs with the pattern's bindings in
+		// scope. It names no failure continuation, because the branches after this one
+		// already say where a failed guard goes.
+		cont = &CoreGuard{
+			Cond:   matchCase.Guard,
+			Cont:   cont,
+			Origin: At(OriginGuard, matchCase.Guard),
+		}
+	}
+	return &CoreBranch{
+		Pattern: matchCase.Pattern,
+		Cont:    cont,
+		Arm:     matchCase,
+		Origin:  origin,
+	}
+}
+
+// DesugarIfVal lowers `if val pat = target { cons } else { alt }` into the same
+// two-branch split a two-arm `match` produces. The pattern branch carries the
+// consequent, and the `else` becomes the split's fallthrough rather than a second
+// branch.
+func DesugarIfVal(e *ast.IfValExpr) *CoreSplit {
+	origin := At(OriginIfVal, e)
+	return &CoreSplit{
+		Scrutinee: NewRoot(e.Target, origin),
+		Branches: []*CoreBranch{{
+			Pattern: e.Pattern,
+			Cont:    &BodyLeaf{Body: ast.BlockOrExpr{Block: &e.Cons}, Arm: e, Origin: origin},
+			Arm:     e,
+			Origin:  origin,
+		}},
+		Else:   ifValElse(e, origin),
+		Origin: origin,
+	}
+}
+
+// ifValElse builds the fallthrough of an `if val`. An expression that wrote an
+// `else` gets a leaf holding that block or expression.
+//
+// An `if val` with no `else` still falls through. It evaluates to `undefined` when
+// the pattern does not match, so the fallthrough is invented rather than left empty,
+// and a nil Else would instead claim no continuation covers the failure. The
+// invented leaf is synthetic and carries no arm back-reference, since no surface arm
+// produced it. Its cause is origin, so NearestSpan reaches the `if val` the user
+// wrote.
+func ifValElse(e *ast.IfValExpr, origin Origin) Core {
+	if e.Alt != nil {
+		return &BodyLeaf{Body: *e.Alt, Arm: e, Origin: origin}
+	}
+	undefined := ast.NewLitExpr(ast.NewUndefined(ast.Span{}))
+	return &BodyLeaf{
+		Body:   ast.BlockOrExpr{Expr: undefined},
+		Origin: InventedFrom(OriginIfVal, origin),
+	}
+}
+
+// DesugarValElse lowers `val pat = init else { … }` into a split whose pattern
+// branch is the success path and whose fallthrough is the `else`. It returns false
+// for a declaration that is not a `val … else`, meaning one with no `else` block,
+// and for one the parser left without an initializer.
+//
+// The success path is an EscapeLeaf rather than a body leaf. A `val … else` writes
+// no body for the matched case. Its bindings escape into the enclosing block, and
+// the rest of that block is the continuation.
+//
+// A narrowing annotation such as the `number` of `val x: number = u else { … }` sits
+// on the declaration rather than on the pattern, so the branch pattern does not
+// carry it. A consumer that needs it reads TypeAnn off the arm back-reference, which
+// is the declaration itself.
+func DesugarValElse(d *ast.VarDecl) (*CoreSplit, bool) {
+	if d.Else == nil || d.Init == nil {
+		return nil, false
+	}
+	origin := At(OriginValElse, d)
+	return &CoreSplit{
+		Scrutinee: NewRoot(d.Init, origin),
+		Branches: []*CoreBranch{{
+			Pattern: d.Pattern,
+			Cont:    &EscapeLeaf{Arm: d, Origin: origin},
+			Arm:     d,
+			Origin:  origin,
+		}},
+		Else: &FallbackLeaf{
+			Body:   ast.BlockOrExpr{Block: d.Else},
+			Arm:    d,
+			Origin: origin,
+		},
+		Origin: origin,
+	}, true
+}

--- a/internal/solver/ucs/desugar.go
+++ b/internal/solver/ucs/desugar.go
@@ -35,16 +35,31 @@ func DesugarMatch(e *ast.MatchExpr) *CoreSplit {
 		branches[i] = desugarMatchCase(matchCase)
 	}
 	return &CoreSplit{
-		Scrutinee: NewRoot(e.Target, origin),
+		Scrutinee: NewRoot(e.Target, scrutineeOrigin(OriginMatchArm, e.Target, origin)),
 		Branches:  branches,
 		Origin:    origin,
 	}
 }
 
+// scrutineeOrigin builds the origin of a root scrutinee. It blames the target
+// expression rather than the whole construct. A message about the value being
+// tested then underlines `f()` instead of the entire `match f() { … }`.
+//
+// A construct the parser left without a target has no expression to blame. Its
+// origin is then synthetic with the construct as its cause, so NearestSpan still
+// reaches a real span instead of naming no position at all.
+func scrutineeOrigin(kind OriginKind, target ast.Expr, cause Origin) Origin {
+	origin := At(kind, target)
+	if origin.Synthetic {
+		return InventedFrom(kind, cause)
+	}
+	return origin
+}
+
 // desugarMatchCase lowers one `match` arm into a branch. It takes an *ast.MatchCase
-// rather than a whole expression, so the catch clauses of a `TryCatchExpr`, which
-// the AST also stores as []*ast.MatchCase, can lower through the same path once the
-// solver types them.
+// rather than a whole expression so that more than one surface form can reach it.
+// The AST stores a `TryCatchExpr`'s catch clauses as []*ast.MatchCase too, so those
+// clauses can lower through this path once the solver types them.
 func desugarMatchCase(matchCase *ast.MatchCase) *CoreBranch {
 	origin := At(OriginMatchArm, matchCase)
 	var cont Core = &BodyLeaf{Body: matchCase.Body, Arm: matchCase, Origin: origin}
@@ -73,7 +88,7 @@ func desugarMatchCase(matchCase *ast.MatchCase) *CoreBranch {
 func DesugarIfVal(e *ast.IfValExpr) *CoreSplit {
 	origin := At(OriginIfVal, e)
 	return &CoreSplit{
-		Scrutinee: NewRoot(e.Target, origin),
+		Scrutinee: NewRoot(e.Target, scrutineeOrigin(OriginIfVal, e.Target, origin)),
 		Branches: []*CoreBranch{{
 			Pattern: e.Pattern,
 			Cont:    &BodyLeaf{Body: ast.BlockOrExpr{Block: &e.Cons}, Arm: e, Origin: origin},
@@ -85,20 +100,26 @@ func DesugarIfVal(e *ast.IfValExpr) *CoreSplit {
 	}
 }
 
-// ifValElse builds the fallthrough of an `if val`. An expression that wrote an
-// `else` gets a leaf holding that block or expression.
+// ifValElse builds the fallthrough of an `if val`. One that wrote an `else` gets a
+// leaf holding that block or expression.
 //
-// An `if val` with no `else` still falls through. It evaluates to `undefined` when
-// the pattern does not match, so the fallthrough is invented rather than left empty,
-// and a nil Else would instead claim no continuation covers the failure. The
-// invented leaf is synthetic and carries no arm back-reference, since no surface arm
-// produced it. Its cause is origin, so NearestSpan reaches the `if val` the user
-// wrote.
+// An `if val` with no `else` still falls through, evaluating to `undefined` when the
+// pattern does not match. Its fallthrough is therefore invented rather than left
+// empty. A nil Else would instead claim no continuation covers the failure. Giving
+// the invented leaf a real `undefined` body is what lets a later walk infer it as an
+// ordinary expression rather than special-casing a missing `else`.
+//
+// The leaf is synthetic and carries no arm back-reference, since no surface arm
+// produced it. Its cause is `origin`, so NearestSpan reaches the `if val` the user
+// wrote. The `undefined` expression takes that same span. A consumer reads a body's
+// position through BodySpan, which knows nothing about Origin and so cannot fall
+// back to the cause chain, and an empty span there would put a diagnostic at line 0
+// of whichever file holds source ID 0.
 func ifValElse(e *ast.IfValExpr, origin Origin) Core {
 	if e.Alt != nil {
 		return &BodyLeaf{Body: *e.Alt, Arm: e, Origin: origin}
 	}
-	undefined := ast.NewLitExpr(ast.NewUndefined(ast.Span{}))
+	undefined := ast.NewLitExpr(ast.NewUndefined(e.Span()))
 	return &BodyLeaf{
 		Body:   ast.BlockOrExpr{Expr: undefined},
 		Origin: InventedFrom(OriginIfVal, origin),
@@ -107,8 +128,8 @@ func ifValElse(e *ast.IfValExpr, origin Origin) Core {
 
 // DesugarValElse lowers `val pat = init else { … }` into a split whose pattern
 // branch is the success path and whose fallthrough is the `else`. It returns false
-// for a declaration that is not a `val … else`, meaning one with no `else` block,
-// and for one the parser left without an initializer.
+// for a declaration that is not a `val … else`. That is one with no `else` block, or
+// one the parser left without an initializer.
 //
 // The success path is an EscapeLeaf rather than a body leaf. A `val … else` writes
 // no body for the matched case. Its bindings escape into the enclosing block, and
@@ -124,7 +145,7 @@ func DesugarValElse(d *ast.VarDecl) (*CoreSplit, bool) {
 	}
 	origin := At(OriginValElse, d)
 	return &CoreSplit{
-		Scrutinee: NewRoot(d.Init, origin),
+		Scrutinee: NewRoot(d.Init, scrutineeOrigin(OriginValElse, d.Init, origin)),
 		Branches: []*CoreBranch{{
 			Pattern: d.Pattern,
 			Cont:    &EscapeLeaf{Arm: d, Origin: origin},

--- a/internal/solver/ucs/desugar_test.go
+++ b/internal/solver/ucs/desugar_test.go
@@ -18,10 +18,10 @@ import (
 // back-reference assertions read.
 //
 // A `match` arm's span starts where the token before it ended, so the first arm of
-// a multi-line `match` renders `arm=1:10-2:12` — from just past the opening brace to
-// the end of the arm. Parser.matchCase reads its start location before skipping the
-// whitespace ahead of the pattern. The desugarer copies whatever span the arm
-// carries, so the snapshots below show that start.
+// a multi-line `match` renders `arm=1:10-2:12`. That runs from just past the opening
+// brace to the end of the arm. Parser.matchCase reads its start location before
+// skipping the whitespace ahead of the pattern. The desugarer copies whatever span
+// the arm carries, so the snapshots below show that start.
 
 // parseScript parses an in-memory Escalier script. Test sources hold one conditional
 // each, so the finders below can take the first node of a kind and get the one the
@@ -180,13 +180,51 @@ func TestDesugarIfValInventsItsFallthrough(t *testing.T) {
   pat {x, y} [if val] arm=1:1-1:27 => leaf { cons } [if val] arm=1:1-1:27
 } else leaf undefined [synthetic if val] arm=none`))
 
-	// The invented leaf has no span of its own, so a diagnostic about it follows the
-	// cause chain back to the `if val` and underlines that.
+	// The invented leaf has no surface node of its own, so a diagnostic about it
+	// follows the cause chain back to the `if val` and underlines that.
 	invented := core.Else.Prov()
 	require.True(t, invented.Synthetic)
 	_, direct := invented.SourceSpan()
 	require.False(t, direct)
 	nearest, ok := invented.NearestSpan()
+	require.True(t, ok)
+	require.Equal(t, expr.Span(), nearest)
+
+	// The `undefined` body takes the same span. BodySpan reads a body's position
+	// without consulting Origin, so an empty span here would resolve to line 0 of
+	// source 0 rather than to the `if val`.
+	body, hasBody := BodySpan(core.Else.(*BodyLeaf).Body)
+	require.True(t, hasBody)
+	require.Equal(t, expr.Span(), body)
+}
+
+// A root scrutinee blames the target expression, which is narrower than the whole
+// construct, so a message about the value being tested underlines `f()` rather than
+// the entire `match f() { … }`.
+func TestDesugarScrutineeBlamesTheTarget(t *testing.T) {
+	expr := findExpr[*ast.MatchExpr](t, `match f() {
+	1 => "one",
+}`)
+
+	core := DesugarMatch(expr)
+
+	scrutinee, ok := core.Scrutinee.SourceSpan()
+	require.True(t, ok)
+	require.Equal(t, expr.Target.Span(), scrutinee)
+	require.NotEqual(t, expr.Span(), scrutinee)
+}
+
+// A `match` the parser left without a target has no expression for its scrutinee to
+// blame, so the scrutinee's origin is synthetic and names the `match` as its cause.
+// A diagnostic then still reaches a span the user can see.
+func TestDesugarScrutineeWithoutATargetFallsBackToTheConstruct(t *testing.T) {
+	expr := ast.NewMatch(nil, nil, span(1, 1, 12))
+
+	core := DesugarMatch(expr)
+
+	origin := core.Scrutinee.Prov()
+	require.True(t, origin.Synthetic)
+	nearest, ok := origin.NearestSpan()
 	require.True(t, ok)
 	require.Equal(t, expr.Span(), nearest)
 }

--- a/internal/solver/ucs/desugar_test.go
+++ b/internal/solver/ucs/desugar_test.go
@@ -87,11 +87,13 @@ func findVarDecl(t *testing.T, src string) *ast.VarDecl {
 	return decls[0]
 }
 
-// showProvenance renders a term with both its origin tags and its arm
-// back-references, the two facts a desugarer snapshot asserts beyond the shape.
+// showProvenance renders a term with its origin tags, the span each node blames, and
+// its arm back-references. Those three facts are what a desugarer snapshot asserts
+// beyond the shape, since setting them is most of what desugaring does.
 func showProvenance(term Term) string {
 	opts := DefaultPrintOptions()
 	opts.ShowOrigins = true
+	opts.ShowSpans = true
 	opts.ShowArms = true
 	return Print(term, opts)
 }
@@ -108,9 +110,9 @@ func TestDesugarMatchLiteralArms(t *testing.T) {
 	core := DesugarMatch(expr)
 
 	require.Nil(t, core.Else)
-	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split n [match arm] {
-  pat 1 [match arm] arm=1:10-2:12 => leaf "one" [match arm] arm=1:10-2:12
-  pat _ [match arm] arm=2:13-3:14 => leaf "other" [match arm] arm=2:13-3:14
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split n [match arm] at=1:1-4:2 {
+  pat 1 [match arm] at=1:10-2:12 arm=1:10-2:12 => leaf "one" [match arm] at=1:10-2:12 arm=1:10-2:12
+  pat _ [match arm] at=2:13-3:14 arm=2:13-3:14 => leaf "other" [match arm] at=2:13-3:14 arm=2:13-3:14
 }`))
 }
 
@@ -125,20 +127,19 @@ func TestDesugarMatchGuardedArm(t *testing.T) {
 
 	core := DesugarMatch(expr)
 
-	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [match arm] {
-  pat {x, y} [match arm] arm=1:10-2:22 => guard (x > y) [guard] => leaf x [match arm] arm=1:10-2:22
-  pat _ [match arm] arm=2:23-3:8 => leaf 0 [match arm] arm=2:23-3:8
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [match arm] at=1:1-4:2 {
+  pat {x, y} [match arm] at=1:10-2:22 arm=1:10-2:22 => guard (x > y) [guard] at=2:12-2:17 => leaf x [match arm] at=1:10-2:22 arm=1:10-2:22
+  pat _ [match arm] at=2:23-3:8 arm=2:23-3:8 => leaf 0 [match arm] at=2:23-3:8 arm=2:23-3:8
 }`))
 
-	// The snapshot shows no `arm=` tag on the guard, because ShowArms renders the Arm
-	// back-reference and a guard carries none. Its span comes from its own origin
-	// instead, which points at the condition and so underlines `x > y` alone.
+	// The guard carries no `arm=` tag, because ShowArms renders the Arm
+	// back-reference and a guard has no such field. The `at=` span in the snapshot is
+	// the guard's own origin, which is the condition node itself rather than a copy of
+	// its position.
 	guard, isGuard := core.Branches[0].Cont.(*CoreGuard)
 	require.True(t, isGuard)
-	cond, ok := guard.Prov().SourceSpan()
-	require.True(t, ok)
-	require.Equal(t, expr.Cases[0].Guard.Span(), cond)
-	require.Equal(t, "2:12-2:17", cond.String())
+	require.Same(t, expr.Cases[0].Guard, guard.Cond)
+	require.Same(t, expr.Cases[0].Guard, guard.Prov().Node)
 }
 
 // A nested pattern stays one deep shape on its branch. Flattening it into successive
@@ -173,9 +174,9 @@ func TestDesugarIfVal(t *testing.T) {
 
 	core := DesugarIfVal(expr)
 
-	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] {
-  pat {x, y} [if val] arm=1:1-1:40 => leaf { cons } [if val] arm=1:1-1:40
-} else leaf { alt } [if val] arm=1:1-1:40`))
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] at=1:1-1:40 {
+  pat {x, y} [if val] at=1:1-1:40 arm=1:1-1:40 => leaf { cons } [if val] at=1:1-1:40 arm=1:1-1:40
+} else leaf { alt } [if val] at=1:1-1:40 arm=1:1-1:40`))
 }
 
 // An `if val` with no `else` still falls through, evaluating to `undefined` when the
@@ -186,9 +187,9 @@ func TestDesugarIfValInventsItsFallthrough(t *testing.T) {
 
 	core := DesugarIfVal(expr)
 
-	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] {
-  pat {x, y} [if val] arm=1:1-1:27 => leaf { cons } [if val] arm=1:1-1:27
-} else leaf undefined [synthetic if val] arm=none`))
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] at=1:1-1:27 {
+  pat {x, y} [if val] at=1:1-1:27 arm=1:1-1:27 => leaf { cons } [if val] at=1:1-1:27 arm=1:1-1:27
+} else leaf undefined [synthetic if val] at~1:1-1:27 arm=none`))
 
 	// The invented leaf has no surface node of its own, so a diagnostic about it
 	// follows the cause chain back to the `if val` and underlines that.
@@ -248,9 +249,9 @@ func TestDesugarValElse(t *testing.T) {
 	core, ok := DesugarValElse(decl)
 
 	require.True(t, ok)
-	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [val else] {
-  pat {x, y} [val else] arm=1:1-1:33 => escape [val else] arm=1:1-1:33
-} else fallback { fallback } [val else] arm=1:1-1:33`))
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [val else] at=1:1-1:33 {
+  pat {x, y} [val else] at=1:1-1:33 arm=1:1-1:33 => escape [val else] at=1:1-1:33 arm=1:1-1:33
+} else fallback { fallback } [val else] at=1:1-1:33 arm=1:1-1:33`))
 }
 
 // A narrowing annotation on a `val … else` sits on the declaration, not on the

--- a/internal/solver/ucs/desugar_test.go
+++ b/internal/solver/ucs/desugar_test.go
@@ -129,6 +129,16 @@ func TestDesugarMatchGuardedArm(t *testing.T) {
   pat {x, y} [match arm] arm=1:10-2:22 => guard (x > y) [guard] => leaf x [match arm] arm=1:10-2:22
   pat _ [match arm] arm=2:23-3:8 => leaf 0 [match arm] arm=2:23-3:8
 }`))
+
+	// The snapshot shows no `arm=` tag on the guard, because ShowArms renders the Arm
+	// back-reference and a guard carries none. Its span comes from its own origin
+	// instead, which points at the condition and so underlines `x > y` alone.
+	guard, isGuard := core.Branches[0].Cont.(*CoreGuard)
+	require.True(t, isGuard)
+	cond, ok := guard.Prov().SourceSpan()
+	require.True(t, ok)
+	require.Equal(t, expr.Cases[0].Guard.Span(), cond)
+	require.Equal(t, "2:12-2:17", cond.String())
 }
 
 // A nested pattern stays one deep shape on its branch. Flattening it into successive

--- a/internal/solver/ucs/desugar_test.go
+++ b/internal/solver/ucs/desugar_test.go
@@ -1,0 +1,274 @@
+package ucs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests below state their input as Escalier source and parse it, rather than
+// hand-building an AST the way the printer tests do. A desugarer's job is to read
+// the nodes the parser produces, so a snapshot is only worth as much as the surface
+// it ran on. Parsing also gives every arm a real span, which is what the
+// back-reference assertions read.
+//
+// A `match` arm's span starts where the token before it ended, so the first arm of
+// a multi-line `match` renders `arm=1:10-2:12` — from just past the opening brace to
+// the end of the arm. Parser.matchCase reads its start location before skipping the
+// whitespace ahead of the pattern. The desugarer copies whatever span the arm
+// carries, so the snapshots below show that start.
+
+// parseScript parses an in-memory Escalier script. Test sources hold one conditional
+// each, so the finders below can take the first node of a kind and get the one the
+// test means.
+func parseScript(t *testing.T, src string) *ast.Script {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	source := &ast.Source{ID: 0, Path: "input.esc", Contents: src}
+	script, errs := parser.NewParser(ctx, source).ParseScript()
+	require.Empty(t, errs, "expected no parse errors")
+	return script
+}
+
+// nodeFinder collects the expressions and variable declarations of a script in
+// source order, using the shared AST visitor rather than a walk of its own.
+type nodeFinder struct {
+	ast.DefaultVisitor
+	exprs []ast.Expr
+	decls []*ast.VarDecl
+}
+
+func (f *nodeFinder) EnterExpr(e ast.Expr) bool {
+	f.exprs = append(f.exprs, e)
+	return true
+}
+
+func (f *nodeFinder) EnterDecl(d ast.Decl) bool {
+	if found, is := d.(*ast.VarDecl); is {
+		f.decls = append(f.decls, found)
+	}
+	return true
+}
+
+// walk parses src and returns the finder that walked it.
+func walk(t *testing.T, src string) *nodeFinder {
+	t.Helper()
+	finder := &nodeFinder{}
+	for _, stmt := range parseScript(t, src).Stmts {
+		stmt.Accept(finder)
+	}
+	return finder
+}
+
+// findExpr returns the first expression of type T in src.
+func findExpr[T ast.Expr](t *testing.T, src string) T {
+	t.Helper()
+	var zero T
+	for _, e := range walk(t, src).exprs {
+		if found, is := e.(T); is {
+			return found
+		}
+	}
+	require.Fail(t, "the parsed script holds no expression of the wanted kind", "wanted %T", zero)
+	return zero
+}
+
+// findVarDecl returns the first variable declaration in src.
+func findVarDecl(t *testing.T, src string) *ast.VarDecl {
+	t.Helper()
+	decls := walk(t, src).decls
+	require.NotEmpty(t, decls, "no variable declaration in the parsed script")
+	return decls[0]
+}
+
+// showProvenance renders a term with both its origin tags and its arm
+// back-references, the two facts a desugarer snapshot asserts beyond the shape.
+func showProvenance(term Term) string {
+	opts := DefaultPrintOptions()
+	opts.ShowOrigins = true
+	opts.ShowArms = true
+	return Print(term, opts)
+}
+
+// A literal `match` becomes one branch per arm, in source order. The catch-all is an
+// ordinary branch and the split writes no `else`, so nothing has moved into a
+// default tail yet.
+func TestDesugarMatchLiteralArms(t *testing.T) {
+	expr := findExpr[*ast.MatchExpr](t, `match n {
+	1 => "one",
+	_ => "other",
+}`)
+
+	core := DesugarMatch(expr)
+
+	require.Nil(t, core.Else)
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split n [match arm] {
+  pat 1 [match arm] arm=1:10-2:12 => leaf "one" [match arm] arm=1:10-2:12
+  pat _ [match arm] arm=2:13-3:14 => leaf "other" [match arm] arm=2:13-3:14
+}`))
+}
+
+// A guarded arm puts the guard between its branch and its body, so the condition
+// runs with `x` and `y` in scope. The guard's origin blames the condition the user
+// wrote rather than the whole arm.
+func TestDesugarMatchGuardedArm(t *testing.T) {
+	expr := findExpr[*ast.MatchExpr](t, `match p {
+	{x, y} if x > y => x,
+	_ => 0,
+}`)
+
+	core := DesugarMatch(expr)
+
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [match arm] {
+  pat {x, y} [match arm] arm=1:10-2:22 => guard (x > y) [guard] => leaf x [match arm] arm=1:10-2:22
+  pat _ [match arm] arm=2:23-3:8 => leaf 0 [match arm] arm=2:23-3:8
+}`))
+}
+
+// A nested pattern stays one deep shape on its branch. Flattening it into successive
+// one-tag-level splits is normalization's job, not the desugarer's.
+func TestDesugarMatchKeepsNestedPatternWhole(t *testing.T) {
+	expr := findExpr[*ast.MatchExpr](t, `match l {
+	Line { start: {x, y} } => [x, y],
+}`)
+
+	core := DesugarMatch(expr)
+
+	snaps.MatchInlineSnapshot(t, core.String(), snaps.Inline(`split l {
+  pat Line {start: {x, y}} => leaf [x, y]
+}`))
+}
+
+// A `match` with no arms lowers to a split with no branches. It covers nothing, and
+// the coverage check is what reports that later.
+func TestDesugarMatchWithNoArms(t *testing.T) {
+	expr := findExpr[*ast.MatchExpr](t, `match n {}`)
+
+	core := DesugarMatch(expr)
+
+	require.Empty(t, core.Branches)
+	require.Equal(t, "split n {}", core.String())
+}
+
+// `if val` lowers to the same two-branch split a two-arm `match` produces. The
+// `else` is the split's fallthrough rather than a second branch.
+func TestDesugarIfVal(t *testing.T) {
+	expr := findExpr[*ast.IfValExpr](t, `if val {x, y} = p { cons } else { alt }`)
+
+	core := DesugarIfVal(expr)
+
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] {
+  pat {x, y} [if val] arm=1:1-1:40 => leaf { cons } [if val] arm=1:1-1:40
+} else leaf { alt } [if val] arm=1:1-1:40`))
+}
+
+// An `if val` with no `else` still falls through, evaluating to `undefined` when the
+// pattern does not match, so the desugarer invents that leaf. It is marked synthetic
+// and points at no arm, since the user wrote neither.
+func TestDesugarIfValInventsItsFallthrough(t *testing.T) {
+	expr := findExpr[*ast.IfValExpr](t, `if val {x, y} = p { cons }`)
+
+	core := DesugarIfVal(expr)
+
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] {
+  pat {x, y} [if val] arm=1:1-1:27 => leaf { cons } [if val] arm=1:1-1:27
+} else leaf undefined [synthetic if val] arm=none`))
+
+	// The invented leaf has no span of its own, so a diagnostic about it follows the
+	// cause chain back to the `if val` and underlines that.
+	invented := core.Else.Prov()
+	require.True(t, invented.Synthetic)
+	_, direct := invented.SourceSpan()
+	require.False(t, direct)
+	nearest, ok := invented.NearestSpan()
+	require.True(t, ok)
+	require.Equal(t, expr.Span(), nearest)
+}
+
+// `val pat = init else { … }` lowers to the same split, but its success path carries
+// no body. The bindings escape into the enclosing block, and the `else` is a fallback
+// rather than an arm that covers the scrutinee.
+func TestDesugarValElse(t *testing.T) {
+	decl := findVarDecl(t, `val {x, y} = p else { fallback }`)
+
+	core, ok := DesugarValElse(decl)
+
+	require.True(t, ok)
+	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [val else] {
+  pat {x, y} [val else] arm=1:1-1:33 => escape [val else] arm=1:1-1:33
+} else fallback { fallback } [val else] arm=1:1-1:33`))
+}
+
+// A narrowing annotation on a `val … else` sits on the declaration, not on the
+// pattern, so the branch pattern renders without it. A consumer that needs the
+// annotation reads it off the arm back-reference, which is the declaration.
+func TestDesugarValElseLeavesTheAnnotationOnTheDeclaration(t *testing.T) {
+	decl := findVarDecl(t, `val x: number = u else { 0 }`)
+
+	core, ok := DesugarValElse(decl)
+
+	require.True(t, ok)
+	require.Equal(t, "split u {\n  pat x => escape\n} else fallback { 0 }", core.String())
+	require.Same(t, decl, core.Branches[0].Arm)
+	require.NotNil(t, decl.TypeAnn)
+}
+
+// Only a declaration that wrote an `else` is a `val … else`. A plain `val` and a
+// declaration the parser left without an initializer both lower to nothing, so a
+// caller keeps its ordinary declaration path for them.
+func TestDesugarValElseRejectsOtherDeclarations(t *testing.T) {
+	withoutElse := findVarDecl(t, `val {x, y} = p`)
+	withoutInit := findVarDecl(t, `val {x, y} = p else { fallback }`)
+	withoutInit.Init = nil
+
+	tests := []struct {
+		name string
+		decl *ast.VarDecl
+	}{
+		{"NoElse", withoutElse},
+		{"NoInitializer", withoutInit},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			core, ok := DesugarValElse(test.decl)
+			require.False(t, ok)
+			require.Nil(t, core)
+		})
+	}
+}
+
+// Lowering points at the surface nodes rather than copying them. Sharing the target
+// expression is what keeps a side-effecting scrutinee evaluated once, and sharing the
+// pattern and body nodes is what lets a later stage read their annotations and infer
+// their types against the source the user wrote.
+func TestDesugarPointsAtTheSurfaceNodes(t *testing.T) {
+	expr := findExpr[*ast.MatchExpr](t, `match f() {
+	{x, y} if x > y => x,
+}`)
+
+	core := DesugarMatch(expr)
+
+	require.Same(t, expr.Target, core.Scrutinee.Target)
+	require.True(t, core.Scrutinee.IsRoot())
+
+	arm := expr.Cases[0]
+	branch := core.Branches[0]
+	require.Same(t, arm.Pattern, branch.Pattern)
+	require.Same(t, arm, branch.Arm)
+
+	guard, isGuard := branch.Cont.(*CoreGuard)
+	require.True(t, isGuard)
+	require.Same(t, arm.Guard, guard.Cond)
+
+	leaf, isLeaf := guard.Cont.(*BodyLeaf)
+	require.True(t, isLeaf)
+	require.Equal(t, arm.Body, leaf.Body)
+	require.Same(t, arm, leaf.Arm)
+}

--- a/internal/solver/ucs/desugar_test.go
+++ b/internal/solver/ucs/desugar_test.go
@@ -111,8 +111,8 @@ func TestDesugarMatchLiteralArms(t *testing.T) {
 
 	require.Nil(t, core.Else)
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split n [match arm] at=1:1-4:2 {
-  pat 1 [match arm] at=1:10-2:12 arm=1:10-2:12 => leaf "one" [match arm] at=1:10-2:12 arm=1:10-2:12
-  pat _ [match arm] at=2:13-3:14 arm=2:13-3:14 => leaf "other" [match arm] at=2:13-3:14 arm=2:13-3:14
+  pat 1 [match arm] at=1:10-2:12 arm=same => leaf "one" [match arm] at=1:10-2:12 arm=same
+  pat _ [match arm] at=2:13-3:14 arm=same => leaf "other" [match arm] at=2:13-3:14 arm=same
 }`))
 }
 
@@ -128,8 +128,8 @@ func TestDesugarMatchGuardedArm(t *testing.T) {
 	core := DesugarMatch(expr)
 
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [match arm] at=1:1-4:2 {
-  pat {x, y} [match arm] at=1:10-2:22 arm=1:10-2:22 => guard (x > y) [guard] at=2:12-2:17 => leaf x [match arm] at=1:10-2:22 arm=1:10-2:22
-  pat _ [match arm] at=2:23-3:8 arm=2:23-3:8 => leaf 0 [match arm] at=2:23-3:8 arm=2:23-3:8
+  pat {x, y} [match arm] at=1:10-2:22 arm=same => guard (x > y) [guard] at=2:12-2:17 => leaf x [match arm] at=1:10-2:22 arm=same
+  pat _ [match arm] at=2:23-3:8 arm=same => leaf 0 [match arm] at=2:23-3:8 arm=same
 }`))
 
 	// The guard carries no `arm=` tag, because ShowArms renders the Arm
@@ -175,8 +175,8 @@ func TestDesugarIfVal(t *testing.T) {
 	core := DesugarIfVal(expr)
 
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] at=1:1-1:40 {
-  pat {x, y} [if val] at=1:1-1:40 arm=1:1-1:40 => leaf { cons } [if val] at=1:1-1:40 arm=1:1-1:40
-} else leaf { alt } [if val] at=1:1-1:40 arm=1:1-1:40`))
+  pat {x, y} [if val] at=1:1-1:40 arm=same => leaf { cons } [if val] at=1:1-1:40 arm=same
+} else leaf { alt } [if val] at=1:1-1:40 arm=same`))
 }
 
 // An `if val` with no `else` still falls through, evaluating to `undefined` when the
@@ -188,7 +188,7 @@ func TestDesugarIfValInventsItsFallthrough(t *testing.T) {
 	core := DesugarIfVal(expr)
 
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] at=1:1-1:27 {
-  pat {x, y} [if val] at=1:1-1:27 arm=1:1-1:27 => leaf { cons } [if val] at=1:1-1:27 arm=1:1-1:27
+  pat {x, y} [if val] at=1:1-1:27 arm=same => leaf { cons } [if val] at=1:1-1:27 arm=same
 } else leaf undefined [synthetic if val] at~1:1-1:27 arm=none`))
 
 	// The invented leaf has no surface node of its own, so a diagnostic about it
@@ -250,8 +250,8 @@ func TestDesugarValElse(t *testing.T) {
 
 	require.True(t, ok)
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [val else] at=1:1-1:33 {
-  pat {x, y} [val else] at=1:1-1:33 arm=1:1-1:33 => escape [val else] at=1:1-1:33 arm=1:1-1:33
-} else fallback { fallback } [val else] at=1:1-1:33 arm=1:1-1:33`))
+  pat {x, y} [val else] at=1:1-1:33 arm=same => escape [val else] at=1:1-1:33 arm=same
+} else fallback { fallback } [val else] at=1:1-1:33 arm=same`))
 }
 
 // A narrowing annotation on a `val … else` sits on the declaration, not on the

--- a/internal/solver/ucs/print.go
+++ b/internal/solver/ucs/print.go
@@ -1,6 +1,10 @@
 package ucs
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+)
 
 // PrintOptions configures how Print renders a term.
 type PrintOptions struct {
@@ -15,6 +19,11 @@ type PrintOptions struct {
 	// `arm=1:5-1:14` from the arm's span, or `arm=none` when the node carries no
 	// back-reference. A test that asserts a merged or flattened split still blames
 	// the arm the user typed turns it on.
+	//
+	// With ShowSpans also on, an arm whose span matches the one ShowSpans wrote
+	// renders `arm=same` rather than repeating it. Desugaring gives a node the same
+	// surface node for both, so that is the usual rendering, and a printed pair of
+	// spans marks the case where normalization synthesized the origin.
 	ShowArms bool
 	// ShowSpans appends the span a node blames, written `at=2:12-2:17`. A synthetic
 	// node has no span of its own, so it renders the one its cause chain reaches with
@@ -115,14 +124,14 @@ func (p *printer) branches(count int, write func(i int)) {
 func (p *printer) core(n Core) {
 	switch n := n.(type) {
 	case *CoreSplit:
-		p.write("split " + scrutineeString(n.Scrutinee) + p.originTag(n.Origin) + p.spanTag(n.Origin))
+		p.write("split " + scrutineeString(n.Scrutinee) + p.tags(n.Origin))
 		p.branches(len(n.Branches), func(i int) { p.coreBranch(n.Branches[i]) })
 		if n.Else != nil {
 			p.write(" else ")
 			p.core(n.Else)
 		}
 	case *CoreGuard:
-		p.write("guard (" + exprString(n.Cond) + ")" + p.originTag(n.Origin) + p.spanTag(n.Origin) + " => ")
+		p.write("guard (" + exprString(n.Cond) + ")" + p.tags(n.Origin) + " => ")
 		p.core(n.Cont)
 	case *CoreBind:
 		// coreBinds writes the whole bind clause, so it must run before the
@@ -135,7 +144,7 @@ func (p *printer) core(n Core) {
 }
 
 func (p *printer) coreBranch(b *CoreBranch) {
-	p.write("pat " + patString(b.Pattern) + p.originTag(b.Origin) + p.spanTag(b.Origin) + p.armTag(b.Arm) + " => ")
+	p.write("pat " + patString(b.Pattern) + p.armTags(b.Origin, b.Arm) + " => ")
 	p.core(b.Cont)
 }
 
@@ -148,7 +157,7 @@ func (p *printer) coreBinds(n *CoreBind) Core {
 		if i > 0 {
 			p.write(", ")
 		}
-		p.write(n.Name + " = " + scrutineeString(n.Source) + p.originTag(n.Origin) + p.spanTag(n.Origin))
+		p.write(n.Name + " = " + scrutineeString(n.Source) + p.tags(n.Origin))
 		next, ok := n.Cont.(*CoreBind)
 		if !ok {
 			break
@@ -162,12 +171,12 @@ func (p *printer) coreBinds(n *CoreBind) Core {
 func (p *printer) norm(n Norm) {
 	switch n := n.(type) {
 	case *NormSplit:
-		p.write("split " + scrutineeString(n.Scrutinee) + p.originTag(n.Origin) + p.spanTag(n.Origin))
+		p.write("split " + scrutineeString(n.Scrutinee) + p.tags(n.Origin))
 		p.branches(len(n.Branches), func(i int) { p.normBranch(n.Branches[i]) })
 		p.write(" default ")
 		p.norm(n.Default)
 	case *NormGuard:
-		p.write("guard (" + exprString(n.Cond) + ")" + p.originTag(n.Origin) + p.spanTag(n.Origin))
+		p.write("guard (" + exprString(n.Cond) + ")" + p.tags(n.Origin))
 		p.branches(1, func(int) { p.norm(n.Cont) })
 		p.write(" default ")
 		p.norm(n.Default)
@@ -182,7 +191,7 @@ func (p *printer) norm(n Norm) {
 }
 
 func (p *printer) normBranch(b *NormBranch) {
-	p.write(testString(b.Test) + p.originTag(b.Origin) + p.spanTag(b.Origin) + p.armTag(b.Arm) + " => ")
+	p.write(testString(b.Test) + p.armTags(b.Origin, b.Arm) + " => ")
 	p.norm(b.Cont)
 }
 
@@ -194,7 +203,7 @@ func (p *printer) normBinds(n *NormBind) Norm {
 		if i > 0 {
 			p.write(", ")
 		}
-		p.write(n.Name + " = " + scrutineeString(n.Source) + p.originTag(n.Origin) + p.spanTag(n.Origin))
+		p.write(n.Name + " = " + scrutineeString(n.Source) + p.tags(n.Origin))
 		next, ok := n.Cont.(*NormBind)
 		if !ok {
 			break
@@ -212,11 +221,11 @@ func (p *printer) leaf(t Term) {
 	case nil:
 		p.write("✗")
 	case *BodyLeaf:
-		p.write("leaf " + bodyString(n.Body) + p.originTag(n.Origin) + p.spanTag(n.Origin) + p.armTag(n.Arm))
+		p.write("leaf " + bodyString(n.Body) + p.armTags(n.Origin, n.Arm))
 	case *EscapeLeaf:
-		p.write("escape" + p.originTag(n.Origin) + p.spanTag(n.Origin) + p.armTag(n.Arm))
+		p.write("escape" + p.armTags(n.Origin, n.Arm))
 	case *FallbackLeaf:
-		p.write("fallback " + bodyString(n.Body) + p.originTag(n.Origin) + p.spanTag(n.Origin) + p.armTag(n.Arm))
+		p.write("fallback " + bodyString(n.Body) + p.armTags(n.Origin, n.Arm))
 	default:
 		p.write(nodeKind(t))
 	}
@@ -252,14 +261,46 @@ func (p *printer) spanTag(o Origin) string {
 }
 
 // armTag renders a branch's or leaf's surface-arm back-reference as the arm's span,
-// or nothing when the caller did not ask for it.
-func (p *printer) armTag(arm Spanned) string {
+// or nothing when the caller did not ask for it. A node carrying no back-reference
+// renders `arm=none`.
+//
+// An arm whose span matches the one spanTag already wrote renders `arm=same` rather
+// than repeating the coordinates. That is the shape straight out of desugaring,
+// where a node's origin and its back-reference are the same surface node. The two
+// part ways once normalization synthesizes an origin over a merged or flattened
+// split, and then both spans print, which is the case a reader is looking for.
+func (p *printer) armTag(o Origin, arm Spanned) string {
 	if !p.opts.ShowArms {
 		return ""
 	}
-	s, ok := SpanOf(arm)
+	span, ok := SpanOf(arm)
 	if !ok {
 		return " arm=none"
 	}
-	return " arm=" + s.String()
+	if shown, wrote := p.shownSpan(o); wrote && shown == span {
+		return " arm=same"
+	}
+	return " arm=" + span.String()
+}
+
+// shownSpan returns the span spanTag wrote for o, and false when it wrote none.
+// NearestSpan yields a node's own span when it has one and the span its cause chain
+// reaches otherwise, which is the same order spanTag renders in.
+func (p *printer) shownSpan(o Origin) (ast.Span, bool) {
+	if !p.opts.ShowSpans {
+		return ast.Span{}, false
+	}
+	return o.NearestSpan()
+}
+
+// tags renders the annotations that follow a node with no surface-arm
+// back-reference: its origin and the span it blames.
+func (p *printer) tags(o Origin) string {
+	return p.originTag(o) + p.spanTag(o)
+}
+
+// armTags renders the same annotations for a branch or leaf, followed by its
+// surface-arm back-reference.
+func (p *printer) armTags(o Origin, arm Spanned) string {
+	return p.tags(o) + p.armTag(o, arm)
 }

--- a/internal/solver/ucs/print.go
+++ b/internal/solver/ucs/print.go
@@ -16,6 +16,18 @@ type PrintOptions struct {
 	// back-reference. A test that asserts a merged or flattened split still blames
 	// the arm the user typed turns it on.
 	ShowArms bool
+	// ShowSpans appends the span a node blames, written `at=2:12-2:17`. A synthetic
+	// node has no span of its own, so it renders the one its cause chain reaches with
+	// a `~` in place of the `=`, written `at~1:1-1:27`. A node that reaches no span at
+	// all renders `at=none`.
+	//
+	// It renders on the same nodes ShowOrigins tags, which is every core and
+	// normalized term. A scrutinee renders neither, so a test that needs a
+	// scrutinee's span reads Prov().SourceSpan() rather than the printed form.
+	//
+	// This is what shows the span of a node that carries no arm back-reference, such
+	// as a guard, whose origin points at the condition the user wrote.
+	ShowSpans bool
 }
 
 // DefaultPrintOptions renders shape alone, with two-space indentation.
@@ -103,14 +115,14 @@ func (p *printer) branches(count int, write func(i int)) {
 func (p *printer) core(n Core) {
 	switch n := n.(type) {
 	case *CoreSplit:
-		p.write("split " + scrutineeString(n.Scrutinee) + p.originTag(n.Origin))
+		p.write("split " + scrutineeString(n.Scrutinee) + p.originTag(n.Origin) + p.spanTag(n.Origin))
 		p.branches(len(n.Branches), func(i int) { p.coreBranch(n.Branches[i]) })
 		if n.Else != nil {
 			p.write(" else ")
 			p.core(n.Else)
 		}
 	case *CoreGuard:
-		p.write("guard (" + exprString(n.Cond) + ")" + p.originTag(n.Origin) + " => ")
+		p.write("guard (" + exprString(n.Cond) + ")" + p.originTag(n.Origin) + p.spanTag(n.Origin) + " => ")
 		p.core(n.Cont)
 	case *CoreBind:
 		// coreBinds writes the whole bind clause, so it must run before the
@@ -123,7 +135,7 @@ func (p *printer) core(n Core) {
 }
 
 func (p *printer) coreBranch(b *CoreBranch) {
-	p.write("pat " + patString(b.Pattern) + p.originTag(b.Origin) + p.armTag(b.Arm) + " => ")
+	p.write("pat " + patString(b.Pattern) + p.originTag(b.Origin) + p.spanTag(b.Origin) + p.armTag(b.Arm) + " => ")
 	p.core(b.Cont)
 }
 
@@ -136,7 +148,7 @@ func (p *printer) coreBinds(n *CoreBind) Core {
 		if i > 0 {
 			p.write(", ")
 		}
-		p.write(n.Name + " = " + scrutineeString(n.Source) + p.originTag(n.Origin))
+		p.write(n.Name + " = " + scrutineeString(n.Source) + p.originTag(n.Origin) + p.spanTag(n.Origin))
 		next, ok := n.Cont.(*CoreBind)
 		if !ok {
 			break
@@ -150,12 +162,12 @@ func (p *printer) coreBinds(n *CoreBind) Core {
 func (p *printer) norm(n Norm) {
 	switch n := n.(type) {
 	case *NormSplit:
-		p.write("split " + scrutineeString(n.Scrutinee) + p.originTag(n.Origin))
+		p.write("split " + scrutineeString(n.Scrutinee) + p.originTag(n.Origin) + p.spanTag(n.Origin))
 		p.branches(len(n.Branches), func(i int) { p.normBranch(n.Branches[i]) })
 		p.write(" default ")
 		p.norm(n.Default)
 	case *NormGuard:
-		p.write("guard (" + exprString(n.Cond) + ")" + p.originTag(n.Origin))
+		p.write("guard (" + exprString(n.Cond) + ")" + p.originTag(n.Origin) + p.spanTag(n.Origin))
 		p.branches(1, func(int) { p.norm(n.Cont) })
 		p.write(" default ")
 		p.norm(n.Default)
@@ -170,7 +182,7 @@ func (p *printer) norm(n Norm) {
 }
 
 func (p *printer) normBranch(b *NormBranch) {
-	p.write(testString(b.Test) + p.originTag(b.Origin) + p.armTag(b.Arm) + " => ")
+	p.write(testString(b.Test) + p.originTag(b.Origin) + p.spanTag(b.Origin) + p.armTag(b.Arm) + " => ")
 	p.norm(b.Cont)
 }
 
@@ -182,7 +194,7 @@ func (p *printer) normBinds(n *NormBind) Norm {
 		if i > 0 {
 			p.write(", ")
 		}
-		p.write(n.Name + " = " + scrutineeString(n.Source) + p.originTag(n.Origin))
+		p.write(n.Name + " = " + scrutineeString(n.Source) + p.originTag(n.Origin) + p.spanTag(n.Origin))
 		next, ok := n.Cont.(*NormBind)
 		if !ok {
 			break
@@ -200,11 +212,11 @@ func (p *printer) leaf(t Term) {
 	case nil:
 		p.write("✗")
 	case *BodyLeaf:
-		p.write("leaf " + bodyString(n.Body) + p.originTag(n.Origin) + p.armTag(n.Arm))
+		p.write("leaf " + bodyString(n.Body) + p.originTag(n.Origin) + p.spanTag(n.Origin) + p.armTag(n.Arm))
 	case *EscapeLeaf:
-		p.write("escape" + p.originTag(n.Origin) + p.armTag(n.Arm))
+		p.write("escape" + p.originTag(n.Origin) + p.spanTag(n.Origin) + p.armTag(n.Arm))
 	case *FallbackLeaf:
-		p.write("fallback " + bodyString(n.Body) + p.originTag(n.Origin) + p.armTag(n.Arm))
+		p.write("fallback " + bodyString(n.Body) + p.originTag(n.Origin) + p.spanTag(n.Origin) + p.armTag(n.Arm))
 	default:
 		p.write(nodeKind(t))
 	}
@@ -220,6 +232,23 @@ func (p *printer) originTag(o Origin) string {
 		return " [synthetic " + o.Kind.String() + "]"
 	}
 	return " [" + o.Kind.String() + "]"
+}
+
+// spanTag renders the span a node blames, or nothing when the caller did not ask for
+// it. A node with a surface node of its own renders that node's span after `at=`. A
+// synthetic node renders the span its cause chain reaches after `at~`, so a reader
+// can tell an inherited span from an owned one.
+func (p *printer) spanTag(o Origin) string {
+	if !p.opts.ShowSpans {
+		return ""
+	}
+	if span, ok := o.SourceSpan(); ok {
+		return " at=" + span.String()
+	}
+	if span, ok := o.NearestSpan(); ok {
+		return " at~" + span.String()
+	}
+	return " at=none"
 }
 
 // armTag renders a branch's or leaf's surface-arm back-reference as the arm's span,

--- a/internal/solver/ucs/print_test.go
+++ b/internal/solver/ucs/print_test.go
@@ -499,6 +499,54 @@ func TestPrintShowsArmBackReferences(t *testing.T) {
 } default leaf undefined arm=none`))
 }
 
+// ShowSpans turns on the span each node itself blames, which is the only way to see
+// the span of a node that carries no arm back-reference. The guard here renders the
+// condition's span, `x > y` at 2:14-2:19, while its branch renders the whole arm's.
+//
+// A synthetic node owns no span, so it renders the one its cause chain reaches
+// behind `at~`. The invented fallthrough below was minted from the `match`, so it
+// renders that expression's span.
+func TestPrintShowsSpans(t *testing.T) {
+	guardCond := ast.NewBinary(ident("x"), ident("y"), ast.GreaterThan, span(2, 14, 19))
+	guarded := matchCase(objPat("x", "y"), guardCond, ident("x"), span(2, 5, 30))
+	target := ident("p")
+	expr := ast.NewMatch(target, []*ast.MatchCase{guarded}, span(1, 1, 40))
+	origin := At(OriginMatchArm, expr)
+	armOrigin := At(OriginMatchArm, guarded)
+
+	core := &CoreSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*CoreBranch{{
+			Pattern: guarded.Pattern,
+			Cont: &CoreGuard{
+				Cond:   guardCond,
+				Cont:   &BodyLeaf{Body: guarded.Body, Arm: guarded, Origin: armOrigin},
+				Origin: At(OriginGuard, guardCond),
+			},
+			Arm:    guarded,
+			Origin: armOrigin,
+		}},
+		Else:   &BodyLeaf{Body: exprBody(num(0)), Origin: InventedFrom(OriginMatchArm, origin)},
+		Origin: origin,
+	}
+
+	opts := DefaultPrintOptions()
+	opts.ShowSpans = true
+	snaps.MatchInlineSnapshot(t, Print(core, opts), snaps.Inline(`split p at=1:1-1:40 {
+  pat {x, y} at=2:5-2:30 => guard (x > y) at=2:14-2:19 => leaf x at=2:5-2:30
+} else leaf 0 at~1:1-1:40`))
+}
+
+// A node whose cause chain reaches no surface node at all names no position, so it
+// renders `at=none` rather than inventing one.
+func TestPrintShowsNoSpanForAnUncausedSyntheticNode(t *testing.T) {
+	leaf := &BodyLeaf{Body: exprBody(num(0)), Origin: Invented(OriginIfVal)}
+
+	opts := DefaultPrintOptions()
+	opts.ShowSpans = true
+	require.Equal(t, "leaf 0 at=none", Print(leaf, opts))
+}
+
 // An empty Indent falls back to two spaces, so a zero-value PrintOptions still
 // renders nested splits readably.
 func TestPrintDefaultsIndentWhenEmpty(t *testing.T) {

--- a/internal/solver/ucs/print_test.go
+++ b/internal/solver/ucs/print_test.go
@@ -537,6 +537,46 @@ func TestPrintShowsSpans(t *testing.T) {
 } else leaf 0 at~1:1-1:40`))
 }
 
+// With both options on, an arm back-reference that repeats the node's own span
+// collapses to `arm=same`, and one that differs still prints in full. The second
+// branch below is what normalization produces when it merges two arms: the branch's
+// origin points at the merged split while its back-reference keeps the arm the user
+// typed, and a reader needs both spans to see that.
+func TestPrintCollapsesAnArmThatRepeatsTheNodeSpan(t *testing.T) {
+	one := matchCase(numPat(1), nil, str("one"), span(2, 5, 18))
+	two := matchCase(numPat(2), nil, str("two"), span(3, 5, 18))
+	target := ident("n")
+	expr := ast.NewMatch(target, []*ast.MatchCase{one, two}, span(1, 1, 40))
+	origin := At(OriginMatchArm, expr)
+
+	norm := &NormSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*NormBranch{
+			{
+				Test:   &LitTest{Lit: ast.NewNumber(1, ast.Span{})},
+				Cont:   &BodyLeaf{Body: one.Body, Arm: one, Origin: At(OriginMatchArm, one)},
+				Arm:    one,
+				Origin: At(OriginMatchArm, one),
+			},
+			{
+				Test:   &LitTest{Lit: ast.NewNumber(2, ast.Span{})},
+				Cont:   &BodyLeaf{Body: two.Body, Arm: two, Origin: At(OriginMatchArm, two)},
+				Arm:    two,
+				Origin: origin,
+			},
+		},
+		Origin: origin,
+	}
+
+	opts := DefaultPrintOptions()
+	opts.ShowSpans = true
+	opts.ShowArms = true
+	snaps.MatchInlineSnapshot(t, Print(norm, opts), snaps.Inline(`split n at=1:1-1:40 {
+  1 at=2:5-2:18 arm=same => leaf "one" at=2:5-2:18 arm=same
+  2 at=1:1-1:40 arm=3:5-3:18 => leaf "two" at=3:5-3:18 arm=same
+} default ✗`))
+}
+
 // A node whose cause chain reaches no surface node at all names no position, so it
 // renders `at=none` rather than inventing one.
 func TestPrintShowsNoSpanForAnUncausedSyntheticNode(t *testing.T) {


### PR DESCRIPTION
Fixes #1021.
Refs #882.

Adds desugaring functions that lower Escalier's three conditional surface forms (`match`, `if val`, and `val else`) into a unified core representation based on `CoreSplit`. This enables a single downstream walk to handle all three constructs uniformly.

**Key changes:**

- `DesugarMatch` lowers `match` expressions into a `CoreSplit` with one branch per arm, keeping patterns whole and inserting `CoreGuard` nodes for guarded arms
- `DesugarIfVal` lowers `if val pat = target { cons } else { alt }` into a two-branch split where the `else` becomes the split's fallthrough rather than a second branch
- `DesugarValElse` lowers `val pat = init else { … }` declarations into a split with an `EscapeLeaf` success path (since bindings escape to the enclosing block) and a `FallbackLeaf` for the `else` clause
- `scrutineeOrigin` builds origins for root scrutinees that blame the target expression rather than the whole construct, with synthetic fallback when no target exists
- Comprehensive test suite with 11 tests covering literal arms, guarded arms, nested patterns, empty matches, fallthrough invention, origin tracking, and surface node sharing

**Implementation details:**

Desugaring points at surface nodes rather than copying them—branches hold the arm's own pattern, leaves hold the arm's own body, and the root scrutinee holds the target expression. This sharing keeps side-effecting scrutinees evaluated once and lets consumers read annotations directly from the surface. No `CoreBind` nodes are minted here; patterns stay whole and flattening into projections is normalization's job. Tests use snapshot assertions to verify both the desugared structure and origin/arm back-reference metadata.

**Scope note:** issue #1021 lists "represent intermediate bindings as `Bind` nodes." No current surface form produces one — a core branch keeps its pattern whole, so every name it binds is still inside that pattern, and the `bind x = p.x` nodes arrive with normalization in PR3/PR4. That reasoning is recorded in `desugar.go` rather than emitting a redundant `CoreBind`.

https://claude.ai/code/session_01S9cfdpdZ2rH9Rcsh93bDSi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `match`, `if val`, and `val … else` expressions and declarations.
  * Preserved source locations, patterns, guards, and surface syntax references for accurate diagnostics and tooling.
  * Added handling for fallthrough behavior, including implicit `undefined` results where needed.

* **Bug Fixes**
  * Invalid `val … else` declarations are now safely rejected.

* **Tests**
  * Added comprehensive coverage for matching, guards, nested patterns, empty matches, fallthroughs, and source attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->