### PR TITLE
Implement exactness-driven merges for objects, tuples, and functions

### DIFF
--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -114,9 +114,10 @@ func (c *Context) constrainNF(sub, super soltype.Type, seen *seenPairs, mutCtx b
 //
 // Three things follow from deciding by one pair.
 //
-//   - It is incomplete. A meet can be a subtype of a join through its parts taken
-//     together, which no pair states, so `{x: number} & {y: number} <: {x: number,
-//     y: number}` is rejected. #1064's exact-record merge settles that one.
+//   - It is incomplete. A type can be a subtype of a join through the join's
+//     members taken together, which no single pair states. `boolean <: true |
+//     false` is rejected for that reason. The two literals do not fuse into one
+//     atom, and `boolean` is a subtype of neither of them on its own.
 //   - A pair repeating the caller's own question against an inexact union is
 //     skipped. Such a union is one atom, so normalizing `boolean <: (number |
 //     string | ...)` hands back the pair it started from and no smaller question

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2545,8 +2545,11 @@ func TestInferCondCaptureFromConstraint(t *testing.T) {
 		{
 			// An intersection Check is decomposed by constrain too, so a pattern reads a member off
 			// whichever operand carries it.
+			// The two operands are inexact so the intersection is inhabited. Exact records
+			// over disjoint fields meet to `never`, which satisfies the Check vacuously and
+			// leaves the capture unconstrained.
 			name:         "IntersectionCheckCaptures",
-			src:          `type Result = if {a: number} & {b: string} : {a: infer A, ...} { [A] } else { "no" }`,
+			src:          `type Result = if {a: number, ...} & {b: string, ...} : {a: infer A, ...} { [A] } else { "no" }`,
 			wantExpanded: `[number]`,
 		},
 	}

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -78,9 +78,10 @@ import (
 // values. widerByMarker records both directions in one place.
 //
 // This file is the only place structural exactness is decided. newIntersection and
-// newUnion in lattice.go flatten, prune, dedup, and order a lattice node, and they
-// leave an uninhabited meet standing (#927), so a merge here cannot delegate its
-// exactness rule to them without asking the question back.
+// newUnion in lattice.go flatten, prune, dedup, and order a lattice node. They
+// leave an uninhabited meet standing, which is escalier-lang/escalier#927, so a
+// merge here cannot delegate its exactness rule to them without asking the question
+// back.
 //
 // # What is deliberately left to a later PR
 //
@@ -181,7 +182,7 @@ func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
 			// exactly what the diagnostics print. An `Open` flag on the DNF would
 			// distribute, but nothing says what the tail meets C to, so the mark would
 			// have to be polarity-aware to stay sound. Neither buys a verdict the opaque
-			// atom gets wrong. Escalier issue #1064 records the full comparison.
+			// atom gets wrong. The full comparison is on escalier-lang/escalier#1064.
 			return dnfAtom(t)
 		}
 		out := DNF{Conjuncts: nil}
@@ -737,11 +738,24 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 // other's, and comparing. That reuses equalType rather than re-spelling per-kind
 // structural equality, and it keeps the test in step with equalType as kinds gain
 // fields.
+//
+// An UNREDUCED atom is left alone, which is the same refusal plainProps and
+// comparableTuples make. A `{...S}` does not know its own field names and a
+// `[...P]` does not know its own positions, so neither supports the claim that the
+// exact side caps what the inexact side leaves open. The constraint rules treat
+// such an atom as inert and relate two of them only when they are equal. Fusing
+// the pair therefore leaves those rules an atom they cannot take apart, and this
+// declaration stops checking:
+//
+//	fn go<P>(x: [...P]) -> [...P] | [...P, ...] { return x }
 func widerByMarker(a, b soltype.Type) (soltype.Type, bool) {
 	switch a := a.(type) {
 	case *soltype.ObjectType:
 		b, isObj := b.(*soltype.ObjectType)
 		if !isObj || a.Inexact == b.Inexact {
+			return nil, false
+		}
+		if soltype.HasResidualElem(a.Elems) || soltype.HasResidualElem(b.Elems) {
 			return nil, false
 		}
 		flipped := *a
@@ -756,6 +770,9 @@ func widerByMarker(a, b soltype.Type) (soltype.Type, bool) {
 	case *soltype.TupleType:
 		b, isTuple := b.(*soltype.TupleType)
 		if !isTuple || a.Inexact == b.Inexact {
+			return nil, false
+		}
+		if hasSpreadElem(a.Elems) || hasSpreadElem(b.Elems) {
 			return nil, false
 		}
 		flipped := *a
@@ -929,7 +946,7 @@ func joinValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 }
 
 // meetObjects fuses two object atoms field by field, returns `never` when no value
-// satisfies both, or keeps them apart when neither answer is available. Keeping two
+// satisfies both, or keeps them apart when it can reach neither answer. Keeping two
 // atoms is just as precise and costs only the extra atom, so the fusion is an
 // optimization rather than an obligation.
 //
@@ -944,18 +961,21 @@ func joinValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 //
 // # The rule
 //
-// The meet's floor is the union of the two floors and its cap is the intersection
-// of the two caps, since a value has to satisfy both objects at once. So:
+// A value has to satisfy both objects at once, so the meet's floor is the union of
+// the two floors and its cap is the intersection of the two caps. Three rules
+// follow.
 //
-//  1. A field either side REQUIRES that the other side caps out is a contradiction,
-//     and the meet is `never`. This is what makes exact `{x} & {y}` uninhabited.
-//  2. A field inside the meet's cap survives. Both sides naming it means the meet
+//  1. Take a field one side REQUIRES and the other side caps out. Carrying it
+//     breaks the second object's cap and omitting it breaks the first object's
+//     floor, so no value satisfies both and the meet is `never`. This is what makes
+//     exact `{x} & {y}` uninhabited.
+//  2. A field inside the meet's cap survives. When both sides name it the meet
 //     narrows it to their meet, and a field either side requires is required on the
 //     meet, so `{x: A} & {x?: B}` is `{x: A & B}`.
-//  3. A field only one side names and the other side caps out drops. Nothing
-//     required is lost, since rule 1 already answered that case. Exact
-//     `{x: A, y?: B} & {x: C}` is `{x: A & C}`, because the second object admits no
-//     y at all.
+//  3. A field only one side names and the other side caps out drops. Rule 1 already
+//     answered the case where such a field is required, so nothing required is lost
+//     here. Exact `{x: A, y?: B} & {x: C}` is `{x: A & C}`, because the second
+//     object admits no y at all.
 //
 // The meet is exact when either side is, since one cap is enough to close the key
 // set.
@@ -1006,9 +1026,10 @@ func (c *Context) meetObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 	return &soltype.ObjectType{Elems: sortedByName(elems), Inexact: a.Inexact && b.Inexact}, true
 }
 
-// requiredFieldsWithin reports whether every field props REQUIRES is one that
-// allowed names. open says whether the object allowed came from is inexact, which
-// caps nothing and so admits any field name.
+// requiredFieldsWithin reports whether every field props REQUIRES is one the
+// allowed list names. Pass open as true when allowed came off an inexact object.
+// Such an object caps nothing, so it admits any field name and the check passes
+// without reading either list.
 func requiredFieldsWithin(props, allowed []*soltype.PropertyElem, open bool) bool {
 	if open {
 		return true
@@ -1101,8 +1122,9 @@ func (c *Context) joinObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 // # The rule
 //
 // The meet's floor is the longer element list and its cap is the tighter of the
-// two caps. A cap below that floor admits no length, so the meet is `never`, which
-// is what makes exact `[A] & [A, B]` and exact `[A] & [A', B', ...]` uninhabited.
+// two caps. A cap below that floor admits no length, so the meet is `never`. Both
+// `[A] & [A, B]` and `[A] & [A', B', ...]` are uninhabited for that reason: the
+// exact `[A]` caps the length at one, and the other side needs two.
 //
 // Otherwise every position of the longer list survives. A position both lists name
 // narrows to the meet of the two elements. A position only the longer list names is
@@ -1203,8 +1225,8 @@ func hasSpreadElem(elems []soltype.Type) bool {
 // into a claim that the value accepts a number paired with a string.
 //
 // The fused arrow is inexact when either side is. An arrow's marker says the value
-// tolerates every argument count from its arity up, and a value satisfying both
-// arrows has to tolerate both demands, so the open one carries.
+// tolerates every argument count from its arity up. A value satisfying both arrows
+// meets both demands, and the open one is the stronger of the two.
 func (c *Context) meetFuncs(a, b *soltype.FuncType) (soltype.Type, bool) {
 	if !fusableFuncs(a, b) {
 		return nil, false

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -58,12 +58,32 @@ import (
 //     makes every subtype pass against a supertype union of two records. A list
 //     keeps `{x: number} | {y: number}` precise in supertype position.
 //
+// # Exactness
+//
+// An `Inexact` flag on an object, a tuple, a function, or a union marks the type
+// OPEN: the object tolerates fields it does not name, the tuple tolerates
+// positions past the ones it lists, and the function tolerates argument counts
+// past its arity. The zero value is exact, which is Escalier's default.
+//
+// The merges below decide exactness rather than carrying it through, because a
+// blind field-union would be unsound for an exact object. Exact `{x}` names its
+// whole key set, so nothing is both exactly-`{x}` and exactly-`{y}` and their meet
+// is `never`, where the inexact pair meets at `{x, y, ...}`. The rules per kind are
+// on meetObjects, meetTuples, and meetFuncs.
+//
+// The open marker also runs in OPPOSITE directions per kind, which is why one
+// shared rule would be wrong. An exact object is a subtype of the otherwise-equal
+// inexact one, since capping the key set only removes values. An inexact FUNCTION
+// is the subtype instead, since tolerating more argument counts only removes
+// values. widerByMarker records both directions in one place.
+//
+// This file is the only place structural exactness is decided. newIntersection and
+// newUnion in lattice.go flatten, prune, dedup, and order a lattice node, and they
+// leave an uninhabited meet standing (#927), so a merge here cannot delegate its
+// exactness rule to them without asking the question back.
+//
 // # What is deliberately left to a later PR
 //
-//   - Exactness-driven merges. An atom's `Inexact` flag rides through every merge
-//     here, and two atoms whose flags disagree are kept separate rather than
-//     fused under a guess. PR7 (#1064) decides the exact cases, such as two exact
-//     objects with differing required fields meeting to `never`.
 //   - Ref atoms. A RefType is an opaque atom that normalization never takes apart.
 //     PR8 (#1065) owns the lifetime split and the guard rejecting `¬(mut 'a T)`.
 
@@ -151,8 +171,17 @@ func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
 			// `A | B | ...` names A, B, and an open tail of unknown content. The tail has
 			// no atom to stand for it, so taking the union apart would drop it and hand
 			// back a type narrower than the source wrote. The whole node stays one atom,
-			// which round-trips exactly and keeps the flag. PR7 (#1064) decides how far
-			// an inexact union can be decomposed.
+			// which round-trips exactly and keeps the flag.
+			//
+			// The opaque atom is the final shape rather than a placeholder, and it costs
+			// only DISTRIBUTION. `(A | B | ...) & C` stays a two-atom meet instead of
+			// becoming `(A & C) | (B & C) | ...`. Two alternatives were weighed and both
+			// are worse. An atom of its own for the tail would have to denote ⊤, which
+			// absorbs the named members and turns `A | B | ...` into `unknown`, losing
+			// exactly what the diagnostics print. An `Open` flag on the DNF would
+			// distribute, but nothing says what the tail meets C to, so the mark would
+			// have to be polarity-aware to stay sound. Neither buys a verdict the opaque
+			// atom gets wrong. Escalier issue #1064 records the full comparison.
 			return dnfAtom(t)
 		}
 		out := DNF{Conjuncts: nil}
@@ -664,6 +693,9 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	if carriesKnot(a) || carriesKnot(b) {
 		return nil, false
 	}
+	if wider, ok := widerByMarker(a, b); ok {
+		return wider, true
+	}
 	if fused, ok := joinValueAtoms(a, b); ok {
 		return fused, true
 	}
@@ -681,6 +713,75 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	// `(A -> C) | (A -> D)` has a single arrow that denotes it: a value of
 	// `A -> (C | D)` may return a C on one input and a D on another, which no member
 	// of the union permits.
+	return nil, false
+}
+
+// widerByMarker returns the wider of two atoms that are EQUAL APART FROM their open
+// marker, and reports whether the pair is such a pair. A union of two types where
+// one contains the other is the containing one, so joinAtoms fuses to it.
+//
+// Which side is wider depends on the kind, because the marker opens a different
+// dimension in each one.
+//
+//   - An OBJECT's marker opens its key set. `{x: A, ...}` admits every record
+//     `{x: A}` admits and also those carrying further fields, so the inexact side
+//     is wider.
+//   - A TUPLE's marker opens its length. `[A, ...]` admits every tuple `[A]` admits
+//     and also the longer ones, so the inexact side is wider again.
+//   - A FUNCTION's marker opens the argument counts a call may use, and the value
+//     filling the type has to tolerate all of them. `fn (x: A, ...) -> B` admits
+//     only functions taking any number of arguments, which is FEWER than
+//     `fn (x: A) -> B` admits. Here the exact side is the wider one.
+//
+// Each arm tests likeness by copying one atom, flipping the copy's marker to the
+// other's, and comparing. That reuses equalType rather than re-spelling per-kind
+// structural equality, and it keeps the test in step with equalType as kinds gain
+// fields.
+func widerByMarker(a, b soltype.Type) (soltype.Type, bool) {
+	switch a := a.(type) {
+	case *soltype.ObjectType:
+		b, isObj := b.(*soltype.ObjectType)
+		if !isObj || a.Inexact == b.Inexact {
+			return nil, false
+		}
+		flipped := *a
+		flipped.Inexact = b.Inexact
+		if !equalType(&flipped, b) {
+			return nil, false
+		}
+		if a.Inexact {
+			return a, true
+		}
+		return b, true
+	case *soltype.TupleType:
+		b, isTuple := b.(*soltype.TupleType)
+		if !isTuple || a.Inexact == b.Inexact {
+			return nil, false
+		}
+		flipped := *a
+		flipped.Inexact = b.Inexact
+		if !equalType(&flipped, b) {
+			return nil, false
+		}
+		if a.Inexact {
+			return a, true
+		}
+		return b, true
+	case *soltype.FuncType:
+		b, isFunc := b.(*soltype.FuncType)
+		if !isFunc || a.Inexact == b.Inexact {
+			return nil, false
+		}
+		flipped := *a
+		flipped.Inexact = b.Inexact
+		if !equalType(&flipped, b) {
+			return nil, false
+		}
+		if a.Inexact {
+			return b, true
+		}
+		return a, true
+	}
 	return nil, false
 }
 
@@ -827,29 +928,38 @@ func joinValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	return nil, false
 }
 
-// meetObjects fuses two object atoms field by field, or keeps them apart when no
-// single object denotes their meet. Keeping two atoms is just as precise and costs
-// only the extra atom, so the fusion is an optimization rather than an obligation.
+// meetObjects fuses two object atoms field by field, returns `never` when no value
+// satisfies both, or keeps them apart when neither answer is available. Keeping two
+// atoms is just as precise and costs only the extra atom, so the fusion is an
+// optimization rather than an obligation.
 //
-// Two INEXACT objects always fuse. Each denotes the values carrying its own fields
-// plus anything else, so their meet is the values carrying both field sets plus
-// anything else, and that is what the merged object denotes.
+// # What an object atom denotes
 //
-// Two EXACT objects fuse when they name the same fields. Neither admits a field
-// its type does not name, so the meet only narrows the fields they share.
+// Read an object as two bounds on the key set S of the values it admits. Every
+// field it marks required is IN S, which is the floor. An exact object also caps S
+// at the fields it names, and an inexact one leaves S uncapped.
 //
-// Two EXACT objects naming DIFFERENT fields are kept apart. Their meet is really
-// `never`, since an exact object carries only the fields its type names and no
-// value satisfies two such objects at once. Settling that is PR7's
-// exactness-aware merge. TODO(#1064). Two objects whose `Inexact` flags disagree
-// are kept apart for the same reason.
+//	{x: A, y?: B}       admits S = {x} and S = {x, y}
+//	{x: A, y?: B, ...}  admits every S containing x
 //
-// A field one side requires and the other makes optional is required on the meet,
-// since a value has to satisfy both objects, so `{x: A} & {x?: B}` is `{x: A & B}`.
+// # The rule
+//
+// The meet's floor is the union of the two floors and its cap is the intersection
+// of the two caps, since a value has to satisfy both objects at once. So:
+//
+//  1. A field either side REQUIRES that the other side caps out is a contradiction,
+//     and the meet is `never`. This is what makes exact `{x} & {y}` uninhabited.
+//  2. A field inside the meet's cap survives. Both sides naming it means the meet
+//     narrows it to their meet, and a field either side requires is required on the
+//     meet, so `{x: A} & {x?: B}` is `{x: A & B}`.
+//  3. A field only one side names and the other side caps out drops. Nothing
+//     required is lost, since rule 1 already answered that case. Exact
+//     `{x: A, y?: B} & {x: C}` is `{x: A & C}`, because the second object admits no
+//     y at all.
+//
+// The meet is exact when either side is, since one cap is enough to close the key
+// set.
 func (c *Context) meetObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
-	if a.Inexact != b.Inexact {
-		return nil, false
-	}
 	pa, ok := plainProps(a)
 	if !ok {
 		return nil, false
@@ -858,13 +968,16 @@ func (c *Context) meetObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 	if !ok {
 		return nil, false
 	}
-	if !a.Inexact && !sameFieldNames(pa, pb) {
-		return nil, false
+	if !requiredFieldsWithin(pa, pb, b.Inexact) || !requiredFieldsWithin(pb, pa, a.Inexact) {
+		return &soltype.NeverType{}, true
 	}
 	elems := make([]soltype.ObjTypeElem, 0, len(pa)+len(pb))
 	for _, p := range pa {
 		q, shared := propNamed(pb, p.Name)
 		if !shared {
+			if !b.Inexact {
+				continue
+			}
 			elems = append(elems, p)
 			continue
 		}
@@ -874,8 +987,6 @@ func (c *Context) meetObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 		if p.Readonly != q.Readonly {
 			return nil, false
 		}
-		// A field either side requires is required on the meet, since a value has to
-		// satisfy both.
 		elems = append(elems, &soltype.PropertyElem{
 			Name:     p.Name,
 			Type:     c.meetTypes(p.Type, q.Type),
@@ -884,11 +995,33 @@ func (c *Context) meetObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 		})
 	}
 	for _, q := range pb {
-		if _, shared := propNamed(pa, q.Name); !shared {
-			elems = append(elems, q)
+		if _, shared := propNamed(pa, q.Name); shared {
+			continue
+		}
+		if !a.Inexact {
+			continue
+		}
+		elems = append(elems, q)
+	}
+	return &soltype.ObjectType{Elems: sortedByName(elems), Inexact: a.Inexact && b.Inexact}, true
+}
+
+// requiredFieldsWithin reports whether every field props REQUIRES is one that
+// allowed names. open says whether the object allowed came from is inexact, which
+// caps nothing and so admits any field name.
+func requiredFieldsWithin(props, allowed []*soltype.PropertyElem, open bool) bool {
+	if open {
+		return true
+	}
+	for _, p := range props {
+		if p.Optional {
+			continue
+		}
+		if _, ok := propNamed(allowed, p.Name); !ok {
+			return false
 		}
 	}
-	return &soltype.ObjectType{Elems: sortedByName(elems), Inexact: a.Inexact}, true
+	return true
 }
 
 // joinObjects fuses two object atoms under a union. One object denotes their union
@@ -906,6 +1039,12 @@ func (c *Context) meetObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 // budget, so `{x: A, y: C} | {x?: A, y: D}` keeps both atoms rather than fusing to
 // a record that admits an absent x beside a y drawn from C. Differing field names
 // break the fusion too, which is why `{x: number} | {y: number}` keeps both.
+//
+// Objects whose open markers disagree are kept apart. `{x: A} | {x: B, ...}` is not
+// `{x: A | B, ...}`, which would admit a record carrying an x drawn from A beside a
+// second field, and only the exact member admits an x from A. The pair that would
+// fuse is the one whose fields also agree, and joinAtoms answers that one through
+// widerByMarker before reaching here.
 func (c *Context) joinObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 	if a.Inexact != b.Inexact {
 		return nil, false
@@ -947,42 +1086,51 @@ func (c *Context) joinObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 	return &soltype.ObjectType{Elems: sortedByName(elems), Inexact: a.Inexact}, true
 }
 
-// meetTuples fuses two tuple atoms position by position.
+// meetTuples fuses two tuple atoms position by position, or returns `never` when
+// the two admit no common length.
 //
-// Two tuples of the same length meet at each position. Two INEXACT tuples of
-// different lengths meet as well. `[A, ...]` denotes the tuples of length at least
-// one whose first element is an A, so meeting it with `[A', B', ...]` gives the
-// tuples of length at least two whose first element is in `A & A'` and whose
-// second is a B'. That is `[A & A', B', ...]`, which is the longer length, the
-// shared prefix narrowed, and the longer tuple's remaining positions carried over.
+// # What a tuple atom denotes
 //
-// Two EXACT tuples of different lengths are kept apart. An exact tuple is
-// fixed-length, so no value is both and their meet is really `never`. Settling
-// that is PR7's exactness-aware merge, and keeping two atoms is sound meanwhile.
-// TODO(#1064). Two tuples whose open markers disagree are kept apart for the same
-// reason.
+// A tuple's length set is a floor and a cap, the way an object's key set is. Its
+// element list is the floor, and an exact tuple caps the length there while an
+// inexact one leaves it uncapped.
+//
+//	[A, B]     admits length 2 alone
+//	[A, ...]   admits every length from 1 up
+//
+// # The rule
+//
+// The meet's floor is the longer element list and its cap is the tighter of the
+// two caps. A cap below that floor admits no length, so the meet is `never`, which
+// is what makes exact `[A] & [A, B]` and exact `[A] & [A', B', ...]` uninhabited.
+//
+// Otherwise every position of the longer list survives. A position both lists name
+// narrows to the meet of the two elements. A position only the longer list names is
+// unconstrained by the shorter one, whose open tail admits anything there, so the
+// longer one's element carries over. `[A, ...] & [A', B', ...]` is
+// `[A & A', B', ...]`.
+//
+// The meet is exact when either side is, since one cap is enough to fix the length.
 func (c *Context) meetTuples(a, b *soltype.TupleType) (soltype.Type, bool) {
 	if !comparableTuples(a, b) {
 		return nil, false
 	}
-	if len(a.Elems) != len(b.Elems) && !a.Inexact {
-		return nil, false
+	length := max(len(a.Elems), len(b.Elems))
+	if (!a.Inexact && length > len(a.Elems)) || (!b.Inexact && length > len(b.Elems)) {
+		return &soltype.NeverType{}, true
 	}
-	long, short := a, b
-	if len(b.Elems) > len(a.Elems) {
-		long, short = b, a
-	}
-	elems := make([]soltype.Type, len(long.Elems))
-	for i := range long.Elems {
-		if i < len(short.Elems) {
-			elems[i] = c.meetTypes(short.Elems[i], long.Elems[i])
-			continue
+	elems := make([]soltype.Type, length)
+	for i := range elems {
+		switch {
+		case i < len(a.Elems) && i < len(b.Elems):
+			elems[i] = c.meetTypes(a.Elems[i], b.Elems[i])
+		case i < len(a.Elems):
+			elems[i] = a.Elems[i]
+		default:
+			elems[i] = b.Elems[i]
 		}
-		// A position only the longer tuple names is unconstrained by the shorter one,
-		// whose open tail admits anything there.
-		elems[i] = long.Elems[i]
 	}
-	return &soltype.TupleType{Elems: elems, Inexact: a.Inexact}, true
+	return &soltype.TupleType{Elems: elems, Inexact: a.Inexact && b.Inexact}, true
 }
 
 // joinTuples fuses two tuple atoms under a union. One tuple denotes their union
@@ -996,8 +1144,12 @@ func (c *Context) meetTuples(a, b *soltype.TupleType) (soltype.Type, bool) {
 // case that would fuse, a shared prefix matching position for position, where the
 // longer tuple is a subtype of the shorter and the union is the shorter one.
 // Recognizing it is a later refinement, not something the union rule needs.
+//
+// Tuples whose open markers disagree are kept apart too, since their length sets
+// differ. The pair that would fuse is the one where the element lists also agree,
+// and joinAtoms answers that one through widerByMarker before reaching here.
 func (c *Context) joinTuples(a, b *soltype.TupleType) (soltype.Type, bool) {
-	if !comparableTuples(a, b) || len(a.Elems) != len(b.Elems) {
+	if !comparableTuples(a, b) || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
 		return nil, false
 	}
 	elems := make([]soltype.Type, len(a.Elems))
@@ -1019,15 +1171,11 @@ func (c *Context) joinTuples(a, b *soltype.TupleType) (soltype.Type, bool) {
 // comparableTuples reports whether two tuple atoms can be lined up position for
 // position at all. A `...P` spread element rules the pair out, since the element
 // list is not yet the tuple's real positions and pairing them up would compare a
-// spread against an ordinary element. Open markers that disagree rule it out too,
-// since one tuple is fixed-length and the other is not.
+// spread against an ordinary element.
 //
-// Length is not checked here, because the meet and the join differ on it. Each
-// applies its own length rule.
+// Neither the length nor the open marker is checked here, because the meet and the
+// join differ on both. Each applies its own rule.
 func comparableTuples(a, b *soltype.TupleType) bool {
-	if a.Inexact != b.Inexact {
-		return false
-	}
 	return !hasSpreadElem(a.Elems) && !hasSpreadElem(b.Elems)
 }
 
@@ -1053,6 +1201,10 @@ func hasSpreadElem(elems []soltype.Type) bool {
 // The one-parameter restriction is load-bearing. Unioning each position
 // independently would fuse `(number, number) -> C` and `(string, string) -> C`
 // into a claim that the value accepts a number paired with a string.
+//
+// The fused arrow is inexact when either side is. An arrow's marker says the value
+// tolerates every argument count from its arity up, and a value satisfying both
+// arrows has to tolerate both demands, so the open one carries.
 func (c *Context) meetFuncs(a, b *soltype.FuncType) (soltype.Type, bool) {
 	if !fusableFuncs(a, b) {
 		return nil, false
@@ -1063,7 +1215,7 @@ func (c *Context) meetFuncs(a, b *soltype.FuncType) (soltype.Type, bool) {
 			Params:         a.Params,
 			Ret:            c.meetTypes(a.Ret, b.Ret),
 			Throws:         a.Throws,
-			Inexact:        a.Inexact,
+			Inexact:        a.Inexact || b.Inexact,
 			TypeParams:     nil,
 			LifetimeParams: nil,
 		}, true
@@ -1081,7 +1233,7 @@ func (c *Context) meetFuncs(a, b *soltype.FuncType) (soltype.Type, bool) {
 			Params:         []*soltype.FuncParam{fused},
 			Ret:            a.Ret,
 			Throws:         a.Throws,
-			Inexact:        a.Inexact,
+			Inexact:        a.Inexact || b.Inexact,
 			TypeParams:     nil,
 			LifetimeParams: nil,
 		}, true
@@ -1091,9 +1243,10 @@ func (c *Context) meetFuncs(a, b *soltype.FuncType) (soltype.Type, bool) {
 
 // fusableFuncs reports whether two function atoms are alike enough for meetFuncs
 // to build one arrow from them. Everything a fused arrow does not recompute must
-// already agree: the arity, the per-parameter markers, the trailing `...`, and what
-// a call may raise. A receiver or a quantifier rules the pair out, since one arrow
-// cannot say which receiver it takes or how the two binder lists correspond.
+// already agree: the arity, the per-parameter markers, and what a call may raise. A
+// receiver or a quantifier rules the pair out, since one arrow cannot say which
+// receiver it takes or how the two binder lists correspond. The trailing `...` is
+// recomputed rather than required to agree, so it is not checked here.
 //
 // Demanding equal raises is conservative. `(A -> C throws E) & (A -> C throws F)`
 // really raises `E & F`, but that merge belongs with PR9's throws threading.
@@ -1108,7 +1261,7 @@ func fusableFuncs(a, b *soltype.FuncType) bool {
 	if len(a.LifetimeParams) > 0 || len(b.LifetimeParams) > 0 {
 		return false
 	}
-	if a.Inexact != b.Inexact || len(a.Params) != len(b.Params) {
+	if len(a.Params) != len(b.Params) {
 		return false
 	}
 	for i := range a.Params {

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -75,7 +75,7 @@ import (
 // shared rule would be wrong. An exact object is a subtype of the otherwise-equal
 // inexact one, since capping the key set only removes values. An inexact FUNCTION
 // is the subtype instead, since tolerating more argument counts only removes
-// values. widerByMarker records both directions in one place.
+// values. widerByExactness records both directions in one place.
 //
 // This file is the only place structural exactness is decided. newIntersection and
 // newUnion in lattice.go flatten, prune, dedup, and order a lattice node. They
@@ -694,7 +694,7 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	if carriesKnot(a) || carriesKnot(b) {
 		return nil, false
 	}
-	if wider, ok := widerByMarker(a, b); ok {
+	if wider, ok := widerByExactness(a, b); ok {
 		return wider, true
 	}
 	if fused, ok := joinValueAtoms(a, b); ok {
@@ -717,24 +717,24 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	return nil, false
 }
 
-// widerByMarker returns the wider of two atoms that are EQUAL APART FROM their open
-// marker, and reports whether the pair is such a pair. A union of two types where
-// one contains the other is the containing one, so joinAtoms fuses to it.
+// widerByExactness returns the wider of two atoms that are EQUAL APART FROM their
+// exactness, and reports whether the pair is such a pair. A union of two types
+// where one contains the other is the containing one, so joinAtoms fuses to it.
 //
-// Which side is wider depends on the kind, because the marker opens a different
+// Which side is wider depends on the kind, because inexactness relaxes a different
 // dimension in each one.
 //
-//   - An OBJECT's marker opens its key set. `{x: A, ...}` admits every record
-//     `{x: A}` admits and also those carrying further fields, so the inexact side
-//     is wider.
-//   - A TUPLE's marker opens its length. `[A, ...]` admits every tuple `[A]` admits
-//     and also the longer ones, so the inexact side is wider again.
-//   - A FUNCTION's marker opens the argument counts a call may use, and the value
-//     filling the type has to tolerate all of them. `fn (x: A, ...) -> B` admits
-//     only functions taking any number of arguments, which is FEWER than
+//   - An OBJECT's inexactness relaxes its key set. `{x: A, ...}` admits every
+//     record `{x: A}` admits and also those carrying further fields, so the inexact
+//     side is wider.
+//   - A TUPLE's inexactness relaxes its length. `[A, ...]` admits every tuple `[A]`
+//     admits and also the longer ones, so the inexact side is wider again.
+//   - A FUNCTION's inexactness relaxes the argument counts a call may use, and the
+//     value filling the type has to tolerate all of them. `fn (x: A, ...) -> B`
+//     admits only functions taking any number of arguments, which is FEWER than
 //     `fn (x: A) -> B` admits. Here the exact side is the wider one.
 //
-// Each arm tests likeness by copying one atom, flipping the copy's marker to the
+// Each arm tests likeness by copying one atom, flipping the copy's exactness to the
 // other's, and comparing. That reuses equalType rather than re-spelling per-kind
 // structural equality, and it keeps the test in step with equalType as kinds gain
 // fields.
@@ -748,7 +748,7 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 // declaration stops checking:
 //
 //	fn go<P>(x: [...P]) -> [...P] | [...P, ...] { return x }
-func widerByMarker(a, b soltype.Type) (soltype.Type, bool) {
+func widerByExactness(a, b soltype.Type) (soltype.Type, bool) {
 	switch a := a.(type) {
 	case *soltype.ObjectType:
 		b, isObj := b.(*soltype.ObjectType)
@@ -1065,7 +1065,7 @@ func requiredFieldsWithin(props, allowed []*soltype.PropertyElem, open bool) boo
 // `{x: A | B, ...}`, which would admit a record carrying an x drawn from A beside a
 // second field, and only the exact member admits an x from A. The pair that would
 // fuse is the one whose fields also agree, and joinAtoms answers that one through
-// widerByMarker before reaching here.
+// widerByExactness before reaching here.
 func (c *Context) joinObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 	if a.Inexact != b.Inexact {
 		return nil, false
@@ -1169,7 +1169,7 @@ func (c *Context) meetTuples(a, b *soltype.TupleType) (soltype.Type, bool) {
 //
 // Tuples whose open markers disagree are kept apart too, since their length sets
 // differ. The pair that would fuse is the one where the element lists also agree,
-// and joinAtoms answers that one through widerByMarker before reaching here.
+// and joinAtoms answers that one through widerByExactness before reaching here.
 func (c *Context) joinTuples(a, b *soltype.TupleType) (soltype.Type, bool) {
 	if !comparableTuples(a, b) || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
 		return nil, false

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -599,13 +599,16 @@ func TestDeMorganOverAnInexactUnion(t *testing.T) {
 //
 // Each source below returns its own argument, which has to check.
 func TestUnreducedAtomsKeepTheirOpenMarkerApart(t *testing.T) {
-	tests := map[string]string{
-		"Tuple":  `fn go<P>(x: [...P]) -> [...P] | [...P, ...] { return x }`,
-		"Object": `fn go<S>(x: {...S}) -> {...S} | {...S, ...} { return x }`,
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "Tuple", src: `fn go<P>(x: [...P]) -> [...P] | [...P, ...] { return x }`},
+		{name: "Object", src: `fn go<S>(x: {...S}) -> {...S} | {...S, ...} { return x }`},
 	}
-	for name, src := range tests {
-		t.Run(name, func(t *testing.T) {
-			_, _, errs := inferSource(t, src)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
 			require.Empty(t, errs)
 		})
 	}

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -212,7 +212,7 @@ func TestDNFRoundTrip(t *testing.T) {
 		},
 		// The three rows below join an atom with the open version of itself. The open
 		// marker decides which side contains the other, and it points the opposite way
-		// for an arrow than for a record or a tuple. widerByMarker states why.
+		// for an arrow than for a record or a tuple. widerByExactness states why.
 		{
 			name: "a record joins with its open version at the open one",
 			in:   "{x: number} | {x: number, ...}",
@@ -591,7 +591,7 @@ func TestDeMorganOverAnInexactUnion(t *testing.T) {
 	require.NotEqual(t, meetOfComplements, normDNF(c, not(open)))
 }
 
-// TestUnreducedAtomsKeepTheirOpenMarkerApart guards the one pair widerByMarker must
+// TestUnreducedAtomsKeepTheirOpenMarkerApart guards the one pair widerByExactness must
 // refuse. A `{...S}` does not know its own field names and a `[...P]` does not know
 // its own positions, so neither says what the exact side caps. The constraint rules
 // treat such an atom as inert and relate two of them only when they are equal, so

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -264,8 +264,8 @@ func TestCNFRoundTrip(t *testing.T) {
 		{name: "the top of the lattice", in: "unknown", want: "unknown"},
 		{name: "a union is one disjunct", in: "number | string", want: "number | string"},
 		// A tuple and a record are the un-fusable pair these two rows need. No merge
-		// takes a pair of different kinds apart, and both stay inhabited: a value
-		// carrying an `x` alongside its indexed elements satisfies each of them.
+		// takes a pair of different kinds apart. Both also stay inhabited, since a
+		// value carrying an `x` alongside its indexed elements satisfies each of them.
 		{name: "an intersection is two disjuncts", in: "[number] & {x: number}", want: "[number] & {x: number}"},
 		{
 			name: "a union distributes over an intersection",
@@ -591,8 +591,30 @@ func TestDeMorganOverAnInexactUnion(t *testing.T) {
 	require.NotEqual(t, meetOfComplements, normDNF(c, not(open)))
 }
 
+// TestUnreducedAtomsKeepTheirOpenMarkerApart guards the one pair widerByMarker must
+// refuse. A `{...S}` does not know its own field names and a `[...P]` does not know
+// its own positions, so neither says what the exact side caps. The constraint rules
+// treat such an atom as inert and relate two of them only when they are equal, so
+// fusing the pair leaves those rules an atom they cannot take apart.
+//
+// Each source below returns its own argument, which has to check.
+func TestUnreducedAtomsKeepTheirOpenMarkerApart(t *testing.T) {
+	tests := map[string]string{
+		"Tuple":  `fn go<P>(x: [...P]) -> [...P] | [...P, ...] { return x }`,
+		"Object": `fn go<S>(x: {...S}) -> {...S} | {...S, ...} { return x }`,
+	}
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, src)
+			require.Empty(t, errs)
+		})
+	}
+}
+
 // TestComplementsKeepTheOpenMarker covers exactness and negation threading through
-// normalization at once, which is the pairing #1064 calls out as easy to break.
+// normalization at once. The two are orthogonal, which is what makes the pairing
+// easy to break. A change that gets either one right on its own can still drop the
+// other where they cross.
 //
 // `¬{x: number}` excludes the records whose only field is an x. `¬{x: number, ...}`
 // excludes every record carrying an x, which is a strictly larger set, so the two

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -64,9 +64,9 @@ func TestDNFRoundTrip(t *testing.T) {
 		{name: "a borrow is an opaque atom", in: "mut {x: number}", want: "mut {x: number}"},
 		{name: "a union of two primitives keeps both", in: "number | string", want: "number | string"},
 		{
-			name: "two exact records keep both atoms",
+			name: "two exact records over disjoint fields meet to the bottom of the lattice",
 			in:   "{x: number} & {y: number}",
-			want: "{x: number} & {y: number}",
+			want: "never",
 		},
 		{
 			name: "two inexact records merge field-wise",
@@ -77,6 +77,21 @@ func TestDNFRoundTrip(t *testing.T) {
 			name: "two exact records over one field narrow that field",
 			in:   "{x: number | string} & {x: string | boolean}",
 			want: "{x: string}",
+		},
+		{
+			name: "an optional field the other exact record caps out drops",
+			in:   "{x: number, y?: string} & {x: number}",
+			want: "{x: number}",
+		},
+		{
+			name: "an exact record caps the fields an inexact one leaves open",
+			in:   "{x: number, y?: string} & {x: number, ...}",
+			want: "{x: number, y?: string}",
+		},
+		{
+			name: "an inexact record requiring a field the exact one caps out meets to never",
+			in:   "{x: number} & {y: number, ...}",
+			want: "never",
 		},
 		{
 			name: "a field either side requires is required on the meet",
@@ -99,14 +114,19 @@ func TestDNFRoundTrip(t *testing.T) {
 			want: "[string, boolean, ...]",
 		},
 		{
-			name: "two exact tuples of different lengths keep both atoms",
+			name: "two exact tuples of different lengths meet to the bottom of the lattice",
 			in:   "[number] & [number, boolean]",
-			want: "[number] & [number, boolean]",
+			want: "never",
 		},
 		{
-			name: "two tuples whose open markers disagree keep both atoms",
+			name: "an exact tuple fixes the length an inexact one leaves open",
 			in:   "[number, ...] & [number, boolean]",
-			want: "[number, boolean] & [number, ...]",
+			want: "[number, boolean]",
+		},
+		{
+			name: "an exact tuple shorter than an inexact one's floor meets to never",
+			in:   "[number] & [number, boolean, ...]",
+			want: "never",
 		},
 		{
 			name: "two disjoint primitives meet to the bottom of the lattice",
@@ -139,9 +159,11 @@ func TestDNFRoundTrip(t *testing.T) {
 			want: "{x: number}",
 		},
 		{
+			// The members are inexact so that each distributed meet is inhabited. Two exact
+			// records over disjoint fields would meet to `never` and leave nothing to read.
 			name: "an intersection distributes over a union",
-			in:   "({x: number} | {y: number}) & {z: number}",
-			want: "{x: number} & {z: number} | {y: number} & {z: number}",
+			in:   "({x: number, ...} | {y: number, ...}) & {z: number, ...}",
+			want: "{x: number, z: number, ...} | {y: number, z: number, ...}",
 		},
 		{
 			name: "a primitive absorbs a literal of its own family",
@@ -188,6 +210,29 @@ func TestDNFRoundTrip(t *testing.T) {
 			in:   "[number] | [number, boolean]",
 			want: "[number] | [number, boolean]",
 		},
+		// The three rows below join an atom with the open version of itself. The open
+		// marker decides which side contains the other, and it points the opposite way
+		// for an arrow than for a record or a tuple. widerByMarker states why.
+		{
+			name: "a record joins with its open version at the open one",
+			in:   "{x: number} | {x: number, ...}",
+			want: "{x: number, ...}",
+		},
+		{
+			name: "a tuple joins with its open version at the open one",
+			in:   "[number] | [number, ...]",
+			want: "[number, ...]",
+		},
+		{
+			name: "an arrow joins with its open version at the CLOSED one",
+			in:   "(fn (x: number) -> boolean) | (fn (x: number, ...) -> boolean)",
+			want: "fn (x: number) -> boolean",
+		},
+		{
+			name: "and the meet of that arrow pair takes the open one",
+			in:   "(fn (x: number) -> boolean) & (fn (x: number, ...) -> boolean)",
+			want: "fn (x: number, ...) -> boolean",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -218,11 +263,14 @@ func TestCNFRoundTrip(t *testing.T) {
 		{name: "the bottom of the lattice", in: "never", want: "never"},
 		{name: "the top of the lattice", in: "unknown", want: "unknown"},
 		{name: "a union is one disjunct", in: "number | string", want: "number | string"},
-		{name: "an intersection is two disjuncts", in: "{x: number} & {y: number}", want: "{x: number} & {y: number}"},
+		// A tuple and a record are the un-fusable pair these two rows need. No merge
+		// takes a pair of different kinds apart, and both stay inhabited: a value
+		// carrying an `x` alongside its indexed elements satisfies each of them.
+		{name: "an intersection is two disjuncts", in: "[number] & {x: number}", want: "[number] & {x: number}"},
 		{
 			name: "a union distributes over an intersection",
-			in:   "({x: number} & {y: number}) | {z: number}",
-			want: "({x: number} | {z: number}) & ({y: number} | {z: number})",
+			in:   "([number] & {x: number}) | {z: number}",
+			want: "([number] | {z: number}) & ({x: number} | {z: number})",
 		},
 		{
 			name: "a primitive absorbs a literal of its own family",
@@ -397,9 +445,9 @@ func TestCNFNegationRoundTrip(t *testing.T) {
 		{
 			name: "a complemented intersection is one disjunct negating both atoms",
 			in: func(t *testing.T) soltype.Type {
-				return notSrc(t, "{x: number} & {y: number}")
+				return notSrc(t, "[number] & {x: number}")
 			},
-			want: "¬({x: number} & {y: number})",
+			want: "¬([number] & {x: number})",
 		},
 		{
 			name: "a complement beside a positive atom",
@@ -541,6 +589,57 @@ func TestDeMorganOverAnInexactUnion(t *testing.T) {
 	open := newUnion(nil, []soltype.Type{a, b}, true)
 	require.Equal(t, "¬({x: number} | {y: number} | ...)", normDNF(c, not(open)))
 	require.NotEqual(t, meetOfComplements, normDNF(c, not(open)))
+}
+
+// TestComplementsKeepTheOpenMarker covers exactness and negation threading through
+// normalization at once, which is the pairing #1064 calls out as easy to break.
+//
+// `¬{x: number}` excludes the records whose only field is an x. `¬{x: number, ...}`
+// excludes every record carrying an x, which is a strictly larger set, so the two
+// complements denote different types. Normalization has to keep them apart as atoms
+// and still apply the containment between them when they meet or join.
+func TestComplementsKeepTheOpenMarker(t *testing.T) {
+	c := &Context{}
+	closed, open := parseType(t, "{x: number}"), parseType(t, "{x: number, ...}")
+
+	// Each complement round-trips with its marker intact.
+	require.Equal(t, "¬{x: number}", normDNF(c, not(closed)))
+	require.Equal(t, "¬{x: number, ...}", normDNF(c, not(open)))
+
+	// The two complements are distinct types, so nothing downstream may dedup one
+	// into the other. compareType is checked alongside equalType because the merges
+	// order atoms before they compare them.
+	require.False(t, equalType(not(closed), not(open)))
+	require.NotEqual(t, 0, compareType(not(closed), not(open)))
+
+	// `{x: number}` is contained in `{x: number, ...}`, so complementing flips which
+	// side absorbs. The meet of the complements excludes the larger set and the join
+	// of them excludes the smaller one.
+	require.Equal(t, "¬{x: number, ...}",
+		normDNF(c, newIntersection(nil, []soltype.Type{not(closed), not(open)})))
+	require.Equal(t, "¬{x: number}",
+		normDNF(c, newUnion(nil, []soltype.Type{not(closed), not(open)}, false)))
+}
+
+// TestExactUnionNormalizesClosed contrasts a closed union with the open union of
+// the same members. `"a" | "b"` names its whole member set, so normalization takes
+// it apart into one conjunct per member. `"a" | "b" | ...` also admits an open tail
+// that no atom stands for, so it stays whole.
+//
+// The conjunct counts are the substantive half. A meet distributes over the closed
+// union's members and cannot distribute over the open one, which is the cost the
+// mkDNF arm's comment weighs.
+func TestExactUnionNormalizesClosed(t *testing.T) {
+	c := &Context{}
+	members := parseTypes(t, `"a"`, `"b"`)
+	closed := newUnion(nil, members, false)
+	open := newUnion(nil, members, true)
+
+	require.Equal(t, `"a" | "b"`, normDNF(c, closed))
+	require.Len(t, c.mkDNF(closed, soltype.Positive).Conjuncts, 2)
+
+	require.Equal(t, `"a" | "b" | ...`, normDNF(c, open))
+	require.Len(t, c.mkDNF(open, soltype.Positive).Conjuncts, 1)
 }
 
 // TestValueAtomsAnswerEqualAtoms checks the value-family merges on their own,
@@ -777,9 +876,9 @@ func TestFuncMerge(t *testing.T) {
 			want: "fn (x: number, y: string) -> string",
 		},
 		{
-			name: "arms differing in the trailing open marker are kept apart",
+			name: "arms differing in the trailing open marker fuse to the open one",
 			in:   "(fn (x: number) -> boolean) & (fn (x: string, ...) -> boolean)",
-			want: "(fn (x: number) -> boolean) & (fn (x: string, ...) -> boolean)",
+			want: "fn (x: number | string, ...) -> boolean",
 		},
 		{
 			name: "a union of two arrows keeps both, since no single arrow denotes it",
@@ -853,9 +952,12 @@ func TestCanonicalOrderIsPermutationStable(t *testing.T) {
 			want:    "{x: number} | {y: number} | {z: number}",
 		},
 		{
-			name:    "an intersection of records",
-			members: []string{"{y: number}", "{x: number}", "{z: number}"},
-			want:    "{x: number} & {y: number} & {z: number}",
+			// Three records would not do here. Exact records over disjoint fields meet to
+			// `never`, which leaves no member order to compare, so the row draws one atom
+			// from each of three kinds no merge fuses.
+			name:    "an intersection of atoms no merge fuses",
+			members: []string{"{x: number}", "fn () -> boolean", "[number]"},
+			want:    "[number] & {x: number} & (fn () -> boolean)",
 		},
 		{
 			name:    "an intersection of inexact records, which fuses into one",

--- a/internal/solver/ucs_coverage_test.go
+++ b/internal/solver/ucs_coverage_test.go
@@ -583,3 +583,43 @@ func TestNonExhaustiveMessageNamesTheConstruct(t *testing.T) {
 		})
 	}
 }
+
+// TestMatchCoverageExactUnionNeedsNoDefault is the exactness payoff #1064 names. A
+// union written without a trailing `...` is closed, so its members are the whole set of
+// values a scrutinee of that type can take. Arms covering each member therefore leave
+// nothing for a default arm to catch, and asking for one would name a branch that could
+// never run.
+//
+// The inexact union of the same members is the contrast. Its open tail admits values no
+// arm names, so the same arms are not exhaustive there.
+//
+// The arms discriminate by field NAME. Discriminating a closed union by a literal tag
+// field, the `{kind: "circle"}` shape, is not credited yet: a literal inside an object
+// pattern reads as refutable, so its arm covers no member. That is the M5 tag-exhaustiveness
+// half of the payoff, and it lands with M5 rather than here.
+func TestMatchCoverageExactUnionNeedsNoDefault(t *testing.T) {
+	arms := `
+		return match s {
+			{x} => x,
+			{y} => y
+		}
+	`
+
+	t.Run("Exact", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn pick(s: {x: number} | {y: number}) {`+arms+`}
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn (s: {x: number} | {y: number}) -> number", values["pick"])
+	})
+
+	t.Run("Inexact", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn pick(s: {x: number} | {y: number} | ...) {`+arms+`}
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t,
+			"3:10-6:4: match is not exhaustive; `{x: number} | {y: number} | ...` is inexact and admits values no pattern names, so add a catch-all branch",
+			msgWithSpan(errs[0]))
+	})
+}

--- a/internal/solver/ucs_coverage_test.go
+++ b/internal/solver/ucs_coverage_test.go
@@ -584,19 +584,18 @@ func TestNonExhaustiveMessageNamesTheConstruct(t *testing.T) {
 	}
 }
 
-// TestMatchCoverageExactUnionNeedsNoDefault is the exactness payoff #1064 names. A
-// union written without a trailing `...` is closed, so its members are the whole set of
-// values a scrutinee of that type can take. Arms covering each member therefore leave
-// nothing for a default arm to catch, and asking for one would name a branch that could
-// never run.
+// TestMatchCoverageExactUnionNeedsNoDefault covers what exactness buys a `match`. A union
+// written without a trailing `...` is closed, so its members are the whole set of values a
+// scrutinee of that type can take. Arms covering each member therefore leave nothing for a
+// default arm to catch, and asking for one would name a branch that could never run.
 //
 // The inexact union of the same members is the contrast. Its open tail admits values no
 // arm names, so the same arms are not exhaustive there.
 //
-// The arms discriminate by field NAME. Discriminating a closed union by a literal tag
-// field, the `{kind: "circle"}` shape, is not credited yet: a literal inside an object
-// pattern reads as refutable, so its arm covers no member. That is the M5 tag-exhaustiveness
-// half of the payoff, and it lands with M5 rather than here.
+// The arms below discriminate by field NAME. Discriminating a closed union by a literal
+// tag field, the `{kind: "circle"}` shape, is not credited yet. A literal inside an object
+// pattern reads as refutable, so its arm covers no member. That half of the payoff lands
+// with the declared-subtype milestone M5 rather than here.
 func TestMatchCoverageExactUnionNeedsNoDefault(t *testing.T) {
 	arms := `
 		return match s {


### PR DESCRIPTION
Fixes #1064.

Implements the exactness-aware merge logic for structural types that was previously deferred. The `Inexact` flag on objects, tuples, functions, and unions now drives how these types combine under meet and join operations.

## Summary

The key insight is that the marker opens a different dimension in each kind, and it does not point the same way in all of them:

- **Objects**: An inexact object admits extra fields beyond those it names, so `{x: A, ...}` is wider than `{x: A}`.
- **Tuples**: An inexact tuple admits longer lengths, so `[A, ...]` is wider than `[A]`.
- **Functions**: An inexact function must tolerate every argument count from its arity up, which is a stricter demand on the value. So `fn (x: A, ...) -> B` is *narrower* than `fn (x: A) -> B`, the opposite direction from the two kinds above. This matches `acceptSet` in `constrain.go`.

## Key changes

- **`meetObjects`**: Reads an object as a floor and a cap on the key set it admits. Required fields are the floor; an exact object caps the set at the fields it names and an inexact one leaves it uncapped. The meet takes the union of the floors and the intersection of the caps, so a field either side requires that the other side caps out makes the meet `never`. Exact `{x} & {y}` is therefore uninhabited, and so is exact `{x} & {y, ...}`. A field only one side names and the other caps out drops instead, so exact `{x: A, y?: B} & {x: C}` is `{x: A & C}`. The meet is **exact when either side is**, since one cap is enough to close the key set.
- **`meetTuples`**: The same floor-and-cap rule over lengths. `[A] & [A, B]` and `[A] & [A', B', ...]` are both `never`, while `[A, ...] & [A', B', ...]` is `[A & A', B', ...]`. The meet is exact when either side is.
- **`meetFuncs`**: The fused arrow is inexact when either side is, since the open marker is the stronger demand.
- **`widerByMarker`**: New helper that identifies when two atoms differ only in their `Inexact` flag and returns the wider one, recording the per-kind direction in one place. `joinAtoms` consults it.
- **`joinObjects` and `joinTuples`**: Keep atoms apart when the markers disagree. `widerByMarker` has already answered the one pair that fuses.
- **`comparableTuples`**: No longer rejects tuples whose markers differ; the meet and the join each apply their own rule.
- **`fusableFuncs`**: No longer requires the markers to agree, since `meetFuncs` recomputes the marker.

## Notable details

- Unreduced atoms such as `{...S}` and `[...P]` are left alone by `widerByMarker`. Neither knows its own field names or positions, so neither supports the claim that one side caps what the other leaves open, and the constraint rules relate two of them only when they are equal. Fusing the pair stopped `fn go<P>(x: [...P]) -> [...P] | [...P, ...] { return x }` from checking.
- The inexact union stays one opaque atom, which is the shape decision the issue asked for. A tail atom denoting the top of the lattice would absorb the named members and turn `A | B | ...` into `unknown`, and an `Open` flag on the DNF would need a polarity-aware rule for what the tail meets to. Neither buys a verdict the opaque atom gets wrong. The cost is distribution alone, and it is documented on the `mkDNF` arm.
- The issue proposed delegating the merges to `newIntersection` / `newUnion`. That premise does not hold: those constructors flatten, prune, dedup, and order a lattice node but leave an uninhabited meet standing (#927), so delegating would ask the question back. `normal.go` stays the single place structural exactness is decided, and the file header now says so.
- Test cases updated where they pinned the old keep-both-atoms behavior. Exact records over disjoint fields now meet to `never`, so rows needing an un-fusable pair draw from two different kinds instead. `IntersectionCheckCaptures` in `infer_typeops_test.go` needed inexact operands, since its written intersection is now `never` and satisfies the Check vacuously.
- `constrainImplied`'s incompleteness example was `{x: number} & {y: number} <: {x: number, y: number}`, which this change settles. It now cites `boolean <: true | false`, which is still rejected.

https://claude.ai/code/session_01Kmc4HsMbLizDs3VmYrgKe6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type normalization for exact and open objects, tuples, functions, and unions.
  * More accurately detects incompatible structural combinations and reduces them to impossible types.
  * Preserves openness information during type complements and decomposition.
  * Improved match coverage detection for exact object unions, while retaining diagnostics for open unions.

* **Tests**
  * Added comprehensive coverage for structural intersections, exactness, markers, complements, and union normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->