### PR TITLE
printer: keep receivers and looser type members grouped

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -819,8 +819,51 @@ func borrowExprArgNeedsParens(e ast.Expr) bool {
 	}
 }
 
+// printReceiver renders a receiver, the expression a call reads its callee from and the
+// one an index or a member access reads its object from. A receiver binds tighter than
+// every operator, so an operator expression left bare in that position names a different
+// expression than the tree holds. `(a + b).c` would print as `a + b.c`, which reads the
+// property off `b`, and `(-a).c` would print as `-a.c`, which negates the property.
+//
+// An argument, an index, and a tuple element are already delimited by their own brackets,
+// so those positions stay bare.
+func (p *Printer) printReceiver(expr ast.Expr) {
+	if !receiverNeedsParens(expr) {
+		p.printExpr(expr)
+		return
+	}
+	p.writeString("(")
+	p.printExpr(expr)
+	p.writeString(")")
+}
+
+// receiverNeedsParens reports whether an expression must be parenthesized to survive
+// being reparsed in receiver position. Three families qualify.
+//
+//  1. A prefix form such as `-a`, `&a`, `await a`, or `a: number` binds looser than the
+//     `.`, `[`, or `(` that follows it, so the receiver would attach to the operand
+//     rather than to the whole form.
+//  2. A form ending in a block, such as `if`, `match`, `do`, or a function expression,
+//     would let the receiver read as part of that block instead.
+//  3. A number literal takes the following `.` as its own decimal point, so `(5).toFixed()`
+//     printed bare would lex as the number `5.` followed by the identifier `toFixed`.
+func receiverNeedsParens(e ast.Expr) bool {
+	switch e := e.(type) {
+	case *ast.BinaryExpr, *ast.UnaryExpr, *ast.BorrowExpr, *ast.AwaitExpr,
+		*ast.ThrowExpr, *ast.YieldExpr, *ast.TypeCastExpr, *ast.ArraySpreadExpr,
+		*ast.IfElseExpr, *ast.IfValExpr, *ast.MatchExpr, *ast.TryCatchExpr,
+		*ast.DoExpr, *ast.FuncExpr:
+		return true
+	case *ast.LiteralExpr:
+		_, isNum := e.Lit.(*ast.NumLit)
+		return isNum
+	default:
+		return false
+	}
+}
+
 func (p *Printer) printCallExpr(expr *ast.CallExpr) {
-	p.printExpr(expr.Callee)
+	p.printReceiver(expr.Callee)
 	if expr.OptChain {
 		p.writeString("?(")
 	} else {
@@ -837,7 +880,7 @@ func (p *Printer) printCallExpr(expr *ast.CallExpr) {
 }
 
 func (p *Printer) printIndexExpr(expr *ast.IndexExpr) {
-	p.printExpr(expr.Object)
+	p.printReceiver(expr.Object)
 	if expr.OptChain {
 		p.writeString("?[")
 	} else {
@@ -848,7 +891,7 @@ func (p *Printer) printIndexExpr(expr *ast.IndexExpr) {
 }
 
 func (p *Printer) printMemberExpr(expr *ast.MemberExpr) {
-	p.printExpr(expr.Object)
+	p.printReceiver(expr.Object)
 	if expr.OptChain {
 		p.writeString("?.")
 	} else {
@@ -1072,7 +1115,7 @@ func (p *Printer) printTemplateLitExpr(expr *ast.TemplateLitExpr) {
 }
 
 func (p *Printer) printTaggedTemplateLitExpr(expr *ast.TaggedTemplateLitExpr) {
-	p.printExpr(expr.Tag)
+	p.printReceiver(expr.Tag)
 	p.writeString("`")
 	for i, quasi := range expr.Quasis {
 		p.writeString(quasi.Value)
@@ -1295,12 +1338,15 @@ func (p *Printer) printTypeAnn(typ ast.TypeAnn) {
 		p.printFuncTypeAnn(t)
 	case *ast.KeyOfTypeAnn:
 		p.writeString("keyof ")
-		p.printTypeAnn(t.Type)
+		p.printPrefixTypeAnnOperand(t.Type)
 	case *ast.TypeOfTypeAnn:
 		p.writeString("typeof ")
 		p.printQualIdent(t.Value)
 	case *ast.IndexTypeAnn:
-		p.printTypeAnn(t.Target)
+		// An indexed access reads from a target that binds as tightly as a type
+		// reference, so anything carrying an operator has to be wrapped. `(keyof A)[B]`
+		// printed bare would reparse as `keyof (A[B])`.
+		p.printTypeAnnAt(t.Target, precTypePrimary)
 		p.writeString("[")
 		p.printTypeAnn(t.Index)
 		p.writeString("]")
@@ -1345,7 +1391,7 @@ func (p *Printer) printTypeAnn(typ ast.TypeAnn) {
 		p.printMatchTypeAnn(t)
 	case *ast.MutableTypeAnn:
 		p.writeString("mut ")
-		p.printTypeAnn(t.Target)
+		p.printPrefixTypeAnnOperand(t.Target)
 	case *ast.RefTypeAnn:
 		p.printRefTypeAnn(t)
 	case *ast.ErrorTypeAnn:
@@ -1498,12 +1544,64 @@ func (p *Printer) printTupleTypeAnn(typ *ast.TupleTypeAnn) {
 	p.writeString("]")
 }
 
+// Binding power of an Escalier type operator. A larger number binds tighter, so
+// `A | B & C` groups as `A | (B & C)`. The scale ranks only the operators whose grouping
+// the surface syntax can change. A conditional type and a match type end in a closing
+// brace, so neither can be pulled apart and both rank as primary.
+const (
+	// precTypeOpenEnded covers the two forms that have no closing delimiter of their own,
+	// the function type `fn (a: A) -> B` and the rest spread `...A`. Each reaches as far
+	// right as the syntax allows, which is why `fn () -> A | B` reads as
+	// `fn () -> (A | B)` and either form inside a union or an intersection has to be
+	// wrapped.
+	precTypeOpenEnded    = 1
+	precTypeUnion        = 2
+	precTypeIntersection = 3
+	// precTypePrefix covers `keyof A`, `mut A`, `&A`, and `infer A`. Each takes the whole
+	// annotation that follows it.
+	precTypePrefix = 4
+	// precTypePrimary is for an annotation that nothing can regroup, such as a type
+	// reference, an object type, a tuple, or an indexed access.
+	precTypePrimary = 5
+)
+
+// typeAnnPrecedence returns the binding power of a type annotation's top-level operator.
+func typeAnnPrecedence(t ast.TypeAnn) int {
+	switch t.(type) {
+	case *ast.FuncTypeAnn, *ast.RestSpreadTypeAnn:
+		return precTypeOpenEnded
+	case *ast.UnionTypeAnn:
+		return precTypeUnion
+	case *ast.IntersectionTypeAnn:
+		return precTypeIntersection
+	case *ast.KeyOfTypeAnn, *ast.MutableTypeAnn, *ast.RefTypeAnn, *ast.InferTypeAnn:
+		return precTypePrefix
+	default:
+		return precTypePrimary
+	}
+}
+
+// printTypeAnnAt prints a type annotation, parenthesizing it when its own operator binds
+// looser than minPrec. Callers pass the binding power the surrounding position demands.
+// An intersection member demands precTypeIntersection, so `(number | string) & boolean`
+// keeps its parentheses rather than reprinting as `number | string & boolean`, which
+// reparses as `number | (string & boolean)`.
+func (p *Printer) printTypeAnnAt(t ast.TypeAnn, minPrec int) {
+	if typeAnnPrecedence(t) >= minPrec {
+		p.printTypeAnn(t)
+		return
+	}
+	p.writeString("(")
+	p.printTypeAnn(t)
+	p.writeString(")")
+}
+
 func (p *Printer) printUnionTypeAnn(typ *ast.UnionTypeAnn) {
 	for i, t := range typ.Types {
 		if i > 0 {
 			p.writeString(" | ")
 		}
-		p.printTypeAnn(t)
+		p.printTypeAnnAt(t, precTypeUnion)
 	}
 }
 
@@ -1512,7 +1610,7 @@ func (p *Printer) printIntersectionTypeAnn(typ *ast.IntersectionTypeAnn) {
 		if i > 0 {
 			p.writeString(" & ")
 		}
-		p.printTypeAnn(t)
+		p.printTypeAnnAt(t, precTypeIntersection)
 	}
 }
 
@@ -1570,9 +1668,11 @@ func borrowInnerNeedsParens(typ ast.TypeAnn) bool {
 }
 
 // needsTypeAnnParens reports whether a type annotation must be parenthesized
-// when it appears as the operand of a tighter-binding prefix such as a borrow
-// `&` or a type cast. Union and intersection bind looser than those prefixes,
-// so they are the cases that need wrapping.
+// when it appears as the operand of a prefix such as a borrow `&`, a `mut`, a
+// `keyof`, or a type cast. A prefix takes the whole annotation that follows it,
+// so only the two infix operators can be pulled apart by what surrounds the
+// prefix. `keyof A | B` reads as `(keyof A) | B`, which is why a union operand
+// needs wrapping, while `keyof fn () -> A` already reads the way the tree holds.
 func needsTypeAnnParens(typ ast.TypeAnn) bool {
 	switch typ.(type) {
 	case *ast.UnionTypeAnn, *ast.IntersectionTypeAnn:
@@ -1580,6 +1680,18 @@ func needsTypeAnnParens(typ ast.TypeAnn) bool {
 	default:
 		return false
 	}
+}
+
+// printPrefixTypeAnnOperand prints the operand of a `keyof` or a `mut` on the rule
+// needsTypeAnnParens states.
+func (p *Printer) printPrefixTypeAnnOperand(t ast.TypeAnn) {
+	if !needsTypeAnnParens(t) {
+		p.printTypeAnn(t)
+		return
+	}
+	p.writeString("(")
+	p.printTypeAnn(t)
+	p.writeString(")")
 }
 
 // printLifetimeAnn renders a lifetime annotation node, the `'a` in `'a Point`.

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -445,6 +445,128 @@ func TestPrintPrecedenceAndParentheses(t *testing.T) {
 	}
 }
 
+// TestPrintReceiverGrouping pins the parentheses the printer keeps around a receiver, the
+// expression a call reads its callee from and the one an index or a member access reads
+// its object from. The AST records grouping in its tree shape and has no parenthesis node,
+// so dropping them names a different expression than the tree holds. Each case parses
+// source and asserts the reprint reparses to the same tree.
+func TestPrintReceiverGrouping(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// A binary or unary receiver binds looser than the `.`, `[`, or `(` after it, so
+		// bare output would attach the receiver to the operand instead of the whole form.
+		{"sum as member object", "(a + b).c", "(a + b).c"},
+		{"sum as index object", "(a + b)[c]", "(a + b)[c]"},
+		{"sum as callee", "(a + b)(c)", "(a + b)(c)"},
+		{"sum as tagged-template tag", "(a + b)`x`", "(a + b)`x`"},
+		{"negation as member object", "(-a).c", "(-a).c"},
+		{"logical not as member object", "(!a).c", "(!a).c"},
+		{"comparison as member object", "(a > b).c", "(a > b).c"},
+		{"borrow as member object", "(&a).c", "(&a).c"},
+		{"await as member object", "(await a).c", "(await a).c"},
+		// A number literal takes the following `.` as its own decimal point, so a bare
+		// `5.toFixed()` would lex as the number `5.` followed by the identifier.
+		{"number as member object", "(5).toFixed(2)", "(5).toFixed(2)"},
+		{"number as callee", "(5)(a)", "(5)(a)"},
+		// A string or a boolean literal has no such reading, so it stays bare.
+		{"string as member object", `("a").length`, `"a".length`},
+		{"boolean as member object", "(true).c", "true.c"},
+		// A form ending in a block would let the receiver read as part of that block.
+		// The printer renders a block across lines, so the grouping shows up around the
+		// whole multi-line form.
+		{"if-else as member object", "(if a { b } else { c }).d", "(if a {\n    b\n} else {\n    c\n}).d"},
+		// A receiver carrying no operator of its own is already grouped.
+		{"member chain", "a.b.c", "a.b.c"},
+		{"call of member", "a.b(c)", "a.b(c)"},
+		{"index of call", "a(b)[c]", "a(b)[c]"},
+		{"tuple as member object", "[a, b].c", "[a, b].c"},
+		// An argument, an index, and a tuple element are delimited by their own brackets,
+		// so an operator expression in any of those positions stays bare.
+		{"sum as argument", "a(b + c)", "a(b + c)"},
+		{"sum as index", "a[b + c]", "a[b + c]"},
+		{"sum as tuple element", "[a + b, c]", "[a + b, c]"},
+	}
+
+	opts := DefaultOptions()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := parseExpr(t, tt.input)
+			result, err := Print(expr, opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+
+			// Reparsing the printed form has to yield the same rendering, which it cannot
+			// do if the print dropped a grouping the tree depends on.
+			reparsed, err := Print(parseExpr(t, result), opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, reparsed)
+		})
+	}
+}
+
+// TestPrintTypeAnnGrouping pins the parentheses the type-annotation printer keeps. The
+// AST records grouping in its tree shape and has no parenthesis node, so a member that
+// binds looser than the position it sits in has to be wrapped. Each case parses an
+// annotation and asserts the reprint reparses to the same tree.
+func TestPrintTypeAnnGrouping(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// `&` binds tighter than `|`, so without the parentheses the two distinct trees
+		// `(number | string) & boolean` and `number | (string & boolean)` would share one
+		// rendering, and it would be the second of the two.
+		{"union in intersection", "(number | string) & boolean", "(number | string) & boolean"},
+		{"union as second member", "boolean & (number | string)", "boolean & (number | string)"},
+		// An intersection inside a union needs no parentheses, since the tighter operator
+		// already groups the way the tree does.
+		{"intersection in union", "number | (string & boolean)", "number | string & boolean"},
+		{"flat union", "number | string | boolean", "number | string | boolean"},
+		{"flat intersection", "number & string & boolean", "number & string & boolean"},
+		// A function type's return reaches as far right as the syntax allows, so a
+		// function type inside a union or an intersection has to be wrapped.
+		{"function type in union", "(fn () -> A) | B", "(fn () -> A) | B"},
+		{"function type returning union", "fn () -> A | B", "fn () -> A | B"},
+		{"function type in intersection", "(fn () -> A) & B", "(fn () -> A) & B"},
+		// A rest spread takes the whole annotation after it, so it needs the same
+		// wrapping. `[...A | B]` names a rest of the union, not a union of the rest.
+		{"rest spread in union", "[(...A) | B]", "[(...A) | B]"},
+		{"rest spread of union", "[...A | B]", "[...A | B]"},
+		// A conditional type ends in a closing brace, so nothing can pull it apart and it
+		// stays bare in either position.
+		{"conditional type in union", "A | if B : C { D } else { E }", "A | if B : C { D } else { E }"},
+		// A prefix takes the whole annotation that follows it, so `keyof A | B` reads as
+		// `(keyof A) | B` and an infix operand has to be wrapped.
+		{"union under keyof", "keyof (A | B)", "keyof (A | B)"},
+		{"keyof in union", "keyof A | B", "keyof A | B"},
+		{"union under mut", "mut (A | B)", "mut (A | B)"},
+		{"function type under keyof", "keyof fn () -> A", "keyof fn () -> A"},
+		// An indexed access reads from a target that binds as tightly as a type
+		// reference, so anything carrying an operator has to be wrapped.
+		{"union as index target", "(A | B)[C]", "(A | B)[C]"},
+		{"keyof as index target", "(keyof A)[B]", "(keyof A)[B]"},
+		{"index chain", "A[B][C]", "A[B][C]"},
+	}
+
+	opts := DefaultOptions()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typeAnn := parseTypeAnn(t, tt.input)
+			result, err := Print(typeAnn, opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+
+			reparsed, err := Print(parseTypeAnn(t, result), opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, reparsed)
+		})
+	}
+}
+
 func TestPrintFunctionExpressions(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fixes #1039.

Second of three stacked PRs. Based on #1048, which fixes the same two gaps in `internal/codegen/printer.go`. Review the top commit only; the diff against `main` includes #1048's work. #1050 builds on this one.

## Receivers

`printCallExpr`, `printIndexExpr`, and `printMemberExpr` printed their receiver through a plain `printExpr`, so reprinting a file changed what it meant:

| source | printed |
| --- | --- |
| `(a + b).c` | `a + b.c` |
| `(a + b)[c]` | `a + b[c]` |
| `(a + b)(c)` | `a + b(c)` |
| `(-a).c` | `-a.c` |

A new `printReceiver` wraps the forms that cannot survive that position:

- A prefix form such as `-a`, `&a`, `await a`, or `a: number`, which binds looser than the `.`, `[`, or `(` after it.
- A form ending in a block such as `if`, `match`, `do`, or a function expression, which would swallow the receiver into the block.
- A number literal. `(5).toFixed()` printed bare lexes as the number `5.` followed by the identifier `toFixed`, and reparses to just `5` — the member access and the call are dropped silently. `5.0.toFixed(2)` had the same fate.

The tagged-template tag reads from the same position, so it goes through the same helper. A string or boolean literal has no such reading and stays bare.

## Type annotations

`typeAnnString`'s intersection case joined its members with `" & "` and no grouping, so `(number | string) & boolean` and `number | (string & boolean)` shared one rendering — the second of the two.

Type annotations get a precedence scale matching the one #1048 adds to codegen, adapted to Escalier's surface syntax. `typeAnnPrecedence` ranks the operators whose grouping the syntax can change, and `printTypeAnnAt` wraps a member that binds looser than its position. Alongside the union-in-intersection case the issue names, three more were found by reviewing the first cut:

- A function type or a rest spread inside a union or an intersection. Each reaches as far right as the syntax allows, so `(fn () -> A) | B` printed bare comes back as `fn () -> A | B`, a function returning a union.
- A union or an intersection as a `keyof` or `mut` operand, since `keyof A | B` reads as `(keyof A) | B`.
- Anything carrying an operator as an indexed-access target, since `(keyof A)[B]` printed bare reads as `keyof (A[B])`.

Escalier's conditional type ends in a closing brace, so nothing can pull it apart and it stays bare in every position. That is where this scale departs from the TypeScript one in #1048, where a conditional type is open-ended and has to be wrapped.

A prefix takes the whole annotation that follows it, so only the two infix operators need wrapping in prefix position. `keyof fn () -> A` already reads the way the tree holds it and keeps no parentheses.

## Tests

`TestPrintReceiverGrouping` and `TestPrintTypeAnnGrouping` are new. Both reparse the printed form and assert it renders the same way, which it cannot do if the print dropped a grouping the tree depends on. Each table includes the positions that correctly stay bare — arguments, indices, tuple elements, and an intersection inside a union.

## Verification

`go test ./...` is green with no snapshot or fixture churn, which is the check that this changes only the trees that were being misrendered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGBVtB9psbR42akV73sNUg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of complex expressions and type annotations by adding parentheses where needed.
  * Prevented ambiguous output and preserved correct parsing for calls, indexing, member access, tagged templates, unions, intersections, and related syntax.

* **Tests**
  * Added coverage for grouping behavior and verified that formatted output remains stable when parsed and printed again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->