### PR TITLE
Extract recursion guards into reusable set utilities

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -24,8 +24,8 @@ type Checker struct {
 	PackageRegistry       *PackageRegistry           // Registry for package namespaces (separate from scope chain)
 	GlobalScope           *Scope                     // Explicit reference to global scope (contains globals like Array, Promise, etc.)
 	FileScopes            map[int]*Scope             // Populated by InferModule: SourceID → file-specific scope
-	expandCache           expandSeen                 // Cross-call cache for getMemberType's expansion loop (#453)
-	substCache            expandSeen                 // Cross-call cache for expandTypeRef's SubstituteTypeParams (#461)
+	expandCache           expandResultCache          // Cross-call cache for getMemberType's expansion loop (#453)
+	substCache            expandResultCache          // Cross-call cache for expandTypeRef's SubstituteTypeParams (#461)
 	memberCache           memberCache                // Per-property cache for lazy member substitution (#461)
 
 	// loadingExternalTypes is true while ingesting TypeScript types
@@ -78,8 +78,8 @@ func NewChecker(ctx context.Context) *Checker {
 		OverloadDecls:         make(map[string][]*ast.FuncDecl),
 		PackageRegistry:       NewPackageRegistry(),
 		GlobalScope:           nil, // Will be set by initializeGlobalScope() during prelude loading
-		expandCache:           make(expandSeen),
-		substCache:            make(expandSeen),
+		expandCache:           make(expandResultCache),
+		substCache:            make(expandResultCache),
 		memberCache:           make(memberCache),
 		stdlibNextSourceID:    1 << 20, // 1,048,576 — well above any plausible user source ID
 	}

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -28,14 +28,15 @@ type expandSeenKey struct {
 	typeArgs string         // typeArgKey(typeArgs)
 }
 
-// expandSeen records one alias instantiation per key while a single expansion pass runs. An
-// instantiation asked for again while its own expansion is still running is a cycle and comes
-// back unexpanded. One that finished replays its result rather than being expanded twice.
+// expandSeen is one expansion pass's record of the alias instantiations it has expanded, keyed
+// by the alias and its type arguments. An instantiation asked for again while its own expansion
+// is still running is a cycle, and the inner ask gets the reference back unexpanded. An
+// instantiation whose expansion finished replays the stored result instead of expanding twice.
 type expandSeen = set.Table[expandSeenKey, type_system.Type]
 
-// expandResultCache maps an alias instantiation to a finished type, with no in-progress state to
-// track. It backs the two cross-call caches on Checker, which are populated only after the work
-// they memoize has returned.
+// expandResultCache maps an alias instantiation to a finished type. It backs the two cross-call
+// caches on Checker. Both store an entry only after the work they memoize has returned, so
+// neither needs the in-progress state expandSeen tracks.
 type expandResultCache map[expandSeenKey]type_system.Type
 
 // memberCacheKey identifies a specific property on a specific instantiation of
@@ -543,10 +544,10 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 			}
 		}
 
-		// This alias instantiation is the key its own expansion is recorded under. Reaching it
-		// again from inside that expansion is a cycle, and the inner ask returns the reference
-		// unexpanded so the outer one still gets to finish. Reaching it after the expansion
-		// finished replays the stored result.
+		// Key this expansion by the alias and its type arguments, so a self-referential alias
+		// closes as a cycle rather than expanding forever. Do runs the body below on the first
+		// ask. A cycle that re-enters this key gets nil, leaving the reference unexpanded, and
+		// an ask arriving after the body returned replays the stored result.
 		key := expandSeenKey{
 			alias:    unsafe.Pointer(typeAlias),
 			typeArgs: typeArgKey(t.TypeArgs),

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
@@ -27,10 +28,15 @@ type expandSeenKey struct {
 	typeArgs string         // typeArgKey(typeArgs)
 }
 
-// expandSeen tracks type alias expansions in progress and caches completed results.
-// A nil value means the expansion is in progress (re-encounter = cycle).
-// A non-nil value is the cached expansion result (re-encounter = reuse).
-type expandSeen map[expandSeenKey]type_system.Type
+// expandSeen records one alias instantiation per key while a single expansion pass runs. An
+// instantiation asked for again while its own expansion is still running is a cycle and comes
+// back unexpanded. One that finished replays its result rather than being expanded twice.
+type expandSeen = set.Table[expandSeenKey, type_system.Type]
+
+// expandResultCache maps an alias instantiation to a finished type, with no in-progress state to
+// track. It backs the two cross-call caches on Checker, which are populated only after the work
+// they memoize has returned.
+type expandResultCache map[expandSeenKey]type_system.Type
 
 // memberCacheKey identifies a specific property on a specific instantiation of
 // a generic type alias. Used by lazyMemberLookup to cache per-property
@@ -161,10 +167,10 @@ func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool
 // TODO(#452): Extract a separate ExpandNonRefTypes helper for the count=0 case
 // to make call sites self-documenting.
 func (c *Checker) ExpandType(ctx Context, t type_system.Type, expandTypeRefsCount int) (type_system.Type, []Error) {
-	return c.expandTypeWithConfig(ctx, t, expandTypeRefsCount, make(expandSeen))
+	return c.expandTypeWithConfig(ctx, t, expandTypeRefsCount, set.NewTable[expandSeenKey, type_system.Type]())
 }
 
-func (c *Checker) expandTypeWithConfig(ctx Context, t type_system.Type, expandTypeRefsCount int, seen expandSeen) (type_system.Type, []Error) {
+func (c *Checker) expandTypeWithConfig(ctx Context, t type_system.Type, expandTypeRefsCount int, seen *expandSeen) (type_system.Type, []Error) {
 	t = type_system.Prune(t)
 	visitor := NewTypeExpansionVisitor(c, ctx, expandTypeRefsCount)
 	visitor.seen = seen
@@ -180,7 +186,7 @@ type TypeExpansionVisitor struct {
 	errors              []Error
 	skipTypeRefsCount   int // if > 0, skip expanding TypeRefTypes
 	expandTypeRefsCount int // if > 0, number of TypeRefTypes expanded, if -1 then unlimited
-	seen                expandSeen
+	seen                *expandSeen
 }
 
 // NewTypeExpansionVisitor creates a new visitor for expanding type references
@@ -537,84 +543,75 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 			}
 		}
 
-		// Cycle detection: check if we're already expanding this alias+typeArgs.
+		// This alias instantiation is the key its own expansion is recorded under. Reaching it
+		// again from inside that expansion is a cycle, and the inner ask returns the reference
+		// unexpanded so the outer one still gets to finish. Reaching it after the expansion
+		// finished replays the stored result.
 		key := expandSeenKey{
 			alias:    unsafe.Pointer(typeAlias),
 			typeArgs: typeArgKey(t.TypeArgs),
 		}
-		if cached, exists := v.seen[key]; exists {
-			if cached == nil {
-				// In progress — this is a cycle. Return unexpanded.
-				return nil
-			}
-			// Completed — reuse the cached expansion.
-			return cached
-		}
-		v.seen[key] = nil // mark as in progress
-
-		// TODO(#475): Handle default type params, then ensure the number of type
-		// args matches the number of type params unless there are type params with
-		// defaults, in which case the number of type args can be fewer as long as
-		// there are enough for the required type params.
-		if len(typeAlias.TypeParams) > 0 && len(t.TypeArgs) > 0 {
-			// Do not perform distributions if the conditional type is the child
-			// of any other type.
-			switch prunedType := type_system.Prune(expandedType).(type) {
-			case *type_system.CondType:
-				// generateSubstitutionSets expands each arg internally to check
-				// whether it's a union for distribution purposes, so we don't
-				// need to pre-expand args here.
-				substitutionSets, subSetErrors := v.checker.generateSubstitutionSets(v.ctx, typeAlias.TypeParams, t.TypeArgs)
-				if len(subSetErrors) > 0 {
-					v.errors = slices.Concat(v.errors, subSetErrors)
-				}
-
-				// If there are more than one substitution sets, distribute the
-				// type arguments across the conditional type.
-				if len(substitutionSets) > 1 {
-					expandedTypes := make([]type_system.Type, len(substitutionSets))
-					for i, substitutionSet := range substitutionSets {
-						expandedTypes[i] = SubstituteTypeParams(prunedType, substitutionSet)
+		return v.seen.Do(key, func() type_system.Type { return nil }, func() type_system.Type {
+			// TODO(#475): Handle default type params, then ensure the number of type
+			// args matches the number of type params unless there are type params with
+			// defaults, in which case the number of type args can be fewer as long as
+			// there are enough for the required type params.
+			if len(typeAlias.TypeParams) > 0 && len(t.TypeArgs) > 0 {
+				// Do not perform distributions if the conditional type is the child
+				// of any other type.
+				switch prunedType := type_system.Prune(expandedType).(type) {
+				case *type_system.CondType:
+					// generateSubstitutionSets expands each arg internally to check
+					// whether it's a union for distribution purposes, so we don't
+					// need to pre-expand args here.
+					substitutionSets, subSetErrors := v.checker.generateSubstitutionSets(v.ctx, typeAlias.TypeParams, t.TypeArgs)
+					if len(subSetErrors) > 0 {
+						v.errors = slices.Concat(v.errors, subSetErrors)
 					}
-					// Create a union type of all expanded types
-					expandedType = type_system.NewUnionType(nil, expandedTypes...)
-				} else {
+
+					// If there are more than one substitution sets, distribute the
+					// type arguments across the conditional type.
+					if len(substitutionSets) > 1 {
+						expandedTypes := make([]type_system.Type, len(substitutionSets))
+						for i, substitutionSet := range substitutionSets {
+							expandedTypes[i] = SubstituteTypeParams(prunedType, substitutionSet)
+						}
+						// Create a union type of all expanded types
+						expandedType = type_system.NewUnionType(nil, expandedTypes...)
+					} else {
+						substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
+						expandedType = SubstituteTypeParams(prunedType, substitutions)
+					}
+				case *type_system.ObjectType:
+					// Expand any MappedElem elements in the object type
+					substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
+					objType := SubstituteTypeParams(prunedType, substitutions)
+					expandedType = v.expandMappedElems(objType)
+				default:
+					// Use raw type args — the recursive expansion at the end of
+					// this block will expand any TypeRefs in the substituted body.
+					// This avoids eagerly expanding args that resolve to large
+					// types when their structure isn't needed for the substitution.
 					substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
 					expandedType = SubstituteTypeParams(prunedType, substitutions)
 				}
-			case *type_system.ObjectType:
-				// Expand any MappedElem elements in the object type
-				substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
-				objType := SubstituteTypeParams(prunedType, substitutions)
-				expandedType = v.expandMappedElems(objType)
-			default:
-				// Use raw type args — the recursive expansion at the end of
-				// this block will expand any TypeRefs in the substituted body.
-				// This avoids eagerly expanding args that resolve to large
-				// types when their structure isn't needed for the substitution.
-				substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
-				expandedType = SubstituteTypeParams(prunedType, substitutions)
+			} else if len(typeAlias.TypeParams) == 0 && len(t.TypeArgs) == 0 {
+				// Expand MappedElems in ObjectTypes even if there are no type params/args
+				// `{[P]: string for P in "foo" | "bar"}` should be expanded to
+				// `{foo: string, bar: string}`
+				if objType, ok := type_system.Prune(expandedType).(*type_system.ObjectType); ok {
+					expandedType = v.expandMappedElems(objType)
+				}
 			}
-		} else if len(typeAlias.TypeParams) == 0 && len(t.TypeArgs) == 0 {
-			// Expand MappedElems in ObjectTypes even if there are no type params/args
-			// `{[P]: string for P in "foo" | "bar"}` should be expanded to
-			// `{foo: string, bar: string}`
-			if objType, ok := type_system.Prune(expandedType).(*type_system.ObjectType); ok {
-				expandedType = v.expandMappedElems(objType)
+
+			// Recursively expand the resolved type using the same visitor to maintain state
+			if v.expandTypeRefsCount == -1 {
+				result, _ := v.checker.expandTypeWithConfig(v.ctx, expandedType, -1, v.seen)
+				return result
 			}
-		}
-
-		// Recursively expand the resolved type using the same visitor to maintain state
-		var result type_system.Type
-		if v.expandTypeRefsCount == -1 {
-			result, _ = v.checker.expandTypeWithConfig(v.ctx, expandedType, -1, v.seen)
-		} else {
-			result, _ = v.checker.expandTypeWithConfig(v.ctx, expandedType, v.expandTypeRefsCount-1, v.seen)
-		}
-
-		// Cache the expanded result for reuse
-		v.seen[key] = result
-		return result
+			result, _ := v.checker.expandTypeWithConfig(v.ctx, expandedType, v.expandTypeRefsCount-1, v.seen)
+			return result
+		})
 	case *type_system.TemplateLitType:
 		// Expand template literal types by generating all possible string combinations
 		// from the cartesian product of the union types in the template

--- a/internal/set/guard.go
+++ b/internal/set/guard.go
@@ -1,0 +1,106 @@
+package set
+
+// Recursion guards over a `seen` set, in the two flavours the compiler's walks need.
+//
+// Both take the set, the key identifying the current step, and the work to do at that step.
+// They differ in when the entry comes back out. `Once` leaves the key in the set forever, so
+// the work runs at most once per key for the lifetime of the set. `OnPath` removes the key
+// once the work returns, so the set holds exactly the keys on the current recursion path.
+//
+// That difference decides which one a site wants. Use `Once` when the result depends only on
+// the key, which makes a second visit redundant work. Use `OnPath` when the result depends on
+// the context the walk arrived through, such as polarity or the open μ-binders, since two
+// arrivals through different contexts then need two separate walks.
+
+// Once runs fn the first time key is offered to seen and returns fn's result. Every later call
+// with the same key returns onRepeat() and does not run fn. A repeat is not necessarily a
+// cycle. The key stays in seen after fn returns, so an independent branch reaching the same key
+// later also takes the onRepeat path.
+//
+// Because a repeat returns onRepeat() rather than the answer fn would have produced, Once fits
+// only where fn's real output lands in state the caller reads afterwards. That state is an
+// out-parameter at collectAllFrom and a field on the visitor at typeParamCollector.
+//
+// onRepeat is a thunk rather than a plain value so a site whose repeat answer is computed does
+// not have to compute it on the first visit too.
+func Once[K comparable, R any](seen Set[K], key K, onRepeat func() R, fn func() R) R {
+	if seen.Contains(key) {
+		return onRepeat()
+	}
+	seen.Add(key)
+	return fn()
+}
+
+// OnceDo is Once for work that returns nothing. A repeat does nothing at all, so there is no
+// onRepeat thunk to pass.
+func OnceDo[K comparable](seen Set[K], key K, fn func()) {
+	if seen.Contains(key) {
+		return
+	}
+	seen.Add(key)
+	fn()
+}
+
+// OnPath runs fn with key added to seen and removes key again once fn returns, so seen holds
+// exactly the keys on the current recursion path. Offering a key already on that path is a
+// genuine cycle: OnPath returns onCycle() and does not run fn. Two independent branches
+// reaching the same key both run fn, because the first branch removed its entry before the
+// second one started.
+//
+// The removal is deferred, so a panic unwinding through fn leaves seen as it found it.
+//
+// onCycle is a thunk rather than a plain value because the answer at a cycle is not always a
+// constant. coalescer returns a reference to the μ-binder it minted for the key.
+func OnPath[K comparable, R any](seen Set[K], key K, onCycle func() R, fn func() R) R {
+	if seen.Contains(key) {
+		return onCycle()
+	}
+	seen.Add(key)
+	defer seen.Remove(key)
+	return fn()
+}
+
+// Table memoizes one value per key and reports a key that is asked for again while its own fn
+// is still running. It is the guard for a walk that has to hand back a real result rather than
+// accumulate into shared state, so neither Once nor OnPath fits.
+//
+// A key moves through three states. It starts absent. Do marks it in progress before calling
+// fn, and marks it settled with fn's result once fn returns. Asking for an in-progress key is
+// a cycle, since the only way to reach one is from inside its own fn.
+//
+// The zero Table is ready to use.
+type Table[K comparable, V any] struct {
+	entries map[K]tableEntry[V]
+}
+
+// tableEntry is one key's slot in a Table. settled distinguishes a finished derivation from one
+// still running, which a nil or zero value alone cannot do for an arbitrary V.
+type tableEntry[V any] struct {
+	value   V
+	settled bool
+}
+
+// NewTable creates a new empty Table.
+func NewTable[K comparable, V any]() *Table[K, V] {
+	return &Table[K, V]{entries: map[K]tableEntry[V]{}}
+}
+
+// Do returns the value for key. On the first ask it runs fn and stores the result, which every
+// later ask replays without re-running fn. An ask that arrives while fn is still running for
+// that same key returns onCycle() instead, leaving the in-progress entry alone so the original
+// fn still gets to settle it.
+func (t *Table[K, V]) Do(key K, onCycle func() V, fn func() V) V {
+	if e, found := t.entries[key]; found {
+		if !e.settled {
+			return onCycle()
+		}
+		return e.value
+	}
+	if t.entries == nil {
+		t.entries = map[K]tableEntry[V]{}
+	}
+	t.entries[key] = tableEntry[V]{}
+	value := fn()
+	t.entries[key] = tableEntry[V]{value: value, settled: true}
+	return value
+}

--- a/internal/set/guard.go
+++ b/internal/set/guard.go
@@ -1,28 +1,27 @@
 package set
 
-// Recursion guards over a `seen` set, in the two flavours the compiler's walks need.
-//
-// Both take the set, the key identifying the current step, and the work to do at that step.
-// They differ in when the entry comes back out. `Once` leaves the key in the set forever, so
-// the work runs at most once per key for the lifetime of the set. `OnPath` removes the key
-// once the work returns, so the set holds exactly the keys on the current recursion path.
+// Recursion guards over a `seen` set. Each one takes the set, the key identifying the current
+// step of the walk, and the work to do at that step. They differ in when the key comes back out
+// of the set. `Once` leaves it there for good, so the work runs at most once per key for the
+// lifetime of the set. `OnPath` removes it once the work returns, so the set holds exactly the
+// keys on the current recursion path.
 //
 // That difference decides which one a site wants. Use `Once` when the result depends only on
 // the key, which makes a second visit redundant work. Use `OnPath` when the result depends on
 // the context the walk arrived through, such as polarity or the open μ-binders, since two
 // arrivals through different contexts then need two separate walks.
 
-// Once runs fn the first time key is offered to seen and returns fn's result. Every later call
-// with the same key returns onRepeat() and does not run fn. A repeat is not necessarily a
-// cycle. The key stays in seen after fn returns, so an independent branch reaching the same key
-// later also takes the onRepeat path.
+// Once runs fn the first time it sees key and returns fn's result. Every later call with the
+// same key returns onRepeat() and does not run fn. A repeat is not necessarily a cycle. The key
+// stays in seen after fn returns, so an independent branch reaching the same key later also
+// takes the onRepeat path.
 //
 // Because a repeat returns onRepeat() rather than the answer fn would have produced, Once fits
 // only where fn's real output lands in state the caller reads afterwards. That state is an
 // out-parameter at collectAllFrom and a field on the visitor at typeParamCollector.
 //
-// onRepeat is a thunk rather than a plain value so a site whose repeat answer is computed does
-// not have to compute it on the first visit too.
+// onRepeat is a function rather than a plain value so that a site whose repeat answer costs
+// something to compute does not pay for it on the first visit, where the answer goes unused.
 func Once[K comparable, R any](seen Set[K], key K, onRepeat func() R, fn func() R) R {
 	if seen.Contains(key) {
 		return onRepeat()
@@ -42,14 +41,14 @@ func OnceDo[K comparable](seen Set[K], key K, fn func()) {
 }
 
 // OnPath runs fn with key added to seen and removes key again once fn returns, so seen holds
-// exactly the keys on the current recursion path. Offering a key already on that path is a
-// genuine cycle: OnPath returns onCycle() and does not run fn. Two independent branches
-// reaching the same key both run fn, because the first branch removed its entry before the
-// second one started.
+// exactly the keys on the current recursion path. A key already on that path has been reached
+// from inside its own fn, which is a genuine cycle. OnPath then returns onCycle() and does not
+// run fn. Two independent branches reaching the same key both run fn, because the first branch
+// removed its entry before the second one started.
 //
 // The removal is deferred, so a panic unwinding through fn leaves seen as it found it.
 //
-// onCycle is a thunk rather than a plain value because the answer at a cycle is not always a
+// onCycle is a function rather than a plain value because the answer at a cycle is not always a
 // constant. coalescer returns a reference to the μ-binder it minted for the key.
 func OnPath[K comparable, R any](seen Set[K], key K, onCycle func() R, fn func() R) R {
 	if seen.Contains(key) {

--- a/internal/set/guard_test.go
+++ b/internal/set/guard_test.go
@@ -1,0 +1,146 @@
+package set
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnce(t *testing.T) {
+	seen := NewSet[int]()
+	calls := []int{}
+
+	first := Once(seen, 1, func() string { return "repeat" }, func() string {
+		calls = append(calls, 1)
+		return "fresh"
+	})
+	require.Equal(t, "fresh", first)
+
+	second := Once(seen, 1, func() string { return "repeat" }, func() string {
+		calls = append(calls, 1)
+		return "fresh"
+	})
+	require.Equal(t, "repeat", second)
+	require.Equal(t, []int{1}, calls)
+	require.True(t, seen.Contains(1))
+}
+
+// A key Once ran fn for stays in seen after fn returns, so a sibling branch reaching the same
+// key takes the onRepeat path rather than walking it a second time.
+func TestOnceKeepsKeyAfterFnReturns(t *testing.T) {
+	seen := NewSet[int]()
+	Once(seen, 1, func() int { return 0 }, func() int { return 0 })
+	require.True(t, seen.Contains(1))
+
+	repeats := 0
+	Once(seen, 1, func() int { repeats++; return 0 }, func() int { return 0 })
+	require.Equal(t, 1, repeats)
+}
+
+func TestOnceDo(t *testing.T) {
+	seen := NewSet[string]()
+	visits := []string{}
+	visit := func(key string) {
+		OnceDo(seen, key, func() { visits = append(visits, key) })
+	}
+
+	visit("a")
+	visit("b")
+	visit("a")
+
+	require.Equal(t, []string{"a", "b"}, visits)
+}
+
+func TestOnPath(t *testing.T) {
+	seen := NewSet[int]()
+
+	result := OnPath(seen, 1, func() string { return "cycle" }, func() string {
+		require.True(t, seen.Contains(1), "key should be on the path while fn runs")
+		return "fresh"
+	})
+
+	require.Equal(t, "fresh", result)
+	require.False(t, seen.Contains(1), "key should be off the path once fn returns")
+}
+
+// Re-entering a key from inside its own fn is a cycle, while reaching the same key from a
+// sibling branch that starts after the first one finished is not.
+func TestOnPathSeparatesCyclesFromRepeats(t *testing.T) {
+	seen := NewSet[int]()
+	cycles := 0
+	walks := 0
+
+	var walk func(depth int) int
+	walk = func(depth int) int {
+		return OnPath(seen, 1, func() int { cycles++; return -1 }, func() int {
+			walks++
+			if depth > 0 {
+				return walk(depth - 1)
+			}
+			return depth
+		})
+	}
+
+	require.Equal(t, -1, walk(1), "the inner call re-enters key 1 and closes the cycle")
+	require.Equal(t, 1, cycles)
+	require.Equal(t, 1, walks)
+
+	require.Equal(t, 0, walk(0), "a later independent walk runs fn again")
+	require.Equal(t, 1, cycles)
+	require.Equal(t, 2, walks)
+}
+
+func TestOnPathRemovesKeyOnPanic(t *testing.T) {
+	seen := NewSet[int]()
+
+	require.Panics(t, func() {
+		OnPath(seen, 1, func() int { return 0 }, func() int { panic("boom") })
+	})
+	require.False(t, seen.Contains(1))
+}
+
+func TestTable(t *testing.T) {
+	table := NewTable[string, int]()
+	calls := 0
+
+	first := table.Do("a", func() int { return -1 }, func() int { calls++; return 7 })
+	require.Equal(t, 7, first)
+
+	second := table.Do("a", func() int { return -1 }, func() int { calls++; return 9 })
+	require.Equal(t, 7, second, "a settled key replays its stored value")
+	require.Equal(t, 1, calls)
+}
+
+// A key asked for again from inside its own fn is mid-derivation and takes the onCycle path.
+// Once that fn returns, the key is settled and later asks replay the stored value.
+func TestTableCycle(t *testing.T) {
+	table := NewTable[string, int]()
+	inner := 0
+
+	outer := table.Do("a", func() int { return -1 }, func() int {
+		inner = table.Do("a", func() int { return -1 }, func() int { return 100 })
+		return 7
+	})
+
+	require.Equal(t, -1, inner)
+	require.Equal(t, 7, outer)
+	require.Equal(t, 7, table.Do("a", func() int { return -1 }, func() int { return 100 }))
+}
+
+// A zero Table works without NewTable, so a struct field of type Table needs no constructor.
+func TestTableZeroValue(t *testing.T) {
+	var table Table[string, int]
+	require.Equal(t, 7, table.Do("a", func() int { return -1 }, func() int { return 7 }))
+	require.Equal(t, 7, table.Do("a", func() int { return -1 }, func() int { return 9 }))
+}
+
+// A settled entry replays even when its value is the zero value, so a walk that legitimately
+// produces nil is not mistaken for one still in progress.
+func TestTableSettlesZeroValue(t *testing.T) {
+	table := NewTable[string, *int]()
+	calls := 0
+
+	require.Nil(t, table.Do("a", func() *int { return nil }, func() *int { calls++; return nil }))
+	require.Nil(t, table.Do("a", func() *int { return nil }, func() *int { calls++; return nil }))
+	require.Equal(t, 1, calls)
+}

--- a/internal/simplesub/infer.go
+++ b/internal/simplesub/infer.go
@@ -3,6 +3,7 @@ package simplesub
 import (
 	"fmt"
 
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
@@ -384,9 +385,9 @@ func inferWith(in *Inferer, term Term) (type_system.Type, []error) {
 	// Occurrence + co-occurrence analysis, then merge variables that always
 	// co-occur.
 	occurrences := map[int]map[Polarity]bool{}
-	analyze(st, Positive, occurrences, map[polKey]bool{})
+	analyze(st, Positive, occurrences, set.NewSet[polKey]())
 	coOcc := map[polKey]map[int]bool{}
-	collectCoOcc(st, Positive, coOcc, map[polKey]bool{})
+	collectCoOcc(st, Positive, coOcc, set.NewSet[polKey]())
 	uf := mergeCoOccurring(vars, occurrences, coOcc)
 
 	mergedOccurrences := map[int]map[Polarity]bool{}

--- a/internal/simplesub/simplify.go
+++ b/internal/simplesub/simplify.go
@@ -1,6 +1,10 @@
 package simplesub
 
-import "sort"
+import (
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/set"
+)
 
 // ---- Occurrence analysis ----
 
@@ -11,21 +15,18 @@ type polKey struct {
 
 // analyze records, for each variable, the polarities it occurs in (following
 // bounds in the relevant direction). This drives single-polarity elimination.
-func analyze(st SimpleType, pol Polarity, occurrences map[int]map[Polarity]bool, seen map[polKey]bool) {
+func analyze(st SimpleType, pol Polarity, occurrences map[int]map[Polarity]bool, seen set.Set[polKey]) {
 	switch t := st.(type) {
 	case *Variable:
 		if occurrences[t.id] == nil {
 			occurrences[t.id] = map[Polarity]bool{}
 		}
 		occurrences[t.id][pol] = true
-		pk := polKey{t.id, pol}
-		if seen[pk] {
-			return
-		}
-		seen[pk] = true
-		for _, b := range t.boundsAt(pol) {
-			analyze(b, pol, occurrences, seen)
-		}
+		set.OnceDo(seen, polKey{t.id, pol}, func() {
+			for _, b := range t.boundsAt(pol) {
+				analyze(b, pol, occurrences, seen)
+			}
+		})
 	case *Function:
 		for _, p := range t.params {
 			analyze(p, pol.flip(), occurrences, seen)
@@ -173,7 +174,7 @@ func gatherGroup(v *Variable, pol Polarity, g map[int]bool) {
 
 // collectCoOcc records, per (variable, polarity), the set of variables that
 // co-occur with it (share a union/intersection node).
-func collectCoOcc(st SimpleType, pol Polarity, coOcc map[polKey]map[int]bool, seen map[polKey]bool) {
+func collectCoOcc(st SimpleType, pol Polarity, coOcc map[polKey]map[int]bool, seen set.Set[polKey]) {
 	switch t := st.(type) {
 	case *Variable:
 		g := map[int]bool{}
@@ -189,14 +190,11 @@ func collectCoOcc(st SimpleType, pol Polarity, coOcc map[polKey]map[int]bool, se
 				}
 			}
 		}
-		pk := polKey{t.id, pol}
-		if seen[pk] {
-			return
-		}
-		seen[pk] = true
-		for _, b := range t.boundsAt(pol) {
-			collectCoOcc(b, pol, coOcc, seen)
-		}
+		set.OnceDo(seen, polKey{t.id, pol}, func() {
+			for _, b := range t.boundsAt(pol) {
+				collectCoOcc(b, pol, coOcc, seen)
+			}
+		})
 	case *Function:
 		for _, p := range t.params {
 			collectCoOcc(p, pol.flip(), coOcc, seen)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -163,15 +163,20 @@ func muBinderName(i int) string {
 	return "X" + strconv.Itoa(i)
 }
 
-// coalescer is the soltype-visitor form of coalesce. The structural arms and the
-// variance flip come from soltype.Accept (the shared rewriting visitor); the var
-// node — whose bounds are a side graph, not tree children — is the whole content
-// here, handled in EnterType. seen is the path-scoped set of variables currently
-// being inlined: it holds only the variables on the *current* recursion path
-// (added before descending into bounds, removed after), so a variable reused in
-// independent branches — e.g. the identity function's shared param (negative) and
-// return (positive) var — is unaffected; only re-entering a variable already on
-// the path is a genuine cycle.
+// skipChildren is the EnterResult that keeps a node as it stands and stops soltype.Accept from
+// descending into it. Every arm of a var walk hands it back, since a var's bounds are a side
+// graph the arm walks itself rather than children Accept could rebuild.
+func skipChildren() soltype.EnterResult { return soltype.EnterResult{SkipChildren: true} }
+
+// coalescer is the soltype-visitor form of coalesce. The structural arms and the variance flip
+// come from soltype.Accept, the shared rewriting visitor. The var node is the whole content
+// here and is handled in EnterType, because its bounds are a side graph rather than tree
+// children. seen holds the variables currently being inlined and nothing else. set.OnPath adds
+// a variable before descending into its bounds and removes it on the way back up, so seen holds
+// only the variables on the current recursion path. A variable reached again through an
+// independent branch is therefore walked again, which is what the identity function needs: its
+// shared variable is reached once negatively through the parameter and once positively through
+// the return. Only re-entering a variable already on the path is a genuine cycle.
 type coalescer struct {
 	seen set.Set[*soltype.TypeVarType]
 	// mu holds the μ-binder open for each variable on that same path, so a cycle back to one
@@ -207,37 +212,37 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	// binder cannot cover, meaning one reached at the opposite polarity, collapses to the polarity
 	// identity instead. See muBinders.ref. That is the same value the position takes when its
 	// bounds are empty.
-	if c.seen.Contains(v) {
+	onCycle := func() soltype.EnterResult {
 		if ref := c.mu.ref(v, pol); ref != nil {
 			return soltype.EnterResult{Type: ref, SkipChildren: true}
 		}
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
-	c.seen.Add(v)
-	defer c.seen.Remove(v) // path-scoped: pop on the way back up (panic-safe)
-	binder := c.mu.push(v, pol)
-	defer c.mu.pop(v) // path-scoped like `seen`, so a binder is open only while v is on the path
-	// Uniform inline: drop the variable, keep only its (recursively coalesced)
-	// bounds in the current polarity.
-	bs := v.BoundsAt(pol)
-	bounds := make([]soltype.Type, 0, len(bs))
-	for _, b := range bs {
-		bounds = append(bounds, b.Accept(c, pol))
-	}
-	// A kept type-parameter var flowing into v is a lower-bound contribution the var-var
-	// edge stored on the parameter's side rather than on v (see keptFlowMap). It is a
-	// positive-position value, so add it only in Positive position and recurse so a kept
-	// var stays symbolic through the keep check above.
-	if pol == soltype.Positive {
-		for _, kv := range c.flow[v] {
-			bounds = append(bounds, kv.Accept(c, pol))
+	return set.OnPath(c.seen, v, onCycle, func() soltype.EnterResult {
+		binder := c.mu.push(v, pol)
+		defer c.mu.pop(v) // path-scoped like `seen`, so a binder is open only while v is on the path
+		// Uniform inline: drop the variable, keep only its bounds in the current polarity,
+		// each one coalesced by the same walk.
+		bs := v.BoundsAt(pol)
+		bounds := make([]soltype.Type, 0, len(bs))
+		for _, b := range bs {
+			bounds = append(bounds, b.Accept(c, pol))
 		}
-	}
-	if len(bounds) == 0 {
-		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
-	}
-	inlined := widenVar(v, pol, combine(pol, dedup(bounds), v.Open))
-	return soltype.EnterResult{Type: binder.tie(pol, inlined), SkipChildren: true}
+		// A kept type-parameter var flowing into v is a lower-bound contribution the var-var
+		// edge stored on the parameter's side rather than on v. See keptFlowMap. It is a
+		// positive-position value, so add it only in Positive position and recurse so a kept
+		// var stays symbolic through the keep check above.
+		if pol == soltype.Positive {
+			for _, kv := range c.flow[v] {
+				bounds = append(bounds, kv.Accept(c, pol))
+			}
+		}
+		if len(bounds) == 0 {
+			return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
+		}
+		inlined := widenVar(v, pol, combine(pol, dedup(bounds), v.Open))
+		return soltype.EnterResult{Type: binder.tie(pol, inlined), SkipChildren: true}
+	})
 }
 
 func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
@@ -428,17 +433,17 @@ func (tc *typeParamCollector) EnterType(t soltype.Type, pol soltype.Polarity) so
 		}
 		return soltype.EnterResult{} // descend into params, return, and type-param bounds
 	case *soltype.TypeVarType:
-		if tc.seen.Contains(t) {
-			return soltype.EnterResult{SkipChildren: true}
-		}
-		tc.seen.Add(t)
-		for _, b := range t.LowerBounds {
-			b.Accept(tc, pol)
-		}
-		for _, b := range t.UpperBounds {
-			b.Accept(tc, pol)
-		}
-		return soltype.EnterResult{SkipChildren: true}
+		// A second arrival at the same var would add the same entries to keep, so the entry
+		// stays in seen and only buys an exponential re-walk of a shared subgraph if popped.
+		return set.Once(tc.seen, t, skipChildren, func() soltype.EnterResult {
+			for _, b := range t.LowerBounds {
+				b.Accept(tc, pol)
+			}
+			for _, b := range t.UpperBounds {
+				b.Accept(tc, pol)
+			}
+			return skipChildren()
+		})
 	}
 	return soltype.EnterResult{}
 }
@@ -495,13 +500,13 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	// display copy, so an artifact reached in a structural position reads as the declared
 	// parameter rather than a second name for the same type.
 	rep = c.displayBinder(rep)
-	if c.seen.Contains(rep) {
-		// A cycle back to a variable already on the path. A retained type parameter keeps its name.
-		// The quantifier already binds it, so the name IS the recursive reference and no separate
-		// binder is needed. An inlined variable has no name to come back to, so the cycle renders
-		// as a reference to the μ-binder minted for it and the finished body closes over the loop
-		// as a knot. A cycle the binder cannot cover, meaning one reached at the opposite polarity,
-		// collapses to the polarity identity. See muBinders.ref.
+	// A cycle back to a variable already on the path. A retained type parameter keeps its name.
+	// The quantifier already binds it, so the name IS the recursive reference and no separate
+	// binder is needed. An inlined variable has no name to come back to, so the cycle renders
+	// as a reference to the μ-binder minted for it and the finished body closes over the loop
+	// as a knot. A cycle the binder cannot cover, meaning one reached at the opposite polarity,
+	// collapses to the polarity identity. See muBinders.ref.
+	onCycle := func() soltype.EnterResult {
 		if retain {
 			return soltype.EnterResult{Type: rep, SkipChildren: true}
 		}
@@ -510,43 +515,43 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		}
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
-	c.seen.Add(rep)
-	defer c.seen.Remove(rep) // path-scoped: pop on the way back up (panic-safe)
-	binder := c.mu.push(rep, pol)
-	defer c.mu.pop(rep) // path-scoped like `seen`, so a binder is open only while rep is on the path
+	return set.OnPath(c.seen, rep, onCycle, func() soltype.EnterResult {
+		binder := c.mu.push(rep, pol)
+		defer c.mu.pop(rep) // path-scoped like `seen`, so a binder is open only while rep is on the path
 
-	// v's own bounds, not the representative's.
-	bs := v.BoundsAt(pol)
+		// v's own bounds, not the representative's.
+		bs := v.BoundsAt(pol)
 
-	// Pre-size parts with rep at index 0 when retaining, rather than appending then
-	// prepending. At the front, rep appears first in the union or intersection combine
-	// builds, and dedup keeps it distinct from any bound that cycles back to it.
-	n := len(bs)
-	if retain {
-		n++
-	}
-	parts := make([]soltype.Type, 0, n)
-	if retain {
-		parts = append(parts, rep)
-	}
-	// Recursively coalesce each bound. When a bound is another member of v's class
-	// whose rep is already on the path, the seen guard short-circuits it to the name
-	// and its own bounds go unwalked. No information is lost. constrain copies a
-	// concrete bound to every variable along a var↔var subtyping chain, so the class's
-	// reachable concrete bounds already sit on v, the first member reached. This holds
-	// because the body is propagation-closed, meaning every variable already carries
-	// the bounds propagated to it. coalesceScheme renders a component only after it is
-	// fully constrained, so that is always true here.
-	for _, b := range bs {
-		parts = append(parts, b.Accept(c, pol))
-	}
-	if len(parts) == 0 {
-		// Only reachable with !retain and no bounds — empty bounds under retain
-		// already leave parts=[rep]. Collapse to the polarity identity.
-		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
-	}
-	inlined := widenVar(v, pol, combine(pol, dedup(parts), v.Open))
-	return soltype.EnterResult{Type: binder.tie(pol, inlined), SkipChildren: true}
+		// Pre-size parts with rep at index 0 when retaining, rather than appending then
+		// prepending. At the front, rep appears first in the union or intersection combine
+		// builds, and dedup keeps it distinct from any bound that cycles back to it.
+		n := len(bs)
+		if retain {
+			n++
+		}
+		parts := make([]soltype.Type, 0, n)
+		if retain {
+			parts = append(parts, rep)
+		}
+		// Recursively coalesce each bound. When a bound is another member of v's class
+		// whose rep is already on the path, the seen guard short-circuits it to the name
+		// and its own bounds go unwalked. No information is lost. constrain copies a
+		// concrete bound to every variable along a var↔var subtyping chain, so the class's
+		// reachable concrete bounds already sit on v, the first member reached. This holds
+		// because the body is propagation-closed, meaning every variable already carries
+		// the bounds propagated to it. coalesceScheme renders a component only after it is
+		// fully constrained, so that is always true here.
+		for _, b := range bs {
+			parts = append(parts, b.Accept(c, pol))
+		}
+		if len(parts) == 0 {
+			// Only reachable with !retain and no bounds — empty bounds under retain
+			// already leave parts=[rep]. Collapse to the polarity identity.
+			return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
+		}
+		inlined := widenVar(v, pol, combine(pol, dedup(parts), v.Open))
+		return soltype.EnterResult{Type: binder.tie(pol, inlined), SkipChildren: true}
+	})
 }
 
 func (c *schemeCoalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -163,20 +163,18 @@ func muBinderName(i int) string {
 	return "X" + strconv.Itoa(i)
 }
 
-// skipChildren is the EnterResult that keeps a node as it stands and stops soltype.Accept from
-// descending into it. Every arm of a var walk hands it back, since a var's bounds are a side
-// graph the arm walks itself rather than children Accept could rebuild.
-func skipChildren() soltype.EnterResult { return soltype.EnterResult{SkipChildren: true} }
-
 // coalescer is the soltype-visitor form of coalesce. The structural arms and the variance flip
 // come from soltype.Accept, the shared rewriting visitor. The var node is the whole content
 // here and is handled in EnterType, because its bounds are a side graph rather than tree
-// children. seen holds the variables currently being inlined and nothing else. set.OnPath adds
-// a variable before descending into its bounds and removes it on the way back up, so seen holds
-// only the variables on the current recursion path. A variable reached again through an
-// independent branch is therefore walked again, which is what the identity function needs: its
-// shared variable is reached once negatively through the parameter and once positively through
-// the return. Only re-entering a variable already on the path is a genuine cycle.
+// children.
+//
+// set.OnPath adds a variable to seen before descending into its bounds and removes it on the way
+// back up, so seen holds only the variables on the current recursion path. A variable reached
+// again through an independent branch is therefore walked again. The identity function needs
+// exactly that. Inference gives `val id = fn (x) { return x }` one variable standing for both
+// the parameter and the return, so the walk reaches it twice, negatively through the parameter
+// and positively through the return. Both arrivals have to be walked, and neither is a cycle.
+// Only re-entering a variable already on the path is one.
 type coalescer struct {
 	seen set.Set[*soltype.TypeVarType]
 	// mu holds the μ-binder open for each variable on that same path, so a cycle back to one
@@ -425,6 +423,12 @@ type typeParamCollector struct {
 	seen set.Set[*soltype.TypeVarType]
 }
 
+// keepVarNode is the answer typeParamCollector gives at a var node. A nil Type keeps the node as
+// it stands, and SkipChildren stops Accept from descending, since this visitor only reads the
+// var and walks its bounds itself. It is the wrong answer for a visitor that rewrites the node.
+// That is why the two coalescers spell out their own EnterResult with a replacement Type set.
+func keepVarNode() soltype.EnterResult { return soltype.EnterResult{SkipChildren: true} }
+
 func (tc *typeParamCollector) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	switch t := t.(type) {
 	case *soltype.FuncType:
@@ -433,16 +437,17 @@ func (tc *typeParamCollector) EnterType(t soltype.Type, pol soltype.Polarity) so
 		}
 		return soltype.EnterResult{} // descend into params, return, and type-param bounds
 	case *soltype.TypeVarType:
-		// A second arrival at the same var would add the same entries to keep, so the entry
-		// stays in seen and only buys an exponential re-walk of a shared subgraph if popped.
-		return set.Once(tc.seen, t, skipChildren, func() soltype.EnterResult {
+		// A second arrival at the same var adds the same entries to keep, so re-walking it
+		// produces nothing new. The entry therefore stays in seen for good. Popping it would
+		// only buy an exponential re-walk of a shared subgraph.
+		return set.Once(tc.seen, t, keepVarNode, func() soltype.EnterResult {
 			for _, b := range t.LowerBounds {
 				b.Accept(tc, pol)
 			}
 			for _, b := range t.UpperBounds {
 				b.Accept(tc, pol)
 			}
-			return skipChildren()
+			return keepVarNode()
 		})
 	}
 	return soltype.EnterResult{}

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -598,14 +598,12 @@ func (c *checker) collectAllFrom(
 	out, seen set.Set[liveness.VarID],
 	fieldBorrowGraph map[liveness.VarID][]fieldBorrow,
 ) {
-	if seen.Contains(node) {
-		return
-	}
-	seen.Add(node)
-	for _, edge := range fieldBorrowGraph[node] {
-		out.Add(edge.referent)
-		c.collectAllFrom(edge.referent, out, seen, fieldBorrowGraph)
-	}
+	set.OnceDo(seen, node, func() {
+		for _, edge := range fieldBorrowGraph[node] {
+			out.Add(edge.referent)
+			c.collectAllFrom(edge.referent, out, seen, fieldBorrowGraph)
+		}
+	})
 }
 
 // appendSeg returns base with one more named field segment appended, copying the path so

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -338,9 +338,8 @@ type inferDeclFinder struct {
 }
 
 func (f *inferDeclFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
-	if iv, ok := t.(*soltype.InferType); ok && !f.seen.Contains(iv.ID) {
-		f.seen.Add(iv.ID)
-		f.ids = append(f.ids, iv.ID)
+	if iv, ok := t.(*soltype.InferType); ok {
+		set.OnceDo(f.seen, iv.ID, func() { f.ids = append(f.ids, iv.ID) })
 	}
 	return soltype.EnterResult{}
 }


### PR DESCRIPTION
Refs #1073

This PR extracts the recursion-guard boilerplate that was hand-written at each site into shared helpers in the `set` package, so the guard stops being interleaved with the surrounding algorithm.

It covers steps 1 through 3 of the order the issue suggests. Step 4, unify's `seen`-carrier problem, is left for separate work.

**New helpers — `internal/set/guard.go`:**

- `Once` / `OnceDo` run the work the first time they see a key. The key stays in the set afterwards, so a second, independent branch reaching the same key also takes the repeat path. `OnceDo` is the form for work that returns nothing, where a repeat does nothing at all and there is no repeat value to supply.
- `OnPath` runs the work with the key added and removes it once the work returns, so the set holds exactly the keys on the current recursion path. Only re-entering a key from inside its own work is a cycle. It supplies the deferred removal that the path-scoped sites wrote by hand, which makes them panic-safe uniformly.
- `Table` memoizes one value per key and separates an in-progress derivation from a settled one. It is the guard for a walk that has to hand back a real result rather than accumulate into shared state, so neither `Once` nor `OnPath` fits.

The choice between `Once` and `OnPath` is not stylistic. `Once` suits work whose result depends only on the key, which makes a second visit redundant. `OnPath` suits work whose result depends on the context the walk arrived through, such as polarity, where two arrivals need two separate walks.

**Converted sites:**

| Site | Helper |
| --- | --- |
| `collectAllFrom` — `internal/solver/return_escape.go` | `OnceDo` |
| `typeParamCollector.EnterType` — `internal/solver/coalesce.go` | `Once` |
| `inferDeclFinder.EnterType` — `internal/solver/typeops.go` | `OnceDo` |
| `analyze`, `collectCoOcc` — `internal/simplesub/simplify.go` | `OnceDo` |
| `coalescer.EnterType` — `internal/solver/coalesce.go` | `OnPath` |
| `schemeCoalescer.EnterType` — `internal/solver/coalesce.go` | `OnPath` |
| `expandTypeRefType` — `internal/checker/expand_type.go` | `Table` |

**Supporting changes:**

- `analyze` and `collectCoOcc` took a `map[polKey]bool` and now take a `set.Set[polKey]`.
- `expandSeen` is now a `set.Table`. The two cross-call caches on `Checker` reused that name for a plain memo map with no in-progress state, so they move to a new `expandResultCache` type.

**Deliberately not converted:**

- The two `unifyPruned` guards. The issue schedules these behind the `seen`-carrier fix, which decides whether the guard should stay shape 3 or become shape 2.
- `simplesub.constrain`. `Once` would mean wrapping a 197-line function in a closure to save four lines of guard.
- `seenPairs`. Not part of the issue's suggested order, and the Amadio–Cardelli depth bookkeeping around it is explicitly out of scope.

**Verification:**

`go build ./...`, `go vet ./...`, and `go test ./...` all pass, with no snapshot or fixture drift. The refactor is behavior-preserving at every site: the add-before-recurse ordering is unchanged, and in the two coalescers the inner `mu.pop` still runs before the outer `seen` removal, matching the original LIFO defer order.

One latent hazard is fixed along the way. The old `expandSeen` map stored `nil` both for "in progress" and for a completed nil result. `Table` separates the two with an explicit settled flag. Both paths still return `nil`, so no behavior changes today.

`internal/set/guard_test.go` covers the distinction that matters, including that `OnPath` fires on a genuine cycle but not on a later independent walk, that it removes the key even when the work panics, and that `Table` replays a settled zero value rather than mistaking it for an in-progress entry.

https://claude.ai/code/session_015cf1dJBZcEjsg6k5c3io38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recursive type-alias expansion, including safer handling of cyclic references and reuse of completed results.
  * Prevented repeated traversal of shared type and borrow graphs while preserving existing inference behavior.
  * Improved cycle detection and memoization across type coalescing and simplification.

* **Tests**
  * Added comprehensive coverage for recursion guards, cycle handling, memoization, panic recovery, and zero-value results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->