### PR TITLE
Rename narrowMatchArm to narrowArmScrutinee

### DIFF
--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3187,7 +3187,7 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	// lower bound, which would otherwise leak a phantom member into the coalesced union read
 	// after the walk. Both the coverage check and the arms below a catch-all read their union
 	// structure off this. The borrow stays on the snapshot rather than being peeled the way
-	// groundedCarrier peels one, since narrowMatchArm rewraps what it narrows and
+	// groundedCarrier peels one, since narrowArmScrutinee rewraps what it narrows and
 	// checkCondExhaustive reads its own carrier.
 	matchShape := scrutinee
 	if carrierIsVar(scrutinee) {
@@ -3241,20 +3241,22 @@ func (c *checker) reportUnreachableArms(arms []*ast.MatchCase, walked set.Set[uc
 	return unreachable
 }
 
-// inferMatchArms types each arm of a `match` or of a `try`'s catch clause, constrains every
-// non-diverging body into res, and returns those bodies for the caller's ownership check.
-// Each arm binds in a fresh child scope, so a name one arm binds is invisible to the next,
-// and node is blamed for each body's join. shape is the coalesced scrutinee narrowMatchArm
-// reads union members from. scrutinee is what an arm binds against when no narrowing
-// applies, so a var's identity and borrow survive there. inferMatch passes a snapshot and
-// the original, inferTryCatch one already-concrete type for both.
+// inferMatchArms types each arm of a `try`'s catch clause and each unreachable arm of a
+// `match`, constrains every non-diverging body into res, and returns those bodies for the
+// caller's ownership check. Each arm binds in a fresh child scope, so a name one arm binds is
+// invisible to the next, and node is blamed for each body's join. shape is the coalesced
+// scrutinee narrowArmScrutinee reads union members from. scrutinee is what an arm binds
+// against when no narrowing applies, so a var's identity and borrow survive there. inferMatch
+// passes a snapshot and the original, inferTryCatch one already-concrete type for both.
+//
+// The reachable arms of a `match` are typed by condWalk instead, off the normalized form.
 func (c *checker) inferMatchArms(
 	scope *Scope, lvl int, node ast.Node, arms []*ast.MatchCase, shape, scrutinee, res soltype.Type,
 ) []soltype.Type {
 	var bodies []soltype.Type
 	for _, arm := range arms {
 		armScope := scope.Child()
-		armScrut := narrowMatchArm(shape, scrutinee, arm.Pattern)
+		armScrut := narrowArmScrutinee(shape, scrutinee, arm.Pattern)
 		c.bindPattern(armScope, lvl, arm.Pattern, armScrut, nil)
 		if arm.Guard != nil {
 			// A guard is an ordinary boolean condition over the arm's bindings. As in
@@ -3594,15 +3596,21 @@ func tuplePatArity(p *ast.TuplePat) (fixed int, hasRest bool) {
 	return fixed, hasRest
 }
 
-// narrowMatchArm returns the type a match arm's pattern binds against. For a structural
-// object or tuple pattern over a union scrutinee, it keeps only the members whose shape the
-// pattern matches, so the pattern destructures those members and leaves the rest for other
-// arms. Narrowing is sound only in a refutable context such as a match arm. An irrefutable
-// binding must still require the pattern's fields on every member. Every other pattern, and
-// every non-union scrutinee, binds against the scrutinee unchanged. shape is the coalesced
-// scrutinee the union structure is read from. scrutinee is what a non-narrowing arm binds
-// against, so its var identity and borrow survive when no narrowing applies.
-func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
+// narrowArmScrutinee returns the type an arm's pattern binds against. inferMatchArms is its
+// only caller. For a structural object or tuple pattern over a union scrutinee, it keeps only
+// the members whose shape the pattern matches, so the pattern destructures those members and
+// leaves the rest for other arms. Narrowing is sound only in a refutable context such as an
+// arm of a `match` or of a `try`'s catch clause. An irrefutable binding must still require
+// the pattern's fields on every member. Every other pattern, and every non-union scrutinee,
+// binds against the scrutinee unchanged.
+//
+// shape is the coalesced scrutinee the union structure is read from. scrutinee is what a
+// non-narrowing arm binds against, so its var identity and borrow survive when no narrowing
+// applies.
+//
+// The reachable arms of a `match` narrow through condWalk instead, which reads the same rule
+// off the IR's tag tests rather than off the source pattern.
+func narrowArmScrutinee(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 	switch pat.(type) {
 	case *ast.ObjectPat, *ast.TuplePat:
 	default:
@@ -3630,7 +3638,7 @@ func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 // all of them, in which case the narrowed union would reproduce the original including an
 // inexact one's open tail.
 //
-// It is the narrowing rule itself, shared by narrowMatchArm and the UCS IR's structural
+// It is the narrowing rule itself, shared by narrowArmScrutinee and the UCS IR's structural
 // tests. shape must already be peeled of any borrow. Rewrapping is the caller's job,
 // because the IR carries the borrow in its binding mode rather than on the type.
 func narrowUnionMembers(shape soltype.Type, keep func(soltype.Type) bool) (soltype.Type, bool) {

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -473,8 +473,8 @@ func TestInferMatchTupleRestPattern(t *testing.T) {
 	require.Equal(t, "fn (p: [string] | [number, number]) -> number | string", values["f"])
 }
 
-// An inexact union's open `...` tail survives match-arm narrowing. narrowMatchArm keeps the
-// tail, so `{x}` over `{x: number} | {y: string} | ...` narrows to `{x: number} | ...`. The
+// An inexact union's open `...` tail survives match-arm narrowing. The `{x}` branch's object
+// test narrows `{x: number} | {y: string} | ...` to `{x: number} | ...`, keeping the tail. The
 // field-read rule (M5 D4) then reads `x` off that narrowed inexact union as `number | unknown`,
 // which collapses to `unknown`, so the arm type-checks and `x` binds `unknown`. The `_` arm
 // keeps the match exhaustive, which an inexact union still requires.

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -449,3 +449,31 @@ func TestInferTryCatchExpandsAliasedErrorTypes(t *testing.T) {
 		},
 	})
 }
+
+// A catch arm is a refutable context, so a structural pattern over a union of caught types
+// binds against only the members it can destructure. `[a, b]` keeps `[number, number]` and
+// drops `[string]`, which is what stops the arm from reporting a length mismatch against a
+// member it was never meant to match. One diagnostic remains. It comes from the open `...`
+// tail caughtType puts on every caught type, not from the dropped member. A fixed-arity tuple
+// pattern cannot destructure that tail, so `[a, b]` still fails against
+// `[number, number] | ...`.
+func TestInferTryCatchArmNarrowsItsScrutinee(t *testing.T) {
+	runThrowsErrCases(t, []throwsErrCase{
+		{
+			name: "TuplePatternKeepsOnlyTheMembersItDestructures",
+			src: `
+				fn f(b: boolean) {
+					return try {
+						if b { throw [1, 2] } else { throw ["a"] }
+					} catch {
+						[a, b] => a,
+						e => 0
+					}
+				}
+			`,
+			wantErrs: []string{
+				"6:7-6:13: cannot constrain tuple | ... <: tuple",
+			},
+		},
+	})
+}

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -417,9 +417,9 @@ func (b *pathBinder) narrowingAnn(s *ucs.Scrutinee) (ast.TypeAnn, bool) {
 
 // narrowUnion drops the union members the test cannot destructure, so a branch that
 // tests one variant binds against that variant alone rather than against the whole
-// union. It is narrowMatchArm read off the IR's tag test instead of off the source
-// pattern, and it keeps that function's rules so PR6 inherits variant-narrowing
-// unchanged.
+// union. It applies the same narrowing rule as narrowArmScrutinee, read off the IR's tag
+// test instead of off the source pattern, so a reachable arm and an arm typed outside the
+// walk agree on which members a branch keeps.
 func (b *pathBinder) narrowUnion(v scrutineeView, test ucs.Test) scrutineeView {
 	if b.joined {
 		// The value the leaves read holds a half no test admitted, so no member can be
@@ -438,7 +438,7 @@ func (b *pathBinder) narrowUnion(v scrutineeView, test ucs.Test) scrutineeView {
 	})
 	if !ok {
 		// Narrowing does not apply, so the scrutinee's own type stays the bind target. The
-		// borrow needs no rewrap the way narrowMatchArm's does, since it rides mode rather
+		// borrow needs no rewrap the way narrowArmScrutinee's does, since it rides mode rather
 		// than the type.
 		return v
 	}
@@ -451,7 +451,7 @@ func (b *pathBinder) narrowUnion(v scrutineeView, test ucs.Test) scrutineeView {
 // patternMatchesMemberShape read off the IR's test rather than off the source pattern. An
 // object test fits an object member carrying every key the test names, and a tuple test
 // fits a tuple member of its fixed arity, or of at least that arity under a trailing
-// rest. Every other test kind returns false, the same gate narrowMatchArm puts on object
+// rest. Every other test kind returns false, the same gate narrowArmScrutinee puts on object
 // and tuple patterns alone.
 func testMatchesMemberShape(test ucs.Test, member soltype.Type) bool {
 	switch t := test.(type) {

--- a/internal/solver/ucs_walk_test.go
+++ b/internal/solver/ucs_walk_test.go
@@ -357,6 +357,23 @@ func TestInferMatchGuardedCatchAllLeavesLaterArmsReachable(t *testing.T) {
 	require.Equal(t, `fn (n: number, b: boolean) -> number | "one"`, values["f"])
 }
 
+// An unreachable arm is typed outside the walk, so narrowArmScrutinee rather than the IR's
+// tag test decides what its pattern binds against. `[a, b]` keeps only the member it can
+// destructure, narrowing the exact union to `[number, number]`, so the dead arm draws the
+// unreachable diagnostic alone. Binding it against the whole union would add a second message
+// naming the `[string]` member the pattern was never meant to match.
+func TestInferMatchUnreachableArmNarrowsItsScrutinee(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: [number, number] | [string]) {
+			return match p {
+				_ => 0,
+				[a, b] => a
+			}
+		}
+	`)
+	require.Equal(t, []string{unreachableArm(5, 5, 16)}, messagesWithSpan(errs))
+}
+
 // unreachableArm renders the unreachable-arm message prefixed by the span of the arm it
 // blames, which runs from startCol to endCol on line.
 func unreachableArm(line, startCol, endCol int) string {

--- a/planning/ucs/implementation_plan.md
+++ b/planning/ucs/implementation_plan.md
@@ -256,9 +256,11 @@ split p {                       split p {
   algorithm is written here — that is Phase 2's residual-based check. The interim
   check is `checkCondExhaustive` in
   [internal/solver/ucs_coverage.go](../../internal/solver/ucs_coverage.go), and the
-  typed predicates it and the arms below a catch-all lean on — `structuralInexact`,
-  `narrowArmScrutinee`, and `isCatchAll` — are in
-  [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go).
+  typed predicates it and the arms below a catch-all lean on — `structuralInexact`
+  and `narrowArmScrutinee` — are in
+  [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go). The
+  catch-all test itself is `ast.IsCatchAllPat` in
+  [internal/ast/pattern.go](../../internal/ast/pattern.go), which needs no type.
 - **Reuse the shared pattern path.** Leaf binding keeps going through
   `bindPattern` / `bindPatternWith` in
   [internal/solver/pattern.go](../../internal/solver/pattern.go). It already
@@ -310,9 +312,11 @@ split p {                       split p {
   desugarer is shaped to accept one branch producing several core branches, but
   wiring real alternatives needs parser and AST work first. Flagged, not built.
 - **`try` / `catch` arms.** `TryCatchExpr` carries `[]*MatchCase` for its catch
-  clauses but has no solver typing yet. The desugarer is designed so catch arms
-  can lower through the same `Split`, but throws-narrowing is a Phase 2 (#883)
-  payoff and is not part of this plan.
+  clauses, and `inferTryCatch` already types them through `inferMatchArms` off the
+  source patterns. They do not lower through the IR. The desugarer is designed so
+  they could reach the same `Split`, but throws-narrowing is a Phase 2 (#883) payoff
+  and is not part of this plan. Leaving them on the source path is what keeps
+  `narrowArmScrutinee` and the pattern-shaped coverage predicates alive after PR9.
 
 ## Package layout
 
@@ -444,7 +448,8 @@ testing before anything calls it. Retyping split into PR6 and PR7, since rewirin
 all four ad-hoc paths at once put four entry points and their whole test surface in
 one review. PR1 through PR5 change no inferred type — PR1 through PR4 are pure IR
 and PR5 is an unwired helper. PR6 and PR7 flip type checking onto the IR. PR8 moves
-coverage. PR9 deletes the superseded code. The
+coverage and deletes the helpers that move makes dead. PR9 retires the names left
+behind. The
 [dependency graph](#dependency-graph-and-parallelism) below marks the two windows
 where PRs can proceed in parallel.
 
@@ -658,7 +663,8 @@ on any current input.
   `match`. It reads the IR's split structure but keeps its type-dependent
   predicates in `internal/solver`: deciding exact-union membership, inexactness, and
   guarded-arm coverage needs `soltype`, so this is a typed coverage adapter, not
-  ast-only logic. It is the replacement PR9 deletes the old helpers in favor of.
+  ast-only logic. It replaces `unionMatchExhaustive` and `armCoversShape`, which
+  this PR deletes along with the arm-walking check that called them.
 - Keep the interim semantics identical: an inexact scrutinee needs a catch-all, an
   exact union is covered when every member has an unguarded covering branch, and a
   guarded branch covers nothing. This is the seam Phase 2 (#883) later replaces
@@ -671,7 +677,7 @@ split's `Origin` per the [Diagnostics](#diagnostics) section rather than assumin
 reads it to narrow the arms below a catch-all and needs the borrow the coverage
 carrier peels.
 
-### PR9 — Remove the superseded ad-hoc helpers
+### PR9 — Retire the superseded helper names
 
 Cleanup only, no behavior change.
 
@@ -717,7 +723,7 @@ code it supersedes.
 | PR6 — Type-check `match` | PR2, PR4, PR5 | — |
 | PR7 — Type-check `if val` / `else` | PR6 | PR8 |
 | PR8 — Coverage off the IR | PR6 | PR7 |
-| PR9 — Remove superseded helpers | PR7, PR8 | — |
+| PR9 — Retire superseded helper names | PR7, PR8 | — |
 
 Two parallel windows open up:
 
@@ -745,7 +751,7 @@ graph TD
     PR6["PR6 · Type-check match"]
     PR7["PR7 · Type-check if val / else"]
     PR8["PR8 · Coverage off the IR"]
-    PR9["PR9 · Remove superseded helpers"]
+    PR9["PR9 · Retire superseded helper names"]
 
     PR0 --> PR5
     PR1 --> PR2
@@ -773,7 +779,7 @@ graph TD
 Green is the PR0 prerequisite, on M9's types rather than the UCS IR. Blue is
 IR-only work that changes no inferred type — PR1 through PR4 build the IR and PR5
 adds the unwired project-and-bind helper. Orange flips type checking or coverage
-onto the IR, purple is deletion. The two diamonds in the graph, PR6 and PR9, are
+onto the IR, purple is cleanup. The two diamonds in the graph, PR6 and PR9, are
 the join points where a parallel window closes.
 
 ## Handoff to Phase 2 (#883)

--- a/planning/ucs/implementation_plan.md
+++ b/planning/ucs/implementation_plan.md
@@ -257,7 +257,7 @@ split p {                       split p {
   check is `checkCondExhaustive` in
   [internal/solver/ucs_coverage.go](../../internal/solver/ucs_coverage.go), and the
   typed predicates it and the arms below a catch-all lean on — `structuralInexact`,
-  `narrowMatchArm`, and `isCatchAll` — are in
+  `narrowArmScrutinee`, and `isCatchAll` — are in
   [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go).
 - **Reuse the shared pattern path.** Leaf binding keeps going through
   `bindPattern` / `bindPatternWith` in
@@ -594,7 +594,7 @@ pure-IR PRs land unwired.
   propagation — then bind through `bindPattern` / `bindPatternWith`. The `ucs`
   package supplies only the ast-level path; every type is computed here in
   `internal/solver`.
-- Reproduce `narrowMatchArm`'s union narrowing at the path level: a path into one
+- Reproduce `narrowArmScrutinee`'s union narrowing at the path level: a path into one
   union variant must resolve against only that variant's members, so PR6 inherits
   variant-narrowing with no regression.
 
@@ -675,18 +675,30 @@ carrier peels.
 
 Cleanup only, no behavior change.
 
-- Delete only the helpers PR8's coverage walk has made truly dead: `narrowMatchArm`
-  and the pattern-shape branches of `isCatchAll`. PR8 removed `unionMatchExhaustive`
-  and `armCoversShape` along with the arm-walking check that called them, and its
-  own carrier dispatch still calls `structuralInexact`.
-- Do not move these into the `ucs` package. They inspect `soltype` — exact-union
-  membership, inexact-scrutinee shape, guarded-arm coverage — and `ucs` is ast-only,
-  so it cannot host type-dependent logic. Their replacement is the typed coverage
-  adapter PR8 already puts in `internal/solver`. If any predicate is still reachable
-  after PR8, it stays solver-side; nothing type-dependent folds into `ucs`.
+PR8 already deleted `unionMatchExhaustive` and `armCoversShape` along with the
+arm-walking check that called them, so no helper is left to remove. What PR9 ships
+instead is the rename of `narrowMatchArm` to `narrowArmScrutinee` and two tests
+pinning the narrowing that keeps it alive. The rest of the ad-hoc helpers stay,
+each for a reason:
 
-**Tests.** `go test ./...` unchanged; this PR removes code with no reachable
-callers after PR7 and PR8.
+- `structuralInexact` is live. `checkCondExhaustive` calls it to read the
+  exactness of an object or tuple carrier.
+- `isCatchAll` is `ast.IsCatchAllPat`, and it already tests only a wildcard and an
+  identifier. There are no pattern-shape branches to strip.
+- `narrowArmScrutinee` is live, under that name because it no longer narrows a
+  reachable `match` arm. `inferMatchArms` calls it for the arms of a `try`'s catch
+  clause and for the unreachable arms below a catch-all, neither of which the walk
+  types. Dropping the call adds a redundant diagnostic where an arm's tuple pattern
+  meets a union of tuples: `match p { _ => 0, [a, b] => a }` over
+  `[number, number] | [string]` gains `cannot constrain tuple of length 1 <: tuple
+  of length 2` on top of the unreachable-arm error. Retiring it takes routing catch
+  arms through the IR, which is its own change.
+- Nothing moves into the `ucs` package. These inspect `soltype` — exact-union
+  membership, inexact-scrutinee shape, guarded-arm coverage — and `ucs` is ast-only,
+  so it cannot host type-dependent logic. Every predicate that survives stays
+  solver-side, alongside the typed coverage adapter PR8 puts in `internal/solver`.
+
+**Tests.** `go test ./...` unchanged.
 
 ## Dependency graph and parallelism
 
@@ -784,7 +796,7 @@ with an ast-only dependency lets codegen import it later without a solver cycle.
   be the same projection `bindPattern` would compute through `CarrierOf` and the
   member-lookup path, or leaf types drift. Mitigate by having the IR walk call the
   existing projection rather than recomputing it.
-- **Union-variant narrowing.** `narrowMatchArm` currently drops the union members
+- **Union-variant narrowing.** `narrowArmScrutinee` currently drops the union members
   an arm cannot destructure. The normalized split must reproduce this so a
   one-variant arm does not bind against the whole union. Snapshot the normalized
   IR for a union scrutinee to lock the split boundaries.


### PR DESCRIPTION
Refs #1028.

Rename `narrowMatchArm` to `narrowArmScrutinee` to clarify its scope and update documentation to reflect the current architecture.

## Summary

#1028 asked for the deletion of `unionMatchExhaustive`, `armCoversShape`, `structuralInexact`, `narrowMatchArm`, and the pattern-shape branches of `isCatchAll`. None of them are dead:

- `unionMatchExhaustive` and `armCoversShape` were already deleted by #1074, along with the arm-walking check that called them.
- `structuralInexact` is called by `checkCondExhaustive` to read the exactness of an object or tuple carrier.
- `isCatchAll` is `ast.IsCatchAllPat`, and it already tests only a wildcard and an identifier. There are no pattern-shape branches to strip.
- `narrowMatchArm` is still called by `inferMatchArms`, which types the arms of a `try`'s catch clause and the unreachable arms below a catch-all. Neither goes through the walk.

So this PR renames the one misleadingly-named survivor instead of deleting it. `narrowArmScrutinee` says what it does now that it no longer narrows a reachable `match` arm.

## Changes

- Rename `narrowMatchArm` to `narrowArmScrutinee` in `internal/solver/infer_expr.go`, and update every call site and comment naming it.
- Clarify in the function and caller documentation that reachable match arms are typed by `condWalk` instead, which reads the same narrowing rule off the IR's tag tests rather than off the source pattern.
- Update `planning/ucs/implementation_plan.md` so the PR9 section records why each helper stays rather than listing them for deletion.
- Add two tests pinning the narrowing that keeps the function alive:
  - `TestInferTryCatchArmNarrowsItsScrutinee` in `internal/solver/infer_try_catch_test.go`
  - `TestInferMatchUnreachableArmNarrowsItsScrutinee` in `internal/solver/ucs_walk_test.go`
- Update comments in `internal/solver/ucs_bind.go` to reference the renamed function and to drop the milestone narration in `narrowUnion`'s doc.

## Why the tests are there

Deleting the call keeps `go test ./...` green, which is why the helper reads as dead. It is not. Without it, a tuple pattern over a union of tuples draws an extra diagnostic in both remaining callers:

```rust
fn f(p: [number, number] | [string]) {
  return match p {
    _ => 0,
    [a, b] => a
  }
}
```

reports only the unreachable-arm error today, and gains `cannot constrain tuple of length 1 <: tuple of length 2` without the narrowing. The equivalent catch arm behaves the same way. Both new tests fail with the call removed, so the next attempt to retire the helper will not be silent. Actually retiring it takes routing catch arms through the IR, which is its own change.

https://claude.ai/code/session_01G7GcF1ym2E5VDr5FwsQBRo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type narrowing for pattern-matching and catch arms.
  * Unreachable arms are now type-checked while reporting only the relevant unreachable-arm diagnostic.
  * Preserved open-tail constraints when narrowing inexact union patterns.

* **Tests**
  * Added coverage for tuple-pattern narrowing in catch arms.
  * Added regression coverage for unreachable tuple-pattern arms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->