### PR TITLE
Join fallback leaves in val-else destructuring patterns

### DIFF
--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3292,11 +3292,18 @@ func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, esca
 // fallback has to fit it. `val {x::number} = p else { {x: "s"} }` reports the `"s"` rather
 // than widening `x` to `number | "s"`.
 //
-// A leaf of a BORROWED scrutinee is not one of the two. Such a leaf carries a lifetime, and
-// what it names is a place inside the initializer. The fallback is a fresh value that lives
-// nowhere in there, so it joins beside the borrow and the name binds a union. A write
-// through it is then rejected, which is the honest answer for a name that holds a borrow on
-// one path and a temporary on the other.
+// An UNANNOTATED leaf of a borrowed scrutinee is neither. It carries a lifetime, and what it
+// names is a place inside the initializer. The fallback is a fresh value living nowhere in
+// there, so it joins beside the borrow and the name binds a union. A write through that
+// union is rejected, which is the honest answer for a name holding a borrow on one path and
+// a temporary on the other.
+//
+// An ANNOTATED leaf of that same scrutinee is no borrow. concreteLeaf drops the shape hint
+// for every annotated leaf, and applyBindMode wraps a leaf only where that hint says the
+// value is borrowable. Such a leaf takes the annotation above, so its fallback fits the
+// annotation exactly as it would over an owned scrutinee. The one leaf the annotation branch
+// hands back a borrow for is one the annotation itself named a borrow type for, which the
+// fallback then has to fit.
 func leafFixedType(matched soltype.Type, node ast.Node) (soltype.Type, bool) {
 	if ref, isRef := matched.(*soltype.RefType); isRef && ref.Mut && ref.Lt == nil {
 		return ref.Inner, true

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3248,28 +3248,40 @@ func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, esca
 	c.constrain(d, fallback, produced)
 	for s := escaped; s != nil && s != scope; s = s.parent {
 		for name, binding := range s.bindings() {
-			leaf, projected := leaves[name]
-			matched, mono := monoTypeOf(binding)
-			if !projected || !mono {
-				continue
+			if leaf, projected := leaves[name]; projected {
+				c.joinLeaf(s, lvl, d, name, binding, leaf)
 			}
-			if fixed, ok := leafFixedType(matched, leaf.node); ok {
-				// The name's type is already settled. The fallback flows into it rather than
-				// widening it, and the binding stays as the success path left it.
-				c.constrain(d, leaf.ty, fixed)
-				continue
-			}
-			join := c.freshAt(lvl)
-			c.recordProv(join, d, ValElseBranch)
-			c.constrain(d, matched, join)
-			c.constrain(d, leaf.ty, join)
-			binding.Schemes = []TypeScheme{monoScheme(join)}
-			s.defineValue(name, binding)
-			// The join replaces what the binding walk recorded, the leaf projected off the
-			// initializer alone, so an editor reads the type the name really binds at.
-			c.recordType(leaf.node, join)
 		}
 	}
+}
+
+// joinLeaf folds what the fallback supplies for one name into what the success path bound
+// it to. binding is that success-path binding and leaf the fallback's projection. scope is
+// where the name was bound, which is where a rebind lands. Every constraint is anchored to
+// d, the whole declaration.
+//
+// A leaf whose type is already settled takes no join, and the fallback flows into that type
+// instead. leafFixedType decides which leaves those are.
+func (c *checker) joinLeaf(
+	scope *Scope, lvl int, d *ast.VarDecl, name string, binding ValueBinding, leaf fallbackLeaf,
+) {
+	matched, mono := monoTypeOf(binding)
+	if !mono {
+		return
+	}
+	if fixed, ok := leafFixedType(matched, leaf.node); ok {
+		c.constrain(d, leaf.ty, fixed)
+		return
+	}
+	join := c.freshAt(lvl)
+	c.recordProv(join, d, ValElseBranch)
+	c.constrain(d, matched, join)
+	c.constrain(d, leaf.ty, join)
+	binding.Schemes = []TypeScheme{monoScheme(join)}
+	scope.defineValue(name, binding)
+	// The join replaces what the binding walk recorded, the leaf projected off the
+	// initializer alone, so an editor reads the type the name really binds at.
+	c.recordType(leaf.node, join)
 }
 
 // leafFixedType returns the type a leaf's fallback has to fit when the leaf takes no join,

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3164,8 +3164,12 @@ func (c *checker) typeAdmits(ann, t soltype.Type) bool {
 // The success path ends in the binding-escape leaf, which carries no body because the rest
 // of the block is its continuation. Its leaves are installed in the block's scope once the
 // walk is done. The `else` runs precisely when the pattern bound none of them, so it is
-// typed first and never sees them. A non-diverging `else` supplies the binding's fallback
-// value, which has to fit the type the binding takes.
+// typed first and never sees them.
+//
+// A non-diverging `else` supplies the value the declaration binds when the pattern did not
+// match. Where an annotation pins the binding's type, that value has to fit the annotation.
+// Otherwise joinFallbackLeaves takes it apart with the same pattern and joins each of its
+// leaves into the leaf the success path bound.
 func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 	core, ok := ucs.DesugarValElse(d)
 	if !ok {
@@ -3184,48 +3188,151 @@ func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 		c.reportUnsupportedFeature(d.Pattern, "narrowing type annotation on a destructuring pattern")
 	}
 
-	// A declaration is pinned when its annotation narrows a bare identifier. The annotation
-	// then fixes the binding's type on its own. An annotation on a destructuring pattern is
-	// the one reported above, and it pins nothing.
-	pinned := d.TypeAnn != nil && identPat
-
-	// `root` is the value the pattern's leaves are projected out of, and `bound` the type a
-	// non-diverging `else`'s fallback value has to fit. Where there is a fallback to join
-	// and no pin, both are one fresh var carrying the matched initializer and that fallback,
-	// so a leaf reads either source. A pinned declaration and one whose `else` diverges each
-	// project off the initializer alone: the first has its type already, and the second has
-	// no fallback value at all.
-	//
-	// Divergence is a syntactic property of the block, so it is settled here rather than
-	// after the walk types the `else`.
-	root, bound := initType, initType
-	joins := !pinned && !blockDiverges(d.Else)
-	if joins {
-		res := c.freshAt(lvl)
-		c.recordProv(res, d, ValElseBranch)
-		c.constrain(d, initType, res)
-		root, bound = res, res
-	}
-
-	// The binder is seeded with the type above, so the walk never re-infers the initializer
-	// and a side-effecting one such as `val x = f() else { … }` runs its call once. Marking
-	// it joined is what keeps the fallback checked against the pattern, since no tag test
-	// admitted that half of `root`. It is why `val {x} = p else { {y: 1} }` is an error
-	// rather than a leaf reading the initializer's half alone.
-	binder := c.newPathBinder(lvl, d, core.Scrutinee, root)
-	binder.joined = joins
+	// The binder is seeded with the type inferred above, so the walk never re-infers the
+	// initializer and a side-effecting one such as `val x = f() else { … }` runs its call
+	// once. It holds the initializer alone, so each split's tag test narrows it and a leaf
+	// reads only the members the pattern matched.
+	binder := c.newPathBinder(lvl, d, core.Scrutinee, initType)
 	// A `val … else` holds no arm body, so the walk joins nothing and takes no branch-join
 	// var.
 	w := c.walkCond(scope, lvl, d, core, binder, nil)
-	if w.narrowed != nil {
-		// A narrowed identifier pins the binding, so the fallback has to fit the annotated
-		// type rather than the initializer's.
-		bound = w.narrowed
-	}
+	// A diverging `else` produces no fallback value, so the leaves read the narrowed
+	// initializer alone.
 	if elseT, produces := w.fallback(); produces {
-		c.constrain(d, elseT, bound)
+		if w.narrowed != nil {
+			// A narrowing annotation fixes the binding's type on its own, so the fallback has
+			// to fit that type. Such a declaration narrows a bare identifier, so it holds no
+			// leaf below the name to join at.
+			c.constrain(d, elseT, w.narrowed)
+		} else {
+			c.joinFallbackLeaves(scope, lvl, d, w.escaped, elseT)
+		}
 	}
 	installEscaped(scope, w.escaped)
+}
+
+// fallbackLeaf is what the `else`'s fallback value supplies for one name a `val … else`
+// binds. It holds the type projected out of the fallback and the pattern node that named
+// the leaf.
+type fallbackLeaf struct {
+	ty   soltype.Type
+	node ast.Node
+}
+
+// joinFallbackLeaves rebinds every leaf the success path of a `val pat = init else { … }`
+// bound, to the join of that leaf with the same leaf of the fallback value. escaped is the
+// innermost scope the success path bound into, and fallback the type the `else` produced.
+//
+// The join sits BELOW the projection, one var per leaf rather than one for the whole
+// declaration. `val {x} = p else { {x: "s"} }` over `p: {x: number} | {y: string}` binds
+// `x` at `number | "s"`. Joining above the projection instead would leave `{y: string}`
+// present at the read, since the fallback is a value no tag test admitted and nothing may
+// narrow a union holding it. `x` would then pick up the `undefined` that member yields for
+// a key it does not carry, a value the declaration can never bind.
+//
+// Walking the pattern a second time is what keeps the fallback checked against it, so
+// `val {x} = p else { {y: 1} }` still reports the missing `x`. That walk is a projection
+// rather than a binding. It resolves what the fallback supplies for each name and leaves
+// every other part of binding to the walk that already ran. See bindPurpose.
+//
+// The projection emits its requirements against a fresh var carrying the fallback rather
+// than against the fallback itself, which is what keeps such a diagnostic pointing at the
+// value the user wrote. A requirement emitted straight against the fallback is anchored to
+// the pattern leaf that asked for it, and CannotConstrainError blames a node only when it
+// lies inside the anchor. The `5` of `val {x} = p else { 5 }` lies outside the `x` of the
+// pattern, so the message would underline that `x`. Routing through the var moves the anchor
+// to the whole declaration, which the `5` does lie inside.
+func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, escaped *Scope, fallback soltype.Type) {
+	produced := c.freshAt(lvl)
+	leaves := map[string]fallbackLeaf{}
+	// The fallback doubles as the shape, since it has not flowed into `produced` yet and a
+	// `...rest` leaf reads its leftover members off a shape.
+	c.projectLeaves(scope.Child(), lvl, d.Pattern, produced, soltype.CarrierOf(fallback),
+		func(_ *Scope, name string, t soltype.Type, node ast.Node) {
+			leaves[name] = fallbackLeaf{ty: t, node: node}
+		})
+	// The requirements the projection emitted are upper bounds on `produced`. Pushing the
+	// fallback in only now is what checks it against them.
+	c.constrain(d, fallback, produced)
+	for s := escaped; s != nil && s != scope; s = s.parent {
+		for name, binding := range s.bindings() {
+			leaf, projected := leaves[name]
+			matched, mono := monoTypeOf(binding)
+			if !projected || !mono {
+				continue
+			}
+			if fixed, ok := leafFixedType(matched, leaf.node); ok {
+				// The name's type is already settled. The fallback flows into it rather than
+				// widening it, and the binding stays as the success path left it.
+				c.constrain(d, leaf.ty, fixed)
+				continue
+			}
+			join := c.freshAt(lvl)
+			c.recordProv(join, d, ValElseBranch)
+			c.constrain(d, matched, join)
+			c.constrain(d, leaf.ty, join)
+			binding.Schemes = []TypeScheme{monoScheme(join)}
+			s.defineValue(name, binding)
+			// Recording the join replaces what the binding walk recorded, which was the leaf
+			// projected off the initializer alone. An editor then reads the type the name
+			// really binds at.
+			c.recordType(leaf.node, join)
+		}
+	}
+}
+
+// leafFixedType returns the type a leaf's fallback has to fit when the leaf takes no join,
+// and false when the leaf joins its two sources instead. matched is what the success path
+// bound the leaf to and node is the leaf's pattern.
+//
+// Two leaves take no join. An owned `mut` leaf is a cell the rest of the block writes
+// through, so the fallback flows into the cell's contents. Binding the name to a union of
+// that cell and a plain value would leave `x.a = 2` writing through something that is no
+// cell. A leaf carrying its own type annotation has that annotation as its type, so the
+// fallback has to fit it. `val {x::number} = p else { {x: "s"} }` reports the `"s"` rather
+// than widening `x` to `number | "s"`.
+//
+// A leaf of a BORROWED scrutinee is not one of the two. Such a leaf carries a lifetime, and
+// what it names is a place inside the initializer. The fallback is a fresh value that lives
+// nowhere in there, so it joins beside the borrow and the name binds a union. A write
+// through it is then rejected, which is the honest answer for a name that holds a borrow on
+// one path and a temporary on the other.
+func leafFixedType(matched soltype.Type, node ast.Node) (soltype.Type, bool) {
+	if ref, isRef := matched.(*soltype.RefType); isRef && ref.Mut && ref.Lt == nil {
+		return ref.Inner, true
+	}
+	if leafTypeAnn(node) != nil {
+		return matched, true
+	}
+	return nil, false
+}
+
+// leafTypeAnn returns the type annotation a pattern leaf carries, and nil for one that
+// carries none. The two leaf forms hang it off different nodes. A tuple element and an
+// object key-value's value carry it on the identifier, an object shorthand on itself.
+func leafTypeAnn(node ast.Node) ast.TypeAnn {
+	switch n := node.(type) {
+	case *ast.IdentPat:
+		return n.TypeAnn
+	case *ast.ObjShorthandPat:
+		return n.TypeAnn
+	default:
+		return nil
+	}
+}
+
+// monoTypeOf returns the one non-generalized type a binding holds. Every leaf a pattern
+// binds is such a binding. It returns false for an overload set and for a generalized
+// scheme, neither of which a leaf produces.
+func monoTypeOf(b ValueBinding) (soltype.Type, bool) {
+	if len(b.Schemes) != 1 {
+		return nil, false
+	}
+	mono, ok := b.Schemes[0].(*MonoScheme)
+	if !ok {
+		return nil, false
+	}
+	return mono.Ty, true
 }
 
 // inferMatch types a `match` expression off the UCS normalized form. The scrutinee is

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3167,9 +3167,8 @@ func (c *checker) typeAdmits(ann, t soltype.Type) bool {
 // typed first and never sees them.
 //
 // A non-diverging `else` supplies the value the declaration binds when the pattern did not
-// match. Where an annotation pins the binding's type, that value has to fit the annotation.
-// Otherwise joinFallbackLeaves takes it apart with the same pattern and joins each of its
-// leaves into the leaf the success path bound.
+// match. An annotation pins the binding's type, so that value has to fit it. Otherwise
+// joinFallbackLeaves takes the value apart with the same pattern and joins each leaf.
 func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 	core, ok := ucs.DesugarValElse(d)
 	if !ok {
@@ -3211,37 +3210,30 @@ func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 	installEscaped(scope, w.escaped)
 }
 
-// fallbackLeaf is what the `else`'s fallback value supplies for one name a `val … else`
-// binds. It holds the type projected out of the fallback and the pattern node that named
-// the leaf.
+// fallbackLeaf is what the `else`'s fallback supplies for one name a `val … else` binds:
+// the type projected out of the fallback, and the pattern node that named the leaf.
 type fallbackLeaf struct {
 	ty   soltype.Type
 	node ast.Node
 }
 
-// joinFallbackLeaves rebinds every leaf the success path of a `val pat = init else { … }`
-// bound, to the join of that leaf with the same leaf of the fallback value. escaped is the
-// innermost scope the success path bound into, and fallback the type the `else` produced.
+// joinFallbackLeaves rebinds each leaf the success path of a `val pat = init else { … }`
+// bound, to the join of that leaf with the fallback's. escaped is the innermost scope the
+// success path bound into, and fallback the type the `else` produced.
 //
-// The join sits BELOW the projection, one var per leaf rather than one for the whole
-// declaration. `val {x} = p else { {x: "s"} }` over `p: {x: number} | {y: string}` binds
-// `x` at `number | "s"`. Joining above the projection instead would leave `{y: string}`
-// present at the read, since the fallback is a value no tag test admitted and nothing may
-// narrow a union holding it. `x` would then pick up the `undefined` that member yields for
-// a key it does not carry, a value the declaration can never bind.
+// The join sits BELOW the projection, one var per leaf. `val {x} = p else { {x: "s"} }`
+// over `p: {x: number} | {y: string}` binds `x` at `number | "s"`. Joining above it would
+// leave `{y: string}` in the union the leaf reads, since no tag test admitted the fallback
+// and nothing may narrow a union holding it, and `x` would pick up that member's
+// `undefined`.
 //
-// Walking the pattern a second time is what keeps the fallback checked against it, so
-// `val {x} = p else { {y: 1} }` still reports the missing `x`. That walk is a projection
-// rather than a binding. It resolves what the fallback supplies for each name and leaves
-// every other part of binding to the walk that already ran. See bindPurpose.
+// The second walk is a projection rather than a binding, so nothing a leaf carries is
+// applied twice. See bindPurpose. It still checks the fallback against the pattern, which
+// is what reports the missing `x` of `val {x} = p else { {y: 1} }`.
 //
-// The projection emits its requirements against a fresh var carrying the fallback rather
-// than against the fallback itself, which is what keeps such a diagnostic pointing at the
-// value the user wrote. A requirement emitted straight against the fallback is anchored to
-// the pattern leaf that asked for it, and CannotConstrainError blames a node only when it
-// lies inside the anchor. The `5` of `val {x} = p else { 5 }` lies outside the `x` of the
-// pattern, so the message would underline that `x`. Routing through the var moves the anchor
-// to the whole declaration, which the `5` does lie inside.
+// Its requirements go against a fresh var carrying the fallback rather than against the
+// fallback itself. One emitted straight against the fallback is anchored to the pattern
+// leaf, and the `5` of `val {x} = p else { 5 }` would then underline the `x`.
 func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, escaped *Scope, fallback soltype.Type) {
 	produced := c.freshAt(lvl)
 	leaves := map[string]fallbackLeaf{}
@@ -3273,9 +3265,8 @@ func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, esca
 			c.constrain(d, leaf.ty, join)
 			binding.Schemes = []TypeScheme{monoScheme(join)}
 			s.defineValue(name, binding)
-			// Recording the join replaces what the binding walk recorded, which was the leaf
-			// projected off the initializer alone. An editor then reads the type the name
-			// really binds at.
+			// The join replaces what the binding walk recorded, the leaf projected off the
+			// initializer alone, so an editor reads the type the name really binds at.
 			c.recordType(leaf.node, join)
 		}
 	}
@@ -3283,27 +3274,17 @@ func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, esca
 
 // leafFixedType returns the type a leaf's fallback has to fit when the leaf takes no join,
 // and false when the leaf joins its two sources instead. matched is what the success path
-// bound the leaf to and node is the leaf's pattern.
+// bound the leaf to, node the leaf's pattern.
 //
-// Two leaves take no join. An owned `mut` leaf is a cell the rest of the block writes
-// through, so the fallback flows into the cell's contents. Binding the name to a union of
-// that cell and a plain value would leave `x.a = 2` writing through something that is no
-// cell. A leaf carrying its own type annotation has that annotation as its type, so the
-// fallback has to fit it. `val {x::number} = p else { {x: "s"} }` reports the `"s"` rather
-// than widening `x` to `number | "s"`.
+// Two leaves take no join. An owned `mut` leaf is a cell the block writes through, so the
+// fallback flows into its contents. A union of that cell and a plain value would reject
+// `x.a = 2`. An annotated leaf already has the annotation as its type, so the fallback has
+// to fit it. `val {x::number} = p else { {x: "s"} }` reports the `"s"`.
 //
-// An UNANNOTATED leaf of a borrowed scrutinee is neither. It carries a lifetime, and what it
-// names is a place inside the initializer. The fallback is a fresh value living nowhere in
-// there, so it joins beside the borrow and the name binds a union. A write through that
-// union is rejected, which is the honest answer for a name holding a borrow on one path and
-// a temporary on the other.
-//
-// An ANNOTATED leaf of that same scrutinee is no borrow. concreteLeaf drops the shape hint
-// for every annotated leaf, and applyBindMode wraps a leaf only where that hint says the
-// value is borrowable. Such a leaf takes the annotation above, so its fallback fits the
-// annotation exactly as it would over an owned scrutinee. The one leaf the annotation branch
-// hands back a borrow for is one the annotation itself named a borrow type for, which the
-// fallback then has to fit.
+// An unannotated leaf of a borrowed scrutinee is neither. It names a place inside the
+// initializer, where the fallback's fresh value does not live, so the two join and a write
+// through the union is rejected. An annotated leaf of that same scrutinee is no borrow at
+// all, since concreteLeaf drops the shape hint applyBindMode needs to wrap one.
 func leafFixedType(matched soltype.Type, node ast.Node) (soltype.Type, bool) {
 	if ref, isRef := matched.(*soltype.RefType); isRef && ref.Mut && ref.Lt == nil {
 		return ref.Inner, true
@@ -3314,9 +3295,9 @@ func leafFixedType(matched soltype.Type, node ast.Node) (soltype.Type, bool) {
 	return nil, false
 }
 
-// leafTypeAnn returns the type annotation a pattern leaf carries, and nil for one that
-// carries none. The two leaf forms hang it off different nodes. A tuple element and an
-// object key-value's value carry it on the identifier, an object shorthand on itself.
+// leafTypeAnn returns the type annotation a pattern leaf carries, and nil for one carrying
+// none. A tuple element and an object key-value's value hang it off the identifier, an
+// object shorthand off itself.
 func leafTypeAnn(node ast.Node) ast.TypeAnn {
 	switch n := node.(type) {
 	case *ast.IdentPat:
@@ -3329,8 +3310,7 @@ func leafTypeAnn(node ast.Node) ast.TypeAnn {
 }
 
 // monoTypeOf returns the one non-generalized type a binding holds. Every leaf a pattern
-// binds is such a binding. It returns false for an overload set and for a generalized
-// scheme, neither of which a leaf produces.
+// binds is such a binding, and an overload set or a generalized scheme returns false.
 func monoTypeOf(b ValueBinding) (soltype.Type, bool) {
 	if len(b.Schemes) != 1 {
 		return nil, false

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -475,6 +475,53 @@ func TestInferValElseChecksTheFallbackAgainstALeafAnnotation(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number", values["f"])
 }
 
+// A leaf's annotation fixes its type even where the scrutinee is a union of borrows, so the
+// fallback fits the annotation rather than widening the name beside it. Such a leaf is no
+// borrow itself. concreteLeaf drops the shape hint for an annotated leaf, and applyBindMode
+// wraps a leaf in a borrow only where that hint says the value is borrowable.
+//
+// The borrow union reports a lifetime diagnostic of its own. It belongs to the scrutinee
+// rather than to the join, and the same declaration with a diverging `else` reports it too.
+func TestInferValElseChecksAnAnnotatedLeafOfABorrowedUnion(t *testing.T) {
+	tests := map[string]struct {
+		src      string
+		wantErrs []string
+	}{
+		"FallbackFitsTheAnnotation": {
+			src: `fn f(p: &{x: number} | &{y: string}) {
+					val {x: v: number} = p else { {x: 5} }
+					return 0
+				}`,
+			wantErrs: []string{
+				"1:9-1:21: borrowed value object does not live long enough to satisfy object",
+			},
+		},
+		"FallbackViolatesTheAnnotation": {
+			src: `fn f(p: &{x: number} | &{y: string}) {
+					val {x: v: number} = p else { {x: "s"} }
+					return 0
+				}`,
+			wantErrs: []string{
+				"1:9-1:21: borrowed value object does not live long enough to satisfy object",
+				`2:40-2:43: cannot constrain "s" <: number`,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			module := parseModule(t, tt.src)
+			c := newChecker()
+			c.inferDepGraph(sharedPrelude().Child(), 0, module, dep_graph.BuildDepGraph(module))
+			require.Equal(t, tt.wantErrs, messagesWithSpan(c.errs))
+			leaf := findIdentPat(module, "v")
+			require.NotNil(t, leaf)
+			// The name binds at the annotation on both paths, with no fallback member beside it.
+			require.Equal(t, "number", soltype.Print(coalesce(c.info.TypeOf(leaf), soltype.Positive)))
+		})
+	}
+}
+
 // An object `...rest` leaf reads its leftover members off the fallback's own shape, so the
 // members the pattern did not name survive the join. Both `p` and the fallback carry `z`
 // outside the keys `{x, ...rest}` names, so `rest` reads it from either source.

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -3,6 +3,9 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -316,11 +319,14 @@ func TestInferRefutableFormsNarrowUnions(t *testing.T) {
 	}
 }
 
-// A `val … else` whose `else` supplies a fallback binds its leaves off the initializer
-// joined with that fallback, so the fallback has to satisfy the pattern too. No tag test
-// ever admitted it, so nothing narrows the value the leaves read: narrowing to the member
-// the pattern matched would leave the fallback unchecked and the leaves reading only the
-// initializer's half.
+// A `val … else` whose `else` supplies a fallback destructures that fallback with the same
+// pattern, so a fallback the pattern cannot take apart is rejected. Each leaf of the
+// declaration reads the initializer's leaf joined with the fallback's, so a fallback that
+// binds no such leaf leaves the name with nothing to read from that path.
+//
+// Each message underlines the value the `else` produced rather than the pattern leaf that
+// could not take it apart. That is the narrowest span naming something the user can change,
+// since the pattern is what the rest of the block reads.
 func TestInferValElseChecksTheFallbackAgainstThePattern(t *testing.T) {
 	tests := map[string]struct {
 		src  string
@@ -355,11 +361,11 @@ func TestInferValElseChecksTheFallbackAgainstThePattern(t *testing.T) {
 }
 
 // An annotation fixes the binding's type only where it narrows a bare identifier. One on a
-// destructuring pattern is unsupported and pins nothing, so that declaration joins its
-// fallback like an unannotated one: the fallback is checked against the pattern, and the
-// leaves read it. Treating the unsupported annotation as a pin would leave the fallback
-// checked against the initializer alone, which it satisfies, and infer `x: number` off a
-// declaration that can bind no `x` at all.
+// destructuring pattern is unsupported and pins nothing, so that declaration destructures
+// its fallback like an unannotated one and reports the leaf the fallback cannot supply.
+// Treating the unsupported annotation as a pin would check the fallback against the
+// initializer alone, which it satisfies, and infer `x: number` off a declaration that can
+// bind no `x` at all.
 func TestInferValElseJoinsPastAnUnsupportedAnnotation(t *testing.T) {
 	values, _, errs := inferSource(t,
 		`fn f(p: {x: number} | {y: string}) {
@@ -370,30 +376,162 @@ func TestInferValElseJoinsPastAnUnsupportedAnnotation(t *testing.T) {
 		"2:9-2:12: Unsupported: narrowing type annotation on a destructuring pattern",
 		"2:37-2:45: object is missing property: x",
 	}, messagesWithSpan(errs))
-	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number | undefined", values["f"])
+	// The fallback carries no `x`, so the only lower bound reaching the name is the one the
+	// narrowed initializer projected.
+	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number", values["f"])
 }
 
-// A fallback the pattern can destructure contributes its own leaf types, so the bound name
-// reads either source rather than the initializer's alone. Three lower bounds reach `x`
-// here: `number` and `"s"` from the two sources, and `undefined`.
+// A fallback the pattern can destructure contributes its own leaf types, so each bound name
+// reads either source rather than the initializer's alone. Two lower bounds reach `x` in
+// both cases below, one per source.
 //
-// The `undefined` is constrainUnionFieldRead's doing, not the join's. Reading a property
-// off a union joins what each member yields, and `{y: string}` carries no `x`, so that
-// member contributes `undefined`. A plain `val {x} = p` over the same scrutinee infers
-// `number | undefined` for the same reason. What the join decides is only that the union is
-// still whole at the read: the fallback is a half no tag test admitted, so nothing narrows
-// `{y: string}` away the way an `if val` over the same `p` does.
-//
-// That `undefined` is wrong, and #1076 removes it. A `p` holding `{y: string}` fails the
-// `{x}` test and takes the `else`, so the leaf is never absent at run time. What this
-// asserts is today's type rather than the intended one.
+// Neither picks up an `undefined` from the scrutinee member that carries no `x`. The join
+// sits below the projection, so the tag test the pattern makes narrows the initializer
+// before any leaf reads it, and the member constrainUnionFieldRead would answer `undefined`
+// for is gone by then. A `p` holding that member fails the test and takes the `else`, so
+// the name is never absent at run time.
 func TestInferValElseLeavesReadTheFallback(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f(p: {x: number} | {y: string}) {
-			val {x} = p else { {x: "s"} }
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		"OuterLevel": {
+			src: `fn f(p: {x: number} | {y: string}) {
+					val {x} = p else { {x: "s"} }
+					return x
+				}`,
+			want: `fn (p: {x: number} | {y: string}) -> number | "s"`,
+		},
+		// A nested pattern flattens into one split per tag-level and every level narrows, so
+		// the leaf below them joins the same two sources.
+		"NestedLevel": {
+			src: `fn f(p: {a: {x: number}} | {a: {y: string}}) {
+					val {a: {x}} = p else { {a: {x: "s"}} }
+					return x
+				}`,
+			want: `fn (p: {a: {x: number}} | {a: {y: string}}) -> number | "s"`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// The pattern of a `val … else` is walked twice, once binding off the narrowed initializer
+// and once projecting the fallback the `else` produced. The join is recorded over what the
+// binding walk left, so what an editor reads for `v` is what the name binds at rather than
+// the initializer's half alone.
+func TestInferValElseRecordsTheJoinedLeafType(t *testing.T) {
+	module := parseModule(t, `fn f(p: {x: number} | {y: string}) {
+			val {x: v} = p else { {x: "s"} }
+			return v
+		}`)
+	c := newChecker()
+	c.inferDepGraph(sharedPrelude().Child(), 0, module, dep_graph.BuildDepGraph(module))
+	require.Empty(t, c.errs)
+	leaf := findIdentPat(module, "v")
+	require.NotNil(t, leaf)
+	require.Equal(t, `number | "s"`, soltype.Print(coalesce(c.info.TypeOf(leaf), soltype.Positive)))
+}
+
+// The second walk over the pattern projects rather than binds, so a leaf's default and
+// annotation are typed once even though the pattern is walked twice. A fault inside a
+// default is reported once, and the default's expression is inferred once.
+func TestInferValElseTypesALeafDefaultOnce(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f(p: {x: number} | {y: string}) {
+			val {x = nope} = p else { {x: 5} }
+			return x
+		}`)
+	require.Equal(t, []string{"2:13-2:17: Unknown identifier: nope"}, messagesWithSpan(errs))
+}
+
+// A `mut` leaf of an owned scrutinee is an owned-mutable cell, and the fallback flows into
+// the cell's contents rather than joining beside it. The name stays one cell, so the write
+// below it checks against the shape the cell holds.
+func TestInferValElseJoinsInsideAMutLeaf(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: {x: {a: number}} | {y: string}) {
+			val {mut x} = p else { {x: {a: 1}} }
+			x.a = 2
 			return x
 		}`)
 	require.Empty(t, errs)
-	require.Equal(t, `fn (p: {x: number} | {y: string}) -> number | "s" | undefined`, values["f"])
+	require.Equal(t, "fn (p: {x: {a: number}} | {y: string}) -> mut {a: number}", values["f"])
+}
+
+// A leaf's own type annotation fixes what the name binds at, so the fallback has to fit it
+// rather than widening the name to a union with it. The message underlines the value the
+// `else` produced.
+func TestInferValElseChecksTheFallbackAgainstALeafAnnotation(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: {x: number} | {y: string}) {
+			val {x::number} = p else { {x: "s"} }
+			return x
+		}`)
+	require.Equal(t, []string{`2:35-2:38: cannot constrain "s" <: number`}, messagesWithSpan(errs))
+	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number", values["f"])
+}
+
+// An object `...rest` leaf reads its leftover members off the fallback's own shape, so the
+// members the pattern did not name survive the join. Both `p` and the fallback carry `z`
+// outside the keys `{x, ...rest}` names, so `rest` reads it from either source.
+func TestInferValElseJoinsAnObjectRestLeaf(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: {x: number, z: boolean} | {y: string}) {
+			val {x, ...rest} = p else { {x: 1, z: false} }
+			return rest
+		}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {y: string} | {x: number, z: boolean}) -> {z: boolean}", values["f"])
+}
+
+// A leaf's default covers the key being absent from either source, so the fallback may omit
+// it. The projection over the fallback asks for the key the same relaxed way the binding
+// walk does, so `x` reads the default rather than picking up an `undefined`.
+func TestInferValElseFallbackMayOmitADefaultedLeaf(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: {x?: number}) {
+			val {x = 5} = p else { {} }
+			return x
+		}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x?: number}) -> number", values["f"])
+}
+
+// A pattern the walk cannot type reports once, not once per walk. The projection over the
+// fallback runs the same arms the binding walk did, so an ungated report would double every
+// message a pattern raises.
+func TestInferValElseReportsAPatternFaultOnce(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f(p: {x: number}) {
+			val Foo{x} = p else { {x: 1} }
+			return x
+		}`)
+	require.Equal(t, []string{
+		"2:8-2:14: `Foo` does not name a class and cannot be used as an instance pattern.",
+	}, messagesWithSpan(errs))
+}
+
+// findIdentPat returns the identifier pattern binding name, and nil when the module holds
+// none. It walks through the AST visitor rather than reaching into the block the
+// declaration sits in.
+func findIdentPat(module *ast.Module, name string) *ast.IdentPat {
+	f := &identPatFinder{name: name}
+	module.Accept(f)
+	return f.found
+}
+
+type identPatFinder struct {
+	ast.DefaultVisitor
+	name  string
+	found *ast.IdentPat
+}
+
+func (f *identPatFinder) EnterPat(p ast.Pat) bool {
+	if ip, ok := p.(*ast.IdentPat); ok && ip.Name == f.name {
+		f.found = ip
+	}
+	return true
 }
 
 // A nested pattern flattens into one split per tag-level, and each level's leaves bind off

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -695,7 +695,7 @@ func (c *checker) destructurePattern(
 	emit := func(_ *Scope, name string, t soltype.Type, node ast.Node) {
 		md.leaves[name] = destructureLeaf{t: t, node: node}
 	}
-	c.bindPatternWith(scope, lvl, d.Pattern, initType, nil, emit)
+	c.bindPatternWith(scope, lvl, d.Pattern, initType, nil, emit, forBinding)
 	return md
 }
 

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -35,7 +35,7 @@ import (
 // into pre-bound binding vars instead, so it calls bindPatternWith with its own
 // emit (M4 E3).
 func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type) soltype.Pat {
-	return c.bindPatternWith(scope, lvl, pat, scrutinee, leafTypes, defineLeafMono)
+	return c.bindPatternWith(scope, lvl, pat, scrutinee, leafTypes, defineLeafMono, forBinding)
 }
 
 // leafEmit places one bound leaf: it receives the leaf's name, its projected type,
@@ -43,6 +43,31 @@ func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 // for the body-level and function-param paths. The top-level driver passes an emit
 // that constrains the leaf's type into a pre-bound binding var instead (M4 E3).
 type leafEmit func(scope *Scope, name string, t soltype.Type, node ast.Node)
+
+// bindPurpose says what one walk over a pattern is for.
+//
+// forBinding is the ordinary walk. Each leaf lands at the type the name takes, with its
+// annotation, default, and `mut` marker applied, and every node the walk visits records
+// that type for an editor to read.
+//
+// forProjection resolves the same leaf types out of the scrutinee, reports them to the
+// emit, and does nothing else. It runs over a pattern a binding walk has already walked, to
+// ask what a SECOND value supplies for each name the pattern binds. Three things follow
+// from that:
+//
+//   - No leaf extra is applied. The annotation, default, and `mut` marker shape what the
+//     name binds at, which the binding walk settled. Re-applying them would infer a
+//     default's expression a second time.
+//   - No type is recorded. The node's type is what the name binds at, not what this second
+//     value supplies for it.
+//   - Nothing is reported. Every fault in the pattern is one the binding walk already
+//     reported, so reporting again would double each message.
+type bindPurpose byte
+
+const (
+	forBinding bindPurpose = iota
+	forProjection
+)
 
 // defineLeafMono is the default leaf-placement strategy: it defines the leaf as a
 // monomorphic projection of the scrutinee. Used by every body-level and
@@ -96,8 +121,19 @@ func bindModeOf(scrutinee soltype.Type) bindMode {
 // bindPattern for the pattern-typing contract. The emit decides where each bound
 // leaf lands. The binding mode is derived from the scrutinee here and threaded into
 // the recursive walk so nested leaves inherit the scrutinee's borrow.
-func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
-	return c.bindPatMode(scope, lvl, pat, scrutinee, soltype.CarrierOf(scrutinee), bindModeOf(scrutinee), leafTypes, emit)
+func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type, emit leafEmit, purpose bindPurpose) soltype.Pat {
+	return c.bindPatMode(scope, lvl, pat, scrutinee, soltype.CarrierOf(scrutinee), bindModeOf(scrutinee), leafTypes, emit, purpose)
+}
+
+// projectLeaves resolves each leaf pat names out of scrutinee and reports it to found. It
+// binds nothing, records nothing, and reports nothing. See bindPurpose. A `val … else` reads
+// it to find what the `else`'s fallback value supplies for each name the declaration binds.
+//
+// concrete is the scrutinee's statically known shape. A caller whose value has not yet
+// flowed into scrutinee passes that value here, so a `...rest` leaf resolves the leftover
+// members it really has rather than an opaque `{...}`.
+func (c *checker) projectLeaves(scope *Scope, lvl int, pat ast.Pat, scrutinee, concrete soltype.Type, found leafEmit) {
+	c.bindPatMode(scope, lvl, pat, scrutinee, concrete, bindModeOf(concrete), nil, found, forProjection)
 }
 
 // bindPatMode is bindPatternWith's recursive core, carrying the binding mode the
@@ -110,17 +146,20 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 // renders as a clean `mut {…}` cell rather than a variable inside the cell. concrete
 // is nil when the scrutinee's shape is not statically known. The thaw then falls back
 // to the projection variable.
-func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, concrete soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, concrete soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit, purpose bindPurpose) soltype.Pat {
 	scrutinee = soltype.CarrierOf(scrutinee)
 	switch p := pat.(type) {
 	case *ast.IdentPat:
-		t := c.applyLeafExtras(scope, lvl, p, scrutinee, p.TypeAnn, p.Default)
-		t = c.applyBindMode(lvl, p, p.Mutable, t, c.concreteLeaf(concrete, p.TypeAnn), scrutineeMode)
-		c.bindLeaf(scope, p.Name, t, p, leafTypes, emit)
+		t := scrutinee
+		if purpose == forBinding {
+			t = c.applyLeafExtras(scope, lvl, p, scrutinee, p.TypeAnn, p.Default)
+			t = c.applyBindMode(lvl, p, p.Mutable, t, c.concreteLeaf(concrete, p.TypeAnn), scrutineeMode)
+		}
+		c.bindLeaf(scope, p.Name, t, p, leafTypes, emit, purpose)
 		return &soltype.IdentPat{Name: p.Name}
 
 	case *ast.WildcardPat:
-		c.recordType(p, scrutinee)
+		c.recordPatType(purpose, p, scrutinee)
 		return &soltype.WildcardPat{}
 
 	case *ast.LitPat:
@@ -128,12 +167,12 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			// A `null` or `undefined` arm asserts the atom is an admissible value of the
 			// scrutinee, the same direction as the literal case below, and binds nothing.
 			c.constrain(p, atom, scrutinee)
-			c.recordType(p, atom)
+			c.recordPatType(purpose, p, atom)
 			return atomPat
 		}
 		lt, ok := c.litTypeOf(p.Lit)
 		if !ok {
-			c.reportUnsupported(p.Lit)
+			c.reportPatUnsupported(purpose, p.Lit)
 			return &soltype.WildcardPat{}
 		}
 		// A literal pattern asserts the literal is an admissible value of the
@@ -145,7 +184,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// check lands with E2's `match`, which this path is laid out to extend. A
 		// literal pattern binds nothing.
 		c.constrain(p, lt, scrutinee)
-		c.recordType(p, lt)
+		c.recordPatType(purpose, p, lt)
 		return &soltype.LitPat{Lit: lt.Lit}
 
 	case *ast.TuplePat:
@@ -156,7 +195,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// bind. splitTupleRest returns any other one as recovered.
 		fixed, rest, recovered := splitTupleRest(p.Elems)
 		if len(recovered) > 0 {
-			c.reportUnsupported(recovered[0])
+			c.reportPatUnsupported(purpose, recovered[0])
 		}
 		inexact := rest != nil || len(recovered) > 0
 		// Each element sub-pattern blames its own node for the upper-bound pin, so
@@ -169,20 +208,20 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			if concreteTup != nil && i < len(concreteTup.Elems) {
 				elemConcrete = concreteTup.Elems[i]
 			}
-			subs = append(subs, c.bindPatMode(scope, lvl, e, elemTypes[i], elemConcrete, scrutineeMode, leafTypes, emit))
+			subs = append(subs, c.bindPatMode(scope, lvl, e, elemTypes[i], elemConcrete, scrutineeMode, leafTypes, emit, purpose))
 		}
 		if rest != nil {
 			// The rest's sub-pattern binds through the same walk a fixed element does, so
 			// it inherits the scrutinee's borrow and `[a, ...[b, c]]` destructures the
 			// suffix in turn.
 			suffix, suffixConcrete := c.tupleRestType(lvl, rest, scrutinee, scrutTup, concreteTup, len(fixed))
-			sub := c.bindPatMode(scope, lvl, rest.Pattern, suffix, suffixConcrete, scrutineeMode, leafTypes, emit)
+			sub := c.bindPatMode(scope, lvl, rest.Pattern, suffix, suffixConcrete, scrutineeMode, leafTypes, emit, purpose)
 			subs = append(subs, &soltype.RestPat{Pattern: sub})
 		}
 		for _, e := range recovered {
-			subs = append(subs, c.bindRecoveredElem(scope, lvl, e, scrutineeMode, leafTypes, emit))
+			subs = append(subs, c.bindRecoveredElem(scope, lvl, e, scrutineeMode, leafTypes, emit, purpose))
 		}
-		c.recordType(p, scrutinee)
+		c.recordPatType(purpose, p, scrutinee)
 		return &soltype.TuplePat{Elems: subs}
 
 	case *ast.ObjectPat:
@@ -199,9 +238,12 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				// absent, so the requirement must not demand it.
 				beta := c.freshAt(lvl)
 				c.constrain(e, scrutinee, propReq(e.Key.Name, beta, e.Default != nil))
-				t := c.applyLeafExtras(scope, lvl, e, beta, e.TypeAnn, e.Default)
-				t = c.applyBindMode(lvl, e, e.Mutable, t, c.concreteLeaf(fieldConcrete(concrete, e.Key.Name), e.TypeAnn), scrutineeMode)
-				c.bindLeaf(scope, e.Key.Name, t, e, leafTypes, emit)
+				var t soltype.Type = beta
+				if purpose == forBinding {
+					t = c.applyLeafExtras(scope, lvl, e, beta, e.TypeAnn, e.Default)
+					t = c.applyBindMode(lvl, e, e.Mutable, t, c.concreteLeaf(fieldConcrete(concrete, e.Key.Name), e.TypeAnn), scrutineeMode)
+				}
+				c.bindLeaf(scope, e.Key.Name, t, e, leafTypes, emit, purpose)
 				named.Add(e.Key.Name)
 				fields = append(fields, &soltype.ObjectPatField{
 					Name:  e.Key.Name,
@@ -211,7 +253,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				// A default on the value sub-pattern, as in `{x: a = 0}`, likewise makes
 				// the field optional.
 				beta, betaConcrete := c.projectField(e, lvl, scrutinee, concrete, e.Key.Name, patternDefaultsField(e.Value))
-				sub := c.bindPatMode(scope, lvl, e.Value, beta, betaConcrete, scrutineeMode, leafTypes, emit)
+				sub := c.bindPatMode(scope, lvl, e.Value, beta, betaConcrete, scrutineeMode, leafTypes, emit, purpose)
 				named.Add(e.Key.Name)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
 			case *ast.ObjRestPat:
@@ -220,11 +262,11 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				if rest == nil && i == len(p.Elems)-1 {
 					rest = e
 				} else {
-					c.reportUnsupported(elem)
+					c.reportPatUnsupported(purpose, elem)
 					recovered = append(recovered, e.Pattern)
 				}
 			default:
-				c.reportUnsupported(elem)
+				c.reportPatUnsupported(purpose, elem)
 			}
 		}
 		var restPat soltype.Pat
@@ -232,26 +274,26 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			// The rest binds through the same walk a field does, so it inherits the
 			// scrutinee's borrow.
 			leftover, leftoverConcrete := c.objectRestType(lvl, rest, scrutinee, concrete, named)
-			restPat = c.bindPatMode(scope, lvl, rest.Pattern, leftover, leftoverConcrete, scrutineeMode, leafTypes, emit)
+			restPat = c.bindPatMode(scope, lvl, rest.Pattern, leftover, leftoverConcrete, scrutineeMode, leafTypes, emit, purpose)
 		}
 		// A reported rest still binds against a fresh variable, so a later reference to one
 		// of its leaves resolves instead of cascading into an unknown-identifier error.
 		for _, sub := range recovered {
-			c.bindPatMode(scope, lvl, sub, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
+			c.bindPatMode(scope, lvl, sub, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit, purpose)
 		}
-		c.recordType(p, scrutinee)
+		c.recordPatType(purpose, p, scrutinee)
 		return &soltype.ObjectPat{Fields: fields, Rest: restPat}
 
 	case *ast.InstancePat:
-		return c.bindInstancePat(scope, lvl, p, scrutinee, concrete, scrutineeMode, leafTypes, emit)
+		return c.bindInstancePat(scope, lvl, p, scrutinee, concrete, scrutineeMode, leafTypes, emit, purpose)
 
 	case *ast.ExtractorPat:
-		return c.bindExtractorPat(scope, lvl, p, scrutinee, scrutineeMode, leafTypes, emit)
+		return c.bindExtractorPat(scope, lvl, p, scrutinee, scrutineeMode, leafTypes, emit, purpose)
 
 	default:
 		// A bare RestPat is only meaningful inside a tuple or object. Report and bind
 		// nothing.
-		c.reportUnsupported(pat)
+		c.reportPatUnsupported(purpose, pat)
 		return &soltype.WildcardPat{}
 	}
 }
@@ -377,12 +419,12 @@ func splitTupleRest(elems []ast.Pat) (fixed []ast.Pat, rest *ast.RestPat, recove
 // bindRecoveredElem binds a tuple element the walk could not place, reached only after a
 // non-trailing `...rest` was reported. A fresh variable keeps its leaves defined so a later
 // reference does not cascade. A rest is unwrapped, since bindPatMode rejects a bare one.
-func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+func (c *checker) bindRecoveredElem(scope *Scope, lvl int, e ast.Pat, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit, purpose bindPurpose) soltype.Pat {
 	if r, isRest := e.(*ast.RestPat); isRest {
-		sub := c.bindPatMode(scope, lvl, r.Pattern, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
+		sub := c.bindPatMode(scope, lvl, r.Pattern, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit, purpose)
 		return &soltype.RestPat{Pattern: sub}
 	}
-	return c.bindPatMode(scope, lvl, e, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
+	return c.bindPatMode(scope, lvl, e, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit, purpose)
 }
 
 // tupleRestType resolves what a trailing `...rest` binds: the scrutinee's elements past the
@@ -518,21 +560,21 @@ func (c *checker) restObjectShape(scrutinee, concrete soltype.Type) (*soltype.Ob
 // bindInstancePat types a class-instance pattern `Name { x, y }`: it narrows the scrutinee
 // to the named class, then binds each field sub-pattern against the projected member view.
 // A missing field yields a MissingPropertyError; a non-class name an InstancePatternNotClassError.
-func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scrutinee, concrete soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scrutinee, concrete soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit, purpose bindPurpose) soltype.Pat {
 	// Record the pattern node's type against the scrutinee it matches, the same as the
 	// sibling tuple/object cases, so hover and type-at-position resolve on the pattern.
-	c.recordType(p, scrutinee)
+	c.recordPatType(purpose, p, scrutinee)
 	name := ast.QualIdentToString(p.ClassName)
 	ct, ok := c.instancePatClass(scope, name)
 	if !ok {
-		c.report(&InstancePatternNotClassError{Node: p, Name: name})
+		c.reportPat(purpose, &InstancePatternNotClassError{Node: p, Name: name})
 		// Bind the inner fields against a fresh var so a later reference to a bound leaf
 		// stays defined without a second cascade error against the real scrutinee.
-		obj, _ := c.bindPatMode(scope, lvl, p.Object, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit).(*soltype.ObjectPat)
+		obj, _ := c.bindPatMode(scope, lvl, p.Object, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit, purpose).(*soltype.ObjectPat)
 		return &soltype.InstancePat{ClassName: name, Object: obj}
 	}
 	target, targetConcrete := c.narrowToClass(lvl, p, ct, scrutinee, concrete)
-	obj, _ := c.bindPatMode(scope, lvl, p.Object, target, targetConcrete, scrutineeMode, leafTypes, emit).(*soltype.ObjectPat)
+	obj, _ := c.bindPatMode(scope, lvl, p.Object, target, targetConcrete, scrutineeMode, leafTypes, emit, purpose).(*soltype.ObjectPat)
 	return &soltype.InstancePat{ClassName: ct.Name, Object: obj}
 }
 
@@ -569,25 +611,25 @@ func (c *checker) narrowToClass(
 // Binding against constructor parameters is an interim gate. The real protocol deconstructs
 // through the instance's `[Symbol.customMatcher]` method, which needs symbol-keyed members
 // soltype lacks, so it is deferred to M7 (m5-implementation-plan.md §"Nominal patterns").
-func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, scrutinee soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, scrutinee soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit, purpose bindPurpose) soltype.Pat {
 	// Record the pattern node's type against the scrutinee it matches, the same as the
 	// sibling tuple/object cases, so hover and type-at-position resolve on the pattern.
-	c.recordType(p, scrutinee)
+	c.recordPatType(purpose, p, scrutinee)
 	name := ast.QualIdentToString(p.Name)
 	ctor, ok := c.extractorCtor(scope, lvl, p.Name)
 	if !ok {
-		c.report(&ExtractorPatternNotCtorError{Node: p, Name: name})
+		c.reportPat(purpose, &ExtractorPatternNotCtorError{Node: p, Name: name})
 		// Bind each argument against a fresh var so its leaves stay defined and a later
 		// reference does not cascade into an unknown-identifier error.
 		args := make([]soltype.Pat, len(p.Args))
 		for i, a := range p.Args {
-			args[i] = c.bindPatMode(scope, lvl, a, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
+			args[i] = c.bindPatMode(scope, lvl, a, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit, purpose)
 		}
 		return &soltype.ExtractorPat{Name: name, Args: args}
 	}
 	params := c.narrowToExtractor(p, ctor, scrutinee)
 	if len(p.Args) != len(params) {
-		c.report(&ExtractorPatternArityError{Node: p, Name: name, Expected: len(params), Got: len(p.Args)})
+		c.reportPat(purpose, &ExtractorPatternArityError{Node: p, Name: name, Expected: len(params), Got: len(p.Args)})
 	}
 	args := make([]soltype.Pat, len(p.Args))
 	for i, a := range p.Args {
@@ -595,7 +637,7 @@ func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, s
 		if i < len(params) {
 			paramType = params[i].Type
 		}
-		args[i] = c.bindPatMode(scope, lvl, a, paramType, paramType, scrutineeMode, leafTypes, emit)
+		args[i] = c.bindPatMode(scope, lvl, a, paramType, paramType, scrutineeMode, leafTypes, emit, purpose)
 	}
 	return &soltype.ExtractorPat{Name: name, Args: args}
 }
@@ -961,11 +1003,37 @@ func patternDefaultsField(p ast.Pat) bool {
 // pre-pass. The default emit, defineLeafMono, defines a monomorphic projection of the
 // scrutinee in scope. The top-level driver's emit constrains t into a pre-bound
 // binding var instead.
-func (c *checker) bindLeaf(scope *Scope, name string, t soltype.Type, node ast.Node, leafTypes map[string]soltype.Type, emit leafEmit) {
+func (c *checker) bindLeaf(scope *Scope, name string, t soltype.Type, node ast.Node, leafTypes map[string]soltype.Type, emit leafEmit, purpose bindPurpose) {
 	emit(scope, name, t, node)
-	c.recordType(node, t)
+	c.recordPatType(purpose, node, t)
 	if leafTypes != nil {
 		leafTypes[name] = t
+	}
+}
+
+// reportPat reports a fault found while walking a pattern, unless the walk is a projection.
+// A projection walks a pattern the binding walk already walked, so every fault it finds is
+// one the binding walk already reported. See bindPurpose.
+func (c *checker) reportPat(purpose bindPurpose, e SolverError) {
+	if purpose == forBinding {
+		c.report(e)
+	}
+}
+
+// reportPatUnsupported is reportPat for a pattern form the walk cannot type at all.
+// reportUnsupported words that message.
+func (c *checker) reportPatUnsupported(purpose bindPurpose, n ast.Node) {
+	if purpose == forBinding {
+		c.reportUnsupported(n)
+	}
+}
+
+// recordPatType records the type a pattern node resolved to, which is what an editor reads
+// for that node. A projection records nothing, since the node's type belongs to the binding
+// walk rather than to the second value a projection is reading. See bindPurpose.
+func (c *checker) recordPatType(purpose bindPurpose, n ast.Node, t soltype.Type) {
+	if purpose == forBinding {
+		c.recordType(n, t)
 	}
 }
 

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -68,7 +68,7 @@ const (
 	IfValBranch                             // a fresh branch-join var from inferIfVal (the union of cons / alt)
 	TryCatchBranch                          // a fresh branch-join var from inferTryCatch (the union of the try block's value and every catch arm body)
 	CaughtThrows                            // a fresh nested throws sink from inferTryCatch (what the try block raises, before the catch arms narrow it)
-	ValElseBranch                           // a fresh branch-join var from inferValElse (the union of the matched init and a non-diverging else's fallback)
+	ValElseBranch                           // a fresh join var per leaf a val-else binds, the union of that leaf of the narrowed init and of a non-diverging else's fallback
 	BorrowExprOrigin                        // a RefType minted by inferBorrow from a `&p` / `&mut p` expression
 	OwnedMutConstruction                    // an owned-mutable RefType minted for `val mut q = {…}` from a fresh literal
 )

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -110,14 +110,7 @@ type pathBinder struct {
 	// carries no origin the solver can blame. A match arm, for one, has a span but is
 	// not an ast.Node.
 	blame ast.Node
-	// joined marks a binder whose root holds more than the value the splits test, which is
-	// what a `val pat = init else { … }` binds off: the matched initializer joined with the
-	// `else`'s fallback value, a half no tag test ever admitted. Narrowing such a root to
-	// the member a test matched would drop that half, so nothing under this binder narrows.
-	// The mark sits on the binder rather than on one view because every sub-scrutinee is a
-	// projection of the root and carries both halves too.
-	joined bool
-	views  map[*ucs.Scrutinee]scrutineeView
+	views map[*ucs.Scrutinee]scrutineeView
 }
 
 // newPathBinder builds the binder for one conditional form. root is the IR's root
@@ -164,7 +157,7 @@ func (b *pathBinder) narrowedBy(scope *Scope, s *ucs.Scrutinee, test ucs.Test, b
 	if !ok {
 		node = b.blameFor(s)
 	}
-	next := &pathBinder{c: b.c, lvl: b.lvl, blame: b.blame, joined: b.joined, views: maps.Clone(b.views)}
+	next := &pathBinder{c: b.c, lvl: b.lvl, blame: b.blame, views: maps.Clone(b.views)}
 	next.views[s] = next.applyTest(scope, node, v, test)
 	return next
 }
@@ -187,7 +180,7 @@ func (b *pathBinder) bindAtWith(
 	scope *Scope, s *ucs.Scrutinee, pat ast.Pat, leafTypes map[string]soltype.Type, emit leafEmit,
 ) soltype.Pat {
 	v := b.viewOf(scope, s)
-	return b.c.bindPatMode(scope, b.lvl, pat, v.ty, v.concrete, v.mode, leafTypes, emit)
+	return b.c.bindPatMode(scope, b.lvl, pat, v.ty, v.concrete, v.mode, leafTypes, emit, forBinding)
 }
 
 // bindElemAt binds the leaf an object pattern's shorthand element introduces, the `x` of
@@ -204,7 +197,7 @@ func (b *pathBinder) bindElemAt(scope *Scope, s *ucs.Scrutinee, elem *ast.ObjSho
 	v := b.shorthandView(scope, s, elem)
 	t := b.c.applyLeafExtras(scope, b.lvl, elem, v.ty, elem.TypeAnn, elem.Default)
 	t = b.c.applyBindMode(b.lvl, elem, elem.Mutable, t, b.c.concreteLeaf(v.concrete, elem.TypeAnn), v.mode)
-	b.c.bindLeaf(scope, elem.Key.Name, t, elem, nil, defineLeafMono)
+	b.c.bindLeaf(scope, elem.Key.Name, t, elem, nil, defineLeafMono, forBinding)
 }
 
 // shorthandView resolves the field a shorthand element names into the variable its leaf
@@ -421,11 +414,6 @@ func (b *pathBinder) narrowingAnn(s *ucs.Scrutinee) (ast.TypeAnn, bool) {
 // test instead of off the source pattern, so a reachable arm and an arm typed outside the
 // walk agree on which members a branch keeps.
 func (b *pathBinder) narrowUnion(v scrutineeView, test ucs.Test) scrutineeView {
-	if b.joined {
-		// The value the leaves read holds a half no test admitted, so no member can be
-		// ruled out and the leaves stay bound against the whole of it. See pathBinder.joined.
-		return v
-	}
 	// A borrowed shape is left wrapped rather than peeled the way groundedCarrier peels
 	// one. The narrowed result below replaces v.ty and v.concrete, and nothing here
 	// rewraps it, so peeling first would drop the borrow off a nested scrutinee.


### PR DESCRIPTION
When a `val pat = init else { fallback }` declaration destructures a pattern, the fallback value now supplies leaves that join with the initializer's leaves, rather than the fallback being checked only against the initializer's type.

This fixes type inference for destructuring patterns with fallbacks. Previously, `val {x} = p else { {x: "s"} }` over `p: {x: number} | {y: string}` would infer `x: number | undefined` because the fallback was checked against the whole initializer type. Now it correctly infers `x: number | "s"` by destructuring the fallback with the same pattern and joining each leaf.

**Key changes:**

- `inferValElse` now calls `joinFallbackLeaves` when the else produces a fallback and the declaration is not pinned by a narrowing annotation. The join sits below the projection so tag tests narrow the initializer before leaves read it, preventing `undefined` from members the pattern rejected.
- `joinFallbackLeaves` walks the pattern a second time in projection mode to resolve what the fallback supplies for each name, then joins each leaf with its fallback counterpart. Leaves with their own type annotations or owned-mutable cells flow the fallback into a fixed type instead of joining.
- `projectLeaves` is a new public method that resolves leaves out of a scrutinee without binding or recording, used by the fallback join to ask what a second value supplies for each name.
- `bindPurpose` distinguishes binding walks (which apply annotations, defaults, and `mut` markers) from projection walks (which resolve types without side effects). This keeps defaults and annotations typed once even though the pattern is walked twice.
- Helper functions `leafFixedType`, `leafTypeAnn`, and `monoTypeOf` encapsulate the logic for determining when a leaf takes a join versus a fixed type.

The second walk is gated by `bindPurpose` so faults in the pattern are reported once, not doubled. Type recording is also gated so editors read the joined type rather than the initializer's half alone.

https://claude.ai/code/session_015T1CeQGWNELbABfDEnAXF1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `val … else` destructuring so fallback values are matched and inferred for each individual leaf.
  * Preserved narrowed, mutable, and annotated leaf types while correctly combining them with fallback types.
  * Prevented diverging fallbacks and default values from introducing incorrect `undefined` types.
  * Improved handling of object rest, defaults, and fallback validation.
  * Consolidated diagnostics to avoid duplicate pattern errors.

* **Tests**
  * Added coverage for fallback destructuring, type joins, annotations, mutable bindings, defaults, object rest, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->