### PR TITLE
Type match expressions off normalized UCS form

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/escalier-lang/escalier/internal/solver/ucs"
 )
 
 // SolverError is the sealed interface for constraint-solving failures. Each
@@ -1063,6 +1064,27 @@ type NonExhaustiveMatchError struct {
 	Match *ast.MatchExpr
 }
 
+// UnreachableMatchArmError fires when a `match` arm can never run, because an arm above it
+// already matches every value the scrutinee can take. An unguarded wildcard `_` or
+// identifier pattern is such an arm. A guarded one is not, since its condition can be
+// false, so the arms below it stay reachable.
+//
+// The arm is still type-checked. Dead code is code the user can get wrong, and reporting
+// only its position would leave a fault inside it to surface later, when the arm above it
+// is deleted.
+//
+// It blames the unreachable arm and carries the covering arm as its related span, so an
+// IDE can show both ends of the overlap. Covering is nil when nothing above the arm ran,
+// which leaves the error with no related span rather than a wrong one.
+//
+// Each span runs from the arm's pattern to the end of its body. An ast.MatchCase's own
+// span starts where the arm before it ended, so underlining it would reach back onto the
+// previous line.
+type UnreachableMatchArmError struct {
+	Arm      *ast.MatchCase
+	Covering *ast.MatchCase
+}
+
 // MissingCatchArmError fires when a `try` carries no catch arms. The arms are what catch
 // an exception, so a `try` without them changes nothing about the block it wraps. Either
 // resolution is fine. Dropping the `try` keeps the block saying what it already says, and
@@ -1128,6 +1150,7 @@ func (*AsyncThrowsClauseError) isSolverError()              {}
 func (*YieldOutsideGenError) isSolverError()                {}
 func (*GenReturnNotGeneratorError) isSolverError()          {}
 func (*NonExhaustiveMatchError) isSolverError()             {}
+func (*UnreachableMatchArmError) isSolverError()            {}
 func (*MissingCatchArmError) isSolverError()                {}
 func (*UnhandledRethrowError) isSolverError()               {}
 func (*MixedOwnershipError) isSolverError()                 {}
@@ -1758,6 +1781,29 @@ func (e *NonExhaustiveMatchError) Span() ast.Span      { return e.Match.Span() }
 func (e *NonExhaustiveMatchError) Related() []ast.Span { return nil }
 func (e *NonExhaustiveMatchError) Message() string {
 	return "match is not exhaustive; add a catch-all branch"
+}
+
+func (e *UnreachableMatchArmError) Span() ast.Span { return matchArmSpan(e.Arm) }
+func (e *UnreachableMatchArmError) Related() []ast.Span {
+	if e.Covering == nil {
+		return nil
+	}
+	return []ast.Span{matchArmSpan(e.Covering)}
+}
+
+// matchArmSpan returns the span running from an arm's pattern to the end of its body,
+// which is the text the user reads as the arm. An arm whose body is neither an expression
+// nor a block underlines its pattern alone.
+func matchArmSpan(arm *ast.MatchCase) ast.Span {
+	pattern := arm.Pattern.Span()
+	body, ok := ucs.BodySpan(arm.Body)
+	if !ok {
+		return pattern
+	}
+	return ast.MergeSpans(pattern, body)
+}
+func (e *UnreachableMatchArmError) Message() string {
+	return "this match arm is unreachable because an arm above it matches every value; drop it, or move it above that arm"
 }
 
 func (e *MissingCatchArmError) Span() ast.Span       { return e.Try.Span() }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3177,14 +3177,9 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	// the same per-arm path a `try`'s catch clauses take, so a fault inside dead code is
 	// found rather than left for whoever deletes the arm above it.
 	//
-	// Its body joins a variable of its own rather than the match's. The arm cannot run, so
-	// its value is not one the match produces, and constraining it into res would
-	// contradict the diagnostic and pile a second error onto code already reported.
-	//
-	// It stays out of the ownership check for the same reason. checkUniformOwnership asks
-	// whether the values the match joins are all owned or all borrowed, and a value no
-	// execution produces is not one of them. Passing it would report a mix the match cannot
-	// reach, on top of the diagnostic that already names the arm.
+	// Its value is not one the match produces, so it joins neither res nor the ownership
+	// check. Both would report against a value no execution reaches, on top of the
+	// diagnostic that already names the arm.
 	unreachable := c.reportUnreachableArms(e.Cases, w.arms)
 	c.inferMatchArms(scope, lvl, e, unreachable, matchShape, scrutinee, c.freshAt(lvl))
 	c.checkUniformOwnership(e, w.bodies)
@@ -3193,18 +3188,15 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	return res
 }
 
-// reportUnreachableArms reports every arm the walk left untyped that an unguarded
-// catch-all above it covers, and returns all the untyped arms in source order so the
-// caller can still type them.
+// reportUnreachableArms reports every untyped arm an unguarded catch-all above it covers,
+// and returns all the untyped arms in source order so the caller can still type them.
 //
-// Normalization ends a split at the first arm with no tag to test, and that truncation is
-// what keeps an arm out of the form the walk sees. The last arm the walk did type is
-// therefore the one the rest sit below, which the message points at.
+// A split ends at the first arm with no tag to test, which is what keeps the arms below it
+// out of the form the walk sees. The last arm the walk typed is the one they sit below,
+// and the message points at it.
 //
-// That arm covers the rest only when it is a catch-all. A pattern the lowering cannot read
-// a tag off also ends the split, and a bare `...rest` is one: it is already reported
-// unsupported, and calling the arms below it unreachable would follow that with advice
-// that does not fit the input.
+// Only a catch-all covers them. A bare `...rest` ends a split too and is already reported
+// unsupported, so calling the arms below it unreachable would add advice that does not fit.
 func (c *checker) reportUnreachableArms(arms []*ast.MatchCase, walked set.Set[ucs.Spanned]) []*ast.MatchCase {
 	var covering *ast.MatchCase
 	var unreachable []*ast.MatchCase

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3180,6 +3180,11 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	// Its body joins a variable of its own rather than the match's. The arm cannot run, so
 	// its value is not one the match produces, and constraining it into res would
 	// contradict the diagnostic and pile a second error onto code already reported.
+	//
+	// It stays out of the ownership check for the same reason. checkUniformOwnership asks
+	// whether the values the match joins are all owned or all borrowed, and a value no
+	// execution produces is not one of them. Passing it would report a mix the match cannot
+	// reach, on top of the diagnostic that already names the arm.
 	unreachable := c.reportUnreachableArms(e.Cases, w.arms)
 	c.inferMatchArms(scope, lvl, e, unreachable, matchShape, scrutinee, c.freshAt(lvl))
 	c.checkUniformOwnership(e, w.bodies)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3154,9 +3154,8 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	// Snapshot the scrutinee for the exhaustiveness check before any arm binds. A
 	// literal pattern adds its literal as a lower bound, which would otherwise leak
 	// a phantom member into the coalesced union read after the walk. The borrow stays
-	// on the snapshot rather than being peeled the way groundedCarrier peels one.
-	// narrowMatchArm unwraps the shape itself and re-wraps the narrowed carrier under
-	// the same borrow.
+	// on the snapshot rather than being peeled the way groundedCarrier peels one, since
+	// checkMatchExhaustive reads its own carrier off it.
 	matchShape := scrutinee
 	if carrierIsVar(scrutinee) {
 		matchShape = coalesce(scrutinee, soltype.Positive)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3176,21 +3176,30 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	// the split and the walk never reaches it. Report each one, then type it anyway through
 	// the same per-arm path a `try`'s catch clauses take, so a fault inside dead code is
 	// found rather than left for whoever deletes the arm above it.
+	//
+	// Its body joins a variable of its own rather than the match's. The arm cannot run, so
+	// its value is not one the match produces, and constraining it into res would
+	// contradict the diagnostic and pile a second error onto code already reported.
 	unreachable := c.reportUnreachableArms(e.Cases, w.arms)
-	bodies := append(w.bodies, c.inferMatchArms(scope, lvl, e, unreachable, matchShape, scrutinee, res)...)
-	c.checkUniformOwnership(e, bodies)
+	c.inferMatchArms(scope, lvl, e, unreachable, matchShape, scrutinee, c.freshAt(lvl))
+	c.checkUniformOwnership(e, w.bodies)
 	c.checkMatchExhaustive(scope, e, matchShape)
 	c.recordType(e, res)
 	return res
 }
 
-// reportUnreachableArms reports every arm the walk left untyped and returns them in source
-// order, so the caller can still type them.
+// reportUnreachableArms reports every arm the walk left untyped that an unguarded
+// catch-all above it covers, and returns all the untyped arms in source order so the
+// caller can still type them.
 //
-// An untyped arm is an unreachable one. Normalization ends a split at the first arm that
-// matches every value, and that truncation is the only thing that keeps an arm out of the
-// form the walk sees. The last arm the walk did type is therefore the one that covers the
-// rest, which the message points at.
+// Normalization ends a split at the first arm with no tag to test, and that truncation is
+// what keeps an arm out of the form the walk sees. The last arm the walk did type is
+// therefore the one the rest sit below, which the message points at.
+//
+// That arm covers the rest only when it is a catch-all. A pattern the lowering cannot read
+// a tag off also ends the split, and a bare `...rest` is one: it is already reported
+// unsupported, and calling the arms below it unreachable would follow that with advice
+// that does not fit the input.
 func (c *checker) reportUnreachableArms(arms []*ast.MatchCase, walked set.Set[ucs.Spanned]) []*ast.MatchCase {
 	var covering *ast.MatchCase
 	var unreachable []*ast.MatchCase
@@ -3200,7 +3209,9 @@ func (c *checker) reportUnreachableArms(arms []*ast.MatchCase, walked set.Set[uc
 			continue
 		}
 		unreachable = append(unreachable, arm)
-		c.report(&UnreachableMatchArmError{Arm: arm, Covering: covering})
+		if covering != nil && covering.Guard == nil && ast.IsCatchAllPat(covering.Pattern) {
+			c.report(&UnreachableMatchArmError{Arm: arm, Covering: covering})
+		}
 	}
 	return unreachable
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3173,24 +3173,36 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	// fallthrough inherits are all the state the `match` itself started from.
 	w.walkNorm(start, start, start.binder, norm)
 	// An arm below an unguarded catch-all can never run, so normalization leaves it out of
-	// the split and the walk never reaches it. Type it anyway, through the same per-arm
-	// path a `try`'s catch clauses take, so a fault in dead code is still reported.
-	bodies := append(w.bodies, c.inferMatchArms(scope, lvl, e, unwalkedArms(e.Cases, w.arms), matchShape, scrutinee, res)...)
+	// the split and the walk never reaches it. Report each one, then type it anyway through
+	// the same per-arm path a `try`'s catch clauses take, so a fault inside dead code is
+	// found rather than left for whoever deletes the arm above it.
+	unreachable := c.reportUnreachableArms(e.Cases, w.arms)
+	bodies := append(w.bodies, c.inferMatchArms(scope, lvl, e, unreachable, matchShape, scrutinee, res)...)
 	c.checkUniformOwnership(e, bodies)
 	c.checkMatchExhaustive(scope, e, matchShape)
 	c.recordType(e, res)
 	return res
 }
 
-// unwalkedArms returns the arms the walk did not type, in source order.
-func unwalkedArms(arms []*ast.MatchCase, walked set.Set[ucs.Spanned]) []*ast.MatchCase {
-	var left []*ast.MatchCase
+// reportUnreachableArms reports every arm the walk left untyped and returns them in source
+// order, so the caller can still type them.
+//
+// An untyped arm is an unreachable one. Normalization ends a split at the first arm that
+// matches every value, and that truncation is the only thing that keeps an arm out of the
+// form the walk sees. The last arm the walk did type is therefore the one that covers the
+// rest, which the message points at.
+func (c *checker) reportUnreachableArms(arms []*ast.MatchCase, walked set.Set[ucs.Spanned]) []*ast.MatchCase {
+	var covering *ast.MatchCase
+	var unreachable []*ast.MatchCase
 	for _, arm := range arms {
-		if !walked.Contains(arm) {
-			left = append(left, arm)
+		if walked.Contains(arm) {
+			covering = arm
+			continue
 		}
+		unreachable = append(unreachable, arm)
+		c.report(&UnreachableMatchArmError{Arm: arm, Covering: covering})
 	}
-	return left
+	return unreachable
 }
 
 // inferMatchArms types each arm of a `match` or of a `try`'s catch clause, constrains every

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -11,6 +11,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/escalier-lang/escalier/internal/solver/ucs"
 )
 
 // inferLiteral types a literal expression and records it in Info. A number, string, or
@@ -3138,31 +3139,41 @@ func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 	c.bindRefutable(scope, lvl, d.Pattern, source)
 }
 
-// inferMatch types a `match` expression. The scrutinee is inferred once. Each arm
-// then types its pattern against the scrutinee in a child scope carrying the arm's
-// bindings, the same E1 bindPattern path `val` destructuring uses. An optional `if`
-// guard is typed as a boolean, then the arm body is inferred. Every non-diverging
-// arm body is constrained into one fresh branch-join var, exactly as inferIfElse
-// joins its two branches. A diverging arm contributes `never`, so when every arm
-// diverges the result coalesces to `never`.
+// inferMatch types a `match` expression off the UCS normalized form. The scrutinee is
+// inferred once, then the arms are lowered by ucs.DesugarMatch and ucs.Normalize into
+// splits over that one value, and condWalk types the result. Each split narrows the
+// scrutinee by the tag its branch tests, each leaf of a matched pattern binds against
+// the projection the IR names for it, and an optional `if` guard is typed as a boolean
+// over those leaves. Every non-diverging arm body is constrained into one fresh
+// branch-join var, exactly as inferIfElse joins its two branches. A diverging arm
+// contributes `never`, so when every arm diverges the result coalesces to `never`.
 //
 // Exhaustiveness is checked from structural exactness by checkMatchExhaustive.
 func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Type {
 	scrutinee := c.inferExpr(scope, lvl, e.Target)
 	// Snapshot the scrutinee for the exhaustiveness check before any arm binds. A
 	// literal pattern adds its literal as a lower bound, which would otherwise leak
-	// a phantom member into the coalesced union read after the arm loop. The borrow
-	// stays on the snapshot rather than being peeled the way groundedCarrier peels
-	// one. narrowMatchArm unwraps the shape itself and re-wraps the narrowed carrier
-	// under the same borrow.
+	// a phantom member into the coalesced union read after the walk. The borrow stays
+	// on the snapshot rather than being peeled the way groundedCarrier peels one.
+	// narrowMatchArm unwraps the shape itself and re-wraps the narrowed carrier under
+	// the same borrow.
 	matchShape := scrutinee
 	if carrierIsVar(scrutinee) {
 		matchShape = coalesce(scrutinee, soltype.Positive)
 	}
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, MatchBranch)
-	armBodies := c.inferMatchArms(scope, lvl, e, e.Cases, matchShape, scrutinee, res)
-	c.checkUniformOwnership(e, armBodies)
+	core := ucs.DesugarMatch(e)
+	norm := ucs.Normalize(core)
+	// The binder is seeded with the type inferred above, so the walk never re-infers the
+	// target and a side-effecting one such as `match f() { … }` runs its call once.
+	start := condState{scope: scope, binder: c.newPathBinder(lvl, e, core.Scrutinee, scrutinee)}
+	w := newCondWalk(c, lvl, e, res, norm)
+	// No test has matched at the top of a `match`, so the walk starts with nothing
+	// refined: the state it runs in, the state a fallthrough returns to, and the binder a
+	// fallthrough inherits are all the state the `match` itself started from.
+	w.walkNorm(start, start, start.binder, norm)
+	c.checkUniformOwnership(e, w.bodies)
 	c.checkMatchExhaustive(scope, e, matchShape)
 	c.recordType(e, res)
 	return res

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3172,10 +3172,25 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	// refined: the state it runs in, the state a fallthrough returns to, and the binder a
 	// fallthrough inherits are all the state the `match` itself started from.
 	w.walkNorm(start, start, start.binder, norm)
-	c.checkUniformOwnership(e, w.bodies)
+	// An arm below an unguarded catch-all can never run, so normalization leaves it out of
+	// the split and the walk never reaches it. Type it anyway, through the same per-arm
+	// path a `try`'s catch clauses take, so a fault in dead code is still reported.
+	bodies := append(w.bodies, c.inferMatchArms(scope, lvl, e, unwalkedArms(e.Cases, w.arms), matchShape, scrutinee, res)...)
+	c.checkUniformOwnership(e, bodies)
 	c.checkMatchExhaustive(scope, e, matchShape)
 	c.recordType(e, res)
 	return res
+}
+
+// unwalkedArms returns the arms the walk did not type, in source order.
+func unwalkedArms(arms []*ast.MatchCase, walked set.Set[ucs.Spanned]) []*ast.MatchCase {
+	var left []*ast.MatchCase
+	for _, arm := range arms {
+		if !walked.Contains(arm) {
+			left = append(left, arm)
+		}
+	}
+	return left
 }
 
 // inferMatchArms types each arm of a `match` or of a `try`'s catch clause, constrains every

--- a/internal/solver/ucs/desugar.go
+++ b/internal/solver/ucs/desugar.go
@@ -77,8 +77,23 @@ func desugarMatchCase(matchCase *ast.MatchCase) *CoreBranch {
 		Pattern: matchCase.Pattern,
 		Cont:    cont,
 		Arm:     matchCase,
-		Origin:  origin,
+		Origin:  branchOrigin(OriginMatchArm, matchCase.Pattern, origin),
 	}
+}
+
+// branchOrigin builds the origin of a branch, which blames the pattern the branch tests
+// rather than the whole arm. A branch's own diagnostic is about its tag test, so
+// `Point(x)` is the narrowest honest span for "extractor pattern `Point` expects 2
+// arguments but got 1". The arm the user typed stays reachable through the branch's Arm
+// back-reference, so nothing that wants the wider span loses it.
+//
+// A construct the parser left without a pattern has nothing to blame, so the branch falls
+// back to the origin of the construct it lowered from.
+func branchOrigin(kind OriginKind, pat ast.Pat, arm Origin) Origin {
+	if _, ok := SpanOf(pat); !ok {
+		return arm
+	}
+	return At(kind, pat)
 }
 
 // DesugarIfVal lowers `if val pat = target { cons } else { alt }` into the same
@@ -93,7 +108,7 @@ func DesugarIfVal(e *ast.IfValExpr) *CoreSplit {
 			Pattern: e.Pattern,
 			Cont:    &BodyLeaf{Body: ast.BlockOrExpr{Block: &e.Cons}, Arm: e, Origin: origin},
 			Arm:     e,
-			Origin:  origin,
+			Origin:  branchOrigin(OriginIfVal, e.Pattern, origin),
 		}},
 		Else:   ifValElse(e, origin),
 		Origin: origin,
@@ -150,7 +165,7 @@ func DesugarValElse(d *ast.VarDecl) (*CoreSplit, bool) {
 			Pattern: d.Pattern,
 			Cont:    &EscapeLeaf{Arm: d, Origin: origin},
 			Arm:     d,
-			Origin:  origin,
+			Origin:  branchOrigin(OriginValElse, d.Pattern, origin),
 		}},
 		Else: &FallbackLeaf{
 			Body:   ast.BlockOrExpr{Block: d.Else},

--- a/internal/solver/ucs/desugar_test.go
+++ b/internal/solver/ucs/desugar_test.go
@@ -111,8 +111,8 @@ func TestDesugarMatchLiteralArms(t *testing.T) {
 
 	require.Nil(t, core.Else)
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split n [match arm] at=1:1-4:2 {
-  pat 1 [match arm] at=1:10-2:12 arm=same => leaf "one" [match arm] at=1:10-2:12 arm=same
-  pat _ [match arm] at=2:13-3:14 arm=same => leaf "other" [match arm] at=2:13-3:14 arm=same
+  pat 1 [match arm] at=2:2-2:3 arm=1:10-2:12 => leaf "one" [match arm] at=1:10-2:12 arm=same
+  pat _ [match arm] at=3:2-3:3 arm=2:13-3:14 => leaf "other" [match arm] at=2:13-3:14 arm=same
 }`))
 }
 
@@ -128,8 +128,8 @@ func TestDesugarMatchGuardedArm(t *testing.T) {
 	core := DesugarMatch(expr)
 
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [match arm] at=1:1-4:2 {
-  pat {x, y} [match arm] at=1:10-2:22 arm=same => guard (x > y) [guard] at=2:12-2:17 => leaf x [match arm] at=1:10-2:22 arm=same
-  pat _ [match arm] at=2:23-3:8 arm=same => leaf 0 [match arm] at=2:23-3:8 arm=same
+  pat {x, y} [match arm] at=2:2-2:8 arm=1:10-2:22 => guard (x > y) [guard] at=2:12-2:17 => leaf x [match arm] at=1:10-2:22 arm=same
+  pat _ [match arm] at=3:2-3:3 arm=2:23-3:8 => leaf 0 [match arm] at=2:23-3:8 arm=same
 }`))
 
 	// The guard carries no `arm=` tag, because ShowArms renders the Arm
@@ -175,7 +175,7 @@ func TestDesugarIfVal(t *testing.T) {
 	core := DesugarIfVal(expr)
 
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] at=1:1-1:40 {
-  pat {x, y} [if val] at=1:1-1:40 arm=same => leaf { cons } [if val] at=1:1-1:40 arm=same
+  pat {x, y} [if val] at=1:8-1:14 arm=1:1-1:40 => leaf { cons } [if val] at=1:1-1:40 arm=same
 } else leaf { alt } [if val] at=1:1-1:40 arm=same`))
 }
 
@@ -188,7 +188,7 @@ func TestDesugarIfValInventsItsFallthrough(t *testing.T) {
 	core := DesugarIfVal(expr)
 
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [if val] at=1:1-1:27 {
-  pat {x, y} [if val] at=1:1-1:27 arm=same => leaf { cons } [if val] at=1:1-1:27 arm=same
+  pat {x, y} [if val] at=1:8-1:14 arm=1:1-1:27 => leaf { cons } [if val] at=1:1-1:27 arm=same
 } else leaf undefined [synthetic if val] at~1:1-1:27 arm=none`))
 
 	// The invented leaf has no surface node of its own, so a diagnostic about it
@@ -240,6 +240,22 @@ func TestDesugarScrutineeWithoutATargetFallsBackToTheConstruct(t *testing.T) {
 	require.Equal(t, expr.Span(), nearest)
 }
 
+// A branch blames the pattern it tests, while its arm back-reference still names the
+// whole arm. A diagnostic about the branch is about the tag it tests, so it underlines
+// `Point(x)` rather than the entire `Point(x) => x`, and a diagnostic that wants the arm
+// reads Arm instead.
+func TestDesugarBranchBlamesItsPattern(t *testing.T) {
+	expr := findExpr[*ast.MatchExpr](t, `match p {
+	Point(x) => x,
+}`)
+
+	core := DesugarMatch(expr)
+
+	branch := core.Branches[0]
+	require.Same(t, expr.Cases[0].Pattern, branch.Prov().Node)
+	require.Same(t, expr.Cases[0], branch.Arm)
+}
+
 // `val pat = init else { … }` lowers to the same split, but its success path carries
 // no body. The bindings escape into the enclosing block, and the `else` is a fallback
 // rather than an arm that covers the scrutinee.
@@ -250,7 +266,7 @@ func TestDesugarValElse(t *testing.T) {
 
 	require.True(t, ok)
 	snaps.MatchInlineSnapshot(t, showProvenance(core), snaps.Inline(`split p [val else] at=1:1-1:33 {
-  pat {x, y} [val else] at=1:1-1:33 arm=same => escape [val else] at=1:1-1:33 arm=same
+  pat {x, y} [val else] at=1:5-1:11 arm=1:1-1:33 => escape [val else] at=1:1-1:33 arm=same
 } else fallback { fallback } [val else] at=1:1-1:33 arm=same`))
 }
 

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -137,14 +137,21 @@ func (c *checker) newPathBinder(lvl int, blame ast.Node, root *ucs.Scrutinee, ro
 // mints the element variables an index step reads, a class test projects the instance
 // member view a field step reads, and an extractor test resolves the constructor
 // parameters an extract step reads.
-func (b *pathBinder) narrowedBy(scope *Scope, s *ucs.Scrutinee, test ucs.Test) *pathBinder {
+//
+// blame is the surface node a diagnostic about the test anchors to, which is the pattern
+// the branch lowered from. A blame that names no node falls back to s's own origin.
+func (b *pathBinder) narrowedBy(scope *Scope, s *ucs.Scrutinee, test ucs.Test, blame ucs.Spanned) *pathBinder {
 	// Resolve s on the receiver, before the clone, so the memo lands in the binder every
 	// branch of the split shares. Resolving it on the clone instead would project the
 	// scrutinee once per branch, minting a second variable and a second member lookup for
 	// one value.
 	v := b.viewOf(scope, s)
+	node, ok := blamableNode(blame)
+	if !ok {
+		node = b.blameFor(s)
+	}
 	next := &pathBinder{c: b.c, lvl: b.lvl, blame: b.blame, views: maps.Clone(b.views)}
-	next.views[s] = next.applyTest(scope, b.blameFor(s), v, test)
+	next.views[s] = next.applyTest(scope, node, v, test)
 	return next
 }
 
@@ -167,6 +174,39 @@ func (b *pathBinder) bindAtWith(
 ) soltype.Pat {
 	v := b.viewOf(scope, s)
 	return b.c.bindPatMode(scope, b.lvl, pat, v.ty, v.concrete, v.mode, leafTypes, emit)
+}
+
+// bindElemAt binds the leaf an object pattern's shorthand element introduces, the `x` of
+// `{mut x}`. A shorthand is not an ast.Pat, so it cannot go through bindAt, and it carries
+// the annotation, default, and `mut` marker the name alone does not.
+//
+// It resolves the field itself rather than through viewOf, because a shorthand's field
+// lookup takes no upper bound. bindPatMode's shorthand arm takes none either: the leaf IS
+// the projection rather than a value handed to a sub-pattern, and pinning it would make a
+// `&mut` leaf invariantly exact against the scrutinee's field, which applyBindMode's bmMut
+// arm spells out. Reading the same field through projectField would add that pin and make
+// the IR walk reject a `mut` leaf the written pattern accepts.
+func (b *pathBinder) bindElemAt(scope *Scope, s *ucs.Scrutinee, elem *ast.ObjShorthandPat) {
+	v := b.shorthandView(scope, s, elem)
+	t := b.c.applyLeafExtras(scope, b.lvl, elem, v.ty, elem.TypeAnn, elem.Default)
+	t = b.c.applyBindMode(b.lvl, elem, elem.Mutable, t, b.c.concreteLeaf(v.concrete, elem.TypeAnn), v.mode)
+	b.c.bindLeaf(scope, elem.Key.Name, t, elem, nil, defineLeafMono)
+}
+
+// shorthandView resolves the field a shorthand element names into the variable its leaf
+// binds at, memoizing it on s the way viewOf memoizes every other projection. A default
+// relaxes the lookup to tolerate an absent field, since `{x = 0}` binds x either way.
+func (b *pathBinder) shorthandView(scope *Scope, s *ucs.Scrutinee, elem *ast.ObjShorthandPat) scrutineeView {
+	if v, ok := b.views[s]; ok {
+		return v
+	}
+	parent := b.viewOf(scope, s.Parent)
+	name := elem.Key.Name
+	beta := b.c.freshAt(b.lvl)
+	b.c.constrain(elem, parent.ty, propReq(name, beta, elem.Default != nil))
+	v := derive(parent, beta, fieldConcrete(parent.concrete, name))
+	b.views[s] = v
+	return v
 }
 
 // viewOf returns s's view, resolving and memoizing it on first use. Memoizing is what
@@ -422,18 +462,17 @@ func (b *pathBinder) applyLitTest(node ast.Node, v scrutineeView, t *ucs.LitTest
 // member view its field steps read. It is bindInstancePat's narrowing read off the test,
 // with the fields left to the projections rather than bound here.
 func (b *pathBinder) applyClassTest(scope *Scope, node ast.Node, v scrutineeView, t *ucs.ClassTest) scrutineeView {
-	blame := blameName(t.Name, node)
 	name := ast.QualIdentToString(t.Name)
 	ct, ok := b.c.instancePatClass(scope, name)
 	if !ok {
-		b.c.report(&InstancePatternNotClassError{Node: blame, Name: name})
+		b.c.report(&InstancePatternNotClassError{Node: node, Name: name})
 		// Resolve the fields against a fresh variable so a leaf beneath the test stays
 		// defined without a second cascade against the real scrutinee.
 		fresh := b.c.freshAt(b.lvl)
 		v.ty, v.concrete, v.shape = fresh, nil, fresh
 		return v
 	}
-	target, targetConcrete := b.c.narrowToClass(b.lvl, blame, ct, v.ty, v.concrete)
+	target, targetConcrete := b.c.narrowToClass(b.lvl, node, ct, v.ty, v.concrete)
 	v.ty, v.concrete, v.shape = target, targetConcrete, target
 	return v
 }
@@ -442,16 +481,15 @@ func (b *pathBinder) applyClassTest(scope *Scope, node ast.Node, v scrutineeView
 // the parameters its extract steps read. It is bindExtractorPat's narrowing read off the
 // test, with the extracted values left to the projections rather than bound here.
 func (b *pathBinder) applyExtractorTest(scope *Scope, node ast.Node, v scrutineeView, t *ucs.ExtractorTest) scrutineeView {
-	blame := blameName(t.Name, node)
 	name := ast.QualIdentToString(t.Name)
 	ctor, ok := b.c.extractorCtor(scope, b.lvl, t.Name)
 	if !ok {
-		b.c.report(&ExtractorPatternNotCtorError{Node: blame, Name: name})
+		b.c.report(&ExtractorPatternNotCtorError{Node: node, Name: name})
 		return v
 	}
-	params := b.c.narrowToExtractor(blame, ctor, v.ty)
+	params := b.c.narrowToExtractor(node, ctor, v.ty)
 	if t.Arity != len(params) {
-		b.c.report(&ExtractorPatternArityError{Node: blame, Name: name, Expected: len(params), Got: t.Arity})
+		b.c.report(&ExtractorPatternArityError{Node: node, Name: name, Expected: len(params), Got: t.Arity})
 	}
 	v.tested = &testedExtractor{params: params}
 	return v
@@ -469,16 +507,6 @@ func (b *pathBinder) blameFor(s *ucs.Scrutinee) ast.Node {
 		}
 	}
 	return b.blame
-}
-
-// blameName returns the node to blame for a test's class or extractor name, falling back
-// to the caller's node. An ast.QualIdent is guaranteed only to carry a span, so a form
-// that is not also an ast.Node names nothing a diagnostic can anchor to.
-func blameName(qi ast.QualIdent, fallback ast.Node) ast.Node {
-	if n, ok := blamableNode(qi); ok {
-		return n
-	}
-	return fallback
 }
 
 // blamableNode returns n as an ast.Node a diagnostic can anchor to, and false when it is

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -195,7 +195,11 @@ func (b *pathBinder) bindElemAt(scope *Scope, s *ucs.Scrutinee, elem *ast.ObjSho
 
 // shorthandView resolves the field a shorthand element names into the variable its leaf
 // binds at, memoizing it on s the way viewOf memoizes every other projection. A default
-// relaxes the lookup to tolerate an absent field, since `{x = 0}` binds x either way.
+// relaxes the lookup to tolerate an absent field, since `{x = 0}` binds `x` either way.
+//
+// The relaxation is wrong for a scrutinee that cannot carry the field at all, which is
+// #1053. This decides the flag itself rather than through bindPattern's shorthand arm, so
+// the two sites move together when the rule does.
 func (b *pathBinder) shorthandView(scope *Scope, s *ucs.Scrutinee, elem *ast.ObjShorthandPat) scrutineeView {
 	if v, ok := b.views[s]; ok {
 		return v

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -181,11 +181,11 @@ func (b *pathBinder) bindAtWith(
 // the annotation, default, and `mut` marker the name alone does not.
 //
 // It resolves the field itself rather than through viewOf, because a shorthand's field
-// lookup takes no upper bound. bindPatMode's shorthand arm takes none either: the leaf IS
+// lookup takes no upper bound. bindPatMode's shorthand arm takes none either. The leaf is
 // the projection rather than a value handed to a sub-pattern, and pinning it would make a
 // `&mut` leaf invariantly exact against the scrutinee's field, which applyBindMode's bmMut
-// arm spells out. Reading the same field through projectField would add that pin and make
-// the IR walk reject a `mut` leaf the written pattern accepts.
+// arm spells out. Reading the same field through projectField would add that pin and
+// reject a `mut` leaf the written pattern accepts.
 func (b *pathBinder) bindElemAt(scope *Scope, s *ucs.Scrutinee, elem *ast.ObjShorthandPat) {
 	v := b.shorthandView(scope, s, elem)
 	t := b.c.applyLeafExtras(scope, b.lvl, elem, v.ty, elem.TypeAnn, elem.Default)

--- a/internal/solver/ucs_bind_test.go
+++ b/internal/solver/ucs_bind_test.go
@@ -51,6 +51,13 @@ func defaultedLeafPat(name string) *ast.IdentPat {
 	return ast.NewIdentPat(name, false, nil, numExpr(0), builderSpan())
 }
 
+// shorthandElem builds the object-pattern element a `{x}` writes, optionally marked `mut`
+// or carrying a default. It takes no annotation, since every case that needs one goes
+// through bindAt's identifier leaf instead.
+func shorthandElem(name string, mutable bool, def ast.Expr) *ast.ObjShorthandPat {
+	return ast.NewObjShorthandPat(ast.NewIdentifier(name, builderSpan()), mutable, nil, def, builderSpan())
+}
+
 // projectPath applies each step in turn from root, sharing one *ucs.Scrutinee per level
 // the way normalization does, and returns the scrutinee the last step reaches.
 func projectPath(root *ucs.Scrutinee, steps ...ucs.Step) *ucs.Scrutinee {
@@ -308,7 +315,7 @@ func TestPathBinderProjectsAndBinds(t *testing.T) {
 			c, scope := newPathChecker(t, tt.src)
 			root, binder := seedPath(c, tt.rootType(t, c, scope))
 			if tt.test != nil {
-				binder = binder.narrowedBy(scope, root, tt.test)
+				binder = binder.narrowedBy(scope, root, tt.test, nil)
 			}
 			// The leaves of one branch bind in a child scope, so a name one branch binds is
 			// invisible to the next, exactly as inferMatchArms scopes an arm.
@@ -327,7 +334,7 @@ func TestPathBinderProjectsAndBinds(t *testing.T) {
 func TestPathBinderMaterializesEachScrutineeOnce(t *testing.T) {
 	c, scope := newPathChecker(t, "")
 	root, binder := seedPath(c, parseType(t, "{a: {x: number, y: string}}"))
-	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "a"}}})
+	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "a"}}}, nil)
 
 	inner := projectPath(root, ucs.FieldStep{Name: "a"})
 	first := binder.typeAt(scope, inner)
@@ -335,7 +342,7 @@ func TestPathBinderMaterializesEachScrutineeOnce(t *testing.T) {
 	require.Same(t, first, second)
 
 	// Both leaves of the inner split project out of that one shared scrutinee.
-	binder = binder.narrowedBy(scope, inner, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}, {Name: "y"}}})
+	binder = binder.narrowedBy(scope, inner, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}, {Name: "y"}}}, nil)
 	armScope := scope.Child()
 	binder.bindAt(armScope, projectPath(inner, ucs.FieldStep{Name: "x"}), leafPat("x"))
 	binder.bindAt(armScope, projectPath(inner, ucs.FieldStep{Name: "y"}), leafPat("y"))
@@ -352,11 +359,11 @@ func TestPathBinderSiblingBranchesShareOneProjection(t *testing.T) {
 	// The root has no `a`, so resolving `p.a` reports a missing property. Counting that
 	// report is how the test sees whether the projection ran once or once per branch.
 	root, binder := seedPath(c, parseType(t, "{b: number}"))
-	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "a"}}})
+	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "a"}}}, nil)
 	inner := projectPath(root, ucs.FieldStep{Name: "a"})
 
-	first := binder.narrowedBy(scope, inner, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}})
-	second := binder.narrowedBy(scope, inner, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "y"}}})
+	first := binder.narrowedBy(scope, inner, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}}, nil)
+	second := binder.narrowedBy(scope, inner, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "y"}}}, nil)
 
 	require.Equal(t, []string{"1:1-1:2: object is missing property: a"}, messagesWithSpan(c.errs))
 	// Neither test narrows a non-union scrutinee, so both branches still hold the one
@@ -387,8 +394,8 @@ func TestPathBinderBranchesNarrowIndependently(t *testing.T) {
 	c, scope := newPathChecker(t, "")
 	root, binder := seedPath(c, parseType(t, "{x: number} | {y: string}"))
 
-	first := binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}})
-	second := binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "y"}}})
+	first := binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x"}}}, nil)
+	second := binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "y"}}}, nil)
 
 	firstScope := scope.Child()
 	first.bindAt(firstScope, projectPath(root, ucs.FieldStep{Name: "x"}), leafPat("x"))
@@ -408,7 +415,7 @@ func TestPathBinderBranchesNarrowIndependently(t *testing.T) {
 func TestPathBinderDefaultFillsOptionalProperty(t *testing.T) {
 	c, scope := newPathChecker(t, "")
 	root, binder := seedPath(c, exactObj(&soltype.PropertyElem{Name: "x", Type: num(), Optional: true}))
-	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x", Optional: true}}})
+	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x", Optional: true}}}, nil)
 
 	armScope := scope.Child()
 	binder.bindAt(armScope, projectPath(root, ucs.FieldStep{Name: "x"}), defaultedLeafPat("x"))
@@ -430,7 +437,7 @@ func TestPathBinderDefaultFillsOptionalProperty(t *testing.T) {
 func TestPathBinderDefaultedKeyBindsAgainstScrutineeWithoutTheField(t *testing.T) {
 	c, scope := newPathChecker(t, "")
 	root, binder := seedPath(c, parseType(t, "{y: string}"))
-	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x", Optional: true}}})
+	binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{Keys: []ucs.ObjectKey{{Name: "x", Optional: true}}}, nil)
 
 	armScope := scope.Child()
 	binder.bindAt(armScope, projectPath(root, ucs.FieldStep{Name: "x"}), defaultedLeafPat("x"))
@@ -438,9 +445,73 @@ func TestPathBinderDefaultedKeyBindsAgainstScrutineeWithoutTheField(t *testing.T
 	require.Equal(t, "0", boundType(t, c, armScope, "x"))
 }
 
-// A test whose name resolves to no class or constructor reports against the name it
-// wrote, and the leaves beneath it still bind so a later reference does not cascade into
-// an unknown-identifier error.
+// An object pattern's shorthand element is not an ast.Pat, so it binds through bindElemAt
+// rather than bindAt, and it carries the annotation, default, and `mut` marker the name
+// alone does not. Each case renders the type the shorthand's leaf lands at.
+func TestPathBinderBindsShorthandElements(t *testing.T) {
+	// A borrow needs a lifetime to be a real reference rather than an owned-mutable cell.
+	lt := &soltype.LifetimeVar{ID: 0, Level: 0}
+
+	tests := map[string]struct {
+		rootType func(t *testing.T) soltype.Type
+		elem     *ast.ObjShorthandPat
+		want     string
+	}{
+		// A plain `{x}` binds the field at its type.
+		"Plain": {
+			rootType: func(t *testing.T) soltype.Type { return parseType(t, "{x: number}") },
+			elem:     shorthandElem("x", false, nil),
+			want:     "number",
+		},
+		// A default relaxes the field lookup, so `{x = 0}` over an optional property binds
+		// the property type joined with the default's rather than with `undefined`.
+		"Defaulted": {
+			rootType: func(_ *testing.T) soltype.Type {
+				return exactObj(&soltype.PropertyElem{Name: "x", Type: num(), Optional: true})
+			},
+			elem: shorthandElem("x", false, numExpr(0)),
+			want: "number | 0",
+		},
+		// A `mut` leaf moved out of an owned scrutinee thaws into an owned-mutable cell,
+		// the same thaw bindPatMode's shorthand arm performs.
+		"MutLeaf": {
+			rootType: func(t *testing.T) soltype.Type { return parseType(t, "{x: {a: number}}") },
+			elem:     shorthandElem("x", true, nil),
+			want:     "mut {a: number}",
+		},
+		// A leaf of a `&mut` scrutinee is a mutable borrow bounded by the scrutinee's
+		// lifetime. The projection takes no upper bound, which is what leaves the borrowed
+		// shape free to absorb an inexact write requirement.
+		"MutBorrowedScrutinee": {
+			rootType: func(t *testing.T) soltype.Type {
+				return &soltype.RefType{Mut: true, Lt: lt, Inner: parseType(t, "{x: {a: number}}").(soltype.RefInner)}
+			},
+			elem: shorthandElem("x", false, nil),
+			want: "&mut {a: number}",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, scope := newPathChecker(t, "")
+			root, binder := seedPath(c, tt.rootType(t))
+			key := tt.elem.Key.Name
+			binder = binder.narrowedBy(scope, root, &ucs.ObjectTest{
+				Keys: []ucs.ObjectKey{{Name: key, Optional: tt.elem.Default != nil}},
+			}, nil)
+
+			armScope := scope.Child()
+			binder.bindElemAt(armScope, projectPath(root, ucs.FieldStep{Name: key}), tt.elem)
+			require.Empty(t, messagesWithSpan(c.errs))
+			require.Equal(t, tt.want, boundType(t, c, armScope, key))
+		})
+	}
+}
+
+// A test whose name resolves to no class or constructor reports against the node the
+// caller blames, which is the branch's pattern once a walk applies the test and the
+// scrutinee's own origin here. The leaves beneath it still bind, so a later reference does
+// not cascade into an unknown-identifier error.
 func TestPathBinderUnresolvedTagNames(t *testing.T) {
 	tests := map[string]struct {
 		test ucs.Test
@@ -462,7 +533,7 @@ func TestPathBinderUnresolvedTagNames(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c, scope := newPathChecker(t, "")
 			root, binder := seedPath(c, parseType(t, "{x: number}"))
-			binder = binder.narrowedBy(scope, root, tt.test)
+			binder = binder.narrowedBy(scope, root, tt.test, nil)
 			armScope := scope.Child()
 			binder.bindAt(armScope, projectPath(root, tt.step), leafPat("x"))
 			require.Equal(t, []string{tt.want}, messagesWithSpan(c.errs))
@@ -476,7 +547,7 @@ func TestPathBinderUnresolvedTagNames(t *testing.T) {
 func TestPathBinderExtractorArityMismatch(t *testing.T) {
 	c, scope := newPathChecker(t, `class Point { x: number, y: number }`)
 	root, binder := seedPath(c, classType(t, c, scope, "Point"))
-	binder = binder.narrowedBy(scope, root, &ucs.ExtractorTest{Name: ast.NewIdentifier("Point", builderSpan()), Arity: 3})
+	binder = binder.narrowedBy(scope, root, &ucs.ExtractorTest{Name: ast.NewIdentifier("Point", builderSpan()), Arity: 3}, nil)
 
 	armScope := scope.Child()
 	binder.bindAt(armScope, projectPath(root, ucs.ExtractStep{Index: 0}), leafPat("a"))
@@ -506,7 +577,7 @@ func TestPathBinderLiteralTest(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c, scope := newPathChecker(t, "")
 			root, binder := seedPath(c, parseType(t, tt.rootType))
-			binder.narrowedBy(scope, root, &ucs.LitTest{Lit: tt.lit})
+			binder.narrowedBy(scope, root, &ucs.LitTest{Lit: tt.lit}, nil)
 			require.Equal(t, tt.wantErrs, messagesWithSpan(c.errs))
 		})
 	}

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -1,0 +1,253 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/escalier-lang/escalier/internal/solver/ucs"
+)
+
+// The typing walk over the UCS normalized form.
+//
+// A conditional form is lowered by `ucs.Desugar*` and `ucs.Normalize` into a tree of
+// splits, binds, guards, and leaves. This file types that tree. A split applies its
+// branch's tag test to the path binder, a bind resolves its projection and defines the
+// leaf, a guard is an ordinary boolean condition over the names above it, and a leaf
+// infers the body the user wrote for its arm.
+//
+// The walk carries three states rather than one, because a term's continuation does not
+// run in the state the term itself runs in.
+//
+//   - cur is where the term being typed runs.
+//   - fall is where the whole form started. Its scope holds none of the names an arm
+//     bound, and its binder has no branch's tag test applied.
+//   - matched is fall's scope with the enclosing branch's tag test applied. Control that
+//     falls out of a branch reaches the arms below it knowing that branch's test held, so
+//     `Ok(v) if g => v, Ok(v) => v` types the second arm's `v` through the `Ok` the first
+//     arm tested. Normalization drops the second `Ok` test for exactly that reason.
+//
+// A continuation more than one path reaches takes fall rather than matched, per
+// joinPoints below.
+
+// condState is the scope and path binder one point of the walk runs in. A branch derives
+// a new state from the state of the split it belongs to, so two branches of one split
+// neither see each other's names nor each other's narrowing.
+type condState struct {
+	scope  *Scope
+	binder *pathBinder
+}
+
+// condWalk types one conditional form. Everything it holds is fixed for that form: the
+// checker, the level its variables are minted at, the node a body's join is blamed on,
+// and the branch-join variable every non-diverging body constrains into.
+type condWalk struct {
+	c    *checker
+	lvl  int
+	node ast.Node
+	res  soltype.Type
+	// bodies collects the type of each non-diverging body, which the caller hands to
+	// checkUniformOwnership. A diverging body produces no value, so it joins neither res
+	// nor this slice.
+	bodies []soltype.Type
+	// seen holds every term the walk has already typed, so a term two edges reach is
+	// typed once. Typing it twice would infer the arm body twice and report anything
+	// wrong with it twice.
+	seen set.Set[ucs.Norm]
+	// joins answers whether a continuation is one of those shared terms.
+	joins *joinPoints
+}
+
+// newCondWalk builds the walk over norm, the normalized form of one conditional. node is
+// the construct each body's join is blamed on, and res the branch-join variable those
+// bodies constrain into.
+func newCondWalk(c *checker, lvl int, node ast.Node, res soltype.Type, norm ucs.Norm) *condWalk {
+	return &condWalk{
+		c:     c,
+		lvl:   lvl,
+		node:  node,
+		res:   res,
+		seen:  set.NewSet[ucs.Norm](),
+		joins: newJoinPoints(norm),
+	}
+}
+
+// walkNorm types term. cur is the state term runs in, fall the state the whole form
+// started in, and matched fall with the enclosing branch's tag test applied.
+func (w *condWalk) walkNorm(cur, fall condState, matched *pathBinder, term ucs.Norm) {
+	if term == nil || w.seen.Contains(term) {
+		return
+	}
+	w.seen.Add(term)
+	switch n := term.(type) {
+	case *ucs.NormSplit:
+		w.walkSplit(cur, fall, matched, n)
+	case *ucs.NormBind:
+		w.walkBind(cur, fall, matched, n)
+	case *ucs.NormGuard:
+		w.walkGuard(cur, fall, matched, n)
+	case *ucs.BodyLeaf:
+		w.walkBody(cur, n)
+	}
+}
+
+// walkSplit types each branch of a split under the tag test that branch makes, then the
+// tail control reaches when no test matched.
+//
+// The tail is a fallthrough rather than part of the split. A split reached from inside a
+// branch is one normalization built by flattening a nested pattern, and its tail is the
+// fallthrough of the branch that encloses it. In `Line { start: {x, y} } => body` the
+// split over `l.start` falls to whatever the `Line` branch falls to, not back into the
+// `Line` branch, so the tail continues from the state the enclosing branch matched in.
+func (w *condWalk) walkSplit(cur, fall condState, matched *pathBinder, split *ucs.NormSplit) {
+	for _, branch := range split.Branches {
+		tested := cur.binder.narrowedBy(cur.scope, split.Scrutinee, branch.Test, branch.Origin.Node)
+		w.walkNorm(condState{scope: cur.scope, binder: tested}, fall, tested, branch.Cont)
+	}
+	w.walkFallthrough(fall, matched, split.Default)
+}
+
+// walkBind resolves the projection a bind names and defines its leaf, then types what
+// runs with that leaf in scope.
+//
+// The leaf goes into a child scope, so it is visible to the guard and body below it and
+// invisible everywhere else. That matters most for a bind under a split's tail, such as
+// the `other` of `match p { {x, y} if g => x, other => other }`. Defining it in the
+// enclosing scope would leak the name into the block the `match` sits in.
+func (w *condWalk) walkBind(cur, fall condState, matched *pathBinder, bind *ucs.NormBind) {
+	scope := cur.scope.Child()
+	switch {
+	case bind.Elem != nil:
+		cur.binder.bindElemAt(scope, bind.Source, bind.Elem)
+	case bind.Pat != nil:
+		cur.binder.bindAt(scope, bind.Source, bind.Pat)
+	}
+	w.walkNorm(condState{scope: scope, binder: cur.binder}, fall, matched, bind.Cont)
+}
+
+// walkGuard types a guard's condition as a boolean over the names its branch bound, then
+// types both continuations: the body the guard admits, and where a false condition goes.
+func (w *condWalk) walkGuard(cur, fall condState, matched *pathBinder, guard *ucs.NormGuard) {
+	// A guard is an ordinary boolean condition. As in inferIfElse, the synthesized
+	// boolean requirement is left out of Prov. It is a language rule, not a user
+	// annotation, so there is no source node to anchor a related span to.
+	cond := w.c.inferExpr(cur.scope, w.lvl, guard.Cond)
+	w.c.constrain(guard.Cond, cond, &soltype.PrimType{Prim: soltype.BoolPrim})
+	w.walkNorm(cur, fall, matched, guard.Cont)
+	w.walkFallthrough(fall, matched, guard.Default)
+}
+
+// walkFallthrough types where a failed test or a false guard continues. The names the
+// branch bound are out of scope again, so the continuation runs in fall's scope.
+//
+// It keeps the enclosing branch's tag test unless term is a join point. A join point runs
+// both when that test matched and when it did not, so only what holds on both paths may
+// be assumed of it. In `match p { {x, y} if g => x, other => other }` the `other` arm is
+// the join point: the failed guard reaches it, and so does a `p` that is not a `{x, y}`
+// at all, and its one body cannot be typed as though the shape had matched.
+func (w *condWalk) walkFallthrough(fall condState, matched *pathBinder, term ucs.Norm) {
+	next := condState{scope: fall.scope, binder: matched}
+	if w.joins.reachesJoin(term) {
+		next = fall
+	}
+	w.walkNorm(next, fall, next.binder, term)
+}
+
+// walkBody infers an arm body and joins it into the form's result. A diverging body
+// produces no value, so when every body diverges nothing is constrained into res and it
+// coalesces to `never`.
+func (w *condWalk) walkBody(cur condState, leaf *ucs.BodyLeaf) {
+	bodyT, diverges := w.c.inferBlockOrExpr(cur.scope, w.lvl, &leaf.Body)
+	if diverges {
+		return
+	}
+	w.c.constrain(w.node, bodyT, w.res)
+	w.bodies = append(w.bodies, bodyT)
+}
+
+// joinPoints answers which terms of one normalized form more than one path reaches.
+//
+// Normalization copies a branch's continuation into each earlier branch's fallthrough, so
+// a term reached both ways is not always one node. The copies are separate nodes over one
+// shared arm body, which is why a term counts as a join point when it merely reaches one.
+// `match p { {x, y} if g => x, other => other }` produces two `bind other = p` nodes over
+// a single `leaf other`, and both binds have to be treated as joins for the arm's `other`
+// to be typed at what it holds on either path.
+type joinPoints struct {
+	// indeg counts the edges into each term. A term one edge reaches runs under exactly
+	// one set of matched tests.
+	indeg map[ucs.Norm]int
+	// reaches memoizes the answer per term, since a fallthrough shared by several branches
+	// is asked about once per branch.
+	reaches map[ucs.Norm]bool
+}
+
+// newJoinPoints counts the edges of the normalized form rooted at norm.
+func newJoinPoints(norm ucs.Norm) *joinPoints {
+	j := &joinPoints{indeg: map[ucs.Norm]int{}, reaches: map[ucs.Norm]bool{}}
+	j.countEdges(norm, set.NewSet[ucs.Norm]())
+	return j
+}
+
+// countEdges records one entry per edge into each term, visiting each term once so a
+// shared subterm's own edges are not counted twice.
+func (j *joinPoints) countEdges(term ucs.Norm, walked set.Set[ucs.Norm]) {
+	for _, next := range continuations(term) {
+		j.indeg[next]++
+		if walked.Contains(next) {
+			continue
+		}
+		walked.Add(next)
+		j.countEdges(next, walked)
+	}
+}
+
+// reachesJoin reports whether term is reached by more than one edge, or can reach a term
+// that is.
+func (j *joinPoints) reachesJoin(term ucs.Norm) bool {
+	if term == nil {
+		return false
+	}
+	if got, walked := j.reaches[term]; walked {
+		return got
+	}
+	// Seed the memo before recursing. The normalized form is a tree of shared subterms
+	// with no cycle, so the seed is never the answer a caller reads; it bounds the walk if
+	// a later rewrite ever introduces one.
+	j.reaches[term] = false
+	got := j.indeg[term] > 1
+	for _, next := range continuations(term) {
+		if j.reachesJoin(next) {
+			got = true
+		}
+	}
+	j.reaches[term] = got
+	return got
+}
+
+// continuations returns the terms control can reach from term in one step. A nil
+// continuation is left out, which is what a split with no covering branch carries and
+// what a guard with nothing to fall into carries. A leaf continues nowhere.
+func continuations(term ucs.Norm) []ucs.Norm {
+	switch n := term.(type) {
+	case *ucs.NormSplit:
+		next := make([]ucs.Norm, 0, len(n.Branches)+1)
+		for _, branch := range n.Branches {
+			next = appendTerm(next, branch.Cont)
+		}
+		return appendTerm(next, n.Default)
+	case *ucs.NormGuard:
+		return appendTerm(appendTerm(nil, n.Cont), n.Default)
+	case *ucs.NormBind:
+		return appendTerm(nil, n.Cont)
+	default:
+		return nil
+	}
+}
+
+// appendTerm adds term to next when it names a continuation at all.
+func appendTerm(next []ucs.Norm, term ucs.Norm) []ucs.Norm {
+	if term == nil {
+		return next
+	}
+	return append(next, term)
+}

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -26,8 +26,9 @@ import (
 //     `Ok(v) if g => v, Ok(v) => v` that is what resolves the second arm's `v`, since
 //     normalization drops the second `Ok` test as one the first already proved.
 //
-// A continuation more than one path reaches takes fall rather than matched, per normGraph
-// below.
+// Some continuations are reached by more than one path. Such a continuation runs whether
+// or not the enclosing branch's test matched, so it inherits no test. It runs in fall
+// rather than in matched, and normGraph below is what identifies those continuations.
 
 // condState is the scope and path binder one point of the walk runs in. A branch derives
 // a new state from the state of the split it belongs to, so two branches of one split

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -10,10 +10,12 @@ import (
 // The typing walk over the UCS normalized form.
 //
 // A conditional form is lowered by `ucs.Desugar*` and `ucs.Normalize` into a tree of
-// splits, binds, guards, and leaves. This file types that tree for a `match`. A split
-// applies its branch's tag test to the path binder, a bind resolves its projection and
-// defines the leaf, a guard is an ordinary boolean condition over the names above it, and
-// a leaf infers the body the user wrote for its arm.
+// splits, binds, guards, and leaves. A term is one node of that tree, which is what
+// `ucs.Term` names. The bare word `node` is kept for an `ast.Node`, the surface node a
+// diagnostic blames, so neither has to be read from context. This file types the tree for
+// a `match`. A split applies its branch's tag test to the path binder, a bind resolves its
+// projection and defines the leaf, a guard is an ordinary boolean condition over the names
+// above it, and a leaf infers the body the user wrote for its arm.
 //
 // The walk carries three states rather than one, because a term's continuation does not
 // run in the state the term itself runs in.
@@ -176,7 +178,7 @@ func (w *condWalk) walked(term ucs.Norm) bool {
 // makes term a copy of work the walk has done.
 //
 // Normalization emits an arm as a branch of its split and again inside each earlier
-// fallible branch's fallthrough. The copies are separate nodes over one shared arm body, so
+// fallible branch's fallthrough. The copies are separate terms over one shared arm body, so
 // the body is what identifies them. `match p { {x} if b => 1, {y} => 2 }` produces the
 // `{y}` branch twice, and without this its test and its leaf would each run twice.
 //
@@ -213,8 +215,8 @@ func (w *condWalk) walkBody(cur condState, leaf *ucs.BodyLeaf) {
 // Both questions exist because normalization emits an arm more than once. A branch that
 // can fail falls into a copy of everything below it, so an arm is a branch of its own
 // split and again inside each earlier fallible branch's fallthrough. The copies are
-// separate nodes over one shared arm body, which is why neither question can be answered
-// by node identity alone.
+// separate terms over one shared arm body, which is why neither question can be answered
+// by identity alone.
 type normGraph struct {
 	// indeg counts the edges into each term. A term one edge reaches runs under exactly
 	// one set of matched tests.
@@ -252,7 +254,7 @@ func (g *normGraph) countEdges(term ucs.Norm, walked set.Set[ucs.Norm]) {
 
 // reachesJoin reports whether term is reached by more than one edge, or reaches such a
 // term without falling through again. `match p { {x, y} if g => x, other => other }`
-// produces two `bind other = p` nodes over a single `leaf other`, and both binds answer
+// produces two `bind other = p` terms over a single `leaf other`, and both binds answer
 // true through that body.
 //
 // The walk below term is the one underMatchedTest describes. A term this one falls

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -26,8 +26,8 @@ import (
 //     `Ok(v) if g => v, Ok(v) => v` types the second arm's `v` through the `Ok` the first
 //     arm tested. Normalization drops the second `Ok` test for exactly that reason.
 //
-// A continuation more than one path reaches takes fall rather than matched, per
-// joinPoints below.
+// A continuation more than one path reaches takes fall rather than matched, per normGraph
+// below.
 
 // condState is the scope and path binder one point of the walk runs in. A branch derives
 // a new state from the state of the split it belongs to, so two branches of one split
@@ -53,8 +53,9 @@ type condWalk struct {
 	// typed once. Typing it twice would infer the arm body twice and report anything
 	// wrong with it twice.
 	seen set.Set[ucs.Norm]
-	// joins answers whether a continuation is one of those shared terms.
-	joins *joinPoints
+	// graph answers what the walk needs to know about the form's shape: whether a
+	// continuation is one of those shared terms, and which arm bodies a term can reach.
+	graph *normGraph
 }
 
 // newCondWalk builds the walk over norm, the normalized form of one conditional. node is
@@ -67,14 +68,14 @@ func newCondWalk(c *checker, lvl int, node ast.Node, res soltype.Type, norm ucs.
 		node:  node,
 		res:   res,
 		seen:  set.NewSet[ucs.Norm](),
-		joins: newJoinPoints(norm),
+		graph: newNormGraph(norm),
 	}
 }
 
 // walkNorm types term. cur is the state term runs in, fall the state the whole form
 // started in, and matched fall with the enclosing branch's tag test applied.
 func (w *condWalk) walkNorm(cur, fall condState, matched *pathBinder, term ucs.Norm) {
-	if term == nil || w.seen.Contains(term) {
+	if w.walked(term) {
 		return
 	}
 	w.seen.Add(term)
@@ -100,6 +101,12 @@ func (w *condWalk) walkNorm(cur, fall condState, matched *pathBinder, term ucs.N
 // `Line` branch, so the tail continues from the state the enclosing branch matched in.
 func (w *condWalk) walkSplit(cur, fall condState, matched *pathBinder, split *ucs.NormSplit) {
 	for _, branch := range split.Branches {
+		if w.walked(branch.Cont) {
+			// The branch is a copy of one already typed. Its test is asked about before its
+			// continuation is walked, so the skip has to happen here rather than inside
+			// walkNorm, or applying the test would report the same diagnostics a second time.
+			continue
+		}
 		tested := cur.binder.narrowedBy(cur.scope, split.Scrutinee, branch.Test, branch.Origin.Node)
 		w.walkNorm(condState{scope: cur.scope, binder: tested}, fall, tested, branch.Cont)
 	}
@@ -146,10 +153,41 @@ func (w *condWalk) walkGuard(cur, fall condState, matched *pathBinder, guard *uc
 // at all, and its one body cannot be typed as though the shape had matched.
 func (w *condWalk) walkFallthrough(fall condState, matched *pathBinder, term ucs.Norm) {
 	next := condState{scope: fall.scope, binder: matched}
-	if w.joins.reachesJoin(term) {
+	if w.graph.reachesJoin(term) {
 		next = fall
 	}
 	w.walkNorm(next, fall, next.binder, term)
+}
+
+// walked reports whether term carries no work the walk has left to do, either because the
+// walk already typed that very term or because term is a copy of one it typed.
+func (w *condWalk) walked(term ucs.Norm) bool {
+	return term == nil || w.seen.Contains(term) || w.typedAlready(term)
+}
+
+// typedAlready reports whether every arm body term can reach has been typed, which means
+// term is a copy of work the walk has done and re-running it would report the same
+// diagnostics twice.
+//
+// Normalization emits an arm both as a branch of its split and as part of what each
+// earlier fallible branch falls into, and the two are separate nodes over one shared arm
+// body. `match p { {x} if b => 1, {y} => 2 }` produces the `{y}` branch twice, so without
+// this the `{y}` test and its leaf would each run twice. The shared body is what identifies
+// the copies, since the nodes above it are not shared.
+//
+// A term reaching no body at all is not a copy of anything. That is a `✗` tail, which
+// carries no work to skip.
+func (w *condWalk) typedAlready(term ucs.Norm) bool {
+	reached := w.graph.bodiesUnder(term)
+	if len(reached) == 0 {
+		return false
+	}
+	for _, body := range reached {
+		if !w.seen.Contains(body) {
+			return false
+		}
+	}
+	return true
 }
 
 // walkBody infers an arm body and joins it into the form's result. A diverging body
@@ -164,64 +202,111 @@ func (w *condWalk) walkBody(cur condState, leaf *ucs.BodyLeaf) {
 	w.bodies = append(w.bodies, bodyT)
 }
 
-// joinPoints answers which terms of one normalized form more than one path reaches.
+// normGraph is what the walk reads off the shape of one normalized form before typing it:
+// which terms more than one path reaches, and which arm bodies each term can reach.
 //
-// Normalization copies a branch's continuation into each earlier branch's fallthrough, so
-// a term reached both ways is not always one node. The copies are separate nodes over one
-// shared arm body, which is why a term counts as a join point when it merely reaches one.
-// `match p { {x, y} if g => x, other => other }` produces two `bind other = p` nodes over
-// a single `leaf other`, and both binds have to be treated as joins for the arm's `other`
-// to be typed at what it holds on either path.
-type joinPoints struct {
+// Both questions exist because normalization emits an arm more than once. A branch that
+// can fail falls into a copy of everything below it, so an arm is a branch of its own
+// split and again inside each earlier fallible branch's fallthrough. The copies are
+// separate nodes over one shared arm body, which is why neither question can be answered
+// by node identity alone.
+type normGraph struct {
 	// indeg counts the edges into each term. A term one edge reaches runs under exactly
 	// one set of matched tests.
 	indeg map[ucs.Norm]int
-	// reaches memoizes the answer per term, since a fallthrough shared by several branches
+	// joins memoizes reachesJoin per term, since a fallthrough shared by several branches
 	// is asked about once per branch.
-	reaches map[ucs.Norm]bool
+	joins map[ucs.Norm]bool
+	// bodies memoizes bodiesUnder per term.
+	bodies map[ucs.Norm][]ucs.Norm
 }
 
-// newJoinPoints counts the edges of the normalized form rooted at norm.
-func newJoinPoints(norm ucs.Norm) *joinPoints {
-	j := &joinPoints{indeg: map[ucs.Norm]int{}, reaches: map[ucs.Norm]bool{}}
-	j.countEdges(norm, set.NewSet[ucs.Norm]())
-	return j
+// newNormGraph counts the edges of the normalized form rooted at norm.
+func newNormGraph(norm ucs.Norm) *normGraph {
+	g := &normGraph{
+		indeg:  map[ucs.Norm]int{},
+		joins:  map[ucs.Norm]bool{},
+		bodies: map[ucs.Norm][]ucs.Norm{},
+	}
+	g.countEdges(norm, set.NewSet[ucs.Norm]())
+	return g
 }
 
 // countEdges records one entry per edge into each term, visiting each term once so a
 // shared subterm's own edges are not counted twice.
-func (j *joinPoints) countEdges(term ucs.Norm, walked set.Set[ucs.Norm]) {
+func (g *normGraph) countEdges(term ucs.Norm, walked set.Set[ucs.Norm]) {
 	for _, next := range continuations(term) {
-		j.indeg[next]++
+		g.indeg[next]++
 		if walked.Contains(next) {
 			continue
 		}
 		walked.Add(next)
-		j.countEdges(next, walked)
+		g.countEdges(next, walked)
 	}
 }
 
 // reachesJoin reports whether term is reached by more than one edge, or can reach a term
-// that is.
-func (j *joinPoints) reachesJoin(term ucs.Norm) bool {
+// that is. `match p { {x, y} if g => x, other => other }` produces two `bind other = p`
+// nodes over a single `leaf other`, and both binds answer true through that body.
+func (g *normGraph) reachesJoin(term ucs.Norm) bool {
 	if term == nil {
 		return false
 	}
-	if got, walked := j.reaches[term]; walked {
+	if got, walked := g.joins[term]; walked {
 		return got
 	}
 	// Seed the memo before recursing. The normalized form is a tree of shared subterms
 	// with no cycle, so the seed is never the answer a caller reads; it bounds the walk if
 	// a later rewrite ever introduces one.
-	j.reaches[term] = false
-	got := j.indeg[term] > 1
+	g.joins[term] = false
+	got := g.indeg[term] > 1
 	for _, next := range continuations(term) {
-		if j.reachesJoin(next) {
+		if g.reachesJoin(next) {
 			got = true
 		}
 	}
-	j.reaches[term] = got
+	g.joins[term] = got
 	return got
+}
+
+// bodiesUnder returns the arm bodies control can reach from term, each listed once.
+func (g *normGraph) bodiesUnder(term ucs.Norm) []ucs.Norm {
+	if term == nil {
+		return nil
+	}
+	if got, walked := g.bodies[term]; walked {
+		return got
+	}
+	// Seeded before recursing for the reason reachesJoin's memo is.
+	g.bodies[term] = nil
+	reached := set.NewSet[ucs.Norm]()
+	var found []ucs.Norm
+	if isLeaf(term) {
+		found = append(found, term)
+		reached.Add(term)
+	}
+	for _, next := range continuations(term) {
+		for _, body := range g.bodiesUnder(next) {
+			if reached.Contains(body) {
+				continue
+			}
+			reached.Add(body)
+			found = append(found, body)
+		}
+	}
+	g.bodies[term] = found
+	return found
+}
+
+// isLeaf reports whether term ends a branch rather than continuing into another term. The
+// three leaf kinds are the arm bodies the walk types, and no other term carries one.
+func isLeaf(term ucs.Norm) bool {
+	switch term.(type) {
+	case *ucs.BodyLeaf, *ucs.EscapeLeaf, *ucs.FallbackLeaf:
+		return true
+	default:
+		return false
+	}
 }
 
 // continuations returns the terms control can reach from term in one step. A nil

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -218,9 +218,10 @@ func (w *condWalk) walkBody(cur condState, leaf *ucs.BodyLeaf) {
 // separate terms over one shared arm body, which is why neither question can be answered
 // by identity alone.
 type normGraph struct {
-	// indeg counts the edges into each term. A term one edge reaches runs under exactly
-	// one set of matched tests.
-	indeg map[ucs.Norm]int
+	// edgesInto counts the continuations that reach each term. A term reached by one edge
+	// runs under exactly one set of matched tests. A term reached by more can assume only
+	// what holds on every path into it.
+	edgesInto map[ucs.Norm]int
 	// joins memoizes reachesJoin per term, since a fallthrough shared by several branches
 	// is asked about once per branch.
 	joins map[ucs.Norm]bool
@@ -231,9 +232,9 @@ type normGraph struct {
 // newNormGraph counts the edges of the normalized form rooted at norm.
 func newNormGraph(norm ucs.Norm) *normGraph {
 	g := &normGraph{
-		indeg:  map[ucs.Norm]int{},
-		joins:  map[ucs.Norm]bool{},
-		bodies: map[ucs.Norm][]ucs.Norm{},
+		edgesInto: map[ucs.Norm]int{},
+		joins:     map[ucs.Norm]bool{},
+		bodies:    map[ucs.Norm][]ucs.Norm{},
 	}
 	g.countEdges(norm, set.NewSet[ucs.Norm]())
 	return g
@@ -243,7 +244,7 @@ func newNormGraph(norm ucs.Norm) *normGraph {
 // shared subterm's own edges are not counted twice.
 func (g *normGraph) countEdges(term ucs.Norm, walked set.Set[ucs.Norm]) {
 	for _, next := range continuations(term) {
-		g.indeg[next]++
+		g.edgesInto[next]++
 		if walked.Contains(next) {
 			continue
 		}
@@ -271,7 +272,7 @@ func (g *normGraph) reachesJoin(term ucs.Norm) bool {
 	// no cycle, so no caller ever reads the seed. It is there to bound the walk should a
 	// later rewrite introduce one.
 	g.joins[term] = false
-	got := g.indeg[term] > 1
+	got := g.edgesInto[term] > 1
 	for _, next := range underMatchedTest(term) {
 		if g.reachesJoin(next) {
 			got = true

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -101,14 +101,12 @@ func (w *condWalk) walkNorm(cur, fall condState, matched *pathBinder, term ucs.N
 	}
 }
 
-// walkSplit types each branch of a split under the tag test that branch makes, then the
-// tail control reaches when no test matched.
+// walkSplit types each branch under the tag test it makes, then the tail control reaches
+// when no test matched.
 //
-// The tail is a fallthrough rather than part of the split, so it continues from the state
-// the enclosing branch matched in. A split reached from inside a branch is one
-// normalization built by flattening a nested pattern, and its tail is that branch's own
-// fallthrough. In `Line { start: {x, y} } => body` the split over `l.start` falls to
-// whatever the `Line` branch falls to, not back into the `Line` branch.
+// The tail is a fallthrough, so it continues from the state the enclosing branch matched
+// in. In `Line { start: {x, y} } => body` the split over `l.start` is one flattening the
+// nested pattern produced, and its tail is whatever the `Line` branch falls to.
 func (w *condWalk) walkSplit(cur, fall condState, matched *pathBinder, split *ucs.NormSplit) {
 	for _, branch := range split.Branches {
 		if w.walked(branch.Cont) {
@@ -154,13 +152,12 @@ func (w *condWalk) walkGuard(cur, fall condState, matched *pathBinder, guard *uc
 }
 
 // walkFallthrough types where a failed test or a false guard continues. The names the
-// branch bound are out of scope again, so the continuation runs in fall's scope.
+// branch bound are out of scope again, so it runs in fall's scope.
 //
-// It keeps the enclosing branch's tag test unless term is a join point. A join point runs
-// both when that test matched and when it did not, so only what holds on both paths may
-// be assumed of it. In `match p { {x, y} if g => x, other => other }` the `other` arm is
-// the join point: the failed guard reaches it, and so does a `p` that is not a `{x, y}`
-// at all, and its one body cannot be typed as though the shape had matched.
+// It keeps the enclosing branch's tag test unless term is a join point. In
+// `match p { {x, y} if g => x, other => other }` the `other` arm is one. The failed guard
+// reaches it and so does a `p` that is no `{x, y}`, so its one body cannot assume the
+// shape matched.
 func (w *condWalk) walkFallthrough(fall condState, matched *pathBinder, term ucs.Norm) {
 	next := condState{scope: fall.scope, binder: matched}
 	if w.graph.reachesJoin(term) {
@@ -175,18 +172,15 @@ func (w *condWalk) walked(term ucs.Norm) bool {
 	return term == nil || w.seen.Contains(term) || w.typedAlready(term)
 }
 
-// typedAlready reports whether every arm body term can reach has been typed, which means
-// term is a copy of work the walk has done and re-running it would report the same
-// diagnostics twice.
+// typedAlready reports whether every arm body term can reach has already been typed, which
+// makes term a copy of work the walk has done.
 //
-// Normalization emits an arm both as a branch of its split and as part of what each
-// earlier fallible branch falls into, and the two are separate nodes over one shared arm
-// body. `match p { {x} if b => 1, {y} => 2 }` produces the `{y}` branch twice, so without
-// this the `{y}` test and its leaf would each run twice. The shared body is what identifies
-// the copies, since the nodes above it are not shared.
+// Normalization emits an arm as a branch of its split and again inside each earlier
+// fallible branch's fallthrough. The copies are separate nodes over one shared arm body, so
+// the body is what identifies them. `match p { {x} if b => 1, {y} => 2 }` produces the
+// `{y}` branch twice, and without this its test and its leaf would each run twice.
 //
-// A term reaching no body at all is not a copy of anything. That is a `✗` tail, which
-// carries no work to skip.
+// A term reaching no body is not a copy. That is a `✗` tail, with no work to skip.
 func (w *condWalk) typedAlready(term ucs.Norm) bool {
 	reached := w.graph.bodiesUnder(term)
 	if len(reached) == 0 {

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -258,9 +258,11 @@ func (g *normGraph) countEdges(term ucs.Norm, walked set.Set[ucs.Norm]) {
 // produces two `bind other = p` terms over a single `leaf other`, and both binds answer
 // true through that body.
 //
-// The walk below term is the one underMatchedTest describes. A term this one falls
-// through to is left out, since walkFallthrough asks about it separately, and counting it
-// here would answer true for a term whose own arm nothing else reaches.
+// It recurses through underMatchedTest rather than continuations, so it stops at a
+// fallthrough edge. walkFallthrough decides that edge on its own, and following it here
+// would answer true for a term nothing else reaches only because the tail it falls through
+// to is shared. In `{x} if b => x, {x} if c => x, _ => 0` the second arm is such a term,
+// and the `_ => 0` both guards fall into is the shared tail.
 func (g *normGraph) reachesJoin(term ucs.Norm) bool {
 	if term == nil {
 		return false
@@ -269,8 +271,8 @@ func (g *normGraph) reachesJoin(term ucs.Norm) bool {
 		return got
 	}
 	// Seed the memo before recursing. The normalized form is a tree of shared subterms with
-	// no cycle, so no caller ever reads the seed. It is there to bound the walk should a
-	// later rewrite introduce one.
+	// no cycle, so no caller ever reads the seed. It is there to bound the recursion should
+	// a later rewrite introduce one.
 	g.joins[term] = false
 	got := g.edgesInto[term] > 1
 	for _, next := range underMatchedTest(term) {

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -10,10 +10,10 @@ import (
 // The typing walk over the UCS normalized form.
 //
 // A conditional form is lowered by `ucs.Desugar*` and `ucs.Normalize` into a tree of
-// splits, binds, guards, and leaves. This file types that tree. A split applies its
-// branch's tag test to the path binder, a bind resolves its projection and defines the
-// leaf, a guard is an ordinary boolean condition over the names above it, and a leaf
-// infers the body the user wrote for its arm.
+// splits, binds, guards, and leaves. This file types that tree for a `match`. A split
+// applies its branch's tag test to the path binder, a bind resolves its projection and
+// defines the leaf, a guard is an ordinary boolean condition over the names above it, and
+// a leaf infers the body the user wrote for its arm.
 //
 // The walk carries three states rather than one, because a term's continuation does not
 // run in the state the term itself runs in.
@@ -21,10 +21,10 @@ import (
 //   - cur is where the term being typed runs.
 //   - fall is where the whole form started. Its scope holds none of the names an arm
 //     bound, and its binder has no branch's tag test applied.
-//   - matched is fall's scope with the enclosing branch's tag test applied. Control that
-//     falls out of a branch reaches the arms below it knowing that branch's test held, so
-//     `Ok(v) if g => v, Ok(v) => v` types the second arm's `v` through the `Ok` the first
-//     arm tested. Normalization drops the second `Ok` test for exactly that reason.
+//   - matched is fall's binder with the enclosing branch's tag test applied. Control that
+//     falls out of a branch reaches the arms below it knowing that branch's test held. In
+//     `Ok(v) if g => v, Ok(v) => v` that is what resolves the second arm's `v`, since
+//     normalization drops the second `Ok` test as one the first already proved.
 //
 // A continuation more than one path reaches takes fall rather than matched, per normGraph
 // below.
@@ -49,6 +49,10 @@ type condWalk struct {
 	// checkUniformOwnership. A diverging body produces no value, so it joins neither res
 	// nor this slice.
 	bodies []soltype.Type
+	// arms holds the surface arm behind each body the walk typed. Normalization leaves an
+	// arm below an unguarded catch-all out of the split, so a caller reads this to find
+	// the arms it has to type some other way.
+	arms set.Set[ucs.Spanned]
 	// seen holds every term the walk has already typed, so a term two edges reach is
 	// typed once. Typing it twice would infer the arm body twice and report anything
 	// wrong with it twice.
@@ -67,13 +71,14 @@ func newCondWalk(c *checker, lvl int, node ast.Node, res soltype.Type, norm ucs.
 		lvl:   lvl,
 		node:  node,
 		res:   res,
+		arms:  set.NewSet[ucs.Spanned](),
 		seen:  set.NewSet[ucs.Norm](),
 		graph: newNormGraph(norm),
 	}
 }
 
 // walkNorm types term. cur is the state term runs in, fall the state the whole form
-// started in, and matched fall with the enclosing branch's tag test applied.
+// started in, and matched fall's binder with the enclosing branch's tag test applied.
 func (w *condWalk) walkNorm(cur, fall condState, matched *pathBinder, term ucs.Norm) {
 	if w.walked(term) {
 		return
@@ -88,17 +93,21 @@ func (w *condWalk) walkNorm(cur, fall condState, matched *pathBinder, term ucs.N
 		w.walkGuard(cur, fall, matched, n)
 	case *ucs.BodyLeaf:
 		w.walkBody(cur, n)
+	case *ucs.EscapeLeaf, *ucs.FallbackLeaf:
+		// The two leaves of a `val pat = init else { … }`. Its success path carries no body
+		// at all. Its `else` carries one, but binding it needs the declaration's rules rather
+		// than an arm's. Neither is typed here, and `ucs.DesugarMatch` mints neither.
 	}
 }
 
 // walkSplit types each branch of a split under the tag test that branch makes, then the
 // tail control reaches when no test matched.
 //
-// The tail is a fallthrough rather than part of the split. A split reached from inside a
-// branch is one normalization built by flattening a nested pattern, and its tail is the
-// fallthrough of the branch that encloses it. In `Line { start: {x, y} } => body` the
-// split over `l.start` falls to whatever the `Line` branch falls to, not back into the
-// `Line` branch, so the tail continues from the state the enclosing branch matched in.
+// The tail is a fallthrough rather than part of the split, so it continues from the state
+// the enclosing branch matched in. A split reached from inside a branch is one
+// normalization built by flattening a nested pattern, and its tail is that branch's own
+// fallthrough. In `Line { start: {x, y} } => body` the split over `l.start` falls to
+// whatever the `Line` branch falls to, not back into the `Line` branch.
 func (w *condWalk) walkSplit(cur, fall condState, matched *pathBinder, split *ucs.NormSplit) {
 	for _, branch := range split.Branches {
 		if w.walked(branch.Cont) {
@@ -194,6 +203,7 @@ func (w *condWalk) typedAlready(term ucs.Norm) bool {
 // produces no value, so when every body diverges nothing is constrained into res and it
 // coalesces to `never`.
 func (w *condWalk) walkBody(cur condState, leaf *ucs.BodyLeaf) {
+	w.arms.Add(leaf.Arm)
 	bodyT, diverges := w.c.inferBlockOrExpr(cur.scope, w.lvl, &leaf.Body)
 	if diverges {
 		return
@@ -245,9 +255,14 @@ func (g *normGraph) countEdges(term ucs.Norm, walked set.Set[ucs.Norm]) {
 	}
 }
 
-// reachesJoin reports whether term is reached by more than one edge, or can reach a term
-// that is. `match p { {x, y} if g => x, other => other }` produces two `bind other = p`
-// nodes over a single `leaf other`, and both binds answer true through that body.
+// reachesJoin reports whether term is reached by more than one edge, or reaches such a
+// term without falling through again. `match p { {x, y} if g => x, other => other }`
+// produces two `bind other = p` nodes over a single `leaf other`, and both binds answer
+// true through that body.
+//
+// The walk below term is the one underMatchedTest describes. A term this one falls
+// through to is left out, since walkFallthrough asks about it separately, and counting it
+// here would answer true for a term whose own arm nothing else reaches.
 func (g *normGraph) reachesJoin(term ucs.Norm) bool {
 	if term == nil {
 		return false
@@ -255,18 +270,39 @@ func (g *normGraph) reachesJoin(term ucs.Norm) bool {
 	if got, walked := g.joins[term]; walked {
 		return got
 	}
-	// Seed the memo before recursing. The normalized form is a tree of shared subterms
-	// with no cycle, so the seed is never the answer a caller reads; it bounds the walk if
-	// a later rewrite ever introduces one.
+	// Seed the memo before recursing. The normalized form is a tree of shared subterms with
+	// no cycle, so no caller ever reads the seed. It is there to bound the walk should a
+	// later rewrite introduce one.
 	g.joins[term] = false
 	got := g.indeg[term] > 1
-	for _, next := range continuations(term) {
+	for _, next := range underMatchedTest(term) {
 		if g.reachesJoin(next) {
 			got = true
 		}
 	}
 	g.joins[term] = got
 	return got
+}
+
+// underMatchedTest returns the terms control reaches from term while the tag test that
+// admitted term still holds: a split's branches, a guard's admitted continuation, and a
+// bind's. A split's tail and a guard's failure continuation are left out, because each is
+// a fallthrough that walkFallthrough decides the test of on its own.
+func underMatchedTest(term ucs.Norm) []ucs.Norm {
+	switch n := term.(type) {
+	case *ucs.NormSplit:
+		next := make([]ucs.Norm, 0, len(n.Branches))
+		for _, branch := range n.Branches {
+			next = appendTerm(next, branch.Cont)
+		}
+		return next
+	case *ucs.NormGuard:
+		return appendTerm(nil, n.Cont)
+	case *ucs.NormBind:
+		return appendTerm(nil, n.Cont)
+	default:
+		return nil
+	}
 }
 
 // bodiesUnder returns the arm bodies control can reach from term, each listed once.
@@ -298,8 +334,9 @@ func (g *normGraph) bodiesUnder(term ucs.Norm) []ucs.Norm {
 	return found
 }
 
-// isLeaf reports whether term ends a branch rather than continuing into another term. The
-// three leaf kinds are the arm bodies the walk types, and no other term carries one.
+// isLeaf reports whether term ends a branch rather than continuing into another term. A
+// leaf stands for one arm of the surface form, which is what makes it the unit
+// bodiesUnder counts.
 func isLeaf(term ucs.Norm) bool {
 	switch term.(type) {
 	case *ucs.BodyLeaf, *ucs.EscapeLeaf, *ucs.FallbackLeaf:
@@ -309,21 +346,21 @@ func isLeaf(term ucs.Norm) bool {
 	}
 }
 
-// continuations returns the terms control can reach from term in one step. A nil
-// continuation is left out, which is what a split with no covering branch carries and
-// what a guard with nothing to fall into carries. A leaf continues nowhere.
+// continuations returns every term control can reach from term in one step, which is what
+// it reaches with its test still holding plus what it falls through to.
 func continuations(term ucs.Norm) []ucs.Norm {
+	return appendTerm(underMatchedTest(term), fallthroughOf(term))
+}
+
+// fallthroughOf returns where term continues when its own test fails. A split falls to its
+// tail and a guard to its failure continuation. Every other term returns nil, as does a
+// split with no covering branch, which the printer renders `✗`.
+func fallthroughOf(term ucs.Norm) ucs.Norm {
 	switch n := term.(type) {
 	case *ucs.NormSplit:
-		next := make([]ucs.Norm, 0, len(n.Branches)+1)
-		for _, branch := range n.Branches {
-			next = appendTerm(next, branch.Cont)
-		}
-		return appendTerm(next, n.Default)
+		return n.Default
 	case *ucs.NormGuard:
-		return appendTerm(appendTerm(nil, n.Cont), n.Default)
-	case *ucs.NormBind:
-		return appendTerm(nil, n.Cont)
+		return n.Default
 	default:
 		return nil
 	}

--- a/internal/solver/ucs_walk_test.go
+++ b/internal/solver/ucs_walk_test.go
@@ -85,21 +85,65 @@ func TestInferMatchGuardFallsIntoTheNextArm(t *testing.T) {
 	require.Equal(t, `fn (p: {x: number}, b: boolean) -> "guarded" | "plain"`, values["f"])
 }
 
-// A catch-all arm below a guarded arm is reached two ways: the guard falls into it, and
-// the split falls into it when the pattern above did not match. The walk types it once,
-// so the arm body contributes one member to the result rather than two and reports
-// anything wrong with it once.
+// An arm below a guarded arm is reached two ways: the guard falls into it, and the split
+// falls into it when the pattern above did not match. Normalization emits the arm once per
+// way, so the walk has to recognize the second as a copy of the first. Each case below
+// puts a fault in the copied arm and asserts it is reported once.
 func TestInferMatchTypesAFallthroughArmOnce(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f(p: {x: number}, b: boolean) {
-			return match p {
-				{x} if b => 1,
-				other => other.missing
-			}
-		}
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "5:20-5:27: object is missing property: missing", msgWithSpan(errs[0]))
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		// The copied arm is a catch-all, which normalization emits as the split's tail and
+		// again as what the guard falls into. Its fault is in the body.
+		"CatchAllBody": {
+			src: `
+				fn f(p: {x: number}, b: boolean) {
+					return match p {
+						{x} if b => 1,
+						other => other.missing
+					}
+				}
+			`,
+			want: "5:22-5:29: object is missing property: missing",
+		},
+		// The copied arm makes a test of its own, so its fault is in the test rather than
+		// below it. The test is asked about before the arm's continuation is walked, so
+		// recognizing the copy at the body alone would report it twice.
+		"CopiedTest": {
+			src: `
+				fn f(p: {x: number}, b: boolean) {
+					return match p {
+						{x} if b => 1,
+						{y} => 2
+					}
+				}
+			`,
+			want: "2:13-2:24: object is missing property: y",
+		},
+		// A tuple test's fault is the whole-tuple requirement the arity mismatch fails,
+		// which the copy would emit a second time.
+		"CopiedTupleArity": {
+			src: `
+				fn f(t: [number, string], b: boolean) {
+					return match t {
+						[a, c] if b => 1,
+						[a, c, d] => 2,
+						_ => 3
+					}
+				}
+			`,
+			want: "2:13-2:29: cannot constrain tuple of length 2 <: tuple of length 3",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+		})
+	}
 }
 
 // A name an arm binds is scoped to that arm, including a name bound by the arm the

--- a/internal/solver/ucs_walk_test.go
+++ b/internal/solver/ucs_walk_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// UCS IR PR6: `match` types off the normalized form. The match suites in
-// infer_pattern_test.go, infer_pattern_nominal_test.go, infer_pattern_mut_test.go, and
-// infer_expr_test.go pin the inferred types and messages that must not move. The cases
-// here pin what the walk itself is responsible for: first-match order, arm scoping, and
-// typing an arm exactly once however many paths the normalized form reaches it by.
+// These cases pin what the walk over the normalized form is responsible for: first-match
+// order, arm scoping, and typing each arm exactly once however many paths the normalized
+// form reaches it by. The inferred types and messages a `match` produces are pinned by the
+// pattern suites instead, in infer_pattern_test.go, infer_pattern_nominal_test.go,
+// infer_pattern_mut_test.go, and the match cases in infer_expr_test.go.
 
 // A `match` diagnostic names the `match` the user wrote, not a desugared form. Lowering
 // erases the difference between `match`, `if val`, and `val … else`, so without the
@@ -272,17 +272,27 @@ func TestInferMatchNarrowsUnionAtEachLevel(t *testing.T) {
 // An unguarded catch-all arm always runs, so normalization makes it the split's tail and
 // leaves the arms below it out of the form the walk sees. Each one is reported unreachable
 // and typed anyway, but its value stays out of the result, since the arm cannot run.
+// Every arm below the catch-all is reported, and each blames the catch-all rather than the
+// dead arm directly above it, so the second one still names the arm that covers it.
 func TestInferMatchTypesArmsAfterACatchAll(t *testing.T) {
-	values, _, errs := inferSource(t, `
+	src := `
 		fn f(n: number) {
 			return match n {
 				all => all,
-				1 => "one"
+				1 => "one",
+				2 => "two"
 			}
 		}
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, unreachableArm(5, 5, 15), msgWithSpan(errs[0]))
+	`
+	values, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		unreachableArm(5, 5, 15),
+		unreachableArm(6, 5, 15),
+	}, messagesWithSpan(errs))
+	for _, e := range errs {
+		require.Len(t, e.Related(), 1)
+		require.Equal(t, "all => all", spanText(src, e.Related()[0]))
+	}
 	require.Equal(t, "fn (n: number) -> number", values["f"])
 }
 

--- a/internal/solver/ucs_walk_test.go
+++ b/internal/solver/ucs_walk_test.go
@@ -1,0 +1,238 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// UCS IR PR6: `match` types off the normalized form. The match suites in
+// infer_pattern_test.go, infer_pattern_nominal_test.go, infer_pattern_mut_test.go, and
+// infer_expr_test.go pin the inferred types and messages that must not move. The cases
+// here pin what the walk itself is responsible for: first-match order, arm scoping, and
+// typing an arm exactly once however many paths the normalized form reaches it by.
+
+// A `match` diagnostic names the `match` the user wrote, not a desugared form. Lowering
+// erases the difference between `match`, `if val`, and `val … else`, so without the
+// origin the IR carries a message about a failed pattern could name the wrong construct
+// or none at all. This is the golden test for that.
+func TestMatchDiagnosticsNameTheMatch(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		// An inexact scrutinee carries an open tail of unknown values, so it takes a
+		// catch-all arm. The wording asks for a branch, which is what a `match` is
+		// written out of.
+		"NonExhaustive": {
+			src: `
+				fn f(p: {x: number, ...}) {
+					return match p {
+						{x} => x
+					}
+				}
+			`,
+			want: "3:13-5:7: match is not exhaustive; add a catch-all branch",
+		},
+		// A guarded arm can always fail its guard, so it covers nothing and the same
+		// wording applies.
+		"GuardedArmDoesNotCover": {
+			src: `
+				fn f(p: {x: number, ...}, b: boolean) {
+					return match p {
+						{x} if b => x
+					}
+				}
+			`,
+			want: "3:13-5:7: match is not exhaustive; add a catch-all branch",
+		},
+		// An exact union takes an arm per member. The uncovered member leaves the match
+		// non-exhaustive, and the message still names the `match`.
+		"UnionMemberUncovered": {
+			src: `
+				fn f(p: {x: number} | {y: string}) {
+					return match p {
+						{x} => x
+					}
+				}
+			`,
+			want: "3:13-5:7: match is not exhaustive; add a catch-all branch",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+		})
+	}
+}
+
+// A failed guard continues into the arms below it in source order, so an unguarded arm
+// of the same shape stays reachable and joins the result. Normalization is what makes
+// that continuation explicit, and the walk types the arm it reaches.
+func TestInferMatchGuardFallsIntoTheNextArm(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number}, b: boolean) {
+			return match p {
+				{x} if b => "guarded",
+				{x} => "plain"
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn (p: {x: number}, b: boolean) -> "guarded" | "plain"`, values["f"])
+}
+
+// A catch-all arm below a guarded arm is reached two ways: the guard falls into it, and
+// the split falls into it when the pattern above did not match. The walk types it once,
+// so the arm body contributes one member to the result rather than two and reports
+// anything wrong with it once.
+func TestInferMatchTypesAFallthroughArmOnce(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number}, b: boolean) {
+			return match p {
+				{x} if b => 1,
+				other => other.missing
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "5:20-5:27: object is missing property: missing", msgWithSpan(errs[0]))
+}
+
+// A name an arm binds is scoped to that arm, including a name bound by the arm the
+// split falls into. The walk puts every bind in a child scope, so `other` is gone by the
+// statement after the `match`.
+func TestInferMatchArmBindingDoesNotEscape(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number}, b: boolean) {
+			val n = match p {
+				{x} if b => 1,
+				other => 2
+			}
+			return other
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "7:11-7:16: Unknown identifier: other", msgWithSpan(errs[0]))
+}
+
+// The scrutinee is inferred once and the walk binds against that one type, so a
+// side-effecting target is not re-evaluated per arm. A call target whose argument does
+// not fit its parameter would report once per evaluation.
+func TestInferMatchEvaluatesTheTargetOnce(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn g(s: string) { return {x: 1} }
+		fn f(b: boolean) {
+			return match g(2) {
+				{x} if b => x,
+				{x} => x,
+				_ => 0
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "4:19-4:20: cannot constrain 2 <: string", msgWithSpan(errs[0]))
+}
+
+// A diverging arm produces no value, so it joins nothing. A `match` whose arms all
+// diverge coalesces to `never`.
+func TestInferMatchAllArmsDiverge(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(n: number) throws string {
+			val x = match n {
+				1 => throw "one",
+				_ => throw "other"
+			}
+			return x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (n: number) -> never throws string", values["f"])
+}
+
+// A fallthrough runs with its branch's test known to have matched, so the walk keeps
+// that test applied. Normalization drops the second arm's `Point` test, because a value
+// reaching it already passed the first arm's. The extractor the first arm tested is what
+// resolves `a` to the constructor's first parameter. Without it `a` would be an
+// unconstrained variable, and the result would read `0` rather than `number`.
+func TestInferMatchFallthroughKeepsTheMatchedTest(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Point { x: number, y: number }
+		fn f(p: Point, b: boolean) {
+			return match p {
+				Point(a, c) if b => 0,
+				Point(a, c) => a
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Point, b: boolean) -> number", values["f"])
+}
+
+// A continuation both a failed guard and a failed test reach runs whether or not the
+// shape matched, so it inherits no matched test. Here the `other` arm runs on a `p` that
+// is not a `{x}` at all, and its body must read the whole union rather than the member
+// the guarded arm tested.
+func TestInferMatchJoinPointInheritsNoTest(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string}, b: boolean) {
+			return match p {
+				{x} if b => 0,
+				other => other
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string}, b: boolean) -> 0 | {x: number} | {y: string}", values["f"])
+}
+
+// Union narrowing applies at every tag-level, not only the outermost one. Both arms here
+// share the outer `{a}` shape, so the outer split narrows nothing, and each arm's inner
+// split over `p.a` is what picks its member. Narrowing only at the top would bind each
+// arm's leaf against both members and report the field the other member lacks.
+func TestInferMatchNarrowsUnionAtEachLevel(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {a: {x: number}} | {a: {y: string}}) {
+			return match p {
+				{a: {x}} => x,
+				{a: {y}} => y
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {a: {x: number}} | {a: {y: string}}) -> number | string", values["f"])
+}
+
+// An unguarded catch-all arm always runs, so normalization makes it the split's tail and
+// the arms below it are unreachable. The walk types what the normalized form holds, so an
+// unreachable arm's body contributes nothing to the result.
+func TestInferMatchDropsArmsAfterACatchAll(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(n: number) {
+			return match n {
+				all => all,
+				1 => "one"
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (n: number) -> number", values["f"])
+}
+
+// A nested pattern flattens into one split per tag-level, and each level's leaves bind
+// off the projection the level above matched. The bound names read the nested field
+// types, so the walk's projections agree with what one whole pattern would have bound.
+func TestInferMatchNestedPatternBindsThroughProjections(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(l: {start: {x: number, y: string}}) {
+			return match l {
+				{start: {x, y}} => [x, y]
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (l: {start: {x: number, y: string}}) -> [number, string]", values["f"])
+}

--- a/internal/solver/ucs_walk_test.go
+++ b/internal/solver/ucs_walk_test.go
@@ -164,10 +164,14 @@ func TestInferMatchArmBindingDoesNotEscape(t *testing.T) {
 	require.Equal(t, "7:11-7:16: Unknown identifier: other", msgWithSpan(errs[0]))
 }
 
-// The scrutinee is inferred once and the walk binds against that one type, so a
-// side-effecting target is not re-evaluated per arm. A call target whose argument does
-// not fit its parameter would report once per evaluation.
-func TestInferMatchEvaluatesTheTargetOnce(t *testing.T) {
+// The target expression is inferred once, before the walk, and every arm binds against
+// that one type. The ill-typed argument below is the probe: inferring `g(2)` emits one
+// constraint failure, so a walk that re-inferred the target would report it once per arm.
+//
+// This says nothing about how many times the target runs. Evaluating it once is a
+// property of the shared *ucs.Scrutinee node every projection hangs off, which
+// TestPathBinderMaterializesEachScrutineeOnce pins on the solver side.
+func TestInferMatchInfersTheTargetOnce(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn g(s: string) { return {x: 1} }
 		fn f(b: boolean) {

--- a/internal/solver/ucs_walk_test.go
+++ b/internal/solver/ucs_walk_test.go
@@ -216,6 +216,24 @@ func TestInferMatchFallthroughKeepsTheMatchedTest(t *testing.T) {
 	require.Equal(t, "fn (p: Point, b: boolean) -> number", values["f"])
 }
 
+// A term reached by one path keeps the matched test even when the arms below it are
+// shared. Here the second arm is reached only through the first guard's failure, so its
+// `x` narrows to the member the `{x}` test picked, while the `_ => 0` both guards fall
+// into is the shared term and takes no test.
+func TestInferMatchFallthroughKeepsTheTestPastAJoin(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string}, b: boolean, c: boolean) {
+			return match p {
+				{x} if b => x,
+				{x} if c => x,
+				_ => 0
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string}, b: boolean, c: boolean) -> number", values["f"])
+}
+
 // A continuation both a failed guard and a failed test reach runs whether or not the
 // shape matched, so it inherits no matched test. Here the `other` arm runs on a `p` that
 // is not a `{x}` at all, and its body must read the whole union rather than the member
@@ -251,9 +269,9 @@ func TestInferMatchNarrowsUnionAtEachLevel(t *testing.T) {
 }
 
 // An unguarded catch-all arm always runs, so normalization makes it the split's tail and
-// the arms below it are unreachable. The walk types what the normalized form holds, so an
-// unreachable arm's body contributes nothing to the result.
-func TestInferMatchDropsArmsAfterACatchAll(t *testing.T) {
+// leaves the arms below it out of the form the walk sees. Those arms are still typed and
+// still join the result, because dead code the user wrote is code they can get wrong.
+func TestInferMatchTypesArmsAfterACatchAll(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(n: number) {
 			return match n {
@@ -263,7 +281,22 @@ func TestInferMatchDropsArmsAfterACatchAll(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (n: number) -> number", values["f"])
+	require.Equal(t, `fn (n: number) -> number | "one"`, values["f"])
+}
+
+// The fault in such an arm is reported, rather than going unchecked because the arm never
+// reached the IR.
+func TestInferMatchReportsFaultsAfterACatchAll(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(n: number) {
+			return match n {
+				all => all,
+				1 => nope
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "5:10-5:14: Unknown identifier: nope", msgWithSpan(errs[0]))
 }
 
 // A nested pattern flattens into one split per tag-level, and each level's leaves bind

--- a/internal/solver/ucs_walk_test.go
+++ b/internal/solver/ucs_walk_test.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -269,8 +270,8 @@ func TestInferMatchNarrowsUnionAtEachLevel(t *testing.T) {
 }
 
 // An unguarded catch-all arm always runs, so normalization makes it the split's tail and
-// leaves the arms below it out of the form the walk sees. Those arms are still typed and
-// still join the result, because dead code the user wrote is code they can get wrong.
+// leaves the arms below it out of the form the walk sees. Each one is reported unreachable
+// and typed anyway, so it still joins the result.
 func TestInferMatchTypesArmsAfterACatchAll(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(n: number) {
@@ -280,12 +281,13 @@ func TestInferMatchTypesArmsAfterACatchAll(t *testing.T) {
 			}
 		}
 	`)
-	require.Empty(t, errs)
+	require.Len(t, errs, 1)
+	require.Equal(t, unreachableArm(5, 5, 15), msgWithSpan(errs[0]))
 	require.Equal(t, `fn (n: number) -> number | "one"`, values["f"])
 }
 
-// The fault in such an arm is reported, rather than going unchecked because the arm never
-// reached the IR.
+// A fault inside an unreachable arm is reported alongside the unreachable diagnostic,
+// rather than going unchecked because the arm never reached the IR.
 func TestInferMatchReportsFaultsAfterACatchAll(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn f(n: number) {
@@ -295,8 +297,43 @@ func TestInferMatchReportsFaultsAfterACatchAll(t *testing.T) {
 			}
 		}
 	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "5:10-5:14: Unknown identifier: nope", msgWithSpan(errs[0]))
+	require.Equal(t, []string{
+		unreachableArm(5, 5, 14),
+		"5:10-5:14: Unknown identifier: nope",
+	}, messagesWithSpan(errs))
+}
+
+// The unreachable diagnostic blames the dead arm and points at the arm that covers it, so
+// both ends of the overlap are on the message.
+func TestInferMatchUnreachableArmBlamesTheCoveringArm(t *testing.T) {
+	src := "fn f(n: number) { return match n { all => all, 1 => 2 } }"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, unreachableArm(1, 48, 54), "1 => 2", "all => all")
+}
+
+// A guarded catch-all can fail its condition, so it covers nothing and the arms below it
+// stay reachable. Neither is reported.
+func TestInferMatchGuardedCatchAllLeavesLaterArmsReachable(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(n: number, b: boolean) {
+			return match n {
+				all if b => all,
+				1 => "one",
+				_ => 0
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn (n: number, b: boolean) -> number | "one"`, values["f"])
+}
+
+// unreachableArm renders the unreachable-arm message prefixed by the span of the arm it
+// blames, which runs from startCol to endCol on line.
+func unreachableArm(line, startCol, endCol int) string {
+	return fmt.Sprintf(
+		"%d:%d-%d:%d: this match arm is unreachable because an arm above it matches every value; drop it, or move it above that arm",
+		line, startCol, line, endCol,
+	)
 }
 
 // A nested pattern flattens into one split per tag-level, and each level's leaves bind

--- a/internal/solver/ucs_walk_test.go
+++ b/internal/solver/ucs_walk_test.go
@@ -271,7 +271,7 @@ func TestInferMatchNarrowsUnionAtEachLevel(t *testing.T) {
 
 // An unguarded catch-all arm always runs, so normalization makes it the split's tail and
 // leaves the arms below it out of the form the walk sees. Each one is reported unreachable
-// and typed anyway, so it still joins the result.
+// and typed anyway, but its value stays out of the result, since the arm cannot run.
 func TestInferMatchTypesArmsAfterACatchAll(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(n: number) {
@@ -283,7 +283,7 @@ func TestInferMatchTypesArmsAfterACatchAll(t *testing.T) {
 	`)
 	require.Len(t, errs, 1)
 	require.Equal(t, unreachableArm(5, 5, 15), msgWithSpan(errs[0]))
-	require.Equal(t, `fn (n: number) -> number | "one"`, values["f"])
+	require.Equal(t, "fn (n: number) -> number", values["f"])
 }
 
 // A fault inside an unreachable arm is reported alongside the unreachable diagnostic,
@@ -309,6 +309,22 @@ func TestInferMatchUnreachableArmBlamesTheCoveringArm(t *testing.T) {
 	src := "fn f(n: number) { return match n { all => all, 1 => 2 } }"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, unreachableArm(1, 48, 54), "1 => 2", "all => all")
+}
+
+// Only a catch-all covers the arms below it. A bare `...rest` also ends the split, since
+// the lowering reads no tag off it, but it is reported unsupported rather than treated as
+// an arm that matches everything, so the arms below it draw no second message.
+func TestInferMatchBareRestDoesNotCoverLaterArms(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(n: number) {
+			return match n {
+				...rest => 1,
+				2 => 3
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "4:5-4:12: Unsupported: RestPat", msgWithSpan(errs[0]))
 }
 
 // A guarded catch-all can fail its condition, so it covers nothing and the arms below it


### PR DESCRIPTION
Fixes #1025.

Implements typing of `match` expressions using the UCS (Unified Conditional Syntax) normalized intermediate representation. Previously, match arms were typed directly from the AST. Now they are lowered to a tree of splits, binds, guards, and leaves that is then walked and typed, enabling proper handling of pattern narrowing, guard fallthrough, and arm reachability.

## Behavior changes

Typing off the normalized form moves three things a reviewer should look at. Everything else is unchanged: across ~2,400 generated match programs no inferred type moved for any other reason, and every pre-existing diagnostic either stayed put or was deduplicated.

- **A union narrows at every tag-level, not only the outermost one.** Both arms of `match p { {a: {x}} => x, {a: {y}} => y }` over `{a: {x: number}} | {a: {y: string}}` share the outer `{a}` shape, so the outer split narrows nothing and each arm's inner split over `p.a` is what picks its member. Narrowing only at the top bound each arm's leaf against both members and reported the field the other member lacks. Those spurious "object is missing property" errors are gone.
- **A new `UnreachableMatchArmError`.** An arm below an unguarded catch-all can never run, and normalization leaves it out of the split. It is now reported, blaming the dead arm and carrying the covering arm as its related span. It fires on code that compiled before.
- **An arm reported unreachable no longer joins the result type.** `match n { all => 1, 2 => "two" }` infers `1` rather than `1 | "two"`. The arm is still type-checked, against a variable of its own, so a fault inside dead code is still found rather than left for whoever deletes the arm above it. Constraining it into the join would contradict the diagnostic and, under a return annotation, pile a second error onto an arm already reported.

A `try`'s catch clauses do not go through the walk, so a dead catch arm is still silent. That gap is #1071.

## Key changes

- **New `ucs_walk.go`**: Implements `condWalk`, which types a normalized conditional form by walking its tree structure. The walk maintains three states (current, fallthrough, and matched) to correctly handle:
  - Pattern narrowing applied to each branch
  - Guard conditions that can fail and fall through to later arms
  - Arm bodies typed exactly once even when reached by multiple paths
  - Join points that inherit no matched test because they're reachable from multiple branches

- **New `normGraph`**: Analyzes the shape of a normalized form before typing to determine which terms are reached by multiple edges (join points) and which arm bodies each term can reach. This prevents duplicate type-checking of shared subterms.

- **Updated `infer_expr.go`**: `inferMatch` now uses `ucs.DesugarMatch` and `ucs.Normalize` to lower the match to IR, then walks it with `condWalk` instead of directly iterating arms.

- **Updated `ucs_bind.go`**:
  - `narrowedBy` now accepts a `blame` parameter to anchor diagnostics about pattern tests to the pattern itself rather than the whole arm
  - New `bindElemAt` method binds object pattern shorthand elements (e.g., `{x}`) through projections
  - New `shorthandView` resolves shorthand element fields with proper handling of defaults

- **Updated `errors.go`**: Added `UnreachableMatchArmError` to report when an arm can never run because an earlier unguarded catch-all already matches every value.

- **Updated `desugar.go`**: `branchOrigin` now blames the pattern of a branch rather than the whole arm, so diagnostics about tag tests point at the narrowest honest span.

- **Comprehensive test suite in `ucs_walk_test.go`**: Tests covering first-match order, arm scoping, single typing of shared arms, guard fallthrough, join point narrowing, nested patterns, and unreachable arm detection.

## Notable implementation details

The walk carries three states because a term's continuation does not run in the state the term itself runs in. The `matched` state keeps the enclosing branch's tag test applied for fallthroughs, while `fall` (the state the whole form started in) is used for join points that are reached from multiple branches and thus cannot assume any test held.

Normalization emits an arm more than once when it can be reached through multiple paths (e.g., a guarded arm's body is reached both when the guard fails and when the pattern above didn't match). The `typedAlready` check recognizes these copies by examining which arm bodies a term can reach, preventing duplicate type-checking and duplicate diagnostics.

https://claude.ai/code/session_01CxLrvSpyx1tHTfjXC7vc6M