### PR TITLE
Implement normal-form constraint solving for unions and intersections

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -739,16 +739,26 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 	// match and falls through to `"hi" <: T`, recording "hi" as T's lower bound.
 	if supU, ok := super.(*soltype.UnionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && len(supU.Types) > 0 {
-			decision := c.constrainNF(sub, super, seen, mutCtx)
+			// An inexact union's open tail has no atom to stand for it, so normalizing one
+			// hands back the union itself and no member is ever weighed. The decision runs
+			// on the named members alone, and the tail below catches what they miss.
+			named := super
+			if supU.Inexact {
+				named = newUnion(nil, supU.Types, false)
+			}
+			decision := c.constrainNF(sub, named, seen, mutCtx)
 			if !hasHardError(decision.errs) {
 				// The decision carries any warning a nested trial emitted. Propagate it so a
 				// nested ambiguous union is not silently swallowed.
 				diags := decision.errs
 				// A committed bare type-variable member pins that var to sub. Tag it so a
 				// later constraint that forces an incompatible bound onto the var can name
-				// the union choice that pinned it.
-				if v, ok := decision.committed.(*soltype.TypeVarType); ok {
-					c.tagUnionCommit(v, supU)
+				// the union choice that pinned it. The tag is about a member the user wrote,
+				// so a variable the decision reached by some other route does not earn one.
+				if member, ok := writtenMember(supU, decision.committed); ok {
+					if v, isVar := member.(*soltype.TypeVarType); isVar {
+						c.tagUnionCommit(v, supU)
+					}
 				}
 				// When another member would also match while binding an inference variable,
 				// the committed choice is ambiguous. Warn at the union so the user can
@@ -1416,12 +1426,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 }
 
-// ambiguousAlternate returns a union member, other than the committed one, that would also
-// match sub while binding an inference variable, or nil when none does. For `5 <: (T | number)`
-// number commits but T would also match by pinning to 5, so T is returned. Each candidate is
-// trialled under a throwaway probe, so the peek records no bound. A union with no bare
-// type-variable member cannot bind ambiguously, so the scan is skipped, sparing the common
-// all-concrete union super such as an enum value flowing into its variant union.
+// ambiguousAlternate returns a union member, other than the one the decision committed to,
+// that would also match sub while binding an inference variable, or nil when none does. For
+// `5 <: (T | number)` number commits but T would also match by pinning to 5, so T is
+// returned. Each candidate is trialled under a throwaway probe, so the peek records no bound.
+// A union with no bare type-variable member cannot bind ambiguously, so the scan is skipped,
+// sparing the common all-concrete union super such as an enum value flowing into its variant
+// union.
 func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, committed soltype.Type, seen *seenPairs, mutCtx bool) soltype.Type {
 	hasVar := false
 	for _, m := range u.Types {
@@ -1430,11 +1441,11 @@ func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, com
 			break
 		}
 	}
-	if !hasVar {
+	if !hasVar || committed == nil {
 		return nil
 	}
 	for _, j := range specificityOrder(u.Types) {
-		if committed != nil && equalType(u.Types[j], committed) {
+		if c.partOfCommitted(u.Types[j], committed) {
 			continue
 		}
 		if ok, mutated := c.trialMutatesBounds(sub, u.Types[j], seen, mutCtx); ok && mutated {
@@ -1442,6 +1453,41 @@ func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, com
 		}
 	}
 	return nil
+}
+
+// partOfCommitted reports whether the union member m is part of what the decision committed
+// to rather than an alternative to it. The decision runs on normalized atoms, so it may
+// commit to one atom that several members fused into, and each of those members sits below
+// that atom. Naming one of them as the alternative to the atom it helped build would report
+// an ambiguity where no choice was ever made.
+//
+// A bare type variable is exempt. It sits below anything at all, since the trial records an
+// upper bound rather than deciding a shape, so subsumption says nothing about whether it is
+// an alternative. Those are the members the warning exists to name.
+func (c *Context) partOfCommitted(m, committed soltype.Type) bool {
+	if equalType(m, committed) {
+		return true
+	}
+	if _, isVar := m.(*soltype.TypeVarType); isVar {
+		return false
+	}
+	return !hasHardError(c.trialUnderProbe(m, committed))
+}
+
+// writtenMember returns the member of u the decision committed to, and reports whether the
+// committed type is a member at all. It is not when the decision settled on an atom several
+// members fused into, since no single member was picked then. A nil committed type reaches
+// here from a decision no trial settled, such as one every candidate satisfied vacuously.
+func writtenMember(u *soltype.UnionType, committed soltype.Type) (soltype.Type, bool) {
+	if committed == nil {
+		return nil, false
+	}
+	for _, m := range u.Types {
+		if equalType(m, committed) {
+			return m, true
+		}
+	}
+	return nil, false
 }
 
 // breadcrumbUnionCommit stamps each CannotConstrainError in errs with v's union-trial origin

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -715,40 +715,47 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		}
 	}
 
-	// sub <: (A | B) ⟹ sub <: A OR sub <: B. Trial each member under a probe in
-	// specificityOrder, which ranks a variable below every concrete, so a concrete member
-	// is tried before a bare TypeVar member. A var member is therefore a last-resort
-	// catch-all, not a speculative first pin. `5 <: (T | number)` commits `number` and
-	// never touches T. `"hi" <: (T | number)` finds no concrete match and falls through to
-	// `"hi" <: T`, recording "hi" as T's lower bound. This two-pass exists rule settles the
-	// M7 union-super open question. It mirrors the IntersectionType-sub arm below, which
-	// trials its members through the same specificityOrder, so the union-super and
-	// intersection-sub exists rules share one ordering rather than diverging on whether a
-	// var member is trialled.
+	// A complement on either side is decided by the normal-form layer, which is the
+	// only rule that reads one. Moving `¬T` across the `<:` turns it into an ordinary
+	// meet or join, so `5 <: ¬string` holds through `5 ∩ string` being uninhabited
+	// while `5 <: ¬number` fails. A variable operand falls through to the var arms
+	// instead, so `α <: ¬T` records the whole complement as one upper bound and keeps
+	// it on the coalesced binding.
+	if isNegation(sub) || isNegation(super) {
+		_, subIsVar := sub.(*soltype.TypeVarType)
+		_, superIsVar := super.(*soltype.TypeVarType)
+		if !subIsVar && !superIsVar {
+			return c.constrainNF(sub, super, seen, mutCtx).errs
+		}
+	}
+
+	// sub <: (A | B) ⟹ the normal-form layer decides it. Normalizing the union fuses
+	// the members a single atom denotes, so the decision runs on those atoms rather
+	// than on what the source wrote, and a choice among several atoms is trialled in
+	// specificityOrder. That order ranks a variable below every concrete, so a
+	// concrete atom is tried before a bare TypeVar member and a var member is a
+	// last-resort catch-all rather than a speculative first pin. `5 <: (T | number)`
+	// commits `number` and never touches T. `"hi" <: (T | number)` finds no concrete
+	// match and falls through to `"hi" <: T`, recording "hi" as T's lower bound.
 	if supU, ok := super.(*soltype.UnionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && len(supU.Types) > 0 {
-			order := specificityOrder(supU.Types)
-			committed, winIdx, winErrs, _ := c.trialAndCommit(order, func(idx int) []SolverError {
-				// A cloned seen keeps each member's coinductive cache independent, so a
-				// failed member's entries can't wrongly short-circuit a later member.
-				return c.constrain(sub, supU.Types[idx], seen.Clone(), mutCtx)
-			})
-			if committed {
-				// winErrs carries any warning the winning member's own nested trial emitted.
-				// Propagate it so a nested ambiguous union is not silently swallowed.
-				diags := winErrs
+			decision := c.constrainNF(sub, super, seen, mutCtx)
+			if !hasHardError(decision.errs) {
+				// The decision carries any warning a nested trial emitted. Propagate it so a
+				// nested ambiguous union is not silently swallowed.
+				diags := decision.errs
 				// A committed bare type-variable member pins that var to sub. Tag it so a
 				// later constraint that forces an incompatible bound onto the var can name
 				// the union choice that pinned it.
-				if v, ok := supU.Types[winIdx].(*soltype.TypeVarType); ok {
+				if v, ok := decision.committed.(*soltype.TypeVarType); ok {
 					c.tagUnionCommit(v, supU)
 				}
 				// When another member would also match while binding an inference variable,
 				// the committed choice is ambiguous. Warn at the union so the user can
 				// annotate rather than depend on specificity order.
-				if alt := c.ambiguousAlternate(sub, supU, order, winIdx, seen, mutCtx); alt != nil {
+				if alt := c.ambiguousAlternate(sub, supU, decision.committed, seen, mutCtx); alt != nil {
 					diags = append(diags, &AmbiguousUnionCommitWarning{
-						Union: supU, Committed: supU.Types[winIdx], Alternate: alt,
+						Union: supU, Committed: decision.committed, Alternate: alt,
 					})
 				}
 				return diags
@@ -760,8 +767,10 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				// into a closed super because that open tail can't be absorbed.
 				return nil
 			}
-			// Every branch failed, the var members included. Promote a BorrowEscapeError
-			// when sub's peeled inner still satisfies the union; else emit the generic error.
+			// No candidate holds, the var members included, and the decomposition's own
+			// diagnostics are dropped for one that names the union the user wrote. Promote
+			// a BorrowEscapeError when sub's peeled inner still satisfies the union; else
+			// emit the generic error.
 			if ref, ok := sub.(*soltype.RefType); ok && ref.Lt != nil {
 				if !hasHardError(c.trialUnderProbe(ref.Inner, super)) {
 					return []SolverError{&BorrowEscapeError{Sub: ref, Super: super}}
@@ -1332,14 +1341,17 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 		}
 	case *soltype.IntersectionType:
-		// (A & B) <: super ⟹ A <: super OR B <: super. Trial each member in
-		// specificity order under a probe; the first success commits. Stays in
-		// the structural switch (not the pre-switch block) because the switch
-		// already dispatches on sub, so a lattice sub is matched by its own case
-		// here without needing a pre-switch interception. When super is a
-		// TypeVar, fall through to the superVar arm so the whole intersection is
-		// recorded as one lower bound rather than committing to one arm and
-		// discarding the rest. Two callers reach this:
+		// (A & B) <: super ⟹ the normal-form layer decides it. Normalizing the
+		// intersection fuses the members a single atom denotes, which is what
+		// decides an arrow intersection: `((x: number) -> boolean) & ((x: string)
+		// -> boolean)` fuses to `(x: number | string) -> boolean` and then meets
+		// that target by the ordinary arrow rule, where trialling each written arm
+		// on its own rejects it. Stays in the structural switch rather than the
+		// pre-switch block because the switch already dispatches on sub, so a
+		// lattice sub is matched by its own case here without needing a pre-switch
+		// interception. When super is a TypeVar, fall through to the superVar arm
+		// so the whole intersection is recorded as one lower bound rather than
+		// committing to one arm and discarding the rest. Two callers reach this:
 		//
 		//   - Overload synthesis. inferIdent builds an intersection out of an
 		//     overloaded value's arms so a let-bound overload called through the
@@ -1351,19 +1363,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		//     types, so a non-function intersection trials its more-specific
 		//     members first; incomparable members keep declaration order.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar && len(sub.Types) > 0 {
-			committed, _, winErrs, trialErrs := c.trialAndCommit(specificityOrder(sub.Types), func(idx int) []SolverError {
-				// A cloned seen keeps each arm's coinductive cache independent, so a failed
-				// arm's entries can't wrongly short-circuit a later arm to success.
-				return c.constrain(sub.Types[idx], super, seen.Clone(), mutCtx)
-			})
-			if committed {
-				// winErrs carries any warning the winning arm's nested trial emitted.
-				return winErrs
-			}
-			if len(trialErrs) > 0 {
-				return trialErrs[len(trialErrs)-1] // no arm matched: surface the last arm's failure
-			}
-			return nil
+			// The decision carries any warning a nested trial emitted, and on failure the
+			// diagnostics of the last atom pair it tried.
+			return c.constrainNF(sub, super, seen, mutCtx).errs
 		}
 	}
 
@@ -1420,7 +1422,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 // trialled under a throwaway probe, so the peek records no bound. A union with no bare
 // type-variable member cannot bind ambiguously, so the scan is skipped, sparing the common
 // all-concrete union super such as an enum value flowing into its variant union.
-func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, order []int, winIdx int, seen *seenPairs, mutCtx bool) soltype.Type {
+func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, committed soltype.Type, seen *seenPairs, mutCtx bool) soltype.Type {
 	hasVar := false
 	for _, m := range u.Types {
 		if _, ok := m.(*soltype.TypeVarType); ok {
@@ -1431,8 +1433,8 @@ func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, ord
 	if !hasVar {
 		return nil
 	}
-	for _, j := range order {
-		if j == winIdx {
+	for _, j := range specificityOrder(u.Types) {
+		if committed != nil && equalType(u.Types[j], committed) {
 			continue
 		}
 		if ok, mutated := c.trialMutatesBounds(sub, u.Types[j], seen, mutCtx); ok && mutated {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -739,14 +739,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 	// match and falls through to `"hi" <: T`, recording "hi" as T's lower bound.
 	if supU, ok := super.(*soltype.UnionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && len(supU.Types) > 0 {
-			// An inexact union's open tail has no atom to stand for it, so normalizing one
-			// hands back the union itself and no member is ever weighed. The decision runs
-			// on the named members alone, and the tail below catches what they miss.
-			named := super
-			if supU.Inexact {
-				named = newUnion(nil, supU.Types, false)
-			}
-			decision := c.constrainNF(sub, named, seen, mutCtx)
+			decision := c.constrainNF(sub, namedMembers(supU), seen, mutCtx)
 			if !hasHardError(decision.errs) {
 				// The decision carries any warning a nested trial emitted. Propagate it so a
 				// nested ambiguous union is not silently swallowed.
@@ -755,18 +748,23 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				// later constraint that forces an incompatible bound onto the var can name
 				// the union choice that pinned it. The tag is about a member the user wrote,
 				// so a variable the decision reached by some other route does not earn one.
-				if member, ok := writtenMember(supU, decision.committed); ok {
-					if v, isVar := member.(*soltype.TypeVarType); isVar {
-						c.tagUnionCommit(v, supU)
+				for _, committed := range decision.committed {
+					if member, ok := writtenMember(supU, committed); ok {
+						if v, isVar := member.(*soltype.TypeVarType); isVar {
+							c.tagUnionCommit(v, supU)
+						}
 					}
 				}
 				// When another member would also match while binding an inference variable,
 				// the committed choice is ambiguous. Warn at the union so the user can
-				// annotate rather than depend on specificity order.
-				if alt := c.ambiguousAlternate(sub, supU, decision.committed, seen, mutCtx); alt != nil {
-					diags = append(diags, &AmbiguousUnionCommitWarning{
-						Union: supU, Committed: decision.committed, Alternate: alt,
-					})
+				// annotate rather than depend on specificity order. A decision that had to
+				// choose more than once made no single choice to call ambiguous.
+				if len(decision.committed) == 1 {
+					if alt := c.ambiguousAlternate(sub, supU, decision.committed[0], seen, mutCtx); alt != nil {
+						diags = append(diags, &AmbiguousUnionCommitWarning{
+							Union: supU, Committed: decision.committed[0], Alternate: alt,
+						})
+					}
 				}
 				return diags
 			}
@@ -1472,6 +1470,20 @@ func (c *Context) partOfCommitted(m, committed soltype.Type) bool {
 		return false
 	}
 	return !hasHardError(c.trialUnderProbe(m, committed))
+}
+
+// namedMembers is the union the normal-form layer decides a union super against: the same
+// union with no open tail. An open tail has no atom to stand for it, so normalizing a union
+// that carries one hands the layer that union back whole and no member is ever weighed. The
+// members are spliced out of any nested union first, since a nested open tail would put the
+// flag straight back. The union-super rule catches through the tail what the members miss,
+// so dropping the tail here decides nothing the rule does not go on to answer.
+func namedMembers(u *soltype.UnionType) soltype.Type {
+	if !u.Inexact {
+		return u
+	}
+	flat, _ := flattenUnion(u.Types, false)
+	return newUnion(nil, flat, false)
 }
 
 // writtenMember returns the member of u the decision committed to, and reports whether the

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -739,7 +739,17 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 	// match and falls through to `"hi" <: T`, recording "hi" as T's lower bound.
 	if supU, ok := super.(*soltype.UnionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && len(supU.Types) > 0 {
-			decision := c.constrainNF(sub, namedMembers(supU), seen, mutCtx)
+			// An open tail has no atom to stand for it, so the layer hands a union that
+			// carries one straight back and weighs no member at all. The decision runs
+			// against the members with the tail dropped, and the tail rule below catches
+			// what they miss. Splicing the members out of any nested union first is what
+			// keeps a nested tail from putting the flag straight back.
+			named := super
+			if supU.Inexact {
+				flat, _ := flattenUnion(supU.Types, false)
+				named = newUnion(nil, flat, false)
+			}
+			decision := c.constrainNF(sub, named, seen, mutCtx)
 			if !hasHardError(decision.errs) {
 				// The decision carries any warning a nested trial emitted. Propagate it so a
 				// nested ambiguous union is not silently swallowed.
@@ -1470,20 +1480,6 @@ func (c *Context) partOfCommitted(m, committed soltype.Type) bool {
 		return false
 	}
 	return !hasHardError(c.trialUnderProbe(m, committed))
-}
-
-// namedMembers is the union the normal-form layer decides a union super against: the same
-// union with no open tail. An open tail has no atom to stand for it, so normalizing a union
-// that carries one hands the layer that union back whole and no member is ever weighed. The
-// members are spliced out of any nested union first, since a nested open tail would put the
-// flag straight back. The union-super rule catches through the tail what the members miss,
-// so dropping the tail here decides nothing the rule does not go on to answer.
-func namedMembers(u *soltype.UnionType) soltype.Type {
-	if !u.Inexact {
-		return u
-	}
-	flat, _ := flattenUnion(u.Types, false)
-	return newUnion(nil, flat, false)
 }
 
 // writtenMember returns the member of u the decision committed to, and reports whether the

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1455,13 +1455,13 @@ func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, com
 
 // partOfCommitted reports whether the union member m is part of what the decision committed
 // to rather than an alternative to it. The decision runs on normalized atoms, so it may
-// commit to one atom that several members fused into, and each of those members sits below
-// that atom. Naming one of them as the alternative to the atom it helped build would report
-// an ambiguity where no choice was ever made.
+// commit to one atom that several members fused into, and each of those members is a
+// subtype of that atom. Naming one of them as the alternative to the atom it helped build
+// would report an ambiguity where no choice was ever made.
 //
-// A bare type variable is exempt. It sits below anything at all, since the trial records an
-// upper bound rather than deciding a shape, so subsumption says nothing about whether it is
-// an alternative. Those are the members the warning exists to name.
+// A bare type variable is exempt. It is a subtype of anything at all, since the trial
+// records an upper bound rather than deciding a shape, so subsumption says nothing about
+// whether it is an alternative. Those are the members the warning exists to name.
 func (c *Context) partOfCommitted(m, committed soltype.Type) bool {
 	if equalType(m, committed) {
 		return true

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -181,7 +181,7 @@ func (c *Context) decideMeetJoin(
 	}
 	// No single pair holds. An intersection of arrows can still be below an arrow
 	// through the arms taken together, which is what decideArrows weighs.
-	if target, ok := c.decideArrows(subCands, superCands, seen, mutCtx); ok {
+	if target, ok := c.decideArrows(subCands, superCands, seen); ok {
 		return nfDecision{committed: target}
 	}
 	// The last pair's diagnostics are the ones a caller that reports the
@@ -231,7 +231,7 @@ const maxDecomposedArms = 6
 // arrow's domain is a product of positions rather than one type, and covering a
 // product needs the union of the arms' whole domains rather than a union per
 // position, so those keep the pair trial's answer.
-func (c *Context) decideArrows(subCands, superCands []soltype.Type, seen *seenPairs, mutCtx bool) (soltype.Type, bool) {
+func (c *Context) decideArrows(subCands, superCands []soltype.Type, seen *seenPairs) (soltype.Type, bool) {
 	arms := decomposableArrows(subCands)
 	if len(arms) < 2 || len(arms) > maxDecomposedArms {
 		return nil, false
@@ -243,7 +243,7 @@ func (c *Context) decideArrows(subCands, superCands []soltype.Type, seen *seenPa
 		}
 		p := newProbe(c, c.probe)
 		c.probe = p
-		settled := c.arrowLegsHold(arms, target, seen, mutCtx)
+		settled := c.arrowLegsHold(arms, target, seen)
 		c.probe = p.parent
 		if settled {
 			p.Commit()
@@ -257,10 +257,15 @@ func (c *Context) decideArrows(subCands, superCands []soltype.Type, seen *seenPa
 // arrowLegsHold runs the two legs of the decomposition decideArrows documents and
 // reports whether both hold. The caller keeps the bounds the legs recorded only
 // when they do.
-func (c *Context) arrowLegsHold(arms []*soltype.FuncType, target *soltype.FuncType, seen *seenPairs, mutCtx bool) bool {
+//
+// Every leg compares a domain against a domain or a codomain against a codomain,
+// so each runs with the deep-mut context cleared, exactly as the arrow rule in the
+// structural switch clears it. A function carries its own annotation context, so a
+// borrow reaching one of its parameters does not make that parameter invariant.
+func (c *Context) arrowLegsHold(arms []*soltype.FuncType, target *soltype.FuncType, seen *seenPairs) bool {
 	domain := target.Params[0].Type
 	// Leg 1. Every input the target accepts is accepted by some arm.
-	if hasHardError(c.constrain(domain, joinDomains(arms, allArms(arms)), seen.Clone(), mutCtx)) {
+	if hasHardError(c.constrain(domain, joinDomains(arms, allArms(arms)), seen.Clone(), false)) {
 		return false
 	}
 	// Leg 2, over every group of arms. A group is a bit set over arms, so counting
@@ -273,7 +278,7 @@ func (c *Context) arrowLegsHold(arms []*soltype.FuncType, target *soltype.FuncTy
 		if !hasHardError(c.trialUnderProbeSeen(domain, outside, seen.Clone())) {
 			continue
 		}
-		if hasHardError(c.constrain(meetCodomains(arms, group), target.Ret, seen.Clone(), mutCtx)) {
+		if hasHardError(c.constrain(meetCodomains(arms, group), target.Ret, seen.Clone(), false)) {
 			return false
 		}
 	}

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"slices"
+
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -45,13 +47,13 @@ import (
 //     subtype side.
 //
 // The two variable sets move the same way. What is left is a meet of atoms and
-// variables against a join of atoms and variables, which decideMeetJoin settles.
+// variables against a join of atoms and variables, which constrainImplied settles.
 //
 // # Where a choice still remains
 //
 // A meet of two atoms that did not fuse, or a join of two that did not, leaves a
 // genuine choice: `{x: number} | {y: number}` is not one record, so nothing says
-// which side a given subtype has to satisfy. decideMeetJoin trials the pairs in
+// which side a given subtype has to satisfy. constrainImplied trials the pairs in
 // specificity order for exactly that residue. Every trial runs over atoms the
 // normal form produced, so the fusions above have already collapsed the cases a
 // member-by-member search decides wrongly.
@@ -100,9 +102,28 @@ func (c *Context) constrainNF(sub, super soltype.Type, seen *seenPairs, mutCtx b
 
 // constrainImplied decides one conjunct of the subtype's DNF against one disjunct
 // of the supertype's CNF, the implied goal this file's header describes. It moves
-// both negated parts across the `<:` and hands the resulting meet and join to
-// decideMeetJoin. sub and super are the operands constrainNF was called with, and
-// name the failure when the goal has no pair to trial at all.
+// both negated parts across the `<:`, which leaves `⋂subCands <: ⋃superCands` over
+// atoms and variables, and proves that by finding one subtype candidate below one
+// supertype candidate, since `⋂subCands <: sᵢ <: pⱼ <: ⋃superCands` for any such
+// pair. The pairs are trialled in specificity order, so a bare variable is only
+// ever a last resort, and each trial recurses into the ordinary structural rules.
+//
+// sub and super are the operands constrainNF was called with, and name the failure
+// when the goal has no pair to trial at all.
+//
+// Three things follow from deciding by one pair.
+//
+//   - It is incomplete. A meet can be below a join through its parts taken
+//     together, which no pair states, so `{x: number} & {y: number} <: {x: number,
+//     y: number}` is rejected. #1064's exact-record merge settles that one.
+//   - A pair repeating the caller's own question against an inexact union is
+//     skipped. Such a union is one atom, so normalizing `boolean <: (number |
+//     string | ...)` hands back the pair it started from and no smaller question
+//     is ever reached. Every other supertype comes apart into smaller atoms.
+//   - A variable on the supertype side picks up the whole meet as a lower bound,
+//     which is stronger than the goal asks for. `¬T <: number` records `unknown`
+//     under T where `¬number` would do. That is sound, and a variable is reached
+//     only after every concrete candidate failed.
 func (c *Context) constrainImplied(
 	conj Conjunct, disj Disjunct, sub, super soltype.Type, seen *seenPairs, mutCtx bool,
 ) nfDecision {
@@ -122,42 +143,16 @@ func (c *Context) constrainImplied(
 	// A variable is opaque, so it joins the side it sits on as one more candidate
 	// rather than being taken apart. A variable negated on one side stands on the
 	// other, by the same two rewrites the negated structural parts follow.
-	subCands := append(meet, varsAsTypes(conj.Vars)...)
-	subCands = append(subCands, varsAsTypes(disj.NVars)...)
-	superCands := append(join, varsAsTypes(disj.Vars)...)
-	superCands = append(superCands, varsAsTypes(conj.NVars)...)
+	subCands := slices.Concat(meet, varsAsTypes(conj.Vars), varsAsTypes(disj.NVars))
+	superCands := slices.Concat(join, varsAsTypes(disj.Vars), varsAsTypes(conj.NVars))
 
 	if len(subCands) == 0 {
 		// An empty meet is `unknown`, the top of the lattice. Naming it explicitly
-		// gives the decision below something to constrain, and `unknown <: T` still
-		// records a bound when the supertype side is a variable.
+		// gives the trial something to constrain, and `unknown <: T` still records a
+		// bound when the supertype side is a variable.
 		subCands = []soltype.Type{&soltype.UnknownType{}}
 	}
-	return c.decideMeetJoin(subCands, superCands, sub, super, seen, mutCtx)
-}
 
-// decideMeetJoin decides `⋂subCands <: ⋃superCands`, where each candidate is an
-// atom or a type variable. It proves the goal by finding one subtype candidate
-// below one supertype candidate, since `⋂subCands <: sᵢ <: pⱼ <: ⋃superCands` for
-// any such pair, and trials the pairs in specificity order so a bare variable is
-// only ever a last resort. Each trial recurses into the ordinary structural rules.
-//
-// Three things follow from deciding by one pair.
-//
-//   - It is incomplete. A meet can be below a join through its parts taken
-//     together, which no pair states, so `{x: number} & {y: number} <: {x: number,
-//     y: number}` is rejected. #1064's exact-record merge settles that one.
-//   - A pair repeating the caller's own question against an inexact union is
-//     skipped. Such a union is one atom, so normalizing `boolean <: (number |
-//     string | ...)` hands back the pair it started from and no smaller question
-//     is ever reached. Every other supertype comes apart into smaller atoms.
-//   - A variable on the supertype side picks up the whole meet as a lower bound,
-//     which is stronger than the goal asks for. `¬T <: number` records `unknown`
-//     under T where `¬number` would do. That is sound, and a variable is reached
-//     only after every concrete candidate failed.
-func (c *Context) decideMeetJoin(
-	subCands, superCands []soltype.Type, sub, super soltype.Type, seen *seenPairs, mutCtx bool,
-) nfDecision {
 	pairs := orderedPairs(subCands, superCands, sub, super)
 	if len(pairs) == 0 {
 		return nfDecision{errs: []SolverError{&CannotConstrainError{Sub: sub, Super: super}}}
@@ -197,7 +192,7 @@ const maxDecomposedArms = 6
 // settled the goal at all. arrowLegsHold states the two legs, and the corpus
 // header in constrain_nf_test.go derives them.
 //
-// It runs after decideMeetJoin's pair trial found no single arm below the target.
+// It runs after constrainImplied's pair trial found no single arm below the target.
 // Both rules are sound, so which runs first decides the bounds a variable in the
 // target picks up rather than the verdict.
 //
@@ -331,14 +326,14 @@ func sameRaises(arms []*soltype.FuncType, target *soltype.FuncType) bool {
 	return true
 }
 
-// nfPair is one candidate pair decideMeetJoin trials.
+// nfPair is one candidate pair constrainImplied trials.
 type nfPair struct{ sub, super soltype.Type }
 
 // orderedPairs lists the pairs to trial, each side in specificity order and the
 // supertype candidates outermost, so the choice among union members is the one a
 // reader sees first. origSub and origSuper are the constraint the caller is
 // deciding; the pair repeating it against an inexact union is dropped, for the
-// reason decideMeetJoin gives.
+// reason constrainImplied gives.
 func orderedPairs(subCands, superCands []soltype.Type, origSub, origSuper soltype.Type) []nfPair {
 	subOrder := specificityOrder(subCands)
 	pairs := make([]nfPair, 0, len(subCands)*len(superCands))

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -56,14 +56,10 @@ import (
 // normal form produced, so the fusions above have already collapsed the cases a
 // member-by-member search decides wrongly.
 
-// nfDecision is what one constrainNF call derived.
-//
-// committed names the supertype-side atoms and variables the trials settled on,
-// one per implied goal that needed a choice. It is empty when no trial ran or when
-// the decision failed. The union-super rule reads it to report an ambiguous commit
-// and to record that a bare variable member was pinned by a union choice. A
-// decision that settled several goals holds one entry each, since each goal chose
-// on its own.
+// nfDecision is what one constrainNF call derived. committed holds the
+// supertype-side candidate each implied goal settled on, one entry per goal that
+// had a choice to make, and the union-super rule reads it to name an ambiguous or
+// variable-pinning commit.
 type nfDecision struct {
 	errs      []SolverError
 	committed []soltype.Type
@@ -72,9 +68,9 @@ type nfDecision struct {
 // constrainNF decides `sub <: super` through the normal forms of both operands.
 //
 // The whole derivation runs under one probe, so a constraint that fails records no
-// bound. Callers depend on that. The union-super rule reports one union-level
-// diagnostic in place of whatever the decomposition produced, and a bound recorded
-// on the way to that failure would outlive the derivation that justified it.
+// bound. Callers depend on that: the union-super rule replaces the decomposition's
+// diagnostics with one of its own, and a bound recorded on the way to that failure
+// would outlive the derivation that justified it.
 func (c *Context) constrainNF(sub, super soltype.Type, seen *seenPairs, mutCtx bool) nfDecision {
 	lhs := c.mkDeepDNF(sub, soltype.Positive)
 	rhs := c.mkDeepCNF(super, soltype.Negative)
@@ -103,12 +99,10 @@ func (c *Context) constrainNF(sub, super soltype.Type, seen *seenPairs, mutCtx b
 }
 
 // constrainImplied decides one conjunct of the subtype's DNF against one disjunct
-// of the supertype's CNF, the goal this file's header calls an implied goal. It
-// moves both negated parts across the `<:` and hands the resulting meet and join
-// to decideMeetJoin.
-//
-// sub and super are the operands constrainNF was called with. They name the
-// failure when the goal has no pair to trial at all.
+// of the supertype's CNF, the implied goal this file's header describes. It moves
+// both negated parts across the `<:` and hands the resulting meet and join to
+// decideMeetJoin. sub and super are the operands constrainNF was called with, and
+// name the failure when the goal has no pair to trial at all.
 func (c *Context) constrainImplied(
 	conj Conjunct, disj Disjunct, sub, super soltype.Type, seen *seenPairs, mutCtx bool,
 ) nfDecision {
@@ -143,34 +137,24 @@ func (c *Context) constrainImplied(
 }
 
 // decideMeetJoin decides `⋂subCands <: ⋃superCands`, where each candidate is an
-// atom or a type variable.
+// atom or a type variable. It proves the goal by finding one subtype candidate
+// below one supertype candidate, since `⋂subCands <: sᵢ <: pⱼ <: ⋃superCands` for
+// any such pair, and trials the pairs in specificity order so a bare variable is
+// only ever a last resort. Each trial recurses into the ordinary structural rules.
 //
-// It proves the goal by finding one subtype candidate that is below one supertype
-// candidate, since `⋂subCands <: sᵢ <: pⱼ <: ⋃superCands` for any such pair. The
-// pairs are trialled in specificity order, so a concrete candidate is tried
-// before a bare type variable and a variable is only ever a last resort. Each
-// trial recurses into the ordinary structural rules, which is where a class tag
-// meets its parent and an arrow meets an arrow.
+// Three things follow from deciding by one pair.
 //
-// Looking for one pair is sound but incomplete. A meet can be below a join
-// through its parts taken together, which no pair states. `{x: number} & {y:
-// number} <: {x: number, y: number}` is such a goal: neither record alone carries
-// both fields, so no pair holds and the goal is rejected. Two exact records meet
-// to `never` once #1064 lands, which settles that one.
-//
-// A pair that repeats the constraint constrainNF was called with, against an
-// inexact union, is skipped. An inexact union is one atom, since its open tail has
-// no atom to stand for it, so normalizing `boolean <: (number | string | ...)`
-// hands back the pair it started from. Trialling that pair would ask the question
-// the caller is already deciding and never reach a smaller one. Only that shape
-// repeats: every other supertype is taken apart into atoms smaller than itself.
-//
-// A variable on the supertype side picks up the whole meet as a lower bound, which
-// is stronger than the goal asks for. `¬T <: number` becomes `unknown <: number ∪ T`
-// and settles by recording `unknown` under T, where `¬number` under T is the
-// weakest bound that would do. The stronger bound is sound, and a variable is only
-// ever reached after every concrete candidate failed, so the imprecision is
-// confined to a goal nothing else settles.
+//   - It is incomplete. A meet can be below a join through its parts taken
+//     together, which no pair states, so `{x: number} & {y: number} <: {x: number,
+//     y: number}` is rejected. #1064's exact-record merge settles that one.
+//   - A pair repeating the caller's own question against an inexact union is
+//     skipped. Such a union is one atom, so normalizing `boolean <: (number |
+//     string | ...)` hands back the pair it started from and no smaller question
+//     is ever reached. Every other supertype comes apart into smaller atoms.
+//   - A variable on the supertype side picks up the whole meet as a lower bound,
+//     which is stronger than the goal asks for. `¬T <: number` records `unknown`
+//     under T where `¬number` would do. That is sound, and a variable is reached
+//     only after every concrete candidate failed.
 func (c *Context) decideMeetJoin(
 	subCands, superCands []soltype.Type, sub, super soltype.Type, seen *seenPairs, mutCtx bool,
 ) nfDecision {
@@ -202,47 +186,25 @@ func (c *Context) decideMeetJoin(
 }
 
 // maxDecomposedArms caps how many arrow atoms decideArrows weighs. It tries every
-// group of arms, so the work doubles with each further arm. Six arms is 63 groups,
-// past which the decomposition costs more than the constraints it settles. An
-// intersection of more arrows than that is decided by the pair trial alone, which
-// is sound and only ever rejects what the decomposition would have accepted.
+// group of arms, so the work doubles with each further arm, and six arms is
+// already 63 groups. An intersection of more arrows is left to the pair trial,
+// which is sound and only rejects what the decomposition would have accepted.
 const maxDecomposedArms = 6
 
 // decideArrows decides `⋂arms <: target` when the subtype side holds several arrow
-// atoms that no fusion merged into one. It returns the target it settled on and
-// reports whether it settled the goal at all.
+// atoms that no fusion merged into one, by the Frisch-Castagna-Benzaken
+// decomposition. It returns the target it settled on and reports whether it
+// settled the goal at all. arrowLegsHold states the two legs, and the corpus
+// header in constrain_nf_test.go derives them.
 //
-// The rule is the Frisch-Castagna-Benzaken decomposition, which weighs the arms
-// together instead of collapsing them to one arrow. Writing the arms `Aᵢ -> Cᵢ`
-// and the target `E -> F`, both legs must hold:
+// It runs after decideMeetJoin's pair trial found no single arm below the target.
+// Both rules are sound, so which runs first decides the bounds a variable in the
+// target picks up rather than the verdict.
 //
-//  1. The target's domain is covered: `E <: ⋃ᵢ Aᵢ`. No input the target accepts
-//     may fall outside every arm's domain, since no arm says what the value does
-//     with such an input.
-//  2. For every group P of arms, either the inputs are still covered without P —
-//     `E <: ⋃_{i∉P} Aᵢ` — or the arms in P return something the target tolerates,
-//     `⋂_{i∈P} Cᵢ <: F`. A value carrying every arm type returns, on a given
-//     input, something in the codomain of every arm whose domain accepts that
-//     input. So the goal fails exactly when some group is the only cover for part
-//     of E while its combined codomain escapes F.
-//
-// `((x: number) -> boolean) & ((x: string) -> null) <: (x: number | string) ->
-// (boolean | null)` holds under this rule: each arm alone returns something the
-// target tolerates, and the group holding both returns `boolean & null`, which no
-// value inhabits. Checking the arms one at a time rejects it, since neither arm
-// alone accepts both a number and a string.
-//
-// It runs after decideMeetJoin's pair trial found no single arm below the target,
-// so a goal one arm already settles never reaches it. Both rules are sound, so
-// which runs first decides the bounds a variable in the target picks up rather
-// than the verdict.
-//
-// The decomposition is restricted to plain one-parameter arrows: the arms and the
-// target must agree on what a call may raise, and none may carry a receiver, a
-// quantifier, an optional or rest parameter, or a trailing `...`. A multi-parameter
-// arrow's domain is a product of positions rather than one type, and covering a
-// product needs the union of the arms' whole domains rather than a union per
-// position, so those keep the pair trial's answer.
+// Only plain one-parameter arrows are weighed, the shape decomposableArrow admits.
+// A multi-parameter arrow's domain is a product of positions rather than one type,
+// and covering a product needs the union of the arms' whole domains rather than a
+// union per position.
 func (c *Context) decideArrows(subCands, superCands []soltype.Type, seen *seenPairs) (soltype.Type, bool) {
 	arms := decomposableArrows(subCands)
 	if len(arms) < 2 || len(arms) > maxDecomposedArms {
@@ -266,14 +228,20 @@ func (c *Context) decideArrows(subCands, superCands []soltype.Type, seen *seenPa
 	return nil, false
 }
 
-// arrowLegsHold runs the two legs of the decomposition decideArrows documents and
-// reports whether both hold. The caller keeps the bounds the legs recorded only
-// when they do.
+// arrowLegsHold reports whether both legs of the decomposition hold for arms
+// `Aᵢ -> Cᵢ` against target `E -> F`. The caller keeps the bounds they recorded
+// only when they do.
 //
-// Every leg compares a domain against a domain or a codomain against a codomain,
-// so each runs with the deep-mut context cleared, exactly as the arrow rule in the
-// structural switch clears it. A function carries its own annotation context, so a
-// borrow reaching one of its parameters does not make that parameter invariant.
+//  1. The target's domain is covered, `E <: ⋃ᵢ Aᵢ`, since no arm says what the
+//     value does with an input outside every arm's domain.
+//  2. For every group P of arms, either the arms outside P still cover the inputs,
+//     `E <: ⋃_{i∉P} Aᵢ`, or P returns something the target tolerates,
+//     `⋂_{i∈P} Cᵢ <: F`. A value carrying every arm type returns, on a given
+//     input, something in the codomain of every arm that accepts it.
+//
+// Every leg compares domain against domain or codomain against codomain, so each
+// runs with the deep-mut context cleared, as the arrow rule in the structural
+// switch clears it. A function carries its own annotation context.
 func (c *Context) arrowLegsHold(arms []*soltype.FuncType, target *soltype.FuncType, seen *seenPairs) bool {
 	domain := target.Params[0].Type
 	// Leg 1. Every input the target accepts is accepted by some arm.
@@ -302,8 +270,8 @@ func allArms(arms []*soltype.FuncType) int {
 	return 1<<len(arms) - 1
 }
 
-// joinDomains is the union of the domains of the arms in group, and `never` when
-// the group is empty, since an empty union covers no input at all.
+// joinDomains is the union of the domains of the arms in group, and `never` for an
+// empty group, since an empty union covers no input.
 func joinDomains(arms []*soltype.FuncType, group int) soltype.Type {
 	parts := make([]soltype.Type, 0, len(arms))
 	for i, arm := range arms {
@@ -326,9 +294,8 @@ func meetCodomains(arms []*soltype.FuncType, group int) soltype.Type {
 	return newIntersection(nil, parts)
 }
 
-// decomposableArrows returns the atoms of a meet the decomposition can weigh,
-// dropping every other atom. Dropping is sound: a meet is below each of its parts,
-// so a decision reached from the arrows alone holds for the whole meet.
+// decomposableArrows returns the atoms of a meet the decomposition can weigh and
+// drops the rest, which is sound because a meet is below each of its parts.
 func decomposableArrows(atoms []soltype.Type) []*soltype.FuncType {
 	arrows := make([]*soltype.FuncType, 0, len(atoms))
 	for _, atom := range atoms {
@@ -339,8 +306,9 @@ func decomposableArrows(atoms []soltype.Type) []*soltype.FuncType {
 	return arrows
 }
 
-// decomposableArrow reports whether one arrow has the plain shape the
-// decomposition is restricted to, spelled out in decideArrows.
+// decomposableArrow reports whether one arrow is plain enough to decompose: one
+// parameter, no receiver, no quantifier, and no optional, rest, or `...` marker.
+// Everything a leg does not compare has to be absent, since no leg would see it.
 func decomposableArrow(f *soltype.FuncType) bool {
 	if f.SelfParam != nil || len(f.TypeParams) > 0 || len(f.LifetimeParams) > 0 || f.Inexact {
 		return false
@@ -351,9 +319,9 @@ func decomposableArrow(f *soltype.FuncType) bool {
 	return !f.Params[0].Optional && !f.Params[0].Rest
 }
 
-// sameRaises reports whether every arm raises what the target raises. The
-// decomposition reasons about the domains and the codomains alone, so a call that
-// could raise something the target does not name has to be ruled out here.
+// sameRaises reports whether every arm raises what the target raises. The legs
+// compare domains and codomains alone, so an arm that could raise something the
+// target does not name is ruled out here.
 func sameRaises(arms []*soltype.FuncType, target *soltype.FuncType) bool {
 	for _, arm := range arms {
 		if !equalType(arm.ThrowsOrNever(), target.ThrowsOrNever()) {
@@ -366,14 +334,11 @@ func sameRaises(arms []*soltype.FuncType, target *soltype.FuncType) bool {
 // nfPair is one candidate pair decideMeetJoin trials.
 type nfPair struct{ sub, super soltype.Type }
 
-// orderedPairs lists the pairs to trial, supertype candidate first and subtype
-// candidate second, each in specificity order. Ordering the supertype candidates
-// outermost keeps the choice among union members the one a reader sees first, and
-// it is the order the rule this layer replaces used.
-//
-// origSub and origSuper are the constraint the caller is deciding. The pair that
-// repeats it against an inexact union is dropped, for the reason decideMeetJoin
-// gives.
+// orderedPairs lists the pairs to trial, each side in specificity order and the
+// supertype candidates outermost, so the choice among union members is the one a
+// reader sees first. origSub and origSuper are the constraint the caller is
+// deciding; the pair repeating it against an inexact union is dropped, for the
+// reason decideMeetJoin gives.
 func orderedPairs(subCands, superCands []soltype.Type, origSub, origSuper soltype.Type) []nfPair {
 	subOrder := specificityOrder(subCands)
 	pairs := make([]nfPair, 0, len(subCands)*len(superCands))
@@ -398,15 +363,15 @@ func varsAsTypes(vars set.Set[*soltype.TypeVarType]) []soltype.Type {
 	return out
 }
 
-// isNegation reports whether t is a complement, the node whose presence on either
-// side of a constraint routes the constraint through the normal-form layer.
+// isNegation reports whether t is a complement, the node that routes a constraint
+// through the normal-form layer from either side.
 func isNegation(t soltype.Type) bool {
 	_, ok := t.(*soltype.NegationType)
 	return ok
 }
 
 // isInexactUnion reports whether t is a union with an open tail, the one supertype
-// normalization hands back whole instead of taking apart.
+// normalization hands back whole.
 func isInexactUnion(t soltype.Type) bool {
 	u, ok := t.(*soltype.UnionType)
 	return ok && u.Inexact

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -71,12 +71,10 @@ type nfDecision struct {
 
 // constrainNF decides `sub <: super` through the normal forms of both operands.
 //
-// The whole derivation runs under one probe, so a constraint that fails records
-// no bound. That is the discipline the member-by-member trials it replaces
-// followed, and callers depend on it: the union-super rule reports one
-// union-level diagnostic in place of whatever the decomposition produced, and a
-// bound recorded on the way to that failure would outlive the derivation that
-// justified it.
+// The whole derivation runs under one probe, so a constraint that fails records no
+// bound. Callers depend on that. The union-super rule reports one union-level
+// diagnostic in place of whatever the decomposition produced, and a bound recorded
+// on the way to that failure would outlive the derivation that justified it.
 func (c *Context) constrainNF(sub, super soltype.Type, seen *seenPairs, mutCtx bool) nfDecision {
 	lhs := c.mkDeepDNF(sub, soltype.Positive)
 	rhs := c.mkDeepCNF(super, soltype.Negative)
@@ -154,10 +152,11 @@ func (c *Context) constrainImplied(
 // trial recurses into the ordinary structural rules, which is where a class tag
 // meets its parent and an arrow meets an arrow.
 //
-// Looking for one pair is sound but incomplete. Two exact records meet to `never`
-// once #1064 lands, and until then `{x: number} & {y: number} <: {x: number, y:
-// number}` finds no single pair and is rejected, which is what the rule it
-// replaces answered too.
+// Looking for one pair is sound but incomplete. A meet can be below a join
+// through its parts taken together, which no pair states. `{x: number} & {y:
+// number} <: {x: number, y: number}` is such a goal: neither record alone carries
+// both fields, so no pair holds and the goal is rejected. Two exact records meet
+// to `never` once #1064 lands, which settles that one.
 //
 // A pair that repeats the constraint constrainNF was called with, against an
 // inexact union, is skipped. An inexact union is one atom, since its open tail has
@@ -233,9 +232,10 @@ const maxDecomposedArms = 6
 // value inhabits. Checking the arms one at a time rejects it, since neither arm
 // alone accepts both a number and a string.
 //
-// It runs only after the pair trial in decideMeetJoin found no single arm below
-// the target, so it can only add acceptances. Both rules are sound, so the order
-// decides which bounds a variable in the target picks up, not the verdict.
+// It runs after decideMeetJoin's pair trial found no single arm below the target,
+// so a goal one arm already settles never reaches it. Both rules are sound, so
+// which runs first decides the bounds a variable in the target picks up rather
+// than the verdict.
 //
 // The decomposition is restricted to plain one-parameter arrows: the arms and the
 // target must agree on what a call may raise, and none may carry a receiver, a

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -134,8 +134,12 @@ func (c *Context) constrainImplied(
 	meet, inhabited := c.fuseAtoms(pooled(conj.Lnf.Atoms, disj.Lnf.Atoms), meetOfAtoms)
 	if !inhabited {
 		// No value inhabits the subtype side, so the goal holds however the supertype
-		// side reads. `5 <: ¬number` reaches this: the negated `number` moves to the
-		// subtype side, and `5 ∩ number` is `never`.
+		// side reads. `5 <: ¬string` reaches this: the complement moves `string` to the
+		// subtype side as a positive atom, and `5 ∩ string` is `never`, since a literal
+		// and a primitive of another family are disjoint.
+		//
+		// `5 <: ¬number` does not reach it. That meet is `5 ∩ number`, which is `5`, so
+		// the goal goes on to the trial below and fails there against an empty join.
 		return nfDecision{}
 	}
 	join, _ := c.fuseAtoms(pooled(conj.Rnf.Atoms, disj.Rnf.Atoms), joinOfAtoms)

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -33,7 +33,7 @@ import (
 //
 // `sub <: super` becomes `DNF(sub) <: CNF(super)`. A DNF is a union of conjuncts
 // and a CNF an intersection of disjuncts, so the constraint holds exactly when
-// every conjunct is below every disjunct. That product is the deterministic
+// every conjunct is a subtype of every disjunct. That product is the deterministic
 // decomposition: no member is guessed, and each implied goal is settled on its
 // own.
 //
@@ -103,17 +103,18 @@ func (c *Context) constrainNF(sub, super soltype.Type, seen *seenPairs, mutCtx b
 // constrainImplied decides one conjunct of the subtype's DNF against one disjunct
 // of the supertype's CNF, the implied goal this file's header describes. It moves
 // both negated parts across the `<:`, which leaves `⋂subCands <: ⋃superCands` over
-// atoms and variables, and proves that by finding one subtype candidate below one
-// supertype candidate, since `⋂subCands <: sᵢ <: pⱼ <: ⋃superCands` for any such
-// pair. The pairs are trialled in specificity order, so a bare variable is only
-// ever a last resort, and each trial recurses into the ordinary structural rules.
+// atoms and variables, and proves that by finding a pair, one candidate from each
+// side, whose subtype-side candidate is a subtype of its supertype-side one, since
+// `⋂subCands <: sᵢ <: pⱼ <: ⋃superCands` for any such pair. The pairs are trialled
+// in specificity order, so a bare variable is only ever a last resort, and each
+// trial recurses into the ordinary structural rules.
 //
 // sub and super are the operands constrainNF was called with, and name the failure
 // when the goal has no pair to trial at all.
 //
 // Three things follow from deciding by one pair.
 //
-//   - It is incomplete. A meet can be below a join through its parts taken
+//   - It is incomplete. A meet can be a subtype of a join through its parts taken
 //     together, which no pair states, so `{x: number} & {y: number} <: {x: number,
 //     y: number}` is rejected. #1064's exact-record merge settles that one.
 //   - A pair repeating the caller's own question against an inexact union is
@@ -173,8 +174,8 @@ func (c *Context) constrainImplied(
 	if committed {
 		return nfDecision{errs: winErrs, committed: []soltype.Type{pairs[winIdx].super}}
 	}
-	// No single pair holds. An intersection of arrows can still be below an arrow
-	// through the arms taken together, which is what decideArrows weighs.
+	// No single pair holds. An intersection of arrows can still be a subtype of an
+	// arrow through the arms taken together, which is what decideArrows weighs.
 	if target, ok := c.decideArrows(subCands, superCands, seen); ok {
 		return nfDecision{committed: []soltype.Type{target}}
 	}
@@ -196,9 +197,9 @@ const maxDecomposedArms = 6
 // settled the goal at all. arrowLegsHold states the two legs, and the corpus
 // header in constrain_nf_test.go derives them.
 //
-// It runs after constrainImplied's pair trial found no single arm below the target.
-// Both rules are sound, so which runs first decides the bounds a variable in the
-// target picks up rather than the verdict.
+// It runs after constrainImplied's pair trial found no single arm that is a subtype
+// of the target. Both rules are sound, so which runs first decides the bounds a
+// variable in the target picks up rather than the verdict.
 //
 // Only plain one-parameter arrows are weighed, the shape decomposableArrow admits.
 // A multi-parameter arrow's domain is a product of positions rather than one type,
@@ -294,7 +295,7 @@ func meetCodomains(arms []*soltype.FuncType, group int) soltype.Type {
 }
 
 // decomposableArrows returns the atoms of a meet the decomposition can weigh and
-// drops the rest, which is sound because a meet is below each of its parts.
+// drops the rest, which is sound because a meet is a subtype of each of its parts.
 func decomposableArrows(atoms []soltype.Type) []*soltype.FuncType {
 	arrows := make([]*soltype.FuncType, 0, len(atoms))
 	for _, atom := range atoms {

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -58,13 +58,15 @@ import (
 
 // nfDecision is what one constrainNF call derived.
 //
-// committed names the supertype-side atom or variable a trial settled on, and is
-// nil when no trial ran or when every trial failed. The union-super rule reads it
-// to report an ambiguous commit and to record that a bare variable member was
-// pinned by a union choice.
+// committed names the supertype-side atoms and variables the trials settled on,
+// one per implied goal that needed a choice. It is empty when no trial ran or when
+// the decision failed. The union-super rule reads it to report an ambiguous commit
+// and to record that a bare variable member was pinned by a union choice. A
+// decision that settled several goals holds one entry each, since each goal chose
+// on its own.
 type nfDecision struct {
 	errs      []SolverError
-	committed soltype.Type
+	committed []soltype.Type
 }
 
 // constrainNF decides `sub <: super` through the normal forms of both operands.
@@ -82,21 +84,23 @@ func (c *Context) constrainNF(sub, super soltype.Type, seen *seenPairs, mutCtx b
 	p := newProbe(c, c.probe)
 	c.probe = p
 	var out nfDecision
+	// Every implied goal has to hold, so the first one that fails settles the whole
+	// constraint. Stopping there keeps a failure from reporting the same diagnostic
+	// once per goal, which two conjuncts failing the same way would otherwise do.
 	for _, conj := range lhs.Conjuncts {
 		for _, disj := range rhs.Disjuncts {
 			implied := c.constrainImplied(conj, disj, sub, super, seen, mutCtx)
 			out.errs = append(out.errs, implied.errs...)
-			if implied.committed != nil {
-				out.committed = implied.committed
+			out.committed = append(out.committed, implied.committed...)
+			if hasHardError(implied.errs) {
+				c.probe = p.parent
+				p.Discard()
+				return nfDecision{errs: out.errs}
 			}
 		}
 	}
 	c.probe = p.parent
-	if hasHardError(out.errs) {
-		p.Discard()
-	} else {
-		p.Commit()
-	}
+	p.Commit()
 	return out
 }
 
@@ -155,11 +159,19 @@ func (c *Context) constrainImplied(
 // number}` finds no single pair and is rejected, which is what the rule it
 // replaces answered too.
 //
-// A pair repeating the constraint constrainNF was called with is skipped. An
-// inexact union is one atom, since its open tail has no atom to stand for it, so
-// normalizing `boolean <: (number | string | ...)` hands back the pair it started
-// from. Trialling that pair would ask the question the caller is already
-// deciding and never reach a smaller one.
+// A pair that repeats the constraint constrainNF was called with, against an
+// inexact union, is skipped. An inexact union is one atom, since its open tail has
+// no atom to stand for it, so normalizing `boolean <: (number | string | ...)`
+// hands back the pair it started from. Trialling that pair would ask the question
+// the caller is already deciding and never reach a smaller one. Only that shape
+// repeats: every other supertype is taken apart into atoms smaller than itself.
+//
+// A variable on the supertype side picks up the whole meet as a lower bound, which
+// is stronger than the goal asks for. `¬T <: number` becomes `unknown <: number ∪ T`
+// and settles by recording `unknown` under T, where `¬number` under T is the
+// weakest bound that would do. The stronger bound is sound, and a variable is only
+// ever reached after every concrete candidate failed, so the imprecision is
+// confined to a goal nothing else settles.
 func (c *Context) decideMeetJoin(
 	subCands, superCands []soltype.Type, sub, super soltype.Type, seen *seenPairs, mutCtx bool,
 ) nfDecision {
@@ -177,12 +189,12 @@ func (c *Context) decideMeetJoin(
 		return c.constrain(pairs[idx].sub, pairs[idx].super, seen.Clone(), mutCtx)
 	})
 	if committed {
-		return nfDecision{errs: winErrs, committed: pairs[winIdx].super}
+		return nfDecision{errs: winErrs, committed: []soltype.Type{pairs[winIdx].super}}
 	}
 	// No single pair holds. An intersection of arrows can still be below an arrow
 	// through the arms taken together, which is what decideArrows weighs.
 	if target, ok := c.decideArrows(subCands, superCands, seen); ok {
-		return nfDecision{committed: target}
+		return nfDecision{committed: []soltype.Type{target}}
 	}
 	// The last pair's diagnostics are the ones a caller that reports the
 	// decomposition surfaces; the union-super rule replaces them with one
@@ -360,13 +372,14 @@ type nfPair struct{ sub, super soltype.Type }
 // it is the order the rule this layer replaces used.
 //
 // origSub and origSuper are the constraint the caller is deciding. The pair that
-// repeats it is dropped, for the reason decideMeetJoin gives.
+// repeats it against an inexact union is dropped, for the reason decideMeetJoin
+// gives.
 func orderedPairs(subCands, superCands []soltype.Type, origSub, origSuper soltype.Type) []nfPair {
 	subOrder := specificityOrder(subCands)
 	pairs := make([]nfPair, 0, len(subCands)*len(superCands))
 	for _, j := range specificityOrder(superCands) {
 		for _, i := range subOrder {
-			if equalType(subCands[i], origSub) && equalType(superCands[j], origSuper) {
+			if isInexactUnion(superCands[j]) && equalType(subCands[i], origSub) && equalType(superCands[j], origSuper) {
 				continue
 			}
 			pairs = append(pairs, nfPair{sub: subCands[i], super: superCands[j]})
@@ -390,4 +403,11 @@ func varsAsTypes(vars set.Set[*soltype.TypeVarType]) []soltype.Type {
 func isNegation(t soltype.Type) bool {
 	_, ok := t.(*soltype.NegationType)
 	return ok
+}
+
+// isInexactUnion reports whether t is a union with an open tail, the one supertype
+// normalization hands back whole instead of taking apart.
+func isInexactUnion(t soltype.Type) bool {
+	u, ok := t.(*soltype.UnionType)
+	return ok && u.Inexact
 }

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -1,0 +1,388 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// The normal-form layer of constraint solving, MLstruct's `constrainNF` /
+// `annoying`. It decides a constraint whose Boolean structure the deterministic
+// "for all" rules in constrain.go cannot take apart: a union in supertype
+// position, an intersection in subtype position, and a negation anywhere.
+//
+// # What normalization buys
+//
+// Both operands are pushed into a normal form first, so the decision runs on
+// FUSED atoms rather than on the members the source wrote. An atom is a single
+// structural type the Boolean algebra does not take apart, such as one object
+// type or one arrow. normal.go fuses two atoms whenever a single atom denotes
+// their meet or their join exactly, so
+//
+//	((x: number) -> boolean) & ((x: string) -> boolean)
+//
+// reaches this layer as the one arrow `(x: number | string) -> boolean`. Deciding
+// that against `(x: number | string) -> boolean` is then an ordinary arrow
+// comparison. Trialling the two written arms one at a time, which is what a
+// member-by-member search does, rejects the same constraint, because neither arm
+// alone accepts a string. constrain_nf_test.go states the verdicts this layer is
+// measured against, derived by hand from a types-as-values reading.
+//
+// # The shape of one goal
+//
+// `sub <: super` becomes `DNF(sub) <: CNF(super)`. A DNF is a union of conjuncts
+// and a CNF an intersection of disjuncts, so the constraint holds exactly when
+// every conjunct is below every disjunct. That product is the deterministic
+// decomposition: no member is guessed, and each implied goal is settled on its
+// own.
+//
+// One implied goal reads `Lc ∩ ⋂Vc ∩ ¬Rc ∩ ⋂¬Nc <: Rd ∪ ⋃Vd ∪ ¬Ld ∪ ⋃¬Nd`. Every
+// negated part moves to the other side of the `<:`, which is where negation
+// enters the decision without any node having to be guessed:
+//
+//   - `X ∩ ¬R <: Y` is `X <: Y ∪ R`, so a conjunct's negated part joins the
+//     supertype side.
+//   - `X <: Y ∪ ¬L` is `X ∩ L <: Y`, so a disjunct's negated part joins the
+//     subtype side.
+//
+// The two variable sets move the same way. What is left is a meet of atoms and
+// variables against a join of atoms and variables, which decideMeetJoin settles.
+//
+// # Where a choice still remains
+//
+// A meet of two atoms that did not fuse, or a join of two that did not, leaves a
+// genuine choice: `{x: number} | {y: number}` is not one record, so nothing says
+// which side a given subtype has to satisfy. decideMeetJoin trials the pairs in
+// specificity order for exactly that residue. Every trial runs over atoms the
+// normal form produced, so the fusions above have already collapsed the cases a
+// member-by-member search decides wrongly.
+
+// nfDecision is what one constrainNF call derived.
+//
+// committed names the supertype-side atom or variable a trial settled on, and is
+// nil when no trial ran or when every trial failed. The union-super rule reads it
+// to report an ambiguous commit and to record that a bare variable member was
+// pinned by a union choice.
+type nfDecision struct {
+	errs      []SolverError
+	committed soltype.Type
+}
+
+// constrainNF decides `sub <: super` through the normal forms of both operands.
+//
+// The whole derivation runs under one probe, so a constraint that fails records
+// no bound. That is the discipline the member-by-member trials it replaces
+// followed, and callers depend on it: the union-super rule reports one
+// union-level diagnostic in place of whatever the decomposition produced, and a
+// bound recorded on the way to that failure would outlive the derivation that
+// justified it.
+func (c *Context) constrainNF(sub, super soltype.Type, seen *seenPairs, mutCtx bool) nfDecision {
+	lhs := c.mkDeepDNF(sub, soltype.Positive)
+	rhs := c.mkDeepCNF(super, soltype.Negative)
+
+	p := newProbe(c, c.probe)
+	c.probe = p
+	var out nfDecision
+	for _, conj := range lhs.Conjuncts {
+		for _, disj := range rhs.Disjuncts {
+			implied := c.constrainImplied(conj, disj, sub, super, seen, mutCtx)
+			out.errs = append(out.errs, implied.errs...)
+			if implied.committed != nil {
+				out.committed = implied.committed
+			}
+		}
+	}
+	c.probe = p.parent
+	if hasHardError(out.errs) {
+		p.Discard()
+	} else {
+		p.Commit()
+	}
+	return out
+}
+
+// constrainImplied decides one conjunct of the subtype's DNF against one disjunct
+// of the supertype's CNF, the goal this file's header calls an implied goal. It
+// moves both negated parts across the `<:` and hands the resulting meet and join
+// to decideMeetJoin.
+//
+// sub and super are the operands constrainNF was called with. They name the
+// failure when the goal has no pair to trial at all.
+func (c *Context) constrainImplied(
+	conj Conjunct, disj Disjunct, sub, super soltype.Type, seen *seenPairs, mutCtx bool,
+) nfDecision {
+	// The two positive parts meet on the subtype side and the two negated ones join
+	// on the supertype side. Each list was fused within its own normal form, so the
+	// pooled list is fused once more: an atom of the conjunct may fuse with one the
+	// disjunct contributed.
+	meet, inhabited := c.fuseAtoms(pooled(conj.Lnf.Atoms, disj.Lnf.Atoms), meetOfAtoms)
+	if !inhabited {
+		// No value inhabits the subtype side, so the goal holds however the supertype
+		// side reads. `5 <: ¬number` reaches this: the negated `number` moves to the
+		// subtype side, and `5 ∩ number` is `never`.
+		return nfDecision{}
+	}
+	join, _ := c.fuseAtoms(pooled(conj.Rnf.Atoms, disj.Rnf.Atoms), joinOfAtoms)
+
+	// A variable is opaque, so it joins the side it sits on as one more candidate
+	// rather than being taken apart. A variable negated on one side stands on the
+	// other, by the same two rewrites the negated structural parts follow.
+	subCands := append(meet, varsAsTypes(conj.Vars)...)
+	subCands = append(subCands, varsAsTypes(disj.NVars)...)
+	superCands := append(join, varsAsTypes(disj.Vars)...)
+	superCands = append(superCands, varsAsTypes(conj.NVars)...)
+
+	if len(subCands) == 0 {
+		// An empty meet is `unknown`, the top of the lattice. Naming it explicitly
+		// gives the decision below something to constrain, and `unknown <: T` still
+		// records a bound when the supertype side is a variable.
+		subCands = []soltype.Type{&soltype.UnknownType{}}
+	}
+	return c.decideMeetJoin(subCands, superCands, sub, super, seen, mutCtx)
+}
+
+// decideMeetJoin decides `⋂subCands <: ⋃superCands`, where each candidate is an
+// atom or a type variable.
+//
+// It proves the goal by finding one subtype candidate that is below one supertype
+// candidate, since `⋂subCands <: sᵢ <: pⱼ <: ⋃superCands` for any such pair. The
+// pairs are trialled in specificity order, so a concrete candidate is tried
+// before a bare type variable and a variable is only ever a last resort. Each
+// trial recurses into the ordinary structural rules, which is where a class tag
+// meets its parent and an arrow meets an arrow.
+//
+// Looking for one pair is sound but incomplete. Two exact records meet to `never`
+// once #1064 lands, and until then `{x: number} & {y: number} <: {x: number, y:
+// number}` finds no single pair and is rejected, which is what the rule it
+// replaces answered too.
+//
+// A pair repeating the constraint constrainNF was called with is skipped. An
+// inexact union is one atom, since its open tail has no atom to stand for it, so
+// normalizing `boolean <: (number | string | ...)` hands back the pair it started
+// from. Trialling that pair would ask the question the caller is already
+// deciding and never reach a smaller one.
+func (c *Context) decideMeetJoin(
+	subCands, superCands []soltype.Type, sub, super soltype.Type, seen *seenPairs, mutCtx bool,
+) nfDecision {
+	pairs := orderedPairs(subCands, superCands, sub, super)
+	if len(pairs) == 0 {
+		return nfDecision{errs: []SolverError{&CannotConstrainError{Sub: sub, Super: super}}}
+	}
+	order := make([]int, len(pairs))
+	for i := range order {
+		order[i] = i
+	}
+	committed, winIdx, winErrs, trialErrs := c.trialAndCommit(order, func(idx int) []SolverError {
+		// A cloned seen keeps each pair's coinductive cache independent, so a failed
+		// pair's entries cannot short-circuit a later pair to success.
+		return c.constrain(pairs[idx].sub, pairs[idx].super, seen.Clone(), mutCtx)
+	})
+	if committed {
+		return nfDecision{errs: winErrs, committed: pairs[winIdx].super}
+	}
+	// No single pair holds. An intersection of arrows can still be below an arrow
+	// through the arms taken together, which is what decideArrows weighs.
+	if target, ok := c.decideArrows(subCands, superCands, seen, mutCtx); ok {
+		return nfDecision{committed: target}
+	}
+	// The last pair's diagnostics are the ones a caller that reports the
+	// decomposition surfaces; the union-super rule replaces them with one
+	// union-level diagnostic instead.
+	return nfDecision{errs: trialErrs[len(trialErrs)-1]}
+}
+
+// maxDecomposedArms caps how many arrow atoms decideArrows weighs. It tries every
+// group of arms, so the work doubles with each further arm. Six arms is 63 groups,
+// past which the decomposition costs more than the constraints it settles. An
+// intersection of more arrows than that is decided by the pair trial alone, which
+// is sound and only ever rejects what the decomposition would have accepted.
+const maxDecomposedArms = 6
+
+// decideArrows decides `⋂arms <: target` when the subtype side holds several arrow
+// atoms that no fusion merged into one. It returns the target it settled on and
+// reports whether it settled the goal at all.
+//
+// The rule is the Frisch-Castagna-Benzaken decomposition, which weighs the arms
+// together instead of collapsing them to one arrow. Writing the arms `Aᵢ -> Cᵢ`
+// and the target `E -> F`, both legs must hold:
+//
+//  1. The target's domain is covered: `E <: ⋃ᵢ Aᵢ`. No input the target accepts
+//     may fall outside every arm's domain, since no arm says what the value does
+//     with such an input.
+//  2. For every group P of arms, either the inputs are still covered without P —
+//     `E <: ⋃_{i∉P} Aᵢ` — or the arms in P return something the target tolerates,
+//     `⋂_{i∈P} Cᵢ <: F`. A value carrying every arm type returns, on a given
+//     input, something in the codomain of every arm whose domain accepts that
+//     input. So the goal fails exactly when some group is the only cover for part
+//     of E while its combined codomain escapes F.
+//
+// `((x: number) -> boolean) & ((x: string) -> null) <: (x: number | string) ->
+// (boolean | null)` holds under this rule: each arm alone returns something the
+// target tolerates, and the group holding both returns `boolean & null`, which no
+// value inhabits. Checking the arms one at a time rejects it, since neither arm
+// alone accepts both a number and a string.
+//
+// It runs only after the pair trial in decideMeetJoin found no single arm below
+// the target, so it can only add acceptances. Both rules are sound, so the order
+// decides which bounds a variable in the target picks up, not the verdict.
+//
+// The decomposition is restricted to plain one-parameter arrows: the arms and the
+// target must agree on what a call may raise, and none may carry a receiver, a
+// quantifier, an optional or rest parameter, or a trailing `...`. A multi-parameter
+// arrow's domain is a product of positions rather than one type, and covering a
+// product needs the union of the arms' whole domains rather than a union per
+// position, so those keep the pair trial's answer.
+func (c *Context) decideArrows(subCands, superCands []soltype.Type, seen *seenPairs, mutCtx bool) (soltype.Type, bool) {
+	arms := decomposableArrows(subCands)
+	if len(arms) < 2 || len(arms) > maxDecomposedArms {
+		return nil, false
+	}
+	for _, cand := range superCands {
+		target, ok := cand.(*soltype.FuncType)
+		if !ok || !decomposableArrow(target) || !sameRaises(arms, target) {
+			continue
+		}
+		p := newProbe(c, c.probe)
+		c.probe = p
+		settled := c.arrowLegsHold(arms, target, seen, mutCtx)
+		c.probe = p.parent
+		if settled {
+			p.Commit()
+			return cand, true
+		}
+		p.Discard()
+	}
+	return nil, false
+}
+
+// arrowLegsHold runs the two legs of the decomposition decideArrows documents and
+// reports whether both hold. The caller keeps the bounds the legs recorded only
+// when they do.
+func (c *Context) arrowLegsHold(arms []*soltype.FuncType, target *soltype.FuncType, seen *seenPairs, mutCtx bool) bool {
+	domain := target.Params[0].Type
+	// Leg 1. Every input the target accepts is accepted by some arm.
+	if hasHardError(c.constrain(domain, joinDomains(arms, allArms(arms)), seen.Clone(), mutCtx)) {
+		return false
+	}
+	// Leg 2, over every group of arms. A group is a bit set over arms, so counting
+	// from 1 to 2ⁿ-1 enumerates each non-empty one exactly once.
+	for group := 1; group < 1<<len(arms); group++ {
+		// The inputs the arms outside this group already cover need nothing from the
+		// group itself. The check is speculative, so it runs under a discarding probe
+		// and records no bound.
+		outside := joinDomains(arms, allArms(arms)&^group)
+		if !hasHardError(c.trialUnderProbeSeen(domain, outside, seen.Clone())) {
+			continue
+		}
+		if hasHardError(c.constrain(meetCodomains(arms, group), target.Ret, seen.Clone(), mutCtx)) {
+			return false
+		}
+	}
+	return true
+}
+
+// allArms is the bit set holding every arm, the group leg 1 unions the domains of.
+func allArms(arms []*soltype.FuncType) int {
+	return 1<<len(arms) - 1
+}
+
+// joinDomains is the union of the domains of the arms in group, and `never` when
+// the group is empty, since an empty union covers no input at all.
+func joinDomains(arms []*soltype.FuncType, group int) soltype.Type {
+	parts := make([]soltype.Type, 0, len(arms))
+	for i, arm := range arms {
+		if group&(1<<i) != 0 {
+			parts = append(parts, arm.Params[0].Type)
+		}
+	}
+	return newUnion(nil, parts, false)
+}
+
+// meetCodomains is the intersection of the codomains of the arms in group, what a
+// value carrying every arm type returns on an input only this group accepts.
+func meetCodomains(arms []*soltype.FuncType, group int) soltype.Type {
+	parts := make([]soltype.Type, 0, len(arms))
+	for i, arm := range arms {
+		if group&(1<<i) != 0 {
+			parts = append(parts, arm.Ret)
+		}
+	}
+	return newIntersection(nil, parts)
+}
+
+// decomposableArrows returns the atoms of a meet the decomposition can weigh,
+// dropping every other atom. Dropping is sound: a meet is below each of its parts,
+// so a decision reached from the arrows alone holds for the whole meet.
+func decomposableArrows(atoms []soltype.Type) []*soltype.FuncType {
+	arrows := make([]*soltype.FuncType, 0, len(atoms))
+	for _, atom := range atoms {
+		if f, ok := atom.(*soltype.FuncType); ok && decomposableArrow(f) {
+			arrows = append(arrows, f)
+		}
+	}
+	return arrows
+}
+
+// decomposableArrow reports whether one arrow has the plain shape the
+// decomposition is restricted to, spelled out in decideArrows.
+func decomposableArrow(f *soltype.FuncType) bool {
+	if f.SelfParam != nil || len(f.TypeParams) > 0 || len(f.LifetimeParams) > 0 || f.Inexact {
+		return false
+	}
+	if len(f.Params) != 1 {
+		return false
+	}
+	return !f.Params[0].Optional && !f.Params[0].Rest
+}
+
+// sameRaises reports whether every arm raises what the target raises. The
+// decomposition reasons about the domains and the codomains alone, so a call that
+// could raise something the target does not name has to be ruled out here.
+func sameRaises(arms []*soltype.FuncType, target *soltype.FuncType) bool {
+	for _, arm := range arms {
+		if !equalType(arm.ThrowsOrNever(), target.ThrowsOrNever()) {
+			return false
+		}
+	}
+	return true
+}
+
+// nfPair is one candidate pair decideMeetJoin trials.
+type nfPair struct{ sub, super soltype.Type }
+
+// orderedPairs lists the pairs to trial, supertype candidate first and subtype
+// candidate second, each in specificity order. Ordering the supertype candidates
+// outermost keeps the choice among union members the one a reader sees first, and
+// it is the order the rule this layer replaces used.
+//
+// origSub and origSuper are the constraint the caller is deciding. The pair that
+// repeats it is dropped, for the reason decideMeetJoin gives.
+func orderedPairs(subCands, superCands []soltype.Type, origSub, origSuper soltype.Type) []nfPair {
+	subOrder := specificityOrder(subCands)
+	pairs := make([]nfPair, 0, len(subCands)*len(superCands))
+	for _, j := range specificityOrder(superCands) {
+		for _, i := range subOrder {
+			if equalType(subCands[i], origSub) && equalType(superCands[j], origSuper) {
+				continue
+			}
+			pairs = append(pairs, nfPair{sub: subCands[i], super: superCands[j]})
+		}
+	}
+	return pairs
+}
+
+// varsAsTypes returns a variable set's members as types, ordered by id so a
+// candidate list reads the same however the set was built.
+func varsAsTypes(vars set.Set[*soltype.TypeVarType]) []soltype.Type {
+	out := make([]soltype.Type, 0, vars.Len())
+	for _, v := range sortedVars(vars) {
+		out = append(out, v)
+	}
+	return out
+}
+
+// isNegation reports whether t is a complement, the node whose presence on either
+// side of a constraint routes the constraint through the normal-form layer.
+func isNegation(t soltype.Type) bool {
+	_, ok := t.(*soltype.NegationType)
+	return ok
+}

--- a/internal/solver/constrain_nf_rules_test.go
+++ b/internal/solver/constrain_nf_rules_test.go
@@ -84,10 +84,12 @@ func TestConstrainNegation(t *testing.T) {
 			super: &soltype.UnionType{Types: []soltype.Type{num(), negate(num())}},
 		},
 		{
-			// An object really is disjoint from a primitive, so the sound answer holds. The
-			// meet of two atoms is only known uninhabited for the primitives, the literals,
-			// `null`, and `undefined`, so this pair keeps both atoms and the goal is
-			// rejected. Widening that disjointness is #1063's simplifier.
+			// No object is a number, so a types-as-values reading answers "holds" here.
+			// The solver rejects it instead. Two atoms are known to meet at `never` only
+			// when both are drawn from the primitives, the literals, `null`, or
+			// `undefined`, so an object met with `number` keeps both atoms and the
+			// subtype side reads as inhabited. Widening that disjointness is #1063's
+			// simplifier.
 			name:     "an object against the complement of a primitive",
 			sub:      exactObj(propElem("x", num())),
 			super:    negate(num()),

--- a/internal/solver/constrain_nf_rules_test.go
+++ b/internal/solver/constrain_nf_rules_test.go
@@ -159,6 +159,69 @@ func TestConstrainArrowDecompositionRestrictions(t *testing.T) {
 	}, Messages(c.Constrain(sub, super)))
 }
 
+// TestConstrainRecursiveListThroughNormalForm covers a recursive type whose body
+// is a union, the shape a list builder with a base case infers. See
+// recursive_test.go for the source that produces it.
+//
+//	μX.({head: number, tail: undefined} | {head: number, tail: X})
+//
+// Deciding two of them terminates only if each unfolding reaches a pair of knots
+// the solver is already comparing, so the comparison closes on the knots rather
+// than on what a fusion rebuilt around them.
+func TestConstrainRecursiveListThroughNormalForm(t *testing.T) {
+	list := func(id int, name string) soltype.Type {
+		return muKnot(id, name, func(ref *soltype.RecursiveVarType) soltype.Type {
+			return newUnion(nil, []soltype.Type{
+				exactObj(propElem("head", num()), propElem("tail", &soltype.UndefinedType{})),
+				exactObj(propElem("head", num()), propElem("tail", ref)),
+			}, false)
+		})
+	}
+	require.Empty(t, Messages((&Context{}).Constrain(list(0, "X0"), list(4, "X1"))))
+	require.Empty(t, Messages((&Context{}).Constrain(list(4, "X1"), list(0, "X0"))))
+}
+
+// TestConstrainInexactUnionSuperWeighsNamedMembers pins that an inexact union's
+// named members are weighed before its open tail absorbs anything. The tail has
+// no atom to stand for it, so the union is one atom and the members would
+// otherwise never be reached. A member that matches has to bind what it binds:
+// here the matching member's property type is an inference variable, and it picks
+// up the subtype's property as a lower bound.
+func TestConstrainInexactUnionSuperWeighsNamedMembers(t *testing.T) {
+	c := &Context{}
+	prop := c.freshVar(0)
+	super := &soltype.UnionType{
+		Types:   []soltype.Type{exactObj(propElem("x", prop)), str()},
+		Inexact: true,
+	}
+
+	require.Empty(t, Messages(c.Constrain(exactObj(propElem("x", numLit(5))), super)))
+	require.Len(t, prop.LowerBounds, 1)
+	require.Equal(t, "5", soltype.Print(coalesce(prop, soltype.Positive)))
+}
+
+// TestConstrainUnionCommitOnAFusedAtom covers the ambiguity warning when the
+// decision commits to an atom several members fused into. The two object members
+// below fuse to `{x: number | string}`, so no member was picked over the other and
+// neither is an alternative to the atom it helped build. The bare variable member
+// is one, since it would also match by binding, so the warning names it.
+func TestConstrainUnionCommitOnAFusedAtom(t *testing.T) {
+	c := &Context{}
+	catchAll := c.freshVar(0)
+	super := newUnion(nil, []soltype.Type{
+		exactObj(propElem("x", num())),
+		exactObj(propElem("x", str())),
+		catchAll,
+	}, false).(*soltype.UnionType)
+
+	errs := c.Constrain(exactObj(propElem("x", numLit(5))), super)
+	require.Equal(t, []string{
+		"ambiguous match against t0 | object | object: committed object, " +
+			"but t0 would also match; annotate to disambiguate",
+	}, Messages(errs))
+	require.False(t, hasHardError(errs))
+}
+
 // TestConstrainNegationThroughRecursiveUnion covers termination. The knot below
 // carries a complement inside a union, so comparing two of them re-asks the same
 // pair on every unfolding. The coinductive cache closes that pair, which is what

--- a/internal/solver/constrain_nf_rules_test.go
+++ b/internal/solver/constrain_nf_rules_test.go
@@ -1,0 +1,184 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- The rules constrain routes through the normal-form layer ---
+//
+// constrain_nf_test.go states the conformance corpus, the verdicts the layer is
+// measured against. The tests here cover the layer's own rules: how a complement
+// is decided, what a complement records on a variable, what an intersection fuses
+// to before it is compared, and that a constraint recursing through a complement
+// closes on the coinductive cache.
+
+// TestConstrainNegation covers the rule that routes a complement on either side
+// through the normal-form layer. Every row is settled by moving the complement
+// across the `<:`, so the decision is an ordinary meet or join of atoms.
+//
+// A complement has no annotation syntax yet, so each row builds its operands as
+// solver types rather than parsing them.
+func TestConstrainNegation(t *testing.T) {
+	negate := func(t soltype.Type) soltype.Type { return &soltype.NegationType{Inner: t} }
+
+	tests := []struct {
+		name       string
+		sub, super soltype.Type
+		wantErrs   []string
+	}{
+		{
+			// `5 ∩ string` holds no value, so nothing has to be checked. A literal and a
+			// primitive of another family are disjoint, which is the fact that settles it.
+			name:  "a literal against the complement of another family",
+			sub:   numLit(5),
+			super: negate(str()),
+		},
+		{
+			// `5 ∩ number` is `5`, and the supertype side is empty, which reads as `never`.
+			name:     "a literal against the complement of its own primitive",
+			sub:      numLit(5),
+			super:    negate(num()),
+			wantErrs: []string{"cannot constrain 5 <: ¬number"},
+		},
+		{
+			name:  "a primitive against the complement of another primitive",
+			sub:   num(),
+			super: negate(str()),
+		},
+		{
+			// The complement moves to the supertype side, which leaves an empty meet on the
+			// subtype side. An empty meet is `unknown`, and the diagnostic names it.
+			name:     "the complement of a primitive against that primitive's sibling",
+			sub:      negate(num()),
+			super:    str(),
+			wantErrs: []string{"cannot constrain unknown <: string"},
+		},
+		{
+			// De Morgan: `¬(number | string)` normalizes to the two goals `boolean ∩ number`
+			// and `boolean ∩ string`, and neither meet is inhabited.
+			name:  "a primitive against the complement of a union",
+			sub:   boolT(),
+			super: negate(&soltype.UnionType{Types: []soltype.Type{num(), str()}}),
+		},
+		{
+			// No value is both a number and a string, so the complement of that meet admits
+			// every value.
+			name:  "any type against the complement of an uninhabited intersection",
+			sub:   num(),
+			super: negate(&soltype.IntersectionType{Types: []soltype.Type{num(), str()}}),
+		},
+		{
+			name:  "a literal against a double complement of its primitive",
+			sub:   numLit(5),
+			super: negate(negate(num())),
+		},
+		{
+			// The union super is `number ∪ ¬number`, which every value inhabits. The
+			// complement moves to the subtype side, so the goal becomes `string ∩ number <:
+			// number` and the meet is uninhabited.
+			name:  "a primitive against a union of a type and its complement",
+			sub:   str(),
+			super: &soltype.UnionType{Types: []soltype.Type{num(), negate(num())}},
+		},
+		{
+			// An object really is disjoint from a primitive, so the sound answer holds. The
+			// meet of two atoms is only known uninhabited for the primitives, the literals,
+			// `null`, and `undefined`, so this pair keeps both atoms and the goal is
+			// rejected. Widening that disjointness is #1063's simplifier.
+			name:     "an object against the complement of a primitive",
+			sub:      exactObj(propElem("x", num())),
+			super:    negate(num()),
+			wantErrs: []string{"cannot constrain object <: ¬number"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.wantErrs, Messages(c.Constrain(tt.sub, tt.super)))
+		})
+	}
+}
+
+// TestConstrainNegationIntoVarRecordsBound pins what a complement in supertype
+// position does to a variable. The variable arms record it whole rather than
+// routing it through the normal-form layer, so the complement survives on the
+// bound list and coalescing renders it.
+func TestConstrainNegationIntoVarRecordsBound(t *testing.T) {
+	c := &Context{}
+	a := c.freshVar(0)
+
+	require.Empty(t, Messages(c.Constrain(a, &soltype.NegationType{Inner: str()})))
+	require.Len(t, a.UpperBounds, 1)
+	require.Empty(t, a.LowerBounds)
+	require.Equal(t, "¬string", soltype.Print(coalesce(a, soltype.Negative)))
+}
+
+// TestConstrainIntersectionFusesBeforeComparing covers the subtype-side win the
+// normal-form layer brings. Two inexact objects meet to one object carrying both
+// fields, so the intersection satisfies a target naming both. Comparing the
+// written members one at a time rejects it, since neither member alone carries
+// both fields.
+func TestConstrainIntersectionFusesBeforeComparing(t *testing.T) {
+	inexactObj := func(elems ...soltype.ObjTypeElem) *soltype.ObjectType {
+		return &soltype.ObjectType{Elems: elems, Inexact: true}
+	}
+	c := &Context{}
+	sub := &soltype.IntersectionType{Types: []soltype.Type{
+		inexactObj(propElem("x", num())),
+		inexactObj(propElem("y", str())),
+	}}
+
+	require.Empty(t, Messages(c.Constrain(sub, inexactObj(propElem("x", num()), propElem("y", str())))))
+}
+
+// TestConstrainArrowDecompositionRestrictions pins where the arrow decomposition
+// stops. It weighs one-parameter arrows only, so the same shape written with two
+// parameters is decided by the weaker rule that checks one arm at a time and is
+// rejected. A multi-parameter arrow's domain is a product of positions, and
+// covering a product needs the union of the arms' whole domains rather than a
+// union per position.
+//
+// The one-parameter form of this shape is the corpus row "distinct domains,
+// distinct codomains: the target unions both codomains", which holds.
+func TestConstrainArrowDecompositionRestrictions(t *testing.T) {
+	c := &Context{}
+	env := map[string]soltype.Type{}
+	sub := parseTypeIn(t, env,
+		"(fn (x: number, y: number) -> boolean) & (fn (x: string, y: string) -> null)")
+	super := parseTypeIn(t, env,
+		"fn (x: number | string, y: number | string) -> boolean | null")
+
+	// Both diagnostics come from the last arm the pair trial tried, one per parameter
+	// position it could not accept.
+	require.Equal(t, []string{
+		"cannot constrain number <: string",
+		"cannot constrain number <: string",
+	}, Messages(c.Constrain(sub, super)))
+}
+
+// TestConstrainNegationThroughRecursiveUnion covers termination. The knot below
+// carries a complement inside a union, so comparing two of them re-asks the same
+// pair on every unfolding. The coinductive cache closes that pair, which is what
+// keeps the comparison finite.
+//
+//	μX.{next: X, tag: string | ¬number}
+//
+// The two knots number their binders differently, so a comparison that only
+// succeeded on identical operands would not settle either direction.
+func TestConstrainNegationThroughRecursiveUnion(t *testing.T) {
+	knot := func(id int, name string) soltype.Type {
+		return muKnot(id, name, func(ref *soltype.RecursiveVarType) soltype.Type {
+			return exactObj(
+				propElem("next", ref),
+				propElem("tag", &soltype.UnionType{
+					Types: []soltype.Type{str(), &soltype.NegationType{Inner: num()}},
+				}),
+			)
+		})
+	}
+	require.Empty(t, Messages((&Context{}).Constrain(knot(0, "X0"), knot(4, "X1"))))
+	require.Empty(t, Messages((&Context{}).Constrain(knot(4, "X1"), knot(0, "X0"))))
+}

--- a/internal/solver/constrain_nf_rules_test.go
+++ b/internal/solver/constrain_nf_rules_test.go
@@ -183,21 +183,68 @@ func TestConstrainRecursiveListThroughNormalForm(t *testing.T) {
 
 // TestConstrainInexactUnionSuperWeighsNamedMembers pins that an inexact union's
 // named members are weighed before its open tail absorbs anything. The tail has
-// no atom to stand for it, so the union is one atom and the members would
-// otherwise never be reached. A member that matches has to bind what it binds:
-// here the matching member's property type is an inference variable, and it picks
-// up the subtype's property as a lower bound.
+// no atom to stand for it, so such a union is one atom and the members would
+// otherwise never be reached, leaving the constraint accepted through the tail
+// with nothing recorded.
+//
+// A member that matches has to bind what it binds. Each row's matching member is
+// `{x: T}` for a fresh T, so a row that weighed it records the subtype's property
+// as T's lower bound and T coalesces to `5`.
 func TestConstrainInexactUnionSuperWeighsNamedMembers(t *testing.T) {
-	c := &Context{}
-	prop := c.freshVar(0)
-	super := &soltype.UnionType{
-		Types:   []soltype.Type{exactObj(propElem("x", prop)), str()},
-		Inexact: true,
+	tests := []struct {
+		name string
+		// rest names the members beside `{x: T}`, and open says whether the union
+		// itself carries the tail.
+		rest []soltype.Type
+		open bool
+	}{
+		{
+			name: "beside another member",
+			rest: []soltype.Type{str()},
+			open: true,
+		},
+		{
+			// The union collapses to the one member, which is the member to weigh.
+			name: "the only member",
+			open: true,
+		},
+		{
+			// The tail rides on a member rather than on the union. Splicing the members
+			// out of the nested union is what keeps the outer one from inheriting it.
+			name: "the tail rides a nested union member",
+			rest: []soltype.Type{&soltype.UnionType{Types: []soltype.Type{str(), boolT()}, Inexact: true}},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			prop := c.freshVar(0)
+			members := append([]soltype.Type{exactObj(propElem("x", prop))}, tt.rest...)
+			super := &soltype.UnionType{Types: members, Inexact: tt.open}
 
-	require.Empty(t, Messages(c.Constrain(exactObj(propElem("x", numLit(5))), super)))
-	require.Len(t, prop.LowerBounds, 1)
-	require.Equal(t, "5", soltype.Print(coalesce(prop, soltype.Positive)))
+			require.Empty(t, Messages(c.Constrain(exactObj(propElem("x", numLit(5))), super)))
+			require.Len(t, prop.LowerBounds, 1)
+			require.Equal(t, "5", soltype.Print(coalesce(prop, soltype.Positive)))
+		})
+	}
+}
+
+// TestConstrainReportsOneDiagnosticPerFailure pins that a failure is reported
+// once. The subtype below normalizes to two conjuncts, `{a: number, c: number}`
+// and `{b: number, c: number}`, and each fails against `string` the same way. The
+// constraint is settled by the first goal that fails, so the diagnostic does not
+// repeat per goal.
+func TestConstrainReportsOneDiagnosticPerFailure(t *testing.T) {
+	c := &Context{}
+	sub := &soltype.IntersectionType{Types: []soltype.Type{
+		newUnion(nil, []soltype.Type{
+			inexactObj(propElem("a", num())),
+			inexactObj(propElem("b", num())),
+		}, false),
+		inexactObj(propElem("c", num())),
+	}}
+
+	require.Equal(t, []string{"cannot constrain object <: string"}, Messages(c.Constrain(sub, str())))
 }
 
 // TestConstrainUnionCommitOnAFusedAtom covers the ambiguity warning when the

--- a/internal/solver/constrain_nf_test.go
+++ b/internal/solver/constrain_nf_test.go
@@ -59,6 +59,26 @@ import (
 // two rows vary exactly that. Their members share the field name `tag` and differ
 // only in its literal type, which isolates differing field names as the cause
 // rather than a record union in supertype position as such.
+//
+// # How the MLscript column was filled
+//
+// The mlscript column is derived from the two source reads recorded in
+// planning/ml_struct/06-open-items.md, not from a run of hkust-taco/mlstruct. Each
+// arrow row is what finding 2's rule answers: intersected arrows merge to
+// `(A | B) -> (C & D)` and the plain arrow rule decides that one merged arrow, so
+// the row's answer is the merged arrow's. A record row whose two members name
+// DIFFERENT fields is what finding 1's widening answers: that supertype union
+// becomes `unknown`, which every subtype satisfies, so the row answers "holds".
+//
+// The two tagged rows stay unobserved. Their members share the field name `tag`,
+// and a same-named second field is not what makes the widening bail, so neither
+// finding settles them. Filling those two needs a run.
+//
+// Two rows disagree with the oracle under those rules, and each says so in its
+// why. Both are cases where the merged codomain collapses to `never` and the
+// merged arrow accepts an input no single arm covers. That divergence is what
+// caveat 4 in planning/ml_struct/02-caveats-and-mitigations.md asks the port to
+// document, and the port follows the sound column.
 
 // nfVerdict is a subtyping answer. nfUnobserved is the zero value so a row that
 // nobody has run against MLscript reads as blank rather than as "fails".
@@ -97,12 +117,10 @@ type nfRow struct {
 	// why records the step that produces sound — which leg of the arrow
 	// decomposition decides the row, or which part of the record-union reasoning.
 	why string
-	// mlscript is what MLscript answers. A row settled by the source reads in
-	// planning/ml_struct/06-open-items.md carries that answer and cites the
-	// finding in why; the rest stay nfUnobserved until the case is run against
-	// hkust-taco/mlstruct. Where the two columns disagree, sound wins and the
-	// divergence is documented — see caveat 4 in
-	// planning/ml_struct/02-caveats-and-mitigations.md.
+	// mlscript is what MLscript answers, derived from the source reads as the
+	// header section "How the MLscript column was filled" describes. Where the two
+	// columns disagree, sound wins and the divergence is documented — see caveat 4
+	// in planning/ml_struct/02-caveats-and-mitigations.md.
 	mlscript nfVerdict
 	// wantErrs is the full set of diagnostics the solver reports for the row, nil
 	// when it reports none. It is empty exactly when sound is nfHolds, a
@@ -110,12 +128,6 @@ type nfRow struct {
 	// message here says what a user sees. It need not name the step why gives,
 	// because a row can reach the right verdict by another route.
 	wantErrs []string
-	// needsNF marks a row whose sound verdict the solver cannot yet reach. The
-	// union-super and intersection-sub rules trial each member whole under a
-	// probe, so they settle a row only when one member alone settles it. A row
-	// that needs the arms weighed together waits for the normal-form layer. Such
-	// a row parses and then skips, so its annotations stay checked meanwhile.
-	needsNF bool
 }
 
 // nfArrowCorpus holds the arrow-intersection rows. Worked examples A and B come
@@ -129,7 +141,6 @@ var nfArrowCorpus = []nfRow{
 		why: "leg 1 holds since number | string is exactly the union of the two arm domains. Every " +
 			"group of arms returns a boolean, so leg 2 holds through its codomain half",
 		mlscript: nfHolds,
-		needsNF:  true,
 	},
 	{
 		name:  "example B: distinct domains, conflicting codomains",
@@ -147,6 +158,18 @@ var nfArrowCorpus = []nfRow{
 		},
 	},
 	{
+		name:  "distinct domains, distinct codomains: the target unions both codomains",
+		sub:   "(fn (x: number) -> boolean) & (fn (x: string) -> null)",
+		super: "fn (x: number | string) -> boolean | null",
+		sound: nfHolds,
+		why: "the same arms as example B against a target that tolerates both codomains. Leg 1 " +
+			"holds since the arm domains cover number | string. Leg 2 holds for each group: the " +
+			"number arm alone returns a boolean, the string arm alone returns null, and the group " +
+			"holding both returns boolean & null, which no value inhabits. Checking one arm at a " +
+			"time rejects the row, since neither arm alone accepts both a number and a string",
+		mlscript: nfHolds,
+	},
+	{
 		name:  "shared domain, distinct codomains: the target takes their meet",
 		sub:   "(fn (x: number) -> number | string) & (fn (x: number) -> string | boolean)",
 		super: "fn (x: number) -> string",
@@ -154,7 +177,7 @@ var nfArrowCorpus = []nfRow{
 		why: "the (A -> B) & (A -> C) <: A -> (B & C) shape. Only the group holding both arms is " +
 			"uncovered, and its combined codomain (number | string) & (string | boolean) is string, " +
 			"which the target accepts",
-		needsNF: true,
+		mlscript: nfHolds,
 	},
 	{
 		name:  "shared domain, distinct codomains: the target misses their meet",
@@ -163,6 +186,7 @@ var nfArrowCorpus = []nfRow{
 		sound: nfFails,
 		why: "the meet of the codomains is number, so a number input can yield a number where the " +
 			"target promises a string. Leg 2 fails for the group holding both arms",
+		mlscript: nfFails,
 		wantErrs: []string{"cannot constrain number <: string"},
 	},
 	{
@@ -175,7 +199,7 @@ var nfArrowCorpus = []nfRow{
 			"number input, and no value is both, so such a value never returns on a number input. " +
 			"Its combined codomain is `never`, and `never` <: boolean, so leg 2 holds for the group " +
 			"holding both arms",
-		needsNF: true,
+		mlscript: nfHolds,
 	},
 	{
 		name:  "overlapping domains, shared codomain",
@@ -185,7 +209,7 @@ var nfArrowCorpus = []nfRow{
 		why: "leg 1 holds since number | boolean sits inside number | string | boolean, and every " +
 			"group returns a boolean, so leg 2 holds through its codomain half. The overlap on " +
 			"number changes nothing, since covering an input twice is not a conflict",
-		needsNF: true,
+		mlscript: nfHolds,
 	},
 	{
 		name:  "overlapping domains, one codomain escapes",
@@ -193,7 +217,10 @@ var nfArrowCorpus = []nfRow{
 		super: "fn (x: number | boolean) -> boolean",
 		sound: nfFails,
 		why: "leg 2 fails for the group holding the boolean arm alone: a boolean input is covered " +
-			"by no other arm, and that arm returns a number",
+			"by no other arm, and that arm returns a number. This is the second row where MLscript " +
+			"diverges: it merges the arms to (number | string | boolean) -> (boolean & number), " +
+			"whose codomain is `never`, and accepts (06-open-items.md finding 2)",
+		mlscript: nfHolds,
 		wantErrs: []string{"cannot constrain boolean <: number | string"},
 	},
 	{
@@ -203,10 +230,8 @@ var nfArrowCorpus = []nfRow{
 		sound: nfFails,
 		why: "leg 1 fails: a boolean input is outside both arm domains, so no arm says what the " +
 			"value does with it. This is the leg that distinguishes the row from example A",
-		wantErrs: []string{
-			"cannot constrain number <: string",
-			"cannot constrain boolean <: string",
-		},
+		mlscript: nfFails,
+		wantErrs: []string{"cannot constrain boolean <: number | string"},
 	},
 	{
 		name:  "nested arrows: the intersection sits in the codomain",
@@ -215,7 +240,7 @@ var nfArrowCorpus = []nfRow{
 		sound: nfHolds,
 		why: "the codomains are compared covariantly, and that comparison is example A, so the " +
 			"decomposition has to run underneath an ordinary arrow rule rather than only at the top",
-		needsNF: true,
+		mlscript: nfHolds,
 	},
 	{
 		name: "nested arrows: the arms take functions",
@@ -225,7 +250,7 @@ var nfArrowCorpus = []nfRow{
 		sound: nfHolds,
 		why: "example A one level up, with function types as the domains. Leg 1 holds since the " +
 			"target domain is the union of the two arm domains, and every group returns a boolean",
-		needsNF: true,
+		mlscript: nfHolds,
 	},
 	{
 		name:  "an arm's codomain is a free type variable",
@@ -235,7 +260,7 @@ var nfArrowCorpus = []nfRow{
 		sound: nfHolds,
 		why: "example A with T for boolean. The verdict does not depend on what T is, since the " +
 			"domains cover number | string and every group's combined codomain is T & T = T",
-		needsNF: true,
+		mlscript: nfHolds,
 	},
 }
 
@@ -309,11 +334,10 @@ func TestConstrainNFRecordCorpus(t *testing.T) {
 	runNFCorpus(t, nfRecordCorpus)
 }
 
-// runNFCorpus checks each row against the solver. It parses both operands first,
-// so a row waiting on the normal-form layer still has its annotations validated,
-// then asserts the diagnostics the row records. A row where MLscript is known to
-// disagree with the oracle logs the disagreement, so a verbose run reads as the
-// divergence roster caveat 4 asks the port to document.
+// runNFCorpus checks each row against the solver, asserting the diagnostics the
+// row records. A row where MLscript is known to disagree with the oracle logs the
+// disagreement, so a verbose run reads as the divergence roster caveat 4 asks the
+// port to document.
 func runNFCorpus(t *testing.T, corpus []nfRow) {
 	t.Helper()
 	for _, tt := range corpus {
@@ -335,13 +359,6 @@ func runNFCorpus(t *testing.T, corpus []nfRow) {
 			if tt.mlscript != nfUnobserved && tt.mlscript != tt.sound {
 				t.Logf("MLscript answers %s here; the port follows the sound column", tt.mlscript)
 			}
-			if tt.needsNF {
-				// Nothing runs, so there are no diagnostics to have recorded. Whoever
-				// removes the skip fills wantErrs from what the solver then reports.
-				require.Empty(t, tt.wantErrs, "a row waiting on the normal-form layer records no diagnostics")
-				t.Skip("enabled by PR5 #1062")
-			}
-
 			// The two columns state the same thing about a row that runs, so a row
 			// that reports errors while claiming to hold is a table mistake rather
 			// than a solver result worth reporting.

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -1148,7 +1148,8 @@ func TestConstrainExtrusionBothPolarities(t *testing.T) {
 // and gains an UPPER bound. Reaching it at Negative would wire a lower bound instead and
 // invert every constraint extruded through a negation.
 //
-// constrain has no rule for a complement, so the test drives extrude directly.
+// constrain decides a complement by normalizing it rather than by rewriting it, so the test
+// drives extrude directly.
 func TestExtrudeThroughNegation(t *testing.T) {
 	c := &Context{}
 	a := c.freshVar(1) // level 1, so the level-0 extrusion must descend to it

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -240,8 +240,15 @@ func (c *Context) normalizeDeep(t soltype.Type, pol soltype.Polarity) soltype.Ty
 // node itself only has to settle the Boolean structure at that one level.
 type deepNormalizer struct{ ctx *Context }
 
-// EnterType takes over the walk for a borrow, and leaves every other node to the
-// ordinary bottom-up rebuild.
+// EnterType takes over the walk for a borrow, keeps a μ-knot as written, and
+// leaves every other node to the ordinary bottom-up rebuild.
+//
+// A μ-knot stands for an infinite type, and comparing two of them terminates only
+// because the solver's cache recognizes a pair of knots it is already deciding.
+// That cache keys on node identity, so rewriting a knot into an equal one hands the
+// comparison a pair it has never seen. Each unfolding would then rewrite the copy
+// it produced and the comparison would never close. So the knot is kept as
+// written, and the constraint rules normalize what an unfolding exposes.
 //
 // A borrow needs its own arm because RefType.Accept PEELS the wrapper when the
 // rewritten inner is not a type a borrow can point at, which is right for
@@ -251,6 +258,9 @@ type deepNormalizer struct{ ctx *Context }
 // borrowable. Otherwise the borrow stands as written, which keeps the wrapper the
 // header promises normalization never takes apart.
 func (n *deepNormalizer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if _, isKnot := t.(*soltype.RecursiveType); isKnot {
+		return soltype.EnterResult{Type: t, SkipChildren: true}
+	}
 	ref, isRef := t.(*soltype.RefType)
 	if !isRef {
 		return soltype.EnterResult{Type: nil, SkipChildren: false}
@@ -615,6 +625,9 @@ func (c *Context) meetAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	if equalType(a, b) {
 		return a, true
 	}
+	if carriesKnot(a) || carriesKnot(b) {
+		return nil, false
+	}
 	if fused, ok := meetValueAtoms(a, b); ok {
 		return fused, true
 	}
@@ -648,6 +661,9 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	if equalType(a, b) {
 		return a, true
 	}
+	if carriesKnot(a) || carriesKnot(b) {
+		return nil, false
+	}
 	if fused, ok := joinValueAtoms(a, b); ok {
 		return fused, true
 	}
@@ -667,6 +683,37 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	// of the union permits.
 	return nil, false
 }
+
+// carriesKnot reports whether t holds a μ-knot anywhere inside it. A fusion over
+// such an atom is skipped, which keeps both atoms and loses no precision.
+//
+// The reason is the solver's cycle detection. Comparing two recursive types
+// terminates because the constraint cache recognizes a pair of knots it is already
+// deciding, and that cache keys on node identity. A fusion rebuilds the children it
+// merges, so fusing `{next: undefined} | {next: μX.…}` into `{next: undefined | μX.…}`
+// mints a fresh union node holding the knot. Each unfolding would mint another one,
+// so the comparison would ask a pair the cache has never seen on every lap and would
+// never close. Leaving the two atoms apart keeps the knot reachable as one operand
+// of a pair, which is the pair the cache closes on.
+func carriesKnot(t soltype.Type) bool {
+	f := &knotFinder{}
+	t.Accept(f, soltype.Positive)
+	return f.found
+}
+
+// knotFinder is the walking visitor behind carriesKnot. It flags the first μ-knot
+// it reaches and skips that node's children, since one occurrence is enough.
+type knotFinder struct{ found bool }
+
+func (f *knotFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if _, ok := t.(*soltype.RecursiveType); ok {
+		f.found = true
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (f *knotFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
 
 // valueFamily is a set of runtime values no value outside it belongs to. Two
 // atoms drawn from different families are disjoint, so their meet is `never`.

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -1031,3 +1031,37 @@ func permutations(items []string) [][]string {
 	}
 	return out
 }
+
+// TestDeepNormalizeKeepsKnots covers the identity discipline a μ-knot needs. The
+// solver decides two recursive types by recognizing a pair of knots it is already
+// comparing, and it recognizes them by node identity, so normalization hands a
+// knot back as written and no fusion rebuilds one.
+func TestDeepNormalizeKeepsKnots(t *testing.T) {
+	// μX0.({head: number, tail: undefined} | {head: number, tail: X0}), the shape a
+	// recursive list builder infers. Its body is the union whose members would
+	// otherwise fuse into `{head: number, tail: undefined | X0}`.
+	knot := muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
+		return newUnion(nil, []soltype.Type{
+			exactObj(propElem("head", num()), propElem("tail", &soltype.UndefinedType{})),
+			exactObj(propElem("head", num()), propElem("tail", ref)),
+		}, false)
+	})
+
+	t.Run("the knot itself is handed back", func(t *testing.T) {
+		c := &Context{}
+		require.Same(t, knot, c.mkDeepDNF(knot, soltype.Positive).toType())
+	})
+
+	t.Run("a union of atoms carrying the knot keeps both", func(t *testing.T) {
+		// The two members differ in one field, which is what joinObjects fuses. They
+		// stay apart because the fused field would hold the knot in a fresh node.
+		c := &Context{}
+		members := newUnion(nil, []soltype.Type{
+			exactObj(propElem("head", num()), propElem("tail", &soltype.UndefinedType{})),
+			exactObj(propElem("head", num()), propElem("tail", knot)),
+		}, false)
+		require.Equal(t,
+			"{head: number, tail: undefined} | {head: number, tail: μX0.({head: number, tail: undefined} | {head: number, tail: X0})}",
+			soltype.Print(c.mkDeepDNF(members, soltype.Positive).toType()))
+	})
+}

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -312,10 +312,11 @@ func (c *checker) openProbe() *Probe {
 // report the last trial's diagnostics. The union-super rule, for example, promotes a
 // uniform BorrowEscapeError when every trial reports one.
 //
-// This is the single path for the speculative member trials the lattice arms run. Both
-// constrain's IntersectionType-sub exists rule and its UnionType-super exists rule route
-// through it, so the probe push-and-pop discipline lives in one place. Each trial body
-// owns its own coinductive seen clone, since only the caller holds the constraint key.
+// This is the single path for the speculative candidate trials a subtyping decision runs,
+// so the probe push-and-pop discipline lives in one place. Its caller is the normal-form
+// layer's decideMeetJoin, which trials the candidate pairs a meet against a join leaves to
+// choose between. Each trial body owns its own coinductive seen clone, since only the caller
+// holds the constraint key.
 func (c *Context) trialAndCommit(order []int, trial func(idx int) []SolverError) (committed bool, winIdx int, winErrs []SolverError, trialErrs [][]SolverError) {
 	for _, idx := range order {
 		p := newProbe(c, c.probe)

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -314,8 +314,8 @@ func (c *checker) openProbe() *Probe {
 //
 // This is the single path for the speculative candidate trials a subtyping decision runs,
 // so the probe push-and-pop discipline lives in one place. Its caller is the normal-form
-// layer's decideMeetJoin, which trials the candidate pairs a meet against a join leaves to
-// choose between. Each trial body owns its own coinductive seen clone, since only the caller
+// layer's constrainImplied, which trials the candidate pairs a meet against a join leaves
+// to choose between. Each trial body owns its own coinductive seen clone, since only the caller
 // holds the constraint key.
 func (c *Context) trialAndCommit(order []int, trial func(idx int) []SolverError) (committed bool, winIdx int, winErrs []SolverError, trialErrs [][]SolverError) {
 	for _, idx := range order {


### PR DESCRIPTION
Fixes #1062. Part of the MLstruct adoption epic #1057 (PR5).

Adds the normal-form layer of constraint solving, which decides constraints whose Boolean structure the deterministic structural rules cannot decompose: unions in supertype position, intersections in subtype position, and negations anywhere.

## Summary

The normal-form layer normalizes both operands into DNF (disjunctive normal form) and CNF (conjunctive normal form) respectively, fusing atoms where possible so decisions run on the minimal set of candidates. It then decomposes the constraint into implied goals—one per pair of conjunct and disjunct—and decides each through a meet-join trial. For arrow intersections that don't fuse, it implements the Frisch-Castagna-Benzaken decomposition, which weighs the arms together rather than collapsing them to one arrow.

## Key changes

- **New file `constrain_nf.go`**: Implements the normal-form decision layer with:
  - `constrainNF`: Entry point that normalizes both operands and decides all implied goals
  - `constrainImplied`: Decides one conjunct-disjunct pair by moving negated parts across the constraint
  - `decideMeetJoin`: Trials candidate pairs in specificity order to find one subtype below one supertype
  - `decideArrows`: Implements the arrow decomposition for intersections of multiple arrows
  - Helper functions for atom fusion, domain/codomain extraction, and pair ordering

- **Modified `constrain.go`**: Routes constraints through the normal-form layer:
  - Negations on either side now go through `constrainNF` (except when a variable is involved)
  - Union-super rule now calls `constrainNF` instead of trialling members directly
  - Intersection-sub rule now calls `constrainNF` instead of trialling members directly
  - Updated comments to explain the normal-form approach and its benefits

- **Modified `normal.go`**: Preserves recursive type identity:
  - `deepNormalizer.EnterType` now keeps μ-knots as written instead of rewriting them
  - `meetAtoms` and `joinAtoms` skip fusion when either atom carries a knot
  - Adds `carriesKnot` helper to detect recursive types in a structure

- **New test file `constrain_nf_rules_test.go`**: Tests the normal-form layer's own rules:
  - Negation routing and movement across constraints
  - Intersection fusion before comparison
  - Arrow decomposition restrictions
  - Recursive types through the normal form
  - Inexact union member weighting
  - Diagnostic deduplication

- **Modified `constrain_nf_test.go`**: Documents how the MLscript column was filled and removes the `needsNF` marker since all rows now pass

- **Modified `normal_test.go`**: Adds test coverage for knot identity preservation

## Acceptance

The #1059 conformance corpus runs in full: the rows that waited on this layer are un-skipped, worked example A holds and example B fails, and the negative-position record-union rows keep their sound verdicts. `α <: ¬T` records a negated upper bound that coalesces to `¬string`, a constraint recursing through a complement inside a union terminates, and the existing `constrain_test.go` / `constrain_lattice_test.go` union and intersection suites are unchanged and green.

## Notable implementation details

The normal-form layer is sound but incomplete: it finds one pair of candidates that satisfies the constraint, which works for most cases but misses constraints where the meet or join of multiple candidates together satisfies the goal. The arrow decomposition extends this for the specific case of arrow intersections, where multiple arms can be below a target through their domains and codomains taken together.

Recursive types (μ-knots) are kept as written during normalization because the solver recognizes pairs of knots by node identity. Rewriting a knot into an equal one would break the coinductive cache that terminates comparisons of recursive types.

Negations are moved across the constraint boundary using De Morgan's laws: a negated part in a conjunct joins the supertype side, and a negated part in a disjunct joins the subtype side. This converts negations into ordinary meets and joins that the structural rules can decide.

## Verification gate

The issue asks for the MLscript-observed column to be filled by running the seed cases against `hkust-taco/mlstruct`. No Scala toolchain was available, so each entry is instead **derived** from the source reads already recorded in `planning/ml_struct/06-open-items.md` — finding 2's naive arrow merge and finding 1's record-union widening. The corpus header says so explicitly, and the two tagged-union rows that neither finding settles stay `unobserved`. Two rows diverge from the oracle under those rules and are documented as the caveat 4 divergence roster; the port follows the sound column in both.

https://claude.ai/code/session_01QEs23uUsGfKDp3TABzjFz4