### PR TITLE
Add complement type support to type reduction

### DIFF
--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2850,7 +2850,7 @@ func TestInferMappedTypeReduction(t *testing.T) {
 		},
 		{
 			// A single-key operand emits a single-field object; `keyof` collapsed its union to the
-			// lone literal, which mappedKeyMembers reads as one key.
+			// lone literal, which unionMembers reads as one key.
 			name: "SingleKey",
 			src: `
 				type One = {only: number}

--- a/internal/solver/productivity.go
+++ b/internal/solver/productivity.go
@@ -202,9 +202,9 @@ func (v *unguardedRefCollector) ExitType(t soltype.Type, _ soltype.Polarity) sol
 //
 // Every other kind emits nothing. A union or intersection is a choice among its members rather than
 // a wrapper, so `type A<T> = {x: T} | A<{y: T}>` unfolds to an ever-widening union and settles on no
-// type. A complement is the same: `¬T` admits the values T rejects, which is a statement about T's
-// own values rather than a level of structure built over them, so `type T = ¬T` is the contradiction
-// `type T = T` in disguise and is rejected alongside it. The type-level operators — `keyof`, indexed
+// type. A complement is the same. `¬T` admits the values T rejects, which states something about
+// T's own values rather than building a level of structure over them. So `type T = ¬T` is rejected
+// on the same terms as `type T = T`. The type-level operators — `keyof`, indexed
 // access, the string intrinsics — read a component out of their operand instead of wrapping it, so a
 // lap through one emits nothing either.
 func guardsEveryOperand(t soltype.Type) bool {

--- a/internal/solver/productivity.go
+++ b/internal/solver/productivity.go
@@ -202,8 +202,11 @@ func (v *unguardedRefCollector) ExitType(t soltype.Type, _ soltype.Polarity) sol
 //
 // Every other kind emits nothing. A union or intersection is a choice among its members rather than
 // a wrapper, so `type A<T> = {x: T} | A<{y: T}>` unfolds to an ever-widening union and settles on no
-// type. The type-level operators — `keyof`, indexed access, the string intrinsics — read a
-// component out of their operand instead of wrapping it, so a lap through one emits nothing either.
+// type. A complement is the same: `¬T` admits the values T rejects, which is a statement about T's
+// own values rather than a level of structure built over them, so `type T = ¬T` is the contradiction
+// `type T = T` in disguise and is rejected alongside it. The type-level operators — `keyof`, indexed
+// access, the string intrinsics — read a component out of their operand instead of wrapping it, so a
+// lap through one emits nothing either.
 func guardsEveryOperand(t soltype.Type) bool {
 	switch t.(type) {
 	case *soltype.FuncType, *soltype.RefType, *soltype.PromiseType, *soltype.GeneratorType,

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -163,6 +163,10 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		return e.reduceStringIntrinsic(t.Kind, t.Operand)
 	case *soltype.ExactnessType:
 		return e.reduceExactness(t.Kind, t.Operand)
+	case *soltype.IntersectionType:
+		// A meet carrying a complement is a set difference, which reduces to the members its
+		// excluded side leaves. Any other meet comes back untouched. See typeops_negation.go.
+		return e.reduceDifference(t)
 	default:
 		return t
 	}
@@ -178,6 +182,9 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 //   - a Check or Extends still carrying a type parameter or an unreduced residual keeps the whole
 //     conditional symbolic, rebuilt around the reduced Check and Extends, and reduces later once
 //     they ground. Then and Else stay unreduced in the symbolic form, since neither is selected yet.
+//     One family of undecidable conditional has an answer even so. A distributive conditional whose
+//     branches drop or keep the operand itself is a set difference, so `Exclude<T, string>` over a
+//     type parameter reduces to `T ∩ ¬string` rather than staying symbolic. See nativeDifference.
 //
 // A conditional written over a naked type parameter distributes: a Check that grounds to a union is
 // decided one member at a time and the branch results union, so `type Wrap<T> = if T : string { [T] }
@@ -192,6 +199,11 @@ func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 	// unsubstituted. That position stands for a type no match has chosen yet, so the Check is not
 	// ground and the conditional stays symbolic.
 	if !condOperandGround(check) || containsInfer(check) || !condOperandGround(extends) {
+		// A distributive conditional that filters its own operand denotes a set difference, which
+		// an operand with no members to filter still has an answer for. See nativeDifference.
+		if diff, ok := e.nativeDifference(t, check, extends); ok {
+			return diff
+		}
 		return &soltype.CondType{Check: check, Extends: extends, Then: t.Then, Else: t.Else, Distribute: t.Distribute}
 	}
 	if union, ok := check.(*soltype.UnionType); ok && t.Distribute {
@@ -301,7 +313,15 @@ func (s *occurrenceSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.T
 // The probe is discarded, so the variables and every bound recorded against them are gone by the
 // time this returns and the evaluator's no-mutation invariant holds. A failed constraint selects
 // Else, which covers a shape mismatch and a pattern whose written positions reject the Check alike.
+//
+// The Check is matched through positiveSkeleton, so a complement it carries takes no part in the
+// match. `¬X` names the values X rejects rather than any structure of its own, so no pattern
+// position aligns with it.
 func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check, extends soltype.Type) soltype.Type {
+	skeleton, matchable := positiveSkeleton(check)
+	if !matchable {
+		return e.reduceBranch(t.Else)
+	}
 	decls := inferDeclIDs(extends)
 	vars := make([]*soltype.TypeVarType, len(decls))
 	holes := make(map[int]soltype.Type, len(decls))
@@ -311,7 +331,7 @@ func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check, extends solt
 		vars[i] = e.ctx.freshVar(0)
 		holes[id] = vars[i]
 	}
-	captured, ok := e.ctx.trialCaptures(check, substituteInfer(extends, holes), vars, e.seen.Clone())
+	captured, ok := e.ctx.trialCaptures(skeleton, substituteInfer(extends, holes), vars, e.seen.Clone())
 	if !ok {
 		return e.reduceBranch(t.Else)
 	}
@@ -796,7 +816,7 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 		return reduced, nil, false, false
 	}
 	source, homomorphic := e.homomorphicSource(t.Keys)
-	members, inexactKeys := mappedKeyMembers(keys)
+	members, inexactKeys := unionMembers(keys)
 	pos := make(map[string]int, len(members))
 	for _, member := range members {
 		built, ok := e.mappedFields(t, member, source, homomorphic)
@@ -815,18 +835,21 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 	return reduced, fields, inexactKeys, true
 }
 
-// mappedKeyMembers splits a mapped type's reduced Keys operand into the individual keys to emit a
-// field for, and reports whether the key set is inexact. A union contributes its members and carries
-// its own inexact marker through; `never` is the empty key set, so it contributes none; any other
-// type is a single key.
-func mappedKeyMembers(keys soltype.Type) ([]soltype.Type, bool) {
-	switch keys := keys.(type) {
+// unionMembers splits a reduced type into the members a rule runs over one at a time, and reports
+// whether the set they make up is inexact. A union contributes its members and carries its own
+// inexact marker through; `never` is the empty set, so it contributes none; any other type is a
+// single member.
+//
+// A mapped type splits its key set this way to emit one field per key, and a set difference splits
+// its positive side this way to settle one member at a time against what is excluded.
+func unionMembers(t soltype.Type) ([]soltype.Type, bool) {
+	switch t := t.(type) {
 	case *soltype.UnionType:
-		return keys.Types, keys.Inexact
+		return t.Types, t.Inexact
 	case *soltype.NeverType:
 		return nil, false
 	default:
-		return []soltype.Type{keys}, false
+		return []soltype.Type{t}, false
 	}
 }
 
@@ -904,7 +927,7 @@ func (e *typeEvaluator) mappedFields(t *soltype.MappedElem, key soltype.Type, so
 // name position reduces to something that cannot name a field, which keeps the mapped type symbolic.
 func (e *typeEvaluator) remappedNames(t *soltype.MappedElem, key soltype.Type) ([]string, bool) {
 	remapped := e.groundOperand(substituteMappedKey(t.Name, t.Key, key))
-	members, _ := mappedKeyMembers(remapped)
+	members, _ := unionMembers(remapped)
 	names := make([]string, 0, len(members))
 	for _, member := range members {
 		if _, dropped := member.(*soltype.NeverType); dropped {
@@ -1065,6 +1088,12 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, inexact bool) soltype.
 	case *soltype.IntersectionType:
 		// An intersection carries every operand's members, so its key sets union.
 		return e.keyofIntersection(op.Types, inexact)
+	case *soltype.NegationType:
+		// A complement admits every value its operand rejects, which is values of every shape
+		// other than that one. No key can be read from all of them, so the key set is empty. This
+		// is the same reason `keyof unknown` is `never`, and it holds whatever the operand is, so
+		// the operand needs no reduction.
+		return &soltype.NeverType{}
 	case *soltype.PrimType, *soltype.LitType, *soltype.NeverType, *soltype.UnknownType,
 		*soltype.NullType, *soltype.UndefinedType:
 		// None of these carries a readable member, so its key set is empty. `null` and
@@ -1197,22 +1226,24 @@ func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
 // every key the result names one that every member definitely carries, and the trailing `...`
 // records that the true key set may be larger.
 //
-// Some members have no key set to intersect. A type parameter is one, and so is an operator
-// whose own operands are not ground. Such a member can only shrink the intersection, never grow
-// it, so the fold skips it and keeps going. If the members it can read intersect to nothing, the
-// whole intersection is empty whatever the skipped member's keys turn out to be, and the result
-// is never. Otherwise the intersection is uncomputable and the whole operator stays symbolic,
-// rendering `keyof (T | {a: number})`. Skipping rather than bailing out on the first such member
-// keeps the result independent of the order the operand lists its members.
+// Some members have no key set to enumerate. A type parameter is one, and so is an operator whose
+// own operands are not ground. Such a member reduces to a `keyof` residual, and the law the whole
+// rule states holds for it too: `keyof (A | B)` is `keyof A ∩ keyof B`. So the result is the meet
+// of the literal keys the readable members share with each residual the others left, and
+// `keyof (T | {a: number})` reduces to `"a" ∩ keyof T`. If the members it can read intersect to
+// nothing, the whole meet is empty whatever the residual members' keys turn out to be, and the
+// result is never. Folding every readable member before consulting the residuals keeps the result
+// independent of the order the operand lists its members.
 func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.Type {
 	var shared []soltype.Type
+	var residuals []soltype.Type
 	seeded := false
-	unreadable := false
 	sharedInexact := op.Inexact
 	for _, m := range op.Types {
-		keys, memberInexact, ok := literalKeys(e.reduceKeyof(m, inexact))
+		reduced := e.reduceKeyof(m, inexact)
+		keys, memberInexact, ok := literalKeys(reduced)
 		if !ok {
-			unreadable = true
+			residuals = append(residuals, reduced)
 			continue
 		}
 		if memberInexact {
@@ -1229,15 +1260,19 @@ func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.
 		}
 		if len(shared) == 0 {
 			// No later member can put a key back into an empty intersection, so stop here rather
-			// than reducing the rest. This holds for an unreadable member too, which is why the
-			// answer is never even when one has already been skipped.
+			// than reducing the rest. This holds for a residual member too, which is why the
+			// answer is never even when one has already been set aside.
 			return &soltype.NeverType{}
 		}
 	}
-	if unreadable {
-		return &soltype.KeyofType{Operand: op, Inexact: inexact}
+	if len(residuals) == 0 {
+		return newUnion(nil, shared, sharedInexact)
 	}
-	return newUnion(nil, shared, sharedInexact)
+	if !seeded {
+		// Every member left a residual, so there are no literal keys to meet them with.
+		return newIntersection(nil, residuals)
+	}
+	return newIntersection(nil, append([]soltype.Type{newUnion(nil, shared, sharedInexact)}, residuals...))
 }
 
 // literalKeys decomposes a reduced `keyof` result into the literal keys it names and whether its

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -165,8 +165,9 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		return e.reduceExactness(t.Kind, t.Operand)
 	case *soltype.IntersectionType:
 		// A meet carrying a complement is a set difference, which reduces to the members its
-		// excluded side leaves. Any other meet comes back untouched. See typeops_negation.go.
-		return e.reduceDifference(t)
+		// excluded side leaves. Any other meet has its members reduced in place. See
+		// typeops_negation.go.
+		return e.reduceIntersection(t)
 	default:
 		return t
 	}
@@ -199,8 +200,8 @@ func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 	// unsubstituted. That position stands for a type no match has chosen yet, so the Check is not
 	// ground and the conditional stays symbolic.
 	if !condOperandGround(check) || containsInfer(check) || !condOperandGround(extends) {
-		// A distributive conditional that filters its own operand denotes a set difference, which
-		// an operand with no members to filter still has an answer for. See nativeDifference.
+		// A distributive conditional that filters its own operand denotes a set difference, and a
+		// difference has an answer over an operand with no members to filter. See nativeDifference.
 		if diff, ok := e.nativeDifference(t, check, extends); ok {
 			return diff
 		}
@@ -1089,10 +1090,10 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, inexact bool) soltype.
 		// An intersection carries every operand's members, so its key sets union.
 		return e.keyofIntersection(op.Types, inexact)
 	case *soltype.NegationType:
-		// A complement admits every value its operand rejects, which is values of every shape
-		// other than that one. No key can be read from all of them, so the key set is empty. This
-		// is the same reason `keyof unknown` is `never`, and it holds whatever the operand is, so
-		// the operand needs no reduction.
+		// A complement admits every value its operand rejects, and those values share no shape. No
+		// key can be read from all of them, so the key set is empty. `keyof unknown` is `never` for
+		// the same reason. The rule holds whatever the operand is, so the operand needs no
+		// reduction.
 		return &soltype.NeverType{}
 	case *soltype.PrimType, *soltype.LitType, *soltype.NeverType, *soltype.UnknownType,
 		*soltype.NullType, *soltype.UndefinedType:
@@ -1227,13 +1228,15 @@ func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
 // records that the true key set may be larger.
 //
 // Some members have no key set to enumerate. A type parameter is one, and so is an operator whose
-// own operands are not ground. Such a member reduces to a `keyof` residual, and the law the whole
-// rule states holds for it too: `keyof (A | B)` is `keyof A ∩ keyof B`. So the result is the meet
-// of the literal keys the readable members share with each residual the others left, and
-// `keyof (T | {a: number})` reduces to `"a" ∩ keyof T`. If the members it can read intersect to
-// nothing, the whole meet is empty whatever the residual members' keys turn out to be, and the
-// result is never. Folding every readable member before consulting the residuals keeps the result
-// independent of the order the operand lists its members.
+// own operands are not ground. Such a member reduces to a `keyof` residual, and the rule this whole
+// reduction states covers it too, since `keyof (A | B)` is `keyof A ∩ keyof B` whatever A and B
+// are. So the result is the meet of two things: the literal keys the readable members share, and
+// each residual the other members left. `keyof (T | {a: number})` reduces to `"a" ∩ keyof T`.
+//
+// If the members it can read intersect to nothing, the whole meet is empty whatever the residual
+// members' keys turn out to be, and the result is never. Folding every readable member before
+// consulting the residuals keeps the result independent of the order the operand lists its
+// members.
 func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.Type {
 	var shared []soltype.Type
 	var residuals []soltype.Type
@@ -1269,7 +1272,13 @@ func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.
 		return newUnion(nil, shared, sharedInexact)
 	}
 	if !seeded {
-		// Every member left a residual, so there are no literal keys to meet them with.
+		// Every member left a residual, so there are no literal keys to meet them with. An
+		// intersection carries no exactness marker, and with no key union among its members there
+		// is nothing to hang the open tail on, so an open key set keeps the whole operator
+		// symbolic rather than dropping what the tail stands for.
+		if sharedInexact {
+			return &soltype.KeyofType{Operand: op, Inexact: inexact}
+		}
 		return newIntersection(nil, residuals)
 	}
 	return newIntersection(nil, append([]soltype.Type{newUnion(nil, shared, sharedInexact)}, residuals...))

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -168,6 +168,15 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		// excluded side leaves. Any other meet has its members reduced in place. See
 		// typeops_negation.go.
 		return e.reduceIntersection(t)
+	case *soltype.NegationType:
+		// A complement stands for the values its operand rejects, so reducing the operand is all
+		// there is to do. The node is rebuilt only when that changed something, so a complement
+		// over a concrete type keeps its pointer.
+		inner := e.reduce(t.Inner)
+		if inner == t.Inner {
+			return t
+		}
+		return &soltype.NegationType{Inner: inner}
 	default:
 		return t
 	}
@@ -524,7 +533,14 @@ func (e *typeEvaluator) groundTuple(t *soltype.TupleType) (*soltype.TupleType, b
 // leaves the operand unexpanded, which keeps the enclosing operator symbolic. The tuple-spread,
 // template-literal, string-intrinsic, and mapped-type reductions share it.
 func (e *typeEvaluator) groundOperand(operand soltype.Type) soltype.Type {
-	reduced := e.reduce(operand)
+	return e.groundReduced(e.reduce(operand))
+}
+
+// groundReduced expands a named alias in an operand that is already reduced, the second half of
+// groundOperand. A caller that reduced its operands for some other purpose first grounds them
+// through this, so no operand is reduced twice and a diagnostic the reduction records is recorded
+// once.
+func (e *typeEvaluator) groundReduced(reduced soltype.Type) soltype.Type {
 	alias, ok := reduced.(*soltype.AliasType)
 	if !ok {
 		return reduced

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -42,13 +42,17 @@ import (
 // The rewrite is not sticky either. An alias body is stored unreduced, so a later instantiation
 // with a ground argument reduces from the conditional again and takes the filter.
 
-// reduceIntersection reduces a meet. A meet carrying a complement is a set difference, which
-// reduceDifference settles. Any other meet has its members reduced in place, so a member that is
-// itself an operator reaches its value. `"a" ∩ keyof {a: number, b: string}` reduces to `"a"`. That
-// meet is the shape keyofUnion mints for a union operand it could not read every member of.
+// reduceIntersection reduces a meet of any members, not only of key sets. Every member is reduced
+// first, so one that is itself an operator reaches its value and `{a: string}["a"] ∩ {b: number}`
+// becomes `string ∩ {b: number}`. What becomes of the reduced members depends on what they turned
+// out to be.
 //
-// A meet that neither folds to a key set nor has any member reduce comes back untouched, keeping
-// its pointer, so a plain intersection of concrete types costs nothing.
+//   - A complement among them makes the meet a set difference, which reduceDifference settles.
+//   - A meet whose members are all enumerable key sets folds to the keys they share, so
+//     `"a" ∩ keyof {a: number, b: string}` reduces to `"a"`. This is the one rule here that asks
+//     what kind its members are. See meetKeySets.
+//   - Anything else is rebuilt as a meet. A meet whose members each reduced to themselves comes
+//     back untouched, keeping its pointer, so a plain intersection of concrete types costs nothing.
 func (e *typeEvaluator) reduceIntersection(t *soltype.IntersectionType) soltype.Type {
 	reduced := make([]soltype.Type, len(t.Types))
 	changed := false

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -1,0 +1,206 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// Complements in the operator layer.
+//
+// The operator reducers meet the same surface union and intersection nodes they always have, plus
+// one more kind, the complement `¬T`. This file holds the three places a complement changes what a
+// reduction produces.
+//
+//  1. A meet carrying a complement is a set difference. reduceDifference computes it, so a key set
+//     written `keyof T ∩ ¬K` enumerates the keys of T other than K.
+//  2. A distributive conditional that filters its own operand is a set difference too.
+//     nativeDifference rewrites one whose operand is not ground into that meet, which is what makes
+//     `Exclude`, `Omit`, and `NonNullable` total over a type variable.
+//  3. An `infer` pattern matches against structure a value carries. A complement names the values
+//     its operand rejects and carries no structure of its own, so positiveSkeleton drops it before
+//     the match.
+//
+// # Which reading each utility type takes
+//
+// TypeScript defines `Exclude<U, V>` as the distributive conditional `U extends V ? never : U`,
+// which filters whole members of a union. The set difference `U ∩ ¬V` cuts inside a member as well.
+// The two agree whenever every member of U is either wholly inside V or disjoint from it, and
+// diverge otherwise. `Exclude<string, "a">` is `string` under the filter, since `string` is not a
+// subtype of `"a"`, and `string ∩ ¬"a"` under the difference.
+//
+// Escalier takes the filter when the operand is ground and the difference when it is not:
+//
+//   - A ground operand reduces the way TypeScript's does, so ported code keeps its meaning.
+//   - A type-variable operand has no members to filter, so the filter is stuck. The difference is
+//     an answer, and it reduces to the filter's answer once the variable grounds to a union whose
+//     members are each inside or disjoint from V.
+//
+// The fork is therefore only reachable where the filter produced nothing at all.
+
+// reduceDifference reduces a meet carrying at least one complement — `A ∩ ¬B`, the values of A that
+// are not values of B. It is the reduction behind every Boolean key set: `Omit<T, "b">` maps over
+// `keyof T ∩ ¬"b"`, which reduces to `"a" | "c"` for `type T = {a: X, b: Y, c: Z}` so the mapped
+// type has keys to iterate.
+//
+// A meet with no complement is returned untouched, keeping its pointer, since an ordinary
+// intersection is not something reduction works out.
+//
+// The difference distributes over the positive side's members, `(A | B) ∩ ¬X` being
+// `(A ∩ ¬X) | (B ∩ ¬X)`, and each member is settled against each excluded type by two subtype
+// questions the normal-form layer decides:
+//
+//   - `m <: x` means every value of m is excluded, so m contributes nothing.
+//   - `m <: ¬x` means the two are disjoint, so x removes nothing from m and the complement is
+//     dropped from m's result.
+//   - Neither holds when x removes part of m, and that part is not expressible as a union of the
+//     members at hand, so m keeps the complement and renders as `m ∩ ¬x`.
+//
+// An operand that is not ground leaves the whole difference standing, so it reduces later once the
+// operand grounds. That residual is the `∩ ¬` form itself rather than a stuck operator, which is
+// what a caller such as a mapped-type key set or a constraint reads.
+//
+// An inexact positive side names only some of its members, and which of the unnamed ones the
+// exclusion removes cannot be worked out, so the result keeps the open tail. `("a" | ...) ∩ ¬"a"`
+// reduces to the inexact empty set rather than to `never`.
+func (e *typeEvaluator) reduceDifference(t *soltype.IntersectionType) soltype.Type {
+	positives := make([]soltype.Type, 0, len(t.Types))
+	var excluded []soltype.Type
+	for _, m := range t.Types {
+		if neg, ok := m.(*soltype.NegationType); ok {
+			excluded = append(excluded, e.reduce(neg.Inner))
+			continue
+		}
+		positives = append(positives, e.reduce(m))
+	}
+	if len(excluded) == 0 {
+		return t
+	}
+	base := newIntersection(nil, positives)
+	if !groundDifference(base, excluded) {
+		return newIntersection(nil, append([]soltype.Type{base}, complementsOf(excluded)...))
+	}
+	members, inexact := unionMembers(base)
+	survivors := make([]soltype.Type, 0, len(members))
+	for _, m := range members {
+		if narrowed, keep := e.excludeFrom(m, excluded); keep {
+			survivors = append(survivors, narrowed)
+		}
+	}
+	return newUnion(nil, survivors, inexact)
+}
+
+// excludeFrom settles one member of a difference's positive side against every excluded type. It
+// reports whether the member survives at all, and returns what is left of it: the member itself
+// when no exclusion cuts into it, and the member met with the complements of those that do.
+func (e *typeEvaluator) excludeFrom(m soltype.Type, excluded []soltype.Type) (soltype.Type, bool) {
+	overlapping := make([]soltype.Type, 0, len(excluded))
+	for _, x := range excluded {
+		if e.ctx.condExtends(m, x, e.seen) {
+			return nil, false
+		}
+		if e.ctx.condExtends(m, &soltype.NegationType{Inner: x}, e.seen) {
+			continue
+		}
+		overlapping = append(overlapping, &soltype.NegationType{Inner: x})
+	}
+	if len(overlapping) == 0 {
+		return m, true
+	}
+	return newIntersection(nil, append([]soltype.Type{m}, overlapping...)), true
+}
+
+// groundDifference reports whether a difference's operands are concrete enough to settle. Every
+// member of the positive side is asked two subtype questions per excluded type, and neither can be
+// decided over a type variable or an unreduced operator.
+func groundDifference(base soltype.Type, excluded []soltype.Type) bool {
+	if !condOperandGround(base) {
+		return false
+	}
+	for _, x := range excluded {
+		if !condOperandGround(x) {
+			return false
+		}
+	}
+	return true
+}
+
+// complementsOf wraps each type in a complement, rebuilding the negated half of a difference the
+// reduction left standing.
+func complementsOf(types []soltype.Type) []soltype.Type {
+	out := make([]soltype.Type, len(types))
+	for i, t := range types {
+		out[i] = &soltype.NegationType{Inner: t}
+	}
+	return out
+}
+
+// nativeDifference rewrites a distributive conditional that filters its own operand into the set
+// difference or intersection it denotes, and reports whether the conditional had that shape.
+//
+//	if U : V { never } else { U }   ⟹  U ∩ ¬V
+//	if U : V { U } else { never }   ⟹  U ∩ V
+//
+// Those are `Exclude<U, V>` and `Extract<U, V>` as TypeScript's library writes them, and the same
+// two shapes back `NonNullable<T>`, whose V is `null | undefined`, and `Omit<T, Ks>`, whose key set
+// filters `keyof T` through the first one.
+//
+// reduceCond calls this only for a conditional it could not decide, so the rewrite fires exactly
+// where the filter had no answer. The header of this file states why the two readings may then
+// diverge and why the divergence is not reachable from a ground operand.
+//
+// The conditional must be distributive, which is to say its Check was written as a bare type
+// parameter. That is the shape whose branches read the operand member by member, and it is what
+// makes the filter a set operation rather than a single yes-or-no test over the whole operand. A
+// conditional over any other Check keeps its own semantics and stays symbolic.
+//
+// A branch is compared against the Check as the source wrote it, since both are reduced from the
+// same node and a naked type parameter reduces to itself.
+func (e *typeEvaluator) nativeDifference(t *soltype.CondType, check, extends soltype.Type) (soltype.Type, bool) {
+	if !t.Distribute || containsInfer(check) || containsInfer(extends) {
+		return nil, false
+	}
+	switch {
+	case isNever(t.Then) && equalType(t.Check, t.Else):
+		return newIntersection(nil, []soltype.Type{check, &soltype.NegationType{Inner: extends}}), true
+	case isNever(t.Else) && equalType(t.Check, t.Then):
+		return newIntersection(nil, []soltype.Type{check, extends}), true
+	}
+	return nil, false
+}
+
+// positiveSkeleton returns the part of a conditional's Check an `infer` pattern matches against,
+// and reports whether any of it is left to match. A pattern binds a capture by aligning against
+// structure the scrutinee carries, and a complement names the values its operand rejects rather
+// than any structure of its own. So `¬X` matches no pattern position, and a meet contributes only
+// its positive members: `(Array<number> ∩ ¬X) extends Array<infer R>` binds R to number.
+//
+// A Check that is nothing but complements has no skeleton to align, so the match fails and the
+// conditional takes its Else branch.
+func positiveSkeleton(check soltype.Type) (soltype.Type, bool) {
+	switch t := check.(type) {
+	case *soltype.NegationType:
+		return nil, false
+	case *soltype.IntersectionType:
+		positives := make([]soltype.Type, 0, len(t.Types))
+		for _, m := range t.Types {
+			if _, negated := m.(*soltype.NegationType); !negated {
+				positives = append(positives, m)
+			}
+		}
+		if len(positives) == 0 {
+			return nil, false
+		}
+		if len(positives) == len(t.Types) {
+			return check, true
+		}
+		return newIntersection(nil, positives), true
+	default:
+		return check, true
+	}
+}
+
+// isNever reports whether t is the empty type, the branch a set-difference conditional drops its
+// operand through.
+func isNever(t soltype.Type) bool {
+	_, ok := t.(*soltype.NeverType)
+	return ok
+}

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"slices"
+
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -45,25 +47,24 @@ import (
 // its pointer, so a plain intersection of concrete types costs nothing.
 func (e *typeEvaluator) reduceIntersection(t *soltype.IntersectionType) soltype.Type {
 	reduced := make([]soltype.Type, len(t.Types))
-	negated := false
 	changed := false
 	for i, m := range t.Types {
 		reduced[i] = e.reduce(m)
 		changed = changed || reduced[i] != m
-		if _, ok := reduced[i].(*soltype.NegationType); ok {
-			negated = true
-		}
 	}
-	if negated {
-		return e.reduceDifference(reduced)
+	// A member may have reduced to a difference of its own, as an `Exclude<T, string>` member does,
+	// so the members are spliced together before the meet is read for a complement.
+	flat := flattenIntersection(reduced)
+	if slices.ContainsFunc(flat, isNegation) {
+		return e.reduceDifference(flat)
 	}
-	if folded, ok := meetKeySets(reduced); ok {
+	if folded, ok := meetKeySets(flat); ok {
 		return folded
 	}
 	if !changed {
 		return t
 	}
-	return newIntersection(nil, reduced)
+	return newIntersection(nil, flat)
 }
 
 // meetKeySets folds a meet whose every member is an enumerable key set into the keys they share,
@@ -101,8 +102,8 @@ func meetKeySets(members []soltype.Type) (soltype.Type, bool) {
 // `keyof T ∩ ¬"b"`, which reduces to `"a" | "c"` for `type T = {a: X, b: Y, c: Z}` so the mapped
 // type has keys to iterate.
 //
-// Each member of the meet grounds through groundOperand, so an alias named on either side expands
-// to the type whose values the difference is taken over.
+// Each member of the meet is already reduced and grounds through groundReduced, so an alias named
+// on either side expands to the type whose values the difference is taken over.
 //
 // The difference distributes over the positive side's members, `(A | B) ∩ ¬X` being
 // `(A ∩ ¬X) | (B ∩ ¬X)`, and each member is settled against each excluded type by two subtype
@@ -129,10 +130,10 @@ func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
 	var excluded []soltype.Type
 	for _, m := range members {
 		if neg, ok := m.(*soltype.NegationType); ok {
-			excluded = append(excluded, e.groundOperand(neg.Inner))
+			excluded = append(excluded, e.groundReduced(neg.Inner))
 			continue
 		}
-		positives = append(positives, e.groundOperand(m))
+		positives = append(positives, e.groundReduced(m))
 	}
 	base, folded := meetKeySets(positives)
 	if !folded {

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -158,23 +158,20 @@ func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
 	if !folded {
 		base = newIntersection(nil, positives)
 	}
-	unreduced := func() soltype.Type {
-		return newIntersection(nil, append([]soltype.Type{base}, complementsOf(excluded)...))
-	}
-	if !groundDifference(base, excluded) {
-		return unreduced()
-	}
-	baseMembers, inexact := unionMembers(base)
-	survivors := make([]soltype.Type, 0, len(baseMembers))
-	for _, m := range baseMembers {
-		if narrowed, keep := e.excludeFrom(m, excluded); keep {
-			survivors = append(survivors, narrowed)
+	if groundDifference(base, excluded) {
+		baseMembers, inexact := unionMembers(base)
+		survivors := make([]soltype.Type, 0, len(baseMembers))
+		for _, m := range baseMembers {
+			if narrowed, keep := e.excludeFrom(m, excluded); keep {
+				survivors = append(survivors, narrowed)
+			}
+		}
+		// A tail with no surviving member to ride on falls through to the residual below.
+		if len(survivors) > 0 || !inexact {
+			return newUnion(nil, survivors, inexact)
 		}
 	}
-	if len(survivors) == 0 && inexact {
-		return unreduced()
-	}
-	return newUnion(nil, survivors, inexact)
+	return newIntersection(nil, append([]soltype.Type{base}, complementsOf(excluded)...))
 }
 
 // excludeFrom settles one member of a difference's positive side against every excluded type. It

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -36,7 +36,11 @@ import (
 //     an answer, and it reduces to the filter's answer once the variable grounds to a union whose
 //     members are each inside or disjoint from V.
 //
-// The fork is therefore only reachable where the filter produced nothing at all.
+// Where the filter has an answer, that is the answer, so the two readings never disagree on the
+// same operand. The difference is reached only where the filter is stuck.
+//
+// The rewrite is not sticky either. An alias body is stored unreduced, so a later instantiation
+// with a ground argument reduces from the conditional again and takes the filter.
 
 // reduceIntersection reduces a meet. A meet carrying a complement is a set difference, which
 // reduceDifference settles. Any other meet has its members reduced in place, so a member that is

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -36,13 +36,73 @@ import (
 //
 // The fork is therefore only reachable where the filter produced nothing at all.
 
-// reduceDifference reduces a meet carrying at least one complement — `A ∩ ¬B`, the values of A that
+// reduceIntersection reduces a meet. A meet carrying a complement is a set difference, which
+// reduceDifference settles. Any other meet has its members reduced in place, so a member that is
+// itself an operator reaches its value. `"a" ∩ keyof {a: number, b: string}` reduces to `"a"`. That
+// meet is the shape keyofUnion mints for a union operand it could not read every member of.
+//
+// A meet that neither folds to a key set nor has any member reduce comes back untouched, keeping
+// its pointer, so a plain intersection of concrete types costs nothing.
+func (e *typeEvaluator) reduceIntersection(t *soltype.IntersectionType) soltype.Type {
+	reduced := make([]soltype.Type, len(t.Types))
+	negated := false
+	changed := false
+	for i, m := range t.Types {
+		reduced[i] = e.reduce(m)
+		changed = changed || reduced[i] != m
+		if _, ok := reduced[i].(*soltype.NegationType); ok {
+			negated = true
+		}
+	}
+	if negated {
+		return e.reduceDifference(reduced)
+	}
+	if folded, ok := meetKeySets(reduced); ok {
+		return folded
+	}
+	if !changed {
+		return t
+	}
+	return newIntersection(nil, reduced)
+}
+
+// meetKeySets folds a meet whose every member is an enumerable key set into the keys they share,
+// and reports whether it had that shape. Take `keyof (T | {a: number, b: string})`, which reduces to
+// `"a" ∩ keyof T`. Once T grounds to an object carrying "a" and "b", that meet reads
+// `"a" ∩ ("a" | "b")`. Folding it to `"a"` is what leaves a mapped type over it a key to iterate.
+//
+// A member with an open key set stops the fold. Such a set names some of its keys and leaves the
+// rest to a tail, so a key the other members name may or may not be among them, and the meet is
+// undecided. The whole meet stays as it is in that case, which is what an undecided key set reduces
+// to elsewhere too.
+func meetKeySets(members []soltype.Type) (soltype.Type, bool) {
+	if len(members) < 2 {
+		return nil, false
+	}
+	var shared []soltype.Type
+	for i, m := range members {
+		keys, inexact, ok := literalKeys(m)
+		if !ok || inexact {
+			return nil, false
+		}
+		if i == 0 {
+			// literalKeys hands back the member's own slice, and newUnion sorts its input in
+			// place, so seed the accumulator with a copy.
+			shared = append([]soltype.Type(nil), keys...)
+			continue
+		}
+		shared = intersectTypes(shared, keys)
+	}
+	return newUnion(nil, shared, false), true
+}
+
+// reduceDifference settles a meet carrying at least one complement — `A ∩ ¬B`, the values of A that
 // are not values of B. It is the reduction behind every Boolean key set: `Omit<T, "b">` maps over
 // `keyof T ∩ ¬"b"`, which reduces to `"a" | "c"` for `type T = {a: X, b: Y, c: Z}` so the mapped
 // type has keys to iterate.
 //
-// A meet with no complement is returned untouched, keeping its pointer, since an ordinary
-// intersection is not something reduction works out.
+// Each member of the meet grounds through groundOperand, so an alias named on either side expands
+// to the type whose values the difference is taken over.
 //
 // The difference distributes over the positive side's members, `(A | B) ∩ ¬X` being
 // `(A ∩ ¬X) | (B ∩ ¬X)`, and each member is settled against each excluded type by two subtype
@@ -58,32 +118,41 @@ import (
 // operand grounds. That residual is the `∩ ¬` form itself rather than a stuck operator, which is
 // what a caller such as a mapped-type key set or a constraint reads.
 //
-// An inexact positive side names only some of its members, and which of the unnamed ones the
-// exclusion removes cannot be worked out, so the result keeps the open tail. `("a" | ...) ∩ ¬"a"`
-// reduces to the inexact empty set rather than to `never`.
-func (e *typeEvaluator) reduceDifference(t *soltype.IntersectionType) soltype.Type {
-	positives := make([]soltype.Type, 0, len(t.Types))
+// An inexact positive side names only some of its members. The rest sit in an open tail, and what
+// the exclusion removes from those cannot be worked out. The result union keeps the tail, which
+// stands for whatever those undecided members contribute, so `("a" | "b" | ...) ∩ ¬"a"` reduces to
+// `"b" | ...`. When no named member survives, there is no union left to carry the tail, since an
+// empty union is `never` however the marker is set. The difference then stays as it stands rather
+// than claiming the tail is empty too.
+func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
+	positives := make([]soltype.Type, 0, len(members))
 	var excluded []soltype.Type
-	for _, m := range t.Types {
+	for _, m := range members {
 		if neg, ok := m.(*soltype.NegationType); ok {
-			excluded = append(excluded, e.reduce(neg.Inner))
+			excluded = append(excluded, e.groundOperand(neg.Inner))
 			continue
 		}
-		positives = append(positives, e.reduce(m))
+		positives = append(positives, e.groundOperand(m))
 	}
-	if len(excluded) == 0 {
-		return t
+	base, folded := meetKeySets(positives)
+	if !folded {
+		base = newIntersection(nil, positives)
 	}
-	base := newIntersection(nil, positives)
-	if !groundDifference(base, excluded) {
+	unreduced := func() soltype.Type {
 		return newIntersection(nil, append([]soltype.Type{base}, complementsOf(excluded)...))
 	}
-	members, inexact := unionMembers(base)
-	survivors := make([]soltype.Type, 0, len(members))
-	for _, m := range members {
+	if !groundDifference(base, excluded) {
+		return unreduced()
+	}
+	baseMembers, inexact := unionMembers(base)
+	survivors := make([]soltype.Type, 0, len(baseMembers))
+	for _, m := range baseMembers {
 		if narrowed, keep := e.excludeFrom(m, excluded); keep {
 			survivors = append(survivors, narrowed)
 		}
+	}
+	if len(survivors) == 0 && inexact {
+		return unreduced()
 	}
 	return newUnion(nil, survivors, inexact)
 }
@@ -152,16 +221,16 @@ func complementsOf(types []soltype.Type) []soltype.Type {
 // makes the filter a set operation rather than a single yes-or-no test over the whole operand. A
 // conditional over any other Check keeps its own semantics and stays symbolic.
 //
-// A branch is compared against the Check as the source wrote it, since both are reduced from the
-// same node and a naked type parameter reduces to itself.
+// The shape test reads the stored branches and the stored Check rather than their reduced forms,
+// so it states what the source wrote. The result is built from the reduced operands.
 func (e *typeEvaluator) nativeDifference(t *soltype.CondType, check, extends soltype.Type) (soltype.Type, bool) {
 	if !t.Distribute || containsInfer(check) || containsInfer(extends) {
 		return nil, false
 	}
 	switch {
-	case isNever(t.Then) && equalType(t.Check, t.Else):
+	case isNeverType(t.Then) && equalType(t.Check, t.Else):
 		return newIntersection(nil, []soltype.Type{check, &soltype.NegationType{Inner: extends}}), true
-	case isNever(t.Else) && equalType(t.Check, t.Then):
+	case isNeverType(t.Else) && equalType(t.Check, t.Then):
 		return newIntersection(nil, []soltype.Type{check, extends}), true
 	}
 	return nil, false
@@ -171,7 +240,8 @@ func (e *typeEvaluator) nativeDifference(t *soltype.CondType, check, extends sol
 // and reports whether any of it is left to match. A pattern binds a capture by aligning against
 // structure the scrutinee carries, and a complement names the values its operand rejects rather
 // than any structure of its own. So `¬X` matches no pattern position, and a meet contributes only
-// its positive members: `(Array<number> ∩ ¬X) extends Array<infer R>` binds R to number.
+// its positive members. Matching `Array<number> ∩ ¬X` against the pattern `Array<infer R>` binds R
+// to number.
 //
 // A Check that is nothing but complements has no skeleton to align, so the match fails and the
 // conditional takes its Else branch.
@@ -196,11 +266,4 @@ func positiveSkeleton(check soltype.Type) (soltype.Type, bool) {
 	default:
 		return check, true
 	}
-}
-
-// isNever reports whether t is the empty type, the branch a set-difference conditional drops its
-// operand through.
-func isNever(t soltype.Type) bool {
-	_, ok := t.(*soltype.NeverType)
-	return ok
 }

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -127,12 +127,17 @@ func meetKeySets(members []soltype.Type) (soltype.Type, bool) {
 // operand grounds. That residual is the `∩ ¬` form itself rather than a stuck operator, which is
 // what a caller such as a mapped-type key set or a constraint reads.
 //
-// An inexact positive side names only some of its members. The rest sit in an open tail, and what
-// the exclusion removes from those cannot be worked out. The result union keeps the tail, which
-// stands for whatever those undecided members contribute, so `("a" | "b" | ...) ∩ ¬"a"` reduces to
-// `"b" | ...`. When no named member survives, there is no union left to carry the tail, since an
-// empty union is `never` however the marker is set. The difference then stays as it stands rather
-// than claiming the tail is empty too.
+// An inexact positive side names only some of its members. The rest sit in an open tail that the
+// reduction cannot enumerate, so what the exclusion takes from them cannot be worked out. The
+// result union keeps the tail, which stands for whatever those undecided members contribute, so
+// `("a" | "b" | ...) ∩ ¬"a"` reduces to `"b" | ...`.
+//
+// When no named member survives, the difference stays as it stands, since neither answer available
+// is the one the reduction means. `newUnion` over an empty member list is `never` however the
+// marker is set, which would claim the tail is empty too. Reading the open union as `unknown` —
+// which is what it is for subtyping, since its tail accepts every value — would answer `¬X`, and
+// that is wrong for the key sets this reduction mostly serves. `keyof {a: X, ...}` is `"a" | ...`,
+// where the tail stands for the keys the object did not name, not for every key there is.
 func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
 	positives := make([]soltype.Type, 0, len(members))
 	var excluded []soltype.Type

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -135,6 +135,12 @@ func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
 		}
 		positives = append(positives, e.groundReduced(m))
 	}
+	// Settling a member against an exclusion asks whether the two are disjoint, which is the
+	// constraint `m <: ¬x`, and rebuilding an unsettled difference re-mints each `¬x`. Both need a
+	// complement of x, so an x no complement may name leaves the meet exactly as it arrived.
+	if !negatableOperands(excluded) {
+		return newIntersection(nil, members)
+	}
 	base, folded := meetKeySets(positives)
 	if !folded {
 		base = newIntersection(nil, positives)
@@ -161,16 +167,20 @@ func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
 // excludeFrom settles one member of a difference's positive side against every excluded type. It
 // reports whether the member survives at all, and returns what is left of it: the member itself
 // when no exclusion cuts into it, and the member met with the complements of those that do.
+//
+// Every excluded type is one a complement may name, which reduceDifference checked before calling
+// this. soltype.NewNegation asserts that here, so a caller that skipped the check is caught at the
+// site that builds the forbidden node rather than deep inside normalization.
 func (e *typeEvaluator) excludeFrom(m soltype.Type, excluded []soltype.Type) (soltype.Type, bool) {
 	overlapping := make([]soltype.Type, 0, len(excluded))
 	for _, x := range excluded {
 		if e.ctx.condExtends(m, x, e.seen) {
 			return nil, false
 		}
-		if e.ctx.condExtends(m, &soltype.NegationType{Inner: x}, e.seen) {
+		if e.ctx.condExtends(m, soltype.NewNegation(x), e.seen) {
 			continue
 		}
-		overlapping = append(overlapping, &soltype.NegationType{Inner: x})
+		overlapping = append(overlapping, soltype.NewNegation(x))
 	}
 	if len(overlapping) == 0 {
 		return m, true
@@ -194,13 +204,55 @@ func groundDifference(base soltype.Type, excluded []soltype.Type) bool {
 }
 
 // complementsOf wraps each type in a complement, rebuilding the negated half of a difference the
-// reduction left standing.
+// reduction left standing. It mints through newNegation, the lattice's complement constructor, so
+// an operand whose complement the surface type set already names comes back under that name.
 func complementsOf(types []soltype.Type) []soltype.Type {
 	out := make([]soltype.Type, len(types))
 	for i, t := range types {
-		out[i] = &soltype.NegationType{Inner: t}
+		out[i] = newNegation(t)
 	}
 	return out
+}
+
+// negatableOperands reports whether a complement may name every one of these types.
+func negatableOperands(types []soltype.Type) bool {
+	for _, t := range types {
+		if !negatableOperand(t) {
+			return false
+		}
+	}
+	return true
+}
+
+// negatableOperand reports whether a complement may name t, which is the ¬Ref exclusion invariant
+// asked ahead of time rather than asserted. soltype.AssertNegatable panics on a borrow, and
+// normalization applies it to every atom of a negated part, so a borrow anywhere in t's lattice
+// spine is forbidden and not only one at the top. `¬({x: number} | &'a {y: string})` is
+// `¬{x: number} ∩ ¬(&'a {y: string})` by De Morgan, which names the borrow.
+//
+// The walk stops at the spine. A borrow nested inside an atom, as in `¬{a: &'a T}`, is a field of
+// the object the negated part names rather than a negated part of its own, so it is allowed.
+//
+// A borrow under a second complement is negatable in truth, since `¬¬(&'a T)` cancels, but this
+// reports it forbidden. The reduction that would build such a type does not arise, and answering
+// conservatively costs a residual rather than a wrong type.
+//
+// Reduction consults this where it chooses an operand to complement. A site that only re-mints an
+// existing complement around a rewritten operand chooses nothing, which is why soltype.NewNegation
+// draws the same distinction.
+func negatableOperand(t soltype.Type) bool {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		return false
+	case *soltype.UnionType:
+		return negatableOperands(t.Types)
+	case *soltype.IntersectionType:
+		return negatableOperands(t.Types)
+	case *soltype.NegationType:
+		return negatableOperand(t.Inner)
+	default:
+		return true
+	}
 }
 
 // nativeDifference rewrites a distributive conditional that filters its own operand into the set
@@ -208,6 +260,10 @@ func complementsOf(types []soltype.Type) []soltype.Type {
 //
 //	if U : V { never } else { U }   ⟹  U ∩ ¬V
 //	if U : V { U } else { never }   ⟹  U ∩ V
+//
+// Both meets are minted through the lattice constructors, so a V whose complement the surface type
+// set already names comes back under that name. `Exclude<T, never>` is `T ∩ ¬never`, which is
+// `T ∩ unknown` and then `T`.
 //
 // Those are `Exclude<U, V>` and `Extract<U, V>` as TypeScript's library writes them, and the same
 // two shapes back `NonNullable<T>`, whose V is `null | undefined`, and `Omit<T, Ks>`, whose key set
@@ -230,7 +286,14 @@ func (e *typeEvaluator) nativeDifference(t *soltype.CondType, check, extends sol
 	}
 	switch {
 	case isNeverType(t.Then) && equalType(t.Check, t.Else):
-		return newIntersection(nil, []soltype.Type{check, &soltype.NegationType{Inner: extends}}), true
+		// The difference is `check ∩ ¬extends`, so an Extends no complement may name has no
+		// difference form and the conditional stays as it is. The test reads the grounded
+		// operand, since an alias naming a borrow is that same forbidden complement with a name
+		// in front of it. See negatableOperand.
+		if !negatableOperand(e.groundReduced(extends)) {
+			return nil, false
+		}
+		return newIntersection(nil, []soltype.Type{check, newNegation(extends)}), true
 	case isNeverType(t.Else) && equalType(t.Check, t.Then):
 		return newIntersection(nil, []soltype.Type{check, extends}), true
 	}

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -279,6 +279,20 @@ func TestNativeSetDifferenceOverTypeVariable(t *testing.T) {
 			want: "t16 & ¬t17",
 		},
 		{
+			// Excluding the empty type removes nothing. `¬never` is `unknown`, the identity of a
+			// meet, so the difference is the operand itself.
+			name: "ExcludeOfNever",
+			src:  `type Result<T> = Exclude<T, never>`,
+			want: "t16",
+		},
+		{
+			// Excluding every value leaves nothing, and `¬unknown` is `never`. The meet does not
+			// collapse on that `never` yet, which is the uninhabited-intersection gap #927 tracks.
+			name: "ExcludeOfUnknown",
+			src:  `type Result<T> = Exclude<T, unknown>`,
+			want: "never & t16",
+		},
+		{
 			// `Omit`'s key set over a type parameter: the keys of T other than "x". Neither half
 			// grounds, so the whole key set stays a difference.
 			name: "OmitKeySetOverVariable",
@@ -289,6 +303,74 @@ func TestNativeSetDifferenceOverTypeVariable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nodes, ctx, errs := inferTypeNodes(t, nativeDifferenceDecls+tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// No complement may name a borrow, which is the ¬Ref exclusion invariant in
+// `internal/soltype/negation.go`. A borrow carries a lifetime as well as a type, and the outlives
+// lattice has no complement, so `¬(&'a T)` names nothing.
+//
+// A set difference is the one reduction that chooses an operand to complement, so it is where the
+// invariant has to be honored rather than asserted. A difference whose excluded side would take a
+// borrow leaves the whole meet as it arrived, and the conditional it would have been rewritten from
+// stays symbolic. Neither loses anything that reduces today: the solver decides disjointness only
+// within the value families, so a borrow exclusion would leave an unsettled residual even if the
+// complement were allowed. #1125 carries the work to lift the exclusion.
+func TestSetDifferenceDeclinesToComplementABorrow(t *testing.T) {
+	// Every case applies `Exclude` to an operand the reduction cannot filter, so the rewrite to a
+	// difference is what would mint the complement.
+	const decls = `
+		type Exclude<U, V> = if U : V { never } else { U }
+		type Point = {x: number}
+		type Handle = &Point
+	`
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// `Exclude<T, &'a Point>` has no difference form, so it keeps the shape the source
+			// wrote instead of reducing to `T & ¬(&'a Point)`.
+			name: "BorrowExclusion",
+			src:  `type Result<T, 'a> = Exclude<T, &'a Point>`,
+			want: "if t6 : &Point { never } else { t6 }",
+		},
+		{
+			// De Morgan would put the borrow in a negated part of its own, so a borrow anywhere in
+			// the excluded side's lattice spine stops the rewrite, not only one at the top.
+			name: "BorrowInExcludedUnion",
+			src:  `type Result<T, 'a> = Exclude<T, &'a Point | string>`,
+			want: "if t6 : string | &Point { never } else { t6 }",
+		},
+		{
+			// An alias naming a borrow is the same forbidden complement with a name in front of
+			// it, so the test reads the grounded operand and this stays symbolic too.
+			name: "AliasNamingABorrow",
+			src:  `type Result<T> = Exclude<T, Handle>`,
+			want: "if t6 : Handle { never } else { t6 }",
+		},
+		{
+			// A borrow inside an atom is allowed. The negated part names the object, and the
+			// borrow is one of its fields rather than a negated part of its own.
+			name: "BorrowInsideAnExcludedAtom",
+			src:  `type Result<T, 'a> = Exclude<T, {a: &'a Point}>`,
+			want: "t6 & ¬{a: &Point}",
+		},
+		{
+			// A borrow on the positive side is allowed too. The complement names `string`, so the
+			// invariant has nothing to say and the borrow rides through as a member.
+			name: "BorrowOnThePositiveSide",
+			src:  `type Result<T, 'a> = Exclude<T | &'a Point, string>`,
+			want: "(t6 | &Point) & ¬string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, decls+tt.src)
 			require.Empty(t, errs)
 			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
 		})

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -120,9 +120,9 @@ func TestReduceSetDifference(t *testing.T) {
 		{
 			// `("a" | ...) & ¬"a"`
 			//
-			// Every named member is excluded and the tail is not, so there is no union left to
-			// carry the tail and the difference stays as it stands. Collapsing it would answer
-			// `never`, which claims the tail is empty too.
+			// Every named member is excluded and the tail is undecided, so the difference stays
+			// as it stands. Building the union would answer `never`, which claims the tail is
+			// empty too.
 			name: "InexactPositiveSideWithNoSurvivorsStays",
 			diff: meet(&soltype.UnionType{Types: []soltype.Type{strLit("a")}, Inexact: true}, negate(strLit("a"))),
 			want: `("a" | ...) & ¬"a"`,

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -1,0 +1,520 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// A complement has no annotation syntax, so a test that needs one builds it as a solver type
+// through normal.go's negate, the way constrain_nf_rules_test.go does.
+
+// reduceType reduces one type against an empty alias environment, the reduction constrain performs
+// when it checks a constraint against a residual operator.
+func reduceType(t soltype.Type) soltype.Type {
+	return newTypeEvaluator(&Context{}, newSeenPairs()).reduce(t)
+}
+
+// meet builds an unnormalized intersection, so a test states the members it means rather than the
+// canonical order newIntersection would put them in.
+func meet(types ...soltype.Type) soltype.Type {
+	return &soltype.IntersectionType{Types: types}
+}
+
+// join builds an exact union of the given members.
+func join(types ...soltype.Type) soltype.Type {
+	return &soltype.UnionType{Types: types}
+}
+
+// A meet carrying a complement is a set difference, and reduction settles each member of its
+// positive side against each excluded type. Every row states the difference as a solver type and
+// asserts what it reduces to.
+//
+// The rows cover the four outcomes a member can meet: it is excluded outright, the exclusion is
+// disjoint from it, the exclusion cuts into it and the complement stays, or an operand is not ground
+// enough to decide any of those.
+func TestReduceSetDifference(t *testing.T) {
+	tests := []struct {
+		name string
+		diff soltype.Type
+		want string
+	}{
+		{
+			// The key set an `Omit<T, "b">` maps over. Each key is a literal, so each is either
+			// the excluded one or disjoint from it, and the difference is a plain key union the
+			// mapped type can iterate.
+			name: "KeySetDropsOneKey",
+			diff: meet(join(strLit("a"), strLit("b"), strLit("c")), negate(strLit("b"))),
+			want: `"a" | "c"`,
+		},
+		{
+			// Two exclusions each drop their own member.
+			name: "KeySetDropsTwoKeys",
+			diff: meet(join(strLit("a"), strLit("b"), strLit("c")), negate(strLit("a")), negate(strLit("c"))),
+			want: `"b"`,
+		},
+		{
+			// Excluding the whole positive side leaves the empty type.
+			name: "EverythingExcluded",
+			diff: meet(join(strLit("a"), strLit("b")), negate(join(strLit("a"), strLit("b")))),
+			want: "never",
+		},
+		{
+			// No number is a string, so the exclusion removes nothing and the complement goes.
+			name: "DisjointExclusionDrops",
+			diff: meet(num(), negate(str())),
+			want: "number",
+		},
+		{
+			// `"a"` is one of the strings the exclusion names, and the strings that are left are
+			// not a union of anything at hand, so the complement stays. This is the answer
+			// TypeScript's distributive `Exclude<string, "a">` cannot express, where it yields
+			// `string` instead.
+			name: "PartialOverlapKeepsComplement",
+			diff: meet(str(), negate(strLit("a"))),
+			want: `string & ¬"a"`,
+		},
+		{
+			// The exclusion cuts into one member and misses the other, so only the member it cuts
+			// into keeps the complement.
+			name: "PartialOverlapOnOneMemberOnly",
+			diff: meet(join(str(), num()), negate(strLit("a"))),
+			want: `number | string & ¬"a"`,
+		},
+		{
+			// An open tail names members the reduction cannot enumerate, so which of them the
+			// exclusion removes is undecided and the tail survives.
+			name: "InexactPositiveSideKeepsTail",
+			diff: meet(&soltype.UnionType{Types: []soltype.Type{strLit("a"), strLit("b")}, Inexact: true}, negate(strLit("a"))),
+			want: `"b" | ...`,
+		},
+		{
+			// A meet with no complement is not a difference, so it comes back as it was.
+			name: "NoComplementIsUntouched",
+			diff: meet(num(), str()),
+			want: "number & string",
+		},
+		{
+			// Nested complements reduce as one difference, since newIntersection flattens the
+			// meet before the members are settled.
+			name: "NestedMeetFlattens",
+			diff: meet(meet(join(strLit("a"), strLit("b")), negate(strLit("a"))), negate(strLit("b"))),
+			want: "never",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, soltype.Print(reduceType(tt.diff)))
+		})
+	}
+}
+
+// A difference over an operand that is not ground stays a difference. The `∩ ¬` form is itself the
+// answer, so the reduction hands back a type the caller can store and reduce again later, rather
+// than a stuck operator. Each row builds its variable at level 0, the level a ground operand sits
+// at.
+func TestReduceSetDifferenceStaysSymbolic(t *testing.T) {
+	tests := []struct {
+		name string
+		diff func(v *soltype.TypeVarType) soltype.Type
+		want string
+	}{
+		{
+			// The `Exclude<T, string>` residual. Nothing is known about T's members, so nothing
+			// can be dropped from it.
+			name: "VariablePositiveSide",
+			diff: func(v *soltype.TypeVarType) soltype.Type { return meet(v, negate(str())) },
+			want: "t0 & ¬string",
+		},
+		{
+			// The exclusion is the variable this time, so no member of the positive side can be
+			// settled against it.
+			name: "VariableExclusion",
+			diff: func(v *soltype.TypeVarType) soltype.Type {
+				return meet(join(strLit("a"), strLit("b")), negate(v))
+			},
+			want: `("a" | "b") & ¬t0`,
+		},
+		{
+			// A `keyof T` operand is not ground either, and the difference keeps it whole so the
+			// key set reduces once T does.
+			name: "ResidualOperatorPositiveSide",
+			diff: func(v *soltype.TypeVarType) soltype.Type {
+				return meet(&soltype.KeyofType{Operand: v}, negate(strLit("b")))
+			},
+			want: `¬"b" & keyof t0`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, soltype.Print(reduceType(tt.diff(c.freshVar(0)))))
+		})
+	}
+}
+
+// nativeDifferenceDecls writes the set-difference utilities the way TypeScript's library does, as
+// distributive conditionals that filter their own operand. Reduction rewrites one whose operand it
+// cannot filter into the meet it denotes, so each utility below has an answer over a type variable.
+//
+// `MapKeys<T, Ks>` maps T's value types over the key set Ks. `Omit<T, Ks>` is that mapped type over
+// the key set `Exclude<keyof T, Ks>`, which is the native form of the utility — the keys of T less
+// the ones Ks names — rather than the per-key filter clause the suite in utility_types_test.go
+// writes it with.
+const nativeDifferenceDecls = `
+	type Exclude<U, V> = if U : V { never } else { U }
+	type Extract<U, V> = if U : V { U } else { never }
+	type NonNullable<T> = if T : null | undefined { never } else { T }
+	type MapKeys<T, Ks> = {[K]: T[K] for K in Ks}
+	type Point = {x: number, y: string}
+`
+
+// The set-difference family over an operand that does not ground. Each row applies one utility to a
+// type parameter and asserts the `∩ ¬` form it reduces to, the answer the distributive filter has
+// none of.
+//
+// The type variables render as `t<id>`, and the ids are those the declarations above draw, so a
+// declaration added to nativeDifferenceDecls shifts them.
+func TestNativeSetDifferenceOverTypeVariable(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// `Exclude<T, V>` is `T ∩ ¬V`.
+			name: "Exclude",
+			src:  `type Result<T> = Exclude<T, string>`,
+			want: "t15 & ¬string",
+		},
+		{
+			// `Extract<T, V>` is the meet itself, with no complement to take.
+			name: "Extract",
+			src:  `type Result<T> = Extract<T, string>`,
+			want: "t15 & string",
+		},
+		{
+			// `NonNullable<T>` excludes the two absence markers together, since the conditional
+			// names them as one union.
+			name: "NonNullable",
+			src:  `type Result<T> = NonNullable<T>`,
+			want: "t15 & ¬(null | undefined)",
+		},
+		{
+			// Both operands may be variables. The difference is still representable, and it is
+			// what makes the rule total rather than only more precise.
+			name: "ExcludeOverTwoVariables",
+			src:  `type Result<T, U> = Exclude<T, U>`,
+			want: "t15 & ¬t16",
+		},
+		{
+			// `Omit`'s key set over a type parameter: the keys of T other than "x". Neither half
+			// grounds, so the whole key set stays a difference.
+			name: "OmitKeySetOverVariable",
+			src:  `type Result<T> = Exclude<keyof T, "x">`,
+			want: `¬"x" & keyof t15`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, nativeDifferenceDecls+tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A conditional keeps the filter reading whenever it can run it, so a ground operand reduces the
+// way TypeScript's does and the two readings only ever differ where the filter had no answer. The
+// rows below are the ground counterparts of the ones above.
+func TestGroundSetDifferenceKeepsFilterReading(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// The filter drops the members that are subtypes of the excluded type and keeps the
+			// rest whole.
+			name: "ExcludeOverGroundUnion",
+			src:  `type Result = Exclude<"a" | "b" | 1, string>`,
+			want: "1",
+		},
+		{
+			// The divergence between the two readings, from the side the filter decides.
+			// `string` is not a subtype of `"a"`, so the filter keeps it whole where the
+			// difference would answer `string ∩ ¬"a"`.
+			name: "ExcludeOfLiteralFromPrimitive",
+			src:  `type Result = Exclude<string, "a">`,
+			want: "string",
+		},
+		{
+			name: "NonNullableOverGroundUnion",
+			src:  `type Result = NonNullable<string | null>`,
+			want: "string",
+		},
+		{
+			// `Omit<Point, "x">` written natively, as a mapped type over the key set
+			// `Exclude<keyof Point, "x">`. Every operand is ground, so the key set reduces to
+			// `"y"` and the mapped type emits that one field.
+			name: "OmitOverGroundObject",
+			src:  `type Result = MapKeys<Point, Exclude<keyof Point, "x">>`,
+			want: "{y: string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, nativeDifferenceDecls+tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A mapped type iterates a key set that is a Boolean combination rather than a plain literal union.
+// The key set reduces to the keys it names before the mapped type splits it, so a difference
+// enumerates the same way a union does and the mapped type emits one field per surviving key.
+//
+// Each case maps over `Point` with a key set built as a solver type, since only a reduction that
+// began before its operands ground produces a difference and a complement has no annotation syntax.
+func TestMappedTypeIteratesBooleanKeySet(t *testing.T) {
+	point := &soltype.AliasType{Name: "Point"}
+	keyofPoint := &soltype.KeyofType{Operand: point}
+
+	tests := []struct {
+		name string
+		keys soltype.Type
+		want string
+	}{
+		{
+			// `Omit<Point, "x">`'s key set. `keyof Point` grounds to `"x" | "y"`, the difference
+			// drops "x", and the mapped type emits the one field left.
+			name: "KeyofLessOneKey",
+			keys: meet(keyofPoint, negate(strLit("x"))),
+			want: "{y: string}",
+		},
+		{
+			// Excluding every key leaves nothing to iterate, so the mapped type emits an empty
+			// object rather than staying symbolic.
+			name: "KeyofLessEveryKey",
+			keys: meet(keyofPoint, negate(join(strLit("x"), strLit("y")))),
+			want: "{}",
+		},
+		{
+			// An exclusion naming no key of the source removes nothing.
+			name: "ExclusionMissesEveryKey",
+			keys: meet(keyofPoint, negate(strLit("z"))),
+			want: "{x: number, y: string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx, errs := inferTypeNodes(t, nativeDifferenceDecls)
+			require.Empty(t, errs)
+			inst := &soltype.AliasType{Name: "MapKeys", TypeArgs: []soltype.Type{point, tt.keys}}
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, inst)))
+		})
+	}
+}
+
+// `keyof` over a union is the meet of its members' key sets, since a value of the union is one of
+// its members and only a key every member carries can be read from it. A member with no enumerable
+// key set contributes its own `keyof` residual to that meet rather than stopping the reduction, so
+// the law holds over a type parameter too.
+func TestReduceKeyofDistributesOverUnion(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// One member's keys are known and the other's are not, so the meet names both.
+			name: "OneVariableMember",
+			src:  `type Result<T> = keyof (T | {a: number})`,
+			want: `"a" & keyof t15`,
+		},
+		{
+			// Neither member has a key set to read, and the meet is still the answer.
+			name: "TwoVariableMembers",
+			src:  `type Result<T, U> = keyof (T | U)`,
+			want: "keyof t15 & keyof t16",
+		},
+		{
+			// The readable members share no key, so the meet is empty whatever the variable's
+			// keys turn out to be, and the reduction stops before consulting it.
+			name: "DisjointReadableMembers",
+			src:  `type Result<T> = keyof ({a: number} | {b: number} | T)`,
+			want: "never",
+		},
+		{
+			// With every member readable the meet is the shared keys alone.
+			name: "AllMembersReadable",
+			src:  `type Result = keyof ({a: number, shared: string} | {b: boolean, shared: string})`,
+			want: `"shared"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, nativeDifferenceDecls+tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// `keyof ¬T` is the empty key set. A complement admits every value its operand rejects, and no key
+// can be read from all of them.
+func TestReduceKeyofComplement(t *testing.T) {
+	require.Equal(t, "never", soltype.Print(reduceType(&soltype.KeyofType{Operand: negate(exactObj(propElem("x", num())))})))
+}
+
+// A conditional decides its branch with the solver's subtyping relation, so the arrow-intersection
+// rules that relation carries are observable through a conditional type. These are the worked
+// examples of planning/ml_struct/04-type-level-operators.md.
+//
+// Both examples ask whether a value carrying two arrow types is callable with the union of their
+// domains. TypeScript answers "not" to both, reading the intersection as an overload table and
+// trying each signature on its own. Escalier reads it set-theoretically and answers each example on
+// its own terms.
+func TestConditionalOverArrowIntersection(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// Example A. Both arms return a boolean, so a value carrying both returns a boolean
+			// for every input in `number | string` and genuinely has the target type. Escalier
+			// diverges from TypeScript here and is sound in doing so.
+			name: "CodomainsAgree",
+			src: `
+				type Fn = (fn (x: number) -> boolean) & (fn (x: string) -> boolean)
+				type Result = if Fn : fn (x: number | string) -> boolean { "callable" } else { "not" }
+			`,
+			want: `"callable"`,
+		},
+		{
+			// Example B. The string arm returns null, so feeding the value a string yields a
+			// null rather than a boolean and the target type is a false claim. Escalier rejects
+			// it, reconverging with TypeScript. MLstruct accepts it, because it merges the two
+			// arms into `(number | string) -> (boolean & null)` and compares that one arrow;
+			// Escalier keeps the arms apart and decides them by the Frisch-Castagna-Benzaken
+			// decomposition instead. See internal/solver/constrain_nf.go.
+			name: "CodomainsConflict",
+			src: `
+				type Fn = (fn (x: number) -> boolean) & (fn (x: string) -> null)
+				type Result = if Fn : fn (x: number | string) -> boolean { "callable" } else { "not" }
+			`,
+			want: `"not"`,
+		},
+		{
+			// The `infer` face of example A. The two arms fuse into one arrow over the union of
+			// their domains, so the capture binds that union where TypeScript's `Parameters`
+			// binds the last overload's parameter alone.
+			name: "ParametersBindsTheUnionDomain",
+			src: `
+				type Fn = (fn (x: number) -> boolean) & (fn (x: string) -> boolean)
+				type Result = if Fn : fn (...args: infer P) -> _ { P } else { never }
+			`,
+			want: "[number | string]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// An `infer` pattern binds a capture by aligning against structure the scrutinee carries. A
+// complement names the values its operand rejects rather than any structure, so it takes no part in
+// the match. Each case applies a capturing conditional to an operand built as a solver type, since
+// a complement has no annotation syntax.
+func TestInferMatchesPositiveSkeleton(t *testing.T) {
+	const src = `
+		type Elem<T> = if T : Array<infer R> { R } else { never }
+	`
+	tests := []struct {
+		name  string
+		scrut soltype.Type
+		want  string
+	}{
+		{
+			// The positive member is what the pattern aligns with, so the capture binds the
+			// element type of the array the meet carries.
+			name:  "ComplementMemberIsSkipped",
+			scrut: meet(&soltype.ArrayType{Elem: num()}, negate(str())),
+			want:  "number",
+		},
+		{
+			// A scrutinee that is nothing but a complement has no skeleton to align, so the
+			// match fails and the conditional takes its Else branch.
+			name:  "BareComplementMatchesNothing",
+			scrut: negate(&soltype.ArrayType{Elem: num()}),
+			want:  "never",
+		},
+		{
+			// The positive part is what decides a failed match too. No array is a number, so the
+			// pattern rejects the meet whatever it excludes.
+			name:  "PositivePartStillDecidesAFailedMatch",
+			scrut: meet(num(), negate(str())),
+			want:  "never",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx, errs := inferTypeNodes(t, src)
+			require.Empty(t, errs)
+			inst := &soltype.AliasType{Name: "Elem", TypeArgs: []soltype.Type{tt.scrut}}
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, inst)))
+		})
+	}
+}
+
+// Contractivity: a recursion that returns to its own alias through a complement emits no structure,
+// so `type T = ¬T` names no type. It is the equation `T = ¬T`, which no set satisfies, and the
+// productivity check rejects it for the same reason it rejects `type T = T`.
+//
+// A complement has no annotation syntax, so the bodies are built as solver types and handed to the
+// collector checkProductive builds its reference graph with.
+func TestNegationGuardsNoRecursion(t *testing.T) {
+	tests := []struct {
+		name string
+		body soltype.Type
+		want []string
+	}{
+		{
+			// `type T = ¬T`. The reference is reached with no constructor in between.
+			name: "SelfComplement",
+			body: negate(&soltype.AliasType{Name: "T"}),
+			want: []string{"T"},
+		},
+		{
+			// `type T = ¬¬T`. Two complements are no more of a constructor than one.
+			name: "DoubleComplement",
+			body: negate(negate(&soltype.AliasType{Name: "T"})),
+			want: []string{"T"},
+		},
+		{
+			// `type T = {a: ¬T}`. The object is the constructor, and a complement under one is
+			// as productive as any other member type.
+			name: "ComplementUnderAnObject",
+			body: exactObj(propElem("a", negate(&soltype.AliasType{Name: "T"}))),
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := &unguardedRefCollector{
+				within: set.FromSlice([]string{"T"}),
+				found:  set.NewSet[string](),
+			}
+			tt.body.Accept(collector, soltype.Positive)
+			require.Equal(t, tt.want, collector.found.ToSlice())
+		})
+	}
+}

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -449,10 +449,10 @@ func TestConditionalOverArrowIntersection(t *testing.T) {
 		{
 			// Example B. The string arm returns null, so feeding the value a string yields a
 			// null rather than a boolean and the target type is a false claim. Escalier rejects
-			// it, reconverging with TypeScript. MLstruct accepts it, because it merges the two
-			// arms into `(number | string) -> (boolean & null)` and compares that one arrow;
+			// it, reconverging with TypeScript. MLstruct accepts it instead, since it merges the
+			// two arms into `(number | string) -> (boolean & null)` and compares that one arrow.
 			// Escalier keeps the arms apart and decides them by the Frisch-Castagna-Benzaken
-			// decomposition instead. See internal/solver/constrain_nf.go.
+			// decomposition. See internal/solver/constrain_nf.go.
 			name: "CodomainsConflict",
 			src: `
 				type Fn = (fn (x: number) -> boolean) & (fn (x: string) -> null)

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -107,6 +107,17 @@ func TestReduceSetDifference(t *testing.T) {
 			want: `"b" | ...`,
 		},
 		{
+			// `(string | null) & ¬(null | undefined)`
+			//
+			// `NonNullable<string | null>` written natively. Each member is settled against the
+			// exclusion union: `null` is inside it and goes, and `string` is disjoint from both
+			// absence markers, so it stays bare. The filter reading answers the same, which
+			// TestGroundSetDifferenceKeepsFilterReading asserts.
+			name: "NonNullableDropsTheAbsenceMarkers",
+			diff: meet(join(str(), &soltype.NullType{}), negate(join(&soltype.NullType{}, &soltype.UndefinedType{}))),
+			want: "string",
+		},
+		{
 			// `("a" | ...) & ¬"a"`
 			//
 			// Every named member is excluded and the tail is not, so there is no union left to
@@ -148,6 +159,21 @@ func TestReduceIntersectionMembers(t *testing.T) {
 	t.Run("NothingToReduceKeepsThePointer", func(t *testing.T) {
 		concrete := meet(num(), str())
 		require.Same(t, concrete, reduceType(concrete))
+	})
+
+	// `("a" | "b" | 1) & string`, which is `Extract<"a" | "b" | 1, string>` written natively.
+	//
+	// The meet stays as it stands. A difference settles each member of its positive side against
+	// what is excluded, and a plain meet has no such rule, so nothing here distributes `string`
+	// over the union or drops the member no value inhabits. The filter reading is what answers
+	// this one, and TestUtilityTypeReductions/Extract asserts `"a" | "b"` for it.
+	//
+	// The two are only ever asked of different operands. A meet is minted for `Extract` when the
+	// operand does not ground, and an operand that does ground takes the filter instead, so the
+	// concrete meet above is reachable only by building it.
+	t.Run("ExtractMeetDoesNotDistribute", func(t *testing.T) {
+		extract := meet(join(strLit("a"), strLit("b"), numLit(1)), str())
+		require.Same(t, extract, reduceType(extract))
 	})
 }
 

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -91,10 +91,12 @@ func TestReduceSetDifference(t *testing.T) {
 			want: `"b" | ...`,
 		},
 		{
-			// A meet with no complement is not a difference, so it comes back as it was.
-			name: "NoComplementIsUntouched",
-			diff: meet(num(), str()),
-			want: "number & string",
+			// Every named member is excluded and the tail is not, so there is no union left to
+			// carry the tail and the difference stays as it stands. Collapsing it would answer
+			// `never`, which claims the tail is empty too.
+			name: "InexactPositiveSideWithNoSurvivorsStays",
+			diff: meet(&soltype.UnionType{Types: []soltype.Type{strLit("a")}, Inexact: true}, negate(strLit("a"))),
+			want: `("a" | ...) & ¬"a"`,
 		},
 		{
 			// Nested complements reduce as one difference, since newIntersection flattens the
@@ -109,6 +111,22 @@ func TestReduceSetDifference(t *testing.T) {
 			require.Equal(t, tt.want, soltype.Print(reduceType(tt.diff)))
 		})
 	}
+}
+
+// A meet with no complement is not a difference, but its members still reduce, so an operator
+// written as one of them reaches its value. `"a" & keyof {…}` is the shape keyofUnion mints for a
+// union operand it could not read every member of, and it has to ground the same way any other key
+// set does.
+func TestReduceIntersectionMembers(t *testing.T) {
+	t.Run("OperatorMemberReduces", func(t *testing.T) {
+		keys := &soltype.KeyofType{Operand: exactObj(propElem("a", num()), propElem("b", str()))}
+		require.Equal(t, `"a"`, soltype.Print(reduceType(meet(strLit("a"), keys))))
+	})
+
+	t.Run("NothingToReduceKeepsThePointer", func(t *testing.T) {
+		concrete := meet(num(), str())
+		require.Same(t, concrete, reduceType(concrete))
+	})
 }
 
 // A difference over an operand that is not ground stays a difference. The `∩ ¬` form is itself the
@@ -169,6 +187,7 @@ const nativeDifferenceDecls = `
 	type NonNullable<T> = if T : null | undefined { never } else { T }
 	type MapKeys<T, Ks> = {[K]: T[K] for K in Ks}
 	type Point = {x: number, y: string}
+	type PointKeys = "x" | "y"
 `
 
 // The set-difference family over an operand that does not ground. Each row applies one utility to a
@@ -187,34 +206,34 @@ func TestNativeSetDifferenceOverTypeVariable(t *testing.T) {
 			// `Exclude<T, V>` is `T ∩ ¬V`.
 			name: "Exclude",
 			src:  `type Result<T> = Exclude<T, string>`,
-			want: "t15 & ¬string",
+			want: "t16 & ¬string",
 		},
 		{
 			// `Extract<T, V>` is the meet itself, with no complement to take.
 			name: "Extract",
 			src:  `type Result<T> = Extract<T, string>`,
-			want: "t15 & string",
+			want: "t16 & string",
 		},
 		{
 			// `NonNullable<T>` excludes the two absence markers together, since the conditional
 			// names them as one union.
 			name: "NonNullable",
 			src:  `type Result<T> = NonNullable<T>`,
-			want: "t15 & ¬(null | undefined)",
+			want: "t16 & ¬(null | undefined)",
 		},
 		{
 			// Both operands may be variables. The difference is still representable, and it is
 			// what makes the rule total rather than only more precise.
 			name: "ExcludeOverTwoVariables",
 			src:  `type Result<T, U> = Exclude<T, U>`,
-			want: "t15 & ¬t16",
+			want: "t16 & ¬t17",
 		},
 		{
 			// `Omit`'s key set over a type parameter: the keys of T other than "x". Neither half
 			// grounds, so the whole key set stays a difference.
 			name: "OmitKeySetOverVariable",
 			src:  `type Result<T> = Exclude<keyof T, "x">`,
-			want: `¬"x" & keyof t15`,
+			want: `¬"x" & keyof t16`,
 		},
 	}
 	for _, tt := range tests {
@@ -308,6 +327,13 @@ func TestMappedTypeIteratesBooleanKeySet(t *testing.T) {
 			keys: meet(keyofPoint, negate(strLit("z"))),
 			want: "{x: number, y: string}",
 		},
+		{
+			// A named key set on the positive side expands to the keys it stands for, the way
+			// every other operand of a reduction does.
+			name: "AliasKeySetLessOneKey",
+			keys: meet(&soltype.AliasType{Name: "PointKeys"}, negate(strLit("x"))),
+			want: "{y: string}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -333,13 +359,13 @@ func TestReduceKeyofDistributesOverUnion(t *testing.T) {
 			// One member's keys are known and the other's are not, so the meet names both.
 			name: "OneVariableMember",
 			src:  `type Result<T> = keyof (T | {a: number})`,
-			want: `"a" & keyof t15`,
+			want: `"a" & keyof t16`,
 		},
 		{
 			// Neither member has a key set to read, and the meet is still the answer.
 			name: "TwoVariableMembers",
 			src:  `type Result<T, U> = keyof (T | U)`,
-			want: "keyof t15 & keyof t16",
+			want: "keyof t16 & keyof t17",
 		},
 		{
 			// The readable members share no key, so the meet is empty whatever the variable's
@@ -353,6 +379,14 @@ func TestReduceKeyofDistributesOverUnion(t *testing.T) {
 			name: "AllMembersReadable",
 			src:  `type Result = keyof ({a: number, shared: string} | {b: boolean, shared: string})`,
 			want: `"shared"`,
+		},
+		{
+			// An open operand union stands for members the reduction cannot name, and an
+			// intersection has no marker to record that with. With no readable member to put a
+			// key union among the residuals, the whole operator stays symbolic.
+			name: "OpenUnionWithNoReadableMember",
+			src:  `type Result<T, U> = keyof (T | U | ...)`,
+			want: "keyof (t16 | t17 | ...)",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 // A complement has no annotation syntax, so a test that needs one builds it as a solver type
-// through normal.go's negate, the way constrain_nf_rules_test.go does.
+// through normal.go's negate, the way constrain_nf_rules_test.go does. A case that builds its
+// operands leads with the type it built, written in annotation syntax with `¬` for the complement,
+// since the constructor calls are harder to read than the type they stand for.
 
 // reduceType reduces one type against an empty alias environment, the reduction constrain performs
 // when it checks a constraint against a residual operator.
@@ -42,6 +44,8 @@ func TestReduceSetDifference(t *testing.T) {
 		want string
 	}{
 		{
+			// `("a" | "b" | "c") & ¬"b"`
+			//
 			// The key set an `Omit<T, "b">` maps over. Each key is a literal, so each is either
 			// the excluded one or disjoint from it, and the difference is a plain key union the
 			// mapped type can iterate.
@@ -50,24 +54,32 @@ func TestReduceSetDifference(t *testing.T) {
 			want: `"a" | "c"`,
 		},
 		{
+			// `("a" | "b" | "c") & ¬"a" & ¬"c"`
+			//
 			// Two exclusions each drop their own member.
 			name: "KeySetDropsTwoKeys",
 			diff: meet(join(strLit("a"), strLit("b"), strLit("c")), negate(strLit("a")), negate(strLit("c"))),
 			want: `"b"`,
 		},
 		{
+			// `("a" | "b") & ¬("a" | "b")`
+			//
 			// Excluding the whole positive side leaves the empty type.
 			name: "EverythingExcluded",
 			diff: meet(join(strLit("a"), strLit("b")), negate(join(strLit("a"), strLit("b")))),
 			want: "never",
 		},
 		{
+			// `number & ¬string`
+			//
 			// No number is a string, so the exclusion removes nothing and the complement goes.
 			name: "DisjointExclusionDrops",
 			diff: meet(num(), negate(str())),
 			want: "number",
 		},
 		{
+			// `string & ¬"a"`
+			//
 			// `"a"` is one of the strings the exclusion names, and the strings that are left are
 			// not a union of anything at hand, so the complement stays. This is the answer
 			// TypeScript's distributive `Exclude<string, "a">` cannot express, where it yields
@@ -77,6 +89,8 @@ func TestReduceSetDifference(t *testing.T) {
 			want: `string & ¬"a"`,
 		},
 		{
+			// `(string | number) & ¬"a"`
+			//
 			// The exclusion cuts into one member and misses the other, so only the member it cuts
 			// into keeps the complement.
 			name: "PartialOverlapOnOneMemberOnly",
@@ -84,6 +98,8 @@ func TestReduceSetDifference(t *testing.T) {
 			want: `number | string & ¬"a"`,
 		},
 		{
+			// `("a" | "b" | ...) & ¬"a"`
+			//
 			// An open tail names members the reduction cannot enumerate, so which of them the
 			// exclusion removes is undecided and the tail survives.
 			name: "InexactPositiveSideKeepsTail",
@@ -91,6 +107,8 @@ func TestReduceSetDifference(t *testing.T) {
 			want: `"b" | ...`,
 		},
 		{
+			// `("a" | ...) & ¬"a"`
+			//
 			// Every named member is excluded and the tail is not, so there is no union left to
 			// carry the tail and the difference stays as it stands. Collapsing it would answer
 			// `never`, which claims the tail is empty too.
@@ -99,6 +117,8 @@ func TestReduceSetDifference(t *testing.T) {
 			want: `("a" | ...) & ¬"a"`,
 		},
 		{
+			// `(("a" | "b") & ¬"a") & ¬"b"`
+			//
 			// Nested complements reduce as one difference, since newIntersection flattens the
 			// meet before the members are settled.
 			name: "NestedMeetFlattens",
@@ -118,20 +138,24 @@ func TestReduceSetDifference(t *testing.T) {
 // union operand it could not read every member of, and it has to ground the same way any other key
 // set does.
 func TestReduceIntersectionMembers(t *testing.T) {
+	// `"a" & keyof {a: number, b: string}`
 	t.Run("OperatorMemberReduces", func(t *testing.T) {
 		keys := &soltype.KeyofType{Operand: exactObj(propElem("a", num()), propElem("b", str()))}
 		require.Equal(t, `"a"`, soltype.Print(reduceType(meet(strLit("a"), keys))))
 	})
 
+	// `number & string`
 	t.Run("NothingToReduceKeepsThePointer", func(t *testing.T) {
 		concrete := meet(num(), str())
 		require.Same(t, concrete, reduceType(concrete))
 	})
 }
 
+// `{[K: string]: number} & ¬T`
+//
 // Every operand of a difference is reduced once, so a diagnostic the reduction records is recorded
-// once. The positive side here is `{[K: string]: number}`, a required index signature over a key
-// set with no keys to enumerate, which draws one diagnostic on its own. It is the shape
+// once. The positive side is a required index signature over a key set with no keys to enumerate,
+// which draws one diagnostic on its own. The whole meet is the shape
 // `Exclude<{[K: string]: number}, T>` mints, and the evaluator's diagnostics reach the user through
 // the constraint site that reduced the residual.
 func TestReduceSetDifferenceRecordsOneDiagnostic(t *testing.T) {
@@ -160,6 +184,8 @@ func TestReduceSetDifferenceStaysSymbolic(t *testing.T) {
 		want string
 	}{
 		{
+			// `T & ¬string`
+			//
 			// The `Exclude<T, string>` residual. Nothing is known about T's members, so nothing
 			// can be dropped from it.
 			name: "VariablePositiveSide",
@@ -167,6 +193,8 @@ func TestReduceSetDifferenceStaysSymbolic(t *testing.T) {
 			want: "t0 & ¬string",
 		},
 		{
+			// `("a" | "b") & ¬T`
+			//
 			// The exclusion is the variable this time, so no member of the positive side can be
 			// settled against it.
 			name: "VariableExclusion",
@@ -176,6 +204,8 @@ func TestReduceSetDifferenceStaysSymbolic(t *testing.T) {
 			want: `("a" | "b") & ¬t0`,
 		},
 		{
+			// `keyof T & ¬"b"`
+			//
 			// A `keyof T` operand is not ground either, and the difference keeps it whole so the
 			// key set reduces once T does.
 			name: "ResidualOperatorPositiveSide",
@@ -316,8 +346,9 @@ func TestGroundSetDifferenceKeepsFilterReading(t *testing.T) {
 // The key set reduces to the keys it names before the mapped type splits it, so a difference
 // enumerates the same way a union does and the mapped type emits one field per surviving key.
 //
-// Each case maps over `Point` with a key set built as a solver type, since only a reduction that
-// began before its operands ground produces a difference and a complement has no annotation syntax.
+// Each case reduces `MapKeys<Point, Keys>` over the key set its row names, built as a solver type
+// since only a reduction that began before its operands ground produces a difference. `Point` is
+// `{x: number, y: string}` and `PointKeys` is `"x" | "y"`, both from nativeDifferenceDecls.
 func TestMappedTypeIteratesBooleanKeySet(t *testing.T) {
 	point := &soltype.AliasType{Name: "Point"}
 	keyofPoint := &soltype.KeyofType{Operand: point}
@@ -328,28 +359,29 @@ func TestMappedTypeIteratesBooleanKeySet(t *testing.T) {
 		want string
 	}{
 		{
-			// `Omit<Point, "x">`'s key set. `keyof Point` grounds to `"x" | "y"`, the difference
-			// drops "x", and the mapped type emits the one field left.
+			// `keyof Point & ¬"x"`, which is `Omit<Point, "x">`'s key set. `keyof Point` grounds
+			// to `"x" | "y"`, the difference drops "x", and the mapped type emits the one field
+			// left.
 			name: "KeyofLessOneKey",
 			keys: meet(keyofPoint, negate(strLit("x"))),
 			want: "{y: string}",
 		},
 		{
-			// Excluding every key leaves nothing to iterate, so the mapped type emits an empty
-			// object rather than staying symbolic.
+			// `keyof Point & ¬("x" | "y")`. Excluding every key leaves nothing to iterate, so the
+			// mapped type emits an empty object rather than staying symbolic.
 			name: "KeyofLessEveryKey",
 			keys: meet(keyofPoint, negate(join(strLit("x"), strLit("y")))),
 			want: "{}",
 		},
 		{
-			// An exclusion naming no key of the source removes nothing.
+			// `keyof Point & ¬"z"`. An exclusion naming no key of the source removes nothing.
 			name: "ExclusionMissesEveryKey",
 			keys: meet(keyofPoint, negate(strLit("z"))),
 			want: "{x: number, y: string}",
 		},
 		{
-			// A named key set on the positive side expands to the keys it stands for, the way
-			// every other operand of a reduction does.
+			// `PointKeys & ¬"x"`. A named key set on the positive side expands to the keys it
+			// stands for, the way every other operand of a reduction does.
 			name: "AliasKeySetLessOneKey",
 			keys: meet(&soltype.AliasType{Name: "PointKeys"}, negate(strLit("x"))),
 			want: "{y: string}",
@@ -418,6 +450,8 @@ func TestReduceKeyofDistributesOverUnion(t *testing.T) {
 	}
 }
 
+// `keyof ¬{x: number}`
+//
 // `keyof ¬T` is the empty key set. A complement admits every value its operand rejects, and no key
 // can be read from all of them.
 func TestReduceKeyofComplement(t *testing.T) {
@@ -498,22 +532,22 @@ func TestInferMatchesPositiveSkeleton(t *testing.T) {
 		want  string
 	}{
 		{
-			// The positive member is what the pattern aligns with, so the capture binds the
-			// element type of the array the meet carries.
+			// `Elem<Array<number> & ¬string>`. The positive member is what the pattern aligns
+			// with, so the capture binds the element type of the array the meet carries.
 			name:  "ComplementMemberIsSkipped",
 			scrut: meet(&soltype.ArrayType{Elem: num()}, negate(str())),
 			want:  "number",
 		},
 		{
-			// A scrutinee that is nothing but a complement has no skeleton to align, so the
-			// match fails and the conditional takes its Else branch.
+			// `Elem<¬Array<number>>`. A scrutinee that is nothing but a complement has no
+			// skeleton to align, so the match fails and the conditional takes its Else branch.
 			name:  "BareComplementMatchesNothing",
 			scrut: negate(&soltype.ArrayType{Elem: num()}),
 			want:  "never",
 		},
 		{
-			// The positive part is what decides a failed match too. No array is a number, so the
-			// pattern rejects the meet whatever it excludes.
+			// `Elem<number & ¬string>`. The positive part is what decides a failed match too. No
+			// array is a number, so the pattern rejects the meet whatever it excludes.
 			name:  "PositivePartStillDecidesAFailedMatch",
 			scrut: meet(num(), negate(str())),
 			want:  "never",

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -143,7 +143,10 @@ func TestReduceSetDifferenceRecordsOneDiagnostic(t *testing.T) {
 	c := &Context{}
 	e := newTypeEvaluator(c, newSeenPairs())
 	e.reduce(meet(required, negate(c.freshVar(0))))
-	require.Len(t, e.errs, 1)
+	require.Equal(t, []string{
+		"no object has a field at every key of string, so [K: string]: number is uninhabited; " +
+			"write [K: string]?: number instead",
+	}, Messages(e.errs))
 }
 
 // A difference over an operand that is not ground stays a difference. The `∩ ¬` form is itself the

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -129,6 +129,23 @@ func TestReduceIntersectionMembers(t *testing.T) {
 	})
 }
 
+// Every operand of a difference is reduced once, so a diagnostic the reduction records is recorded
+// once. The positive side here is `{[K: string]: number}`, a required index signature over a key
+// set with no keys to enumerate, which draws one diagnostic on its own. It is the shape
+// `Exclude<{[K: string]: number}, T>` mints, and the evaluator's diagnostics reach the user through
+// the constraint site that reduced the residual.
+func TestReduceSetDifferenceRecordsOneDiagnostic(t *testing.T) {
+	required := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.MappedElem{
+		Key:   &soltype.MappedKeyType{ID: 0, Name: "K"},
+		Keys:  str(),
+		Value: num(),
+	}}}
+	c := &Context{}
+	e := newTypeEvaluator(c, newSeenPairs())
+	e.reduce(meet(required, negate(c.freshVar(0))))
+	require.Len(t, e.errs, 1)
+}
+
 // A difference over an operand that is not ground stays a difference. The `∩ ¬` form is itself the
 // answer, so the reduction hands back a type the caller can store and reduce again later, rather
 // than a stuck operator. Each row builds its variable at level 0, the level a ground operand sits

--- a/planning/ml_struct/04-type-level-operators.md
+++ b/planning/ml_struct/04-type-level-operators.md
@@ -51,6 +51,28 @@ set difference. The two diverge in corner cases. Choose per operator whether it
 means "TS distributive conditional" or "native `& ¬`," and document it, because
 users porting TS code will assume the former.
 
+### The decision: the filter where it runs, the difference where it does not
+
+Escalier takes both readings, split by whether the filter has an operand it can
+filter:
+
+- A **ground** operand reduces through the distributive conditional, so ported TS
+  code keeps its meaning. `Exclude<string, "a">` is `string`.
+- An operand that does **not** ground — a type variable, or an operator over one —
+  reduces to the meet. `Exclude<T, string>` is `T & ¬string`, and
+  `NonNullable<T>` is `T & ¬(null | undefined)`.
+
+The two readings agree whenever every member of the operand is either wholly
+inside the excluded type or disjoint from it, and diverge otherwise. The divergent
+case is reachable only where the filter produced nothing at all, since a ground
+operand never takes the second path. `Omit`'s key set is the same rule one level
+down: `Exclude<keyof T, Ks>` is `keyof T & ¬Ks` while T is abstract, and reduces
+to a plain key union once T grounds, which is the key set the mapped type
+iterates.
+
+The rule is in `nativeDifference`, and `reduceDifference` computes the meet, both
+in `internal/solver/typeops_negation.go`.
+
 ---
 
 ## Coupling point 2 (the hazard): conditional `extends` runs on MLstruct's `<:`
@@ -158,6 +180,16 @@ than inheriting MLstruct's merge** — or deliberately accept and document the
 non-standard result. The `constrainNF` implementation (PR5, #1062) and the
 type-level operators (PR10, #1067) both depend on this decision.
 
+**Escalier takes the sound reading.** `meetFuncs` fuses two arrows only where a
+single arrow denotes their meet exactly — equal domains, or equal codomains and
+one parameter — so example A's arms fuse and example B's stay apart. Arms that
+did not fuse are decided by `decideArrows`, the FCB decomposition, in
+`internal/solver/constrain_nf.go`. So the conditional in example A yields
+`"callable"`, diverging from TypeScript and sound, and the one in example B yields
+`"not"`, reconverging with TypeScript where MLstruct would answer `"callable"`.
+`TestConditionalOverArrowIntersection` in
+`internal/solver/typeops_negation_test.go` states both verdicts.
+
 ---
 
 ## Coupling point 3: distribution must compose with the algebra
@@ -207,7 +239,9 @@ subtyping does not change that ordering; operator reduction remains the
 budget-governed part. Negation adds exactly one new well-formedness obligation that
 folds into the existing regularity machinery: **contractivity** must reject `type T
 = ¬T` (an unguarded recursive complement), alongside the `type T = T | T` cases M9
-already rejects.
+already rejects. `guardsEveryOperand` in `internal/solver/productivity.go` counts a
+complement as emitting no structure, so the productivity check rejects that shape on
+the same terms it rejects `type T = T`.
 
 ---
 
@@ -215,9 +249,9 @@ already rejects.
 
 | Operator family | Interaction with MLstruct |
 |---|---|
-| `Exclude` / `Extract` / `NonNullable` / `Omit` | **Upgrade** — native `& ¬` makes them total on type variables, not just ground unions. Design fork: TS-distributive vs native set difference. |
-| Conditional `T extends U ? …` | **Hazard** — `extends` runs on MLstruct's non-TS-standard `<:`; divergence becomes user-visible (examples A/B). Verify against MLscript. |
-| `keyof`, indexed access, mapped types | Compose with union/intersection distribution; need a `NegationType` arm and Boolean key sets. |
-| `infer` | Orthogonal to normalization; needs a rule for negated members. Binds differently over merged arrow intersections (example A). |
+| `Exclude` / `Extract` / `NonNullable` / `Omit` | **Upgrade** — native `& ¬` makes them total on type variables, not just ground unions. Fork resolved: the TS-distributive filter over a ground operand, the native set difference over one that does not ground. |
+| Conditional `T extends U ? …` | **Hazard** — `extends` runs on the new `<:`, so its divergence from TypeScript is user-visible (examples A/B). Escalier decides unfused arrow arms by the FCB decomposition, so example A yields `"callable"` and example B `"not"`. |
+| `keyof`, indexed access, mapped types | Compose with union/intersection distribution; `keyof` of a union is the meet of its members' key sets even when one is a residual, and a mapped type iterates a key set that is a difference. |
+| `infer` | Orthogonal to normalization; matches the positive skeleton, so a complement in the scrutinee takes no part in the match. Binds the union domain over a fused arrow intersection (example A). |
 | Template literal types | Orthogonal; negation is not meaningful in the string domain. |
 | Recursion / termination | Operator budget dominates; negation adds the contractivity check for `type T = ¬T`. |

--- a/planning/ml_struct/04-type-level-operators.md
+++ b/planning/ml_struct/04-type-level-operators.md
@@ -185,8 +185,10 @@ single arrow denotes their meet exactly — equal domains, or equal codomains an
 one parameter — so example A's arms fuse and example B's stay apart. Arms that
 did not fuse are decided by `decideArrows`, the FCB decomposition, in
 `internal/solver/constrain_nf.go`. So the conditional in example A yields
-`"callable"`, diverging from TypeScript and sound, and the one in example B yields
-`"not"`, reconverging with TypeScript where MLstruct would answer `"callable"`.
+`"callable"`, which is set-theoretically sound and differs from TypeScript only
+because TypeScript reads the intersection as an overload table. The one in
+example B yields `"not"`, reconverging with TypeScript, where MLstruct would
+answer `"callable"`.
 `TestConditionalOverArrowIntersection` in
 `internal/solver/typeops_negation_test.go` states both verdicts.
 


### PR DESCRIPTION
Fixes #1067

Adds support for complement types (`¬T`) in the type operator reduction layer, enabling set-difference semantics for utility types like `Exclude`, `Omit`, and `NonNullable`.

## Summary

This PR implements the complement type (`NegationType`) reduction rules described in `planning/ml_struct/04-type-level-operators.md`. Complements represent the values a type rejects, and when combined with intersections, they form set differences. The implementation handles three key scenarios:

1. **Set difference reduction**: A meet carrying a complement (`A ∩ ¬B`) reduces by settling each member of the positive side against each excluded type, distributing the difference over unions.

2. **Native utility type rewriting**: Distributive conditionals that filter their own operand (like `Exclude` written as `U extends V ? never : U`) are rewritten to set-difference form when the operand is not ground, allowing them to reduce over type variables.

3. **Infer pattern matching**: The `infer` mechanism now skips complements when matching patterns, since they carry no structure to align with.

## Key changes

- **typeops_negation.go** (new file): Core reduction logic for complements and set differences
  - `reduceIntersection`: Handles meets, detecting complements and delegating to set-difference reduction
  - `reduceDifference`: Computes set differences by settling positive members against excluded types
  - `excludeFrom`: Determines what survives when a member is settled against exclusions
  - `nativeDifference`: Rewrites distributive conditionals to set-difference form
  - `positiveSkeleton`: Extracts the matchable part of a type for `infer` patterns

- **typeops.go**: Integrated complement reduction into the main reduction pipeline
  - Added cases for `IntersectionType` and `NegationType` in `reduce()`
  - Updated `reduceCond()` to call `nativeDifference()` for undecidable conditionals
  - Updated `reduceCondInfer()` to use `positiveSkeleton()` before pattern matching
  - Extracted `groundReduced()` helper to avoid double-reduction
  - `keyofUnion` now returns `keyof A ∩ keyof B` for a union member whose key set it cannot enumerate, rather than leaving the whole operator symbolic

- **productivity.go**: Updated to recognize that complements don&#39;t guard recursion (a complement carries no structure, so `type T = ¬T` is unproductive)

- **typeops_negation_test.go** (new file): Comprehensive test suite covering:
  - Set difference reduction over ground and symbolic operands
  - Native utility type behavior over type variables and ground types
  - Mapped type iteration over Boolean key sets
  - `keyof` distribution over unions
  - Conditional behavior with arrow intersections
  - `infer` pattern matching with complements

## Implementation details

The reduction strategy splits on whether operands are ground:
- **Ground operands**: Use the distributive conditional reading (TypeScript-compatible)
- **Non-ground operands**: Use the set-difference reading (enables reduction over type variables)

This ensures ported TypeScript code keeps its meaning while allowing utilities like `Exclude` to reduce to `T ∩ ¬string` rather than staying symbolic.

Set differences distribute over unions and handle inexact unions (with open tails) by preserving the tail when some members survive, or keeping the difference unreduced when no members survive but the tail is open.

## Conditional `extends` on the new `<:`

The issue's acceptance criteria include the doc-04 worked examples, which the PR5 subtyping core already decides: example A (codomains agree) yields `"callable"`, diverging from TypeScript and sound, and example B (codomains conflict) yields `"not"`, reconverging with TypeScript where MLstruct's naive arrow merge would accept it. `infer` over a fused arrow intersection binds the union domain. These are now pinned by tests rather than assumed, and the resolved design decisions are recorded in `planning/ml_struct/04-type-level-operators.md`.

https://claude.ai/code/session_01YDnrWCsso7v8dT6gxm7LkC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved type-level operator evaluation, including intersections, negations, set differences, and conditional types.
  * Enhanced `keyof` behavior for unions and complements.
  * Improved mapped-type handling for boolean and union key sets.
  * Refined conditional and `infer` matching for complex types.

* **Bug Fixes**
  * Improved recursive type safety and diagnostic handling for complement-based types.

* **Documentation**
  * Updated type-operator semantics and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->