### PR TITLE
PR3 (6/6) — Normalize an atom's children, keeping a borrow's wrapper

### DIFF
--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -58,12 +58,17 @@ import (
 //     makes every subtype pass against a supertype union of two records. A list
 //     keeps `{x: number} | {y: number}` precise in supertype position.
 //
-// # What a later PR adds
+// # What is deliberately left to a later PR
 //
-// Normalizing an atom's CHILDREN — pushing a negation buried in a function's
-// return or a record's field down as well — lands next. The nominal meet is still
-// the glbClass stub (TODO(#1061)) and the exactness-driven merges are still
-// deferred (TODO(#1064)).
+//   - The nominal meet of two class tags. glbClass only fuses identical tags and
+//     keeps unrelated ones separate; PR4 (#1061) wires it to the M5
+//     declared-subtype graph so unrelated classes collapse the conjunct to `never`.
+//   - Exactness-driven merges. An atom's `Inexact` flag rides through every merge
+//     here, and two atoms whose flags disagree are kept separate rather than
+//     fused under a guess. PR7 (#1064) decides the exact cases, such as two exact
+//     objects with differing required fields meeting to `never`.
+//   - Ref atoms. A RefType is an opaque atom that normalization never takes apart.
+//     PR8 (#1065) owns the lifetime split and the guard rejecting `¬(mut 'a T)`.
 
 // DNF is a union of conjuncts, the disjunctive normal form of a type. An empty
 // conjunct list is `never`, the identity of `|`.
@@ -129,14 +134,13 @@ func (l LhsNf) Base() (*soltype.ClassType, bool) {
 // mkDNF pushes t into disjunctive normal form at polarity pol. It normalizes the
 // BOOLEAN structure only: a union, an intersection, a negation, and a type
 // variable are taken apart, and every other node becomes one structural atom with
-// its children untouched.
+// its children untouched. mkDeepDNF normalizes those children too.
 //
 // pol is the position t occupies. A negation flips it before normalizing its
 // operand, so the polarity stays accurate all the way down, but no arm below reads
 // it for anything else. The shallow form is therefore the same at either polarity.
-// pol is threaded so that a later pass can normalize an atom's children at the
-// polarity they really occupy, which is where the parameters of a function and the
-// operand of a negation part company.
+// pol earns its place in mkDeepDNF, which threads it into the children so a
+// function's parameters normalize at the polarity they really occupy.
 func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
 	switch t := t.(type) {
 	case *soltype.NeverType:
@@ -208,6 +212,62 @@ func (c *Context) mkCNF(t soltype.Type, pol soltype.Polarity) CNF {
 	default:
 		return cnfAtom(t)
 	}
+}
+
+// mkDeepDNF pushes t into disjunctive normal form and normalizes every position
+// INSIDE its structural atoms as well, so a negation buried in a function's return
+// or an object's field is pushed down rather than left as a surface node. This is
+// the form constraint solving consumes. PR5 (#1062) calls it on both operands.
+func (c *Context) mkDeepDNF(t soltype.Type, pol soltype.Polarity) DNF {
+	return c.mkDNF(c.normalizeDeep(t, pol), pol)
+}
+
+// mkDeepCNF is the conjunctive twin of mkDeepDNF.
+func (c *Context) mkDeepCNF(t soltype.Type, pol soltype.Polarity) CNF {
+	return c.mkCNF(c.normalizeDeep(t, pol), pol)
+}
+
+// normalizeDeep rewrites every node of t into normal form and back, bottom-up, so
+// the result is a surface type whose every position is normalized. It rides the
+// soltype rewriting visitor, which visits a function's parameters and a
+// negation's operand at the flipped polarity, so each position normalizes at the
+// polarity it occupies.
+func (c *Context) normalizeDeep(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	return t.Accept(&deepNormalizer{ctx: c}, pol)
+}
+
+// deepNormalizer is the rewriting visitor behind normalizeDeep. ExitType fires
+// bottom-up, after a node's children are already normalized, so normalizing the
+// node itself only has to settle the Boolean structure at that one level.
+type deepNormalizer struct{ ctx *Context }
+
+// EnterType takes over the walk for a borrow, and leaves every other node to the
+// ordinary bottom-up rebuild.
+//
+// A borrow needs its own arm because RefType.Accept PEELS the wrapper when the
+// rewritten inner is not a type a borrow can point at, which is right for
+// coalescing but wrong here: normalizing the inner of `mut (number | 5)` gives
+// `number`, and peeling would hand back a bare `number` that has lost the `mut`.
+// So the inner is normalized here and the result is kept only when it is still
+// borrowable. Otherwise the borrow stands as written, which keeps the wrapper the
+// header promises normalization never takes apart.
+func (n *deepNormalizer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	ref, isRef := t.(*soltype.RefType)
+	if !isRef {
+		return soltype.EnterResult{Type: nil, SkipChildren: false}
+	}
+	inner, borrowable := ref.Inner.Accept(n, pol).(soltype.RefInner)
+	if !borrowable {
+		return soltype.EnterResult{Type: ref, SkipChildren: true}
+	}
+	return soltype.EnterResult{
+		Type:         &soltype.RefType{Mut: ref.Mut, Lt: ref.Lt, Inner: inner},
+		SkipChildren: true,
+	}
+}
+
+func (n *deepNormalizer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	return n.ctx.mkDNF(t, pol).toType()
 }
 
 // dnfTop is `unknown` as a DNF: one conjunct with nothing in it, since an empty
@@ -1031,7 +1091,7 @@ func equalParamTypes(a, b *soltype.FuncType) bool {
 // The recursion terminates because the operands are proper sub-parts of the two
 // atoms being merged, and the kinds that could recur without shrinking — a μ-knot
 // and a borrow — are opaque atoms that no merge takes apart. The polarity passed
-// is Positive because normalization reads the same at either one.
+// is Positive because a shallow normalization reads the same at either one.
 func (c *Context) meetTypes(a, b soltype.Type) soltype.Type {
 	return c.mkDNF(newIntersection(nil, []soltype.Type{a, b}), soltype.Positive).toType()
 }

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -916,6 +916,102 @@ func TestCanonicalOrderIsPermutationStable(t *testing.T) {
 	}
 }
 
+// TestMkDeepNormalizesChildren contrasts the shallow form with the deep one. The
+// shallow form settles the Boolean structure at the top level and leaves an atom's
+// children alone; the deep form normalizes every position, including the
+// contravariant ones a function's parameters sit in.
+func TestMkDeepNormalizesChildren(t *testing.T) {
+	tests := []struct {
+		name string
+		// build assembles the input around a doubly-complemented sub-part, the
+		// simplest thing normalization removes.
+		build func(t *testing.T) soltype.Type
+		// shallow is the form mkDNF reaches, which leaves the sub-part untouched.
+		shallow string
+		// deep is the form mkDeepDNF reaches.
+		deep string
+	}{
+		{
+			name: "a complement in a return type",
+			build: func(t *testing.T) soltype.Type {
+				return &soltype.FuncType{
+					SelfParam: nil,
+					Params:    []*soltype.FuncParam{identParam("x", num())},
+					Ret:       not(notSrc(t, "string")),
+					Throws:    nil, Inexact: false, TypeParams: nil, LifetimeParams: nil,
+				}
+			},
+			shallow: "fn (x: number) -> ¬¬string",
+			deep:    "fn (x: number) -> string",
+		},
+		{
+			name: "a complement in a parameter, which sits at the flipped polarity",
+			build: func(t *testing.T) soltype.Type {
+				return &soltype.FuncType{
+					SelfParam: nil,
+					Params:    []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: not(notSrc(t, "number")), Optional: false, Rest: false}},
+					Ret:       str(),
+					Throws:    nil, Inexact: false, TypeParams: nil, LifetimeParams: nil,
+				}
+			},
+			shallow: "fn (x: ¬¬number) -> string",
+			deep:    "fn (x: number) -> string",
+		},
+		{
+			name: "an uninhabited meet in a field",
+			build: func(t *testing.T) soltype.Type {
+				return exactObj(propElem("x", newIntersection(nil, parseTypes(t, "number", "string"))))
+			},
+			shallow: "{x: number & string}",
+			deep:    "{x: never}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			in := tt.build(t)
+			require.Equal(t, tt.shallow, normDNF(c, in))
+			require.Equal(t, tt.deep, soltype.Print(c.mkDeepDNF(in, soltype.Positive).toType()))
+			require.Equal(t, tt.deep, soltype.Print(c.mkDeepCNF(in, soltype.Negative).toType()))
+		})
+	}
+}
+
+// TestDeepNormalizeKeepsBorrows pins that normalizing a borrow's inner never
+// costs the borrow its wrapper. soltype's visitor peels a `mut` whose rewritten
+// inner is not borrowable, which is right for coalescing and would silently drop
+// mutability here.
+func TestDeepNormalizeKeepsBorrows(t *testing.T) {
+	tests := []struct {
+		name string
+		// build assembles the borrow, since `mut` over a union has no annotation
+		// form the test parser accepts alongside the members these rows need.
+		build func(t *testing.T) soltype.Type
+		want  string
+	}{
+		{
+			name: "an inner that normalizes to a borrowable type is rewritten",
+			build: func(t *testing.T) soltype.Type {
+				return mutRef(newUnion(nil, parseTypes(t, "{x: number, ...}", "{y: number, ...}"), false).(soltype.RefInner))
+			},
+			want: "mut ({x: number, ...} | {y: number, ...})",
+		},
+		{
+			name: "an inner that normalizes to a bare primitive keeps the borrow as written",
+			build: func(t *testing.T) soltype.Type {
+				return mutRef(newUnion(nil, parseTypes(t, "number", "5"), false).(soltype.RefInner))
+			},
+			want: "mut (number | 5)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, soltype.Print(c.mkDeepDNF(tt.build(t), soltype.Positive).toType()))
+		})
+	}
+}
+
 // permutations returns every ordering of items. The member lists are three long,
 // so the six orderings are cheap to run in full.
 func permutations(items []string) [][]string {


### PR DESCRIPTION
Fixes #1060.

**Part 6 of 6.** Base: `claude/github-issue-1060-8bqdhc-3e` (part 5), so the diff shows only this stage. Merging the stack completes PR3.

`mkDNF` settles the Boolean structure at one level and leaves an atom's children alone, so a negation buried in a function's return or a record's field survives it. `mkDeepDNF` normalizes those positions too, which is the form constraint solving consumes — PR5 (#1062) calls it on both operands.

It rides the `soltype` rewriting visitor, so each position normalizes at the polarity it really occupies — a function's parameters and a negation's operand contravariantly. That is what the `pol` argument threaded through `mkDNF` has been carrying all along.

## The borrow arm

A borrow needs its own arm. `RefType.Accept` **peels** the wrapper when the rewritten inner is not a type a borrow can point at, which is right for coalescing and wrong here: normalizing the inner of `mut (number | 5)` gives `number`, and peeling would hand back a bare `number` that has lost the `mut`.

So the inner is normalized and the result kept only when it is still borrowable; otherwise the borrow stands as written. That holds up the invariant the module's header states — that normalization never takes a borrow apart — which PR8 (#1065) builds the lifetime split on.

## Where the module stands

Complete, solver-internal, and transient throughout. Nothing reaches the `Info` side table, the printer, or coalesced output, and nothing is wired into `constrain` yet.

Deferred with a `TODO` each: the nominal `glb` over class tags (#1061), the exactness-aware merges (#1064), the throws merge in a fused arrow (#1066), and the Ref/lifetime split (#1065). `Inexact` flags ride through every merge from the start, and two atoms whose flags disagree are kept apart rather than fused under a guess.

## Testing

Fully isolated from `constrain` — 82 subtests covering `type → DNF → type` round-trips, the CNF twin, De Morgan on four operand shapes, the `{x} | {y}` caveat-4 regression guard in both positions, the arrow merge table, permutation stability over member sets that admit competing fusions, and deep normalization keeping a borrow's wrapper.

Confluence was additionally checked out-of-band over 4000 random member sets across the DNF, CNF, deep, and negated forms; that harness was temporary and is not in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXN9PmM4WqFTQVhbjJHnAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXN9PmM4WqFTQVhbjJHnAU)_