### PR TITLE
Add NegationType to represent set-theoretic complements

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -33,7 +33,7 @@ func typePrec(t Type) int {
 		return precIntersection
 	case *NegationType:
 		// `¬T` leads with a prefix operator, so it binds like the `mut` borrow and `keyof`
-		// forms: tighter than `|` and `&`, looser than an atom.
+		// forms. It is tighter than `|` and `&` and looser than an atom.
 		return precPrefix
 	case *RefType:
 		return precPrefix
@@ -1012,8 +1012,8 @@ func (p *namedPrinter) printType(t Type) string {
 		// set-theoretic notation rather than a mirror of a parser form, the same choice the
 		// μ-knot arm makes.
 		//
-		// The operand prints at precPrefix, so a looser operand is parenthesized and the
-		// prefix cannot swallow what follows it: a union renders `¬(A | B)`, an intersection
+		// The operand prints at precPrefix, so a looser operand is parenthesized and the `¬`
+		// cannot swallow what follows it. A union renders `¬(A | B)`, an intersection
 		// `¬(A & B)`, and a function `¬(fn () -> number)`. An atom stays bare, as in `¬number`.
 		return "¬" + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *SkolemType:

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -31,6 +31,10 @@ func typePrec(t Type) int {
 		return precUnion
 	case *IntersectionType:
 		return precIntersection
+	case *NegationType:
+		// `¬T` leads with a prefix operator, so it binds like the `mut` borrow and `keyof`
+		// forms: tighter than `|` and `&`, looser than an atom.
+		return precPrefix
 	case *RefType:
 		return precPrefix
 	case *KeyofType:
@@ -589,6 +593,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 			for _, m := range t.Types {
 				walk(m)
 			}
+		case *NegationType:
+			walk(t.Inner)
 		}
 	}
 	walk(t)
@@ -1001,6 +1007,15 @@ func (p *namedPrinter) printType(t Type) string {
 			parts[i] = p.printTypeMinPrec(m, precIntersection)
 		}
 		return strings.Join(parts, " & ")
+	case *NegationType:
+		// `¬T`. Escalier has no surface syntax for a complement, so this is the standard
+		// set-theoretic notation rather than a mirror of a parser form, the same choice the
+		// μ-knot arm makes.
+		//
+		// The operand prints at precPrefix, so a looser operand is parenthesized and the
+		// prefix cannot swallow what follows it: a union renders `¬(A | B)`, an intersection
+		// `¬(A & B)`, and a function `¬(fn () -> number)`. An atom stays bare, as in `¬number`.
+		return "¬" + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *SkolemType:
 		// A skolem renders under its source parameter name. It is transient to a
 		// checking-mode pass and does not survive into a displayed type, so this arm is

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1008,13 +1008,10 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		return strings.Join(parts, " & ")
 	case *NegationType:
-		// `¬T`. Escalier has no surface syntax for a complement, so this is the standard
-		// set-theoretic notation rather than a mirror of a parser form, the same choice the
-		// μ-knot arm makes.
-		//
-		// The operand prints at precPrefix, so a looser operand is parenthesized and the `¬`
-		// cannot swallow what follows it. A union renders `¬(A | B)`, an intersection
-		// `¬(A & B)`, and a function `¬(fn () -> number)`. An atom stays bare, as in `¬number`.
+		// `¬T`, the standard set-theoretic notation, since Escalier has no surface syntax for a
+		// complement to mirror. The operand prints at precPrefix, so a union renders
+		// `¬(A | B)`, an intersection `¬(A & B)`, a function `¬(fn () -> number)`, and an atom
+		// stays bare as `¬number`.
 		return "¬" + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *SkolemType:
 		// A skolem renders under its source parameter name. It is transient to a

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -203,7 +203,7 @@ func TestPrintRoundTrips(t *testing.T) {
 			"¬number | string",
 		},
 		{
-			// A negated object needs no parens: the braces already delimit the operand.
+			// A negated object needs no parens. The braces already delimit the operand.
 			"negated object stays bare",
 			&NegationType{Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
 			"¬{x: number}",

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -175,6 +175,40 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"null atom", &NullType{}, "null"},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
 
+		// Complements. Escalier has no surface syntax for one, so `¬T` is the standard
+		// set-theoretic notation. The operand prints at precPrefix, so a union,
+		// intersection, or function operand is parenthesized and an atom stays bare.
+		{"negated primitive", &NegationType{Inner: numP()}, "¬number"},
+		{"double negation", &NegationType{Inner: &NegationType{Inner: numP()}}, "¬¬number"},
+		{
+			"negated union parenthesizes its operand",
+			&NegationType{Inner: &UnionType{Types: []Type{numP(), strP()}}},
+			"¬(number | string)",
+		},
+		{
+			"negated intersection parenthesizes its operand",
+			&NegationType{Inner: &IntersectionType{Types: []Type{numP(), strP()}}},
+			"¬(number & string)",
+		},
+		{
+			"negated function parenthesizes its operand",
+			&NegationType{Inner: &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}},
+			"¬(fn (x: number) -> string)",
+		},
+		{
+			// A negation binds tighter than `|`, so as a union member it stays bare and
+			// the `¬` covers only its own operand.
+			"negation inside a union stays bare",
+			&UnionType{Types: []Type{&NegationType{Inner: numP()}, strP()}},
+			"¬number | string",
+		},
+		{
+			// A negated object needs no parens: the braces already delimit the operand.
+			"negated object stays bare",
+			&NegationType{Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
+			"¬{x: number}",
+		},
+
 		// Promises (M3). A rejecting promise renders its Err as a second argument
 		// (M9 PR10c); a nil or `never` Err is the non-rejecting shorthand and renders
 		// the one-argument form, the same suppression the throws clause gets.

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -892,6 +892,24 @@ type UnionType struct {
 }
 type IntersectionType struct{ Types []Type }
 
+// NegationType is the set-theoretic complement ¬Inner, the value that inhabits every type
+// Inner does not. It joins UnionType and IntersectionType as a lattice former and completes
+// them into a Boolean algebra, where every type has a complement and `A & ¬A` is `never`.
+//
+// It is the one former that inverts polarity on its child, because a complement shrinks as
+// its operand grows. Accept visits Inner at the flipped polarity, so coalesce, extrude, and
+// freshenAbove inherit that inversion without a rule of their own.
+//
+// Nothing mints one yet. No source syntax spells a complement, and constrain rejects a
+// constraint whose operand is one, so a negation reaches the solver only once the
+// normalization layer produces it. The representation lands ahead of that so the structural
+// passes — the visitor, LevelOf, structural equality, the canonical member order, and the
+// printer — already carry it.
+//
+// It is deliberately not a RefInner. A borrow is over a value someone allocated, and a
+// complement names no such value, so `&¬T` has no meaning to give it.
+type NegationType struct{ Inner Type }
+
 // ErrorType is the error-recovery sentinel (M3 PR8) — a childless atom distinct
 // from never (⊥) and unknown (⊤). Unlike those two, which are coalesced-OUTPUT
 // only ("appear only as coalesced output, never as constrain inputs", above),
@@ -1300,6 +1318,7 @@ func (*NeverType) isType()           {}
 func (*UnknownType) isType()         {}
 func (*UnionType) isType()           {}
 func (*IntersectionType) isType()    {}
+func (*NegationType) isType()        {}
 func (*ErrorType) isType()           {}
 func (*ClassType) isType()           {}
 func (*AliasType) isType()           {}
@@ -1454,6 +1473,13 @@ func LevelOf(t Type) int {
 		return maxMemberLevel(t.Types)
 	case *IntersectionType:
 		return maxMemberLevel(t.Types)
+	case *NegationType:
+		// A complement's level is its operand's, the single-child rule the KeyofType arm
+		// follows, so a `¬T` over an out-of-level variable lifts the level and the
+		// freshener/extruder prune descends to freshen that variable. Polarity does not enter
+		// here; the level prune asks how deep a variable was minted, not which side of a
+		// constraint it stands on.
+		return LevelOf(t.Inner)
 	default:
 		// PrimType, LitType, NullType, UndefinedType, NeverType, UnknownType,
 		// ErrorType, InferType, MappedKeyType, RecursiveVarType: childless leaves. ErrorType is a

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -893,23 +893,18 @@ type UnionType struct {
 type IntersectionType struct{ Types []Type }
 
 // NegationType is the set-theoretic complement ¬Inner, the type admitting every value Inner
-// rejects. It stands beside UnionType and IntersectionType, which supply joins and meets,
-// and completes the three into a Boolean algebra. Every type then has a complement, `A & ¬A`
-// is `never`, and `A | ¬A` is `unknown`.
+// rejects. It stands beside UnionType and IntersectionType, which supply joins and meets, and
+// completes the three into a Boolean algebra. `A & ¬A` is `never` and `A | ¬A` is `unknown`.
 //
 // It is the one node that inverts polarity on its child, because a complement shrinks as its
-// operand grows. Accept visits Inner at the flipped polarity. Every structural rewriter
-// rides on Accept, so coalesce, extrude, and freshenAbove inherit that inversion with no
-// rule of their own.
+// operand grows. Accept visits Inner at the flipped polarity, and every structural rewriter
+// rides on Accept, so coalesce, extrude, and freshenAbove inherit that inversion.
 //
-// Nothing mints one yet. No source syntax spells a complement and constrain has no rule for
-// one, so a negation reaches the solver only once the normalization layer produces it. The
-// representation lands ahead of that so every structural pass already carries a negation
-// arm. Those passes are the visitor, LevelOf, structural equality, the canonical member
-// order, and the printer.
+// No source syntax spells a complement and constrain has no rule for one, so the
+// normalization layer is the only producer of a negation.
 //
-// It is deliberately not a RefInner. A borrow points at a value someone allocated, and a
-// complement names no such value, so `&¬T` would point at nothing.
+// It is not a RefInner. A borrow points at a value someone allocated and a complement names
+// no such value, so `&¬T` would point at nothing.
 type NegationType struct{ Inner Type }
 
 // ErrorType is the error-recovery sentinel (M3 PR8) — a childless atom distinct
@@ -1477,10 +1472,8 @@ func LevelOf(t Type) int {
 		return maxMemberLevel(t.Types)
 	case *NegationType:
 		// A complement's level is its operand's, the single-child rule the KeyofType arm
-		// follows, so a `¬T` over an out-of-level variable lifts the level and the
-		// freshener/extruder prune descends to freshen that variable. Polarity does not enter
-		// here. The level prune asks how deep a variable was minted, not which side of a
-		// constraint it stands on.
+		// follows. A `¬T` over an out-of-level variable therefore lifts the level, and the
+		// freshener/extruder prune descends to freshen that variable.
 		return LevelOf(t.Inner)
 	default:
 		// PrimType, LitType, NullType, UndefinedType, NeverType, UnknownType,

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -892,22 +892,24 @@ type UnionType struct {
 }
 type IntersectionType struct{ Types []Type }
 
-// NegationType is the set-theoretic complement ¬Inner, the value that inhabits every type
-// Inner does not. It joins UnionType and IntersectionType as a lattice former and completes
-// them into a Boolean algebra, where every type has a complement and `A & ¬A` is `never`.
+// NegationType is the set-theoretic complement ¬Inner, the type admitting every value Inner
+// rejects. It stands beside UnionType and IntersectionType, which supply joins and meets,
+// and completes the three into a Boolean algebra. Every type then has a complement, `A & ¬A`
+// is `never`, and `A | ¬A` is `unknown`.
 //
-// It is the one former that inverts polarity on its child, because a complement shrinks as
-// its operand grows. Accept visits Inner at the flipped polarity, so coalesce, extrude, and
-// freshenAbove inherit that inversion without a rule of their own.
+// It is the one node that inverts polarity on its child, because a complement shrinks as its
+// operand grows. Accept visits Inner at the flipped polarity. Every structural rewriter
+// rides on Accept, so coalesce, extrude, and freshenAbove inherit that inversion with no
+// rule of their own.
 //
-// Nothing mints one yet. No source syntax spells a complement, and constrain rejects a
-// constraint whose operand is one, so a negation reaches the solver only once the
-// normalization layer produces it. The representation lands ahead of that so the structural
-// passes — the visitor, LevelOf, structural equality, the canonical member order, and the
-// printer — already carry it.
+// Nothing mints one yet. No source syntax spells a complement and constrain has no rule for
+// one, so a negation reaches the solver only once the normalization layer produces it. The
+// representation lands ahead of that so every structural pass already carries a negation
+// arm. Those passes are the visitor, LevelOf, structural equality, the canonical member
+// order, and the printer.
 //
-// It is deliberately not a RefInner. A borrow is over a value someone allocated, and a
-// complement names no such value, so `&¬T` has no meaning to give it.
+// It is deliberately not a RefInner. A borrow points at a value someone allocated, and a
+// complement names no such value, so `&¬T` would point at nothing.
 type NegationType struct{ Inner Type }
 
 // ErrorType is the error-recovery sentinel (M3 PR8) — a childless atom distinct
@@ -1477,7 +1479,7 @@ func LevelOf(t Type) int {
 		// A complement's level is its operand's, the single-child rule the KeyofType arm
 		// follows, so a `¬T` over an out-of-level variable lifts the level and the
 		// freshener/extruder prune descends to freshen that variable. Polarity does not enter
-		// here; the level prune asks how deep a variable was minted, not which side of a
+		// here. The level prune asks how deep a variable was minted, not which side of a
 		// constraint it stands on.
 		return LevelOf(t.Inner)
 	default:

--- a/internal/soltype/type_test.go
+++ b/internal/soltype/type_test.go
@@ -131,6 +131,32 @@ func TestLevelOf(t *testing.T) {
 			ty:   &RefType{Mut: true, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: num}}}},
 			want: 0,
 		},
+		{
+			// A complement carries no variable of its own, so its level is its operand's.
+			// Negating a type does not move the variable it holds to another level.
+			name: "negation: level of its operand",
+			ty:   &NegationType{Inner: v5},
+			want: 5,
+		},
+		{
+			name: "negation over a concrete operand is level 0",
+			ty:   &NegationType{Inner: num},
+			want: 0,
+		},
+		{
+			// Two negations reach the same operand, so the level is unchanged by the depth.
+			name: "double negation: level of its operand",
+			ty:   &NegationType{Inner: &NegationType{Inner: v2}},
+			want: 2,
+		},
+		{
+			name: "negation over a function: max over the signature",
+			ty: &NegationType{Inner: &FuncType{
+				Params: []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: v2}},
+				Ret:    v5,
+			}},
+			want: 5,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -469,12 +469,10 @@ func (t *NegationType) Accept(v TypeVisitor, pol Polarity) Type {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
 	cur := descendReplacement(t, e)
-	// A complement is contravariant in its operand, since ¬Inner shrinks as Inner grows. So
-	// the operand walks at the opposite polarity, the flip acceptParams applies to a
-	// function's parameters. UnionType and IntersectionType walk their members at the
-	// current polarity, and this is the one node that inverts. Every rewriter rides on
-	// Accept, so this single flip is what gives coalesce, extrude, and freshenAbove the
-	// right variance under a negation.
+	// ¬Inner shrinks as Inner grows, so the operand walks at the flipped polarity, the flip
+	// acceptParams applies to a function's parameters. This is the only node that inverts,
+	// and every rewriter rides on Accept, so the single flip here is what gives coalesce,
+	// extrude, and freshenAbove their variance under a negation.
 	inner := cur.Inner.Accept(v, pol.Flip())
 	out := cur
 	if inner != cur.Inner {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -472,9 +472,9 @@ func (t *NegationType) Accept(v TypeVisitor, pol Polarity) Type {
 	// A complement is contravariant in its operand, since ¬Inner shrinks as Inner grows. So
 	// the operand walks at the opposite polarity, the flip acceptParams applies to a
 	// function's parameters. UnionType and IntersectionType walk their members at the
-	// current polarity; this is the one node that inverts. Every rewriter rides on Accept,
-	// so this single flip is what gives coalesce, extrude, and freshenAbove the right
-	// variance under a negation.
+	// current polarity, and this is the one node that inverts. Every rewriter rides on
+	// Accept, so this single flip is what gives coalesce, extrude, and freshenAbove the
+	// right variance under a negation.
 	inner := cur.Inner.Accept(v, pol.Flip())
 	out := cur
 	if inner != cur.Inner {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -463,6 +463,26 @@ func (t *IntersectionType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *NegationType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// A complement is contravariant in its operand, since ¬Inner shrinks as Inner grows. So
+	// the operand walks at the opposite polarity, the flip acceptParams applies to a
+	// function's parameters. UnionType and IntersectionType walk their members at the
+	// current polarity; this is the one node that inverts. Every rewriter rides on Accept,
+	// so this single flip is what gives coalesce, extrude, and freshenAbove the right
+	// variance under a negation.
+	inner := cur.Inner.Accept(v, pol.Flip())
+	out := cur
+	if inner != cur.Inner {
+		out = &NegationType{Inner: inner}
+	}
+	return v.ExitType(out, pol)
+}
+
 func (t *ClassType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -309,7 +309,7 @@ func TestAcceptUnionIdentityPreservation(t *testing.T) {
 // A complement is contravariant in its operand, so Accept walks Inner at the flipped
 // polarity. The flip composes with the one a function's parameters already get, so a
 // parameter under a negation is covariant, and a second negation flips back to where it
-// started. It is the only node that inverts — a tuple's elements stay covariant.
+// started. It is the only node that inverts, so a tuple's elements stay covariant.
 func TestAcceptNegationFlipsPolarity(t *testing.T) {
 	param := &TypeVarType{ID: 1}
 	ret := &PrimType{Prim: NumPrim}

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -306,6 +306,65 @@ func TestAcceptUnionIdentityPreservation(t *testing.T) {
 	require.Same(t, u, u.Accept(identityVisitor{}, Positive), "an unchanged UnionType keeps its pointer")
 }
 
+// A complement is contravariant in its operand, so Accept walks Inner at the flipped
+// polarity. The flip composes with the one a function's parameters already get, so a
+// parameter under a negation is covariant, and a second negation flips back to where it
+// started. It is the only node that inverts — a tuple's elements stay covariant.
+func TestAcceptNegationFlipsPolarity(t *testing.T) {
+	param := &TypeVarType{ID: 1}
+	ret := &PrimType{Prim: NumPrim}
+	atom := &PrimType{Prim: StrPrim}
+
+	// [¬(fn (x: param) -> ret), ¬¬atom], walked from Positive. A tuple element is
+	// covariant, so each negation is entered at the root polarity.
+	fn := &FuncType{
+		Params: []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: param}},
+		Ret:    ret,
+	}
+	negFn := &NegationType{Inner: fn}
+	innerNeg := &NegationType{Inner: atom}
+	outerNeg := &NegationType{Inner: innerNeg}
+	root := &TupleType{Elems: []Type{negFn, outerNeg}}
+
+	r := &recorder{seen: map[Type]Polarity{}}
+	root.Accept(r, Positive)
+
+	require.Equal(t, Positive, r.seen[negFn], "a tuple element keeps the root polarity")
+	require.Equal(t, Negative, r.seen[fn], "a negation's operand is contravariant")
+	require.Equal(t, Positive, r.seen[param], "a parameter under a negation flips back")
+	require.Equal(t, Negative, r.seen[ret], "the return of a negated fn stays flipped")
+	require.Equal(t, Positive, r.seen[outerNeg], "the second tuple element keeps the root polarity")
+	require.Equal(t, Negative, r.seen[innerNeg], "the inner negation is contravariant")
+	require.Equal(t, Positive, r.seen[atom], "two negations flip back to the outer polarity")
+}
+
+// A no-op rewrite over a nested negation keeps every pointer, the negation and the
+// function it wraps alike (copy-on-write).
+func TestAcceptNegationIdentityPreservation(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	str := &PrimType{Prim: StrPrim}
+	fn := &FuncType{
+		Params: []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: num}},
+		Ret:    str,
+	}
+	neg := &NegationType{Inner: fn}
+	got := neg.Accept(identityVisitor{}, Positive)
+	require.Same(t, neg, got, "an unchanged NegationType keeps its pointer")
+	require.Same(t, fn, got.(*NegationType).Inner, "so does the operand it wraps")
+}
+
+// Rewriting the operand rebuilds the NegationType around the replacement.
+func TestAcceptNegationCopyOnWrite(t *testing.T) {
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	neg := &NegationType{Inner: a}
+
+	got := neg.Accept(&replaceVar{target: a, repl: str}, Positive).(*NegationType)
+
+	require.NotSame(t, neg, got, "a changed operand forces a new NegationType")
+	require.Same(t, str, got.Inner, "the operand took the replacement")
+}
+
 // An unchanged inexact ObjectType keeps its pointer (copy-on-write): a no-op
 // rewrite allocates nothing.
 func TestAcceptObjectIdentityPreservation(t *testing.T) {

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -306,10 +306,9 @@ func TestAcceptUnionIdentityPreservation(t *testing.T) {
 	require.Same(t, u, u.Accept(identityVisitor{}, Positive), "an unchanged UnionType keeps its pointer")
 }
 
-// A complement is contravariant in its operand, so Accept walks Inner at the flipped
-// polarity. The flip composes with the one a function's parameters already get, so a
-// parameter under a negation is covariant, and a second negation flips back to where it
-// started. It is the only node that inverts, so a tuple's elements stay covariant.
+// Accept walks a complement's operand at the flipped polarity, and that flip composes with
+// the one a function's parameters get. So a parameter under a negation is covariant and a
+// second negation flips back, while a tuple's elements stay covariant.
 func TestAcceptNegationFlipsPolarity(t *testing.T) {
 	param := &TypeVarType{ID: 1}
 	ret := &PrimType{Prim: NumPrim}
@@ -339,7 +338,7 @@ func TestAcceptNegationFlipsPolarity(t *testing.T) {
 }
 
 // A no-op rewrite over a nested negation keeps every pointer, the negation and the
-// function it wraps alike (copy-on-write).
+// function it wraps alike.
 func TestAcceptNegationIdentityPreservation(t *testing.T) {
 	num := &PrimType{Prim: NumPrim}
 	str := &PrimType{Prim: StrPrim}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1482,8 +1482,8 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		return ok && equalTypeSliceWith(a.Types, b.Types, ctx)
 	case *soltype.NegationType:
 		// Two complements are equal when their operands are, so `¬A` equals `¬A` and differs
-		// from `¬B`. A negated member is compared structurally like any other member, which is
-		// what lets a normal form's conjunct list dedup its negated members.
+		// from `¬B`. That is what lets a member list dedup a negated member the same way it
+		// dedups a plain one.
 		b, ok := b.(*soltype.NegationType)
 		return ok && equalTypeWith(a.Inner, b.Inner, ctx)
 	case *soltype.KeyofType:

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1480,6 +1480,12 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 	case *soltype.IntersectionType:
 		b, ok := b.(*soltype.IntersectionType)
 		return ok && equalTypeSliceWith(a.Types, b.Types, ctx)
+	case *soltype.NegationType:
+		// Two complements are equal when their operands are, so `¬A` equals `¬A` and differs
+		// from `¬B`. A negated member is compared structurally like any other member, which is
+		// what lets a normal form's conjunct list dedup its negated members.
+		b, ok := b.(*soltype.NegationType)
+		return ok && equalTypeWith(a.Inner, b.Inner, ctx)
 	case *soltype.KeyofType:
 		// Two inert `keyof` residuals are equal when they carry the same exactness over
 		// equal operands. This compares the residual structurally without reducing it,

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -376,9 +376,8 @@ func TestEqualTypeRef(t *testing.T) {
 	}
 }
 
-// equalType compares two complements by their operands, so `¬A` equals `¬A` and differs
-// from `¬B`. A complement is also never equal to the type it negates, which is what keeps
-// a member and its negation from collapsing into one another under dedup.
+// equalType compares two complements by their operands, so `¬A` equals `¬A`, differs from
+// `¬B`, and never equals the type it negates.
 func TestEqualTypeNegation(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -376,6 +376,59 @@ func TestEqualTypeRef(t *testing.T) {
 	}
 }
 
+// equalType compares two complements by their operands, so `¬A` equals `¬A` and differs
+// from `¬B`. A complement is also never equal to the type it negates, which is what keeps
+// a member and its negation from collapsing into one another under dedup.
+func TestEqualTypeNegation(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "same operand",
+			a:    &soltype.NegationType{Inner: num()},
+			b:    &soltype.NegationType{Inner: num()},
+			want: true,
+		},
+		{
+			name: "operand differs",
+			a:    &soltype.NegationType{Inner: num()},
+			b:    &soltype.NegationType{Inner: str()},
+			want: false,
+		},
+		{
+			name: "structural operands compare structurally",
+			a:    &soltype.NegationType{Inner: exactObj(propElem("x", num()))},
+			b:    &soltype.NegationType{Inner: exactObj(propElem("x", num()))},
+			want: true,
+		},
+		{
+			name: "negation is not its bare operand",
+			a:    &soltype.NegationType{Inner: num()},
+			b:    num(),
+			want: false,
+		},
+		{
+			name: "double negation is not a single one",
+			a:    &soltype.NegationType{Inner: &soltype.NegationType{Inner: num()}},
+			b:    &soltype.NegationType{Inner: num()},
+			want: false,
+		},
+		{
+			name: "double negations over the same operand are equal",
+			a:    &soltype.NegationType{Inner: &soltype.NegationType{Inner: num()}},
+			b:    &soltype.NegationType{Inner: &soltype.NegationType{Inner: num()}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}
+
 // equalType on a ClassType is nominal: it compares the qualified Name and the Final
 // exactness flag, then the type arguments positionally. Two instances of different
 // classes, or of the same class with different arguments or exactness, are not equal.

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -1151,7 +1151,7 @@ func TestConstrainExtrusionBothPolarities(t *testing.T) {
 // gain a lower bound instead, silently inverting every constraint extruded through a
 // negation.
 //
-// constrain rejects a negated operand, so the test calls extrude directly rather than
+// constrain has no rule for a complement, so the test drives extrude directly rather than
 // going through Constrain.
 func TestExtrudeThroughNegation(t *testing.T) {
 	c := &Context{}
@@ -1180,6 +1180,42 @@ func TestExtrudeThroughNegation(t *testing.T) {
 	require.Len(t, a.UpperBounds, 1, "a parameter under a negation is extruded at Positive polarity")
 	require.Same(t, soltype.Type(fresh), a.UpperBounds[0])
 	require.Empty(t, a.LowerBounds, "the Negative wiring would have added a lower bound")
+}
+
+// TestDescribeNegation renders a complement in a diagnostic. describe is the nominal
+// renderer beside soltype.Print, so a structural operand collapses to its kind word and
+// only a union or intersection operand needs parens to stop its `|` or `&` from binding
+// past the `¬`.
+func TestDescribeNegation(t *testing.T) {
+	tests := []struct {
+		name string
+		in   soltype.Type
+		want string
+	}{
+		{"primitive operand", &soltype.NegationType{Inner: num()}, "¬number"},
+		{"double negation", &soltype.NegationType{Inner: &soltype.NegationType{Inner: num()}}, "¬¬number"},
+		{
+			"union operand is parenthesized",
+			&soltype.NegationType{Inner: &soltype.UnionType{Types: []soltype.Type{num(), str()}}},
+			"¬(number | string)",
+		},
+		{
+			"intersection operand is parenthesized",
+			&soltype.NegationType{Inner: &soltype.IntersectionType{Types: []soltype.Type{num(), str()}}},
+			"¬(number & string)",
+		},
+		{
+			// A function collapses to the bare kind word, which cannot run on, so it stays bare.
+			"function operand stays bare",
+			&soltype.NegationType{Inner: &soltype.FuncType{Ret: num()}},
+			"¬function",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, describe(tt.in))
+		})
+	}
 }
 
 // --- The coinductive seen-set's two records ---

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -1139,20 +1139,16 @@ func TestConstrainExtrusionBothPolarities(t *testing.T) {
 	require.Equal(t, 0, retVar.Level)
 }
 
-// TestExtrudeThroughNegation pins the polarity a variable under a complement is extruded
-// at. extrude wires a fresh variable to the original through the bound direction the
-// polarity picks: an upper bound in Positive position and a lower bound in Negative. So
-// the direction the original gains is an observable readout of the polarity the walk
-// reached it at.
+// TestExtrudeThroughNegation pins the polarity a variable under a complement is extruded at.
+// extrude wires the fresh variable through the bound direction the polarity picks, an upper
+// bound in Positive position and a lower bound in Negative. The direction the original gains
+// therefore reads back the polarity the walk reached it at.
 //
-// `¬(fn (x: a) -> number)` walked from Positive flips twice. The complement flips to
-// Negative and the parameter flips back to Positive, so `a` gains an UPPER bound. Without
-// the flip in NegationType.Accept the parameter would be reached at Negative and `a` would
-// gain a lower bound instead, silently inverting every constraint extruded through a
-// negation.
+// `¬(fn (x: a) -> number)` walked from Positive flips twice, so `a` is reached at Positive
+// and gains an UPPER bound. Reaching it at Negative would wire a lower bound instead and
+// invert every constraint extruded through a negation.
 //
-// constrain has no rule for a complement, so the test drives extrude directly rather than
-// going through Constrain.
+// constrain has no rule for a complement, so the test drives extrude directly.
 func TestExtrudeThroughNegation(t *testing.T) {
 	c := &Context{}
 	a := c.freshVar(1) // level 1, so the level-0 extrusion must descend to it
@@ -1182,10 +1178,8 @@ func TestExtrudeThroughNegation(t *testing.T) {
 	require.Empty(t, a.LowerBounds, "the Negative wiring would have added a lower bound")
 }
 
-// TestDescribeNegation renders a complement in a diagnostic. describe is the nominal
-// renderer beside soltype.Print, so a structural operand collapses to its kind word and
-// only a union or intersection operand needs parens to stop its `|` or `&` from binding
-// past the `¬`.
+// TestDescribeNegation renders a complement in a diagnostic. describe collapses a structural
+// operand to its kind word, so only a union or intersection operand needs parens.
 func TestDescribeNegation(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -1139,6 +1139,49 @@ func TestConstrainExtrusionBothPolarities(t *testing.T) {
 	require.Equal(t, 0, retVar.Level)
 }
 
+// TestExtrudeThroughNegation pins the polarity a variable under a complement is extruded
+// at. extrude wires a fresh variable to the original through the bound direction the
+// polarity picks: an upper bound in Positive position and a lower bound in Negative. So
+// the direction the original gains is an observable readout of the polarity the walk
+// reached it at.
+//
+// `¬(fn (x: a) -> number)` walked from Positive flips twice. The complement flips to
+// Negative and the parameter flips back to Positive, so `a` gains an UPPER bound. Without
+// the flip in NegationType.Accept the parameter would be reached at Negative and `a` would
+// gain a lower bound instead, silently inverting every constraint extruded through a
+// negation.
+//
+// constrain rejects a negated operand, so the test calls extrude directly rather than
+// going through Constrain.
+func TestExtrudeThroughNegation(t *testing.T) {
+	c := &Context{}
+	a := c.freshVar(1) // level 1, so the level-0 extrusion must descend to it
+	fn := &soltype.FuncType{
+		Params: []*soltype.FuncParam{identParam("x", a)},
+		Ret:    num(),
+	}
+	neg := &soltype.NegationType{Inner: fn}
+
+	got := c.extrude(neg, soltype.Positive, 0, map[extrudeKey]*soltype.TypeVarType{})
+
+	// The rewritten type keeps its shape: a complement over a function whose parameter is
+	// the fresh level-0 variable.
+	gotNeg, ok := got.(*soltype.NegationType)
+	require.True(t, ok, "extrude rebuilds the complement rather than peeling it")
+	gotFn, ok := gotNeg.Inner.(*soltype.FuncType)
+	require.True(t, ok, "the operand is still the function")
+	fresh, ok := gotFn.Params[0].Type.(*soltype.TypeVarType)
+	require.True(t, ok, "the parameter extruded to a variable")
+	require.NotSame(t, a, fresh, "the original level-1 variable did not leak in")
+	require.Equal(t, 0, fresh.Level, "it was copied down to the extrusion level")
+
+	// The Positive wiring: the original gains the fresh variable as an UPPER bound and no
+	// lower bound at all.
+	require.Len(t, a.UpperBounds, 1, "a parameter under a negation is extruded at Positive polarity")
+	require.Same(t, soltype.Type(fresh), a.UpperBounds[0])
+	require.Empty(t, a.LowerBounds, "the Negative wiring would have added a lower bound")
+}
+
 // --- The coinductive seen-set's two records ---
 
 // nestedRecursiveObj builds the cyclic object type `{p: pt, next: {q: <the outer object>}}` and

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2936,6 +2936,11 @@ func describe(t soltype.Type) string {
 		return s
 	case *soltype.IntersectionType:
 		return joinDescribe(t.Types, " & ")
+	case *soltype.NegationType:
+		// A complement renders `¬T` over the nominal inner, recursing like the union and
+		// intersection arms. constrain rejects a constraint whose operand is a negation, so
+		// this arm is what names the rejected operand in that message.
+		return "¬" + describe(t.Inner)
 	case *soltype.TypeVarType:
 		return "t" + strconv.Itoa(t.ID)
 	case *soltype.SkolemType:

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2938,9 +2938,20 @@ func describe(t soltype.Type) string {
 		return joinDescribe(t.Types, " & ")
 	case *soltype.NegationType:
 		// A complement renders `¬T` over the nominal inner, recursing like the union and
-		// intersection arms. constrain rejects a constraint whose operand is a negation, so
-		// this arm is what names the rejected operand in that message.
-		return "¬" + describe(t.Inner)
+		// intersection arms, so a constraint naming one reads `¬number` rather than the
+		// default `?`.
+		//
+		// A union or intersection operand is parenthesized. Its `|` or `&` would otherwise
+		// bind past the `¬`, so `¬(number | string)` would render as `¬number | string` and
+		// read back as `(¬number) | string`. Every other operand renders as a single word or
+		// a delimited form. A function renders as the bare "function" and an object as
+		// "object", so neither can run on into what follows.
+		inner := describe(t.Inner)
+		switch t.Inner.(type) {
+		case *soltype.UnionType, *soltype.IntersectionType:
+			return "¬(" + inner + ")"
+		}
+		return "¬" + inner
 	case *soltype.TypeVarType:
 		return "t" + strconv.Itoa(t.ID)
 	case *soltype.SkolemType:

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2938,14 +2938,10 @@ func describe(t soltype.Type) string {
 		return joinDescribe(t.Types, " & ")
 	case *soltype.NegationType:
 		// A complement renders `¬T` over the nominal inner, recursing like the union and
-		// intersection arms, so a constraint naming one reads `¬number` rather than the
-		// default `?`.
-		//
-		// A union or intersection operand is parenthesized. Its `|` or `&` would otherwise
-		// bind past the `¬`, so `¬(number | string)` would render as `¬number | string` and
-		// read back as `(¬number) | string`. Every other operand renders as a single word or
-		// a delimited form. A function renders as the bare "function" and an object as
-		// "object", so neither can run on into what follows.
+		// intersection arms. A union or intersection operand is parenthesized, since its `|`
+		// or `&` would otherwise bind past the `¬` and `¬number | string` reads back as
+		// `(¬number) | string`. Every other operand renders as one word or a delimited form,
+		// so none can run on. Giving describe the precedence data Print already has is #1092.
 		inner := describe(t.Inner)
 		switch t.Inner.(type) {
 		case *soltype.UnionType, *soltype.IntersectionType:

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -645,10 +645,10 @@ func lifetimeKindOrder(lt soltype.Lifetime) int {
 // members before its absence markers. NullType precedes UndefinedType, so
 // `T0 | number | null | undefined` is the canonical render.
 //
-// NegationType joins UnionType and IntersectionType among the lattice forms.
-// Ranking it there gives a normal form's conjuncts and disjuncts a canonical
-// order to dedup under, so `¬A` lands at one position whatever order the
-// members were minted in.
+// NegationType is ranked with UnionType and IntersectionType among the
+// lattice forms. That slot is what gives a member list holding negations a
+// canonical order to dedup under, so `¬A` sorts to one position whatever
+// order the members were minted in.
 func typeKindOrder(t soltype.Type) int {
 	switch t.(type) {
 	case *soltype.NeverType:

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -480,6 +480,10 @@ func compareSameKind(a, b soltype.Type) int {
 			return c
 		}
 		return compareTypeSlice(a.Types, b.Types)
+	case *soltype.NegationType:
+		// Two complements order by their operands, so the order over negated members mirrors
+		// the order over the members themselves and `¬number` precedes `¬string`.
+		return compareType(a.Inner, b.(*soltype.NegationType).Inner)
 	}
 	return 0
 }
@@ -640,6 +644,11 @@ func lifetimeKindOrder(lt soltype.Lifetime) int {
 // NullType and UndefinedType. A union renders its parameters and data
 // members before its absence markers. NullType precedes UndefinedType, so
 // `T0 | number | null | undefined` is the canonical render.
+//
+// NegationType joins UnionType and IntersectionType among the lattice forms.
+// Ranking it there gives a normal form's conjuncts and disjuncts a canonical
+// order to dedup under, so `¬A` lands at one position whatever order the
+// members were minted in.
 func typeKindOrder(t soltype.Type) int {
 	switch t.(type) {
 	case *soltype.NeverType:
@@ -672,10 +681,12 @@ func typeKindOrder(t soltype.Type) int {
 		return 13
 	case *soltype.IntersectionType:
 		return 14
-	case *soltype.NullType:
+	case *soltype.NegationType:
 		return 15
-	case *soltype.UndefinedType:
+	case *soltype.NullType:
 		return 16
+	case *soltype.UndefinedType:
+		return 17
 	}
-	return 17
+	return 18
 }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -646,9 +646,9 @@ func lifetimeKindOrder(lt soltype.Lifetime) int {
 // `T0 | number | null | undefined` is the canonical render.
 //
 // NegationType is ranked with UnionType and IntersectionType among the
-// lattice forms. That slot is what gives a member list holding negations a
-// canonical order to dedup under, so `¬A` sorts to one position whatever
-// order the members were minted in.
+// lattice forms. The slot makes the order over member lists holding
+// negations stable, so `¬A` sorts to one position whatever order the members
+// were minted in.
 func typeKindOrder(t soltype.Type) int {
 	switch t.(type) {
 	case *soltype.NeverType:

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -394,12 +394,10 @@ func TestCompareTypeKindOrder(t *testing.T) {
 	require.Less(t, compareType(parseType(t, "unknown"), v), 0, "UnknownType < TypeVarType")
 }
 
-// TestCompareTypeNegation pins the canonical order over complements. A normal form's
-// conjunct and disjunct lists dedup under this order, so `¬A` must land at one position
-// whatever order the members were minted in. Two complements order by their operands, and
-// a complement occupies a kind slot of its own beside the union and intersection forms.
-// A complement has no surface syntax, so parseType cannot author one and the operands are
-// built directly.
+// TestCompareTypeNegation pins the canonical order over complements. Two complements order
+// by their operands, and a complement occupies a kind slot of its own beside the union and
+// intersection forms. A complement has no surface syntax, so parseType cannot author one and
+// the operands are built directly.
 func TestCompareTypeNegation(t *testing.T) {
 	negNum := &soltype.NegationType{Inner: num()}
 	negStr := &soltype.NegationType{Inner: str()}

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -370,6 +370,8 @@ func TestCompareTypeConsistentWithEqual(t *testing.T) {
 		// equalType treats objects as equal up to property order; the
 		// comparator must agree.
 		{"objects equal up to order", parseType(t, "{a: number, b: string}"), parseType(t, "{b: string, a: number}")},
+		// A complement has no surface syntax to parse, so its operands are built directly.
+		{"negations over one operand", &soltype.NegationType{Inner: num()}, &soltype.NegationType{Inner: num()}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -390,6 +392,44 @@ func TestCompareTypeKindOrder(t *testing.T) {
 	require.Less(t, compareType(parseType(t, "number"), parseType(t, "1")), 0, "PrimType < LitType")
 	require.Less(t, compareType(parseType(t, "never"), v), 0, "NeverType < TypeVarType")
 	require.Less(t, compareType(parseType(t, "unknown"), v), 0, "UnknownType < TypeVarType")
+}
+
+// TestCompareTypeNegation pins the canonical order over complements. A normal form's
+// conjunct and disjunct lists dedup under this order, so `¬A` must land at one position
+// whatever order the members were minted in. Two complements order by their operands, and
+// a complement occupies a kind slot of its own beside the union and intersection forms.
+// A complement has no surface syntax, so parseType cannot author one and the operands are
+// built directly.
+func TestCompareTypeNegation(t *testing.T) {
+	negNum := &soltype.NegationType{Inner: num()}
+	negStr := &soltype.NegationType{Inner: str()}
+	inter := &soltype.IntersectionType{Types: []soltype.Type{num(), str()}}
+
+	// Two complements order by their operands, so the order over negated members mirrors
+	// the order over the members themselves.
+	require.Less(t, compareType(num(), str()), 0, "precondition: number < string")
+	require.Less(t, compareType(negNum, negStr), 0, "¬number < ¬string")
+
+	// The kind slot sits after the union and intersection forms and before the absence
+	// markers, so a mixed list renders its data members before `null` and `undefined`.
+	require.Less(t, compareType(inter, negNum), 0, "IntersectionType < NegationType")
+	require.Less(t, compareType(negNum, parseType(t, "null")), 0, "NegationType < NullType")
+	require.Less(t, compareType(parseType(t, "null"), parseType(t, "undefined")), 0,
+		"NullType < UndefinedType still holds with the negation slot inserted")
+
+	// The order is total over a mixed list: two different starting permutations sort to
+	// the same sequence.
+	forward := []soltype.Type{num(), negStr, inter, negNum, parseType(t, "null")}
+	reverse := []soltype.Type{parseType(t, "null"), negNum, inter, negStr, num()}
+	sortTypes(forward)
+	sortTypes(reverse)
+	require.Equal(t, len(forward), len(reverse))
+	for i := range forward {
+		require.True(t, equalType(forward[i], reverse[i]),
+			"position %d: %s vs %s", i, soltype.Print(forward[i]), soltype.Print(reverse[i]))
+	}
+	require.True(t, equalType(negNum, forward[2]), "¬number sorts after the intersection")
+	require.True(t, equalType(negStr, forward[3]), "¬string sorts after ¬number")
 }
 
 // TestCompareTypeDistinctRefsWithUnnamedLifetimes pins the structural


### PR DESCRIPTION
Introduces `NegationType` to the type system as the set-theoretic complement `¬Inner`, completing the Boolean algebra alongside `UnionType` and `IntersectionType`. This lands the representation ahead of the normalization layer that will produce complements, ensuring all structural passes already carry a negation arm.

Key changes:

- **Type representation** (`internal/soltype/type.go`): Added `NegationType` struct with documentation explaining its contravariance and role in the type algebra. It is deliberately not a `RefInner` since a complement names no allocated value.

- **Visitor support** (`internal/soltype/visitor.go`): Implemented `Accept` method that walks the operand at flipped polarity, making the complement contravariant. This single inversion point gives all structural rewriters (coalesce, extrude, freshenAbove) the correct variance under negation without needing individual rules.

- **Structural passes**:
  - `LevelOf` (`internal/soltype/type.go`): Returns the operand's level, following the single-child rule.
  - `equalType` (`internal/solver/coalesce.go`): Compares complements by their operands, enabling dedup of negated members.
  - `compareType` (`internal/solver/lattice.go`): Orders complements by operand, giving negated members a canonical sort position. Assigned kind order 15, between `IntersectionType` (14) and `NullType` (16).

- **Printing** (`internal/soltype/print.go`): Renders as `¬T` using set-theoretic notation (no surface syntax exists). Operands looser than prefix precedence are parenthesized: `¬(number | string)`, `¬(number & string)`, `¬(fn () -> number)`. Atoms stay bare: `¬number`.

- **Error diagnostics** (`internal/solver/errors.go`): Added `describe` arm to render complements in constraint diagnostics with the same parenthesization rules as printing.

- **Tests**: Comprehensive coverage across four test files:
  - `TestExtrudeThroughNegation`: Pins polarity flipping during extrusion through a negation.
  - `TestDescribeNegation`: Validates diagnostic rendering.
  - `TestAcceptNegationFlipsPolarity`, `TestAcceptNegationIdentityPreservation`, `TestAcceptNegationCopyOnWrite`: Visitor behavior.
  - `TestEqualTypeNegation`: Equality semantics.
  - `TestCompareTypeNegation`: Canonical ordering.
  - `TestPrintRoundTrips`: Printing with various operand shapes.
  - `TestLevelOf`: Level computation.

The implementation ensures that when the normalization layer produces complements, all existing structural machinery handles them correctly without modification.

https://claude.ai/code/session_01V14pA66svL2TAhi5NUrc2S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for negated types using `¬T` notation.
  * Preserved correct precedence and parentheses for complex negated types.
  * Integrated negated types into type comparison, inference, validation, and diagnostics.

* **Bug Fixes**
  * Improved handling of nested negations and negated function types.
  * Ensured structurally equivalent negated types compare consistently.

* **Tests**
  * Added comprehensive coverage for printing, traversal, inference, equality, ordering, and diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->