### PR TITLE
PR3 (4/6) — Keep intersected arrows apart unless they fuse exactly

### DIFF
--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -40,26 +40,29 @@ import (
 // merge is an optimization that bails rather than a step that must succeed. This
 // is caveat 4 in planning/ml_struct/02-caveats-and-mitigations.md.
 //
-// # A list of atoms per side, not one slot per kind
+// # Two shape decisions this file owns
 //
-// MLscript gives LhsNf and RhsNf one slot per structural kind, which loses
-// precision in two places — see planning/ml_struct/06-open-items.md findings 1 and
-// 2. This port holds a LIST per side instead, so neither loss is inherited.
+// MLscript's normal form is lossy in two places, both a consequence of holding one
+// slot per structural kind. This port holds a LIST per side instead, so neither
+// loss is inherited. See planning/ml_struct/06-open-items.md findings 1 and 2.
 //
-// Finding 1 pays off immediately. A supertype union of two differently-named
-// records stays precise here, where MLscript widens the disjunct to `unknown` on
-// meeting the second field name and makes every subtype pass against it.
+//  1. LhsNf keeps intersected function atoms SEPARATE when they cannot fuse
+//     exactly. MLscript fuses every pair to `(l0 | l1) -> (r0 & r1)`, which is
+//     unsound when the codomains conflict. Keeping the arms apart is what lets
+//     PR5 (#1062) decide an arrow intersection by the Frisch-Castagna-Benzaken
+//     decomposition, the set-theoretically sound rule the conformance corpus in
+//     constrain_nf_test.go states verdicts against. meetFuncs still performs the
+//     fusion for the two cases where it is exact.
+//  2. RhsNf holds a LIST of record atoms. MLscript holds one, and widens a
+//     disjunct to `unknown` on meeting a second differently-named field, which
+//     makes every subtype pass against a supertype union of two records. A list
+//     keeps `{x: number} | {y: number}` precise in supertype position.
 //
 // # What a later PR adds
 //
-// Arrows are still kept apart atom by atom, and two whole conjuncts are never
-// fused into one.
-//
-// Exactness-driven merges are deferred. An atom's `Inexact` flag rides through
-// every merge here, and two atoms whose flags disagree are kept separate rather
-// than fused under a guess. PR7 (#1064) decides the exact cases, such as two exact
-// records with differing required fields meeting to `never`. TODO(#1064). The
-// nominal meet is still the glbClass stub. TODO(#1061).
+// Two whole conjuncts are never fused into one. The nominal meet is still the
+// glbClass stub (TODO(#1061)) and the exactness-driven merges are still deferred
+// (TODO(#1064)).
 
 // DNF is a union of conjuncts, the disjunctive normal form of a type. An empty
 // conjunct list is `never`, the identity of `|`.
@@ -423,7 +426,14 @@ func pooled(a, b []soltype.Type) []soltype.Type {
 //
 // The list is sorted before the scan and again after each fusion, so the pair
 // chosen is decided by canonical order rather than by the order the atoms arrived
-// in.
+// in. That ordering carries weight once a kind admits more than one exact fusion
+// of the same atoms, since taking one rules out the others. The arrows of
+// `(number -> string) & (number -> boolean) & (string -> boolean)` fuse either by
+// the shared domain of the first two, meeting their codomains, or by the shared
+// codomain of the last two, joining their domains. The two results are equal types
+// written differently. Scanning in canonical order settles which one a given SET
+// of atoms reaches, so permuting the source members cannot change the normal form.
+// TestCanonicalOrderIsPermutationStable runs that intersection in every order.
 //
 // Each fusion shortens the list, so the loop runs at most len(atoms) times.
 func (c *Context) fuseAtoms(atoms []soltype.Type, role atomRole) ([]soltype.Type, bool) {
@@ -545,6 +555,10 @@ func (c *Context) meetAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	case *soltype.TupleType:
 		if b, ok := b.(*soltype.TupleType); ok {
 			return c.meetTuples(a, b)
+		}
+	case *soltype.FuncType:
+		if b, ok := b.(*soltype.FuncType); ok {
+			return c.meetFuncs(a, b)
 		}
 	case *soltype.ClassType:
 		if b, ok := b.(*soltype.ClassType); ok {
@@ -906,6 +920,94 @@ func hasSpreadElem(elems []soltype.Type) bool {
 		}
 	}
 	return false
+}
+
+// meetFuncs fuses two function atoms into one arrow, but only for the two cases
+// where a single arrow denotes the intersection exactly.
+//
+//   - The domains agree: `(A -> C) & (A -> D)` is `A -> (C & D)`.
+//   - The codomains agree and there is one parameter: `(A -> C) & (B -> C)` is
+//     `(A | B) -> C`.
+//
+// Any other pair keeps both atoms, which is decision 1 in this file's header and
+// where this port departs from MLscript.
+//
+// The one-parameter restriction is load-bearing. Unioning each position
+// independently would fuse `(number, number) -> C` and `(string, string) -> C`
+// into a claim that the value accepts a number paired with a string.
+func (c *Context) meetFuncs(a, b *soltype.FuncType) (soltype.Type, bool) {
+	if !fusableFuncs(a, b) {
+		return nil, false
+	}
+	if equalParamTypes(a, b) {
+		return &soltype.FuncType{
+			SelfParam:      nil,
+			Params:         a.Params,
+			Ret:            c.meetTypes(a.Ret, b.Ret),
+			Throws:         a.Throws,
+			Inexact:        a.Inexact,
+			TypeParams:     nil,
+			LifetimeParams: nil,
+		}, true
+	}
+	if len(a.Params) == 1 && equalType(a.Ret, b.Ret) {
+		param := a.Params[0]
+		fused := &soltype.FuncParam{
+			Pattern:  param.Pattern,
+			Type:     c.joinTypes(param.Type, b.Params[0].Type),
+			Optional: param.Optional,
+			Rest:     param.Rest,
+		}
+		return &soltype.FuncType{
+			SelfParam:      nil,
+			Params:         []*soltype.FuncParam{fused},
+			Ret:            a.Ret,
+			Throws:         a.Throws,
+			Inexact:        a.Inexact,
+			TypeParams:     nil,
+			LifetimeParams: nil,
+		}, true
+	}
+	return nil, false
+}
+
+// fusableFuncs reports whether two function atoms are alike enough for meetFuncs
+// to build one arrow from them. Everything a fused arrow does not recompute must
+// already agree: the arity, the per-parameter markers, the trailing `...`, and what
+// a call may raise. A receiver or a quantifier rules the pair out, since one arrow
+// cannot say which receiver it takes or how the two binder lists correspond.
+//
+// Demanding equal raises is conservative. `(A -> C throws E) & (A -> C throws F)`
+// really raises `E & F`, but that merge belongs with PR9's throws threading.
+// TODO(#1066).
+func fusableFuncs(a, b *soltype.FuncType) bool {
+	if a.SelfParam != nil || b.SelfParam != nil {
+		return false
+	}
+	if len(a.TypeParams) > 0 || len(b.TypeParams) > 0 {
+		return false
+	}
+	if len(a.LifetimeParams) > 0 || len(b.LifetimeParams) > 0 {
+		return false
+	}
+	if a.Inexact != b.Inexact || len(a.Params) != len(b.Params) {
+		return false
+	}
+	for i := range a.Params {
+		if a.Params[i].Optional != b.Params[i].Optional || a.Params[i].Rest != b.Params[i].Rest {
+			return false
+		}
+	}
+	return equalType(a.ThrowsOrNever(), b.ThrowsOrNever())
+}
+
+func equalParamTypes(a, b *soltype.FuncType) bool {
+	for i := range a.Params {
+		if !equalType(a.Params[i].Type, b.Params[i].Type) {
+			return false
+		}
+	}
+	return true
 }
 
 // meetTypes is the meet a structural merge writes into a fused atom, such as the

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -664,11 +664,79 @@ func TestNominalAtomsStayDistinct(t *testing.T) {
 	})
 }
 
+// TestFuncMerge pins which intersected function atoms fuse into one arrow and
+// which stay apart. The two fusing cases are exact. Keeping the rest apart is the
+// shape decision that lets PR5 (#1062) apply the Frisch-Castagna-Benzaken arrow
+// decomposition rather than inheriting MLscript's unsound merge —
+// planning/ml_struct/06-open-items.md finding 2.
+func TestFuncMerge(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "shared codomain: the domains join",
+			in:   "(fn (x: number) -> boolean) & (fn (x: string) -> boolean)",
+			want: "fn (x: number | string) -> boolean",
+		},
+		{
+			name: "shared domain: the codomains meet",
+			in:   "(fn (x: number) -> number | string) & (fn (x: number) -> string | boolean)",
+			want: "fn (x: number) -> string",
+		},
+		{
+			name: "shared domain, disjoint codomains: the meet is uninhabited",
+			in:   "(fn (x: number) -> number) & (fn (x: number) -> string)",
+			want: "fn (x: number) -> never",
+		},
+		{
+			name: "no shared domain or codomain: both arms are kept",
+			in:   "(fn (x: number) -> boolean) & (fn (x: string) -> null)",
+			want: "(fn (x: number) -> boolean) & (fn (x: string) -> null)",
+		},
+		{
+			name: "a shared codomain over two parameters is not fused position by position",
+			in: "(fn (x: number, y: number) -> boolean) & " +
+				"(fn (x: string, y: string) -> boolean)",
+			want: "(fn (x: number, y: number) -> boolean) & (fn (x: string, y: string) -> boolean)",
+		},
+		{
+			name: "a shared domain over two parameters still meets the codomains",
+			in: "(fn (x: number, y: string) -> number | string) & " +
+				"(fn (x: number, y: string) -> string | boolean)",
+			want: "fn (x: number, y: string) -> string",
+		},
+		{
+			name: "arms differing in the trailing open marker are kept apart",
+			in:   "(fn (x: number) -> boolean) & (fn (x: string, ...) -> boolean)",
+			want: "(fn (x: number) -> boolean) & (fn (x: string, ...) -> boolean)",
+		},
+		{
+			name: "a union of two arrows keeps both, since no single arrow denotes it",
+			in:   "(fn (x: number) -> boolean) | (fn (x: number) -> null)",
+			want: "(fn (x: number) -> boolean) | (fn (x: number) -> null)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, normDNF(c, parseType(t, tt.in)))
+		})
+	}
+}
+
 // TestCanonicalOrderIsPermutationStable builds one type from its members in every
 // order and asserts each order reaches the same normal form. The members are
 // assembled into raw lattice nodes rather than through newUnion and
 // newIntersection, so the smart constructors' own sorting cannot be what makes the
 // orders agree.
+//
+// The arrow row is the one with teeth. Its members admit two DIFFERENT exact
+// fusions, and taking either one rules the other out: the two number-domain arms
+// fuse by meeting their codomains, and the two boolean-codomain arms fuse by
+// joining their domains. Scanning in canonical order is what settles which fusion
+// a given member SET reaches.
 func TestCanonicalOrderIsPermutationStable(t *testing.T) {
 	tests := []struct {
 		name string
@@ -693,6 +761,15 @@ func TestCanonicalOrderIsPermutationStable(t *testing.T) {
 			name:    "an intersection of inexact records, which fuses into one",
 			members: []string{"{y: number, ...}", "{x: number, ...}", "{z: number, ...}"},
 			want:    "{x: number, y: number, z: number, ...}",
+		},
+		{
+			name: "an intersection of arrows where two different fusions compete",
+			members: []string{
+				"fn (x: number) -> string",
+				"fn (x: number) -> boolean",
+				"fn (x: string) -> boolean",
+			},
+			want: "(fn (x: number) -> never) & (fn (x: string) -> boolean)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Refs #1060.

**Part 4 of 6.** Base: `claude/github-issue-1060-8bqdhc-3c` (part 3), so the diff shows only this stage.

This is where decision (a) from the issue's shape-decision comment gets made, so it is deliberately the smallest PR in the stack.

## What MLscript does, and why not to inherit it

MLscript fuses **every** pair of intersected function atoms to `(l0 | l1) -> (r0 & r1)` and then applies the plain arrow rule to the result (`NormalForms.scala:58`, `ConstraintSolver.scala:172`). That accepts

```
(number -> boolean) & (string -> null)  <:  (number | string) -> boolean
```

by meeting the codomains to `never`. It is unsound: the value's `string` arm really does return a `null` where the target promises a `boolean`. The corpus in `constrain_nf_test.go` states this case as **failing**, since that is what a types-as-values reading gives — `06-open-items.md` finding 2.

## The rule here

`meetFuncs` fuses only the two cases where a single arrow denotes the intersection exactly, and keeps both atoms otherwise:

- the domains agree, so `(A -> C) & (A -> D)` is `A -> (C & D)`;
- the codomains agree **and there is one parameter**, so `(A -> C) & (B -> C)` is `(A | B) -> C`.

The one-parameter restriction is load-bearing. Unioning each position independently would fuse `(number, number) -> C` and `(string, string) -> C` into a claim that the value accepts a number paired with a string.

Keeping un-fusable arms apart is what lets PR5 (#1062) decide such an intersection by the Frisch–Castagna–Benzaken decomposition instead of by the plain arrow rule.

Everything a fused arrow does not recompute has to agree before the fusion is attempted — arity, the per-parameter markers, the trailing `...`, and what a call may raise. Merging the raise position belongs with PR9's throws threading. `TODO(#1066)`.

## Nothing fuses under a union

Neither `(A -> C) | (B -> C)` nor `(A -> C) | (A -> D)` has a single arrow that denotes it, since a value of `A -> (C | D)` may return a `C` on one input and a `D` on another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXN9PmM4WqFTQVhbjJHnAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXN9PmM4WqFTQVhbjJHnAU)_