### PR TITLE
Peel borrow unions in pattern destructuring

### DIFF
--- a/internal/soltype/ref.go
+++ b/internal/soltype/ref.go
@@ -22,6 +22,35 @@ func UnwrapRef(t Type) (inner Type, mut bool, lt Lifetime) {
 	return t, false, nil
 }
 
+// UnwrapRefs is the N-ary UnwrapRef, for a caller asking whether one borrow can stand in
+// for a whole set of them. It peels each type into its carrier and lifetime, and reports
+// whether every one of them is mutable.
+//
+// ok is false unless EVERY type is a borrow carrying a lifetime. A plain value is not one,
+// and neither is an owned-mutable `mut {…}` cell, whose nil lifetime makes it a value
+// rather than a borrow. An empty set names no borrow either, so it is false as well.
+//
+// allMut is the conjunction rather than a rejection, since callers differ on what a mixed
+// set means. A join of returned borrows needs every input mutable and gives up otherwise,
+// while a destructured union binds immutable leaves.
+func UnwrapRefs(types []Type) (inners []Type, lts []Lifetime, allMut bool, ok bool) {
+	if len(types) == 0 {
+		return nil, nil, false, false
+	}
+	inners = make([]Type, len(types))
+	lts = make([]Lifetime, len(types))
+	allMut = true
+	for i, t := range types {
+		r, isRef := t.(*RefType)
+		if !isRef || r.Lt == nil {
+			return nil, nil, false, false
+		}
+		inners[i], lts[i] = r.Inner, r.Lt
+		allMut = allMut && r.Mut
+	}
+	return inners, lts, allMut, true
+}
+
 // CarrierOf peels any RefType down to the value it wraps, returning t unchanged
 // when it is not a borrow. Member access and pattern matching look through a borrow
 // to its carrier.

--- a/internal/soltype/ref_test.go
+++ b/internal/soltype/ref_test.go
@@ -44,6 +44,78 @@ func TestUnwrapRef(t *testing.T) {
 	})
 }
 
+// UnwrapRefs answers for a whole set at once, so every rejection is a case where one
+// borrow cannot stand in for all of them. Only a borrow carrying a lifetime counts, which
+// is what separates a real borrow from an owned-mutable cell.
+func TestUnwrapRefs(t *testing.T) {
+	objX := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: &PrimType{Prim: NumPrim}}}}
+	objY := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "y", Type: &PrimType{Prim: StrPrim}}}}
+	ltA, ltB := &LifetimeVar{ID: 1}, &LifetimeVar{ID: 2}
+	borrow := func(mut bool, lt Lifetime, inner RefInner) Type {
+		return &RefType{Mut: mut, Lt: lt, Inner: inner}
+	}
+
+	tests := []struct {
+		name   string
+		types  []Type
+		want   []Type
+		wantLt []Lifetime
+		allMut bool
+		ok     bool
+	}{
+		{
+			name:   "immutable borrows peel to their carriers",
+			types:  []Type{borrow(false, ltA, objX), borrow(false, ltB, objY)},
+			want:   []Type{objX, objY},
+			wantLt: []Lifetime{ltA, ltB},
+		},
+		{
+			name:   "every member mutable reports allMut",
+			types:  []Type{borrow(true, ltA, objX), borrow(true, ltB, objY)},
+			want:   []Type{objX, objY},
+			wantLt: []Lifetime{ltA, ltB},
+			allMut: true,
+		},
+		{
+			// One immutable member is enough to make the set immutable, since a leaf reached
+			// through that member cannot be written.
+			name:   "one immutable member clears allMut",
+			types:  []Type{borrow(true, ltA, objX), borrow(false, ltB, objY)},
+			want:   []Type{objX, objY},
+			wantLt: []Lifetime{ltA, ltB},
+		},
+		{
+			name:  "a plain value is not a borrow",
+			types: []Type{borrow(false, ltA, objX), objY},
+		},
+		{
+			// An owned-mutable `mut {…}` cell carries no lifetime, so it is a value.
+			name:  "an owned-mutable cell is not a borrow",
+			types: []Type{borrow(false, ltA, objX), borrow(true, nil, objY)},
+		},
+		{
+			name:  "an empty set names no borrow",
+			types: []Type{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inners, lts, allMut, ok := UnwrapRefs(tt.types)
+			if tt.want == nil {
+				require.False(t, ok)
+				require.Nil(t, inners)
+				require.Nil(t, lts)
+				require.False(t, allMut)
+				return
+			}
+			require.True(t, ok)
+			require.Equal(t, tt.want, inners)
+			require.Equal(t, tt.wantLt, lts)
+			require.Equal(t, tt.allMut, allMut)
+		})
+	}
+}
+
 func TestCarrierOf(t *testing.T) {
 	obj := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: &PrimType{Prim: NumPrim}}}}
 

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -278,6 +278,31 @@ func (c *Context) freshJoinLifetime(level int) *soltype.LifetimeVar {
 	return lv
 }
 
+// joinLifetimes returns one lifetime that every member of lts outlives, so a value drawn
+// from any of them may carry it. Several distinct lifetimes unite under a fresh join
+// variable holding each of them as a lower bound, which is the join site freshJoinLifetime
+// exists to serve. lts must not be empty.
+//
+// Where lts names one lifetime already, that lifetime is returned unchanged and the common
+// `&'a A | &'a B` mints no join variable.
+func (c *Context) joinLifetimes(level int, lts []soltype.Lifetime) soltype.Lifetime {
+	shared := true
+	for _, lt := range lts[1:] {
+		if !soltype.ContainsLifetime(lts[:1], lt) {
+			shared = false
+			break
+		}
+	}
+	if shared {
+		return lts[0]
+	}
+	joinLt := c.freshJoinLifetime(level)
+	for _, lt := range lts {
+		c.constrainLt(lt, joinLt)
+	}
+	return joinLt
+}
+
 // addLowerLtBound appends lt to v's lower bounds, journaling the mutation in the
 // active probe first so a discarded trial truncates it away. This (and
 // addUpperLtBound) is the ONLY sanctioned way to extend a lifetime bound list —

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -113,11 +113,7 @@ func (c *checker) inferModuleValElse(scope *Scope, lvl int, d *ast.VarDecl) (sol
 		bound = initType
 	default:
 		// The binding is the matched initializer OR the non-diverging fallback.
-		res := c.freshAt(lvl)
-		c.recordProv(res, d, ValElseBranch)
-		c.constrain(d, initType, res)
-		c.constrain(d, elseT, res)
-		bound = res
+		bound = c.joinBranches(d, lvl, ValElseBranch, []soltype.Type{initType, elseT})
 	}
 	c.recordType(ip, bound)
 	return bound, &ast.NodeProvenance{Node: d}, true

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -112,7 +112,9 @@ func (c *checker) inferModuleValElse(scope *Scope, lvl int, d *ast.VarDecl) (sol
 	case elseDiverges:
 		bound = initType
 	default:
-		// The binding is the matched initializer OR the non-diverging fallback.
+		// The binding is the matched initializer OR the non-diverging fallback, so the two
+		// have to agree on ownership.
+		c.checkUniformOwnership(d, []soltype.Type{initType, elseT})
 		bound = c.joinBranches(d, lvl, ValElseBranch, []soltype.Type{initType, elseT})
 	}
 	c.recordType(ip, bound)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -670,20 +670,24 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 		if joined, ok := c.joinBorrows(node, lvl, collected); ok {
 			return joined
 		}
+		c.checkUniformOwnership(node, collected)
 		return c.joinBranches(node, lvl, ReturnJoin, collected)
 	}
 }
 
 // joinBranches unites the values several paths of one form produce into a single type. It
 // mints a fresh variable, records prov on it under kind, and constrains each branch into it
-// in source order, so the rendered union follows the source. The branches have to agree on
-// ownership, which checkUniformOwnership reports on.
+// in source order, so the rendered union follows the source.
 //
-// A form that hands its join variable to a walk cannot use this, because the walk needs the
-// variable before the branch types exist. inferIfElse, inferIfVal, inferMatch, and
-// inferTryCatch all mint their own and call checkUniformOwnership once the walk returns.
+// Whether the branches agree on ownership is the caller's check to run, because the types
+// that answer for ownership are not always the types being joined. A `val … else` joins the
+// plain variable its projection walk lowered each leaf into, and that variable cannot show a
+// borrow the fallback's binding mode carries.
+//
+// A form that hands its join variable to a walk cannot use this at all, because the walk
+// needs the variable before the branch types exist. inferIfElse, inferIfVal, inferMatch, and
+// inferTryCatch each mint their own and check ownership once the walk returns.
 func (c *checker) joinBranches(node ast.Node, lvl int, kind ASTOriginKind, branches []soltype.Type) soltype.Type {
-	c.checkUniformOwnership(node, branches)
 	joinVar := c.freshAt(lvl)
 	c.recordProv(joinVar, node, kind)
 	for _, b := range branches {
@@ -720,7 +724,7 @@ func collectBranchOwnership(t soltype.Type, sawOwned, sawBorrowed *bool) {
 // join is about to union are some owned and some borrowed. Each branch is coalesced
 // first so an inference variable resolves to the shape that flowed into it.
 //
-// One node reports the fault once. A `val … else` runs a separate join per leaf its pattern
+// A node reports the fault once. A `val … else` runs a separate join per leaf its pattern
 // binds, and every one of those joins blames the whole declaration, so a pattern with two
 // mixed leaves would otherwise underline the declaration twice.
 func (c *checker) checkUniformOwnership(node ast.Node, branches []soltype.Type) {
@@ -3242,6 +3246,22 @@ func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 type fallbackLeaf struct {
 	ty   soltype.Type
 	node ast.Node
+	// mode is the binding mode the fallback's own borrow fixed, which ty cannot show. The
+	// projection walk lowers every field into a plain variable, so a leaf of a borrowed
+	// fallback reads as owned unless the mode is consulted.
+	mode bindMode
+}
+
+// ownership returns the type the uniform-ownership check reads for the `else`'s half of this
+// leaf. A leaf the fallback supplied through a borrow reads as that borrow, so a borrowed
+// scrutinee joined with a borrowed fallback is uniform. A leaf whose projected type cannot
+// sit inside a borrow is copied rather than borrowed, and reads as itself.
+func (l fallbackLeaf) ownership() soltype.Type {
+	inner, borrowable := l.ty.(soltype.RefInner)
+	if l.mode.borrow == bmOwned || !borrowable {
+		return l.ty
+	}
+	return &soltype.RefType{Mut: l.mode.borrow == bmMut, Lt: l.mode.lt, Inner: inner}
 }
 
 // joinFallbackLeaves rebinds each leaf the success path of a `val pat = init else { … }`
@@ -3264,15 +3284,20 @@ type fallbackLeaf struct {
 func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, escaped *Scope, fallback soltype.Type) {
 	produced := c.freshAt(lvl)
 	leaves := map[string]fallbackLeaf{}
-	// The fallback doubles as the shape, since it has not flowed into `produced` yet and a
+	// A borrowed fallback is peeled the same way a scrutinee is. The requirements a pattern
+	// emits are owned, so pushing the borrow itself into `produced` would read as a borrow
+	// escaping into an owned destination. The mode is what carries the borrow past the peel,
+	// and each leaf keeps it so joinLeaf can still tell a borrowed fallback from an owned one.
+	carrier, mode := c.scrutineeBinding(lvl, fallback)
+	// The carrier doubles as the shape, since it has not flowed into `produced` yet and a
 	// `...rest` leaf reads its leftover members off a shape.
-	c.projectLeaves(scope.Child(), lvl, d.Pattern, produced, soltype.CarrierOf(fallback),
+	c.projectLeaves(scope.Child(), lvl, d.Pattern, produced, carrier,
 		func(_ *Scope, name string, t soltype.Type, node ast.Node) {
-			leaves[name] = fallbackLeaf{ty: t, node: node}
+			leaves[name] = fallbackLeaf{ty: t, node: node, mode: mode}
 		})
 	// The requirements the projection emitted are upper bounds on `produced`. Pushing the
-	// fallback in only now is what checks it against them.
-	c.constrain(d, fallback, produced)
+	// carrier in only now is what checks it against them.
+	c.constrain(d, carrier, produced)
 	for s := escaped; s != nil && s != scope; s = s.parent {
 		for name, binding := range s.bindings() {
 			if leaf, projected := leaves[name]; projected {
@@ -3290,16 +3315,16 @@ func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, esca
 // A leaf whose type is already settled takes no join, and the fallback flows into that type
 // instead. leafFixedType decides which leaves those are.
 //
-// The join goes through joinBranches, so a leaf of a borrowed scrutinee joined with an owned
-// fallback reports MixedOwnershipError at the declaration. Without that check the two bind
-// as a union of a borrow and a plain value, and the author meets the mismatch only at a
-// later write through the name.
+// The two halves have to agree on ownership, so a leaf of a borrowed scrutinee joined with
+// an owned fallback reports MixedOwnershipError at the declaration. Without that check the
+// name binds a union of a borrow and a plain value, and the author meets the mismatch only at
+// a later write through it.
 //
-// It does not route through joinBorrows the way joinReturnPoints does. joinBorrows applies
-// only where every input is a mutable borrow of a grounded object, and the fallback's leaf is
-// always the raw variable projectLeaves lowered the field into. That walk projects rather
-// than binds, so it never reaches applyBindMode and never wraps a leaf in a borrow. Two
-// borrowed leaves therefore stay un-joined, as `&'c {a: number} | &'d {a: number}`.
+// The join does not route through joinBorrows the way joinReturnPoints does. joinBorrows
+// applies only where every input is a mutable borrow of a grounded object, and the fallback's
+// leaf is always the raw variable projectLeaves lowered the field into. That walk projects
+// rather than binds, so it never reaches applyBindMode and never wraps a leaf in a borrow.
+// Two borrowed leaves therefore stay un-joined, as `&'c {a: number} | &'d {a: number}`.
 func (c *checker) joinLeaf(
 	scope *Scope, lvl int, d *ast.VarDecl, name string, binding ValueBinding, leaf fallbackLeaf,
 ) {
@@ -3311,6 +3336,8 @@ func (c *checker) joinLeaf(
 		c.constrain(d, leaf.ty, fixed)
 		return
 	}
+	// The two sources the name binds from have to agree on ownership.
+	c.checkUniformOwnership(d, []soltype.Type{matched, leaf.ownership()})
 	join := c.joinBranches(d, lvl, ValElseBranch, []soltype.Type{matched, leaf.ty})
 	binding.Schemes = []TypeScheme{monoScheme(join)}
 	scope.defineValue(name, binding)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -864,7 +864,7 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 	for i, r := range refs {
 		lts[i] = r.Lt
 	}
-	return &soltype.RefType{Mut: true, Lt: c.joinLifetimes(lvl, lts), Inner: objs[0]}, true
+	return &soltype.RefType{Mut: true, Lt: c.ctx.joinLifetimes(lvl, lts), Inner: objs[0]}, true
 }
 
 // constrainEscape constrains every borrow lifetime reachable in t to outlive

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -806,21 +806,19 @@ func (c *checker) allReturnsUpgradable(retExprs []ast.Expr) bool {
 // To write, narrow to one branch with
 // `if val r2: mut {x: number} = r` and write through the fresh mutable view.
 func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (soltype.Type, bool) {
-	refs := make([]*soltype.RefType, len(types))
-	objs := make([]*soltype.ObjectType, len(types))
-	for i, t := range types {
-		r, ok := t.(*soltype.RefType)
-		if !ok || !r.Mut || r.Lt == nil {
-			return nil, false
-		}
-		obj, ok := r.Inner.(*soltype.ObjectType)
-		if !ok {
+	inners, lts, allMut, ok := soltype.UnwrapRefs(types)
+	if !ok || !allMut {
+		return nil, false
+	}
+	objs := make([]*soltype.ObjectType, len(inners))
+	for i, inner := range inners {
+		obj, isObj := inner.(*soltype.ObjectType)
+		if !isObj {
 			return nil, false
 		}
 		if i > 0 && !sameObjectKeys(objs[0], obj) {
 			return nil, false
 		}
-		refs[i] = r
 		objs[i] = obj
 	}
 
@@ -860,10 +858,6 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 	// Reconcilable fields: unite the input lifetimes under one join lifetime and return the
 	// single mutable carrier. Uniting them only here keeps the union path from minting a
 	// dead lifetime.
-	lts := make([]soltype.Lifetime, len(refs))
-	for i, r := range refs {
-		lts[i] = r.Lt
-	}
 	return &soltype.RefType{Mut: true, Lt: c.ctx.joinLifetimes(lvl, lts), Inner: objs[0]}, true
 }
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -670,14 +670,26 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 		if joined, ok := c.joinBorrows(node, lvl, collected); ok {
 			return joined
 		}
-		c.checkUniformOwnership(node, collected)
-		joinVar := c.freshAt(lvl)
-		c.recordProv(joinVar, node, ReturnJoin)
-		for _, rt := range collected {
-			c.constrain(node, rt, joinVar)
-		}
-		return joinVar
+		return c.joinBranches(node, lvl, ReturnJoin, collected)
 	}
+}
+
+// joinBranches unites the values several paths of one form produce into a single type. It
+// mints a fresh variable, records prov on it under kind, and constrains each branch into it
+// in source order, so the rendered union follows the source. The branches have to agree on
+// ownership, which checkUniformOwnership reports on.
+//
+// A form that hands its join variable to a walk cannot use this, because the walk needs the
+// variable before the branch types exist. inferIfElse, inferIfVal, inferMatch, and
+// inferTryCatch all mint their own and call checkUniformOwnership once the walk returns.
+func (c *checker) joinBranches(node ast.Node, lvl int, kind ASTOriginKind, branches []soltype.Type) soltype.Type {
+	c.checkUniformOwnership(node, branches)
+	joinVar := c.freshAt(lvl)
+	c.recordProv(joinVar, node, kind)
+	for _, b := range branches {
+		c.constrain(node, b, joinVar)
+	}
+	return joinVar
 }
 
 // collectBranchOwnership sets sawBorrowed for a borrow and sawOwned for an owned
@@ -707,14 +719,29 @@ func collectBranchOwnership(t soltype.Type, sawOwned, sawBorrowed *bool) {
 // checkUniformOwnership reports a MixedOwnershipError against node when the branches a
 // join is about to union are some owned and some borrowed. Each branch is coalesced
 // first so an inference variable resolves to the shape that flowed into it.
+//
+// One node reports the fault once. A `val … else` runs a separate join per leaf its pattern
+// binds, and every one of those joins blames the whole declaration, so a pattern with two
+// mixed leaves would otherwise underline the declaration twice.
 func (c *checker) checkUniformOwnership(node ast.Node, branches []soltype.Type) {
 	sawOwned, sawBorrowed := false, false
 	for _, b := range branches {
 		collectBranchOwnership(coalesce(b, soltype.Positive), &sawOwned, &sawBorrowed)
 	}
-	if sawOwned && sawBorrowed {
-		c.report(&MixedOwnershipError{Node: node})
+	if !sawOwned || !sawBorrowed || c.reportedMixedOwnership(node) {
+		return
 	}
+	c.report(&MixedOwnershipError{Node: node})
+}
+
+// reportedMixedOwnership reports whether node already carries a MixedOwnershipError.
+func (c *checker) reportedMixedOwnership(node ast.Node) bool {
+	for _, e := range c.errs {
+		if prev, ok := e.(*MixedOwnershipError); ok && prev.Node == node {
+			return true
+		}
+	}
+	return false
 }
 
 // constrainReturnAgainstAnnotation constrains a function body's joined return type
@@ -826,14 +853,14 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 		// stay sound.
 		return newUnion(nil, types, false), true
 	}
-	// Reconcilable fields: unite the input lifetimes under one fresh join lifetime,
-	// bounded below by each, and return the single mutable carrier. Allocating the
-	// join lifetime only here keeps the union path from minting a dead lifetime.
-	joinLt := c.ctx.freshJoinLifetime(lvl)
-	for _, r := range refs {
-		c.ctx.constrainLt(r.Lt, joinLt)
+	// Reconcilable fields: unite the input lifetimes under one join lifetime and return the
+	// single mutable carrier. Uniting them only here keeps the union path from minting a
+	// dead lifetime.
+	lts := make([]soltype.Lifetime, len(refs))
+	for i, r := range refs {
+		lts[i] = r.Lt
 	}
-	return &soltype.RefType{Mut: true, Lt: joinLt, Inner: objs[0]}, true
+	return &soltype.RefType{Mut: true, Lt: c.joinLifetimes(lvl, lts), Inner: objs[0]}, true
 }
 
 // constrainEscape constrains every borrow lifetime reachable in t to outlive
@@ -3262,6 +3289,17 @@ func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, esca
 //
 // A leaf whose type is already settled takes no join, and the fallback flows into that type
 // instead. leafFixedType decides which leaves those are.
+//
+// The join goes through joinBranches, so a leaf of a borrowed scrutinee joined with an owned
+// fallback reports MixedOwnershipError at the declaration. Without that check the two bind
+// as a union of a borrow and a plain value, and the author meets the mismatch only at a
+// later write through the name.
+//
+// It does not route through joinBorrows the way joinReturnPoints does. joinBorrows applies
+// only where every input is a mutable borrow of a grounded object, and the fallback's leaf is
+// always the raw variable projectLeaves lowered the field into. That walk projects rather
+// than binds, so it never reaches applyBindMode and never wraps a leaf in a borrow. Two
+// borrowed leaves therefore stay un-joined, as `&'c {a: number} | &'d {a: number}`.
 func (c *checker) joinLeaf(
 	scope *Scope, lvl int, d *ast.VarDecl, name string, binding ValueBinding, leaf fallbackLeaf,
 ) {
@@ -3273,10 +3311,7 @@ func (c *checker) joinLeaf(
 		c.constrain(d, leaf.ty, fixed)
 		return
 	}
-	join := c.freshAt(lvl)
-	c.recordProv(join, d, ValElseBranch)
-	c.constrain(d, matched, join)
-	c.constrain(d, leaf.ty, join)
+	join := c.joinBranches(d, lvl, ValElseBranch, []soltype.Type{matched, leaf.ty})
 	binding.Schemes = []TypeScheme{monoScheme(join)}
 	scope.defineValue(name, binding)
 	// The join replaces what the binding walk recorded, the leaf projected off the
@@ -3779,6 +3814,12 @@ func tuplePatArity(p *ast.TuplePat) (fixed int, hasRest bool) {
 //
 // The reachable arms of a `match` narrow through condWalk instead, which reads the same rule
 // off the IR's tag tests rather than off the source pattern.
+//
+// A union whose members are borrows needs no peel here. objectMemberHasKeys and
+// tupleMemberFitsArity each look through a member's borrow, so narrowing picks the right
+// members, and what it returns still names them as borrows. bindPattern peels the result,
+// through CarrierOf when narrowing kept one member and through peelBorrowUnion when it kept
+// several.
 func narrowArmScrutinee(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 	switch pat.(type) {
 	case *ast.ObjectPat, *ast.TuplePat:

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3246,22 +3246,6 @@ func (c *checker) inferValElse(scope *Scope, lvl int, d *ast.VarDecl) {
 type fallbackLeaf struct {
 	ty   soltype.Type
 	node ast.Node
-	// mode is the binding mode the fallback's own borrow fixed, which ty cannot show. The
-	// projection walk lowers every field into a plain variable, so a leaf of a borrowed
-	// fallback reads as owned unless the mode is consulted.
-	mode bindMode
-}
-
-// ownership returns the type the uniform-ownership check reads for the `else`'s half of this
-// leaf. A leaf the fallback supplied through a borrow reads as that borrow, so a borrowed
-// scrutinee joined with a borrowed fallback is uniform. A leaf whose projected type cannot
-// sit inside a borrow is copied rather than borrowed, and reads as itself.
-func (l fallbackLeaf) ownership() soltype.Type {
-	inner, borrowable := l.ty.(soltype.RefInner)
-	if l.mode.borrow == bmOwned || !borrowable {
-		return l.ty
-	}
-	return &soltype.RefType{Mut: l.mode.borrow == bmMut, Lt: l.mode.lt, Inner: inner}
 }
 
 // joinFallbackLeaves rebinds each leaf the success path of a `val pat = init else { … }`
@@ -3284,19 +3268,23 @@ func (l fallbackLeaf) ownership() soltype.Type {
 func (c *checker) joinFallbackLeaves(scope *Scope, lvl int, d *ast.VarDecl, escaped *Scope, fallback soltype.Type) {
 	produced := c.freshAt(lvl)
 	leaves := map[string]fallbackLeaf{}
-	// A borrowed fallback is peeled the same way a scrutinee is. The requirements a pattern
-	// emits are owned, so pushing the borrow itself into `produced` would read as a borrow
-	// escaping into an owned destination. The mode is what carries the borrow past the peel,
-	// and each leaf keeps it so joinLeaf can still tell a borrowed fallback from an owned one.
-	carrier, mode := c.scrutineeBinding(lvl, fallback)
-	// The carrier doubles as the shape, since it has not flowed into `produced` yet and a
-	// `...rest` leaf reads its leftover members off a shape.
-	c.projectLeaves(scope.Child(), lvl, d.Pattern, produced, carrier,
+	// The fallback doubles as the shape, since it has not flowed into `produced` yet and a
+	// `...rest` leaf reads its leftover members off a shape. It is passed unpeeled, so
+	// projectLeaves reads the borrow off it and each leaf of a borrowed fallback is itself a
+	// borrow. Peeling here instead would hand projectLeaves an owned carrier and every leaf
+	// would bind owned however the `else` was written.
+	c.projectLeaves(scope.Child(), lvl, d.Pattern, produced, fallback,
 		func(_ *Scope, name string, t soltype.Type, node ast.Node) {
-			leaves[name] = fallbackLeaf{ty: t, node: node, mode: mode}
+			leaves[name] = fallbackLeaf{ty: t, node: node}
 		})
 	// The requirements the projection emitted are upper bounds on `produced`. Pushing the
-	// carrier in only now is what checks it against them.
+	// fallback in only now is what checks it against them.
+	//
+	// A borrowed fallback is peeled first, the same way a scrutinee is. The requirements a
+	// pattern emits are owned, so pushing the borrow itself in would read as a borrow escaping
+	// into an owned destination. The borrow is not lost by the peel: the leaves above already
+	// took it off the fallback's binding mode.
+	carrier, _ := c.scrutineeBinding(lvl, fallback)
 	c.constrain(d, carrier, produced)
 	for s := escaped; s != nil && s != scope; s = s.parent {
 		for name, binding := range s.bindings() {
@@ -3337,7 +3325,7 @@ func (c *checker) joinLeaf(
 		return
 	}
 	// The two sources the name binds from have to agree on ownership.
-	c.checkUniformOwnership(d, []soltype.Type{matched, leaf.ownership()})
+	c.checkUniformOwnership(d, []soltype.Type{matched, leaf.ty})
 	join := c.joinBranches(d, lvl, ValElseBranch, []soltype.Type{matched, leaf.ty})
 	binding.Schemes = []TypeScheme{monoScheme(join)}
 	scope.defineValue(name, binding)

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -480,11 +480,12 @@ func TestInferValElseChecksTheFallbackAgainstALeafAnnotation(t *testing.T) {
 // borrow itself. concreteLeaf drops the shape hint for an annotated leaf, and applyBindMode
 // wraps a leaf in a borrow only where that hint says the value is borrowable.
 //
-// The borrow union reports a lifetime diagnostic of its own. It belongs to the scrutinee
-// rather than to the join, and the same declaration with a diverging `else` reports it too.
+// The scrutinee itself checks clean. Its members are peeled per member, so the leaves project
+// out of owned members and the borrow rides the binding mode.
 func TestInferValElseChecksAnAnnotatedLeafOfABorrowedUnion(t *testing.T) {
 	tests := map[string]struct {
-		src      string
+		src string
+		// wantErrs is the full set of expected messages, and nil means the source checks clean.
 		wantErrs []string
 	}{
 		"FallbackFitsTheAnnotation": {
@@ -492,9 +493,6 @@ func TestInferValElseChecksAnAnnotatedLeafOfABorrowedUnion(t *testing.T) {
 					val {x: v: number} = p else { {x: 5} }
 					return 0
 				}`,
-			wantErrs: []string{
-				"1:9-1:21: borrowed value object does not live long enough to satisfy object",
-			},
 		},
 		"FallbackViolatesTheAnnotation": {
 			src: `fn f(p: &{x: number} | &{y: string}) {
@@ -502,7 +500,6 @@ func TestInferValElseChecksAnAnnotatedLeafOfABorrowedUnion(t *testing.T) {
 					return 0
 				}`,
 			wantErrs: []string{
-				"1:9-1:21: borrowed value object does not live long enough to satisfy object",
 				`2:40-2:43: cannot constrain "s" <: number`,
 			},
 		},

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -222,8 +222,10 @@ func TestInferDestructureBorrowUnion(t *testing.T) {
 			wantErrs: []string{"3:5-3:12: cannot constrain immutable object <: mutable object"},
 		},
 		{
-			// One immutable member makes the whole mode immutable, since a leaf the value may
-			// have reached through that member is not writable.
+			// One immutable member makes the whole mode immutable, so the write is rejected.
+			// The `{x}` test can only have matched the mutable member here, so a mode that
+			// narrowed with the members would accept it. peelBorrowUnion fixes the mode at the
+			// whole scrutinee instead, and its TODO tracks the imprecision.
 			name: "mixed mutability binds immutable leaves",
 			src: `fn f(p: &mut {x: {a: number}} | &{y: string}) {
   if val {x: v} = p {
@@ -265,14 +267,35 @@ func TestInferDestructureBorrowUnion(t *testing.T) {
 			wantErrs: []string{"2:3-2:55: " + mixedOwnershipMsg},
 		},
 		{
-			// Both sides of the join are borrows, so ownership is uniform and the leaf binds
-			// the union of the two.
-			name: "val else leaf join accepts a borrowed fallback",
+			// The fallback is an owned object, but the value it supplies for `x` is a borrow, so
+			// both halves of the leaf are borrows and ownership is uniform.
+			name: "val else leaf join accepts a fallback field that is a borrow",
 			src: `fn f(p: &{x: {a: number}} | &{y: string}, q: &{a: number}) {
   val {x: v} = p else { {x: q} }
   return v
 }`,
 			want: "fn <'a: 'd, 'b: 'd, 'c, 'd>(p: &'a {x: {a: number}} | &'b {y: string}, q: &'c {a: number}) -> &'c {a: number} | &'d {a: number}",
+		},
+		{
+			// A borrowed fallback is peeled the way the scrutinee is, so the pattern's owned
+			// requirements meet its carrier. Its leaves reach the borrow through the mode, which
+			// is what makes this join uniform rather than mixed.
+			name: "val else leaf join accepts a fallback that is itself a borrow union",
+			src: `fn f(p: &{x: {a: number}} | &{y: string}, q: &{x: {a: number}} | &{x: {b: number}}) {
+  val {x: v} = p else { q }
+  return 0
+}`,
+			want: "fn (p: &{x: {a: number}} | &{y: string}, q: &{x: {a: number}} | &{x: {b: number}}) -> 0",
+		},
+		{
+			// The reverse mix reports too. An owned initializer and a borrowed fallback cannot
+			// both be what one name binds.
+			name: "val else leaf join rejects a borrowed fallback for an owned scrutinee",
+			src: `fn f(p: {x: {a: number}} | {y: string}, q: &{x: {a: number}}) {
+  val {x: v} = p else { q }
+  return 0
+}`,
+			wantErrs: []string{"2:3-2:28: " + mixedOwnershipMsg},
 		},
 	}
 	for _, tc := range cases {

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -225,7 +225,7 @@ func TestInferDestructureBorrowUnion(t *testing.T) {
 			// One immutable member makes the whole mode immutable, so the write is rejected.
 			// The `{x}` test can only have matched the mutable member here, so a mode that
 			// narrowed with the members would accept it. peelBorrowUnion fixes the mode at the
-			// whole scrutinee instead, and its TODO tracks the imprecision.
+			// whole scrutinee instead, which is #1087. This row flips to a clean check there.
 			name: "mixed mutability binds immutable leaves",
 			src: `fn f(p: &mut {x: {a: number}} | &{y: string}) {
   if val {x: v} = p {

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -267,6 +267,32 @@ func TestInferDestructureBorrowUnion(t *testing.T) {
 			wantErrs: []string{"2:3-2:55: " + mixedOwnershipMsg},
 		},
 		{
+			// Borrowing the value the `else` supplies for `x` is what clears the mixed-ownership
+			// report on the row above. Both halves of the leaf are then borrows. The `&` has to
+			// be written, since an owned value never borrows itself into a join.
+			//
+			// The borrowed literal outlives nothing, so its lifetime stays anonymous while the
+			// scrutinee's half carries the join of the two member lifetimes.
+			name: "val else leaf join accepts a borrowed fallback field",
+			src: `fn f(p: &{x: {a: number}} | &{y: string}) {
+  val {x: v} = p else { {x: &{a: 1}} }
+  return v
+}`,
+			want: "fn <'a: 'c, 'b: 'c, 'c>(p: &'a {x: {a: number}} | &'b {y: string}) -> &'c {a: number} | &{a: 1}",
+		},
+		{
+			// Borrowing the whole object the `else` produced works as well as borrowing the one
+			// field. The borrow rides the fallback's binding mode down to the leaf, the same
+			// match ergonomics a borrowed scrutinee's leaves follow, so `v` binds the same type
+			// either way.
+			name: "val else leaf join accepts a borrow of the whole fallback",
+			src: `fn f(p: &{x: {a: number}} | &{y: string}) {
+  val {x: v} = p else { &{x: {a: 1}} }
+  return v
+}`,
+			want: "fn <'a: 'c, 'b: 'c, 'c>(p: &'a {x: {a: number}} | &'b {y: string}) -> &'c {a: number} | &{a: 1}",
+		},
+		{
 			// The fallback is an owned object, but the value it supplies for `x` is a borrow, so
 			// both halves of the leaf are borrows and ownership is uniform.
 			name: "val else leaf join accepts a fallback field that is a borrow",

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/dep_graph"
 	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
@@ -134,6 +135,242 @@ func TestInferRefUnion(t *testing.T) {
 			require.Equal(t, tc.want, values["f"])
 		})
 	}
+}
+
+// TestInferDestructureBorrowUnion pins what a pattern binds when it takes apart a scrutinee
+// whose type is a union of borrows. Such a union carries no outermost borrow, so the peel
+// runs per member: the leaves project out of the peeled members and reach their borrow
+// through the binding mode, exactly as they do under a single `&{…}` scrutinee.
+//
+// Every refutable form is covered, since each seeds the same path binder. Without the peel
+// a leaf projects out of `&{x: number}` itself and the owned requirement that projection
+// emits reads as a borrow escaping, which is issue #1084.
+func TestInferDestructureBorrowUnion(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		want     string   // rendered type of values["f"] when wantErrs is nil
+		wantErrs []string // exact diagnostics; nil means the source must check cleanly
+	}{
+		{
+			name: "val else over a borrow union",
+			src: `fn f(p: &{x: number} | &{y: string}) {
+  val {x: v} = p else { return 0 }
+  return v
+}`,
+			want: "fn (p: &{x: number} | &{y: string}) -> number",
+		},
+		{
+			name: "match over a borrow union",
+			src: `fn f(p: &{x: number} | &{y: string}) {
+  return match p {
+    {x: v} => v,
+    _ => 0,
+  }
+}`,
+			want: "fn (p: &{x: number} | &{y: string}) -> number",
+		},
+		{
+			name: "if val over a borrow union",
+			src: `fn f(p: &{x: number} | &{y: string}) {
+  return if val {x: v} = p { v } else { 0 }
+}`,
+			want: "fn (p: &{x: number} | &{y: string}) -> number",
+		},
+		{
+			// A function parameter is destructured through bindPattern rather than through the
+			// path binder, so it takes the same peel from the other end. The pattern is
+			// irrefutable, so nothing narrows the union and `x` reads through both members,
+			// picking up the `undefined` the member without it answers.
+			name: "destructured parameter of a borrow union",
+			src:  `fn f({x: v}: &{x: number} | &{y: string}) { return v }`,
+			want: "fn ({x: v}: &{x: number} | &{y: string}) -> number | undefined",
+		},
+		{
+			// Every member is mutable, so the mode is too and the leaf stays writable.
+			name: "mut borrow union leaves stay writable",
+			src: `fn f(p: &mut {x: {a: number}} | &mut {y: string}) {
+  if val {x: v} = p {
+    v.a = 2
+  }
+  return 0
+}`,
+			want: "fn (p: &mut {x: {a: number}} | &mut {y: string}) -> 0",
+		},
+		{
+			// A leaf reached through an immutable member cannot be written, so the write is
+			// rejected rather than silently going through the mutable member.
+			name: "immutable borrow union leaves reject a write",
+			src: `fn f(p: &{x: {a: number}} | &{y: string}) {
+  if val {x: v} = p {
+    v.a = 2
+  }
+  return 0
+}`,
+			wantErrs: []string{"3:5-3:12: cannot constrain immutable object <: mutable object"},
+		},
+		{
+			// One immutable member makes the whole mode immutable, since a leaf the value may
+			// have reached through that member is not writable.
+			name: "mixed mutability binds immutable leaves",
+			src: `fn f(p: &mut {x: {a: number}} | &{y: string}) {
+  if val {x: v} = p {
+    v.a = 2
+  }
+  return 0
+}`,
+			wantErrs: []string{"3:5-3:12: cannot constrain immutable object <: mutable object"},
+		},
+		{
+			name: "tuple destructure over a borrow union",
+			src: `fn f(p: &[number, number] | &[string]) {
+  return match p {
+    [a, b] => a,
+    _ => 0,
+  }
+}`,
+			want: "fn (p: &[number, number] | &[string]) -> number",
+		},
+		{
+			// A leaf of the borrowed initializer names a place inside it, and the fallback is a
+			// fresh owned value, so the two cannot join. The declaration reports it rather than
+			// leaving the author to meet the mismatch at a later write through the name.
+			name: "val else leaf join rejects a mixed-ownership fallback",
+			src: `fn f(p: &{x: {a: number}} | &{y: string}) {
+  val {x: v} = p else { {x: {a: 1}} }
+  return 0
+}`,
+			wantErrs: []string{"2:3-2:38: " + mixedOwnershipMsg},
+		},
+		{
+			// Each leaf a pattern binds joins separately and every join blames the whole
+			// declaration, so the two mixed leaves here report it once.
+			name: "val else reports a mixed-ownership declaration once",
+			src: `fn f(p: &{x: {a: number}, y: {b: number}} | &{z: string}) {
+  val {x: v, y: w} = p else { {x: {a: 1}, y: {b: 2}} }
+  return 0
+}`,
+			wantErrs: []string{"2:3-2:55: " + mixedOwnershipMsg},
+		},
+		{
+			// Both sides of the join are borrows, so ownership is uniform and the leaf binds
+			// the union of the two.
+			name: "val else leaf join accepts a borrowed fallback",
+			src: `fn f(p: &{x: {a: number}} | &{y: string}, q: &{a: number}) {
+  val {x: v} = p else { {x: q} }
+  return v
+}`,
+			want: "fn <'a: 'd, 'b: 'd, 'c, 'd>(p: &'a {x: {a: number}} | &'b {y: string}, q: &'c {a: number}) -> &'c {a: number} | &'d {a: number}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			if tc.wantErrs != nil {
+				require.Equal(t, tc.wantErrs, messagesWithSpan(errs))
+				return
+			}
+			require.Empty(t, errs)
+			require.Equal(t, tc.want, values["f"])
+		})
+	}
+}
+
+// TestBorrowUnionLeafBindsAsBorrow pins the type ONE leaf of a borrow union binds at. Each
+// source destructures `p` into `v`, and the assertion is on `v` itself rather than on the
+// function's rendered type, which the surrounding returns would otherwise widen.
+//
+// A borrowable leaf carries the mode's borrow, so it renders under an `&`. The rows that do
+// not peel are here to bound the rule: a union is peeled only when every member is a borrow
+// carrying a lifetime.
+func TestBorrowUnionLeafBindsAsBorrow(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string // rendered type of the leaf named `v`
+	}{
+		{
+			name: "immutable members give an immutable leaf",
+			src: `fn f(p: &{x: {a: number}} | &{y: string}) {
+  val {x: v} = p else { return 0 }
+  return 0
+}`,
+			want: "&{a: number}",
+		},
+		{
+			name: "mutable members give a mutable leaf",
+			src: `fn f(p: &mut {x: {a: number}} | &mut {y: string}) {
+  val {x: v} = p else { return 0 }
+  return 0
+}`,
+			want: "&mut {a: number}",
+		},
+		{
+			// An owned-mutable `mut {…}` cell carries no lifetime, so it is a value rather than
+			// a borrow and its leaves move out.
+			name: "owned-mutable members are not peeled",
+			src: `fn f(p: mut {x: {a: number}} | mut {y: string}) {
+  val {x: v} = p else { return 0 }
+  return 0
+}`,
+			want: "{a: number}",
+		},
+		{
+			// One owned member leaves no single borrow to lift out, so the scrutinee binds owned.
+			// Both members carry `x`, so no tag test narrows the union and the leaf reads both.
+			name: "a union holding an owned member is not peeled",
+			src: `fn f(p: &{x: {a: number}} | {x: {b: string}}) {
+  val {x: v} = p else { return 0 }
+  return 0
+}`,
+			want: "{a: number} | {b: string}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			module := parseModule(t, tc.src)
+			c := newChecker()
+			c.inferDepGraph(sharedPrelude().Child(), 0, module, dep_graph.BuildDepGraph(module))
+			require.Empty(t, messagesWithSpan(c.errs))
+			leaf := findIdentPat(module, "v")
+			require.NotNil(t, leaf)
+			require.Equal(t, tc.want, soltype.Print(coalesce(c.info.TypeOf(leaf), soltype.Positive)))
+		})
+	}
+}
+
+// TestBorrowUnionLeafLifetime pins the lifetime a leaf of a borrow union carries. The
+// members have no one lifetime between them, so the mode takes their join: a fresh lifetime
+// each member's is bounded above, which is what keeps a leaf from outliving the member it
+// may have been projected from. joinBorrows unites a set of returned borrows the same way.
+//
+// Each source returns the leaf from the only branch that returns anything, so the function's
+// return type IS the leaf's and the signature shows the outlives bounds.
+func TestBorrowUnionLeafLifetime(t *testing.T) {
+	t.Run("distinct member lifetimes take a join", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f(p: &{x: {a: number}} | &{y: string}) {
+  if val {x: v} = p {
+    return v
+  }
+}`)
+		require.Empty(t, errs)
+		// 'c is the join, with the two member lifetimes bounded above it.
+		require.Equal(t,
+			"fn <'a: 'c, 'b: 'c, 'c>(p: &'a {x: {a: number}} | &'b {y: string}) -> &'c {a: number}",
+			values["f"])
+	})
+
+	t.Run("one shared member lifetime needs no join", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f<'a>(p: &'a {x: {a: number}} | &'a {y: string}) {
+  if val {x: v} = p {
+    return v
+  }
+}`)
+		require.Empty(t, errs)
+		require.Equal(t,
+			"fn <'a>(p: &'a {x: {a: number}} | &'a {y: string}) -> &'a {a: number}",
+			values["f"])
+	})
 }
 
 // TestConstrainRefUnion pins the variance of a borrow over a union pointee at the

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -198,6 +198,18 @@ func TestInferDestructureBorrowUnion(t *testing.T) {
 			want: "fn (p: &mut {x: {a: number}} | &mut {y: string}) -> 0",
 		},
 		{
+			// A write through a leaf that several surviving members reach is accepted too, since
+			// the leaf carries the mutable mode rather than being moved out immutable.
+			name: "mut leaf of several surviving members is writable",
+			src: `fn f(p: &mut {x: {a: number}} | &mut {x: {a: number}, y: string}) {
+  if val {x: v} = p {
+    v.a = 2
+  }
+  return 0
+}`,
+			want: "fn (p: &mut {x: {a: number}} | &mut {x: {a: number}, y: string}) -> 0",
+		},
+		{
 			// A leaf reached through an immutable member cannot be written, so the write is
 			// rejected rather than silently going through the mutable member.
 			name: "immutable borrow union leaves reject a write",
@@ -304,6 +316,37 @@ func TestBorrowUnionLeafBindsAsBorrow(t *testing.T) {
   return 0
 }`,
 			want: "&mut {a: number}",
+		},
+		{
+			// Both members carry `x`, so the object test narrows nothing away and the leaf reads
+			// a union. Deciding whether to borrow needs that union's field shape, which is the
+			// union of what each member holds at `x`.
+			name: "a leaf of several surviving members stays borrowed",
+			src: `fn f(p: &{x: {a: number}} | &{x: {b: string}}) {
+  val {x: v} = p else { return 0 }
+  return 0
+}`,
+			want: "&({a: number} | {b: string})",
+		},
+		{
+			// A member that is itself a union flattens into the peeled union, so narrowing sees
+			// its members rather than one nested node it cannot look inside.
+			name: "a union member flattens into the peel",
+			src: `fn f(p: &({x: {a: number}} | {x: {b: number}}) | &{x: {c: number}}) {
+  val {x: v} = p else { return 0 }
+  return 0
+}`,
+			want: "&({a: number} | {b: number} | {c: number})",
+		},
+		{
+			// A tuple element takes the same elementwise read an object field does, so an element
+			// of several surviving members is borrowed rather than moved out.
+			name: "a tuple element of several surviving members stays borrowed",
+			src: `fn f(p: &[{a: number}, string] | &[{b: number}, string]) {
+  val [v, s] = p else { return 0 }
+  return 0
+}`,
+			want: "&({a: number} | {b: number})",
 		},
 		{
 			// An owned-mutable `mut {…}` cell carries no lifetime, so it is a value rather than

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -160,22 +160,15 @@ func (c *checker) scrutineeBinding(lvl int, scrutinee soltype.Type) (soltype.Typ
 // `&mut {x: …} | &{y: …}` testing for `x` binds immutable leaves and rejects a legal write.
 func (c *checker) peelBorrowUnion(lvl int, t soltype.Type) (soltype.Type, bindMode, bool) {
 	u, isUnion := t.(*soltype.UnionType)
-	if !isUnion || u.Inexact || len(u.Types) == 0 {
+	if !isUnion || u.Inexact {
 		return nil, bindMode{}, false
 	}
-	inners := make([]soltype.Type, len(u.Types))
-	lts := make([]soltype.Lifetime, len(u.Types))
-	mut := true
-	for i, member := range u.Types {
-		r, isRef := member.(*soltype.RefType)
-		if !isRef || r.Lt == nil {
-			return nil, bindMode{}, false
-		}
-		inners[i], lts[i] = r.Inner, r.Lt
-		mut = mut && r.Mut
+	inners, lts, allMut, ok := soltype.UnwrapRefs(u.Types)
+	if !ok {
+		return nil, bindMode{}, false
 	}
 	borrow := bmImm
-	if mut {
+	if allMut {
 		borrow = bmMut
 	}
 	// The peel goes through the lattice's one union constructor, so a member that is itself

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -69,6 +69,15 @@ const (
 	forProjection
 )
 
+// leafMut reports whether a leaf's `mut` marker applies at this walk. A projection walk
+// answers false however the leaf was written, for two reasons. The marker's only effect on
+// an owned scrutinee is to thaw the leaf into a cell, which is a binding's business and not
+// a projection's. Against a borrowed one it reports MutLeafThroughSharedBorrowError, which
+// the binding walk over the same pattern already reported.
+func leafMut(marked bool, purpose bindPurpose) bool {
+	return marked && purpose == forBinding
+}
+
 // defineLeafMono is the default leaf-placement strategy: it defines the leaf as a
 // monomorphic projection of the scrutinee. Used by every body-level and
 // function-param destructuring path.
@@ -252,8 +261,8 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		t := scrutinee
 		if purpose == forBinding {
 			t = c.applyLeafExtras(scope, lvl, p, scrutinee, p.TypeAnn, p.Default)
-			t = c.applyBindMode(lvl, p, p.Mutable, t, c.concreteLeaf(concrete, p.TypeAnn), scrutineeMode)
 		}
+		t = c.applyBindMode(lvl, p, leafMut(p.Mutable, purpose), t, c.concreteLeaf(concrete, p.TypeAnn), scrutineeMode)
 		c.bindLeaf(scope, p.Name, t, p, leafTypes, emit, purpose)
 		return &soltype.IdentPat{Name: p.Name}
 
@@ -340,8 +349,8 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				var t soltype.Type = beta
 				if purpose == forBinding {
 					t = c.applyLeafExtras(scope, lvl, e, beta, e.TypeAnn, e.Default)
-					t = c.applyBindMode(lvl, e, e.Mutable, t, c.concreteLeaf(fieldConcrete(concrete, e.Key.Name), e.TypeAnn), scrutineeMode)
 				}
+				t = c.applyBindMode(lvl, e, leafMut(e.Mutable, purpose), t, c.concreteLeaf(fieldConcrete(concrete, e.Key.Name), e.TypeAnn), scrutineeMode)
 				c.bindLeaf(scope, e.Key.Name, t, e, leafTypes, emit, purpose)
 				named.Add(e.Key.Name)
 				fields = append(fields, &soltype.ObjectPatField{

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -147,27 +147,17 @@ func (c *checker) scrutineeBinding(lvl int, scrutinee soltype.Type) (soltype.Typ
 // peelBorrowUnion peels a union whose every member is a borrow into the union of the
 // members' carriers, plus the mode a leaf of that union binds through. So
 // `&'a {x: number} | &'b {y: string}` peels to `{x: number} | {y: string}`, and a leaf
-// projects out of an owned member while the borrow rides the mode exactly as it does for
-// a single `&{…}` scrutinee. Without the peel a leaf projects out of `&'a {x: number}`
-// itself, and the owned requirement that projection emits reads as a borrow escaping into
-// an owned destination.
+// projects out of an owned member while the borrow rides the mode.
 //
-// ok is false for every other type. A union holding one non-borrow member has no single
-// borrow to lift out, and an owned-mutable `mut {…}` cell carries no lifetime, so its
-// leaves move out rather than projecting a borrow. An INEXACT union is refused too. Only
-// its listed members are there to inspect, so its open tail may hold an owned member the
-// peel would wrongly claim as a borrow.
+// ok is false for every other type, including a union holding one non-borrow member, an
+// owned-mutable `mut {…}` cell, and an INEXACT union whose unlisted tail may be owned.
 //
-// The mode is mutable only when every member is, since a leaf reached through an
-// immutable member cannot be written. Its lifetime is the join of the members', which
-// joinLifetimes bounds below by each, so a leaf outlives none of the members it may have
-// been projected from.
+// The mode is mutable only when every member is, since a leaf reached through an immutable
+// member cannot be written. Its lifetime is the members' join.
 //
-// TODO: narrow the mode along with the members. The mode is fixed here, at the whole
-// scrutinee, before any branch's tag test drops members from it. A branch of
-// `&mut {x: …} | &{y: …}` that tests for `x` can only have matched the mutable member, yet
-// its leaves still bind immutable and a write through one is rejected. Rejecting a legal
-// write is the safe direction to be wrong in, but it is still wrong.
+// TODO(#1087): narrow the mode along with the members. It is fixed here, at the whole
+// scrutinee, before any branch's tag test drops members from it, so a branch of
+// `&mut {x: …} | &{y: …}` testing for `x` binds immutable leaves and rejects a legal write.
 func (c *checker) peelBorrowUnion(lvl int, t soltype.Type) (soltype.Type, bindMode, bool) {
 	u, isUnion := t.(*soltype.UnionType)
 	if !isUnion || u.Inexact || len(u.Types) == 0 {
@@ -571,15 +561,14 @@ func (c *checker) restTupleShape(scrutinee soltype.Type, scrutTup, concreteTup *
 }
 
 // concreteTupleShape resolves the statically known tuple a destructured leaf reads its
-// element out of, and nil for a type that fixes no element. A tuple grounds through
-// groundedTuple. A union of tuples grounds to the elementwise union of theirs, which is the
-// shape a leaf reads when narrowing left the scrutinee as several members. So a `[a, b]`
-// over `&[{p: number}, string] | &[{q: number}, string]` reads its first element as
-// `{p: number} | {q: number}` and borrows it, rather than reading no shape and moving it out.
+// element out of, and nil for a type that fixes no element. It is the tuple twin of
+// fieldConcrete's union arm: a tuple grounds through groundedTuple, and a union of tuples
+// grounds to the elementwise union of theirs. So `[a, b]` over
+// `&[{p: number}, string] | &[{q: number}, string]` reads its first element as
+// `{p: number} | {q: number}` and borrows it rather than moving it out.
 //
 // The members must agree on arity, since one element position has to name one type. An
-// inexact member fixes no arity, and neither does an inexact union whose open tail may hold
-// a tuple of any length.
+// inexact member or union fixes no arity at all.
 func (c *checker) concreteTupleShape(t soltype.Type) *soltype.TupleType {
 	if tup, ok := c.groundedTuple(t); ok {
 		return tup

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -186,31 +186,7 @@ func (c *checker) peelBorrowUnion(lvl int, t soltype.Type) (soltype.Type, bindMo
 	// No Context, so subsumption does not run. It trials one member against another under a
 	// probe and drops the subtype, which would change the member set narrowing reads.
 	peeled := newUnion(nil, inners, false)
-	return peeled, bindMode{borrow: borrow, lt: c.joinLifetimes(lvl, lts)}, true
-}
-
-// joinLifetimes returns one lifetime that every member of lts outlives, so a value drawn
-// from any of them may carry it. Several distinct lifetimes unite under a fresh join
-// variable holding each of them as a lower bound. lts must not be empty.
-//
-// Where lts names one lifetime already, that lifetime is returned unchanged and the common
-// `&'a A | &'a B` mints no join variable.
-func (c *checker) joinLifetimes(lvl int, lts []soltype.Lifetime) soltype.Lifetime {
-	shared := true
-	for _, lt := range lts[1:] {
-		if !soltype.ContainsLifetime(lts[:1], lt) {
-			shared = false
-			break
-		}
-	}
-	if shared {
-		return lts[0]
-	}
-	joinLt := c.ctx.freshJoinLifetime(lvl)
-	for _, lt := range lts {
-		c.ctx.constrainLt(lt, joinLt)
-	}
-	return joinLt
+	return peeled, bindMode{borrow: borrow, lt: c.ctx.joinLifetimes(lvl, lts)}, true
 }
 
 // bindPatternWith is bindPattern parameterized by the leaf-placement strategy. See

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -107,6 +107,9 @@ const (
 // borrow with a real lifetime is a reference. An owned-mutable cell has a nil lifetime
 // and is an owned value. Its leaves move out and take their own declared mutability
 // rather than projecting a borrow.
+//
+// A union whose members are all borrows carries no outermost borrow to read, so it takes
+// peelBorrowUnion instead. Callers reach both through scrutineeBinding.
 func bindModeOf(scrutinee soltype.Type) bindMode {
 	if r, ok := scrutinee.(*soltype.RefType); ok && r.Lt != nil {
 		if r.Mut {
@@ -117,12 +120,95 @@ func bindModeOf(scrutinee soltype.Type) bindMode {
 	return bindMode{borrow: bmOwned}
 }
 
+// scrutineeBinding splits a scrutinee into the two things a pattern walk needs from it:
+// the carrier its leaves project out of, and the mode they bind through. The carrier
+// never holds the borrow, since the mode records it instead.
+//
+// A single `&{…}` is peeled by CarrierOf and read by bindModeOf. A union of borrows has
+// no outermost borrow for either to see, so peelBorrowUnion peels it per member. Every
+// other scrutinee keeps CarrierOf's answer and binds owned.
+func (c *checker) scrutineeBinding(lvl int, scrutinee soltype.Type) (soltype.Type, bindMode) {
+	carrier := soltype.CarrierOf(scrutinee)
+	if inner, mode, ok := c.peelBorrowUnion(lvl, carrier); ok {
+		return inner, mode
+	}
+	return carrier, bindModeOf(scrutinee)
+}
+
+// peelBorrowUnion peels a union whose every member is a borrow into the union of the
+// members' carriers, plus the mode a leaf of that union binds through. So
+// `&'a {x: number} | &'b {y: string}` peels to `{x: number} | {y: string}`, and a leaf
+// projects out of an owned member while the borrow rides the mode exactly as it does for
+// a single `&{…}` scrutinee. Without the peel a leaf projects out of `&'a {x: number}`
+// itself, and the owned requirement that projection emits reads as a borrow escaping into
+// an owned destination.
+//
+// ok is false for every other type. A union holding one non-borrow member has no single
+// borrow to lift out, and an owned-mutable `mut {…}` cell carries no lifetime, so its
+// leaves move out rather than projecting a borrow.
+//
+// The mode is mutable only when every member is, since a leaf reached through an
+// immutable member cannot be written. Its lifetime is the join of the members', which
+// joinLifetimes bounds below by each, so a leaf outlives none of the members it may have
+// been projected from.
+func (c *checker) peelBorrowUnion(lvl int, t soltype.Type) (soltype.Type, bindMode, bool) {
+	u, isUnion := t.(*soltype.UnionType)
+	if !isUnion || len(u.Types) == 0 {
+		return nil, bindMode{}, false
+	}
+	inners := make([]soltype.Type, len(u.Types))
+	lts := make([]soltype.Lifetime, len(u.Types))
+	mut := true
+	for i, member := range u.Types {
+		r, isRef := member.(*soltype.RefType)
+		if !isRef || r.Lt == nil {
+			return nil, bindMode{}, false
+		}
+		inners[i], lts[i] = r.Inner, r.Lt
+		mut = mut && r.Mut
+	}
+	borrow := bmImm
+	if mut {
+		borrow = bmMut
+	}
+	// The peeled union keeps the original's open tail. An inexact union's tail member may
+	// itself be a borrow the listed members do not name, and dropping the tail would narrow
+	// the scrutinee to the members that happen to be written out.
+	peeled := &soltype.UnionType{Types: inners, Inexact: u.Inexact}
+	return peeled, bindMode{borrow: borrow, lt: c.joinLifetimes(lvl, lts)}, true
+}
+
+// joinLifetimes returns the one lifetime that outlives no member of lts. Several distinct
+// lifetimes unite under a fresh join variable bounded below by each, which is what lets a
+// value drawn from any of them carry a single lifetime. lts must not be empty.
+//
+// A set that already names one lifetime returns it unchanged, so the common
+// `&'a A | &'a B` needs no join variable.
+func (c *checker) joinLifetimes(lvl int, lts []soltype.Lifetime) soltype.Lifetime {
+	shared := true
+	for _, lt := range lts[1:] {
+		if !soltype.ContainsLifetime(lts[:1], lt) {
+			shared = false
+			break
+		}
+	}
+	if shared {
+		return lts[0]
+	}
+	joinLt := c.ctx.freshJoinLifetime(lvl)
+	for _, lt := range lts {
+		c.ctx.constrainLt(lt, joinLt)
+	}
+	return joinLt
+}
+
 // bindPatternWith is bindPattern parameterized by the leaf-placement strategy. See
 // bindPattern for the pattern-typing contract. The emit decides where each bound
 // leaf lands. The binding mode is derived from the scrutinee here and threaded into
 // the recursive walk so nested leaves inherit the scrutinee's borrow.
 func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type, emit leafEmit, purpose bindPurpose) soltype.Pat {
-	return c.bindPatMode(scope, lvl, pat, scrutinee, soltype.CarrierOf(scrutinee), bindModeOf(scrutinee), leafTypes, emit, purpose)
+	carrier, mode := c.scrutineeBinding(lvl, scrutinee)
+	return c.bindPatMode(scope, lvl, pat, carrier, carrier, mode, leafTypes, emit, purpose)
 }
 
 // projectLeaves resolves each leaf pat names out of scrutinee and reports it to found. It
@@ -133,7 +219,8 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 // flowed into scrutinee passes that value here, so a `...rest` leaf resolves the leftover
 // members it really has rather than an opaque `{...}`.
 func (c *checker) projectLeaves(scope *Scope, lvl int, pat ast.Pat, scrutinee, concrete soltype.Type, found leafEmit) {
-	c.bindPatMode(scope, lvl, pat, scrutinee, concrete, bindModeOf(concrete), nil, found, forProjection)
+	shape, mode := c.scrutineeBinding(lvl, concrete)
+	c.bindPatMode(scope, lvl, pat, scrutinee, shape, mode, nil, found, forProjection)
 }
 
 // bindPatMode is bindPatternWith's recursive core, carrying the binding mode the

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -145,7 +145,7 @@ func (c *checker) scrutineeBinding(lvl int, scrutinee soltype.Type) (soltype.Typ
 //
 // ok is false for every other type. A union holding one non-borrow member has no single
 // borrow to lift out, and an owned-mutable `mut {…}` cell carries no lifetime, so its
-// leaves move out rather than projecting a borrow. An INEXACT union is refused too: only
+// leaves move out rather than projecting a borrow. An INEXACT union is refused too. Only
 // its listed members are there to inspect, so its open tail may hold an owned member the
 // peel would wrongly claim as a borrow.
 //
@@ -153,6 +153,12 @@ func (c *checker) scrutineeBinding(lvl int, scrutinee soltype.Type) (soltype.Typ
 // immutable member cannot be written. Its lifetime is the join of the members', which
 // joinLifetimes bounds below by each, so a leaf outlives none of the members it may have
 // been projected from.
+//
+// TODO: narrow the mode along with the members. The mode is fixed here, at the whole
+// scrutinee, before any branch's tag test drops members from it. A branch of
+// `&mut {x: …} | &{y: …}` that tests for `x` can only have matched the mutable member, yet
+// its leaves still bind immutable and a write through one is rejected. Rejecting a legal
+// write is the safe direction to be wrong in, but it is still wrong.
 func (c *checker) peelBorrowUnion(lvl int, t soltype.Type) (soltype.Type, bindMode, bool) {
 	u, isUnion := t.(*soltype.UnionType)
 	if !isUnion || u.Inexact || len(u.Types) == 0 {
@@ -184,12 +190,12 @@ func (c *checker) peelBorrowUnion(lvl int, t soltype.Type) (soltype.Type, bindMo
 	return peeled, bindMode{borrow: borrow, lt: c.joinLifetimes(lvl, lts)}, true
 }
 
-// joinLifetimes returns the one lifetime that outlives no member of lts. Several distinct
-// lifetimes unite under a fresh join variable bounded below by each, which is what lets a
-// value drawn from any of them carry a single lifetime. lts must not be empty.
+// joinLifetimes returns one lifetime that every member of lts outlives, so a value drawn
+// from any of them may carry it. Several distinct lifetimes unite under a fresh join
+// variable holding each of them as a lower bound. lts must not be empty.
 //
-// A set that already names one lifetime returns it unchanged, so the common
-// `&'a A | &'a B` needs no join variable.
+// Where lts names one lifetime already, that lifetime is returned unchanged and the common
+// `&'a A | &'a B` mints no join variable.
 func (c *checker) joinLifetimes(lvl int, lts []soltype.Lifetime) soltype.Lifetime {
 	shared := true
 	for _, lt := range lts[1:] {
@@ -563,8 +569,8 @@ func (c *checker) restTupleShape(scrutinee soltype.Type, scrutTup, concreteTup *
 // `{p: number} | {q: number}` and borrows it, rather than reading no shape and moving it out.
 //
 // The members must agree on arity, since one element position has to name one type. An
-// inexact member, or an inexact union whose open tail names no elements at all, fixes no
-// arity either.
+// inexact member fixes no arity, and neither does an inexact union whose open tail may hold
+// a tuple of any length.
 func (c *checker) concreteTupleShape(t soltype.Type) *soltype.TupleType {
 	if tup, ok := c.groundedTuple(t); ok {
 		return tup
@@ -1124,9 +1130,9 @@ func fieldConcrete(t soltype.Type, name string) soltype.Type {
 		}
 	case *soltype.UnionType:
 		// A union of objects knows the field's shape as the union of what each member holds
-		// there. Reading it is what lets a leaf of a scrutinee that narrowing left as several
-		// members still decide whether to borrow. An inexact union's open tail may carry the
-		// field at any type, so its shape is not known and the switch falls through to nil.
+		// there. Reading it is what lets a leaf still decide whether to borrow when narrowing
+		// left the scrutinee as several members. An inexact union's open tail may carry the
+		// field at any type, so its shape is not known and the read answers nil.
 		if t.Inexact {
 			return nil
 		}

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -145,7 +145,9 @@ func (c *checker) scrutineeBinding(lvl int, scrutinee soltype.Type) (soltype.Typ
 //
 // ok is false for every other type. A union holding one non-borrow member has no single
 // borrow to lift out, and an owned-mutable `mut {…}` cell carries no lifetime, so its
-// leaves move out rather than projecting a borrow.
+// leaves move out rather than projecting a borrow. An INEXACT union is refused too: only
+// its listed members are there to inspect, so its open tail may hold an owned member the
+// peel would wrongly claim as a borrow.
 //
 // The mode is mutable only when every member is, since a leaf reached through an
 // immutable member cannot be written. Its lifetime is the join of the members', which
@@ -153,7 +155,7 @@ func (c *checker) scrutineeBinding(lvl int, scrutinee soltype.Type) (soltype.Typ
 // been projected from.
 func (c *checker) peelBorrowUnion(lvl int, t soltype.Type) (soltype.Type, bindMode, bool) {
 	u, isUnion := t.(*soltype.UnionType)
-	if !isUnion || len(u.Types) == 0 {
+	if !isUnion || u.Inexact || len(u.Types) == 0 {
 		return nil, bindMode{}, false
 	}
 	inners := make([]soltype.Type, len(u.Types))
@@ -171,10 +173,14 @@ func (c *checker) peelBorrowUnion(lvl int, t soltype.Type) (soltype.Type, bindMo
 	if mut {
 		borrow = bmMut
 	}
-	// The peeled union keeps the original's open tail. An inexact union's tail member may
-	// itself be a borrow the listed members do not name, and dropping the tail would narrow
-	// the scrutinee to the members that happen to be written out.
-	peeled := &soltype.UnionType{Types: inners, Inexact: u.Inexact}
+	// The peel goes through the lattice's one union constructor, so a member that is itself
+	// a union is flattened into the result. Building the node by hand would nest it, and
+	// narrowing reads only a union's top-level members, so `&({a} | {b}) | &{c}` would
+	// destructure as though `{a}` and `{b}` were not there.
+	//
+	// No Context, so subsumption does not run. It trials one member against another under a
+	// probe and drops the subtype, which would change the member set narrowing reads.
+	peeled := newUnion(nil, inners, false)
 	return peeled, bindMode{borrow: borrow, lt: c.joinLifetimes(lvl, lts)}, true
 }
 
@@ -446,7 +452,7 @@ func (c *checker) projectTuple(
 	// a nested level the scrutinee is the parent's element variable, so only the threaded
 	// concrete still carries the element shape a borrowed leaf must inspect to decide
 	// whether to borrow.
-	concreteTup, _ = c.groundedTuple(concrete)
+	concreteTup = c.concreteTupleShape(concrete)
 	// When the scrutinee is a concrete tuple, pin each αi's upper bound to the matching
 	// element. The requirement above gives αi the element only as a lower bound, which
 	// cannot reject a refutable literal sub-pattern of the wrong kind. The upper bound makes
@@ -547,6 +553,47 @@ func (c *checker) restTupleShape(scrutinee soltype.Type, scrutTup, concreteTup *
 		return nil, false
 	}
 	return c.groundedTuple(groundedCarrier(scrutinee))
+}
+
+// concreteTupleShape resolves the statically known tuple a destructured leaf reads its
+// element out of, and nil for a type that fixes no element. A tuple grounds through
+// groundedTuple. A union of tuples grounds to the elementwise union of theirs, which is the
+// shape a leaf reads when narrowing left the scrutinee as several members. So a `[a, b]`
+// over `&[{p: number}, string] | &[{q: number}, string]` reads its first element as
+// `{p: number} | {q: number}` and borrows it, rather than reading no shape and moving it out.
+//
+// The members must agree on arity, since one element position has to name one type. An
+// inexact member, or an inexact union whose open tail names no elements at all, fixes no
+// arity either.
+func (c *checker) concreteTupleShape(t soltype.Type) *soltype.TupleType {
+	if tup, ok := c.groundedTuple(t); ok {
+		return tup
+	}
+	u, isUnion := t.(*soltype.UnionType)
+	if !isUnion || u.Inexact || len(u.Types) == 0 {
+		return nil
+	}
+	members := make([]*soltype.TupleType, len(u.Types))
+	for i, member := range u.Types {
+		tup, ok := c.groundedTuple(member)
+		if !ok || tup.Inexact {
+			return nil
+		}
+		if i > 0 && len(tup.Elems) != len(members[0].Elems) {
+			return nil
+		}
+		members[i] = tup
+	}
+	elems := make([]soltype.Type, len(members[0].Elems))
+	for i := range elems {
+		at := make([]soltype.Type, len(members))
+		for j, m := range members {
+			at[j] = m.Elems[i]
+		}
+		// No Context, so subsumption does not run. See peelBorrowUnion.
+		elems[i] = newUnion(nil, at, false)
+	}
+	return &soltype.TupleType{Elems: elems}
 }
 
 // groundedTuple splices every `...P` spread into position so elements can be read by index,
@@ -1070,10 +1117,32 @@ func (c *checker) concreteLeaf(concrete soltype.Type, typeAnn ast.TypeAnn) solty
 // so it resolves a field even at a nested level where the scrutinee is a projection
 // variable. It is the object-pattern analogue of indexing a concrete tuple's elements.
 func fieldConcrete(t soltype.Type, name string) soltype.Type {
-	if o, ok := t.(*soltype.ObjectType); ok {
-		if prop, found := o.Prop(name); found {
+	switch t := t.(type) {
+	case *soltype.ObjectType:
+		if prop, found := t.Prop(name); found {
 			return prop.Type
 		}
+	case *soltype.UnionType:
+		// A union of objects knows the field's shape as the union of what each member holds
+		// there. Reading it is what lets a leaf of a scrutinee that narrowing left as several
+		// members still decide whether to borrow. An inexact union's open tail may carry the
+		// field at any type, so its shape is not known and the switch falls through to nil.
+		if t.Inexact {
+			return nil
+		}
+		fields := make([]soltype.Type, len(t.Types))
+		for i, member := range t.Types {
+			field := fieldConcrete(member, name)
+			if field == nil {
+				return nil
+			}
+			fields[i] = field
+		}
+		if len(fields) == 0 {
+			return nil
+		}
+		// No Context, so subsumption does not run. See peelBorrowUnion.
+		return newUnion(nil, fields, false)
 	}
 	return nil
 }

--- a/internal/solver/ucs_bind.go
+++ b/internal/solver/ucs_bind.go
@@ -120,17 +120,24 @@ type pathBinder struct {
 // `match`, `if val`, or `val … else`.
 func (c *checker) newPathBinder(lvl int, blame ast.Node, root *ucs.Scrutinee, rootType soltype.Type) *pathBinder {
 	b := &pathBinder{c: c, lvl: lvl, blame: blame, views: map[*ucs.Scrutinee]scrutineeView{}}
-	carrier := soltype.CarrierOf(rootType)
+	carrier, mode := c.scrutineeBinding(lvl, rootType)
 	// Snapshot the scrutinee's union structure before any branch binds. A literal test
 	// adds its literal as a lower bound on the scrutinee variable, so grounding again
 	// under a later branch would read that literal back as an extra union member and
 	// narrow against a member the user never wrote. inferMatch takes the same snapshot
 	// for the same reason.
 	shape := groundedCarrier(carrier)
+	// A root whose type is still an inference variable hides its union structure until the
+	// snapshot resolves it, so a union of borrows is peeled off the snapshot rather than off
+	// the variable. Both the bind target and the mode come from the peel, since a leaf must
+	// project out of an owned member and reach its borrow through the mode.
+	if inner, borrowed, ok := c.peelBorrowUnion(lvl, shape); ok {
+		carrier, shape, mode = inner, inner, borrowed
+	}
 	b.views[root] = scrutineeView{
 		ty:       carrier,
 		concrete: carrier,
-		mode:     bindModeOf(rootType),
+		mode:     mode,
 		shape:    shape,
 	}
 	return b


### PR DESCRIPTION
Fixes #1084

When a pattern destructures a union of borrows like `&{x: number} | &{y: string}`, the compiler now peels the union per-member so leaves project out of owned members while the borrow rides the binding mode. This matches the behavior of a single `&{…}` scrutinee and prevents the owned projection from reading as a borrow escaping into an owned destination.

**Key changes:**

- Added `scrutineeBinding` to split a scrutinee into its carrier and binding mode, routing borrow unions through a new `peelBorrowUnion` that lifts the borrow out of each member.
- `peelBorrowUnion` unites the members' carriers into a union and computes a binding mode whose mutability is the conjunction of all members' and whose lifetime is their join. The mode is fixed at the whole scrutinee before any branch narrows, which is sound but imprecise (see TODO in the implementation).
- Updated `bindPatternWith` and `projectLeaves` to use `scrutineeBinding` instead of calling `bindModeOf` directly.
- Extended `fieldConcrete` to handle unions of objects, so a leaf can still decide whether to borrow when narrowing left the scrutinee as several members.
- Added `concreteTupleShape` to resolve the elementwise union of tuple members' elements, mirroring the object-field logic.
- Added `joinLifetimes` to unite distinct member lifetimes under a fresh join variable bounded below by each, reusing the same logic `joinBorrows` applies to return-point joins.
- Updated `joinFallbackLeaves` to peel borrowed fallbacks the same way scrutinees are peeled, and added `fallbackLeaf.ownership()` to report the correct ownership for uniform-ownership checks when the fallback carries a borrow.
- Added `reportedMixedOwnership` to prevent duplicate MixedOwnershipError reports when a `val … else` pattern with multiple leaves joins them separately.
- Refactored `joinReturnPoints` to use a new `joinBranches` helper that both it and `joinFallbackLeaves` call.

**Test coverage:**

- `TestInferDestructureBorrowUnion` pins destructuring over borrow unions in all refutable forms (val else, match, if val) and parameter patterns, including mutability and mixed-ownership cases.
- `TestBorrowUnionLeafBindsAsBorrow` pins the type a single leaf binds at, covering immutable/mutable members, leaves of several surviving members, flattened nested unions, and tuple elements.
- `TestBorrowUnionLeafLifetime` pins the lifetime a leaf carries when members have distinct lifetimes (join) vs. a shared lifetime (no join).

https://claude.ai/code/session_01Jd7RkZBPQQMPp9EGyfSLK1