### PR TITLE
UCS IR: merge same-scrutinee branches and thread the default tail

### DIFF
--- a/internal/solver/ucs/normalize.go
+++ b/internal/solver/ucs/normalize.go
@@ -1,0 +1,197 @@
+package ucs
+
+// Normalize rewrites a desugared core term into the normalized form. Two rewrites
+// happen here.
+//
+// The first is merging. Every branch of one core split tests the same scrutinee, so
+// all of them become branches of a single normalized split rather than a chain of
+// one-branch splits. A consumer then visits each scrutinee once.
+//
+// The second is the tail. A core branch relies on the branches after it to say where
+// a failed match continues, which is backtracking. Normalization names that
+// continuation outright: a split's Default is what runs when no branch's test matches,
+// and a guard's Default is what runs when its condition is false. Nothing retries a
+// branch above it.
+//
+// A nested sub-pattern is left whole for now. Its branch keeps it as a NormBind with no
+// name, which says "still to be matched against this projection". Flattening those into
+// splits of their own is the next stage of the rewrite; see the PR4 section of
+// planning/ucs/implementation_plan.md. Until then the form is backtracking-free only
+// for a flat match. A nameless bind names no continuation for the case where its
+// sub-pattern does not match, and there is nowhere to put one: the split that flattening
+// puts in its place is what carries that default.
+func Normalize(c Core) Norm {
+	return normalizeTerm(c, nil)
+}
+
+// normalizeTerm rewrites one core term. next is where control goes when the term fails
+// to reach a leaf, which is what a guard falls back to. It is nil when nothing covers
+// the failure, and the printer renders that as `✗`. A leaf cannot fail, so it ignores
+// next and is returned as-is: normalization rewrites the splits around a leaf and
+// leaves the leaf itself alone, which is why the same node ends up in both IRs.
+func normalizeTerm(c Core, next Norm) Norm {
+	switch n := c.(type) {
+	case nil:
+		return nil
+	case *CoreSplit:
+		return normalizeSplit(n, next)
+	case *CoreGuard:
+		return &NormGuard{
+			Cond:    n.Cond,
+			Cont:    normalizeTerm(n.Cont, next),
+			Default: next,
+			Origin:  n.Origin,
+		}
+	case *CoreBind:
+		return &NormBind{
+			Name:   n.Name,
+			Pat:    n.Pat,
+			Source: n.Source,
+			Cont:   normalizeTerm(n.Cont, next),
+			Origin: n.Origin,
+		}
+	case *BodyLeaf, *EscapeLeaf, *FallbackLeaf:
+		return n.(Norm)
+	default:
+		return nil
+	}
+}
+
+// normalizeSplit rewrites a core split into a normalized one. The split's own
+// fallthrough is its `else` when it wrote one, which an `if val` and a `val … else`
+// always do, and otherwise the continuation the enclosing term handed down.
+func normalizeSplit(s *CoreSplit, next Norm) Norm {
+	tail := next
+	if s.Else != nil {
+		tail = normalizeTerm(s.Else, next)
+	}
+
+	cands := make([]candidate, len(s.Branches))
+	for i, branch := range s.Branches {
+		test, binds := shallowTest(branch.Pattern, s.Scrutinee, branch.Origin)
+		cands[i] = candidate{index: i, branch: branch, test: test, binds: binds}
+	}
+
+	b := &splitBuilder{
+		scrutinee: s.Scrutinee,
+		tail:      tail,
+		origin:    s.Origin,
+		built:     map[int]Norm{},
+	}
+	// A core split always becomes a split, even when no branch is left to test, because
+	// the split is what names the scrutinee. Collapsing `match f() { _ => 1 }` to its
+	// leaf would drop the only mention of `f()`, and a consumer walking the IR would
+	// never evaluate the call.
+	branches, dflt := b.build(cands)
+	return &NormSplit{
+		Scrutinee: s.Scrutinee,
+		Branches:  branches,
+		Default:   dflt,
+		Origin:    s.Origin,
+	}
+}
+
+// candidate is a core branch paired with what normalization derived from its pattern:
+// the one tag-level test it makes and the leaves it binds. Deriving them once means a
+// branch that appears both in the split and in an earlier branch's fallthrough is
+// analyzed a single time.
+type candidate struct {
+	// index is the branch's position in the core split, which identifies it while
+	// building.
+	index  int
+	branch *CoreBranch
+	// test is the tag the branch tests, and nil when the branch runs unconditionally,
+	// which is what a catch-all pattern reads to.
+	test  Test
+	binds []bindSpec
+}
+
+// splitBuilder builds the branches of one core split. Everything it holds is fixed for
+// that split: the scrutinee every branch tests, the tail control reaches when no branch
+// covers the value, and the split's own provenance.
+type splitBuilder struct {
+	scrutinee *Scrutinee
+	tail      Norm
+	origin    Origin
+	// built caches the fallthrough term for a run of candidates, keyed by the index of
+	// the first. A guarded branch falls into the branches after it, so without the
+	// cache a run of guarded branches would rebuild overlapping suffixes over and over.
+	// Each cached term is also shared rather than duplicated, so a consumer that walks
+	// the IR visits it once.
+	built map[int]Norm
+}
+
+// term is what a branch continues into when its own continuation fails. Unlike the
+// split the whole core split becomes, it collapses to the unconditional continuation
+// when no candidate is left to test. The scrutinee the collapsed split would have named
+// is already evaluated by the split this term sits inside, so nothing is lost.
+func (b *splitBuilder) term(cands []candidate) Norm {
+	if len(cands) == 0 {
+		return b.tail
+	}
+	if term, ok := b.built[cands[0].index]; ok {
+		return term
+	}
+
+	branches, dflt := b.build(cands)
+	var term Norm = dflt
+	if len(branches) > 0 {
+		term = &NormSplit{
+			Scrutinee: b.scrutinee,
+			Branches:  branches,
+			Default:   dflt,
+			Origin:    b.origin,
+		}
+	}
+	b.built[cands[0].index] = term
+	return term
+}
+
+// build turns a list of candidates into the branches of one split and the default tail
+// control reaches when none of them matches.
+func (b *splitBuilder) build(cands []candidate) ([]*NormBranch, Norm) {
+	var branches []*NormBranch
+	dflt := b.tail
+	for i, cand := range cands {
+		// Only a branch whose continuation can fail needs to name where it continues.
+		// An unguarded arm ends in a leaf, so it never falls through and the
+		// fallthrough would be dead weight.
+		var fallthru Norm
+		if mayFall(cand.branch.Cont) {
+			fallthru = b.term(cands[i+1:])
+		}
+		cont := wrapBinds(cand.binds, normalizeTerm(cand.branch.Cont, fallthru))
+		if cand.test == nil {
+			// The branch always runs, so it is the split's tail and every candidate
+			// after it is unreachable.
+			dflt = cont
+			break
+		}
+		branches = append(branches, &NormBranch{
+			Test:   cand.test,
+			Cont:   cont,
+			Arm:    cand.branch.Arm,
+			Origin: cand.branch.Origin,
+		})
+	}
+	return branches, dflt
+}
+
+// mayFall reports whether a core term can finish without reaching a leaf, so the branch
+// holding it needs a fallthrough. A guard fails when its condition is false. A nested
+// split may match none of its branches. A leaf always produces a value.
+//
+// Answering true when the term in fact always reaches a leaf costs a fallthrough that
+// nothing reads, so the conservative answer for a nested split is safe.
+func mayFall(c Core) bool {
+	switch n := c.(type) {
+	case *CoreGuard:
+		return true
+	case *CoreSplit:
+		return true
+	case *CoreBind:
+		return mayFall(n.Cont)
+	default:
+		return false
+	}
+}

--- a/internal/solver/ucs/normalize.go
+++ b/internal/solver/ucs/normalize.go
@@ -63,6 +63,9 @@ func normalizeTerm(c Core, next Norm) Norm {
 func normalizeSplit(s *CoreSplit, next Norm) Norm {
 	tail := next
 	if s.Else != nil {
+		// next is not dropped here. It becomes the `else`'s own failure continuation. A
+		// leaf `else` cannot fail and ignores it, which is what an `if val` and a
+		// `val … else` both write. A guard or a nested split `else` falls into it.
 		tail = normalizeTerm(s.Else, next)
 	}
 

--- a/internal/solver/ucs/normalize.go
+++ b/internal/solver/ucs/normalize.go
@@ -13,13 +13,13 @@ package ucs
 // and a guard's Default is what runs when its condition is false. Nothing retries a
 // branch above it.
 //
-// A nested sub-pattern is left whole for now. Its branch keeps it as a NormBind with no
-// name, which says "still to be matched against this projection". Flattening those into
-// splits of their own is the next stage of the rewrite; see the PR4 section of
-// planning/ucs/implementation_plan.md. Until then the form is backtracking-free only
-// for a flat match. A nameless bind names no continuation for the case where its
-// sub-pattern does not match, and there is nowhere to put one: the split that flattening
-// puts in its place is what carries that default.
+// A nested sub-pattern is left whole. Its branch keeps it as a NormBind with no name,
+// which says "still to be matched against this projection". Flattening those into splits
+// of their own is the next stage of the rewrite, the one the nested-pattern section of
+// planning/ucs/implementation_plan.md describes. So the form is backtracking-free for a
+// flat match and not yet for a nested one. A nameless bind names no continuation for the
+// case where its sub-pattern does not match, and there is nowhere to put one. The split
+// that flattening puts in its place is what carries that default.
 func Normalize(c Core) Norm {
 	return normalizeTerm(c, nil)
 }

--- a/internal/solver/ucs/normalize_test.go
+++ b/internal/solver/ucs/normalize_test.go
@@ -1,0 +1,254 @@
+package ucs
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// coreMatch builds the core split a `match` lowers to: one branch per arm, in source
+// order, with a guard as a node inside its branch and no `else`, since a catch-all arm
+// is an ordinary branch of the core. It stands in for the desugarer, which normalize
+// does not need.
+func coreMatch(target ast.Expr, arms ...*ast.MatchCase) *CoreSplit {
+	expr := ast.NewMatch(target, arms, span(1, 1, 40))
+	origin := At(OriginMatchArm, expr)
+
+	branches := make([]*CoreBranch, len(arms))
+	for i, armCase := range arms {
+		armOrigin := At(OriginMatchArm, armCase)
+		var cont Core = &BodyLeaf{Body: armCase.Body, Arm: armCase, Origin: armOrigin}
+		if armCase.Guard != nil {
+			cont = &CoreGuard{
+				Cond:   armCase.Guard,
+				Cont:   cont,
+				Origin: At(OriginGuard, armCase.Guard),
+			}
+		}
+		branches[i] = &CoreBranch{
+			Pattern: armCase.Pattern,
+			Cont:    cont,
+			Arm:     armCase,
+			Origin:  armOrigin,
+		}
+	}
+
+	return &CoreSplit{Scrutinee: NewRoot(target, origin), Branches: branches, Origin: origin}
+}
+
+// normalized renders the normalized form of a core term, which is what the shape
+// snapshots below lock.
+func normalized(c Core) string { return Print(Normalize(c), DefaultPrintOptions()) }
+
+// greaterThan builds the `x > y` guard condition the worked examples use.
+func greaterThan() ast.Expr {
+	return ast.NewBinary(ident("x"), ident("y"), ast.GreaterThan, ast.Span{})
+}
+
+// The catch-all arm of a flat literal match becomes the split's default tail, which is
+// the first worked example in planning/ucs/implementation_plan.md.
+func TestNormalizeFlatLiteralMatch(t *testing.T) {
+	core := coreMatch(
+		ident("n"),
+		matchCase(numPat(1), nil, str("one"), span(2, 5, 18)),
+		matchCase(wildcardPat(), nil, str("other"), span(3, 5, 20)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {
+  1 => leaf "one"
+} default leaf "other"`))
+}
+
+// Arms that test one scrutinee against different tags become branches of one split
+// rather than a chain of one-branch splits, so a consumer visits `n` once.
+func TestNormalizeMergesSameScrutineeArms(t *testing.T) {
+	core := coreMatch(
+		ident("n"),
+		matchCase(numPat(1), nil, str("one"), span(2, 5, 18)),
+		matchCase(numPat(2), nil, str("two"), span(3, 5, 18)),
+		matchCase(numPat(3), nil, str("three"), span(4, 5, 20)),
+		matchCase(wildcardPat(), nil, str("other"), span(5, 5, 20)),
+	)
+
+	norm := Normalize(core)
+	split, ok := norm.(*NormSplit)
+	require.True(t, ok, "the top-level term is a split")
+	require.Len(t, split.Branches, 3)
+	snaps.MatchInlineSnapshot(t, Print(norm, DefaultPrintOptions()), snaps.Inline(`split n {
+  1 => leaf "one"
+  2 => leaf "two"
+  3 => leaf "three"
+} default leaf "other"`))
+}
+
+// A guard names where a failed condition continues, which is what makes the form
+// backtracking-free. Here the continuation is the split's own tail, the fourth worked
+// example in the plan.
+func TestNormalizeGuardFallsToTheTail(t *testing.T) {
+	core := coreMatch(
+		ident("p"),
+		matchCase(objPat("x", "y"), greaterThan(), ident("x"), span(2, 5, 30)),
+		matchCase(wildcardPat(), nil, num(0), span(3, 5, 16)),
+	)
+
+	norm := Normalize(core)
+	snaps.MatchInlineSnapshot(t, Print(norm, DefaultPrintOptions()), snaps.Inline(`split p {
+  {x, y} => bind x = p.x, y = p.y; guard (x > y) {
+    leaf x
+  } default leaf 0
+} default leaf 0`))
+
+	// The guard and the split reach the same node, so the arm the guard falls into is
+	// the arm the split falls into and neither is duplicated.
+	split := norm.(*NormSplit)
+	guard := split.Branches[0].Cont.(*NormBind).Cont.(*NormBind).Cont.(*NormGuard)
+	require.Same(t, split.Default, guard.Default)
+}
+
+// An unguarded catch-all arm always runs, so it becomes the tail and every arm after it
+// is unreachable. The split stays, because it is what names the scrutinee.
+func TestNormalizeDropsArmsAfterACatchAll(t *testing.T) {
+	core := coreMatch(
+		ident("n"),
+		matchCase(identPat("all"), nil, ident("all"), span(2, 5, 20)),
+		matchCase(numPat(1), nil, str("one"), span(3, 5, 18)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {} default bind all = n; leaf all`))
+}
+
+// A guarded catch-all does not end the split. Its guard can fail, so the arms after it
+// stay reachable and become what it falls into.
+func TestNormalizeKeepsArmsAfterAGuardedCatchAll(t *testing.T) {
+	core := coreMatch(
+		ident("n"),
+		matchCase(identPat("all"), greaterThan(), ident("all"), span(2, 5, 30)),
+		matchCase(numPat(1), nil, str("one"), span(3, 5, 18)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {} default bind all = n; guard (x > y) {
+  leaf all
+} default split n {
+  1 => leaf "one"
+} default ✗`))
+}
+
+// An `if val` writes its own `else`, which the core keeps as the split's fallthrough
+// and normalization moves into the default tail.
+func TestNormalizeThreadsTheElseIntoTheTail(t *testing.T) {
+	target := ident("p")
+	cons := ast.Block{Stmts: []ast.Stmt{ast.NewExprStmt(ident("cons"), ast.Span{})}}
+	alt := blockBody(ident("alt"))
+	expr := ast.NewIfVal(objPat("x", "y"), target, cons, &alt, span(1, 1, 45))
+	origin := At(OriginIfVal, expr)
+
+	core := &CoreSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*CoreBranch{{
+			Pattern: expr.Pattern,
+			Cont:    &BodyLeaf{Body: ast.BlockOrExpr{Block: &cons}, Arm: expr, Origin: origin},
+			Arm:     expr,
+			Origin:  origin,
+		}},
+		Else:   &BodyLeaf{Body: alt, Arm: expr, Origin: origin},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
+  {x, y} => bind x = p.x, y = p.y; leaf { cons }
+} default leaf { alt }`))
+}
+
+// A `val … else` normalizes the same way, keeping its binding-escape leaf on the
+// success path and its fallback in the tail.
+func TestNormalizeValElse(t *testing.T) {
+	target := ident("p")
+	decl := ast.NewVarDecl(ast.ValKind, objPat("x", "y"), nil, target, false, false, span(1, 1, 35))
+	decl.Else = &ast.Block{Stmts: []ast.Stmt{ast.NewReturnStmt(nil, ast.Span{})}}
+	origin := At(OriginValElse, decl)
+
+	core := &CoreSplit{
+		Scrutinee: NewRoot(target, origin),
+		Branches: []*CoreBranch{{
+			Pattern: decl.Pattern,
+			Cont:    &EscapeLeaf{Arm: decl, Origin: origin},
+			Arm:     decl,
+			Origin:  origin,
+		}},
+		Else:   &FallbackLeaf{Body: ast.BlockOrExpr{Block: decl.Else}, Arm: decl, Origin: origin},
+		Origin: origin,
+	}
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
+  {x, y} => bind x = p.x, y = p.y; escape
+} default fallback { return }`))
+}
+
+// Merging must not cost a branch its provenance. Every branch of the merged split still
+// points at the arm the user wrote, and the origin tags still name the construct each
+// arm lowered from.
+func TestNormalizeKeepsArmBackReferences(t *testing.T) {
+	one := matchCase(numPat(1), nil, str("one"), span(2, 5, 18))
+	two := matchCase(numPat(2), greaterThan(), str("two"), span(3, 5, 26))
+	other := matchCase(wildcardPat(), nil, str("other"), span(4, 5, 20))
+	core := coreMatch(ident("n"), one, two, other)
+
+	norm := Normalize(core)
+	split := norm.(*NormSplit)
+	require.Same(t, one, split.Branches[0].Arm)
+	require.Same(t, two, split.Branches[1].Arm)
+
+	opts := DefaultPrintOptions()
+	opts.ShowArms = true
+	opts.ShowOrigins = true
+	snaps.MatchInlineSnapshot(t, Print(norm, opts), snaps.Inline(`split n [match arm] {
+  1 [match arm] arm=2:5-2:18 => leaf "one" [match arm] arm=2:5-2:18
+  2 [match arm] arm=3:5-3:26 => guard (x > y) [guard] {
+    leaf "two" [match arm] arm=3:5-3:26
+  } default leaf "other" [match arm] arm=4:5-4:20
+} default leaf "other" [match arm] arm=4:5-4:20`))
+}
+
+// Normalization rewrites the splits around a leaf and leaves the leaf itself alone, so
+// the arm body a consumer infers is the node the core held.
+func TestNormalizeKeepsLeafNodes(t *testing.T) {
+	core := coreMatch(
+		ident("n"),
+		matchCase(numPat(1), nil, str("one"), span(2, 5, 18)),
+		matchCase(wildcardPat(), nil, str("other"), span(3, 5, 20)),
+	)
+	matched := core.Branches[0].Cont
+	tailLeaf := core.Branches[1].Cont
+
+	split := Normalize(core).(*NormSplit)
+	require.Same(t, matched, split.Branches[0].Cont)
+	require.Same(t, tailLeaf, split.Default)
+}
+
+// A core split with no branches still becomes a split, so the scrutinee it tests stays
+// named. Nothing covers the value, which the printer renders `✗`.
+func TestNormalizeEmptySplit(t *testing.T) {
+	core := coreMatch(ident("p"))
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {} default ✗`))
+}
+
+// A term that is not a split normalizes to itself, so a caller can hand normalize any
+// core term rather than only the top-level split.
+func TestNormalizeBareTerms(t *testing.T) {
+	origin := At(OriginMatchArm, arm(span(1, 1, 8)))
+	leaf := &BodyLeaf{Body: exprBody(num(1)), Origin: origin}
+
+	require.Nil(t, Normalize(nil))
+	require.Same(t, leaf, Normalize(leaf))
+
+	bind := &CoreBind{
+		Name:   "x",
+		Source: NewRoot(ident("p"), origin),
+		Cont:   leaf,
+		Origin: origin,
+	}
+	require.Equal(t, "bind x = p; leaf 1", normalized(bind))
+}

--- a/internal/solver/ucs/normalize_test.go
+++ b/internal/solver/ucs/normalize_test.go
@@ -56,6 +56,12 @@ func TestNormalizeFlatLiteralMatch(t *testing.T) {
 		matchCase(wildcardPat(), nil, str("other"), span(3, 5, 20)),
 	)
 
+	// Before normalization:
+	//
+	//   split n {
+	//     pat 1 => leaf "one"
+	//     pat _ => leaf "other"
+	//   }
 	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {
   1 => leaf "one"
 } default leaf "other"`))
@@ -72,6 +78,14 @@ func TestNormalizeMergesSameScrutineeArms(t *testing.T) {
 		matchCase(wildcardPat(), nil, str("other"), span(5, 5, 20)),
 	)
 
+	// Before normalization:
+	//
+	//   split n {
+	//     pat 1 => leaf "one"
+	//     pat 2 => leaf "two"
+	//     pat 3 => leaf "three"
+	//     pat _ => leaf "other"
+	//   }
 	norm := Normalize(core)
 	split, ok := norm.(*NormSplit)
 	require.True(t, ok, "the top-level term is a split")
@@ -93,6 +107,12 @@ func TestNormalizeGuardFallsToTheTail(t *testing.T) {
 		matchCase(wildcardPat(), nil, num(0), span(3, 5, 16)),
 	)
 
+	// Before normalization:
+	//
+	//   split p {
+	//     pat {x, y} => guard (x > y) => leaf x
+	//     pat _ => leaf 0
+	//   }
 	norm := Normalize(core)
 	snaps.MatchInlineSnapshot(t, Print(norm, DefaultPrintOptions()), snaps.Inline(`split p {
   {x, y} => bind x = p.x, y = p.y; guard (x > y) {
@@ -116,6 +136,12 @@ func TestNormalizeDropsArmsAfterACatchAll(t *testing.T) {
 		matchCase(numPat(1), nil, str("one"), span(3, 5, 18)),
 	)
 
+	// Before normalization:
+	//
+	//   split n {
+	//     pat all => leaf all
+	//     pat 1 => leaf "one"
+	//   }
 	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {} default bind all = n; leaf all`))
 }
 
@@ -128,6 +154,12 @@ func TestNormalizeKeepsArmsAfterAGuardedCatchAll(t *testing.T) {
 		matchCase(numPat(1), nil, str("one"), span(3, 5, 18)),
 	)
 
+	// Before normalization:
+	//
+	//   split n {
+	//     pat all => guard (x > y) => leaf all
+	//     pat 1 => leaf "one"
+	//   }
 	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {} default bind all = n; guard (x > y) {
   leaf all
 } default split n {
@@ -156,6 +188,12 @@ func TestNormalizeThreadsTheElseIntoTheTail(t *testing.T) {
 		Origin: origin,
 	}
 
+	// Before normalization, where the `else` is the split's fallthrough rather than a
+	// branch:
+	//
+	//   split p {
+	//     pat {x, y} => leaf { cons }
+	//   } else leaf { alt }
 	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
   {x, y} => bind x = p.x, y = p.y; leaf { cons }
 } default leaf { alt }`))
@@ -181,6 +219,11 @@ func TestNormalizeValElse(t *testing.T) {
 		Origin: origin,
 	}
 
+	// Before normalization:
+	//
+	//   split p {
+	//     pat {x, y} => escape
+	//   } else fallback { return }
 	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
   {x, y} => bind x = p.x, y = p.y; escape
 } default fallback { return }`))
@@ -195,6 +238,13 @@ func TestNormalizeKeepsArmBackReferences(t *testing.T) {
 	other := matchCase(wildcardPat(), nil, str("other"), span(4, 5, 20))
 	core := coreMatch(ident("n"), one, two, other)
 
+	// Before normalization:
+	//
+	//   split n {
+	//     pat 1 => leaf "one"
+	//     pat 2 => guard (x > y) => leaf "two"
+	//     pat _ => leaf "other"
+	//   }
 	norm := Normalize(core)
 	split := norm.(*NormSplit)
 	require.Same(t, one, split.Branches[0].Arm)
@@ -219,6 +269,13 @@ func TestNormalizeKeepsLeafNodes(t *testing.T) {
 		matchCase(numPat(1), nil, str("one"), span(2, 5, 18)),
 		matchCase(wildcardPat(), nil, str("other"), span(3, 5, 20)),
 	)
+
+	// Before normalization:
+	//
+	//   split n {
+	//     pat 1 => leaf "one"
+	//     pat _ => leaf "other"
+	//   }
 	matched := core.Branches[0].Cont
 	tailLeaf := core.Branches[1].Cont
 
@@ -232,6 +289,8 @@ func TestNormalizeKeepsLeafNodes(t *testing.T) {
 func TestNormalizeEmptySplit(t *testing.T) {
 	core := coreMatch(ident("p"))
 
+	// Before normalization the split is empty too, written `split p {}`. It survives
+	// because it is what names the scrutinee.
 	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {} default ✗`))
 }
 


### PR DESCRIPTION
Fixes #1022. Second of three PRs. It is stacked on #1045, so review that one first and read this diff against it.

`Normalize` rewrites a desugared core term into the normalized form. It reads each branch's pattern through the `shallowTest` of #1045 and builds the split around what it gets back.

## The two rewrites

**Merging.** Every branch of one core split tests the same scrutinee, so all of them become branches of a single split rather than a chain of one-branch splits. A consumer then visits each scrutinee once.

**The tail.** A core branch relies on the branches after it to say where a failed match continues, which is backtracking. Normalization names that continuation outright. A split's `Default` is what runs when no branch's test matches, and a guard's `Default` is the branches after it in source order. An `else` an `if val` or a `val … else` wrote lands in the tail the same way.

```
match p {                      split p {
    {x, y} if x > y => x,          {x, y} => bind x = p.x, y = p.y; guard (x > y) {
    _              => 0                leaf x
}                                  } default leaf 0
                               } default leaf 0
```

Both defaults there are the same node, not a copy, so the arm the guard falls into is the arm the split falls into.

## Details

- An unguarded catch-all arm always runs, so it becomes the tail and the arms after it are dropped as unreachable. A guarded one does not end the split, since its condition can fail.
- A core split always becomes a split, even with no branch left to test, because the split is what names the scrutinee. Collapsing `match f() { _ => 1 }` to its leaf would drop the only mention of `f()`, and a consumer walking the IR would never evaluate the call.
- Merged branches keep the surface arm they came from and their `Origin`, so a merged split still blames the arm the user wrote.
- Leaves are carried over by identity. Normalization rewrites the splits around a leaf and leaves the leaf itself alone.

## What is left for the third PR

A guarded branch falls into an unspecialized re-test of the branches after it. Pruning that with what the matched test already proved is #1047. The form is correct either way, only more verbose in what it prints, so this PR stands on its own if that one stalls.

Nested patterns are the other half of normalization and ride the next milestone PR. A nameless bind names no continuation for the case where its sub-pattern does not match, so the form is backtracking-free for a flat match and not yet for a nested one. That is called out on `Normalize` itself.

## Tests

Flat matches, merged arms, the guarded worked example from the plan with an assertion that the two defaults are one node, catch-all truncation, a guarded catch-all, `if val`, `val … else`, arm back-references and origin tags through the printer, leaf identity, an empty split, and bare terms. `go test ./...` passes.

## Stack

1. #1045 — read a pattern into a test and its binds
2. **this PR** — merge and thread the tail
3. #1047 — specialize what a guarded branch falls into

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnCHCk3wgtNtYNXiMY7kvM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnCHCk3wgtNtYNXiMY7kvM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pattern-matching behavior across split conditions, guards, and fallback branches.
  * Preserved evaluation order and branch results more reliably, including nested patterns and catch-all cases.
  * Improved handling of empty matches and conditional fallthrough scenarios.
* **Tests**
  * Added comprehensive coverage for matching, guard behavior, fallback paths, provenance, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->