### PR TITLE
Check inherited members when a subclass redeclares them

### DIFF
--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -988,6 +988,16 @@ func newTypeSubst(typeParams []*soltype.TypeParam, typeArgs []soltype.Type, life
 	return s
 }
 
+// apply rewrites t through s, returning t unchanged when s is nil. A nil substitution is
+// what a caller with nothing to rewrite passes, so the call site stays a plain expression
+// rather than a branch.
+func (s *typeSubst) apply(t soltype.Type) soltype.Type {
+	if s == nil {
+		return t
+	}
+	return t.Accept(s, soltype.Positive)
+}
+
 // newClassSubst builds the substitution for one class instance. ct is that instance's
 // type, such as Box<5>, so its TypeArgs and LifetimeArgs are the concrete arguments each
 // of def's parameter vars maps to.

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -280,23 +280,25 @@ func (c *Context) Constrain(sub, super soltype.Type) []SolverError {
 //
 //   - object/object and tuple/tuple, which pin each named field or element the flag marks
 //     writable;
-//   - same-name class/class, whose nominal walk dispatches each type argument by the
-//     class's mutable-view variance vector;
+//   - class/class, whose nominal walk dispatches each type argument by the class's
+//     mutable-view variance vector;
 //   - class/object, which projects the class body and hands the flag to the object arm.
 //
-// Any other inner reaches no such arm, so the whole reverse constraint pins it. That
-// covers a type variable, two mismatched kinds, and one case worth naming: two classes
-// with DIFFERENT names, where the nominal walk decides `Sub <: Super` on the declared
-// extends edge alone. Nothing checks that a subclass redeclaring an inherited field keeps
-// it at the superclass's type, so widening `mut Sub` to `mut Super` would otherwise hand
-// out a write permission the subclass's own field may not accept. The reverse constraint
-// stands in for that missing check until escalier-lang/escalier#985 adds it.
+// A cross-name class pair is one of those arms. The nominal walk decides `Sub <: Super` on
+// the declared `extends` edge, and checkInheritedMembers is what makes that edge stand for
+// something. For every member Super declares as writable, it requires Sub to still offer a
+// write and to accept every value Super's declaration accepts. A write through `mut Super`
+// therefore lands somewhere Sub admits it, so `mut Sub <: mut Super` needs no reverse
+// constraint of its own.
+//
+// Any other inner reaches no such arm, so the whole reverse constraint pins it. That covers
+// a type variable and two mismatched kinds.
 //
 // Both sides are peeled through the transparent wrappers first, so a class or object
 // spelled through an alias dispatches the same way as the bare type it names.
 func (c *Context) needsResidualWriteBack(sub, sup soltype.Type) bool {
 	sub, sup = c.peelTransparent(sub), c.peelTransparent(sup)
-	switch sub := sub.(type) {
+	switch sub.(type) {
 	case *soltype.ObjectType:
 		_, ok := sup.(*soltype.ObjectType)
 		return !ok
@@ -304,10 +306,8 @@ func (c *Context) needsResidualWriteBack(sub, sup soltype.Type) bool {
 		_, ok := sup.(*soltype.TupleType)
 		return !ok
 	case *soltype.ClassType:
-		switch sup := sup.(type) {
-		case *soltype.ClassType:
-			return sub.Name != sup.Name // a cross-name pair rides the extends edge unchecked
-		case *soltype.ObjectType:
+		switch sup.(type) {
+		case *soltype.ClassType, *soltype.ObjectType:
 			return false
 		}
 		return true

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1588,18 +1588,7 @@ func memberReadContribution(obj *soltype.ObjectType, name string) (read soltype.
 	case *soltype.GetterElem:
 		return m.Type, true, false
 	case *soltype.MethodElem:
-		switch len(m.Signatures) {
-		case 0:
-			return &soltype.ErrorType{}, true, false
-		case 1:
-			return callableView(m.Signatures[0]), true, false
-		default:
-			arms := make([]soltype.Type, len(m.Signatures))
-			for i, sig := range m.Signatures {
-				arms[i] = callableView(sig)
-			}
-			return &soltype.IntersectionType{Types: arms}, true, false
-		}
+		return methodReadType(m), true, false
 	case *soltype.SetterElem:
 		return nil, false, true
 	}
@@ -1698,6 +1687,25 @@ func (c *Context) constrainObjMember(superElem soltype.ObjTypeElem, sub, sup *so
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
 }
 
+// methodReadType returns the value a read of a method member yields. A single signature reads
+// as its callable view, and an overload set as the intersection of its arms, so a caller must
+// satisfy every arm. Comparing intersections rather than arm against arm is what keeps a
+// comparison independent of the order the arms are written in. A member whose signature list
+// never landed reads as the error sentinel.
+func methodReadType(elem *soltype.MethodElem) soltype.Type {
+	switch len(elem.Signatures) {
+	case 0:
+		return &soltype.ErrorType{}
+	case 1:
+		return callableView(elem.Signatures[0])
+	}
+	arms := make([]soltype.Type, len(elem.Signatures))
+	for i, sig := range elem.Signatures {
+		arms[i] = callableView(sig)
+	}
+	return &soltype.IntersectionType{Types: arms}
+}
+
 // callableView returns a method signature as the callable value a member read yields:
 // the signature with its receiver dropped, since a method value binds no `self`. It is
 // the subtyping counterpart of memberValue's method projection.
@@ -1719,19 +1727,31 @@ func isNeverType(t soltype.Type) bool {
 }
 
 // skolemizeFuncBinder replaces ft's own type parameters with fresh skolems, so a term checked
-// against ft as a supertype must satisfy it for every instantiation. Each parameter's declared
-// bound becomes its skolem's Upper, seeded first so a bound naming a sibling reaches it. For
-// example `<T>(x: T) -> T` becomes `(x: sk) -> sk` for a fresh skolem sk, which `fn (x) {
-// return 5 }` fails but a polymorphic identity satisfies.
+// against ft as a supertype must satisfy it for every instantiation. `<T>(x: T) -> T` becomes
+// `(x: sk) -> sk` for a fresh skolem sk, which `fn (x) { return 5 }` fails but a polymorphic
+// identity satisfies.
 func (c *Context) skolemizeFuncBinder(ft *soltype.FuncType) *soltype.FuncType {
-	sks := make([]*soltype.SkolemType, len(ft.TypeParams))
-	args := make([]soltype.Type, len(ft.TypeParams))
-	for i, tp := range ft.TypeParams {
+	return substFuncBinder(ft, c.skolemizeParams(ft.TypeParams))
+}
+
+// skolemizeParams mints one fresh skolem per parameter and returns the substitution replacing
+// each parameter's variable with its own. A skolem is opaque and no constraint can bind it, so
+// whatever is checked through the result has to hold for every instantiation. An empty
+// parameter list yields an empty substitution rather than nil, so a caller can apply the
+// result unconditionally.
+//
+// Each parameter's declared constraint becomes its skolem's upper bound, seeded through the
+// same substitution so a bound naming a sibling reaches that sibling's skolem. A function's
+// own binder and a class's own parameters are skolemized alike.
+func (c *Context) skolemizeParams(params []*soltype.TypeParam) *typeSubst {
+	sks := make([]*soltype.SkolemType, len(params))
+	args := make([]soltype.Type, len(params))
+	for i, tp := range params {
 		sks[i] = c.freshSkolem(tp.Name)
 		args[i] = sks[i]
 	}
-	sub := newTypeSubst(ft.TypeParams, args, nil, nil)
-	for i, tp := range ft.TypeParams {
+	sub := newTypeSubst(params, args, nil, nil)
+	for i, tp := range params {
 		// resolveTypeParams records at most one upper bound per parameter, itself an
 		// IntersectionType for a `<T: A & B>` bound, so the first bound is the whole declared
 		// constraint.
@@ -1739,7 +1759,7 @@ func (c *Context) skolemizeFuncBinder(ft *soltype.FuncType) *soltype.FuncType {
 			sks[i].Upper = tp.Var.UpperBounds[0].Accept(sub, soltype.Positive)
 		}
 	}
-	return substFuncBinder(ft, sub)
+	return sub
 }
 
 // instantiateFuncBinder replaces ft's own type parameters with fresh inference vars at lvl, so

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -473,6 +473,54 @@ type TypeParamNotProducibleError struct {
 	Node  ast.Node
 }
 
+// IncompatibleOverrideError fires when a class redeclares a member its superclass chain
+// already declares, at a type an instance of the class cannot stand in for. The nominal
+// subtype rule decides `Dog <: Animal` on the declared `extends` edge alone, so a subclass
+// that gives an inherited field an unrelated type would otherwise contradict its own edge.
+// Given `class Animal { pos: {x: number} }` and `class Dog extends Animal { pos: {x:
+// number, y: number} }`, reading `pos` off a `Dog` through an `Animal`-typed binding hands
+// out a `{x: number, y: number}` typed as `{x: number}`.
+//
+// Member is the member's name, Class the subclass that redeclares it, and SuperClass the
+// ancestor that declares the member being overridden. SubType and SuperType are the two
+// types the override rule compared, subclass first. Position says which of a member's types
+// those are. It is "type" for the value the member carries and "throws type" for what
+// reaching the member may raise. Node is the redeclaring member's source.
+type IncompatibleOverrideError struct {
+	Member     string
+	Class      string
+	SuperClass string
+	Position   string
+	SubType    soltype.Type
+	SuperType  soltype.Type
+	Node       ast.Node
+}
+
+// OverrideFormMismatchError fires when a class redeclares an inherited member in a form the
+// inherited one does not admit. No subtype obligation covers any of these, so each is
+// rejected by naming the two forms:
+//
+//   - the two members are different kinds, such as a method where the superclass declares a
+//     field;
+//   - an inherited writable field is redeclared `readonly`, while the superclass view still
+//     writes through it;
+//   - an inherited required field is redeclared optional, while the superclass view still
+//     reads it as present;
+//   - an inherited member callable through a plain `self` is redeclared with a `mut self`
+//     receiver, which an immutable superclass reference cannot reach.
+//
+// Member is the member's name, Class the subclass, SuperClass the ancestor that declares the
+// member being overridden, and Form and SuperForm the two forms as the message spells them.
+// Node is the redeclaring member's source.
+type OverrideFormMismatchError struct {
+	Member     string
+	Class      string
+	SuperClass string
+	Form       string
+	SuperForm  string
+	Node       ast.Node
+}
+
 func (*CannotConstrainError) isSolverError()         {}
 func (*MutFieldError) isSolverError()                {}
 func (*ReadonlyFieldError) isSolverError()           {}
@@ -504,6 +552,8 @@ func (*NonClassSuperError) isSolverError()           {}
 func (*CannotExtendFinalClassError) isSolverError()  {}
 func (*VarianceMismatchError) isSolverError()        {}
 func (*TypeParamNotProducibleError) isSolverError()  {}
+func (*IncompatibleOverrideError) isSolverError()    {}
+func (*OverrideFormMismatchError) isSolverError()    {}
 
 // --- Per-operand blame (§3.5): each constraint kind follows its operands through
 // Prov on demand, falling back to its own site (where it keeps one) ---
@@ -673,6 +723,14 @@ func (e *VarianceMismatchError) Related() []ast.Span { return nil }
 
 func (e *TypeParamNotProducibleError) Span() ast.Span      { return e.Node.Span() }
 func (e *TypeParamNotProducibleError) Related() []ast.Span { return nil }
+
+// Both override diagnostics blame the redeclaring member's source, degrading to the zero
+// span when the class declares the name in a form that carries no node of its own.
+func (e *IncompatibleOverrideError) Span() ast.Span      { return spanOfNode(e.Node) }
+func (e *IncompatibleOverrideError) Related() []ast.Span { return nil }
+
+func (e *OverrideFormMismatchError) Span() ast.Span      { return spanOfNode(e.Node) }
+func (e *OverrideFormMismatchError) Related() []ast.Span { return nil }
 
 // spanOf blames op's own source node when that node lies *within* the constraint
 // site, and the site itself otherwise (or when op has no entry). The containment
@@ -2620,6 +2678,16 @@ func (e *VarianceMismatchError) Message() string {
 func (e *TypeParamNotProducibleError) Message() string {
 	return fmt.Sprintf("the body forces type parameter `%s` to `%s`, so it cannot stand for an arbitrary type",
 		e.Name, describe(e.Floor))
+}
+
+func (e *IncompatibleOverrideError) Message() string {
+	return fmt.Sprintf("class `%s` redeclares inherited member `%s` with %s `%s`, which is not compatible with `%s` declared by `%s`",
+		e.Class, e.Member, e.Position, soltype.Print(e.SubType), soltype.Print(e.SuperType), e.SuperClass)
+}
+
+func (e *OverrideFormMismatchError) Message() string {
+	return fmt.Sprintf("class `%s` redeclares inherited member `%s` as %s, but `%s` declares it as %s",
+		e.Class, e.Member, e.Form, e.SuperClass, e.SuperForm)
 }
 
 // describeBorrowInner renders the pointee of a borrow for a diagnostic. An immutable

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -126,6 +126,12 @@ type checker struct {
 	// than minting a second, unrelated set of parameter vars. A script class has no pre-pass,
 	// so it is absent here and inferClassDecl resolves its own.
 	classShells map[*ast.ClassDecl]*classShell
+
+	// pendingOverrides holds every class carrying an `extends` edge, each waiting to have
+	// the members it declares checked against the ones they override. The check is queued
+	// rather than run inside inferClassDecl because a subclass can be inferred before its
+	// superclass. queueInheritedMemberCheck spells that ordering out.
+	pendingOverrides []pendingOverrideCheck
 }
 
 // classShell carries the state preBindClassTypeParams resolved for one class declaration.

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -122,6 +122,12 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// sits under.
 	def.Variance, def.MutVariance = c.inferVariance(def, decl)
 
+	// Queue this class for the override check the driver runs once every class is inferred.
+	// The nominal subtype rule decides `Dog <: Animal` on the `extends` edge alone, so that
+	// check is what keeps a subclass from contradicting the edge with a member typed
+	// unrelated to the one it inherits.
+	c.queueInheritedMemberCheck(def, self, decl)
+
 	if quiet() && paramsClean {
 		c.reportUnusedTypeParams(typeParams, decl.TypeParams, classDeclTypes(def, ctorType))
 	}

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1308,34 +1308,30 @@ func TestInferClassMutVariance(t *testing.T) {
 		require.Len(t, errs, 1)
 		require.Equal(t, "cannot constrain string <: number", errs[0].Message())
 	})
-	t.Run("a mut subclass reference does not reach its superclass", func(t *testing.T) {
-		// A cross-name pair stays pinned by the RefType arm's residual write-back, so this
-		// widening is rejected even though the immutable one below is accepted. The
-		// nominal walk decides `Dog <: Animal` on the declared extends edge alone, and
-		// nothing checks that Dog's redeclared `pos` keeps the type Animal declares. Were
-		// the widening accepted, `reset` would store a `{x: number}` into a field Dog
-		// declares as `{x: number, y: number}`. Re-examine this once
-		// escalier-lang/escalier#985 checks an inherited member's type.
+	t.Run("a mut subclass reference reaches its superclass", func(t *testing.T) {
+		// The write `reset` performs lands on `pos`, and checkInheritedMembers makes a
+		// member Dog redeclares invariant against Animal's declaration whenever Animal's is
+		// writable. Every member reachable through `mut Animal` therefore holds the type
+		// Animal declares, so the widening is licensed. Dog's extra `breed` is unreachable
+		// through the Animal view, so adding it changes nothing.
 		_, _, errs := inferSource(t, `
 			class Animal {
 				pos: {x: number},
 				constructor(mut self, pos: {x: number}) { self.pos = pos },
 			}
 			class Dog extends Animal {
-				pos: {x: number, y: number},
-				constructor(mut self, pos: {x: number, y: number}) { self.pos = pos },
+				breed: string,
+				constructor(mut self, breed: string) { self.breed = breed },
 			}
 			fn reset(a: mut Animal) { a.pos = {x: 0} }
 			fn resetDog(d: mut Dog) { reset(d) }
 		`)
-		require.Len(t, errs, 1)
-		require.Equal(t, "cannot constrain Animal <: Dog", errs[0].Message())
+		require.Empty(t, errs)
 	})
 	t.Run("an immutable subclass reference reaches its superclass", func(t *testing.T) {
-		// The immutable widening is the one the extends edge does license. `describe` can
-		// only read through `a`, and every member Animal declares is one Dog carries, so
-		// no read can miss. The redeclared-member gap that blocks the `mut` case above
-		// cannot bite here, since reaching it needs a write.
+		// The immutable widening is licensed for the same reason with less to check.
+		// `describe` can only read through `a`, and every member Animal declares is one Dog
+		// carries, so no read can miss.
 		_, _, errs := inferSource(t, `
 			class Animal {
 				name: string,

--- a/internal/solver/inherit.go
+++ b/internal/solver/inherit.go
@@ -330,10 +330,20 @@ func isOptional(elem soltype.ObjTypeElem) bool {
 // receiverMut reports whether reaching a member needs a mutable reference to the instance.
 // A `mut self` receiver on a method, getter, or setter is what demands one. A field carries
 // no receiver, so it reads as false.
+//
+// An overload set is measured across every arm, so one `mut self` arm makes the whole member
+// demand a mutable reference. buildMemberSigs rejects a set whose arms disagree, but it
+// appends the offending arm all the same, so reading a single arm would answer by
+// declaration order on exactly the input that already disagrees.
 func receiverMut(elem soltype.ObjTypeElem) bool {
 	switch elem := elem.(type) {
 	case *soltype.MethodElem:
-		return len(elem.Signatures) > 0 && selfParamMut(elem.Signatures[0].SelfParam)
+		for _, sig := range elem.Signatures {
+			if selfParamMut(sig.SelfParam) {
+				return true
+			}
+		}
+		return false
 	case *soltype.GetterElem:
 		return selfParamMut(elem.SelfParam)
 	case *soltype.SetterElem:

--- a/internal/solver/inherit.go
+++ b/internal/solver/inherit.go
@@ -134,12 +134,14 @@ func (c *checker) checkOverriddenName(
 		if !declared || formWeakens(subHalf, superHalf) {
 			// The class either does not offer this half at all, or offers it on terms the
 			// inherited member does not impose. No type comparison applies to that, so name
-			// the two forms instead.
+			// the two forms instead. The form is read off whichever member the class declares
+			// under this name, since the half under discussion may have no member at all.
+			own, _ := def.Body.Member(name)
 			c.report(&OverrideFormMismatchError{
 				Member:     name,
 				Class:      self.Name,
 				SuperClass: owner.Name,
-				Form:       memberForm(firstNamed(def.Body, name)),
+				Form:       memberForm(own),
 				SuperForm:  memberForm(superHalf),
 				Node:       overrideBlame(blame, name, subHalf),
 			})
@@ -336,20 +338,7 @@ func halfType(elem soltype.ObjTypeElem, half memberHalf) soltype.Type {
 	case *soltype.SetterElem:
 		return elem.Param
 	case *soltype.MethodElem:
-		switch len(elem.Signatures) {
-		case 0:
-		case 1:
-			return callableView(elem.Signatures[0])
-		default:
-			// An overload set reads as the intersection of its arms, matching what
-			// memberReadContribution hands a caller. Comparing intersections rather than arm
-			// against arm keeps the check independent of the order the arms are written in.
-			arms := make([]soltype.Type, len(elem.Signatures))
-			for i, sig := range elem.Signatures {
-				arms[i] = callableView(sig)
-			}
-			return &soltype.IntersectionType{Types: arms}
-		}
+		return methodReadType(elem)
 	}
 	return &soltype.ErrorType{}
 }
@@ -401,18 +390,6 @@ func mutReceiverForm(base string, elem soltype.ObjTypeElem) string {
 	return base
 }
 
-// firstNamed returns the first member of obj called name, which a diagnostic falls back to
-// naming when the class offers none for the half under discussion. Callers reach it only for a
-// name obj carries, so the nil return is unreachable and renders as the generic form.
-func firstNamed(obj *soltype.ObjectType, name string) soltype.ObjTypeElem {
-	for _, elem := range obj.Elems {
-		if soltype.ObjElemName(elem) == name {
-			return elem
-		}
-	}
-	return nil
-}
-
 // overrideBlame returns the source node an override diagnostic points at, the declaration of
 // the member under discussion. It falls back to the other half's declaration, and then to nil,
 // which leaves the diagnostic on the zero span.
@@ -452,9 +429,10 @@ func instanceMemberNodes(decl *ast.ClassDecl) map[memberBlameKey]ast.Node {
 	return nodes
 }
 
-// skolemizeClassParams returns a substitution replacing a class's own type-parameter variables
-// with fresh skolems, or nil for a non-generic class. An obligation checked through it has to
-// hold for every instantiation rather than being satisfied by recording a bound. Given
+// skolemizeClassParams returns skolemizeParams over a class's own type parameters, or nil for
+// a non-generic class so the result can be applied through typeSubst.apply either way. An
+// obligation checked through it has to hold for every instantiation rather than being
+// satisfied by recording a bound. Given
 //
 //	class Box<T> { value: T, … }
 //	class StrBox<T> extends Box<T> { value: string, … }
@@ -462,28 +440,9 @@ func instanceMemberNodes(decl *ast.ClassDecl) map[memberBlameKey]ast.Node {
 // the obligation is `string <: T`. Against the bare parameter variable that records `string`
 // as a lower bound and reports nothing. Against a skolem it is rejected, which is what a
 // `StrBox<number>` read through `Box<number>` needs.
-//
-// Each parameter's declared constraint becomes its skolem's upper bound, seeded through the
-// same substitution so a bound naming a sibling reaches that sibling's skolem. This mirrors
-// skolemizeFuncBinder.
 func (c *Context) skolemizeClassParams(def *ClassDef) *typeSubst {
 	if len(def.TypeParams) == 0 {
 		return nil
 	}
-	sks := make([]*soltype.SkolemType, len(def.TypeParams))
-	args := make([]soltype.Type, len(def.TypeParams))
-	for i, tp := range def.TypeParams {
-		sks[i] = c.freshSkolem(tp.Name)
-		args[i] = sks[i]
-	}
-	subst := newTypeSubst(def.TypeParams, args, nil, nil)
-	for i, tp := range def.TypeParams {
-		// resolveTypeParams records at most one upper bound per parameter, itself an
-		// IntersectionType for a `<T: A & B>` bound, so the first bound is the whole
-		// declared constraint.
-		if len(tp.Var.UpperBounds) > 0 {
-			sks[i].Upper = tp.Var.UpperBounds[0].Accept(subst, soltype.Positive)
-		}
-	}
-	return subst
+	return c.skolemizeParams(def.TypeParams)
 }

--- a/internal/solver/inherit.go
+++ b/internal/solver/inherit.go
@@ -7,9 +7,8 @@ import (
 )
 
 // memberHalf is one direction of access to a named member: the read `a.f` performs, or the
-// write `a.f = …` performs. An override is checked one half at a time, because a class
-// splits the two across separate members whenever it declares a getter/setter pair, and a
-// `readonly` field carries the read alone.
+// write `a.f = …` performs. An override is checked one half at a time, since a getter/setter
+// pair splits the two across separate members and a `readonly` field carries the read alone.
 type memberHalf int
 
 const (
@@ -20,12 +19,10 @@ const (
 // subtypeGoal is one obligation a redeclared member owes the member it overrides. An access
 // half contributes one goal for the value it carries and one for what reaching it may raise.
 //
-// sub and super are the two operands constrain is called with. A write obligation is
-// contravariant, so there the inherited member's type is the sub operand. shownSub and
-// shownSuper are the same two types held the other way, subclass first, which is the order a
-// diagnostic names them in. position says which of a member's types they are, so the message
-// can distinguish a rejected value type from a rejected `throws`. subElem is the redeclared
-// member the diagnostic is blamed on, and owner the ancestor declaring the inherited one.
+// sub and super are constrain's operands, so a contravariant write obligation holds the
+// inherited type as sub. shownSub and shownSuper are that pair in declaration order, subclass
+// first, which is how a diagnostic names them. position distinguishes a rejected value type
+// from a rejected `throws`. owner is the ancestor declaring the inherited member.
 type subtypeGoal struct {
 	sub, super           soltype.Type
 	shownSub, shownSuper soltype.Type
@@ -34,17 +31,16 @@ type subtypeGoal struct {
 	owner                *soltype.ClassType
 }
 
-// memberBlameKey names one instance member of a class declaration, so a diagnostic about
-// that member can be blamed on the source it was written at. A getter and a setter may
-// share a name, so the setter half is keyed apart from every other kind.
+// memberBlameKey names one instance member of a class declaration, so a diagnostic can be
+// blamed on the source it was written at. A getter and a setter may share a name, so the
+// setter half is keyed apart from every other kind.
 type memberBlameKey struct {
 	name   string
 	setter bool
 }
 
-// pendingOverrideCheck is one subclass waiting to have its members checked against the
-// ones they override. def and self are the class's registered definition and nominal
-// handle, and decl the declaration a diagnostic is blamed on.
+// pendingOverrideCheck is one subclass waiting to have its members checked against the ones
+// they override.
 type pendingOverrideCheck struct {
 	def  *ClassDef
 	self *soltype.ClassType
@@ -55,12 +51,11 @@ type pendingOverrideCheck struct {
 // checked once every class the module declares is inferred.
 //
 // The check cannot run inside inferClassDecl. A class's superclass edge and body are filled
-// in at the class's VALUE key, while an `extends` clause registers a dependency on the
-// superclass's TYPE key alone. A subclass's value key is therefore free to be inferred
-// before its superclass's. Given `class Dog extends Pet` and `class Pet extends Animal`, the
-// driver reaches Dog while Pet still carries no superclass edge and no members. Running
-// every queued check after the last component removes that hazard, since by then each
-// ancestor's edge and body are final.
+// in at its VALUE key, while an `extends` clause registers a dependency on the superclass's
+// TYPE key alone, so a subclass's value key is free to be inferred first. Given `class Dog
+// extends Pet` and `class Pet extends Animal`, the driver reaches Dog while Pet still carries
+// no edge and no members. Running the queue after the last component removes that hazard,
+// since by then every ancestor is final.
 func (c *checker) queueInheritedMemberCheck(def *ClassDef, self *soltype.ClassType, decl *ast.ClassDecl) {
 	if def.Body == nil || len(def.Supers) == 0 {
 		return
@@ -81,28 +76,17 @@ func (c *checker) checkQueuedInheritedMembers() {
 // checkInheritedMembers checks every member a class declares against the same-named member
 // its superclass chain declares, and reports the ones an instance of the class cannot stand
 // in for. The nominal subtype rule decides `Dog <: Animal` on the declared `extends` edge
-// alone, so without this check a subclass can contradict its own superclass edge:
+// alone, so this is what stops a subclass contradicting that edge. IncompatibleOverrideError
+// spells out the case it catches. A name the chain does not carry is new rather than an
+// override, so it is skipped.
 //
-//	class Animal { pos: {x: number}, … }
-//	class Dog extends Animal { pos: {x: number, y: number}, … }
+// Telling a redeclaration from an inherited member rests on ClassDef.Body holding the class's
+// OWN declarations, with everything inherited reached by walking Supers. A body carrying its
+// ancestors' members too would make each inherited member look like a redeclaration of
+// itself, so the whole-body views that need inheritance walk the chain instead.
 //
-// Reading `pos` off a `Dog` through an `Animal`-typed binding would then hand out a
-// `{x: number, y: number}` typed as `{x: number}`, which exactness makes a real mismatch
-// rather than a widening.
-//
-// A member the class declares at a compatible type reports nothing. That covers the common
-// case of redeclaring an inherited field at exactly its inherited type. A name the
-// superclass chain does not carry is new rather than an override, so it is skipped.
-//
-// Telling a redeclaration from an inherited member rests on ClassDef.Body holding the
-// class's OWN declarations alone, with everything inherited reached by walking Supers. A
-// body that also carried its ancestors' members would make every inherited member look like
-// a redeclaration of itself, so the whole-body views that need inheritance have to walk the
-// chain rather than merge it in here.
-//
-// Every class body is frozen by the time this runs, so each member is compared at the type
-// member lookup will read rather than at the fresh variable a field held before the
-// constructor assigned it.
+// Every class body is frozen by the time this runs, so a member is compared at the type
+// lookup will read rather than at the variable a field held before the constructor ran.
 func (c *checker) checkInheritedMembers(def *ClassDef, self *soltype.ClassType, decl *ast.ClassDecl) {
 	if def.Body == nil || len(def.Supers) == 0 {
 		return
@@ -121,23 +105,18 @@ func (c *checker) checkInheritedMembers(def *ClassDef, self *soltype.ClassType, 
 }
 
 // checkOverriddenName checks one name the class declares against the same name on its
-// superclass chain, and reports at most one diagnostic for it.
+// superclass chain, reporting at most one diagnostic for it.
 //
-// Each access half is checked on its own. The superclass chain fixes what an instance of
-// the class must still support, so a half the chain does not expose leaves nothing to keep
-// and is skipped. A half it does expose has to survive the redeclaration in two ways:
+// Each access half is checked on its own. A half the chain does not expose leaves nothing to
+// keep, so it is skipped. A half it does expose has to survive the redeclaration twice over:
 //
-//  1. The class has to keep offering that half at all. A redeclaration shadows the
-//     inherited member rather than merging with it, so `class Dog extends Animal { readonly
-//     pos: … }` over a writable `Animal.pos` leaves an `Animal`-typed reference able to
-//     write a field a `Dog` refuses. The same goes for a subclass that redeclares one half
-//     of an inherited getter/setter pair and drops the other.
-//  2. The type it offers has to fit. A read is covariant and a write contravariant, the
-//     ordinary override rule.
+//  1. The class has to keep offering it. A redeclaration shadows the inherited member rather
+//     than merging with it, so a `readonly` field over a writable one, or one half of an
+//     inherited accessor pair, drops an access the superclass view still performs.
+//  2. The type it offers has to fit, covariantly for a read and contravariantly for a write.
 //
-// The two are checked in that order, over both halves, so a member whose form disagrees is
-// reported as a form mismatch rather than through whichever type comparison the mismatch
-// happens to fail first.
+// Every form check runs before any type comparison, so a member whose form disagrees is
+// reported as a form mismatch rather than through whichever comparison it happens to fail.
 func (c *checker) checkOverriddenName(
 	def *ClassDef,
 	self *soltype.ClassType,
@@ -192,11 +171,9 @@ func (c *checker) checkOverriddenName(
 
 // halfGoals returns the subtype obligations a redeclared member owes the inherited member
 // serving the same access half. A read is covariant in the value it yields and a write
-// contravariant in the value it accepts. What reaching either raises is covariant in both
-// cases, since a `throws` flows out to the caller whether it came from a read or a write.
-//
-// Each goal carries the redeclared member it came from and the ancestor declaring the
-// inherited one, so a rejection is rendered against the half that produced it.
+// contravariant in the value it accepts. What reaching either raises is covariant either way,
+// since a `throws` flows out to the caller. Each goal carries the members it came from, so a
+// rejection is rendered against the half that produced it.
 func halfGoals(subElem, superElem soltype.ObjTypeElem, half memberHalf, owner *soltype.ClassType) []subtypeGoal {
 	value := subtypeGoal{
 		shownSub: halfType(subElem, half), shownSuper: halfType(superElem, half),
@@ -215,13 +192,12 @@ func halfGoals(subElem, superElem soltype.ObjTypeElem, half memberHalf, owner *s
 }
 
 // inheritedHalf finds the member on def's superclass chain that serves one access half of
-// name, projected to the arguments sub writes. It returns that member and the ancestor
-// instance declaring it, or inherited=false when no ancestor offers the half.
+// name, projected to the arguments sub writes, along with the ancestor declaring it.
 //
 // Each `extends` edge is re-expressed at sub's arguments through substituteSuperArgs before
-// the walk descends into it, so `class Dog<T> extends Animal<T>` compares its own members
-// against an Animal whose `T` is Dog's `T`. visited holds the ancestor names already
-// reached, bounding the walk on a cyclic hierarchy the same way constrainNominalWalk does.
+// the walk descends into it, so `class Dog<T> extends Animal<T>` compares against an Animal
+// whose `T` is Dog's `T`. The visited set bounds the walk on a cyclic hierarchy, the way
+// constrainNominalWalk does.
 func (c *checker) inheritedHalf(
 	def *ClassDef,
 	sub *soltype.ClassType,
@@ -258,10 +234,9 @@ func (c *checker) inheritedHalfWalk(
 	return nil, nil, false
 }
 
-// declaredHalf returns the member of obj that serves one access half of name. An accessor
-// declared for that half wins over a field or method sharing the name. That is the same
-// tie-break ObjectType.ReadMember and WriteMember apply. found is false when no member named
-// name serves the half.
+// declaredHalf returns the member of obj that serves one access half of name, or found=false
+// when none does. An accessor declared for that half wins over a field or method sharing the
+// name, the same tie-break ObjectType.ReadMember and WriteMember apply.
 func declaredHalf(obj *soltype.ObjectType, name string, half memberHalf) (soltype.ObjTypeElem, bool) {
 	var found soltype.ObjTypeElem
 	for _, elem := range obj.Elems {
@@ -279,8 +254,8 @@ func declaredHalf(obj *soltype.ObjectType, name string, half memberHalf) (soltyp
 }
 
 // servesHalf reports whether a member provides one access half. A field provides the read
-// always and the write unless it is `readonly`. A method and a getter provide the read
-// alone, and a setter the write alone.
+// always and the write unless it is `readonly`. A method and a getter provide the read alone,
+// and a setter the write alone.
 func servesHalf(elem soltype.ObjTypeElem, half memberHalf) bool {
 	switch elem := elem.(type) {
 	case *soltype.PropertyElem:
@@ -292,8 +267,7 @@ func servesHalf(elem soltype.ObjTypeElem, half memberHalf) bool {
 	case *soltype.SetterElem:
 		return half == writeHalf
 	}
-	// An index signature, a spread, or a constructor is not a named instance member an
-	// `extends` edge can override.
+	// An index signature, a spread, and a constructor are not members an override can name.
 	return false
 }
 
@@ -307,13 +281,12 @@ func isAccessor(elem soltype.ObjTypeElem) bool {
 }
 
 // formWeakens reports whether a redeclared member promises less, or demands more, than the
-// inherited one in a way no subtype obligation covers. Two cases reach it.
+// inherited one in a way no subtype obligation covers:
 //
-//   - The redeclared member is an optional field and the inherited one is not. The
-//     superclass view reads the member as always present, while the subclass may omit it.
-//   - The redeclared member takes a `mut self` receiver and the inherited one takes a plain
-//     `self`. The inherited member is reachable from an immutable superclass reference, and
-//     the redeclared one is not.
+//   - it is an optional field where the inherited one is required, so it may be absent while
+//     the superclass view reads it as always present;
+//   - it takes a `mut self` receiver where the inherited one takes a plain `self`, so an
+//     immutable superclass reference can no longer reach it.
 func formWeakens(subElem, superElem soltype.ObjTypeElem) bool {
 	if isOptional(subElem) && !isOptional(superElem) {
 		return true
@@ -327,14 +300,13 @@ func isOptional(elem soltype.ObjTypeElem) bool {
 	return ok && prop.Optional
 }
 
-// receiverMut reports whether reaching a member needs a mutable reference to the instance.
-// A `mut self` receiver on a method, getter, or setter is what demands one. A field carries
-// no receiver, so it reads as false.
+// receiverMut reports whether reaching a member needs a mutable reference to the instance. A
+// `mut self` receiver on a method, getter, or setter demands one, and a field carries no
+// receiver at all.
 //
-// An overload set is measured across every arm, so one `mut self` arm makes the whole member
-// demand a mutable reference. buildMemberSigs rejects a set whose arms disagree, but it
-// appends the offending arm all the same, so reading a single arm would answer by
-// declaration order on exactly the input that already disagrees.
+// One `mut self` arm makes a whole overload set demand a mutable reference. buildMemberSigs
+// rejects a set whose arms disagree but appends the offending arm anyway, so reading a single
+// arm would answer by declaration order on exactly the input that already disagrees.
 func receiverMut(elem soltype.ObjTypeElem) bool {
 	switch elem := elem.(type) {
 	case *soltype.MethodElem:
@@ -354,7 +326,7 @@ func receiverMut(elem soltype.ObjTypeElem) bool {
 
 // halfType returns the type one access half of a member carries: the value a read yields or
 // the value a write accepts. A method's read yields its signature with the receiver dropped,
-// which is the callable value `a.f` evaluates to.
+// the callable value `a.f` evaluates to.
 func halfType(elem soltype.ObjTypeElem, half memberHalf) soltype.Type {
 	switch elem := elem.(type) {
 	case *soltype.PropertyElem:
@@ -370,9 +342,8 @@ func halfType(elem soltype.ObjTypeElem, half memberHalf) soltype.Type {
 			return callableView(elem.Signatures[0])
 		default:
 			// An overload set reads as the intersection of its arms, matching what
-			// memberReadContribution hands a caller. Comparing the intersections rather than
-			// arm against arm is what keeps the check independent of the order the arms are
-			// written in.
+			// memberReadContribution hands a caller. Comparing intersections rather than arm
+			// against arm keeps the check independent of the order the arms are written in.
 			arms := make([]soltype.Type, len(elem.Signatures))
 			for i, sig := range elem.Signatures {
 				arms[i] = callableView(sig)
@@ -383,8 +354,8 @@ func halfType(elem soltype.ObjTypeElem, half memberHalf) soltype.Type {
 	return &soltype.ErrorType{}
 }
 
-// elemThrows returns the type reaching a member may raise. Only an accessor carries one, so
-// a field and a method read as `never`, which any `throws` position admits.
+// elemThrows returns the type reaching a member may raise. Only an accessor carries one, so a
+// field and a method read as `never`, which any `throws` position admits.
 func elemThrows(elem soltype.ObjTypeElem) soltype.Type {
 	switch elem := elem.(type) {
 	case *soltype.GetterElem:
@@ -395,9 +366,9 @@ func elemThrows(elem soltype.ObjTypeElem) soltype.Type {
 	return &soltype.NeverType{}
 }
 
-// memberForm names the form a member takes, so a diagnostic about two members whose forms
-// disagree can say what each one is. A field's form spells out its `readonly` and optional
-// modifiers, since dropping either is one of the disagreements the check reports.
+// memberForm names the form a member takes, so a diagnostic about two disagreeing members can
+// say what each one is. A field's form spells out its `readonly` and optional modifiers, since
+// dropping either is one of the disagreements reported.
 func memberForm(elem soltype.ObjTypeElem) string {
 	switch elem := elem.(type) {
 	case *soltype.PropertyElem:
@@ -421,8 +392,8 @@ func memberForm(elem soltype.ObjTypeElem) string {
 	return "a member"
 }
 
-// mutReceiverForm appends the receiver to a member's form when reaching it needs a mutable
-// reference, so a diagnostic about two members that differ only there says which is which.
+// mutReceiverForm names the receiver when reaching a member needs a mutable reference, so two
+// members differing only there do not render alike.
 func mutReceiverForm(base string, elem soltype.ObjTypeElem) string {
 	if receiverMut(elem) {
 		return base + " taking `mut self`"
@@ -430,10 +401,9 @@ func mutReceiverForm(base string, elem soltype.ObjTypeElem) string {
 	return base
 }
 
-// firstNamed returns the first member of obj called name, the member a diagnostic falls
-// back to naming when the class offers no member for the half under discussion. The caller
-// reaches it only for a name obj carries, so the nil return is unreachable in practice and
-// renders as the generic form.
+// firstNamed returns the first member of obj called name, which a diagnostic falls back to
+// naming when the class offers none for the half under discussion. Callers reach it only for a
+// name obj carries, so the nil return is unreachable and renders as the generic form.
 func firstNamed(obj *soltype.ObjectType, name string) soltype.ObjTypeElem {
 	for _, elem := range obj.Elems {
 		if soltype.ObjElemName(elem) == name {
@@ -443,10 +413,9 @@ func firstNamed(obj *soltype.ObjectType, name string) soltype.ObjTypeElem {
 	return nil
 }
 
-// overrideBlame returns the source node an override diagnostic points at: the declaration
-// of the member under discussion, falling back to the other half's declaration when the
-// class offers no member for that half. It returns nil when the class declares the name in
-// neither form, which leaves the diagnostic on the class declaration's own span.
+// overrideBlame returns the source node an override diagnostic points at, the declaration of
+// the member under discussion. It falls back to the other half's declaration, and then to nil,
+// which leaves the diagnostic on the zero span.
 func overrideBlame(blame map[memberBlameKey]ast.Node, name string, elem soltype.ObjTypeElem) ast.Node {
 	_, isSetter := elem.(*soltype.SetterElem)
 	if node, ok := blame[memberBlameKey{name: name, setter: isSetter}]; ok {
@@ -455,9 +424,9 @@ func overrideBlame(blame map[memberBlameKey]ast.Node, name string, elem soltype.
 	return blame[memberBlameKey{name: name, setter: !isSetter}]
 }
 
-// instanceMemberNodes maps each instance member a class declaration writes to the source
-// node that declares it, so an override diagnostic points at the member rather than at the
-// whole class. A static member is left out, since `extends` relates instances.
+// instanceMemberNodes maps each instance member a class declaration writes to the node that
+// declares it, so an override diagnostic points at the member rather than the whole class. A
+// static member is left out, since `extends` relates instances.
 func instanceMemberNodes(decl *ast.ClassDecl) map[memberBlameKey]ast.Node {
 	nodes := map[memberBlameKey]ast.Node{}
 	for _, elem := range decl.Body {
@@ -483,21 +452,20 @@ func instanceMemberNodes(decl *ast.ClassDecl) map[memberBlameKey]ast.Node {
 	return nodes
 }
 
-// skolemizeClassParams returns a substitution replacing a class's own type-parameter
-// variables with fresh skolems, or nil for a non-generic class. An override obligation
-// checked through it has to hold for every instantiation of the class rather than being
-// satisfied by recording a bound on the parameter. For
+// skolemizeClassParams returns a substitution replacing a class's own type-parameter variables
+// with fresh skolems, or nil for a non-generic class. An obligation checked through it has to
+// hold for every instantiation rather than being satisfied by recording a bound. Given
 //
 //	class Box<T> { value: T, … }
 //	class StrBox<T> extends Box<T> { value: string, … }
 //
 // the obligation is `string <: T`. Against the bare parameter variable that records `string`
-// as a lower bound of `T` and reports nothing. Against a skolem it is rejected, which is
-// what a `StrBox<number>` read through `Box<number>` needs it to be.
+// as a lower bound and reports nothing. Against a skolem it is rejected, which is what a
+// `StrBox<number>` read through `Box<number>` needs.
 //
 // Each parameter's declared constraint becomes its skolem's upper bound, seeded through the
-// same substitution so a bound naming a sibling parameter reaches that sibling's skolem.
-// This mirrors what skolemizeFuncBinder does for a function's own binder.
+// same substitution so a bound naming a sibling reaches that sibling's skolem. This mirrors
+// skolemizeFuncBinder.
 func (c *Context) skolemizeClassParams(def *ClassDef) *typeSubst {
 	if len(def.TypeParams) == 0 {
 		return nil

--- a/internal/solver/inherit.go
+++ b/internal/solver/inherit.go
@@ -94,6 +94,12 @@ func (c *checker) checkQueuedInheritedMembers() {
 // case of redeclaring an inherited field at exactly its inherited type. A name the
 // superclass chain does not carry is new rather than an override, so it is skipped.
 //
+// Telling a redeclaration from an inherited member rests on ClassDef.Body holding the
+// class's OWN declarations alone, with everything inherited reached by walking Supers. A
+// body that also carried its ancestors' members would make every inherited member look like
+// a redeclaration of itself, so the whole-body views that need inheritance have to walk the
+// chain rather than merge it in here.
+//
 // Every class body is frozen by the time this runs, so each member is compared at the type
 // member lookup will read rather than at the fresh variable a field held before the
 // constructor assigned it.

--- a/internal/solver/inherit.go
+++ b/internal/solver/inherit.go
@@ -1,0 +1,505 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// memberHalf is one direction of access to a named member: the read `a.f` performs, or the
+// write `a.f = …` performs. An override is checked one half at a time, because a class
+// splits the two across separate members whenever it declares a getter/setter pair, and a
+// `readonly` field carries the read alone.
+type memberHalf int
+
+const (
+	readHalf memberHalf = iota
+	writeHalf
+)
+
+// subtypeGoal is one obligation a redeclared member owes the member it overrides. An access
+// half contributes one goal for the value it carries and one for what reaching it may raise.
+//
+// sub and super are the two operands constrain is called with. A write obligation is
+// contravariant, so there the inherited member's type is the sub operand. shownSub and
+// shownSuper are the same two types held the other way, subclass first, which is the order a
+// diagnostic names them in. position says which of a member's types they are, so the message
+// can distinguish a rejected value type from a rejected `throws`. subElem is the redeclared
+// member the diagnostic is blamed on, and owner the ancestor declaring the inherited one.
+type subtypeGoal struct {
+	sub, super           soltype.Type
+	shownSub, shownSuper soltype.Type
+	position             string
+	subElem              soltype.ObjTypeElem
+	owner                *soltype.ClassType
+}
+
+// memberBlameKey names one instance member of a class declaration, so a diagnostic about
+// that member can be blamed on the source it was written at. A getter and a setter may
+// share a name, so the setter half is keyed apart from every other kind.
+type memberBlameKey struct {
+	name   string
+	setter bool
+}
+
+// pendingOverrideCheck is one subclass waiting to have its members checked against the
+// ones they override. def and self are the class's registered definition and nominal
+// handle, and decl the declaration a diagnostic is blamed on.
+type pendingOverrideCheck struct {
+	def  *ClassDef
+	self *soltype.ClassType
+	decl *ast.ClassDecl
+}
+
+// queueInheritedMemberCheck records a class whose `extends` edge has been resolved, to be
+// checked once every class the module declares is inferred.
+//
+// The check cannot run inside inferClassDecl. A class's superclass edge and body are filled
+// in at the class's VALUE key, while an `extends` clause registers a dependency on the
+// superclass's TYPE key alone. A subclass's value key is therefore free to be inferred
+// before its superclass's. Given `class Dog extends Pet` and `class Pet extends Animal`, the
+// driver reaches Dog while Pet still carries no superclass edge and no members. Running
+// every queued check after the last component removes that hazard, since by then each
+// ancestor's edge and body are final.
+func (c *checker) queueInheritedMemberCheck(def *ClassDef, self *soltype.ClassType, decl *ast.ClassDecl) {
+	if def.Body == nil || len(def.Supers) == 0 {
+		return
+	}
+	c.pendingOverrides = append(c.pendingOverrides, pendingOverrideCheck{def: def, self: self, decl: decl})
+}
+
+// checkQueuedInheritedMembers runs every queued override check and clears the queue. The
+// module and script drivers call it once, after the last declaration is inferred.
+func (c *checker) checkQueuedInheritedMembers() {
+	pending := c.pendingOverrides
+	c.pendingOverrides = nil
+	for _, p := range pending {
+		c.checkInheritedMembers(p.def, p.self, p.decl)
+	}
+}
+
+// checkInheritedMembers checks every member a class declares against the same-named member
+// its superclass chain declares, and reports the ones an instance of the class cannot stand
+// in for. The nominal subtype rule decides `Dog <: Animal` on the declared `extends` edge
+// alone, so without this check a subclass can contradict its own superclass edge:
+//
+//	class Animal { pos: {x: number}, … }
+//	class Dog extends Animal { pos: {x: number, y: number}, … }
+//
+// Reading `pos` off a `Dog` through an `Animal`-typed binding would then hand out a
+// `{x: number, y: number}` typed as `{x: number}`, which exactness makes a real mismatch
+// rather than a widening.
+//
+// A member the class declares at a compatible type reports nothing. That covers the common
+// case of redeclaring an inherited field at exactly its inherited type. A name the
+// superclass chain does not carry is new rather than an override, so it is skipped.
+//
+// Every class body is frozen by the time this runs, so each member is compared at the type
+// member lookup will read rather than at the fresh variable a field held before the
+// constructor assigned it.
+func (c *checker) checkInheritedMembers(def *ClassDef, self *soltype.ClassType, decl *ast.ClassDecl) {
+	if def.Body == nil || len(def.Supers) == 0 {
+		return
+	}
+	blame := instanceMemberNodes(decl)
+	rigid := c.ctx.skolemizeClassParams(def)
+	checked := set.NewSet[string]()
+	for _, elem := range def.Body.Elems {
+		name := soltype.ObjElemName(elem)
+		if name == "" || checked.Contains(name) {
+			continue
+		}
+		checked.Add(name)
+		c.checkOverriddenName(def, self, name, blame, rigid)
+	}
+}
+
+// checkOverriddenName checks one name the class declares against the same name on its
+// superclass chain, and reports at most one diagnostic for it.
+//
+// Each access half is checked on its own. The superclass chain fixes what an instance of
+// the class must still support, so a half the chain does not expose leaves nothing to keep
+// and is skipped. A half it does expose has to survive the redeclaration in two ways:
+//
+//  1. The class has to keep offering that half at all. A redeclaration shadows the
+//     inherited member rather than merging with it, so `class Dog extends Animal { readonly
+//     pos: … }` over a writable `Animal.pos` leaves an `Animal`-typed reference able to
+//     write a field a `Dog` refuses. The same goes for a subclass that redeclares one half
+//     of an inherited getter/setter pair and drops the other.
+//  2. The type it offers has to fit. A read is covariant and a write contravariant, the
+//     ordinary override rule.
+//
+// The two are checked in that order, over both halves, so a member whose form disagrees is
+// reported as a form mismatch rather than through whichever type comparison the mismatch
+// happens to fail first.
+func (c *checker) checkOverriddenName(
+	def *ClassDef,
+	self *soltype.ClassType,
+	name string,
+	blame map[memberBlameKey]ast.Node,
+	rigid *typeSubst,
+) {
+	var goals []subtypeGoal
+	for _, half := range []memberHalf{readHalf, writeHalf} {
+		superHalf, owner, inherited := c.inheritedHalf(def, self, name, half)
+		if !inherited {
+			continue
+		}
+		subHalf, declared := declaredHalf(def.Body, name, half)
+		if !declared || formWeakens(subHalf, superHalf) {
+			// The class either does not offer this half at all, or offers it on terms the
+			// inherited member does not impose. No type comparison applies to that, so name
+			// the two forms instead.
+			c.report(&OverrideFormMismatchError{
+				Member:     name,
+				Class:      self.Name,
+				SuperClass: owner.Name,
+				Form:       memberForm(firstNamed(def.Body, name)),
+				SuperForm:  memberForm(superHalf),
+				Node:       overrideBlame(blame, name, subHalf),
+			})
+			return
+		}
+		goals = append(goals, halfGoals(subHalf, superHalf, half, owner)...)
+	}
+	for _, goal := range goals {
+		// The trial rolls its bounds back, so measuring an override records nothing on the
+		// types the class registered.
+		if !hasHardError(c.ctx.trialUnderProbe(rigid.apply(goal.sub), rigid.apply(goal.super))) {
+			continue
+		}
+		c.report(&IncompatibleOverrideError{
+			Member:     name,
+			Class:      self.Name,
+			SuperClass: goal.owner.Name,
+			Position:   goal.position,
+			// The rendered types carry the skolems too, so a member typed through a class
+			// type parameter reads under that parameter's name rather than as a bare
+			// variable id.
+			SubType:   rigid.apply(goal.shownSub),
+			SuperType: rigid.apply(goal.shownSuper),
+			Node:      overrideBlame(blame, name, goal.subElem),
+		})
+		return // one diagnostic per member, whichever obligation rejected first
+	}
+}
+
+// halfGoals returns the subtype obligations a redeclared member owes the inherited member
+// serving the same access half. A read is covariant in the value it yields and a write
+// contravariant in the value it accepts. What reaching either raises is covariant in both
+// cases, since a `throws` flows out to the caller whether it came from a read or a write.
+//
+// Each goal carries the redeclared member it came from and the ancestor declaring the
+// inherited one, so a rejection is rendered against the half that produced it.
+func halfGoals(subElem, superElem soltype.ObjTypeElem, half memberHalf, owner *soltype.ClassType) []subtypeGoal {
+	value := subtypeGoal{
+		shownSub: halfType(subElem, half), shownSuper: halfType(superElem, half),
+		position: "type", subElem: subElem, owner: owner,
+	}
+	value.sub, value.super = value.shownSub, value.shownSuper
+	if half == writeHalf {
+		value.sub, value.super = value.shownSuper, value.shownSub
+	}
+	throws := subtypeGoal{
+		shownSub: elemThrows(subElem), shownSuper: elemThrows(superElem),
+		position: "throws type", subElem: subElem, owner: owner,
+	}
+	throws.sub, throws.super = throws.shownSub, throws.shownSuper
+	return []subtypeGoal{value, throws}
+}
+
+// inheritedHalf finds the member on def's superclass chain that serves one access half of
+// name, projected to the arguments sub writes. It returns that member and the ancestor
+// instance declaring it, or inherited=false when no ancestor offers the half.
+//
+// Each `extends` edge is re-expressed at sub's arguments through substituteSuperArgs before
+// the walk descends into it, so `class Dog<T> extends Animal<T>` compares its own members
+// against an Animal whose `T` is Dog's `T`. visited holds the ancestor names already
+// reached, bounding the walk on a cyclic hierarchy the same way constrainNominalWalk does.
+func (c *checker) inheritedHalf(
+	def *ClassDef,
+	sub *soltype.ClassType,
+	name string,
+	half memberHalf,
+) (soltype.ObjTypeElem, *soltype.ClassType, bool) {
+	return c.inheritedHalfWalk(def, sub, name, half, set.NewSet[string]())
+}
+
+func (c *checker) inheritedHalfWalk(
+	def *ClassDef,
+	sub *soltype.ClassType,
+	name string,
+	half memberHalf,
+	visited set.Set[string],
+) (soltype.ObjTypeElem, *soltype.ClassType, bool) {
+	for _, superType := range def.Supers {
+		superInstance := substituteSuperArgs(def, sub, superType)
+		if visited.Contains(superInstance.Name) {
+			continue
+		}
+		visited.Add(superInstance.Name)
+		superDef, ok := c.ctx.classDef(superInstance.Name)
+		if !ok || superDef.Body == nil {
+			continue
+		}
+		if member, found := declaredHalf(superDef.Body, name, half); found {
+			return c.projectClassMember(superDef, superInstance, member), superInstance, true
+		}
+		if member, owner, found := c.inheritedHalfWalk(superDef, superInstance, name, half, visited); found {
+			return member, owner, true
+		}
+	}
+	return nil, nil, false
+}
+
+// declaredHalf returns the member of obj that serves one access half of name. An accessor
+// declared for that half wins over a field or method sharing the name. That is the same
+// tie-break ObjectType.ReadMember and WriteMember apply. found is false when no member named
+// name serves the half.
+func declaredHalf(obj *soltype.ObjectType, name string, half memberHalf) (soltype.ObjTypeElem, bool) {
+	var found soltype.ObjTypeElem
+	for _, elem := range obj.Elems {
+		if soltype.ObjElemName(elem) != name || !servesHalf(elem, half) {
+			continue
+		}
+		if isAccessor(elem) {
+			return elem, true
+		}
+		if found == nil {
+			found = elem
+		}
+	}
+	return found, found != nil
+}
+
+// servesHalf reports whether a member provides one access half. A field provides the read
+// always and the write unless it is `readonly`. A method and a getter provide the read
+// alone, and a setter the write alone.
+func servesHalf(elem soltype.ObjTypeElem, half memberHalf) bool {
+	switch elem := elem.(type) {
+	case *soltype.PropertyElem:
+		return half == readHalf || !elem.Readonly
+	case *soltype.MethodElem:
+		return half == readHalf
+	case *soltype.GetterElem:
+		return half == readHalf
+	case *soltype.SetterElem:
+		return half == writeHalf
+	}
+	// An index signature, a spread, or a constructor is not a named instance member an
+	// `extends` edge can override.
+	return false
+}
+
+// isAccessor reports whether a member is one half of a getter/setter pair.
+func isAccessor(elem soltype.ObjTypeElem) bool {
+	switch elem.(type) {
+	case *soltype.GetterElem, *soltype.SetterElem:
+		return true
+	}
+	return false
+}
+
+// formWeakens reports whether a redeclared member promises less, or demands more, than the
+// inherited one in a way no subtype obligation covers. Two cases reach it.
+//
+//   - The redeclared member is an optional field and the inherited one is not. The
+//     superclass view reads the member as always present, while the subclass may omit it.
+//   - The redeclared member takes a `mut self` receiver and the inherited one takes a plain
+//     `self`. The inherited member is reachable from an immutable superclass reference, and
+//     the redeclared one is not.
+func formWeakens(subElem, superElem soltype.ObjTypeElem) bool {
+	if isOptional(subElem) && !isOptional(superElem) {
+		return true
+	}
+	return receiverMut(subElem) && !receiverMut(superElem)
+}
+
+// isOptional reports whether a member may be absent, which only a `f?: T` field can be.
+func isOptional(elem soltype.ObjTypeElem) bool {
+	prop, ok := elem.(*soltype.PropertyElem)
+	return ok && prop.Optional
+}
+
+// receiverMut reports whether reaching a member needs a mutable reference to the instance.
+// A `mut self` receiver on a method, getter, or setter is what demands one. A field carries
+// no receiver, so it reads as false.
+func receiverMut(elem soltype.ObjTypeElem) bool {
+	switch elem := elem.(type) {
+	case *soltype.MethodElem:
+		return len(elem.Signatures) > 0 && selfParamMut(elem.Signatures[0].SelfParam)
+	case *soltype.GetterElem:
+		return selfParamMut(elem.SelfParam)
+	case *soltype.SetterElem:
+		return selfParamMut(elem.SelfParam)
+	}
+	return false
+}
+
+// halfType returns the type one access half of a member carries: the value a read yields or
+// the value a write accepts. A method's read yields its signature with the receiver dropped,
+// which is the callable value `a.f` evaluates to.
+func halfType(elem soltype.ObjTypeElem, half memberHalf) soltype.Type {
+	switch elem := elem.(type) {
+	case *soltype.PropertyElem:
+		return elem.Type
+	case *soltype.GetterElem:
+		return elem.Type
+	case *soltype.SetterElem:
+		return elem.Param
+	case *soltype.MethodElem:
+		switch len(elem.Signatures) {
+		case 0:
+		case 1:
+			return callableView(elem.Signatures[0])
+		default:
+			// An overload set reads as the intersection of its arms, matching what
+			// memberReadContribution hands a caller. Comparing the intersections rather than
+			// arm against arm is what keeps the check independent of the order the arms are
+			// written in.
+			arms := make([]soltype.Type, len(elem.Signatures))
+			for i, sig := range elem.Signatures {
+				arms[i] = callableView(sig)
+			}
+			return &soltype.IntersectionType{Types: arms}
+		}
+	}
+	return &soltype.ErrorType{}
+}
+
+// elemThrows returns the type reaching a member may raise. Only an accessor carries one, so
+// a field and a method read as `never`, which any `throws` position admits.
+func elemThrows(elem soltype.ObjTypeElem) soltype.Type {
+	switch elem := elem.(type) {
+	case *soltype.GetterElem:
+		return elem.ThrowsOrNever()
+	case *soltype.SetterElem:
+		return elem.ThrowsOrNever()
+	}
+	return &soltype.NeverType{}
+}
+
+// memberForm names the form a member takes, so a diagnostic about two members whose forms
+// disagree can say what each one is. A field's form spells out its `readonly` and optional
+// modifiers, since dropping either is one of the disagreements the check reports.
+func memberForm(elem soltype.ObjTypeElem) string {
+	switch elem := elem.(type) {
+	case *soltype.PropertyElem:
+		switch {
+		case elem.Optional && elem.Readonly:
+			return "an optional readonly field"
+		case elem.Optional:
+			return "an optional writable field"
+		case elem.Readonly:
+			return "a readonly field"
+		}
+		return "a writable field"
+	case *soltype.MethodElem:
+		return mutReceiverForm("a method", elem)
+	case *soltype.GetterElem:
+		return mutReceiverForm("a getter", elem)
+	case *soltype.SetterElem:
+		// A setter writes, so its receiver is always `mut self` and saying so adds nothing.
+		return "a setter"
+	}
+	return "a member"
+}
+
+// mutReceiverForm appends the receiver to a member's form when reaching it needs a mutable
+// reference, so a diagnostic about two members that differ only there says which is which.
+func mutReceiverForm(base string, elem soltype.ObjTypeElem) string {
+	if receiverMut(elem) {
+		return base + " taking `mut self`"
+	}
+	return base
+}
+
+// firstNamed returns the first member of obj called name, the member a diagnostic falls
+// back to naming when the class offers no member for the half under discussion. The caller
+// reaches it only for a name obj carries, so the nil return is unreachable in practice and
+// renders as the generic form.
+func firstNamed(obj *soltype.ObjectType, name string) soltype.ObjTypeElem {
+	for _, elem := range obj.Elems {
+		if soltype.ObjElemName(elem) == name {
+			return elem
+		}
+	}
+	return nil
+}
+
+// overrideBlame returns the source node an override diagnostic points at: the declaration
+// of the member under discussion, falling back to the other half's declaration when the
+// class offers no member for that half. It returns nil when the class declares the name in
+// neither form, which leaves the diagnostic on the class declaration's own span.
+func overrideBlame(blame map[memberBlameKey]ast.Node, name string, elem soltype.ObjTypeElem) ast.Node {
+	_, isSetter := elem.(*soltype.SetterElem)
+	if node, ok := blame[memberBlameKey{name: name, setter: isSetter}]; ok {
+		return node
+	}
+	return blame[memberBlameKey{name: name, setter: !isSetter}]
+}
+
+// instanceMemberNodes maps each instance member a class declaration writes to the source
+// node that declares it, so an override diagnostic points at the member rather than at the
+// whole class. A static member is left out, since `extends` relates instances.
+func instanceMemberNodes(decl *ast.ClassDecl) map[memberBlameKey]ast.Node {
+	nodes := map[memberBlameKey]ast.Node{}
+	for _, elem := range decl.Body {
+		var key ast.ObjKey
+		var static bool
+		setter := false
+		switch elem := elem.(type) {
+		case *ast.FieldElem:
+			key, static = elem.Name, elem.Static
+		case *ast.MethodElem:
+			key, static = elem.Name, elem.Static
+		case *ast.GetterElem:
+			key, static = elem.Name, elem.Static
+		case *ast.SetterElem:
+			key, static, setter = elem.Name, elem.Static, true
+		default:
+			continue
+		}
+		if name, ok := objKeyName(key); ok && !static {
+			nodes[memberBlameKey{name: name, setter: setter}] = elem
+		}
+	}
+	return nodes
+}
+
+// skolemizeClassParams returns a substitution replacing a class's own type-parameter
+// variables with fresh skolems, or nil for a non-generic class. An override obligation
+// checked through it has to hold for every instantiation of the class rather than being
+// satisfied by recording a bound on the parameter. For
+//
+//	class Box<T> { value: T, … }
+//	class StrBox<T> extends Box<T> { value: string, … }
+//
+// the obligation is `string <: T`. Against the bare parameter variable that records `string`
+// as a lower bound of `T` and reports nothing. Against a skolem it is rejected, which is
+// what a `StrBox<number>` read through `Box<number>` needs it to be.
+//
+// Each parameter's declared constraint becomes its skolem's upper bound, seeded through the
+// same substitution so a bound naming a sibling parameter reaches that sibling's skolem.
+// This mirrors what skolemizeFuncBinder does for a function's own binder.
+func (c *Context) skolemizeClassParams(def *ClassDef) *typeSubst {
+	if len(def.TypeParams) == 0 {
+		return nil
+	}
+	sks := make([]*soltype.SkolemType, len(def.TypeParams))
+	args := make([]soltype.Type, len(def.TypeParams))
+	for i, tp := range def.TypeParams {
+		sks[i] = c.freshSkolem(tp.Name)
+		args[i] = sks[i]
+	}
+	subst := newTypeSubst(def.TypeParams, args, nil, nil)
+	for i, tp := range def.TypeParams {
+		// resolveTypeParams records at most one upper bound per parameter, itself an
+		// IntersectionType for a `<T: A & B>` bound, so the first bound is the whole
+		// declared constraint.
+		if len(tp.Var.UpperBounds) > 0 {
+			sks[i].Upper = tp.Var.UpperBounds[0].Accept(subst, soltype.Positive)
+		}
+	}
+	return subst
+}

--- a/internal/solver/inherit_test.go
+++ b/internal/solver/inherit_test.go
@@ -174,6 +174,37 @@ func TestInferClassOverrideCompat(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "MethodOverriddenAtTheInheritedSignature",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					speak(self) -> string { return "..." },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					speak(self) -> string { return "woof" },
+				}
+			`,
+			// The ordinary override: a new body at the signature the superclass declares.
+			want: nil,
+		},
+		{
+			name: "MethodParamWidenedAndReturnNarrowed",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					pick(self, x: number) -> number | string { return x },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					pick(self, x: number | string) -> number { return 5 },
+				}
+			`,
+			// Both admitted directions at once, which is the widest an override may move the
+			// inherited signature: it accepts more and promises more precisely.
+			want: nil,
+		},
+		{
 			name: "FieldOverriddenByAMethod",
 			src: `
 				class Animal {

--- a/internal/solver/inherit_test.go
+++ b/internal/solver/inherit_test.go
@@ -1,0 +1,400 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInferClassOverrideCompat covers the rule that a member a subclass redeclares must
+// stay compatible with the same-named member its superclass chain declares. The nominal
+// subtype rule decides `Dog <: Animal` on the declared `extends` edge alone, so without
+// this check a subclass could contradict its own edge (escalier-lang/escalier#985).
+func TestInferClassOverrideCompat(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "FieldRedeclaredAtAWiderObject",
+			src: `
+				class Animal {
+					pos: {x: number},
+					constructor(mut self, pos: {x: number}) { self.pos = pos },
+				}
+				class Dog extends Animal {
+					pos: {x: number, y: number},
+					constructor(mut self, pos: {x: number, y: number}) { self.pos = pos },
+				}
+			`,
+			want: []string{
+				"class `Dog` redeclares inherited member `pos` with type `{x: number, y: number}`, " +
+					"which is not compatible with `{x: number}` declared by `Animal`",
+			},
+		},
+		{
+			name: "FieldRedeclaredAtASubtype",
+			src: `
+				class Animal {
+					legs: number | undefined,
+					constructor(mut self, legs: number | undefined) { self.legs = legs },
+				}
+				class Dog extends Animal {
+					legs: number,
+					constructor(mut self, legs: number) { self.legs = legs },
+				}
+			`,
+			// A writable field is invariant, since the `Animal` view admits `a.legs =
+			// undefined` and `undefined` does not fit `Dog`'s `number`.
+			want: []string{
+				"class `Dog` redeclares inherited member `legs` with type `number`, " +
+					"which is not compatible with `number | undefined` declared by `Animal`",
+			},
+		},
+		{
+			name: "FieldRedeclaredAtTheInheritedType",
+			src: `
+				class Animal {
+					legs: number,
+					constructor(mut self, legs: number) { self.legs = legs },
+				}
+				class Dog extends Animal {
+					legs: number,
+					constructor(mut self) { self.legs = 4 },
+				}
+			`,
+			want: nil,
+		},
+		{
+			name: "MemberTheSuperclassDoesNotDeclare",
+			src: `
+				class Animal {
+					legs: number,
+					constructor(mut self, legs: number) { self.legs = legs },
+				}
+				class Dog extends Animal {
+					legs: number,
+					name: string,
+					constructor(mut self) {
+						self.legs = 4
+						self.name = "Rex"
+					},
+				}
+			`,
+			want: nil,
+		},
+		{
+			name: "MethodReturnNotCovariant",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					speak(self) -> string { return "..." },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					speak(self) -> number { return 5 },
+				}
+			`,
+			want: []string{
+				"class `Dog` redeclares inherited member `speak` with type `fn () -> number`, " +
+					"which is not compatible with `fn () -> string` declared by `Animal`",
+			},
+		},
+		{
+			name: "MethodParamNotContravariant",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					eat(self, food: string | number) -> undefined { return undefined },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					eat(self, food: string) -> undefined { return undefined },
+				}
+			`,
+			want: []string{
+				"class `Dog` redeclares inherited member `eat` with type `fn (food: string) -> undefined`, " +
+					"which is not compatible with `fn (food: number | string) -> undefined` declared by `Animal`",
+			},
+		},
+		{
+			name: "MethodWidenedParamIsAllowed",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					eat(self, food: string) -> undefined { return undefined },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					eat(self, food: string | number) -> undefined { return undefined },
+				}
+			`,
+			want: nil,
+		},
+		{
+			name: "FieldOverriddenByAMethod",
+			src: `
+				class Animal {
+					speak: string,
+					constructor(mut self) { self.speak = "..." },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					speak(self) -> string { return "woof" },
+				}
+			`,
+			want: []string{
+				"class `Dog` redeclares inherited member `speak` as a method, " +
+					"but `Animal` declares it as a writable field",
+			},
+		},
+		{
+			name: "InheritedThroughTwoEdges",
+			src: `
+				class Animal {
+					legs: number,
+					constructor(mut self, legs: number) { self.legs = legs },
+				}
+				class Pet extends Animal {
+					constructor(mut self) {},
+				}
+				class Dog extends Pet {
+					legs: string,
+					constructor(mut self) { self.legs = "four" },
+				}
+			`,
+			want: []string{
+				"class `Dog` redeclares inherited member `legs` with type `string`, " +
+					"which is not compatible with `number` declared by `Animal`",
+			},
+		},
+		{
+			name: "GetterOverriddenAtANarrowerType",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					get p(self) -> number | string { return 4 },
+					set p(mut self, v: number | string) {},
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					get p(self) -> number { return 4 },
+					set p(mut self, v: number | string) {},
+				}
+			`,
+			// A read through `Animal` yields `number | string`, which Dog's getter narrows.
+			// The narrowing is the direction a read admits, so nothing is reported.
+			want: nil,
+		},
+		{
+			name: "OverridingOnlyTheGetterHalfDropsTheSetter",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					get p(self) -> number { return 4 },
+					set p(mut self, v: number) {},
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					get p(self) -> number { return 4 },
+				}
+			`,
+			// Dog's getter shadows the whole pair rather than merging with it, so an
+			// `Animal`-typed reference to a Dog could write a member the Dog does not offer.
+			want: []string{
+				"class `Dog` redeclares inherited member `p` as a getter, " +
+					"but `Animal` declares it as a setter",
+			},
+		},
+		{
+			name: "AddingTheMissingAccessorHalfDropsTheInheritedOne",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					get legs(self) -> number { return 4 },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					set legs(mut self, v: number) {},
+				}
+			`,
+			// Reading `legs` off a Dog already reports that the property is write-only,
+			// because a subclass body shadows the inherited accessor rather than merging
+			// with it. This says the same thing at the declaration. Revisit once
+			// escalier-lang/escalier#872 folds inherited members into a subclass's body.
+			want: []string{
+				"class `Dog` redeclares inherited member `legs` as a setter, " +
+					"but `Animal` declares it as a getter",
+			},
+		},
+		{
+			name: "GetterOverriddenWithAThrows",
+			src: `
+				class Animal {
+					flag: boolean,
+					constructor(mut self, flag: boolean) { self.flag = flag },
+					get p(self) -> number { return 4 },
+				}
+				class Dog extends Animal {
+					flag: boolean,
+					constructor(mut self, flag: boolean) { self.flag = flag },
+					get p(self) -> number throws string {
+						if self.flag {
+							throw "x"
+						}
+						return 4
+					},
+				}
+			`,
+			// Reading `p` through `Animal` raises nothing, so a subclass cannot make the read
+			// throw.
+			want: []string{
+				"class `Dog` redeclares inherited member `p` with throws type `string`, " +
+					"which is not compatible with `never` declared by `Animal`",
+			},
+		},
+		{
+			name: "OverloadSetInADifferentOrder",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					f(self, x: number) -> number { return x },
+					f(self, x: string) -> string { return x },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					f(self, x: string) -> string { return x },
+					f(self, x: number) -> number { return x },
+				}
+			`,
+			// An overload set reads as the intersection of its arms, so the two classes
+			// declare the same member and the order the arms are written in does not matter.
+			want: nil,
+		},
+		{
+			name: "MethodOverriddenWithAMutReceiver",
+			src: `
+				class Animal {
+					x: number,
+					constructor(mut self) { self.x = 0 },
+					bump(self) -> undefined { return undefined },
+				}
+				class Dog extends Animal {
+					x: number,
+					constructor(mut self) { self.x = 0 },
+					bump(mut self) -> undefined { self.x = 1 },
+				}
+			`,
+			// An immutable `Animal` reference can call `bump`, so a subclass cannot make the
+			// call need a mutable one.
+			want: []string{
+				"class `Dog` redeclares inherited member `bump` as a method taking `mut self`, " +
+					"but `Animal` declares it as a method",
+			},
+		},
+		{
+			name: "GetterOverriddenByAnOptionalField",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					get p(self) -> number { return 4 },
+				}
+				class Dog extends Animal {
+					p?: number,
+					constructor(mut self) {},
+				}
+			`,
+			// The `Animal` view reads `p` as always present, so a subclass cannot make it a
+			// field that may be absent.
+			want: []string{
+				"class `Dog` redeclares inherited member `p` as an optional writable field, " +
+					"but `Animal` declares it as a getter",
+			},
+		},
+		{
+			name: "GenericSuperclassCheckedAtTheSubclassArgument",
+			src: `
+				class Box<T> {
+					value: T,
+					constructor(mut self, value: T) { self.value = value },
+				}
+				class StrBox<T> extends Box<T> {
+					value: string,
+					constructor(mut self, value: string) { self.value = value },
+				}
+			`,
+			// `Box<T>`'s `value` projects to `StrBox<T>`'s own `T`, and `string` is not a
+			// subtype of an arbitrary `T`.
+			want: []string{
+				"class `StrBox` redeclares inherited member `value` with type `string`, " +
+					"which is not compatible with `T` declared by `Box`",
+			},
+		},
+		{
+			name: "WritableFieldRedeclaredReadonly",
+			src: `
+				class Animal {
+					legs: number,
+					constructor(mut self, legs: number) { self.legs = legs },
+				}
+				class Dog extends Animal {
+					readonly legs: number,
+					constructor(mut self) {},
+				}
+			`,
+			// The `Animal` view still admits `a.legs = 5`, so a subclass cannot take the
+			// write away. The initialization diagnostic rides along because a `readonly`
+			// instance field has no way to be assigned, which is a separate gap.
+			want: []string{
+				"Field 'legs' is not initialized on every path through the constructor.",
+				"class `Dog` redeclares inherited member `legs` as a readonly field, " +
+					"but `Animal` declares it as a writable field",
+			},
+		},
+		{
+			name: "RequiredFieldRedeclaredOptional",
+			src: `
+				class Animal {
+					legs: number,
+					constructor(mut self, legs: number) { self.legs = legs },
+				}
+				class Dog extends Animal {
+					legs?: number,
+					constructor(mut self) {},
+				}
+			`,
+			// The `Animal` view still reads `a.legs` as present, so a subclass cannot make
+			// it optional.
+			want: []string{
+				"class `Dog` redeclares inherited member `legs` as an optional writable field, " +
+					"but `Animal` declares it as a writable field",
+			},
+		},
+		{
+			name: "GenericSuperclassAtTheSameParameter",
+			src: `
+				class Box<T> {
+					value: T,
+					constructor(mut self, value: T) { self.value = value },
+				}
+				class LabelledBox<T> extends Box<T> {
+					value: T,
+					label: string,
+					constructor(mut self, value: T) {
+						self.value = value
+						self.label = "box"
+					},
+				}
+			`,
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Equal(t, test.want, Messages(errs))
+		})
+	}
+}

--- a/internal/solver/inherit_test.go
+++ b/internal/solver/inherit_test.go
@@ -260,6 +260,45 @@ func TestInferClassOverrideCompat(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "SetterParamNarrowed",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					get p(self) -> number { return 4 },
+					set p(mut self, v: number | string) {},
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					get p(self) -> number { return 4 },
+					set p(mut self, v: number) {},
+				}
+			`,
+			// A write is contravariant, so narrowing the setter's parameter breaks the
+			// inherited promise: a holder of an `Animal` may write a `string` the Dog rejects.
+			want: []string{
+				"class `Dog` redeclares inherited member `p` with type `number`, " +
+					"which is not compatible with `number | string` declared by `Animal`",
+			},
+		},
+		{
+			name: "SetterParamWidenedIsAllowed",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					get p(self) -> number { return 4 },
+					set p(mut self, v: number) {},
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					get p(self) -> number { return 4 },
+					set p(mut self, v: number | string) {},
+				}
+			`,
+			// Widening is the direction a write admits. Every value an `Animal` reference
+			// writes still fits the Dog's setter.
+			want: nil,
+		},
+		{
 			name: "OverridingOnlyTheGetterHalfDropsTheSetter",
 			src: `
 				class Animal {
@@ -343,6 +382,31 @@ func TestInferClassOverrideCompat(t *testing.T) {
 			// An overload set reads as the intersection of its arms, so the two classes
 			// declare the same member and the order the arms are written in does not matter.
 			want: nil,
+		},
+		{
+			name: "OverloadSetWithAMutArmAfterAPlainOne",
+			src: `
+				class Animal {
+					x: number,
+					constructor(mut self) { self.x = 0 },
+					f(self, a: number) -> undefined { return undefined },
+				}
+				class Dog extends Animal {
+					x: number,
+					constructor(mut self) { self.x = 0 },
+					f(self, a: number) -> undefined { return undefined },
+					f(mut self, a: string) -> undefined { self.x = 1 },
+				}
+			`,
+			// An arm disagreeing with its siblings on receiver mutability is rejected, yet the
+			// arm still lands in the member's signature list. The override check measures the
+			// receiver across every arm, so Dog's `mut self` arm is seen whichever position it
+			// is written in.
+			want: []string{
+				"Overloaded method 'f' must use the same `self` receiver mutability in every arm.",
+				"class `Dog` redeclares inherited member `f` as a method taking `mut self`, " +
+					"but `Animal` declares it as a method",
+			},
 		},
 		{
 			name: "MethodOverriddenWithAMutReceiver",

--- a/internal/solver/inherit_test.go
+++ b/internal/solver/inherit_test.go
@@ -96,6 +96,8 @@ func TestInferClassOverrideCompat(t *testing.T) {
 					speak(self) -> number { return 5 },
 				}
 			`,
+			// The two returns are unrelated rather than one widening the other, which
+			// MethodWidenedReturn covers.
 			want: []string{
 				"class `Dog` redeclares inherited member `speak` with type `fn () -> number`, " +
 					"which is not compatible with `fn () -> string` declared by `Animal`",
@@ -113,6 +115,8 @@ func TestInferClassOverrideCompat(t *testing.T) {
 					eat(self, food: string) -> undefined { return undefined },
 				}
 			`,
+			// Dog's parameter is a subtype of the one it inherits, so an `Animal` reference
+			// could pass a `number` the Dog does not accept.
 			want: []string{
 				"class `Dog` redeclares inherited member `eat` with type `fn (food: string) -> undefined`, " +
 					"which is not compatible with `fn (food: number | string) -> undefined` declared by `Animal`",
@@ -130,6 +134,43 @@ func TestInferClassOverrideCompat(t *testing.T) {
 					eat(self, food: string | number) -> undefined { return undefined },
 				}
 			`,
+			// A parameter is contravariant, so a subclass may accept more than the inherited
+			// signature promises. Every call an `Animal` reference makes still fits.
+			want: nil,
+		},
+		{
+			name: "MethodWidenedReturn",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					speak(self) -> number { return 5 },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					speak(self) -> number | string { return 5 },
+				}
+			`,
+			// A return is covariant, so widening it breaks the inherited promise: a caller
+			// holding an `Animal` reads the result as `number` and may get a `string`.
+			want: []string{
+				"class `Dog` redeclares inherited member `speak` with type `fn () -> number | string`, " +
+					"which is not compatible with `fn () -> number` declared by `Animal`",
+			},
+		},
+		{
+			name: "MethodNarrowedReturnIsAllowed",
+			src: `
+				class Animal {
+					constructor(mut self) {},
+					speak(self) -> number | string { return 5 },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {},
+					speak(self) -> number { return 5 },
+				}
+			`,
+			// Narrowing is the direction a return admits. A caller holding an `Animal` reads
+			// the result as `number | string`, which every `number` a Dog returns fits.
 			want: nil,
 		},
 		{

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -60,6 +60,9 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 	for _, component := range g.Components {
 		c.inferComponent(scope, lvl, module, g, component, handled, destructured)
 	}
+	// Every class is inferred, so each superclass edge and body is final. Check the members
+	// each subclass redeclares against the ones they override.
+	c.checkQueuedInheritedMembers()
 	// Reconcile against the source: BuildDepGraph only produces binding keys for
 	// the decl kinds it models, so a kind it does not descend into — e.g. a
 	// NamespaceDecl — yields no component and would vanish without a diagnostic.

--- a/internal/solver/script.go
+++ b/internal/solver/script.go
@@ -61,6 +61,9 @@ func InferScript(script *ast.Script) (*Scope, *Info, []SolverError) {
 	// here too. With the whole body walked, replay the recorded reads against the
 	// consumed lattice to report use-after-move.
 	c.checkUseAfterMoves()
+	// Every class the script declares is inferred, so each superclass edge and body is
+	// final. Check the members each subclass redeclares against the ones they override.
+	c.checkQueuedInheritedMembers()
 	// Every function expression the script wrote has been typed, so each one's return type is
 	// final. Report each function whose return type no finite value inhabits.
 	c.checkCanReturn()


### PR DESCRIPTION
Fixes #985.

The nominal subtype rule decides `Dog <: Animal` on the declared `extends` edge alone, so nothing stopped a subclass from redeclaring an inherited member at a type that contradicts the edge:

```esc
class Animal {
    pos: {x: number},
    constructor(mut self, pos: {x: number}) { self.pos = pos },
}
class Dog extends Animal {
    pos: {x: number, y: number},
    constructor(mut self, pos: {x: number, y: number}) { self.pos = pos },
}
```

Reading `pos` off a `Dog` through an `Animal`-typed binding handed out the wider object typed as the narrower one.

## The check

`internal/solver/inherit.go` compares each name a class declares against the same name on its superclass chain, one access half at a time. Splitting reads from writes is what lets a getter/setter pair and a `readonly` field each be measured on the accesses they actually offer. A half the chain exposes has to survive the redeclaration in two ways:

1. the class has to keep offering it;
2. the type it offers has to fit — covariant for a read, contravariant for a write, with an accessor's `throws` covariant either way.

A generic class's own type parameters are skolemized first, so an obligation has to hold for every instantiation rather than being satisfied by recording a bound on the parameter.

Two diagnostics report the failures:

- `IncompatibleOverrideError` names the member, both types, and both classes.
- `OverrideFormMismatchError` names the two forms when the redeclaration drops a write, drops a read, makes a required field optional, or demands a `mut self` receiver the inherited member does not.

The check is queued and run once every class is inferred. A class's superclass edge and body are filled in at its value key, while `extends` only registers a dependency on the superclass's type key, so a subclass can otherwise be reached before its superclass has either.

## Residual write-back

With the check in place, `needsResidualWriteBack` drops its cross-name arm. The reverse constraint was standing in for exactly this check and rejected every `mut Sub <: mut Super` widening, including the sound majority where the subclass adds members rather than redeclaring them. This is the precision #870 left on the table.

## Notes

- A subclass that adds the missing half of an inherited accessor pair is reported. That is accurate for the compiler as it stands, since reading the member already fails — a subclass body shadows the inherited accessor instead of merging with it. Revisit once #872 folds inheritance into the whole-body views; the `AddingTheMissingAccessorHalfDropsTheInheritedOne` test pins today's answer.
- The check tells a redeclaration from an inherited member by reading `ClassDef.Body` as the class's own declarations. #872 should walk the `extends` chain in the whole-body views rather than merge ancestors into `Body`, which would make every inherited member look like a redeclaration of itself.
- A `readonly` instance field is currently undeclarable: assigning it in the constructor is rejected as a readonly write, and omitting it is reported as uninitialized. Pre-existing and unrelated, but it is why one test expects a second message.

Scoped to `internal/solver`, so no fixtures change. `go test ./...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for inherited class-member overrides.
  * Checks overridden fields, methods, accessors, mutability, optionality, overloads, generic types, and thrown errors.
  * Reports clear diagnostics for incompatible types and mismatched member forms.

* **Bug Fixes**
  * Improved class variance handling for compatible mutable subclasses.
  * Corrected constraint handling for class inheritance relationships.

* **Tests**
  * Added comprehensive coverage for inherited-member compatibility across single- and multi-level class hierarchies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->