### PR TITLE
PR3 (1/6) — DNF/CNF normal-form ADTs and their Boolean algebra

### DIFF
--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1,0 +1,701 @@
+package solver
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// The DNF/CNF normal forms MLstruct decides subtyping in, ported from MLscript's
+// NormalForms.scala. A normal form is a Boolean formula over structural atoms and
+// type variables, written either as a union of meets or as an intersection of
+// joins. Pushing both sides of a constraint into one of those two shapes is what
+// lets the solver decompose `sub <: super` deterministically instead of guessing
+// which member of a union to try first.
+//
+// These types are SOLVER-INTERNAL and transient. They live for the duration of a
+// constraint and are never stored in the Info side table, never handed to the
+// printer, and never returned from coalescing. The surface representation stays
+// soltype.Type, and toType converts a normal form back to one.
+//
+// # The two shapes
+//
+// A DNF is a union of Conjuncts and a CNF is an intersection of Disjuncts. A
+// Conjunct is a meet of four parts, written `Lnf ∩ (⋂Vars) ∩ ¬Rnf ∩ (⋂¬NVars)`:
+// a positive structural part, positive type variables, a negated structural part,
+// and negated type variables. A Disjunct is the exact dual, a join written
+// `Rnf ∪ (⋃Vars) ∪ ¬Lnf ∪ (⋃¬NVars)`. Negating one produces the other by
+// permuting those four fields, which is De Morgan's law with no traversal.
+//
+// # A list of atoms per side, not one slot per kind
+//
+// MLscript gives LhsNf and RhsNf one slot per structural kind, which loses
+// precision in two places — see planning/ml_struct/06-open-items.md findings 1 and
+// 2. This port holds a LIST per side instead, so neither loss is inherited.
+//
+// Finding 1 pays off immediately. A supertype union of two differently-named
+// records stays precise here, where MLscript widens the disjunct to `unknown` on
+// meeting the second field name and makes every subtype pass against it.
+//
+// # What a later PR adds
+//
+// Atoms accumulate in their lists. Two equal atoms dedup, and two atoms of one
+// kind that are not equal are both kept. Nothing is merged structurally yet, so
+// `number ∩ string` stays two atoms rather than collapsing to `never`, and two
+// inexact records stay two atoms rather than merging field-wise. The merge table
+// and the rule for fusing whole conjuncts land next, and finding 2 — keeping
+// intersected arrows apart rather than fusing them unsoundly — is settled there.
+
+// DNF is a union of conjuncts, the disjunctive normal form of a type. An empty
+// conjunct list is `never`, the identity of `|`.
+type DNF struct{ Conjuncts []Conjunct }
+
+// CNF is an intersection of disjuncts, the conjunctive normal form of a type. An
+// empty disjunct list is `unknown`, the identity of `&`.
+type CNF struct{ Disjuncts []Disjunct }
+
+// Conjunct is one meet of a DNF, reading `Lnf ∩ (⋂Vars) ∩ ¬Rnf ∩ (⋂¬NVars)`. All
+// four parts may be empty, and a Conjunct with all four empty is `unknown`.
+type Conjunct struct {
+	Lnf   LhsNf
+	Vars  set.Set[*soltype.TypeVarType]
+	Rnf   RhsNf
+	NVars set.Set[*soltype.TypeVarType]
+}
+
+// Disjunct is one join of a CNF and the dual of Conjunct, reading
+// `Rnf ∪ (⋃Vars) ∪ ¬Lnf ∪ (⋃¬NVars)`. A Disjunct with all four parts empty is
+// `never`. Conjunct.neg and Disjunct.neg convert between the two by permuting the
+// four fields.
+type Disjunct struct {
+	Rnf   RhsNf
+	Vars  set.Set[*soltype.TypeVarType]
+	Lnf   LhsNf
+	NVars set.Set[*soltype.TypeVarType]
+}
+
+// LhsNf is a normalized INTERSECTION of structural atoms, the positive part of a
+// Conjunct and the negated part of a Disjunct. Atoms is canonically ordered by
+// sortAtoms and holds no two equal atoms. An empty Atoms is `unknown`.
+type LhsNf struct{ Atoms []soltype.Type }
+
+// RhsNf is a normalized UNION of structural atoms, the dual of LhsNf. It is the
+// positive part of a Disjunct and the negated part of a Conjunct. An empty Atoms
+// is `never`.
+type RhsNf struct{ Atoms []soltype.Type }
+
+// Base returns the single nominal class tag the intersection carries, and reports
+// whether it carries exactly one. This is the slot the nominal meet will write to:
+// once PR4 (#1061) supplies it, two related tags fuse into one and two unrelated
+// ones make the conjunct `never`, so a well-formed conjunct holds at most one tag
+// and this accessor is total on it.
+func (l LhsNf) Base() (*soltype.ClassType, bool) {
+	var found *soltype.ClassType
+	for _, atom := range l.Atoms {
+		ct, ok := atom.(*soltype.ClassType)
+		if !ok {
+			continue
+		}
+		if found != nil {
+			return nil, false
+		}
+		found = ct
+	}
+	return found, found != nil
+}
+
+// --- Construction ---
+
+// mkDNF pushes t into disjunctive normal form at polarity pol. It normalizes the
+// BOOLEAN structure only: a union, an intersection, a negation, and a type
+// variable are taken apart, and every other node becomes one structural atom with
+// its children untouched.
+//
+// pol is the position t occupies. A negation flips it before normalizing its
+// operand, so the polarity stays accurate all the way down, but no arm below reads
+// it for anything else. The shallow form is therefore the same at either polarity.
+// pol is threaded so that a later pass can normalize an atom's children at the
+// polarity they really occupy, which is where the parameters of a function and the
+// operand of a negation part company.
+func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
+	switch t := t.(type) {
+	case *soltype.NeverType:
+		return DNF{Conjuncts: nil}
+	case *soltype.UnknownType:
+		return dnfTop()
+	case *soltype.UnionType:
+		if t.Inexact {
+			// `A | B | ...` names A, B, and an open tail of unknown content. The tail has
+			// no atom to stand for it, so taking the union apart would drop it and hand
+			// back a type narrower than the source wrote. The whole node stays one atom,
+			// which round-trips exactly and keeps the flag. PR7 (#1064) decides how far
+			// an inexact union can be decomposed.
+			return dnfAtom(t)
+		}
+		out := DNF{Conjuncts: nil}
+		for _, m := range t.Types {
+			out = dnfOr(out, c.mkDNF(m, pol))
+		}
+		return DNF{Conjuncts: canonicalConjuncts(out.Conjuncts)}
+	case *soltype.IntersectionType:
+		out := dnfTop()
+		for _, m := range t.Types {
+			out = dnfAnd(out, c.mkDNF(m, pol))
+		}
+		return DNF{Conjuncts: canonicalConjuncts(out.Conjuncts)}
+	case *soltype.NegationType:
+		// ¬T at pol is the complement of T at the flipped polarity, and the complement
+		// of an intersection of joins is a union of meets. So normalize the operand to a
+		// CNF and negate each disjunct into a conjunct. Negating permutes fields without
+		// consulting the merges, so the result is canonicalized afterwards.
+		negated := c.mkCNF(t.Inner, pol.Flip()).neg()
+		return DNF{Conjuncts: canonicalConjuncts(negated.Conjuncts)}
+	case *soltype.TypeVarType:
+		return DNF{Conjuncts: []Conjunct{newConjunct().withVar(t)}}
+	default:
+		return dnfAtom(t)
+	}
+}
+
+// mkCNF pushes t into conjunctive normal form at polarity pol, the dual of mkDNF.
+func (c *Context) mkCNF(t soltype.Type, pol soltype.Polarity) CNF {
+	switch t := t.(type) {
+	case *soltype.UnknownType:
+		return CNF{Disjuncts: nil}
+	case *soltype.NeverType:
+		return cnfBot()
+	case *soltype.IntersectionType:
+		out := CNF{Disjuncts: nil}
+		for _, m := range t.Types {
+			out = cnfAnd(out, c.mkCNF(m, pol))
+		}
+		return CNF{Disjuncts: canonicalDisjuncts(out.Disjuncts)}
+	case *soltype.UnionType:
+		if t.Inexact {
+			// The open tail has no atom to stand for it; see the mkDNF arm.
+			return cnfAtom(t)
+		}
+		out := cnfBot()
+		for _, m := range t.Types {
+			out = cnfOr(out, c.mkCNF(m, pol))
+		}
+		return CNF{Disjuncts: canonicalDisjuncts(out.Disjuncts)}
+	case *soltype.NegationType:
+		negated := c.mkDNF(t.Inner, pol.Flip()).neg()
+		return CNF{Disjuncts: canonicalDisjuncts(negated.Disjuncts)}
+	case *soltype.TypeVarType:
+		return CNF{Disjuncts: []Disjunct{newDisjunct().withVar(t)}}
+	default:
+		return cnfAtom(t)
+	}
+}
+
+// dnfTop is `unknown` as a DNF: one conjunct with nothing in it, since an empty
+// meet is the top of the lattice.
+func dnfTop() DNF {
+	return DNF{Conjuncts: []Conjunct{newConjunct()}}
+}
+
+// cnfBot is `never` as a CNF: one disjunct with nothing in it, since an empty join
+// is the bottom of the lattice.
+func cnfBot() CNF {
+	return CNF{Disjuncts: []Disjunct{newDisjunct()}}
+}
+
+// dnfAtom is a single structural atom as a DNF.
+func dnfAtom(t soltype.Type) DNF {
+	return DNF{Conjuncts: []Conjunct{newConjunct().withAtom(t)}}
+}
+
+// cnfAtom is a single structural atom as a CNF.
+func cnfAtom(t soltype.Type) CNF {
+	return CNF{Disjuncts: []Disjunct{newDisjunct().withAtom(t)}}
+}
+
+// newConjunct is the `unknown` conjunct, the identity the intersection folds start
+// from.
+func newConjunct() Conjunct {
+	return Conjunct{
+		Lnf:   LhsNf{Atoms: nil},
+		Vars:  set.NewSet[*soltype.TypeVarType](),
+		Rnf:   RhsNf{Atoms: nil},
+		NVars: set.NewSet[*soltype.TypeVarType](),
+	}
+}
+
+// newDisjunct is the `never` disjunct, the identity the union folds start from.
+func newDisjunct() Disjunct {
+	return Disjunct{
+		Rnf:   RhsNf{Atoms: nil},
+		Vars:  set.NewSet[*soltype.TypeVarType](),
+		Lnf:   LhsNf{Atoms: nil},
+		NVars: set.NewSet[*soltype.TypeVarType](),
+	}
+}
+
+func (a Conjunct) withAtom(t soltype.Type) Conjunct {
+	a.Lnf = LhsNf{Atoms: []soltype.Type{t}}
+	return a
+}
+
+func (a Conjunct) withVar(v *soltype.TypeVarType) Conjunct {
+	a.Vars = set.FromSlice([]*soltype.TypeVarType{v})
+	return a
+}
+
+func (a Disjunct) withAtom(t soltype.Type) Disjunct {
+	a.Rnf = RhsNf{Atoms: []soltype.Type{t}}
+	return a
+}
+
+func (a Disjunct) withVar(v *soltype.TypeVarType) Disjunct {
+	a.Vars = set.FromSlice([]*soltype.TypeVarType{v})
+	return a
+}
+
+// --- Negation ---
+
+// neg complements a DNF into a CNF. `¬(C₁ ∪ … ∪ Cₙ)` is `¬C₁ ∩ … ∩ ¬Cₙ`, so the
+// conjuncts negate one for one into disjuncts and no atom is traversed. An empty
+// DNF is `never`, and it negates to an empty CNF, which is `unknown`.
+func (d DNF) neg() CNF {
+	out := make([]Disjunct, len(d.Conjuncts))
+	for i, conj := range d.Conjuncts {
+		out[i] = conj.neg()
+	}
+	return CNF{Disjuncts: out}
+}
+
+// neg complements a CNF into a DNF, the dual of DNF.neg.
+func (n CNF) neg() DNF {
+	out := make([]Conjunct, len(n.Disjuncts))
+	for i, disj := range n.Disjuncts {
+		out[i] = disj.neg()
+	}
+	return DNF{Conjuncts: out}
+}
+
+// neg complements a conjunct into a disjunct. `¬(L ∩ V ∩ ¬R ∩ ¬N)` is
+// `R ∪ N ∪ ¬L ∪ ¬V`, which is the same four parts in the dual slots: the two
+// structural parts swap roles and so do the two variable sets. De Morgan's law is
+// therefore a field permutation here rather than a rewrite.
+func (a Conjunct) neg() Disjunct {
+	return Disjunct{Rnf: a.Rnf, Vars: a.NVars, Lnf: a.Lnf, NVars: a.Vars}
+}
+
+// neg complements a disjunct into a conjunct, the dual of Conjunct.neg.
+func (a Disjunct) neg() Conjunct {
+	return Conjunct{Lnf: a.Lnf, Vars: a.NVars, Rnf: a.Rnf, NVars: a.Vars}
+}
+
+// --- Boolean algebra over normal forms ---
+
+// dnfOr unions two DNFs. A union of unions is one longer union, so the conjunct
+// lists simply concatenate.
+//
+// Nothing is ordered here, and neither does dnfAnd below. The mkDNF arms pool
+// every member first and call canonicalConjuncts once over the whole pool, so
+// ordering and deduping see the complete list. Pooling is associative, so folding
+// these binary operations left to right reaches the same pool as any other
+// bracketing.
+func dnfOr(a, b DNF) DNF {
+	out := make([]Conjunct, 0, len(a.Conjuncts)+len(b.Conjuncts))
+	out = append(out, a.Conjuncts...)
+	out = append(out, b.Conjuncts...)
+	return DNF{Conjuncts: out}
+}
+
+// dnfAnd intersects two DNFs by distributing the meet over both unions, so every
+// conjunct of a meets every conjunct of b.
+func dnfAnd(a, b DNF) DNF {
+	out := make([]Conjunct, 0, len(a.Conjuncts)*len(b.Conjuncts))
+	for _, x := range a.Conjuncts {
+		for _, y := range b.Conjuncts {
+			if met, ok := conjunctAnd(x, y); ok {
+				out = append(out, met)
+			}
+		}
+	}
+	return DNF{Conjuncts: out}
+}
+
+// cnfAnd intersects two CNFs, the dual of dnfOr.
+func cnfAnd(a, b CNF) CNF {
+	out := make([]Disjunct, 0, len(a.Disjuncts)+len(b.Disjuncts))
+	out = append(out, a.Disjuncts...)
+	out = append(out, b.Disjuncts...)
+	return CNF{Disjuncts: out}
+}
+
+// cnfOr unions two CNFs by distributing the join over both intersections, the dual
+// of dnfAnd.
+func cnfOr(a, b CNF) CNF {
+	out := make([]Disjunct, 0, len(a.Disjuncts)*len(b.Disjuncts))
+	for _, x := range a.Disjuncts {
+		for _, y := range b.Disjuncts {
+			if joined, ok := disjunctOr(x, y); ok {
+				out = append(out, joined)
+			}
+		}
+	}
+	return CNF{Disjuncts: out}
+}
+
+// conjunctAnd intersects two conjuncts. The positive structural parts pool as one
+// intersection, the negated ones pool as one union, since `¬R₁ ∩ ¬R₂` is
+// `¬(R₁ ∪ R₂)`, and the two variable sets union. ok is false when a variable is
+// held both positively and negatively, which makes the meet `v ∩ ¬v`.
+//
+// The pooled structural parts are put in order later, by normalizeConjunct, once
+// every atom in the surrounding union or intersection is in the pool.
+func conjunctAnd(a, b Conjunct) (Conjunct, bool) {
+	vars := a.Vars.Union(b.Vars)
+	nvars := a.NVars.Union(b.NVars)
+	if vars.Intersection(nvars).Len() > 0 {
+		return Conjunct{}, false
+	}
+	return Conjunct{
+		Lnf:   LhsNf{Atoms: pooled(a.Lnf.Atoms, b.Lnf.Atoms)},
+		Vars:  vars,
+		Rnf:   RhsNf{Atoms: pooled(a.Rnf.Atoms, b.Rnf.Atoms)},
+		NVars: nvars,
+	}, true
+}
+
+// disjunctOr unions two disjuncts, the dual of conjunctAnd. ok is false when a
+// variable is held both positively and negatively, since `v ∪ ¬v` admits every
+// value and `unknown` is the identity of the intersection the disjuncts sit in.
+func disjunctOr(a, b Disjunct) (Disjunct, bool) {
+	vars := a.Vars.Union(b.Vars)
+	nvars := a.NVars.Union(b.NVars)
+	if vars.Intersection(nvars).Len() > 0 {
+		return Disjunct{}, false
+	}
+	return Disjunct{
+		Rnf:   RhsNf{Atoms: pooled(a.Rnf.Atoms, b.Rnf.Atoms)},
+		Vars:  vars,
+		Lnf:   LhsNf{Atoms: pooled(a.Lnf.Atoms, b.Lnf.Atoms)},
+		NVars: nvars,
+	}, true
+}
+
+// --- The structural parts ---
+
+// pooled concatenates two atom lists into a fresh slice, so ordering the result
+// leaves both inputs alone. Two normal forms often share an atom list, since a
+// conjunct that survived canonicalization unchanged keeps the slice it arrived
+// with.
+func pooled(a, b []soltype.Type) []soltype.Type {
+	out := make([]soltype.Type, 0, len(a)+len(b))
+	out = append(out, a...)
+	out = append(out, b...)
+	return out
+}
+
+// copyAtoms is pooled over a single list, for the same reason.
+func copyAtoms(atoms []soltype.Type) []soltype.Type {
+	return append([]soltype.Type(nil), atoms...)
+}
+
+// dedupAtoms orders an atom list canonically and drops the duplicates that pooling
+// two lists can produce, so `number ∩ number` holds one atom rather than two.
+//
+// Dropping a duplicate is the only combining an atom list does at this stage. Two
+// atoms of one kind that are not equal are both kept, which costs nothing: a
+// two-atom list is already the precise meet or join of its atoms.
+func dedupAtoms(atoms []soltype.Type) []soltype.Type {
+	sortAtoms(atoms)
+	if len(atoms) < 2 {
+		return atoms
+	}
+	out := atoms[:1]
+	for _, atom := range atoms[1:] {
+		if !equalType(out[len(out)-1], atom) {
+			out = append(out, atom)
+		}
+	}
+	return out
+}
+
+// sortAtoms orders an atom list in place, canonically.
+//
+// It orders by compareAtom rather than by compareType, because compareType has no
+// structural arm for several kinds an atom can be. A class tag, an alias
+// reference, and the residual type operators all land in one bucket and compare
+// equal to each other there, so `Point & Line` and `Line & Point` would each keep
+// the order they were written in and render differently.
+func sortAtoms(atoms []soltype.Type) {
+	sort.SliceStable(atoms, func(i, j int) bool { return compareAtom(atoms[i], atoms[j]) < 0 })
+}
+
+// compareAtom is the total order over atoms: compareType first, then the
+// qualified rendering for two atoms compareType calls equal without their being
+// equalType-equal. PrintQualified is the collision-free identity key the solver
+// already forms elsewhere, and two atoms it also renders alike keep the order they
+// arrived in, which is no worse than compareType alone.
+func compareAtom(a, b soltype.Type) int {
+	if c := compareType(a, b); c != 0 {
+		return c
+	}
+	if equalType(a, b) {
+		return 0
+	}
+	return strings.Compare(soltype.PrintQualified(a), soltype.PrintQualified(b))
+}
+
+// equalAtomLists reports whether two atom lists hold the same atoms in the same
+// positions. Both are sorted, so this is the equality equalConjunct tests.
+//
+// It compares with equalType rather than by checking compareAtoms for a zero.
+// compareType returns zero both for equal types and for two types it has no
+// structural arm to tell apart, such as two different class tags, so deduping on a
+// zero would treat a conjunct negating `Point` and one negating `Line` as the same
+// conjunct and delete one of them.
+func equalAtomLists(a, b []soltype.Type) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !equalType(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// --- Canonicalizing the conjunct and disjunct lists ---
+
+// canonicalConjuncts orders and dedups the conjuncts of a DNF. The result depends
+// on the SET of conjuncts and not on the order they arrived in, so two normal
+// forms of one type agree member for member. That is what lets a caller compare
+// normal forms directly.
+func canonicalConjuncts(conjuncts []Conjunct) []Conjunct {
+	normalized := make([]Conjunct, 0, len(conjuncts))
+	for _, conj := range conjuncts {
+		normalized = append(normalized, normalizeConjunct(conj))
+	}
+	sortConjuncts(normalized)
+	return dedupSorted(normalized, equalConjunct)
+}
+
+// normalizeConjunct puts a conjunct's two pooled structural parts in order.
+func normalizeConjunct(a Conjunct) Conjunct {
+	return Conjunct{
+		Lnf:   LhsNf{Atoms: dedupAtoms(copyAtoms(a.Lnf.Atoms))},
+		Vars:  a.Vars,
+		Rnf:   RhsNf{Atoms: dedupAtoms(copyAtoms(a.Rnf.Atoms))},
+		NVars: a.NVars,
+	}
+}
+
+// canonicalDisjuncts is the dual of canonicalConjuncts over a CNF.
+func canonicalDisjuncts(disjuncts []Disjunct) []Disjunct {
+	normalized := make([]Disjunct, 0, len(disjuncts))
+	for _, disj := range disjuncts {
+		normalized = append(normalized, normalizeDisjunct(disj))
+	}
+	sortDisjuncts(normalized)
+	return dedupSorted(normalized, equalDisjunct)
+}
+
+// normalizeDisjunct is the dual of normalizeConjunct.
+func normalizeDisjunct(a Disjunct) Disjunct {
+	return Disjunct{
+		Rnf:   RhsNf{Atoms: dedupAtoms(copyAtoms(a.Rnf.Atoms))},
+		Vars:  a.Vars,
+		Lnf:   LhsNf{Atoms: dedupAtoms(copyAtoms(a.Lnf.Atoms))},
+		NVars: a.NVars,
+	}
+}
+
+func sortConjuncts(items []Conjunct) {
+	sort.SliceStable(items, func(i, j int) bool { return compareConjunct(items[i], items[j]) < 0 })
+}
+
+func sortDisjuncts(items []Disjunct) {
+	sort.SliceStable(items, func(i, j int) bool { return compareDisjunct(items[i], items[j]) < 0 })
+}
+
+// dedupSorted drops members equal to the one before them under equal. The input
+// must already be ordered so that equal members are adjacent.
+//
+// equal is a structural equality rather than a zero from the comparator that
+// ordered the list. compareConjunct bottoms out in compareType, which returns zero
+// both for equal types and for two types it has no arm to tell apart, so deduping
+// on a zero would delete a distinct conjunct.
+func dedupSorted[T any](items []T, equal func(a, b T) bool) []T {
+	if len(items) < 2 {
+		return items
+	}
+	out := items[:1]
+	for _, item := range items[1:] {
+		if !equal(out[len(out)-1], item) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// equalConjunct reports whether two conjuncts hold the same four parts.
+func equalConjunct(a, b Conjunct) bool {
+	return equalAtomLists(a.Lnf.Atoms, b.Lnf.Atoms) &&
+		equalAtomLists(a.Rnf.Atoms, b.Rnf.Atoms) &&
+		a.Vars.Equals(b.Vars) && a.NVars.Equals(b.NVars)
+}
+
+// equalDisjunct is the dual of equalConjunct.
+func equalDisjunct(a, b Disjunct) bool {
+	return equalAtomLists(a.Lnf.Atoms, b.Lnf.Atoms) &&
+		equalAtomLists(a.Rnf.Atoms, b.Rnf.Atoms) &&
+		a.Vars.Equals(b.Vars) && a.NVars.Equals(b.NVars)
+}
+
+// --- Canonical ordering ---
+
+// compareConjunct is the total order canonical conjunct order is built on. It
+// compares the four parts in the order they read, so two conjuncts holding the
+// same parts compare equal whatever route built them.
+func compareConjunct(a, b Conjunct) int {
+	if c := compareAtoms(a.Lnf.Atoms, b.Lnf.Atoms); c != 0 {
+		return c
+	}
+	if c := compareVars(a.Vars, b.Vars); c != 0 {
+		return c
+	}
+	if c := compareAtoms(a.Rnf.Atoms, b.Rnf.Atoms); c != 0 {
+		return c
+	}
+	return compareVars(a.NVars, b.NVars)
+}
+
+// compareDisjunct is the dual of compareConjunct.
+func compareDisjunct(a, b Disjunct) int {
+	if c := compareAtoms(a.Rnf.Atoms, b.Rnf.Atoms); c != 0 {
+		return c
+	}
+	if c := compareVars(a.Vars, b.Vars); c != 0 {
+		return c
+	}
+	if c := compareAtoms(a.Lnf.Atoms, b.Lnf.Atoms); c != 0 {
+		return c
+	}
+	return compareVars(a.NVars, b.NVars)
+}
+
+// compareAtoms orders two atom lists by length, then position for position under
+// compareAtom. Both lists are kept sorted by the same order, so two lists holding
+// the same atoms compare equal.
+func compareAtoms(a, b []soltype.Type) int {
+	if c := len(a) - len(b); c != 0 {
+		return c
+	}
+	for i := range a {
+		if c := compareAtom(a[i], b[i]); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+// compareVars orders two variable sets by size, then by their ids. Iterating a
+// set.Set yields no order, so both sides are sorted by id first.
+func compareVars(a, b set.Set[*soltype.TypeVarType]) int {
+	as, bs := sortedVars(a), sortedVars(b)
+	if c := len(as) - len(bs); c != 0 {
+		return c
+	}
+	for i := range as {
+		if c := as[i].ID - bs[i].ID; c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+// sortedVars returns a variable set's members ordered by id, so rendering and
+// comparison read them in one order.
+func sortedVars(vars set.Set[*soltype.TypeVarType]) []*soltype.TypeVarType {
+	out := vars.ToSlice()
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// --- Back to a surface type ---
+
+// toType renders a DNF as the union its conjuncts denote. An empty DNF is `never`.
+// The result is an ordinary soltype.Type: the normal form itself never leaves the
+// solver.
+func (d DNF) toType() soltype.Type {
+	parts := make([]soltype.Type, len(d.Conjuncts))
+	for i, conj := range d.Conjuncts {
+		parts[i] = conj.toType()
+	}
+	return newUnion(nil, parts, false)
+}
+
+// toType renders a CNF as the intersection its disjuncts denote. An empty CNF is
+// `unknown`.
+func (n CNF) toType() soltype.Type {
+	parts := make([]soltype.Type, len(n.Disjuncts))
+	for i, disj := range n.Disjuncts {
+		parts[i] = disj.toType()
+	}
+	return newIntersection(nil, parts)
+}
+
+// toType renders a conjunct as `Lnf ∩ (⋂Vars) ∩ ¬Rnf ∩ (⋂¬NVars)`. An empty part
+// contributes nothing: an empty Lnf is `unknown` and an empty Rnf makes the
+// negated part `¬never`, and both are the identity of the intersection.
+func (a Conjunct) toType() soltype.Type {
+	parts := make([]soltype.Type, 0, len(a.Lnf.Atoms)+a.Vars.Len()+1+a.NVars.Len())
+	parts = append(parts, a.Lnf.Atoms...)
+	for _, v := range sortedVars(a.Vars) {
+		parts = append(parts, v)
+	}
+	if len(a.Rnf.Atoms) > 0 {
+		parts = append(parts, negate(a.Rnf.toType()))
+	}
+	for _, v := range sortedVars(a.NVars) {
+		parts = append(parts, negate(v))
+	}
+	return newIntersection(nil, parts)
+}
+
+// toType renders a disjunct as `Rnf ∪ (⋃Vars) ∪ ¬Lnf ∪ (⋃¬NVars)`, the dual of
+// Conjunct.toType. An empty Lnf makes the negated part `¬unknown`, which is
+// `never`, the identity of the union.
+func (a Disjunct) toType() soltype.Type {
+	parts := make([]soltype.Type, 0, len(a.Rnf.Atoms)+a.Vars.Len()+1+a.NVars.Len())
+	parts = append(parts, a.Rnf.Atoms...)
+	for _, v := range sortedVars(a.Vars) {
+		parts = append(parts, v)
+	}
+	if len(a.Lnf.Atoms) > 0 {
+		parts = append(parts, negate(a.Lnf.toType()))
+	}
+	for _, v := range sortedVars(a.NVars) {
+		parts = append(parts, negate(v))
+	}
+	return newUnion(nil, parts, false)
+}
+
+// toType renders an intersection of atoms. An empty list is `unknown`.
+func (l LhsNf) toType() soltype.Type {
+	return newIntersection(nil, l.Atoms)
+}
+
+// toType renders a union of atoms. An empty list is `never`.
+func (r RhsNf) toType() soltype.Type {
+	return newUnion(nil, r.Atoms, false)
+}
+
+// negate wraps a rendered part in a complement. No simplification is needed at
+// the two sites that call it. The part is a non-empty atom list or a type
+// variable, so it is never a lattice bound whose complement is the other bound,
+// and mkDNF decomposes every negation it meets, so no atom is itself a complement
+// that a second one would cancel.
+func negate(t soltype.Type) soltype.Type {
+	return &soltype.NegationType{Inner: t}
+}

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -346,13 +346,19 @@ func cnfOr(a, b CNF) CNF {
 // conjunctAnd intersects two conjuncts. The positive structural parts pool as one
 // intersection, the negated ones pool as one union, since `¬R₁ ∩ ¬R₂` is
 // `¬(R₁ ∪ R₂)`, and the two variable sets union. ok is false when a variable is
-// held both positively and negatively, which makes the meet `v ∩ ¬v`.
+// held both positively and negatively.
 //
 // The pooled structural parts are put in order later, by normalizeConjunct, once
 // every atom in the surrounding union or intersection is in the pool.
 func conjunctAnd(a, b Conjunct) (Conjunct, bool) {
 	vars := a.Vars.Union(b.Vars)
 	nvars := a.NVars.Union(b.NVars)
+	// The same variable held both ways makes the conjunct `v ∩ ¬v`, which no value
+	// inhabits under any instantiation, so no bound has to be consulted. Dropping
+	// the conjunct rather than reporting an error is right because `never` is the
+	// identity of the union its DNF is. The two sets are keyed by pointer, so this
+	// fires only on one variable held both ways, never on two distinct variables
+	// that solving later makes equal.
 	if vars.Intersection(nvars).Len() > 0 {
 		return Conjunct{}, false
 	}
@@ -365,11 +371,15 @@ func conjunctAnd(a, b Conjunct) (Conjunct, bool) {
 }
 
 // disjunctOr unions two disjuncts, the dual of conjunctAnd. ok is false when a
-// variable is held both positively and negatively, since `v ∪ ¬v` admits every
-// value and `unknown` is the identity of the intersection the disjuncts sit in.
+// variable is held both positively and negatively.
 func disjunctOr(a, b Disjunct) (Disjunct, bool) {
 	vars := a.Vars.Union(b.Vars)
 	nvars := a.NVars.Union(b.NVars)
+	// The dual of the conjunct case. The same variable held both ways makes the
+	// disjunct `v ∪ ¬v`, which every value inhabits under any instantiation, and it
+	// is dropped because `unknown` is the identity of the intersection its CNF is.
+	// The pointer keying is the same, so two distinct variables that solving later
+	// makes equal do not fire this.
 	if vars.Intersection(nvars).Len() > 0 {
 		return Disjunct{}, false
 	}

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"slices"
 	"sort"
 	"strings"
 
@@ -398,15 +399,7 @@ func disjunctOr(a, b Disjunct) (Disjunct, bool) {
 // conjunct that survived canonicalization unchanged keeps the slice it arrived
 // with.
 func pooled(a, b []soltype.Type) []soltype.Type {
-	out := make([]soltype.Type, 0, len(a)+len(b))
-	out = append(out, a...)
-	out = append(out, b...)
-	return out
-}
-
-// copyAtoms is pooled over a single list, for the same reason.
-func copyAtoms(atoms []soltype.Type) []soltype.Type {
-	return append([]soltype.Type(nil), atoms...)
+	return slices.Concat(a, b)
 }
 
 // dedupAtoms orders an atom list canonically and drops the duplicates that pooling
@@ -490,12 +483,15 @@ func canonicalConjuncts(conjuncts []Conjunct) []Conjunct {
 	return dedupSorted(normalized, equalConjunct)
 }
 
-// normalizeConjunct puts a conjunct's two pooled structural parts in order.
+// normalizeConjunct puts a conjunct's two pooled structural parts in order. Each
+// list is cloned first, since dedupAtoms sorts in place and a conjunct that came
+// through canonicalization unchanged still shares its slice with the normal form
+// it arrived from.
 func normalizeConjunct(a Conjunct) Conjunct {
 	return Conjunct{
-		Lnf:   LhsNf{Atoms: dedupAtoms(copyAtoms(a.Lnf.Atoms))},
+		Lnf:   LhsNf{Atoms: dedupAtoms(slices.Clone(a.Lnf.Atoms))},
 		Vars:  a.Vars,
-		Rnf:   RhsNf{Atoms: dedupAtoms(copyAtoms(a.Rnf.Atoms))},
+		Rnf:   RhsNf{Atoms: dedupAtoms(slices.Clone(a.Rnf.Atoms))},
 		NVars: a.NVars,
 	}
 }
@@ -513,9 +509,9 @@ func canonicalDisjuncts(disjuncts []Disjunct) []Disjunct {
 // normalizeDisjunct is the dual of normalizeConjunct.
 func normalizeDisjunct(a Disjunct) Disjunct {
 	return Disjunct{
-		Rnf:   RhsNf{Atoms: dedupAtoms(copyAtoms(a.Rnf.Atoms))},
+		Rnf:   RhsNf{Atoms: dedupAtoms(slices.Clone(a.Rnf.Atoms))},
 		Vars:  a.Vars,
-		Lnf:   LhsNf{Atoms: dedupAtoms(copyAtoms(a.Lnf.Atoms))},
+		Lnf:   LhsNf{Atoms: dedupAtoms(slices.Clone(a.Lnf.Atoms))},
 		NVars: a.NVars,
 	}
 }

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -276,6 +276,41 @@ func TestDeMorgan(t *testing.T) {
 	}
 }
 
+// TestDeMorganOverAnInexactUnion pins the one shape the law above does not cover.
+//
+// An inexact union `A | B | ...` denotes A, B, and an open tail of unknown
+// content, so complementing it excludes that tail too:
+//
+//	¬(A | B | ...)  is  ¬A ∩ ¬B ∩ ¬tail
+//
+// which is strictly narrower than `¬A & ¬B`. The two are therefore different
+// types, and no flag on the intersection would make them agree. Inexactness on a
+// union WIDENS it by an unknown member, and the complement of that is a
+// NARROWING by an unknown set — something an intersection has no slot for.
+// IntersectionType carries no exactness marker at all, since exactness is a
+// property of the result rather than of the meet.
+//
+// So the complement keeps the whole union as one negated atom, tail and all,
+// rather than distributing over its members and silently dropping the tail.
+// Threading the marker through normalization is PR7's remit (#1064).
+func TestDeMorganOverAnInexactUnion(t *testing.T) {
+	c := &Context{}
+	a, b := parseType(t, "{x: number}"), parseType(t, "{y: number}")
+	meetOfComplements := normDNF(c, newIntersection(nil, []soltype.Type{not(a), not(b)}))
+	require.Equal(t, "¬({x: number} | {y: number})", meetOfComplements)
+
+	// The exact union obeys the law, which is what TestDeMorgan states over its
+	// record row. Repeating it here is what makes the rows below a statement about
+	// the marker rather than about the members.
+	closed := newUnion(nil, []soltype.Type{a, b}, false)
+	require.Equal(t, meetOfComplements, normDNF(c, not(closed)))
+
+	// The inexact union does not, and its complement still carries the tail.
+	open := newUnion(nil, []soltype.Type{a, b}, true)
+	require.Equal(t, "¬({x: number} | {y: number} | ...)", normDNF(c, not(open)))
+	require.NotEqual(t, meetOfComplements, normDNF(c, not(open)))
+}
+
 // TestUnionKeepsUnmergeableRecords is the caveat-4 regression guard. Two records
 // with different field names have no single record that denotes their union, so
 // both normal forms keep two members rather than widening. MLscript's RhsNf holds

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -1,0 +1,496 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// The normal-forms tests are isolated from constraint solving. Every case here
+// pushes a type into DNF or CNF and reads the result back, so nothing in this file
+// calls Constrain or records a bound. That keeps the module's behavior pinned
+// independently of the solver PR5 (#1062) grafts it into.
+//
+// A case states its input as an Escalier type annotation and its expected normal
+// form as the annotation the normalized type renders under, which is how the rest
+// of the solver's tests are written. Negation has no surface syntax, so the two
+// helpers below build one.
+
+// not is `¬t`, the complement no annotation can spell.
+func not(t soltype.Type) soltype.Type {
+	return &soltype.NegationType{Inner: t}
+}
+
+// notSrc parses an annotation and complements it, so a case can write `¬number`
+// as notSrc(t, "number").
+func notSrc(t *testing.T, src string) soltype.Type {
+	t.Helper()
+	return not(parseType(t, src))
+}
+
+// normDNF renders the disjunctive normal form of ty, which is what a round-trip
+// case asserts on.
+func normDNF(c *Context, ty soltype.Type) string {
+	return soltype.Print(c.mkDNF(ty, soltype.Positive).toType())
+}
+
+// normCNF renders the conjunctive normal form of ty.
+func normCNF(c *Context, ty soltype.Type) string {
+	return soltype.Print(c.mkCNF(ty, soltype.Negative).toType())
+}
+
+// TestDNFRoundTrip pushes an annotation into DNF and back, and asserts the
+// annotation the result renders under. A row whose want repeats its in is a
+// round-trip: normalization left the type alone. A row whose want differs records
+// a normalization the module performs.
+func TestDNFRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "a primitive is one atom", in: "number", want: "number"},
+		{name: "a literal is one atom", in: `"a"`, want: `"a"`},
+		{name: "the bottom of the lattice", in: "never", want: "never"},
+		{name: "the top of the lattice", in: "unknown", want: "unknown"},
+		{name: "a record is one atom", in: "{x: number}", want: "{x: number}"},
+		{name: "an inexact record keeps its open marker", in: "{x: number, ...}", want: "{x: number, ...}"},
+		{name: "a tuple is one atom", in: "[number, string]", want: "[number, string]"},
+		{name: "a function is one atom", in: "fn (x: number) -> string", want: "fn (x: number) -> string"},
+		{name: "a borrow is an opaque atom", in: "mut {x: number}", want: "mut {x: number}"},
+		{name: "a union of two primitives keeps both", in: "number | string", want: "number | string"},
+		{
+			name: "two exact records keep both atoms",
+			in:   "{x: number} & {y: number}",
+			want: "{x: number} & {y: number}",
+		},
+		{
+			name: "two inexact records keep both atoms",
+			in:   "{x: number, ...} & {y: number, ...}",
+			want: "{x: number, ...} & {y: number, ...}",
+		},
+		{
+			name: "two primitives keep both atoms",
+			in:   "number & string",
+			want: "number & string",
+		},
+		{
+			name: "a repeated member of an intersection dedups",
+			in:   "{x: number} & {x: number}",
+			want: "{x: number}",
+		},
+		{
+			name: "a repeated member of a union dedups",
+			in:   "{x: number} | {x: number}",
+			want: "{x: number}",
+		},
+		{
+			name: "an intersection distributes over a union",
+			in:   "({x: number} | {y: number}) & {z: number}",
+			want: "{x: number} & {z: number} | {y: number} & {z: number}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, normDNF(c, parseType(t, tt.in)))
+		})
+	}
+}
+
+// TestCNFRoundTrip is the conjunctive twin of TestDNFRoundTrip. The two forms
+// denote the same type, so a row here states the same annotation the DNF row
+// states, rendered as an intersection of joins rather than a union of meets.
+func TestCNFRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "a primitive is one atom", in: "number", want: "number"},
+		{name: "the bottom of the lattice", in: "never", want: "never"},
+		{name: "the top of the lattice", in: "unknown", want: "unknown"},
+		{name: "a union is one disjunct", in: "number | string", want: "number | string"},
+		{name: "an intersection is two disjuncts", in: "{x: number} & {y: number}", want: "{x: number} & {y: number}"},
+		{
+			name: "a union distributes over an intersection",
+			in:   "({x: number} & {y: number}) | {z: number}",
+			want: "({x: number} | {z: number}) & ({y: number} | {z: number})",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, normCNF(c, parseType(t, tt.in)))
+		})
+	}
+}
+
+// TestNegationRoundTrip pins how a complement normalizes. The `¬` cases a reader
+// should never see — a double negation and a complement of a lattice bound — are
+// gone by the time the form is read back.
+func TestNegationRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   func(t *testing.T) soltype.Type
+		want string
+	}{
+		{
+			name: "a complemented primitive",
+			in:   func(t *testing.T) soltype.Type { return notSrc(t, "number") },
+			want: "¬number",
+		},
+		{
+			name: "a double complement cancels",
+			in:   func(t *testing.T) soltype.Type { return not(notSrc(t, "number")) },
+			want: "number",
+		},
+		{
+			name: "the complement of the bottom of the lattice is the top",
+			in:   func(t *testing.T) soltype.Type { return notSrc(t, "never") },
+			want: "unknown",
+		},
+		{
+			name: "the complement of the top of the lattice is the bottom",
+			in:   func(t *testing.T) soltype.Type { return notSrc(t, "unknown") },
+			want: "never",
+		},
+		{
+			name: "a complemented union stays one negated atom list",
+			in:   func(t *testing.T) soltype.Type { return notSrc(t, "number | string") },
+			want: "¬(number | string)",
+		},
+		{
+			name: "a complemented record",
+			in:   func(t *testing.T) soltype.Type { return notSrc(t, "{x: number}") },
+			want: "¬{x: number}",
+		},
+		{
+			name: "a complement beside a positive atom",
+			in: func(t *testing.T) soltype.Type {
+				return newIntersection(nil, []soltype.Type{parseType(t, "{x: number, ...}"), notSrc(t, "{y: number}")})
+			},
+			want: "{x: number, ...} & ¬{y: number}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, normDNF(c, tt.in(t)))
+		})
+	}
+}
+
+// TestCNFNegationRoundTrip covers the negated structural part of a disjunct, the
+// slot Conjunct.neg moves a conjunct's positive part into.
+func TestCNFNegationRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   func(t *testing.T) soltype.Type
+		want string
+	}{
+		{
+			name: "a complemented record",
+			in:   func(t *testing.T) soltype.Type { return notSrc(t, "{x: number}") },
+			want: "¬{x: number}",
+		},
+		{
+			name: "a complemented intersection is one disjunct negating both atoms",
+			in: func(t *testing.T) soltype.Type {
+				return notSrc(t, "{x: number} & {y: number}")
+			},
+			want: "¬({x: number} & {y: number})",
+		},
+		{
+			name: "a complement beside a positive atom",
+			in: func(t *testing.T) soltype.Type {
+				return newUnion(nil, []soltype.Type{parseType(t, "number"), notSrc(t, "{x: number}")}, false)
+			},
+			want: "number | ¬{x: number}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, normCNF(c, tt.in(t)))
+		})
+	}
+}
+
+// TestDeMorgan asserts that complementing a meet gives the join of the
+// complements, and complementing a join gives the meet of them, after both sides
+// are normalized. The two sides reach their normal forms by different routes —
+// one through Conjunct.neg and one through the ordinary construction — so
+// agreeing is a statement about the module, not about the printer.
+func TestDeMorgan(t *testing.T) {
+	tests := []struct {
+		name string
+		// operands returns the two types the row complements. It takes a Context so a
+		// row can mint type variables that both sides share.
+		operands func(t *testing.T, c *Context) (soltype.Type, soltype.Type)
+	}{
+		{
+			name: "two type variables, which normalization cannot look inside",
+			operands: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				return c.freshVar(0), c.freshVar(0)
+			},
+		},
+		{
+			name: "two records",
+			operands: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				return parseType(t, "{x: number}"), parseType(t, "{y: number}")
+			},
+		},
+		{
+			name: "two primitives",
+			operands: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				return parseType(t, "number"), parseType(t, "string")
+			},
+		},
+		{
+			name: "a record and a function",
+			operands: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				return parseType(t, "{x: number}"), parseType(t, "fn (x: number) -> string")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			a, b := tt.operands(t, c)
+
+			meet := newIntersection(nil, []soltype.Type{a, b})
+			join := newUnion(nil, []soltype.Type{a, b}, false)
+			negA, negB := not(a), not(b)
+
+			require.Equal(t,
+				normDNF(c, newUnion(nil, []soltype.Type{negA, negB}, false)),
+				normDNF(c, not(meet)),
+				"¬(A & B) and ¬A | ¬B normalize alike")
+			require.Equal(t,
+				normDNF(c, newIntersection(nil, []soltype.Type{negA, negB})),
+				normDNF(c, not(join)),
+				"¬(A | B) and ¬A & ¬B normalize alike")
+		})
+	}
+}
+
+// TestUnionKeepsUnmergeableRecords is the caveat-4 regression guard. Two records
+// with different field names have no single record that denotes their union, so
+// both normal forms keep two members rather than widening. MLscript's RhsNf holds
+// one record slot and answers `unknown` for the supertype case, which makes every
+// subtype pass against it — planning/ml_struct/06-open-items.md finding 1.
+func TestUnionKeepsUnmergeableRecords(t *testing.T) {
+	c := &Context{}
+	ty := parseType(t, "{x: number} | {y: number}")
+
+	// Subtype position. The union is a two-conjunct DNF, one conjunct per record.
+	d := c.mkDNF(ty, soltype.Positive)
+	require.Len(t, d.Conjuncts, 2)
+	require.Len(t, d.Conjuncts[0].Lnf.Atoms, 1)
+	require.Len(t, d.Conjuncts[1].Lnf.Atoms, 1)
+	require.Equal(t, "{x: number} | {y: number}", soltype.Print(d.toType()))
+
+	// Supertype position, the one MLscript widens. The union is a single disjunct
+	// holding BOTH records, not a disjunct that gave up and became `unknown`.
+	n := c.mkCNF(ty, soltype.Negative)
+	require.Len(t, n.Disjuncts, 1)
+	require.Len(t, n.Disjuncts[0].Rnf.Atoms, 2)
+	require.Equal(t, "{x: number} | {y: number}", soltype.Print(n.toType()))
+}
+
+// TestInexactUnionStaysOneAtom covers the open tail an `A | B | ...` carries. The
+// tail has no atom to stand for it, so the union is not taken apart and the DNF
+// holds one conjunct rather than one per written member.
+func TestInexactUnionStaysOneAtom(t *testing.T) {
+	c := &Context{}
+	open := newUnion(nil, parseTypes(t, "number", "string"), true)
+
+	d := c.mkDNF(open, soltype.Positive)
+	require.Len(t, d.Conjuncts, 1)
+	require.Len(t, d.Conjuncts[0].Lnf.Atoms, 1)
+	require.Equal(t, "number | string | ...", soltype.Print(d.toType()))
+
+	n := c.mkCNF(open, soltype.Negative)
+	require.Len(t, n.Disjuncts, 1)
+	require.Len(t, n.Disjuncts[0].Rnf.Atoms, 1)
+	require.Equal(t, "number | string | ...", soltype.Print(n.toType()))
+
+	// The exact union of the same members IS taken apart, which is what makes the
+	// two rows above a statement about the marker rather than about the members.
+	closed := newUnion(nil, parseTypes(t, "number", "string"), false)
+	require.Len(t, c.mkDNF(closed, soltype.Positive).Conjuncts, 2)
+}
+
+// TestVariablesStayInTheirSlots checks that a type variable is recorded as a
+// variable rather than as a structural atom, positively or negatively, and that
+// holding one in both slots makes the conjunct uninhabited.
+func TestVariablesStayInTheirSlots(t *testing.T) {
+	c := &Context{}
+	v := c.freshVar(0)
+
+	positive := c.mkDNF(v, soltype.Positive)
+	require.Len(t, positive.Conjuncts, 1)
+	require.True(t, positive.Conjuncts[0].Vars.Contains(v))
+	require.Empty(t, positive.Conjuncts[0].Lnf.Atoms)
+
+	negative := c.mkDNF(not(v), soltype.Positive)
+	require.Len(t, negative.Conjuncts, 1)
+	require.True(t, negative.Conjuncts[0].NVars.Contains(v))
+	require.Empty(t, negative.Conjuncts[0].Rnf.Atoms)
+
+	// `v ∩ ¬v` admits no value, so the conjunct is dropped and the DNF is empty.
+	both := newIntersection(nil, []soltype.Type{v, not(v)})
+	require.Empty(t, c.mkDNF(both, soltype.Positive).Conjuncts)
+	require.Equal(t, "never", normDNF(c, both))
+
+	// `v ∪ ¬v` admits every value, so the disjunct is dropped and the CNF is empty.
+	either := newUnion(nil, []soltype.Type{v, not(v)}, false)
+	require.Empty(t, c.mkCNF(either, soltype.Negative).Disjuncts)
+	require.Equal(t, "unknown", normCNF(c, either))
+}
+
+// TestBaseReadsTheSingleClassTag covers the slot PR4 (#1061) wires the nominal
+// meet to. One tag in a conjunct is the base; two unrelated tags are both kept, so
+// the conjunct has no single base until that PR lands.
+func TestBaseReadsTheSingleClassTag(t *testing.T) {
+	c := &Context{}
+	point := classTag("Point")
+	line := classTag("Line")
+
+	one := c.mkDNF(point, soltype.Positive)
+	require.Len(t, one.Conjuncts, 1)
+	base, ok := one.Conjuncts[0].Lnf.Base()
+	require.True(t, ok)
+	require.Same(t, point, base)
+
+	// Two tags naming one class are equal, so they dedup and the conjunct still has
+	// a single base.
+	same := c.mkDNF(newIntersection(nil, []soltype.Type{point, classTag("Point")}), soltype.Positive)
+	require.Len(t, same.Conjuncts, 1)
+	require.Len(t, same.Conjuncts[0].Lnf.Atoms, 1)
+
+	// TODO(#1061): once PR4 supplies the nominal glb, two unrelated tags collapse
+	// the conjunct to `never` and this DNF is empty.
+	unrelated := c.mkDNF(newIntersection(nil, []soltype.Type{point, line}), soltype.Positive)
+	require.Len(t, unrelated.Conjuncts, 1)
+	require.Len(t, unrelated.Conjuncts[0].Lnf.Atoms, 2)
+	_, ok = unrelated.Conjuncts[0].Lnf.Base()
+	require.False(t, ok)
+}
+
+// classTag is a bare nominal handle, the smallest ClassType a normal form can
+// carry as an atom.
+func classTag(name string) *soltype.ClassType {
+	return &soltype.ClassType{
+		Name: name, TypeArgs: nil, LifetimeArgs: nil, Lt: nil, Final: false, Variant: false,
+	}
+}
+
+// TestNominalAtomsStayDistinct guards the kinds compareType has no structural arm
+// for. Those atoms all compare equal to one another under it, so a normal form
+// that treated a zero from the comparator as equality would delete every class tag
+// but one, and would collapse two conjuncts that negate different tags.
+func TestNominalAtomsStayDistinct(t *testing.T) {
+	point, line, arc := classTag("Point"), classTag("Line"), classTag("Arc")
+
+	t.Run("a union of three tags keeps all three, in one order", func(t *testing.T) {
+		for _, order := range permutations([]string{"Point", "Line", "Arc"}) {
+			c := &Context{}
+			members := make([]soltype.Type, len(order))
+			for i, name := range order {
+				members[i] = classTag(name)
+			}
+			d := c.mkDNF(&soltype.UnionType{Types: members, Inexact: false}, soltype.Positive)
+			require.Len(t, d.Conjuncts, 3, "order %v", order)
+			require.Equal(t, "Arc | Line | Point", soltype.Print(d.toType()), "order %v", order)
+		}
+	})
+
+	t.Run("two conjuncts negating different tags both survive", func(t *testing.T) {
+		c := &Context{}
+		shape := parseType(t, "{a: number, ...}")
+		withoutPoint := newIntersection(nil, []soltype.Type{shape, not(point)})
+		withoutLine := newIntersection(nil, []soltype.Type{shape, not(line)})
+
+		d := c.mkDNF(newUnion(nil, []soltype.Type{withoutPoint, withoutLine}, false), soltype.Positive)
+		require.Len(t, d.Conjuncts, 2)
+		require.Equal(t,
+			"{a: number, ...} & ¬Line | {a: number, ...} & ¬Point",
+			soltype.Print(d.toType()))
+	})
+
+	t.Run("an intersection of two tags keeps both, in one order", func(t *testing.T) {
+		for _, members := range [][]soltype.Type{{point, arc}, {arc, point}} {
+			c := &Context{}
+			d := c.mkDNF(&soltype.IntersectionType{Types: members}, soltype.Positive)
+			require.Len(t, d.Conjuncts, 1)
+			require.Equal(t, "Arc & Point", soltype.Print(d.toType()))
+		}
+	})
+}
+
+// TestCanonicalOrderIsPermutationStable builds one type from its members in every
+// order and asserts each order reaches the same normal form. The members are
+// assembled into raw lattice nodes rather than through newUnion and
+// newIntersection, so the smart constructors' own sorting cannot be what makes the
+// orders agree.
+func TestCanonicalOrderIsPermutationStable(t *testing.T) {
+	tests := []struct {
+		name string
+		// members are the annotations the row combines.
+		members []string
+		// union says whether to combine them with `|` rather than `&`.
+		union bool
+		want  string
+	}{
+		{
+			name:    "a union of records",
+			members: []string{"{y: number}", "{x: number}", "{z: number}"},
+			union:   true,
+			want:    "{x: number} | {y: number} | {z: number}",
+		},
+		{
+			name:    "an intersection of records",
+			members: []string{"{y: number}", "{x: number}", "{z: number}"},
+			want:    "{x: number} & {y: number} & {z: number}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, order := range permutations(tt.members) {
+				c := &Context{}
+				parts := parseTypes(t, order...)
+				var raw soltype.Type
+				if tt.union {
+					raw = &soltype.UnionType{Types: parts, Inexact: false}
+				} else {
+					raw = &soltype.IntersectionType{Types: parts}
+				}
+				require.Equal(t, tt.want, normDNF(c, raw), "order %v", order)
+			}
+		})
+	}
+}
+
+// permutations returns every ordering of items. The member lists are three long,
+// so the six orderings are cheap to run in full.
+func permutations(items []string) [][]string {
+	if len(items) <= 1 {
+		return [][]string{items}
+	}
+	var out [][]string
+	for i := range items {
+		rest := make([]string, 0, len(items)-1)
+		rest = append(rest, items[:i]...)
+		rest = append(rest, items[i+1:]...)
+		for _, tail := range permutations(rest) {
+			order := make([]string, 0, len(items))
+			order = append(order, items[i])
+			order = append(order, tail...)
+			out = append(out, order)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Refs #1060.

**Part 1 of 6.** PR3 — the `internal/solver/normal.go` DNF/CNF module — split into a stack so each piece is reviewable on its own. Base: `main`. Every PR in the stack builds and passes `go test ./...` by itself.

This one establishes the representation and the algebra over it: `DNF`, `CNF`, `Conjunct`, `Disjunct`, `LhsNf`, and `RhsNf`, plus pushing a `soltype.Type` into either form, complementing one, and rendering one back to a surface type.

The types are solver-internal and transient — nothing here reaches the `Info` side table, the printer, or coalesced output — and nothing is wired into `constrain`. PR5 (#1062) grafts them in.

## The stack

Review in order; each PR is based on the one before it, so each diff shows only its own stage.

| | | diff |
|---|---|---|
| 1/6 | #1096 — ADTs, Boolean algebra, De Morgan, rendering, canonical order | +1197 |
| 2/6 | #1097 — atom fusion framework + the value families | +317 −67 |
| 3/6 | #1098 — record and tuple fusion | +303 −9 |
| 4/6 | #1099 — arrow fusion, where shape decision (a) is made | +199 −15 |
| 5/6 | #1100 — conjunct and disjunct fusion | +345 −25 |
| 6/6 | #1101 — deep normalization + the borrow guard | +166 −10 |

## The shape

A `Conjunct` reads as `Lnf ∩ (⋂Vars) ∩ ¬Rnf ∩ (⋂¬NVars)` and a `Disjunct` is its dual, so De Morgan's law is a permutation of the four fields rather than a traversal.

`LhsNf` and `RhsNf` hold a **list** of structural atoms per side, where MLscript holds one slot per structural kind. That is the first of the two shape decisions the issue asks this work to make deliberately rather than inherit, and it pays off immediately for `06-open-items.md` finding 1: a supertype union of two differently-named records stays precise, where MLscript widens the disjunct to `unknown` on meeting the second field name and makes every subtype pass against it. The second decision — keeping intersected arrows apart — is settled in #1099.

## What this part does not do

Atoms only accumulate. Two equal atoms dedup and two unequal atoms of one kind are both kept, so `number & string` stays two atoms rather than collapsing to `never`. Nothing is lost by that: a two-atom list is already the precise meet or join. The merge table lands in #1097–#1099.

Because of this, a few round-trip expectations tighten as the stack lands — `number & string` reads `number & string` here and `never` from #1097, and `{x, ...} & {y, ...}` fuses from #1098.

## Canonical form

The form depends on the **set** of members, not the order they were written in, which is what will let a caller compare normal forms directly. Atoms order by `compareType`, tie-broken by `PrintQualified` for the kinds `compareType` has no structural arm for, so two class tags do not compare equal to each other. Deduping tests `equalType` rather than a zero from the comparator, for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXN9PmM4WqFTQVhbjJHnAU