### PR TITLE
Type-check `if val` and `val … else` off the UCS normalized form

### DIFF
--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3024,43 +3024,62 @@ func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.
 	return res
 }
 
-// inferIfVal types `if val pat = target { cons }` with an optional `else { alt }`.
-// The pattern's names are bound ONLY in the consequent, at the narrowed member type;
-// the alternate runs in the enclosing scope and never sees them. The result joins the
-// consequent and alternate like inferIfElse, each non-diverging branch a lower bound.
+// inferIfVal types `if val pat = target { cons }` with an optional `else { alt }` off the
+// UCS normalized form. The target is inferred once, then ucs.DesugarIfVal and
+// ucs.Normalize lower the form into a split over that one value and condWalk types the
+// result.
+//
+// The pattern's names are bound ONLY in the consequent, at the narrowed member type. The
+// alternate is the split's fallthrough, which the walk types in the scope the form
+// started in, so it reads the scrutinee at its full type and never sees those names. Each
+// non-diverging half constrains into one fresh branch-join var, exactly as inferIfElse
+// joins its two branches.
 func (c *checker) inferIfVal(scope *Scope, lvl int, e *ast.IfValExpr) soltype.Type {
 	scrutinee := c.inferExpr(scope, lvl, e.Target)
-	consScope := scope.Child()
-	c.bindRefutable(consScope, lvl, e.Pattern, scrutinee)
-	consT, consDiverges := c.inferBlock(consScope, lvl, &e.Cons)
-	// The alternate runs in the original scope, so it sees the scrutinee at its full
-	// type without the narrowing the consequent's bindings carry.
-	var altT soltype.Type = &soltype.UndefinedType{}
-	altDiverges := false
-	if e.Alt != nil {
-		altT, altDiverges = c.inferBlockOrExpr(scope, lvl, e.Alt)
-	}
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, IfValBranch)
-	if !consDiverges {
-		c.constrain(e, consT, res)
-	}
-	if !altDiverges {
-		c.constrain(e, altT, res)
+	core := ucs.DesugarIfVal(e)
+	norm := ucs.Normalize(core)
+	// The binder is seeded with the type inferred above, so the walk never re-infers the
+	// target and a side-effecting one such as `if val x = f() { … }` runs its call once.
+	start := condState{scope: scope, binder: c.newPathBinder(lvl, e, core.Scrutinee, scrutinee)}
+	w := newCondWalk(c, lvl, e, res, norm)
+	// Nothing has been tested at the top of the form, so the state the walk runs in, the
+	// state its fallthrough returns to, and the binder that fallthrough inherits are all
+	// the state the `if val` itself started from.
+	w.walkNorm(start, start, start.binder, norm)
+	// A pattern that tests nothing always binds, so normalization drops the `else` as a
+	// path nothing reaches and the walk never types it. `if val x = u { … } else { … }` is
+	// such a form. Type it anyway, in the scope it would have run in, so a fault inside it
+	// is still reported and its value still joins the result. Reporting the `else` itself
+	// as dead is left to the coverage work, which decides reachability off this same form.
+	if alt, ok := core.Else.(*ucs.BodyLeaf); ok && !w.seen.Contains(alt) {
+		w.walkBody(start, alt)
 	}
 	c.recordType(e, res)
 	return res
 }
 
-// bindRefutable binds a refutable pattern's names against a scrutinee, returning the
-// bound type. A bare identifier pattern carrying a narrowing annotation, as in
-// `if val x: number = u`, binds the name at the narrowed member through
-// bindNarrowedIdent. Every other pattern destructures the scrutinee through the shared
-// structural path. The annotation is read from the pattern's own IdentPat.TypeAnn, which
-// the if-val parser fills in.
-func (c *checker) bindRefutable(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type) soltype.Type {
-	if ip, ok := pat.(*ast.IdentPat); ok && ip.TypeAnn != nil {
-		return c.bindNarrowedIdent(scope, lvl, ip, ip.TypeAnn, scrutinee)
+// bindRefutable binds a refutable pattern's names against a scrutinee, returning the type
+// it bound at. It is the solver-side adapter the typing walk calls for a leaf under an
+// annotation test, and it is where the parts of a refutable binding the IR does not model
+// live: the narrowing rule, the leaf's VarID, and the caller's own scope.
+//
+// ann is the narrowing annotation the surface wrote. Each form writes it somewhere else —
+// on the pattern for an `if val`, on the declaration for a `val … else` — so the IR
+// carries it on the branch's test and hands it here rather than leaving each caller to
+// find it. A bare identifier binds at the member the annotation picks, through
+// bindNarrowedIdent.
+//
+// Any other pattern destructures through the shared structural path. Normalization
+// flattens such a pattern into splits and binds and mints no annotation test over it, so
+// this arm is reached only by a lowering that pairs one with a pattern, and it recovers by
+// binding the pattern as written.
+func (c *checker) bindRefutable(
+	scope *Scope, lvl int, pat ast.Pat, ann ast.TypeAnn, scrutinee soltype.Type,
+) soltype.Type {
+	if ip, ok := pat.(*ast.IdentPat); ok && ann != nil {
+		return c.bindNarrowedIdent(scope, lvl, ip, ann, scrutinee)
 	}
 	c.bindPattern(scope, lvl, pat, scrutinee, nil)
 	return scrutinee
@@ -3092,51 +3111,81 @@ func (c *checker) bindNarrowedIdent(scope *Scope, lvl int, ip *ast.IdentPat, ann
 	return narrowed
 }
 
-// inferValElse types a `val pat = init else { … }` binding. The pattern narrows the
-// initializer and binds for the rest of the block; the `else` runs on a failed match
-// and either diverges or supplies the binding's fallback value, which must fit it.
+// inferValElse types a `val pat = init else { … }` binding off the UCS normalized form.
+// The initializer is inferred once, then ucs.DesugarValElse and ucs.Normalize lower the
+// declaration into a split whose one branch is the success path and whose fallthrough is
+// the `else`, and condWalk types the result.
+//
+// The success path ends in the binding-escape leaf, which carries no body because the rest
+// of the block is its continuation. Its leaves are installed in the block's scope once the
+// walk is done. The `else` runs precisely when the pattern bound none of them, so it is
+// typed first and never sees them. A non-diverging `else` supplies the binding's fallback
+// value, which has to fit the type the binding takes.
 func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
-	if d.Init == nil {
+	core, ok := ucs.DesugarValElse(d)
+	if !ok {
+		// A declaration the parser left without an initializer. There is no value to bind
+		// the pattern against and no failure for the `else` to cover.
 		c.reportUnsupported(d)
 		return
 	}
 	initType := c.inferExpr(scope, lvl, d.Init)
-	// The else runs only on a failed match, so it cannot see the pattern's bindings.
-	// Type it in a child scope BEFORE binding the pattern into the enclosing scope.
-	elseT, elseDiverges := c.inferBlock(scope.Child(), lvl, d.Else)
-
-	if d.TypeAnn != nil {
-		// A val-else annotation lives on the decl. A bare identifier narrows to it through
-		// bindNarrowedIdent, pinning the binding so a non-diverging else's fallback value
-		// must fit the pinned type. A destructuring pattern cannot distribute the
-		// annotation across its leaves, as in `val [a, b]: [number, string] = u else { … }`,
-		// so report it unsupported and bind structurally.
-		var bound soltype.Type
-		if ip, ok := d.Pattern.(*ast.IdentPat); ok {
-			bound = c.bindNarrowedIdent(scope, lvl, ip, d.TypeAnn, initType)
-		} else {
-			c.reportUnsupportedFeature(d.Pattern, "narrowing type annotation on a destructuring pattern")
-			c.bindPattern(scope, lvl, d.Pattern, initType, nil)
-			bound = initType
-		}
-		if !elseDiverges {
-			c.constrain(d, elseT, bound)
-		}
-		return
+	// A `val … else` annotation lives on the declaration. A bare identifier narrows to it
+	// through the split's annotation test. A destructuring pattern cannot distribute the
+	// annotation across its leaves, as in `val [a, b]: [number, string] = u else { … }`, so
+	// the lowering leaves that annotation out of the IR and it is reported here.
+	_, identPat := d.Pattern.(*ast.IdentPat)
+	if d.TypeAnn != nil && !identPat {
+		c.reportUnsupportedFeature(d.Pattern, "narrowing type annotation on a destructuring pattern")
 	}
 
-	// With no annotation the binding's type is inferred. The pattern binds against the
-	// matched initializer joined with a non-diverging else's fallback value, so the
-	// leaves read either source.
-	source := initType
-	if !elseDiverges {
+	// `root` is the value the pattern's leaves are projected out of, and `bound` the type a
+	// non-diverging `else`'s fallback value has to fit. With no annotation and a fallback to
+	// join, both are one fresh var carrying the matched initializer and that fallback, so a
+	// leaf reads either source. An `else` that diverges produces no value to join, and an
+	// annotated binding is pinned by its annotation instead, so each of those projects off
+	// the initializer alone.
+	//
+	// Divergence is a syntactic property of the block, so it is settled here rather than
+	// after the walk types the `else`.
+	root, bound := initType, initType
+	joins := d.TypeAnn == nil && !blockDiverges(d.Else)
+	if joins {
 		res := c.freshAt(lvl)
 		c.recordProv(res, d, ValElseBranch)
 		c.constrain(d, initType, res)
-		c.constrain(d, elseT, res)
-		source = res
+		root, bound = res, res
 	}
-	c.bindRefutable(scope, lvl, d.Pattern, source)
+
+	norm := ucs.Normalize(core)
+	// The binder is seeded with the type above, so the walk never re-infers the initializer
+	// and a side-effecting one such as `val x = f() else { … }` runs its call once. Marking
+	// it joined is what keeps the fallback checked against the pattern, since no tag test
+	// admitted that half of `root`. It is why `val {x} = p else { {y: 1} }` is an error
+	// rather than a leaf reading the initializer's half alone.
+	binder := c.newPathBinder(lvl, d, core.Scrutinee, root)
+	binder.joined = joins
+	// A `val … else` holds no arm body, so the walk joins nothing and takes no branch-join
+	// var.
+	start := condState{scope: scope, binder: binder}
+	w := newCondWalk(c, lvl, d, nil, norm)
+	w.walkNorm(start, start, start.binder, norm)
+	// A pattern that tests nothing always binds, so normalization drops the `else` as a
+	// path nothing reaches. `val n = u else { 0 }` is such a declaration. Type it anyway,
+	// in the scope it would have run in, for the reason inferIfVal types its dropped
+	// alternate.
+	if leaf, isFallback := core.Else.(*ucs.FallbackLeaf); isFallback && !w.seen.Contains(leaf) {
+		w.walkFallback(start, leaf)
+	}
+	if w.narrowed != nil {
+		// A narrowed identifier pins the binding, so the fallback has to fit the annotated
+		// type rather than the initializer's.
+		bound = w.narrowed
+	}
+	if elseT, produces := w.fallback(); produces {
+		c.constrain(d, elseT, bound)
+	}
+	installEscaped(scope, w.escaped)
 }
 
 // inferMatch types a `match` expression off the UCS normalized form. The scrutinee is

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3056,6 +3056,9 @@ func (c *checker) inferIfVal(scope *Scope, lvl int, e *ast.IfValExpr) soltype.Ty
 	if alt, ok := core.Else.(*ucs.BodyLeaf); ok && !w.seen.Contains(alt) {
 		w.walkBody(start, alt)
 	}
+	// The two halves join into one value, so they have to agree on ownership, exactly as
+	// inferIfElse's do. A diverging half produces no value and is left out of the check.
+	c.checkUniformOwnership(e, w.bodies)
 	c.recordType(e, res)
 	return res
 }
@@ -3139,17 +3142,22 @@ func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 		c.reportUnsupportedFeature(d.Pattern, "narrowing type annotation on a destructuring pattern")
 	}
 
+	// A declaration is pinned when its annotation narrows a bare identifier. The annotation
+	// then fixes the binding's type on its own. An annotation on a destructuring pattern is
+	// the one reported above, and it pins nothing.
+	pinned := d.TypeAnn != nil && identPat
+
 	// `root` is the value the pattern's leaves are projected out of, and `bound` the type a
-	// non-diverging `else`'s fallback value has to fit. With no annotation and a fallback to
-	// join, both are one fresh var carrying the matched initializer and that fallback, so a
-	// leaf reads either source. An `else` that diverges produces no value to join, and an
-	// annotated binding is pinned by its annotation instead, so each of those projects off
-	// the initializer alone.
+	// non-diverging `else`'s fallback value has to fit. Where there is a fallback to join
+	// and no pin, both are one fresh var carrying the matched initializer and that fallback,
+	// so a leaf reads either source. A pinned declaration and one whose `else` diverges each
+	// project off the initializer alone: the first has its type already, and the second has
+	// no fallback value at all.
 	//
 	// Divergence is a syntactic property of the block, so it is settled here rather than
 	// after the walk types the `else`.
 	root, bound := initType, initType
-	joins := d.TypeAnn == nil && !blockDiverges(d.Else)
+	joins := !pinned && !blockDiverges(d.Else)
 	if joins {
 		res := c.freshAt(lvl)
 		c.recordProv(res, d, ValElseBranch)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3064,20 +3064,18 @@ func (c *checker) inferIfVal(scope *Scope, lvl int, e *ast.IfValExpr) soltype.Ty
 }
 
 // bindRefutable binds a refutable pattern's names against a scrutinee, returning the type
-// it bound at. It is the solver-side adapter the typing walk calls for a leaf under an
-// annotation test, and it is where the parts of a refutable binding the IR does not model
-// live: the narrowing rule, the leaf's VarID, and the caller's own scope.
+// it bound at. The typing walk calls it for a leaf under an annotation test. It holds the
+// parts of a refutable binding the IR does not model: the narrowing rule, the leaf's
+// VarID, and the caller's own scope.
 //
-// ann is the narrowing annotation the surface wrote. Each form writes it somewhere else —
-// on the pattern for an `if val`, on the declaration for a `val … else` — so the IR
-// carries it on the branch's test and hands it here rather than leaving each caller to
-// find it. A bare identifier binds at the member the annotation picks, through
-// bindNarrowedIdent.
+// ann is the narrowing annotation the surface wrote. An `if val` writes it on the pattern
+// and a `val … else` on the declaration. The IR carries it on the branch's test and passes
+// it here, so neither caller has to know which node holds it. A bare identifier binds at
+// the member the annotation picks, through bindNarrowedIdent.
 //
-// Any other pattern destructures through the shared structural path. Normalization
-// flattens such a pattern into splits and binds and mints no annotation test over it, so
-// this arm is reached only by a lowering that pairs one with a pattern, and it recovers by
-// binding the pattern as written.
+// Any other pattern destructures through the shared structural path. Normalization mints
+// no annotation test over such a pattern, so that arm recovers from a lowering that pairs
+// one with a pattern anyway.
 func (c *checker) bindRefutable(
 	scope *Scope, lvl int, pat ast.Pat, ann ast.TypeAnn, scrutinee soltype.Type,
 ) soltype.Type {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3039,23 +3039,10 @@ func (c *checker) inferIfVal(scope *Scope, lvl int, e *ast.IfValExpr) soltype.Ty
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, IfValBranch)
 	core := ucs.DesugarIfVal(e)
-	norm := ucs.Normalize(core)
 	// The binder is seeded with the type inferred above, so the walk never re-infers the
 	// target and a side-effecting one such as `if val x = f() { … }` runs its call once.
-	start := condState{scope: scope, binder: c.newPathBinder(lvl, e, core.Scrutinee, scrutinee)}
-	w := newCondWalk(c, lvl, e, res, norm)
-	// Nothing has been tested at the top of the form, so the state the walk runs in, the
-	// state its fallthrough returns to, and the binder that fallthrough inherits are all
-	// the state the `if val` itself started from.
-	w.walkNorm(start, start, start.binder, norm)
-	// A pattern that tests nothing always binds, so normalization drops the `else` as a
-	// path nothing reaches and the walk never types it. `if val x = u { … } else { … }` is
-	// such a form. Type it anyway, in the scope it would have run in, so a fault inside it
-	// is still reported and its value still joins the result. Reporting the `else` itself
-	// as dead is left to the coverage work, which decides reachability off this same form.
-	if alt, ok := core.Else.(*ucs.BodyLeaf); ok && !w.seen.Contains(alt) {
-		w.walkBody(start, alt)
-	}
+	binder := c.newPathBinder(lvl, e, core.Scrutinee, scrutinee)
+	w := c.walkCond(scope, lvl, e, core, binder, res)
 	// The two halves join into one value, so they have to agree on ownership, exactly as
 	// inferIfElse's do. A diverging half produces no value and is left out of the check.
 	c.checkUniformOwnership(e, w.bodies)
@@ -3163,7 +3150,6 @@ func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 		root, bound = res, res
 	}
 
-	norm := ucs.Normalize(core)
 	// The binder is seeded with the type above, so the walk never re-infers the initializer
 	// and a side-effecting one such as `val x = f() else { … }` runs its call once. Marking
 	// it joined is what keeps the fallback checked against the pattern, since no tag test
@@ -3173,16 +3159,7 @@ func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 	binder.joined = joins
 	// A `val … else` holds no arm body, so the walk joins nothing and takes no branch-join
 	// var.
-	start := condState{scope: scope, binder: binder}
-	w := newCondWalk(c, lvl, d, nil, norm)
-	w.walkNorm(start, start, start.binder, norm)
-	// A pattern that tests nothing always binds, so normalization drops the `else` as a
-	// path nothing reaches. `val n = u else { 0 }` is such a declaration. Type it anyway,
-	// in the scope it would have run in, for the reason inferIfVal types its dropped
-	// alternate.
-	if leaf, isFallback := core.Else.(*ucs.FallbackLeaf); isFallback && !w.seen.Contains(leaf) {
-		w.walkFallback(start, leaf)
-	}
+	w := c.walkCond(scope, lvl, d, core, binder, nil)
 	if w.narrowed != nil {
 		// A narrowed identifier pins the binding, so the fallback has to fit the annotated
 		// type rather than the initializer's.
@@ -3218,15 +3195,10 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, MatchBranch)
 	core := ucs.DesugarMatch(e)
-	norm := ucs.Normalize(core)
 	// The binder is seeded with the type inferred above, so the walk never re-infers the
 	// target and a side-effecting one such as `match f() { … }` runs its call once.
-	start := condState{scope: scope, binder: c.newPathBinder(lvl, e, core.Scrutinee, scrutinee)}
-	w := newCondWalk(c, lvl, e, res, norm)
-	// No test has matched at the top of a `match`, so the walk starts with nothing
-	// refined: the state it runs in, the state a fallthrough returns to, and the binder a
-	// fallthrough inherits are all the state the `match` itself started from.
-	w.walkNorm(start, start, start.binder, norm)
+	binder := c.newPathBinder(lvl, e, core.Scrutinee, scrutinee)
+	w := c.walkCond(scope, lvl, e, core, binder, res)
 	// An arm below an unguarded catch-all can never run, so normalization leaves it out of
 	// the split and the walk never reaches it. Report each one, then type it anyway through
 	// the same per-arm path a `try`'s catch clauses take, so a fault inside dead code is

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -337,6 +337,22 @@ func TestInferValElseChecksTheFallbackAgainstThePattern(t *testing.T) {
 	}
 }
 
+// An annotation fixes the binding's type only where it narrows a bare identifier. One on a
+// destructuring pattern is unsupported and pins nothing, so that declaration joins its
+// fallback like an unannotated one: the fallback is checked against the pattern, and the
+// leaves read it. Treating the unsupported annotation as a pin would leave the fallback
+// checked against the initializer alone, which it satisfies, and infer `x: number` off a
+// declaration that can bind no `x` at all.
+func TestInferValElseJoinsPastAnUnsupportedAnnotation(t *testing.T) {
+	values, _, errs := inferSource(t,
+		"fn f(p: {x: number} | {y: string}) {\n\tval {x}: {x: number} = p else { {y: \"s\"} }\n\treturn x\n}")
+	require.Equal(t, []string{
+		"2:6-2:9: Unsupported: narrowing type annotation on a destructuring pattern",
+		"2:34-2:42: object is missing property: x",
+	}, messagesWithSpan(errs))
+	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number | undefined", values["f"])
+}
+
 // A fallback the pattern can destructure contributes its own leaf types, so the bound name
 // reads either source rather than the initializer's alone. The `undefined` comes from the
 // same rule: the union is left whole, so `x` is read off the `{y: string}` member too,

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -456,3 +456,104 @@ func TestInferRefutableFormsTypeAnUnreachableElse(t *testing.T) {
 		})
 	}
 }
+
+// A type annotation on a pattern leaf asserts rather than narrows, which is the opposite of
+// what the same syntax does on a whole binding. A top-level `if val x: number = u` picks the
+// member of `u` the annotation names, so a `u` that is a `string` takes the `else`. A leaf's
+// annotation names no tag the branch tests: the leaf binds at the annotated type and the
+// projection has to fit it, so `[a: string, …]` over `[number, …]` is rejected outright
+// rather than sending control to the `else`.
+//
+// The three nested spellings each hang the annotation off a different node — a tuple
+// element and an object key-value's value are `IdentPat.TypeAnn`, an object shorthand is
+// `ObjShorthandPat.TypeAnn` written with `::` — and all three reach the same rule.
+func TestInferNestedLeafAnnotations(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		// want is the printed type of `f`, checked when wantErrs is nil.
+		want string
+		// wantErrs, when non-nil, is the full set of expected messages.
+		wantErrs []string
+	}{
+		{
+			name: "match arm tuple leaves",
+			src:  "fn f(p: [number, string]) { return match p {\n\t[a: number, b: string] => [a, b],\n} }",
+			want: "fn (p: [number, string]) -> [number, string]",
+		},
+		{
+			name: "if val tuple leaves",
+			src:  `fn f(p: [number, string]) { return if val [a: number, b: string] = p { [a, b] } else { [0, ""] } }`,
+			want: "fn (p: [number, string]) -> [number, string]",
+		},
+		{
+			name: "val else tuple leaves",
+			src:  "fn f(p: [number, string]) {\n\tval [a: number, b: string] = p else { return [0, \"\"] }\n\treturn [a, b]\n}",
+			want: "fn (p: [number, string]) -> [number, string]",
+		},
+		{
+			name: "if val object key-value leaves",
+			src:  `fn f(p: {a: number, b: string}) { return if val {a: x: number, b: y: string} = p { [x, y] } else { [0, ""] } }`,
+			want: "fn (p: {a: number, b: string}) -> [number, string]",
+		},
+		{
+			name: "if val object shorthand leaves",
+			src:  `fn f(p: {a: number, b: string}) { return if val {a::number, b::string} = p { [a, b] } else { [0, ""] } }`,
+			want: "fn (p: {a: number, b: string}) -> [number, string]",
+		},
+		{
+			name: "val else object shorthand leaf",
+			src:  "fn f(p: {a: number, b: string}) {\n\tval {a::number} = p else { return 0 }\n\treturn a\n}",
+			want: "fn (p: {a: number, b: string}) -> number",
+		},
+		{
+			// The leaf binds at the annotation, so a wider one widens the name. A `5` element
+			// read through `a: number` binds `a` at `number` rather than at the literal.
+			name: "a leaf annotation widens the name",
+			src:  `fn f(p: [5, string]) { return if val [a: number, b: string] = p { a } else { 0 } }`,
+			want: "fn (p: [5, string]) -> number",
+		},
+		{
+			// The element is a `number` and the annotation says `string`, so the projection
+			// does not fit. Control does not fall to the `else` the way a failed tag test
+			// would send it.
+			name:     "if val tuple leaf annotation must fit",
+			src:      `fn f(p: [number, string]) { return if val [a: string, b: string] = p { [a, b] } else { ["", ""] } }`,
+			wantErrs: []string{"1:44-1:53: cannot constrain number <: string"},
+		},
+		{
+			name:     "val else tuple leaf annotation must fit",
+			src:      "fn f(p: [number, string]) {\n\tval [a: string, b: string] = p else { return [\"\", \"\"] }\n\treturn [a, b]\n}",
+			wantErrs: []string{"2:7-2:16: cannot constrain number <: string"},
+		},
+		{
+			name:     "if val object shorthand annotation must fit",
+			src:      `fn f(p: {a: number, b: string}) { return if val {a::string} = p { a } else { "" } }`,
+			wantErrs: []string{"1:50-1:59: cannot constrain number <: string"},
+		},
+		{
+			name:     "if val object key-value annotation must fit",
+			src:      `fn f(p: {a: number, b: string}) { return if val {a: x: string} = p { x } else { "" } }`,
+			wantErrs: []string{"1:53-1:62: cannot constrain number <: string"},
+		},
+		{
+			// The branch's own tag still narrows the scrutinee, so the leaf's annotation is
+			// checked against the member the object test picked rather than the whole union.
+			name: "a leaf annotation reads the narrowed member",
+			src:  `fn f(p: {a: number} | {b: string}) { return if val {a: x: number} = p { x } else { 0 } }`,
+			want: "fn (p: {a: number} | {b: string}) -> number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			if tt.wantErrs != nil {
+				require.Equal(t, tt.wantErrs, messagesWithSpan(errs))
+				return
+			}
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -212,3 +212,231 @@ func TestInferIfValAndValElse(t *testing.T) {
 		})
 	}
 }
+
+// --- The walk over the normalized form ---
+//
+// The cases below pin what routing `if val` and `val … else` through the UCS IR is
+// responsible for: the scope each half runs in, the projections a nested pattern binds
+// through, and typing each half once. The types and messages the two forms produce are
+// pinned by TestInferIfValAndValElse above.
+
+// A diagnostic from either form names the construct the user wrote. Lowering erases the
+// difference between `match`, `if val`, and `val … else`, so without the origin the IR
+// carries, a message about a failed pattern could name the wrong one. This is the golden
+// test for that: every case blames a span inside the construct it came from, and none
+// reaches for a `match`'s wording.
+func TestIfValAndValElseDiagnosticsNameTheirConstruct(t *testing.T) {
+	tests := map[string]struct {
+		src     string
+		want    string
+		blame   string
+		related []string
+	}{
+		// An annotation that is no member of the scrutinee's union underlines the
+		// annotation the `if val` wrote.
+		"IfValNarrowRejectsNonMember": {
+			src:     `fn f(u: number | string) { return if val x: boolean = u { x } else { 0 } }`,
+			want:    "1:45-1:52: cannot constrain boolean <: number | string",
+			blame:   "boolean",
+			related: []string{"number | string"},
+		},
+		// A fault inside the consequent blames the consequent, not the whole `if val`.
+		"IfValConsequentFault": {
+			src:   `fn f(u: number | string) { return if val x: number = u { x.nope } else { 0 } }`,
+			want:  "1:58-1:64: cannot constrain number <: object",
+			blame: "x.nope",
+		},
+		// A `val … else` names its `else`: the fallback that does not fit the annotated
+		// binding underlines the value the `else` produced.
+		"ValElseFallbackDoesNotFit": {
+			src:     "fn f(u: number | string) {\n\tval x: number = u else { \"no\" }\n\treturn x\n}",
+			want:    `2:27-2:31: cannot constrain "no" <: number`,
+			blame:   `"no"`,
+			related: []string{"number"},
+		},
+		// A name the `else` cannot see is reported against the `else`'s own reference.
+		"ValElseCannotSeeTheBinding": {
+			src:   "fn f(u: number | string) {\n\tval x: number = u else { return x }\n\treturn x\n}",
+			want:  "2:34-2:35: Unknown identifier: x",
+			blame: "x",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			requireBlame(t, tt.src, errs, tt.want, tt.blame, tt.related...)
+			require.NotContains(t, errs[0].Message(), "match")
+		})
+	}
+}
+
+// Union narrowing applies to both refutable forms, at every tag-level rather than only
+// the outermost. Each level's test picks the members it can destructure, so the leaf reads
+// the field of the member the pattern matched. Without narrowing the leaf would read the
+// field off both members and pick up the `undefined` the other one leaves.
+func TestInferRefutableFormsNarrowUnions(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		"IfValOuterLevel": {
+			src:  `fn f(p: {x: number} | {y: string}) { return if val {x} = p { x } else { 0 } }`,
+			want: "fn (p: {x: number} | {y: string}) -> number",
+		},
+		"IfValNestedLevel": {
+			src:  `fn f(p: {a: {x: number}} | {a: {y: string}}) { return if val {a: {x}} = p { x } else { 0 } }`,
+			want: "fn (p: {a: {x: number}} | {a: {y: string}}) -> number",
+		},
+		// A diverging `else` produces no value, so the declaration's leaves read only the
+		// initializer and narrowing applies to them the same way.
+		"ValElseWithADivergingElse": {
+			src:  "fn f(p: {x: number} | {y: string}) {\n\tval {x} = p else { return 0 }\n\treturn x\n}",
+			want: "fn (p: {x: number} | {y: string}) -> number",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// A `val … else` whose `else` supplies a fallback binds its leaves off the initializer
+// joined with that fallback, so the fallback has to satisfy the pattern too. No tag test
+// ever admitted it, so nothing narrows the value the leaves read: narrowing to the member
+// the pattern matched would leave the fallback unchecked and the leaves reading only the
+// initializer's half.
+func TestInferValElseChecksTheFallbackAgainstThePattern(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		// The fallback is an object of the union's other shape, which the pattern cannot
+		// destructure.
+		"FallbackMissesAField": {
+			src:  "fn f(p: {x: number} | {y: string}) {\n\tval {x} = p else { {y: 1} }\n\treturn x\n}",
+			want: "2:21-2:27: object is missing property: x",
+		},
+		// The fallback is not an object at all.
+		"FallbackIsNotAnObject": {
+			src:  "fn f(p: {x: number} | {y: string}) {\n\tval {x} = p else { 5 }\n\treturn x\n}",
+			want: "2:21-2:22: cannot constrain 5 <: object",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+		})
+	}
+}
+
+// A fallback the pattern can destructure contributes its own leaf types, so the bound name
+// reads either source rather than the initializer's alone. The `undefined` comes from the
+// same rule: the union is left whole, so `x` is read off the `{y: string}` member too,
+// which carries no such field.
+func TestInferValElseLeavesReadTheFallback(t *testing.T) {
+	values, _, errs := inferSource(t, "fn f(p: {x: number} | {y: string}) {\n\tval {x} = p else { {x: \"s\"} }\n\treturn x\n}")
+	require.Empty(t, errs)
+	require.Equal(t, `fn (p: {x: number} | {y: string}) -> number | "s" | undefined`, values["f"])
+}
+
+// A nested pattern flattens into one split per tag-level, and each level's leaves bind off
+// the projection the level above matched. The bound names read the nested field types, so
+// the walk's projections agree with what one whole pattern would have bound.
+func TestInferRefutableFormsBindThroughProjections(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		"IfVal": {
+			src:  `fn f(l: {start: {x: number, y: string}}) { return if val {start: {x, y}} = l { [x, y] } else { [0, ""] } }`,
+			want: `fn (l: {start: {x: number, y: string}}) -> [number, string]`,
+		},
+		"ValElse": {
+			src:  "fn f(l: {start: {x: number, y: string}}) {\n\tval {start: {x, y}} = l else { return [0, \"\"] }\n\treturn [x, y]\n}",
+			want: `fn (l: {start: {x: number, y: string}}) -> [number, string]`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// The names an `if val` binds are scoped to its consequent. The walk puts every bind in a
+// child scope, so `x` is gone by the statement after the form.
+func TestInferIfValBindingDoesNotEscape(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number}) {
+			if val {x} = p { x } else { 0 }
+			return x
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "4:11-4:12: Unknown identifier: x", msgWithSpan(errs[0]))
+}
+
+// The target expression is inferred once, before the walk, and the pattern binds against
+// that one type. The ill-typed argument below is the probe: inferring `g(2)` emits one
+// constraint failure, so a walk that re-inferred the target would report it twice.
+func TestInferRefutableFormsInferTheTargetOnce(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		"IfVal": {
+			src:  "fn g(s: string) { return {x: 1} }\nfn f() { return if val {x} = g(2) { x } else { 0 } }",
+			want: "2:32-2:33: cannot constrain 2 <: string",
+		},
+		"ValElse": {
+			src:  "fn g(s: string) { return {x: 1} }\nfn f() {\n\tval {x} = g(2) else { return 0 }\n\treturn x\n}",
+			want: "3:14-3:15: cannot constrain 2 <: string",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+		})
+	}
+}
+
+// A pattern that tests nothing always binds, so normalization drops the `else` below it as
+// a path nothing reaches. Both forms type that `else` anyway, so a fault inside it is
+// still reported rather than going unchecked until the pattern gains an annotation.
+func TestInferRefutableFormsTypeAnUnreachableElse(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		"IfVal": {
+			src:  `fn f(u: number | string) { return if val x = u { x } else { nope } }`,
+			want: "1:61-1:65: Unknown identifier: nope",
+		},
+		"ValElse": {
+			src:  "fn f(u: number | string) {\n\tval n = u else { nope }\n\treturn n\n}",
+			want: "2:19-2:23: Unknown identifier: nope",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, msgWithSpan(errs[0]))
+		})
+	}
+}

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -354,9 +354,15 @@ func TestInferValElseJoinsPastAnUnsupportedAnnotation(t *testing.T) {
 }
 
 // A fallback the pattern can destructure contributes its own leaf types, so the bound name
-// reads either source rather than the initializer's alone. The `undefined` comes from the
-// same rule: the union is left whole, so `x` is read off the `{y: string}` member too,
-// which carries no such field.
+// reads either source rather than the initializer's alone. Three lower bounds reach `x`
+// here: `number` and `"s"` from the two sources, and `undefined`.
+//
+// The `undefined` is constrainUnionFieldRead's doing, not the join's. Reading a property
+// off a union joins what each member yields, and `{y: string}` carries no `x`, so that
+// member contributes `undefined`. A plain `val {x} = p` over the same scrutinee infers
+// `number | undefined` for the same reason. What the join decides is only that the union is
+// still whole at the read: the fallback is a half no tag test admitted, so nothing narrows
+// `{y: string}` away the way an `if val` over the same `p` does.
 func TestInferValElseLeavesReadTheFallback(t *testing.T) {
 	values, _, errs := inferSource(t, "fn f(p: {x: number} | {y: string}) {\n\tval {x} = p else { {x: \"s\"} }\n\treturn x\n}")
 	require.Empty(t, errs)

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -363,6 +363,10 @@ func TestInferValElseJoinsPastAnUnsupportedAnnotation(t *testing.T) {
 // `number | undefined` for the same reason. What the join decides is only that the union is
 // still whole at the read: the fallback is a half no tag test admitted, so nothing narrows
 // `{y: string}` away the way an `if val` over the same `p` does.
+//
+// That `undefined` is wrong, and #1076 removes it. A `p` holding `{y: string}` fails the
+// `{x}` test and takes the `else`, so the leaf is never absent at run time. What this
+// asserts is today's type rather than the intended one.
 func TestInferValElseLeavesReadTheFallback(t *testing.T) {
 	values, _, errs := inferSource(t, "fn f(p: {x: number} | {y: string}) {\n\tval {x} = p else { {x: \"s\"} }\n\treturn x\n}")
 	require.Empty(t, errs)

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -71,6 +71,16 @@ func TestInferRefUnion(t *testing.T) {
 			wantErrs: []string{"2:11-5:4: " + mixedOwnershipMsg},
 		},
 		{
+			// An `if val` joins its two halves into one value the same way an `if/else`
+			// does, so the same ownership rule applies to it.
+			name: "mixed ownership across an if val",
+			src: `fn f(p: &mut {x: number}, u: number | string) {
+  val r = if val n: number = u { p } else { {x: 5} }
+  return r
+}`,
+			wantErrs: []string{"2:10-2:53: " + mixedOwnershipMsg},
+		},
+		{
 			name: "uniform owned union",
 			src: `fn f() {
   if true { return {x: 5} } else { return {x: 6} }

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -129,6 +129,13 @@ func (s *Scope) defineValue(name string, b ValueBinding) {
 	s.values[name] = b
 }
 
+// bindings returns THIS scope's own value bindings, without a parent's. The walk over a
+// `val pat = init else { … }` reads them to send the declaration's leaves into the
+// enclosing block once the `else` has been typed without them.
+func (s *Scope) bindings() map[string]ValueBinding {
+	return s.values
+}
+
 // removeValue deletes name from THIS scope's value map (a no-op if absent). The
 // SCC driver uses it to retract a value binding it pre-bound to a fresh var but
 // whose declaration then failed to produce a definition, so the mutation goes

--- a/internal/solver/ucs/core.go
+++ b/internal/solver/ucs/core.go
@@ -39,13 +39,10 @@ type CoreBranch struct {
 	Cont Core
 	// Ann is the narrowing type annotation the branch tests, the `number` of
 	// `if val x: number = u` and of `val x: number = u else { … }`. It is nil on every
-	// `match` arm and on any branch whose surface form wrote no annotation.
-	//
-	// The two refutable forms put the annotation in different places, on the pattern
-	// for an `if val` and on the declaration for a `val … else`, so lowering reads it
-	// off whichever node holds it and records it here. Normalization turns it into the
-	// branch's AnnTest, which is what makes the branch refutable and so keeps the
-	// split's `else` reachable.
+	// `match` arm and wherever the surface wrote no annotation. Lowering reads it off
+	// whichever node holds it, since an `if val` writes it on the pattern and a
+	// `val … else` on the declaration. Normalization turns it into the branch's AnnTest,
+	// which is what makes the branch refutable and keeps the split's `else` reachable.
 	Ann ast.TypeAnn
 	// Arm is the surface arm this branch came from. It survives the merging and
 	// flattening that normalization does, so a diagnostic blames the arm the user

--- a/internal/solver/ucs/core.go
+++ b/internal/solver/ucs/core.go
@@ -37,6 +37,16 @@ type CoreBranch struct {
 	// Cont is what runs once Pattern matches. A guarded arm puts a CoreGuard here so
 	// the guard reads the bindings the pattern introduced.
 	Cont Core
+	// Ann is the narrowing type annotation the branch tests, the `number` of
+	// `if val x: number = u` and of `val x: number = u else { … }`. It is nil on every
+	// `match` arm and on any branch whose surface form wrote no annotation.
+	//
+	// The two refutable forms put the annotation in different places, on the pattern
+	// for an `if val` and on the declaration for a `val … else`, so lowering reads it
+	// off whichever node holds it and records it here. Normalization turns it into the
+	// branch's AnnTest, which is what makes the branch refutable and so keeps the
+	// split's `else` reachable.
+	Ann ast.TypeAnn
 	// Arm is the surface arm this branch came from. It survives the merging and
 	// flattening that normalization does, so a diagnostic blames the arm the user
 	// typed. Origin.Node can point at a synthesized node after those rewrites; Arm

--- a/internal/solver/ucs/desugar.go
+++ b/internal/solver/ucs/desugar.go
@@ -100,6 +100,9 @@ func branchOrigin(kind OriginKind, pat ast.Pat, arm Origin) Origin {
 // two-branch split a two-arm `match` produces. The pattern branch carries the
 // consequent, and the `else` becomes the split's fallthrough rather than a second
 // branch.
+//
+// An `if val` writes its narrowing annotation inside the pattern, as the `number` of
+// `if val x: number = u`, so the branch reads it from there.
 func DesugarIfVal(e *ast.IfValExpr) *CoreSplit {
 	origin := At(OriginIfVal, e)
 	return &CoreSplit{
@@ -108,11 +111,24 @@ func DesugarIfVal(e *ast.IfValExpr) *CoreSplit {
 			Pattern: e.Pattern,
 			Cont:    &BodyLeaf{Body: ast.BlockOrExpr{Block: &e.Cons}, Arm: e, Origin: origin},
 			Arm:     e,
+			Ann:     patternNarrowingAnn(e.Pattern),
 			Origin:  branchOrigin(OriginIfVal, e.Pattern, origin),
 		}},
 		Else:   ifValElse(e, origin),
 		Origin: origin,
 	}
+}
+
+// patternNarrowingAnn returns the narrowing annotation a pattern carries, and nil when it
+// carries none. Only a bare identifier can carry one. Distributing an annotation across a
+// destructuring pattern's leaves, as `[a, b]: [number, string]` would need, is not
+// supported, so a branch over such a pattern tests its own shape and nothing else.
+func patternNarrowingAnn(p ast.Pat) ast.TypeAnn {
+	ident, ok := p.(*ast.IdentPat)
+	if !ok {
+		return nil
+	}
+	return ident.TypeAnn
 }
 
 // ifValElse builds the fallthrough of an `if val`. One that wrote an `else` gets a
@@ -151,9 +167,9 @@ func ifValElse(e *ast.IfValExpr, origin Origin) Core {
 // the rest of that block is the continuation.
 //
 // A narrowing annotation such as the `number` of `val x: number = u else { … }` sits
-// on the declaration rather than on the pattern, so the branch pattern does not
-// carry it. A consumer that needs it reads TypeAnn off the arm back-reference, which
-// is the declaration itself.
+// on the declaration rather than on the pattern, so the branch reads it from the
+// declaration and records it on Ann. Everything downstream then finds the annotation in
+// one place whichever form wrote it.
 func DesugarValElse(d *ast.VarDecl) (*CoreSplit, bool) {
 	if d.Else == nil || d.Init == nil {
 		return nil, false
@@ -165,6 +181,7 @@ func DesugarValElse(d *ast.VarDecl) (*CoreSplit, bool) {
 			Pattern: d.Pattern,
 			Cont:    &EscapeLeaf{Arm: d, Origin: origin},
 			Arm:     d,
+			Ann:     declNarrowingAnn(d),
 			Origin:  branchOrigin(OriginValElse, d.Pattern, origin),
 		}},
 		Else: &FallbackLeaf{
@@ -174,4 +191,16 @@ func DesugarValElse(d *ast.VarDecl) (*CoreSplit, bool) {
 		},
 		Origin: origin,
 	}, true
+}
+
+// declNarrowingAnn returns the narrowing annotation a `val … else` declaration carries,
+// and nil when it carries none. A declaration's annotation applies to the whole binding,
+// so it narrows only a bare identifier, the same restriction patternNarrowingAnn spells
+// out. A destructuring pattern keeps its own shape as the branch's tag, and the consumer
+// reports the annotation it cannot distribute.
+func declNarrowingAnn(d *ast.VarDecl) ast.TypeAnn {
+	if _, ok := d.Pattern.(*ast.IdentPat); !ok {
+		return nil
+	}
+	return d.TypeAnn
 }

--- a/internal/solver/ucs/desugar.go
+++ b/internal/solver/ucs/desugar.go
@@ -120,9 +120,8 @@ func DesugarIfVal(e *ast.IfValExpr) *CoreSplit {
 }
 
 // patternNarrowingAnn returns the narrowing annotation a pattern carries, and nil when it
-// carries none. Only a bare identifier can carry one. Distributing an annotation across a
-// destructuring pattern's leaves, as `[a, b]: [number, string]` would need, is not
-// supported, so a branch over such a pattern tests its own shape and nothing else.
+// carries none. Only a bare identifier can carry one: distributing an annotation across a
+// destructuring pattern's leaves, as `[a, b]: [number, string]` would need, is unsupported.
 func patternNarrowingAnn(p ast.Pat) ast.TypeAnn {
 	ident, ok := p.(*ast.IdentPat)
 	if !ok {
@@ -194,10 +193,8 @@ func DesugarValElse(d *ast.VarDecl) (*CoreSplit, bool) {
 }
 
 // declNarrowingAnn returns the narrowing annotation a `val … else` declaration carries,
-// and nil when it carries none. A declaration's annotation applies to the whole binding,
-// so it narrows only a bare identifier, the same restriction patternNarrowingAnn spells
-// out. A destructuring pattern keeps its own shape as the branch's tag, and the consumer
-// reports the annotation it cannot distribute.
+// and nil when it carries none. It narrows only a bare identifier, under the restriction
+// patternNarrowingAnn spells out.
 func declNarrowingAnn(d *ast.VarDecl) ast.TypeAnn {
 	if _, ok := d.Pattern.(*ast.IdentPat); !ok {
 		return nil

--- a/internal/solver/ucs/desugar_test.go
+++ b/internal/solver/ucs/desugar_test.go
@@ -270,10 +270,9 @@ func TestDesugarValElse(t *testing.T) {
 } else fallback { fallback } [val else] at=1:1-1:33 arm=same`))
 }
 
-// A narrowing annotation on a `val … else` sits on the declaration, not on the
-// pattern, so the branch pattern renders without it. The branch reads it off the
-// declaration and records it on Ann, which is where every form's annotation ends up
-// however the surface wrote it.
+// A narrowing annotation on a `val … else` sits on the declaration, not on the pattern, so
+// the branch pattern renders without it. The branch records it on Ann, where every form's
+// annotation ends up however the surface wrote it.
 func TestDesugarValElseReadsTheAnnotationOffTheDeclaration(t *testing.T) {
 	decl := findVarDecl(t, `val x: number = u else { 0 }`)
 

--- a/internal/solver/ucs/desugar_test.go
+++ b/internal/solver/ucs/desugar_test.go
@@ -271,9 +271,10 @@ func TestDesugarValElse(t *testing.T) {
 }
 
 // A narrowing annotation on a `val … else` sits on the declaration, not on the
-// pattern, so the branch pattern renders without it. A consumer that needs the
-// annotation reads it off the arm back-reference, which is the declaration.
-func TestDesugarValElseLeavesTheAnnotationOnTheDeclaration(t *testing.T) {
+// pattern, so the branch pattern renders without it. The branch reads it off the
+// declaration and records it on Ann, which is where every form's annotation ends up
+// however the surface wrote it.
+func TestDesugarValElseReadsTheAnnotationOffTheDeclaration(t *testing.T) {
 	decl := findVarDecl(t, `val x: number = u else { 0 }`)
 
 	core, ok := DesugarValElse(decl)
@@ -281,6 +282,32 @@ func TestDesugarValElseLeavesTheAnnotationOnTheDeclaration(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "split u {\n  pat x => escape\n} else fallback { 0 }", core.String())
 	require.Same(t, decl, core.Branches[0].Arm)
+	require.Same(t, decl.TypeAnn, core.Branches[0].Ann)
+}
+
+// An `if val` writes its annotation inside the pattern, so the branch reads it from
+// there. Both forms therefore hand the same annotation to normalization, which is what
+// lets one test kind cover them.
+func TestDesugarIfValReadsTheAnnotationOffThePattern(t *testing.T) {
+	expr := findExpr[*ast.IfValExpr](t, `if val x: number = u { cons } else { alt }`)
+
+	core := DesugarIfVal(expr)
+
+	ident, ok := expr.Pattern.(*ast.IdentPat)
+	require.True(t, ok)
+	require.Same(t, ident.TypeAnn, core.Branches[0].Ann)
+}
+
+// A narrowing annotation applies to the whole binding, so it narrows only a bare
+// identifier. A destructuring pattern's branch carries none, and the consumer reports
+// the annotation it cannot distribute across the pattern's leaves.
+func TestDesugarLeavesADestructuringAnnotationOffTheBranch(t *testing.T) {
+	decl := findVarDecl(t, `val [a, b]: [number, string] = u else { return }`)
+
+	core, ok := DesugarValElse(decl)
+
+	require.True(t, ok)
+	require.Nil(t, core.Branches[0].Ann)
 	require.NotNil(t, decl.TypeAnn)
 }
 

--- a/internal/solver/ucs/normalize.go
+++ b/internal/solver/ucs/normalize.go
@@ -75,6 +75,15 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 	cands := make([]candidate, len(s.Branches))
 	for i, branch := range s.Branches {
 		test, binds := shallowTest(branch.Pattern, s.Scrutinee, branch.Origin)
+		if test == nil && branch.Ann != nil {
+			// The pattern names no tag, so the branch's narrowing annotation is what it
+			// tests. `if val x: number = u` runs its consequent only for a `u` holding a
+			// `number`, which is what keeps the `else` below reachable. A pattern that does
+			// name a tag keeps it: an annotation over such a pattern cannot be distributed
+			// across its leaves, and the consumer reports that rather than the IR carrying
+			// two tags on one branch.
+			test = &AnnTest{Ann: branch.Ann}
+		}
 		cands[i] = candidate{
 			index:  i,
 			branch: branch,

--- a/internal/solver/ucs/normalize.go
+++ b/internal/solver/ucs/normalize.go
@@ -78,10 +78,8 @@ func normalizeSplit(s *CoreSplit, next Norm) Norm {
 		if test == nil && branch.Ann != nil {
 			// The pattern names no tag, so the branch's narrowing annotation is what it
 			// tests. `if val x: number = u` runs its consequent only for a `u` holding a
-			// `number`, which is what keeps the `else` below reachable. A pattern that does
-			// name a tag keeps it: an annotation over such a pattern cannot be distributed
-			// across its leaves, and the consumer reports that rather than the IR carrying
-			// two tags on one branch.
+			// `number`, which is what keeps the `else` below reachable. A pattern that
+			// names a tag of its own keeps it, so no branch ever carries two.
 			test = &AnnTest{Ann: branch.Ann}
 		}
 		cands[i] = candidate{

--- a/internal/solver/ucs/normalize_test.go
+++ b/internal/solver/ucs/normalize_test.go
@@ -641,8 +641,7 @@ func TestNormalizeUnannotatedBindingDropsTheElse(t *testing.T) {
 }
 
 // A destructuring pattern keeps its own shape as the branch's tag. The declaration's
-// annotation is left off the branch, since it cannot be distributed across the pattern's
-// leaves, so no branch ends up carrying two tags.
+// annotation is left off the branch, so no branch ends up carrying two tags.
 func TestNormalizeDestructuringKeepsItsOwnTag(t *testing.T) {
 	core := mustDesugarValElse(t, `val [a, b]: [number, string] = u else { return }`)
 

--- a/internal/solver/ucs/normalize_test.go
+++ b/internal/solver/ucs/normalize_test.go
@@ -658,3 +658,43 @@ func mustDesugarValElse(t *testing.T, src string) *CoreSplit {
 	require.True(t, ok)
 	return core
 }
+
+// A type annotation on a pattern leaf is not a tag the branch tests. Only the annotation a
+// refutable form writes on its whole binding becomes an AnnTest. A leaf's own annotation
+// stays on the bind, where the solver reads it off the pattern node, so the branch's tag is
+// the container's shape as it would be without any annotation.
+func TestNormalizeNestedAnnotationIsNotATag(t *testing.T) {
+	// `{a: x: string}` annotates a key-value pattern's value, and `{b::number}` a shorthand
+	// element. The two carry their annotation on different nodes, so both are checked.
+	core := DesugarIfVal(findExpr[*ast.IfValExpr](t, `if val {a: x: string, b::number} = p { cons } else { alt }`))
+
+	require.Nil(t, core.Branches[0].Ann)
+	branch := Normalize(core).(*NormSplit).Branches[0]
+	require.IsType(t, &ObjectTest{}, branch.Test)
+
+	value := branch.Cont.(*NormBind)
+	require.Equal(t, "x", value.Name)
+	require.NotNil(t, value.Pat.(*ast.IdentPat).TypeAnn)
+
+	shorthand := value.Cont.(*NormBind)
+	require.Equal(t, "b", shorthand.Name)
+	require.NotNil(t, shorthand.Elem.TypeAnn)
+}
+
+// A tuple element's annotation behaves the same way: the branch tests the tuple's arity and
+// each annotated element is an ordinary bind on its projection.
+func TestNormalizeNestedTupleAnnotationIsNotATag(t *testing.T) {
+	core := DesugarIfVal(findExpr[*ast.IfValExpr](t, `if val [a: string, b: number] = p { cons } else { alt }`))
+
+	require.Nil(t, core.Branches[0].Ann)
+	branch := Normalize(core).(*NormSplit).Branches[0]
+	require.IsType(t, &TupleTest{}, branch.Test)
+
+	first := branch.Cont.(*NormBind)
+	require.Equal(t, "a", first.Name)
+	require.NotNil(t, first.Pat.(*ast.IdentPat).TypeAnn)
+
+	second := first.Cont.(*NormBind)
+	require.Equal(t, "b", second.Name)
+	require.NotNil(t, second.Pat.(*ast.IdentPat).TypeAnn)
+}

--- a/internal/solver/ucs/normalize_test.go
+++ b/internal/solver/ucs/normalize_test.go
@@ -599,3 +599,63 @@ func TestNormalizeBareTerms(t *testing.T) {
 	}
 	require.Equal(t, "bind x = p; leaf 1", normalized(bind))
 }
+
+// A narrowing annotation is a tag the branch tests, so the branch it sits on can fail and
+// the `else` below it stays reachable. `if val x: number = u` runs its consequent only for
+// a `u` holding a `number`.
+func TestNormalizeAnnotationIsARefutableTag(t *testing.T) {
+	tests := map[string]struct {
+		core *CoreSplit
+		want string
+	}{
+		// An `if val` writes the annotation inside its pattern.
+		"IfVal": {
+			core: DesugarIfVal(findExpr[*ast.IfValExpr](t, `if val x: number = u { cons } else { alt }`)),
+			want: `split u {
+  : number => bind x = u; leaf { cons }
+} default leaf { alt }`,
+		},
+		// A `val … else` writes it on the declaration. Both reach the same tag.
+		"ValElse": {
+			core: mustDesugarValElse(t, `val x: number = u else { 0 }`),
+			want: `split u {
+  : number => bind x = u; escape
+} default fallback { 0 }`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, normalized(test.core))
+		})
+	}
+}
+
+// A pattern with no annotation names no tag at all, so its branch always runs and becomes
+// the split's tail. The `else` below it is then unreachable and normalization drops it,
+// which is what tells a consumer the failure path can never be taken.
+func TestNormalizeUnannotatedBindingDropsTheElse(t *testing.T) {
+	core := DesugarIfVal(findExpr[*ast.IfValExpr](t, `if val x = u { cons } else { alt }`))
+
+	require.Equal(t, "split u {} default bind x = u; leaf { cons }", normalized(core))
+}
+
+// A destructuring pattern keeps its own shape as the branch's tag. The declaration's
+// annotation is left off the branch, since it cannot be distributed across the pattern's
+// leaves, so no branch ends up carrying two tags.
+func TestNormalizeDestructuringKeepsItsOwnTag(t *testing.T) {
+	core := mustDesugarValElse(t, `val [a, b]: [number, string] = u else { return }`)
+
+	require.Equal(t, `split u {
+  [_, _] => bind a = u.0, b = u.1; escape
+} default fallback { return }`, normalized(core))
+}
+
+// mustDesugarValElse lowers the first declaration of src, which the tests above write as a
+// `val … else` so the lowering applies.
+func mustDesugarValElse(t *testing.T, src string) *CoreSplit {
+	t.Helper()
+	core, ok := DesugarValElse(findVarDecl(t, src))
+	require.True(t, ok)
+	return core
+}

--- a/internal/solver/ucs/render.go
+++ b/internal/solver/ucs/render.go
@@ -27,6 +27,9 @@ func exprString(e ast.Expr) string { return renderNode(e) }
 // patString renders a pattern on one line.
 func patString(p ast.Pat) string { return renderNode(p) }
 
+// annString renders a type annotation on one line.
+func annString(a ast.TypeAnn) string { return renderNode(a) }
+
 // litString renders a literal on one line. A literal is not an ast.Node, so it reaches the
 // printer wrapped in the expression form that holds one.
 func litString(lit ast.Lit) string {

--- a/internal/solver/ucs/test.go
+++ b/internal/solver/ucs/test.go
@@ -108,15 +108,13 @@ type ExtractorTest struct {
 	Arity int
 }
 
-// AnnTest matches a narrowing type annotation, the `number` of `if val x: number = u`.
-// A value passes when it is one of the annotation's, so a `u` holding a `string` fails
-// the test and takes the `else`. This is what makes an annotated binding refutable: with
-// no annotation the same identifier matches every value and writes no failure path.
+// AnnTest matches a narrowing type annotation, the `number` of `if val x: number = u`. A
+// value passes when it is one of the annotation's, so a `u` holding a `string` fails and
+// takes the `else`. That is what makes an annotated binding refutable, where the same
+// identifier without one matches every value.
 //
-// The tag comes from what the surface wrote rather than from a pattern's shape, and each
-// form writes it in a different place. An `if val` puts it on the pattern and a
-// `val … else` on the declaration, so lowering reads it off whichever node holds it.
-// A `match` arm never produces this test.
+// The tag comes from what the surface wrote rather than from a pattern's shape, so only
+// `if val` and `val … else` produce it and never a `match` arm.
 type AnnTest struct{ Ann ast.TypeAnn }
 
 // String renders the tag test.

--- a/internal/solver/ucs/test.go
+++ b/internal/solver/ucs/test.go
@@ -62,6 +62,7 @@ func (*TupleTest) isTest()     {}
 func (*LitTest) isTest()       {}
 func (*ClassTest) isTest()     {}
 func (*ExtractorTest) isTest() {}
+func (*AnnTest) isTest()       {}
 
 // ObjectKey is one field an object test names.
 type ObjectKey struct {
@@ -107,12 +108,24 @@ type ExtractorTest struct {
 	Arity int
 }
 
+// AnnTest matches a narrowing type annotation, the `number` of `if val x: number = u`.
+// A value passes when it is one of the annotation's, so a `u` holding a `string` fails
+// the test and takes the `else`. This is what makes an annotated binding refutable: with
+// no annotation the same identifier matches every value and writes no failure path.
+//
+// The tag comes from what the surface wrote rather than from a pattern's shape, and each
+// form writes it in a different place. An `if val` puts it on the pattern and a
+// `val … else` on the declaration, so lowering reads it off whichever node holds it.
+// A `match` arm never produces this test.
+type AnnTest struct{ Ann ast.TypeAnn }
+
 // String renders the tag test.
 func (t *ObjectTest) String() string    { return testString(t) }
 func (t *TupleTest) String() string     { return testString(t) }
 func (t *LitTest) String() string       { return testString(t) }
 func (t *ClassTest) String() string     { return testString(t) }
 func (t *ExtractorTest) String() string { return testString(t) }
+func (t *AnnTest) String() string       { return testString(t) }
 
 // testString renders a branch's tag test. A structural test relaxed by a rest
 // pattern renders a trailing `...`, matching how an inexact type prints.
@@ -154,6 +167,10 @@ func testString(t Test) string {
 			args[i] = "_"
 		}
 		return ast.QualIdentToString(t.Name) + "(" + strings.Join(args, ", ") + ")"
+	case *AnnTest:
+		// The leading colon is the syntax the annotation is written with, so the test
+		// reads as the tail of the binding it came from: `: number`.
+		return ": " + annString(t.Ann)
 	default:
 		return nodeKind(t)
 	}

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -65,6 +65,7 @@ type tested interface{ isTested() }
 func (*testedObject) isTested()    {}
 func (*testedTuple) isTested()     {}
 func (*testedExtractor) isTested() {}
+func (*testedAnn) isTested()       {}
 
 // testedObject carries the object test itself, which a field step consults to ask whether
 // the key the pattern defaulted may be absent. Nothing else about an object test is
@@ -88,6 +89,14 @@ type testedTuple struct {
 // also binds through until M7's `[Symbol.customMatcher]` lands.
 type testedExtractor struct{ params []*soltype.FuncParam }
 
+// testedAnn carries the narrowing annotation an `if val` or a `val … else` tested, which
+// the leaf beneath reads through narrowingAnn.
+//
+// Applying the test resolves nothing on its own. bindNarrowedIdent both picks the member
+// the annotation names and binds the identifier at it, so resolving the annotation here as
+// well would report an unsupported one twice and record its type twice.
+type testedAnn struct{ ann ast.TypeAnn }
+
 // pathBinder resolves IR projection paths into types and binds leaf patterns off them.
 // It is seeded with the root scrutinee's inferred type, which is the only type the IR
 // itself cannot supply.
@@ -103,7 +112,15 @@ type pathBinder struct {
 	// carries no origin the solver can blame. A match arm, for one, has a span but is
 	// not an ast.Node.
 	blame ast.Node
-	views map[*ucs.Scrutinee]scrutineeView
+	// joined marks a binder whose root holds more than the value the splits test. A
+	// `val pat = init else { … }` binds its leaves off the matched initializer joined with
+	// the `else`'s fallback value, and no tag test ever admitted that fallback. Narrowing
+	// such a root to the member a test matched would drop the fallback half, so nothing
+	// under this binder narrows. Every sub-scrutinee is a projection of the root and
+	// carries both halves too, which is why the mark sits on the binder rather than on one
+	// view.
+	joined bool
+	views  map[*ucs.Scrutinee]scrutineeView
 }
 
 // newPathBinder builds the binder for one conditional form. root is the IR's root
@@ -150,7 +167,7 @@ func (b *pathBinder) narrowedBy(scope *Scope, s *ucs.Scrutinee, test ucs.Test, b
 	if !ok {
 		node = b.blameFor(s)
 	}
-	next := &pathBinder{c: b.c, lvl: b.lvl, blame: b.blame, views: maps.Clone(b.views)}
+	next := &pathBinder{c: b.c, lvl: b.lvl, blame: b.blame, joined: b.joined, views: maps.Clone(b.views)}
 	next.views[s] = next.applyTest(scope, node, v, test)
 	return next
 }
@@ -382,9 +399,23 @@ func (b *pathBinder) applyTest(scope *Scope, node ast.Node, v scrutineeView, tes
 		return b.applyClassTest(scope, node, v, t)
 	case *ucs.ExtractorTest:
 		return b.applyExtractorTest(scope, node, v, t)
+	case *ucs.AnnTest:
+		v.tested = &testedAnn{ann: t.Ann}
+		return v
 	default:
 		return v
 	}
+}
+
+// narrowingAnn returns the annotation the split over s tested it against, and false when
+// no annotation test applies to s. The typing walk reads it to bind the leaf beneath the
+// test through bindRefutable rather than through the ordinary projection.
+func (b *pathBinder) narrowingAnn(s *ucs.Scrutinee) (ast.TypeAnn, bool) {
+	tested, ok := b.views[s].tested.(*testedAnn)
+	if !ok {
+		return nil, false
+	}
+	return tested.ann, true
 }
 
 // narrowUnion drops the union members the test cannot destructure, so a branch that
@@ -393,6 +424,11 @@ func (b *pathBinder) applyTest(scope *Scope, node ast.Node, v scrutineeView, tes
 // pattern, and it keeps that function's rules so PR6 inherits variant-narrowing
 // unchanged.
 func (b *pathBinder) narrowUnion(v scrutineeView, test ucs.Test) scrutineeView {
+	if b.joined {
+		// The value the leaves read holds a half no test admitted, so no member can be
+		// ruled out and the leaves stay bound against the whole of it. See pathBinder.joined.
+		return v
+	}
 	// A borrowed shape is left wrapped rather than peeled the way groundedCarrier peels
 	// one. The narrowed result below replaces v.ty and v.concrete, and nothing here
 	// rewraps it, so peeling first would drop the borrow off a nested scrutinee.

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -90,11 +90,9 @@ type testedTuple struct {
 type testedExtractor struct{ params []*soltype.FuncParam }
 
 // testedAnn carries the narrowing annotation an `if val` or a `val … else` tested, which
-// the leaf beneath reads through narrowingAnn.
-//
-// Applying the test resolves nothing on its own. bindNarrowedIdent both picks the member
-// the annotation names and binds the identifier at it, so resolving the annotation here as
-// well would report an unsupported one twice and record its type twice.
+// the leaf beneath reads through narrowingAnn. Applying the test resolves nothing itself:
+// bindNarrowedIdent both picks the member the annotation names and binds the identifier at
+// it, so resolving it here too would report an unsupported one twice.
 type testedAnn struct{ ann ast.TypeAnn }
 
 // pathBinder resolves IR projection paths into types and binds leaf patterns off them.
@@ -112,13 +110,12 @@ type pathBinder struct {
 	// carries no origin the solver can blame. A match arm, for one, has a span but is
 	// not an ast.Node.
 	blame ast.Node
-	// joined marks a binder whose root holds more than the value the splits test. A
-	// `val pat = init else { … }` binds its leaves off the matched initializer joined with
-	// the `else`'s fallback value, and no tag test ever admitted that fallback. Narrowing
-	// such a root to the member a test matched would drop the fallback half, so nothing
-	// under this binder narrows. Every sub-scrutinee is a projection of the root and
-	// carries both halves too, which is why the mark sits on the binder rather than on one
-	// view.
+	// joined marks a binder whose root holds more than the value the splits test, which is
+	// what a `val pat = init else { … }` binds off: the matched initializer joined with the
+	// `else`'s fallback value, a half no tag test ever admitted. Narrowing such a root to
+	// the member a test matched would drop that half, so nothing under this binder narrows.
+	// The mark sits on the binder rather than on one view because every sub-scrutinee is a
+	// projection of the root and carries both halves too.
 	joined bool
 	views  map[*ucs.Scrutinee]scrutineeView
 }

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -13,9 +13,16 @@ import (
 // splits, binds, guards, and leaves. A term is one node of that tree, which is what
 // `ucs.Term` names. The bare word `node` is kept for an `ast.Node`, the surface node a
 // diagnostic blames, so neither has to be read from context. This file types the tree for
-// a `match`. A split applies its branch's tag test to the path binder, a bind resolves its
-// projection and defines the leaf, a guard is an ordinary boolean condition over the names
-// above it, and a leaf infers the body the user wrote for its arm.
+// all three surface forms. A split applies its branch's tag test to the path binder, a
+// bind resolves its projection and defines the leaf, a guard is an ordinary boolean
+// condition over the names above it, and a leaf infers the body the user wrote for its
+// arm.
+//
+// The three leaf kinds are what the forms differ by. A `match` arm and each half of an
+// `if val` end in a body leaf, whose value joins the form's result. A `val … else` ends
+// its success path in a binding-escape leaf, which carries no body because the rest of the
+// enclosing block is its continuation, and its `else` in a fallback leaf, whose value the
+// declaration binds rather than the form evaluating to it.
 //
 // The walk carries three states rather than one, because a term's continuation does not
 // run in the state the term itself runs in.
@@ -60,6 +67,19 @@ type condWalk struct {
 	// typed once. Typing it twice would infer the arm body twice and report anything
 	// wrong with it twice.
 	seen set.Set[ucs.Norm]
+	// narrowed is the type an annotation test's leaf bound at, which a `val … else` reads
+	// to pin the type its `else` has to produce. It is nil until such a leaf binds, and
+	// stays nil for every form that writes no narrowing annotation.
+	narrowed soltype.Type
+	// escaped is the innermost scope the success path of a `val … else` bound its leaves
+	// into, and nil until the walk reaches the binding-escape leaf. The caller installs
+	// those leaves in the enclosing block; installEscaped says why the walk does not.
+	escaped *Scope
+	// fallbackT and fallbackDiverges are what the `else` of a `val … else` produced, read
+	// through fallback. They stay zero for every other form, none of which mints a
+	// fallback leaf.
+	fallbackT        soltype.Type
+	fallbackDiverges bool
 	// graph answers what the walk needs to know about the form's shape: whether a
 	// continuation is one of those shared terms, and which arm bodies a term can reach.
 	graph *normGraph
@@ -67,7 +87,8 @@ type condWalk struct {
 
 // newCondWalk builds the walk over norm, the normalized form of one conditional. node is
 // the construct each body's join is blamed on, and res the branch-join variable those
-// bodies constrain into.
+// bodies constrain into. res may be nil for a form whose normalized shape holds no body
+// leaf, which is what a `val … else` lowers to.
 func newCondWalk(c *checker, lvl int, node ast.Node, res soltype.Type, norm ucs.Norm) *condWalk {
 	return &condWalk{
 		c:     c,
@@ -96,10 +117,10 @@ func (w *condWalk) walkNorm(cur, fall condState, matched *pathBinder, term ucs.N
 		w.walkGuard(cur, fall, matched, n)
 	case *ucs.BodyLeaf:
 		w.walkBody(cur, n)
-	case *ucs.EscapeLeaf, *ucs.FallbackLeaf:
-		// The two leaves of a `val pat = init else { … }`. Its success path carries no body
-		// at all. Its `else` carries one, but binding it needs the declaration's rules rather
-		// than an arm's. Neither is typed here, and `ucs.DesugarMatch` mints neither.
+	case *ucs.EscapeLeaf:
+		w.walkEscape(cur)
+	case *ucs.FallbackLeaf:
+		w.walkFallback(cur, n)
 	}
 }
 
@@ -136,9 +157,25 @@ func (w *condWalk) walkBind(cur, fall condState, matched *pathBinder, bind *ucs.
 	case bind.Elem != nil:
 		cur.binder.bindElemAt(scope, bind.Source, bind.Elem)
 	case bind.Pat != nil:
-		cur.binder.bindAt(scope, bind.Source, bind.Pat)
+		w.bindPat(scope, cur.binder, bind)
 	}
 	w.walkNorm(condState{scope: scope, binder: cur.binder}, fall, matched, bind.Cont)
+}
+
+// bindPat defines the leaf one bind names, choosing between the two ways the solver binds
+// against a value the IR pointed at.
+//
+// A leaf under an annotation test goes through bindRefutable, which binds the name at the
+// member the annotation picks and carries the rename-assigned VarID onto the binding. The
+// IR models neither, since both come from the annotation the surface wrote rather than
+// from the branch's shape. Every other leaf binds through the path binder's projection.
+func (w *condWalk) bindPat(scope *Scope, binder *pathBinder, bind *ucs.NormBind) {
+	ann, narrows := binder.narrowingAnn(bind.Source)
+	if !narrows {
+		binder.bindAt(scope, bind.Source, bind.Pat)
+		return
+	}
+	w.narrowed = w.c.bindRefutable(scope, w.lvl, bind.Pat, ann, binder.typeAt(scope, bind.Source))
 }
 
 // walkGuard types a guard's condition as a boolean over the names its branch bound, then
@@ -207,6 +244,56 @@ func (w *condWalk) walkBody(cur condState, leaf *ucs.BodyLeaf) {
 	}
 	w.c.constrain(w.node, bodyT, w.res)
 	w.bodies = append(w.bodies, bodyT)
+}
+
+// walkEscape records where the success path of a `val pat = init else { … }` left its
+// bindings. That path carries no body: the rest of the enclosing block is its
+// continuation, so the names it bound have to outlive the walk.
+//
+// They are recorded rather than defined into the block's own scope, because the `else` has
+// still to be typed and it runs in that scope. Defining them now would put the
+// declaration's names in scope for a block that runs precisely when the pattern bound
+// none of them.
+func (w *condWalk) walkEscape(cur condState) {
+	w.escaped = cur.scope
+}
+
+// walkFallback types the `else` of a `val pat = init else { … }` and records what it
+// produced. Its value is not one the form evaluates to, the way an arm body's is. It is
+// the value the declaration binds when the pattern did not match, so the caller
+// constrains it into the binding rather than into a branch-join var.
+func (w *condWalk) walkFallback(cur condState, leaf *ucs.FallbackLeaf) {
+	w.fallbackT, w.fallbackDiverges = w.c.inferBlockOrExpr(cur.scope, w.lvl, &leaf.Body)
+}
+
+// fallback returns the value the `else` of a `val … else` produced, and false when it
+// produces none. An `else` that diverges is one such case. So is a form whose lowering
+// minted no fallback leaf, which is every form but a `val … else`.
+func (w *condWalk) fallback() (soltype.Type, bool) {
+	if w.fallbackT == nil || w.fallbackDiverges {
+		return nil, false
+	}
+	return w.fallbackT, true
+}
+
+// installEscaped defines in scope every binding the walk left in the chain of child scopes
+// below it, which is how a `val pat = init else { … }` sends its leaves into the enclosing
+// block. from is the innermost of those scopes and scope is the block's own, so the walk
+// stops there. It runs after the walk, once the `else` has been typed in a scope that
+// still holds none of these names.
+//
+// The chain is applied outermost first, so a name an inner scope rebound wins, matching
+// what a reference inside the walk would have resolved to.
+func installEscaped(scope, from *Scope) {
+	var chain []*Scope
+	for s := from; s != nil && s != scope; s = s.parent {
+		chain = append(chain, s)
+	}
+	for i := len(chain) - 1; i >= 0; i-- {
+		for name, binding := range chain[i].bindings() {
+			scope.defineValue(name, binding)
+		}
+	}
 }
 
 // normGraph is what the walk reads off the shape of one normalized form before typing it:

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -103,6 +103,35 @@ func newCondWalk(c *checker, lvl int, node ast.Node, res soltype.Type, norm ucs.
 	}
 }
 
+// walkCond normalizes one desugared form and types it, returning the walk so the caller can
+// read what it collected. node is the construct a body's join is blamed on, binder resolves
+// the projections the form's paths name, and res the branch-join variable each body
+// constrains into. It is what every surface form's infer function calls once it has lowered
+// itself and inferred its scrutinee.
+//
+// Nothing has been tested at the top of a form, so the state the walk runs in, the state its
+// fallthrough returns to, and the binder that fallthrough inherits are all the state the
+// form itself started from.
+//
+// The `else` gets a second walk. A pattern that tests nothing always matches, so
+// normalization drops the `else` below it as a path nothing reaches, and the first walk
+// never sees it. `if val x = u { … } else { … }` and `val n = u else { … }` are the two such
+// forms. Typing it anyway is what keeps a fault inside it reported and its value joined.
+// walkNorm skips a term it has already typed, so the second call is a no-op for the `else`
+// of a refutable form, and a `match` names no `else` at all.
+func (c *checker) walkCond(
+	scope *Scope, lvl int, node ast.Node, core *ucs.CoreSplit, binder *pathBinder, res soltype.Type,
+) *condWalk {
+	norm := ucs.Normalize(core)
+	start := condState{scope: scope, binder: binder}
+	w := newCondWalk(c, lvl, node, res, norm)
+	w.walkNorm(start, start, start.binder, norm)
+	if dropped, isLeaf := core.Else.(ucs.Norm); isLeaf {
+		w.walkNorm(start, start, start.binder, dropped)
+	}
+	return w
+}
+
 // walkNorm types term. cur is the state term runs in, fall the state the whole form
 // started in, and matched fall's binder with the enclosing branch's tag test applied.
 func (w *condWalk) walkNorm(cur, fall condState, matched *pathBinder, term ucs.Norm) {

--- a/internal/solver/ucs_walk.go
+++ b/internal/solver/ucs_walk.go
@@ -13,10 +13,12 @@ import (
 // splits, binds, guards, and leaves. A term is one node of that tree, which is what
 // `ucs.Term` names. The bare word `node` is kept for an `ast.Node`, the surface node a
 // diagnostic blames, so neither has to be read from context. This file types the tree for
-// all three surface forms. A split applies its branch's tag test to the path binder, a
-// bind resolves its projection and defines the leaf, a guard is an ordinary boolean
-// condition over the names above it, and a leaf infers the body the user wrote for its
-// arm.
+// all three surface forms.
+//
+//   - A split applies its branch's tag test to the path binder.
+//   - A bind resolves its projection and defines the leaf.
+//   - A guard is an ordinary boolean condition over the names above it.
+//   - A leaf infers the body the user wrote for its arm.
 //
 // The three leaf kinds are what the forms differ by. A `match` arm and each half of an
 // `if val` end in a body leaf, whose value joins the form's result. A `val … else` ends


### PR DESCRIPTION
Fixes #1026.

`inferIfVal` and `inferValElse` now desugar with `ucs.DesugarIfVal` / `ucs.DesugarValElse`, normalize, and type the result with `condWalk`, the walk PR6 introduced for `match`. The `IfValBranch` and `ValElseBranch` provenance edges, the else-scope isolation, and the escape of a `val … else`'s success bindings into the enclosing block are unchanged.

## What the IR had to learn

**`AnnTest`, the narrowing annotation as a tag.** Without it an annotated binding read as a catch-all, normalization dropped the `else` as unreachable, and `if val x: number = u { x }` would have lost its `undefined` half. An `if val` writes the annotation on its pattern and a `val … else` on its declaration, so `CoreBranch.Ann` records it from wherever the surface put it and the walk reads it from one place.

**Binding-escape and fallback leaves.** The escape leaf records where its names were bound; `inferValElse` installs them in the block once the `else` has been typed without them. The fallback leaf's value is the one the declaration binds rather than one the form evaluates to, so it constrains into the binding rather than into a branch-join var.

**`pathBinder.joined`.** A root that holds a half no tag test admitted, which is what a `val … else` binds off when its `else` supplies a fallback. Nothing under such a binder narrows: narrowing to the member the pattern matched would leave the fallback unchecked, so `val {x} = p else { {y: 1} }` would stop reporting the field the fallback lacks.

`bindRefutable` stays the solver-side binding adapter. It now takes the annotation as a parameter rather than reading it off the pattern, so both forms reach `bindNarrowedIdent` and the leaf keeps its `VarID`.

## Behavior

One thing moves, the same way it moved for `match` in PR6. A union narrows at every tag-level, so `if val {x} = p { x }` over `{x: number} | {y: string}` binds `x` at `number` rather than `number | undefined`. A `val … else` narrows the same way when its `else` diverges and there is no fallback to preserve.

A pattern that tests nothing leaves its `else` unreachable and normalization drops it. Both forms type that `else` anyway, so a fault inside it is still reported and its value still joins. That is what keeps every current input's type and message unchanged. Reporting such an `else` as dead is a coverage question rather than one this change answers.

Two further corrections came out of review, in the second commit:

- An annotation on a destructuring pattern is reported unsupported and pins nothing, so it no longer suppresses the fallback join. `val {x}: {x: number} = p else { {y: "s"} }` had checked the fallback against the initializer alone and inferred `x: number` off a declaration that can bind no `x`.
- `inferIfVal` runs `checkUniformOwnership`, which `inferIfElse` and `inferMatch` already did. `if val n: number = u { p } else { {x: 5} }` over a `&mut` `p` reported no mixed ownership.

## Out of scope

Module-level `val … else` keeps its own path in `inferModuleValElse`. It returns a type for the SCC driver to place rather than binding into a scope, which is outside what #1026 covers.

## Tests

`go test ./...` is green. New coverage: golden tests that each form's diagnostics blame a span inside the construct the user wrote and never reach for a `match`'s wording; per-level union narrowing for both forms; nested patterns binding through projections; the target inferred once; a dropped `else` still typed; the fallback checked against the pattern; and the two review fixes above. `internal/solver/ucs` gains normalization snapshots for the annotation tag and for the shapes that leave the `else` unreachable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ch3CWD14AEDKk6FfChfdnX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type narrowing for `if val` and `val … else` expressions, including union and nested patterns.
  * Preserved single evaluation of conditional targets and improved handling of unreachable branches.
  * Improved ownership checks, fallback validation, scope isolation, and diagnostic source locations.
  * Added support for narrowing annotations and projection-based bindings, with clearer handling of unsupported destructuring annotations.
* **Tests**
  * Expanded coverage for conditional inference, diagnostics, ownership, annotations, and nested patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->