### PR TITLE
Implement borrow atom merging and ¬Ref exclusion invariant

### DIFF
--- a/internal/soltype/negation.go
+++ b/internal/soltype/negation.go
@@ -1,0 +1,56 @@
+package soltype
+
+import "fmt"
+
+// The ¬Ref exclusion invariant: no complement ever names a borrow.
+//
+// A borrow carries two sorts. Its Inner is a type and its Lt is a lifetime. Only
+// the type sort is a Boolean algebra. The outlives lattice the lifetime sort is
+// solved in has a join and a meet but no complement, so `¬'a` names nothing. A
+// `¬(mut 'a T)` node would therefore carry a lifetime with no reading.
+//
+// The polarity machinery makes the same point from the other side. A complement
+// shrinks as its operand grows, so NegationType.Accept visits its operand at the
+// flipped polarity. RefType.Accept does not walk Lt at all, because a Lifetime is
+// not a Type, so that flip stops at the wrapper. A `¬(mut 'a T)` would keep 'a
+// pointing the way the un-negated borrow left it, and every outlives constraint
+// derived from it would run backwards.
+//
+// Both readings say the same thing. A complement of a borrow has no sound
+// lifetime, and a solver that admitted one would owe a rule flipping the
+// lifetime's outlives direction. Ruling the node out at construction is what
+// removes that obligation rather than discharging it. A borrow stays an opaque
+// atom of the structural constraint rules, and the normalization layer never takes
+// one apart.
+//
+// Negation INSIDE a borrow is a different node and is allowed. A NegationType is
+// not itself a RefInner, so the complement sits under a union or an intersection,
+// which are. `mut 'a ({x: number} | ¬{y: string})` puts it in the pure type sort,
+// where it normalizes by the ordinary rules while the wrapper stays opaque.
+
+// AssertNegatable panics when t is a borrow, the one operand a complement may not
+// name. Call it wherever a complement is about to be built or taken apart.
+//
+// It panics rather than reporting an error, following AsProperty. A caller that
+// reaches here has already built a type the invariant forbids, so the bug is in
+// the layer that built it.
+func AssertNegatable(t Type) {
+	if r, ok := t.(*RefType); ok {
+		panic(fmt.Sprintf("AssertNegatable: forbidden complement of the borrow %s", Print(r)))
+	}
+}
+
+// NewNegation builds the complement ¬t, enforcing the ¬Ref exclusion invariant
+// where the operand is chosen. Every site that decides what to complement goes
+// through it.
+//
+// A site that RE-MINTS an existing complement around a rewritten operand does not,
+// because it chooses nothing. NegationType.Accept and the solver's foldNegation
+// are both that shape: some rewriter already replaced the operand, and the
+// decision to complement it was made wherever the node was first built. Coalescing
+// a `¬α` whose α inlines to a borrow lands there, and rejecting it would fail a
+// display pass over a type the solver reached legitimately.
+func NewNegation(t Type) Type {
+	AssertNegatable(t)
+	return &NegationType{Inner: t}
+}

--- a/internal/soltype/negation.go
+++ b/internal/soltype/negation.go
@@ -4,52 +4,30 @@ import "fmt"
 
 // The ¬Ref exclusion invariant: no complement ever names a borrow.
 //
-// A borrow carries two sorts. Its Inner is a type and its Lt is a lifetime. Only
-// the type sort is a Boolean algebra. The outlives lattice the lifetime sort is
-// solved in has a join and a meet but no complement, so `¬'a` names nothing. A
-// `¬(mut 'a T)` node would therefore carry a lifetime with no reading.
+// A borrow carries two sorts, and only the type sort is a Boolean algebra. The
+// outlives lattice has a join and a meet but no complement, so `¬'a` names nothing.
+// Lifetime coalescing also mis-classifies a borrow under a complement and drops its
+// name from the rendered signature. See escalier-lang/escalier#1125, which carries
+// the measurements and a fix for the second half.
 //
-// The polarity machinery makes the same point from the other side. A complement
-// shrinks as its operand grows, so NegationType.Accept visits its operand at the
-// flipped polarity. RefType.Accept does not walk Lt at all, because a Lifetime is
-// not a Type, so that flip stops at the wrapper. A `¬(mut 'a T)` would keep 'a
-// pointing the way the un-negated borrow left it, and every outlives constraint
-// derived from it would run backwards.
-//
-// Both readings say the same thing. A complement of a borrow has no sound
-// lifetime, and a solver that admitted one would owe a rule flipping the
-// lifetime's outlives direction. Ruling the node out at construction is what
-// removes that obligation rather than discharging it. A borrow stays an opaque
-// atom of the structural constraint rules, and the normalization layer never takes
-// one apart.
-//
-// Negation INSIDE a borrow is a different node and is allowed. A NegationType is
-// not itself a RefInner, so the complement sits under a union or an intersection,
-// which are. `mut 'a ({x: number} | ¬{y: string})` puts it in the pure type sort,
-// where it normalizes by the ordinary rules while the wrapper stays opaque.
+// Negation INSIDE a borrow is allowed. A NegationType is not a RefInner, so the
+// complement sits under a union or an intersection, as in
+// `mut 'a ({x: number} | ¬{y: string})`, and normalizes by the ordinary rules.
 
 // AssertNegatable panics when t is a borrow, the one operand a complement may not
-// name. Call it wherever a complement is about to be built or taken apart.
-//
-// It panics rather than reporting an error, following AsProperty. A caller that
-// reaches here has already built a type the invariant forbids, so the bug is in
-// the layer that built it.
+// name. It panics rather than reporting an error, following AsProperty. Call it
+// wherever a complement is built or taken apart.
 func AssertNegatable(t Type) {
 	if r, ok := t.(*RefType); ok {
 		panic(fmt.Sprintf("AssertNegatable: forbidden complement of the borrow %s", Print(r)))
 	}
 }
 
-// NewNegation builds the complement ¬t, enforcing the ¬Ref exclusion invariant
-// where the operand is chosen. Every site that decides what to complement goes
-// through it.
-//
-// A site that RE-MINTS an existing complement around a rewritten operand does not,
-// because it chooses nothing. NegationType.Accept and the solver's foldNegation
-// are both that shape: some rewriter already replaced the operand, and the
-// decision to complement it was made wherever the node was first built. Coalescing
-// a `¬α` whose α inlines to a borrow lands there, and rejecting it would fail a
-// display pass over a type the solver reached legitimately.
+// NewNegation builds the complement ¬t, enforcing the invariant where the operand is
+// chosen. A site that RE-MINTS an existing complement around a rewritten operand
+// chooses nothing and does not go through it. NegationType.Accept and the solver's
+// foldNegation are both that shape, and coalescing a `¬α` whose α inlines to a
+// borrow lands there.
 func NewNegation(t Type) Type {
 	AssertNegatable(t)
 	return &NegationType{Inner: t}

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -315,7 +315,12 @@ func PrintAsSchemeWith(
 		return "fn <" + strings.Join(binders, ", ") + ">" + p.printFuncBody(ft)
 	}
 	prefix := "<" + strings.Join(append(labels, ltLabels...), ", ") + ">"
-	return prefix + " " + p.printType(t)
+	// The prefix binds the WHOLE body, and a body joined by `|` or `&` needs parens to
+	// say so. `<'a, 'b> &'a T | &'b T` reads as though the prefix covered the first
+	// member alone, which would leave 'b bound by nothing. A body that is one atom or
+	// one prefix form cannot be split by a following operator, so it needs none: the
+	// class-constructor rendering stays `<T> {new (value: T) -> Node<T>}`.
+	return prefix + " " + p.printTypeMinPrec(t, precPrefix)
 }
 
 // lifetimeBinder renders one lifetime binder in the quantifier prefix: the bare name

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -737,6 +737,26 @@ func TestPrintScheme(t *testing.T) {
 		require.Equal(t, "<T0> [T0, T0]", PrintAsScheme(ty))
 	})
 
+	// The quantifier prefix on a non-function body binds the WHOLE body. A body
+	// joined by `|` or `&` takes parens to say so, since `<T0, T1> T0 | T1` reads as
+	// though the prefix covered T0 alone, which would leave T1 bound by nothing. A
+	// body that is one atom or one prefix form cannot be split by a following
+	// operator, so it keeps the bare form the two rows above show.
+	t.Run("a union body is parenthesized under the prefix", func(t *testing.T) {
+		a := &TypeVarType{ID: 1, Level: 1}
+		b := &TypeVarType{ID: 2, Level: 1}
+		require.Equal(t, "<T0, T1> (T0 | T1)", PrintAsScheme(&UnionType{Types: []Type{a, b}}))
+		require.Equal(t, "<T0, T1> (T0 & T1)", PrintAsScheme(&IntersectionType{Types: []Type{a, b}}))
+	})
+
+	t.Run("a prefix-form body needs no parens", func(t *testing.T) {
+		a := &TypeVarType{ID: 1, Level: 1}
+		ty := &RefType{Mut: true, Lt: &LifetimeVar{ID: 0}, Inner: &ObjectType{
+			Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: a}},
+		}}
+		require.Equal(t, "<T0, 'a> &'a mut {x: T0}", PrintAsScheme(ty))
+	})
+
 	t.Run("object property vars are named in property order", func(t *testing.T) {
 		a := &TypeVarType{ID: 1, Level: 1}
 		b := &TypeVarType{ID: 2, Level: 1}

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1267,7 +1267,7 @@ func hasSpreadElem(elems []soltype.Type) bool {
 // # What the lifetime sort does NOT fuse
 //
 // Two borrows over one pointee whose lifetimes are two distinct variables stay two
-// atoms. The tempting fusion is the single borrow over the JOIN of the two
+// atoms. The fusion ruled out here is the single borrow over the JOIN of the two
 // lifetimes, the `&'c mut T` with 'a and 'b each outliving 'c. A return uniting
 // two `mut` parameters produces exactly that borrow. It denotes strictly more than
 // `(&'a mut T) | (&'b mut T)` does, because it also admits a borrow valid for 'c

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -330,13 +330,11 @@ func (n *deepNormalizer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.
 	return n.ctx.mkDNF(t, pol).toType()
 }
 
-// assertBorrowFreeNegatedParts panics when any member of a normalized complement
-// carries a borrow in its negated structural part. negatedPart reads that part off
-// one member: a conjunct holds it in Rnf and a disjunct in Lnf.
-//
-// This is where the ¬Ref exclusion invariant is enforced. A borrow that reached a
-// negated part would be a `¬(mut 'a T)` however the source wrote it, and
-// soltype.AssertNegatable says why no such type has a sound lifetime.
+// assertBorrowFreeNegatedParts enforces the ¬Ref exclusion invariant over a
+// normalized complement. A borrow in a negated structural part would be a
+// `¬(mut 'a T)` however the source wrote it, which soltype.AssertNegatable rejects.
+// negatedPart reads that part off one member, Rnf for a conjunct and Lnf for a
+// disjunct.
 func assertBorrowFreeNegatedParts[T any](members []T, negatedPart func(T) []soltype.Type) {
 	for _, member := range members {
 		for _, atom := range negatedPart(member) {
@@ -1255,28 +1253,19 @@ func hasSpreadElem(elems []soltype.Type) bool {
 }
 
 // The borrow atom merges split their work by sort. The pointees combine in the
-// type algebra through combineRefInners and the two lifetimes combine in the
+// type algebra through combineRefInners, and the two lifetimes combine in the
 // outlives lattice through meetRefLifetimes or joinRefLifetimes. Neither sort is
-// consulted about the other, which is the split the borrow wrapper already draws:
-// Inner is a Type and Lt is a Lifetime.
+// consulted about the other, which is the split the wrapper already draws: Inner is
+// a Type and Lt is a Lifetime. Both merges keep borrows of differing mutability
+// apart, since mut-decay relates those rather than a fused wrapper.
 //
-// Both merges keep two borrows of different mutability apart. A `mut` borrow and
-// an immutable one over one pointee are related by mut-decay rather than by a
-// fused wrapper, and no single wrapper says both.
-//
-// # What the lifetime sort does NOT fuse
-//
-// Two borrows over one pointee whose lifetimes are two distinct variables stay two
-// atoms. The fusion ruled out here is the single borrow over the JOIN of the two
-// lifetimes, the `&'c mut T` with 'a and 'b each outliving 'c. A return uniting
-// two `mut` parameters produces exactly that borrow. It denotes strictly more than
-// `(&'a mut T) | (&'b mut T)` does, because it also admits a borrow valid for 'c
-// alone, and such a borrow is neither an 'a borrow nor a 'b borrow.
-//
-// joinBorrows in infer_expr.go may widen to that join, because it is choosing one
-// type for a value at a branch. A merge here may not. This file's contract is that
-// a fusion denotes exactly what the two atoms it replaces denoted, and a two-atom
-// list already denotes the union precisely.
+// Two borrows over one pointee whose lifetimes are distinct variables stay two
+// atoms. The fusion ruled out is the one over the JOIN of the two lifetimes, the
+// `&'c mut T` a return uniting two `mut` parameters produces. It also admits a
+// borrow valid for 'c alone, which neither member admits, so it denotes strictly
+// more than the union does. joinBorrows in infer_expr.go may widen to it because it
+// is choosing one type for a value at a branch. A fusion here must denote exactly
+// what it replaces, and a two-atom list already denotes the union precisely.
 
 // meetRefs fuses two borrow atoms of an intersection. An uninhabited pointee makes
 // the whole meet `never`. No value inhabits the pointee, so nothing is there to
@@ -1302,13 +1291,9 @@ func (c *Context) meetRefs(a, b *soltype.RefType) (soltype.Type, bool) {
 // joinRefs fuses two borrow atoms of a union, the dual of meetRefs. It fuses only
 // when the two borrows already agree on ONE of the two sorts, because a union does
 // not distribute over the pair of them. `(&'static {x: number}) | (&'a {x: string})`
-// would fuse to `&'a {x: number | string}`, which admits an `&'a {x: number}`.
-// Neither member admits that value, since the number-holding member demands
-// 'static.
-//
-// An intersection has no such restriction, which is why meetRefs combines both
-// sorts unconditionally. A value that is both borrows is a borrow of both
-// lifetimes over a pointee of both types, so the meet distributes.
+// would fuse to `&'a {x: number | string}`, which admits an `&'a {x: number}` that
+// neither member does. An intersection distributes, so meetRefs combines both sorts
+// unconditionally.
 func (c *Context) joinRefs(a, b *soltype.RefType) (soltype.Type, bool) {
 	if a.Mut != b.Mut {
 		return nil, false
@@ -1330,24 +1315,17 @@ func (c *Context) joinRefs(a, b *soltype.RefType) (soltype.Type, bool) {
 	return soltype.NewRef(a.Mut, lt, inner), true
 }
 
-// combineRefInners combines the pointees of two borrows being fused, in the type
-// algebra alone. role says which direction to combine in, meetOfAtoms for an
-// intersection of the two borrows and joinOfAtoms for a union of them.
-// uninhabited reports that the combination is `never`, which only a meet reaches.
+// combineRefInners combines the pointees of two borrows in the type algebra alone.
+// role picks the direction, meetOfAtoms for an intersection of the two borrows and
+// joinOfAtoms for a union. uninhabited reports a combination of `never`, which only
+// a meet reaches, and ok is false when no exact combination exists, which keeps the
+// two borrows as separate atoms.
 //
-// A MUTABLE borrow's pointee is invariant, since a holder both reads and writes
-// through it, so the two pointees must already be equal and nothing is combined.
-// Widening them would be unsound. Fusing `&'a mut {x: number}` with
-// `&'a mut {x: string}` into `&'a mut {x: number | string}` would let a holder
-// write a string into the cell holding the number.
-//
-// An IMMUTABLE borrow is read-only, so its pointee combines covariantly by the
-// ordinary atom merges. `(&'a {x: number}) | (&'a {x: string})` fuses to
-// `&'a {x: number | string}`, and every read off it yields a value one of the two
-// members really holds.
-//
-// ok is false when the pointees have no exact combination, which keeps the two
-// borrows as separate atoms. That is just as precise and costs only the extra atom.
+// A MUTABLE borrow's pointee is invariant, since a holder reads and writes through
+// it, so the two pointees must already be equal. Fusing `&'a mut {x: number}` with
+// `&'a mut {x: string}` into `&'a mut {x: number | string}` would let a holder write
+// a string into the cell holding the number. An IMMUTABLE borrow is read-only, so
+// its pointee combines covariantly by the ordinary atom merges.
 func (c *Context) combineRefInners(a, b *soltype.RefType, role atomRole) (inner soltype.RefInner, uninhabited, ok bool) {
 	if equalType(a.Inner, b.Inner) {
 		return a.Inner, false, true
@@ -1378,27 +1356,18 @@ func (c *Context) combineRefInners(a, b *soltype.RefType, role atomRole) (inner 
 	return borrowable, false, true
 }
 
-// meetRefLifetimes combines the lifetimes of two borrows being met, in the
-// outlives lattice alone. The meet is the lifetime the fused borrow is valid for,
-// which is the longer-lived of the two, since a value that is both borrows is
+// meetRefLifetimes combines two borrows' lifetimes in the outlives lattice alone.
+// The meet is the longer-lived of the two, since a value that is both borrows is
 // usable wherever either is. ok is false where no lifetime already names that,
 // which keeps the two borrows as separate atoms.
 //
-// A nil slot is an owned cell rather than a borrow, and carries no lifetime. Two
-// of them combine to none. One owned cell paired with one borrow bails, since the
-// two are not the same kind of value.
-//
-// Two equal lifetimes meet to themselves. 'static is the bottom of the outlives
-// lattice and outlives every other lifetime, so it absorbs the meet and
-// `(&'static T) & (&'a T)` is `&'static T`. That is the absorption meetValueAtoms
-// performs when a literal meets its primitive.
-//
-// Two distinct lifetime variables bail. No lifetime already names their meet, and
-// this file's contract is to keep two atoms rather than name one inexactly.
-//
-// Equality is ltEqual, the same rule equalType's RefType arm applies to a borrow's
-// Lt, so a merge and a type comparison agree on when two borrows carry one
-// lifetime.
+// Equal lifetimes meet to themselves, under the ltEqual that equalType's RefType
+// arm applies, so a merge and a type comparison agree on when two borrows carry one
+// lifetime. 'static is the bottom of the lattice and outlives everything else, so it
+// absorbs the meet, the absorption meetValueAtoms performs for a literal and its
+// primitive. A nil slot is an owned cell carrying no lifetime, so two of them
+// combine to none while one paired with a borrow bails. Two distinct variables bail
+// for the reason the header above gives.
 func meetRefLifetimes(a, b soltype.Lifetime) (soltype.Lifetime, bool) {
 	if ltEqual(a, b) {
 		return a, true
@@ -1412,15 +1381,11 @@ func meetRefLifetimes(a, b soltype.Lifetime) (soltype.Lifetime, bool) {
 	return nil, false
 }
 
-// joinRefLifetimes is the dual of meetRefLifetimes. It returns the lifetime the
-// fused borrow is valid for under a union, which is the shorter-lived of the two.
-// A value drawn from either borrow is usable only where both are. The owned-cell
-// and equal-lifetime rules read the same as the meet's, and two distinct lifetime
-// variables bail there too.
-//
-// 'static drops out of the join for the same reason it absorbs the meet. Every
-// other lifetime outlives it, so `(&'static T) | (&'a T)` is `&'a T`. That is the
-// absorption joinValueAtoms performs when a primitive joins its literal.
+// joinRefLifetimes is the dual of meetRefLifetimes, returning the shorter-lived of
+// the two, since a value drawn from either borrow is usable only where both are.
+// The owned-cell and equal-lifetime rules read the same, and two distinct variables
+// bail there too. 'static drops OUT of the join rather than absorbing it, since
+// every other lifetime outlives it, so `(&'static T) | (&'a T)` is `&'a T`.
 func joinRefLifetimes(a, b soltype.Lifetime) (soltype.Lifetime, bool) {
 	if ltEqual(a, b) {
 		return a, true

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -83,10 +83,19 @@ import (
 // merge here cannot delegate its exactness rule to them without asking the question
 // back.
 //
-// # What is deliberately left to a later PR
+// # Borrows
 //
-//   - Ref atoms. A RefType is an opaque atom that normalization never takes apart.
-//     PR8 (#1065) owns the lifetime split and the guard rejecting `¬(mut 'a T)`.
+// A RefType is an atom, and normalization never takes the wrapper apart. Two
+// borrow atoms that land in one conjunct or disjunct do fuse, and the fusion
+// splits its work by sort: the pointees combine in the type algebra and the two
+// lifetimes combine in the outlives lattice. meetRefs and joinRefs are that split,
+// and the comment above them states which lifetime pairs combine exactly.
+//
+// A borrow is also the one atom a complement may not name, the `¬Ref` exclusion
+// invariant. soltype.AssertNegatable states it and the two NegationType arms of
+// mkDNF and mkCNF enforce it. Negation INSIDE a borrow is a different node and
+// normalizes by the ordinary rules, so `mut 'a ({x: number} | ¬{y: string})` is
+// fine.
 
 // DNF is a union of conjuncts, the disjunctive normal form of a type. An empty
 // conjunct list is `never`, the identity of `|`.
@@ -202,7 +211,15 @@ func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
 		// CNF and negate each disjunct into a conjunct. Negating permutes fields without
 		// consulting the merges, so the result is canonicalized afterwards.
 		negated := c.mkCNF(t.Inner, pol.Flip()).neg()
-		return DNF{Conjuncts: c.canonicalConjuncts(negated.Conjuncts)}
+		conjuncts := c.canonicalConjuncts(negated.Conjuncts)
+		// A borrow lands in a conjunct's Rnf exactly when the complement names it, so
+		// scanning the result is what enforces the ¬Ref exclusion invariant. The scan
+		// reads the result rather than t.Inner because a borrow reaches a negated part
+		// from two shapes, not one. `¬(mut 'a T)` names the borrow directly, and
+		// `¬(A | mut 'a T)` reaches it through De Morgan's law, which turns the
+		// complement of a join into a meet of complements.
+		assertBorrowFreeNegatedParts(conjuncts, func(a Conjunct) []soltype.Type { return a.Rnf.Atoms })
+		return DNF{Conjuncts: conjuncts}
 	case *soltype.TypeVarType:
 		return DNF{Conjuncts: []Conjunct{newConjunct().withVar(t)}}
 	default:
@@ -234,8 +251,12 @@ func (c *Context) mkCNF(t soltype.Type, pol soltype.Polarity) CNF {
 		}
 		return CNF{Disjuncts: c.canonicalDisjuncts(out.Disjuncts)}
 	case *soltype.NegationType:
+		// The dual of the mkDNF arm. A disjunct holds its negated part in Lnf, so that
+		// is the list the ¬Ref scan reads.
 		negated := c.mkDNF(t.Inner, pol.Flip()).neg()
-		return CNF{Disjuncts: c.canonicalDisjuncts(negated.Disjuncts)}
+		disjuncts := c.canonicalDisjuncts(negated.Disjuncts)
+		assertBorrowFreeNegatedParts(disjuncts, func(a Disjunct) []soltype.Type { return a.Lnf.Atoms })
+		return CNF{Disjuncts: disjuncts}
 	case *soltype.TypeVarType:
 		return CNF{Disjuncts: []Disjunct{newDisjunct().withVar(t)}}
 	default:
@@ -307,6 +328,21 @@ func (n *deepNormalizer) EnterType(t soltype.Type, pol soltype.Polarity) soltype
 
 func (n *deepNormalizer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	return n.ctx.mkDNF(t, pol).toType()
+}
+
+// assertBorrowFreeNegatedParts panics when any member of a normalized complement
+// carries a borrow in its negated structural part. negatedPart reads that part off
+// one member: a conjunct holds it in Rnf and a disjunct in Lnf.
+//
+// This is where the ¬Ref exclusion invariant is enforced. A borrow that reached a
+// negated part would be a `¬(mut 'a T)` however the source wrote it, and
+// soltype.AssertNegatable says why no such type has a sound lifetime.
+func assertBorrowFreeNegatedParts[T any](members []T, negatedPart func(T) []soltype.Type) {
+	for _, member := range members {
+		for _, atom := range negatedPart(member) {
+			soltype.AssertNegatable(atom)
+		}
+	}
 }
 
 // dnfTop is `unknown` as a DNF: one conjunct with nothing in it, since an empty
@@ -678,6 +714,10 @@ func (c *Context) meetAtoms(a, b soltype.Type) (soltype.Type, bool) {
 		if b, ok := b.(*soltype.ClassType); ok {
 			return c.glbClass(a, b)
 		}
+	case *soltype.RefType:
+		if b, ok := b.(*soltype.RefType); ok {
+			return c.meetRefs(a, b)
+		}
 	}
 	return nil, false
 }
@@ -708,6 +748,10 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	case *soltype.TupleType:
 		if b, ok := b.(*soltype.TupleType); ok {
 			return c.joinTuples(a, b)
+		}
+	case *soltype.RefType:
+		if b, ok := b.(*soltype.RefType); ok {
+			return c.joinRefs(a, b)
 		}
 	}
 	// Two function atoms never fuse under a union. Neither `(A -> C) | (B -> C)` nor
@@ -1208,6 +1252,187 @@ func hasSpreadElem(elems []soltype.Type) bool {
 		}
 	}
 	return false
+}
+
+// The borrow atom merges split their work by sort. The pointees combine in the
+// type algebra through combineRefInners and the two lifetimes combine in the
+// outlives lattice through meetRefLifetimes or joinRefLifetimes. Neither sort is
+// consulted about the other, which is the split the borrow wrapper already draws:
+// Inner is a Type and Lt is a Lifetime.
+//
+// Both merges keep two borrows of different mutability apart. A `mut` borrow and
+// an immutable one over one pointee are related by mut-decay rather than by a
+// fused wrapper, and no single wrapper says both.
+//
+// # What the lifetime sort does NOT fuse
+//
+// Two borrows over one pointee whose lifetimes are two distinct variables stay two
+// atoms. The tempting fusion is the single borrow over the JOIN of the two
+// lifetimes, the `&'c mut T` with 'a and 'b each outliving 'c. A return uniting
+// two `mut` parameters produces exactly that borrow. It denotes strictly more than
+// `(&'a mut T) | (&'b mut T)` does, because it also admits a borrow valid for 'c
+// alone, and such a borrow is neither an 'a borrow nor a 'b borrow.
+//
+// joinBorrows in infer_expr.go may widen to that join, because it is choosing one
+// type for a value at a branch. A merge here may not. This file's contract is that
+// a fusion denotes exactly what the two atoms it replaces denoted, and a two-atom
+// list already denotes the union precisely.
+
+// meetRefs fuses two borrow atoms of an intersection. An uninhabited pointee makes
+// the whole meet `never`. No value inhabits the pointee, so nothing is there to
+// borrow.
+func (c *Context) meetRefs(a, b *soltype.RefType) (soltype.Type, bool) {
+	if a.Mut != b.Mut {
+		return nil, false
+	}
+	lt, ok := meetRefLifetimes(a.Lt, b.Lt)
+	if !ok {
+		return nil, false
+	}
+	inner, uninhabited, ok := c.combineRefInners(a, b, meetOfAtoms)
+	if !ok {
+		return nil, false
+	}
+	if uninhabited {
+		return &soltype.NeverType{}, true
+	}
+	return soltype.NewRef(a.Mut, lt, inner), true
+}
+
+// joinRefs fuses two borrow atoms of a union, the dual of meetRefs. It fuses only
+// when the two borrows already agree on ONE of the two sorts, because a union does
+// not distribute over the pair of them. `(&'static {x: number}) | (&'a {x: string})`
+// would fuse to `&'a {x: number | string}`, which admits an `&'a {x: number}`.
+// Neither member admits that value, since the number-holding member demands
+// 'static.
+//
+// An intersection has no such restriction, which is why meetRefs combines both
+// sorts unconditionally. A value that is both borrows is a borrow of both
+// lifetimes over a pointee of both types, so the meet distributes.
+func (c *Context) joinRefs(a, b *soltype.RefType) (soltype.Type, bool) {
+	if a.Mut != b.Mut {
+		return nil, false
+	}
+	if !ltEqual(a.Lt, b.Lt) && !equalType(a.Inner, b.Inner) {
+		return nil, false
+	}
+	lt, ok := joinRefLifetimes(a.Lt, b.Lt)
+	if !ok {
+		return nil, false
+	}
+	inner, uninhabited, ok := c.combineRefInners(a, b, joinOfAtoms)
+	// An uninhabited join needs both pointees uninhabited, which no atom pair
+	// reaches, and fuseAtoms reads a `never` from a join as a failed MEET. Keeping
+	// the two borrows apart states the join just as precisely.
+	if !ok || uninhabited {
+		return nil, false
+	}
+	return soltype.NewRef(a.Mut, lt, inner), true
+}
+
+// combineRefInners combines the pointees of two borrows being fused, in the type
+// algebra alone. role says which direction to combine in, meetOfAtoms for an
+// intersection of the two borrows and joinOfAtoms for a union of them.
+// uninhabited reports that the combination is `never`, which only a meet reaches.
+//
+// A MUTABLE borrow's pointee is invariant, since a holder both reads and writes
+// through it, so the two pointees must already be equal and nothing is combined.
+// Widening them would be unsound. Fusing `&'a mut {x: number}` with
+// `&'a mut {x: string}` into `&'a mut {x: number | string}` would let a holder
+// write a string into the cell holding the number.
+//
+// An IMMUTABLE borrow is read-only, so its pointee combines covariantly by the
+// ordinary atom merges. `(&'a {x: number}) | (&'a {x: string})` fuses to
+// `&'a {x: number | string}`, and every read off it yields a value one of the two
+// members really holds.
+//
+// ok is false when the pointees have no exact combination, which keeps the two
+// borrows as separate atoms. That is just as precise and costs only the extra atom.
+func (c *Context) combineRefInners(a, b *soltype.RefType, role atomRole) (inner soltype.RefInner, uninhabited, ok bool) {
+	if equalType(a.Inner, b.Inner) {
+		return a.Inner, false, true
+	}
+	if a.Mut {
+		return nil, false, false
+	}
+	var combined soltype.Type
+	if role == meetOfAtoms {
+		combined, ok = c.meetAtoms(a.Inner, b.Inner)
+	} else {
+		combined, ok = c.joinAtoms(a.Inner, b.Inner)
+	}
+	if !ok {
+		return nil, false, false
+	}
+	if _, isNever := combined.(*soltype.NeverType); isNever {
+		return nil, true, true
+	}
+	// A combination that is not itself borrowable, such as a pointee that fused to a
+	// primitive, has no wrapper to sit in. Keeping the two borrows apart is precise.
+	borrowable, isRefInner := combined.(soltype.RefInner)
+	if !isRefInner {
+		return nil, false, false
+	}
+	return borrowable, false, true
+}
+
+// meetRefLifetimes combines the lifetimes of two borrows being met, in the
+// outlives lattice alone. The meet is the lifetime the fused borrow is valid for,
+// which is the longer-lived of the two, since a value that is both borrows is
+// usable wherever either is. ok is false where no lifetime already names that,
+// which keeps the two borrows as separate atoms.
+//
+// A nil slot is an owned cell rather than a borrow, and carries no lifetime. Two
+// of them combine to none. One owned cell paired with one borrow bails, since the
+// two are not the same kind of value.
+//
+// Two equal lifetimes meet to themselves. 'static is the bottom of the outlives
+// lattice and outlives every other lifetime, so it absorbs the meet and
+// `(&'static T) & (&'a T)` is `&'static T`. That is the absorption meetValueAtoms
+// performs when a literal meets its primitive.
+//
+// Two distinct lifetime variables bail. No lifetime already names their meet, and
+// this file's contract is to keep two atoms rather than name one inexactly.
+//
+// Equality is ltEqual, the same rule equalType's RefType arm applies to a borrow's
+// Lt, so a merge and a type comparison agree on when two borrows carry one
+// lifetime.
+func meetRefLifetimes(a, b soltype.Lifetime) (soltype.Lifetime, bool) {
+	if ltEqual(a, b) {
+		return a, true
+	}
+	if a == nil || b == nil {
+		return nil, false
+	}
+	if soltype.IsStaticLifetime(a) || soltype.IsStaticLifetime(b) {
+		return soltype.Static, true
+	}
+	return nil, false
+}
+
+// joinRefLifetimes is the dual of meetRefLifetimes. It returns the lifetime the
+// fused borrow is valid for under a union, which is the shorter-lived of the two.
+// A value drawn from either borrow is usable only where both are. The owned-cell
+// and equal-lifetime rules read the same as the meet's, and two distinct lifetime
+// variables bail there too.
+//
+// 'static drops out of the join for the same reason it absorbs the meet. Every
+// other lifetime outlives it, so `(&'static T) | (&'a T)` is `&'a T`. That is the
+// absorption joinValueAtoms performs when a primitive joins its literal.
+func joinRefLifetimes(a, b soltype.Lifetime) (soltype.Lifetime, bool) {
+	if ltEqual(a, b) {
+		return a, true
+	}
+	if a == nil || b == nil {
+		return nil, false
+	}
+	if soltype.IsStaticLifetime(a) {
+		return b, true
+	}
+	if soltype.IsStaticLifetime(b) {
+		return a, true
+	}
+	return nil, false
 }
 
 // meetFuncs fuses two function atoms into one arrow, but only for the two cases
@@ -1829,6 +2054,12 @@ func (r RhsNf) toType() soltype.Type {
 // variable, so it is never a lattice bound whose complement is the other bound,
 // and mkDNF decomposes every negation it meets, so no atom is itself a complement
 // that a second one would cancel.
+//
+// It goes through soltype.NewNegation, which enforces the ¬Ref exclusion
+// invariant. Nothing is expected to trip that check here, since the parts rendered
+// below come from a normal form whose negated side mkDNF already scanned for a
+// borrow. It is the construction-site gate, applied wherever a complement is
+// built.
 func negate(t soltype.Type) soltype.Type {
-	return &soltype.NegationType{Inner: t}
+	return soltype.NewNegation(t)
 }

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1367,8 +1367,10 @@ func (c *Context) combineRefInners(a, b *soltype.RefType, role atomRole) (inner 
 	if _, isNever := combined.(*soltype.NeverType); isNever {
 		return nil, true, true
 	}
-	// A combination that is not itself borrowable, such as a pointee that fused to a
-	// primitive, has no wrapper to sit in. Keeping the two borrows apart is precise.
+	// A combination no borrow may point at has no wrapper to sit in, so the two
+	// borrows stay apart. Every merge arm over two borrowable pointees yields a
+	// borrowable one or `never`, so this guards the RefInner set against a future
+	// arm rather than answering a pair the merges reach today.
 	borrowable, isRefInner := combined.(soltype.RefInner)
 	if !isRefInner {
 		return nil, false, false

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1251,12 +1251,13 @@ func hasSpreadElem(elems []soltype.Type) bool {
 	return false
 }
 
-// The borrow atom merges split their work by sort. The pointees combine in the
-// type algebra through combineRefInners, and the two lifetimes combine in the
-// outlives lattice through meetRefLifetimes or joinRefLifetimes. Neither sort is
-// consulted about the other, which is the split the wrapper already draws: Inner is
-// a Type and Lt is a Lifetime. Both merges keep borrows of differing mutability
-// apart, since mut-decay relates those rather than a fused wrapper.
+// meetRefs and joinRefs below, and the three helpers they call, split their work by
+// sort. The pointees combine in the type algebra through combineRefInners, and the
+// two lifetimes combine in the outlives lattice through meetRefLifetimes or
+// joinRefLifetimes. Neither sort is consulted about the other, which is the split the
+// wrapper already draws: Inner is a Type and Lt is a Lifetime. Both merges keep
+// borrows of differing mutability apart, since mut-decay relates those rather than a
+// fused wrapper.
 //
 // Two borrows over one pointee whose lifetimes are distinct variables stay two
 // atoms. The fusion ruled out is the one over the JOIN of the two lifetimes, the

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -331,10 +331,9 @@ func (n *deepNormalizer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.
 }
 
 // assertBorrowFreeNegatedParts enforces the ¬Ref exclusion invariant over a
-// normalized complement. A borrow in a negated structural part would be a
-// `¬(mut 'a T)` however the source wrote it, which soltype.AssertNegatable rejects.
-// negatedPart reads that part off one member, Rnf for a conjunct and Lnf for a
-// disjunct.
+// normalized complement. A borrow in a negated part is a `¬(mut 'a T)` however the
+// source wrote it. negatedPart reads that part off one member, Rnf for a conjunct
+// and Lnf for a disjunct.
 func assertBorrowFreeNegatedParts[T any](members []T, negatedPart func(T) []soltype.Type) {
 	for _, member := range members {
 		for _, atom := range negatedPart(member) {
@@ -1268,8 +1267,7 @@ func hasSpreadElem(elems []soltype.Type) bool {
 // what it replaces, and a two-atom list already denotes the union precisely.
 
 // meetRefs fuses two borrow atoms of an intersection. An uninhabited pointee makes
-// the whole meet `never`. No value inhabits the pointee, so nothing is there to
-// borrow.
+// the whole meet `never`, since nothing is there to borrow.
 func (c *Context) meetRefs(a, b *soltype.RefType) (soltype.Type, bool) {
 	if a.Mut != b.Mut {
 		return nil, false
@@ -1288,12 +1286,11 @@ func (c *Context) meetRefs(a, b *soltype.RefType) (soltype.Type, bool) {
 	return soltype.NewRef(a.Mut, lt, inner), true
 }
 
-// joinRefs fuses two borrow atoms of a union, the dual of meetRefs. It fuses only
-// when the two borrows already agree on ONE of the two sorts, because a union does
-// not distribute over the pair of them. `(&'static {x: number}) | (&'a {x: string})`
-// would fuse to `&'a {x: number | string}`, which admits an `&'a {x: number}` that
-// neither member does. An intersection distributes, so meetRefs combines both sorts
-// unconditionally.
+// joinRefs is the dual of meetRefs. It fuses only when the two borrows already agree
+// on ONE of the two sorts, because a union does not distribute over the pair of
+// them. Fusing `(&'static {x: number}) | (&'a {x: string})` would give
+// `&'a {x: number | string}`, which admits an `&'a {x: number}` that neither member
+// does.
 func (c *Context) joinRefs(a, b *soltype.RefType) (soltype.Type, bool) {
 	if a.Mut != b.Mut {
 		return nil, false
@@ -1315,17 +1312,11 @@ func (c *Context) joinRefs(a, b *soltype.RefType) (soltype.Type, bool) {
 	return soltype.NewRef(a.Mut, lt, inner), true
 }
 
-// combineRefInners combines the pointees of two borrows in the type algebra alone.
-// role picks the direction, meetOfAtoms for an intersection of the two borrows and
-// joinOfAtoms for a union. uninhabited reports a combination of `never`, which only
-// a meet reaches, and ok is false when no exact combination exists, which keeps the
-// two borrows as separate atoms.
-//
-// A MUTABLE borrow's pointee is invariant, since a holder reads and writes through
-// it, so the two pointees must already be equal. Fusing `&'a mut {x: number}` with
-// `&'a mut {x: string}` into `&'a mut {x: number | string}` would let a holder write
-// a string into the cell holding the number. An IMMUTABLE borrow is read-only, so
-// its pointee combines covariantly by the ordinary atom merges.
+// combineRefInners combines two borrows' pointees in the type algebra alone. role
+// picks the direction, uninhabited reports a `never`, and ok is false when no exact
+// combination exists. A MUTABLE borrow's pointee is invariant, so the two must
+// already be equal. Widening `{x: number}` and `{x: string}` to `{x: number | string}`
+// would let a holder write a string into the cell holding the number.
 func (c *Context) combineRefInners(a, b *soltype.RefType, role atomRole) (inner soltype.RefInner, uninhabited, ok bool) {
 	if equalType(a.Inner, b.Inner) {
 		return a.Inner, false, true
@@ -1357,17 +1348,9 @@ func (c *Context) combineRefInners(a, b *soltype.RefType, role atomRole) (inner 
 }
 
 // meetRefLifetimes combines two borrows' lifetimes in the outlives lattice alone.
-// The meet is the longer-lived of the two, since a value that is both borrows is
-// usable wherever either is. ok is false where no lifetime already names that,
-// which keeps the two borrows as separate atoms.
-//
-// Equal lifetimes meet to themselves, under the ltEqual that equalType's RefType
-// arm applies, so a merge and a type comparison agree on when two borrows carry one
-// lifetime. 'static is the bottom of the lattice and outlives everything else, so it
-// absorbs the meet, the absorption meetValueAtoms performs for a literal and its
-// primitive. A nil slot is an owned cell carrying no lifetime, so two of them
-// combine to none while one paired with a borrow bails. Two distinct variables bail
-// for the reason the header above gives.
+// The meet is the longer-lived of the two, so 'static absorbs it as the bottom of
+// the lattice. A nil slot is an owned cell carrying no lifetime. ok is false where
+// no lifetime already names the meet, which keeps the two borrows as separate atoms.
 func meetRefLifetimes(a, b soltype.Lifetime) (soltype.Lifetime, bool) {
 	if ltEqual(a, b) {
 		return a, true
@@ -1382,10 +1365,8 @@ func meetRefLifetimes(a, b soltype.Lifetime) (soltype.Lifetime, bool) {
 }
 
 // joinRefLifetimes is the dual of meetRefLifetimes, returning the shorter-lived of
-// the two, since a value drawn from either borrow is usable only where both are.
-// The owned-cell and equal-lifetime rules read the same, and two distinct variables
-// bail there too. 'static drops OUT of the join rather than absorbing it, since
-// every other lifetime outlives it, so `(&'static T) | (&'a T)` is `&'a T`.
+// the two. 'static drops OUT of the join rather than absorbing it, since every other
+// lifetime outlives it, so `(&'static T) | (&'a T)` is `&'a T`.
 func joinRefLifetimes(a, b soltype.Lifetime) (soltype.Lifetime, bool) {
 	if ltEqual(a, b) {
 		return a, true

--- a/internal/solver/normal_ref_test.go
+++ b/internal/solver/normal_ref_test.go
@@ -112,6 +112,49 @@ func TestRefAtomMerge(t *testing.T) {
 			inter: "&'static mut {x: number}",
 		},
 		{
+			// An exact record names its whole key set, so nothing is both exactly
+			// `{x: number}` and exactly `{y: string}` and the pointees meet at `never`.
+			// A borrow of an uninhabited pointee points at nothing, so the whole meet is
+			// `never`. Their join has no single record that denotes it, so the union
+			// keeps both borrows even though they share a lifetime.
+			name: "immutable borrows over records naming different fields",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				lt := c.freshLifetime(0)
+				return borrow(false, lt, refObj(t, "{x: number}")), borrow(false, lt, refObj(t, "{y: string}"))
+			},
+			union: "<'a> &'a {x: number} | &'a {y: string}",
+			inter: "never",
+		},
+		{
+			// A pointee still under inference is opaque to the atom merges, which have
+			// no arm for a type variable, so neither the meet nor the join combines the
+			// two and both borrows stay.
+			name: "immutable borrows over distinct type variables",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				lt := c.freshLifetime(0)
+				return borrow(false, lt, c.freshVar(0)), borrow(false, lt, c.freshVar(0))
+			},
+			union: "<T0, T1, 'a> &'a T0 | &'a T1",
+			inter: "<T0, T1, 'a> &'a T0 & &'a T1",
+		},
+		{
+			// Two unrelated class tags are disjoint, so their meet is `never`. No value
+			// inhabits the pointee, and a borrow of an uninhabited pointee points at
+			// nothing, so the whole meet is `never` rather than a borrow of one.
+			name: "immutable borrows over disjoint class tags",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				c.registerClass("Point", &ClassDef{})
+				c.registerClass("Line", &ClassDef{})
+				lt := c.freshLifetime(0)
+				return borrow(false, lt, &soltype.ClassType{Name: "Point"}),
+					borrow(false, lt, &soltype.ClassType{Name: "Line"})
+			},
+			// A union of two class tags has no single tag that denotes it, so joinAtoms
+			// leaves the pointees alone and both borrows stay.
+			union: "<'a> &'a Line | &'a Point",
+			inter: "never",
+		},
+		{
 			// A union does not distribute over the lifetime and the pointee at once, so
 			// two borrows that differ in BOTH stay two atoms. Fusing them would give
 			// `&'a {x: number | string}`, which admits an `&'a {x: number}` that neither
@@ -171,6 +214,49 @@ func TestRefAtomMerge(t *testing.T) {
 			c = &Context{}
 			a, b = tt.build(t, c)
 			require.Equal(t, tt.inter, normScheme(c, newIntersection(nil, []soltype.Type{a, b})))
+		})
+	}
+}
+
+// TestRefLifetimeCombination pins the lifetime half of the merge on its own, one
+// pair of lifetimes at a time. The atom merges reach these two functions only in
+// the order sortAtoms puts the borrows in, so a table over the pairs is what
+// states the rule in both argument orders.
+func TestRefLifetimeCombination(t *testing.T) {
+	c := &Context{}
+	lt := c.freshLifetime(0)
+	other := c.freshLifetime(0)
+	// A second 'static instance, since 'static is a lattice bound compared by value
+	// rather than an origin compared by identity.
+	otherStatic := &soltype.StaticLifetime{}
+
+	tests := []struct {
+		name     string
+		a, b     soltype.Lifetime
+		meet     soltype.Lifetime
+		join     soltype.Lifetime
+		combines bool
+	}{
+		{name: "two owned cells", a: nil, b: nil, meet: nil, join: nil, combines: true},
+		{name: "an owned cell and a borrow", a: nil, b: lt, combines: false},
+		{name: "a borrow and an owned cell", a: lt, b: nil, combines: false},
+		{name: "one lifetime with itself", a: lt, b: lt, meet: lt, join: lt, combines: true},
+		{name: "two 'static instances", a: soltype.Static, b: otherStatic, meet: soltype.Static, join: soltype.Static, combines: true},
+		{name: "'static then a variable", a: soltype.Static, b: lt, meet: soltype.Static, join: lt, combines: true},
+		{name: "a variable then 'static", a: lt, b: soltype.Static, meet: soltype.Static, join: lt, combines: true},
+		{name: "two distinct variables", a: lt, b: other, combines: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			met, metOK := meetRefLifetimes(tt.a, tt.b)
+			require.Equal(t, tt.combines, metOK)
+			joined, joinedOK := joinRefLifetimes(tt.a, tt.b)
+			require.Equal(t, tt.combines, joinedOK)
+			if !tt.combines {
+				return
+			}
+			require.Equal(t, tt.meet, met)
+			require.Equal(t, tt.join, joined)
 		})
 	}
 }

--- a/internal/solver/normal_ref_test.go
+++ b/internal/solver/normal_ref_test.go
@@ -1,0 +1,290 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// The borrow half of the normal-form module: the ref-atom merge that splits its
+// work between the type sort and the lifetime sort, and the `¬Ref` exclusion
+// invariant that keeps a borrow out of every complement.
+//
+// A case builds its borrows directly rather than parsing an annotation, because
+// parseType does not accept a named lifetime. It renders the result with
+// PrintAsScheme, which names each surviving lifetime variable 'a, 'b, … by first
+// appearance, so a fused borrow reads `&'a mut {x: number}` and an unfused pair
+// reads `&'a mut {x: number} | &'b mut {x: number}`.
+
+// borrow builds a borrow atom. inner is stated as a soltype.RefInner so a case
+// reads as the type it writes.
+func borrow(mut bool, lt soltype.Lifetime, inner soltype.RefInner) *soltype.RefType {
+	return &soltype.RefType{Mut: mut, Lt: lt, Inner: inner}
+}
+
+// refObj parses an annotation into a pointee a borrow may wrap, failing the test
+// when the annotation names a type that is not a RefInner.
+func refObj(t *testing.T, src string) soltype.RefInner {
+	t.Helper()
+	obj, ok := parseType(t, src).(soltype.RefInner)
+	require.True(t, ok, "%s is not borrowable", src)
+	return obj
+}
+
+// normScheme renders a normal form the way a signature carrying it would read, so
+// two distinct lifetimes show as two names rather than as two bare `&`s.
+func normScheme(c *Context, ty soltype.Type) string {
+	return soltype.PrintAsScheme(c.mkDNF(ty, soltype.Positive).toType())
+}
+
+// TestRefAtomMerge pins which pairs of borrow atoms fuse and what the fusion
+// carries. Each row unions or intersects two borrows and asserts the normal form.
+func TestRefAtomMerge(t *testing.T) {
+	tests := []struct {
+		name string
+		// build returns the two borrow atoms, given the context the case runs in, so
+		// a row can mint the lifetimes it needs.
+		build func(t *testing.T, c *Context) (soltype.Type, soltype.Type)
+		union string // the DNF of `a | b`
+		inter string // the DNF of `a & b`
+	}{
+		{
+			// Two distinct lifetime variables have no lifetime that already names their
+			// meet or their join, so both borrows stay. A single borrow over the join of
+			// the two lifetimes would admit a borrow valid for that join alone, which
+			// neither member admits — see the comment above meetRefs.
+			name: "borrows differing only in lifetime",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				obj := refObj(t, "{x: number}")
+				return borrow(true, c.freshLifetime(0), obj), borrow(true, c.freshLifetime(0), obj)
+			},
+			union: "<'a, 'b> &'a mut {x: number} | &'b mut {x: number}",
+			inter: "<'a, 'b> &'a mut {x: number} & &'b mut {x: number}",
+		},
+		{
+			// One shared lifetime combines to itself, so two borrows over one pointee
+			// and one lifetime are the same atom and collapse.
+			name: "borrows sharing one lifetime and one pointee",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				obj := refObj(t, "{x: number}")
+				lt := c.freshLifetime(0)
+				return borrow(true, lt, obj), borrow(true, lt, obj)
+			},
+			union: "<'a> &'a mut {x: number}",
+			inter: "<'a> &'a mut {x: number}",
+		},
+		{
+			// A mutable borrow's pointee is invariant, so two borrows over different
+			// pointees stay separate rather than fusing to a carrier that would accept a
+			// string written into the cell holding the number.
+			name: "mutable borrows over different pointees",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				return borrow(true, c.freshLifetime(0), refObj(t, "{x: number}")),
+					borrow(true, c.freshLifetime(0), refObj(t, "{x: string}"))
+			},
+			union: "<'a, 'b> &'a mut {x: number} | &'b mut {x: string}",
+			inter: "<'a, 'b> &'a mut {x: number} & &'b mut {x: string}",
+		},
+		{
+			// An immutable borrow is read-only, so its pointee combines covariantly and
+			// the union fuses through joinObjects. Both borrows carry one lifetime, so
+			// the fusion asks the lifetime sort for nothing.
+			name: "immutable borrows over different pointees",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				lt := c.freshLifetime(0)
+				return borrow(false, lt, refObj(t, "{x: number}")), borrow(false, lt, refObj(t, "{x: string}"))
+			},
+			union: "<'a> &'a {x: number | string}",
+			// Two exact records naming one field meet field by field, which is what
+			// meetObjects does whether or not a borrow wraps them.
+			inter: "<'a> &'a {x: never}",
+		},
+		{
+			// 'static is the bottom of the outlives lattice, so it drops out of the join
+			// and absorbs the meet.
+			name: "a 'static borrow beside a variable one",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				obj := refObj(t, "{x: number}")
+				return borrow(true, soltype.Static, obj), borrow(true, c.freshLifetime(0), obj)
+			},
+			union: "<'a> &'a mut {x: number}",
+			inter: "&'static mut {x: number}",
+		},
+		{
+			// A union does not distribute over the lifetime and the pointee at once, so
+			// two borrows that differ in BOTH stay two atoms. Fusing them would give
+			// `&'a {x: number | string}`, which admits an `&'a {x: number}` that neither
+			// member admits: the number-holding member demands 'static. The intersection
+			// has no such restriction and fuses both sorts.
+			name: "borrows differing in lifetime and pointee at once",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				return borrow(false, soltype.Static, refObj(t, "{x: number}")),
+					borrow(false, c.freshLifetime(0), refObj(t, "{x: string}"))
+			},
+			union: "<'a> &'static {x: number} | &'a {x: string}",
+			inter: "&'static {x: never}",
+		},
+		{
+			// An owned cell carries no lifetime, so it is not a borrow and has nothing
+			// to combine with one. 'static does not absorb it.
+			name: "an owned mutable cell beside a 'static borrow",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				obj := refObj(t, "{x: number}")
+				return borrow(true, nil, obj), borrow(true, soltype.Static, obj)
+			},
+			union: "mut {x: number} | &'static mut {x: number}",
+			inter: "mut {x: number} & &'static mut {x: number}",
+		},
+		{
+			// A mutable borrow and an immutable one over one pointee are related by
+			// mut-decay rather than by a fused wrapper, so both stay.
+			name: "borrows of differing mutability",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				obj := refObj(t, "{x: number}")
+				lt := c.freshLifetime(0)
+				return borrow(true, lt, obj), borrow(false, lt, obj)
+			},
+			union: "<'a> &'a {x: number} | &'a mut {x: number}",
+			inter: "<'a> &'a {x: number} & &'a mut {x: number}",
+		},
+		{
+			// One shared lifetime needs no join variable, so the fusion combines the two
+			// pointees alone. The literal `5` is narrower than `number`, so the union
+			// widens the field to `number` and the meet narrows it to `5`.
+			name: "immutable borrows sharing one lifetime",
+			build: func(t *testing.T, c *Context) (soltype.Type, soltype.Type) {
+				lt := c.freshLifetime(0)
+				return borrow(false, lt, refObj(t, "{x: number}")), borrow(false, lt, refObj(t, "{x: 5}"))
+			},
+			union: "<'a> &'a {x: number}",
+			inter: "<'a> &'a {x: 5}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			a, b := tt.build(t, c)
+			require.Equal(t, tt.union, normScheme(c, newUnion(nil, []soltype.Type{a, b}, false)))
+
+			c = &Context{}
+			a, b = tt.build(t, c)
+			require.Equal(t, tt.inter, normScheme(c, newIntersection(nil, []soltype.Type{a, b})))
+		})
+	}
+}
+
+// TestRefMergeRecordsNoLifetimeBound holds the line normalization draws around the
+// lifetime sort: a merge READS the two lifetimes and never constrains them.
+//
+// Two things rest on that. constrainNF normalizes both operands before opening the
+// probe its derivation runs under, so a bound recorded during a merge would
+// outlive a failed constraint. And naming the join of two lifetime variables would
+// take a fresh variable bounded below both, which is a bound, so a merge cannot
+// name one.
+func TestRefMergeRecordsNoLifetimeBound(t *testing.T) {
+	c := &Context{}
+	obj := refObj(t, "{x: number}")
+	first, second := c.freshLifetime(0), c.freshLifetime(0)
+	union := newUnion(nil, []soltype.Type{borrow(true, first, obj), borrow(true, second, obj)}, false)
+
+	c.mkDNF(union, soltype.Positive)
+	for _, lt := range []*soltype.LifetimeVar{first, second} {
+		require.Empty(t, lt.LowerBounds)
+		require.Empty(t, lt.UpperBounds)
+	}
+	require.Equal(t, 2, c.lifetimeCounter, "no merge minted a lifetime")
+}
+
+// TestNegatedBorrowPanics pins the `¬Ref` exclusion invariant. A complement of a
+// borrow has no sound lifetime, so it is rejected at construction and again where
+// normalization would take it apart, rather than being given a reading.
+func TestNegatedBorrowPanics(t *testing.T) {
+	c := &Context{}
+	ref := borrow(true, c.freshLifetime(0), refObj(t, "{x: number}"))
+	message := "AssertNegatable: forbidden complement of the borrow &mut {x: number}"
+
+	t.Run("the smart constructor rejects it", func(t *testing.T) {
+		require.PanicsWithValue(t, message, func() { soltype.NewNegation(ref) })
+	})
+	t.Run("pushing it into DNF rejects it", func(t *testing.T) {
+		require.PanicsWithValue(t, message, func() { c.mkDNF(not(ref), soltype.Positive) })
+	})
+	t.Run("pushing it into CNF rejects it", func(t *testing.T) {
+		require.PanicsWithValue(t, message, func() { c.mkCNF(not(ref), soltype.Negative) })
+	})
+	// De Morgan's law turns the complement of a join into a meet of complements, so
+	// a borrow the source wrote as a union member still reaches a negated part.
+	t.Run("a borrow inside a negated union is rejected", func(t *testing.T) {
+		joined := newUnion(nil, []soltype.Type{parseType(t, "{a: number}"), ref}, false)
+		require.PanicsWithValue(t, message, func() { c.mkDNF(not(joined), soltype.Positive) })
+		require.PanicsWithValue(t, message, func() { c.mkCNF(not(joined), soltype.Negative) })
+	})
+}
+
+// TestNegationInsideBorrowNormalizes pins the case the invariant leaves alone. A
+// complement INSIDE a borrow sits in the pure type sort, which RefInner already
+// admits through UnionType and IntersectionType, so it normalizes by the ordinary
+// rules while the wrapper stays opaque.
+func TestNegationInsideBorrowNormalizes(t *testing.T) {
+	c := &Context{}
+	// `&'a ({a: number} | ¬¬{x: number})`. Complementing twice returns the original
+	// set, so the pointee normalizes to `{a: number} | {x: number}` while the borrow
+	// stands as written. The complement sits under a union, which is the only way one
+	// sits inside a borrow. RefInner admits UnionType, and NegationType is not a
+	// RefInner.
+	doubled := not(not(parseType(t, "{x: number}")))
+	inner, ok := newUnion(nil, []soltype.Type{parseType(t, "{a: number}"), doubled}, false).(soltype.RefInner)
+	require.True(t, ok)
+	ref := borrow(false, c.freshLifetime(0), inner)
+
+	require.Equal(t,
+		"<'a> &'a ({a: number} | {x: number})",
+		soltype.PrintAsScheme(c.normalizeDeep(ref, soltype.Positive)))
+}
+
+// TestBorrowNarrowingKeepsBorrowsWhole pins the rule the `¬Ref` invariant rests
+// on: normalization never takes a borrow wrapper apart. A borrow reaches the
+// normal-form layer as ONE atom and is handed straight back to the structural
+// rules, which is what keeps the RefType arm of constrain the only code that reads
+// a borrow's mutability and lifetime.
+//
+// The two operands are the ones `if val r2: mut {x: number} = r` produces over a
+// borrow union: the owned-mutable annotation on the subtype side and the union of
+// the two borrows on the supertype side. TestInferIfVal's "if-val narrows borrow
+// union for write" row runs that program end to end.
+//
+// The atoms are compared structurally rather than by identity, because
+// deepNormalizer rebuilds each borrow around its normalized pointee. What the
+// comparison states is that the rebuild carries the same mutability, lifetime, and
+// pointee, so nothing about the wrapper was taken apart or dropped.
+func TestBorrowNarrowingKeepsBorrowsWhole(t *testing.T) {
+	c := &Context{}
+	first := borrow(true, c.freshLifetime(0), refObj(t, "{x: number}"))
+	second := borrow(true, c.freshLifetime(0), refObj(t, "{x: string}"))
+	scrutinee := newUnion(nil, []soltype.Type{first, second}, false)
+	// The narrowing annotation `mut {x: number}` is an owned mutable cell, a borrow
+	// wrapper with no lifetime.
+	annotation := borrow(true, nil, refObj(t, "{x: number}"))
+
+	super := c.mkDeepCNF(scrutinee, soltype.Negative)
+	require.Len(t, super.Disjuncts, 1)
+	require.Equal(t, []soltype.Type{first, second}, super.Disjuncts[0].Rnf.Atoms)
+	require.Empty(t, super.Disjuncts[0].Lnf.Atoms, "no borrow reaches a negated part")
+
+	sub := c.mkDeepDNF(annotation, soltype.Positive)
+	require.Len(t, sub.Conjuncts, 1)
+	require.Equal(t, []soltype.Type{soltype.Type(annotation)}, sub.Conjuncts[0].Lnf.Atoms)
+	require.Empty(t, sub.Conjuncts[0].Rnf.Atoms, "no borrow reaches a negated part")
+}
+
+// TestNegationIsNotBorrowable pins the other half of the invariant: no borrow can
+// point AT a complement either, so `&¬T` cannot be built in the first place. A
+// complement names no allocated value, so there is nothing there to borrow.
+func TestNegationIsNotBorrowable(t *testing.T) {
+	var complement soltype.Type = &soltype.NegationType{Inner: parseType(t, "{x: number}")}
+	_, borrowable := complement.(soltype.RefInner)
+	require.False(t, borrowable, "NegationType must not be a RefInner")
+	require.False(t, soltype.BorrowableType(complement))
+}

--- a/internal/solver/normal_ref_test.go
+++ b/internal/solver/normal_ref_test.go
@@ -263,8 +263,9 @@ func TestRefLifetimeCombination(t *testing.T) {
 	}
 }
 
-// TestRefMergeRecordsNoLifetimeBound holds the line normalization draws around the
-// lifetime sort: a merge READS the two lifetimes and never constrains them.
+// TestRefMergeRecordsNoLifetimeBound checks what a merge does to the lifetime
+// sort. It READS the two lifetimes and never constrains them, so it records no
+// outlives bound and mints no lifetime variable.
 //
 // Two things rest on that. constrainNF normalizes both operands before opening the
 // probe its derivation runs under, so a bound recorded during a merge would

--- a/internal/solver/normal_ref_test.go
+++ b/internal/solver/normal_ref_test.go
@@ -14,8 +14,10 @@ import (
 // A case builds its borrows directly rather than parsing an annotation, because
 // parseType does not accept a named lifetime. It renders the result with
 // PrintAsScheme, which names each surviving lifetime variable 'a, 'b, … by first
-// appearance, so a fused borrow reads `&'a mut {x: number}` and an unfused pair
-// reads `&'a mut {x: number} | &'b mut {x: number}`.
+// appearance and prefixes the type with the names it bound. A fused borrow reads
+// `<'a> &'a mut {x: number}` and an unfused pair reads
+// `<'a, 'b> (&'a mut {x: number} | &'b mut {x: number})`, where the parens mark
+// that the prefix binds both members rather than only the first.
 
 // borrow builds a borrow atom. inner is stated as a soltype.RefInner so a case
 // reads as the type it writes.
@@ -59,8 +61,8 @@ func TestRefAtomMerge(t *testing.T) {
 				obj := refObj(t, "{x: number}")
 				return borrow(true, c.freshLifetime(0), obj), borrow(true, c.freshLifetime(0), obj)
 			},
-			union: "<'a, 'b> &'a mut {x: number} | &'b mut {x: number}",
-			inter: "<'a, 'b> &'a mut {x: number} & &'b mut {x: number}",
+			union: "<'a, 'b> (&'a mut {x: number} | &'b mut {x: number})",
+			inter: "<'a, 'b> (&'a mut {x: number} & &'b mut {x: number})",
 		},
 		{
 			// One shared lifetime combines to itself, so two borrows over one pointee
@@ -83,8 +85,8 @@ func TestRefAtomMerge(t *testing.T) {
 				return borrow(true, c.freshLifetime(0), refObj(t, "{x: number}")),
 					borrow(true, c.freshLifetime(0), refObj(t, "{x: string}"))
 			},
-			union: "<'a, 'b> &'a mut {x: number} | &'b mut {x: string}",
-			inter: "<'a, 'b> &'a mut {x: number} & &'b mut {x: string}",
+			union: "<'a, 'b> (&'a mut {x: number} | &'b mut {x: string})",
+			inter: "<'a, 'b> (&'a mut {x: number} & &'b mut {x: string})",
 		},
 		{
 			// An immutable borrow is read-only, so its pointee combines covariantly and
@@ -122,7 +124,7 @@ func TestRefAtomMerge(t *testing.T) {
 				lt := c.freshLifetime(0)
 				return borrow(false, lt, refObj(t, "{x: number}")), borrow(false, lt, refObj(t, "{y: string}"))
 			},
-			union: "<'a> &'a {x: number} | &'a {y: string}",
+			union: "<'a> (&'a {x: number} | &'a {y: string})",
 			inter: "never",
 		},
 		{
@@ -134,8 +136,8 @@ func TestRefAtomMerge(t *testing.T) {
 				lt := c.freshLifetime(0)
 				return borrow(false, lt, c.freshVar(0)), borrow(false, lt, c.freshVar(0))
 			},
-			union: "<T0, T1, 'a> &'a T0 | &'a T1",
-			inter: "<T0, T1, 'a> &'a T0 & &'a T1",
+			union: "<T0, T1, 'a> (&'a T0 | &'a T1)",
+			inter: "<T0, T1, 'a> (&'a T0 & &'a T1)",
 		},
 		{
 			// Two unrelated class tags are disjoint, so their meet is `never`. No value
@@ -151,7 +153,7 @@ func TestRefAtomMerge(t *testing.T) {
 			},
 			// A union of two class tags has no single tag that denotes it, so joinAtoms
 			// leaves the pointees alone and both borrows stay.
-			union: "<'a> &'a Line | &'a Point",
+			union: "<'a> (&'a Line | &'a Point)",
 			inter: "never",
 		},
 		{
@@ -165,7 +167,7 @@ func TestRefAtomMerge(t *testing.T) {
 				return borrow(false, soltype.Static, refObj(t, "{x: number}")),
 					borrow(false, c.freshLifetime(0), refObj(t, "{x: string}"))
 			},
-			union: "<'a> &'static {x: number} | &'a {x: string}",
+			union: "<'a> (&'static {x: number} | &'a {x: string})",
 			inter: "&'static {x: never}",
 		},
 		{
@@ -188,8 +190,8 @@ func TestRefAtomMerge(t *testing.T) {
 				lt := c.freshLifetime(0)
 				return borrow(true, lt, obj), borrow(false, lt, obj)
 			},
-			union: "<'a> &'a {x: number} | &'a mut {x: number}",
-			inter: "<'a> &'a {x: number} & &'a mut {x: number}",
+			union: "<'a> (&'a {x: number} | &'a mut {x: number})",
+			inter: "<'a> (&'a {x: number} & &'a mut {x: number})",
 		},
 		{
 			// One shared lifetime needs no join variable, so the fusion combines the two


### PR DESCRIPTION
Adds support for merging borrow atoms during type normalization and enforces the ¬Ref exclusion invariant that prevents complements from naming borrows.

## Summary

This implements the borrow half of the normal-form module, allowing two `RefType` atoms in the same conjunct or disjunct to fuse when sound. The fusion splits work by sort: pointees combine in the type algebra and lifetimes combine in the outlives lattice. It also establishes and enforces the ¬Ref exclusion invariant, which prevents any complement from naming a borrow, since a borrow carries a lifetime that has no complement in the outlives lattice.

## Key changes

- **Borrow atom merging**: Added `meetRefs` and `joinRefs` to fuse two borrow atoms in intersections and unions respectively. These delegate to `combineRefInners` for type-sort combination and `meetRefLifetimes`/`joinRefLifetimes` for lifetime-sort combination.
  - Mutable borrows keep invariant pointees, so they only fuse if pointees are already equal
  - Immutable borrows have covariant pointees and combine them through the ordinary atom merges
  - Lifetimes only fuse when they are equal, both nil (owned cells), or one is `'static`
  - Two borrows differing in both lifetime and pointee stay separate to preserve precision

- **¬Ref exclusion invariant**: Added `soltype.AssertNegatable` and `soltype.NewNegation` to enforce that no complement can name a borrow. The invariant is checked:
  - At construction via `NewNegation`, the gate where all complements are built
  - During normalization via `assertBorrowFreeNegatedParts`, which scans negated parts of DNF conjuncts and CNF disjuncts after De Morgan's law expansion

- **Test coverage**: Added `normal_ref_test.go` with comprehensive tests for borrow merging behavior, lifetime bound tracking, and the ¬Ref invariant enforcement across multiple scenarios.

## Implementation details

The borrow merges are conservative by design. They only fuse when the result denotes exactly what the two atoms denoted, never widening to an inexact carrier. For example, `(&'a mut T) | (&'b mut T)` stays two atoms rather than fusing to `&'c mut T` (where 'c is the join), because the latter would admit a borrow valid for 'c alone that neither member admits.

Negation inside a borrow is allowed since `NegationType` is not a `RefInner`, so the complement sits in the pure type sort and normalizes by ordinary rules while the wrapper remains opaque.

https://claude.ai/code/session_01QQmfao2XttwYAjffoTkc6T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for borrow types in type normalization and compatibility analysis.
  - Improved handling of lifetimes, mutability, pointee variance, static references, and owned cells.
  - Added safer negation behavior, including validation of unsupported negated borrow types.
  - Improved detection of incompatible or uninhabited type combinations.

- **Bug Fixes**
  - Preserved borrow wrappers during type narrowing.
  - Prevented invalid lifetime constraints from being introduced during type merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->