### PR TITLE
Extract type grounding logic into reusable helpers

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -41,6 +41,33 @@ func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	return coalesceKeeping(t, pol, funcTypeParamVars(t), nil)
 }
 
+// groundedCarrier reports the shape of t, looking through any borrow and resolving t if it is
+// still an inference variable. That shape is what a type switch needs before it can dispatch
+// on t. A borrow is peeled, so `&xs` grounds to the shape of `xs`. An unsolved variable is
+// coalesced to the union of its lower bounds, and that union is peeled in turn.
+//
+// When a caller grounds a type is a decision of its own. Coalescing reads the variable's
+// bounds as they stand, and testing a literal against that variable adds the literal as a
+// further lower bound. A caller that inspects one scrutinee across several branches must
+// ground it once, before any branch binds. Grounding it again later reads the tested literal
+// back as a union member the user never wrote. inferMatch and newPathBinder ground up front
+// for that reason.
+func groundedCarrier(t soltype.Type) soltype.Type {
+	t = soltype.CarrierOf(t)
+	if carrierIsVar(t) {
+		t = soltype.CarrierOf(coalesce(t, soltype.Positive))
+	}
+	return t
+}
+
+// carrierIsVar reports whether t is an inference variable the solve has not shaped, looking
+// through a borrow so a `&x` over an unsolved `x` reports true. A caller that must keep the
+// borrow on the type it inspects asks this rather than calling groundedCarrier, which peels.
+func carrierIsVar(t soltype.Type) bool {
+	_, isVar := soltype.CarrierOf(t).(*soltype.TypeVarType)
+	return isVar
+}
+
 // coalesceKeeping is coalesce with a set of variables held symbolic rather than inlined to
 // their bounds, plus a kept-flow map naming the kept vars that flow into each other var
 // through the upper-bound graph. It is the generic-class analogue of coalesce: a class

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2050,7 +2050,7 @@ func (c *checker) mutFieldRead(lvl int, blame ast.Node, provNode ast.Node, name 
 			}
 		}
 	}
-	if _, isVar := soltype.CarrierOf(recv).(*soltype.TypeVarType); !isVar {
+	if !carrierIsVar(recv) {
 		// Concrete receiver: a plain read composes the chain correctly.
 		return c.valueProp(lvl, blame, provNode, name, recv).value
 	}
@@ -2895,8 +2895,7 @@ func (c *checker) inferYield(scope *Scope, lvl int, e *ast.YieldExpr) soltype.Ty
 // read one. A failed delegate is the ErrorType placeholder, not a variable, so it is
 // excluded and keeps absorbing.
 func (c *checker) delegateIsUnsolved(t soltype.Type) bool {
-	_, isVar := soltype.CarrierOf(t).(*soltype.TypeVarType)
-	return isVar
+	return carrierIsVar(t)
 }
 
 // delegateElemType resolves what a `yield from` delegate hands back:
@@ -2915,12 +2914,7 @@ func (c *checker) delegateIsUnsolved(t soltype.Type) bool {
 // branch is live, so the Next results meet instead. Branches with no Next slot put no
 // requirement on the delegator and drop out of that meet.
 func (c *checker) delegateElemType(t soltype.Type) (soltype.Type, soltype.Type, soltype.Type, bool) {
-	carrier := soltype.CarrierOf(t)
-	// An inference-variable delegate is coalesced to its structural lower-bound shape,
-	// the same snapshot syncElemType takes before inspecting a variable operand.
-	if _, isVar := carrier.(*soltype.TypeVarType); isVar {
-		carrier = soltype.CarrierOf(coalesce(carrier, soltype.Positive))
-	}
+	carrier := groundedCarrier(t)
 	if u, isUnion := carrier.(*soltype.UnionType); isUnion {
 		// syncElemType walks a union too, but reports only element types. Recursing here
 		// keeps each branch's Ret slot and lets an async branch through under the same
@@ -3157,9 +3151,12 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	scrutinee := c.inferExpr(scope, lvl, e.Target)
 	// Snapshot the scrutinee for the exhaustiveness check before any arm binds. A
 	// literal pattern adds its literal as a lower bound, which would otherwise leak
-	// a phantom member into the coalesced union read after the arm loop.
+	// a phantom member into the coalesced union read after the arm loop. The borrow
+	// stays on the snapshot rather than being peeled the way groundedCarrier peels
+	// one. narrowMatchArm unwraps the shape itself and re-wraps the narrowed carrier
+	// under the same borrow.
 	matchShape := scrutinee
-	if _, isVar := soltype.CarrierOf(scrutinee).(*soltype.TypeVarType); isVar {
+	if carrierIsVar(scrutinee) {
 		matchShape = coalesce(scrutinee, soltype.Positive)
 	}
 	res := c.freshAt(lvl)

--- a/internal/solver/infer_for_in.go
+++ b/internal/solver/infer_for_in.go
@@ -105,10 +105,7 @@ func (c *checker) constrainIterationRaise(site ast.Expr, t soltype.Type, lvl int
 // is peeled and an inference variable coalesced first, the same normalization the
 // element-type walk applies.
 func (c *checker) iterationRaise(t soltype.Type) (soltype.Type, bool) {
-	t = soltype.CarrierOf(t)
-	if _, isVar := t.(*soltype.TypeVarType); isVar {
-		t = soltype.CarrierOf(coalesce(t, soltype.Positive))
-	}
+	t = groundedCarrier(t)
 	switch t := t.(type) {
 	case *soltype.GeneratorType:
 		if !t.Raises() {
@@ -155,10 +152,7 @@ func (c *checker) iterableElemType(await bool, t soltype.Type) (soltype.Type, bo
 // failing when any branch is not async-iterable. A sync generator is not an
 // AsyncIterable, and neither is a tuple, so both are rejected here.
 func (c *checker) asyncElemType(t soltype.Type) (soltype.Type, bool) {
-	t = soltype.CarrierOf(t)
-	if _, isVar := t.(*soltype.TypeVarType); isVar {
-		t = soltype.CarrierOf(coalesce(t, soltype.Positive))
-	}
+	t = groundedCarrier(t)
 	switch t := t.(type) {
 	case *soltype.GeneratorType:
 		if !t.Async {
@@ -196,10 +190,7 @@ func (c *checker) asyncElemType(t soltype.Type) (soltype.Type, bool) {
 // `number | ...` rather than a bare `number`. The precise type of the tail needs
 // the Array<T> the tuple approximates, which lands in M7.
 func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
-	t = soltype.CarrierOf(t)
-	if _, isVar := t.(*soltype.TypeVarType); isVar {
-		t = soltype.CarrierOf(coalesce(t, soltype.Positive))
-	}
+	t = groundedCarrier(t)
 	switch t := t.(type) {
 	case *soltype.GeneratorType:
 		// A sync generator iterates its yields. An async one needs a `for await`, whose

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -417,7 +417,7 @@ func (c *checker) restTupleShape(scrutinee soltype.Type, scrutTup, concreteTup *
 	if _, isVar := scrutinee.(*soltype.TypeVarType); !isVar {
 		return nil, false
 	}
-	return c.groundedTuple(soltype.CarrierOf(coalesce(scrutinee, soltype.Positive)))
+	return c.groundedTuple(groundedCarrier(scrutinee))
 }
 
 // groundedTuple splices every `...P` spread into position so elements can be read by index,
@@ -512,7 +512,7 @@ func (c *checker) restObjectShape(scrutinee, concrete soltype.Type) (*soltype.Ob
 	if _, isVar := scrutinee.(*soltype.TypeVarType); !isVar {
 		return nil, false
 	}
-	return eval.groundToObject(soltype.CarrierOf(coalesce(scrutinee, soltype.Positive)))
+	return eval.groundToObject(groundedCarrier(scrutinee))
 }
 
 // bindInstancePat types a class-instance pattern `Name { x, y }`: it narrows the scrutinee

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -114,15 +114,12 @@ type pathBinder struct {
 func (c *checker) newPathBinder(lvl int, blame ast.Node, root *ucs.Scrutinee, rootType soltype.Type) *pathBinder {
 	b := &pathBinder{c: c, lvl: lvl, blame: blame, views: map[*ucs.Scrutinee]scrutineeView{}}
 	carrier := soltype.CarrierOf(rootType)
-	shape := carrier
-	if _, isVar := carrier.(*soltype.TypeVarType); isVar {
-		// Snapshot the scrutinee's union structure before any branch binds. A literal test
-		// adds its literal as a lower bound on the scrutinee variable, so coalescing again
-		// under a later branch would read that literal back as an extra union member and
-		// narrow against a member the user never wrote. inferMatch takes the same snapshot
-		// for the same reason.
-		shape = soltype.CarrierOf(coalesce(rootType, soltype.Positive))
-	}
+	// Snapshot the scrutinee's union structure before any branch binds. A literal test
+	// adds its literal as a lower bound on the scrutinee variable, so grounding again
+	// under a later branch would read that literal back as an extra union member and
+	// narrow against a member the user never wrote. inferMatch takes the same snapshot
+	// for the same reason.
+	shape := groundedCarrier(carrier)
 	b.views[root] = scrutineeView{
 		ty:       carrier,
 		concrete: carrier,
@@ -352,9 +349,12 @@ func (b *pathBinder) applyTest(scope *Scope, node ast.Node, v scrutineeView, tes
 // pattern, and it keeps that function's rules so PR6 inherits variant-narrowing
 // unchanged.
 func (b *pathBinder) narrowUnion(v scrutineeView, test ucs.Test) scrutineeView {
+	// A borrowed shape is left wrapped rather than peeled the way groundedCarrier peels
+	// one. The narrowed result below replaces v.ty and v.concrete, and nothing here
+	// rewraps it, so peeling first would drop the borrow off a nested scrutinee.
 	shape := v.shape
 	if _, isVar := shape.(*soltype.TypeVarType); isVar {
-		shape = soltype.CarrierOf(coalesce(shape, soltype.Positive))
+		shape = groundedCarrier(shape)
 	}
 	narrowed, ok := narrowUnionMembers(shape, func(member soltype.Type) bool {
 		return testMatchesMemberShape(test, member)


### PR DESCRIPTION
This refactoring extracts the pattern of resolving inference variables through coalescing into two new helper functions: `groundedCarrier` and `carrierIsVar`. These helpers eliminate duplication across the solver and make the intent clearer at call sites.

**Key changes:**

- Added `groundedCarrier(t)` to resolve a type by peeling borrows and coalescing unsolved variables to their structural lower bounds. This is the snapshot operation needed before inspecting a variable's shape across multiple branches.
- Added `carrierIsVar(t)` to test whether a type (looking through borrows) is an unsolved inference variable, without resolving it.
- Replaced six instances of the inline pattern `soltype.CarrierOf(t)` followed by a type assertion and conditional coalesce with calls to `groundedCarrier`.
- Replaced three instances of the inline type-assertion pattern with calls to `carrierIsVar`.
- Updated comments in `newPathBinder`, `narrowUnion`, and `inferMatch` to clarify the grounding semantics and why the borrow is preserved on snapshots rather than peeled.

The changes consolidate logic used in `ucs_bind.go`, `infer_expr.go`, `infer_for_in.go`, and `pattern.go`, making the codebase easier to maintain and the grounding behavior more consistent.

https://claude.ai/code/session_01U6R4Y7ySKoWNQDcWxKCEhW