### PR TITLE
Run the interim coverage check off the normalized form

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1050,18 +1050,19 @@ type CannotAssignToImmutableError struct {
 	Decl   ast.Node        // the introducing decl, related; nil for prelude bindings
 }
 
-// NonExhaustiveMatchError fires when a `match` expression does not cover every
-// value its scrutinee can take, so a value could fall through every arm. In M4 the
-// coverage decision reads only the scrutinee's structural exactness. An exact object
-// or tuple scrutinee is covered by a structural arm matching its shape. An inexact
-// scrutinee carries an open tail of unknown values, so it requires a catch-all arm.
-// A catch-all is an unguarded wildcard `_` or identifier pattern. Union-scrutinee
-// exhaustiveness is M6 and enum exhaustiveness is M5, and both extend this same form.
+// NonExhaustiveMatchError fires when a conditional form does not cover every value its
+// scrutinee can take, so a value could fall through every arm. The coverage decision reads
+// the scrutinee's union structure and its structural exactness. An exact object or tuple
+// scrutinee is covered by a branch matching its shape, and an exact union by a branch per
+// member. An inexact scrutinee carries an open tail of unknown values, so it requires a
+// catch-all arm, which is an unguarded wildcard `_` or identifier pattern.
 //
-// It is a bridge error born in inferMatch with the match node in hand, so it
-// self-blames the whole match through Span and carries no related node.
+// It carries the origin of the split whose arms leave the value uncovered. The origin names
+// the surface construct the message speaks about and the node it blames, so the wording
+// follows the form the user wrote rather than assuming a `match`. The error self-blames that
+// whole construct through Span and carries no related node.
 type NonExhaustiveMatchError struct {
-	Match *ast.MatchExpr
+	Origin ucs.Origin
 }
 
 // UnreachableMatchArmError fires when a `match` arm can never run, because an arm above it
@@ -1777,10 +1778,37 @@ func (e *MixedOwnershipError) Message() string {
 	return "a union or intersection mixes owned and borrowed members. Make ownership uniform first. Clone the borrowed member to own it, or borrow the owned member."
 }
 
-func (e *NonExhaustiveMatchError) Span() ast.Span      { return e.Match.Span() }
+// Span underlines the construct the origin blames. A synthetic origin has no span of its
+// own, so NearestSpan follows its cause chain to the construct it was minted while lowering.
+func (e *NonExhaustiveMatchError) Span() ast.Span {
+	span, _ := e.Origin.NearestSpan()
+	return span
+}
 func (e *NonExhaustiveMatchError) Related() []ast.Span { return nil }
+
+// Message names the surface construct the uncovered split lowered from. Only a `match`
+// reports this today. An `if val` and a `val … else` each write an `else` path, so no value
+// falls through either one.
 func (e *NonExhaustiveMatchError) Message() string {
-	return "match is not exhaustive; add a catch-all branch"
+	return constructName(e.Origin.Kind) + " is not exhaustive; add a catch-all branch"
+}
+
+// constructName renders an origin kind as the phrase a message uses to name the surface
+// construct. It is distinct from OriginKind.String, which names the part of the construct a
+// node lowered from: an arm of a `match` rather than the `match` itself.
+func constructName(kind ucs.OriginKind) string {
+	switch kind {
+	case ucs.OriginMatchArm:
+		return "match"
+	case ucs.OriginIfVal:
+		return "if val"
+	case ucs.OriginValElse:
+		return "val ... else"
+	case ucs.OriginGuard:
+		return "guard"
+	default:
+		return "conditional"
+	}
 }
 
 func (e *UnreachableMatchArmError) Span() ast.Span { return matchArmSpan(e.Arm) }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1780,6 +1780,11 @@ func (e *MixedOwnershipError) Message() string {
 
 // Span underlines the construct the origin blames. A synthetic origin has no span of its
 // own, so NearestSpan follows its cause chain to the construct it was minted while lowering.
+//
+// An origin whose chain reaches no surface node at all yields the zero span, which points at
+// line 0 of whichever file holds source ID 0. Every construct the coverage check runs on
+// lowers from a node the user wrote, so the miss is recovery rather than a position any
+// diagnostic reaches.
 func (e *NonExhaustiveMatchError) Span() ast.Span {
 	span, _ := e.Origin.NearestSpan()
 	return span

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3148,14 +3148,15 @@ func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 // branch-join var, exactly as inferIfElse joins its two branches. A diverging arm
 // contributes `never`, so when every arm diverges the result coalesces to `never`.
 //
-// Exhaustiveness is checked from structural exactness by checkMatchExhaustive.
+// Exhaustiveness is checked off the same normalized form by checkCondExhaustive.
 func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Type {
 	scrutinee := c.inferExpr(scope, lvl, e.Target)
-	// Snapshot the scrutinee for the exhaustiveness check before any arm binds. A
-	// literal pattern adds its literal as a lower bound, which would otherwise leak
-	// a phantom member into the coalesced union read after the walk. The borrow stays
-	// on the snapshot rather than being peeled the way groundedCarrier peels one, since
-	// checkMatchExhaustive reads its own carrier off it.
+	// Snapshot the scrutinee before any arm binds. A literal pattern adds its literal as a
+	// lower bound, which would otherwise leak a phantom member into the coalesced union read
+	// after the walk. Both the coverage check and the arms below a catch-all read their union
+	// structure off this. The borrow stays on the snapshot rather than being peeled the way
+	// groundedCarrier peels one, since narrowMatchArm rewraps what it narrows and
+	// checkCondExhaustive reads its own carrier.
 	matchShape := scrutinee
 	if carrierIsVar(scrutinee) {
 		matchShape = coalesce(scrutinee, soltype.Positive)
@@ -3183,7 +3184,7 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	unreachable := c.reportUnreachableArms(e.Cases, w.arms)
 	c.inferMatchArms(scope, lvl, e, unreachable, matchShape, scrutinee, c.freshAt(lvl))
 	c.checkUniformOwnership(e, w.bodies)
-	c.checkMatchExhaustive(scope, e, matchShape)
+	c.checkCondExhaustive(scope, norm, matchShape)
 	c.recordType(e, res)
 	return res
 }
@@ -3399,55 +3400,6 @@ func unionParts(t soltype.Type) []soltype.Type {
 		return u.Types
 	}
 	return []soltype.Type{t}
-}
-
-// checkMatchExhaustive reports a NonExhaustiveMatchError when no arm covers every
-// value the coalesced scrutinee can take, dispatching on its union or object/tuple shape.
-func (c *checker) checkMatchExhaustive(scope *Scope, e *ast.MatchExpr, scrutinee soltype.Type) {
-	// A transparent alias scrutinee, an enum handle or a user `type` reference, carries the
-	// alias rather than the type it stands for. Expand it to that type before dispatching, the
-	// same unfold constrain performs, so `match c { Color.RGB(..) => .., Color.Hex(..) => .. }`
-	// over `val c: Color` covers the variant union without a default arm.
-	carrier := c.expandAliasChain(soltype.CarrierOf(scrutinee))
-	if u, ok := carrier.(*soltype.UnionType); ok {
-		if !c.unionMatchExhaustive(scope, e, u) {
-			c.report(&NonExhaustiveMatchError{Match: e})
-		}
-		return
-	}
-	inexact, isStructural := structuralInexact(carrier)
-	if !isStructural {
-		return
-	}
-	for _, arm := range e.Cases {
-		// A guarded arm can always fail its guard, so it never makes a match
-		// exhaustive. Only an unguarded covering arm does.
-		if arm.Guard == nil && armCoversShape(arm.Pattern, inexact) {
-			return
-		}
-	}
-	c.report(&NonExhaustiveMatchError{Match: e})
-}
-
-// unionMatchExhaustive reports whether the unguarded arms cover a union scrutinee. An
-// inexact union needs a catch-all. An exact one is exhaustive when every member is
-// covered. A literal member is covered by an equal literal pattern. A nominal member, an
-// enum variant or class handle, is covered by an instance or extractor pattern naming that
-// class. A structural object or tuple member is covered by an irrefutable object or tuple
-// pattern of the member's shape. A member no arm covers leaves the match non-exhaustive.
-func (c *checker) unionMatchExhaustive(scope *Scope, e *ast.MatchExpr, u *soltype.UnionType) bool {
-	if ast.HasUnguardedCatchAll(e.Cases) {
-		return true
-	}
-	if u.Inexact {
-		return false
-	}
-	for _, member := range u.Types {
-		if !c.unionMemberCovered(scope, member, e.Cases) {
-			return false
-		}
-	}
-	return true
 }
 
 // unionMemberCovered reports whether some unguarded arm covers a single union member,
@@ -3732,26 +3684,6 @@ func structuralInexact(t soltype.Type) (inexact bool, ok bool) {
 		return t.Inexact, true
 	default:
 		return false, false
-	}
-}
-
-// armCoversShape reports whether an unguarded arm makes the match exhaustive for a
-// scrutinee of the given exactness. A wildcard or identifier pattern binds
-// unconditionally, so it covers any value. An object or tuple pattern covers an
-// exact scrutinee only when it is irrefutable. Every sub-pattern must itself be
-// irrefutable, so a nested literal such as `{x: 1}` does not count. Such a pattern
-// never covers an inexact scrutinee. An inexact scrutinee's open tail may hold
-// values the pattern cannot see, so it still needs a true catch-all. A literal
-// pattern is refutable and never covers.
-func armCoversShape(p ast.Pat, inexact bool) bool {
-	if ast.IsCatchAllPat(p) {
-		return true
-	}
-	switch p.(type) {
-	case *ast.ObjectPat, *ast.TuplePat:
-		return !inexact && irrefutablePat(p)
-	default:
-		return false
 	}
 }
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3334,7 +3334,7 @@ func (c *checker) caughtType(collected soltype.Type) soltype.Type {
 // throws sink. A value matching no arm is re-raised at runtime, so uncovered members draw a
 // rethrow rather than the non-exhaustiveness error the equivalent `match` would draw.
 // Coverage comes from ast.HasUnguardedCatchAll and unionMemberCovered, so it agrees with
-// checkMatchExhaustive, and a guarded arm can fail its guard and covers nothing. Only the
+// checkCondExhaustive, and a guarded arm can fail its guard and covers nothing. Only the
 // MEMBERS are rethrown: every throws type is open already, and only `unknown` could carry
 // the tail, so adding it would erase the named types the clause had.
 func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, enclosing soltype.Type) {
@@ -3352,7 +3352,7 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 			// alias rather than the type it stands for. unionMemberCovered has no arm for
 			// one, so an unexpanded alias reads as uncovered however many arms name its
 			// members, and `type Err = "a" | "b"` would behave unlike the union spelled
-			// inline. checkMatchExhaustive expands for the same reason.
+			// inline. checkCondExhaustive expands for the same reason.
 			for _, part := range unionParts(c.expandAliasChain(m)) {
 				if !c.unionMemberCovered(scope, part, e.Catch) {
 					uncovered = append(uncovered, part)

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -304,7 +304,7 @@ func TestInferMatchEnumExhaustiveness(t *testing.T) {
 
 // TestInferMatchGenericEnumExhaustiveness checks that a match over a generic enum value is
 // exhaustive through the alias. The scrutinee `o: MyOption<number>` carries the enum's alias
-// handle with a `number` argument, and checkMatchExhaustive expands it to the substituted
+// handle with a `number` argument, and checkCondExhaustive expands it to the substituted
 // variant union `MyOption.Some<number> | MyOption.None<number>`. An arm per variant covers
 // that union without a catch-all.
 func TestInferMatchGenericEnumExhaustiveness(t *testing.T) {

--- a/internal/solver/ucs_coverage.go
+++ b/internal/solver/ucs_coverage.go
@@ -93,6 +93,12 @@ func (w *coverageWalk) collect(term ucs.Norm) {
 // continuation, so a branch holding one covers its tag only when that continuation reaches
 // a body too. A lone `{x} if b => x` does not, which is what makes a guarded arm cover
 // nothing.
+//
+// A bind names a value and tests nothing, so it matches whenever what runs below it does.
+// That covers the identifier arm of `match p { other => 1 }`, and it covers a bare `...rest`
+// arm too, which normalization keeps whole as a nameless bind rather than flattening into a
+// split. Such an arm binds every value, so a coverage error would ask for a catch-all the
+// arm already is, on top of the unsupported-pattern error the pass that binds it reports.
 func (w *coverageWalk) alwaysMatches(term ucs.Norm) bool {
 	if term == nil {
 		return false
@@ -109,7 +115,7 @@ func (w *coverageWalk) alwaysMatches(term ucs.Norm) bool {
 	case *ucs.BodyLeaf:
 		got = true
 	case *ucs.NormBind:
-		got = bindsEveryValue(n) && w.alwaysMatches(n.Cont)
+		got = w.alwaysMatches(n.Cont)
 	case *ucs.NormGuard:
 		got = w.alwaysMatches(n.Cont) && w.alwaysMatches(n.Default)
 	case *ucs.NormSplit:
@@ -155,16 +161,6 @@ func (w *coverageWalk) branchesAlwaysMatch(split *ucs.NormSplit) bool {
 		}
 	}
 	return true
-}
-
-// bindsEveryValue reports whether a bind names its projection without testing it, which is
-// what a wildcard or identifier pattern does. A nameless bind instead holds a pattern
-// normalization kept whole rather than flattening into a split. A bare rest is the only such
-// pattern flattening leaves, the `...rest` of `match p { ...rest => 1 }`, and it covers
-// nothing. ast.IsCatchAllPat gives it the same verdict, and the pass that lowers the surface
-// reports it unsupported on its own.
-func bindsEveryValue(bind *ucs.NormBind) bool {
-	return bind.Name != "" || bind.Pat == nil
 }
 
 // checkCondExhaustive reports a NonExhaustiveMatchError when the arms of one conditional

--- a/internal/solver/ucs_coverage.go
+++ b/internal/solver/ucs_coverage.go
@@ -49,12 +49,10 @@ type coverageWalk struct {
 
 // readCoverage collects what the arms of the form rooted at split cover.
 //
-// Every split over the root scrutinee is read, not the top-level one alone. Normalization
-// emits an arm again inside each earlier fallible branch's fallthrough, and it drops the
-// top-level branch of an arm whose continuation such a copy already runs. An arm's tag test
-// can therefore live only in a copy. `match x { 1 if g => a, 1 => b }` is one such form: the
-// unguarded `1` survives as what the guard falls into, and its own branch is dropped as a
-// duplicate.
+// More than the top-level split is read. A guarded arm whose pattern makes no test takes the
+// whole split's tail, so the arms after it are branches of a split inside that tail and of no
+// other. `match v { _ if g => 0, {x} => 1, {y} => 2 }` is one such form, and reading its
+// top-level split alone would find no covering branch at all.
 func readCoverage(split *ucs.NormSplit) coverage {
 	w := &coverageWalk{
 		root:    split.Scrutinee,
@@ -67,21 +65,50 @@ func readCoverage(split *ucs.NormSplit) coverage {
 	return coverage{catchAll: catchAll, tags: w.tags}
 }
 
-// collect records the covering tag tests of every split over the root scrutinee.
+// collect records the covering tag tests every value of the scrutinee is offered. It walks
+// the terms such a value reaches before it has passed a tag test, following default tails
+// down from the top-level split.
+//
+// A branch's continuation is left out, and that is what keeps the credit sound. Normalization
+// copies the arms below a branch into its fallthrough, specialized against the tag that
+// branch tested, so a covering branch inside one is offered only to values that already
+// passed that tag. `match v { {a} if g => 0, {b} if g => 1, {a} => 2 }` puts a covering `{b}`
+// branch inside the `{a}` branch's fallthrough. A `{b: string}` value never reaches it. It
+// takes the top-level `{b}` branch, whose guard falls into a tail that covers nothing, so the
+// form is not exhaustive.
+//
+// A guard's failure continuation stays on the walk. Whether a condition holds is no fact
+// about the value's tag, so a value reaching the guard reaches that continuation with nothing
+// yet passed. Its success continuation is left out along with every other branch, since it
+// runs the arm's own body rather than offering a test to anything else.
 func (w *coverageWalk) collect(term ucs.Norm) {
-	if term == nil || w.seen.Contains(term) {
-		return
-	}
-	w.seen.Add(term)
-	if split, ok := term.(*ucs.NormSplit); ok && split.Scrutinee == w.root {
-		for _, branch := range split.Branches {
-			if branch.Test != nil && w.alwaysMatches(branch.Cont) {
-				w.tags = append(w.tags, branch.Test)
-			}
+	for term != nil && !w.seen.Contains(term) {
+		w.seen.Add(term)
+		switch n := term.(type) {
+		case *ucs.NormSplit:
+			w.creditBranches(n)
+			term = n.Default
+		case *ucs.NormGuard:
+			term = n.Default
+		case *ucs.NormBind:
+			term = n.Cont
+		default:
+			return
 		}
 	}
-	for _, next := range continuations(term) {
-		w.collect(next)
+}
+
+// creditBranches records the tag of every branch of split that covers what it tests. A split
+// over a projection tests a value reached through the scrutinee rather than the scrutinee
+// itself, so its tags say nothing about which of the scrutinee's own values are covered.
+func (w *coverageWalk) creditBranches(split *ucs.NormSplit) {
+	if split.Scrutinee != w.root {
+		return
+	}
+	for _, branch := range split.Branches {
+		if branch.Test != nil && w.alwaysMatches(branch.Cont) {
+			w.tags = append(w.tags, branch.Test)
+		}
 	}
 }
 

--- a/internal/solver/ucs_coverage.go
+++ b/internal/solver/ucs_coverage.go
@@ -7,52 +7,44 @@ import (
 	"github.com/escalier-lang/escalier/internal/solver/ucs"
 )
 
-// The interim coverage check, read off the UCS normalized form.
+// The interim coverage check, read off the UCS normalized form: the tag tests over the root
+// scrutinee, and the default tail a value reaches when none of them matched. The predicates
+// stay here rather than moving into `ucs`, since union exactness, an open structural tail,
+// and which member a tag covers are all facts about a soltype.
 //
-// A conditional form is exhaustive when no value of its scrutinee falls through every arm.
-// What the decision reads is the split structure the IR already carries: the tag tests over
-// the root scrutinee, and the default tail a value reaches when none of those tests matched.
-// The predicates it rests on stay here rather than moving into `ucs`, because each one reads
-// a soltype. Whether a union is exact, whether an object or tuple carries an open tail, and
-// which union member a tag test covers are all facts about the type.
-//
-// The rules are the interim ones M4 and M6 settled on. An inexact scrutinee takes a
-// catch-all, an exact union is covered once every member has a covering branch, and an arm
-// that can fail its guard covers nothing on its own. Phase 2 (#883) replaces all three with
-// `residual = scrutinee ∧ ¬covered ; exhaustive iff residual <: ⊥`, and this file is the
-// seam it replaces.
+// The rules are M4's and M6's. An inexact scrutinee takes a catch-all, an exact union is
+// covered once every member has a covering branch, and an arm that can fail its guard covers
+// nothing on its own. Phase 2 (#883) replaces all three with
+// `residual = scrutinee ∧ ¬covered ; exhaustive iff residual <: ⊥`.
 
 // coverage is what the check reads off one normalized form.
 type coverage struct {
 	// catchAll reports whether a value failing every tag test at the root still reaches an
-	// arm body. It is the IR's reading of an unguarded catch-all arm, which normalization
-	// moves out of the branches and into the split's default tail.
+	// arm body. It is the IR's reading of an unguarded catch-all arm.
 	catchAll bool
-	// tags holds the tag test of every branch over the root scrutinee that covers what it
-	// tests, meaning every path below the branch reaches an arm body. A union member is
-	// covered when one of these tests names it.
+	// tags holds the tag test of every branch that covers what it tests. A union member is
+	// covered when one of these names it.
 	tags []ucs.Test
 }
 
-// coverageWalk reads the coverage of one normalized form. root is the scrutinee the form's
-// top-level split tests, which is what tells a test of the whole value apart from a test of
-// a projection out of it.
+// coverageWalk reads the coverage of one normalized form. root is the scrutinee the
+// top-level split tests, which tells a test of the whole value apart from one of a projection
+// out of it.
 type coverageWalk struct {
 	root *ucs.Scrutinee
 	tags []ucs.Test
-	// matched memoizes alwaysMatches per term, since a tail several branches fall into is
-	// asked about once per branch.
+	// matched memoizes alwaysMatches, since a tail is asked about once per branch falling
+	// into it.
 	matched map[ucs.Norm]bool
-	// seen holds every term collect has read, so a term two edges reach is read once.
+	// seen bounds the walk to one visit per term.
 	seen set.Set[ucs.Norm]
 }
 
-// readCoverage collects what the arms of the form rooted at split cover.
-//
-// More than the top-level split is read. A guarded arm whose pattern makes no test takes the
-// whole split's tail, so the arms after it are branches of a split inside that tail and of no
-// other. `match v { _ if g => 0, {x} => 1, {y} => 2 }` is one such form, and reading its
-// top-level split alone would find no covering branch at all.
+// readCoverage collects what the arms of the form rooted at split cover. More than the
+// top-level split is read: a guarded arm whose pattern makes no test takes the whole split's
+// tail, so the arms after it are branches of a split inside that tail and of no other.
+// Reading the top-level split of `match v { _ if g => 0, {x} => 1, {y} => 2 }` alone would
+// find no covering branch at all.
 func readCoverage(split *ucs.NormSplit) coverage {
 	w := &coverageWalk{
 		root:    split.Scrutinee,
@@ -65,22 +57,18 @@ func readCoverage(split *ucs.NormSplit) coverage {
 	return coverage{catchAll: catchAll, tags: w.tags}
 }
 
-// collect records the covering tag tests every value of the scrutinee is offered. It walks
-// the terms such a value reaches before it has passed a tag test, following default tails
-// down from the top-level split.
+// collect records the covering tags every value of the scrutinee is offered, following
+// default tails down from the top-level split.
 //
-// A branch's continuation is left out, and that is what keeps the credit sound. Normalization
-// copies the arms below a branch into its fallthrough, specialized against the tag that
-// branch tested, so a covering branch inside one is offered only to values that already
-// passed that tag. `match v { {a} if g => 0, {b} if g => 1, {a} => 2 }` puts a covering `{b}`
-// branch inside the `{a}` branch's fallthrough. A `{b: string}` value never reaches it. It
-// takes the top-level `{b}` branch, whose guard falls into a tail that covers nothing, so the
-// form is not exhaustive.
+// Leaving out a branch's continuation is what keeps the credit sound. Normalization copies
+// the arms below a branch into its fallthrough, specialized against the tag that branch
+// tested, so a covering branch inside one is offered only to values that already passed that
+// tag. `match v { {a} if g => 0, {b} if g => 1, {a} => 2 }` puts a covering `{b}` branch
+// inside the `{a}` branch's fallthrough, which no `{b: string}` value reaches.
 //
 // A guard's failure continuation stays on the walk. Whether a condition holds is no fact
 // about the value's tag, so a value reaching the guard reaches that continuation with nothing
-// yet passed. Its success continuation is left out along with every other branch, since it
-// runs the arm's own body rather than offering a test to anything else.
+// yet passed.
 func (w *coverageWalk) collect(term ucs.Norm) {
 	for term != nil && !w.seen.Contains(term) {
 		w.seen.Add(term)
@@ -99,8 +87,8 @@ func (w *coverageWalk) collect(term ucs.Norm) {
 }
 
 // creditBranches records the tag of every branch of split that covers what it tests. A split
-// over a projection tests a value reached through the scrutinee rather than the scrutinee
-// itself, so its tags say nothing about which of the scrutinee's own values are covered.
+// over a projection tests a value reached through the scrutinee, so its tags say nothing
+// about which of the scrutinee's own values are covered.
 func (w *coverageWalk) creditBranches(split *ucs.NormSplit) {
 	if split.Scrutinee != w.root {
 		return
@@ -113,19 +101,15 @@ func (w *coverageWalk) creditBranches(split *ucs.NormSplit) {
 }
 
 // alwaysMatches reports whether control reaching term reaches an arm body however the tests
-// below it turn out. A branch whose continuation always matches covers the tag it tested,
-// and a default tail that always matches covers everything the branches left.
+// below it turn out.
 //
-// This is where the guard rule lives. A guard sends a false condition to its own failure
-// continuation, so a branch holding one covers its tag only when that continuation reaches
-// a body too. A lone `{x} if b => x` does not, which is what makes a guarded arm cover
-// nothing.
+// This is where the guard rule lives. A false condition goes to the guard's own failure
+// continuation, so a branch holding a guard covers its tag only when that continuation
+// reaches a body too. A lone `{x} if b => x` does not.
 //
 // A bind names a value and tests nothing, so it matches whenever what runs below it does.
-// That covers the identifier arm of `match p { other => 1 }`, and it covers a bare `...rest`
-// arm too, which normalization keeps whole as a nameless bind rather than flattening into a
-// split. Such an arm binds every value, so a coverage error would ask for a catch-all the
-// arm already is, on top of the unsupported-pattern error the pass that binds it reports.
+// That covers the `other` of `match p { other => 1 }`, and a bare `...rest` arm too, which
+// binds every value. Such an arm is already reported unsupported by the pass that binds it.
 func (w *coverageWalk) alwaysMatches(term ucs.Norm) bool {
 	if term == nil {
 		return false
@@ -133,9 +117,8 @@ func (w *coverageWalk) alwaysMatches(term ucs.Norm) bool {
 	if got, asked := w.matched[term]; asked {
 		return got
 	}
-	// Seed the memo before recursing. The normalized form is a tree of shared subterms with
-	// no cycle, so no caller reads the seed. It bounds the recursion should a later rewrite
-	// introduce one.
+	// Seed the memo before recursing. The form has no cycle, so no caller reads the seed. It
+	// bounds the recursion should a later rewrite introduce one.
 	w.matched[term] = false
 	got := false
 	switch n := term.(type) {
@@ -148,26 +131,24 @@ func (w *coverageWalk) alwaysMatches(term ucs.Norm) bool {
 	case *ucs.NormSplit:
 		got = w.splitAlwaysMatches(n)
 	case *ucs.EscapeLeaf, *ucs.FallbackLeaf:
-		// The two leaves of a `val pat = init else { … }`. The fallback runs precisely when
-		// the pattern failed, so counting it as a body would make every such declaration
-		// cover its scrutinee. The escape leaf ends the success path and carries no body at
-		// all. Neither is an arm a coverage question is asked about, and `ucs.DesugarMatch`
-		// mints neither.
+		// The two leaves of a `val pat = init else { … }`. Its fallback runs precisely when the
+		// pattern failed, so counting it as a body would make every such declaration cover its
+		// scrutinee, and its escape leaf carries no body at all. `ucs.DesugarMatch` mints
+		// neither.
 	}
 	w.matched[term] = got
 	return got
 }
 
 // splitAlwaysMatches reports whether control reaching a split reaches an arm body. A value
-// either passes one branch's test and continues below it, or fails every test and continues
-// into the tail, so the split matches when all of those continuations do.
+// passes one branch's test and continues below it or fails every test and continues into the
+// tail, so the split matches when all of those continuations do.
 //
-// A split over a projection gets a second reading. `{a: {b}}` tests `{a}` on the scrutinee
-// and then `{b}` on the projection `p.a`. The interim rules read a structural sub-pattern as
-// irrefutable, so such a split matches whenever the continuation under its test does. A
-// projected literal, class, or extractor test is refutable and gets no such reading. Neither
-// does a test of the root scrutinee. Whether a structural test covers the whole value
-// depends on the scrutinee's exactness, which checkCondExhaustive decides from the type.
+// A split over a projection gets a second reading, since the interim rules read a structural
+// sub-pattern as irrefutable: `{a: {b}}` tests `{a}` on the scrutinee and then `{b}` on the
+// projection `p.a`, and the second test is taken to hold. A projected literal, class, or
+// extractor test is refutable and gets no such reading. Neither does a test of the root
+// scrutinee, whose coverage depends on the exactness checkCondExhaustive reads off the type.
 func (w *coverageWalk) splitAlwaysMatches(split *ucs.NormSplit) bool {
 	if w.alwaysMatches(split.Default) && w.branchesAlwaysMatch(split) {
 		return true
@@ -190,13 +171,10 @@ func (w *coverageWalk) branchesAlwaysMatch(split *ucs.NormSplit) bool {
 	return true
 }
 
-// checkCondExhaustive reports a NonExhaustiveMatchError when the arms of one conditional
-// form leave a value of its scrutinee uncovered. norm is the form's normalized IR, and
-// shape the scrutinee snapshot taken before any arm bound, which is what the union members
-// and the structural exactness are read off.
-//
-// The message names the construct the top-level split lowered from rather than assuming a
-// `match`, so the wording follows the surface form the user wrote.
+// checkCondExhaustive reports a NonExhaustiveMatchError when the arms of one conditional form
+// leave a value of its scrutinee uncovered. shape is the scrutinee snapshot taken before any
+// arm bound, which the union members and the structural exactness are read off. The message
+// names the construct the top-level split lowered from rather than assuming a `match`.
 func (c *checker) checkCondExhaustive(scope *Scope, norm ucs.Norm, shape soltype.Type) {
 	split, isSplit := norm.(*ucs.NormSplit)
 	if !isSplit {
@@ -207,9 +185,9 @@ func (c *checker) checkCondExhaustive(scope *Scope, norm ucs.Norm, shape soltype
 		return
 	}
 	// A transparent alias scrutinee, an enum handle or a user `type` reference, carries the
-	// alias rather than the type it stands for. Expand it to that type before dispatching, the
-	// same unfold constrain performs, so `match c { Color.RGB(..) => .., Color.Hex(..) => .. }`
-	// over `val c: Color` covers the variant union without a default arm.
+	// alias rather than the type it stands for. Expanding it first, the same unfold constrain
+	// performs, is what lets `match c { Color.RGB(..) => .., Color.Hex(..) => .. }` over
+	// `val c: Color` cover the variant union without a default arm.
 	carrier := c.expandAliasChain(soltype.CarrierOf(shape))
 	if u, isUnion := carrier.(*soltype.UnionType); isUnion {
 		if !c.unionTagsExhaustive(scope, u, cov.tags) {
@@ -229,9 +207,9 @@ func (c *checker) checkCondExhaustive(scope *Scope, norm ucs.Norm, shape soltype
 	c.report(&NonExhaustiveMatchError{Origin: split.Origin})
 }
 
-// unionTagsExhaustive reports whether the covering tag tests cover a union scrutinee. An
-// inexact union carries an open tail no tag names, so it takes a catch-all, which the caller
-// has already ruled out. An exact one is covered when every member is.
+// unionTagsExhaustive reports whether the covering tags cover a union scrutinee. An inexact
+// union carries an open tail no tag names, so it takes the catch-all the caller has already
+// ruled out. An exact one is covered when every member is.
 func (c *checker) unionTagsExhaustive(scope *Scope, u *soltype.UnionType, tags []ucs.Test) bool {
 	if u.Inexact {
 		return false
@@ -244,11 +222,9 @@ func (c *checker) unionTagsExhaustive(scope *Scope, u *soltype.UnionType, tags [
 	return true
 }
 
-// memberTagged reports whether some covering tag test names a single union member,
-// dispatching on the member's kind. A literal member needs an equal literal test, a `null`
-// or `undefined` member a test on that same word, a nominal member a class or extractor test
-// naming its class, and a structural object or tuple member a test of its shape. Any other
-// member kind has no tag short of a catch-all, which the caller has already ruled out.
+// memberTagged reports whether some covering tag names a single union member, dispatching on
+// the member's kind. Any kind with no arm below has no tag short of a catch-all, which the
+// caller has already ruled out.
 func (c *checker) memberTagged(scope *Scope, member soltype.Type, tags []ucs.Test) bool {
 	switch m := member.(type) {
 	case *soltype.LitType:
@@ -264,8 +240,7 @@ func (c *checker) memberTagged(scope *Scope, member soltype.Type, tags []ucs.Tes
 	}
 }
 
-// litTagged reports whether some covering test is a literal equal to the given literal
-// member.
+// litTagged reports whether some covering test is a literal equal to the literal member.
 func (c *checker) litTagged(member *soltype.LitType, tags []ucs.Test) bool {
 	for _, tag := range tags {
 		lit, isLit := tag.(*ucs.LitTest)
@@ -279,9 +254,8 @@ func (c *checker) litTagged(member *soltype.LitType, tags []ucs.Test) bool {
 	return false
 }
 
-// atomTagged reports whether some covering test names the given member, which is the `null`
-// or the `undefined` atom. It is the atom twin of litTagged, and equalType decides the match
-// since neither atom carries a value to compare.
+// atomTagged is the twin of litTagged for a `null` or `undefined` member. Neither atom
+// carries a value to compare, so equalType decides the match.
 func atomTagged(member soltype.Type, tags []ucs.Test) bool {
 	for _, tag := range tags {
 		lit, isLit := tag.(*ucs.LitTest)
@@ -295,11 +269,9 @@ func atomTagged(member soltype.Type, tags []ucs.Test) bool {
 	return false
 }
 
-// nominalTagged reports whether some covering test names the member's class. An instance
-// pattern lowers to a class test and an extractor pattern to an extractor test, and each
-// resolves its name through the type sort so `Color.RGB` covers the `Color.RGB` variant.
-// Whether the values under the tag are bound irrefutably is already settled: a refutable
-// sub-pattern becomes a split of its own, which leaves the branch out of the covering tags.
+// nominalTagged reports whether some covering test names the member's class, resolving the
+// test's name through the type sort so `Color.RGB` covers the `Color.RGB` variant. An
+// instance pattern lowers to a class test and an extractor pattern to an extractor test.
 func (c *checker) nominalTagged(scope *Scope, member *soltype.ClassType, tags []ucs.Test) bool {
 	for _, tag := range tags {
 		switch t := tag.(type) {
@@ -318,8 +290,8 @@ func (c *checker) nominalTagged(scope *Scope, member *soltype.ClassType, tags []
 	return false
 }
 
-// structuralTagged reports whether some covering test is an object or tuple shape the member
-// carries, which is what lets the branch under that test destructure the member.
+// structuralTagged reports whether some covering test is a shape the member carries, which is
+// what lets the branch under that test destructure it.
 func structuralTagged(member soltype.Type, tags []ucs.Test) bool {
 	for _, tag := range tags {
 		if testMatchesMemberShape(tag, member) {
@@ -340,9 +312,8 @@ func hasStructuralTag(tags []ucs.Test) bool {
 	return false
 }
 
-// structuralTest reports whether a tag test names an object or tuple shape. Those are the
-// two tests a value of a structural type can pass, and the two the interim semantics read
-// as irrefutable below the level they test.
+// structuralTest reports whether a tag names an object or tuple shape. Those are the two the
+// interim rules read as irrefutable below the level they test.
 func structuralTest(test ucs.Test) bool {
 	switch test.(type) {
 	case *ucs.ObjectTest, *ucs.TupleTest:

--- a/internal/solver/ucs_coverage.go
+++ b/internal/solver/ucs_coverage.go
@@ -175,6 +175,10 @@ func (w *coverageWalk) branchesAlwaysMatch(split *ucs.NormSplit) bool {
 // leave a value of its scrutinee uncovered. shape is the scrutinee snapshot taken before any
 // arm bound, which the union members and the structural exactness are read off. The message
 // names the construct the top-level split lowered from rather than assuming a `match`.
+//
+// The inexact rule below is conservative, which is #1077. An object tag matches a value
+// carrying extra fields, and a rest-relaxed tuple tag matches a longer one, so both cover an
+// inexact scrutinee that this asks a catch-all for.
 func (c *checker) checkCondExhaustive(scope *Scope, norm ucs.Norm, shape soltype.Type) {
 	split, isSplit := norm.(*ucs.NormSplit)
 	if !isSplit {

--- a/internal/solver/ucs_coverage.go
+++ b/internal/solver/ucs_coverage.go
@@ -1,0 +1,330 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/escalier-lang/escalier/internal/solver/ucs"
+)
+
+// The interim coverage check, read off the UCS normalized form.
+//
+// A conditional form is exhaustive when no value of its scrutinee falls through every arm.
+// What the decision reads is the split structure the IR already carries: the tag tests over
+// the root scrutinee, and the default tail a value reaches when none of those tests matched.
+// The predicates it rests on stay here rather than moving into `ucs`, because each one reads
+// a soltype. Whether a union is exact, whether an object or tuple carries an open tail, and
+// which union member a tag test covers are all facts about the type.
+//
+// The rules are the interim ones M4 and M6 settled on. An inexact scrutinee takes a
+// catch-all, an exact union is covered once every member has a covering branch, and an arm
+// that can fail its guard covers nothing on its own. Phase 2 (#883) replaces all three with
+// `residual = scrutinee ∧ ¬covered ; exhaustive iff residual <: ⊥`, and this file is the
+// seam it replaces.
+
+// coverage is what the check reads off one normalized form.
+type coverage struct {
+	// catchAll reports whether a value failing every tag test at the root still reaches an
+	// arm body. It is the IR's reading of an unguarded catch-all arm, which normalization
+	// moves out of the branches and into the split's default tail.
+	catchAll bool
+	// tags holds the tag test of every branch over the root scrutinee that covers what it
+	// tests, meaning every path below the branch reaches an arm body. A union member is
+	// covered when one of these tests names it.
+	tags []ucs.Test
+}
+
+// coverageWalk reads the coverage of one normalized form. root is the scrutinee the form's
+// top-level split tests, which is what tells a test of the whole value apart from a test of
+// a projection out of it.
+type coverageWalk struct {
+	root *ucs.Scrutinee
+	tags []ucs.Test
+	// matched memoizes alwaysMatches per term, since a tail several branches fall into is
+	// asked about once per branch.
+	matched map[ucs.Norm]bool
+	// seen holds every term collect has read, so a term two edges reach is read once.
+	seen set.Set[ucs.Norm]
+}
+
+// readCoverage collects what the arms of the form rooted at split cover.
+//
+// Every split over the root scrutinee is read, not the top-level one alone. Normalization
+// emits an arm again inside each earlier fallible branch's fallthrough, and it drops the
+// top-level branch of an arm whose continuation such a copy already runs. An arm's tag test
+// can therefore live only in a copy. `match x { 1 if g => a, 1 => b }` is one such form: the
+// unguarded `1` survives as what the guard falls into, and its own branch is dropped as a
+// duplicate.
+func readCoverage(split *ucs.NormSplit) coverage {
+	w := &coverageWalk{
+		root:    split.Scrutinee,
+		tags:    nil,
+		matched: map[ucs.Norm]bool{},
+		seen:    set.NewSet[ucs.Norm](),
+	}
+	catchAll := w.alwaysMatches(split.Default)
+	w.collect(split)
+	return coverage{catchAll: catchAll, tags: w.tags}
+}
+
+// collect records the covering tag tests of every split over the root scrutinee.
+func (w *coverageWalk) collect(term ucs.Norm) {
+	if term == nil || w.seen.Contains(term) {
+		return
+	}
+	w.seen.Add(term)
+	if split, ok := term.(*ucs.NormSplit); ok && split.Scrutinee == w.root {
+		for _, branch := range split.Branches {
+			if branch.Test != nil && w.alwaysMatches(branch.Cont) {
+				w.tags = append(w.tags, branch.Test)
+			}
+		}
+	}
+	for _, next := range continuations(term) {
+		w.collect(next)
+	}
+}
+
+// alwaysMatches reports whether control reaching term reaches an arm body however the tests
+// below it turn out. A branch whose continuation always matches covers the tag it tested,
+// and a default tail that always matches covers everything the branches left.
+//
+// This is where the guard rule lives. A guard sends a false condition to its own failure
+// continuation, so a branch holding one covers its tag only when that continuation reaches
+// a body too. A lone `{x} if b => x` does not, which is what makes a guarded arm cover
+// nothing.
+func (w *coverageWalk) alwaysMatches(term ucs.Norm) bool {
+	if term == nil {
+		return false
+	}
+	if got, asked := w.matched[term]; asked {
+		return got
+	}
+	// Seed the memo before recursing. The normalized form is a tree of shared subterms with
+	// no cycle, so no caller reads the seed. It bounds the recursion should a later rewrite
+	// introduce one.
+	w.matched[term] = false
+	got := false
+	switch n := term.(type) {
+	case *ucs.BodyLeaf:
+		got = true
+	case *ucs.NormBind:
+		got = bindsEveryValue(n) && w.alwaysMatches(n.Cont)
+	case *ucs.NormGuard:
+		got = w.alwaysMatches(n.Cont) && w.alwaysMatches(n.Default)
+	case *ucs.NormSplit:
+		got = w.splitAlwaysMatches(n)
+	case *ucs.EscapeLeaf, *ucs.FallbackLeaf:
+		// The two leaves of a `val pat = init else { … }`. The fallback runs precisely when
+		// the pattern failed, so counting it as a body would make every such declaration
+		// cover its scrutinee. The escape leaf ends the success path and carries no body at
+		// all. Neither is an arm a coverage question is asked about, and `ucs.DesugarMatch`
+		// mints neither.
+	}
+	w.matched[term] = got
+	return got
+}
+
+// splitAlwaysMatches reports whether control reaching a split reaches an arm body. A value
+// either passes one branch's test and continues below it, or fails every test and continues
+// into the tail, so the split matches when all of those continuations do.
+//
+// A split over a projection gets a second reading. `{a: {b}}` tests `{a}` on the scrutinee
+// and then `{b}` on the projection `p.a`. The interim rules read a structural sub-pattern as
+// irrefutable, so such a split matches whenever the continuation under its test does. A
+// projected literal, class, or extractor test is refutable and gets no such reading. Neither
+// does a test of the root scrutinee. Whether a structural test covers the whole value
+// depends on the scrutinee's exactness, which checkCondExhaustive decides from the type.
+func (w *coverageWalk) splitAlwaysMatches(split *ucs.NormSplit) bool {
+	if w.alwaysMatches(split.Default) && w.branchesAlwaysMatch(split) {
+		return true
+	}
+	if split.Scrutinee == w.root || len(split.Branches) != 1 {
+		return false
+	}
+	branch := split.Branches[0]
+	return structuralTest(branch.Test) && w.alwaysMatches(branch.Cont)
+}
+
+// branchesAlwaysMatch reports whether every branch of a split reaches an arm body once its
+// test matched.
+func (w *coverageWalk) branchesAlwaysMatch(split *ucs.NormSplit) bool {
+	for _, branch := range split.Branches {
+		if !w.alwaysMatches(branch.Cont) {
+			return false
+		}
+	}
+	return true
+}
+
+// bindsEveryValue reports whether a bind names its projection without testing it, which is
+// what a wildcard or identifier pattern does. A nameless bind instead holds a pattern
+// normalization kept whole rather than flattening into a split. A bare rest is the only such
+// pattern flattening leaves, the `...rest` of `match p { ...rest => 1 }`, and it covers
+// nothing. ast.IsCatchAllPat gives it the same verdict, and the pass that lowers the surface
+// reports it unsupported on its own.
+func bindsEveryValue(bind *ucs.NormBind) bool {
+	return bind.Name != "" || bind.Pat == nil
+}
+
+// checkCondExhaustive reports a NonExhaustiveMatchError when the arms of one conditional
+// form leave a value of its scrutinee uncovered. norm is the form's normalized IR, and
+// shape the scrutinee snapshot taken before any arm bound, which is what the union members
+// and the structural exactness are read off.
+//
+// The message names the construct the top-level split lowered from rather than assuming a
+// `match`, so the wording follows the surface form the user wrote.
+func (c *checker) checkCondExhaustive(scope *Scope, norm ucs.Norm, shape soltype.Type) {
+	split, isSplit := norm.(*ucs.NormSplit)
+	if !isSplit {
+		return
+	}
+	cov := readCoverage(split)
+	if cov.catchAll {
+		return
+	}
+	// A transparent alias scrutinee, an enum handle or a user `type` reference, carries the
+	// alias rather than the type it stands for. Expand it to that type before dispatching, the
+	// same unfold constrain performs, so `match c { Color.RGB(..) => .., Color.Hex(..) => .. }`
+	// over `val c: Color` covers the variant union without a default arm.
+	carrier := c.expandAliasChain(soltype.CarrierOf(shape))
+	if u, isUnion := carrier.(*soltype.UnionType); isUnion {
+		if !c.unionTagsExhaustive(scope, u, cov.tags) {
+			c.report(&NonExhaustiveMatchError{Origin: split.Origin})
+		}
+		return
+	}
+	inexact, isStructural := structuralInexact(carrier)
+	if !isStructural {
+		return
+	}
+	// An exact object or tuple is covered by a branch that destructures its shape. An inexact
+	// one carries an open tail of values no such branch can see, so only a catch-all covers it.
+	if !inexact && hasStructuralTag(cov.tags) {
+		return
+	}
+	c.report(&NonExhaustiveMatchError{Origin: split.Origin})
+}
+
+// unionTagsExhaustive reports whether the covering tag tests cover a union scrutinee. An
+// inexact union carries an open tail no tag names, so it takes a catch-all, which the caller
+// has already ruled out. An exact one is covered when every member is.
+func (c *checker) unionTagsExhaustive(scope *Scope, u *soltype.UnionType, tags []ucs.Test) bool {
+	if u.Inexact {
+		return false
+	}
+	for _, member := range u.Types {
+		if !c.memberTagged(scope, member, tags) {
+			return false
+		}
+	}
+	return true
+}
+
+// memberTagged reports whether some covering tag test names a single union member,
+// dispatching on the member's kind. A literal member needs an equal literal test, a `null`
+// or `undefined` member a test on that same word, a nominal member a class or extractor test
+// naming its class, and a structural object or tuple member a test of its shape. Any other
+// member kind has no tag short of a catch-all, which the caller has already ruled out.
+func (c *checker) memberTagged(scope *Scope, member soltype.Type, tags []ucs.Test) bool {
+	switch m := member.(type) {
+	case *soltype.LitType:
+		return c.litTagged(m, tags)
+	case *soltype.NullType, *soltype.UndefinedType:
+		return atomTagged(member, tags)
+	case *soltype.ClassType:
+		return c.nominalTagged(scope, m, tags)
+	case *soltype.ObjectType, *soltype.TupleType:
+		return structuralTagged(member, tags)
+	default:
+		return false
+	}
+}
+
+// litTagged reports whether some covering test is a literal equal to the given literal
+// member.
+func (c *checker) litTagged(member *soltype.LitType, tags []ucs.Test) bool {
+	for _, tag := range tags {
+		lit, isLit := tag.(*ucs.LitTest)
+		if !isLit {
+			continue
+		}
+		if lt, ok := c.litTypeOf(lit.Lit); ok && member.Equal(lt) {
+			return true
+		}
+	}
+	return false
+}
+
+// atomTagged reports whether some covering test names the given member, which is the `null`
+// or the `undefined` atom. It is the atom twin of litTagged, and equalType decides the match
+// since neither atom carries a value to compare.
+func atomTagged(member soltype.Type, tags []ucs.Test) bool {
+	for _, tag := range tags {
+		lit, isLit := tag.(*ucs.LitTest)
+		if !isLit {
+			continue
+		}
+		if atom, _, isAtom := atomLitOf(lit.Lit); isAtom && equalType(atom, member) {
+			return true
+		}
+	}
+	return false
+}
+
+// nominalTagged reports whether some covering test names the member's class. An instance
+// pattern lowers to a class test and an extractor pattern to an extractor test, and each
+// resolves its name through the type sort so `Color.RGB` covers the `Color.RGB` variant.
+// Whether the values under the tag are bound irrefutably is already settled: a refutable
+// sub-pattern becomes a split of its own, which leaves the branch out of the covering tags.
+func (c *checker) nominalTagged(scope *Scope, member *soltype.ClassType, tags []ucs.Test) bool {
+	for _, tag := range tags {
+		switch t := tag.(type) {
+		case *ucs.ClassTest:
+			if ct, ok := c.instancePatClass(scope, ast.QualIdentToString(t.Name)); ok && ct.Name == member.Name {
+				return true
+			}
+		case *ucs.ExtractorTest:
+			if ct, ok := c.resolveQualClassType(scope, t.Name); ok && ct.Name == member.Name {
+				return true
+			}
+		default:
+			// A structural or literal tag names no class, so it covers no nominal member.
+		}
+	}
+	return false
+}
+
+// structuralTagged reports whether some covering test is an object or tuple shape the member
+// carries, which is what lets the branch under that test destructure the member.
+func structuralTagged(member soltype.Type, tags []ucs.Test) bool {
+	for _, tag := range tags {
+		if testMatchesMemberShape(tag, member) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasStructuralTag reports whether some covering test is an object or tuple shape, which is
+// what covers an exact structural scrutinee.
+func hasStructuralTag(tags []ucs.Test) bool {
+	for _, tag := range tags {
+		if structuralTest(tag) {
+			return true
+		}
+	}
+	return false
+}
+
+// structuralTest reports whether a tag test names an object or tuple shape. Those are the
+// two tests a value of a structural type can pass, and the two the interim semantics read
+// as irrefutable below the level they test.
+func structuralTest(test ucs.Test) bool {
+	switch test.(type) {
+	case *ucs.ObjectTest, *ucs.TupleTest:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/solver/ucs_coverage_test.go
+++ b/internal/solver/ucs_coverage_test.go
@@ -1,0 +1,166 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/solver/ucs"
+	"github.com/stretchr/testify/require"
+)
+
+// These cases pin the coverage check against the shapes normalization produces, which do
+// not line up one-to-one with the arms the user wrote. An arm can lose its own branch to a
+// copy inside an earlier branch's fallthrough, a guarded arm can truncate the top-level
+// split, and a nested pattern becomes a split of its own. The verdict has to come out the
+// same as reading the arms would give.
+//
+// The messages a non-exhaustive form reports are pinned in full by the pattern suites and by
+// TestMatchDiagnosticsNameTheMatch in ucs_walk_test.go.
+
+// A guarded arm whose pattern makes no test becomes the split's default tail and takes every
+// branch below it with it, leaving the top-level split with no branch of its own. The arms
+// live on inside the tail, so the members they cover are still covered.
+func TestMatchCoverageReadsArmsBelowAGuardedCatchAll(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string}, b: boolean) {
+			return match p {
+				_ if b => 0,
+				{x} => x,
+				{y} => 1
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string}, b: boolean) -> number", values["f"])
+}
+
+// A guarded arm covers nothing on its own, and a guarded catch-all does not save an inexact
+// scrutinee. The open tail still holds values no structural arm can see.
+func TestMatchCoverageGuardedCatchAllLeavesInexactUncovered(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number, ...}, b: boolean) {
+			return match p {
+				_ if b => 0,
+				{x} => x
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "3:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+}
+
+// A failed guard falls into the arms below it, so an unguarded catch-all below a guarded one
+// still covers every value. Normalization writes that continuation as the guard's own
+// default rather than as another branch.
+func TestMatchCoverageCatchAllBelowAGuard(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number, ...}, b: boolean) {
+			return match p {
+				_ if b => 0,
+				_ => 1
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number, ...}, b: boolean) -> 0 | 1", values["f"])
+}
+
+// An arm repeating the tag of a guarded arm above it is the continuation that guard falls
+// into, so normalization drops its own branch as a duplicate. The tag it covers is read off
+// the guarded branch, whose every path now reaches a body.
+func TestMatchCoverageArmDroppedAsADuplicateStillCovers(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(n: 1 | 2, b: boolean) {
+			return match n {
+				1 if b => "guarded",
+				1 => "one",
+				2 => "two"
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn (n: 1 | 2, b: boolean) -> "guarded" | "one" | "two"`, values["f"])
+}
+
+// A nested structural pattern becomes a split over the projection it matches. Such a split
+// always matches under the interim semantics, the same reading that made `{a: {b}}` an
+// irrefutable pattern, so the arm covers an exact object scrutinee.
+func TestMatchCoverageNestedObjectPatternCovers(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {a: {b: number}}) {
+			return match p {
+				{a: {b}} => b
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {a: {b: number}}) -> number", values["f"])
+}
+
+// A literal below a field is refutable, so the arm holding it covers nothing and the arm
+// below it is what covers the scrutinee. Normalization clears the second arm's tag as one
+// the first already proved, leaving it as what the projected literal split falls into.
+func TestMatchCoverageLiteralFieldArmFallsIntoThePlainArm(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number}) {
+			return match p {
+				{x: 1} => "one",
+				{x} => "other"
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn (p: {x: number}) -> "one" | "other"`, values["f"])
+}
+
+// The same two arms over an inexact scrutinee stay non-exhaustive. Neither reaches the open
+// tail's values, so the form still takes a catch-all.
+func TestMatchCoverageLiteralFieldArmsLeaveInexactUncovered(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number, ...}) {
+			return match p {
+				{x: 1} => "one",
+				{x} => "other"
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "3:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+}
+
+// The wording is a function of the split's origin rather than of the node the error holds.
+// Lowering erases the difference between `match`, `if val`, and `val … else`, so a message
+// keyed off anything else would name the wrong construct once a second form reports this.
+// Only a `match` reaches the check today, which is the first row.
+func TestNonExhaustiveMessageNamesTheConstruct(t *testing.T) {
+	tests := map[string]struct {
+		kind ucs.OriginKind
+		want string
+	}{
+		"MatchArm": {kind: ucs.OriginMatchArm, want: "match is not exhaustive; add a catch-all branch"},
+		"IfVal":    {kind: ucs.OriginIfVal, want: "if val is not exhaustive; add a catch-all branch"},
+		"ValElse":  {kind: ucs.OriginValElse, want: "val ... else is not exhaustive; add a catch-all branch"},
+		"Guard":    {kind: ucs.OriginGuard, want: "guard is not exhaustive; add a catch-all branch"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := &NonExhaustiveMatchError{Origin: ucs.Invented(tt.kind)}
+			require.Equal(t, tt.want, err.Message())
+		})
+	}
+}
+
+// A literal arm covers only its own value, so a union member no literal names is uncovered
+// however many arms the form has.
+func TestMatchCoverageUncoveredLiteralMember(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(n: 1 | 2 | 3) {
+			return match n {
+				1 => "one",
+				2 => "two"
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "3:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+}

--- a/internal/solver/ucs_coverage_test.go
+++ b/internal/solver/ucs_coverage_test.go
@@ -127,6 +127,50 @@ func TestMatchCoverageLiteralFieldArmsLeaveInexactUncovered(t *testing.T) {
 	require.Equal(t, "3:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
 }
 
+// An arm below a fallible branch is copied into that branch's fallthrough, specialized
+// against the tag the branch tested. A branch inside such a copy covers only values that
+// already passed that tag, so its test is no coverage claim about the scrutinee's other
+// values. Each form below leaves a member uncovered behind a copy that reads as covering.
+func TestMatchCoverageIgnoresBranchesUnderAnotherTag(t *testing.T) {
+	// A `{b: string}` value takes the second arm, whose guard can fail into a tail no arm
+	// covers. The `{b}` branch that does cover sits inside the first arm's fallthrough, which
+	// only a `{a: number}` value reaches.
+	t.Run("ObjectUnion", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(v: {a: number} | {b: string}, g: boolean) {
+				return match v {
+					{a} if g => 0,
+					{b} if g => 1,
+					{a} => 2
+				}
+			}
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "3:12-7:6: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+	})
+
+	// The same shape on the nominal path. `Color.RGB(0, g, b)` matches only when the first
+	// field is 0, so it covers no variant, and the covering `Color.Hex` branch sits inside the
+	// first arm's fallthrough. `Color.RGB(1, 2, 3)` matches no arm.
+	t.Run("EnumVariants", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			enum Color {
+				RGB(r: number, g: number, b: number),
+				Hex(code: string),
+			}
+			fn f(c: Color) {
+				return match c {
+					Color.Hex("x") => 0,
+					Color.RGB(0, g, b) => 1,
+					Color.Hex(code) => 2
+				}
+			}
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "7:12-11:6: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+	})
+}
+
 // A bare `...rest` arm is reported unsupported by the pass that binds it, and the coverage
 // check adds nothing on top. The arm binds every value, so asking for a catch-all would name
 // a branch the user already wrote, and the arms below it are out of the split entirely.

--- a/internal/solver/ucs_coverage_test.go
+++ b/internal/solver/ucs_coverage_test.go
@@ -33,19 +33,61 @@ func TestMatchCoverageReadsArmsBelowAGuardedCatchAll(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number} | {y: string}, b: boolean) -> number", values["f"])
 }
 
-// A guarded arm covers nothing on its own, and a guarded catch-all does not save an inexact
-// scrutinee. The open tail still holds values no structural arm can see.
-func TestMatchCoverageGuardedCatchAllLeavesInexactUncovered(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f(p: {x: number, ...}, b: boolean) {
-			return match p {
-				_ if b => 0,
-				{x} => x
-			}
-		}
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "3:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+// Each form below leaves a value matching no arm, and each reports one error naming the
+// `match`. The span runs from `match` to the closing brace of its arms.
+func TestMatchCoverageNonExhaustive(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		// A guarded arm covers nothing on its own, and a guarded catch-all does not save an
+		// inexact scrutinee. The open tail still holds values no structural arm can see.
+		"GuardedCatchAllOverInexact": {
+			src: `
+				fn f(p: {x: number, ...}, b: boolean) {
+					return match p {
+						_ if b => 0,
+						{x} => x
+					}
+				}
+			`,
+			want: "3:13-6:7: match is not exhaustive; add a catch-all branch",
+		},
+		// A literal below a field is refutable and the plain arm below it reaches only the
+		// values the scrutinee's fields describe, so the open tail stays uncovered.
+		"LiteralFieldArmsOverInexact": {
+			src: `
+				fn f(p: {x: number, ...}) {
+					return match p {
+						{x: 1} => "one",
+						{x} => "other"
+					}
+				}
+			`,
+			want: "3:13-6:7: match is not exhaustive; add a catch-all branch",
+		},
+		// A literal arm covers only its own value, so a union member no literal names is
+		// uncovered however many arms the form has.
+		"UncoveredLiteralMember": {
+			src: `
+				fn f(n: 1 | 2 | 3) {
+					return match n {
+						1 => "one",
+						2 => "two"
+					}
+				}
+			`,
+			want: "3:13-6:7: match is not exhaustive; add a catch-all branch",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+		})
+	}
 }
 
 // A failed guard falls into the arms below it, so an unguarded catch-all below a guarded one
@@ -110,21 +152,6 @@ func TestMatchCoverageLiteralFieldArmFallsIntoThePlainArm(t *testing.T) {
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, `fn (p: {x: number}) -> "one" | "other"`, values["f"])
-}
-
-// The same two arms over an inexact scrutinee stay non-exhaustive. Neither reaches the open
-// tail's values, so the form still takes a catch-all.
-func TestMatchCoverageLiteralFieldArmsLeaveInexactUncovered(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f(p: {x: number, ...}) {
-			return match p {
-				{x: 1} => "one",
-				{x} => "other"
-			}
-		}
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "3:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
 }
 
 // An arm below a fallible branch is copied into that branch's fallthrough, specialized
@@ -223,19 +250,4 @@ func TestNonExhaustiveMessageNamesTheConstruct(t *testing.T) {
 			require.Equal(t, tt.want, err.Message())
 		})
 	}
-}
-
-// A literal arm covers only its own value, so a union member no literal names is uncovered
-// however many arms the form has.
-func TestMatchCoverageUncoveredLiteralMember(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f(n: 1 | 2 | 3) {
-			return match n {
-				1 => "one",
-				2 => "two"
-			}
-		}
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "3:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
 }

--- a/internal/solver/ucs_coverage_test.go
+++ b/internal/solver/ucs_coverage_test.go
@@ -127,6 +127,37 @@ func TestMatchCoverageLiteralFieldArmsLeaveInexactUncovered(t *testing.T) {
 	require.Equal(t, "3:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
 }
 
+// A bare `...rest` arm is reported unsupported by the pass that binds it, and the coverage
+// check adds nothing on top. The arm binds every value, so asking for a catch-all would name
+// a branch the user already wrote, and the arms below it are out of the split entirely.
+func TestMatchCoverageBareRestArmReportsOnlyTheUnsupportedPattern(t *testing.T) {
+	tests := map[string]string{
+		"Alone": `
+			fn f(p: {x: number}) {
+				return match p {
+					...rest => 0
+				}
+			}
+		`,
+		"AboveACatchAll": `
+			fn f(n: 1 | 2) {
+				return match n {
+					...rest => 0,
+					_ => 1
+				}
+			}
+		`,
+	}
+
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, src)
+			require.Len(t, errs, 1)
+			require.Equal(t, "4:6-4:13: Unsupported: RestPat", msgWithSpan(errs[0]))
+		})
+	}
+}
+
 // The wording is a function of the split's origin rather than of the node the error holds.
 // Lowering erases the difference between `match`, `if val`, and `val … else`, so a message
 // keyed off anything else would name the wrong construct once a second form reports this.

--- a/planning/ucs/implementation_plan.md
+++ b/planning/ucs/implementation_plan.md
@@ -188,8 +188,8 @@ key set is exactly the keys named at this object pattern, so a key matched by a
 deeper nested split does not remove it from a shallower `rest`.
 
 For coverage, the instance and extractor tags cover nominal union members the same
-way `unionMatchExhaustive` already does, and a rest-relaxed inexact split needs a
-catch-all, matching today's `structuralInexact` rule. Neither changes the interim
+way `unionTagsExhaustive` does, and a rest-relaxed inexact split needs a
+catch-all, matching the `structuralInexact` rule. Neither changes the interim
 coverage semantics PR8 carries over.
 
 ### A guard
@@ -254,8 +254,10 @@ split p {                       split p {
 - **Interim coverage stays.** The existing top-level exhaustiveness check moves
   onto the normalized form with its semantics unchanged. No new coverage
   algorithm is written here — that is Phase 2's residual-based check. The interim
-  helpers are `checkMatchExhaustive`, `unionMatchExhaustive`, `armCoversShape`,
-  `structuralInexact`, `narrowMatchArm`, and `isCatchAll`, all in
+  check is `checkCondExhaustive` in
+  [internal/solver/ucs_coverage.go](../../internal/solver/ucs_coverage.go), and the
+  typed predicates it and the arms below a catch-all lean on — `structuralInexact`,
+  `narrowMatchArm`, and `isCatchAll` — are in
   [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go).
 - **Reuse the shared pattern path.** Leaf binding keeps going through
   `bindPattern` / `bindPatternWith` in
@@ -651,9 +653,9 @@ names `if val` and a `val … else` error names its `else`, per the
 Move the top-level exhaustiveness check onto the IR without changing its verdict
 on any current input.
 
-- Reimplement `checkMatchExhaustive` to read the normalized form's top-level
-  split and its default tail instead of the `matchShape` scrutinee snapshot taken
-  in `inferMatch`. It reads the IR's split structure but keeps its type-dependent
+- Reimplement the check as `checkCondExhaustive`, reading the normalized form's
+  top-level split and its default tail instead of the arms of the surface
+  `match`. It reads the IR's split structure but keeps its type-dependent
   predicates in `internal/solver`: deciding exact-union membership, inexactness, and
   guarded-arm coverage needs `soltype`, so this is a typed coverage adapter, not
   ast-only logic. It is the replacement PR9 deletes the old helpers in favor of.
@@ -665,16 +667,18 @@ on any current input.
 **Tests.** Every current `NonExhaustiveMatchError` case keeps its exact message,
 asserted in full per [CLAUDE.md](../../CLAUDE.md), with the message keyed off the
 split's `Origin` per the [Diagnostics](#diagnostics) section rather than assuming a
-`match`. The `matchShape` snapshot logic in `inferMatch` is removed once coverage
-reads the IR.
+`match`. The `matchShape` snapshot in `inferMatch` stays, since `inferMatchArms`
+reads it to narrow the arms below a catch-all and needs the borrow the coverage
+carrier peels.
 
 ### PR9 — Remove the superseded ad-hoc helpers
 
 Cleanup only, no behavior change.
 
-- Delete only the helpers PR8's coverage walk has made truly dead:
-  `unionMatchExhaustive`, `armCoversShape`, `structuralInexact`, `narrowMatchArm`,
-  and the pattern-shape branches of `isCatchAll`.
+- Delete only the helpers PR8's coverage walk has made truly dead: `narrowMatchArm`
+  and the pattern-shape branches of `isCatchAll`. PR8 removed `unionMatchExhaustive`
+  and `armCoversShape` along with the arm-walking check that called them, and its
+  own carrier dispatch still calls `structuralInexact`.
 - Do not move these into the `ucs` package. They inspect `soltype` — exact-union
   membership, inexact-scrutinee shape, guarded-arm coverage — and `ucs` is ast-only,
   so it cannot host type-dependent logic. Their replacement is the typed coverage
@@ -767,7 +771,7 @@ Phase 2 plugs into two seams this plan creates:
 - **The normalized form IR** is what `#883`'s residual coverage check consumes.
   `residual = scrutinee ∧ ¬covered` is computed over the same splits, and the
   residual's DNF is the uncovered witness set.
-- **`checkMatchExhaustive`** is the function `#883` supersedes. Phase 1 leaves it
+- **`checkCondExhaustive`** is the function `#883` supersedes. Phase 1 leaves it
   reading off the IR so Phase 2 swaps the body for the algebra without touching
   the surface lowering.
 


### PR DESCRIPTION
Fixes #1027. Refs #882.

UCS IR — PR8. `checkMatchExhaustive` read the arms of the surface `match` to decide coverage. The same decision is now read off the normalized form, by the new `checkCondExhaustive` in [internal/solver/ucs_coverage.go](https://github.com/escalier-lang/escalier/blob/claude/pr-1027-lv06mm/internal/solver/ucs_coverage.go). The type-dependent predicates stay solver-side, since exact-union membership, structural exactness, and which member a tag names are all facts about a `soltype`. The check is the seam Phase 2 (#883) replaces with `residual = scrutinee ∧ ¬covered`.

## What the check reads

- **Catch-all** — the top-level split's default tail always reaches an arm body. A guarded catch-all counts only when the arms its guard falls into reach one too.
- **Covering branch** — every path below the branch reaches a body. That is what leaves a guarded arm and a refutable sub-pattern covering nothing, and it credits an arm whose own branch normalization dropped as a duplicate, as in `match x { 1 if g => a, 1 => b }`.
- **Projected structural test** — matches unconditionally, the reading that made a nested object or tuple pattern such as `{a: {b}}` irrefutable.
- Tags are collected by walking the default tails down from the top-level split, the terms a value reaches before it has passed a tag test of its own. A guarded arm whose pattern makes no test takes the whole split's tail, so the arms after it are branches of a split inside that tail and of no other. Reading the top-level split alone would find no covering branch for `match v { _ if g => 0, {x} => 1, {y} => 2 }`.

`NonExhaustiveMatchError` now carries the `ucs.Origin` of the uncovered split rather than the match node, so both its span and its wording follow the construct the user wrote. `unionMatchExhaustive` and `armCoversShape` go with their only caller.

## Verdict parity

Every existing message is unchanged, and the message tests assert in full. On top of the suite I ran a differential sweep of 3559 generated `match` forms against this branch's parent — literal unions, object unions, exact and inexact objects, nested objects, tuples, `null`/`undefined` atoms, and enum variants, with guards and every arm ordering up to three arms. No diagnostic differs.

One deliberate difference, in the other direction: a bare `...rest` arm now draws only `Unsupported: RestPat`. Such an arm ends the split, so the arms below it are outside the IR and the old rule cannot be reproduced both ways. The arm binds every value, so asking for a catch-all would name a branch the user did write, which is the stance `reportUnreachableArms` already takes after a bare rest.

## Deviation from the issue

The issue expected the `matchShape` snapshot in `inferMatch` to go away. It stays: `inferMatchArms` reads it to narrow the arms below a catch-all, and it needs the borrow that the coverage carrier peels. Its comment now names both consumers.

## Tests

- `internal/solver/ucs_coverage_test.go` pins the shapes normalization produces that do not line up with the arms: an arm below a guarded catch-all, an arm dropped as a duplicate, a nested structural pattern, a literal field arm falling into a plain one, a bare rest, and the branch-copy case a covering-looking tag must not be credited from.
- `TestNonExhaustiveMessageNamesTheConstruct` pins that the wording templates off `Origin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9YNMxmDdEMdgSapRFzZUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9YNMxmDdEMdgSapRFzZUE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pattern coverage checks for conditional matching, including nested patterns, unions, objects, tuples, and aliases.
  * Reduced incorrect non-exhaustive-match warnings for duplicate, fallthrough, and catch-all cases.
  * Improved diagnostic messages to identify the relevant conditional construct and highlight the appropriate source location.
  * Added clearer handling for guarded catch-alls, inexact values, and unsupported patterns.

* **Tests**
  * Expanded coverage for match exhaustiveness, inferred types, diagnostics, and source spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->