### PR TITLE
Implement nominal meet of class tags via declared subtype graph

### DIFF
--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -56,11 +56,9 @@ type ClassDef struct {
 	Implements []*soltype.ClassType
 
 	// EdgesPending marks a def the SCC pre-pass registered as a bare identity, before the
-	// declaration's `extends` and `implements` clauses were resolved. Supers and Implements
-	// are empty on such a def because they have not been read yet, not because the class
-	// declares none. A reader concluding from an empty Supers that a class has no
-	// superclass must check this first. inferClassDecl clears it when it fills both fields
-	// in, and a def built anywhere else carries its edges from the start.
+	// declaration's `extends` and `implements` clauses resolved. Supers and Implements are
+	// empty on such a def for want of reading, not for want of a declaration, so a reader
+	// concluding a class has no superclass must check this first. inferClassDecl clears it.
 	EdgesPending bool
 
 	// Body is the instance member view a class projects: one element per field,
@@ -469,31 +467,24 @@ func substituteSuperArgs(def *ClassDef, sub, superType *soltype.ClassType) *solt
 
 // --- The nominal meet ---
 
-// glbClass is the greatest lower bound of two class tags, the nominal meet the
-// normal form's LhsNf reads through Base. It answers one of three ways.
+// glbClass is the greatest lower bound of two class tags, the nominal meet LhsNf
+// reads through Base. It settles three ways.
 //
-//  1. The two tags name one class. The meet is that class at the per-position meet
-//     of their type arguments, which meetClassArgs computes.
-//  2. One tag's class reaches the other's through the declared `extends` graph. The
-//     meet is the lower of the two, since every instance of the lower one already
-//     carries the higher one's tag.
-//  3. Neither class reaches the other in a graph both walks read to the end. No
-//     value carries both tags, so the meet is `never` and the conjunct holding them
-//     is dropped. This is the fast path caveat 1 in
-//     planning/ml_struct/02-caveats-and-mitigations.md names: an intersection of
-//     unrelated classes is settled here and never reaches structural work. Calling
-//     such a pair disjoint is sound because a class declares at most one
-//     superclass, so two classes neither of which reaches the other have no common
+//  1. Two tags of one class meet position by position, through meetClassArgs.
+//  2. Two tags the declared `extends` graph orders meet to the lower one, since
+//     every instance of that one already carries the other's tag.
+//  3. Two tags neither of which reaches the other meet to `never`, dropping the
+//     conjunct. This is the fast path from caveat 1 in
+//     planning/ml_struct/02-caveats-and-mitigations.md: an intersection of
+//     unrelated classes is settled here rather than in structural work. It is sound
+//     because a class declares at most one superclass, so such a pair has no common
 //     subclass.
 //
-// ok is false when none of the three settles the pair, which keeps the two tags as
-// separate atoms in the intersection. That loses no precision, since a two-atom
-// list already denotes the meet exactly.
+// ok is false when none of the three applies, which keeps both tags as atoms and
+// loses nothing, since a two-atom list already denotes the meet exactly.
 //
-// This is a pure query. It reads the class registry and records nothing, which is
-// what separates it from constrainNominal, the rule that decides the same declared
-// graph by emitting bounds. Normalization rewrites a type rather than solving a
-// constraint, so it has no goal to record a bound against.
+// It reads the registry and records nothing, unlike constrainNominal, which decides
+// the same graph by emitting bounds.
 func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
 	if a.Name == b.Name {
 		if met, ok := c.meetClassArgs(a, b); ok {
@@ -512,26 +503,22 @@ func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
 	if !aReaches && !bReaches && aSettled && bSettled {
 		return &soltype.NeverType{}, true
 	}
-	// The two tags stay separate atoms for one of two reasons. Either one class reaches
-	// the other while the instance below carries a type argument the one above rules
-	// out, or a walk ran into a graph that is still being built. Meeting
+	// Either one class reaches the other while the instance below carries an argument
+	// the one above rules out, or a walk ran into a graph still being built. Meeting
 	// `Wrapper<string>` with `Reader<number>` under `class Wrapper<T> extends Reader<T>`
-	// is the first case. Neither tag is below the other, and `Wrapper<never>` is below
-	// both, so the pair is not disjoint either.
+	// is the first: `Wrapper<never>` is below both, so the pair is not disjoint either.
 	return nil, false
 }
 
 // nominalSubtype reports whether the class instance sub is below super, following
-// the declared `extends` graph and checking the type arguments sub carries at
-// super's class. It is the pure twin of constrainNominal, which decides the same
-// relation by emitting constraints. The nominal meet asks this one instead,
-// because normalizing a type may not record a bound.
+// the declared `extends` graph and checking sub's arguments at super's class. It is
+// the pure twin of constrainNominal, which decides the same relation by emitting
+// bounds.
 //
-// Where the two differ is which variance vector the arguments dispatch by. This one
-// always reads the mutable view, so it rejects a pair constrainNominal accepts
-// outside a mutable borrow, such as `Box<5> <: Box<number>` for a Box covariant to
-// a reader and invariant to a writer. The direction of the difference is what makes
-// it safe. A rejection here keeps two atoms the meet would otherwise have fused.
+// It always dispatches arguments by the mutable-view variance, so it rejects pairs
+// constrainNominal accepts outside a mutable borrow, such as `Box<5> <: Box<number>`
+// for a Box covariant to a reader and invariant to a writer. That direction is the
+// safe one, since a rejection only leaves two atoms unfused.
 func (c *Context) nominalSubtype(sub, super *soltype.ClassType) bool {
 	up, reaches, _ := c.ancestorInstance(sub, super.Name)
 	return reaches && c.instanceBelow(up, super)
@@ -539,28 +526,22 @@ func (c *Context) nominalSubtype(sub, super *soltype.ClassType) bool {
 
 // instanceBelow reports whether up is below super, where both name ONE class and up
 // is what ancestorInstance projected. Meeting the two leaves up unchanged exactly
-// when up is the lower of the two, since the meet of a type with something above it
-// is that type. A covariant position therefore accepts a narrower argument, `Sub<5>`
-// below `Sub<number>`, and an invariant position demands that the two match.
+// when up is the lower, since a type met with something above it is itself.
 func (c *Context) instanceBelow(up, super *soltype.ClassType) bool {
 	met, ok := c.meetClassArgs(up, super)
 	return ok && equalType(met, up)
 }
 
 // meetClassArgs meets two instances of ONE class, position by position, dispatching
-// each position by the variance the class registry records for it. ok is false when
-// a position admits no exact meet, which keeps the two tags separate.
+// each by the variance the registry records for it. ok is false when a position
+// admits no exact meet, which keeps the two tags separate.
 //
-// The variance read is the MUTABLE-view vector, the stricter of the two. A normal
-// form carries no borrow around the tag to say whether a write can reach a
-// position, so the meet takes the vector that admits one. A position a write
-// reaches is invariant there, so it fuses only when the two arguments match. The
-// immutable view would have met them instead.
+// The vector read is the MUTABLE view, the stricter of the two. A normal form
+// carries no borrow around the tag to say whether a write can reach a position, so
+// the meet assumes one can, which pins a writable position to matching arguments.
 //
-// The exactness and enum-variant flags must agree. Both are read off the
-// declaration, so two tags naming one class carry the same pair, and a
-// disagreement means one of them was built by hand. Fusing two tags whose
-// exactness differs is left to the exactness-aware merge, #1064.
+// The exactness and enum-variant flags must agree, since both are read off the
+// declaration. Fusing two tags whose exactness differs is left to #1064.
 func (c *Context) meetClassArgs(a, b *soltype.ClassType) (*soltype.ClassType, bool) {
 	if a.Final != b.Final || a.Variant != b.Variant || len(a.TypeArgs) != len(b.TypeArgs) {
 		return nil, false
@@ -568,9 +549,8 @@ func (c *Context) meetClassArgs(a, b *soltype.ClassType) (*soltype.ClassType, bo
 	if !sameLifetimeSlice(a.LifetimeArgs, b.LifetimeArgs, &alphaCtx{}) {
 		return nil, false
 	}
-	// varianceAt yields Invariant for a nil receiver, so every position of an
-	// unregistered class is invariant. Two tags naming one then fuse only when their
-	// arguments match, the conservative reading.
+	// varianceAt reads Invariant off a nil def, so two tags of an unregistered class
+	// fuse only on matching arguments.
 	def, _ := c.classDef(a.Name)
 	args := make([]soltype.Type, len(a.TypeArgs))
 	same := true
@@ -578,16 +558,13 @@ func (c *Context) meetClassArgs(a, b *soltype.ClassType) (*soltype.ClassType, bo
 		argA, argB := a.TypeArgs[i], b.TypeArgs[i]
 		switch def.varianceAt(i, true) {
 		case Covariant:
-			// `C<A> & C<B>` is `C<A & B>` when the position is covariant: an instance below
-			// both reads the position at both types, so it reads it at their meet.
+			// An instance below both reads the position at both types, so at their meet.
 			args[i] = c.meetTypes(argA, argB)
 		case Contravariant:
-			// The dual. An instance below both accepts a write of either type at the
-			// position, so it accepts their join.
+			// The dual. Such an instance accepts a write of either type, so of their join.
 			args[i] = c.joinTypes(argA, argB)
 		case Bivariant:
-			// A phantom parameter appears nowhere in the body, so the two arguments say
-			// nothing about the instances and either one stands for the meet.
+			// A phantom parameter says nothing about the instances, so either argument does.
 			args[i] = argA
 		default: // Invariant
 			if !equalType(argA, argB) {
@@ -598,8 +575,7 @@ func (c *Context) meetClassArgs(a, b *soltype.ClassType) (*soltype.ClassType, bo
 		same = same && equalType(args[i], argA)
 	}
 	if same {
-		// Every position met to the argument a already carries, so a IS the meet. Handing
-		// back the same handle keeps the atom the normal form arrived with.
+		// Every position met to a's own argument, so a IS the meet.
 		return a, true
 	}
 	return &soltype.ClassType{
@@ -616,20 +592,16 @@ func (c *Context) meetClassArgs(a, b *soltype.ClassType) (*soltype.ClassType, bo
 // class named `name`. It returns three things.
 //
 //   - up is the instance of that class ct denotes, with ct's arguments substituted
-//     into each edge along the way, so `class B<T> extends A<T>` asked for A at B<5>
-//     yields A<5>. ct itself is returned when it already names the class.
+//     into each edge, so `class B<T> extends A<T>` asked for A at B<5> yields A<5>.
 //   - reaches says whether the class was found, which is when up is meaningful.
 //   - settled says whether the walk read a finished graph. It is false when the walk
-//     stopped at a class the registry does not hold, or at one whose declared edges
-//     have not been resolved yet. A false reaches may then mean only that the edge
-//     leading there has not been read yet, so a caller must not take it for "cannot
-//     reach".
+//     stopped at an unregistered class or at one whose edges are unresolved, so a
+//     false reaches must not be taken for "cannot reach".
 //
 // The edges are `extends` alone, the same ones constrainNominalWalk follows, so the
-// meet decides the subtype relation the solver decides rather than a wider one. An
-// `implements` clause is a conformance assertion the nominal walk skips, so a class
-// implementing an interface is not below it. The walk is keyed by class name, so a
-// cyclic `extends` chain terminates.
+// meet decides the solver's subtype relation rather than a wider one. An
+// `implements` clause is a conformance assertion the walk skips. The walk is keyed
+// by class name, so a cyclic chain terminates.
 func (c *Context) ancestorInstance(ct *soltype.ClassType, name string) (up *soltype.ClassType, reaches, settled bool) {
 	return c.ancestorInstanceWalk(ct, name, set.NewSet[string]())
 }
@@ -639,8 +611,7 @@ func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walke
 		return ct, true, true
 	}
 	if walked.Contains(ct.Name) {
-		// An enclosing call is already walking this class. Whatever its edges reach, and
-		// whether they are resolved, is that call's answer to report.
+		// An enclosing call is walking this class already, so its answer covers these edges.
 		return nil, false, true
 	}
 	walked.Add(ct.Name)
@@ -648,10 +619,9 @@ func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walke
 	if !ok || def.EdgesPending {
 		return nil, false, false
 	}
-	// One walked set is shared by the whole walk rather than kept per path. Supers holds
-	// at most one edge, so a class is reachable by a single path and no branch can shut
-	// another out of one. A hierarchy admitting several nominal edges would have to
-	// record the walk per path to keep that true.
+	// One walked set is shared across the walk rather than kept per path. Supers holds at
+	// most one edge, so a class is reachable by a single path and no branch can shut
+	// another out of one. Several nominal edges would need the walk recorded per path.
 	settled := true
 	for _, superType := range def.Supers {
 		found, reaches, superSettled := c.ancestorInstanceWalk(substituteSuperArgs(def, ct, superType), name, walked)

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -55,6 +55,14 @@ type ClassDef struct {
 	// and the walk land in C1; B1 only records the targets.
 	Implements []*soltype.ClassType
 
+	// EdgesPending marks a def the SCC pre-pass registered as a bare identity, before the
+	// declaration's `extends` and `implements` clauses were resolved. Supers and Implements
+	// are empty on such a def because they have not been read yet, not because the class
+	// declares none. A reader concluding from an empty Supers that a class has no
+	// superclass must check this first. inferClassDecl clears it when it fills both fields
+	// in, and a def built anywhere else carries its edges from the start.
+	EdgesPending bool
+
 	// Body is the instance member view a class projects: one element per field,
 	// method, getter, and setter. Member access and the class-vs-object constrain
 	// rule read it.
@@ -469,11 +477,14 @@ func substituteSuperArgs(def *ClassDef, sub, superType *soltype.ClassType) *solt
 //  2. One tag's class reaches the other's through the declared `extends` graph. The
 //     meet is the lower of the two, since every instance of the lower one already
 //     carries the higher one's tag.
-//  3. Neither class reaches the other. No value carries both tags, so the meet is
-//     `never` and the conjunct holding them is dropped. This is the fast path
-//     caveat 1 in planning/ml_struct/02-caveats-and-mitigations.md names: an
-//     intersection of unrelated classes is settled here and never reaches
-//     structural work.
+//  3. Neither class reaches the other in a graph both walks read to the end. No
+//     value carries both tags, so the meet is `never` and the conjunct holding them
+//     is dropped. This is the fast path caveat 1 in
+//     planning/ml_struct/02-caveats-and-mitigations.md names: an intersection of
+//     unrelated classes is settled here and never reaches structural work. Calling
+//     such a pair disjoint is sound because a class declares at most one
+//     superclass, so two classes neither of which reaches the other have no common
+//     subclass.
 //
 // ok is false when none of the three settles the pair, which keeps the two tags as
 // separate atoms in the intersection. That loses no precision, since a two-atom
@@ -490,27 +501,23 @@ func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
 		}
 		return nil, false
 	}
-	// An unregistered class has no edges to read. Its relationship to the other tag is
-	// unknown rather than absent, so the pair is kept separate instead of collapsing.
-	if _, ok := c.classDef(a.Name); !ok {
-		return nil, false
-	}
-	if _, ok := c.classDef(b.Name); !ok {
-		return nil, false
-	}
-	if c.nominalSubtype(a, b) {
+	aUp, aReaches, aSettled := c.ancestorInstance(a, b.Name)
+	if aReaches && c.instanceBelow(aUp, b) {
 		return a, true
 	}
-	if c.nominalSubtype(b, a) {
+	bUp, bReaches, bSettled := c.ancestorInstance(b, a.Name)
+	if bReaches && c.instanceBelow(bUp, a) {
 		return b, true
 	}
-	if !c.classReaches(a.Name, b.Name) && !c.classReaches(b.Name, a.Name) {
+	if !aReaches && !bReaches && aSettled && bSettled {
 		return &soltype.NeverType{}, true
 	}
-	// One class reaches the other, but the instance below carries a type argument the
-	// one above rules out. Take `class Wrapper<T> extends Reader<T>` and meet
-	// `Wrapper<string>` with `Reader<number>`. Neither tag is below the other, and
-	// `Wrapper<never>` is below both, so the pair is not disjoint either.
+	// The two tags are left as separate atoms for one of two reasons. Either one class
+	// reaches the other but the instance below carries a type argument the one above
+	// rules out, or a walk read a graph that is still being built. Meeting
+	// `Wrapper<string>` with `Reader<number>`, where `class Wrapper<T> extends
+	// Reader<T>`, is the first: neither tag is below the other, and `Wrapper<never>` is
+	// below both, so the pair is not disjoint either.
 	return nil, false
 }
 
@@ -520,16 +527,22 @@ func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
 // relation by emitting constraints. The nominal meet asks this one instead,
 // because normalizing a type may not record a bound.
 //
-// The argument check goes through meetClassArgs, which leaves sub's projection at
-// super's class unchanged exactly when sub is below super. A covariant position
-// therefore accepts a narrower argument. `Sub<5>` is below `Super<number>` when
-// `class Sub<T> extends Super<T>`. An invariant position demands that the two
-// arguments match.
+// Where the two differ is which variance vector the arguments dispatch by. This one
+// always reads the mutable view, so it rejects a pair constrainNominal accepts
+// outside a mutable borrow, such as `Box<5> <: Box<number>` for a Box covariant to
+// a reader and invariant to a writer. The direction of the difference is what makes
+// it safe: a rejection here keeps two atoms the meet would otherwise have fused.
 func (c *Context) nominalSubtype(sub, super *soltype.ClassType) bool {
-	up, ok := c.ancestorInstance(sub, super.Name)
-	if !ok {
-		return false
-	}
+	up, reaches, _ := c.ancestorInstance(sub, super.Name)
+	return reaches && c.instanceBelow(up, super)
+}
+
+// instanceBelow reports whether up is below super, where both name ONE class and up
+// is what ancestorInstance projected. Meeting the two leaves up unchanged exactly
+// when up is the lower of the two, since the meet of a type with something above it
+// is that type. A covariant position therefore accepts a narrower argument, `Sub<5>`
+// below `Sub<number>`, and an invariant position demands that the two match.
+func (c *Context) instanceBelow(up, super *soltype.ClassType) bool {
 	met, ok := c.meetClassArgs(up, super)
 	return ok && equalType(met, up)
 }
@@ -599,74 +612,51 @@ func (c *Context) meetClassArgs(a, b *soltype.ClassType) (*soltype.ClassType, bo
 	}, true
 }
 
-// ancestorInstance returns the instance of the class named `name` that ct denotes,
-// substituting ct's arguments into each declared `extends` edge along the way, so
-// `class B<T> extends A<T>` asked for A at B<5> yields A<5>. ct itself is returned
-// when it already names that class. ok is false when ct's class does not reach the
-// name.
+// ancestorInstance walks the declared `extends` graph up from ct, looking for the
+// class named `name`. It returns three things.
 //
-// The walk follows the same edges and substitution constrainNominalWalk does, and
-// is keyed by class name so a cyclic `extends` chain terminates.
-func (c *Context) ancestorInstance(ct *soltype.ClassType, name string) (*soltype.ClassType, bool) {
-	return c.ancestorInstanceWalk(ct, name, set.NewSet[string]())
-}
-
-func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walked set.Set[string]) (*soltype.ClassType, bool) {
-	if ct.Name == name {
-		return ct, true
-	}
-	if walked.Contains(ct.Name) {
-		return nil, false
-	}
-	walked.Add(ct.Name)
-	def, ok := c.classDef(ct.Name)
-	if !ok {
-		return nil, false
-	}
-	for _, superType := range def.Supers {
-		if found, ok := c.ancestorInstanceWalk(substituteSuperArgs(def, ct, superType), name, walked); ok {
-			return found, true
-		}
-	}
-	return nil, false
-}
-
-// classReaches reports whether the class named from is at or below the one named
-// to in the declared `extends` graph. ancestorInstance answers the same question by
-// returning the instance itself. This one serves a caller with no arguments to
-// substitute.
+//   - up is the instance of that class ct denotes, with ct's arguments substituted
+//     into each edge along the way, so `class B<T> extends A<T>` asked for A at B<5>
+//     yields A<5>. ct itself is returned when it already names the class.
+//   - reaches says whether the class was found, which is when up is meaningful.
+//   - settled says whether the walk read a finished graph. It is false when the walk
+//     stopped at a class the registry does not hold, or at one whose declared edges
+//     have not been resolved yet. A reaches of false may then mean only that the edge
+//     leading there is missing so far, so a caller must not read it as "cannot
+//     reach".
 //
 // The edges are `extends` alone, the same ones constrainNominalWalk follows, so the
 // meet decides the subtype relation the solver decides rather than a wider one. An
-// `implements` clause is a conformance assertion the nominal walk skips. A class
-// implementing an interface is therefore not below it, and the two tags are
-// disjoint the way any other unordered pair is.
-//
-// Calling an unreachable pair disjoint is sound because a class declares at most
-// one superclass. Two classes neither of which reaches the other therefore have no
-// common subclass, so no value carries both tags.
-func (c *Context) classReaches(from, to string) bool {
-	return c.classReachesWalk(from, to, set.NewSet[string]())
+// `implements` clause is a conformance assertion the nominal walk skips, so a class
+// implementing an interface is not below it. The walk is keyed by class name, so a
+// cyclic `extends` chain terminates.
+func (c *Context) ancestorInstance(ct *soltype.ClassType, name string) (up *soltype.ClassType, reaches, settled bool) {
+	return c.ancestorInstanceWalk(ct, name, set.NewSet[string]())
 }
 
-func (c *Context) classReachesWalk(from, to string, walked set.Set[string]) bool {
-	if from == to {
-		return true
+func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walked set.Set[string]) (*soltype.ClassType, bool, bool) {
+	if ct.Name == name {
+		return ct, true, true
 	}
-	if walked.Contains(from) {
-		return false
+	if walked.Contains(ct.Name) {
+		// An enclosing call is walking this class already, so whatever its edges reach and
+		// whether they are resolved is that call's answer to give.
+		return nil, false, true
 	}
-	walked.Add(from)
-	def, ok := c.classDef(from)
-	if !ok {
-		return false
+	walked.Add(ct.Name)
+	def, ok := c.classDef(ct.Name)
+	if !ok || def.EdgesPending {
+		return nil, false, false
 	}
-	for _, super := range def.Supers {
-		if c.classReachesWalk(super.Name, to, walked) {
-			return true
+	settled := true
+	for _, superType := range def.Supers {
+		found, reaches, superSettled := c.ancestorInstanceWalk(substituteSuperArgs(def, ct, superType), name, walked)
+		if reaches {
+			return found, true, true
 		}
+		settled = settled && superSettled
 	}
-	return false
+	return nil, false, settled
 }
 
 // projectedMember resolves a member access against a class instance by looking the

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -469,9 +469,9 @@ func substituteSuperArgs(def *ClassDef, sub, superType *soltype.ClassType) *solt
 //  2. One tag's class reaches the other's through the declared `extends` graph. The
 //     meet is the lower of the two, since every instance of the lower one already
 //     carries the higher one's tag.
-//  3. No declared edge relates the two classes. No value carries both tags, so the
-//     meet is `never` and the conjunct holding them is dropped. This is the fast
-//     path caveat 1 in planning/ml_struct/02-caveats-and-mitigations.md names: an
+//  3. Neither class reaches the other. No value carries both tags, so the meet is
+//     `never` and the conjunct holding them is dropped. This is the fast path
+//     caveat 1 in planning/ml_struct/02-caveats-and-mitigations.md names: an
 //     intersection of unrelated classes is settled here and never reaches
 //     structural work.
 //
@@ -504,12 +504,13 @@ func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
 	if c.nominalSubtype(b, a) {
 		return b, true
 	}
-	if !c.classesRelated(a.Name, b.Name) {
+	if !c.classReaches(a.Name, b.Name) && !c.classReaches(b.Name, a.Name) {
 		return &soltype.NeverType{}, true
 	}
-	// The graph relates the two classes without putting either instance below the
-	// other. A declared `implements` edge and a type argument the superclass rules out
-	// both land here.
+	// One class reaches the other, but the instance below carries a type argument the
+	// one above rules out. Take `class Wrapper<T> extends Reader<T>` and meet
+	// `Wrapper<string>` with `Reader<number>`. Neither tag is below the other, and
+	// `Wrapper<never>` is below both, so the pair is not disjoint either.
 	return nil, false
 }
 
@@ -519,11 +520,11 @@ func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
 // relation by emitting constraints. The nominal meet asks this one instead,
 // because normalizing a type may not record a bound.
 //
-// The argument check goes through meetClassArgs: sub is below super exactly when
-// meeting sub's projection at super's class with super leaves that projection
-// unchanged. A covariant position therefore accepts a narrower argument, `Sub<5>`
-// below `Super<number>` when `class Sub<T> extends Super<T>`, and an invariant one
-// demands the arguments match.
+// The argument check goes through meetClassArgs, which leaves sub's projection at
+// super's class unchanged exactly when sub is below super. A covariant position
+// therefore accepts a narrower argument. `Sub<5>` is below `Super<number>` when
+// `class Sub<T> extends Super<T>`. An invariant position demands that the two
+// arguments match.
 func (c *Context) nominalSubtype(sub, super *soltype.ClassType) bool {
 	up, ok := c.ancestorInstance(sub, super.Name)
 	if !ok {
@@ -533,15 +534,15 @@ func (c *Context) nominalSubtype(sub, super *soltype.ClassType) bool {
 	return ok && equalType(met, up)
 }
 
-// meetClassArgs meets two instances of ONE class position by position, dispatching
+// meetClassArgs meets two instances of ONE class, position by position, dispatching
 // each position by the variance the class registry records for it. ok is false when
 // a position admits no exact meet, which keeps the two tags separate.
 //
 // The variance read is the MUTABLE-view vector, the stricter of the two. A normal
 // form carries no borrow around the tag to say whether a write can reach a
 // position, so the meet takes the vector that admits one. A position a write
-// reaches is invariant there, so it fuses only when the two arguments match, where
-// the immutable view would have met them.
+// reaches is invariant there, so it fuses only when the two arguments match. The
+// immutable view would have met them instead.
 //
 // The exactness and enum-variant flags must agree. Both are read off the
 // declaration, so two tags naming one class carry the same pair, and a
@@ -554,8 +555,8 @@ func (c *Context) meetClassArgs(a, b *soltype.ClassType) (*soltype.ClassType, bo
 	if !sameLifetimeSlice(a.LifetimeArgs, b.LifetimeArgs, &alphaCtx{}) {
 		return nil, false
 	}
-	// A missing def leaves every position invariant, which varianceAt already yields for
-	// a nil receiver. Two tags naming one unregistered class then fuse only when their
+	// varianceAt yields Invariant for a nil receiver, so every position of an
+	// unregistered class is invariant. Two tags naming one then fuse only when their
 	// arguments match, the conservative reading.
 	def, _ := c.classDef(a.Name)
 	args := make([]soltype.Type, len(a.TypeArgs))
@@ -630,24 +631,25 @@ func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walke
 	return nil, false
 }
 
-// classesRelated reports whether the declared graph connects the two class names in
-// either direction. Only a pair it separates meets to `never`.
+// classReaches reports whether the class named from is at or below the one named
+// to in the declared `extends` graph. ancestorInstance answers the same question by
+// returning the instance itself. This one serves a caller with no arguments to
+// substitute.
 //
-// It follows `implements` edges as well as `extends`, which is wider than the
-// nominal subtype walk. A class that implements an interface is not a nominal
-// subtype of it, so the meet cannot fuse the pair to the class. An instance of that
-// class is still meant to stand for the interface, so calling the two tags disjoint
-// would be wrong, and the meet keeps them as separate atoms instead.
+// The edges are `extends` alone, the same ones constrainNominalWalk follows, so the
+// meet decides the subtype relation the solver decides rather than a wider one. An
+// `implements` clause is a conformance assertion the nominal walk skips. A class
+// implementing an interface is therefore not below it, and the two tags are
+// disjoint the way any other unordered pair is.
 //
-// Separating an unrelated pair is sound because a class declares at most one
-// superclass. Two classes neither of which reaches the other therefore have no
+// Calling an unreachable pair disjoint is sound because a class declares at most
+// one superclass. Two classes neither of which reaches the other therefore have no
 // common subclass, so no value carries both tags.
-func (c *Context) classesRelated(a, b string) bool {
-	return c.declaredReaches(a, b, set.NewSet[string]()) ||
-		c.declaredReaches(b, a, set.NewSet[string]())
+func (c *Context) classReaches(from, to string) bool {
+	return c.classReachesWalk(from, to, set.NewSet[string]())
 }
 
-func (c *Context) declaredReaches(from, to string, walked set.Set[string]) bool {
+func (c *Context) classReachesWalk(from, to string, walked set.Set[string]) bool {
 	if from == to {
 		return true
 	}
@@ -660,12 +662,7 @@ func (c *Context) declaredReaches(from, to string, walked set.Set[string]) bool 
 		return false
 	}
 	for _, super := range def.Supers {
-		if c.declaredReaches(super.Name, to, walked) {
-			return true
-		}
-	}
-	for _, iface := range def.Implements {
-		if c.declaredReaches(iface.Name, to, walked) {
+		if c.classReachesWalk(super.Name, to, walked) {
 			return true
 		}
 	}

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -512,12 +512,12 @@ func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
 	if !aReaches && !bReaches && aSettled && bSettled {
 		return &soltype.NeverType{}, true
 	}
-	// The two tags are left as separate atoms for one of two reasons. Either one class
-	// reaches the other but the instance below carries a type argument the one above
-	// rules out, or a walk read a graph that is still being built. Meeting
-	// `Wrapper<string>` with `Reader<number>`, where `class Wrapper<T> extends
-	// Reader<T>`, is the first: neither tag is below the other, and `Wrapper<never>` is
-	// below both, so the pair is not disjoint either.
+	// The two tags stay separate atoms for one of two reasons. Either one class reaches
+	// the other while the instance below carries a type argument the one above rules
+	// out, or a walk ran into a graph that is still being built. Meeting
+	// `Wrapper<string>` with `Reader<number>` under `class Wrapper<T> extends Reader<T>`
+	// is the first case. Neither tag is below the other, and `Wrapper<never>` is below
+	// both, so the pair is not disjoint either.
 	return nil, false
 }
 
@@ -531,7 +531,7 @@ func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
 // always reads the mutable view, so it rejects a pair constrainNominal accepts
 // outside a mutable borrow, such as `Box<5> <: Box<number>` for a Box covariant to
 // a reader and invariant to a writer. The direction of the difference is what makes
-// it safe: a rejection here keeps two atoms the meet would otherwise have fused.
+// it safe. A rejection here keeps two atoms the meet would otherwise have fused.
 func (c *Context) nominalSubtype(sub, super *soltype.ClassType) bool {
 	up, reaches, _ := c.ancestorInstance(sub, super.Name)
 	return reaches && c.instanceBelow(up, super)
@@ -621,8 +621,8 @@ func (c *Context) meetClassArgs(a, b *soltype.ClassType) (*soltype.ClassType, bo
 //   - reaches says whether the class was found, which is when up is meaningful.
 //   - settled says whether the walk read a finished graph. It is false when the walk
 //     stopped at a class the registry does not hold, or at one whose declared edges
-//     have not been resolved yet. A reaches of false may then mean only that the edge
-//     leading there is missing so far, so a caller must not read it as "cannot
+//     have not been resolved yet. A false reaches may then mean only that the edge
+//     leading there has not been read yet, so a caller must not take it for "cannot
 //     reach".
 //
 // The edges are `extends` alone, the same ones constrainNominalWalk follows, so the
@@ -639,8 +639,8 @@ func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walke
 		return ct, true, true
 	}
 	if walked.Contains(ct.Name) {
-		// An enclosing call is walking this class already, so whatever its edges reach and
-		// whether they are resolved is that call's answer to give.
+		// An enclosing call is already walking this class. Whatever its edges reach, and
+		// whether they are resolved, is that call's answer to report.
 		return nil, false, true
 	}
 	walked.Add(ct.Name)

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -459,6 +459,219 @@ func substituteSuperArgs(def *ClassDef, sub, superType *soltype.ClassType) *solt
 	return superType
 }
 
+// --- The nominal meet ---
+
+// glbClass is the greatest lower bound of two class tags, the nominal meet the
+// normal form's LhsNf reads through Base. It answers one of three ways.
+//
+//  1. The two tags name one class. The meet is that class at the per-position meet
+//     of their type arguments, which meetClassArgs computes.
+//  2. One tag's class reaches the other's through the declared `extends` graph. The
+//     meet is the lower of the two, since every instance of the lower one already
+//     carries the higher one's tag.
+//  3. No declared edge relates the two classes. No value carries both tags, so the
+//     meet is `never` and the conjunct holding them is dropped. This is the fast
+//     path caveat 1 in planning/ml_struct/02-caveats-and-mitigations.md names: an
+//     intersection of unrelated classes is settled here and never reaches
+//     structural work.
+//
+// ok is false when none of the three settles the pair, which keeps the two tags as
+// separate atoms in the intersection. That loses no precision, since a two-atom
+// list already denotes the meet exactly.
+//
+// This is a pure query. It reads the class registry and records nothing, which is
+// what separates it from constrainNominal, the rule that decides the same declared
+// graph by emitting bounds. Normalization rewrites a type rather than solving a
+// constraint, so it has no goal to record a bound against.
+func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
+	if a.Name == b.Name {
+		if met, ok := c.meetClassArgs(a, b); ok {
+			return met, true
+		}
+		return nil, false
+	}
+	// An unregistered class has no edges to read. Its relationship to the other tag is
+	// unknown rather than absent, so the pair is kept separate instead of collapsing.
+	if _, ok := c.classDef(a.Name); !ok {
+		return nil, false
+	}
+	if _, ok := c.classDef(b.Name); !ok {
+		return nil, false
+	}
+	if c.nominalSubtype(a, b) {
+		return a, true
+	}
+	if c.nominalSubtype(b, a) {
+		return b, true
+	}
+	if !c.classesRelated(a.Name, b.Name) {
+		return &soltype.NeverType{}, true
+	}
+	// The graph relates the two classes without putting either instance below the
+	// other. A declared `implements` edge and a type argument the superclass rules out
+	// both land here.
+	return nil, false
+}
+
+// nominalSubtype reports whether the class instance sub is below super, following
+// the declared `extends` graph and checking the type arguments sub carries at
+// super's class. It is the pure twin of constrainNominal, which decides the same
+// relation by emitting constraints. The nominal meet asks this one instead,
+// because normalizing a type may not record a bound.
+//
+// The argument check goes through meetClassArgs: sub is below super exactly when
+// meeting sub's projection at super's class with super leaves that projection
+// unchanged. A covariant position therefore accepts a narrower argument, `Sub<5>`
+// below `Super<number>` when `class Sub<T> extends Super<T>`, and an invariant one
+// demands the arguments match.
+func (c *Context) nominalSubtype(sub, super *soltype.ClassType) bool {
+	up, ok := c.ancestorInstance(sub, super.Name)
+	if !ok {
+		return false
+	}
+	met, ok := c.meetClassArgs(up, super)
+	return ok && equalType(met, up)
+}
+
+// meetClassArgs meets two instances of ONE class position by position, dispatching
+// each position by the variance the class registry records for it. ok is false when
+// a position admits no exact meet, which keeps the two tags separate.
+//
+// The variance read is the MUTABLE-view vector, the stricter of the two. A normal
+// form carries no borrow around the tag to say whether a write can reach a
+// position, so the meet takes the vector that admits one. A position a write
+// reaches is invariant there, so it fuses only when the two arguments match, where
+// the immutable view would have met them.
+//
+// The exactness and enum-variant flags must agree. Both are read off the
+// declaration, so two tags naming one class carry the same pair, and a
+// disagreement means one of them was built by hand. Fusing two tags whose
+// exactness differs is left to the exactness-aware merge, #1064.
+func (c *Context) meetClassArgs(a, b *soltype.ClassType) (*soltype.ClassType, bool) {
+	if a.Final != b.Final || a.Variant != b.Variant || len(a.TypeArgs) != len(b.TypeArgs) {
+		return nil, false
+	}
+	if !sameLifetimeSlice(a.LifetimeArgs, b.LifetimeArgs, &alphaCtx{}) {
+		return nil, false
+	}
+	// A missing def leaves every position invariant, which varianceAt already yields for
+	// a nil receiver. Two tags naming one unregistered class then fuse only when their
+	// arguments match, the conservative reading.
+	def, _ := c.classDef(a.Name)
+	args := make([]soltype.Type, len(a.TypeArgs))
+	same := true
+	for i := range a.TypeArgs {
+		argA, argB := a.TypeArgs[i], b.TypeArgs[i]
+		switch def.varianceAt(i, true) {
+		case Covariant:
+			// `C<A> & C<B>` is `C<A & B>` when the position is covariant: an instance below
+			// both reads the position at both types, so it reads it at their meet.
+			args[i] = c.meetTypes(argA, argB)
+		case Contravariant:
+			// The dual. An instance below both accepts a write of either type at the
+			// position, so it accepts their join.
+			args[i] = c.joinTypes(argA, argB)
+		case Bivariant:
+			// A phantom parameter appears nowhere in the body, so the two arguments say
+			// nothing about the instances and either one stands for the meet.
+			args[i] = argA
+		default: // Invariant
+			if !equalType(argA, argB) {
+				return nil, false
+			}
+			args[i] = argA
+		}
+		same = same && equalType(args[i], argA)
+	}
+	if same {
+		// Every position met to the argument a already carries, so a IS the meet. Handing
+		// back the same handle keeps the atom the normal form arrived with.
+		return a, true
+	}
+	return &soltype.ClassType{
+		Name:         a.Name,
+		TypeArgs:     args,
+		LifetimeArgs: a.LifetimeArgs,
+		Lt:           a.Lt,
+		Final:        a.Final,
+		Variant:      a.Variant,
+	}, true
+}
+
+// ancestorInstance returns the instance of the class named `name` that ct denotes,
+// substituting ct's arguments into each declared `extends` edge along the way, so
+// `class B<T> extends A<T>` asked for A at B<5> yields A<5>. ct itself is returned
+// when it already names that class. ok is false when ct's class does not reach the
+// name.
+//
+// The walk follows the same edges and substitution constrainNominalWalk does, and
+// is keyed by class name so a cyclic `extends` chain terminates.
+func (c *Context) ancestorInstance(ct *soltype.ClassType, name string) (*soltype.ClassType, bool) {
+	return c.ancestorInstanceWalk(ct, name, set.NewSet[string]())
+}
+
+func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walked set.Set[string]) (*soltype.ClassType, bool) {
+	if ct.Name == name {
+		return ct, true
+	}
+	if walked.Contains(ct.Name) {
+		return nil, false
+	}
+	walked.Add(ct.Name)
+	def, ok := c.classDef(ct.Name)
+	if !ok {
+		return nil, false
+	}
+	for _, superType := range def.Supers {
+		if found, ok := c.ancestorInstanceWalk(substituteSuperArgs(def, ct, superType), name, walked); ok {
+			return found, true
+		}
+	}
+	return nil, false
+}
+
+// classesRelated reports whether the declared graph connects the two class names in
+// either direction. Only a pair it separates meets to `never`.
+//
+// It follows `implements` edges as well as `extends`, which is wider than the
+// nominal subtype walk. A class that implements an interface is not a nominal
+// subtype of it, so the meet cannot fuse the pair to the class. An instance of that
+// class is still meant to stand for the interface, so calling the two tags disjoint
+// would be wrong, and the meet keeps them as separate atoms instead.
+//
+// Separating an unrelated pair is sound because a class declares at most one
+// superclass. Two classes neither of which reaches the other therefore have no
+// common subclass, so no value carries both tags.
+func (c *Context) classesRelated(a, b string) bool {
+	return c.declaredReaches(a, b, set.NewSet[string]()) ||
+		c.declaredReaches(b, a, set.NewSet[string]())
+}
+
+func (c *Context) declaredReaches(from, to string, walked set.Set[string]) bool {
+	if from == to {
+		return true
+	}
+	if walked.Contains(from) {
+		return false
+	}
+	walked.Add(from)
+	def, ok := c.classDef(from)
+	if !ok {
+		return false
+	}
+	for _, super := range def.Supers {
+		if c.declaredReaches(super.Name, to, walked) {
+			return true
+		}
+	}
+	for _, iface := range def.Implements {
+		if c.declaredReaches(iface.Name, to, walked) {
+			return true
+		}
+	}
+	return false
+}
+
 // projectedMember resolves a member access against a class instance by looking the
 // member up on the class body — walking the declared `extends` chain for a member the
 // class inherits rather than declares — and projecting just that member to the instance's

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -648,6 +648,10 @@ func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walke
 	if !ok || def.EdgesPending {
 		return nil, false, false
 	}
+	// One walked set is shared by the whole walk rather than kept per path. Supers holds
+	// at most one edge, so a class is reachable by a single path and no branch can shut
+	// another out of one. A hierarchy admitting several nominal edges would have to
+	// record the walk per path to keep that true.
 	settled := true
 	for _, superType := range def.Supers {
 		found, reaches, superSettled := c.ancestorInstanceWalk(substituteSuperArgs(def, ct, superType), name, walked)

--- a/internal/solver/classes_test.go
+++ b/internal/solver/classes_test.go
@@ -356,16 +356,17 @@ func TestProjectClassBodyDoesNotMutateRegistry(t *testing.T) {
 
 // nominalGraph registers the class hierarchy the nominal-meet cases share.
 //
-//	Shape          Vec     Printable                Loop ──┐
-//	├── Point                  ▲                     ▲     │
-//	│   └── Pixel              └── implemented by Doc └─────┘
-//	└── Line
+//	Shape           Vec     Printable      Loop ──┐
+//	├── Point                   ▲           ▲     │
+//	│   └── Pixel               │           └─────┘
+//	├── Line                    │
+//	└── Doc ── implements ──────┘
 //
-// It also registers one generic class per variance — covariant Reader, mutable-view
-// invariant Box, contravariant Consumer, invariant Cell, bivariant Ghost — plus two
-// classes extending a generic one: `Wrapper<T> extends Reader<T>`, which substitutes
-// its own argument into the edge, and `NumReader extends Reader<number>`, which fixes
-// the argument at the declaration.
+// It also registers one generic class per variance: covariant Reader, mutable-view
+// invariant Box, contravariant Consumer, invariant Cell, and bivariant Ghost. Two
+// further classes extend a generic one. `Wrapper<T> extends Reader<T>` substitutes
+// its own argument into the edge, and `NumReader extends Reader<number>` fixes the
+// argument at the declaration.
 func nominalGraph() *Context {
 	c := &Context{}
 	for _, name := range []string{"Shape", "Vec", "Printable"} {
@@ -374,7 +375,10 @@ func nominalGraph() *Context {
 	c.registerClass("Point", &ClassDef{Supers: []*soltype.ClassType{cls("Shape", false)}})
 	c.registerClass("Pixel", &ClassDef{Supers: []*soltype.ClassType{cls("Point", false)}})
 	c.registerClass("Line", &ClassDef{Supers: []*soltype.ClassType{cls("Shape", false)}})
-	c.registerClass("Doc", &ClassDef{Implements: []*soltype.ClassType{cls("Printable", false)}})
+	c.registerClass("Doc", &ClassDef{
+		Supers:     []*soltype.ClassType{cls("Shape", false)},
+		Implements: []*soltype.ClassType{cls("Printable", false)},
+	})
 	// A class extending itself is not something the checker builds. Registering one here
 	// pins that the walk stops on a cyclic edge instead of recurring forever.
 	c.registerClass("Loop", &ClassDef{Supers: []*soltype.ClassType{cls("Loop", false)}})
@@ -397,16 +401,16 @@ func nominalGraph() *Context {
 		TypeParams:  []*soltype.TypeParam{{Name: "T", Var: wrapperVar}},
 		Variance:    []Variance{Covariant},
 		MutVariance: []Variance{Covariant},
-		Supers:      []*soltype.ClassType{generics("Reader", wrapperVar)},
+		Supers:      []*soltype.ClassType{genericCls("Reader", wrapperVar)},
 	})
 	c.registerClass("NumReader", &ClassDef{
-		Supers: []*soltype.ClassType{generics("Reader", num())},
+		Supers: []*soltype.ClassType{genericCls("Reader", num())},
 	})
 	return c
 }
 
-// generics builds an instance handle for a generic class at the given arguments.
-func generics(name string, args ...soltype.Type) *soltype.ClassType {
+// genericCls builds an instance handle for a generic class at the given arguments.
+func genericCls(name string, args ...soltype.Type) *soltype.ClassType {
 	return &soltype.ClassType{Name: name, TypeArgs: args}
 }
 
@@ -462,9 +466,14 @@ func TestGlbClass(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "an implemented interface is related but not above the class",
+			name: "an implemented interface is not above the class that implements it",
 			a:    cls("Doc", false), b: cls("Printable", false),
-			want: "",
+			want: "never",
+		},
+		{
+			name: "an interface is unordered against the superclass of an implementor",
+			a:    cls("Shape", false), b: cls("Printable", false),
+			want: "never",
 		},
 		{
 			name: "two tags disagreeing on exactness stay separate",
@@ -473,52 +482,52 @@ func TestGlbClass(t *testing.T) {
 		},
 		{
 			name: "a covariant position meets its two arguments",
-			a:    generics("Reader", num()), b: generics("Reader", numOrStr),
+			a:    genericCls("Reader", num()), b: genericCls("Reader", numOrStr),
 			want: "Reader<number>",
 		},
 		{
 			name: "a covariant position may meet to never",
-			a:    generics("Reader", num()), b: generics("Reader", str()),
+			a:    genericCls("Reader", num()), b: genericCls("Reader", str()),
 			want: "Reader<never>",
 		},
 		{
 			name: "a contravariant position joins its two arguments",
-			a:    generics("Consumer", num()), b: generics("Consumer", str()),
+			a:    genericCls("Consumer", num()), b: genericCls("Consumer", str()),
 			want: "Consumer<number | string>",
 		},
 		{
 			name: "an invariant position fuses only equal arguments",
-			a:    generics("Cell", num()), b: generics("Cell", num()),
+			a:    genericCls("Cell", num()), b: genericCls("Cell", num()),
 			want: "Cell<number>",
 		},
 		{
 			name: "an invariant position with differing arguments stays separate",
-			a:    generics("Cell", num()), b: generics("Cell", str()),
+			a:    genericCls("Cell", num()), b: genericCls("Cell", str()),
 			want: "",
 		},
 		{
 			name: "a bivariant position imposes nothing on its arguments",
-			a:    generics("Ghost", num()), b: generics("Ghost", str()),
+			a:    genericCls("Ghost", num()), b: genericCls("Ghost", str()),
 			want: "Ghost<number>",
 		},
 		{
 			name: "a position a write reaches is dispatched as invariant",
-			a:    generics("Box", num()), b: generics("Box", numOrStr),
+			a:    genericCls("Box", num()), b: genericCls("Box", numOrStr),
 			want: "",
 		},
 		{
 			name: "an inherited argument is substituted along the edge",
-			a:    generics("Wrapper", numLit(5)), b: generics("Reader", num()),
+			a:    genericCls("Wrapper", numLit(5)), b: genericCls("Reader", num()),
 			want: "Wrapper<5>",
 		},
 		{
 			name: "an inherited argument the superclass rules out stays separate",
-			a:    generics("Wrapper", str()), b: generics("Reader", num()),
+			a:    genericCls("Wrapper", str()), b: genericCls("Reader", num()),
 			want: "",
 		},
 		{
 			name: "an edge declared at a fixed argument reaches its superclass",
-			a:    cls("NumReader", false), b: generics("Reader", numOrStr),
+			a:    cls("NumReader", false), b: genericCls("Reader", numOrStr),
 			want: "NumReader",
 		},
 	}
@@ -564,6 +573,15 @@ func TestGlbClassInNormalForm(t *testing.T) {
 		require.Equal(t, "(fn (x: number) -> string) & Point", soltype.Print(d.toType()))
 	})
 
+	t.Run("two tags of one class survive when no argument stands for the meet", func(t *testing.T) {
+		conflicting := meet(genericCls("Cell", num()), genericCls("Cell", str()))
+		d := c.mkDNF(conflicting, soltype.Positive)
+		require.Len(t, d.Conjuncts, 1)
+		require.Len(t, d.Conjuncts[0].Lnf.Atoms, 2)
+		_, ok := d.Conjuncts[0].Lnf.Base()
+		require.False(t, ok)
+	})
+
 	t.Run("an unrelated tag drops one member of a union and keeps the rest", func(t *testing.T) {
 		either := newUnion(nil, []soltype.Type{
 			meet(cls("Point", false), cls("Vec", false)),
@@ -589,9 +607,10 @@ func TestNominalSubtype(t *testing.T) {
 		{name: "two edges still reach", sub: cls("Pixel", false), super: cls("Shape", false), want: true},
 		{name: "siblings are unrelated", sub: cls("Point", false), super: cls("Line", false), want: false},
 		{name: "an implemented interface is not a nominal supertype", sub: cls("Doc", false), super: cls("Printable", false), want: false},
-		{name: "a covariant argument may narrow", sub: generics("Reader", numLit(5)), super: generics("Reader", num()), want: true},
-		{name: "a covariant argument may not widen", sub: generics("Reader", num()), super: generics("Reader", numLit(5)), want: false},
-		{name: "an inherited argument is checked at the superclass", sub: generics("Wrapper", numLit(5)), super: generics("Reader", num()), want: true},
+		{name: "an implementor is still below its superclass", sub: cls("Doc", false), super: cls("Shape", false), want: true},
+		{name: "a covariant argument may narrow", sub: genericCls("Reader", numLit(5)), super: genericCls("Reader", num()), want: true},
+		{name: "a covariant argument may not widen", sub: genericCls("Reader", num()), super: genericCls("Reader", numLit(5)), want: false},
+		{name: "an inherited argument is checked at the superclass", sub: genericCls("Wrapper", numLit(5)), super: genericCls("Reader", num()), want: true},
 	}
 
 	for _, test := range tests {

--- a/internal/solver/classes_test.go
+++ b/internal/solver/classes_test.go
@@ -408,10 +408,21 @@ func nominalGraph() *Context {
 		MutVariance: []Variance{Covariant},
 		Supers:      []*soltype.ClassType{genericCls("Reader", wrapperVar)},
 	})
+	// Held carries borrowed data, so its instances differ by lifetime argument rather than
+	// by type argument.
+	c.registerClass("Held", &ClassDef{
+		LifetimeParams: []*soltype.LifetimeParam{{Name: "a", Var: &soltype.LifetimeVar{ID: 410, Level: 1}}},
+	})
 	c.registerClass("NumReader", &ClassDef{
 		Supers: []*soltype.ClassType{genericCls("Reader", num())},
 	})
 	return c
+}
+
+// borrowing builds an instance handle for a class that holds borrowed data, carrying one
+// lifetime argument and no type arguments.
+func borrowing(name string, lt soltype.Lifetime) *soltype.ClassType {
+	return &soltype.ClassType{Name: name, LifetimeArgs: []soltype.Lifetime{lt}}
 }
 
 // genericCls builds an instance handle for a generic class at the given arguments.
@@ -424,6 +435,9 @@ func genericCls(name string, args ...soltype.Type) *soltype.ClassType {
 // the intersection keeps both tags as separate atoms.
 func TestGlbClass(t *testing.T) {
 	numOrStr := &soltype.UnionType{Types: []soltype.Type{num(), str()}}
+	// One lifetime shared by two tags, so the pair differs from the two-distinct-lifetimes
+	// row only in which lifetime each argument names.
+	sharedLt := &soltype.LifetimeVar{ID: 402, Level: 1}
 
 	tests := []struct {
 		name string
@@ -494,6 +508,17 @@ func TestGlbClass(t *testing.T) {
 			name: "two tags disagreeing on exactness stay separate",
 			a:    cls("Point", true), b: cls("Point", false),
 			want: "",
+		},
+		{
+			name: "two tags disagreeing on a lifetime argument stay separate",
+			a:    borrowing("Held", &soltype.LifetimeVar{ID: 400, Level: 1}),
+			b:    borrowing("Held", &soltype.LifetimeVar{ID: 401, Level: 1}),
+			want: "",
+		},
+		{
+			name: "two tags sharing a lifetime argument fuse",
+			a:    borrowing("Held", sharedLt), b: borrowing("Held", sharedLt),
+			want: "Held<'l402>",
 		},
 		{
 			name: "a covariant position meets its two arguments",

--- a/internal/solver/classes_test.go
+++ b/internal/solver/classes_test.go
@@ -349,7 +349,254 @@ func TestProjectClassBodyDoesNotMutateRegistry(t *testing.T) {
 
 	proj, ok := c.projectClassBody(&soltype.ClassType{Name: "Phantom", TypeArgs: []soltype.Type{num()}})
 	require.True(t, ok)
-	require.NotSame(t, body, proj)  // a fresh wrapper, not the shared registry Body
-	require.True(t, proj.Inexact)   // the non-final instance projects an inexact view
-	require.False(t, body.Inexact)  // the registry Body stays exact — never mutated
+	require.NotSame(t, body, proj) // a fresh wrapper, not the shared registry Body
+	require.True(t, proj.Inexact)  // the non-final instance projects an inexact view
+	require.False(t, body.Inexact) // the registry Body stays exact — never mutated
+}
+
+// nominalGraph registers the class hierarchy the nominal-meet cases share.
+//
+//	Shape          Vec     Printable                Loop ──┐
+//	├── Point                  ▲                     ▲     │
+//	│   └── Pixel              └── implemented by Doc └─────┘
+//	└── Line
+//
+// It also registers one generic class per variance — covariant Reader, mutable-view
+// invariant Box, contravariant Consumer, invariant Cell, bivariant Ghost — plus two
+// classes extending a generic one: `Wrapper<T> extends Reader<T>`, which substitutes
+// its own argument into the edge, and `NumReader extends Reader<number>`, which fixes
+// the argument at the declaration.
+func nominalGraph() *Context {
+	c := &Context{}
+	for _, name := range []string{"Shape", "Vec", "Printable"} {
+		c.registerClass(name, &ClassDef{})
+	}
+	c.registerClass("Point", &ClassDef{Supers: []*soltype.ClassType{cls("Shape", false)}})
+	c.registerClass("Pixel", &ClassDef{Supers: []*soltype.ClassType{cls("Point", false)}})
+	c.registerClass("Line", &ClassDef{Supers: []*soltype.ClassType{cls("Shape", false)}})
+	c.registerClass("Doc", &ClassDef{Implements: []*soltype.ClassType{cls("Printable", false)}})
+	// A class extending itself is not something the checker builds. Registering one here
+	// pins that the walk stops on a cyclic edge instead of recurring forever.
+	c.registerClass("Loop", &ClassDef{Supers: []*soltype.ClassType{cls("Loop", false)}})
+
+	generic := func(name string, immut, mut Variance, id int) {
+		c.registerClass(name, &ClassDef{
+			TypeParams:  []*soltype.TypeParam{{Name: "T", Var: &soltype.TypeVarType{ID: id}}},
+			Variance:    []Variance{immut},
+			MutVariance: []Variance{mut},
+		})
+	}
+	generic("Reader", Covariant, Covariant, 300)
+	generic("Box", Covariant, Invariant, 301)
+	generic("Consumer", Contravariant, Contravariant, 302)
+	generic("Cell", Invariant, Invariant, 303)
+	generic("Ghost", Bivariant, Bivariant, 304)
+
+	wrapperVar := &soltype.TypeVarType{ID: 305}
+	c.registerClass("Wrapper", &ClassDef{
+		TypeParams:  []*soltype.TypeParam{{Name: "T", Var: wrapperVar}},
+		Variance:    []Variance{Covariant},
+		MutVariance: []Variance{Covariant},
+		Supers:      []*soltype.ClassType{generics("Reader", wrapperVar)},
+	})
+	c.registerClass("NumReader", &ClassDef{
+		Supers: []*soltype.ClassType{generics("Reader", num())},
+	})
+	return c
+}
+
+// generics builds an instance handle for a generic class at the given arguments.
+func generics(name string, args ...soltype.Type) *soltype.ClassType {
+	return &soltype.ClassType{Name: name, TypeArgs: args}
+}
+
+// TestGlbClass covers the nominal meet of two class tags. want is the annotation the
+// fused tag renders under, and an empty want says the pair admits no exact fusion, so
+// the intersection keeps both tags as separate atoms.
+func TestGlbClass(t *testing.T) {
+	numOrStr := &soltype.UnionType{Types: []soltype.Type{num(), str()}}
+
+	tests := []struct {
+		name string
+		a, b *soltype.ClassType
+		want string
+	}{
+		{
+			name: "one class met with itself is that class",
+			a:    cls("Point", false), b: cls("Point", false),
+			want: "Point",
+		},
+		{
+			name: "a subclass met with its superclass is the subclass",
+			a:    cls("Point", false), b: cls("Shape", false),
+			want: "Point",
+		},
+		{
+			name: "the superclass may be written first",
+			a:    cls("Shape", false), b: cls("Point", false),
+			want: "Point",
+		},
+		{
+			name: "a subclass two edges down still reaches",
+			a:    cls("Pixel", false), b: cls("Shape", false),
+			want: "Pixel",
+		},
+		{
+			name: "two unrelated classes have no common instance",
+			a:    cls("Point", false), b: cls("Vec", false),
+			want: "never",
+		},
+		{
+			name: "two siblings under one superclass are unrelated to each other",
+			a:    cls("Point", false), b: cls("Line", false),
+			want: "never",
+		},
+		{
+			name: "a cyclic extends edge terminates and reports no relation",
+			a:    cls("Loop", false), b: cls("Vec", false),
+			want: "never",
+		},
+		{
+			name: "an unregistered class settles nothing",
+			a:    cls("Point", false), b: cls("Unregistered", false),
+			want: "",
+		},
+		{
+			name: "an implemented interface is related but not above the class",
+			a:    cls("Doc", false), b: cls("Printable", false),
+			want: "",
+		},
+		{
+			name: "two tags disagreeing on exactness stay separate",
+			a:    cls("Point", true), b: cls("Point", false),
+			want: "",
+		},
+		{
+			name: "a covariant position meets its two arguments",
+			a:    generics("Reader", num()), b: generics("Reader", numOrStr),
+			want: "Reader<number>",
+		},
+		{
+			name: "a covariant position may meet to never",
+			a:    generics("Reader", num()), b: generics("Reader", str()),
+			want: "Reader<never>",
+		},
+		{
+			name: "a contravariant position joins its two arguments",
+			a:    generics("Consumer", num()), b: generics("Consumer", str()),
+			want: "Consumer<number | string>",
+		},
+		{
+			name: "an invariant position fuses only equal arguments",
+			a:    generics("Cell", num()), b: generics("Cell", num()),
+			want: "Cell<number>",
+		},
+		{
+			name: "an invariant position with differing arguments stays separate",
+			a:    generics("Cell", num()), b: generics("Cell", str()),
+			want: "",
+		},
+		{
+			name: "a bivariant position imposes nothing on its arguments",
+			a:    generics("Ghost", num()), b: generics("Ghost", str()),
+			want: "Ghost<number>",
+		},
+		{
+			name: "a position a write reaches is dispatched as invariant",
+			a:    generics("Box", num()), b: generics("Box", numOrStr),
+			want: "",
+		},
+		{
+			name: "an inherited argument is substituted along the edge",
+			a:    generics("Wrapper", numLit(5)), b: generics("Reader", num()),
+			want: "Wrapper<5>",
+		},
+		{
+			name: "an inherited argument the superclass rules out stays separate",
+			a:    generics("Wrapper", str()), b: generics("Reader", num()),
+			want: "",
+		},
+		{
+			name: "an edge declared at a fixed argument reaches its superclass",
+			a:    cls("NumReader", false), b: generics("Reader", numOrStr),
+			want: "NumReader",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			met, ok := nominalGraph().glbClass(test.a, test.b)
+			if test.want == "" {
+				require.False(t, ok)
+				require.Nil(t, met)
+				return
+			}
+			require.True(t, ok)
+			require.Equal(t, test.want, soltype.Print(met))
+		})
+	}
+}
+
+// TestGlbClassInNormalForm covers what the meet's three answers do to the conjunct
+// holding the tags, which is the reason the meet exists.
+func TestGlbClassInNormalForm(t *testing.T) {
+	c := nominalGraph()
+	meet := func(members ...soltype.Type) soltype.Type {
+		return newIntersection(nil, members)
+	}
+
+	t.Run("unrelated tags drop the conjunct before any structural work", func(t *testing.T) {
+		require.Equal(t, "never", normDNF(c, meet(cls("Point", false), cls("Vec", false))))
+	})
+
+	t.Run("a subclass absorbs its superclass tag", func(t *testing.T) {
+		require.Equal(t, "Pixel", normDNF(c, meet(cls("Pixel", false), cls("Shape", false))))
+	})
+
+	t.Run("a tag and a structural atom fill both slots of one conjunct", func(t *testing.T) {
+		mixed := meet(cls("Point", false), parseType(t, "fn (x: number) -> string"))
+		d := c.mkDNF(mixed, soltype.Positive)
+		require.Len(t, d.Conjuncts, 1)
+		require.Len(t, d.Conjuncts[0].Lnf.Atoms, 2)
+		base, ok := d.Conjuncts[0].Lnf.Base()
+		require.True(t, ok)
+		require.Equal(t, "Point", soltype.Print(base))
+		require.Equal(t, "(fn (x: number) -> string) & Point", soltype.Print(d.toType()))
+	})
+
+	t.Run("an unrelated tag drops one member of a union and keeps the rest", func(t *testing.T) {
+		either := newUnion(nil, []soltype.Type{
+			meet(cls("Point", false), cls("Vec", false)),
+			cls("Line", false),
+		}, false)
+		require.Equal(t, "Line", normDNF(c, either))
+	})
+}
+
+// TestNominalSubtype covers the pure subtype query the nominal meet asks, which
+// decides the same declared graph constrainNominal does without recording a bound.
+func TestNominalSubtype(t *testing.T) {
+	c := nominalGraph()
+
+	tests := []struct {
+		name       string
+		sub, super *soltype.ClassType
+		want       bool
+	}{
+		{name: "a class is below itself", sub: cls("Point", false), super: cls("Point", false), want: true},
+		{name: "a subclass is below its superclass", sub: cls("Point", false), super: cls("Shape", false), want: true},
+		{name: "a superclass is not below its subclass", sub: cls("Shape", false), super: cls("Point", false), want: false},
+		{name: "two edges still reach", sub: cls("Pixel", false), super: cls("Shape", false), want: true},
+		{name: "siblings are unrelated", sub: cls("Point", false), super: cls("Line", false), want: false},
+		{name: "an implemented interface is not a nominal supertype", sub: cls("Doc", false), super: cls("Printable", false), want: false},
+		{name: "a covariant argument may narrow", sub: generics("Reader", numLit(5)), super: generics("Reader", num()), want: true},
+		{name: "a covariant argument may not widen", sub: generics("Reader", num()), super: generics("Reader", numLit(5)), want: false},
+		{name: "an inherited argument is checked at the superclass", sub: generics("Wrapper", numLit(5)), super: generics("Reader", num()), want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, c.nominalSubtype(test.sub, test.super))
+		})
+	}
 }

--- a/internal/solver/classes_test.go
+++ b/internal/solver/classes_test.go
@@ -382,6 +382,11 @@ func nominalGraph() *Context {
 	// A class extending itself is not something the checker builds. Registering one here
 	// pins that the walk stops on a cyclic edge instead of recurring forever.
 	c.registerClass("Loop", &ClassDef{Supers: []*soltype.ClassType{cls("Loop", false)}})
+	// Pending is the shell the SCC pre-pass registers for a class in a mutually recursive
+	// component, before its `extends` clause is resolved. BelowPending sits under it, so a
+	// walk from there runs into the unresolved edge one step up.
+	c.registerClass("Pending", &ClassDef{EdgesPending: true})
+	c.registerClass("BelowPending", &ClassDef{Supers: []*soltype.ClassType{cls("Pending", false)}})
 
 	generic := func(name string, immut, mut Variance, id int) {
 		c.registerClass(name, &ClassDef{
@@ -463,6 +468,16 @@ func TestGlbClass(t *testing.T) {
 		{
 			name: "an unregistered class settles nothing",
 			a:    cls("Point", false), b: cls("Unregistered", false),
+			want: "",
+		},
+		{
+			name: "a class whose edges are still pending settles nothing",
+			a:    cls("Pending", false), b: cls("Vec", false),
+			want: "",
+		},
+		{
+			name: "a pending class along the walk settles nothing for the class below it",
+			a:    cls("BelowPending", false), b: cls("Vec", false),
 			want: "",
 		},
 		{

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -80,6 +80,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// check them; B1 records them only.
 	def.Supers = c.resolveClassSupers(declScope, lvl, decl)
 	def.Implements = c.resolveClassImplements(declScope, lvl, decl)
+	def.EdgesPending = false
 
 	// Two-phase member walk (B3). Phase 1 appends a signature element for every field,
 	// method, getter, and setter to the instance or static body before any body is
@@ -255,6 +256,10 @@ func (c *checker) getOrCreateClass(scope *Scope, decl *ast.ClassDecl, ns string)
 		Arity:  arityOfParamDecls(decl.TypeParams),
 		Body:   &soltype.ObjectType{},
 		Static: &soltype.ObjectType{},
+		// The `extends` and `implements` clauses resolve in the second phase, so until then
+		// the two edge lists are empty for want of reading rather than for want of a
+		// declaration.
+		EdgesPending: true,
 	}
 	c.ctx.registerClass(qname, def)
 	// Register the type binding under the qualified name so a cross-namespace reference

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -60,9 +60,6 @@ import (
 //
 // # What is deliberately left to a later PR
 //
-//   - The nominal meet of two class tags. glbClass only fuses identical tags and
-//     keeps unrelated ones separate; PR4 (#1061) wires it to the M5
-//     declared-subtype graph so unrelated classes collapse the conjunct to `never`.
 //   - Exactness-driven merges. An atom's `Inexact` flag rides through every merge
 //     here, and two atoms whose flags disagree are kept separate rather than
 //     fused under a guess. PR7 (#1064) decides the exact cases, such as two exact
@@ -110,10 +107,11 @@ type LhsNf struct{ Atoms []soltype.Type }
 type RhsNf struct{ Atoms []soltype.Type }
 
 // Base returns the single nominal class tag the intersection carries, and reports
-// whether it carries exactly one. This is the slot the nominal meet writes to:
-// once PR4 (#1061) lands, glbClass fuses two related tags into one and collapses
-// two unrelated ones to `never`, so a well-formed conjunct holds at most one tag
-// and this accessor is total on it.
+// whether it carries exactly one. This is the slot the nominal meet writes to.
+// glbClass fuses two related tags into one and collapses two unrelated ones to
+// `never`, so the only intersection reaching this accessor with two tags left is
+// one whose classes the declared graph relates without ordering, such as a class
+// met with an interface it implements.
 func (l LhsNf) Base() (*soltype.ClassType, bool) {
 	var found *soltype.ClassType
 	for _, atom := range l.Atoms {
@@ -1100,20 +1098,6 @@ func (c *Context) meetTypes(a, b soltype.Type) soltype.Type {
 // widened record field are written from.
 func (c *Context) joinTypes(a, b soltype.Type) soltype.Type {
 	return c.mkDNF(newUnion(nil, []soltype.Type{a, b}, false), soltype.Positive).toType()
-}
-
-// glbClass is the nominal meet of two class tags, the slot LhsNf.Base reads. It
-// fuses two tags naming one class and keeps unrelated ones separate.
-//
-// TODO(#1061): PR4 replaces this with the M5 declared-subtype graph. Two related
-// classes then fuse to the lower of the two, and two unrelated ones return `never`
-// so the enclosing conjunct is dropped before any structural work — the
-// combinatorial fast path caveat 1 relies on.
-func (c *Context) glbClass(a, b *soltype.ClassType) (soltype.Type, bool) {
-	if equalType(a, b) {
-		return a, true
-	}
-	return nil, false
 }
 
 // plainProps returns an object's members as properties, and ok is false when the

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -108,10 +108,11 @@ type RhsNf struct{ Atoms []soltype.Type }
 
 // Base returns the single nominal class tag the intersection carries, and reports
 // whether it carries exactly one. This is the slot the nominal meet writes to.
-// glbClass fuses two related tags into one and collapses two unrelated ones to
-// `never`, so the only intersection reaching this accessor with two tags left is
-// one whose classes the declared graph relates without ordering, such as a class
-// met with an interface it implements.
+// glbClass fuses two ordered tags into one and collapses two unordered ones to
+// `never`, so an intersection that still holds two tags here is one glbClass found
+// no exact fusion for. `Cell<number> & Cell<string>` at an invariant position is
+// such a pair. The two tags name one class, and neither argument stands for the
+// meet.
 func (l LhsNf) Base() (*soltype.ClassType, bool) {
 	var found *soltype.ClassType
 	for _, atom := range l.Atoms {

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -654,11 +654,12 @@ func TestVariablesStayInTheirSlots(t *testing.T) {
 	require.Equal(t, "unknown", normCNF(c, either))
 }
 
-// TestBaseReadsTheSingleClassTag covers the slot PR4 (#1061) wires the nominal
-// meet to. One tag in a conjunct is the base; two unrelated tags are both kept, so
-// the conjunct has no single base until that PR lands.
+// TestBaseReadsTheSingleClassTag covers the slot the nominal meet writes to. One
+// tag in a conjunct is the base, and the meet leaves at most one there.
 func TestBaseReadsTheSingleClassTag(t *testing.T) {
 	c := &Context{}
+	c.registerClass("Point", &ClassDef{})
+	c.registerClass("Line", &ClassDef{})
 	point := classTag("Point")
 	line := classTag("Line")
 
@@ -674,13 +675,11 @@ func TestBaseReadsTheSingleClassTag(t *testing.T) {
 	require.Len(t, same.Conjuncts, 1)
 	require.Len(t, same.Conjuncts[0].Lnf.Atoms, 1)
 
-	// TODO(#1061): once PR4 supplies the nominal glb, two unrelated tags collapse
-	// the conjunct to `never` and this DNF is empty.
+	// No declared edge relates Point to Line, so no value carries both tags and the
+	// conjunct is dropped from the DNF.
 	unrelated := c.mkDNF(newIntersection(nil, []soltype.Type{point, line}), soltype.Positive)
-	require.Len(t, unrelated.Conjuncts, 1)
-	require.Len(t, unrelated.Conjuncts[0].Lnf.Atoms, 2)
-	_, ok = unrelated.Conjuncts[0].Lnf.Base()
-	require.False(t, ok)
+	require.Empty(t, unrelated.Conjuncts)
+	require.Equal(t, "never", normDNF(c, newIntersection(nil, []soltype.Type{point, line})))
 }
 
 // classTag is a bare nominal handle, the smallest ClassType a normal form can


### PR DESCRIPTION
Fixes #1061

Implements the nominal meet (`glbClass`) for class tags by walking the declared `extends` graph, enabling the normal form to fuse related classes and collapse unrelated ones to `never`. This is the fast-path optimization that settles intersections of unrelated classes before structural work, as described in planning/ml_struct/02-caveats-and-mitigations.md caveat 1.

**Key changes:**

- `glbClass` now walks the `extends` graph to determine class relationships. It answers three ways: (1) two tags name one class — meet their type arguments by variance; (2) one class reaches the other — return the lower one; (3) neither reaches the other and both walks finish — return `never` to drop the conjunct.

- Added `nominalSubtype` as the pure query twin of `constrainNominal`, checking whether one class instance is below another without recording bounds. Uses the mutable-view variance vector (stricter) to conservatively reject cases the solver might accept outside a mutable borrow.

- Added `instanceBelow` to check if two instances of one class have a meet that equals the first, which determines subtype ordering under variance.

- Added `meetClassArgs` to meet two instances of one class position-by-position, dispatching each by the mutable-view variance. Invariant positions fuse only when arguments match; covariant positions meet their arguments; contravariant positions join them; bivariant positions ignore arguments.

- Added `ancestorInstance` and `ancestorInstanceWalk` to traverse the `extends` graph, substituting type arguments along edges and detecting cycles by class name. Returns whether the target class was found and whether the walk read a finished graph (false if edges are still pending or the class is unregistered).

- Added `EdgesPending` flag to `ClassDef` to mark classes the SCC pre-pass registered as bare identities before their `extends` and `implements` clauses were resolved. `inferClassDecl` clears it when edges are filled in. Readers checking for superclasses must check this flag first.

- Updated `LhsNf.Base` documentation to reflect that two tags may remain when `glbClass` finds no exact fusion, such as `Cell<number> & Cell<string>` at an invariant position.

- Added comprehensive test coverage in `TestGlbClass`, `TestGlbClassInNormalForm`, and `TestNominalSubtype` with a shared `nominalGraph` fixture covering class hierarchies, generic classes with all variance kinds, and edge cases like cycles and pending edges.

- Updated existing test `TestBaseReadsTheSingleClassTag` to register classes and verify that unrelated tags now collapse the conjunct to `never`.

An `implements` clause is deliberately not followed: it is a conformance assertion the nominal subtype walk skips, so the meet decides exactly the relation `constrainNominal` decides rather than a wider one.

The normal-form machinery still has no non-test callers — PR5 (#1062) wires it into `constrain` — so these changes are latent by design.

https://claude.ai/code/session_018hGk3BnRtYBS9J7aLmYvMk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved type handling for classes, inheritance, interfaces, and generic variance.
  * Added support for determining compatible class intersections and identifying incompatible class combinations.
  * Added safer handling for unresolved inheritance or interface relationships.

* **Bug Fixes**
  * Unrelated class types now correctly resolve to `never` instead of remaining as separate unresolved types.
  * Improved inherited type-argument substitution and cycle detection during subtype checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->