### PR TITLE
UCS IR: read a pattern into one tag-level test and its binds

### DIFF
--- a/internal/solver/ucs/norm.go
+++ b/internal/solver/ucs/norm.go
@@ -64,12 +64,21 @@ type NormGuard struct {
 // tests the `Point` tag and then binds `x` and `y` from the projections `p.x` and
 // `p.y`.
 type NormBind struct {
-	// Name is the bound identifier.
+	// Name is the bound identifier. It is empty when the bind names no identifier,
+	// which is how a sub-pattern normalization has not flattened into a split of its
+	// own is held: `{start: {x, y}}` keeps `{x, y}` whole as a nameless bind on the
+	// projection `p.start`.
 	Name string
 	// Pat is the pattern leaf the name came from, which the solver binds through so
 	// the leaf keeps its annotation and its borrow mode. It is nil for a name the
-	// desugarer invented, which has no pattern leaf behind it.
+	// desugarer invented, which has no pattern leaf behind it, and for a shorthand
+	// object element, which Elem names instead.
 	Pat ast.Pat
+	// Elem is the shorthand object element the name came from, the `x` of `{mut x}`.
+	// An element is not an ast.Pat, so it cannot ride Pat, and it carries the same
+	// annotation, default, and `mut` marker the solver reads when it binds a leaf.
+	// Exactly one of Pat and Elem is set on a bind that came from a pattern.
+	Elem *ast.ObjShorthandPat
 	// Source is the projection the name binds to. Sibling binds under one branch
 	// share their parent *Scrutinee, so the parent is evaluated once.
 	Source *Scrutinee

--- a/internal/solver/ucs/pattern.go
+++ b/internal/solver/ucs/pattern.go
@@ -1,0 +1,233 @@
+package ucs
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// This file reads a source pattern into the two things a normalized branch is made of:
+// the one tag-level test the branch makes, and the leaves it binds out of the value the
+// branch matched. It is the half of normalization that looks at patterns. The half that
+// merges branches into a split and threads the default tail through them consumes what
+// this produces and lands next; see the PR3 section of
+// planning/ucs/implementation_plan.md.
+
+// bindSpec is one leaf a branch's pattern binds. It holds the name, the pattern leaf or
+// shorthand element the solver binds through, and the projection the value comes from. A
+// spec with no name holds a sub-pattern this stage does not flatten, which its branch
+// keeps whole until nested patterns become splits of their own.
+type bindSpec struct {
+	name   string
+	pat    ast.Pat
+	elem   *ast.ObjShorthandPat
+	source *Scrutinee
+	origin Origin
+}
+
+// wrapBinds nests a branch's binds around its continuation, so the leaves are in scope
+// for everything the branch runs, a guard condition included.
+func wrapBinds(binds []bindSpec, cont Norm) Norm {
+	for i := len(binds) - 1; i >= 0; i-- {
+		bind := binds[i]
+		cont = &NormBind{
+			Name:   bind.name,
+			Pat:    bind.pat,
+			Elem:   bind.elem,
+			Source: bind.source,
+			Cont:   cont,
+			Origin: bind.origin,
+		}
+	}
+	return cont
+}
+
+// shallowTest reads one tag-level off a pattern: the tag its branch tests, and the
+// leaves it binds out of the scrutinee. The test is nil for a catch-all, which binds
+// without testing.
+//
+// It goes exactly one level deep. A sub-pattern that is an identifier becomes a bind on
+// its projection, and any other sub-pattern becomes a nameless bind that keeps the
+// sub-pattern whole. Turning those into splits over their projections is the stage of
+// the rewrite that flattens nesting.
+func shallowTest(p ast.Pat, scrutinee *Scrutinee, origin Origin) (Test, []bindSpec) {
+	switch p := p.(type) {
+	case nil, *ast.WildcardPat:
+		// A wildcard binds without testing. A branch carrying no pattern at all is a
+		// lowering bug rather than a form the surface can write, and treating it the
+		// same way keeps the read total so the bug shows up as a printable IR.
+		return nil, nil
+	case *ast.IdentPat:
+		// An identifier pattern binds the scrutinee itself rather than a projection of
+		// it, so the bind's source is the scrutinee node.
+		return nil, []bindSpec{{
+			name:   p.Name,
+			pat:    p,
+			source: scrutinee,
+			origin: leafOrigin(origin, p),
+		}}
+	case *ast.LitPat:
+		return &LitTest{Lit: p.Lit}, nil
+	case *ast.TuplePat:
+		return tupleTest(p, scrutinee, origin)
+	case *ast.ObjectPat:
+		return objectTest(p, scrutinee, origin)
+	case *ast.InstancePat:
+		// An instance pattern tests a nominal tag and then reaches its fields the same
+		// way a structural object does. The fields are not part of the tag, so the
+		// object test objectTest derives is dropped and only its binds are kept.
+		_, binds := objectTest(p.Object, scrutinee, origin)
+		return &ClassTest{Name: p.ClassName}, binds
+	case *ast.ExtractorPat:
+		binds := make([]bindSpec, 0, len(p.Args))
+		for i, arg := range p.Args {
+			binds = appendBind(binds, arg, scrutinee, ExtractStep{Index: i}, origin)
+		}
+		return &ExtractorTest{Name: p.Name, Arity: len(p.Args)}, binds
+	default:
+		// A bare rest pattern is the only form left, and it is meaningful only inside a
+		// tuple or an object. Keeping it whole as a nameless bind hands it to the
+		// solver's pattern walk, which reports it, instead of dropping the names under
+		// it here.
+		return nil, []bindSpec{{pat: p, source: scrutinee, origin: leafOrigin(origin, p)}}
+	}
+}
+
+// tupleTest derives the tag and binds of a tuple pattern. Len counts the fixed prefix,
+// and a trailing rest relaxes the test to that prefix and binds the suffix past it.
+//
+// A rest anywhere but last names no suffix a SuffixStep can reach, as SuffixStep spells
+// out, so the test relaxes to the prefix before it and the elements from the rest on
+// bind nothing. Their leaves go unnamed by the IR, so the pass that lowers the surface
+// has to reject the pattern before a consumer binds names off the split. It is the pass
+// that can: it holds the source span a message points at, and the IR does not.
+func tupleTest(p *ast.TuplePat, scrutinee *Scrutinee, origin Origin) (Test, []bindSpec) {
+	fixed, rest := splitTrailingRest(p.Elems)
+	binds := make([]bindSpec, 0, len(fixed)+1)
+	for i, elem := range fixed {
+		binds = appendBind(binds, elem, scrutinee, IndexStep{Index: i}, origin)
+	}
+	kind := NoRest
+	if len(fixed) < len(p.Elems) {
+		kind = TrailingRest
+	}
+	if rest != nil {
+		binds = appendBind(binds, rest.Pattern, scrutinee, SuffixStep{From: len(fixed)}, origin)
+	}
+	return &TupleTest{Len: len(fixed), Rest: kind}, binds
+}
+
+// splitTrailingRest splits a tuple pattern's elements at its first rest. fixed holds
+// the elements before it, which bind by position. rest is that element only when it is
+// the pattern's last one, the only position whose suffix is expressible. It mirrors how
+// the solver's pattern walk splits the same elements.
+func splitTrailingRest(elems []ast.Pat) (fixed []ast.Pat, rest *ast.RestPat) {
+	for i, elem := range elems {
+		r, isRest := elem.(*ast.RestPat)
+		if !isRest {
+			continue
+		}
+		if i == len(elems)-1 {
+			return elems[:i], r
+		}
+		return elems[:i], nil
+	}
+	return elems, nil
+}
+
+// objectTest derives the tag and binds of an object pattern. Keys are the fields the
+// pattern names at this level in source order, and a field's own sub-pattern becomes a
+// bind on the projected field rather than part of the tag.
+//
+// A rest binds the scrutinee with the keys named here removed. The key set it excludes
+// is exactly those keys, so a field a deeper pattern matches is still in a shallower
+// rest.
+func objectTest(p *ast.ObjectPat, scrutinee *Scrutinee, origin Origin) (Test, []bindSpec) {
+	if p == nil {
+		return &ObjectTest{}, nil
+	}
+	objKeys := make([]ObjectKey, 0, len(p.Elems))
+	binds := make([]bindSpec, 0, len(p.Elems))
+	named := set.NewSet[string]()
+	var rest *ast.ObjRestPat
+
+	for i, elem := range p.Elems {
+		switch e := elem.(type) {
+		case *ast.ObjShorthandPat:
+			// A default binds the field even when it is absent, so the test must not
+			// demand it. The solver's pattern walk makes the same field optional.
+			objKeys = append(objKeys, ObjectKey{Name: e.Key.Name, Optional: e.Default != nil})
+			named.Add(e.Key.Name)
+			// A shorthand element is not an ast.Pat, so it rides the bind's Elem field.
+			// The solver reads the annotation, default, and `mut` marker off it, none of
+			// which the name alone carries.
+			leaf := leafOrigin(origin, e)
+			binds = append(binds, bindSpec{
+				name:   e.Key.Name,
+				elem:   e,
+				source: scrutinee.Project(FieldStep{Name: e.Key.Name}, leaf),
+				origin: leaf,
+			})
+		case *ast.ObjKeyValuePat:
+			objKeys = append(objKeys, ObjectKey{
+				Name:     e.Key.Name,
+				Optional: valueDefaultsField(e.Value),
+			})
+			named.Add(e.Key.Name)
+			binds = appendBind(binds, e.Value, scrutinee, FieldStep{Name: e.Key.Name}, origin)
+		case *ast.ObjRestPat:
+			// One rest takes every property the pattern did not name, so a second has
+			// nothing left, and only a last one holds the whole remainder. Any other
+			// placement binds nothing here, the same way a non-trailing tuple rest does
+			// and for the same reason, so the lowering pass has to reject it.
+			if rest == nil && i == len(p.Elems)-1 {
+				rest = e
+			}
+		}
+	}
+
+	kind := NoRest
+	if rest != nil {
+		kind = TrailingRest
+		step := RemainderStep{Exclude: named}
+		binds = appendBind(binds, rest.Pattern, scrutinee, step, origin)
+	}
+	return &ObjectTest{Keys: objKeys, Rest: kind}, binds
+}
+
+// valueDefaultsField reports whether an object pattern's value sub-pattern carries a
+// default, as `{x: a = 0}` does, which makes the field optional the same way a
+// shorthand default does.
+func valueDefaultsField(p ast.Pat) bool {
+	ident, ok := p.(*ast.IdentPat)
+	return ok && ident.Default != nil
+}
+
+// appendBind adds what a sub-pattern contributes at the projection step reaches. A
+// wildcard binds nothing and needs no test, so it adds nothing at all. An identifier
+// binds the projection. Any other sub-pattern is kept whole as a nameless bind for the
+// stage that flattens nesting.
+func appendBind(binds []bindSpec, p ast.Pat, parent *Scrutinee, step Step, origin Origin) []bindSpec {
+	if p == nil {
+		return binds
+	}
+	if _, isWildcard := p.(*ast.WildcardPat); isWildcard {
+		return binds
+	}
+	leaf := leafOrigin(origin, p)
+	spec := bindSpec{pat: p, source: parent.Project(step, leaf), origin: leaf}
+	if ident, ok := p.(*ast.IdentPat); ok {
+		spec.name = ident.Name
+	}
+	return append(binds, spec)
+}
+
+// leafOrigin points a bind and its projection at the pattern leaf they came from, so a
+// message about one blames the field the user wrote rather than the whole arm. It keeps
+// the branch's kind, since the leaf lowered from the same surface construct, and falls
+// back to the branch's origin when the leaf names no node.
+func leafOrigin(branch Origin, leaf Spanned) Origin {
+	if _, ok := SpanOf(leaf); !ok {
+		return branch
+	}
+	return At(branch.Kind, leaf)
+}

--- a/internal/solver/ucs/pattern.go
+++ b/internal/solver/ucs/pattern.go
@@ -7,10 +7,9 @@ import (
 
 // This file reads a source pattern into the two things a normalized branch is made of:
 // the one tag-level test the branch makes, and the leaves it binds out of the value the
-// branch matched. It is the half of normalization that looks at patterns. The half that
-// merges branches into a split and threads the default tail through them consumes what
-// this produces and lands next; see the PR3 section of
-// planning/ucs/implementation_plan.md.
+// branch matched. It is the half of normalization that looks at patterns. The other half
+// merges the branches of a split and threads the default tail through them, and it reads
+// what this produces.
 
 // bindSpec is one leaf a branch's pattern binds. It holds the name, the pattern leaf or
 // shorthand element the solver binds through, and the projection the value comes from. A

--- a/internal/solver/ucs/pattern_test.go
+++ b/internal/solver/ucs/pattern_test.go
@@ -1,0 +1,240 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// readPattern renders what a pattern reads to: the tag its branch tests, then the binds
+// it introduces wrapped around a stand-in leaf. A pattern that tests nothing renders
+// `no test`, which is what a catch-all reads to.
+func readPattern(p ast.Pat, target string) string {
+	origin := At(OriginMatchArm, arm(span(2, 5, 20)))
+	scrutinee := NewRoot(ident(target), origin)
+	test, binds := shallowTest(p, scrutinee, origin)
+
+	tag := "no test"
+	if test != nil {
+		tag = testString(test)
+	}
+	leaf := &BodyLeaf{Body: exprBody(num(0)), Origin: origin}
+	return tag + " => " + Print(wrapBinds(binds, leaf), DefaultPrintOptions())
+}
+
+// Every pattern kind reads to one tag and a bind per leaf, each on a projection off the
+// scrutinee. The cases are the worked examples in planning/ucs/implementation_plan.md,
+// minus the nested flattening a later stage adds.
+func TestShallowTestPatternKinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern ast.Pat
+		target  string
+		want    string
+	}{
+		{
+			name:    "wildcard",
+			pattern: wildcardPat(),
+			target:  "p",
+			want:    "no test => leaf 0",
+		},
+		{
+			name:    "identifier binds the scrutinee itself",
+			pattern: identPat("all"),
+			target:  "p",
+			want:    "no test => bind all = p; leaf 0",
+		},
+		{
+			name:    "literal",
+			pattern: numPat(1),
+			target:  "n",
+			want:    "1 => leaf 0",
+		},
+		{
+			name:    "object",
+			pattern: objPat("x", "y"),
+			target:  "p",
+			want:    "{x, y} => bind x = p.x, y = p.y; leaf 0",
+		},
+		{
+			name:    "object renaming a field",
+			pattern: ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("x", identPat("a"))}, ast.Span{}),
+			target:  "p",
+			want:    "{x} => bind a = p.x; leaf 0",
+		},
+		{
+			name:    "object matching a field against a wildcard",
+			pattern: ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("x", wildcardPat())}, ast.Span{}),
+			target:  "p",
+			want:    "{x} => leaf 0",
+		},
+		{
+			name: "object rest",
+			pattern: ast.NewObjectPat(
+				[]ast.ObjPatElem{shorthandElem("x"), objRestElem("rest")},
+				ast.Span{},
+			),
+			target: "p",
+			want:   `{x, ...} => bind x = p.x, rest = p \ {x}; leaf 0`,
+		},
+		{
+			name:    "tuple",
+			pattern: ast.NewTuplePat([]ast.Pat{identPat("a"), identPat("b")}, ast.Span{}),
+			target:  "xs",
+			want:    "[_, _] => bind a = xs.0, b = xs.1; leaf 0",
+		},
+		{
+			name: "tuple rest",
+			pattern: ast.NewTuplePat(
+				[]ast.Pat{identPat("first"), ast.NewRestPat(identPat("rest"), ast.Span{})},
+				ast.Span{},
+			),
+			target: "xs",
+			want:   "[_, ...] => bind first = xs.0, rest = xs[1..]; leaf 0",
+		},
+		{
+			name: "instance",
+			pattern: ast.NewInstancePat(
+				ast.NewIdentifier("Point", ast.Span{}),
+				objPat("x", "y"),
+				ast.Span{},
+			),
+			target: "p",
+			want:   "Point => bind x = p.x, y = p.y; leaf 0",
+		},
+		{
+			name: "extractor",
+			pattern: ast.NewExtractorPat(
+				ast.NewIdentifier("Ok", ast.Span{}),
+				[]ast.Pat{identPat("v")},
+				ast.Span{},
+			),
+			target: "r",
+			want:   "Ok(_) => bind v = r.#0; leaf 0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, readPattern(test.pattern, test.target))
+		})
+	}
+}
+
+// A sub-pattern that is not an identifier is kept whole on its projection, which is
+// what leaves the nesting for the stage that flattens it. The read goes one level deep:
+// the branch tests `Line` and nothing under it.
+func TestShallowTestKeepsANestedPatternWhole(t *testing.T) {
+	nested := ast.NewInstancePat(
+		ast.NewIdentifier("Line", ast.Span{}),
+		ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("start", objPat("x", "y"))}, ast.Span{}),
+		ast.Span{},
+	)
+	require.Equal(t,
+		"Line => bind {x, y} = l.start; leaf 0",
+		readPattern(nested, "l"),
+	)
+
+	// A literal sub-pattern is nesting too. The tag names the key and the literal it
+	// has still to match rides the bind.
+	literalField := ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("x", numPat(1))}, ast.Span{})
+	require.Equal(t, "{x} => bind 1 = p.x; leaf 0", readPattern(literalField, "p"))
+}
+
+// A field with a default is optional: `{x = 0}` binds even when the field is absent, so
+// the test must not demand it. The two spellings of a default, on a shorthand element
+// and on a renamed field's value, both mark the key optional.
+func TestShallowTestMarksDefaultedFieldsOptional(t *testing.T) {
+	shorthand := ast.NewObjShorthandPat(
+		ast.NewIdentifier("x", ast.Span{}), false, nil, num(0), ast.Span{},
+	)
+	renamed := ast.NewObjKeyValuePat(
+		ast.NewIdentifier("y", ast.Span{}),
+		ast.NewIdentPat("b", false, nil, num(1), ast.Span{}),
+		ast.Span{},
+	)
+	pattern := ast.NewObjectPat([]ast.ObjPatElem{shorthand, renamed}, ast.Span{})
+
+	require.Equal(t,
+		"{x?, y?} => bind x = p.x, b = p.y; leaf 0",
+		readPattern(pattern, "p"),
+	)
+}
+
+// A rest anywhere but last names no suffix a projection can reach, so the test relaxes
+// to the elements before it and nothing from the rest on binds. The same holds for an
+// object rest that is not last. Both patterns are unsupported downstream, and the pass
+// that lowers the surface is what rejects them.
+func TestShallowTestMalformedRests(t *testing.T) {
+	tuple := ast.NewTuplePat([]ast.Pat{
+		identPat("first"),
+		ast.NewRestPat(identPat("mid"), ast.Span{}),
+		identPat("last"),
+	}, ast.Span{})
+	require.Equal(t, "[_, ...] => bind first = xs.0; leaf 0", readPattern(tuple, "xs"))
+
+	object := ast.NewObjectPat(
+		[]ast.ObjPatElem{objRestElem("rest"), shorthandElem("x")},
+		ast.Span{},
+	)
+	require.Equal(t, "{x} => bind x = p.x; leaf 0", readPattern(object, "p"))
+}
+
+// A bare rest is meaningful only inside a tuple or an object. It is kept whole rather
+// than dropped, so the solver's pattern walk still sees the names under it and reports
+// the pattern itself.
+func TestShallowTestKeepsABareRestWhole(t *testing.T) {
+	require.Equal(t,
+		"no test => bind ...rest = p; leaf 0",
+		readPattern(ast.NewRestPat(identPat("rest"), ast.Span{}), "p"),
+	)
+}
+
+// A shorthand element carries an annotation, a default, and a `mut` marker, none of
+// which the bound name holds. The bind points at the element so the solver can read
+// them when it binds the leaf.
+func TestShallowTestKeepsShorthandElements(t *testing.T) {
+	elem := ast.NewObjShorthandPat(
+		ast.NewIdentifier("x", ast.Span{}), true, ast.NewNumberTypeAnn(ast.Span{}), nil, span(2, 7, 20),
+	)
+	pattern := ast.NewObjectPat([]ast.ObjPatElem{elem}, ast.Span{})
+	origin := At(OriginMatchArm, arm(span(2, 5, 30)))
+
+	_, binds := shallowTest(pattern, NewRoot(ident("p"), origin), origin)
+	require.Len(t, binds, 1)
+	require.Equal(t, "x", binds[0].name)
+	require.Nil(t, binds[0].pat)
+	require.Same(t, elem, binds[0].elem)
+}
+
+// Every projection hangs off the one scrutinee node the branch tests, so a consumer
+// evaluates `f()` once and reads both fields off that one value.
+func TestShallowTestSharesTheScrutinee(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(2, 5, 24)))
+	scrutinee := NewRoot(ast.NewCall(ident("f"), []ast.Expr{}, false, ast.Span{}), origin)
+
+	_, binds := shallowTest(objPat("x", "y"), scrutinee, origin)
+	require.Len(t, binds, 2)
+	require.Same(t, scrutinee, binds[0].source.Parent)
+	require.Same(t, scrutinee, binds[1].source.Parent)
+	require.Equal(t, "f().x", binds[0].source.String())
+	require.Equal(t, "f().y", binds[1].source.String())
+}
+
+// A bind and its projection point at the pattern leaf they came from rather than at the
+// whole arm, so a message about one field blames the field the user wrote.
+func TestShallowTestPointsAtThePatternLeaf(t *testing.T) {
+	value := ast.NewIdentPat("a", false, nil, nil, span(2, 12, 13))
+	pattern := ast.NewObjectPat([]ast.ObjPatElem{ast.NewObjKeyValuePat(
+		ast.NewIdentifier("x", ast.Span{}), value, ast.Span{},
+	)}, ast.Span{})
+	origin := At(OriginMatchArm, arm(span(2, 5, 24)))
+
+	_, binds := shallowTest(pattern, NewRoot(ident("p"), origin), origin)
+	require.Len(t, binds, 1)
+	require.Same(t, value, binds[0].pat)
+	require.Same(t, value, binds[0].origin.Node)
+	require.Same(t, value, binds[0].source.Origin.Node)
+	require.Equal(t, OriginMatchArm, binds[0].source.Origin.Kind)
+}

--- a/internal/solver/ucs/pattern_test.go
+++ b/internal/solver/ucs/pattern_test.go
@@ -208,6 +208,9 @@ func TestShallowTestKeepsShorthandElements(t *testing.T) {
 	pattern := ast.NewObjectPat([]ast.ObjPatElem{elem}, ast.Span{})
 	origin := At(OriginMatchArm, arm(span(2, 5, 30)))
 
+	// `{mut x: number}` reads to `{x} => bind x = p.x; leaf 0`. The rendering names the
+	// key and the bound leaf and stops there, so the assertions below read the element
+	// the bind points at, which is where the annotation and the `mut` marker live.
 	_, binds := shallowTest(pattern, NewRoot(ident("p"), origin), origin)
 	require.Len(t, binds, 1)
 	require.Equal(t, "x", binds[0].name)
@@ -221,6 +224,10 @@ func TestShallowTestSharesTheScrutinee(t *testing.T) {
 	origin := At(OriginMatchArm, arm(span(2, 5, 24)))
 	scrutinee := NewRoot(ast.NewCall(ident("f"), []ast.Expr{}, false, ast.Span{}), origin)
 
+	// `{x, y}` against `f()` reads to `{x, y} => bind x = f().x, y = f().y; leaf 0`. The
+	// rendering spells the call out once per projection, which is what it would look
+	// like if each projection re-derived it, so the assertions below read the pointers
+	// rather than the path.
 	_, binds := shallowTest(objPat("x", "y"), scrutinee, origin)
 	require.Len(t, binds, 2)
 	require.Same(t, scrutinee, binds[0].source.Parent)
@@ -238,6 +245,8 @@ func TestShallowTestPointsAtThePatternLeaf(t *testing.T) {
 	)}, ast.Span{})
 	origin := At(OriginMatchArm, arm(span(2, 5, 24)))
 
+	// `{x: a}` reads to `{x} => bind a = p.x; leaf 0`. A span never renders, so the
+	// assertions below read the node each part of the bind blames.
 	_, binds := shallowTest(pattern, NewRoot(ident("p"), origin), origin)
 	require.Len(t, binds, 1)
 	require.Same(t, value, binds[0].pat)

--- a/internal/solver/ucs/pattern_test.go
+++ b/internal/solver/ucs/pattern_test.go
@@ -145,21 +145,28 @@ func TestShallowTestKeepsANestedPatternWhole(t *testing.T) {
 // A field with a default is optional: `{x = 0}` binds even when the field is absent, so
 // the test must not demand it. The two spellings of a default, on a shorthand element
 // and on a renamed field's value, both mark the key optional.
+//
+// Optionality is all the rendering says about a default. The value a leaf takes when its
+// field is absent stays on the leaf node the bind points at, which is why the assertions
+// below read that node rather than the printed form.
 func TestShallowTestMarksDefaultedFieldsOptional(t *testing.T) {
 	shorthand := ast.NewObjShorthandPat(
 		ast.NewIdentifier("x", ast.Span{}), false, nil, num(0), ast.Span{},
 	)
-	renamed := ast.NewObjKeyValuePat(
-		ast.NewIdentifier("y", ast.Span{}),
-		ast.NewIdentPat("b", false, nil, num(1), ast.Span{}),
-		ast.Span{},
-	)
+	defaulted := ast.NewIdentPat("b", false, nil, num(1), ast.Span{})
+	renamed := ast.NewObjKeyValuePat(ast.NewIdentifier("y", ast.Span{}), defaulted, ast.Span{})
 	pattern := ast.NewObjectPat([]ast.ObjPatElem{shorthand, renamed}, ast.Span{})
 
 	require.Equal(t,
 		"{x?, y?} => bind x = p.x, b = p.y; leaf 0",
 		readPattern(pattern, "p"),
 	)
+
+	origin := At(OriginMatchArm, arm(span(2, 5, 30)))
+	_, binds := shallowTest(pattern, NewRoot(ident("p"), origin), origin)
+	require.Len(t, binds, 2)
+	require.Same(t, shorthand, binds[0].elem)
+	require.Same(t, defaulted, binds[1].pat)
 }
 
 // A rest anywhere but last names no suffix a projection can reach, so the test relaxes

--- a/internal/solver/ucs/print.go
+++ b/internal/solver/ucs/print.go
@@ -157,7 +157,7 @@ func (p *printer) coreBinds(n *CoreBind) Core {
 		if i > 0 {
 			p.write(", ")
 		}
-		p.write(n.Name + " = " + scrutineeString(n.Source) + p.tags(n.Origin))
+		p.write(bindTarget(n.Name, n.Pat) + " = " + scrutineeString(n.Source) + p.tags(n.Origin))
 		next, ok := n.Cont.(*CoreBind)
 		if !ok {
 			break
@@ -203,7 +203,7 @@ func (p *printer) normBinds(n *NormBind) Norm {
 		if i > 0 {
 			p.write(", ")
 		}
-		p.write(n.Name + " = " + scrutineeString(n.Source) + p.tags(n.Origin))
+		p.write(bindTarget(n.Name, n.Pat) + " = " + scrutineeString(n.Source) + p.tags(n.Origin))
 		next, ok := n.Cont.(*NormBind)
 		if !ok {
 			break
@@ -229,6 +229,20 @@ func (p *printer) leaf(t Term) {
 	default:
 		p.write(nodeKind(t))
 	}
+}
+
+// bindTarget renders what a bind introduces. A named bind writes its identifier. A
+// bind with no name holds a sub-pattern that is not flattened into a split yet, so it
+// writes the pattern: `bind {x, y} = l.start` says the branch has still to match
+// `{x, y}` against the projection `l.start`.
+func bindTarget(name string, pat ast.Pat) string {
+	if name != "" {
+		return name
+	}
+	if pat == nil {
+		return "_"
+	}
+	return patString(pat)
 }
 
 // originTag renders a node's provenance, or nothing when the caller did not ask for


### PR DESCRIPTION
Refs #1022. First of three PRs that together add `normalize`; this one is the half that looks at patterns, and it is unwired, the way PR1 and PR5 land in the plan.

`shallowTest` reads a source pattern into the tag its branch tests and the leaves it binds, each on a projection off the branch's scrutinee. `wrapBinds` nests those binds around a continuation so the leaves are in scope for everything the branch runs.

## What it reads

- Every pattern kind reads to one tag: a literal, a structural object or tuple shape, a nominal class tag, or an extractor tag. A catch-all reads to no tag at all.
- A rest adds no tag. It relaxes the shape to a prefix and binds the remainder through a `SuffixStep` for a tuple or a `RemainderStep` for an object.
- A sub-pattern that is an identifier binds its projection. Any other sub-pattern is kept whole as a nameless bind, which the stage that flattens nesting turns into a split of its own. `Line { start: {x, y} }` reads to the `Line` tag and `bind {x, y} = l.start`.
- A field with a default is optional, matching how `bindPattern` builds the same requirement.
- Sibling binds share the scrutinee node they project out of, so a side-effecting target is evaluated once.
- A bind and its projection point at the pattern leaf they came from, so a message about one field blames the field the user wrote.

## Two things worth review attention

`NormBind` gains an `Elem` field for a shorthand object element. An element is an `ObjPatElem`, not an `ast.Pat`, so it cannot ride `Pat`, and the annotation, default, and `mut` marker on it are what the solver reads when it binds the leaf. Without it `{mut x}` and `{x: number}` lose their borrow mode and annotation before the project-and-bind PR ever sees them.

A non-trailing tuple rest, and an object rest that is not last, name no projection anything can reach. The test relaxes to the elements before the rest and the leaves past it go unnamed. `SuffixStep`'s doc already says not to invent a projection here, so rejecting the pattern belongs to the pass that lowers the surface, which still holds the span a message points at. Both cases are tested.

## Tests

A table over every pattern kind, plus the nested-pattern seam, optional fields, both malformed rests, a bare rest, shorthand elements, scrutinee sharing, and leaf provenance. `go test ./...` passes.

## Stack

1. **this PR** — read a pattern into a test and its binds
2. merge same-scrutinee branches and thread the default tail, which closes #1022
3. specialize what a guarded branch falls into

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnCHCk3wgtNtYNXiMY7kvM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnCHCk3wgtNtYNXiMY7kvM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pattern handling across wildcards, literals, tuples, objects, defaults, rest patterns, and nested patterns.
  * Preserved shorthand object bindings and pattern source information for more accurate processing.
  * Enhanced display of unnamed bindings using `_` or their associated pattern.

* **Bug Fixes**
  * Improved handling of optional defaulted fields, malformed rests, and shared pattern sources.

* **Tests**
  * Added comprehensive coverage for shallow pattern processing and binding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->