### PR TITLE
Flatten nested patterns into separate tag-level splits

### DIFF
--- a/internal/solver/ucs/helpers_test.go
+++ b/internal/solver/ucs/helpers_test.go
@@ -46,6 +46,22 @@ func objPat(keys ...string) *ast.ObjectPat {
 	return ast.NewObjectPat(elems, ast.Span{})
 }
 
+// fieldPat builds `{key: value}`, an object pattern of one named field whose value is a
+// sub-pattern.
+func fieldPat(key string, value ast.Pat) *ast.ObjectPat {
+	return ast.NewObjectPat([]ast.ObjPatElem{keyValueElem(key, value)}, ast.Span{})
+}
+
+// tuplePat builds a tuple pattern of the given elements, the `[a, b]` form.
+func tuplePat(elems ...ast.Pat) *ast.TuplePat {
+	return ast.NewTuplePat(elems, ast.Span{})
+}
+
+// instancePat builds `Name { … }`, the pattern that tests a nominal class tag.
+func instancePat(name string, object *ast.ObjectPat) *ast.InstancePat {
+	return ast.NewInstancePat(ast.NewIdentifier(name, ast.Span{}), object, ast.Span{})
+}
+
 func identPat(name string) *ast.IdentPat {
 	return ast.NewIdentPat(name, false, nil, nil, ast.Span{})
 }

--- a/internal/solver/ucs/norm.go
+++ b/internal/solver/ucs/norm.go
@@ -65,9 +65,9 @@ type NormGuard struct {
 // `p.y`.
 type NormBind struct {
 	// Name is the bound identifier. It is empty when the bind names no identifier,
-	// which is how a sub-pattern normalization has not flattened into a split of its
-	// own is held: `{start: {x, y}}` keeps `{x, y}` whole as a nameless bind on the
-	// projection `p.start`.
+	// which is how a pattern that makes no tag test of its own is held. A bare rest is
+	// the only one left after flattening, since every other sub-pattern becomes a split
+	// over the projection it matches.
 	Name string
 	// Pat is the pattern leaf the name came from, which the solver binds through so
 	// the leaf keeps its annotation and its borrow mode. It is nil for a name the

--- a/internal/solver/ucs/normalize.go
+++ b/internal/solver/ucs/normalize.go
@@ -5,41 +5,33 @@ import "github.com/escalier-lang/escalier/internal/set"
 // Normalize rewrites a desugared core term into the normalized form. Three rewrites
 // happen here.
 //
-// The first is merging. Every branch of one core split tests the same scrutinee, so
-// all of them become branches of a single normalized split rather than a chain of
-// one-branch splits. A consumer then visits each scrutinee once.
+// Merging. Every branch of one core split tests the same scrutinee, so all of them become
+// branches of a single normalized split and a consumer visits each scrutinee once.
 //
-// The second is the tail. A core branch relies on the branches after it to say where
-// a failed match continues, which is backtracking. Normalization names that
-// continuation outright: a split's Default is what runs when no branch's test matches,
-// and a guard's Default is what runs when its condition is false. Nothing retries a
-// branch above it.
+// The tail. A core branch relies on the branches after it to say where a failed match
+// continues, which is backtracking. Normalization names that continuation outright. A
+// split's Default runs when no branch's test matches, a guard's Default runs when its
+// condition is false, and nothing retries a branch above it.
 //
-// The third is flattening. A core branch keeps its arm's pattern whole, nesting and all.
-// Normalization reads one tag-level off it and turns each sub-pattern below that level
-// into a split over the projection it matches, recursing to whatever depth the pattern
-// has. `Line { start: {x, y} }` becomes a split on `l` testing `Line`, then a split on
-// `l.start` testing `{x, y}`, then binds of `l.start.x` and `l.start.y`. A consumer
-// therefore never sees more than one tag-level at a time. A projected split fails the
-// same way the branch's guard does, into the branch's fallthrough, so flattening adds no
-// backtracking.
+// Flattening. A core branch keeps its arm's pattern whole, nesting and all. Normalization
+// reads one tag-level off it and turns each sub-pattern below that level into a split over
+// the projection it matches, to whatever depth the pattern has. `Line { start: {x, y} }`
+// becomes a split on `l` testing `Line`, then one on `l.start` testing `{x, y}`, then binds
+// of `l.start.x` and `l.start.y`. A projected split fails into the branch's fallthrough,
+// where a failed guard also goes, so flattening adds no backtracking.
 //
-// When two branches nest under one tag, their projected splits chain rather than merging
-// into a single split. In `{a: {x}} => …, {a: [y]} => …` the first branch's `{a}` already
-// proves the second's, so the first falls into a second split over `p.a` instead of both
-// sub-patterns becoming branches of one. Neither split is specialized against the other
-// either, so a chain can re-test a tag it has already decided. `{x: 1} if g => a,
-// {x: 1} => b` tests `p.x` against 1 a second time when the guard fails. Specializing
-// across tag-levels is a rewrite this stage does not make.
+// Two branches that nest under one tag chain rather than merging into a single projected
+// split, and nothing specializes one projected split against another, so a chain can
+// re-test a tag it has already decided. `{x: 1} if g => a, {x: 1} => b` tests `p.x` against
+// 1 a second time when the guard fails.
 func Normalize(c Core) Norm {
 	return normalizeTerm(c, nil)
 }
 
-// normalizeTerm rewrites one core term. next is where control goes when the term fails
-// to reach a leaf, which is what a guard falls back to. It is nil when nothing covers
-// the failure, and the printer renders that as `✗`. A leaf cannot fail, so it ignores
-// next and is returned as-is: normalization rewrites the splits around a leaf and
-// leaves the leaf itself alone, which is why the same node ends up in both IRs.
+// normalizeTerm rewrites one core term. next is where control goes when the term fails to
+// reach a leaf, which is what a guard falls back to. It is nil when nothing covers the
+// failure, and the printer renders that as `✗`. A leaf cannot fail, so it ignores next and
+// is returned as-is, which is why the same node ends up in both IRs.
 func normalizeTerm(c Core, next Norm) Norm {
 	switch n := c.(type) {
 	case nil:
@@ -74,9 +66,8 @@ func normalizeTerm(c Core, next Norm) Norm {
 func normalizeSplit(s *CoreSplit, next Norm) Norm {
 	tail := next
 	if s.Else != nil {
-		// next is not dropped here. It becomes the `else`'s own failure continuation. A
-		// leaf `else` cannot fail and ignores it, which is what an `if val` and a
-		// `val … else` both write. A guard or a nested split `else` falls into it.
+		// next is not dropped. It becomes the `else`'s own failure continuation, which a
+		// leaf `else` ignores and a guard or nested split `else` falls into.
 		tail = normalizeTerm(s.Else, next)
 	}
 
@@ -101,10 +92,9 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 		inlined:   set.NewSet[int](),
 		reads:     reads,
 	}
-	// A core split always becomes a split, even when no branch is left to test, because
-	// the split is what names the scrutinee. Collapsing `match f() { _ => 1 }` to its
-	// leaf would drop the only mention of `f()`, and a consumer walking the IR would
-	// never evaluate the call.
+	// A core split always becomes a split, even with no branch left to test, because the
+	// split is what names the scrutinee. Collapsing `match f() { _ => 1 }` to its leaf
+	// would drop the only mention of `f()`, and nothing walking the IR would run the call.
 	branches, dflt := b.build(cands)
 	return &NormSplit{
 		Scrutinee: s.Scrutinee,
@@ -114,25 +104,23 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 	}
 }
 
-// candidate is a core branch paired with what normalization derived from its pattern:
-// the one tag-level test it makes and the leaves it binds. Deriving them once means a
-// branch that appears both in the split and in an earlier branch's fallthrough is
-// analyzed a single time. The projections memo does the same for the sub-patterns below
-// that tag, which are read as each copy of the branch is built.
+// candidate is a core branch paired with what normalization derived from its pattern: the
+// one tag-level test it makes and the leaves it binds. Deriving them once means a branch
+// that appears both in the split and in an earlier branch's fallthrough is analyzed a
+// single time, and the projections memo does the same for the sub-patterns below its tag.
 type candidate struct {
 	// index is the branch's position in the core split, which identifies it while
 	// building. Two candidate lists holding the same branches build the same term.
 	index  int
 	branch *CoreBranch
-	// test is the tag the branch tests, and nil when the branch runs
-	// unconditionally. A catch-all pattern has no tag, and specialize also clears the
-	// test of a branch an already-matched test guarantees.
+	// test is the tag the branch tests, and nil when the branch runs unconditionally. A
+	// catch-all pattern has no tag, and specialize also clears the test of a branch an
+	// already-matched test guarantees.
 	test  Test
 	binds []bindSpec
 	// nested marks a branch whose pattern nests below the tag-level its test names. In
-	// `{x: 1}` the test names the key `x` and a split over `p.x` matches the literal
-	// `1`, so passing the test does not mean the branch matched. Such a branch needs a
-	// fallthrough, since a value that reaches it can still end up in the arms below.
+	// `{x: 1}` a split over `p.x` matches the literal, so passing the `{x}` test does not
+	// mean the branch matched, and the branch needs a fallthrough.
 	nested bool
 }
 
@@ -144,34 +132,29 @@ type splitBuilder struct {
 	tail      Norm
 	origin    Origin
 	// built caches the fallthrough term for a set of candidates. A branch that can fail
-	// falls into the branches after it, so without the cache a run of such branches
-	// would rebuild overlapping subsets over and over. Each cached term is also shared
-	// rather than duplicated, so a consumer that walks the IR visits it once.
+	// falls into the branches after it, so without the cache a run of such branches would
+	// rebuild overlapping subsets. Each cached term is shared rather than duplicated, so a
+	// consumer that walks the IR visits it once.
 	//
-	// A branch's own continuation is not shared with the copy of it inside an earlier
-	// branch's fallthrough, because the two are reached under different specializations
-	// and need not be the same term. In `{a: 1} => …, {b: 2} => …, _ => …` the second
-	// arm is built once for its branch of the split and once inside the first arm's
-	// fallthrough, so a run of arms that can fail costs nodes with the square of its
-	// length. A run of arms testing one tag does not pay it, since their tests clear and
-	// their branches drop. A match short enough for a person to read keeps the squared
-	// count small either way.
+	// A branch's own continuation is not shared with the copy inside an earlier branch's
+	// fallthrough, since the two are reached under different specializations. A run of
+	// arms that can fail therefore costs nodes with the square of its length, which stays
+	// small for a match short enough to read.
 	built map[string]Norm
-	// reads memoizes the tag-level read of each sub-pattern below the branches' own
-	// tags, so the copies this rewrite makes of a branch name one *Scrutinee per path
-	// rather than one per copy.
+	// reads memoizes the tag-level read of each sub-pattern below the branches' own tags,
+	// so the copies this rewrite makes of a branch name one *Scrutinee per path.
 	reads projections
-	// inlined holds the index of every candidate whose continuation an already-built
-	// term runs unconditionally, which is what specializing a fallthrough does to a
-	// branch the matched test proved. A branch for one of those is a duplicate this
-	// rewrite introduced, and build drops it rather than emit a test that cannot pass.
+	// inlined holds the index of every candidate whose continuation an already-built term
+	// runs unconditionally, which is what specializing a fallthrough does to a branch the
+	// matched test proved. A branch for one of those is a duplicate this rewrite
+	// introduced, and build drops it rather than emit a test that cannot pass.
 	inlined set.Set[int]
 }
 
-// term is what a branch continues into when its own continuation fails. Unlike the
-// split the whole core split becomes, it collapses to the unconditional continuation
-// when no candidate is left to test. The scrutinee the collapsed split would have named
-// is already evaluated by the split this term sits inside, so nothing is lost.
+// term is what a branch continues into when its own continuation fails. Unlike the split
+// the whole core split becomes, it collapses to the unconditional continuation when no
+// candidate is left to test. The split this term sits inside already evaluated the
+// scrutinee the collapsed one would have named, so nothing is lost.
 func (b *splitBuilder) term(cands []candidate) Norm {
 	if len(cands) == 0 {
 		return b.tail
@@ -202,25 +185,20 @@ func (b *splitBuilder) build(cands []candidate) ([]*NormBranch, Norm) {
 	dflt := b.tail
 	for i, cand := range cands {
 		if cand.test != nil && b.inlined.Contains(cand.index) && capturedBy(cands[:i], cand.test) {
-			// An earlier branch's fallthrough already runs this branch's continuation,
-			// and an earlier test already captured every value this one would match, so
-			// nothing can reach the branch. Emitting it would cost a test that always
-			// fails and a second copy of the arm's binds and body.
+			// An earlier branch's fallthrough already runs this branch's continuation, and
+			// an earlier test captured every value this one would match, so nothing reaches
+			// the branch. capturedBy is what makes the drop sound rather than a guess, and
+			// it keeps the drop correct if testImplies ever holds between unequal tags.
 			//
-			// capturedBy is what makes the drop sound rather than a guess. It is not
-			// separately observable while testImplies holds only between equal tags,
-			// since an inlined candidate is then always captured too, and it is what
-			// keeps the drop correct if that relation ever becomes one-directional.
-			//
-			// A branch nothing inlined is left alone even when it is unreachable. That
-			// is an arm the user wrote dead rather than one this rewrite duplicated, and
+			// A branch nothing inlined is left alone even when it is unreachable. That is
+			// an arm the user wrote dead rather than one this rewrite duplicated, and
 			// dropping it would leave the coverage check nothing to report.
 			continue
 		}
 		// Only a branch that can fail needs to name where it continues. An unguarded arm
-		// whose pattern nests no further ends in a leaf, so it never falls through and
-		// the fallthrough would be dead weight. Nesting is the other way a branch fails:
-		// the tag test passes and a split over a projection below it does not match.
+		// whose pattern nests no further ends in a leaf, so the fallthrough would be dead
+		// weight. Nesting is the other way a branch fails, when the tag test passes and a
+		// split over a projection below it matches nothing.
 		var fallthru Norm
 		if cand.nested || mayFall(cand.branch.Cont) {
 			fallthru = b.term(specialize(cands[i+1:], cand.test))
@@ -228,12 +206,10 @@ func (b *splitBuilder) build(cands []candidate) ([]*NormBranch, Norm) {
 		nest := binder{fallthru: fallthru, arm: cand.branch.Arm, reads: b.reads}
 		cont := nest.wrap(cand.binds, normalizeTerm(cand.branch.Cont, fallthru))
 		if cand.test == nil {
-			// The branch makes no test, so control reaches it whenever it reaches the
-			// split at all and it becomes the split's tail. A candidate after it is
-			// reachable only through this one's fallthrough, which is where a failed
-			// guard and an unmatched sub-pattern both continue. Recording it is what lets
-			// an outer branch for the same candidate be dropped, since this term already
-			// runs its continuation.
+			// The branch makes no test, so it runs whenever control reaches the split and
+			// it becomes the tail. A candidate after it is reachable only through this
+			// one's fallthrough. Recording it is what lets an outer branch for the same
+			// candidate be dropped, since this term already runs its continuation.
 			dflt = cont
 			b.inlined.Add(cand.index)
 			break
@@ -249,11 +225,9 @@ func (b *splitBuilder) build(cands []candidate) ([]*NormBranch, Norm) {
 }
 
 // mayFall reports whether a core term can finish without reaching a leaf, so the branch
-// holding it needs a fallthrough. A guard fails when its condition is false. A nested
-// split may match none of its branches. A leaf always produces a value.
-//
-// Answering true when the term in fact always reaches a leaf costs a fallthrough that
-// nothing reads, so the conservative answer for a nested split is safe.
+// holding it needs a fallthrough. A guard fails when its condition is false, a nested split
+// may match none of its branches, and a leaf always produces a value. Answering true when
+// the term in fact always reaches a leaf only costs a fallthrough nothing reads.
 func mayFall(c Core) bool {
 	switch n := c.(type) {
 	case *CoreGuard:

--- a/internal/solver/ucs/normalize.go
+++ b/internal/solver/ucs/normalize.go
@@ -2,7 +2,7 @@ package ucs
 
 import "github.com/escalier-lang/escalier/internal/set"
 
-// Normalize rewrites a desugared core term into the normalized form. Two rewrites
+// Normalize rewrites a desugared core term into the normalized form. Three rewrites
 // happen here.
 //
 // The first is merging. Every branch of one core split tests the same scrutinee, so
@@ -15,13 +15,22 @@ import "github.com/escalier-lang/escalier/internal/set"
 // and a guard's Default is what runs when its condition is false. Nothing retries a
 // branch above it.
 //
-// A nested sub-pattern is left whole. Its branch keeps it as a NormBind with no name,
-// which says "still to be matched against this projection". Flattening those into splits
-// of their own is the next stage of the rewrite, the one the nested-pattern section of
-// planning/ucs/implementation_plan.md describes. So the form is backtracking-free for a
-// flat match and not yet for a nested one. A nameless bind names no continuation for the
-// case where its sub-pattern does not match, and there is nowhere to put one. The split
-// that flattening puts in its place is what carries that default.
+// The third is flattening. A core branch keeps its arm's pattern whole, nesting and all.
+// Normalization reads one tag-level off it and turns each sub-pattern below that level
+// into a split over the projection it matches, recursing to whatever depth the pattern
+// has. `Line { start: {x, y} }` becomes a split on `l` testing `Line`, then a split on
+// `l.start` testing `{x, y}`, then binds of `l.start.x` and `l.start.y`. A consumer
+// therefore never sees more than one tag-level at a time. A projected split fails the
+// same way the branch's guard does, into the branch's fallthrough, so flattening adds no
+// backtracking.
+//
+// When two branches nest under one tag, their projected splits chain rather than merging
+// into a single split. In `{a: {x}} => …, {a: [y]} => …` the first branch's `{a}` already
+// proves the second's, so the first falls into a second split over `p.a` instead of both
+// sub-patterns becoming branches of one. Neither split is specialized against the other
+// either, so a chain can re-test a tag it has already decided. `{x: 1} if g => a,
+// {x: 1} => b` tests `p.x` against 1 a second time when the guard fails. Specializing
+// across tag-levels is a rewrite this stage does not make.
 func Normalize(c Core) Norm {
 	return normalizeTerm(c, nil)
 }
@@ -71,6 +80,7 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 		tail = normalizeTerm(s.Else, next)
 	}
 
+	reads := projections{}
 	cands := make([]candidate, len(s.Branches))
 	for i, branch := range s.Branches {
 		test, binds := shallowTest(branch.Pattern, s.Scrutinee, branch.Origin)
@@ -79,7 +89,7 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 			branch: branch,
 			test:   test,
 			binds:  binds,
-			nested: hasUnflattenedBind(binds),
+			nested: reads.hasSplit(binds),
 		}
 	}
 
@@ -89,6 +99,7 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 		origin:    s.Origin,
 		built:     map[string]Norm{},
 		inlined:   set.NewSet[int](),
+		reads:     reads,
 	}
 	// A core split always becomes a split, even when no branch is left to test, because
 	// the split is what names the scrutinee. Collapsing `match f() { _ => 1 }` to its
@@ -106,7 +117,8 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 // candidate is a core branch paired with what normalization derived from its pattern:
 // the one tag-level test it makes and the leaves it binds. Deriving them once means a
 // branch that appears both in the split and in an earlier branch's fallthrough is
-// analyzed a single time.
+// analyzed a single time. The projections memo does the same for the sub-patterns below
+// that tag, which are read as each copy of the branch is built.
 type candidate struct {
 	// index is the branch's position in the core split, which identifies it while
 	// building. Two candidate lists holding the same branches build the same term.
@@ -117,11 +129,10 @@ type candidate struct {
 	// test of a branch an already-matched test guarantees.
 	test  Test
 	binds []bindSpec
-	// nested marks a branch holding a sub-pattern this stage does not flatten, which is
-	// matching the tag test does not account for. In `{x: 1}` the test names the key
-	// `x` and the literal `1` rides a nameless bind, so passing the test does not mean
-	// the branch matched. Such a branch is never made unconditional: a value that
-	// reaches it can still fall through to the arms below.
+	// nested marks a branch whose pattern nests below the tag-level its test names. In
+	// `{x: 1}` the test names the key `x` and a split over `p.x` matches the literal
+	// `1`, so passing the test does not mean the branch matched. Such a branch needs a
+	// fallthrough, since a value that reaches it can still end up in the arms below.
 	nested bool
 }
 
@@ -132,11 +143,24 @@ type splitBuilder struct {
 	scrutinee *Scrutinee
 	tail      Norm
 	origin    Origin
-	// built caches the fallthrough term for a set of candidates. A guarded branch falls
-	// into the branches after it, so without the cache a run of guarded branches would
-	// rebuild overlapping subsets over and over. Each cached term is also shared rather
-	// than duplicated, so a consumer that walks the IR visits it once.
+	// built caches the fallthrough term for a set of candidates. A branch that can fail
+	// falls into the branches after it, so without the cache a run of such branches
+	// would rebuild overlapping subsets over and over. Each cached term is also shared
+	// rather than duplicated, so a consumer that walks the IR visits it once.
+	//
+	// A branch's own continuation is not shared with the copy of it inside an earlier
+	// branch's fallthrough, because the two are reached under different specializations
+	// and need not be the same term. In `{a: 1} => …, {b: 2} => …, _ => …` the second
+	// arm is built once for its branch of the split and once inside the first arm's
+	// fallthrough, so a run of arms that can fail costs nodes with the square of its
+	// length. A run of arms testing one tag does not pay it, since their tests clear and
+	// their branches drop. A match short enough for a person to read keeps the squared
+	// count small either way.
 	built map[string]Norm
+	// reads memoizes the tag-level read of each sub-pattern below the branches' own
+	// tags, so the copies this rewrite makes of a branch name one *Scrutinee per path
+	// rather than one per copy.
+	reads projections
 	// inlined holds the index of every candidate whose continuation an already-built
 	// term runs unconditionally, which is what specializing a fallthrough does to a
 	// branch the matched test proved. A branch for one of those is a duplicate this
@@ -193,18 +217,23 @@ func (b *splitBuilder) build(cands []candidate) ([]*NormBranch, Norm) {
 			// dropping it would leave the coverage check nothing to report.
 			continue
 		}
-		// Only a branch whose continuation can fail needs to name where it continues.
-		// An unguarded arm ends in a leaf, so it never falls through and the
-		// fallthrough would be dead weight.
+		// Only a branch that can fail needs to name where it continues. An unguarded arm
+		// whose pattern nests no further ends in a leaf, so it never falls through and
+		// the fallthrough would be dead weight. Nesting is the other way a branch fails:
+		// the tag test passes and a split over a projection below it does not match.
 		var fallthru Norm
-		if mayFall(cand.branch.Cont) {
+		if cand.nested || mayFall(cand.branch.Cont) {
 			fallthru = b.term(specialize(cands[i+1:], cand.test))
 		}
-		cont := wrapBinds(cand.binds, normalizeTerm(cand.branch.Cont, fallthru))
+		nest := binder{fallthru: fallthru, arm: cand.branch.Arm, reads: b.reads}
+		cont := nest.wrap(cand.binds, normalizeTerm(cand.branch.Cont, fallthru))
 		if cand.test == nil {
-			// The branch always runs, so it is the split's tail and every candidate
-			// after it is unreachable. Recording it is what lets an outer branch for the
-			// same candidate be dropped, since this term already runs its continuation.
+			// The branch makes no test, so control reaches it whenever it reaches the
+			// split at all and it becomes the split's tail. A candidate after it is
+			// reachable only through this one's fallthrough, which is where a failed
+			// guard and an unmatched sub-pattern both continue. Recording it is what lets
+			// an outer branch for the same candidate be dropped, since this term already
+			// runs its continuation.
 			dflt = cont
 			b.inlined.Add(cand.index)
 			break

--- a/internal/solver/ucs/normalize_test.go
+++ b/internal/solver/ucs/normalize_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
 )
@@ -229,6 +230,262 @@ func TestNormalizeValElse(t *testing.T) {
 } default fallback { return }`))
 }
 
+// A nested pattern becomes one split per tag-level, each over the projection the level
+// above it matched. This is the second worked example in
+// planning/ucs/implementation_plan.md: `l` splits on the `Line` tag, then `l.start`
+// splits on the `{x, y}` shape, so nothing sees the deep shape at once.
+func TestNormalizeFlattensANestedObjectPattern(t *testing.T) {
+	start := objPat("x", "y")
+	core := coreMatch(
+		ident("l"),
+		matchCase(instancePat("Line", fieldPat("start", start)), nil, ident("body"), span(2, 5, 34)),
+	)
+
+	// Before normalization the arm's pattern is one deep shape:
+	//
+	//   split l {
+	//     pat Line {start: {x, y}} => leaf body
+	//   }
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split l {
+  Line => split l.start {
+    {x, y} => bind x = l.start.x, y = l.start.y; leaf body
+  } default ✗
+} default ✗`))
+
+	// The projection the inner split tests points at the sub-pattern it came from, so a
+	// message about that split blames the `{x, y}` the user wrote rather than the
+	// internal path `l.start`.
+	outer := Normalize(core).(*NormSplit)
+	inner := outer.Branches[0].Cont.(*NormSplit)
+	require.Same(t, start, inner.Scrutinee.Origin.Node)
+	require.Same(t, start, inner.Origin.Node)
+}
+
+// A tuple element flattens the same way a field does, splitting on the element the outer
+// test projected. The outer test counts the elements and says nothing about their shapes.
+func TestNormalizeFlattensANestedTuplePattern(t *testing.T) {
+	core := coreMatch(
+		ident("xs"),
+		matchCase(
+			tuplePat(tuplePat(identPat("a"), identPat("b")), identPat("c")),
+			nil, ident("a"), span(2, 5, 30),
+		),
+	)
+
+	// Before normalization:
+	//
+	//   split xs {
+	//     pat [[a, b], c] => leaf a
+	//   }
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split xs {
+  [_, _] => split xs.0 {
+    [_, _] => bind a = xs.0.0, b = xs.0.1, c = xs.1; leaf a
+  } default ✗
+} default ✗`))
+}
+
+// Flattening recurses to whatever depth the pattern has, one tag-level per split, and
+// each split names the projection the one above it matched.
+func TestNormalizeFlattensToArbitraryDepth(t *testing.T) {
+	core := coreMatch(
+		ident("p"),
+		matchCase(fieldPat("a", fieldPat("b", fieldPat("c", numPat(1)))), nil, str("deep"), span(2, 5, 32)),
+	)
+
+	// Before normalization:
+	//
+	//   split p {
+	//     pat {a: {b: {c: 1}}} => leaf "deep"
+	//   }
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
+  {a} => split p.a {
+    {b} => split p.a.b {
+      {c} => split p.a.b.c {
+        1 => leaf "deep"
+      } default ✗
+    } default ✗
+  } default ✗
+} default ✗`))
+}
+
+// A projected split fails into the branch's fallthrough, the same continuation a failed
+// guard takes, so flattening adds no backtracking. Here that is the arm below, and the
+// projected split and the outer split reach the same node rather than two copies of it.
+func TestNormalizeNestedSplitFallsToTheArmBelow(t *testing.T) {
+	core := coreMatch(
+		ident("p"),
+		matchCase(fieldPat("x", numPat(1)), nil, str("one"), span(2, 5, 22)),
+		matchCase(wildcardPat(), nil, str("other"), span(3, 5, 20)),
+	)
+
+	// Before normalization:
+	//
+	//   split p {
+	//     pat {x: 1} => leaf "one"
+	//     pat _ => leaf "other"
+	//   }
+	norm := Normalize(core)
+	snaps.MatchInlineSnapshot(t, Print(norm, DefaultPrintOptions()), snaps.Inline(`split p {
+  {x} => split p.x {
+    1 => leaf "one"
+  } default leaf "other"
+} default leaf "other"`))
+
+	outer := norm.(*NormSplit)
+	inner := outer.Branches[0].Cont.(*NormSplit)
+	require.Same(t, outer.Default, inner.Default)
+}
+
+// The names an arm binds sit under the splits its sub-patterns became, not over them. A
+// projected split's default runs the arm below, so a name in scope over that default
+// would put one arm's leaves in the scope of another arm's body.
+func TestNormalizeKeepsTheFallthroughOutOfTheArmsScope(t *testing.T) {
+	pattern := ast.NewObjectPat([]ast.ObjPatElem{
+		shorthandElem("x"),
+		keyValueElem("y", tuplePat(identPat("z"))),
+	}, ast.Span{})
+	core := coreMatch(
+		ident("p"),
+		matchCase(pattern, nil, str("one"), span(2, 5, 28)),
+		matchCase(wildcardPat(), nil, str("other"), span(3, 5, 20)),
+	)
+
+	// Before normalization:
+	//
+	//   split p {
+	//     pat {x, y: [z]} => leaf "one"
+	//     pat _ => leaf "other"
+	//   }
+	norm := Normalize(core)
+	snaps.MatchInlineSnapshot(t, Print(norm, DefaultPrintOptions()), snaps.Inline(`split p {
+  {x, y} => split p.y {
+    [_] => bind z = p.y.0, x = p.x; leaf "one"
+  } default leaf "other"
+} default leaf "other"`))
+
+	// `x` is named at the outer tag-level and still binds below the split over `p.y`,
+	// which is what keeps that split's default clear of it.
+	_, isSplit := norm.(*NormSplit).Branches[0].Cont.(*NormSplit)
+	require.True(t, isSplit, "the branch continues into a split rather than a bind")
+}
+
+// pathNodes collects the distinct *Scrutinee nodes a normalized term names, keyed by the
+// projection path each one renders to. seen keeps a term the rewrite shared from being
+// walked twice.
+func pathNodes(t Norm, seen set.Set[Norm], out map[string]set.Set[*Scrutinee]) {
+	if t == nil || seen.Contains(t) {
+		return
+	}
+	seen.Add(t)
+	add := func(s *Scrutinee) {
+		path := scrutineeString(s)
+		if _, found := out[path]; !found {
+			out[path] = set.NewSet[*Scrutinee]()
+		}
+		out[path].Add(s)
+	}
+	switch n := t.(type) {
+	case *NormSplit:
+		add(n.Scrutinee)
+		for _, branch := range n.Branches {
+			pathNodes(branch.Cont, seen, out)
+		}
+		pathNodes(n.Default, seen, out)
+	case *NormGuard:
+		pathNodes(n.Cont, seen, out)
+		pathNodes(n.Default, seen, out)
+	case *NormBind:
+		add(n.Source)
+		pathNodes(n.Cont, seen, out)
+	}
+}
+
+// Merging copies a branch, and each copy names the same projections. Every path is one
+// node across the copies, which is what lets a consumer evaluate `p.y` once and read the
+// split over it and the binds under it off that one value.
+func TestNormalizeNamesOneScrutineePerPath(t *testing.T) {
+	core := coreMatch(
+		ident("p"),
+		matchCase(fieldPat("x", numPat(1)), nil, str("first"), span(2, 5, 22)),
+		matchCase(fieldPat("y", objPat("z")), nil, str("second"), span(3, 5, 26)),
+		matchCase(wildcardPat(), nil, str("other"), span(4, 5, 20)),
+	)
+
+	// The second arm is built twice, once for its own branch of the split over `p` and
+	// once inside the first arm's fallthrough, so its projections are the ones a
+	// per-copy read would duplicate.
+	nodes := map[string]set.Set[*Scrutinee]{}
+	pathNodes(Normalize(core), set.NewSet[Norm](), nodes)
+
+	require.Contains(t, nodes, "p.y.z")
+	for path, found := range nodes {
+		require.Equal(t, 1, found.Len(), "the term names one scrutinee node for %s", path)
+	}
+}
+
+// Two arms whose patterns nest under the same tag chain rather than sharing one projected
+// split. The second arm's `{a}` is already proved, so the first arm falls straight into a
+// second split over `p.a`.
+func TestNormalizeChainsArmsThatNestUnderOneTag(t *testing.T) {
+	core := coreMatch(
+		ident("p"),
+		matchCase(fieldPat("a", objPat("x")), nil, str("obj"), span(2, 5, 26)),
+		matchCase(fieldPat("a", tuplePat(identPat("y"))), nil, str("tuple"), span(3, 5, 26)),
+	)
+
+	// Before normalization:
+	//
+	//   split p {
+	//     pat {a: {x}} => leaf "obj"
+	//     pat {a: [y]} => leaf "tuple"
+	//   }
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
+  {a} => split p.a {
+    {x} => bind x = p.a.x; leaf "obj"
+  } default split p.a {
+    [_] => bind y = p.a.0; leaf "tuple"
+  } default ✗
+} default ✗`))
+}
+
+// The leaves a nested split binds are in scope for the guard below it, since the guard
+// sits inside the innermost split rather than above the ones that project its values.
+func TestNormalizeGuardReadsNestedBinds(t *testing.T) {
+	core := coreMatch(
+		ident("p"),
+		matchCase(fieldPat("start", objPat("x", "y")), greaterThan(), ident("x"), span(2, 5, 40)),
+		matchCase(wildcardPat(), nil, num(0), span(3, 5, 16)),
+	)
+
+	// Before normalization:
+	//
+	//   split p {
+	//     pat {start: {x, y}} guard (x > y) => leaf x
+	//     pat _ => leaf 0
+	//   }
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
+  {start} => split p.start {
+    {x, y} => bind x = p.start.x, y = p.start.y; guard (x > y) {
+      leaf x
+    } default leaf 0
+  } default leaf 0
+} default leaf 0`))
+}
+
+// A pattern that tests no tag of its own has no split to become. A bare rest is the only
+// one, and it stays a nameless bind that hands the pattern to the solver's walk.
+func TestNormalizeKeepsATagLessPatternWhole(t *testing.T) {
+	rest := ast.NewRestPat(identPat("rest"), ast.Span{})
+	core := coreMatch(ident("xs"), matchCase(rest, nil, ident("rest"), span(2, 5, 24)))
+
+	// Before normalization:
+	//
+	//   split xs {
+	//     pat ...rest => leaf rest
+	//   }
+	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split xs {} default bind ...rest = xs; leaf rest`))
+}
+
 // Merging must not cost a branch its provenance. Every branch of the merged split still
 // points at the arm the user wrote, and the origin tags still name the construct each
 // arm lowered from.
@@ -259,6 +516,37 @@ func TestNormalizeKeepsArmBackReferences(t *testing.T) {
     leaf "two" [match arm] arm=3:5-3:26
   } default leaf "other" [match arm] arm=4:5-4:20
 } default leaf "other" [match arm] arm=4:5-4:20`))
+}
+
+// A split flattening introduced blames the sub-pattern it tests and still points back at
+// the arm the user wrote. The `at=` span is the nested `{x, y}`, and `arm=` is the whole
+// arm, so a message about the projected split can name either.
+func TestNormalizeFlattenedSplitKeepsItsArmAndPattern(t *testing.T) {
+	x := ast.NewObjShorthandPat(ast.NewIdentifier("x", ast.Span{}), false, nil, nil, span(2, 20, 21))
+	y := ast.NewObjShorthandPat(ast.NewIdentifier("y", ast.Span{}), false, nil, nil, span(2, 23, 24))
+	start := ast.NewObjectPat([]ast.ObjPatElem{x, y}, span(2, 19, 25))
+	pattern := ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("start", start)}, span(2, 5, 26))
+	armCase := matchCase(pattern, nil, ident("x"), span(2, 5, 31))
+	core := coreMatch(ident("p"), armCase)
+
+	// Before normalization:
+	//
+	//   split p {
+	//     pat {start: {x, y}} => leaf x
+	//   }
+	opts := DefaultPrintOptions()
+	opts.ShowArms = true
+	opts.ShowSpans = true
+	norm := Normalize(core)
+	snaps.MatchInlineSnapshot(t, Print(norm, opts), snaps.Inline(`split p at=1:1-1:40 {
+  {start} at=2:5-2:31 arm=same => split p.start at=2:19-2:25 {
+    {x, y} at=2:19-2:25 arm=2:5-2:31 => bind x = p.start.x at=2:20-2:21, y = p.start.y at=2:23-2:24; leaf x at=2:5-2:31 arm=same
+  } default ✗
+} default ✗`))
+
+	inner := norm.(*NormSplit).Branches[0].Cont.(*NormSplit)
+	require.Same(t, armCase, inner.Branches[0].Arm)
+	require.Same(t, start, inner.Scrutinee.Origin.Node)
 }
 
 // Normalization rewrites the splits around a leaf and leaves the leaf itself alone, so

--- a/internal/solver/ucs/pattern.go
+++ b/internal/solver/ucs/pattern.go
@@ -5,16 +5,16 @@ import (
 	"github.com/escalier-lang/escalier/internal/set"
 )
 
-// This file reads a source pattern into the two things a normalized branch is made of:
-// the one tag-level test the branch makes, and the leaves it binds out of the value the
-// branch matched. It is the half of normalization that looks at patterns. The other half
-// merges the branches of a split and threads the default tail through them, and it reads
-// what this produces.
+// This file reads a source pattern into what a normalized branch is made of: the one
+// tag-level test the branch makes, the leaves it binds out of the value the branch
+// matched, and the splits its nested sub-patterns become. It is the half of
+// normalization that looks at patterns. The other half merges the branches of a split
+// and threads the default tail through them, and it reads what this produces.
 
 // bindSpec is one leaf a branch's pattern binds. It holds the name, the pattern leaf or
 // shorthand element the solver binds through, and the projection the value comes from. A
-// spec with no name holds a sub-pattern this stage does not flatten, which its branch
-// keeps whole until nested patterns become splits of their own.
+// spec with no name holds a sub-pattern the branch has still to match, which binder.wrap
+// turns into a split over that projection.
 type bindSpec struct {
 	name   string
 	pat    ast.Pat
@@ -23,21 +23,127 @@ type bindSpec struct {
 	origin Origin
 }
 
-// wrapBinds nests a branch's binds around its continuation, so the leaves are in scope
-// for everything the branch runs, a guard condition included.
-func wrapBinds(binds []bindSpec, cont Norm) Norm {
-	for i := len(binds) - 1; i >= 0; i-- {
-		bind := binds[i]
-		cont = &NormBind{
-			Name:   bind.name,
-			Pat:    bind.pat,
-			Elem:   bind.elem,
-			Source: bind.source,
-			Cont:   cont,
-			Origin: bind.origin,
+// projection is the one tag-level read of a nameless bind's sub-pattern: the tag its
+// split tests, and the binds under that tag.
+type projection struct {
+	test  Test
+	binds []bindSpec
+}
+
+// projections memoizes those reads for one core split, keyed by the sub-scrutinee the
+// bind names. A branch is built more than once, since an earlier branch's fallthrough
+// holds a copy of it, and every copy reads the same sub-patterns. Without the memo each
+// copy would mint its own *Scrutinee for a path they all name. One node per path is what
+// lets a consumer evaluate a projection once and read every test and bind under it off
+// that one value, as the Scrutinee doc explains.
+//
+// The sub-scrutinee identifies the read because Project mints one per nameless bind, and
+// a branch derives its binds once and shares them with its copies. Two arms that name the
+// same path get two keys, since each points its projection at its own sub-pattern.
+type projections map[*Scrutinee]projection
+
+// read returns the tag-level read of one nameless bind, deriving it on first use.
+func (p projections) read(bind bindSpec) projection {
+	if got, ok := p[bind.source]; ok {
+		return got
+	}
+	test, binds := shallowTest(bind.pat, bind.source, bind.origin)
+	got := projection{test: test, binds: binds}
+	p[bind.source] = got
+	return got
+}
+
+// hasSplit reports whether any of a branch's binds becomes a split of its own, which is a
+// nameless bind whose sub-pattern tests a tag. Such a split can fail, so the branch's own
+// tag test passing does not say whether the branch matched, and the branch needs a
+// fallthrough. A nameless bind that tests nothing binds unconditionally and adds no way
+// for the branch to fail.
+func (p projections) hasSplit(binds []bindSpec) bool {
+	for _, bind := range binds {
+		if bind.name == "" && p.read(bind).test != nil {
+			return true
 		}
 	}
-	return cont
+	return false
+}
+
+// binder builds what one branch runs once its tag test matches. Every field is fixed for
+// that branch. fallthru is where control goes when a sub-pattern below the tag fails to
+// match, which is the same continuation the branch's guard falls into. arm is the surface
+// arm each split it emits points back at, so a message about a projected split still
+// names the arm the user typed. reads is the memo the branch's sub-patterns are read
+// through, shared with the other branches of the same core split.
+type binder struct {
+	fallthru Norm
+	arm      Spanned
+	reads    projections
+}
+
+// wrap nests a branch's binds around its continuation, so the leaves are in scope for
+// everything the branch runs, a guard condition included. A nameless bind holds a
+// sub-pattern the branch has still to match, and wrap puts a split over that
+// sub-pattern's projection in its place.
+//
+// The splits go outside the names. A split's Default is the branch's fallthrough, which
+// runs the arms below this one, so a name left in scope over that default would put one
+// arm's leaves in the scope of another arm's body. A tag test reads no bound name, so
+// sinking the names below the splits costs nothing.
+func (b binder) wrap(binds []bindSpec, cont Norm) Norm {
+	term := cont
+	for i := len(binds) - 1; i >= 0; i-- {
+		if binds[i].name != "" {
+			term = bindNode(binds[i], term)
+		}
+	}
+	// A sub-pattern's split holds everything the branch runs below it, so the splits
+	// build from the last one back and each becomes the continuation of the one before.
+	for i := len(binds) - 1; i >= 0; i-- {
+		if binds[i].name == "" {
+			term = b.flatten(binds[i], term)
+		}
+	}
+	return term
+}
+
+// flatten turns a nameless bind into a split over the projection it names. The
+// sub-pattern's own tag-level becomes that split's single branch, the leaves under the
+// tag bind inside it, and a value that fails the tag falls to the branch's fallthrough.
+//
+// This is what keeps every split at one tag-level. `Line { start: {x, y} }` tests the
+// `Line` tag on `l`, then the `{x, y}` tag on the projection `l.start`, then binds
+// `l.start.x` and `l.start.y`, rather than handing a consumer one deep shape.
+//
+// A sub-pattern that makes no test of its own has no split to become. A bare rest is the
+// only pattern that reaches here, and it stays a nameless bind, which hands the pattern
+// whole to the solver's pattern walk.
+func (b binder) flatten(bind bindSpec, cont Norm) Norm {
+	read := b.reads.read(bind)
+	if read.test == nil {
+		return bindNode(bind, cont)
+	}
+	return &NormSplit{
+		Scrutinee: bind.source,
+		Branches: []*NormBranch{{
+			Test:   read.test,
+			Cont:   b.wrap(read.binds, cont),
+			Arm:    b.arm,
+			Origin: bind.origin,
+		}},
+		Default: b.fallthru,
+		Origin:  bind.origin,
+	}
+}
+
+// bindNode names one projection for the term underneath it.
+func bindNode(bind bindSpec, cont Norm) Norm {
+	return &NormBind{
+		Name:   bind.name,
+		Pat:    bind.pat,
+		Elem:   bind.elem,
+		Source: bind.source,
+		Cont:   cont,
+		Origin: bind.origin,
+	}
 }
 
 // shallowTest reads one tag-level off a pattern: the tag its branch tests, and the
@@ -46,8 +152,8 @@ func wrapBinds(binds []bindSpec, cont Norm) Norm {
 //
 // It goes exactly one level deep. A sub-pattern that is an identifier becomes a bind on
 // its projection, and any other sub-pattern becomes a nameless bind that keeps the
-// sub-pattern whole. Turning those into splits over their projections is the stage of
-// the rewrite that flattens nesting.
+// sub-pattern whole. binder.wrap is what reads a level off each of those in turn, so the
+// recursion that flattens a nested pattern lives there rather than here.
 func shallowTest(p ast.Pat, scrutinee *Scrutinee, origin Origin) (Test, []bindSpec) {
 	switch p := p.(type) {
 	case nil, *ast.WildcardPat:
@@ -203,8 +309,8 @@ func valueDefaultsField(p ast.Pat) bool {
 
 // appendBind adds what a sub-pattern contributes at the projection step reaches. A
 // wildcard binds nothing and needs no test, so it adds nothing at all. An identifier
-// binds the projection. Any other sub-pattern is kept whole as a nameless bind for the
-// stage that flattens nesting.
+// binds the projection. Any other sub-pattern is kept whole as a nameless bind, which
+// binder.wrap turns into a split over that projection.
 func appendBind(binds []bindSpec, p ast.Pat, parent *Scrutinee, step Step, origin Origin) []bindSpec {
 	if p == nil {
 		return binds

--- a/internal/solver/ucs/pattern_test.go
+++ b/internal/solver/ucs/pattern_test.go
@@ -10,6 +10,10 @@ import (
 // readPattern renders what a pattern reads to: the tag its branch tests, then the binds
 // it introduces wrapped around a stand-in leaf. A pattern that tests nothing renders
 // `no test`, which is what a catch-all reads to.
+//
+// The binds nest as they come, so the rendering shows the one level shallowTest read.
+// binder.wrap is what turns a nameless bind into a split of its own, and the tests that
+// assert flattening go through Normalize.
 func readPattern(p ast.Pat, target string) string {
 	origin := At(OriginMatchArm, arm(span(2, 5, 20)))
 	scrutinee := NewRoot(ident(target), origin)
@@ -19,13 +23,16 @@ func readPattern(p ast.Pat, target string) string {
 	if test != nil {
 		tag = testString(test)
 	}
-	leaf := &BodyLeaf{Body: exprBody(num(0)), Origin: origin}
-	return tag + " => " + Print(wrapBinds(binds, leaf), DefaultPrintOptions())
+	var cont Norm = &BodyLeaf{Body: exprBody(num(0)), Origin: origin}
+	for i := len(binds) - 1; i >= 0; i-- {
+		cont = bindNode(binds[i], cont)
+	}
+	return tag + " => " + Print(cont, DefaultPrintOptions())
 }
 
 // Every pattern kind reads to one tag and a bind per leaf, each on a projection off the
 // scrutinee. The cases are the worked examples in planning/ucs/implementation_plan.md,
-// minus the nested flattening a later stage adds.
+// minus the flattening normalization wraps around them.
 func TestShallowTestPatternKinds(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/solver/ucs/print.go
+++ b/internal/solver/ucs/print.go
@@ -232,9 +232,10 @@ func (p *printer) leaf(t Term) {
 }
 
 // bindTarget renders what a bind introduces. A named bind writes its identifier. A
-// bind with no name holds a sub-pattern that is not flattened into a split yet, so it
-// writes the pattern: `bind {x, y} = l.start` says the branch has still to match
-// `{x, y}` against the projection `l.start`.
+// bind with no name holds a pattern rather than a name, so it writes that pattern:
+// `bind ...rest = xs` says the branch has still to match `...rest` against `xs`. A core
+// bind is where most of those appear, since normalization gives every sub-pattern that
+// makes a tag test a split of its own.
 func bindTarget(name string, pat ast.Pat) string {
 	if name != "" {
 		return name

--- a/internal/solver/ucs/specialize.go
+++ b/internal/solver/ucs/specialize.go
@@ -12,15 +12,18 @@ import (
 // and dropping what cannot run is what keeps the continuation from re-testing a tag the
 // value is already known to fail.
 //
-// Three things can happen to a later candidate. A test the matched one guarantees
-// becomes unconditional, since a value that passed the first passes the second too. A
-// test that cannot hold of the same value is dropped. Anything else survives with its
-// test intact and is re-tested.
+// Three things can happen to a later candidate. A test the matched one guarantees is
+// cleared, since a value that passed the first passes the second too. A test that cannot
+// hold of the same value is dropped. Anything else survives with its test intact and is
+// re-tested.
 //
-// An unconditional candidate does not end the list, because its own continuation can
-// still fail: `1 if f() => a, 1 if g() => b, _ => c` reaches `c` when both guards fail.
-// Truncating the branch list at an unconditional candidate is build's job, and it
-// truncates only the branches, not what that candidate falls into.
+// Clearing a test says the tag needs no re-testing, not that the candidate's branch
+// matched. A candidate with no test still fails when its guard's condition is false or
+// when a split over a projection below its tag matches nothing, and both continue into
+// the candidates after it. `1 if f() => a, 1 if g() => b, _ => c` reaches `c` when both
+// guards fail, and `{x: 1} => a, {x: 2} => b, _ => c` reaches `c` when `p.x` is neither.
+// Truncating the branch list at a cleared candidate is build's job, and it truncates only
+// the branches, not what that candidate falls into.
 //
 // A candidate that made no test taught nothing, so every later candidate survives
 // unchanged.
@@ -33,7 +36,7 @@ func specialize(cands []candidate, matched Test) []candidate {
 		switch {
 		case cand.test == nil:
 			out = append(out, cand)
-		case testImplies(matched, cand.test) && !cand.nested:
+		case testImplies(matched, cand.test):
 			cand.test = nil
 			out = append(out, cand)
 		case testsDisjoint(matched, cand.test):
@@ -57,18 +60,6 @@ func specialize(cands []candidate, matched Test) []candidate {
 func capturedBy(earlier []candidate, test Test) bool {
 	for _, cand := range earlier {
 		if cand.test != nil && testImplies(test, cand.test) {
-			return true
-		}
-	}
-	return false
-}
-
-// hasUnflattenedBind reports whether any of a branch's binds holds a sub-pattern that
-// is still to be matched. A branch with one can fail after its tag test passes, so the
-// test alone does not say whether the branch matched.
-func hasUnflattenedBind(binds []bindSpec) bool {
-	for _, bind := range binds {
-		if bind.name == "" {
 			return true
 		}
 	}

--- a/internal/solver/ucs/specialize_test.go
+++ b/internal/solver/ucs/specialize_test.go
@@ -129,10 +129,14 @@ func TestSpecializeKeepsTheArmNoFallthroughCouldTake(t *testing.T) {
 } default ✗`))
 }
 
-// A branch holding a sub-pattern this stage does not flatten is never made
-// unconditional. Passing the `{x}` test says nothing about whether the literal `2`
-// matched, so the arm below the second one stays reachable.
-func TestSpecializeKeepsATestWhoseBranchStillHasASubPattern(t *testing.T) {
+// A tag the matched test proved is not re-tested, and a branch whose pattern nests below
+// that tag is no exception. The second arm's `{x}` is cleared in the first arm's
+// fallthrough, leaving only the split over `p.x` to run there, and the arm's branch in
+// the outer split goes with it, since that fallthrough already runs its continuation.
+//
+// Clearing the test does not make the arm cover what reaches it. Its split over `p.x`
+// matches 2 alone, so `"c"` still runs when the guard fails and `p.x` is neither literal.
+func TestSpecializeClearsANestedBranchsTest(t *testing.T) {
 	first := ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("x", numPat(1))}, ast.Span{})
 	second := ast.NewObjectPat([]ast.ObjPatElem{keyValueElem("x", numPat(2))}, ast.Span{})
 	core := coreMatch(
@@ -143,12 +147,15 @@ func TestSpecializeKeepsATestWhoseBranchStillHasASubPattern(t *testing.T) {
 	)
 
 	snaps.MatchInlineSnapshot(t, normalized(core), snaps.Inline(`split p {
-  {x} => bind 1 = p.x; guard (g) {
-    leaf "a"
-  } default split p {
-    {x} => bind 2 = p.x; leaf "b"
+  {x} => split p.x {
+    1 => guard (g) {
+      leaf "a"
+    } default split p.x {
+      2 => leaf "b"
+    } default leaf "c"
+  } default split p.x {
+    2 => leaf "b"
   } default leaf "c"
-  {x} => bind 2 = p.x; leaf "b"
 } default leaf "c"`))
 }
 


### PR DESCRIPTION
Fixes #1024.

Normalization now flattens nested patterns by turning each sub-pattern into a split over its projection, one tag-level per split. This keeps the normalized form at one tag-level per split, so a consumer never sees a deep shape at once.

Previously, a branch kept its entire pattern whole, nesting and all. Now `Line { start: {x, y} }` becomes a split on `l` testing `Line`, then a split on `l.start` testing `{x, y}`, then binds of `l.start.x` and `l.start.y`. A projected split fails the same way the branch&#39;s guard does, into the branch&#39;s fallthrough, so flattening adds no backtracking.

Key changes:

- **pattern.go**: Introduced `binder` type to manage wrapping binds and flattening sub-patterns. The `wrap` method nests named binds around the continuation and turns nameless binds (sub-patterns) into splits via `flatten`. The splits go outside the names, so a projected split&#39;s default — which runs the arms below — is not in the scope of the arm&#39;s own leaves. Added `projections` memo to ensure each path names one `*Scrutinee` across branch copies, so a consumer can evaluate a projection once and read every test and bind under it off that one value.

- **normalize.go**: Updated `normalizeSplit` to pass the `projections` memo to the `splitBuilder`, and changed the `nested` flag logic to use `reads.hasSplit(binds)` instead of `hasUnflattenedBind`. A branch that nests below its tag now gets a fallthrough, since its projected split can fail. Updated comments to describe the three-stage rewrite (merging, threading defaults, and flattening).

- **specialize.go**: Removed the `!cand.nested` condition from the test-clearing logic. A tag the matched test proved is now cleared even if the candidate&#39;s pattern nests below it, since the split over the projection below the tag will still fail if needed. Without this, arms testing one tag re-test that tag in every fallthrough, and the form grows with the square of their count: 32 same-tag arms went from 1649 nodes to 99.

- **normalize_test.go**: Added comprehensive tests for flattening behavior: `TestNormalizeFlattensANestedObjectPattern`, `TestNormalizeFlattensANestedTuplePattern`, `TestNormalizeFlattensToArbitraryDepth`, `TestNormalizeNestedSplitFallsToTheArmBelow`, `TestNormalizeKeepsTheFallthroughOutOfTheArmsScope`, `TestNormalizeNamesOneScrutineePerPath`, `TestNormalizeChainsArmsThatNestUnderOneTag`, `TestNormalizeGuardReadsNestedBinds`, `TestNormalizeKeepsATagLessPatternWhole`, and `TestNormalizeFlattenedSplitKeepsItsArmAndPattern`. Added `pathNodes` helper to verify that each path names exactly one scrutinee node.

- **specialize_test.go**: Renamed `TestSpecializeKeepsATestWhoseBranchStillHasASubPattern` to `TestSpecializeClearsANestedBranchsTest` and updated its assertion to reflect the new flattening behavior.

- **helpers_test.go**: Added helper functions `fieldPat`, `tuplePat`, and `instancePat` for building test patterns.

- **pattern_test.go**, **print.go**, **norm.go**: Updated comments to reflect that nameless binds now represent patterns that make no tag test of their own (like bare rests), rather than unflattened sub-patterns.

The split shape was checked against the [`hkust-taco/ucs`](https://github.com/hkust-taco/ucs) reference, which coins a fresh sub-scrutinee per field and matches one level at a time. The difference is placement: the reference decomposes nested patterns in its desugaring stage, and this plan puts the decomposition in normalization.

Not in this PR: projected splits are never specialized against one another, so `{x: 1} if g => a, {x: 1} => b` tests `p.x` against 1 again when the guard fails, and arms under different tags still duplicate their continuations quadratically. Both need the merging PR3 does at the top level extended across tag-levels, which is a design change beyond this PR&#39;s scope.

https://claude.ai/code/session_013QkEjS2Bw4xnKYtgfi5A9X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching for nested object and tuple patterns, including patterns nested to arbitrary depths.
  * Preserved correct fallthrough behavior when nested matches or guards fail.
  * Improved handling of nested bindings, tag-less patterns, and repeated scrutinee reads.
  * Ensured specialization correctly reuses proven outer-pattern tests.

* **Tests**
  * Added comprehensive coverage for nested normalization, bindings, fallthroughs, guards, and pattern provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->