### PR TITLE
Simplify negations in intersection types using disjointness

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -243,23 +243,34 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	// Borrow lifetimes are left raw here and resolved by the coalesceLifetimes
 	// post-pass, which needs the whole type to analyze lifetime occurrence (D4).
-	return coalesceNegation(t)
+	return foldNegation(t)
 }
 
-// coalesceNegation re-mints a complement through newNegation once its operand has
-// been coalesced, and returns every other node unchanged. Both coalescers call it
-// from ExitType, which fires bottom-up, so the operand it reads is the coalesced
-// one rather than the bound as stored.
+// foldNegation re-mints a complement through newNegation once its operand has been
+// rewritten, and returns every other node unchanged. Both coalescers call it from
+// ExitType, which fires bottom-up, so the operand it reads is the rewritten one
+// rather than the bound as stored. subsumeFinal calls it for the same reason, since
+// its own rewrites can turn an operand into a lattice bound.
 //
-// The re-mint is what keeps a complement over an empty variable readable. A var
-// with the single upper bound `¬β` and a β with no lower bounds inlines β to
-// `never`, and the bare rebuild would render the meaningless `¬never` where the
-// bound really says unknown.
-func coalesceNegation(t soltype.Type) soltype.Type {
-	if n, ok := t.(*soltype.NegationType); ok {
-		return newNegation(n.Inner)
+// The re-mint is what keeps a complement over an empty variable readable. A var with
+// the single upper bound `¬β` and a β with no lower bounds inlines β to `never`, and
+// the bare rebuild would render the meaningless `¬never` where the bound really says
+// unknown.
+//
+// A complement newNegation does not collapse is returned as the caller passed it, so
+// the walk keeps the node it already has and no ancestor is rebuilt on its account.
+// newNegation wraps its operand in a fresh node whenever no collapse applies, so a
+// result still wrapping the SAME operand is what identifies that case.
+func foldNegation(t soltype.Type) soltype.Type {
+	n, isNeg := t.(*soltype.NegationType)
+	if !isNeg {
+		return t
 	}
-	return t
+	folded := newNegation(n.Inner)
+	if fn, stillNeg := folded.(*soltype.NegationType); stillNeg && fn.Inner == n.Inner {
+		return t
+	}
+	return folded
 }
 
 // bubbleOwnedMut rewrites a coalesced display type so no owned-mutable cell ever
@@ -568,7 +579,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 func (c *schemeCoalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	// Borrow lifetimes are left raw here and resolved by the coalesceLifetimes
 	// post-pass, which needs the whole type to analyze lifetime occurrence (D4).
-	return coalesceNegation(t)
+	return foldNegation(t)
 }
 
 // displayBinder maps a binder var to its cleaned display copy when one exists, else

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -243,6 +243,22 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	// Borrow lifetimes are left raw here and resolved by the coalesceLifetimes
 	// post-pass, which needs the whole type to analyze lifetime occurrence (D4).
+	return coalesceNegation(t)
+}
+
+// coalesceNegation re-mints a complement through newNegation once its operand has
+// been coalesced, and returns every other node unchanged. Both coalescers call it
+// from ExitType, which fires bottom-up, so the operand it reads is the coalesced
+// one rather than the bound as stored.
+//
+// The re-mint is what keeps a complement over an empty variable readable. A var
+// with the single upper bound `¬β` and a β with no lower bounds inlines β to
+// `never`, and the bare rebuild would render the meaningless `¬never` where the
+// bound really says unknown.
+func coalesceNegation(t soltype.Type) soltype.Type {
+	if n, ok := t.(*soltype.NegationType); ok {
+		return newNegation(n.Inner)
+	}
 	return t
 }
 
@@ -552,7 +568,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 func (c *schemeCoalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	// Borrow lifetimes are left raw here and resolved by the coalesceLifetimes
 	// post-pass, which needs the whole type to analyze lifetime occurrence (D4).
-	return t
+	return coalesceNegation(t)
 }
 
 // displayBinder maps a binder var to its cleaned display copy when one exists, else

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -252,15 +252,15 @@ func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type 
 // rather than the bound as stored. subsumeFinal calls it for the same reason, since
 // its own rewrites can turn an operand into a lattice bound.
 //
-// The re-mint is what keeps a complement over an empty variable readable. A var with
-// the single upper bound `¬β` and a β with no lower bounds inlines β to `never`, and
-// the bare rebuild would render the meaningless `¬never` where the bound really says
-// unknown.
+// The re-mint is what keeps a complement over an empty variable readable. Take a var
+// whose single upper bound is `¬β`, over a β with no lower bounds. Coalescing inlines
+// β to `never`, so the bare rebuild would render the meaningless `¬never` where the
+// bound really says `unknown`.
 //
-// A complement newNegation does not collapse is returned as the caller passed it, so
-// the walk keeps the node it already has and no ancestor is rebuilt on its account.
-// newNegation wraps its operand in a fresh node whenever no collapse applies, so a
-// result still wrapping the SAME operand is what identifies that case.
+// A complement that newNegation does not collapse is returned as the caller passed
+// it, so the walk keeps the node it already has and no ancestor is rebuilt on its
+// account. newNegation wraps its operand in a fresh node whenever no collapse
+// applies, so a result still wrapping the SAME operand is what identifies that case.
 func foldNegation(t soltype.Type) soltype.Type {
 	n, isNeg := t.(*soltype.NegationType)
 	if !isNeg {

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -1082,3 +1082,85 @@ func TestBijectionRebindKeepsOneToOne(t *testing.T) {
 		})
 	}
 }
+
+// A complement on a variable's bounds survives coalescing and renders as `¬T`. The
+// operand is coalesced first, at the flipped polarity NegationType.Accept walks it
+// at, and the result is re-minted through newNegation so a complement over a
+// lattice bound reads as the bound it really names.
+func TestCoalesceNegatedBound(t *testing.T) {
+	tests := []struct {
+		name string
+		// build returns the variable to coalesce, given the Context that mints it.
+		build func(c *Context) *soltype.TypeVarType
+		pol   soltype.Polarity
+		want  string
+	}{
+		{
+			// The plain case: a negated upper bound renders as written.
+			name: "negated upper bound",
+			build: func(c *Context) *soltype.TypeVarType {
+				a := c.freshVar(0)
+				a.UpperBounds = []soltype.Type{&soltype.NegationType{Inner: str()}}
+				return a
+			},
+			pol:  soltype.Negative,
+			want: "¬string",
+		},
+		{
+			// The operand is a variable, so it coalesces before the complement is
+			// re-minted. Its own lower bound is what the complement excludes.
+			name: "operand coalesces to its bound",
+			build: func(c *Context) *soltype.TypeVarType {
+				inner := c.freshVar(0)
+				inner.LowerBounds = []soltype.Type{str()}
+				a := c.freshVar(0)
+				a.UpperBounds = []soltype.Type{&soltype.NegationType{Inner: inner}}
+				return a
+			},
+			pol:  soltype.Negative,
+			want: "¬string",
+		},
+		{
+			// An operand with no lower bounds coalesces to `never`, and the complement
+			// of `never` is unknown. The re-mint is what keeps `¬never` off the display.
+			name: "operand with no bounds",
+			build: func(c *Context) *soltype.TypeVarType {
+				a := c.freshVar(0)
+				a.UpperBounds = []soltype.Type{&soltype.NegationType{Inner: c.freshVar(0)}}
+				return a
+			},
+			pol:  soltype.Negative,
+			want: "unknown",
+		},
+		{
+			// Complementing twice returns the operand, which the bottom-up ExitType
+			// walk folds one level at a time.
+			name: "double complement",
+			build: func(c *Context) *soltype.TypeVarType {
+				a := c.freshVar(0)
+				a.UpperBounds = []soltype.Type{&soltype.NegationType{Inner: &soltype.NegationType{Inner: str()}}}
+				return a
+			},
+			pol:  soltype.Negative,
+			want: "string",
+		},
+		{
+			// A complement nested in a structural position is re-minted like a
+			// top-level one, since every rewriter rides on the same walk.
+			name: "complement inside an object property",
+			build: func(c *Context) *soltype.TypeVarType {
+				a := c.freshVar(0)
+				a.UpperBounds = []soltype.Type{exactObj(propElem("x", &soltype.NegationType{Inner: str()}))}
+				return a
+			},
+			pol:  soltype.Negative,
+			want: "{x: ¬string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, soltype.Print(coalesce(tt.build(c), tt.pol)))
+		})
+	}
+}

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -1037,9 +1037,15 @@ func TestInferNestedLeafAnnotations(t *testing.T) {
 
 // Binding-based narrowing keeps a chained guard's display clean. Escalier rebinds on
 // refinement rather than re-typing the scrutinee, so each guard computes a fresh binding
-// whose type is simplified and frozen at that site. A later guard starts from that clean
-// base rather than accumulating one complement per level on a single long-lived variable,
-// which is what would leave a deeply nested guard displaying a pile of negated members.
+// whose type is frozen at that site and a later guard starts from that clean base.
+//
+// NO COMPLEMENT ARISES ALONG THE WAY. Narrowing drops the union members a guard's
+// annotation cannot admit, so the chain below reaches `boolean` as a plain member list and
+// the negation simplifier in simplify.go is never reached. A solver that re-typed one
+// long-lived variable would instead accumulate `& ¬string & ¬number` on it and need that
+// simplifier to read `boolean` back out. These cases pin that the accumulating form never
+// arises, which is what keeps the simplifier's input small when a complement does show up
+// from somewhere else.
 //
 // Each case returns the binding a guard introduced, so the function's return type IS that
 // binding's rendered type. A diverging `else` supplies the other path, and its string
@@ -1059,8 +1065,8 @@ func TestInferChainedGuardsRenderSimplifiedBindings(t *testing.T) {
 			want: "fn (u: number | string | boolean) -> number",
 		},
 		// The first guard's binding is a two-member union, and the second narrows THAT
-		// rather than the scrutinee. Both levels render as plain unions.
-		"TwoGuards": {
+		// rather than the scrutinee. Both levels render as plain member lists.
+		"TwoGuardsEndingAtOneMember": {
 			src: `fn f(u: number | string | boolean) {
 					val x: number | string = u else { return "no value" }
 					val y: string = x else { return "not a string" }
@@ -1068,10 +1074,11 @@ func TestInferChainedGuardsRenderSimplifiedBindings(t *testing.T) {
 				}`,
 			want: "fn (u: number | string | boolean) -> string",
 		},
-		// A third level, which unsimplified would read
-		// `(string | number | boolean) ∩ ¬string ∩ ¬number`. Each level narrows the
-		// previous binding, so the last one renders as the single member left.
-		"ThreeGuards": {
+		// Two guards that between them exclude two of the three members. This is the
+		// chain a flow-narrowing solver would render as
+		// `(number | string | boolean) & ¬string & ¬number`; here the first guard binds
+		// `number | boolean` and the second binds `boolean`, with no complement built.
+		"TwoGuardsReachingTheThirdMember": {
 			src: `fn f(u: number | string | boolean) {
 					val x: number | boolean = u else { return true }
 					val y: boolean = x else { return false }

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -1039,7 +1039,7 @@ func TestInferNestedLeafAnnotations(t *testing.T) {
 // refinement rather than re-typing the scrutinee, so each guard computes a fresh binding
 // whose type is simplified and frozen at that site. A later guard starts from that clean
 // base rather than accumulating one complement per level on a single long-lived variable,
-// which is the readability problem the MLstruct plan's caveat 2 names.
+// which is what would leave a deeply nested guard displaying a pile of negated members.
 //
 // Each case returns the binding a guard introduced, so the function's return type IS that
 // binding's rendered type. A diverging `else` supplies the other path, and its string
@@ -1068,7 +1068,7 @@ func TestInferChainedGuardsRenderSimplifiedBindings(t *testing.T) {
 				}`,
 			want: "fn (u: number | string | boolean) -> string",
 		},
-		// A third level is the chain caveat 2 works through, written unsimplified as
+		// A third level, which unsimplified would read
 		// `(string | number | boolean) ∩ ¬string ∩ ¬number`. Each level narrows the
 		// previous binding, so the last one renders as the single member left.
 		"ThreeGuards": {

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -1034,3 +1034,68 @@ func TestInferNestedLeafAnnotations(t *testing.T) {
 		})
 	}
 }
+
+// Binding-based narrowing keeps a chained guard's display clean. Escalier rebinds on
+// refinement rather than re-typing the scrutinee, so each guard computes a fresh binding
+// whose type is simplified and frozen at that site. A later guard starts from that clean
+// base rather than accumulating one complement per level on a single long-lived variable,
+// which is the readability problem the MLstruct plan's caveat 2 names.
+//
+// Each case returns the binding a guard introduced, so the function's return type IS that
+// binding's rendered type. A diverging `else` supplies the other path, and its string
+// fallbacks are subsumed into `string` at finalization.
+func TestInferChainedGuardsRenderSimplifiedBindings(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		// One guard over a three-member union binds exactly the member its annotation
+		// admits, with no residual complement over the two it excluded.
+		"OneGuard": {
+			src: `fn f(u: number | string | boolean) {
+					val x: number = u else { return 0 }
+					return x
+				}`,
+			want: "fn (u: number | string | boolean) -> number",
+		},
+		// The first guard's binding is a two-member union, and the second narrows THAT
+		// rather than the scrutinee. Both levels render as plain unions.
+		"TwoGuards": {
+			src: `fn f(u: number | string | boolean) {
+					val x: number | string = u else { return "no value" }
+					val y: string = x else { return "not a string" }
+					return y
+				}`,
+			want: "fn (u: number | string | boolean) -> string",
+		},
+		// A third level is the chain caveat 2 works through, `(string | number | boolean)
+		// ∩ ¬string ∩ ¬number`. Each level narrows the previous binding, so the last one
+		// renders as the single member left.
+		"ThreeGuards": {
+			src: `fn f(u: number | string | boolean) {
+					val x: number | boolean = u else { return true }
+					val y: boolean = x else { return false }
+					return y
+				}`,
+			want: "fn (u: number | string | boolean) -> boolean",
+		},
+		// Narrowing binds a fresh name and never re-types the scrutinee, so `u` still
+		// reads at its declared union after two guards have run.
+		"ScrutineeKeepsItsDeclaredType": {
+			src: `fn f(u: number | string | boolean) {
+					val x: number | string = u else { return u }
+					val y: string = x else { return u }
+					return u
+				}`,
+			want: "fn (u: number | string | boolean) -> number | string | boolean",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -1068,9 +1068,9 @@ func TestInferChainedGuardsRenderSimplifiedBindings(t *testing.T) {
 				}`,
 			want: "fn (u: number | string | boolean) -> string",
 		},
-		// A third level is the chain caveat 2 works through, `(string | number | boolean)
-		// ∩ ¬string ∩ ¬number`. Each level narrows the previous binding, so the last one
-		// renders as the single member left.
+		// A third level is the chain caveat 2 works through, written unsimplified as
+		// `(string | number | boolean) ∩ ¬string ∩ ¬number`. Each level narrows the
+		// previous binding, so the last one renders as the single member left.
 		"ThreeGuards": {
 			src: `fn f(u: number | string | boolean) {
 					val x: number | boolean = u else { return true }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -56,13 +56,14 @@ func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 	return collapseIntersection(pruned, hadError)
 }
 
-// newNegation is the complement twin of newUnion and newIntersection: the single
-// mint path for a NegationType in coalesced output. It collapses the three
-// operands whose complement the surface type set already spells, and wraps
-// everything else.
+// newNegation is the complement twin of newUnion and newIntersection, the single
+// mint path for a NegationType in coalesced output. Three operands have a
+// complement the surface type set already names. It returns that name for them and
+// wraps everything else.
 //
-//   - `¬never` is unknown, since never admits no value and unknown admits every one.
-//   - `¬unknown` is never, the same identity read the other way.
+//   - `¬never` is `unknown`, since `never` admits no value and `unknown` admits
+//     every one.
+//   - `¬unknown` is `never`, the same identity read the other way.
 //   - `¬¬T` is T, since complementing twice returns the original set.
 //
 // It does NOT push the complement through a union or an intersection. `¬(A | B)`
@@ -327,8 +328,8 @@ func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, 
 
 // subtypeHolds reports whether sub <: super, decided speculatively so the answer
 // costs no bound. The trial runs under a discard-only probe, so a variable the
-// decision reached keeps the bounds it had. Every display-time pass that has to
-// weigh one type against another asks through here.
+// decision reached keeps the bounds it had. Every display-time pass that compares
+// one type against another asks through here.
 func subtypeHolds(c *Context, sub, super soltype.Type) bool {
 	return !hasHardError(c.trialUnderProbe(sub, super))
 }
@@ -361,8 +362,8 @@ func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
 // `number`; an inferred `{x, ...} & {x, y, ...}` becomes `{x, y, ...}`.
 //
 // It is also where the disjointness-aware negation simplification runs, so an
-// intersection carrying a complement is collapsed before subsumption weighs what is
-// left. See simplify.go.
+// intersection carrying a complement is collapsed before subsumption runs over what
+// is left. See simplify.go.
 func (c *checker) subsumeFinal(t soltype.Type) soltype.Type {
 	return t.Accept(&finalSubsumer{ctx: c.ctx}, soltype.Positive)
 }
@@ -404,7 +405,7 @@ func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.T
 	case *soltype.NegationType:
 		// The operand was already rewritten by this walk, so a complement whose
 		// operand collapsed to a lattice bound is folded here rather than left as the
-		// meaningless `¬never`. `¬(string & ¬string)` reads unknown.
+		// meaningless `¬never`. `¬(string & ¬string)` reads `unknown`.
 		return foldNegation(t)
 	}
 	return t

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -401,6 +401,11 @@ func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.T
 			return t
 		}
 		return collapseIntersection(kept, false)
+	case *soltype.NegationType:
+		// The operand was already rewritten by this walk, so a complement whose
+		// operand collapsed to a lattice bound is folded here rather than left as the
+		// meaningless `¬never`. `¬(string & ¬string)` reads unknown.
+		return foldNegation(t)
 	}
 	return t
 }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -56,6 +56,34 @@ func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 	return collapseIntersection(pruned, hadError)
 }
 
+// newNegation is the complement twin of newUnion and newIntersection: the single
+// mint path for a NegationType in coalesced output. It collapses the three
+// operands whose complement the surface type set already spells, and wraps
+// everything else.
+//
+//   - `¬never` is unknown, since never admits no value and unknown admits every one.
+//   - `¬unknown` is never, the same identity read the other way.
+//   - `¬¬T` is T, since complementing twice returns the original set.
+//
+// It does NOT push the complement through a union or an intersection. `¬(A | B)`
+// is a faithful render of what the bound says, and De Morgan's law would only
+// trade one node for two.
+//
+// normal.go's negate is the solver-internal twin. That one wraps unconditionally,
+// because the parts it negates are already known to be neither lattice bound nor
+// complement.
+func newNegation(inner soltype.Type) soltype.Type {
+	switch inner := inner.(type) {
+	case *soltype.NeverType:
+		return &soltype.UnknownType{}
+	case *soltype.UnknownType:
+		return &soltype.NeverType{}
+	case *soltype.NegationType:
+		return inner.Inner
+	}
+	return &soltype.NegationType{Inner: inner}
+}
+
 // flattenUnion splices nested UnionType members into the outer member list
 // and carries an inner inexact flag out to the caller. The splice is
 // recursive, so a UnionType whose members include another UnionType is fully
@@ -268,7 +296,7 @@ func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, 
 	// variable, so it is skipped by the concrete gate below.
 	hasVar := make([]bool, len(parts))
 	for i, p := range parts {
-		hasVar[i] = soltype.HasTypeVar(p) || soltype.HasLifetimeVar(p)
+		hasVar[i] = !concreteMember(p)
 	}
 	dropped := set.NewSet[int]()
 	for i, a := range parts {
@@ -297,10 +325,26 @@ func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, 
 	return out
 }
 
+// subtypeHolds reports whether sub <: super, decided speculatively so the answer
+// costs no bound. The trial runs under a discard-only probe, so a variable the
+// decision reached keeps the bounds it had. Every display-time pass that has to
+// weigh one type against another asks through here.
+func subtypeHolds(c *Context, sub, super soltype.Type) bool {
+	return !hasHardError(c.trialUnderProbe(sub, super))
+}
+
+// concreteMember reports whether t carries no free type or lifetime variable. A
+// member failing it is left out of every speculative comparison, for the two
+// reasons subsumeMembers gives: trialling against an inference variable could pin
+// it, and two members differing only in a lifetime variable would compare equal.
+func concreteMember(t soltype.Type) bool {
+	return !soltype.HasTypeVar(t) && !soltype.HasLifetimeVar(t)
+}
+
 // unionDrops returns true when union member m should be dropped because the
 // sibling subsumes it. The check is m <: sibling.
 func unionDrops(c *Context, m, sibling soltype.Type) bool {
-	return !hasHardError(c.trialUnderProbe(m, sibling))
+	return subtypeHolds(c, m, sibling)
 }
 
 // intersectionDrops returns true when intersection member m should be
@@ -308,13 +352,17 @@ func unionDrops(c *Context, m, sibling soltype.Type) bool {
 // <: m. The sibling is narrower, so it already implies m, and m is the wider
 // one to discard.
 func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
-	return !hasHardError(c.trialUnderProbe(sibling, m))
+	return subtypeHolds(c, sibling, m)
 }
 
 // subsumeFinal re-mints every UnionType and IntersectionType node in a finalized
 // display type through newUnion / newIntersection with the ambient Context, so a
 // member a concrete sibling subsumes is dropped. An inferred `1 | number` becomes
 // `number`; an inferred `{x, ...} & {x, y, ...}` becomes `{x, y, ...}`.
+//
+// It is also where the disjointness-aware negation simplification runs, so an
+// intersection carrying a complement is collapsed before subsumption weighs what is
+// left. See simplify.go.
 func (c *checker) subsumeFinal(t soltype.Type) soltype.Type {
 	return t.Accept(&finalSubsumer{ctx: c.ctx}, soltype.Positive)
 }
@@ -344,8 +392,12 @@ func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.T
 		}
 		return collapseUnion(kept, t.Inexact, false)
 	case *soltype.IntersectionType:
-		kept := subsumeMembers(s.ctx, t.Types, intersectionDrops)
-		if len(kept) == len(t.Types) {
+		members, changed, uninhabited := simplifyNegations(s.ctx, t.Types)
+		if uninhabited {
+			return &soltype.NeverType{}
+		}
+		kept := subsumeMembers(s.ctx, members, intersectionDrops)
+		if !changed && len(kept) == len(t.Types) {
 			return t
 		}
 		return collapseIntersection(kept, false)

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -64,6 +64,9 @@ func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 //   - `¬never` is `unknown`, since `never` admits no value and `unknown` admits
 //     every one.
 //   - `¬unknown` is `never`, the same identity read the other way.
+//   - `¬(A | B | ...)` is `never`. An inexact union is the top of the subtype
+//     lattice, since its open tail accepts every value, so its complement admits
+//     none. TestOpenUnionIsTopForSubtypingOnly pins that reading.
 //   - `¬¬T` is T, since complementing twice returns the original set.
 //
 // It does NOT push the complement through a union or an intersection. `¬(A | B)`
@@ -79,6 +82,10 @@ func newNegation(inner soltype.Type) soltype.Type {
 		return &soltype.UnknownType{}
 	case *soltype.UnknownType:
 		return &soltype.NeverType{}
+	case *soltype.UnionType:
+		if inner.Inexact {
+			return &soltype.NeverType{}
+		}
 	case *soltype.NegationType:
 		return inner.Inner
 	}

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -393,8 +393,8 @@ func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.T
 		}
 		return collapseUnion(kept, t.Inexact, false)
 	case *soltype.IntersectionType:
-		members, changed, uninhabited := simplifyNegations(s.ctx, t.Types)
-		if uninhabited {
+		members, changed, provedEmpty := simplifyNegations(s.ctx, t.Types)
+		if provedEmpty {
 			return &soltype.NeverType{}
 		}
 		kept := subsumeMembers(s.ctx, members, intersectionDrops)

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -574,11 +574,25 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 // gate concreteMember states. Nothing proves an abstract operand disjoint from
 // anything, so the complement carries real information.
 //
-// An INEXACT union is refused because every type is a subtype of one. Constrain's
-// open-tail rule accepts anything against `A | ...`, since the tail names content the
-// union does not spell. Reading that as containment would let `¬(boolean | ...)`
-// exclude every arm it is met with, so `number & ¬(boolean | ...)` would collapse to
-// `never`. Deciding what an open tail excludes is left to the exactness-aware merge.
+// An INEXACT union is refused because what it denotes is unsettled, not because
+// collapsing it would contradict the solver. For the subtype relation `A | ...` is
+// already the top of the lattice. Constrain's open-tail rule accepts every type
+// against it, and it is below neither `number` nor `boolean`, matching `unknown` on
+// both counts. Under those rules `¬(A | ...)` is `never`, so
+// `number & ¬(boolean | ...)` really is empty and the collapse would be consistent.
+// TestOpenUnionIsTopForSubtypingOnly pins that reading.
+//
+// Two things make it the wrong call for this pass to act on. An open union is not
+// `unknown` everywhere. Reading a member off `{x: number} | {x: string} | ...` yields
+// `unknown`, where the same read off `unknown` is rejected outright, so the named
+// members carry meaning the subtype relation discards. And that relation is a
+// leniency in the accept-more direction, written so a value matching no named member
+// is still ACCEPTED. A display that collapsed to `never` would turn it around into a
+// claim that no such value can exist, which is a pass making a type look narrower
+// than the bound says.
+//
+// Whether an open union should be top at all is the exactness-aware merge's question
+// to settle. Until it does, this pass renders the complement as written.
 func usableOperand(n soltype.Type) bool {
 	return concreteMember(n) && !isInexactUnion(n)
 }

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -490,17 +490,20 @@ func simplifyScheme(body soltype.Type, genLevel int, keep set.Set[*soltype.TypeV
 //
 // provedEmpty reports that THIS PASS derived that no value satisfies the members, in
 // which case the returned list carries nothing. It is one-directional. A false says
-// the pass reached no such derivation, NOT that the meet has an inhabitant. Every
-// member the pass declines to weigh comes back false, and some of those really are
-// empty. `number & ¬(boolean | ...)` is one: constrain accepts every type against an
-// inexact union, so nothing satisfies its complement, yet usableOperand refuses that
-// operand and the pass reports false. Read the flag as "collapse this to `never`",
+// the pass reached no such derivation, NOT that the meet has an inhabitant. A meet
+// whose members the concreteness gate below keeps the pass away from comes back
+// false whether or not it is empty. Read the flag as "collapse this to `never`",
 // never as a claim about the type.
 //
 // A member carrying a free variable is left alone, on the concreteness gate
 // concreteMember states. That is what keeps `T & ¬Tag` over an abstract T intact:
 // nothing proves T disjoint from Tag, so the complement is real information and
 // stays on the rendered type.
+//
+// An INEXACT operand is weighed like any other. `A | B | ...` is the top of the
+// subtype lattice, so nothing satisfies `¬(A | B | ...)` and a meet carrying one is
+// empty. `number & ¬(boolean | string | ...)` collapses to `never` on that reading.
+// TestOpenUnionIsTopForSubtypingOnly pins it.
 func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type, changed, provedEmpty bool) {
 	out := slices.Clone(members)
 	// negIdx holds the position of each complement both rewrites can act on, and
@@ -508,7 +511,7 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 	var posIdx, negIdx []int
 	for i, m := range out {
 		if n, isNeg := m.(*soltype.NegationType); isNeg {
-			if usableOperand(n.Inner) {
+			if concreteMember(n.Inner) {
 				negIdx = append(negIdx, i)
 			}
 			continue
@@ -565,36 +568,6 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 		}
 	}
 	return kept, true, false
-}
-
-// usableOperand reports whether a complement's operand is one both rewrites can act
-// on. Two shapes are refused.
-//
-// A free type or lifetime variable makes the operand abstract, on the concreteness
-// gate concreteMember states. Nothing proves an abstract operand disjoint from
-// anything, so the complement carries real information.
-//
-// An INEXACT union is refused because what it denotes is unsettled, not because
-// collapsing it would contradict the solver. For the subtype relation `A | ...` is
-// already the top of the lattice. Constrain's open-tail rule accepts every type
-// against it, and it is below neither `number` nor `boolean`, matching `unknown` on
-// both counts. Under those rules `¬(A | ...)` is `never`, so
-// `number & ¬(boolean | ...)` really is empty and the collapse would be consistent.
-// TestOpenUnionIsTopForSubtypingOnly pins that reading.
-//
-// Two things make it the wrong call for this pass to act on. An open union is not
-// `unknown` everywhere. Reading a member off `{x: number} | {x: string} | ...` yields
-// `unknown`, where the same read off `unknown` is rejected outright, so the named
-// members carry meaning the subtype relation discards. And that relation is a
-// leniency in the accept-more direction, written so a value matching no named member
-// is still ACCEPTED. A display that collapsed to `never` would turn it around into a
-// claim that no such value can exist, which is a pass making a type look narrower
-// than the bound says.
-//
-// Whether an open union should be top at all is the exactness-aware merge's question
-// to settle. Until it does, this pass renders the complement as written.
-func usableOperand(n soltype.Type) bool {
-	return concreteMember(n) && !isInexactUnion(n)
 }
 
 // excludeArms returns p with every part that ¬n rules out removed, and reports

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -496,10 +496,14 @@ func simplifyScheme(body soltype.Type, genLevel int, keep set.Set[*soltype.TypeV
 // stays on the rendered type.
 func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type, changed, uninhabited bool) {
 	out := slices.Clone(members)
+	// negIdx holds the position of each complement both rewrites can act on, and
+	// posIdx the position of every other member.
 	var posIdx, negIdx []int
 	for i, m := range out {
-		if _, isNeg := m.(*soltype.NegationType); isNeg {
-			negIdx = append(negIdx, i)
+		if n, isNeg := m.(*soltype.NegationType); isNeg {
+			if usableOperand(n.Inner) {
+				negIdx = append(negIdx, i)
+			}
 			continue
 		}
 		posIdx = append(posIdx, i)
@@ -515,9 +519,6 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 	// left and `(string | number | boolean) & ¬string & ¬number` reaches `boolean`.
 	for _, ni := range negIdx {
 		n := out[ni].(*soltype.NegationType).Inner
-		if !concreteMember(n) {
-			continue
-		}
 		for _, pi := range posIdx {
 			narrowed, dropped := excludeArms(c, out[pi], n)
 			if !dropped {
@@ -543,7 +544,7 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 	}
 	redundant := set.NewSet[int]()
 	for _, ni := range negIdx {
-		if concreteMember(out[ni]) && subtypeHolds(c, meet, out[ni]) {
+		if subtypeHolds(c, meet, out[ni]) {
 			redundant.Add(ni)
 		}
 	}
@@ -559,13 +560,29 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 	return kept, true, false
 }
 
+// usableOperand reports whether a complement's operand is one both rewrites can
+// weigh. Two shapes are refused.
+//
+// A free type or lifetime variable makes the operand abstract, on the concreteness
+// gate concreteMember states. Nothing proves an abstract operand disjoint from
+// anything, so the complement carries real information.
+//
+// An INEXACT union is refused because every type is a subtype of one: constrain's
+// open-tail rule accepts anything against `A | ...`, since the tail names content
+// the union does not spell. Reading that as containment would let `¬(boolean | ...)`
+// exclude every arm it is met with, so `number & ¬(boolean | ...)` would collapse to
+// `never`. Deciding what an open tail excludes is left to the exactness-aware merge.
+func usableOperand(n soltype.Type) bool {
+	return concreteMember(n) && !isInexactUnion(n)
+}
+
 // excludeArms returns p with every part that ¬n rules out removed, and reports
 // whether anything was removed. A union loses each arm that is a subtype of n,
 // since meeting such an arm with ¬n leaves no value. A non-union p that is itself a
 // subtype of n leaves nothing at all, which excludeArms returns as `never`.
 //
-// An INEXACT union is left as written. Its open tail admits values no arm names, so
-// dropping an arm would render a type narrower than the tail still allows.
+// An INEXACT union in p is left as written. Its open tail admits values no arm
+// names, so dropping an arm would render a type narrower than the tail still allows.
 func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
 	u, isUnion := p.(*soltype.UnionType)
 	if !isUnion {

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -455,3 +455,139 @@ func simplifyScheme(body soltype.Type, genLevel int, keep set.Set[*soltype.TypeV
 	}
 	return &schemeSimplification{uf: uf, mergedOcc: mergedOcc, idToVar: vars}
 }
+
+// Disjointness-aware negation simplification. A complement enters a variable's
+// bounds when the solver moves a negated part across a `<:`, so `α <: ¬string`
+// stores `¬string` as an upper bound and coalescing renders it. The literal form
+// is faithful but unreadable. Narrowing a `string | number` against "not a string"
+// coalesces to `(string | number) & ¬string`, where the user means `number`.
+//
+// Two facts the solver already decides collapse that form, and both are asked
+// through subtypeHolds, which trials under a discarding probe:
+//
+//  1. An arm the complement rules out contributes nothing. `string & ¬string`
+//     admits no value, so the arm is dropped and `(string | number) & ¬string`
+//     becomes `number & ¬string`.
+//  2. A complement whose operand shares no value with what is left states nothing
+//     more. `number` and `string` are disjoint, so `number & ¬string` is `number`.
+//
+// Disjointness is decided by `T <: ¬U`, which the normal-form layer settles by
+// moving `U` back to the subtype side and finding `T ∩ U` uninhabited. That reads
+// the same class-tag and literal/primitive facts the meet of two atoms reads, so
+// this pass adds no disjointness knowledge of its own.
+//
+// It is a DISPLAY pass. It runs over an already-coalesced type inside subsumeFinal
+// and never inside constrain, so disabling it makes an inferred type uglier and
+// never changes what the solver accepts. Nothing here reads or writes a bound.
+//
+// Its input stays small because Escalier rebinds on refinement rather than
+// re-typing the scrutinee: each guard computes a fresh binding whose type is
+// simplified and frozen, so nested guards do not pile `& ¬A & ¬B` onto one
+// long-lived variable.
+
+// simplifyNegations applies the two rewrites above to one intersection's members.
+// changed reports whether any member was rewritten or dropped, and uninhabited
+// reports that the members admit no value at all, in which case the returned list
+// carries nothing.
+//
+// A member carrying a free variable is left alone, on the concreteness gate
+// concreteMember states. That is what keeps `T & ¬Tag` over an abstract T intact:
+// nothing proves T disjoint from Tag, so the complement is real information and
+// stays on the rendered type.
+func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type, changed, uninhabited bool) {
+	out := slices.Clone(members)
+	var posIdx, negIdx []int
+	for i, m := range out {
+		if _, isNeg := m.(*soltype.NegationType); isNeg {
+			negIdx = append(negIdx, i)
+			continue
+		}
+		posIdx = append(posIdx, i)
+	}
+	// A meet with no complement has nothing to simplify, and one with no positive
+	// part has nothing to simplify against.
+	if len(negIdx) == 0 || len(posIdx) == 0 {
+		return members, false, false
+	}
+
+	// Rewrite 1, over every (complement, positive member) pair. Each excluded arm
+	// is written back in place, so a later complement narrows what the earlier one
+	// left and `(string | number | boolean) & ¬string & ¬number` reaches `boolean`.
+	for _, ni := range negIdx {
+		n := out[ni].(*soltype.NegationType).Inner
+		if !concreteMember(n) {
+			continue
+		}
+		for _, pi := range posIdx {
+			narrowed, dropped := excludeArms(c, out[pi], n)
+			if !dropped {
+				continue
+			}
+			if _, isNever := narrowed.(*soltype.NeverType); isNever {
+				return nil, true, true
+			}
+			out[pi] = narrowed
+			changed = true
+		}
+	}
+
+	// Rewrite 2. The surviving positive members meet to one type, and a complement
+	// disjoint from that meet is dropped.
+	positives := make([]soltype.Type, 0, len(posIdx))
+	for _, pi := range posIdx {
+		positives = append(positives, out[pi])
+	}
+	meet := newIntersection(nil, positives)
+	if !concreteMember(meet) {
+		return out, changed, false
+	}
+	redundant := set.NewSet[int]()
+	for _, ni := range negIdx {
+		if concreteMember(out[ni]) && subtypeHolds(c, meet, out[ni]) {
+			redundant.Add(ni)
+		}
+	}
+	if redundant.Len() == 0 {
+		return out, changed, false
+	}
+	kept = make([]soltype.Type, 0, len(out)-redundant.Len())
+	for i, m := range out {
+		if !redundant.Contains(i) {
+			kept = append(kept, m)
+		}
+	}
+	return kept, true, false
+}
+
+// excludeArms returns p with every part that ¬n rules out removed, and reports
+// whether anything was removed. A union loses each arm that is a subtype of n,
+// since meeting such an arm with ¬n leaves no value. A non-union p that is itself a
+// subtype of n leaves nothing at all, which excludeArms returns as `never`.
+//
+// An INEXACT union is left as written. Its open tail admits values no arm names, so
+// dropping an arm would render a type narrower than the tail still allows.
+func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
+	u, isUnion := p.(*soltype.UnionType)
+	if !isUnion {
+		if concreteMember(p) && subtypeHolds(c, p, n) {
+			return &soltype.NeverType{}, true
+		}
+		return p, false
+	}
+	if u.Inexact {
+		return p, false
+	}
+	arms := make([]soltype.Type, 0, len(u.Types))
+	for _, arm := range u.Types {
+		if concreteMember(arm) && subtypeHolds(c, arm, n) {
+			continue
+		}
+		arms = append(arms, arm)
+	}
+	if len(arms) == len(u.Types) {
+		return p, false
+	}
+	// collapseUnion returns `never` for an empty arm list, which is the caller's
+	// signal that the whole meet is uninhabited.
+	return collapseUnion(arms, u.Inexact, false), true
+}

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -486,15 +486,22 @@ func simplifyScheme(body soltype.Type, genLevel int, keep set.Set[*soltype.TypeV
 // one long-lived variable.
 
 // simplifyNegations applies the two rewrites above to one intersection's members.
-// changed reports whether any member was rewritten or dropped, and uninhabited
-// reports that the members admit no value at all, in which case the returned list
-// carries nothing.
+// changed reports whether any member was rewritten or dropped.
+//
+// provedEmpty reports that THIS PASS derived that no value satisfies the members, in
+// which case the returned list carries nothing. It is one-directional. A false says
+// the pass reached no such derivation, NOT that the meet has an inhabitant. Every
+// member the pass declines to weigh comes back false, and some of those really are
+// empty. `number & ¬(boolean | ...)` is one: constrain accepts every type against an
+// inexact union, so nothing satisfies its complement, yet usableOperand refuses that
+// operand and the pass reports false. Read the flag as "collapse this to `never`",
+// never as a claim about the type.
 //
 // A member carrying a free variable is left alone, on the concreteness gate
 // concreteMember states. That is what keeps `T & ¬Tag` over an abstract T intact:
 // nothing proves T disjoint from Tag, so the complement is real information and
 // stays on the rendered type.
-func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type, changed, uninhabited bool) {
+func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type, changed, provedEmpty bool) {
 	out := slices.Clone(members)
 	// negIdx holds the position of each complement both rewrites can act on, and
 	// posIdx the position of every other member.

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -466,10 +466,17 @@ func simplifyScheme(body soltype.Type, genLevel int, keep set.Set[*soltype.TypeV
 //
 // The normal-form layer's move-across-`<:` rewrite does the opposite, which is worth
 // knowing when tracking down where a complement came from. It turns a negated part
-// into a positive one on the far side, so the goal below leaves α with a positive
-// bound and no complement at all:
+// into a positive one on the far side:
 //
-//	α ∩ ¬string <: number   ⟹   α <: number | string   ⟹   α.UpperBounds = [number]
+//	α ∩ ¬string <: number   ⟹   α <: number | string
+//
+// α ends up with ONE positive upper bound there, never a complement and never both
+// members. A variable's upper bounds are read as a meet, so recording both would say
+// `α <: number & string` and reject what the goal allows. A union in supertype
+// position is an exists rule, so the layer trials `α <: number` and `α <: string` and
+// keeps the first that holds. Which one that is depends on α's other bounds. An
+// unconstrained α commits `number`, while an α carrying the lower bound `"hi"` fails
+// that trial and commits `string`.
 //
 // TestNegatedBoundReachesAVariable pins both. The literal stored form is faithful but
 // unreadable. Narrowing a `string | number` against "not a string" coalesces to

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -456,11 +456,24 @@ func simplifyScheme(body soltype.Type, genLevel int, keep set.Set[*soltype.TypeV
 	return &schemeSimplification{uf: uf, mergedOcc: mergedOcc, idToVar: vars}
 }
 
-// Disjointness-aware negation simplification. A complement enters a variable's
-// bounds when the solver moves a negated part across a `<:`, so `α <: ¬string`
-// stores `¬string` as an upper bound and coalescing renders it. The literal form
-// is faithful but unreadable. Narrowing a `string | number` against "not a string"
-// coalesces to `(string | number) & ¬string`, where the user means `number`.
+// Disjointness-aware negation simplification. A complement reaches a variable's
+// bounds when the variable stands on the subtype side of one. Constrain routes a goal
+// to the normal-form layer only when NEITHER operand is a variable, so a variable
+// operand falls through to the ordinary variable arm and the complement is stored
+// whole:
+//
+//	α <: ¬string        ⟹   α.UpperBounds = [¬string]
+//
+// The normal-form layer's move-across-`<:` rewrite does the opposite, which is worth
+// knowing when tracking down where a complement came from. It turns a negated part
+// into a positive one on the far side, so the goal below leaves α with a positive
+// bound and no complement at all:
+//
+//	α ∩ ¬string <: number   ⟹   α <: number | string   ⟹   α.UpperBounds = [number]
+//
+// TestNegatedBoundReachesAVariable pins both. The literal stored form is faithful but
+// unreadable. Narrowing a `string | number` against "not a string" coalesces to
+// `(string | number) & ¬string`, where the user means `number`.
 //
 // Two facts the solver already decides collapse that form, and both are asked
 // through subtypeHolds, which trials under a discarding probe:

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -488,22 +488,15 @@ func simplifyScheme(body soltype.Type, genLevel int, keep set.Set[*soltype.TypeV
 // simplifyNegations applies the two rewrites above to one intersection's members.
 // changed reports whether any member was rewritten or dropped.
 //
-// provedEmpty reports that THIS PASS derived that no value satisfies the members, in
-// which case the returned list carries nothing. It is one-directional. A false says
-// the pass reached no such derivation, NOT that the meet has an inhabitant. A meet
-// whose members the concreteness gate below keeps the pass away from comes back
-// false whether or not it is empty. Read the flag as "collapse this to `never`",
-// never as a claim about the type.
+// provedEmpty is one-directional. True means the pass derived that no value satisfies
+// the members, and the returned list is then empty. False is not a claim that the meet
+// has an inhabitant, only that the pass derived nothing. Read it as "collapse this to
+// `never`".
 //
-// A member carrying a free variable is left alone, on the concreteness gate
-// concreteMember states. That is what keeps `T & ¬Tag` over an abstract T intact:
-// nothing proves T disjoint from Tag, so the complement is real information and
-// stays on the rendered type.
-//
-// An INEXACT operand is weighed like any other. `A | B | ...` is the top of the
-// subtype lattice, so nothing satisfies `¬(A | B | ...)` and a meet carrying one is
-// empty. `number & ¬(boolean | string | ...)` collapses to `never` on that reading.
-// TestOpenUnionIsTopForSubtypingOnly pins it.
+// A member carrying a free variable is left alone, on concreteMember's gate. That is
+// what keeps `T & ¬Tag` over an abstract T intact. An inexact operand is weighed like
+// any other, since `A | B | ...` is top and nothing satisfies its complement.
+// TestOpenUnionIsTopForSubtypingOnly pins that reading.
 func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type, changed, provedEmpty bool) {
 	out := slices.Clone(members)
 	// negIdx holds the position of each complement both rewrites can act on, and
@@ -575,8 +568,8 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 // since meeting such an arm with ¬n leaves no value. A non-union p that is itself a
 // subtype of n leaves nothing at all, which excludeArms returns as `never`.
 //
-// An INEXACT union in p is left as written. Its open tail admits values no arm
-// names, so dropping an arm would render a type narrower than the tail still allows.
+// An INEXACT union in p is left as written. It is top, so none of its arms bounds the
+// type and dropping one would discard a named member for no gain.
 func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
 	u, isUnion := p.(*soltype.UnionType)
 	if !isUnion {

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -481,9 +481,9 @@ func simplifyScheme(body soltype.Type, genLevel int, keep set.Set[*soltype.TypeV
 // never changes what the solver accepts. Nothing here reads or writes a bound.
 //
 // Its input stays small because Escalier rebinds on refinement rather than
-// re-typing the scrutinee: each guard computes a fresh binding whose type is
-// simplified and frozen, so nested guards do not pile `& ¬A & ¬B` onto one
-// long-lived variable.
+// re-typing the scrutinee. Each guard computes a fresh binding whose type is
+// simplified and frozen at that site, so nested guards do not pile `& ¬A & ¬B` onto
+// one long-lived variable.
 
 // simplifyNegations applies the two rewrites above to one intersection's members.
 // changed reports whether any member was rewritten or dropped, and uninhabited
@@ -560,16 +560,16 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 	return kept, true, false
 }
 
-// usableOperand reports whether a complement's operand is one both rewrites can
-// weigh. Two shapes are refused.
+// usableOperand reports whether a complement's operand is one both rewrites can act
+// on. Two shapes are refused.
 //
 // A free type or lifetime variable makes the operand abstract, on the concreteness
 // gate concreteMember states. Nothing proves an abstract operand disjoint from
 // anything, so the complement carries real information.
 //
-// An INEXACT union is refused because every type is a subtype of one: constrain's
-// open-tail rule accepts anything against `A | ...`, since the tail names content
-// the union does not spell. Reading that as containment would let `¬(boolean | ...)`
+// An INEXACT union is refused because every type is a subtype of one. Constrain's
+// open-tail rule accepts anything against `A | ...`, since the tail names content the
+// union does not spell. Reading that as containment would let `¬(boolean | ...)`
 // exclude every arm it is met with, so `number & ¬(boolean | ...)` would collapse to
 // `never`. Deciding what an open tail excludes is left to the exactness-aware merge.
 func usableOperand(n soltype.Type) bool {

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -231,3 +231,61 @@ func TestNewNegation(t *testing.T) {
 		})
 	}
 }
+
+// An inexact union is the top of the lattice for the subtype relation and nothing more.
+// usableOperand's refusal of such an operand rests on both halves of that, so both are
+// pinned here rather than left to a comment.
+//
+// The first half is the reason the collapse this pass declines would be CONSISTENT: if
+// `boolean | ...` accepts every value then nothing satisfies `¬(boolean | ...)`, and
+// `number & ¬(boolean | ...)` is empty. The second half is the reason it is still the
+// wrong call: an open union's named members survive a property read, so the type carries
+// meaning the subtype relation throws away, and reading that relation as a statement about
+// which values inhabit the type overcommits.
+//
+// Whether an open union should be top at all is the exactness-aware merge's question. This
+// test states the behavior as it stands, so a change to it is visible rather than silent.
+func TestOpenUnionIsTopForSubtypingOnly(t *testing.T) {
+	c := newChecker()
+	open := newUnion(nil, []soltype.Type{boolT()}, true) // boolean | ...
+	unknownT := func() soltype.Type { return &soltype.UnknownType{} }
+
+	// For subtyping the two are interchangeable in both directions.
+	t.Run("indistinguishable from unknown", func(t *testing.T) {
+		probes := []struct {
+			name     string
+			sub, sup soltype.Type
+			want     bool
+		}{
+			{"every type is below an open union", num(), open, true},
+			{"every type is below unknown", num(), unknownT(), true},
+			{"an open union is not below a primitive", open, num(), false},
+			{"unknown is not below a primitive", unknownT(), num(), false},
+			{"an open union is not below its own member", open, boolT(), false},
+			{"unknown is not below boolean", unknownT(), boolT(), false},
+			{"unknown is below an open union", unknownT(), open, true},
+			{"an open union is below unknown", open, unknownT(), true},
+		}
+		for _, p := range probes {
+			require.Equal(t, p.want, subtypeHolds(c.ctx, p.sub, p.sup), p.name)
+		}
+	})
+
+	// Nothing inhabits the complement of a type every value is below, which is what makes
+	// the refused collapse consistent with the rules above.
+	t.Run("nothing is below an open union's complement", func(t *testing.T) {
+		require.False(t, subtypeHolds(c.ctx, num(), negT(open)))
+		require.False(t, subtypeHolds(c.ctx, numLit(5), negT(open)))
+	})
+
+	// A property read is where the two part ways. The open union answers from its named
+	// members, widened by the tail; unknown has no members to answer from at all.
+	t.Run("a property read tells them apart", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f(u: {x: number} | {x: string} | ...) { return u.x }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn (u: {x: number} | {x: string} | ...) -> unknown", values["f"])
+
+		_, _, errs = inferSource(t, `fn g(u: unknown) { return u.x }`)
+		require.Equal(t, []string{"1:27-1:30: cannot constrain unknown <: object"}, messagesWithSpan(errs))
+	})
+}

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -1,0 +1,180 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- MLstruct PR6: the disjointness-aware negation simplifier ---
+
+// negT wraps a type in a complement without the newNegation collapses, so a test can
+// hand the simplifier the literal form a bound carries.
+func negT(inner soltype.Type) soltype.Type { return &soltype.NegationType{Inner: inner} }
+
+// unionT and interT mint the two lattice nodes the way coalesced output does, with no
+// Context, so the input to the simplifier is normalized exactly as coalescing leaves it.
+func unionT(parts ...soltype.Type) soltype.Type { return newUnion(nil, parts, false) }
+func interT(parts ...soltype.Type) soltype.Type { return newIntersection(nil, parts) }
+
+// A complement in a coalesced intersection collapses against the disjointness facts the
+// solver already decides. Each case is the type a bound carrying a negation coalesces to,
+// finalized through subsumeFinal, which is where the pass runs.
+func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
+	tests := []struct {
+		name string
+		// build returns the coalesced intersection, given a checker whose Context the
+		// case may seed with class declarations.
+		build func(c *checker) soltype.Type
+		want  string
+	}{
+		{
+			// One guard over a two-member union. `string` cannot survive `¬string`, and
+			// what is left is disjoint from `string`, so the complement goes too.
+			name:  "one guard over a union",
+			build: func(*checker) soltype.Type { return interT(unionT(str(), num()), negT(str())) },
+			want:  "number",
+		},
+		{
+			// Three chained guards, the accumulation caveat 2 names. Each complement
+			// narrows what the previous one left.
+			name: "three-guard chain",
+			build: func(*checker) soltype.Type {
+				return interT(unionT(str(), num(), boolT()), negT(str()), negT(num()))
+			},
+			want: "boolean",
+		},
+		{
+			// A complement over a primitive excludes the literals of that family, since
+			// `"a" <: string`.
+			name:  "literal arm excluded by its primitive",
+			build: func(*checker) soltype.Type { return interT(unionT(numLit(5), strLit("a")), negT(str())) },
+			want:  "5",
+		},
+		{
+			// Nothing was excluded, and the remaining member is disjoint from the
+			// operand, so only the complement drops.
+			name:  "already-disjoint positive drops the complement",
+			build: func(*checker) soltype.Type { return interT(num(), negT(str())) },
+			want:  "number",
+		},
+		{
+			// The positive part is entirely excluded, so the meet admits no value.
+			name:  "complement excludes the whole positive part",
+			build: func(*checker) soltype.Type { return interT(str(), negT(str())) },
+			want:  "never",
+		},
+		{
+			// Two class tags neither of which is below the other are disjoint, which is
+			// the M5 fact glbClass decides. `(Dog | Cat) & ¬Dog` is `Cat`.
+			name: "class tags",
+			build: func(c *checker) soltype.Type {
+				c.ctx.registerClass("Animal", &ClassDef{})
+				c.ctx.registerClass("Dog", &ClassDef{Supers: []*soltype.ClassType{cls("Animal", false)}})
+				c.ctx.registerClass("Cat", &ClassDef{Supers: []*soltype.ClassType{cls("Animal", false)}})
+				return interT(unionT(cls("Dog", false), cls("Cat", false)), negT(cls("Dog", false)))
+			},
+			want: "Cat",
+		},
+		{
+			// A subclass is below the excluded tag, so it goes with it.
+			name: "subclass excluded with its parent",
+			build: func(c *checker) soltype.Type {
+				c.ctx.registerClass("Animal", &ClassDef{})
+				c.ctx.registerClass("Dog", &ClassDef{Supers: []*soltype.ClassType{cls("Animal", false)}})
+				c.ctx.registerClass("Puppy", &ClassDef{Supers: []*soltype.ClassType{cls("Dog", false)}})
+				c.ctx.registerClass("Cat", &ClassDef{Supers: []*soltype.ClassType{cls("Animal", false)}})
+				return interT(unionT(cls("Puppy", false), cls("Cat", false)), negT(cls("Dog", false)))
+			},
+			want: "Cat",
+		},
+		{
+			// A complement standing on its own carries the whole meaning of the type, so
+			// it is left as written.
+			name:  "bare complement is left alone",
+			build: func(*checker) soltype.Type { return negT(str()) },
+			want:  "¬string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newChecker()
+			require.Equal(t, tt.want, soltype.Print(c.subsumeFinal(tt.build(c))))
+		})
+	}
+}
+
+// A complement over an abstract type parameter is irreducible: nothing proves T disjoint
+// from the excluded tag, so the pass must render it faithfully rather than drop it. The
+// scheme goes through generalize, the path a real binding takes to its display type.
+func TestSimplifyNegationsKeepsIrreducibleComplement(t *testing.T) {
+	c := newChecker()
+	c.ctx.registerClass("Tag", &ClassDef{})
+	param := c.freshAt(1)
+	// `fn (x: T) -> T & ¬Tag` — T occurs in both polarities, so it is retained as a
+	// type parameter rather than inlined to its bounds.
+	body := &soltype.FuncType{
+		Params: []*soltype.FuncParam{fparam("x", param)},
+		Ret:    interT(param, negT(cls("Tag", false))),
+	}
+	require.Equal(t, "fn <T0>(x: T0) -> T0 & ¬Tag", renderScheme(c.generalize(body, 0)))
+}
+
+// The cases the pass answers through its return values rather than through the type it
+// produces. subsumeFinal runs subsumeMembers over whatever comes back, so calling the pass
+// directly is what isolates its own decision.
+func TestSimplifyNegationsMemberRewrites(t *testing.T) {
+	c := newChecker()
+
+	// An empty meet is reported rather than returned as a `never` member, so the caller
+	// decides what an uninhabited intersection renders as.
+	t.Run("excluded positive part is uninhabited", func(t *testing.T) {
+		kept, changed, uninhabited := simplifyNegations(c.ctx, []soltype.Type{str(), negT(str())})
+		require.True(t, uninhabited)
+		require.True(t, changed)
+		require.Empty(t, kept)
+	})
+
+	// A meet with no complement is handed back untouched, so the finalizer keeps the node
+	// it already had.
+	t.Run("nothing to simplify", func(t *testing.T) {
+		members := []soltype.Type{num(), str()}
+		kept, changed, uninhabited := simplifyNegations(c.ctx, members)
+		require.False(t, uninhabited)
+		require.False(t, changed)
+		require.Equal(t, members, kept)
+	})
+
+	// An open tail admits values no arm names, so no arm is dropped and the complement
+	// stays as the only statement about what the tail excludes.
+	t.Run("inexact union keeps its arms", func(t *testing.T) {
+		open := newUnion(nil, []soltype.Type{str(), num()}, true)
+		members := []soltype.Type{open, negT(str())}
+		kept, changed, uninhabited := simplifyNegations(c.ctx, members)
+		require.False(t, uninhabited)
+		require.False(t, changed)
+		require.Equal(t, members, kept)
+	})
+}
+
+// newNegation collapses the three operands whose complement the surface type set already
+// spells, and wraps everything else.
+func TestNewNegation(t *testing.T) {
+	tests := []struct {
+		name  string
+		inner soltype.Type
+		want  string
+	}{
+		{"never", &soltype.NeverType{}, "unknown"},
+		{"unknown", &soltype.UnknownType{}, "never"},
+		{"double complement", negT(str()), "string"},
+		{"primitive", str(), "¬string"},
+		{"union", unionT(str(), num()), "¬(number | string)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, soltype.Print(newNegation(tt.inner)))
+		})
+	}
+}

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -37,9 +37,8 @@ func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 			want:  "number",
 		},
 		{
-			// Three chained guards, the accumulation the MLstruct plan's caveat 2
-			// describes. Each complement narrows what the previous one left, so the
-			// last member standing is what renders.
+			// Three chained guards. Each complement narrows what the previous one
+			// left, so the last member standing is what renders.
 			name: "three-guard chain",
 			build: func(*checker) soltype.Type {
 				return interT(unionT(str(), num(), boolT()), negT(str()), negT(num()))

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -19,55 +19,67 @@ func unionT(parts ...soltype.Type) soltype.Type { return newUnion(nil, parts, fa
 func interT(parts ...soltype.Type) soltype.Type { return newIntersection(nil, parts) }
 
 // A complement in a coalesced intersection collapses against the disjointness facts the
-// solver already decides. Each case is the type a bound carrying a negation coalesces to,
-// finalized through subsumeFinal, which is where the pass runs.
+// solver already decides. Each case builds the unsimplified type a bound carrying a
+// negation coalesces to, then finalizes it through subsumeFinal, which is where the pass
+// runs.
+//
+// unsimplified is asserted alongside want, so the before-and-after pair below is the real
+// one rather than a claim that can drift from what build returns.
 func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 	tests := []struct {
 		name string
-		// build returns the coalesced intersection, given a checker whose Context the
-		// case may seed with class declarations.
+		// build returns the intersection before the pass runs, given a checker whose
+		// Context the case may seed with class declarations.
 		build func(c *checker) soltype.Type
-		want  string
+		// unsimplified is what build returns, rendered.
+		unsimplified string
+		// want is what the pass leaves.
+		want string
 	}{
 		{
 			// One guard over a two-member union. `string` cannot survive `¬string`, and
 			// what is left is disjoint from `string`, so the complement goes too.
-			name:  "one guard over a union",
-			build: func(*checker) soltype.Type { return interT(unionT(str(), num()), negT(str())) },
-			want:  "number",
+			name:         "one guard over a union",
+			build:        func(*checker) soltype.Type { return interT(unionT(str(), num()), negT(str())) },
+			unsimplified: "(number | string) & ¬string",
+			want:         "number",
 		},
 		{
-			// Three chained guards. Each complement narrows what the previous one
-			// left, so the last member standing is what renders.
-			name: "three-guard chain",
+			// Two complements over a three-member union. Each excludes one arm, so the
+			// third is the only member standing.
+			name: "two complements over one union",
 			build: func(*checker) soltype.Type {
 				return interT(unionT(str(), num(), boolT()), negT(str()), negT(num()))
 			},
-			want: "boolean",
+			unsimplified: "(number | string | boolean) & ¬number & ¬string",
+			want:         "boolean",
 		},
 		{
 			// A complement over a primitive excludes the literals of that family, since
 			// `"a" <: string`.
-			name:  "literal arm excluded by its primitive",
-			build: func(*checker) soltype.Type { return interT(unionT(numLit(5), strLit("a")), negT(str())) },
-			want:  "5",
+			name:         "literal arm excluded by its primitive",
+			build:        func(*checker) soltype.Type { return interT(unionT(numLit(5), strLit("a")), negT(str())) },
+			unsimplified: `(5 | "a") & ¬string`,
+			want:         "5",
 		},
 		{
 			// Nothing was excluded, and the remaining member is disjoint from the
 			// operand, so only the complement drops.
-			name:  "already-disjoint positive drops the complement",
-			build: func(*checker) soltype.Type { return interT(num(), negT(str())) },
-			want:  "number",
+			name:         "already-disjoint positive drops the complement",
+			build:        func(*checker) soltype.Type { return interT(num(), negT(str())) },
+			unsimplified: "number & ¬string",
+			want:         "number",
 		},
 		{
 			// The positive part is entirely excluded, so the meet admits no value.
-			name:  "complement excludes the whole positive part",
-			build: func(*checker) soltype.Type { return interT(str(), negT(str())) },
-			want:  "never",
+			name:         "complement excludes the whole positive part",
+			build:        func(*checker) soltype.Type { return interT(str(), negT(str())) },
+			unsimplified: "string & ¬string",
+			want:         "never",
 		},
 		{
 			// Two class tags neither of which is below the other are disjoint, which is
-			// what glbClass decides. `(Dog | Cat) & ¬Dog` is `Cat`.
+			// what glbClass decides.
 			name: "class tags",
 			build: func(c *checker) soltype.Type {
 				c.ctx.registerClass("Animal", &ClassDef{})
@@ -75,7 +87,8 @@ func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 				c.ctx.registerClass("Cat", &ClassDef{Supers: []*soltype.ClassType{cls("Animal", false)}})
 				return interT(unionT(cls("Dog", false), cls("Cat", false)), negT(cls("Dog", false)))
 			},
-			want: "Cat",
+			unsimplified: "(Dog | Cat) & ¬Dog",
+			want:         "Cat",
 		},
 		{
 			// A subclass is below the excluded tag, so it goes with it.
@@ -87,27 +100,32 @@ func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 				c.ctx.registerClass("Cat", &ClassDef{Supers: []*soltype.ClassType{cls("Animal", false)}})
 				return interT(unionT(cls("Puppy", false), cls("Cat", false)), negT(cls("Dog", false)))
 			},
-			want: "Cat",
+			unsimplified: "(Puppy | Cat) & ¬Dog",
+			want:         "Cat",
 		},
 		{
 			// A complement standing on its own carries the whole meaning of the type, so
 			// it is left as written.
-			name:  "bare complement is left alone",
-			build: func(*checker) soltype.Type { return negT(str()) },
-			want:  "¬string",
+			name:         "bare complement is left alone",
+			build:        func(*checker) soltype.Type { return negT(str()) },
+			unsimplified: "¬string",
+			want:         "¬string",
 		},
 		{
 			// The operand is rewritten before the complement over it, so an operand this
 			// pass empties is folded rather than left as the meaningless `¬never`.
-			name:  "complement over an emptied operand",
-			build: func(*checker) soltype.Type { return negT(interT(str(), negT(str()))) },
-			want:  "unknown",
+			name:         "complement over an emptied operand",
+			build:        func(*checker) soltype.Type { return negT(interT(str(), negT(str()))) },
+			unsimplified: "¬(string & ¬string)",
+			want:         "unknown",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newChecker()
-			require.Equal(t, tt.want, soltype.Print(c.subsumeFinal(tt.build(c))))
+			in := tt.build(c)
+			require.Equal(t, tt.unsimplified, soltype.Print(in), "input to the pass")
+			require.Equal(t, tt.want, soltype.Print(c.subsumeFinal(in)))
 		})
 	}
 }
@@ -119,8 +137,9 @@ func TestSimplifyNegationsKeepsIrreducibleComplement(t *testing.T) {
 	c := newChecker()
 	c.ctx.registerClass("Tag", &ClassDef{})
 	param := c.freshAt(1)
-	// `fn (x: T) -> T & ¬Tag` — T occurs in both polarities, so it is retained as a
-	// type parameter rather than inlined to its bounds.
+	// The unsimplified body is `fn (x: T) -> T & ¬Tag`. T occurs in both polarities, so
+	// it is retained as a type parameter rather than inlined to its bounds, and the
+	// return keeps both members because nothing proves T disjoint from Tag.
 	body := &soltype.FuncType{
 		Params: []*soltype.FuncParam{fparam("x", param)},
 		Ret:    interT(param, negT(cls("Tag", false))),
@@ -134,8 +153,9 @@ func TestSimplifyNegationsKeepsIrreducibleComplement(t *testing.T) {
 func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 	c := newChecker()
 
-	// An empty meet is reported rather than returned as a `never` member, so the caller
-	// decides what an uninhabited intersection renders as.
+	// `string & ¬string` admits no value. The empty meet is reported rather than returned
+	// as a `never` member, so the caller decides what an uninhabited intersection renders
+	// as.
 	t.Run("excluded positive part is uninhabited", func(t *testing.T) {
 		kept, changed, uninhabited := simplifyNegations(c.ctx, []soltype.Type{str(), negT(str())})
 		require.True(t, uninhabited)
@@ -143,8 +163,8 @@ func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 		require.Empty(t, kept)
 	})
 
-	// A meet with no complement is handed back untouched, so the finalizer keeps the node
-	// it already had.
+	// `number & string` carries no complement, so it is handed back untouched and the
+	// finalizer keeps the node it already had.
 	t.Run("nothing to simplify", func(t *testing.T) {
 		members := []soltype.Type{num(), str()}
 		kept, changed, uninhabited := simplifyNegations(c.ctx, members)
@@ -153,8 +173,9 @@ func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 		require.Equal(t, members, kept)
 	})
 
-	// An open tail admits values no arm names, so no arm is dropped and the complement
-	// stays as the only statement about what the tail excludes.
+	// `(string | number | ...) & ¬string`. An open tail admits values no arm names, so no
+	// arm is dropped and the complement stays as the only statement about what the tail
+	// excludes.
 	t.Run("inexact union keeps its arms", func(t *testing.T) {
 		open := newUnion(nil, []soltype.Type{str(), num()}, true)
 		members := []soltype.Type{open, negT(str())}
@@ -164,9 +185,9 @@ func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 		require.Equal(t, members, kept)
 	})
 
-	// Every type is a subtype of an inexact union under the open-tail rule, so a
-	// complement over one would exclude whatever it is met with. Such an operand is
-	// refused, leaving `number & ¬(boolean | ...)` with both members.
+	// `number & ¬(boolean | ...)`. Every type is a subtype of an inexact union under the
+	// open-tail rule, so a complement over one would exclude whatever it is met with.
+	// Such an operand is refused, leaving both members standing.
 	t.Run("inexact union operand is refused", func(t *testing.T) {
 		open := newUnion(nil, []soltype.Type{boolT()}, true)
 		require.True(t, subtypeHolds(c.ctx, num(), open))

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -37,8 +37,9 @@ func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 			want:  "number",
 		},
 		{
-			// Three chained guards, the accumulation caveat 2 names. Each complement
-			// narrows what the previous one left.
+			// Three chained guards, the accumulation the MLstruct plan's caveat 2
+			// describes. Each complement narrows what the previous one left, so the
+			// last member standing is what renders.
 			name: "three-guard chain",
 			build: func(*checker) soltype.Type {
 				return interT(unionT(str(), num(), boolT()), negT(str()), negT(num()))
@@ -67,7 +68,7 @@ func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 		},
 		{
 			// Two class tags neither of which is below the other are disjoint, which is
-			// the M5 fact glbClass decides. `(Dog | Cat) & ¬Dog` is `Cat`.
+			// what glbClass decides. `(Dog | Cat) & ¬Dog` is `Cat`.
 			name: "class tags",
 			build: func(c *checker) soltype.Type {
 				c.ctx.registerClass("Animal", &ClassDef{})

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -307,3 +307,40 @@ func TestOpenUnionIsTopForSubtypingOnly(t *testing.T) {
 		require.Equal(t, []string{"1:27-1:30: cannot constrain unknown <: object"}, messagesWithSpan(errs))
 	})
 }
+
+// The two routes a complement can take past a variable, which the section comment above
+// simplifyNegations describes. They go opposite ways, and only the first leaves a
+// complement behind for that pass to find.
+func TestNegatedBoundReachesAVariable(t *testing.T) {
+	// A variable on the subtype side of a complement stores it whole. Constrain sends a
+	// goal to the normal-form layer only when neither operand is a variable, so this one
+	// falls through to the variable arm.
+	t.Run("a variable below a complement stores it", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		require.Empty(t, Messages(c.Constrain(a, negT(str()))))
+		require.Equal(t, []string{"¬string"}, printedBounds(a.UpperBounds))
+		require.Empty(t, a.LowerBounds)
+	})
+
+	// The normal-form layer moves a negated part to the far side of the `<:` as a
+	// POSITIVE one, so `α ∩ ¬string <: number` becomes `α <: number | string`. The bound
+	// α ends up with is one of those members, never a complement.
+	t.Run("a negated part crosses over positive", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		sub := newIntersection(nil, []soltype.Type{a, negT(str())})
+		require.Empty(t, Messages(c.Constrain(sub, num())))
+		require.Equal(t, []string{"number"}, printedBounds(a.UpperBounds))
+	})
+}
+
+// printedBounds renders a variable's bound list for comparison against Escalier type
+// syntax, which is what makes a bound assertion readable.
+func printedBounds(bounds []soltype.Type) []string {
+	out := make([]string, len(bounds))
+	for i, b := range bounds {
+		out[i] = soltype.Print(b)
+	}
+	return out
+}

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -96,6 +96,13 @@ func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 			build: func(*checker) soltype.Type { return negT(str()) },
 			want:  "¬string",
 		},
+		{
+			// The operand is rewritten before the complement over it, so an operand this
+			// pass empties is folded rather than left as the meaningless `¬never`.
+			name:  "complement over an emptied operand",
+			build: func(*checker) soltype.Type { return negT(interT(str(), negT(str()))) },
+			want:  "unknown",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -151,6 +158,19 @@ func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 	t.Run("inexact union keeps its arms", func(t *testing.T) {
 		open := newUnion(nil, []soltype.Type{str(), num()}, true)
 		members := []soltype.Type{open, negT(str())}
+		kept, changed, uninhabited := simplifyNegations(c.ctx, members)
+		require.False(t, uninhabited)
+		require.False(t, changed)
+		require.Equal(t, members, kept)
+	})
+
+	// Every type is a subtype of an inexact union under the open-tail rule, so a
+	// complement over one would exclude whatever it is met with. Such an operand is
+	// refused, leaving `number & ¬(boolean | ...)` with both members.
+	t.Run("inexact union operand is refused", func(t *testing.T) {
+		open := newUnion(nil, []soltype.Type{boolT()}, true)
+		require.True(t, subtypeHolds(c.ctx, num(), open))
+		members := []soltype.Type{num(), negT(open)}
 		kept, changed, uninhabited := simplifyNegations(c.ctx, members)
 		require.False(t, uninhabited)
 		require.False(t, changed)

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -119,6 +119,29 @@ func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 			unsimplified: "¬(string & ¬string)",
 			want:         "unknown",
 		},
+		{
+			// An inexact union is the top of the subtype lattice, so nothing satisfies
+			// its complement and the meet is empty. Rendering `never` says that, where
+			// leaving the complement standing would read as a live constraint on a type
+			// no value inhabits.
+			name: "complement over an open union empties the meet",
+			build: func(*checker) soltype.Type {
+				return interT(num(), negT(newUnion(nil, []soltype.Type{boolT(), str()}, true)))
+			},
+			unsimplified: "number & ¬(string | boolean | ...)",
+			want:         "never",
+		},
+		{
+			// The same holds with the open union on both sides. Here the complement folds
+			// to `never` on its own, before the meet is weighed at all.
+			name: "an open union meets its own complement",
+			build: func(*checker) soltype.Type {
+				open := func() soltype.Type { return newUnion(nil, []soltype.Type{str(), num()}, true) }
+				return interT(open(), negT(open()))
+			},
+			unsimplified: "(number | string | ...) & ¬(number | string | ...)",
+			want:         "never",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -152,8 +175,8 @@ func TestSimplifyNegationsKeepsIrreducibleComplement(t *testing.T) {
 // directly is what isolates its own decision.
 //
 // Each case asserts provedEmpty, which reports what the pass DERIVED rather than whether
-// the meet has an inhabitant. A false means the pass reached no derivation, and the last
-// case below is one where the meet really is empty and the flag is still false.
+// the meet has an inhabitant. A false means the pass reached no derivation, which for a
+// meet the concreteness gate keeps it away from says nothing either way.
 func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 	c := newChecker()
 
@@ -189,25 +212,18 @@ func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 		require.Equal(t, members, kept)
 	})
 
-	// `number & ¬(boolean | ...)`. Constrain accepts every type against an inexact union,
-	// asserted below, so nothing satisfies the complement of one and this meet is in fact
-	// empty. usableOperand refuses such an operand anyway, so the pass derives nothing and
-	// both members stand.
-	//
-	// provedEmpty is therefore false over a meet that has no inhabitant. That is the flag
-	// working as documented: it reports the pass's derivation, not the type. Collapsing
-	// here would turn constrain's one-directional leniency, which exists so a value
-	// matching no named member is still ACCEPTED, into a display claiming no such value
-	// can exist. What an open tail excludes is left to the exactness-aware merge.
-	t.Run("inexact union operand is refused", func(t *testing.T) {
+	// `number & ¬(boolean | ...)`. An inexact union is the top of the subtype lattice, so
+	// nothing satisfies its complement and the meet has no inhabitant. The two subtype
+	// facts the derivation rests on are asserted first, so a change to either shows up
+	// here as well as in TestOpenUnionIsTopForSubtypingOnly.
+	t.Run("inexact union operand collapses the meet", func(t *testing.T) {
 		open := newUnion(nil, []soltype.Type{boolT()}, true)
 		require.True(t, subtypeHolds(c.ctx, num(), open), "every type is below an inexact union")
 		require.False(t, subtypeHolds(c.ctx, num(), negT(open)), "so nothing is below its complement")
-		members := []soltype.Type{num(), negT(open)}
-		kept, changed, provedEmpty := simplifyNegations(c.ctx, members)
-		require.False(t, provedEmpty)
-		require.False(t, changed)
-		require.Equal(t, members, kept)
+		kept, changed, provedEmpty := simplifyNegations(c.ctx, []soltype.Type{num(), negT(open)})
+		require.True(t, provedEmpty)
+		require.True(t, changed)
+		require.Empty(t, kept)
 	})
 }
 
@@ -222,8 +238,11 @@ func TestNewNegation(t *testing.T) {
 		{"never", &soltype.NeverType{}, "unknown"},
 		{"unknown", &soltype.UnknownType{}, "never"},
 		{"double complement", negT(str()), "string"},
+		// An inexact union accepts every value, so its complement accepts none.
+		{"open union", newUnion(nil, []soltype.Type{boolT(), str()}, true), "never"},
 		{"primitive", str(), "¬string"},
-		{"union", unionT(str(), num()), "¬(number | string)"},
+		// A closed union bounds its members, so its complement is a real type.
+		{"closed union", unionT(str(), num()), "¬(number | string)"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -232,19 +251,18 @@ func TestNewNegation(t *testing.T) {
 	}
 }
 
-// An inexact union is the top of the lattice for the subtype relation and nothing more.
-// usableOperand's refusal of such an operand rests on both halves of that, so both are
-// pinned here rather than left to a comment.
+// An inexact union is the top of the subtype lattice, and two passes now depend on that.
+// newNegation folds `¬(A | B | ...)` to `never`, and simplifyNegations collapses a meet
+// carrying such a complement. Both rest on the probes below, so they are pinned here
+// rather than left to a comment.
 //
-// The first half is the reason the collapse this pass declines would be CONSISTENT: if
-// `boolean | ...` accepts every value then nothing satisfies `¬(boolean | ...)`, and
-// `number & ¬(boolean | ...)` is empty. The second half is the reason it is still the
-// wrong call: an open union's named members survive a property read, so the type carries
-// meaning the subtype relation throws away, and reading that relation as a statement about
-// which values inhabit the type overcommits.
+// The second subtest is the step from top-ness to the fold: if `boolean | ...` accepts
+// every value then nothing satisfies `¬(boolean | ...)`.
 //
-// Whether an open union should be top at all is the exactness-aware merge's question. This
-// test states the behavior as it stands, so a change to it is visible rather than silent.
+// The third records where an open union and `unknown` part ways. A property read answers
+// from the open union's named members and is rejected outright on `unknown`. That is the
+// one place the named members still carry weight, and it is why an open union is top for
+// SUBTYPING rather than identical to `unknown` outright.
 func TestOpenUnionIsTopForSubtypingOnly(t *testing.T) {
 	c := newChecker()
 	open := newUnion(nil, []soltype.Type{boolT()}, true) // boolean | ...

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -324,14 +324,39 @@ func TestNegatedBoundReachesAVariable(t *testing.T) {
 	})
 
 	// The normal-form layer moves a negated part to the far side of the `<:` as a
-	// POSITIVE one, so `α ∩ ¬string <: number` becomes `α <: number | string`. The bound
-	// α ends up with is one of those members, never a complement.
+	// POSITIVE one, so `α ∩ ¬string <: number` becomes `α <: number | string`. A union in
+	// supertype position is an exists rule, so ONE member is kept, never both and never a
+	// complement. Recording both would read as the meet `number & string`, which is
+	// stronger than the goal.
+	//
+	// Which member survives depends on α's other bounds, so both outcomes are pinned. A
+	// `"hi"` lower bound fails the `number` trial and pushes the choice to `string`.
 	t.Run("a negated part crosses over positive", func(t *testing.T) {
+		cases := map[string]struct {
+			lower []soltype.Type
+			want  []string
+		}{
+			"unconstrained commits the first member": {want: []string{"number"}},
+			"a string lower bound commits string":    {lower: []soltype.Type{strLit("hi")}, want: []string{"string"}},
+		}
+		for name, tt := range cases {
+			t.Run(name, func(t *testing.T) {
+				c := &Context{}
+				a := c.freshVar(0)
+				a.LowerBounds = tt.lower
+				sub := newIntersection(nil, []soltype.Type{a, negT(str())})
+				require.Empty(t, Messages(c.Constrain(sub, num())))
+				require.Equal(t, tt.want, printedBounds(a.UpperBounds))
+			})
+		}
+	})
+
+	// The meet reading of the upper-bound list is what rules out recording both members.
+	t.Run("upper bounds are read as a meet", func(t *testing.T) {
 		c := &Context{}
 		a := c.freshVar(0)
-		sub := newIntersection(nil, []soltype.Type{a, negT(str())})
-		require.Empty(t, Messages(c.Constrain(sub, num())))
-		require.Equal(t, []string{"number"}, printedBounds(a.UpperBounds))
+		a.UpperBounds = []soltype.Type{num(), str()}
+		require.Equal(t, "number & string", soltype.Print(coalesce(a, soltype.Negative)))
 	})
 }
 

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -150,15 +150,19 @@ func TestSimplifyNegationsKeepsIrreducibleComplement(t *testing.T) {
 // The cases the pass answers through its return values rather than through the type it
 // produces. subsumeFinal runs subsumeMembers over whatever comes back, so calling the pass
 // directly is what isolates its own decision.
+//
+// Each case asserts provedEmpty, which reports what the pass DERIVED rather than whether
+// the meet has an inhabitant. A false means the pass reached no derivation, and the last
+// case below is one where the meet really is empty and the flag is still false.
 func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 	c := newChecker()
 
-	// `string & ¬string` admits no value. The empty meet is reported rather than returned
-	// as a `never` member, so the caller decides what an uninhabited intersection renders
-	// as.
-	t.Run("excluded positive part is uninhabited", func(t *testing.T) {
-		kept, changed, uninhabited := simplifyNegations(c.ctx, []soltype.Type{str(), negT(str())})
-		require.True(t, uninhabited)
+	// `string & ¬string` admits no value and the pass derives it. The empty meet is
+	// reported rather than returned as a `never` member, so the caller decides what an
+	// empty intersection renders as.
+	t.Run("excluded positive part is proved empty", func(t *testing.T) {
+		kept, changed, provedEmpty := simplifyNegations(c.ctx, []soltype.Type{str(), negT(str())})
+		require.True(t, provedEmpty)
 		require.True(t, changed)
 		require.Empty(t, kept)
 	})
@@ -167,8 +171,8 @@ func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 	// finalizer keeps the node it already had.
 	t.Run("nothing to simplify", func(t *testing.T) {
 		members := []soltype.Type{num(), str()}
-		kept, changed, uninhabited := simplifyNegations(c.ctx, members)
-		require.False(t, uninhabited)
+		kept, changed, provedEmpty := simplifyNegations(c.ctx, members)
+		require.False(t, provedEmpty)
 		require.False(t, changed)
 		require.Equal(t, members, kept)
 	})
@@ -179,21 +183,29 @@ func TestSimplifyNegationsMemberRewrites(t *testing.T) {
 	t.Run("inexact union keeps its arms", func(t *testing.T) {
 		open := newUnion(nil, []soltype.Type{str(), num()}, true)
 		members := []soltype.Type{open, negT(str())}
-		kept, changed, uninhabited := simplifyNegations(c.ctx, members)
-		require.False(t, uninhabited)
+		kept, changed, provedEmpty := simplifyNegations(c.ctx, members)
+		require.False(t, provedEmpty)
 		require.False(t, changed)
 		require.Equal(t, members, kept)
 	})
 
-	// `number & ¬(boolean | ...)`. Every type is a subtype of an inexact union under the
-	// open-tail rule, so a complement over one would exclude whatever it is met with.
-	// Such an operand is refused, leaving both members standing.
+	// `number & ¬(boolean | ...)`. Constrain accepts every type against an inexact union,
+	// asserted below, so nothing satisfies the complement of one and this meet is in fact
+	// empty. usableOperand refuses such an operand anyway, so the pass derives nothing and
+	// both members stand.
+	//
+	// provedEmpty is therefore false over a meet that has no inhabitant. That is the flag
+	// working as documented: it reports the pass's derivation, not the type. Collapsing
+	// here would turn constrain's one-directional leniency, which exists so a value
+	// matching no named member is still ACCEPTED, into a display claiming no such value
+	// can exist. What an open tail excludes is left to the exactness-aware merge.
 	t.Run("inexact union operand is refused", func(t *testing.T) {
 		open := newUnion(nil, []soltype.Type{boolT()}, true)
-		require.True(t, subtypeHolds(c.ctx, num(), open))
+		require.True(t, subtypeHolds(c.ctx, num(), open), "every type is below an inexact union")
+		require.False(t, subtypeHolds(c.ctx, num(), negT(open)), "so nothing is below its complement")
 		members := []soltype.Type{num(), negT(open)}
-		kept, changed, uninhabited := simplifyNegations(c.ctx, members)
-		require.False(t, uninhabited)
+		kept, changed, provedEmpty := simplifyNegations(c.ctx, members)
+		require.False(t, provedEmpty)
 		require.False(t, changed)
 		require.Equal(t, members, kept)
 	})


### PR DESCRIPTION
Fixes #1063.

Adds a display-time pass that collapses complements in intersection types by applying two disjointness-aware rewrites. When a variable's bound carries a negated part (e.g., from `α <: ¬string`), coalescing renders it literally as `(string | number) & ¬string`. This pass simplifies that to `number` by reading the subtype facts the solver already decides.

The two rewrites are:
1. Drop union arms that the complement rules out. `string & ¬string` admits no value, so `(string | number) & ¬string` becomes `number & ¬string`.
2. Drop complements disjoint from what remains. `number` and `string` are disjoint, so `number & ¬string` is just `number`.

Both rewrites ask through `subtypeHolds`, which trials speculatively under a discard-only probe, so they read the same class-tag and literal/primitive facts the solver uses elsewhere. The pass runs in `subsumeFinal` after coalescing, making it a display-only simplification that never changes what the checker accepts.

Key changes:
- `simplifyNegations` in `simplify.go` applies the two rewrites to an intersection's members, with `excludeArms` handling the first rewrite and a disjointness check handling the second.
- `newNegation` in `lattice.go` is the single mint path for complements in coalesced output, collapsing `¬never` to `unknown`, `¬unknown` to `never`, and `¬¬T` to `T`.
- `foldNegation` in `coalesce.go` re-mints complements after their operands are rewritten, keeping `¬never` from appearing on display types.
- `subsumeFinal` now calls `simplifyNegations` before subsumption, so chained guards render cleanly without accumulating complements.
- Helper functions `subtypeHolds` and `concreteMember` in `lattice.go` support speculative comparison and filter out members carrying free variables.

Tests cover the main simplification cases (union narrowing, disjoint complements, class tags, subclass exclusion), irreducible complements over abstract type parameters, and the member-rewrite return values. Integration tests verify that chained guards render as plain unions rather than nested complements.

Two notes on scope:
- The issue's acceptance asks for a `fixtures/` fixture exercising `if val` bindings. The fixture pipeline (`internal/compiler`) still runs the old `internal/checker` and does not touch `internal/solver` until the M12 flip, so a fixture would not exercise this change. The equivalent chained-guard cases live in `internal/solver/infer_if_val_test.go`, driving real Escalier source through `inferSource`.
- `subsumeMembers` treats an inexact union as a supertype of everything under constrain's open-tail rule, so `number & ¬(boolean | ...)` finalizes to `¬(boolean | ...)`. That predates this change and belongs to PR7 (#1064); `usableOperand` refuses an inexact operand so this pass does not compound it.

https://claude.ai/code/session_01JXPQ6dr8gN6XQ5wGhjHLTK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved type negation and complement simplification.
  * Simplified contradictory or empty type combinations to clearer results.
  * Collapsed redundant and double negations while preserving meaningful complements.
  * Improved narrowing behavior across chained conditional guards.
  * Enhanced handling of negated bounds, nested properties, unions, intersections, and class types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->