### PR TITLE
UCS IR: specialize what a guarded branch falls into

### DIFF
--- a/internal/solver/ucs/normalize.go
+++ b/internal/solver/ucs/normalize.go
@@ -72,14 +72,20 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 	cands := make([]candidate, len(s.Branches))
 	for i, branch := range s.Branches {
 		test, binds := shallowTest(branch.Pattern, s.Scrutinee, branch.Origin)
-		cands[i] = candidate{index: i, branch: branch, test: test, binds: binds}
+		cands[i] = candidate{
+			index:  i,
+			branch: branch,
+			test:   test,
+			binds:  binds,
+			nested: hasUnflattenedBind(binds),
+		}
 	}
 
 	b := &splitBuilder{
 		scrutinee: s.Scrutinee,
 		tail:      tail,
 		origin:    s.Origin,
-		built:     map[int]Norm{},
+		built:     map[string]Norm{},
 	}
 	// A core split always becomes a split, even when no branch is left to test, because
 	// the split is what names the scrutinee. Collapsing `match f() { _ => 1 }` to its
@@ -100,13 +106,20 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 // analyzed a single time.
 type candidate struct {
 	// index is the branch's position in the core split, which identifies it while
-	// building.
+	// building. Two candidate lists holding the same branches build the same term.
 	index  int
 	branch *CoreBranch
-	// test is the tag the branch tests, and nil when the branch runs unconditionally,
-	// which is what a catch-all pattern reads to.
+	// test is the tag the branch tests, and nil when the branch runs
+	// unconditionally. A catch-all pattern has no tag, and specialize also clears the
+	// test of a branch an already-matched test guarantees.
 	test  Test
 	binds []bindSpec
+	// nested marks a branch holding a sub-pattern this stage does not flatten, which is
+	// matching the tag test does not account for. In `{x: 1}` the test names the key
+	// `x` and the literal `1` rides a nameless bind, so passing the test does not mean
+	// the branch matched. Such a branch is never made unconditional: a value that
+	// reaches it can still fall through to the arms below.
+	nested bool
 }
 
 // splitBuilder builds the branches of one core split. Everything it holds is fixed for
@@ -116,12 +129,11 @@ type splitBuilder struct {
 	scrutinee *Scrutinee
 	tail      Norm
 	origin    Origin
-	// built caches the fallthrough term for a run of candidates, keyed by the index of
-	// the first. A guarded branch falls into the branches after it, so without the
-	// cache a run of guarded branches would rebuild overlapping suffixes over and over.
-	// Each cached term is also shared rather than duplicated, so a consumer that walks
-	// the IR visits it once.
-	built map[int]Norm
+	// built caches the fallthrough term for a set of candidates. A guarded branch falls
+	// into the branches after it, so without the cache a run of guarded branches would
+	// rebuild overlapping subsets over and over. Each cached term is also shared rather
+	// than duplicated, so a consumer that walks the IR visits it once.
+	built map[string]Norm
 }
 
 // term is what a branch continues into when its own continuation fails. Unlike the
@@ -132,7 +144,8 @@ func (b *splitBuilder) term(cands []candidate) Norm {
 	if len(cands) == 0 {
 		return b.tail
 	}
-	if term, ok := b.built[cands[0].index]; ok {
+	key := candidatesKey(cands)
+	if term, ok := b.built[key]; ok {
 		return term
 	}
 
@@ -146,7 +159,7 @@ func (b *splitBuilder) term(cands []candidate) Norm {
 			Origin:    b.origin,
 		}
 	}
-	b.built[cands[0].index] = term
+	b.built[key] = term
 	return term
 }
 
@@ -161,7 +174,7 @@ func (b *splitBuilder) build(cands []candidate) ([]*NormBranch, Norm) {
 		// fallthrough would be dead weight.
 		var fallthru Norm
 		if mayFall(cand.branch.Cont) {
-			fallthru = b.term(cands[i+1:])
+			fallthru = b.term(specialize(cands[i+1:], cand.test))
 		}
 		cont := wrapBinds(cand.binds, normalizeTerm(cand.branch.Cont, fallthru))
 		if cand.test == nil {

--- a/internal/solver/ucs/normalize.go
+++ b/internal/solver/ucs/normalize.go
@@ -1,5 +1,7 @@
 package ucs
 
+import "github.com/escalier-lang/escalier/internal/set"
+
 // Normalize rewrites a desugared core term into the normalized form. Two rewrites
 // happen here.
 //
@@ -86,6 +88,7 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 		tail:      tail,
 		origin:    s.Origin,
 		built:     map[string]Norm{},
+		inlined:   set.NewSet[int](),
 	}
 	// A core split always becomes a split, even when no branch is left to test, because
 	// the split is what names the scrutinee. Collapsing `match f() { _ => 1 }` to its
@@ -134,6 +137,11 @@ type splitBuilder struct {
 	// rebuild overlapping subsets over and over. Each cached term is also shared rather
 	// than duplicated, so a consumer that walks the IR visits it once.
 	built map[string]Norm
+	// inlined holds the index of every candidate whose continuation an already-built
+	// term runs unconditionally, which is what specializing a fallthrough does to a
+	// branch the matched test proved. A branch for one of those is a duplicate this
+	// rewrite introduced, and build drops it rather than emit a test that cannot pass.
+	inlined set.Set[int]
 }
 
 // term is what a branch continues into when its own continuation fails. Unlike the
@@ -169,6 +177,22 @@ func (b *splitBuilder) build(cands []candidate) ([]*NormBranch, Norm) {
 	var branches []*NormBranch
 	dflt := b.tail
 	for i, cand := range cands {
+		if cand.test != nil && b.inlined.Contains(cand.index) && capturedBy(cands[:i], cand.test) {
+			// An earlier branch's fallthrough already runs this branch's continuation,
+			// and an earlier test already captured every value this one would match, so
+			// nothing can reach the branch. Emitting it would cost a test that always
+			// fails and a second copy of the arm's binds and body.
+			//
+			// capturedBy is what makes the drop sound rather than a guess. It is not
+			// separately observable while testImplies holds only between equal tags,
+			// since an inlined candidate is then always captured too, and it is what
+			// keeps the drop correct if that relation ever becomes one-directional.
+			//
+			// A branch nothing inlined is left alone even when it is unreachable. That
+			// is an arm the user wrote dead rather than one this rewrite duplicated, and
+			// dropping it would leave the coverage check nothing to report.
+			continue
+		}
 		// Only a branch whose continuation can fail needs to name where it continues.
 		// An unguarded arm ends in a leaf, so it never falls through and the
 		// fallthrough would be dead weight.
@@ -179,8 +203,10 @@ func (b *splitBuilder) build(cands []candidate) ([]*NormBranch, Norm) {
 		cont := wrapBinds(cand.binds, normalizeTerm(cand.branch.Cont, fallthru))
 		if cand.test == nil {
 			// The branch always runs, so it is the split's tail and every candidate
-			// after it is unreachable.
+			// after it is unreachable. Recording it is what lets an outer branch for the
+			// same candidate be dropped, since this term already runs its continuation.
 			dflt = cont
+			b.inlined.Add(cand.index)
 			break
 		}
 		branches = append(branches, &NormBranch{

--- a/internal/solver/ucs/specialize.go
+++ b/internal/solver/ucs/specialize.go
@@ -45,6 +45,24 @@ func specialize(cands []candidate, matched Test) []candidate {
 	return out
 }
 
+// capturedBy reports whether one of the earlier candidates already takes every value
+// test would match, which means control cannot reach the branch test belongs to. Those
+// candidates are the branches ahead of it in the same split, and reaching it means each
+// of their tests failed. A test the failed one takes every value of fails too.
+//
+// This is the opposite direction from the implication specialize uses. There the
+// question is what an already-matched test proves about a later one, so the matched test
+// is the narrower one. Here the later test has to be the narrower one for its branch to
+// be dead.
+func capturedBy(earlier []candidate, test Test) bool {
+	for _, cand := range earlier {
+		if cand.test != nil && testImplies(test, cand.test) {
+			return true
+		}
+	}
+	return false
+}
+
 // hasUnflattenedBind reports whether any of a branch's binds holds a sub-pattern that
 // is still to be matched. A branch with one can fail after its tag test passes, so the
 // test alone does not say whether the branch matched.

--- a/internal/solver/ucs/specialize.go
+++ b/internal/solver/ucs/specialize.go
@@ -1,0 +1,172 @@
+package ucs
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+// specialize returns the candidates that can still run once the matched test has
+// succeeded, in source order. This is what a branch whose guard fails continues into,
+// and dropping what cannot run is what keeps the continuation from re-testing a tag the
+// value is already known to fail.
+//
+// Three things can happen to a later candidate. A test the matched one guarantees
+// becomes unconditional, since a value that passed the first passes the second too. A
+// test that cannot hold of the same value is dropped. Anything else survives with its
+// test intact and is re-tested.
+//
+// An unconditional candidate does not end the list, because its own continuation can
+// still fail: `1 if f() => a, 1 if g() => b, _ => c` reaches `c` when both guards fail.
+// Truncating the branch list at an unconditional candidate is build's job, and it
+// truncates only the branches, not what that candidate falls into.
+//
+// A candidate that made no test taught nothing, so every later candidate survives
+// unchanged.
+func specialize(cands []candidate, matched Test) []candidate {
+	if matched == nil {
+		return cands
+	}
+	out := make([]candidate, 0, len(cands))
+	for _, cand := range cands {
+		switch {
+		case cand.test == nil:
+			out = append(out, cand)
+		case testImplies(matched, cand.test) && !cand.nested:
+			cand.test = nil
+			out = append(out, cand)
+		case testsDisjoint(matched, cand.test):
+			// Nothing to do: no value passes both tests, so this candidate cannot run.
+		default:
+			out = append(out, cand)
+		}
+	}
+	return out
+}
+
+// hasUnflattenedBind reports whether any of a branch's binds holds a sub-pattern that
+// is still to be matched. A branch with one can fail after its tag test passes, so the
+// test alone does not say whether the branch matched.
+func hasUnflattenedBind(binds []bindSpec) bool {
+	for _, bind := range binds {
+		if bind.name == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// candidatesKey identifies a candidate list by the branches in it and whether each
+// still makes its test, which is everything build reads. A `!` marks a candidate
+// specialize made unconditional, so it does not key the same as the branch with its
+// test intact. Specializing can drop a candidate from the middle of a run, so the key
+// names every candidate rather than only the first.
+func candidatesKey(cands []candidate) string {
+	var sb strings.Builder
+	for _, cand := range cands {
+		sb.WriteString(strconv.Itoa(cand.index))
+		if cand.test == nil {
+			sb.WriteByte('!')
+		}
+		sb.WriteByte(',')
+	}
+	return sb.String()
+}
+
+// testImplies reports whether every value passing a also passes b, which lets a branch
+// that already matched a run b's branch without re-testing.
+//
+// It answers true only where the two tests hold of the same values under any reading of
+// what a structural test accepts. Whether an object test rejects a value carrying extra
+// fields is left to the consumer, as the RestKind doc explains, so two object tests
+// that name different keys are not compared. Answering false only costs a re-test in
+// the normalized form.
+func testImplies(a, b Test) bool {
+	switch a := a.(type) {
+	case *LitTest:
+		b, ok := b.(*LitTest)
+		return ok && litEqual(a.Lit, b.Lit)
+	case *ObjectTest:
+		b, ok := b.(*ObjectTest)
+		return ok && a.Rest == b.Rest && sameKeys(a.Keys, b.Keys)
+	case *TupleTest:
+		b, ok := b.(*TupleTest)
+		return ok && a.Len == b.Len && a.Rest == b.Rest
+	case *ClassTest:
+		b, ok := b.(*ClassTest)
+		return ok && ast.QualIdentToString(a.Name) == ast.QualIdentToString(b.Name)
+	case *ExtractorTest:
+		// Two runs of one extractor are taken to agree, the same assumption a branch
+		// order relies on when the surface repeats a pattern.
+		b, ok := b.(*ExtractorTest)
+		return ok && a.Arity == b.Arity &&
+			ast.QualIdentToString(a.Name) == ast.QualIdentToString(b.Name)
+	default:
+		return false
+	}
+}
+
+// testsDisjoint reports whether no value passes both tests, which lets a branch that
+// already matched drop the other branch from what it falls through to.
+//
+// Only two different literals qualify. Every other pair could hold of one value: a
+// subclass passes both its own class test and its parent's, an extractor is free to
+// match a value of any shape, and two structural tests overlap whenever one shape
+// extends the other. Answering false only keeps a branch that cannot run.
+func testsDisjoint(a, b Test) bool {
+	litA, aIsLit := a.(*LitTest)
+	litB, bIsLit := b.(*LitTest)
+	return aIsLit && bIsLit && !litEqual(litA.Lit, litB.Lit)
+}
+
+// sameKeys reports whether two object tests name the same fields with the same
+// optionality. Order does not matter, since `{x, y}` and `{y, x}` accept the same
+// values.
+func sameKeys(a, b []ObjectKey) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	optional := make(map[string]bool, len(a))
+	for _, key := range a {
+		optional[key.Name] = key.Optional
+	}
+	for _, key := range b {
+		was, found := optional[key.Name]
+		if !found || was != key.Optional {
+			return false
+		}
+	}
+	return true
+}
+
+// litEqual reports whether two literals name the same value. A literal test compares
+// values rather than nodes, so the `1` of one arm and the `1` of another are the same
+// tag.
+func litEqual(a, b ast.Lit) bool {
+	switch a := a.(type) {
+	case *ast.BoolLit:
+		b, ok := b.(*ast.BoolLit)
+		return ok && a.Value == b.Value
+	case *ast.NumLit:
+		b, ok := b.(*ast.NumLit)
+		return ok && a.Value == b.Value
+	case *ast.StrLit:
+		b, ok := b.(*ast.StrLit)
+		return ok && a.Value == b.Value
+	case *ast.RegexLit:
+		b, ok := b.(*ast.RegexLit)
+		return ok && a.Value == b.Value
+	case *ast.BigIntLit:
+		b, ok := b.(*ast.BigIntLit)
+		return ok && a.Value.Cmp(&b.Value) == 0
+	case *ast.NullLit:
+		_, ok := b.(*ast.NullLit)
+		return ok
+	case *ast.UndefinedLit:
+		_, ok := b.(*ast.UndefinedLit)
+		return ok
+	default:
+		return false
+	}
+}

--- a/internal/solver/ucs/specialize_test.go
+++ b/internal/solver/ucs/specialize_test.go
@@ -12,6 +12,10 @@ import (
 // Two arms of the same shape overlap: the second matches whenever the first does. The
 // first's test already proved the second's, so the guard falls straight into the second
 // arm's continuation instead of testing `{x, y}` again.
+//
+// That leaves no branch for the second arm. One would be dead, since reaching it means
+// the identical test above it failed, and it would carry a second copy of the arm's
+// binds and body.
 func TestSpecializeOverlappingArmsOfTheSameShape(t *testing.T) {
 	core := coreMatch(
 		ident("p"),
@@ -23,7 +27,6 @@ func TestSpecializeOverlappingArmsOfTheSameShape(t *testing.T) {
   {x, y} => bind x = p.x, y = p.y; guard (x > y) {
     leaf x
   } default bind x = p.x, y = p.y; leaf 0
-  {x, y} => bind x = p.x, y = p.y; leaf 0
 } default ✗`))
 }
 
@@ -69,6 +72,9 @@ func TestSpecializeDropsArmsTheGuardedTestRulesOut(t *testing.T) {
 // Two guarded arms of the same tag chain: the first proves the second's test, so the
 // second runs without re-testing, and its own guard still falls through to the arm
 // below. Making an arm unconditional must not cut off what it falls into.
+//
+// The chain leaves one branch rather than two, since the second arm's continuation
+// already runs inside the first branch's fallthrough.
 func TestSpecializeChainsGuardsOnOneTag(t *testing.T) {
 	core := coreMatch(
 		ident("n"),
@@ -83,10 +89,44 @@ func TestSpecializeChainsGuardsOnOneTag(t *testing.T) {
   } default guard (g) {
     leaf "b"
   } default leaf "c"
-  1 => guard (g) {
-    leaf "b"
-  } default leaf "c"
 } default leaf "c"`))
+}
+
+// Only a branch this rewrite duplicated is dropped. Two unguarded arms of the same tag
+// inline nothing, since the first cannot fail, so the second keeps its branch even
+// though nothing reaches it. That branch is the only record of an arm the user wrote
+// dead, and the coverage check is what reports it.
+func TestSpecializeKeepsAnArmNothingInlined(t *testing.T) {
+	core := coreMatch(
+		ident("n"),
+		matchCase(numPat(1), nil, str("a"), span(2, 5, 20)),
+		matchCase(numPat(1), nil, str("b"), span(3, 5, 20)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {
+  1 => leaf "a"
+  1 => leaf "b"
+} default ✗`))
+}
+
+// The two rules meet on one split. The guarded arm's fallthrough takes the arm below it,
+// so that arm's branch goes. The third arm reaches nothing and nothing inlines it, since
+// the second arm cannot fail and ends the fallthrough, so its branch stays for the
+// coverage check to report.
+func TestSpecializeKeepsTheArmNoFallthroughCouldTake(t *testing.T) {
+	core := coreMatch(
+		ident("n"),
+		matchCase(numPat(1), ident("f"), str("a"), span(2, 5, 24)),
+		matchCase(numPat(1), nil, str("b"), span(3, 5, 20)),
+		matchCase(numPat(1), nil, str("c"), span(4, 5, 20)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {
+  1 => guard (f) {
+    leaf "a"
+  } default leaf "b"
+  1 => leaf "c"
+} default ✗`))
 }
 
 // A branch holding a sub-pattern this stage does not flatten is never made
@@ -154,6 +194,40 @@ func TestTestRelations(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.implies, testImplies(test.a, test.b), "testImplies")
 			require.Equal(t, test.disjoint, testsDisjoint(test.a, test.b), "testsDisjoint")
+		})
+	}
+}
+
+// capturedBy asks the reverse of what specialize asks: whether an earlier test takes
+// every value of a later one, which is what makes the later branch unreachable. Getting
+// the direction wrong would drop a branch that can still run, so the wider-then-narrower
+// order is pinned here.
+func TestCapturedBy(t *testing.T) {
+	one := candidate{index: 0, test: &LitTest{Lit: ast.NewNumber(1, ast.Span{})}}
+	two := candidate{index: 1, test: &LitTest{Lit: ast.NewNumber(2, ast.Span{})}}
+	catchAll := candidate{index: 2}
+
+	tests := []struct {
+		name     string
+		earlier  []candidate
+		test     Test
+		captured bool
+	}{
+		{name: "no earlier branch", test: one.test},
+		{name: "the same tag", earlier: []candidate{one}, test: one.test, captured: true},
+		{name: "a different tag", earlier: []candidate{two}, test: one.test},
+		{
+			name:     "one of several earlier tags",
+			earlier:  []candidate{two, one},
+			test:     one.test,
+			captured: true,
+		},
+		{name: "an earlier branch with no test", earlier: []candidate{catchAll}, test: one.test},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.captured, capturedBy(test.earlier, test.test))
 		})
 	}
 }

--- a/internal/solver/ucs/specialize_test.go
+++ b/internal/solver/ucs/specialize_test.go
@@ -1,0 +1,198 @@
+package ucs
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// Two arms of the same shape overlap: the second matches whenever the first does. The
+// first's test already proved the second's, so the guard falls straight into the second
+// arm's continuation instead of testing `{x, y}` again.
+func TestSpecializeOverlappingArmsOfTheSameShape(t *testing.T) {
+	core := coreMatch(
+		ident("p"),
+		matchCase(objPat("x", "y"), greaterThan(), ident("x"), span(2, 5, 30)),
+		matchCase(objPat("x", "y"), nil, num(0), span(3, 5, 22)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
+  {x, y} => bind x = p.x, y = p.y; guard (x > y) {
+    leaf x
+  } default bind x = p.x, y = p.y; leaf 0
+  {x, y} => bind x = p.x, y = p.y; leaf 0
+} default ✗`))
+}
+
+// Two arms whose shapes overlap without either proving the other keep their tests. A
+// value with an `x` and a `y` reaches the second arm when the guard fails, so the
+// fallthrough tests `{x}` rather than assuming it.
+func TestSpecializeOverlappingArmsOfDifferentShapes(t *testing.T) {
+	core := coreMatch(
+		ident("p"),
+		matchCase(objPat("x", "y"), greaterThan(), ident("x"), span(2, 5, 30)),
+		matchCase(objPat("x"), nil, num(1), span(3, 5, 20)),
+		matchCase(wildcardPat(), nil, num(0), span(4, 5, 16)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
+  {x, y} => bind x = p.x, y = p.y; guard (x > y) {
+    leaf x
+  } default split p {
+    {x} => bind x = p.x; leaf 1
+  } default leaf 0
+  {x} => bind x = p.x; leaf 1
+} default leaf 0`))
+}
+
+// An arm the guarded one rules out is dropped from what the guard falls into. No value
+// is both 1 and 2, so a failed guard on the `1` arm continues past the `2` arm.
+func TestSpecializeDropsArmsTheGuardedTestRulesOut(t *testing.T) {
+	core := coreMatch(
+		ident("n"),
+		matchCase(numPat(1), greaterThan(), str("one"), span(2, 5, 26)),
+		matchCase(numPat(2), nil, str("two"), span(3, 5, 18)),
+		matchCase(wildcardPat(), nil, str("other"), span(4, 5, 20)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {
+  1 => guard (x > y) {
+    leaf "one"
+  } default leaf "other"
+  2 => leaf "two"
+} default leaf "other"`))
+}
+
+// Two guarded arms of the same tag chain: the first proves the second's test, so the
+// second runs without re-testing, and its own guard still falls through to the arm
+// below. Making an arm unconditional must not cut off what it falls into.
+func TestSpecializeChainsGuardsOnOneTag(t *testing.T) {
+	core := coreMatch(
+		ident("n"),
+		matchCase(numPat(1), ident("f"), str("a"), span(2, 5, 24)),
+		matchCase(numPat(1), ident("g"), str("b"), span(3, 5, 24)),
+		matchCase(wildcardPat(), nil, str("c"), span(4, 5, 16)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split n {
+  1 => guard (f) {
+    leaf "a"
+  } default guard (g) {
+    leaf "b"
+  } default leaf "c"
+  1 => guard (g) {
+    leaf "b"
+  } default leaf "c"
+} default leaf "c"`))
+}
+
+// A branch holding a sub-pattern this stage does not flatten is never made
+// unconditional. Passing the `{x}` test says nothing about whether the literal `2`
+// matched, so the arm below the second one stays reachable.
+func TestSpecializeKeepsATestWhoseBranchStillHasASubPattern(t *testing.T) {
+	first := ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("x", numPat(1))}, ast.Span{})
+	second := ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("x", numPat(2))}, ast.Span{})
+	core := coreMatch(
+		ident("p"),
+		matchCase(first, ident("g"), str("a"), span(2, 5, 26)),
+		matchCase(second, nil, str("b"), span(3, 5, 22)),
+		matchCase(wildcardPat(), nil, str("c"), span(4, 5, 16)),
+	)
+
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
+  {x} => bind 1 = p.x; guard (g) {
+    leaf "a"
+  } default split p {
+    {x} => bind 2 = p.x; leaf "b"
+  } default leaf "c"
+  {x} => bind 2 = p.x; leaf "b"
+} default leaf "c"`))
+}
+
+// A tag one arm proves is not always a tag another arm's value shares. Only a pair the
+// two relations can decide changes the fallthrough, and every other pair is left to
+// re-test.
+func TestTestRelations(t *testing.T) {
+	one := &LitTest{Lit: ast.NewNumber(1, ast.Span{})}
+	alsoOne := &LitTest{Lit: ast.NewNumber(1, ast.Span{})}
+	two := &LitTest{Lit: ast.NewNumber(2, ast.Span{})}
+	xy := &ObjectTest{Keys: keys("x", "y")}
+	yx := &ObjectTest{Keys: keys("y", "x")}
+	x := &ObjectTest{Keys: keys("x")}
+	xOptional := &ObjectTest{Keys: []ObjectKey{{Name: "x", Optional: true}}}
+	pair := &TupleTest{Len: 2}
+	pairPrefix := &TupleTest{Len: 2, Rest: TrailingRest}
+	point := &ClassTest{Name: ast.NewIdentifier("Point", ast.Span{})}
+	line := &ClassTest{Name: ast.NewIdentifier("Line", ast.Span{})}
+	ok1 := &ExtractorTest{Name: ast.NewIdentifier("Ok", ast.Span{}), Arity: 1}
+	ok2 := &ExtractorTest{Name: ast.NewIdentifier("Ok", ast.Span{}), Arity: 2}
+
+	tests := []struct {
+		name     string
+		a, b     Test
+		implies  bool
+		disjoint bool
+	}{
+		{name: "a literal proves itself", a: one, b: alsoOne, implies: true},
+		{name: "two literals are disjoint", a: one, b: two, disjoint: true},
+		{name: "an object proves the same keys in any order", a: xy, b: yx, implies: true},
+		{name: "a wider object does not prove a narrower one", a: xy, b: x},
+		{name: "an optional key is a different test", a: x, b: xOptional},
+		{name: "a tuple proves the same length", a: pair, b: &TupleTest{Len: 2}, implies: true},
+		{name: "an exact tuple does not prove a prefix", a: pair, b: pairPrefix},
+		{name: "a class proves itself", a: point, b: point, implies: true},
+		{name: "two classes may share a value", a: point, b: line},
+		{name: "an extractor proves itself at one arity", a: ok1, b: ok1, implies: true},
+		{name: "arity separates two extractor tests", a: ok1, b: ok2},
+		{name: "a literal and an object may share a value", a: one, b: x},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.implies, testImplies(test.a, test.b), "testImplies")
+			require.Equal(t, test.disjoint, testsDisjoint(test.a, test.b), "testsDisjoint")
+		})
+	}
+}
+
+// A literal test compares values rather than nodes, so the `1` of one arm and the `1`
+// of another are the same tag. Every literal kind compares by its own value.
+func TestLitEqual(t *testing.T) {
+	tests := []struct {
+		name  string
+		a, b  ast.Lit
+		equal bool
+	}{
+		{name: "numbers", a: ast.NewNumber(1, ast.Span{}), b: ast.NewNumber(1, ast.Span{}), equal: true},
+		{name: "different numbers", a: ast.NewNumber(1, ast.Span{}), b: ast.NewNumber(2, ast.Span{})},
+		{name: "strings", a: ast.NewString("a", ast.Span{}), b: ast.NewString("a", ast.Span{}), equal: true},
+		{name: "different strings", a: ast.NewString("a", ast.Span{}), b: ast.NewString("b", ast.Span{})},
+		{name: "booleans", a: ast.NewBoolean(true, ast.Span{}), b: ast.NewBoolean(true, ast.Span{}), equal: true},
+		{name: "different booleans", a: ast.NewBoolean(true, ast.Span{}), b: ast.NewBoolean(false, ast.Span{})},
+		{name: "regexes", a: ast.NewRegex("/a/", ast.Span{}), b: ast.NewRegex("/a/", ast.Span{}), equal: true},
+		{
+			name:  "bigints",
+			a:     ast.NewBigInt(*big.NewInt(1), ast.Span{}),
+			b:     ast.NewBigInt(*big.NewInt(1), ast.Span{}),
+			equal: true,
+		},
+		{
+			name: "different bigints",
+			a:    ast.NewBigInt(*big.NewInt(1), ast.Span{}),
+			b:    ast.NewBigInt(*big.NewInt(2), ast.Span{}),
+		},
+		{name: "null", a: ast.NewNull(ast.Span{}), b: ast.NewNull(ast.Span{}), equal: true},
+		{name: "undefined", a: ast.NewUndefined(ast.Span{}), b: ast.NewUndefined(ast.Span{}), equal: true},
+		{name: "null and undefined", a: ast.NewNull(ast.Span{}), b: ast.NewUndefined(ast.Span{})},
+		{name: "a number and a string", a: ast.NewNumber(1, ast.Span{}), b: ast.NewString("1", ast.Span{})},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.equal, litEqual(test.a, test.b))
+		})
+	}
+}


### PR DESCRIPTION
Refs #1022. Third of three PRs. It is stacked on #1046, so review that one first and read this diff against it.

A guarded branch falls into the branches after it in source order. Those branches are reached only when the guard's own test already matched, which says something about which of them can still run. Reading the branch list under that knowledge is what keeps a fallthrough from re-testing a tag the value is known to pass or known to fail.

## What specialization does

- A later branch the matched test guarantees runs unconditionally, so `{x, y} if f() => a, {x, y} => b` falls straight into the second arm rather than testing `{x, y}` twice.
- A later branch no value can share with the matched test is dropped, so a failed guard on a `1` arm continues past a `2` arm to the catch-all.
- Anything else keeps its test and is re-tested, which is what an overlap neither relation can decide comes to. `{x, y} if f() => a` followed by `{x} => b` re-tests `{x}`.

## The two relations

`testImplies` and `testsDisjoint` answer only where the two tests hold of the same values under any reading of what a structural test accepts. Whether an object test rejects a value carrying extra fields is left to the consumer, as `RestKind` spells out, so two object tests naming different keys are not compared. A subclass passes both its own class test and its parent's, so two class names are never called disjoint. Answering `false` costs a re-test or a branch that cannot run, never a wrong answer.

Two cases the relations must not get wrong, both of which delete an arm if they do:

- An unconditional branch does not end the candidate list, because its own guard can fail. `1 if f() => a, 1 if g() => b, _ => c` reaches `c` when both guards fail.
- A branch holding a sub-pattern this stage does not flatten is never made unconditional. In `{x: 1} if f() => a, {x: 2} => b, _ => c` the literals ride nameless binds the tag test says nothing about, so the second arm can still fail and `c` stays reachable.

## Sharing

The builder caches a fallthrough term by the candidates in it, so a run of guarded branches does not rebuild overlapping subsets, and a term two branches reach is one node rather than two copies.

## Tests

Both overlap directions, the disjoint drop, the guard chain, the unflattened-sub-pattern case, a table over the two relations across every test kind, and a table over `litEqual` for every literal kind. `go test ./...` passes.

## Stack

1. #1045 — read a pattern into a test and its binds
2. #1046 — merge and thread the tail, which closes #1022
3. **this PR** — specialize the fallthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnCHCk3wgtNtYNXiMY7kvM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnCHCk3wgtNtYNXiMY7kvM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pattern matching for nested bindings and conditional branches.
  - Corrected fallthrough behavior when multiple pattern candidates overlap.
  - Preserved necessary guard and sub-pattern checks during chained matching.
  - Improved handling of disjoint patterns so irrelevant branches are skipped.
  - Ensured literal comparisons work consistently across supported value types.

- **Tests**
  - Added comprehensive coverage for overlapping patterns, guarded fallthrough, nested bindings, and literal matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->