### PR TITLE
Implement set-difference semantics for try/catch exception handling

### DIFF
--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -213,7 +213,7 @@ func (c *Context) decideArrows(subCands, superCands []soltype.Type, seen *seenPa
 	}
 	for _, cand := range superCands {
 		target, ok := cand.(*soltype.FuncType)
-		if !ok || !decomposableArrow(target) || !sameRaises(arms, target) {
+		if !ok || !decomposableArrow(target) {
 			continue
 		}
 		p := newProbe(c, c.probe)
@@ -236,13 +236,17 @@ func (c *Context) decideArrows(subCands, superCands []soltype.Type, seen *seenPa
 //  1. The target's domain is covered, `E <: ⋃ᵢ Aᵢ`, since no arm says what the
 //     value does with an input outside every arm's domain.
 //  2. For every group P of arms, either the arms outside P still cover the inputs,
-//     `E <: ⋃_{i∉P} Aᵢ`, or P returns something the target tolerates,
-//     `⋂_{i∈P} Cᵢ <: F`. A value carrying every arm type returns, on a given
-//     input, something in the codomain of every arm that accepts it.
+//     `E <: ⋃_{i∉P} Aᵢ`, or P produces outputs the target tolerates. A value
+//     carrying every arm type answers a given input the way every arm that accepts
+//     it does, so both of the arrow's outputs are checked over the group:
+//     `⋂_{i∈P} Cᵢ <: F` for the codomains and `⋂_{i∈P} Eᵢ <: G` for the raises.
+//     `throws` is a covariant output alongside the return type, so it rides the
+//     leg the codomain rides.
 //
-// Every leg compares domain against domain or codomain against codomain, so each
-// runs with the deep-mut context cleared, as the arrow rule in the structural
-// switch clears it. A function carries its own annotation context.
+// Every leg compares like against like. A domain is weighed against a domain, a
+// codomain against a codomain, and a clause against a clause. Each therefore runs
+// with the deep-mut context cleared, as the arrow rule in the structural switch
+// clears it. A function carries its own annotation context.
 func (c *Context) arrowLegsHold(arms []*soltype.FuncType, target *soltype.FuncType, seen *seenPairs) bool {
 	domain := target.Params[0].Type
 	// Leg 1. Every input the target accepts is accepted by some arm.
@@ -260,6 +264,9 @@ func (c *Context) arrowLegsHold(arms []*soltype.FuncType, target *soltype.FuncTy
 			continue
 		}
 		if hasHardError(c.constrain(meetCodomains(arms, group), target.Ret, seen.Clone(), false)) {
+			return false
+		}
+		if hasHardError(c.constrain(meetRaises(arms, group), target.ThrowsOrNever(), seen.Clone(), false)) {
 			return false
 		}
 	}
@@ -295,6 +302,19 @@ func meetCodomains(arms []*soltype.FuncType, group int) soltype.Type {
 	return newIntersection(nil, parts)
 }
 
+// meetRaises is the intersection of the raises of the arms in group, what a value
+// carrying every arm type may raise on an input only this group accepts. It is the
+// throws twin of meetCodomains.
+func meetRaises(arms []*soltype.FuncType, group int) soltype.Type {
+	parts := make([]soltype.Type, 0, len(arms))
+	for i, arm := range arms {
+		if group&(1<<i) != 0 {
+			parts = append(parts, arm.ThrowsOrNever())
+		}
+	}
+	return newIntersection(nil, parts)
+}
+
 // decomposableArrows returns the atoms of a meet the decomposition can weigh and
 // drops the rest, which is sound because a meet is a subtype of each of its parts.
 func decomposableArrows(atoms []soltype.Type) []*soltype.FuncType {
@@ -318,18 +338,6 @@ func decomposableArrow(f *soltype.FuncType) bool {
 		return false
 	}
 	return !f.Params[0].Optional && !f.Params[0].Rest
-}
-
-// sameRaises reports whether every arm raises what the target raises. The legs
-// compare domains and codomains alone, so an arm that could raise something the
-// target does not name is ruled out here.
-func sameRaises(arms []*soltype.FuncType, target *soltype.FuncType) bool {
-	for _, arm := range arms {
-		if !equalType(arm.ThrowsOrNever(), target.ThrowsOrNever()) {
-			return false
-		}
-	}
-	return true
 }
 
 // nfPair is one candidate pair constrainImplied trials.

--- a/internal/solver/constrain_nf_test.go
+++ b/internal/solver/constrain_nf_test.go
@@ -32,19 +32,26 @@ import (
 // # The arrow decomposition
 //
 // The sound verdict for an arrow row comes from the Frisch-Castagna-Benzaken
-// decomposition, which does not collapse the intersection to one arrow. To decide
-// `⋂ᵢ (Aᵢ → Cᵢ) <: (E → F)`, both of these must hold.
+// decomposition, which does not collapse the intersection to one arrow. An arrow
+// has two outputs, the value it returns and the exception it raises, so a row is
+// written `Aᵢ → Cᵢ raises Gᵢ` and the target `E → F raises H`. To decide
+// `⋂ᵢ (Aᵢ → Cᵢ raises Gᵢ) <: (E → F raises H)`, both of these must hold.
 //
 //  1. The target domain is covered: `E <: ⋃ᵢ Aᵢ`. No input the target accepts may
 //     fall outside every arm's domain.
 //  2. For every subset P of the arms, either the inputs are still covered without
-//     P — `E <: ⋃_{i∉P} Aᵢ` — or the arms in P return something the target
-//     tolerates, `⋂_{i∈P} Cᵢ <: F`.
+//     P — `E <: ⋃_{i∉P} Aᵢ` — or the arms in P produce outputs the target
+//     tolerates, both `⋂_{i∈P} Cᵢ <: F` and `⋂_{i∈P} Gᵢ <: H`.
 //
 // Leg 2 reads concretely as follows. A value that has all of the arm types
-// returns, on a given input, something in the codomain of every arm whose domain
-// accepts that input. So the subtyping fails exactly when some group of arms is
-// the only cover for part of E while their combined codomain escapes F.
+// answers a given input the way every arm whose domain accepts that input does, so
+// it returns something in each of their codomains and raises something each of
+// their clauses admits. The subtyping therefore fails exactly when some group of
+// arms is the only cover for part of E while their combined codomain escapes F or
+// their combined clause escapes H.
+//
+// A row that writes no `throws` clause raises `never`, so its raises half of leg 2
+// is `never <: never` and the row is decided by its codomain half alone.
 //
 // # The record-union widening
 //
@@ -73,6 +80,9 @@ import (
 // The two tagged rows stay unobserved. Their members share the field name `tag`,
 // and a same-named second field is not what makes the widening bail, so neither
 // finding settles them. Filling those two needs a run.
+//
+// Every row carrying a `throws` clause stays unobserved as well. MLscript has no
+// such clause, so it cannot state the row at all and no finding settles it.
 //
 // Two rows disagree with the oracle under those rules, and each says so in its
 // why. Both are cases where the merged codomain collapses to `never` and the
@@ -261,6 +271,73 @@ var nfArrowCorpus = []nfRow{
 		why: "example A with T for boolean. The verdict does not depend on what T is, since the " +
 			"domains cover number | string and every group's combined codomain is T & T = T",
 		mlscript: nfHolds,
+	},
+	{
+		name: "shared codomain and raises: the target widens the clause",
+		sub: `(fn (x: number) -> boolean throws "a") & ` +
+			`(fn (x: string) -> boolean throws "a")`,
+		super: `fn (x: number | string) -> boolean throws "a" | "b"`,
+		sound: nfHolds,
+		why: `example A with a clause on every arrow. The arms agree on both outputs, so they ` +
+			`fuse to the one arrow fn (x: number | string) -> boolean throws "a", and the ` +
+			`fused clause is compared covariantly against the target's wider one`,
+	},
+	{
+		name:  "the reverse direction: the target narrows the clause",
+		sub:   `fn (x: number | string) -> boolean throws "a" | "b"`,
+		super: `fn (x: number | string) -> boolean throws "a"`,
+		sound: nfFails,
+		why: `the mirror of the row above, and the one that pins the direction. A call may raise ` +
+			`"b", which the target's clause does not admit, so the covariant comparison of the ` +
+			`two clauses fails`,
+		wantErrs: []string{`cannot constrain "b" <: "a"`},
+	},
+	{
+		name: "distinct domains, distinct raises: the target unions both clauses",
+		sub: `(fn (x: number) -> boolean throws "a") & ` +
+			`(fn (x: string) -> boolean throws "b")`,
+		super: `fn (x: number | string) -> boolean throws "a" | "b"`,
+		sound: nfHolds,
+		why: `the arms disagree on what they raise, so no single arrow denotes their meet and the ` +
+			`decomposition decides the row. Leg 1 holds since the arm domains cover ` +
+			`number | string. Leg 2 holds for each group: the number arm alone raises "a", the ` +
+			`string arm alone raises "b", and the group holding both raises "a" & "b", which no ` +
+			`value inhabits`,
+	},
+	{
+		name: "distinct domains: one arm's clause escapes the target",
+		sub: `(fn (x: number) -> boolean throws "a") & ` +
+			`(fn (x: string) -> boolean throws "b")`,
+		super: `fn (x: number | string) -> boolean throws "a"`,
+		sound: nfFails,
+		why: `leg 2 fails for the group holding the string arm alone: a string input is covered by ` +
+			`no other arm, and that arm raises "b", which the target's clause does not admit. ` +
+			`This is the raises half of the leg that example B fails through its codomain half`,
+		wantErrs: []string{
+			"cannot constrain number <: string",
+			`cannot constrain "b" <: "a"`,
+		},
+	},
+	{
+		name: "shared domain, distinct raises: the target takes their meet",
+		sub: `(fn (x: number) -> boolean throws "a" | "b") & ` +
+			`(fn (x: number) -> boolean throws "b" | "c")`,
+		super: `fn (x: number) -> boolean throws "b"`,
+		sound: nfHolds,
+		why: `the raises twin of the shared-domain codomain row. A value with both arm types raises ` +
+			`only what both clauses admit, so a call raises ("a" | "b") & ("b" | "c"), which is ` +
+			`"b", and the target accepts it`,
+	},
+	{
+		name: "shared domain, disjoint raises: the combined clause is uninhabited",
+		sub: `(fn (x: number) -> boolean throws "a") & ` +
+			`(fn (x: number) -> boolean throws "b")`,
+		super: "fn (x: number) -> boolean",
+		sound: nfHolds,
+		why: `the verdict is vacuous, the raises twin of the disjoint-codomains row. A value with ` +
+			`both arm types would have to raise both "a" and "b" on any number input, and no value ` +
+			`is both, so such a value never raises on a number input. Its combined clause is ` +
+			"`never`, which the target's unwritten clause admits",
 	},
 }
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3575,14 +3575,21 @@ func (c *checker) caughtType(collected soltype.Type) soltype.Type {
 // rethrowUnhandled sends the part of the caught union no arm covers into the enclosing
 // throws sink. A value matching no arm is re-raised at runtime, so uncovered members draw a
 // rethrow rather than the non-exhaustiveness error the equivalent `match` would draw.
-// Coverage comes from ast.HasUnguardedCatchAll and unionMemberCovered, so it agrees with
-// checkCondExhaustive, and a guarded arm can fail its guard and covers nothing. Only the
-// MEMBERS are rethrown: every throws type is open already, and only `unknown` could carry
-// the tail, so adding it would erase the named types the clause had.
+//
+// What escapes is the set difference `caught ∩ ¬handled`, where handled is the type the arms
+// catch. The difference is taken one member at a time, which is exact because meeting a
+// complement distributes over a union: `(A | B) ∩ ¬H` is `(A ∩ ¬H) | (B ∩ ¬H)`. A member
+// survives when the meet still holds a value, which memberCaught decides.
+//
+// A guarded arm can fail its guard, so it catches nothing and contributes nothing to handled.
+// An unguarded catch-all catches every value and is answered before the difference is taken.
+// Only the MEMBERS are rethrown: every throws type is open already, and only `unknown` could
+// carry the tail, so adding it would erase the named types the clause had.
 func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, enclosing soltype.Type) {
 	if ast.HasUnguardedCatchAll(e.Catch) {
 		return
 	}
+	handled := c.armsCatchType(scope, e.Catch)
 	// A non-union `caught` carries no named member to rethrow. It is `unknown`, the bare
 	// open tail caughtType renders for a block that raises nothing known, or the ErrorType
 	// recovery placeholder. Neither leaves anything for the enclosing clause to record.
@@ -3591,14 +3598,16 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 		uncovered := make([]soltype.Type, 0, len(u.Types))
 		for _, m := range u.Types {
 			// A transparent alias member, an enum handle or a `type` reference, carries the
-			// alias rather than the type it stands for. unionMemberCovered has no arm for
-			// one, so an unexpanded alias reads as uncovered however many arms name its
-			// members, and `type Err = "a" | "b"` would behave unlike the union spelled
-			// inline. checkCondExhaustive expands for the same reason.
+			// alias rather than the type it stands for. The difference is decided against the
+			// alias handle, which no arm's type is a supertype of, so an unexpanded alias
+			// reads as uncovered however many arms name its members, and
+			// `type Err = "a" | "b"` would behave unlike the union spelled inline.
+			// checkCondExhaustive expands for the same reason.
 			for _, part := range unionParts(c.expandAliasChain(m)) {
-				if !c.unionMemberCovered(scope, part, e.Catch) {
-					uncovered = append(uncovered, part)
+				if c.memberCaught(scope, part, handled, e.Catch) {
+					continue
 				}
+				uncovered = append(uncovered, part)
 			}
 		}
 		rethrown = newUnion(c.ctx, uncovered, false)
@@ -3644,65 +3653,151 @@ func unionParts(t soltype.Type) []soltype.Type {
 	return []soltype.Type{t}
 }
 
-// unionMemberCovered reports whether some unguarded arm covers a single union member,
-// dispatching on the member's kind. A literal member needs an equal literal pattern, a
-// `null` or `undefined` member an arm spelling that same word, a nominal member an
-// instance or extractor pattern naming its class, and a structural object or tuple
-// member an irrefutable pattern of its shape. Any other member kind has no covering
-// pattern short of a catch-all, which the caller has already checked.
-func (c *checker) unionMemberCovered(scope *Scope, member soltype.Type, arms []*ast.MatchCase) bool {
-	switch m := member.(type) {
-	case *soltype.LitType:
-		return c.litMemberCovered(m, arms)
-	case *soltype.NullType, *soltype.UndefinedType:
-		return atomMemberCovered(member, arms)
-	case *soltype.ClassType:
-		return c.nominalMemberCovered(scope, m, arms)
-	case *soltype.ObjectType, *soltype.TupleType:
-		return structuralMemberCovered(member, arms)
-	default:
-		return false
-	}
+// memberCaught reports whether the catch arms catch every value of one member of the caught
+// type, which is what keeps that member out of the rethrow. Three rules answer it, and the
+// member is caught when any of them does.
+//
+//  1. The set difference. handled is the type the arms catch, so the member is caught when
+//     `member ∩ ¬handled` holds no value. This is the primary rule, and it is the one that
+//     reads through subtyping: an arm naming a base class catches a subclass member, which
+//     comparing class names cannot see.
+//  2. The nominal name rule. A class arm catches every instance of the class it names,
+//     whatever type arguments that instance carries, and rule 1 declines the member when
+//     deciding it would pin a type argument. `catch { Err{x} => … }` therefore still catches
+//     an `Err<number>` member through this rule.
+//  3. The structural shape rule. An object or tuple pattern admits every value of a shape
+//     rather than of a type, so it has no entry in handled at all and structuralMemberCovered
+//     reads the shape against the member.
+//
+// Each rule only ever catches more, so a member no rule answers is rethrown. That is the safe
+// direction. A clause naming a type the block cannot raise is still checked against the
+// enclosing clause, where a clause silent about one the block can raise would let an exception
+// escape unnamed.
+func (c *checker) memberCaught(scope *Scope, member, handled soltype.Type, arms []*ast.MatchCase) bool {
+	return c.memberSubtracted(member, handled) ||
+		c.nominalMemberCovered(scope, member, arms) ||
+		structuralMemberCovered(member, arms)
 }
 
-// nominalMemberCovered reports whether some unguarded arm covers a nominal union member.
-// An instance or extractor pattern covers the member when it names the member's class and
+// nominalMemberCovered reports whether some unguarded arm names the class of a nominal
+// member. An instance or extractor pattern covers the member when it names that class and
 // every sub-pattern is irrefutable, so `Color.RGB(r, g, b)` covers `Color.RGB` but
-// `Color.RGB(1, g, b)`, which matches only when the first field is 1, does not.
-func (c *checker) nominalMemberCovered(scope *Scope, member *soltype.ClassType, arms []*ast.MatchCase) bool {
+// `Color.RGB(1, g, b)`, which matches only when the first field is 1, does not. A member of
+// any other kind is never covered here.
+//
+// The class names are compared rather than the class types, so the rule holds whatever type
+// arguments either side carries. That is what it adds over the set difference, which declines
+// a member whose subtraction would pin a type argument.
+func (c *checker) nominalMemberCovered(scope *Scope, member soltype.Type, arms []*ast.MatchCase) bool {
+	ct, isClass := member.(*soltype.ClassType)
+	if !isClass {
+		return false
+	}
 	for _, arm := range arms {
 		if arm.Guard != nil {
 			continue
 		}
-		if c.nominalArmCovers(scope, arm.Pattern, member) {
+		named, ok := c.armCatchType(scope, arm.Pattern)
+		if !ok {
+			continue
+		}
+		if armClass, isClass := named.(*soltype.ClassType); isClass && armClass.Name == ct.Name {
 			return true
 		}
 	}
 	return false
 }
 
-// nominalArmCovers reports whether an arm's pattern irrefutably matches every value of a
-// nominal member. The pattern must name the member's class through the type sort and carry
-// only irrefutable sub-patterns.
-func (c *checker) nominalArmCovers(scope *Scope, p ast.Pat, member *soltype.ClassType) bool {
+// armsCatchType returns the type the unguarded catch arms catch, as one union. It is the
+// `handled` side of the difference rethrowUnhandled takes, so a member of the caught type
+// escapes rule 1 of memberCaught exactly when this type does not cover it.
+//
+// A guarded arm is skipped. Its guard can fail, so no value is caught on the strength of the
+// arm's pattern alone. A pattern armCatchType cannot name contributes nothing, which makes
+// the difference subtract less and the rethrow name more than what actually escapes.
+func (c *checker) armsCatchType(scope *Scope, arms []*ast.MatchCase) soltype.Type {
+	parts := make([]soltype.Type, 0, len(arms))
+	for _, arm := range arms {
+		if arm.Guard != nil {
+			continue
+		}
+		if caught, ok := c.armCatchType(scope, arm.Pattern); ok {
+			parts = append(parts, caught)
+		}
+	}
+	return newUnion(c.ctx, parts, false)
+}
+
+// armCatchType returns the type one arm's pattern catches, and reports whether the pattern
+// names a type at all.
+//
+//   - A wildcard or identifier binds every value, so it catches `unknown`.
+//   - A literal pattern catches that literal's type, and the `null` and `undefined`
+//     spellings catch those two atoms.
+//   - An instance or extractor pattern catches the class it names, provided its
+//     sub-patterns all bind unconditionally. `Color.RGB(r, g, b)` catches `Color.RGB`, but
+//     `Color.RGB(0, g, b)` matches only when the first field is 0 and names no type.
+//
+// An object or tuple pattern reports false. It admits every value of a shape rather than of
+// a type, and objectMemberHasKeys and tupleMemberFitsArity are what read that shape against a
+// member, including through a borrow. structuralMemberCovered applies them, and the UCS IR's
+// own tests apply the same two, so a written pattern and its IR test cannot disagree about
+// which members a branch reaches. Rule 3 of memberCaught is where such a pattern is weighed.
+func (c *checker) armCatchType(scope *Scope, p ast.Pat) (soltype.Type, bool) {
 	switch pat := p.(type) {
+	case *ast.WildcardPat, *ast.IdentPat:
+		return &soltype.UnknownType{}, true
+	case *ast.LitPat:
+		if atom, _, isAtom := atomLitOf(pat.Lit); isAtom {
+			return atom, true
+		}
+		if lt, ok := c.litTypeOf(pat.Lit); ok {
+			return lt, true
+		}
 	case *ast.InstancePat:
 		ct, ok := c.instancePatClass(scope, ast.QualIdentToString(pat.ClassName))
-		return ok && ct.Name == member.Name && irrefutablePat(pat.Object)
+		if ok && irrefutablePat(pat.Object) {
+			return ct, true
+		}
 	case *ast.ExtractorPat:
 		ct, ok := c.resolveQualClassType(scope, pat.Name)
-		if !ok || ct.Name != member.Name {
+		if ok && allIrrefutable(pat.Args) {
+			return ct, true
+		}
+	}
+	return nil, false
+}
+
+// allIrrefutable reports whether every one of pats binds unconditionally, so a pattern built
+// from them matches every value of a compatible type.
+func allIrrefutable(pats []ast.Pat) bool {
+	for _, p := range pats {
+		if !irrefutablePat(p) {
 			return false
 		}
-		for _, arg := range pat.Args {
-			if !irrefutablePat(arg) {
-				return false
-			}
-		}
-		return true
-	default:
-		return false
 	}
+	return true
+}
+
+// memberSubtracted reports whether handled leaves nothing of one caught member, which is
+// what removes that member from the rethrow. The question it asks is whether the meet
+// `member ∩ ¬handled` holds a value, and the complement is what states that question to the
+// solver. The normal-form layer moves `¬handled` to the supertype side, so the trial runs as
+// `member <: handled` over fused atoms.
+//
+// A member is subtracted only when the trial records no bound, which is the fidelity boundary
+// of the difference. A trial that records one settled the member by choosing an instantiation
+// for a type variable rather than by finding the member covered outright, and the probe then
+// rolls that choice back. `Sub<number> ∩ ¬Base<T>` is such a trial when the arm names the
+// generic class `Base` and `T` is its own parameter. Declining it keeps the member, so the
+// difference under-subtracts where an arm's type is abstract and never over-subtracts.
+// memberCaught's rules 2 and 3 are what recover the cases this declines.
+func (c *checker) memberSubtracted(member, handled soltype.Type) bool {
+	// The intersection is built with a nil Context so its subsumption never calls constrain,
+	// the same reason capturedBound builds its result that way.
+	remainder := newIntersection(nil, []soltype.Type{member, &soltype.NegationType{Inner: handled}})
+	empty, mutated := c.ctx.trialMutatesBounds(remainder, &soltype.NeverType{}, newSeenPairs(), false)
+	return empty && !mutated
 }
 
 // structuralMemberCovered reports whether some unguarded arm's object or tuple pattern
@@ -3886,45 +3981,6 @@ func narrowUnionMembers(shape soltype.Type, keep func(soltype.Type) bool) (solty
 	// read each field before the tail widens it. Binding against bare `unknown` would leave
 	// nothing to destructure.
 	return &soltype.UnionType{Types: kept, Inexact: u.Inexact}, true
-}
-
-// litMemberCovered reports whether some unguarded arm is a literal pattern equal to
-// the given literal union member. The caller has already excluded an unguarded
-// catch-all, which would otherwise cover the member too.
-func (c *checker) litMemberCovered(member *soltype.LitType, arms []*ast.MatchCase) bool {
-	for _, arm := range arms {
-		if arm.Guard != nil {
-			continue
-		}
-		armLit, ok := arm.Pattern.(*ast.LitPat)
-		if !ok {
-			continue
-		}
-		if lt, ok := c.litTypeOf(armLit.Lit); ok && member.Equal(lt) {
-			return true
-		}
-	}
-	return false
-}
-
-// atomMemberCovered reports whether some unguarded arm is a `null` or `undefined` pattern
-// matching the given union member, which is one of those two atoms. It is the atom twin of
-// litMemberCovered, and the caller has likewise already excluded an unguarded catch-all.
-// equalType decides the match, since neither atom carries a value to compare.
-func atomMemberCovered(member soltype.Type, arms []*ast.MatchCase) bool {
-	for _, arm := range arms {
-		if arm.Guard != nil {
-			continue
-		}
-		armLit, ok := arm.Pattern.(*ast.LitPat)
-		if !ok {
-			continue
-		}
-		if atom, _, isAtom := atomLitOf(armLit.Lit); isAtom && equalType(atom, member) {
-			return true
-		}
-	}
-	return false
 }
 
 // structuralInexact returns the Inexact flag of an object or tuple type and whether

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3638,22 +3638,11 @@ func (c *checker) expandAliasChain(t soltype.Type) soltype.Type {
 	}
 }
 
-// caughtMembers returns the members one member of the caught union stands for, each weighed
-// against the catch arms on its own. A transparent alias, an enum handle or a `type`
-// reference, carries the alias rather than the type it names, so it is expanded, and a union
-// it expands to is taken apart member by member. The expansion repeats through both, since an
-// alias may name a union whose own members are aliases.
-//
-//	type Inner = "a" | "b"
-//	type Outer = Inner | "c"
-//
-// `Outer` yields `"a"`, `"b"`, and `"c"`. Stopping one level in would weigh the whole of
-// `Inner` against the arms, so an arm naming `"a"` alone would leave `Inner` uncovered and
-// rethrow `"b"` under the alias's name together with the `"a"` the arm did catch. Expanding
-// also keeps an aliased error type behaving like the union spelled inline, which is why
-// checkCondExhaustive expands as well.
-//
-// A member that is neither an alias nor a union is returned as it is.
+// caughtMembers returns the members one member of the caught union stands for, so each is
+// weighed against the catch arms on its own. It expands a transparent alias and takes a union
+// apart, and repeats through both, since an alias may name a union whose own members are
+// aliases. `type Outer = Inner | "c"` over `type Inner = "a" | "b"` yields `"a"`, `"b"`, and
+// `"c"`. A member that is neither an alias nor a union is returned as it is.
 func (c *checker) caughtMembers(t soltype.Type) []soltype.Type {
 	return c.appendCaughtMembers(nil, t, set.NewSet[string]())
 }
@@ -3690,20 +3679,10 @@ func unionParts(t soltype.Type) []soltype.Type {
 }
 
 // memberCaught reports whether the catch arms catch every value of one member of the caught
-// type, which is what keeps that member out of the rethrow. Two rules answer it, and the
-// member is caught when either does.
-//
-//  1. The set difference. handled is the type the arms catch, so the member is caught when
-//     `member ∩ ¬handled` holds no value. This rule reads through subtyping, so an arm naming
-//     a base class catches a subclass member whatever type arguments either side carries.
-//  2. The structural shape rule. An object or tuple pattern admits every value of a shape
-//     rather than of a type, so it has no entry in handled at all and structuralMemberCovered
-//     reads the shape against the member.
-//
-// Both rules only ever catch more, so a member neither answers is rethrown. That is the safe
-// direction. A clause naming a type the block cannot raise is still checked against the
-// enclosing clause, where a clause silent about one the block can raise would let an exception
-// escape unnamed.
+// type, which keeps that member out of the rethrow. Either of two rules answers it. The set
+// difference catches the member when `member ∩ ¬handled` holds no value, reading through
+// subtyping so a base-class arm catches a subclass member. structuralMemberCovered reads an
+// object or tuple pattern's shape, which names no type and so has no entry in handled.
 func (c *checker) memberCaught(member, handled soltype.Type, arms []*ast.MatchCase) bool {
 	return c.memberSubtracted(member, handled) ||
 		structuralMemberCovered(member, arms)
@@ -3780,27 +3759,11 @@ func allIrrefutable(pats []ast.Pat) bool {
 	return true
 }
 
-// memberSubtracted reports whether handled leaves nothing of one caught member, which is
-// what removes that member from the rethrow. The question it asks is whether the meet
-// `member ∩ ¬handled` holds a value, and the complement is what states that question to the
-// solver. The normal-form layer moves `¬handled` to the supertype side, so the trial runs as
-// `member <: handled` over fused atoms.
-//
-// A member is subtracted only when the trial binds none of the member's OWN type variables.
-// That is the fidelity boundary of the difference, and which side a binding lands on is what
-// it turns on.
-//
-//   - A binding on the member's side settles the member by choosing what it stands for, and
-//     the probe then rolls that choice back. Subtracting on the strength of it would drop a
-//     member the block can still raise under a different choice, so the member is kept.
-//   - A binding on the arm's side is the arm doing its job. An instance pattern tests the
-//     class alone, so `catch { Failure{payload} => … }` catches every `Failure`, and deciding
-//     `Timeout<number> <: Failure<T>` for T the class's own parameter is how the solver states
-//     that. Binding T is not a choice about the member.
-//
-// Watching the member's variables rather than every variable is what makes a generic class arm
-// behave like a non-generic one. `catch { AppError{code} => … }` and
-// `catch { Failure{payload} => … }` both catch a subclass member.
+// memberSubtracted reports whether handled leaves nothing of one caught member. The complement
+// states that question to the solver, which moves `¬handled` to the supertype side and runs the
+// trial as `member <: handled`. Only the member's OWN type variables are watched. Binding one
+// settles what the member stands for, so the member is kept. Binding the arm's is the arm doing
+// its job, and is what lets `catch { Failure{payload} => … }` catch a `Timeout<number>` member.
 func (c *checker) memberSubtracted(member, handled soltype.Type) bool {
 	// The intersection is built with a nil Context so its subsumption never calls constrain,
 	// the same reason capturedBound builds its result that way.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3598,7 +3598,7 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 		uncovered := make([]soltype.Type, 0, len(u.Types))
 		for _, m := range u.Types {
 			for _, part := range c.caughtMembers(m) {
-				if c.memberCaught(scope, part, handled, e.Catch) {
+				if c.memberCaught(part, handled, e.Catch) {
 					continue
 				}
 				uncovered = append(uncovered, part)
@@ -3690,58 +3690,23 @@ func unionParts(t soltype.Type) []soltype.Type {
 }
 
 // memberCaught reports whether the catch arms catch every value of one member of the caught
-// type, which is what keeps that member out of the rethrow. Three rules answer it, and the
-// member is caught when any of them does.
+// type, which is what keeps that member out of the rethrow. Two rules answer it, and the
+// member is caught when either does.
 //
 //  1. The set difference. handled is the type the arms catch, so the member is caught when
-//     `member ∩ ¬handled` holds no value. This is the primary rule, and it is the one that
-//     reads through subtyping: an arm naming a base class catches a subclass member, which
-//     comparing class names cannot see.
-//  2. The nominal name rule. A class arm catches every instance of the class it names,
-//     whatever type arguments that instance carries, and rule 1 declines the member when
-//     deciding it would pin a type argument. `catch { Err{x} => … }` therefore still catches
-//     an `Err<number>` member through this rule.
-//  3. The structural shape rule. An object or tuple pattern admits every value of a shape
+//     `member ∩ ¬handled` holds no value. This rule reads through subtyping, so an arm naming
+//     a base class catches a subclass member whatever type arguments either side carries.
+//  2. The structural shape rule. An object or tuple pattern admits every value of a shape
 //     rather than of a type, so it has no entry in handled at all and structuralMemberCovered
 //     reads the shape against the member.
 //
-// Each rule only ever catches more, so a member no rule answers is rethrown. That is the safe
+// Both rules only ever catch more, so a member neither answers is rethrown. That is the safe
 // direction. A clause naming a type the block cannot raise is still checked against the
 // enclosing clause, where a clause silent about one the block can raise would let an exception
 // escape unnamed.
-func (c *checker) memberCaught(scope *Scope, member, handled soltype.Type, arms []*ast.MatchCase) bool {
+func (c *checker) memberCaught(member, handled soltype.Type, arms []*ast.MatchCase) bool {
 	return c.memberSubtracted(member, handled) ||
-		c.nominalMemberCovered(scope, member, arms) ||
 		structuralMemberCovered(member, arms)
-}
-
-// nominalMemberCovered reports whether some unguarded arm names the class of a nominal
-// member. An instance or extractor pattern covers the member when it names that class and
-// every sub-pattern is irrefutable, so `Color.RGB(r, g, b)` covers `Color.RGB` but
-// `Color.RGB(1, g, b)`, which matches only when the first field is 1, does not. A member of
-// any other kind is never covered here.
-//
-// The class names are compared rather than the class types, so the rule holds whatever type
-// arguments either side carries. That is what it adds over the set difference, which declines
-// a member whose subtraction would pin a type argument.
-func (c *checker) nominalMemberCovered(scope *Scope, member soltype.Type, arms []*ast.MatchCase) bool {
-	ct, isClass := member.(*soltype.ClassType)
-	if !isClass {
-		return false
-	}
-	for _, arm := range arms {
-		if arm.Guard != nil {
-			continue
-		}
-		named, ok := c.armCatchType(scope, arm.Pattern)
-		if !ok {
-			continue
-		}
-		if armClass, isClass := named.(*soltype.ClassType); isClass && armClass.Name == ct.Name {
-			return true
-		}
-	}
-	return false
 }
 
 // armsCatchType returns the type the unguarded catch arms catch, as one union. It is the
@@ -3778,7 +3743,7 @@ func (c *checker) armsCatchType(scope *Scope, arms []*ast.MatchCase) soltype.Typ
 // a type, and objectMemberHasKeys and tupleMemberFitsArity are what read that shape against a
 // member, including through a borrow. structuralMemberCovered applies them, and the UCS IR's
 // own tests apply the same two, so a written pattern and its IR test cannot disagree about
-// which members a branch reaches. Rule 3 of memberCaught is where such a pattern is weighed.
+// which members a branch reaches. Rule 2 of memberCaught is where such a pattern is weighed.
 func (c *checker) armCatchType(scope *Scope, p ast.Pat) (soltype.Type, bool) {
 	switch pat := p.(type) {
 	case *ast.WildcardPat, *ast.IdentPat:
@@ -3821,19 +3786,45 @@ func allIrrefutable(pats []ast.Pat) bool {
 // solver. The normal-form layer moves `¬handled` to the supertype side, so the trial runs as
 // `member <: handled` over fused atoms.
 //
-// A member is subtracted only when the trial records no bound, which is the fidelity boundary
-// of the difference. A trial that records one settled the member by choosing an instantiation
-// for a type variable rather than by finding the member covered outright, and the probe then
-// rolls that choice back. `Sub<number> ∩ ¬Base<T>` is such a trial when the arm names the
-// generic class `Base` and `T` is its own parameter. Declining it keeps the member, so the
-// difference under-subtracts where an arm's type is abstract and never over-subtracts.
-// memberCaught's rules 2 and 3 are what recover the cases this declines.
+// A member is subtracted only when the trial binds none of the member's OWN type variables.
+// That is the fidelity boundary of the difference, and which side a binding lands on is what
+// it turns on.
+//
+//   - A binding on the member's side settles the member by choosing what it stands for, and
+//     the probe then rolls that choice back. Subtracting on the strength of it would drop a
+//     member the block can still raise under a different choice, so the member is kept.
+//   - A binding on the arm's side is the arm doing its job. An instance pattern tests the
+//     class alone, so `catch { Failure{payload} => … }` catches every `Failure`, and deciding
+//     `Timeout<number> <: Failure<T>` for T the class's own parameter is how the solver states
+//     that. Binding T is not a choice about the member.
+//
+// Watching the member's variables rather than every variable is what makes a generic class arm
+// behave like a non-generic one. `catch { AppError{code} => … }` and
+// `catch { Failure{payload} => … }` both catch a subclass member.
 func (c *checker) memberSubtracted(member, handled soltype.Type) bool {
 	// The intersection is built with a nil Context so its subsumption never calls constrain,
 	// the same reason capturedBound builds its result that way.
 	remainder := newIntersection(nil, []soltype.Type{member, &soltype.NegationType{Inner: handled}})
-	empty, mutated := c.ctx.trialMutatesBounds(remainder, &soltype.NeverType{}, newSeenPairs(), false)
-	return empty && !mutated
+	empty, bound := c.ctx.trialBindsWatched(remainder, &soltype.NeverType{}, typeVarsIn(member))
+	return empty && !bound
+}
+
+// typeVarsIn returns every type variable reachable from t, ordered by id so the walk is
+// repeatable. A variable reached only through another's bound list counts, since binding it
+// constrains what t can stand for just as directly.
+func typeVarsIn(t soltype.Type) []*soltype.TypeVarType {
+	vars := map[int]*soltype.TypeVarType{}
+	t.Accept(&varCollector{out: vars, seen: set.NewSet[*soltype.TypeVarType]()}, soltype.Positive)
+	ids := make([]int, 0, len(vars))
+	for id := range vars {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	out := make([]*soltype.TypeVarType, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, vars[id])
+	}
+	return out
 }
 
 // structuralMemberCovered reports whether some unguarded arm's object or tuple pattern

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3597,13 +3597,7 @@ func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, en
 	if u, isUnion := caught.(*soltype.UnionType); isUnion {
 		uncovered := make([]soltype.Type, 0, len(u.Types))
 		for _, m := range u.Types {
-			// A transparent alias member, an enum handle or a `type` reference, carries the
-			// alias rather than the type it stands for. The difference is decided against the
-			// alias handle, which no arm's type is a supertype of, so an unexpanded alias
-			// reads as uncovered however many arms name its members, and
-			// `type Err = "a" | "b"` would behave unlike the union spelled inline.
-			// checkCondExhaustive expands for the same reason.
-			for _, part := range unionParts(c.expandAliasChain(m)) {
+			for _, part := range c.caughtMembers(m) {
 				if c.memberCaught(scope, part, handled, e.Catch) {
 					continue
 				}
@@ -3642,6 +3636,48 @@ func (c *checker) expandAliasChain(t soltype.Type) soltype.Type {
 		seen.Add(at.Name)
 		t = c.ctx.expandAlias(at)
 	}
+}
+
+// caughtMembers returns the members one member of the caught union stands for, each weighed
+// against the catch arms on its own. A transparent alias, an enum handle or a `type`
+// reference, carries the alias rather than the type it names, so it is expanded, and a union
+// it expands to is taken apart member by member. The expansion repeats through both, since an
+// alias may name a union whose own members are aliases.
+//
+//	type Inner = "a" | "b"
+//	type Outer = Inner | "c"
+//
+// `Outer` yields `"a"`, `"b"`, and `"c"`. Stopping one level in would weigh the whole of
+// `Inner` against the arms, so an arm naming `"a"` alone would leave `Inner` uncovered and
+// rethrow `"b"` under the alias's name together with the `"a"` the arm did catch. Expanding
+// also keeps an aliased error type behaving like the union spelled inline, which is why
+// checkCondExhaustive expands as well.
+//
+// A member that is neither an alias nor a union is returned as it is.
+func (c *checker) caughtMembers(t soltype.Type) []soltype.Type {
+	return c.appendCaughtMembers(nil, t, set.NewSet[string]())
+}
+
+// appendCaughtMembers is caughtMembers' walk, accumulating into out. seen holds the alias
+// names already expanded, so a self-referential alias such as `type A = A | "x"` contributes
+// `"x"` once and stops rather than expanding forever. The set is shared across the whole walk,
+// which is sound because the result is a union: a name reached twice contributes the same
+// members both times.
+func (c *checker) appendCaughtMembers(out []soltype.Type, t soltype.Type, seen set.Set[string]) []soltype.Type {
+	switch t := t.(type) {
+	case *soltype.AliasType:
+		if seen.Contains(t.Name) {
+			return out
+		}
+		seen.Add(t.Name)
+		return c.appendCaughtMembers(out, c.ctx.expandAlias(t), seen)
+	case *soltype.UnionType:
+		for _, m := range t.Types {
+			out = c.appendCaughtMembers(out, m, seen)
+		}
+		return out
+	}
+	return append(out, t)
 }
 
 // unionParts returns a union's members, or the type itself as a one-element slice. It lets a

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -529,6 +529,32 @@ func TestInferTryCatchExpandsAliasedErrorTypes(t *testing.T) {
 			`,
 			want: "fn () -> undefined",
 		},
+		{
+			// Expanding repeats through a union whose own members are aliases, so an alias
+			// nested inside another reaches the arms as its underlying members.
+			name: "ANestedAliasIsCovered",
+			src: `
+				type Inner = "a" | "b"
+				type Outer = Inner | "c"
+				fn a() throws Outer { throw "a" }
+				fn f() { try { a() } catch { "a" => 0, "b" => 1, "c" => 2 } }
+			`,
+			want: "fn () -> undefined",
+		},
+		{
+			// Partial coverage of a nested alias rethrows only the members left over. Without
+			// the repeated expansion the whole of `Inner` would be weighed as one member,
+			// which no arm covers, so the clause would carry `Inner` and name the `"a"` the
+			// arm did catch.
+			name: "OnlyTheUncoveredMemberOfANestedAliasIsRethrown",
+			src: `
+				type Inner = "a" | "b"
+				type Outer = Inner | "c"
+				fn a() throws Outer { throw "a" }
+				fn f() throws _ { try { a() } catch { "a" => 0, "c" => 2 } }
+			`,
+			want: `fn () -> undefined throws "b"`,
+		},
 	})
 	runThrowsErrCases(t, []throwsErrCase{
 		{

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -359,6 +359,103 @@ func TestInferTryCatchOverClassErrors(t *testing.T) {
 	})
 }
 
+// What escapes a `try` is the set difference `caught & ¬handled`, where handled is the type
+// the arms catch. Taking a difference rather than matching each member against each pattern
+// by name is what lets an arm subtract more than the one type it spells: an arm naming a base
+// class catches every value of a subclass, so a subclass member is subtracted too.
+func TestInferTryCatchSubtractsThroughSubtyping(t *testing.T) {
+	// base declares a root error class, a subclass of it, and an unrelated class, so a case
+	// can vary which of the three an arm names.
+	const base = `
+		class AppError { code: number, constructor(mut self) { self.code = 0 } }
+		class ParseError extends AppError { constructor(mut self) { super() } }
+		class OtherError { tag: string, constructor(mut self) { self.tag = "" } }
+	`
+	runThrowsCases(t, []throwsCase{
+		{
+			// The block raises the subclass, and the arm names the base class. Every
+			// ParseError is an AppError, so nothing is left over and the enclosing function
+			// needs no clause.
+			name: "ABaseClassArmSubtractsASubclassMember",
+			src: base + `
+				fn a() throws ParseError { throw ParseError() }
+				fn f() { try { a() } catch { AppError{code} => code } }
+			`,
+			want: "fn () -> undefined",
+		},
+		{
+			// The reverse does not subtract. An AppError need not be a ParseError, so the
+			// member survives the difference and reaches the clause.
+			name: "ASubclassArmLeavesTheBaseClassMember",
+			src: base + `
+				fn a() throws AppError { throw AppError() }
+				fn f() throws _ { try { a() } catch { ParseError{code} => code } }
+			`,
+			want: "fn () -> undefined throws AppError",
+		},
+		{
+			// One arm subtracts both members it covers, and the member outside the class
+			// hierarchy is rethrown on its own.
+			name: "ABaseClassArmLeavesAnUnrelatedMember",
+			src: base + `
+				fn a(c: boolean) throws ParseError | OtherError {
+					if c { throw ParseError() } else { throw OtherError() }
+				}
+				fn f(c: boolean) throws _ { try { a(c) } catch { AppError{code} => code } }
+			`,
+			want: "fn (c: boolean) -> undefined throws OtherError",
+		},
+	})
+}
+
+// The difference subtracts a member only when deciding it settles nothing about a type
+// variable. A generic class arm is where that bites: subtracting a member against `Base<T>`,
+// for T the class's own parameter, would have to choose what T stands for, so the difference
+// declines and the member survives it.
+//
+// An arm naming the member's own class still catches it, since comparing class names needs no
+// choice of type argument. What the difference alone would have caught, and the name rule
+// cannot, is a SUBCLASS member under a base-class arm. That pair is the fidelity boundary: it
+// is rethrown, where the same pair over non-generic classes is subtracted.
+func TestInferTryCatchIsConservativeOverGenericClasses(t *testing.T) {
+	// base declares a generic root error class and a generic subclass of it, so a case can
+	// vary whether the arm names the member's own class or its base.
+	const base = `
+		class Failure<T> {
+			payload: T,
+			constructor(mut self, payload: T) { self.payload = payload }
+		}
+		class Timeout<T> extends Failure<T> {
+			constructor(mut self, payload: T) { super(payload) }
+		}
+	`
+	runThrowsCases(t, []throwsCase{
+		{
+			// The arm names the member's own class. The name rule catches it whatever the
+			// type argument is, so nothing escapes and the function needs no clause.
+			name: "AnArmNamingTheMembersOwnGenericClassCatchesIt",
+			src: base + `
+				fn a() throws Failure<number> { throw Failure(0) }
+				fn f() { try { a() } catch { Failure{payload} => 0 } }
+			`,
+			want: "fn () -> undefined",
+		},
+		{
+			// The arm names the member's base class, which only the difference could read,
+			// and the difference declines because subtracting would pin the base class's own
+			// parameter. The member is rethrown even though every Timeout<number> is a
+			// Failure<number>. Over the non-generic pair of
+			// TestInferTryCatchSubtractsThroughSubtyping the same shape is subtracted.
+			name: "ABaseClassArmDoesNotSubtractAGenericSubclassMember",
+			src: base + `
+				fn a() throws Timeout<number> { throw Timeout(0) }
+				fn f() throws _ { try { a() } catch { Failure{payload} => 0 } }
+			`,
+			want: "fn () -> undefined throws Timeout<number>",
+		},
+	})
+}
+
 // The form's value is the join of the try block's tail value and each non-diverging arm
 // body, the same branch join `match` builds from its arms.
 func TestInferTryCatchValue(t *testing.T) {
@@ -397,9 +494,9 @@ func TestInferTryCatchLeavesAnUnusedClauseUnused(t *testing.T) {
 
 // Coverage is decided against the type an alias stands for, not against the alias handle. A
 // transparent alias, an enum handle or a user `type` reference, carries the alias rather than
-// its underlying union, and unionMemberCovered has no arm for one. Without expanding first, an
-// aliased error type would read as uncovered however many arms name its members, so naming a
-// union would behave unlike spelling it inline.
+// its underlying union, and no arm's type is a supertype of the handle. Without expanding
+// first, an aliased error type would read as uncovered however many arms name its members, so
+// naming a union would behave unlike spelling it inline.
 func TestInferTryCatchExpandsAliasedErrorTypes(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -408,16 +408,15 @@ func TestInferTryCatchSubtractsThroughSubtyping(t *testing.T) {
 	})
 }
 
-// The difference subtracts a member only when deciding it settles nothing about a type
-// variable. A generic class arm is where that bites: subtracting a member against `Base<T>`,
-// for T the class's own parameter, would have to choose what T stands for, so the difference
-// declines and the member survives it.
+// A generic class arm behaves exactly like a non-generic one. `catch { Failure{payload} => … }`
+// tests the class alone, so it catches every Failure whatever type argument the value carries,
+// including a Timeout that inherits from it.
 //
-// An arm naming the member's own class still catches it, since comparing class names needs no
-// choice of type argument. What the difference alone would have caught, and the name rule
-// cannot, is a SUBCLASS member under a base-class arm. That pair is the fidelity boundary: it
-// is rethrown, where the same pair over non-generic classes is subtracted.
-func TestInferTryCatchIsConservativeOverGenericClasses(t *testing.T) {
+// The difference is what reads this. Deciding `Timeout<number> <: Failure<T>`, for T the base
+// class's own parameter, binds T, and memberSubtracted permits that because T belongs to the
+// arm rather than to the member. Watching every variable instead would decline the subtraction
+// and rethrow a member the arm demonstrably catches.
+func TestInferTryCatchSubtractsThroughGenericClasses(t *testing.T) {
 	// base declares a generic root error class and a generic subclass of it, so a case can
 	// vary whether the arm names the member's own class or its base.
 	const base = `
@@ -431,8 +430,8 @@ func TestInferTryCatchIsConservativeOverGenericClasses(t *testing.T) {
 	`
 	runThrowsCases(t, []throwsCase{
 		{
-			// The arm names the member's own class. The name rule catches it whatever the
-			// type argument is, so nothing escapes and the function needs no clause.
+			// The arm names the member's own class, so the type argument is all that has to
+			// be decided and nothing escapes.
 			name: "AnArmNamingTheMembersOwnGenericClassCatchesIt",
 			src: base + `
 				fn a() throws Failure<number> { throw Failure(0) }
@@ -441,17 +440,26 @@ func TestInferTryCatchIsConservativeOverGenericClasses(t *testing.T) {
 			want: "fn () -> undefined",
 		},
 		{
-			// The arm names the member's base class, which only the difference could read,
-			// and the difference declines because subtracting would pin the base class's own
-			// parameter. The member is rethrown even though every Timeout<number> is a
-			// Failure<number>. Over the non-generic pair of
-			// TestInferTryCatchSubtractsThroughSubtyping the same shape is subtracted.
-			name: "ABaseClassArmDoesNotSubtractAGenericSubclassMember",
+			// The arm names the member's base class. Every Timeout<number> is a
+			// Failure<number>, so the member is subtracted and the function needs no clause,
+			// the same verdict the non-generic pair of
+			// TestInferTryCatchSubtractsThroughSubtyping reaches.
+			name: "ABaseClassArmSubtractsAGenericSubclassMember",
 			src: base + `
 				fn a() throws Timeout<number> { throw Timeout(0) }
-				fn f() throws _ { try { a() } catch { Failure{payload} => 0 } }
+				fn f() { try { a() } catch { Failure{payload} => 0 } }
 			`,
-			want: "fn () -> undefined throws Timeout<number>",
+			want: "fn () -> undefined",
+		},
+		{
+			// The reverse still does not subtract. A Failure<number> need not be a Timeout, so
+			// the member survives the difference and reaches the clause.
+			name: "ASubclassArmLeavesTheGenericBaseClassMember",
+			src: base + `
+				fn a() throws Failure<number> { throw Failure(0) }
+				fn f() throws _ { try { a() } catch { Timeout{payload} => 0 } }
+			`,
+			want: "fn () -> undefined throws Failure<number>",
 		},
 	})
 }

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1213,9 +1213,10 @@ func hasSpreadElem(elems []soltype.Type) bool {
 // meetFuncs fuses two function atoms into one arrow, but only for the two cases
 // where a single arrow denotes the intersection exactly.
 //
-//   - The domains agree: `(A -> C) & (A -> D)` is `A -> (C & D)`.
-//   - The codomains agree and there is one parameter: `(A -> C) & (B -> C)` is
-//     `(A | B) -> C`.
+//   - The domains agree: `(A -> C throws E) & (A -> D throws F)` is
+//     `A -> (C & D) throws (E & F)`.
+//   - The codomains and the raises agree and there is one parameter:
+//     `(A -> C throws E) & (B -> C throws E)` is `(A | B) -> C throws E`.
 //
 // Any other pair keeps both atoms, which is decision 1 in this file's header and
 // where this port departs from MLscript.
@@ -1223,6 +1224,14 @@ func hasSpreadElem(elems []soltype.Type) bool {
 // The one-parameter restriction is load-bearing. Unioning each position
 // independently would fuse `(number, number) -> C` and `(string, string) -> C`
 // into a claim that the value accepts a number paired with a string.
+//
+// The second case demands equal raises where the first meets them. A value
+// carrying both arrow types raises, on a given input, only what every arm that
+// accepts that input admits. Under agreeing domains every input reaches both arms,
+// so the meet of the two clauses is what a call raises. Under differing domains
+// only the arm that accepts the input constrains it, so an input in `A` but outside
+// `B` raises `E` rather than `E & F`. One clause cannot state both, so the pair is
+// kept as two atoms instead.
 //
 // The fused arrow is inexact when either side is. An arrow's marker says the value
 // tolerates every argument count from its arity up. A value satisfying both arrows
@@ -1236,13 +1245,13 @@ func (c *Context) meetFuncs(a, b *soltype.FuncType) (soltype.Type, bool) {
 			SelfParam:      nil,
 			Params:         a.Params,
 			Ret:            c.meetTypes(a.Ret, b.Ret),
-			Throws:         a.Throws,
+			Throws:         c.meetThrows(a, b),
 			Inexact:        a.Inexact || b.Inexact,
 			TypeParams:     nil,
 			LifetimeParams: nil,
 		}, true
 	}
-	if len(a.Params) == 1 && equalType(a.Ret, b.Ret) {
+	if len(a.Params) == 1 && equalType(a.Ret, b.Ret) && sameThrows(a, b) {
 		param := a.Params[0]
 		fused := &soltype.FuncParam{
 			Pattern:  param.Pattern,
@@ -1265,14 +1274,13 @@ func (c *Context) meetFuncs(a, b *soltype.FuncType) (soltype.Type, bool) {
 
 // fusableFuncs reports whether two function atoms are alike enough for meetFuncs
 // to build one arrow from them. Everything a fused arrow does not recompute must
-// already agree: the arity, the per-parameter markers, and what a call may raise. A
-// receiver or a quantifier rules the pair out, since one arrow cannot say which
-// receiver it takes or how the two binder lists correspond. The trailing `...` is
-// recomputed rather than required to agree, so it is not checked here.
+// already agree: the arity and the per-parameter markers. A receiver or a quantifier
+// rules the pair out, since one arrow cannot say which receiver it takes or how the
+// two binder lists correspond. The trailing `...` is recomputed rather than required
+// to agree, so it is not checked here.
 //
-// Demanding equal raises is conservative. `(A -> C throws E) & (A -> C throws F)`
-// really raises `E & F`, but that merge belongs with PR9's throws threading.
-// TODO(#1066).
+// The raises are not checked here. meetFuncs recomputes them in its first case and
+// requires them equal in its second, so each case states its own rule.
 func fusableFuncs(a, b *soltype.FuncType) bool {
 	if a.SelfParam != nil || b.SelfParam != nil {
 		return false
@@ -1291,7 +1299,28 @@ func fusableFuncs(a, b *soltype.FuncType) bool {
 			return false
 		}
 	}
+	return true
+}
+
+// sameThrows reports whether two arrows raise the same type. The nil shorthand for
+// `never` is resolved first, so `fn () -> C` and `fn () -> C throws never` compare
+// equal.
+func sameThrows(a, b *soltype.FuncType) bool {
 	return equalType(a.ThrowsOrNever(), b.ThrowsOrNever())
+}
+
+// meetThrows returns what a call to the arrow meetFuncs fuses may raise. The
+// clauses meet, the way the codomains do, since `throws` is a covariant output
+// position like the return type.
+//
+// An unwritten clause is kept unwritten when both arrows agree, so fusing two
+// non-throwing arrows yields a third whose Throws stays nil rather than an explicit
+// `never` the printer would have to suppress.
+func (c *Context) meetThrows(a, b *soltype.FuncType) soltype.Type {
+	if sameThrows(a, b) {
+		return a.Throws
+	}
+	return c.meetTypes(a.ThrowsOrNever(), b.ThrowsOrNever())
 }
 
 func equalParamTypes(a, b *soltype.FuncType) bool {

--- a/internal/solver/normal_test.go
+++ b/internal/solver/normal_test.go
@@ -910,6 +910,34 @@ func TestFuncMerge(t *testing.T) {
 			in:   "(fn (x: number) -> boolean) | (fn (x: number) -> null)",
 			want: "(fn (x: number) -> boolean) | (fn (x: number) -> null)",
 		},
+		{
+			name: "shared domain: the raises meet alongside the codomains",
+			in: `(fn (x: number) -> boolean throws "a" | "b") & ` +
+				`(fn (x: number) -> boolean throws "b" | "c")`,
+			want: `fn (x: number) -> boolean throws "b"`,
+		},
+		{
+			name: "shared domain, disjoint raises: the fused arrow raises nothing",
+			in:   `(fn (x: number) -> boolean throws "a") & (fn (x: number) -> boolean throws "b")`,
+			want: "fn (x: number) -> boolean",
+		},
+		{
+			name: "shared domain, one arm non-throwing: the fused arrow raises nothing",
+			in:   `(fn (x: number) -> boolean throws "a") & (fn (x: number) -> boolean)`,
+			want: "fn (x: number) -> boolean",
+		},
+		{
+			name: "shared codomain and raises: the domains join and the clause is kept",
+			in: `(fn (x: number) -> boolean throws "a") & ` +
+				`(fn (x: string) -> boolean throws "a")`,
+			want: `fn (x: number | string) -> boolean throws "a"`,
+		},
+		{
+			name: "shared codomain but differing raises: both arms are kept",
+			in: `(fn (x: number) -> boolean throws "a") & ` +
+				`(fn (x: string) -> boolean throws "b")`,
+			want: `(fn (x: number) -> boolean throws "a") & (fn (x: string) -> boolean throws "b")`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/solver/parse_type_test.go
+++ b/internal/solver/parse_type_test.go
@@ -135,12 +135,16 @@ func litToSoltype(t *testing.T, lit ast.Lit) soltype.Type {
 	return nil
 }
 
-// funcToSoltype lowers a `fn (x: T) -> U` annotation into a soltype.FuncType.
-// It accepts positional parameters written as `name: T`, an optional `?`
-// marker, and the trailing `...` inexactness marker. A destructuring or rest
-// pattern, a missing parameter or return annotation, and the type-parameter,
-// lifetime, and `throws` clauses all fail the test, mirroring how the rest of
-// this converter refuses what it cannot lower faithfully.
+// funcToSoltype lowers a `fn (x: T) -> U throws E` annotation into a
+// soltype.FuncType. It accepts positional parameters written as `name: T`, an
+// optional `?` marker, the trailing `...` inexactness marker, and a `throws`
+// clause. A destructuring or rest pattern, a missing parameter or return
+// annotation, and the type-parameter and lifetime clauses all fail the test,
+// mirroring how the rest of this converter refuses what it cannot lower
+// faithfully.
+//
+// An omitted `throws` leaves Throws nil, the shorthand for `never` that
+// FuncType.ThrowsOrNever resolves.
 //
 // An `open p` parameter fails for the same reason. soltype.FuncParam has no
 // slot for the marker, so lowering one would drop it and hand back a signature
@@ -149,7 +153,6 @@ func funcToSoltype(t *testing.T, env map[string]soltype.Type, ta *ast.FuncTypeAn
 	t.Helper()
 	require.Empty(t, ta.TypeParams, "parseType: type parameters on a fn annotation")
 	require.Empty(t, ta.LifetimeParams, "parseType: lifetime parameters on a fn annotation")
-	require.Nil(t, ta.Throws, "parseType: throws clause on a fn annotation")
 	require.NotNil(t, ta.Return, "parseType: fn annotation without a return type")
 	params := make([]*soltype.FuncParam, len(ta.Params))
 	for i, p := range ta.Params {
@@ -163,9 +166,14 @@ func funcToSoltype(t *testing.T, env map[string]soltype.Type, ta *ast.FuncTypeAn
 			Optional: p.Optional,
 		}
 	}
+	var throws soltype.Type
+	if ta.Throws != nil {
+		throws = toSoltype(t, env, ta.Throws)
+	}
 	return &soltype.FuncType{
 		Params:  params,
 		Ret:     toSoltype(t, env, ta.Return),
+		Throws:  throws,
 		Inexact: ta.Inexact,
 	}
 }

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -349,6 +349,33 @@ func (c *Context) trialMutatesBounds(sub, super soltype.Type, seen *seenPairs, m
 	return !hasHardError(errs), mutated
 }
 
+// trialBindsWatched trials sub <: super under a throwaway probe, reporting whether it succeeded
+// and whether it recorded a bound on any of the watched variables. It is trialMutatesBounds
+// narrowed to a chosen set, for a caller that cares which side of the constraint a binding
+// landed on rather than whether one happened at all.
+//
+// The bound lists are read after constrain returns and before the probe rolls them back, the
+// same window trialMutatesBounds and trialCaptures read in. The trial is discarded either way,
+// so no bound survives on any type the caller handed in.
+func (c *Context) trialBindsWatched(sub, super soltype.Type, watch []*soltype.TypeVarType) (ok, bound bool) {
+	widths := make([]int, len(watch))
+	for i, v := range watch {
+		widths[i] = len(v.LowerBounds) + len(v.UpperBounds)
+	}
+	p := newProbe(c, c.probe)
+	c.probe = p
+	errs := c.constrain(sub, super, newSeenPairs(), false)
+	for i, v := range watch {
+		if len(v.LowerBounds)+len(v.UpperBounds) != widths[i] {
+			bound = true
+			break
+		}
+	}
+	c.probe = p.parent
+	p.Discard()
+	return !hasHardError(errs), bound
+}
+
 // trialCaptures trials `sub <: super` under a throwaway probe and reports what each variable in vars
 // picked up, or ok=false when the trial failed. A conditional's `infer` reduction calls it with one
 // fresh variable per `infer` clause standing in the pattern, so the constraint that decides the

--- a/internal/solver/probe_test.go
+++ b/internal/solver/probe_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -339,5 +340,48 @@ func TestProbeRestoresShallowestAssumedOnDiscardOnly(t *testing.T) {
 		c.shallowestAssumed = 3
 		p.Discard()
 		require.Equal(t, 3, c.shallowestAssumed)
+	})
+}
+
+// TestTrialBindsWatched pins the asymmetry the try/catch difference turns on. The trial
+// reports a binding only for the variables the caller watches, so one constraint answers
+// "bound" or "not bound" depending on which side of it the caller cares about.
+//
+// memberSubtracted reads it that way. It watches the caught member's own variables and leaves
+// the arm's alone, so `Timeout<number> <: Failure<T>` subtracts the member by binding the
+// arm's class parameter, where `T <: "boom"` for an abstract member does not.
+func TestTrialBindsWatched(t *testing.T) {
+	t.Run("a constraint over no variable binds nothing", func(t *testing.T) {
+		c := &Context{}
+		ok, bound := c.trialBindsWatched(&soltype.LitType{Lit: &soltype.NumLit{Value: 5}}, num(), nil)
+		require.True(t, ok)
+		require.False(t, bound)
+	})
+
+	t.Run("a watched variable reports its binding", func(t *testing.T) {
+		c := &Context{}
+		v := c.freshVar(0)
+		ok, bound := c.trialBindsWatched(&soltype.LitType{Lit: &soltype.NumLit{Value: 5}}, v,
+			[]*soltype.TypeVarType{v})
+		require.True(t, ok)
+		require.True(t, bound)
+		// The probe rolls the trial back, so the bound it saw does not outlive the trial.
+		require.Empty(t, v.LowerBounds)
+	})
+
+	t.Run("an unwatched variable's binding goes unreported", func(t *testing.T) {
+		c := &Context{}
+		v := c.freshVar(0)
+		ok, bound := c.trialBindsWatched(&soltype.LitType{Lit: &soltype.NumLit{Value: 5}}, v, nil)
+		require.True(t, ok)
+		require.False(t, bound)
+		require.Empty(t, v.LowerBounds)
+	})
+
+	t.Run("a failing trial reports the failure", func(t *testing.T) {
+		c := &Context{}
+		ok, bound := c.trialBindsWatched(str(), num(), nil)
+		require.False(t, ok)
+		require.False(t, bound)
 	})
 }

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1578,14 +1578,14 @@ and the M7 interlock.
   calls to throwing functions emit `constrain(thrown, throws_var)`. Throws
   polymorphism (`<E>(f: () -> T throws E) -> T throws E`) falls out of M3's
   let-generalization without special handling — `E` is just another type
-  variable that gets quantified. **Open design question, not settled in
-  this plan:** how `try`/`catch` narrows the inferred throws of the body
-  (i.e., the "subtract `K` from `body_throws` for everything not in the
-  `catch` clause" semantics). A two-variable encoding (`body_throws <:
-  surrounding_throws ∪ caught_throws`) works in the existing lattice and is
-  the conservative starting point; integration with the existing checker's
-  narrowing semantics is the actual question to resolve before
-  implementation.
+  variable that gets quantified. How `try`/`catch` narrows the inferred
+  throws of the body — the "subtract `K` from `body_throws` for everything
+  not in the `catch` clause" semantics — was left open here. It is settled
+  by MLstruct PR9 (#1066) as the native set difference
+  `surrounding_throws = body_throws ∩ ¬caught`, which negation expresses
+  directly. The two-variable encoding (`body_throws <: surrounding_throws ∪
+  caught_throws`) was the conservative fallback for a lattice without
+  negation and is not what the solver runs.
 
 **Accept:** the spike's type-operator cases against real source —
 `keyof`/indexed access over ground and usage-inferred operands; conditional

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -796,9 +796,11 @@ is the exceptional twin of `UnusedLifetimeParamError`.
   `never`, and `throws _` makes it a fresh variable whose coalesced value becomes the
   inferred clause. Each exceptional exit is therefore checked at its own site. A `try`
   block then needs no new lattice machinery: it pushes a nested sink, and the enclosing
-  sink receives only the part the `catch` arms leave unhandled. That is the
-  two-variable encoding `body_throws <: surrounding_throws ∪ caught_throws` with the
-  union realized by the arms' patterns rather than by a second variable.
+  sink receives only the part the `catch` arms leave unhandled. MLstruct PR9 (#1066)
+  states that part as the set difference `body_throws ∩ ¬caught`, which negation
+  expresses directly. The two-variable encoding
+  `body_throws <: surrounding_throws ∪ caught_throws` was the fallback for a lattice
+  without negation.
 
   The nested sink is also what makes a clause-less function usable once `try`/`catch`
   lands: a call wrapped in a `try` whose arms are exhaustive contributes nothing to the
@@ -843,12 +845,11 @@ body, so a `try` inside a `try` nests for free.
   the caught union. Per [06_error_handling.md](../../docs/06_error_handling.md), "if
   there is no catch-all, the compiler will automatically re-throw the unhandled error",
   so an uncovered member is constrained into the ENCLOSING sink instead of being
-  reported. `unionMemberCovered` and `isCatchAll`
-  ([infer_expr.go](../../internal/solver/infer_expr.go)) already decide coverage per
-  member for `checkMatchExhaustive`; this reads the same relation the other way, keeping
-  one definition of "this pattern covers this member". A catch-all therefore
-  contributes nothing to the enclosing sink, which is what makes a clause-less caller
-  legal.
+  reported. `memberCaught` and `ast.HasUnguardedCatchAll`
+  ([infer_expr.go](../../internal/solver/infer_expr.go)) decide coverage per member,
+  reading the same shape rules `checkCondExhaustive` reads so there is one definition of
+  "this pattern covers this member". A catch-all therefore contributes nothing to the
+  enclosing sink, which is what makes a clause-less caller legal.
 - **The caught union is inexact.** The docs are explicit that a caught error is always
   an open union — `FooError | ...` — because any function can throw something the type
   system did not predict. `soltype.UnionType` already carries `Inexact`, so the caught


### PR DESCRIPTION
Fixes #1066
Refs #1057

Refactor exception handling in try/catch blocks to use set-difference semantics (`caught ∩ ¬handled`) instead of pattern-matching individual members. This allows catch arms to subtract more exceptions than their spelled type through subtyping relationships.

## Summary

The rethrow logic now computes what exceptions escape a try/catch as the set difference between caught exceptions and those the arms handle. This is more precise than checking each member against each pattern, because an arm naming a base class catches every subclass member, which pattern matching alone cannot express.

## Key changes

- **New `memberCaught` function**: Replaces `unionMemberCovered` with three rules that determine if an arm catches a member:
  1. Set difference: `member ∩ ¬handled` holds no value (primary rule, reads through subtyping)
  2. Nominal name rule: An arm naming a class catches it regardless of type arguments
  3. Structural shape rule: Object/tuple patterns admit shapes rather than types

- **New `armsCatchType` and `armCatchType` functions**: Compute the type an arm or set of arms catches, enabling the set-difference calculation. Handles wildcards, literals, atoms, and nominal patterns.

- **New `memberSubtracted` function**: Implements the set-difference check by testing whether `member ∩ ¬handled` is empty via the solver&#39;s subsumption machinery.

- **Removed `unionMemberCovered`, `litMemberCovered`, `atomMemberCovered`**: These pattern-matching functions are replaced by the new approach.

- **Updated `nominalMemberCovered`**: Now uses class name comparison rather than pattern matching, and works with any member type (returning false for non-classes).

- **Function throws handling**: Updated `meetFuncs` and related logic to properly meet/compare `throws` clauses as covariant outputs alongside return types. Added `meetThrows`, `sameThrows`, and `meetRaises` helpers.

- **Arrow decomposition in constraint checking**: Extended the Frisch-Castagna-Benzaken decomposition to check both codomain and raises in leg 2, ensuring exception types are validated the same way return types are.

## Notable details

- The set-difference check is conservative: it only subtracts when the solver finds no bound, avoiding over-subtraction when type variables would need to be pinned. The nominal and structural rules recover cases the difference declines.

- Guarded catch arms contribute nothing to `handled` since their guard can fail at runtime.

- Unguarded catch-all arms short-circuit the entire rethrow check, as before.

- Only union members are rethrown (not the open tail), preserving named types in the clause.

- Tests added for subtyping-based subtraction and conservative handling of generic classes.

https://claude.ai/code/session_01G43g9CBQSsFgn4NSnMXBs8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Function types now support optional `throws` clauses.
  * Exception types participate in function compatibility, decomposition, and intersection merging.
  * `try`/`catch` analysis more accurately narrows unhandled exceptions, including aliased, generic, class-based, tuple, and object patterns.
  * Catch coverage now accounts for guarded handlers and structural matching.

* **Documentation**
  * Updated exception covariance and `try`/`catch` narrowing guidance.
  * Documented limitations when evaluating rows containing `throws` clauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->