### PR TITLE
Implement project-and-bind over UCS IR projection paths (PR5)

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1223,12 +1223,16 @@ func (e *ReadOnlyPropertyError) Message() string {
 // resolves to no class — either the name is unbound or it names a value or type parameter
 // rather than a class. An instance pattern deconstructs a class instance through the named
 // class's member view, so the name must be a class.
+//
+// Node is the node the message underlines. A written pattern blames the whole
+// `Name { ... }`. A branch of the UCS IR, whose tag test names the class without keeping
+// the pattern that produced it, blames the class name alone.
 type InstancePatternNotClassError struct {
-	Pat  *ast.InstancePat
+	Node ast.Node
 	Name string
 }
 
-func (e *InstancePatternNotClassError) Span() ast.Span      { return e.Pat.Span() }
+func (e *InstancePatternNotClassError) Span() ast.Span      { return e.Node.Span() }
 func (e *InstancePatternNotClassError) Related() []ast.Span { return nil }
 func (e *InstancePatternNotClassError) Message() string {
 	return "`" + e.Name + "` does not name a class and cannot be used as an instance pattern."
@@ -1238,12 +1242,14 @@ func (e *InstancePatternNotClassError) Message() string {
 // resolves to no constructor — the name is unbound, or its value is not callable as a
 // constructor. An extractor pattern deconstructs a value through the named constructor's
 // parameters, so the name must resolve to a constructor.
+// Node is the node the message underlines, the same choice
+// InstancePatternNotClassError makes.
 type ExtractorPatternNotCtorError struct {
-	Pat  *ast.ExtractorPat
+	Node ast.Node
 	Name string
 }
 
-func (e *ExtractorPatternNotCtorError) Span() ast.Span      { return e.Pat.Span() }
+func (e *ExtractorPatternNotCtorError) Span() ast.Span      { return e.Node.Span() }
 func (e *ExtractorPatternNotCtorError) Related() []ast.Span { return nil }
 func (e *ExtractorPatternNotCtorError) Message() string {
 	return "`" + e.Name + "` is not a constructor and cannot be used as an extractor pattern."
@@ -1252,14 +1258,16 @@ func (e *ExtractorPatternNotCtorError) Message() string {
 // ExtractorPatternArityError fires when an extractor pattern `Name(a, b, ...)` supplies
 // a different number of sub-patterns than the constructor has parameters. Each sub-pattern
 // binds one constructor parameter, so the counts must match.
+// Node is the node the message underlines, the same choice
+// InstancePatternNotClassError makes.
 type ExtractorPatternArityError struct {
-	Pat      *ast.ExtractorPat
+	Node     ast.Node
 	Name     string
 	Expected int
 	Got      int
 }
 
-func (e *ExtractorPatternArityError) Span() ast.Span      { return e.Pat.Span() }
+func (e *ExtractorPatternArityError) Span() ast.Span      { return e.Node.Span() }
 func (e *ExtractorPatternArityError) Related() []ast.Span { return nil }
 func (e *ExtractorPatternArityError) Message() string {
 	return fmt.Sprintf("extractor pattern `%s` expects %d arguments but got %d", e.Name, e.Expected, e.Got)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3495,29 +3495,45 @@ func structuralMemberCovered(member soltype.Type, arms []*ast.MatchCase) bool {
 func patternMatchesMemberShape(pat ast.Pat, member soltype.Type) bool {
 	switch p := pat.(type) {
 	case *ast.ObjectPat:
-		obj, ok := soltype.CarrierOf(member).(*soltype.ObjectType)
-		if !ok {
-			return false
-		}
-		for _, name := range objectPatFieldNames(p) {
-			if _, found := obj.Prop(name); !found {
-				return false
-			}
-		}
-		return true
+		return objectMemberHasKeys(member, objectPatFieldNames(p))
 	case *ast.TuplePat:
-		tup, ok := soltype.CarrierOf(member).(*soltype.TupleType)
-		if !ok {
-			return false
-		}
 		arity, hasRest := tuplePatArity(p)
-		if hasRest {
-			return len(tup.Elems) >= arity
-		}
-		return len(tup.Elems) == arity
+		return tupleMemberFitsArity(member, arity, hasRest)
 	default:
 		return false
 	}
+}
+
+// objectMemberHasKeys reports whether a union member is an object carrying every one of
+// names, which is what lets an object shape destructure that member. It is the shape rule
+// itself, shared by a written object pattern and the UCS IR's object test so the two cannot
+// disagree about which members a branch narrows to.
+func objectMemberHasKeys(member soltype.Type, names []string) bool {
+	obj, ok := soltype.CarrierOf(member).(*soltype.ObjectType)
+	if !ok {
+		return false
+	}
+	for _, name := range names {
+		if _, found := obj.Prop(name); !found {
+			return false
+		}
+	}
+	return true
+}
+
+// tupleMemberFitsArity reports whether a union member is a tuple a shape of the given fixed
+// arity can destructure. A trailing rest matches any tuple at least that long; without one
+// the arity must match exactly. It is the tuple twin of objectMemberHasKeys, shared for the
+// same reason.
+func tupleMemberFitsArity(member soltype.Type, arity int, hasRest bool) bool {
+	tup, ok := soltype.CarrierOf(member).(*soltype.TupleType)
+	if !ok {
+		return false
+	}
+	if hasRest {
+		return len(tup.Elems) >= arity
+	}
+	return len(tup.Elems) == arity
 }
 
 // objectPatFieldNames returns the field names an object pattern binds. A shorthand or
@@ -3572,36 +3588,11 @@ func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 		return scrutinee
 	}
 	inner, mut, lt := soltype.UnwrapRef(shape)
-	u, ok := inner.(*soltype.UnionType)
+	narrowed, ok := narrowUnionMembers(inner, func(m soltype.Type) bool {
+		return patternMatchesMemberShape(pat, m)
+	})
 	if !ok {
 		return scrutinee
-	}
-	kept := make([]soltype.Type, 0, len(u.Types))
-	for _, m := range u.Types {
-		if patternMatchesMemberShape(pat, m) {
-			kept = append(kept, m)
-		}
-	}
-	// When the pattern matches no listed member, there is nothing to narrow to. When it
-	// matches every listed member, narrowing would reproduce the whole union, including an
-	// inexact union's open tail. Either way, bind against the original scrutinee and keep the
-	// whole-union behavior.
-	if len(kept) == 0 || len(kept) == len(u.Types) {
-		return scrutinee
-	}
-	// An inexact union keeps its open `...` tail through narrowing. A tail member may carry
-	// the pattern's fields at any type, so the tail is retained and the field-read rule (D4)
-	// reads a narrowed inexact member's fields as `... | unknown`, i.e. unknown. An exact
-	// union narrows to precisely the members the pattern matches.
-	var narrowed soltype.Type
-	if len(kept) == 1 && !u.Inexact {
-		narrowed = kept[0]
-	} else {
-		// Keep the structured inexact union rather than returning unknown: it is the bind target
-		// for the arm's pattern, and constrainUnionFieldRead needs the listed members to read
-		// each field before the tail widens it to unknown. Binding the pattern against bare
-		// unknown would leave nothing to destructure.
-		narrowed = &soltype.UnionType{Types: kept, Inexact: u.Inexact}
 	}
 	// A kept object or tuple member is a RefInner, as is a rebuilt union, so a borrowed
 	// scrutinee re-wraps its narrowed carrier under the same borrow. NewRef drops the
@@ -3610,6 +3601,43 @@ func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 		return soltype.NewRef(mut, lt, ri)
 	}
 	return narrowed
+}
+
+// narrowUnionMembers drops the members of a union shape that keep rejects, returning the
+// narrowed type. ok=false means narrowing does not apply and the caller keeps the type it
+// started from: shape is not a union, keep accepted none of its members, or keep accepted
+// all of them, in which case the narrowed union would reproduce the original including an
+// inexact one's open tail.
+//
+// It is the narrowing rule itself, shared by narrowMatchArm and the UCS IR's structural
+// tests. shape must already be peeled of any borrow. Rewrapping is the caller's job,
+// because the IR carries the borrow in its binding mode rather than on the type.
+func narrowUnionMembers(shape soltype.Type, keep func(soltype.Type) bool) (soltype.Type, bool) {
+	u, isUnion := shape.(*soltype.UnionType)
+	if !isUnion {
+		return nil, false
+	}
+	kept := make([]soltype.Type, 0, len(u.Types))
+	for _, m := range u.Types {
+		if keep(m) {
+			kept = append(kept, m)
+		}
+	}
+	if len(kept) == 0 || len(kept) == len(u.Types) {
+		return nil, false
+	}
+	// An inexact union keeps its open `...` tail through narrowing. A tail member may carry
+	// the tested fields at any type, so the tail is retained and the field-read rule (D4)
+	// reads a narrowed inexact member's fields as `... | unknown`, i.e. `unknown`. An exact
+	// union narrows to precisely the members that matched.
+	if len(kept) == 1 && !u.Inexact {
+		return kept[0], true
+	}
+	// Keep the structured inexact union rather than returning `unknown`. It is the bind
+	// target for the branch's leaves, and constrainUnionFieldRead needs the listed members to
+	// read each field before the tail widens it. Binding against bare `unknown` would leave
+	// nothing to destructure.
+	return &soltype.UnionType{Types: kept, Inexact: u.Inexact}, true
 }
 
 // litMemberCovered reports whether some unguarded arm is a literal pattern equal to

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -153,6 +153,11 @@ func TestInferObjectPatternLeafTypeAnnAdopted(t *testing.T) {
 // A field default makes the field optional, so destructuring an absent field
 // that carries a default binds the default's type instead of reporting a missing
 // property.
+//
+// The scrutinee here cannot carry `z` at all, which #1053 argues should be a missing
+// property rather than a match. TestPathBinderDefaultedKeyBindsAgainstScrutineeWithoutTheField
+// in ucs_bind_test.go pins the same answer for the UCS IR path binder, so change the two
+// together.
 func TestInferObjectPatternLeafDefault(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(p: {x: number}) {

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -169,6 +169,33 @@ func TestInferObjectPatternLeafDefault(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number}) -> 0", values["f"])
 }
 
+// An optional property reads as `T | undefined`, and both object-pattern forms bind that
+// whole type. The key-value form used to pin its projection's upper bound to the declared
+// `T` even for an optional property, which rejected the `undefined` half and reported
+// `cannot constrain undefined <: number` on a legal destructuring. The shorthand form
+// pins nothing, so the two disagreed on the same field.
+func TestInferObjectPatternOptionalProperty(t *testing.T) {
+	tests := map[string]string{
+		"Shorthand": `
+			fn f(p: {x?: number}) {
+				val {x} = p
+				return x
+			}`,
+		"KeyValue": `
+			fn f(p: {x?: number}) {
+				val {x: a} = p
+				return a
+			}`,
+	}
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, src)
+			require.Empty(t, messagesWithSpan(errs))
+			require.Equal(t, "fn (p: {x?: number}) -> number | undefined", values["f"])
+		})
+	}
+}
+
 // A trailing rest element relaxes the tuple requirement to an inexact prefix, so
 // the fixed elements bind without a spurious arity error.
 func TestInferTuplePatternRestPrefix(t *testing.T) {

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -240,8 +240,14 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				// cannot reject a refutable literal sub-pattern of the wrong kind. The
 				// upper bound makes a nested literal flow against the real field type, so
 				// `{x: "hi"}` against `{x: number}` reports the mismatch.
+				//
+				// An optional property gets no pin. Reading `x` off `{x?: number}` produces
+				// `number | undefined`, so a bound of `number` rejects the `undefined` half
+				// of the value the field actually holds. The shorthand arm above pins
+				// nothing at all, so without this `{x: a}` and `{x}` disagree on a legal
+				// destructuring.
 				if o, ok := scrutinee.(*soltype.ObjectType); ok {
-					if prop, found := o.Prop(e.Key.Name); found {
+					if prop, found := o.Prop(e.Key.Name); found && !prop.Optional {
 						c.constrain(e, beta, prop.Type)
 					}
 				}

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -159,33 +159,10 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			c.reportUnsupported(recovered[0])
 		}
 		inexact := rest != nil || len(recovered) > 0
-		elemTypes := make([]soltype.Type, len(fixed))
-		for i := range fixed {
-			elemTypes[i] = c.freshAt(lvl)
-		}
-		// Each αi lowers from the scrutinee's matching element, so a sub-pattern binds
-		// at that element's type.
-		c.constrain(p, scrutinee, &soltype.TupleType{Elems: elemTypes, Inexact: inexact})
-		// Both shapes are spliced once, since every read below is by index. See
-		// groundedTuple.
-		scrutTup, _ := c.groundedTuple(scrutinee)
-		// Child concrete types come from the threaded concrete tuple, not from the
-		// scrutinee: at a nested level the scrutinee is the parent's element variable,
-		// so only the threaded concrete still carries the element shape a borrowed leaf
-		// must inspect to decide whether to borrow.
-		concreteTup, _ := c.groundedTuple(concrete)
-		// When the scrutinee is a concrete tuple, pin each αi's upper bound to the
-		// matching element. The constraint above gives αi the element only as a lower
-		// bound, which cannot reject a refutable literal sub-pattern of the wrong kind.
-		// The upper bound makes a nested literal flow against the real element type, so
-		// `[a, "hi"]` against `[number, number]` reports the mismatch.
-		if scrutTup != nil {
-			for i := range fixed {
-				if i < len(scrutTup.Elems) {
-					c.constrain(fixed[i], elemTypes[i], scrutTup.Elems[i])
-				}
-			}
-		}
+		// Each element sub-pattern blames its own node for the upper-bound pin, so
+		// `[a, "hi"]` against `[number, number]` underlines the literal rather than the
+		// whole pattern.
+		elemTypes, scrutTup, concreteTup := c.projectTuple(p, lvl, scrutinee, concrete, len(fixed), inexact, func(i int) ast.Node { return fixed[i] })
 		subs := make([]soltype.Pat, 0, len(p.Elems))
 		for i, e := range fixed {
 			var elemConcrete soltype.Type
@@ -233,25 +210,8 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			case *ast.ObjKeyValuePat:
 				// A default on the value sub-pattern, as in `{x: a = 0}`, likewise makes
 				// the field optional.
-				beta := c.freshAt(lvl)
-				c.constrain(e, scrutinee, propReq(e.Key.Name, beta, patternDefaultsField(e.Value)))
-				// When the scrutinee is a concrete object, pin beta's upper bound to the
-				// field type. propReq gives beta the field only as a lower bound, which
-				// cannot reject a refutable literal sub-pattern of the wrong kind. The
-				// upper bound makes a nested literal flow against the real field type, so
-				// `{x: "hi"}` against `{x: number}` reports the mismatch.
-				//
-				// An optional property gets no pin. Reading `x` off `{x?: number}` produces
-				// `number | undefined`, so a bound of `number` rejects the `undefined` half
-				// of the value the field actually holds. The shorthand arm above pins
-				// nothing at all, so without this `{x: a}` and `{x}` disagree on a legal
-				// destructuring.
-				if o, ok := scrutinee.(*soltype.ObjectType); ok {
-					if prop, found := o.Prop(e.Key.Name); found && !prop.Optional {
-						c.constrain(e, beta, prop.Type)
-					}
-				}
-				sub := c.bindPatMode(scope, lvl, e.Value, beta, fieldConcrete(concrete, e.Key.Name), scrutineeMode, leafTypes, emit)
+				beta, betaConcrete := c.projectField(e, lvl, scrutinee, concrete, e.Key.Name, patternDefaultsField(e.Value))
+				sub := c.bindPatMode(scope, lvl, e.Value, beta, betaConcrete, scrutineeMode, leafTypes, emit)
 				named.Add(e.Key.Name)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
 			case *ast.ObjRestPat:
@@ -294,6 +254,88 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		c.reportUnsupported(pat)
 		return &soltype.WildcardPat{}
 	}
+}
+
+// projectField lowers the scrutinee's `name` field into a fresh variable through the
+// member-lookup requirement, returning that variable and the concrete field type to thread
+// beside it. It is the one field projection, shared by an object pattern's key-value arm
+// and the UCS IR's field step, so the two cannot drift.
+//
+// optional relaxes the requirement to tolerate an absent field, which a destructuring
+// default asks for. blame is the node the requirement is anchored to.
+//
+// An object pattern's SHORTHAND arm does not call this. It binds the projection as the leaf
+// itself rather than handing it to a sub-pattern, so it needs neither the concrete field
+// type nor the upper bound below, and pinning there would make a `&mut` leaf invariantly
+// exact against the scrutinee's element. See applyBindMode's bmMut arm.
+func (c *checker) projectField(
+	blame ast.Node, lvl int, scrutinee, concrete soltype.Type, name string, optional bool,
+) (proj, projConcrete soltype.Type) {
+	beta := c.freshAt(lvl)
+	c.constrain(blame, scrutinee, propReq(name, beta, optional))
+	// When the scrutinee is a concrete object, pin beta's upper bound to the field type.
+	// propReq gives beta the field only as a lower bound, which cannot reject a refutable
+	// literal sub-pattern of the wrong kind. The upper bound makes a nested literal flow
+	// against the real field type, so `{x: "hi"}` against `{x: number}` reports the
+	// mismatch.
+	//
+	// An optional property gets no pin. Reading `x` off `{x?: number}` produces
+	// `number | undefined`, so a bound of `number` would reject the `undefined` half of the
+	// value the field actually holds.
+	if obj, ok := scrutinee.(*soltype.ObjectType); ok {
+		if prop, found := obj.Prop(name); found && !prop.Optional {
+			c.constrain(blame, beta, prop.Type)
+		}
+	}
+	return beta, fieldConcrete(concrete, name)
+}
+
+// projectTuple lowers the scrutinee's first count elements into fresh variables through one
+// whole-tuple requirement, returning those variables and the grounded scrutinee and concrete
+// tuples a `...rest` reads its suffix out of. It is the one tuple projection, shared by a
+// tuple pattern and the UCS IR's tuple test, so the two cannot drift.
+//
+// inexact relaxes the requirement to "a tuple at least this long", which a trailing rest
+// asks for. An exact requirement is what rejects a wrong arity. blame anchors the
+// requirement, and blameElem anchors each element's upper bound, so a caller holding
+// sub-patterns can underline the offending element rather than the whole shape. Pass nil for
+// blameElem to anchor every pin to blame.
+func (c *checker) projectTuple(
+	blame ast.Node, lvl int, scrutinee, concrete soltype.Type, count int, inexact bool, blameElem func(int) ast.Node,
+) (elems []soltype.Type, scrutTup, concreteTup *soltype.TupleType) {
+	elems = make([]soltype.Type, count)
+	for i := range elems {
+		elems[i] = c.freshAt(lvl)
+	}
+	// Each αi lowers from the scrutinee's matching element, so a sub-pattern binds at that
+	// element's type.
+	c.constrain(blame, scrutinee, &soltype.TupleType{Elems: elems, Inexact: inexact})
+	// Both shapes are spliced once, since every read by the caller is by index. See
+	// groundedTuple.
+	scrutTup, _ = c.groundedTuple(scrutinee)
+	// Child concrete types come from the threaded concrete tuple, not from the scrutinee. At
+	// a nested level the scrutinee is the parent's element variable, so only the threaded
+	// concrete still carries the element shape a borrowed leaf must inspect to decide
+	// whether to borrow.
+	concreteTup, _ = c.groundedTuple(concrete)
+	// When the scrutinee is a concrete tuple, pin each αi's upper bound to the matching
+	// element. The requirement above gives αi the element only as a lower bound, which
+	// cannot reject a refutable literal sub-pattern of the wrong kind. The upper bound makes
+	// a nested literal flow against the real element type, so `[a, "hi"]` against
+	// `[number, number]` reports the mismatch.
+	if scrutTup != nil {
+		for i := range elems {
+			if i >= len(scrutTup.Elems) {
+				continue
+			}
+			node := blame
+			if blameElem != nil {
+				node = blameElem(i)
+			}
+			c.constrain(node, elems[i], scrutTup.Elems[i])
+		}
+	}
+	return elems, scrutTup, concreteTup
 }
 
 // objectPatNamesRest reports whether pat is an object pattern carrying a `...rest`. Only
@@ -489,22 +531,35 @@ func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scr
 		obj, _ := c.bindPatMode(scope, lvl, p.Object, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit).(*soltype.ObjectPat)
 		return &soltype.InstancePat{ClassName: name, Object: obj}
 	}
+	target, targetConcrete := c.narrowToClass(lvl, p, ct, scrutinee, concrete)
+	obj, _ := c.bindPatMode(scope, lvl, p.Object, target, targetConcrete, scrutineeMode, leafTypes, emit).(*soltype.ObjectPat)
+	return &soltype.InstancePat{ClassName: ct.Name, Object: obj}
+}
+
+// narrowToClass narrows scrutinee to the class ct and returns the instance member view its
+// fields project out of, along with the concrete type to thread beside it. Both come back
+// as the scrutinee and concrete passed in when the class has no projectable body.
+//
+// It is the narrowing half of an instance pattern, shared with the UCS IR's class test so
+// the two cannot drift. blame is the node the narrowing constraint is anchored to: the
+// written pattern for bindInstancePat, the tag test's class name for the IR.
+func (c *checker) narrowToClass(
+	lvl int, blame ast.Node, ct *soltype.ClassType, scrutinee, concrete soltype.Type,
+) (target, targetConcrete soltype.Type) {
 	inst := c.freshClassInstance(ct, lvl)
 	// The pattern narrows the scrutinee to the named class. The instance flows into the
 	// scrutinee, so a scrutinee that cannot be this class is rejected here.
-	c.constrain(p, inst, scrutinee)
+	c.constrain(blame, inst, scrutinee)
 	// Project the scrutinee's own instance when it names the same class, so its concrete
 	// arguments give the field types directly; a downcast falls back to the asserted instance.
 	projected := inst
 	if sc, ok := classCarrier(scrutinee); ok && sc.Name == ct.Name {
 		projected = sc
 	}
-	target, targetConcrete := scrutinee, concrete
 	if body, ok := c.ctx.projectClassBody(projected); ok {
-		target, targetConcrete = body, body
+		return body, body
 	}
-	obj, _ := c.bindPatMode(scope, lvl, p.Object, target, targetConcrete, scrutineeMode, leafTypes, emit).(*soltype.ObjectPat)
-	return &soltype.InstancePat{ClassName: ct.Name, Object: obj}
+	return scrutinee, concrete
 }
 
 // bindExtractorPat types an extractor pattern `Name(a, b)`: it narrows the scrutinee to the
@@ -530,17 +585,7 @@ func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, s
 		}
 		return &soltype.ExtractorPat{Name: name, Args: args}
 	}
-	// The extracted value is an instance of the constructor's return type. Narrow the
-	// scrutinee to it, the same assertion an instance pattern makes.
-	c.constrain(p, ctor.Ret, scrutinee)
-	// Read the parameters at the scrutinee's concrete arguments by substituting them
-	// directly, rather than relying on the narrowing constraint above to back-propagate them.
-	params := ctor.Params
-	if sc, ok := classCarrier(scrutinee); ok {
-		if ret, ok := ctor.Ret.(*soltype.ClassType); ok && ret.Name == sc.Name {
-			params = ctorParamsAt(ctor.Params, ret, sc)
-		}
-	}
+	params := c.narrowToExtractor(p, ctor, scrutinee)
 	if len(p.Args) != len(params) {
 		c.report(&ExtractorPatternArityError{Node: p, Name: name, Expected: len(params), Got: len(p.Args)})
 	}
@@ -553,6 +598,27 @@ func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, s
 		args[i] = c.bindPatMode(scope, lvl, a, paramType, paramType, scrutineeMode, leafTypes, emit)
 	}
 	return &soltype.ExtractorPat{Name: name, Args: args}
+}
+
+// narrowToExtractor narrows scrutinee to ctor's return type and returns the parameters the
+// extracted values bind against, read at the scrutinee's own type arguments.
+//
+// It is the narrowing half of an extractor pattern, shared with the UCS IR's extractor test
+// so the two cannot drift. blame is the node the narrowing constraint is anchored to: the
+// written pattern for bindExtractorPat, the tag test's name for the IR. The caller checks
+// the returned count against how many values its pattern takes.
+func (c *checker) narrowToExtractor(blame ast.Node, ctor *soltype.FuncType, scrutinee soltype.Type) []*soltype.FuncParam {
+	// The extracted value is an instance of the constructor's return type. Narrow the
+	// scrutinee to it, the same assertion an instance pattern makes.
+	c.constrain(blame, ctor.Ret, scrutinee)
+	// Read the parameters at the scrutinee's concrete arguments by substituting them
+	// directly, rather than relying on the narrowing constraint above to back-propagate them.
+	if sc, ok := classCarrier(scrutinee); ok {
+		if ret, isClass := ctor.Ret.(*soltype.ClassType); isClass && ret.Name == sc.Name {
+			return ctorParamsAt(ctor.Params, ret, sc)
+		}
+	}
+	return ctor.Params
 }
 
 // ctorParamsAt rewrites a constructor's parameter types from its return instance's argument

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -477,7 +477,7 @@ func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scr
 	name := ast.QualIdentToString(p.ClassName)
 	ct, ok := c.instancePatClass(scope, name)
 	if !ok {
-		c.report(&InstancePatternNotClassError{Pat: p, Name: name})
+		c.report(&InstancePatternNotClassError{Node: p, Name: name})
 		// Bind the inner fields against a fresh var so a later reference to a bound leaf
 		// stays defined without a second cascade error against the real scrutinee.
 		obj, _ := c.bindPatMode(scope, lvl, p.Object, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit).(*soltype.ObjectPat)
@@ -515,7 +515,7 @@ func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, s
 	name := ast.QualIdentToString(p.Name)
 	ctor, ok := c.extractorCtor(scope, lvl, p.Name)
 	if !ok {
-		c.report(&ExtractorPatternNotCtorError{Pat: p, Name: name})
+		c.report(&ExtractorPatternNotCtorError{Node: p, Name: name})
 		// Bind each argument against a fresh var so its leaves stay defined and a later
 		// reference does not cascade into an unknown-identifier error.
 		args := make([]soltype.Pat, len(p.Args))
@@ -536,7 +536,7 @@ func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, s
 		}
 	}
 	if len(p.Args) != len(params) {
-		c.report(&ExtractorPatternArityError{Pat: p, Name: name, Expected: len(params), Got: len(p.Args)})
+		c.report(&ExtractorPatternArityError{Node: p, Name: name, Expected: len(params), Got: len(p.Args)})
 	}
 	args := make([]soltype.Pat, len(p.Args))
 	for i, a := range p.Args {

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -1,0 +1,552 @@
+package solver
+
+import (
+	"maps"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/escalier-lang/escalier/internal/solver/ucs"
+)
+
+// Project-and-bind over a UCS IR projection path.
+//
+// The `ucs` package names a sub-scrutinee as a path rather than as a type. The path
+// `l.start.x` is the root scrutinee `l`, a field step to `start`, then a field step to
+// `x`. Turning that path into the type its value has is this file's job, and it is the
+// one solver-side operation every walk over the IR depends on.
+//
+// The projection rule it applies is bindPatMode's. A leaf bound off a path must land at
+// the type the same leaf would land at nested inside one whole pattern. Otherwise the IR
+// walk and the `bindPattern` path everything else destructures through would infer
+// different types for one leaf. That is why a resolved scrutinee carries the same triple
+// bindPatMode threads down a nested pattern — the projection variable, the statically
+// known shape, and the binding mode — and hands all three back to bindPatMode rather than
+// rebuilding them from a single type.
+
+// scrutineeView is what the solver has worked out about the value one IR scrutinee
+// names. A binder holds one view per scrutinee it has reached, so a scrutinee shared by
+// an inner split and every leaf beneath it is projected once.
+type scrutineeView struct {
+	// ty is the type a leaf's requirements are emitted against: the projection variable
+	// a member lookup lowered the value into, or the root scrutinee's own carrier. Any
+	// borrow is already peeled off it, since mode records the borrow instead.
+	ty soltype.Type
+	// concrete is the value's statically known shape, and nil when the path did not
+	// reach one. It is what decides whether a leaf of a borrowed scrutinee projects a
+	// borrow, so dropping it would silently bind such a leaf as an owned value.
+	concrete soltype.Type
+	// mode is the binding mode the root scrutinee's borrow fixed. It propagates
+	// unchanged down the path, the same match ergonomics bindPatMode follows.
+	mode bindMode
+	// test is the tag test the split over this scrutinee applied, and nil until one is.
+	// Only fieldOptional reads it, to ask an object test whether a key the pattern
+	// defaulted may be absent. Every other test kind leaves its result in a field of its
+	// own.
+	test ucs.Test
+	// shape is the type union narrowing reads its members off. It is the scrutinee's own
+	// type once that is concrete, and a coalesced snapshot of it while it is still an
+	// inference variable.
+	shape soltype.Type
+	// elems holds one projection variable per fixed element of a tuple test, minted when
+	// that test emitted its whole-tuple requirement. An index step reads its element out
+	// of this rather than emitting a requirement of its own.
+	elems []soltype.Type
+	// tuple and concreteTuple are the grounded tuple shapes the same tuple test
+	// resolved, which a suffix step reads its `...rest` slice out of. Each is nil when
+	// the corresponding type is not a grounded tuple.
+	tuple, concreteTuple *soltype.TupleType
+	// params holds the constructor parameters an extractor test resolved. An extract
+	// step reads its value's type out of this, the interim protocol bindExtractorPat
+	// also binds through until M7's `[Symbol.customMatcher]` lands.
+	params []*soltype.FuncParam
+}
+
+// pathBinder resolves IR projection paths into types and binds leaf patterns off them.
+// It is seeded with the root scrutinee's inferred type, which is the only type the IR
+// itself cannot supply.
+//
+// A split applies its branch's tag test through narrowedBy, which returns a derived
+// binder instead of mutating this one. Two branches of the same split therefore narrow
+// the same scrutinee differently without seeing each other's view, and each branch
+// projects its own variables for the sub-scrutinees beneath it.
+type pathBinder struct {
+	c   *checker
+	lvl int
+	// blame is the node a constraint is anchored to when the scrutinee being resolved
+	// carries no origin the solver can blame. A match arm, for one, has a span but is
+	// not an ast.Node.
+	blame ast.Node
+	views map[*ucs.Scrutinee]scrutineeView
+}
+
+// newPathBinder builds the binder for one conditional form. root is the IR's root
+// scrutinee and rootType the type the walk inferred for the match target, so the binder
+// never re-infers the target and a side-effecting one such as `match f() { … }` is
+// evaluated once. blame is the node a constraint falls back to, normally the whole
+// `match`, `if val`, or `val … else`.
+func (c *checker) newPathBinder(lvl int, blame ast.Node, root *ucs.Scrutinee, rootType soltype.Type) *pathBinder {
+	b := &pathBinder{c: c, lvl: lvl, blame: blame, views: map[*ucs.Scrutinee]scrutineeView{}}
+	carrier := soltype.CarrierOf(rootType)
+	shape := carrier
+	if _, isVar := carrier.(*soltype.TypeVarType); isVar {
+		// Snapshot the scrutinee's union structure before any branch binds. A literal test
+		// adds its literal as a lower bound on the scrutinee variable, so coalescing again
+		// under a later branch would read that literal back as an extra union member and
+		// narrow against a member the user never wrote. inferMatch takes the same snapshot
+		// for the same reason.
+		shape = soltype.CarrierOf(coalesce(rootType, soltype.Positive))
+	}
+	b.views[root] = scrutineeView{
+		ty:       carrier,
+		concrete: carrier,
+		mode:     bindModeOf(rootType),
+		shape:    shape,
+	}
+	return b
+}
+
+// narrowedBy returns a binder in which the split over s has tested it against test. The
+// receiver is left untouched, so a caller can apply a different test to the same
+// scrutinee for the next branch.
+//
+// Applying a test is what makes the projections beneath it resolvable. A tuple test
+// mints the element variables an index step reads, a class test projects the instance
+// member view a field step reads, and an extractor test resolves the constructor
+// parameters an extract step reads.
+func (b *pathBinder) narrowedBy(scope *Scope, s *ucs.Scrutinee, test ucs.Test) *pathBinder {
+	// Resolve s on the receiver, before the clone, so the memo lands in the binder every
+	// branch of the split shares. Resolving it on the clone instead would project the
+	// scrutinee once per branch, minting a second variable and a second member lookup for
+	// one value.
+	v := b.viewOf(scope, s)
+	next := &pathBinder{c: b.c, lvl: b.lvl, blame: b.blame, views: maps.Clone(b.views)}
+	next.views[s] = next.applyTest(scope, b.blameFor(s), v, test)
+	return next
+}
+
+// typeAt resolves the path s names to the type its value has.
+func (b *pathBinder) typeAt(scope *Scope, s *ucs.Scrutinee) soltype.Type {
+	return b.viewOf(scope, s).ty
+}
+
+// bindAt binds pat against the value the path s names, defining each leaf the pattern
+// introduces as a monomorphic binding in scope. It is the project-and-bind operation the
+// typing walk calls for every leaf of a normalized branch.
+func (b *pathBinder) bindAt(scope *Scope, s *ucs.Scrutinee, pat ast.Pat) soltype.Pat {
+	return b.bindAtWith(scope, s, pat, nil, defineLeafMono)
+}
+
+// bindAtWith is bindAt parameterized by the leaf-placement strategy, the same split
+// bindPatternWith makes for the top-level driver's pre-bound binding vars.
+func (b *pathBinder) bindAtWith(
+	scope *Scope, s *ucs.Scrutinee, pat ast.Pat, leafTypes map[string]soltype.Type, emit leafEmit,
+) soltype.Pat {
+	v := b.viewOf(scope, s)
+	return b.c.bindPatMode(scope, b.lvl, pat, v.ty, v.concrete, v.mode, leafTypes, emit)
+}
+
+// viewOf returns s's view, resolving and memoizing it on first use. Memoizing is what
+// materializes each scrutinee once: the inner split and every leaf beneath it hold the
+// same *ucs.Scrutinee pointer, so they share one projection rather than each emitting
+// its own member lookup.
+func (b *pathBinder) viewOf(scope *Scope, s *ucs.Scrutinee) scrutineeView {
+	if v, ok := b.views[s]; ok {
+		return v
+	}
+	var v scrutineeView
+	if s.IsRoot() {
+		// A root the binder was not seeded with names a target whose type nothing
+		// inferred. Bind against a fresh variable so its leaves still land in scope and a
+		// later reference resolves instead of cascading into an unknown-identifier error.
+		fresh := b.c.freshAt(b.lvl)
+		v = scrutineeView{ty: fresh, shape: fresh}
+	} else {
+		v = b.project(scope, s)
+	}
+	b.views[s] = v
+	return v
+}
+
+// project resolves one step of a path, building the view of s from the view of its
+// parent.
+func (b *pathBinder) project(scope *Scope, s *ucs.Scrutinee) scrutineeView {
+	parent := b.viewOf(scope, s.Parent)
+	node := b.blameFor(s)
+	switch step := s.Step.(type) {
+	case ucs.FieldStep:
+		return b.projectField(parent, node, step.Name)
+	case ucs.IndexStep:
+		return b.projectIndex(s.Parent, parent, node, step.Index)
+	case ucs.ExtractStep:
+		return b.projectExtract(parent, step.Index)
+	case ucs.SuffixStep:
+		return b.projectSuffix(parent, node, step.From)
+	case ucs.RemainderStep:
+		return b.projectRemainder(parent, node, step.Exclude)
+	default:
+		// ucs.Step is a closed interface, so this arm is reached only by a step kind added
+		// to the IR without a projection rule here. Recover with a fresh variable rather
+		// than resolving to something the leaf would silently mis-bind against.
+		return derive(parent, b.c.freshAt(b.lvl), nil)
+	}
+}
+
+// projectField resolves `parent.name`. The lookup is the same inexact one-property
+// requirement bindPatMode's object arm emits, so a field the scrutinee lacks surfaces
+// MissingPropertyError from the same rule a written `{name}` pattern does.
+func (b *pathBinder) projectField(parent scrutineeView, node ast.Node, name string) scrutineeView {
+	beta := b.c.freshAt(b.lvl)
+	b.c.constrain(node, parent.ty, propReq(name, beta, parent.fieldOptional(name)))
+	// Pin beta's upper bound to the field's own type when the scrutinee is a concrete
+	// object. The requirement above gives beta the field only as a lower bound, which
+	// cannot reject a refutable literal sub-pattern of the wrong kind, so `{x: "hi"}`
+	// against `{x: number}` would go unreported. bindPatMode's key-value arm adds the same
+	// bound for the same reason.
+	//
+	// An optional property gets no pin. Reading `x` off `{x?: number}` produces
+	// `number | undefined`, so a bound of `number` would reject the `undefined` half of the
+	// value the field actually holds. bindPatMode's shorthand arm, which every `{x}` goes
+	// through, adds no pin at all for the same reason.
+	if obj, ok := parent.ty.(*soltype.ObjectType); ok {
+		if prop, found := obj.Prop(name); found && !prop.Optional {
+			b.c.constrain(node, beta, prop.Type)
+		}
+	}
+	return derive(parent, beta, fieldConcrete(parent.concrete, name))
+}
+
+// projectIndex resolves `parent.i`, the i-th element of a tuple. parentScrut names the
+// scrutinee `parent` is the view of, so a tuple shape minted here is written back onto it
+// and every later step off the same value reads that one shape.
+func (b *pathBinder) projectIndex(parentScrut *ucs.Scrutinee, parent scrutineeView, node ast.Node, i int) scrutineeView {
+	if i >= len(parent.elems) {
+		// No tuple test fixed this scrutinee's arity, so nothing has minted a variable for
+		// position i yet. Emit an inexact requirement pinning the positions up to it —
+		// "the scrutinee is a tuple at least this long" — so any path resolves, not only one
+		// a split has already tested. A normalized index step always sits under a tuple
+		// test, so this runs only for a path built without one, and it mints another
+		// requirement if a still deeper index arrives afterwards.
+		parent.elems, parent.tuple, parent.concreteTuple = b.tupleShapeReq(parent, node, i+1, true)
+		b.views[parentScrut] = parent
+	}
+	var concrete soltype.Type
+	if parent.concreteTuple != nil && i < len(parent.concreteTuple.Elems) {
+		concrete = parent.concreteTuple.Elems[i]
+	}
+	return derive(parent, parent.elems[i], concrete)
+}
+
+// projectExtract resolves the i-th positional value an extractor yields, the `v` of
+// `Ok(v)`. The values come from the constructor parameters the enclosing extractor test
+// resolved, the interim protocol bindExtractorPat binds through until M7 replaces it with
+// `[Symbol.customMatcher]`. Nothing is constrained here, so the step blames no node. The
+// extractor test already narrowed the scrutinee when it resolved the constructor.
+func (b *pathBinder) projectExtract(parent scrutineeView, i int) scrutineeView {
+	if i >= len(parent.params) {
+		// Either no extractor test resolved a constructor for this scrutinee, or the
+		// pattern took more values than the constructor yields. The arity error is reported
+		// where the test is applied, so recovering with a fresh variable here keeps the
+		// leaves defined without a second diagnostic.
+		return derive(parent, b.c.freshAt(b.lvl), nil)
+	}
+	param := parent.params[i].Type
+	return derive(parent, param, param)
+}
+
+// projectSuffix resolves `parent[from..]`, the tuple elements past a fixed prefix, which
+// is what a tuple pattern's `...rest` binds.
+func (b *pathBinder) projectSuffix(parent scrutineeView, node ast.Node, from int) scrutineeView {
+	suffix, concrete := b.c.tupleRestType(b.lvl, node, parent.ty, parent.tuple, parent.concreteTuple, from)
+	return derive(parent, suffix, concrete)
+}
+
+// projectRemainder resolves `parent \ exclude`, the scrutinee's members minus the keys
+// the object pattern named, which is what an object pattern's `...rest` binds.
+func (b *pathBinder) projectRemainder(parent scrutineeView, node ast.Node, exclude set.Set[string]) scrutineeView {
+	leftover, concrete := b.c.objectRestType(b.lvl, node, parent.ty, parent.concrete, exclude)
+	return derive(parent, leftover, concrete)
+}
+
+// derive builds the view of a value projected out of parent. The binding mode carries
+// over unchanged, which is what makes every leaf of a borrowed scrutinee a borrow however
+// deep the path reaches it.
+func derive(parent scrutineeView, ty, concrete soltype.Type) scrutineeView {
+	shape := concrete
+	if shape == nil {
+		shape = ty
+	}
+	return scrutineeView{ty: ty, concrete: concrete, mode: parent.mode, shape: shape}
+}
+
+// fieldOptional reports whether the object test over this scrutinee tolerates the named
+// field being absent, which a destructuring default produces. `{x = 0}` binds x to 0 when
+// the field is absent, so a requirement that demanded it would reject a value the pattern
+// matches. Absent an object test the field is required, matching a pattern with no
+// default.
+func (v scrutineeView) fieldOptional(name string) bool {
+	obj, ok := v.test.(*ucs.ObjectTest)
+	if !ok {
+		return false
+	}
+	for _, key := range obj.Keys {
+		if key.Name == name {
+			return key.Optional
+		}
+	}
+	return false
+}
+
+// applyTest narrows v by the tag test one branch of a split applies to it, and resolves
+// whatever that test leaves behind for the projections beneath it.
+func (b *pathBinder) applyTest(scope *Scope, node ast.Node, v scrutineeView, test ucs.Test) scrutineeView {
+	v.test = test
+	switch t := test.(type) {
+	case *ucs.ObjectTest:
+		// An object test emits nothing itself. Its keys are looked up one at a time, by the
+		// field steps beneath it, which is the same per-field dispatch bindPatMode's object
+		// arm makes.
+		return b.narrowUnion(v, test)
+	case *ucs.TupleTest:
+		v = b.narrowUnion(v, test)
+		v.elems, v.tuple, v.concreteTuple = b.tupleShapeReq(v, node, t.Len, t.Rest == ucs.TrailingRest)
+		return v
+	case *ucs.LitTest:
+		b.applyLitTest(node, v, t)
+		return v
+	case *ucs.ClassTest:
+		return b.applyClassTest(scope, node, v, t)
+	case *ucs.ExtractorTest:
+		return b.applyExtractorTest(scope, node, v, t)
+	default:
+		return v
+	}
+}
+
+// narrowUnion drops the union members the test cannot destructure, so a branch that
+// tests one variant binds against that variant alone rather than against the whole
+// union. It is narrowMatchArm read off the IR's tag test instead of off the source
+// pattern, and it keeps that function's rules so PR6 inherits variant-narrowing
+// unchanged.
+func (b *pathBinder) narrowUnion(v scrutineeView, test ucs.Test) scrutineeView {
+	shape := v.shape
+	if _, isVar := shape.(*soltype.TypeVarType); isVar {
+		shape = soltype.CarrierOf(coalesce(shape, soltype.Positive))
+	}
+	u, ok := shape.(*soltype.UnionType)
+	if !ok {
+		return v
+	}
+	kept := make([]soltype.Type, 0, len(u.Types))
+	for _, member := range u.Types {
+		if testMatchesMemberShape(test, member) {
+			kept = append(kept, member)
+		}
+	}
+	// When the test matches no listed member there is nothing to narrow to. When it
+	// matches every listed member, narrowing would reproduce the whole union, including an
+	// inexact union's open tail. Either way the scrutinee's own type is the bind target.
+	if len(kept) == 0 || len(kept) == len(u.Types) {
+		return v
+	}
+	var narrowed soltype.Type
+	if len(kept) == 1 && !u.Inexact {
+		narrowed = kept[0]
+	} else {
+		// An inexact union keeps its open `...` tail through narrowing. A tail member may
+		// carry the test's fields at any type, so the tail is retained and a narrowed
+		// inexact member's fields read as `unknown`. Keeping the structured union rather
+		// than collapsing to bare `unknown` is what leaves the listed members for the field
+		// steps beneath to read.
+		narrowed = &soltype.UnionType{Types: kept, Inexact: u.Inexact}
+	}
+	v.ty, v.concrete, v.shape = narrowed, narrowed, narrowed
+	return v
+}
+
+// testMatchesMemberShape reports whether a structural tag test's shape fits a union
+// member, so a branch under that test can destructure the member. It is
+// patternMatchesMemberShape read off the IR's test rather than off the source pattern. An
+// object test fits an object member carrying every key the test names, and a tuple test
+// fits a tuple member of its fixed arity, or of at least that arity under a trailing
+// rest. Every other test kind returns false, the same gate narrowMatchArm puts on object
+// and tuple patterns alone.
+func testMatchesMemberShape(test ucs.Test, member soltype.Type) bool {
+	switch t := test.(type) {
+	case *ucs.ObjectTest:
+		obj, ok := soltype.CarrierOf(member).(*soltype.ObjectType)
+		if !ok {
+			return false
+		}
+		for _, key := range t.Keys {
+			if _, found := obj.Prop(key.Name); !found {
+				return false
+			}
+		}
+		return true
+	case *ucs.TupleTest:
+		tup, ok := soltype.CarrierOf(member).(*soltype.TupleType)
+		if !ok {
+			return false
+		}
+		if t.Rest == ucs.TrailingRest {
+			return len(tup.Elems) >= t.Len
+		}
+		return len(tup.Elems) == t.Len
+	default:
+		return false
+	}
+}
+
+// tupleShapeReq mints one projection variable per element position and emits the
+// whole-tuple requirement that lowers the scrutinee's matching element into each. inexact
+// relaxes the requirement to "a tuple at least this long", which is what a trailing rest
+// asks for; an exact requirement is what rejects a wrong arity with
+// TupleLengthMismatchError. It returns the grounded scrutinee and concrete tuples
+// alongside, which a suffix step reads its slice out of.
+func (b *pathBinder) tupleShapeReq(
+	v scrutineeView, node ast.Node, count int, inexact bool,
+) (elems []soltype.Type, scrutTup, concreteTup *soltype.TupleType) {
+	elems = make([]soltype.Type, count)
+	for i := range elems {
+		elems[i] = b.c.freshAt(b.lvl)
+	}
+	b.c.constrain(node, v.ty, &soltype.TupleType{Elems: elems, Inexact: inexact})
+	scrutTup, _ = b.c.groundedTuple(v.ty)
+	concreteTup, _ = b.c.groundedTuple(v.concrete)
+	// Pin each variable's upper bound to the scrutinee's own element when the scrutinee is
+	// a grounded tuple. The requirement above gives each one the element only as a lower
+	// bound, so without this a refutable literal sub-pattern of the wrong kind, `[a, "hi"]`
+	// against `[number, number]`, would go unreported. bindPatMode's tuple arm adds the
+	// same bound.
+	if scrutTup != nil {
+		for i := range elems {
+			if i < len(scrutTup.Elems) {
+				b.c.constrain(node, elems[i], scrutTup.Elems[i])
+			}
+		}
+	}
+	return elems, scrutTup, concreteTup
+}
+
+// applyLitTest asserts the branch's literal is an admissible value of the scrutinee, so
+// the literal flows INTO the scrutinee and `5 <: number` checks. It binds nothing, since
+// a literal test names no sub-scrutinee. It is bindPatMode's literal arm read off the
+// test.
+func (b *pathBinder) applyLitTest(node ast.Node, v scrutineeView, t *ucs.LitTest) {
+	if atom, _, isAtom := atomLitOf(t.Lit); isAtom {
+		// A `null` or `undefined` test asserts the atom is admissible, the same direction as
+		// the literal below.
+		b.c.constrain(node, atom, v.ty)
+		return
+	}
+	lt, ok := b.c.litTypeOf(t.Lit)
+	if !ok {
+		b.c.reportUnsupported(t.Lit)
+		return
+	}
+	b.c.constrain(node, lt, v.ty)
+}
+
+// applyClassTest narrows the scrutinee to the named class and resolves the instance
+// member view its field steps read. It is bindInstancePat's narrowing read off the test,
+// with the fields left to the projections rather than bound here.
+func (b *pathBinder) applyClassTest(scope *Scope, node ast.Node, v scrutineeView, t *ucs.ClassTest) scrutineeView {
+	blame := blameName(t.Name, node)
+	name := ast.QualIdentToString(t.Name)
+	ct, ok := b.c.instancePatClass(scope, name)
+	if !ok {
+		b.c.report(&InstancePatternNotClassError{Node: blame, Name: name})
+		// Resolve the fields against a fresh variable so a leaf beneath the test stays
+		// defined without a second cascade against the real scrutinee.
+		fresh := b.c.freshAt(b.lvl)
+		v.ty, v.concrete, v.shape = fresh, nil, fresh
+		return v
+	}
+	inst := b.c.freshClassInstance(ct, b.lvl)
+	// The test narrows the scrutinee to the named class, so the instance flows into the
+	// scrutinee and a scrutinee that cannot be this class is rejected here.
+	b.c.constrain(blame, inst, v.ty)
+	// Project the scrutinee's own instance when it names the same class, so its concrete
+	// arguments give the field types directly. A downcast falls back to the asserted
+	// instance.
+	projected := inst
+	if sc, ok := classCarrier(v.ty); ok && sc.Name == ct.Name {
+		projected = sc
+	}
+	body, ok := b.c.ctx.projectClassBody(projected)
+	if !ok {
+		return v
+	}
+	v.ty, v.concrete, v.shape = body, body, body
+	return v
+}
+
+// applyExtractorTest narrows the scrutinee to the constructor's return type and resolves
+// the parameters its extract steps read. It is bindExtractorPat's narrowing read off the
+// test, with the extracted values left to the projections rather than bound here.
+func (b *pathBinder) applyExtractorTest(scope *Scope, node ast.Node, v scrutineeView, t *ucs.ExtractorTest) scrutineeView {
+	blame := blameName(t.Name, node)
+	name := ast.QualIdentToString(t.Name)
+	ctor, ok := b.c.extractorCtor(scope, b.lvl, t.Name)
+	if !ok {
+		b.c.report(&ExtractorPatternNotCtorError{Node: blame, Name: name})
+		return v
+	}
+	// The extracted value is an instance of the constructor's return type. Narrow the
+	// scrutinee to it, the same assertion a class test makes.
+	b.c.constrain(blame, ctor.Ret, v.ty)
+	// Read the parameters at the scrutinee's concrete arguments by substituting them
+	// directly, rather than relying on the narrowing constraint above to back-propagate
+	// them.
+	params := ctor.Params
+	if sc, ok := classCarrier(v.ty); ok {
+		if ret, isClass := ctor.Ret.(*soltype.ClassType); isClass && ret.Name == sc.Name {
+			params = ctorParamsAt(ctor.Params, ret, sc)
+		}
+	}
+	if t.Arity != len(params) {
+		b.c.report(&ExtractorPatternArityError{Node: blame, Name: name, Expected: len(params), Got: t.Arity})
+	}
+	v.params = params
+	return v
+}
+
+// blameFor returns the node a constraint emitted while resolving s is anchored to. A
+// scrutinee's origin points at the source pattern the projection came from, which is the
+// narrowest honest span. That origin holds only a Spanned, so a scrutinee whose origin
+// names something the solver cannot blame falls back to the node the binder was seeded
+// with.
+func (b *pathBinder) blameFor(s *ucs.Scrutinee) ast.Node {
+	if s != nil {
+		if n, ok := blamableNode(s.Origin.Node); ok {
+			return n
+		}
+	}
+	return b.blame
+}
+
+// blameName returns the node to blame for a test's class or extractor name, falling back
+// to the caller's node. An ast.QualIdent is guaranteed only to carry a span, so a form
+// that is not also an ast.Node names nothing a diagnostic can anchor to.
+func blameName(qi ast.QualIdent, fallback ast.Node) ast.Node {
+	if n, ok := blamableNode(qi); ok {
+		return n
+	}
+	return fallback
+}
+
+// blamableNode returns n as an ast.Node a diagnostic can anchor to, and false when it is
+// not one or holds no node at all.
+//
+// The nil test runs through ucs.SpanOf rather than through `n != nil`. A Spanned field can
+// hold a typed nil pointer, which is non-nil as an interface value, satisfies the ast.Node
+// assertion, and then panics the moment a diagnostic reads its span. SpanOf is the guard
+// the ucs package added for exactly that hazard.
+func blamableNode(n ucs.Spanned) (ast.Node, bool) {
+	if _, ok := ucs.SpanOf(n); !ok {
+		return nil, false
+	}
+	node, ok := n.(ast.Node)
+	return node, ok
+}

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -39,28 +39,54 @@ type scrutineeView struct {
 	// mode is the binding mode the root scrutinee's borrow fixed. It propagates
 	// unchanged down the path, the same match ergonomics bindPatMode follows.
 	mode bindMode
-	// test is the tag test the split over this scrutinee applied, and nil until one is.
-	// Only fieldOptional reads it, to ask an object test whether a key the pattern
-	// defaulted may be absent. Every other test kind leaves its result in a field of its
-	// own.
-	test ucs.Test
 	// shape is the type union narrowing reads its members off. It is the scrutinee's own
 	// type once that is concrete, and a coalesced snapshot of it while it is still an
 	// inference variable.
 	shape soltype.Type
-	// elems holds one projection variable per fixed element of a tuple test, minted when
-	// that test emitted its whole-tuple requirement. An index step reads its element out
-	// of this rather than emitting a requirement of its own.
-	elems []soltype.Type
-	// tuple and concreteTuple are the grounded tuple shapes the same tuple test
-	// resolved, which a suffix step reads its `...rest` slice out of. Each is nil when
-	// the corresponding type is not a grounded tuple.
-	tuple, concreteTuple *soltype.TupleType
-	// params holds the constructor parameters an extractor test resolved. An extract
-	// step reads its value's type out of this, the interim protocol bindExtractorPat
-	// also binds through until M7's `[Symbol.customMatcher]` lands.
-	params []*soltype.FuncParam
+	// tested is what the split's tag test left behind for the projections beneath this
+	// scrutinee. It is nil until a split tests it, and nil afterwards for a test that
+	// leaves nothing behind.
+	tested tested
 }
+
+// tested is what one branch's tag test resolved for the steps that project out of the
+// scrutinee it tested.
+//
+// It is a sum rather than a group of fields on scrutineeView because the alternatives are
+// disjoint. A scrutinee is tested against exactly one tag, and each tag kind resolves a
+// different thing. A tuple test mints element variables and an extractor test resolves
+// constructor parameters, so no one value ever carries both.
+//
+// A literal test and a class test resolve nothing and leave it nil. A class test narrows
+// the scrutinee's own type to the instance member view instead, so its field steps read
+// that view through the ordinary member lookup and need nothing carried here.
+type tested interface{ isTested() }
+
+func (*testedObject) isTested()    {}
+func (*testedTuple) isTested()     {}
+func (*testedExtractor) isTested() {}
+
+// testedObject carries the object test itself, which a field step consults to ask whether
+// the key the pattern defaulted may be absent. Nothing else about an object test is
+// resolved up front, since its keys are looked up one at a time by the steps beneath it.
+type testedObject struct{ test *ucs.ObjectTest }
+
+// testedTuple carries what a tuple test's whole-tuple requirement produced.
+type testedTuple struct {
+	// elems holds one projection variable per fixed element, minted when the requirement
+	// was emitted. An index step reads its element out of this rather than emitting a
+	// requirement of its own.
+	elems []soltype.Type
+	// scrut and concrete are the grounded tuple shapes the test resolved, which a suffix
+	// step reads its `...rest` slice out of. Each is nil when the corresponding type is
+	// not a grounded tuple.
+	scrut, concrete *soltype.TupleType
+}
+
+// testedExtractor carries the constructor parameters an extractor test resolved. An
+// extract step reads its value's type out of them, the interim protocol bindExtractorPat
+// also binds through until M7's `[Symbol.customMatcher]` lands.
+type testedExtractor struct{ params []*soltype.FuncParam }
 
 // pathBinder resolves IR projection paths into types and binds leaf patterns off them.
 // It is seeded with the root scrutinee's inferred type, which is the only type the IR
@@ -220,21 +246,23 @@ func (b *pathBinder) projectField(parent scrutineeView, node ast.Node, name stri
 // scrutinee `parent` is the view of, so a tuple shape minted here is written back onto it
 // and every later step off the same value reads that one shape.
 func (b *pathBinder) projectIndex(parentScrut *ucs.Scrutinee, parent scrutineeView, node ast.Node, i int) scrutineeView {
-	if i >= len(parent.elems) {
+	tup, ok := parent.tested.(*testedTuple)
+	if !ok || i >= len(tup.elems) {
 		// No tuple test fixed this scrutinee's arity, so nothing has minted a variable for
 		// position i yet. Emit an inexact requirement pinning the positions up to it —
 		// "the scrutinee is a tuple at least this long" — so any path resolves, not only one
 		// a split has already tested. A normalized index step always sits under a tuple
 		// test, so this runs only for a path built without one, and it mints another
 		// requirement if a still deeper index arrives afterwards.
-		parent.elems, parent.tuple, parent.concreteTuple = b.tupleShapeReq(parent, node, i+1, true)
+		tup = b.tupleShapeReq(parent, node, i+1, true)
+		parent.tested = tup
 		b.views[parentScrut] = parent
 	}
 	var concrete soltype.Type
-	if parent.concreteTuple != nil && i < len(parent.concreteTuple.Elems) {
-		concrete = parent.concreteTuple.Elems[i]
+	if tup.concrete != nil && i < len(tup.concrete.Elems) {
+		concrete = tup.concrete.Elems[i]
 	}
-	return derive(parent, parent.elems[i], concrete)
+	return derive(parent, tup.elems[i], concrete)
 }
 
 // projectExtract resolves the i-th positional value an extractor yields, the `v` of
@@ -243,21 +271,28 @@ func (b *pathBinder) projectIndex(parentScrut *ucs.Scrutinee, parent scrutineeVi
 // `[Symbol.customMatcher]`. Nothing is constrained here, so the step blames no node. The
 // extractor test already narrowed the scrutinee when it resolved the constructor.
 func (b *pathBinder) projectExtract(parent scrutineeView, i int) scrutineeView {
-	if i >= len(parent.params) {
+	ext, ok := parent.tested.(*testedExtractor)
+	if !ok || i >= len(ext.params) {
 		// Either no extractor test resolved a constructor for this scrutinee, or the
 		// pattern took more values than the constructor yields. The arity error is reported
 		// where the test is applied, so recovering with a fresh variable here keeps the
 		// leaves defined without a second diagnostic.
 		return derive(parent, b.c.freshAt(b.lvl), nil)
 	}
-	param := parent.params[i].Type
+	param := ext.params[i].Type
 	return derive(parent, param, param)
 }
 
 // projectSuffix resolves `parent[from..]`, the tuple elements past a fixed prefix, which
 // is what a tuple pattern's `...rest` binds.
 func (b *pathBinder) projectSuffix(parent scrutineeView, node ast.Node, from int) scrutineeView {
-	suffix, concrete := b.c.tupleRestType(b.lvl, node, parent.ty, parent.tuple, parent.concreteTuple, from)
+	// With no tuple test above it the grounded shapes are unknown, and tupleRestType falls
+	// back to grounding the scrutinee itself.
+	var scrutTup, concreteTup *soltype.TupleType
+	if tup, ok := parent.tested.(*testedTuple); ok {
+		scrutTup, concreteTup = tup.scrut, tup.concrete
+	}
+	suffix, concrete := b.c.tupleRestType(b.lvl, node, parent.ty, scrutTup, concreteTup, from)
 	return derive(parent, suffix, concrete)
 }
 
@@ -285,11 +320,11 @@ func derive(parent scrutineeView, ty, concrete soltype.Type) scrutineeView {
 // matches. Absent an object test the field is required, matching a pattern with no
 // default.
 func (v scrutineeView) fieldOptional(name string) bool {
-	obj, ok := v.test.(*ucs.ObjectTest)
+	obj, ok := v.tested.(*testedObject)
 	if !ok {
 		return false
 	}
-	for _, key := range obj.Keys {
+	for _, key := range obj.test.Keys {
 		if key.Name == name {
 			return key.Optional
 		}
@@ -300,16 +335,20 @@ func (v scrutineeView) fieldOptional(name string) bool {
 // applyTest narrows v by the tag test one branch of a split applies to it, and resolves
 // whatever that test leaves behind for the projections beneath it.
 func (b *pathBinder) applyTest(scope *Scope, node ast.Node, v scrutineeView, test ucs.Test) scrutineeView {
-	v.test = test
+	// A scrutinee is tested against one tag per branch, so whatever an earlier call left
+	// here belongs to a different branch's test and must not be read by this one's steps.
+	v.tested = nil
 	switch t := test.(type) {
 	case *ucs.ObjectTest:
 		// An object test emits nothing itself. Its keys are looked up one at a time, by the
 		// field steps beneath it, which is the same per-field dispatch bindPatMode's object
 		// arm makes.
-		return b.narrowUnion(v, test)
+		v = b.narrowUnion(v, test)
+		v.tested = &testedObject{test: t}
+		return v
 	case *ucs.TupleTest:
 		v = b.narrowUnion(v, test)
-		v.elems, v.tuple, v.concreteTuple = b.tupleShapeReq(v, node, t.Len, t.Rest == ucs.TrailingRest)
+		v.tested = b.tupleShapeReq(v, node, t.Len, t.Rest == ucs.TrailingRest)
 		return v
 	case *ucs.LitTest:
 		b.applyLitTest(node, v, t)
@@ -402,18 +441,16 @@ func testMatchesMemberShape(test ucs.Test, member soltype.Type) bool {
 // whole-tuple requirement that lowers the scrutinee's matching element into each. inexact
 // relaxes the requirement to "a tuple at least this long", which is what a trailing rest
 // asks for; an exact requirement is what rejects a wrong arity with
-// TupleLengthMismatchError. It returns the grounded scrutinee and concrete tuples
+// TupleLengthMismatchError. It resolves the grounded scrutinee and concrete tuples
 // alongside, which a suffix step reads its slice out of.
-func (b *pathBinder) tupleShapeReq(
-	v scrutineeView, node ast.Node, count int, inexact bool,
-) (elems []soltype.Type, scrutTup, concreteTup *soltype.TupleType) {
-	elems = make([]soltype.Type, count)
+func (b *pathBinder) tupleShapeReq(v scrutineeView, node ast.Node, count int, inexact bool) *testedTuple {
+	elems := make([]soltype.Type, count)
 	for i := range elems {
 		elems[i] = b.c.freshAt(b.lvl)
 	}
 	b.c.constrain(node, v.ty, &soltype.TupleType{Elems: elems, Inexact: inexact})
-	scrutTup, _ = b.c.groundedTuple(v.ty)
-	concreteTup, _ = b.c.groundedTuple(v.concrete)
+	scrutTup, _ := b.c.groundedTuple(v.ty)
+	concreteTup, _ := b.c.groundedTuple(v.concrete)
 	// Pin each variable's upper bound to the scrutinee's own element when the scrutinee is
 	// a grounded tuple. The requirement above gives each one the element only as a lower
 	// bound, so without this a refutable literal sub-pattern of the wrong kind, `[a, "hi"]`
@@ -426,7 +463,7 @@ func (b *pathBinder) tupleShapeReq(
 			}
 		}
 	}
-	return elems, scrutTup, concreteTup
+	return &testedTuple{elems: elems, scrut: scrutTup, concrete: concreteTup}
 }
 
 // applyLitTest asserts the branch's literal is an admissible value of the scrutinee, so
@@ -508,7 +545,7 @@ func (b *pathBinder) applyExtractorTest(scope *Scope, node ast.Node, v scrutinee
 	if t.Arity != len(params) {
 		b.c.report(&ExtractorPatternArityError{Node: blame, Name: name, Expected: len(params), Got: t.Arity})
 	}
-	v.params = params
+	v.tested = &testedExtractor{params: params}
 	return v
 }
 

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -356,32 +356,14 @@ func (b *pathBinder) narrowUnion(v scrutineeView, test ucs.Test) scrutineeView {
 	if _, isVar := shape.(*soltype.TypeVarType); isVar {
 		shape = soltype.CarrierOf(coalesce(shape, soltype.Positive))
 	}
-	u, ok := shape.(*soltype.UnionType)
+	narrowed, ok := narrowUnionMembers(shape, func(member soltype.Type) bool {
+		return testMatchesMemberShape(test, member)
+	})
 	if !ok {
+		// Narrowing does not apply, so the scrutinee's own type stays the bind target. The
+		// borrow needs no rewrap the way narrowMatchArm's does, since it rides mode rather
+		// than the type.
 		return v
-	}
-	kept := make([]soltype.Type, 0, len(u.Types))
-	for _, member := range u.Types {
-		if testMatchesMemberShape(test, member) {
-			kept = append(kept, member)
-		}
-	}
-	// When the test matches no listed member there is nothing to narrow to. When it
-	// matches every listed member, narrowing would reproduce the whole union, including an
-	// inexact union's open tail. Either way the scrutinee's own type is the bind target.
-	if len(kept) == 0 || len(kept) == len(u.Types) {
-		return v
-	}
-	var narrowed soltype.Type
-	if len(kept) == 1 && !u.Inexact {
-		narrowed = kept[0]
-	} else {
-		// An inexact union keeps its open `...` tail through narrowing. A tail member may
-		// carry the test's fields at any type, so the tail is retained and a narrowed
-		// inexact member's fields read as `unknown`. Keeping the structured union rather
-		// than collapsing to bare `unknown` is what leaves the listed members for the field
-		// steps beneath to read.
-		narrowed = &soltype.UnionType{Types: kept, Inexact: u.Inexact}
 	}
 	v.ty, v.concrete, v.shape = narrowed, narrowed, narrowed
 	return v
@@ -397,25 +379,13 @@ func (b *pathBinder) narrowUnion(v scrutineeView, test ucs.Test) scrutineeView {
 func testMatchesMemberShape(test ucs.Test, member soltype.Type) bool {
 	switch t := test.(type) {
 	case *ucs.ObjectTest:
-		obj, ok := soltype.CarrierOf(member).(*soltype.ObjectType)
-		if !ok {
-			return false
+		names := make([]string, len(t.Keys))
+		for i, key := range t.Keys {
+			names[i] = key.Name
 		}
-		for _, key := range t.Keys {
-			if _, found := obj.Prop(key.Name); !found {
-				return false
-			}
-		}
-		return true
+		return objectMemberHasKeys(member, names)
 	case *ucs.TupleTest:
-		tup, ok := soltype.CarrierOf(member).(*soltype.TupleType)
-		if !ok {
-			return false
-		}
-		if t.Rest == ucs.TrailingRest {
-			return len(tup.Elems) >= t.Len
-		}
-		return len(tup.Elems) == t.Len
+		return tupleMemberFitsArity(member, t.Len, t.Rest == ucs.TrailingRest)
 	default:
 		return false
 	}

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -218,28 +218,12 @@ func (b *pathBinder) project(scope *Scope, s *ucs.Scrutinee) scrutineeView {
 	}
 }
 
-// projectField resolves `parent.name`. The lookup is the same inexact one-property
-// requirement bindPatMode's object arm emits, so a field the scrutinee lacks surfaces
-// MissingPropertyError from the same rule a written `{name}` pattern does.
+// projectField resolves `parent.name` through the checker's one field projection, so a
+// field the scrutinee lacks surfaces MissingPropertyError from the same rule a written
+// `{name: sub}` pattern does.
 func (b *pathBinder) projectField(parent scrutineeView, node ast.Node, name string) scrutineeView {
-	beta := b.c.freshAt(b.lvl)
-	b.c.constrain(node, parent.ty, propReq(name, beta, parent.fieldOptional(name)))
-	// Pin beta's upper bound to the field's own type when the scrutinee is a concrete
-	// object. The requirement above gives beta the field only as a lower bound, which
-	// cannot reject a refutable literal sub-pattern of the wrong kind, so `{x: "hi"}`
-	// against `{x: number}` would go unreported. bindPatMode's key-value arm adds the same
-	// bound for the same reason.
-	//
-	// An optional property gets no pin. Reading `x` off `{x?: number}` produces
-	// `number | undefined`, so a bound of `number` would reject the `undefined` half of the
-	// value the field actually holds. bindPatMode's shorthand arm, which every `{x}` goes
-	// through, adds no pin at all for the same reason.
-	if obj, ok := parent.ty.(*soltype.ObjectType); ok {
-		if prop, found := obj.Prop(name); found && !prop.Optional {
-			b.c.constrain(node, beta, prop.Type)
-		}
-	}
-	return derive(parent, beta, fieldConcrete(parent.concrete, name))
+	proj, concrete := b.c.projectField(node, b.lvl, parent.ty, parent.concrete, name, parent.fieldOptional(name))
+	return derive(parent, proj, concrete)
 }
 
 // projectIndex resolves `parent.i`, the i-th element of a tuple. parentScrut names the
@@ -437,32 +421,11 @@ func testMatchesMemberShape(test ucs.Test, member soltype.Type) bool {
 	}
 }
 
-// tupleShapeReq mints one projection variable per element position and emits the
-// whole-tuple requirement that lowers the scrutinee's matching element into each. inexact
-// relaxes the requirement to "a tuple at least this long", which is what a trailing rest
-// asks for; an exact requirement is what rejects a wrong arity with
-// TupleLengthMismatchError. It resolves the grounded scrutinee and concrete tuples
-// alongside, which a suffix step reads its slice out of.
+// tupleShapeReq resolves what a tuple test leaves for the steps beneath it, through the
+// checker's one tuple projection. Every element's upper bound is anchored to node, since a
+// normalized test names no sub-pattern to underline the way a written tuple pattern does.
 func (b *pathBinder) tupleShapeReq(v scrutineeView, node ast.Node, count int, inexact bool) *testedTuple {
-	elems := make([]soltype.Type, count)
-	for i := range elems {
-		elems[i] = b.c.freshAt(b.lvl)
-	}
-	b.c.constrain(node, v.ty, &soltype.TupleType{Elems: elems, Inexact: inexact})
-	scrutTup, _ := b.c.groundedTuple(v.ty)
-	concreteTup, _ := b.c.groundedTuple(v.concrete)
-	// Pin each variable's upper bound to the scrutinee's own element when the scrutinee is
-	// a grounded tuple. The requirement above gives each one the element only as a lower
-	// bound, so without this a refutable literal sub-pattern of the wrong kind, `[a, "hi"]`
-	// against `[number, number]`, would go unreported. bindPatMode's tuple arm adds the
-	// same bound.
-	if scrutTup != nil {
-		for i := range elems {
-			if i < len(scrutTup.Elems) {
-				b.c.constrain(node, elems[i], scrutTup.Elems[i])
-			}
-		}
-	}
+	elems, scrutTup, concreteTup := b.c.projectTuple(node, b.lvl, v.ty, v.concrete, count, inexact, nil)
 	return &testedTuple{elems: elems, scrut: scrutTup, concrete: concreteTup}
 }
 
@@ -500,22 +463,8 @@ func (b *pathBinder) applyClassTest(scope *Scope, node ast.Node, v scrutineeView
 		v.ty, v.concrete, v.shape = fresh, nil, fresh
 		return v
 	}
-	inst := b.c.freshClassInstance(ct, b.lvl)
-	// The test narrows the scrutinee to the named class, so the instance flows into the
-	// scrutinee and a scrutinee that cannot be this class is rejected here.
-	b.c.constrain(blame, inst, v.ty)
-	// Project the scrutinee's own instance when it names the same class, so its concrete
-	// arguments give the field types directly. A downcast falls back to the asserted
-	// instance.
-	projected := inst
-	if sc, ok := classCarrier(v.ty); ok && sc.Name == ct.Name {
-		projected = sc
-	}
-	body, ok := b.c.ctx.projectClassBody(projected)
-	if !ok {
-		return v
-	}
-	v.ty, v.concrete, v.shape = body, body, body
+	target, targetConcrete := b.c.narrowToClass(b.lvl, blame, ct, v.ty, v.concrete)
+	v.ty, v.concrete, v.shape = target, targetConcrete, target
 	return v
 }
 
@@ -530,18 +479,7 @@ func (b *pathBinder) applyExtractorTest(scope *Scope, node ast.Node, v scrutinee
 		b.c.report(&ExtractorPatternNotCtorError{Node: blame, Name: name})
 		return v
 	}
-	// The extracted value is an instance of the constructor's return type. Narrow the
-	// scrutinee to it, the same assertion a class test makes.
-	b.c.constrain(blame, ctor.Ret, v.ty)
-	// Read the parameters at the scrutinee's concrete arguments by substituting them
-	// directly, rather than relying on the narrowing constraint above to back-propagate
-	// them.
-	params := ctor.Params
-	if sc, ok := classCarrier(v.ty); ok {
-		if ret, isClass := ctor.Ret.(*soltype.ClassType); isClass && ret.Name == sc.Name {
-			params = ctorParamsAt(ctor.Params, ret, sc)
-		}
-	}
+	params := b.c.narrowToExtractor(blame, ctor, v.ty)
 	if t.Arity != len(params) {
 		b.c.report(&ExtractorPatternArityError{Node: blame, Name: name, Expected: len(params), Got: t.Arity})
 	}

--- a/internal/solver/ucs_bind_test.go
+++ b/internal/solver/ucs_bind_test.go
@@ -423,9 +423,10 @@ func TestPathBinderDefaultFillsOptionalProperty(t *testing.T) {
 // members disagree, so neither distinguishes it.
 //
 // Whether `{x = 0}` should match a scrutinee with no `x` at all is a question about
-// bindPattern rather than about the IR. TestInferObjectPatternLeafDefault in
-// infer_pattern_test.go pins the same answer for `val {z = 0} = p` over `{x: number}`, and
-// this case exists to hold the path binder to it. Change the two together or not at all.
+// bindPattern rather than about the IR, and #1053 argues it should not.
+// TestInferObjectPatternLeafDefault in infer_pattern_test.go pins the same answer for
+// `val {z = 0} = p` over `{x: number}`, and this case exists to hold the path binder to
+// it. Change the two together or not at all.
 func TestPathBinderDefaultedKeyBindsAgainstScrutineeWithoutTheField(t *testing.T) {
 	c, scope := newPathChecker(t, "")
 	root, binder := seedPath(c, parseType(t, "{y: string}"))

--- a/internal/solver/ucs_bind_test.go
+++ b/internal/solver/ucs_bind_test.go
@@ -1,0 +1,483 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/escalier-lang/escalier/internal/solver/ucs"
+	"github.com/stretchr/testify/require"
+)
+
+// UCS IR PR5: project-and-bind over an IR projection path. Every case here hands the
+// binder a path the `ucs` package could have produced and checks the type its leaf binds
+// at. Nothing calls the binder from the inference walk yet, so no case runs a `match`
+// through it; that arrives with PR6.
+
+// newPathChecker infers src into a fresh checker and returns it with the module scope, so
+// a case can name a class the source declared. Pass an empty source when the root type is
+// built by hand.
+func newPathChecker(t *testing.T, src string) (*checker, *Scope) {
+	t.Helper()
+	c := newChecker()
+	scope := sharedPrelude().Child()
+	module := parseModule(t, src)
+	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))
+	require.Empty(t, messagesWithSpan(c.errs), "the harness source must infer cleanly")
+	return c, scope
+}
+
+// seedPath builds the root scrutinee for a target written `p` and the binder over it,
+// the state a walk is in once it has inferred the match target. The identifier is also
+// the node a constraint the resolution emits blames.
+func seedPath(c *checker, rootType soltype.Type) (*ucs.Scrutinee, *pathBinder) {
+	target := identExpr("p")
+	root := ucs.NewRoot(target, ucs.At(ucs.OriginMatchArm, target))
+	return root, c.newPathBinder(0, target, root, rootType)
+}
+
+// leafPat builds the plain identifier leaf a bind node names, `ast.NewIdentPat`'s
+// no-annotation, no-default, immutable form.
+func leafPat(name string) *ast.IdentPat {
+	return ast.NewIdentPat(name, false, nil, nil, builderSpan())
+}
+
+// projectPath applies each step in turn from root, sharing one *ucs.Scrutinee per level
+// the way normalization does, and returns the scrutinee the last step reaches.
+func projectPath(root *ucs.Scrutinee, steps ...ucs.Step) *ucs.Scrutinee {
+	s := root
+	for _, step := range steps {
+		s = s.Project(step, ucs.At(ucs.OriginMatchArm, root.Target))
+	}
+	return s
+}
+
+// boundType renders the type a leaf landed at in scope, coalesced the way a rendered
+// binding is, so a case asserts Escalier annotation syntax rather than a raw variable.
+func boundType(t *testing.T, c *checker, scope *Scope, name string) string {
+	t.Helper()
+	b, ok := scope.values[name]
+	require.True(t, ok, "no binding for %q", name)
+	require.Len(t, b.Schemes, 1)
+	return c.renderValueBinding(b.Schemes[0])
+}
+
+// classType returns the handle of a class the harness source declared, which is the
+// scrutinee type a `match` over an instance of that class starts from.
+func classType(t *testing.T, c *checker, scope *Scope, name string) soltype.Type {
+	t.Helper()
+	ct, ok := c.instancePatClass(scope, name)
+	require.True(t, ok, "no class named %q", name)
+	return ct
+}
+
+// TestPathBinderProjectsAndBinds is the contract: given a hand-built path, the leaf binds
+// at the type the same leaf nested inside one whole pattern would bind at. Each case
+// seeds a root scrutinee, applies the tag test the split over it would apply, projects
+// the path, and binds one identifier leaf off it.
+func TestPathBinderProjectsAndBinds(t *testing.T) {
+	// A borrow needs a lifetime to be a real reference rather than an owned-mutable cell,
+	// so the borrowed cases mint one.
+	lt := &soltype.LifetimeVar{ID: 0, Level: 0}
+
+	tests := map[string]struct {
+		// src declares whatever the case names, and is empty when the root type is built
+		// by hand.
+		src string
+		// rootType is the type the walk inferred for the match target.
+		rootType func(t *testing.T, c *checker, scope *Scope) soltype.Type
+		// test is the tag test the split over the root applies, and nil when the case
+		// projects with no split above it.
+		test ucs.Test
+		// steps is the projection path from the root down to the leaf's source.
+		steps []ucs.Step
+		// leaf is the name the bind node introduces.
+		leaf string
+		// want is the leaf's rendered type.
+		want string
+		// wantErrs is the full set of messages the resolution reports, span-prefixed.
+		wantErrs []string
+	}{
+		// A field of a structural object resolves through the same inexact one-property
+		// requirement a written `{x}` pattern emits.
+		"Field": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "{x: number, y: string}")
+			},
+			test:  &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}, {Name: "y"}}},
+			steps: []ucs.Step{ucs.FieldStep{Name: "x"}},
+			leaf:  "x",
+			want:  "number",
+		},
+		// A field the scrutinee lacks fails the same requirement, so the path reports the
+		// missing property rather than binding the leaf at a silent `never`.
+		"FieldMissing": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "{x: number}")
+			},
+			test:     &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "z"}}},
+			steps:    []ucs.Step{ucs.FieldStep{Name: "z"}},
+			leaf:     "z",
+			want:     "never",
+			wantErrs: []string{"1:1-1:2: object is missing property: z"},
+		},
+		// An optional property reads as `T | undefined`, so the projection takes no upper
+		// bound of `T`: the bound would reject the `undefined` half of what the field
+		// actually holds. bindPatMode's shorthand arm, which every written `{x}` goes
+		// through, adds no bound either.
+		"OptionalField": {
+			rootType: func(_ *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return exactObj(&soltype.PropertyElem{Name: "x", Type: num(), Optional: true})
+			},
+			test:  &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}},
+			steps: []ucs.Step{ucs.FieldStep{Name: "x"}},
+			leaf:  "x",
+			want:  "number | undefined",
+		},
+		// A tuple index reads the element the tuple test's whole-tuple requirement lowered
+		// into position 1.
+		"TupleIndex": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "[number, string]")
+			},
+			test:  &ucs.TupleTest{Len: 2},
+			steps: []ucs.Step{ucs.IndexStep{Index: 1}},
+			leaf:  "b",
+			want:  "string",
+		},
+		// The tuple test's requirement is exact without a rest, so a scrutinee of the wrong
+		// arity is rejected at the test rather than at any one element. The rejected
+		// requirement leaves each element variable unbounded, so the leaf recovers as
+		// `never`.
+		"TupleIndexWrongArity": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "[number, string]")
+			},
+			test:     &ucs.TupleTest{Len: 3},
+			steps:    []ucs.Step{ucs.IndexStep{Index: 0}},
+			leaf:     "a",
+			want:     "never",
+			wantErrs: []string{"1:1-1:2: cannot constrain tuple of length 2 <: tuple of length 3"},
+		},
+		// A trailing rest relaxes the test to a prefix and binds the suffix, which the path
+		// names with a suffix step rather than with an index.
+		"TupleSuffix": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "[number, string, boolean]")
+			},
+			test:  &ucs.TupleTest{Len: 1, Rest: ucs.TrailingRest},
+			steps: []ucs.Step{ucs.SuffixStep{From: 1}},
+			leaf:  "rest",
+			want:  "[string, boolean]",
+		},
+		// An object rest binds the scrutinee minus the keys the pattern named, which the
+		// path names with a remainder step carrying that key set.
+		"ObjectRemainder": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "{x: number, y: string, z: boolean}")
+			},
+			test:  &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}, Rest: ucs.TrailingRest},
+			steps: []ucs.Step{ucs.RemainderStep{Exclude: set.FromSlice([]string{"x"})}},
+			leaf:  "rest",
+			want:  "{y: string, z: boolean}",
+		},
+		// An extractor's positional value resolves through the constructor parameter it
+		// yields, the interim protocol bindExtractorPat also binds through. Point's
+		// synthesized constructor takes its fields, so value 0 is `x`.
+		"ExtractorResult": {
+			src:      `class Point { x: number, y: number }`,
+			rootType: func(t *testing.T, c *checker, scope *Scope) soltype.Type { return classType(t, c, scope, "Point") },
+			test:     &ucs.ExtractorTest{Name: ast.NewIdentifier("Point", builderSpan()), Arity: 2},
+			steps:    []ucs.Step{ucs.ExtractStep{Index: 0}},
+			leaf:     "x",
+			want:     "number",
+		},
+		// A class test projects the instance member view, so a field step off it reads the
+		// class's own member rather than a structural property.
+		"ClassField": {
+			src:      `class Point { x: number, y: number }`,
+			rootType: func(t *testing.T, c *checker, scope *Scope) soltype.Type { return classType(t, c, scope, "Point") },
+			test:     &ucs.ClassTest{Name: ast.NewIdentifier("Point", builderSpan())},
+			steps:    []ucs.Step{ucs.FieldStep{Name: "y"}},
+			leaf:     "y",
+			want:     "number",
+		},
+		// A structural test over a union keeps only the members it can destructure, so the
+		// field step reads `x` off the one member that has it. Without the narrowing the
+		// lookup would run against both members and widen the leaf to include the absent
+		// field's `undefined`; UnionUnnarrowed below pins that contrast.
+		"UnionNarrowed": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "{x: number} | {y: string}")
+			},
+			test:  &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}},
+			steps: []ucs.Step{ucs.FieldStep{Name: "x"}},
+			leaf:  "x",
+			want:  "number",
+		},
+		// The same path with no test above it: nothing narrowed the union, so the lookup
+		// runs against both members and reads `x` off `{y: string}` as `undefined`. That
+		// widened leaf is what the narrowing in UnionNarrowed prevents.
+		"UnionUnnarrowed": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "{x: number} | {y: string}")
+			},
+			steps: []ucs.Step{ucs.FieldStep{Name: "x"}},
+			leaf:  "x",
+			want:  "number | undefined",
+		},
+		// A test that matches every member narrows nothing, since the narrowed union would
+		// reproduce the original.
+		"UnionMatchesEveryMember": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "{x: number} | {x: string}")
+			},
+			test:  &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}},
+			steps: []ucs.Step{ucs.FieldStep{Name: "x"}},
+			leaf:  "x",
+			want:  "number | string",
+		},
+		// A tuple test narrows a union by arity, the same shape rule
+		// patternMatchesMemberShape applies to a written tuple pattern.
+		"UnionNarrowedByTupleArity": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return parseType(t, "[number] | [string, boolean]")
+			},
+			test:  &ucs.TupleTest{Len: 2},
+			steps: []ucs.Step{ucs.IndexStep{Index: 1}},
+			leaf:  "b",
+			want:  "boolean",
+		},
+		// A `&mut` scrutinee projects each leaf as a mutable borrow bounded by the
+		// scrutinee's lifetime, and the mode reaches the leaf through the path rather than
+		// through a wrapper on the projected type.
+		"MutBorrowedScrutinee": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return &soltype.RefType{Mut: true, Lt: lt, Inner: parseType(t, "{p: {x: number}}").(soltype.RefInner)}
+			},
+			test:  &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "p"}}},
+			steps: []ucs.Step{ucs.FieldStep{Name: "p"}},
+			leaf:  "p",
+			want:  "&mut {x: number}",
+		},
+		// A `&` scrutinee projects a shared borrow the same way.
+		"SharedBorrowedScrutinee": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return &soltype.RefType{Lt: lt, Inner: parseType(t, "{p: {x: number}}").(soltype.RefInner)}
+			},
+			test:  &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "p"}}},
+			steps: []ucs.Step{ucs.FieldStep{Name: "p"}},
+			leaf:  "p",
+			want:  "&{x: number}",
+		},
+		// The borrow propagates the whole way down a path, not just one level, following
+		// the same match ergonomics a nested pattern does.
+		"BorrowPropagatesThroughNestedPath": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return &soltype.RefType{Mut: true, Lt: lt, Inner: parseType(t, "{a: {b: {x: number}}}").(soltype.RefInner)}
+			},
+			test:  &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "a"}}},
+			steps: []ucs.Step{ucs.FieldStep{Name: "a"}, ucs.FieldStep{Name: "b"}},
+			leaf:  "b",
+			want:  "&mut {x: number}",
+		},
+		// A primitive leaf of a borrowed scrutinee is copied rather than borrowed, the same
+		// gate applyBindMode puts on a written pattern's leaves.
+		"BorrowedPrimitiveLeafIsCopied": {
+			rootType: func(t *testing.T, _ *checker, _ *Scope) soltype.Type {
+				return &soltype.RefType{Mut: true, Lt: lt, Inner: parseType(t, "{x: number}").(soltype.RefInner)}
+			},
+			test:  &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}},
+			steps: []ucs.Step{ucs.FieldStep{Name: "x"}},
+			leaf:  "x",
+			want:  "number",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, scope := newPathChecker(t, tt.src)
+			root, binder := seedPath(c, tt.rootType(t, c, scope))
+			if tt.test != nil {
+				binder = binder.narrowedBy(scope, root, tt.test)
+			}
+			// The leaves of one branch bind in a child scope, so a name one branch binds is
+			// invisible to the next, exactly as inferMatchArms scopes an arm.
+			armScope := scope.Child()
+			binder.bindAt(armScope, projectPath(root, tt.steps...), leafPat(tt.leaf))
+			require.Equal(t, tt.wantErrs, messagesWithSpan(c.errs))
+			require.Equal(t, tt.want, boundType(t, c, armScope, tt.leaf))
+		})
+	}
+}
+
+// A scrutinee is materialized once: an inner split and every leaf beneath it hold the
+// same *ucs.Scrutinee pointer, so the binder projects it once and every consumer reads
+// the same type. Re-projecting would mint a second variable and emit a second member
+// lookup, which is what the codegen note in the plan rules out.
+func TestPathBinderMaterializesEachScrutineeOnce(t *testing.T) {
+	c, scope := newPathChecker(t, "")
+	root, binder := seedPath(c, parseType(t, "{a: {x: number, y: string}}"))
+	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "a"}}})
+
+	inner := projectPath(root, ucs.FieldStep{Name: "a"})
+	first := binder.typeAt(scope, inner)
+	second := binder.typeAt(scope, inner)
+	require.Same(t, first, second)
+
+	// Both leaves of the inner split project out of that one shared scrutinee.
+	binder = binder.narrowedBy(scope, inner, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}, {Name: "y"}}})
+	armScope := scope.Child()
+	binder.bindAt(armScope, projectPath(inner, ucs.FieldStep{Name: "x"}), leafPat("x"))
+	binder.bindAt(armScope, projectPath(inner, ucs.FieldStep{Name: "y"}), leafPat("y"))
+	require.Empty(t, messagesWithSpan(c.errs))
+	require.Equal(t, "number", boundType(t, c, armScope, "x"))
+	require.Equal(t, "string", boundType(t, c, armScope, "y"))
+}
+
+// Sibling branches of one split share their scrutinee's projection. Applying a test per
+// branch must not re-project the value the split tests, which would mint a second variable
+// and emit a second member lookup for it.
+func TestPathBinderSiblingBranchesShareOneProjection(t *testing.T) {
+	c, scope := newPathChecker(t, "")
+	// The root has no `a`, so resolving `p.a` reports a missing property. Counting that
+	// report is how the test sees whether the projection ran once or once per branch.
+	root, binder := seedPath(c, parseType(t, "{b: number}"))
+	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "a"}}})
+	inner := projectPath(root, ucs.FieldStep{Name: "a"})
+
+	first := binder.narrowedBy(scope, inner, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}})
+	second := binder.narrowedBy(scope, inner, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "y"}}})
+
+	require.Equal(t, []string{"1:1-1:2: object is missing property: a"}, messagesWithSpan(c.errs))
+	// Neither test narrows a non-union scrutinee, so both branches still hold the one
+	// projection variable the shared resolution minted.
+	require.Same(t, first.typeAt(scope, inner), second.typeAt(scope, inner))
+}
+
+// An index step with no tuple test above it mints the whole-tuple requirement itself and
+// writes the shape back onto the scrutinee, so a sibling step off the same value reads
+// that shape instead of minting a second requirement.
+func TestPathBinderUntestedTupleIndexMintsOneRequirement(t *testing.T) {
+	c, scope := newPathChecker(t, "")
+	// The root is not a tuple, so the requirement an index step mints fails. Counting that
+	// report is how the test sees how many requirements were minted.
+	root, binder := seedPath(c, parseType(t, "{x: number}"))
+	armScope := scope.Child()
+	binder.bindAt(armScope, projectPath(root, ucs.IndexStep{Index: 1}), leafPat("b"))
+	binder.bindAt(armScope, projectPath(root, ucs.IndexStep{Index: 0}), leafPat("a"))
+	require.Equal(t, []string{
+		"1:1-1:2: cannot constrain object <: tuple",
+	}, messagesWithSpan(c.errs))
+}
+
+// Applying a test returns a derived binder rather than mutating the one it came from, so
+// two branches of the same split narrow the same scrutinee to different union members and
+// neither sees the other's view.
+func TestPathBinderBranchesNarrowIndependently(t *testing.T) {
+	c, scope := newPathChecker(t, "")
+	root, binder := seedPath(c, parseType(t, "{x: number} | {y: string}"))
+
+	first := binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}})
+	second := binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "y"}}})
+
+	firstScope := scope.Child()
+	first.bindAt(firstScope, projectPath(root, ucs.FieldStep{Name: "x"}), leafPat("x"))
+	secondScope := scope.Child()
+	second.bindAt(secondScope, projectPath(root, ucs.FieldStep{Name: "y"}), leafPat("y"))
+
+	require.Empty(t, messagesWithSpan(c.errs))
+	require.Equal(t, "number", boundType(t, c, firstScope, "x"))
+	require.Equal(t, "string", boundType(t, c, secondScope, "y"))
+}
+
+// A field an object test marked optional is looked up with an optional requirement, so a
+// leaf that carries a destructuring default still binds against a scrutinee that lacks
+// the field. `{x = 0}` is the pattern that produces the marker.
+func TestPathBinderOptionalKeyToleratesAbsentField(t *testing.T) {
+	c, scope := newPathChecker(t, "")
+	root, binder := seedPath(c, parseType(t, "{y: string}"))
+	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x", Optional: true}}})
+
+	armScope := scope.Child()
+	leaf := ast.NewIdentPat("x", false, nil, numExpr(0), builderSpan())
+	binder.bindAt(armScope, projectPath(root, ucs.FieldStep{Name: "x"}), leaf)
+	require.Empty(t, messagesWithSpan(c.errs))
+	require.Equal(t, "0", boundType(t, c, armScope, "x"))
+}
+
+// A test whose name resolves to no class or constructor reports against the name it
+// wrote, and the leaves beneath it still bind so a later reference does not cascade into
+// an unknown-identifier error.
+func TestPathBinderUnresolvedTagNames(t *testing.T) {
+	tests := map[string]struct {
+		test ucs.Test
+		step ucs.Step
+		want string
+	}{
+		"NotAClass": {
+			test: &ucs.ClassTest{Name: ast.NewIdentifier("Missing", builderSpan())},
+			step: ucs.FieldStep{Name: "x"},
+			want: "1:1-1:2: `Missing` does not name a class and cannot be used as an instance pattern.",
+		},
+		"NotAConstructor": {
+			test: &ucs.ExtractorTest{Name: ast.NewIdentifier("Missing", builderSpan()), Arity: 1},
+			step: ucs.ExtractStep{Index: 0},
+			want: "1:1-1:2: `Missing` is not a constructor and cannot be used as an extractor pattern.",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, scope := newPathChecker(t, "")
+			root, binder := seedPath(c, parseType(t, "{x: number}"))
+			binder = binder.narrowedBy(scope, root, tt.test)
+			armScope := scope.Child()
+			binder.bindAt(armScope, projectPath(root, tt.step), leafPat("x"))
+			require.Equal(t, []string{tt.want}, messagesWithSpan(c.errs))
+			require.Contains(t, armScope.values, "x")
+		})
+	}
+}
+
+// An extractor test that takes a different number of values than the constructor yields
+// reports the arity mismatch once, at the test, rather than once per extract step.
+func TestPathBinderExtractorArityMismatch(t *testing.T) {
+	c, scope := newPathChecker(t, `class Point { x: number, y: number }`)
+	root, binder := seedPath(c, classType(t, c, scope, "Point"))
+	binder = binder.narrowedBy(scope, root, &ucs.ExtractorTest{Name: ast.NewIdentifier("Point", builderSpan()), Arity: 3})
+
+	armScope := scope.Child()
+	binder.bindAt(armScope, projectPath(root, ucs.ExtractStep{Index: 0}), leafPat("a"))
+	binder.bindAt(armScope, projectPath(root, ucs.ExtractStep{Index: 2}), leafPat("c"))
+	require.Equal(t, []string{
+		"1:1-1:2: extractor pattern `Point` expects 2 arguments but got 3",
+	}, messagesWithSpan(c.errs))
+	// Value 0 still resolves through the constructor; value 2, which the constructor does
+	// not yield, recovers against a fresh variable rather than a second diagnostic.
+	require.Equal(t, "number", boundType(t, c, armScope, "a"))
+	require.Contains(t, armScope.values, "c")
+}
+
+// A literal test asserts its literal is an admissible value of the scrutinee, the same
+// direction bindPatMode's literal arm constrains in, and binds nothing itself.
+func TestPathBinderLiteralTest(t *testing.T) {
+	tests := map[string]struct {
+		rootType string
+		lit      ast.Lit
+		wantErrs []string
+	}{
+		"Admissible":   {rootType: "number", lit: ast.NewNumber(1, builderSpan())},
+		"WrongKind":    {rootType: "number", lit: ast.NewString("one", builderSpan()), wantErrs: []string{`1:1-1:2: cannot constrain "one" <: number`}},
+		"NarrowerType": {rootType: "1 | 2", lit: ast.NewNumber(1, builderSpan())},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, scope := newPathChecker(t, "")
+			root, binder := seedPath(c, parseType(t, tt.rootType))
+			binder.narrowedBy(scope, root, &ucs.LitTest{Lit: tt.lit})
+			require.Equal(t, tt.wantErrs, messagesWithSpan(c.errs))
+		})
+	}
+}

--- a/internal/solver/ucs_bind_test.go
+++ b/internal/solver/ucs_bind_test.go
@@ -44,6 +44,13 @@ func leafPat(name string) *ast.IdentPat {
 	return ast.NewIdentPat(name, false, nil, nil, builderSpan())
 }
 
+// defaultedLeafPat builds the leaf a `{x = 0}` shorthand introduces: an identifier whose
+// default supplies a value when the field is absent. An object test marks such a key
+// optional, which is what relaxes the field lookup.
+func defaultedLeafPat(name string) *ast.IdentPat {
+	return ast.NewIdentPat(name, false, nil, numExpr(0), builderSpan())
+}
+
 // projectPath applies each step in turn from root, sharing one *ucs.Scrutinee per level
 // the way normalization does, and returns the scrutinee the last step reaches.
 func projectPath(root *ucs.Scrutinee, steps ...ucs.Step) *ucs.Scrutinee {
@@ -393,17 +400,39 @@ func TestPathBinderBranchesNarrowIndependently(t *testing.T) {
 	require.Equal(t, "string", boundType(t, c, secondScope, "y"))
 }
 
-// A field an object test marked optional is looked up with an optional requirement, so a
-// leaf that carries a destructuring default still binds against a scrutinee that lacks
-// the field. `{x = 0}` is the pattern that produces the marker.
-func TestPathBinderOptionalKeyToleratesAbsentField(t *testing.T) {
+// A destructuring default replaces the `undefined` an optional property reads as, so
+// `{x = 0}` over `{x?: number}` binds the property type joined with the default's, where
+// the same field with no default binds `number | undefined`. The OptionalField case above
+// pins the undefaulted half. This is the meaningful use of the marker an object test
+// carries, and binding the same leaf through bindPattern renders the same `number | 0`.
+func TestPathBinderDefaultFillsOptionalProperty(t *testing.T) {
+	c, scope := newPathChecker(t, "")
+	root, binder := seedPath(c, exactObj(&soltype.PropertyElem{Name: "x", Type: num(), Optional: true}))
+	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x", Optional: true}}})
+
+	armScope := scope.Child()
+	binder.bindAt(armScope, projectPath(root, ucs.FieldStep{Name: "x"}), defaultedLeafPat("x"))
+	require.Empty(t, messagesWithSpan(c.errs))
+	require.Equal(t, "number | 0", boundType(t, c, armScope, "x"))
+}
+
+// A scrutinee that cannot carry the field at all still binds the default rather than
+// reporting a missing property, because the marker relaxes the lookup to an optional
+// requirement. This is the one scrutinee shape the marker is observable on: a required
+// requirement already succeeds against an optional property and against a union whose
+// members disagree, so neither distinguishes it.
+//
+// Whether `{x = 0}` should match a scrutinee with no `x` at all is a question about
+// bindPattern rather than about the IR. TestInferObjectPatternLeafDefault in
+// infer_pattern_test.go pins the same answer for `val {z = 0} = p` over `{x: number}`, and
+// this case exists to hold the path binder to it. Change the two together or not at all.
+func TestPathBinderDefaultedKeyBindsAgainstScrutineeWithoutTheField(t *testing.T) {
 	c, scope := newPathChecker(t, "")
 	root, binder := seedPath(c, parseType(t, "{y: string}"))
 	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x", Optional: true}}})
 
 	armScope := scope.Child()
-	leaf := ast.NewIdentPat("x", false, nil, numExpr(0), builderSpan())
-	binder.bindAt(armScope, projectPath(root, ucs.FieldStep{Name: "x"}), leaf)
+	binder.bindAt(armScope, projectPath(root, ucs.FieldStep{Name: "x"}), defaultedLeafPat("x"))
 	require.Empty(t, messagesWithSpan(c.errs))
 	require.Equal(t, "0", boundType(t, c, armScope, "x"))
 }


### PR DESCRIPTION
Fixes #1023.

Adds the `pathBinder` type and related functions to resolve UCS IR projection paths into types and bind leaf patterns against them. This is the project-and-bind operation that every walk over the IR depends on, enabling the solver to handle destructuring patterns in match expressions by projecting scrutinee values through field accesses, tuple indices, and extractor results.

It is unwired — nothing calls it yet — so it changes no inferred type and no message, the same way PR1 through PR4 landed.

## Key changes

- **New file `internal/solver/ucs_bind.go`**: Implements path projection and binding logic
  - `pathBinder` type: Resolves IR projection paths into types and binds leaf patterns, memoizing scrutinee views to ensure each value is projected once
  - `scrutineeView` type: Tracks the type, concrete shape, binding mode, and test information for a projected value
  - Projection methods for each step kind: `projectField`, `projectIndex`, `projectExtract`, `projectSuffix`, `projectRemainder`
  - Test application: `applyTest` and related methods handle narrowing by object, tuple, literal, class, and extractor tests
  - Union narrowing: `narrowUnion` drops union members the test cannot destructure, reproducing `narrowMatchArm` at the path level so PR6 inherits variant-narrowing

- **New file `internal/solver/ucs_bind_test.go`**: Comprehensive test suite with 20+ test cases covering:
  - Field projection and missing property detection
  - Tuple indexing and suffix binding
  - Object remainder binding
  - Extractor result projection
  - Class and instance member projection
  - Union narrowing by structural shape and arity
  - Borrow propagation through nested paths
  - Scrutinee materialization (each value projected once)
  - Sibling branch independence

- **Modified `internal/solver/errors.go`**: `InstancePatternNotClassError`, `ExtractorPatternNotCtorError`, and `ExtractorPatternArityError` now take a generic `ast.Node` instead of the concrete pattern node, so the error can be reported from both a written pattern and a UCS IR tag test. An IR tag test names the class or constructor without keeping the pattern that produced it.

- **Modified `internal/solver/pattern.go`**: Updated the three call sites to pass the pattern node under the renamed field. Written patterns still pass their own node, so their spans and messages are unchanged.

## Implementation details

The projection rule follows `bindPatMode`'s semantics: a leaf bound off a path lands at the same type it would if nested inside one whole pattern. This is ensured by threading the same triple through the path that `bindPatMode` threads through a nested pattern — the projection variable, the statically known shape, and the binding mode.

Scrutinee views are memoized per binder, so an inner split and every leaf beneath it share one projection rather than each emitting its own member lookup. Applying a test returns a derived binder instead of mutating the receiver, allowing sibling branches to narrow the same scrutinee independently while still sharing that one projection.

The implementation handles all structural test kinds (object, tuple, literal, class, extractor) and properly narrows unions by shape, rejects wrong arities, tolerates optional fields with destructuring defaults, and propagates borrows through nested paths while copying primitive leaves.

https://claude.ai/code/session_01SMTeCn1XoTdHTp4Vbue9h7