### PR TITLE
First-class arrow-intersection overloads and codegen reconciliation

### DIFF
--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -1142,53 +1142,9 @@ func (b *Builder) buildOverloadedFunc(overloads []*ast.FuncDecl, nsName string) 
 		return []Stmt{}
 	}
 
-	// Helper function to count the specificity of a parameter type
-	// For object types, count the number of required properties
-	countTypeSpecificity := func(param *ast.Param) int {
-		if param.TypeAnn == nil {
-			return 0
-		}
-		switch typeAnn := param.TypeAnn.(type) {
-		case *ast.ObjectTypeAnn:
-			// Count required properties (non-optional)
-			count := 0
-			for _, elem := range typeAnn.Elems {
-				if propType, ok := elem.(*ast.PropertyTypeAnn); ok {
-					if !propType.Optional {
-						count++
-					}
-				}
-			}
-			return count
-		default:
-			return 1 // Default specificity for other types
-		}
-	}
-
-	// Sort overloads by specificity (descending) so that more specific overloads
-	// are checked first. This is necessary because without arity checks, function
-	// subtyping allows less specific functions to match more specific calls.
-	// We sort by: 1) parameter count (more first), 2) type specificity (more first)
-	slices.SortFunc(implementedOverloads, func(a, b *ast.FuncDecl) int {
-		// First, compare by parameter count
-		if len(a.Params) != len(b.Params) {
-			return len(b.Params) - len(a.Params) // Descending order
-		}
-
-		// If same parameter count, compare by type specificity
-		// Calculate total specificity for each overload
-		aSpecificity := 0
-		for _, param := range a.Params {
-			aSpecificity += countTypeSpecificity(param)
-		}
-
-		bSpecificity := 0
-		for _, param := range b.Params {
-			bSpecificity += countTypeSpecificity(param)
-		}
-
-		return bSpecificity - aSpecificity // Descending order
-	})
+	// Order the arms so the chain tests the most specific first, matching the order the
+	// checker resolves a call in. See overload_order.go.
+	implementedOverloads = DispatchOrder(implementedOverloads)
 
 	// Collect all unique parameter names across overloads
 	// We'll use the maximum parameter count and give them generic names
@@ -1449,56 +1405,23 @@ func (b *Builder) buildTypeGuard(valueExpr Expr, typeAnn ast.TypeAnn) Expr {
 		// Check if it's an array
 		return buildArrayIsArrayCheck(valueExpr, nil)
 	case *ast.TypeRefTypeAnn:
-		// For type references, expand the type and check if it's a nominal type
-		inferredType := t.InferredType()
-		if inferredType != nil {
-			// Prune type variables to get the actual type
-			prunedType := type_system.Prune(inferredType)
-
-			// Check if it's a TypeRefType with a TypeAlias
-			if typeRef, ok := prunedType.(*type_system.TypeRefType); ok {
-				if typeRef.TypeAlias != nil {
-					// Get the aliased type
-					aliasedType := type_system.Prune(typeRef.TypeAlias.Type)
-
-					// Check if the aliased type is a nominal object type
-					if objType, ok := aliasedType.(*type_system.ObjectType); ok && objType.Nominal {
-						// Generate instanceof check for nominal types
-						typeName := ast.QualIdentToString(t.Name)
-						return NewBinaryExpr(
-							valueExpr,
-							InstanceOf,
-							NewIdentExpr(typeName, "", nil),
-							nil,
-						)
-					}
-				}
-			}
-
-			// Check if it's directly an object type (not aliased)
-			if objType, ok := prunedType.(*type_system.ObjectType); ok && objType.Nominal {
-				// Generate instanceof check for nominal types
-				typeName := ast.QualIdentToString(t.Name)
-				return NewBinaryExpr(
-					valueExpr,
-					InstanceOf,
-					NewIdentExpr(typeName, "", nil),
-					nil,
-				)
-			}
-
-			// TODO(#289): handle non-object types
-			// TODO(#289): handle structural object types
+		// A reference to a nominal type is tested with `instanceof` against the class
+		// name. nominalGuardName resolves the reference through its inferred type, either
+		// directly or through a type alias. dispatchOrder consults the same helper, so the
+		// arm order and the guards agree on which references are testable.
+		//
+		// TODO(#289): handle non-object types
+		// TODO(#289): handle structural object types
+		if typeName, nominal := nominalGuardName(t); nominal {
+			return NewBinaryExpr(
+				valueExpr,
+				InstanceOf,
+				NewIdentExpr(typeName, "", nil),
+				nil,
+			)
 		}
-
-		// For type references like Array<T>, try to infer the check
-		if t.Name != nil {
-			// Get the simple name from QualIdent
-			name := ast.QualIdentToString(t.Name)
-			switch name {
-			case "Array":
-				return buildArrayIsArrayCheck(valueExpr, nil)
-			}
+		if isArrayTypeRef(t) {
+			return buildArrayIsArrayCheck(valueExpr, nil)
 		}
 		// Default: accept anything
 		return NewLitExpr(NewBoolLit(true, nil), nil)

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -1129,22 +1129,24 @@ func (b *Builder) buildOverloadedFunc(overloads []*ast.FuncDecl, nsName string) 
 	// All overloads should have the same name
 	funcName := overloads[0].Name.Name
 
-	// Filter out declare-only functions (they have no body)
+	// Order the arms so the chain tests the most specific first, matching the order the
+	// checker resolves a call in. See overload_order.go.
+	//
+	// The WHOLE set is ranked and the declare-only arms are dropped from the result,
+	// rather than dropped first and the rest ranked on their own. DispatchOrder ranks an
+	// arm by how many OTHER arms outrank it, so an arm removed before the ranking lowers
+	// the count of every arm it outranked. That can reorder two arms the checker, which
+	// ranks the whole set, kept apart.
 	var implementedOverloads []*ast.FuncDecl
-	for _, overload := range overloads {
+	for _, overload := range DispatchOrder(overloads) {
+		// A declare-only arm has no body to dispatch to, so it contributes no branch.
 		if overload.Body != nil {
 			implementedOverloads = append(implementedOverloads, overload)
 		}
 	}
-
-	// If all overloads are declare-only, skip codegen
 	if len(implementedOverloads) == 0 {
 		return []Stmt{}
 	}
-
-	// Order the arms so the chain tests the most specific first, matching the order the
-	// checker resolves a call in. See overload_order.go.
-	implementedOverloads = DispatchOrder(implementedOverloads)
 
 	// Collect all unique parameter names across overloads
 	// We'll use the maximum parameter count and give them generic names
@@ -1407,8 +1409,7 @@ func (b *Builder) buildTypeGuard(valueExpr Expr, typeAnn ast.TypeAnn) Expr {
 	case *ast.TypeRefTypeAnn:
 		// A reference to a nominal type is tested with `instanceof` against the class
 		// name. nominalGuardName resolves the reference through its inferred type, either
-		// directly or through a type alias. dispatchOrder consults the same helper, so the
-		// arm order and the guards agree on which references are testable.
+		// directly or through a type alias.
 		//
 		// TODO(#289): handle non-object types
 		// TODO(#289): handle structural object types

--- a/internal/codegen/overload_order.go
+++ b/internal/codegen/overload_order.go
@@ -30,39 +30,38 @@ import (
 //     values than the matching parameter, and at least one admits strictly fewer. So
 //     `(x: 5)` is tested before `(x: number)`, and `({x, y})` before `({x})`.
 //  3. Source position — source id, then line, then column. This is the declaration
-//     order the checker's armPosLess pins, and it settles every pair the first two keys
-//     leave tied. Sorting the arms rather than taking them as the dep graph happens to
-//     hold them is what keeps the two tiebreaks the same.
+//     order the checker's armPosLess pins. It settles every pair the first two keys
+//     leave tied. Sorting is what makes the two tiebreaks the same, since the dep graph
+//     hands its declarations back in the order they were registered.
 //
 // # Where the two orders can still differ
 //
-// Both keys 2 and 3 are derived from what the arm WROTE, while the checker derives its
-// ranking from what it INFERRED. Two gaps follow, both narrow and both documented at
-// the code that leaves them.
+// Key 2 ranks what the arm WROTE, while the checker ranks what it INFERRED. Three gaps
+// follow. Each is narrow, and each is documented at the code that leaves it.
 //
-//   - A parameter annotated with a type alias. The checker ranks the type the alias
-//     expands to; annSubsumes sees only the name and ranks the pair as a tie. An alias
-//     naming a class is the exception, since nominalGuardName resolves it.
+//   - A parameter annotated with a type reference. annSubsumes reads the name and never
+//     resolves it, so two references tie unless they were spelled the same way. The
+//     checker ranks the type the reference resolves to. An alias for a literal or for an
+//     object can therefore separate a pair this ties. Two class references are safe,
+//     because the checker ties those as well.
 //   - Key 3 orders by source id where armPosLess orders by file path. The compiler
 //     assigns ids by walking the source tree in lexical order, so the two agree for
-//     every program it builds; a caller that hands the parser sources in some other
+//     every program it builds. Only a caller that hands the parser sources in some other
 //     order can separate them.
-//
-// Key 1 has a gap of its own, and it predates this ordering. An optional or rest
-// parameter widens an arm's accepted argument counts, so `(x: string, y?: number|string)`
-// and `(x: string)` both accept a one-argument call and the checker ranks them by
-// declaration order. Key 1 tests the longer arm first, and its `y` guard is a bare
-// `true` because a union is untestable, so the longer arm answers a call the checker
-// gave to the shorter one. Closing this needs the dispatcher to test how many arguments
-// it was called with, which it does not do today.
+//   - Key 1's own gap. An optional or rest parameter widens the argument counts an arm
+//     accepts, so `(x: string, y?: number|string)` and `(x: string)` both accept a
+//     one-argument call. The checker ranks a pair of different arities by declaration
+//     order, while key 1 tests the longer arm first. A union is untestable, so that
+//     arm's `y` guard is a bare `true` and it answers a call the checker gave to the
+//     shorter arm. Closing this needs the dispatcher to test how many arguments it was
+//     called with, which it does not do.
 //
 // One further divergence lives on the checker's side rather than here. When a call
 // argument is a still-unconstrained variable, overloadOrder cannot rank the arms and
-// falls back to plain declaration order, so `fn g(y) { return f(y) }` pins y to the
-// FIRST arm rather than to the one specificity would choose. The dispatcher always
-// ranks by specificity, so a call through g can reach a different arm than the one g
-// was typed with. That fallback is the MVP limitation #723 tracks, and deferred
-// resolution retires this divergence with it.
+// falls back to plain declaration order. So `fn g(y) { return f(y) }` pins y to the
+// FIRST arm rather than to the one specificity would choose, and a call through g can
+// reach a different arm than the one g was typed with. That fallback is the MVP
+// limitation #723 tracks, and deferred resolution retires this divergence with it.
 
 // DispatchOrder returns overloads in the order the generated if-else chain tests them.
 // The input is left untouched.
@@ -114,11 +113,13 @@ func DispatchOrder(overloads []*ast.FuncDecl) []*ast.FuncDecl {
 }
 
 // earlierInSource reports whether a is declared before b, by source id, then line, then
-// column. It is the tiebreak internal/solver's armPosLess applies, with one difference:
+// column. It is the tiebreak internal/solver's armPosLess applies, with one difference.
 // armPosLess orders by file path where this orders by source id. The compiler assigns
 // ids by walking the source tree in lexical order, so id order is path order for every
-// program it builds. Ordering here at all is what matters — the dep graph hands its
-// declarations back in the order they were registered, which no rule pins.
+// program it builds.
+//
+// Ordering here at all is what matters most. The dep graph hands its declarations back
+// in the order they were registered, and no rule pins that order.
 func earlierInSource(a, b *ast.FuncDecl) bool {
 	as, bs := a.Span(), b.Span()
 	if as.SourceID != bs.SourceID {
@@ -206,18 +207,18 @@ func isTopAnn(ann ast.TypeAnn, vars set.Set[string]) bool {
 }
 
 // annSubsumes reports whether the values a admits are a subset of those b admits. It is
-// the dispatch-order counterpart of structuralSubtype in internal/solver, written over
-// the annotations the source wrote rather than over inferred types, and it is
-// deliberately partial in the same way: a pair it cannot rank returns false in both
+// the dispatch-order counterpart of structuralSubtype in internal/solver, reading the
+// annotations the source wrote rather than the types the checker inferred. It is
+// deliberately partial in the same way. A pair it cannot rank returns false in both
 // directions, which armSpecificity reads as a tie and DispatchOrder settles by source
 // position.
 //
-// An annotation buildTypeGuard cannot test at runtime — a union, a function type — is
-// NOT treated as top here, because the checker does not treat it as top either. Such an
-// arm ties with everything, so it keeps its declared place. Its guard is still a bare
-// `true`, which means an untestable arm declared first answers every call that reaches
-// it; that is what the checker's resolution does too, so the two agree on the arm even
-// where the program is a poor one.
+// An annotation buildTypeGuard cannot test at runtime, such as a union or a function
+// type, is NOT top here. The checker does not treat one as top either, so such an arm
+// ties with everything and keeps its declared place. Its guard is still a bare `true`,
+// so an untestable arm declared first answers every call that reaches it. The checker's
+// resolution picks that same arm, which is the agreement this ordering is for, even
+// though the program would be better written with a testable annotation.
 func annSubsumes(a, b armParam) bool {
 	if b.top {
 		return true

--- a/internal/codegen/overload_order.go
+++ b/internal/codegen/overload_order.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/printer"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
@@ -13,23 +15,54 @@ import (
 // runs each arm's guard in turn, so the order decides which arm answers a call two
 // arms both accept. The checker answers the same question statically in
 // internal/solver's resolveOverload. The two have to agree: a call the checker types
-// with one arm's return type must reach that arm at runtime. This file is where the
-// dispatcher's order is derived so it matches the checker's.
+// with one arm's return type must reach that arm at runtime. This file derives the
+// dispatcher's order so it matches the checker's.
 //
-// The order has two keys.
+// The order has three keys, applied in turn.
 //
-//  1. Parameter count, descending. A guard only tests the parameters its own arm
+//  1. Parameter count, descending. A guard tests only the parameters its own arm
 //     declares, so a one-parameter arm placed first would answer a two-argument call
-//     that the two-parameter arm was written for. The checker has no matching rule
-//     because it gates arity separately, in tryOverloadArm, before an arm is ranked at
-//     all. So this key is invisible to the checker rather than in conflict with it.
+//     the two-parameter arm was written for. The checker has no matching rule because
+//     it gates arity separately, in tryOverloadArm, before an arm is ranked at all. So
+//     this key is invisible to the checker rather than in conflict with it.
 //  2. Specificity, most specific first, mirroring the checker's specificityOrder. An
 //     arm is more specific than another when each of its parameters admits no more
 //     values than the matching parameter, and at least one admits strictly fewer. So
-//     `(x: 5)` is tested before `(x: number)` and `({x, y})` before `({x})`.
+//     `(x: 5)` is tested before `(x: number)`, and `({x, y})` before `({x})`.
+//  3. Source position — source id, then line, then column. This is the declaration
+//     order the checker's armPosLess pins, and it settles every pair the first two keys
+//     leave tied. Sorting the arms rather than taking them as the dep graph happens to
+//     hold them is what keeps the two tiebreaks the same.
 //
-// Arms neither ranking separates keep their declaration order, which is the tiebreak
-// the checker's stable sort also falls back on.
+// # Where the two orders can still differ
+//
+// Both keys 2 and 3 are derived from what the arm WROTE, while the checker derives its
+// ranking from what it INFERRED. Two gaps follow, both narrow and both documented at
+// the code that leaves them.
+//
+//   - A parameter annotated with a type alias. The checker ranks the type the alias
+//     expands to; annSubsumes sees only the name and ranks the pair as a tie. An alias
+//     naming a class is the exception, since nominalGuardName resolves it.
+//   - Key 3 orders by source id where armPosLess orders by file path. The compiler
+//     assigns ids by walking the source tree in lexical order, so the two agree for
+//     every program it builds; a caller that hands the parser sources in some other
+//     order can separate them.
+//
+// Key 1 has a gap of its own, and it predates this ordering. An optional or rest
+// parameter widens an arm's accepted argument counts, so `(x: string, y?: number|string)`
+// and `(x: string)` both accept a one-argument call and the checker ranks them by
+// declaration order. Key 1 tests the longer arm first, and its `y` guard is a bare
+// `true` because a union is untestable, so the longer arm answers a call the checker
+// gave to the shorter one. Closing this needs the dispatcher to test how many arguments
+// it was called with, which it does not do today.
+//
+// One further divergence lives on the checker's side rather than here. When a call
+// argument is a still-unconstrained variable, overloadOrder cannot rank the arms and
+// falls back to plain declaration order, so `fn g(y) { return f(y) }` pins y to the
+// FIRST arm rather than to the one specificity would choose. The dispatcher always
+// ranks by specificity, so a call through g can reach a different arm than the one g
+// was typed with. That fallback is the MVP limitation #723 tracks, and deferred
+// resolution retires this divergence with it.
 
 // DispatchOrder returns overloads in the order the generated if-else chain tests them.
 // The input is left untouched.
@@ -68,13 +101,33 @@ func DispatchOrder(overloads []*ast.FuncDecl) []*ast.FuncDecl {
 		if len(ordered[a].Params) != len(ordered[b].Params) {
 			return len(ordered[a].Params) > len(ordered[b].Params)
 		}
-		return dominators[a] < dominators[b]
+		if dominators[a] != dominators[b] {
+			return dominators[a] < dominators[b]
+		}
+		return earlierInSource(ordered[a], ordered[b])
 	})
 	sorted := make([]*ast.FuncDecl, len(ordered))
 	for i, idx := range order {
 		sorted[i] = ordered[idx]
 	}
 	return sorted
+}
+
+// earlierInSource reports whether a is declared before b, by source id, then line, then
+// column. It is the tiebreak internal/solver's armPosLess applies, with one difference:
+// armPosLess orders by file path where this orders by source id. The compiler assigns
+// ids by walking the source tree in lexical order, so id order is path order for every
+// program it builds. Ordering here at all is what matters — the dep graph hands its
+// declarations back in the order they were registered, which no rule pins.
+func earlierInSource(a, b *ast.FuncDecl) bool {
+	as, bs := a.Span(), b.Span()
+	if as.SourceID != bs.SourceID {
+		return as.SourceID < bs.SourceID
+	}
+	if as.Start.Line != bs.Start.Line {
+		return as.Start.Line < bs.Start.Line
+	}
+	return as.Start.Column < bs.Start.Column
 }
 
 // armSpecificity compares two overload arms parameter by parameter. It returns -1 when
@@ -86,12 +139,14 @@ func armSpecificity(a, b *ast.FuncDecl) int {
 	if len(a.Params) != len(b.Params) {
 		return 0
 	}
+	aParams := armParams(a)
+	bParams := armParams(b)
 	aSubB, bSubA := true, true
-	for i := range a.Params {
-		if aSubB && !annSubsumes(a.Params[i].TypeAnn, b.Params[i].TypeAnn) {
+	for i := range aParams {
+		if aSubB && !annSubsumes(aParams[i], bParams[i]) {
 			aSubB = false
 		}
-		if bSubA && !annSubsumes(b.Params[i].TypeAnn, a.Params[i].TypeAnn) {
+		if bSubA && !annSubsumes(bParams[i], aParams[i]) {
 			bSubA = false
 		}
 		if !aSubB && !bSubA {
@@ -107,126 +162,111 @@ func armSpecificity(a, b *ast.FuncDecl) int {
 	return 0
 }
 
-// annSubsumes reports whether the values a's guard accepts are a subset of those b's
-// guard accepts. It is the dispatch-order counterpart of structuralSubtype in
-// internal/solver, written over the annotations buildTypeGuard reads rather than over
-// inferred types, and it is deliberately partial in the same way: a pair it cannot rank
-// returns false in both directions, which armSpecificity reads as a tie and
-// DispatchOrder resolves in declaration order.
-//
-// An annotation buildTypeGuard cannot test emits a bare `true`, so it accepts every
-// value. It is the top of this ordering: everything is a subset of it and it is a
-// subset of nothing else. A missing annotation is the same case, since it emits no
-// guard at all.
-func annSubsumes(a, b ast.TypeAnn) bool {
-	if guardAcceptsAnything(b) {
+// armParam is one parameter of an arm as the ordering reads it: the written annotation
+// plus whether that annotation admits every value.
+type armParam struct {
+	ann ast.TypeAnn
+	// top marks a parameter that accepts anything, so every other parameter is at least
+	// as specific as it. Two cases qualify, and they are the two the checker's
+	// structuralSubtype treats as the top of its own ordering by seeing a type variable:
+	// a parameter with no annotation, whose type is a fresh inference variable, and one
+	// annotated with the arm's own type parameter.
+	top bool
+}
+
+// armParams describes each of decl's parameters for the ordering.
+func armParams(decl *ast.FuncDecl) []armParam {
+	// The arm's own type parameters are the names that stand for a type variable rather
+	// than for a type. A signature with no `<…>` list allocates nothing.
+	var vars set.Set[string]
+	if len(decl.TypeParams) > 0 {
+		vars = set.NewSet[string]()
+		for _, tp := range decl.TypeParams {
+			vars.Add(tp.Name)
+		}
+	}
+	params := make([]armParam, len(decl.Params))
+	for i, p := range decl.Params {
+		params[i] = armParam{ann: p.TypeAnn, top: isTopAnn(p.TypeAnn, vars)}
+	}
+	return params
+}
+
+// isTopAnn reports whether ann admits every value: either there is no annotation, or it
+// names one of vars, the enclosing arm's own type parameters.
+func isTopAnn(ann ast.TypeAnn, vars set.Set[string]) bool {
+	if ann == nil {
 		return true
 	}
-	if guardAcceptsAnything(a) {
+	ref, ok := ann.(*ast.TypeRefTypeAnn)
+	if !ok || ref.Name == nil || vars == nil {
 		return false
 	}
-	if sameGuardedType(a, b) {
+	return vars.Contains(ast.QualIdentToString(ref.Name))
+}
+
+// annSubsumes reports whether the values a admits are a subset of those b admits. It is
+// the dispatch-order counterpart of structuralSubtype in internal/solver, written over
+// the annotations the source wrote rather than over inferred types, and it is
+// deliberately partial in the same way: a pair it cannot rank returns false in both
+// directions, which armSpecificity reads as a tie and DispatchOrder settles by source
+// position.
+//
+// An annotation buildTypeGuard cannot test at runtime — a union, a function type — is
+// NOT treated as top here, because the checker does not treat it as top either. Such an
+// arm ties with everything, so it keeps its declared place. Its guard is still a bare
+// `true`, which means an untestable arm declared first answers every call that reaches
+// it; that is what the checker's resolution does too, so the two agree on the arm even
+// where the program is a poor one.
+func annSubsumes(a, b armParam) bool {
+	if b.top {
+		return true
+	}
+	if a.top {
+		return false
+	}
+	if sameAnn(a.ann, b.ann) {
 		return true
 	}
 	// A literal is one value out of its primitive's set, so `5` is more specific than
 	// `number`. The checker ranks a LitType under its PrimType the same way.
-	if lit, ok := a.(*ast.LitTypeAnn); ok {
-		return litUnderPrimitive(lit.Lit, b)
+	if lit, ok := a.ann.(*ast.LitTypeAnn); ok {
+		return litUnderPrimitive(lit.Lit, b.ann)
 	}
-	if ao, ok := a.(*ast.ObjectTypeAnn); ok {
-		if bo, ok := b.(*ast.ObjectTypeAnn); ok {
+	if ao, ok := a.ann.(*ast.ObjectTypeAnn); ok {
+		if bo, ok := b.ann.(*ast.ObjectTypeAnn); ok {
 			return objectAnnSubsumes(ao, bo)
 		}
 	}
 	return false
 }
 
-// sameGuardedType reports whether two annotations produce guards that accept exactly
-// the same values, so neither arm outranks the other. It covers the annotation kinds
-// buildTypeGuard can actually test.
-func sameGuardedType(a, b ast.TypeAnn) bool {
-	switch at := a.(type) {
-	case *ast.NumberTypeAnn:
-		_, ok := b.(*ast.NumberTypeAnn)
-		return ok
-	case *ast.StringTypeAnn:
-		_, ok := b.(*ast.StringTypeAnn)
-		return ok
-	case *ast.BooleanTypeAnn:
-		_, ok := b.(*ast.BooleanTypeAnn)
-		return ok
-	case *ast.LitTypeAnn:
-		bt, ok := b.(*ast.LitTypeAnn)
-		return ok && sameLitValue(at.Lit, bt.Lit)
-	case *ast.TupleTypeAnn:
-		// Every tuple guard is `Array.isArray`, so two tuple annotations are
-		// indistinguishable at runtime however their elements differ.
-		_, ok := b.(*ast.TupleTypeAnn)
-		return ok
-	case *ast.TypeRefTypeAnn:
-		bt, ok := b.(*ast.TypeRefTypeAnn)
-		if !ok {
-			return false
-		}
-		if aName, aNominal := nominalGuardName(at); aNominal {
-			bName, bNominal := nominalGuardName(bt)
-			return bNominal && aName == bName
-		}
-		// Both reach here as `Array.isArray` guards, since guardAcceptsAnything already
-		// removed every other type reference.
-		return isArrayTypeRef(at) && isArrayTypeRef(bt)
-	case *ast.ObjectTypeAnn:
-		bt, ok := b.(*ast.ObjectTypeAnn)
-		return ok && sameObjectAnn(at, bt)
-	}
-	return false
+// sameAnn reports whether two annotations were written the same way, by rendering each
+// back to source and comparing the text. It stands in for the alpha-equality the
+// checker's structuralSubtype tests first, and covers every annotation form rather than
+// the handful the guard builder can test, so `{x: number | string}` compares equal to
+// itself even though no guard tests a union.
+//
+// Two annotations naming the same type through different spellings — an alias and its
+// expansion, a qualified and an unqualified reference — read as different here and rank
+// as a tie. The checker sees one type and ranks them equal, which is also a tie.
+func sameAnn(a, b ast.TypeAnn) bool {
+	aText, aOK := annText(a)
+	bText, bOK := annText(b)
+	return aOK && bOK && aText == bText
 }
 
-// sameObjectAnn reports whether two object annotations describe the same shape: the
-// same property names, each required on both sides or optional on both, with property
-// types that guard the same values, and the same trailing `...` marker. It stands in
-// for the alpha-equality the checker's structuralSubtype tests first.
-func sameObjectAnn(a, b *ast.ObjectTypeAnn) bool {
-	if a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
-		return false
+// annText renders an annotation back to Escalier source, reporting false for a nil
+// annotation or one the printer cannot render.
+func annText(ann ast.TypeAnn) (string, bool) {
+	if ann == nil {
+		return "", false
 	}
-	for _, elem := range a.Elems {
-		prop, ok := elem.(*ast.PropertyTypeAnn)
-		if !ok {
-			return false // a non-property member is outside what the guard tests
-		}
-		match, found := lookupProp(b, propAnnName(prop))
-		if !found || match.Optional != prop.Optional || !sameGuardedType(match.Value, prop.Value) {
-			return false
-		}
+	text, err := printer.Print(ann, printer.CompactOptions())
+	if err != nil {
+		return "", false
 	}
-	return true
-}
-
-// sameLitValue reports whether two literal annotations name the same value, which is
-// what the `===` guard tests.
-func sameLitValue(a, b ast.Lit) bool {
-	switch al := a.(type) {
-	case *ast.NumLit:
-		bl, ok := b.(*ast.NumLit)
-		return ok && al.Value == bl.Value
-	case *ast.StrLit:
-		bl, ok := b.(*ast.StrLit)
-		return ok && al.Value == bl.Value
-	case *ast.BoolLit:
-		bl, ok := b.(*ast.BoolLit)
-		return ok && al.Value == bl.Value
-	case *ast.BigIntLit:
-		bl, ok := b.(*ast.BigIntLit)
-		return ok && al.Value.Cmp(&bl.Value) == 0
-	case *ast.NullLit:
-		_, ok := b.(*ast.NullLit)
-		return ok
-	case *ast.UndefinedLit:
-		_, ok := b.(*ast.UndefinedLit)
-		return ok
-	}
-	return false
+	return text, true
 }
 
 // litUnderPrimitive reports whether lit is one of the values the primitive annotation
@@ -247,10 +287,7 @@ func litUnderPrimitive(lit ast.Lit, prim ast.TypeAnn) bool {
 }
 
 // objectAnnSubsumes reports whether object annotation a accepts a subset of what b
-// accepts, ranking the two axes the emitted guard can tell apart. It mirrors
-// objectSubsumes in internal/solver.
-//
-// It ranks two axes and ignores a third, exactly as objectSubsumes does.
+// accepts. It ranks two axes and ignores a third, exactly as objectSubsumes does.
 //
 //   - Required-property count. The guard tests that each required property is present
 //     and that its value passes the property's own guard, so a is narrower when its
@@ -264,7 +301,7 @@ func litUnderPrimitive(lit ast.Lit, prim ast.TypeAnn) bool {
 //     that decides which of them answers a call both accept.
 //
 // Property types are NOT ranked. Two arms whose shared properties differ in type tie
-// here and fall back to declaration order.
+// here and fall back to source position.
 //
 // An optional property is never tested and widens the arm rather than narrowing it, so
 // it is not counted: `{x, y?}` accepts everything `{x}` accepts.
@@ -280,7 +317,7 @@ func objectAnnSubsumes(a, b *ast.ObjectTypeAnn) bool {
 		}
 		requiredB++
 		match, found := lookupProp(a, propAnnName(prop))
-		if !found || match.Optional || !sameGuardedType(match.Value, prop.Value) {
+		if !found || match.Optional || !sameAnn(match.Value, prop.Value) {
 			return false
 		}
 	}
@@ -328,27 +365,6 @@ func propAnnName(prop *ast.PropertyTypeAnn) string {
 		return key.Value
 	}
 	return ""
-}
-
-// guardAcceptsAnything reports whether buildTypeGuard emits a bare `true` for typeAnn,
-// which is what it falls back to for an annotation it cannot test at runtime — a union,
-// a type parameter, a function type. Such an arm accepts every argument that reaches
-// it, so DispatchOrder has to sort it after every arm that tests something.
-func guardAcceptsAnything(typeAnn ast.TypeAnn) bool {
-	switch t := typeAnn.(type) {
-	case nil:
-		return true // an un-annotated parameter contributes no guard at all
-	case *ast.NumberTypeAnn, *ast.StringTypeAnn, *ast.BooleanTypeAnn,
-		*ast.LitTypeAnn, *ast.ObjectTypeAnn, *ast.TupleTypeAnn:
-		return false
-	case *ast.TypeRefTypeAnn:
-		if _, nominal := nominalGuardName(t); nominal {
-			return false
-		}
-		return !isArrayTypeRef(t)
-	default:
-		return true
-	}
 }
 
 // nominalGuardName returns the class name an `x instanceof C` guard tests for a

--- a/internal/codegen/overload_order.go
+++ b/internal/codegen/overload_order.go
@@ -1,0 +1,378 @@
+package codegen
+
+import (
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// The order the generated dispatcher tests overload arms in.
+//
+// buildOverloadedFunc compiles an overload set to one function whose if-else chain
+// runs each arm's guard in turn, so the order decides which arm answers a call two
+// arms both accept. The checker answers the same question statically in
+// internal/solver's resolveOverload. The two have to agree: a call the checker types
+// with one arm's return type must reach that arm at runtime. This file is where the
+// dispatcher's order is derived so it matches the checker's.
+//
+// The order has two keys.
+//
+//  1. Parameter count, descending. A guard only tests the parameters its own arm
+//     declares, so a one-parameter arm placed first would answer a two-argument call
+//     that the two-parameter arm was written for. The checker has no matching rule
+//     because it gates arity separately, in tryOverloadArm, before an arm is ranked at
+//     all. So this key is invisible to the checker rather than in conflict with it.
+//  2. Specificity, most specific first, mirroring the checker's specificityOrder. An
+//     arm is more specific than another when each of its parameters admits no more
+//     values than the matching parameter, and at least one admits strictly fewer. So
+//     `(x: 5)` is tested before `(x: number)` and `({x, y})` before `({x})`.
+//
+// Arms neither ranking separates keep their declaration order, which is the tiebreak
+// the checker's stable sort also falls back on.
+
+// DispatchOrder returns overloads in the order the generated if-else chain tests them.
+// The input is left untouched.
+//
+// It is exported so the checker's conformance corpus can measure its own resolution
+// order against this one. Nothing outside that check and buildOverloadedFunc should
+// need it.
+func DispatchOrder(overloads []*ast.FuncDecl) []*ast.FuncDecl {
+	ordered := make([]*ast.FuncDecl, len(overloads))
+	copy(ordered, overloads)
+	// Rank each arm by its DOMINATION COUNT — how many other arms are strictly more
+	// specific than it. Sorting on that integer rather than on the specificity relation
+	// itself is what keeps the sort well-defined. Specificity is only a partial order:
+	// `(x: number)` and `(x: string)` are incomparable, and incomparability is not
+	// transitive, so feeding the relation to a sort would break the strict-weak-ordering
+	// contract sort.SliceStable requires. A count is a total order on integers. An arm
+	// nothing dominates gets 0 and sorts first; the catch-all every other arm beats sorts
+	// last. internal/solver's specificityOrder ranks the same way.
+	dominators := make([]int, len(ordered))
+	for i := range ordered {
+		for j := range ordered {
+			if i == j || len(ordered[i].Params) != len(ordered[j].Params) {
+				continue
+			}
+			if armSpecificity(ordered[j], ordered[i]) < 0 {
+				dominators[i]++
+			}
+		}
+	}
+	order := make([]int, len(ordered))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(x, y int) bool {
+		a, b := order[x], order[y]
+		if len(ordered[a].Params) != len(ordered[b].Params) {
+			return len(ordered[a].Params) > len(ordered[b].Params)
+		}
+		return dominators[a] < dominators[b]
+	})
+	sorted := make([]*ast.FuncDecl, len(ordered))
+	for i, idx := range order {
+		sorted[i] = ordered[idx]
+	}
+	return sorted
+}
+
+// armSpecificity compares two overload arms parameter by parameter. It returns -1 when
+// a is strictly more specific than b, +1 when b is, and 0 when neither is — either
+// because they are incomparable or because they admit the same arguments. Arms of
+// different arity are a 0 here; DispatchOrder separates those by parameter count
+// instead. This mirrors moreSpecific in internal/solver.
+func armSpecificity(a, b *ast.FuncDecl) int {
+	if len(a.Params) != len(b.Params) {
+		return 0
+	}
+	aSubB, bSubA := true, true
+	for i := range a.Params {
+		if aSubB && !annSubsumes(a.Params[i].TypeAnn, b.Params[i].TypeAnn) {
+			aSubB = false
+		}
+		if bSubA && !annSubsumes(b.Params[i].TypeAnn, a.Params[i].TypeAnn) {
+			bSubA = false
+		}
+		if !aSubB && !bSubA {
+			return 0
+		}
+	}
+	if aSubB && !bSubA {
+		return -1
+	}
+	if bSubA && !aSubB {
+		return 1
+	}
+	return 0
+}
+
+// annSubsumes reports whether the values a's guard accepts are a subset of those b's
+// guard accepts. It is the dispatch-order counterpart of structuralSubtype in
+// internal/solver, written over the annotations buildTypeGuard reads rather than over
+// inferred types, and it is deliberately partial in the same way: a pair it cannot rank
+// returns false in both directions, which armSpecificity reads as a tie and
+// DispatchOrder resolves in declaration order.
+//
+// An annotation buildTypeGuard cannot test emits a bare `true`, so it accepts every
+// value. It is the top of this ordering: everything is a subset of it and it is a
+// subset of nothing else. A missing annotation is the same case, since it emits no
+// guard at all.
+func annSubsumes(a, b ast.TypeAnn) bool {
+	if guardAcceptsAnything(b) {
+		return true
+	}
+	if guardAcceptsAnything(a) {
+		return false
+	}
+	if sameGuardedType(a, b) {
+		return true
+	}
+	// A literal is one value out of its primitive's set, so `5` is more specific than
+	// `number`. The checker ranks a LitType under its PrimType the same way.
+	if lit, ok := a.(*ast.LitTypeAnn); ok {
+		return litUnderPrimitive(lit.Lit, b)
+	}
+	if ao, ok := a.(*ast.ObjectTypeAnn); ok {
+		if bo, ok := b.(*ast.ObjectTypeAnn); ok {
+			return objectAnnSubsumes(ao, bo)
+		}
+	}
+	return false
+}
+
+// sameGuardedType reports whether two annotations produce guards that accept exactly
+// the same values, so neither arm outranks the other. It covers the annotation kinds
+// buildTypeGuard can actually test.
+func sameGuardedType(a, b ast.TypeAnn) bool {
+	switch at := a.(type) {
+	case *ast.NumberTypeAnn:
+		_, ok := b.(*ast.NumberTypeAnn)
+		return ok
+	case *ast.StringTypeAnn:
+		_, ok := b.(*ast.StringTypeAnn)
+		return ok
+	case *ast.BooleanTypeAnn:
+		_, ok := b.(*ast.BooleanTypeAnn)
+		return ok
+	case *ast.LitTypeAnn:
+		bt, ok := b.(*ast.LitTypeAnn)
+		return ok && sameLitValue(at.Lit, bt.Lit)
+	case *ast.TupleTypeAnn:
+		// Every tuple guard is `Array.isArray`, so two tuple annotations are
+		// indistinguishable at runtime however their elements differ.
+		_, ok := b.(*ast.TupleTypeAnn)
+		return ok
+	case *ast.TypeRefTypeAnn:
+		bt, ok := b.(*ast.TypeRefTypeAnn)
+		if !ok {
+			return false
+		}
+		if aName, aNominal := nominalGuardName(at); aNominal {
+			bName, bNominal := nominalGuardName(bt)
+			return bNominal && aName == bName
+		}
+		// Both reach here as `Array.isArray` guards, since guardAcceptsAnything already
+		// removed every other type reference.
+		return isArrayTypeRef(at) && isArrayTypeRef(bt)
+	case *ast.ObjectTypeAnn:
+		bt, ok := b.(*ast.ObjectTypeAnn)
+		return ok && sameObjectAnn(at, bt)
+	}
+	return false
+}
+
+// sameObjectAnn reports whether two object annotations describe the same shape: the
+// same property names, each required on both sides or optional on both, with property
+// types that guard the same values, and the same trailing `...` marker. It stands in
+// for the alpha-equality the checker's structuralSubtype tests first.
+func sameObjectAnn(a, b *ast.ObjectTypeAnn) bool {
+	if a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
+		return false
+	}
+	for _, elem := range a.Elems {
+		prop, ok := elem.(*ast.PropertyTypeAnn)
+		if !ok {
+			return false // a non-property member is outside what the guard tests
+		}
+		match, found := lookupProp(b, propAnnName(prop))
+		if !found || match.Optional != prop.Optional || !sameGuardedType(match.Value, prop.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+// sameLitValue reports whether two literal annotations name the same value, which is
+// what the `===` guard tests.
+func sameLitValue(a, b ast.Lit) bool {
+	switch al := a.(type) {
+	case *ast.NumLit:
+		bl, ok := b.(*ast.NumLit)
+		return ok && al.Value == bl.Value
+	case *ast.StrLit:
+		bl, ok := b.(*ast.StrLit)
+		return ok && al.Value == bl.Value
+	case *ast.BoolLit:
+		bl, ok := b.(*ast.BoolLit)
+		return ok && al.Value == bl.Value
+	case *ast.BigIntLit:
+		bl, ok := b.(*ast.BigIntLit)
+		return ok && al.Value.Cmp(&bl.Value) == 0
+	case *ast.NullLit:
+		_, ok := b.(*ast.NullLit)
+		return ok
+	case *ast.UndefinedLit:
+		_, ok := b.(*ast.UndefinedLit)
+		return ok
+	}
+	return false
+}
+
+// litUnderPrimitive reports whether lit is one of the values the primitive annotation
+// prim admits, the `5` under `number` case.
+func litUnderPrimitive(lit ast.Lit, prim ast.TypeAnn) bool {
+	switch lit.(type) {
+	case *ast.NumLit:
+		_, ok := prim.(*ast.NumberTypeAnn)
+		return ok
+	case *ast.StrLit:
+		_, ok := prim.(*ast.StringTypeAnn)
+		return ok
+	case *ast.BoolLit:
+		_, ok := prim.(*ast.BooleanTypeAnn)
+		return ok
+	}
+	return false
+}
+
+// objectAnnSubsumes reports whether object annotation a accepts a subset of what b
+// accepts, ranking the two axes the emitted guard can tell apart. It mirrors
+// objectSubsumes in internal/solver.
+//
+// It ranks two axes and ignores a third, exactly as objectSubsumes does.
+//
+//   - Required-property count. The guard tests that each required property is present
+//     and that its value passes the property's own guard, so a is narrower when its
+//     required properties are a strict superset of b's. `{x: number, y: number}` is
+//     more specific than `{x: number}`. Every required property of b must appear in a
+//     as required and with the same property type; a property a is missing, has as
+//     optional, or types differently leaves the two incomparable and returns false.
+//   - The trailing `...` marker, consulted only when the required sets match. An exact
+//     `{x: number}` is more specific than an inexact `{x: number, ...}`, since it
+//     accepts no extra properties. The two emit the SAME guard, so this is the ranking
+//     that decides which of them answers a call both accept.
+//
+// Property types are NOT ranked. Two arms whose shared properties differ in type tie
+// here and fall back to declaration order.
+//
+// An optional property is never tested and widens the arm rather than narrowing it, so
+// it is not counted: `{x, y?}` accepts everything `{x}` accepts.
+func objectAnnSubsumes(a, b *ast.ObjectTypeAnn) bool {
+	requiredB := 0
+	for _, elem := range b.Elems {
+		prop, ok := elem.(*ast.PropertyTypeAnn)
+		if !ok {
+			return false // a non-property member is outside what the guard tests
+		}
+		if prop.Optional {
+			continue
+		}
+		requiredB++
+		match, found := lookupProp(a, propAnnName(prop))
+		if !found || match.Optional || !sameGuardedType(match.Value, prop.Value) {
+			return false
+		}
+	}
+	requiredA := 0
+	for _, elem := range a.Elems {
+		prop, ok := elem.(*ast.PropertyTypeAnn)
+		if !ok {
+			return false
+		}
+		if !prop.Optional {
+			requiredA++
+		}
+	}
+	if requiredA > requiredB {
+		return true
+	}
+	return !a.Inexact && b.Inexact
+}
+
+// lookupProp returns obj's property named name. A computed key has no name the guard
+// can test, so it never matches.
+func lookupProp(obj *ast.ObjectTypeAnn, name string) (*ast.PropertyTypeAnn, bool) {
+	if name == "" {
+		return nil, false
+	}
+	for _, elem := range obj.Elems {
+		prop, ok := elem.(*ast.PropertyTypeAnn)
+		if !ok {
+			continue
+		}
+		if propAnnName(prop) == name {
+			return prop, true
+		}
+	}
+	return nil, false
+}
+
+// propAnnName returns the property name the `"k" in o` guard tests, or "" for a
+// computed key buildTypeGuard skips.
+func propAnnName(prop *ast.PropertyTypeAnn) string {
+	switch key := prop.Name.(type) {
+	case *ast.IdentExpr:
+		return key.Name
+	case *ast.StrLit:
+		return key.Value
+	}
+	return ""
+}
+
+// guardAcceptsAnything reports whether buildTypeGuard emits a bare `true` for typeAnn,
+// which is what it falls back to for an annotation it cannot test at runtime — a union,
+// a type parameter, a function type. Such an arm accepts every argument that reaches
+// it, so DispatchOrder has to sort it after every arm that tests something.
+func guardAcceptsAnything(typeAnn ast.TypeAnn) bool {
+	switch t := typeAnn.(type) {
+	case nil:
+		return true // an un-annotated parameter contributes no guard at all
+	case *ast.NumberTypeAnn, *ast.StringTypeAnn, *ast.BooleanTypeAnn,
+		*ast.LitTypeAnn, *ast.ObjectTypeAnn, *ast.TupleTypeAnn:
+		return false
+	case *ast.TypeRefTypeAnn:
+		if _, nominal := nominalGuardName(t); nominal {
+			return false
+		}
+		return !isArrayTypeRef(t)
+	default:
+		return true
+	}
+}
+
+// nominalGuardName returns the class name an `x instanceof C` guard tests for a
+// reference to a nominal type, and reports whether the reference is one. A reference
+// resolves through its inferred type, either directly or through a type alias.
+func nominalGuardName(t *ast.TypeRefTypeAnn) (string, bool) {
+	inferred := t.InferredType()
+	if inferred == nil {
+		return "", false
+	}
+	pruned := type_system.Prune(inferred)
+	if typeRef, ok := pruned.(*type_system.TypeRefType); ok && typeRef.TypeAlias != nil {
+		if obj, ok := type_system.Prune(typeRef.TypeAlias.Type).(*type_system.ObjectType); ok && obj.Nominal {
+			return ast.QualIdentToString(t.Name), true
+		}
+	}
+	if obj, ok := pruned.(*type_system.ObjectType); ok && obj.Nominal {
+		return ast.QualIdentToString(t.Name), true
+	}
+	return "", false
+}
+
+// isArrayTypeRef reports whether a reference is the `Array` the guard tests with
+// `Array.isArray`.
+func isArrayTypeRef(t *ast.TypeRefTypeAnn) bool {
+	return t.Name != nil && ast.QualIdentToString(t.Name) == "Array"
+}

--- a/internal/codegen/overload_order_test.go
+++ b/internal/codegen/overload_order_test.go
@@ -84,6 +84,25 @@ fn f(x: string) -> string { return "s" }`,
   } else throw new TypeError("No overload matches the provided arguments for function 'f'");
 }`,
 		},
+		// A declare-only arm gets no branch of its own, but it still takes part in the
+		// ranking, because the checker ranks it too. Here `{y, w, ...}` outranks
+		// `{y, ...}`, which is what leaves the later `{x, ...}` arm ahead of it. Ranking
+		// only the arms that get a branch would drop that and put `{y, ...}` first, so
+		// f({x: 1, y: 2}) would return true where the checker typed it as a number.
+		"DeclareOnlyArmParticipatesInRanking": {
+			src: `fn f(p: {y: number, ...}) -> boolean { return true }
+declare fn f(p: {y: number, w: number, ...}) -> string
+fn f(p: {x: number, ...}) -> number { return 1 }`,
+			expected: `export function f(param0) {
+  if (param0 !== null && typeof param0 === "object" && "x" in param0 && typeof param0.x === "number") {
+    const p = param0;
+    return 1;
+  } else if (param0 !== null && typeof param0 === "object" && "y" in param0 && typeof param0.y === "number") {
+    const p = param0;
+    return true;
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
 		// A guard tests only the parameters its own arm declares, so the arm with more
 		// parameters runs first. Otherwise `typeof param0 === "string"` alone would answer
 		// a two-argument call.

--- a/internal/codegen/overload_order_test.go
+++ b/internal/codegen/overload_order_test.go
@@ -1,0 +1,130 @@
+package codegen
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// The dispatcher's if-else chain tests arms in the order DispatchOrder computes, so
+// the emitted chain is where that order is visible. Each case below writes an overload
+// set whose arms return different strings, so the order the guards appear in — and the
+// body each guard carries — names the order the arms are tested in.
+//
+// The checker ranks the same sets the same way; internal/solver's
+// TestOverloadDispatchAgreesWithResolution measures the two against each other.
+func TestBuildOverloadedFuncDispatchOrder(t *testing.T) {
+	tests := map[string]struct {
+		src      string
+		expected string
+	}{
+		// A literal admits one value out of its primitive's set, so its guard has to run
+		// before the primitive's. Testing `typeof param0 === "number"` first would swallow
+		// f(5) into the primitive arm, which is the arm the checker did NOT resolve it to.
+		"LiteralBeforeItsPrimitive": {
+			src: `fn f(x: number) -> string { return "n" }
+fn f(x: 5) -> string { return "five" }`,
+			expected: `export function f(param0) {
+  if (param0 === 5) {
+    const x = param0;
+    return "five";
+  } else if (typeof param0 === "number") {
+    const x = param0;
+    return "n";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+		// An object with more required properties accepts fewer arguments, so its guard
+		// runs first. Every `{x, y}` is also an `{x}`.
+		"MoreRequiredPropertiesFirst": {
+			src: `fn f(p: {x: number}) -> string { return "x" }
+fn f(p: {x: number, y: number}) -> string { return "xy" }`,
+			expected: `export function f(param0) {
+  if (param0 !== null && typeof param0 === "object" && "x" in param0 && typeof param0.x === "number" && "y" in param0 && typeof param0.y === "number") {
+    const p = param0;
+    return "xy";
+  } else if (param0 !== null && typeof param0 === "object" && "x" in param0 && typeof param0.x === "number") {
+    const p = param0;
+    return "x";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+		// A type parameter cannot be tested at runtime, so its guard is a bare `true`.
+		// Placed first it would answer every call, so it has to run last.
+		"UntestableArmLast": {
+			src: `fn f<T>(x: T) -> string { return "any" }
+fn f(x: string) -> string { return "s" }`,
+			expected: `export function f(param0) {
+  if (typeof param0 === "string") {
+    const x = param0;
+    return "s";
+  } else if (true) {
+    const x = param0;
+    return "any";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+		// Two primitives of different families accept disjoint arguments, so neither
+		// outranks the other and the chain keeps declaration order.
+		"DisjointPrimitivesKeepDeclarationOrder": {
+			src: `fn f(x: number) -> string { return "n" }
+fn f(x: string) -> string { return "s" }`,
+			expected: `export function f(param0) {
+  if (typeof param0 === "number") {
+    const x = param0;
+    return "n";
+  } else if (typeof param0 === "string") {
+    const x = param0;
+    return "s";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+		// A guard tests only the parameters its own arm declares, so the arm with more
+		// parameters runs first. Otherwise `typeof param0 === "string"` alone would answer
+		// a two-argument call.
+		"MoreParametersFirst": {
+			src: `fn f(x: string) -> string { return "one" }
+fn f(x: string, y: string) -> string { return "two" }`,
+			expected: `export function f(param0, param1) {
+  if (typeof param0 === "string" && typeof param1 === "string") {
+    const x = param0;
+    const y = param1;
+    return "two";
+  } else if (typeof param0 === "string") {
+    const x = param0;
+    return "one";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			module, parseErrs := parser.ParseLibFiles(ctx, []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: test.src},
+			})
+			require.Empty(t, parseErrs, "expected no parse errors")
+
+			depGraph := dep_graph.BuildDepGraph(module)
+			builder := &Builder{tempId: 0, depGraph: depGraph}
+			out := builder.BuildTopLevelDecls(depGraph)
+
+			printer := NewPrinter()
+			for i, stmt := range out.Stmts {
+				if i > 0 {
+					printer.NewLine()
+				}
+				printer.PrintStmt(stmt)
+			}
+			require.Equal(t, test.expected, printer.Output)
+		})
+	}
+}

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -918,8 +918,8 @@ type NoMatchingOverloadError struct {
 // arm then swallows every call that reaches it. A bodyless `declare fn` arm
 // contributes no branch to the chain and so is not reported.
 //
-// The set still infers and still binds — inference reads the arms as one intersection
-// of arrows and needs no annotation. Only the runtime dispatch does.
+// The set still infers and still binds. Inference reads the arms as one intersection of
+// arrows and needs no annotation; only the runtime dispatch does.
 //
 // It is a BRIDGE error: born in checkOverloadDispatch with the offending parameter in
 // hand, so it self-blames (Span() is the un-annotated parameter's pattern) and relates

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -909,20 +909,25 @@ type NoMatchingOverloadError struct {
 	Candidates []TypeScheme
 }
 
-// UnannotatedRecursiveOverloadError fires when an overloaded function participates
-// in a mutually-recursive group (a dep-graph component with more than one binding)
-// without fully-annotated overload signatures (PR6). Fixed-point iteration over
-// overload choices is not guaranteed to converge under subtyping, so the overload
-// set must be ground before the group is inferred; self-recursion (a singleton
-// component) is softer and does not trip this. The binding degrades to its first
-// arm so a later reference still resolves.
+// UndispatchableOverloadError fires when an arm of an overload set has a body and
+// leaves one of its parameters un-annotated.
 //
-// It is a BRIDGE error: born in checkOverloadAnnotations with the offending arm's
-// declaration in hand, so it self-blames (Span() is the first unannotated arm).
-// Name is the overloaded binding's name for the message.
-type UnannotatedRecursiveOverloadError struct {
-	Decl ast.Decl
-	Name string
+// An overload set with bodies compiles to a single JavaScript function whose if-else
+// chain tests each arm's written parameter annotations, so an un-annotated parameter
+// leaves the arm's guard with nothing to test. That guard degrades to `true` and the
+// arm then swallows every call that reaches it. A bodyless `declare fn` arm
+// contributes no branch to the chain and so is not reported.
+//
+// The set still infers and still binds — inference reads the arms as one intersection
+// of arrows and needs no annotation. Only the runtime dispatch does.
+//
+// It is a BRIDGE error: born in checkOverloadDispatch with the offending parameter in
+// hand, so it self-blames (Span() is the un-annotated parameter's pattern) and relates
+// the arm it belongs to. Name is the overloaded binding's name for the message.
+type UndispatchableOverloadError struct {
+	Param ast.Node
+	Decl  ast.Decl
+	Name  string
 }
 
 // DuplicateOverloadError fires when two arms of an overload set (PR6) are
@@ -1217,7 +1222,7 @@ func (*BodyDeclNotAllowedError) isSolverError()             {}
 func (*MissingInitializerError) isSolverError()             {}
 func (*DuplicateDeclarationError) isSolverError()           {}
 func (*NoMatchingOverloadError) isSolverError()             {}
-func (*UnannotatedRecursiveOverloadError) isSolverError()   {}
+func (*UndispatchableOverloadError) isSolverError()         {}
 func (*DuplicateOverloadError) isSolverError()              {}
 func (*AwaitOutsideAsyncError) isSolverError()              {}
 func (*ForAwaitOutsideAsyncError) isSolverError()           {}
@@ -1779,8 +1784,7 @@ func (e *SetterReceiverError) Message() string {
 // signature is pre-declared before its body is walked so a sibling call resolves,
 // but an un-annotated return in a cycle stays an inference variable that the cycle
 // cannot ground on its own. An annotation on any member of the cycle breaks it, so
-// every member reports until one is annotated. This mirrors the recursion gate
-// top-level overloaded functions use (UnannotatedRecursiveOverloadError).
+// every member reports until one is annotated.
 type RecursiveMethodAnnotationError struct {
 	Name  string
 	Elem  *ast.MethodElem
@@ -2409,10 +2413,10 @@ func (e *NoMatchingOverloadError) Message() string {
 	return sb.String()
 }
 
-func (e *UnannotatedRecursiveOverloadError) Span() ast.Span      { return e.Decl.Span() }
-func (e *UnannotatedRecursiveOverloadError) Related() []ast.Span { return nil }
-func (e *UnannotatedRecursiveOverloadError) Message() string {
-	return "Overloaded function in a recursive group must have fully-annotated signatures: " + e.Name
+func (e *UndispatchableOverloadError) Span() ast.Span      { return e.Param.Span() }
+func (e *UndispatchableOverloadError) Related() []ast.Span { return []ast.Span{e.Decl.Span()} }
+func (e *UndispatchableOverloadError) Message() string {
+	return "Overload arm with a body must annotate every parameter to be dispatchable: " + e.Name
 }
 
 func (e *DuplicateOverloadError) Span() ast.Span      { return e.Decl.Span() }

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -856,7 +856,6 @@ func (c *checker) bindSelf(scope *Scope, recv *ast.MethodReceiver, body *soltype
 // before its body is walked so a sibling call resolves, but an un-annotated return in a
 // cycle stays an inference variable the cycle cannot ground on its own, so it collapses to
 // `never` rather than a useful type. An annotation on any member of the cycle breaks it.
-// This mirrors the recursion gate top-level overloaded functions use.
 //
 // The check builds the call graph over instance methods with bodies — an edge from a
 // method arm to each sibling method its body reads through `self` — and inspects each

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -166,8 +166,8 @@ func TestInferOverloadNoMatch(t *testing.T) {
 // annotation on any arm. The set reaches its binding variable as the single lower
 // bound `(number -> R1) & (string -> R2)`, and the recursive `f("hi")` inside g
 // records `v <: (string) -> R` against it. The arrow-decomposition rule settles that
-// without picking an arm, so neither the branch choice nor the annotation that used to
-// stand in for it is needed.
+// by weighing both arms together, so nothing has to pick an arm before the group's
+// bodies are inferred and nothing has to be annotated to make that choice possible.
 func TestInferOverloadMutualRecursionInfersUnannotatedReturns(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) { return g(x) }

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -32,13 +32,12 @@ func TestInferOverloadResolvesByArgType(t *testing.T) {
 	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"])
 }
 
-// Unannotated overloads are allowed when NOT recursive — arms are inferred
-// independently and resolution dispatches on arity: f(5) hits the 1-param arm,
-// f(5, "hi") the 2-param arm.
+// Resolution dispatches on arity: f(5) hits the 1-param arm, f(5, "hi") the 2-param
+// arm.
 func TestInferOverloadDispatchesOnArity(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { return x }
-		fn f(x, y) { return x }
+		fn f<T>(x: T) -> T { return x }
+		fn f<T, U>(x: T, y: U) -> T { return x }
 		val a = f(5)
 		val b = f(5, "hi")
 	`)
@@ -126,7 +125,7 @@ val r = f(5)`},
 // the string arm even though the generic arm is declared first and would also match.
 func TestInferOverloadSpecificityBeatsDeclarationOrder(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { return x }
+		fn f<T>(x: T) -> T { return x }
 		fn f(x: string) -> boolean { return true }
 		val r = f("hi")
 	`)
@@ -163,18 +162,87 @@ func TestInferOverloadNoMatch(t *testing.T) {
 		msgWithSpan(errs[0]))
 }
 
-// A mutually-recursive group containing an overloaded function with un-annotated
-// arms is rejected: the overload set must be ground before the group's bodies are
-// inferred. The error blames the offending overloaded participant.
-func TestInferOverloadMutualRecursionRequiresAnnotation(t *testing.T) {
+// An overloaded function in a mutually-recursive group infers without a return
+// annotation on any arm. The set reaches its binding variable as the single lower
+// bound `(number -> R1) & (string -> R2)`, and the recursive `f("hi")` inside g
+// records `v <: (string) -> R` against it. The arrow-decomposition rule settles that
+// without picking an arm, so neither the branch choice nor the annotation that used to
+// stand in for it is needed.
+func TestInferOverloadMutualRecursionInfersUnannotatedReturns(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) { return g(x) }
+		fn f(x: string) { return x }
+		fn g(n: number) { return f("hi") }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: number) -> string) & (fn (x: string) -> string)", values["f"])
+	require.Equal(t, "fn (n: number) -> string", values["g"])
+}
+
+// The same relaxation across a group whose recursion runs through BOTH arms: the
+// number arm returns a literal, the string arm recurses through g, and g calls back
+// into the number arm. Each call site reads its own arm's return type out of the
+// decomposition.
+func TestInferOverloadMutualRecursionResolvesPerArm(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) { return 1 }
+		fn f(x: string) { return g(x) }
+		fn g(s: string) { return f(1) }
+		val a = f(5)
+		val b = f("hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: number) -> 1) & (fn (x: string) -> 1)", values["f"])
+	require.Equal(t, "1", values["a"])
+	require.Equal(t, "1", values["b"])
+}
+
+// Codegen compiles an overload set with bodies to one function whose if-else chain
+// tests each arm's written parameter annotations, so an arm with a body must annotate
+// every parameter. Each offending arm reports once, blaming its first un-annotated
+// parameter. The set still infers: the report is about dispatch, not about the fixed
+// point. Both arms here also end up with the same parameter type, which is the
+// separate indistinguishable-arms report.
+func TestInferOverloadImplementedArmNeedsParamAnnotation(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		fn f(x) { g(x) }
-		fn f(y) { g(y) }
-		fn g(z) { f(z) }
+		fn f(x) { return g(x) }
+		fn f(y) { return g(y) }
+		fn g(z: number) { return z }
+	`)
+	require.Len(t, errs, 3)
+	require.Equal(t,
+		"2:8-2:9: Overload arm with a body must annotate every parameter to be dispatchable: f",
+		msgWithSpan(errs[0]))
+	require.Equal(t,
+		"3:8-3:9: Overload arm with a body must annotate every parameter to be dispatchable: f",
+		msgWithSpan(errs[1]))
+	require.Equal(t,
+		"3:3-3:26: Overload arms must have distinguishable parameter types: f",
+		msgWithSpan(errs[2]))
+}
+
+// A `declare fn` arm contributes no branch to the generated dispatcher, so a
+// declare-only overload set keeps the freedom to leave a parameter un-annotated. This
+// is the `.d.ts`-shaped set the annotation obligation deliberately does not reach.
+func TestInferOverloadDeclareOnlyArmNeedsNoParamAnnotation(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		declare fn f(x)
+		declare fn f(x: string) -> boolean
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: unknown) -> undefined) & (fn (x: string) -> boolean)", values["f"])
+}
+
+// The obligation is per ARM, not per set: an implemented arm alongside a declare-only
+// one still has to annotate its parameters, and only the implemented arm reports.
+func TestInferOverloadMixedDeclareAndBodyReportsOnlyTheBody(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		declare fn f(x: string) -> boolean
+		fn f(y) { return y }
 	`)
 	require.Len(t, errs, 1)
 	require.Equal(t,
-		"2:3-2:19: Overloaded function in a recursive group must have fully-annotated signatures: f",
+		"3:8-3:9: Overload arm with a body must annotate every parameter to be dispatchable: f",
 		msgWithSpan(errs[0]))
 }
 
@@ -248,8 +316,8 @@ func TestInferOverloadValuePosition(t *testing.T) {
 // the level-0 intersection and aliases the arm's type variable across uses.)
 func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { return x }
-		fn f(x, y) { return x }
+		fn f<T>(x: T) -> T { return x }
+		fn f<T, U>(x: T, y: U) -> T { return x }
 		val g = f
 		val a = g("hi")
 		val b = g(true)
@@ -264,7 +332,7 @@ func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 // whether the callee is the overloaded name directly or a let-bound alias.
 func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 	direct, _, errs := inferSource(t, `
-		fn f(x) { return x }
+		fn f<T>(x: T) -> T { return x }
 		fn f(x: string) -> boolean { return true }
 		val r = f("hi")
 	`)
@@ -272,7 +340,7 @@ func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 	require.Equal(t, "boolean", direct["r"], "direct call picks the more specific arm")
 
 	binding, _, errs := inferSource(t, `
-		fn f(x) { return x }
+		fn f<T>(x: T) -> T { return x }
 		fn f(x: string) -> boolean { return true }
 		val g = f
 		val r = g("hi")
@@ -286,7 +354,7 @@ func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 // selects the arm that accepts it, most-specific-first with declaration-order tiebreak.
 func TestInferOverloadThreeArmSpecificity(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { return x }
+		fn f<T>(x: T) -> T { return x }
 		fn f(x: number) -> boolean { return true }
 		fn f(x: string) -> string { return x }
 		val p = f(5)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -459,6 +459,11 @@ func (c *checker) inferComponent(
 			})
 		}
 		if fused {
+			// Sort before fusing, not only in phase 3. The fused bound is what an
+			// in-component recursive call is checked against, and specificityOrder settles a
+			// tie by position in the list it is handed, so an unsorted fusion would resolve
+			// such a call against a different arm order than the exported binding uses.
+			sortArms(module, b.arms)
 			c.fuseOverloadArms(b)
 		}
 	}
@@ -757,22 +762,26 @@ func (c *checker) fuseOverloadArms(b *componentBinding) {
 // `.d.ts`-shaped overload set keeps the freedom to leave a parameter un-annotated.
 //
 // Inference itself needs none of this. An overload set enters the lattice as one
-// intersection of arrows (see fuseOverloadArms), so a set that fails here still infers
-// and still binds.
+// intersection of arrows, the form fuseOverloadArms records, so a set that fails here
+// still infers and still binds.
 func (c *checker) checkOverloadDispatch(g *dep_graph.DepGraph, component []dep_graph.BindingKey) {
 	for _, key := range component {
 		funcs := funcOnlyDecls(g, key)
 		if len(funcs) <= 1 {
-			continue // not an overload set (a mixed val/var name is a duplicate, not reported here)
+			// Not an overload set. A name a `val`/`var` shares with a function is a
+			// duplicate declaration, reported in phase 2 rather than here.
+			continue
 		}
 		for _, fd := range funcs {
 			if fd.Body == nil {
-				continue // declare-only: no dispatcher branch to guard
+				continue // a declare-only arm gets no branch, so it has no guard to write
 			}
 			for _, p := range fd.FuncSig.Params {
 				if p.TypeAnn == nil && p.Pattern != nil {
 					c.report(&UndispatchableOverloadError{Param: p.Pattern, Decl: fd, Name: key.Name()})
-					break // one diagnostic per arm (blame the first gap)
+					// One diagnostic per arm, blaming the first parameter that is missing an
+					// annotation. Each arm is fixed on its own.
+					break
 				}
 			}
 		}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -79,12 +79,10 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 }
 
 // overloadArm is one collected arm of an overload set (PR6): a top-level FuncDecl's
-// raw inferred type plus whether its signature is fully annotated (the recursion
-// gate) and the decl itself (for per-arm Info recording in phase 3).
+// raw inferred type alongside the decl itself, which phase 3 records per-arm Info on.
 type overloadArm struct {
-	decl      *ast.FuncDecl
-	t         soltype.Type // the arm's RAW (variable-carrying) inferred FuncType
-	annotated bool
+	decl *ast.FuncDecl
+	t    soltype.Type // the arm's RAW (variable-carrying) inferred FuncType
 }
 
 // componentBinding tracks the in-flight state of one value binding while its
@@ -120,13 +118,13 @@ type componentBinding struct {
 	// FuncDecl's entry in sources.
 	arms []overloadArm
 	// signatureBound marks an overload set whose arms are ALL fully annotated, so phase
-	// 1 could build their signatures (body-free) and pre-bind the whole set in scope
-	// (b.arms holds the signature types). References WITHIN the component — recursive
-	// calls and value captures — then resolve against the set rather than a single
-	// first-arm var; phase 2 only checks each arm's body. An overload with any
-	// un-annotated arm cannot be signature-bound (its signature isn't known without
-	// inferring the body), so it stays on the ordinary group-var path and cannot be
-	// mutually recursive (the gate forbids it). See checkOverloadAnnotations / annotatedOverloadArms.
+	// 1 could build their signatures body-free and pre-bind the whole set in scope.
+	// b.arms then holds those signature types. A reference WITHIN the component — a
+	// recursive call or a value capture — resolves against the set rather than against a
+	// single first-arm var, and phase 2 only checks each arm's body. A set with any
+	// un-annotated arm has no signature to build without inferring the body, so it stays
+	// on the group-var path, where fuseOverloadArms records the whole set as one lower
+	// bound on that var. See annotatedOverloadArms.
 	signatureBound bool
 }
 
@@ -163,14 +161,11 @@ func (c *checker) inferComponent(
 ) {
 	inner := lvl + 1
 
-	// Recursion gate (PR6): an overloaded function in a mutually-recursive component
-	// (more than one binding) must have fully-annotated arms, since the overload set
-	// has to be ground before bodies are inferred — fixed-point iteration over
-	// overload choices is not guaranteed to converge under subtyping. The gate reports
-	// the offending participants and returns the set of keys to degrade to a single
-	// arm (so a later reference still resolves). Self-recursion (a singleton
-	// component) is softer and is not gated.
-	rejected := c.checkOverloadAnnotations(g, component)
+	// Every arm of an overload set that codegen emits a runtime dispatcher for must
+	// annotate its parameters, since the dispatcher tests those annotations. This is a
+	// codegen obligation, not a recursion one: inference itself needs no annotation,
+	// because an overload set enters the lattice as one intersection of arrows.
+	c.checkOverloadDispatch(g, component)
 
 	// Phase 1: a fresh var per value binding, all defined before any body so a
 	// mutually-recursive reference resolves through the var. M2 only infers value
@@ -184,29 +179,28 @@ func (c *checker) inferComponent(
 		// arm signatures alone (body-free), so references within the component resolve
 		// against every arm via resolveOverload instead of seeing only a single
 		// first-arm binding var (which would make a recursive arm — or a value capture —
-		// type-check against the wrong overload). The recursion gate guarantees a
-		// mutually-recursive overload IS fully annotated, so this is exactly the set it
-		// requires to be ground before bodies are inferred.
-		if !rejected.Contains(key) {
-			if armDecls := annotatedOverloadArms(g, key); armDecls != nil {
-				sortArmDecls(module, armDecls)
-				arms := make([]overloadArm, len(armDecls))
-				schemes := make([]TypeScheme, len(armDecls))
-				for i, fd := range armDecls {
-					// Build the signature body-free under a discarded probe: the arm is fully
-					// annotated, so the signature is concrete (no bounds to roll back), and
-					// discarding keeps phase 2's inferFunc — which re-derives the signature
-					// while checking the body — the single reporter of any signature error.
-					p := c.openProbe()
-					sig := c.inferFunc(scope, inner, fd.FuncSig, nil, fd, true)
-					c.closeProbe(p, false)
-					arms[i] = overloadArm{decl: fd, t: sig, annotated: true}
-					schemes[i] = monoScheme(sig)
-				}
-				bindings[key] = &componentBinding{arms: arms, bound: true, signatureBound: true}
-				scope.defineValue(key.Name(), ValueBinding{Schemes: schemes})
-				continue
+		// type-check against the wrong overload). Each recursive call then picks an arm
+		// and gets that arm's own return type, which is sharper than what the fused
+		// lower bound below derives. A set with any un-annotated arm cannot be built
+		// body-free, so it takes the fused path instead.
+		if armDecls := annotatedOverloadArms(g, key); armDecls != nil {
+			sortArmDecls(module, armDecls)
+			arms := make([]overloadArm, len(armDecls))
+			schemes := make([]TypeScheme, len(armDecls))
+			for i, fd := range armDecls {
+				// Build the signature body-free under a discarded probe: the arm is fully
+				// annotated, so the signature is concrete (no bounds to roll back), and
+				// discarding keeps phase 2's inferFunc — which re-derives the signature
+				// while checking the body — the single reporter of any signature error.
+				p := c.openProbe()
+				sig := c.inferFunc(scope, inner, fd.FuncSig, nil, fd, true)
+				c.closeProbe(p, false)
+				arms[i] = overloadArm{decl: fd, t: sig}
+				schemes[i] = monoScheme(sig)
 			}
+			bindings[key] = &componentBinding{arms: arms, bound: true, signatureBound: true}
+			scope.defineValue(key.Name(), ValueBinding{Schemes: schemes})
+			continue
 		}
 		v := c.freshAt(inner)
 		bindings[key] = &componentBinding{v: v}
@@ -363,6 +357,9 @@ func (c *checker) inferComponent(
 			}
 			continue
 		}
+		// An overload set reaches the binding var as ONE lower bound, the intersection of
+		// its arms, recorded after every arm is inferred. See fuseOverloadArms.
+		fused := len(funcOnlyDecls(g, key)) > 1
 		for _, d := range g.GetDecls(key) {
 			// M4 E3: a top-level destructuring `val [a, b] = …` / `val {x, y} = …`
 			// registers one decl under one leaf key per bound name. Bind it per key it
@@ -407,7 +404,11 @@ func (c *checker) inferComponent(
 			}
 			fd, isFunc := d.(*ast.FuncDecl)
 			if !b.bound {
-				c.constrain(d, t, b.v)
+				// An overload set's lower bound is the fusion of every arm, so the first arm
+				// is collected here and constrained after the loop rather than on its own.
+				if !fused {
+					c.constrain(d, t, b.v)
+				}
 				b.primary = d
 				b.bound = true
 				vd, isVarDecl := d.(*ast.VarDecl)
@@ -437,7 +438,7 @@ func (c *checker) inferComponent(
 				// more FuncDecls follow under this name it becomes an overload set; otherwise
 				// it stays a lone function.
 				if isFunc {
-					b.arms = append(b.arms, overloadArm{decl: fd, t: t, annotated: isFullyAnnotated(fd.FuncSig)})
+					b.arms = append(b.arms, overloadArm{decl: fd, t: t})
 				}
 				continue
 			}
@@ -448,7 +449,7 @@ func (c *checker) inferComponent(
 			// reports a duplicate — a second `val`/`var`, or a FuncDecl colliding with a
 			// variable binding, since a value cannot be overloaded.
 			if isFunc && !b.isVarDecl {
-				b.arms = append(b.arms, overloadArm{decl: fd, t: t, annotated: isFullyAnnotated(fd.FuncSig)})
+				b.arms = append(b.arms, overloadArm{decl: fd, t: t})
 				continue
 			}
 			c.report(&DuplicateDeclarationError{
@@ -456,6 +457,9 @@ func (c *checker) inferComponent(
 				Previous: b.primary,
 				Name:     key.Name(),
 			})
+		}
+		if fused {
+			c.fuseOverloadArms(b)
 		}
 	}
 
@@ -478,12 +482,9 @@ func (c *checker) inferComponent(
 			scope.removeValue(key.Name())
 			continue
 		}
-		// A PR6 overload set is a name with more than one FuncDecl arm. This branch binds
-		// such a set when the recursion gate did not reject it. A rejected set is a
-		// mutually-recursive unannotated overload. It is excluded here and degrades to its
-		// first arm below.
+		// A PR6 overload set is a name with more than one FuncDecl arm.
 		//
-		// Binding an accepted set takes four steps, each detailed at its block below:
+		// Binding a set takes four steps, each detailed at its block below:
 		//
 		//  1. sort the arms into source-position order;
 		//  2. reject any two arms with indistinguishable parameter types;
@@ -494,7 +495,7 @@ func (c *checker) inferComponent(
 		// the arm at arms[i], and Sources[i] all line up. b.sources also carries any
 		// rejected duplicate-declaration decls, which would desync the per-scheme index
 		// that a multi-target go-to-definition relies on.
-		if len(b.arms) > 1 && !rejected.Contains(key) {
+		if len(b.arms) > 1 {
 			// A signature-bound set was already sorted in phase 1, so this stable re-sort is
 			// a no-op for it. It also orders the ordinary group-var path's arms the same way.
 			sortArms(module, b.arms)
@@ -527,9 +528,6 @@ func (c *checker) inferComponent(
 			srcs := make([]provenance.Provenance, len(b.arms))
 			for i, arm := range b.arms {
 				sc := c.generalize(arm.t, lvl)
-				if ps, ok := sc.(*PolyScheme); ok {
-					ps.Annotated = arm.annotated
-				}
 				schemes[i] = sc
 				srcs[i] = &ast.NodeProvenance{Node: arm.decl}
 				if arm.decl.Name != nil {
@@ -542,8 +540,7 @@ func (c *checker) inferComponent(
 		// Generalize the binding var at the component's level (was: coalesce to a
 		// monotype). Every variable at Level > lvl becomes a quantified type
 		// parameter, captured outer variables do not — turning M2's monomorphic
-		// freeze into real let-polymorphism (PR1). A rejected overload degrades here to
-		// its first arm: b.v carries only the primary (first arm) definition.
+		// freeze into real let-polymorphism (PR1).
 		//
 		// PR8: a binding whose definition was wholly the ErrorType sentinel left its
 		// binding var with no bound (ErrorType absorbs in constrain), so generalizing it
@@ -714,42 +711,80 @@ func leafName(g *dep_graph.DepGraph, key dep_graph.BindingKey) string {
 	return name
 }
 
-// checkOverloadAnnotations enforces the PR6 recursion gate. It returns the set of
-// overloaded keys that failed the gate; phase 3 degrades each of them to its first arm.
-// A singleton component is never gated, since self-recursion is softer. Only a
-// genuinely mutually-recursive group of more than one binding requires its overloaded
-// members to have fully-annotated arms. For each overloaded member whose arms are not
-// all annotated, it reports an UnannotatedRecursiveOverloadError blaming the first
-// unannotated arm.
-func (c *checker) checkOverloadAnnotations(
-	g *dep_graph.DepGraph, component []dep_graph.BindingKey,
-) set.Set[dep_graph.BindingKey] {
-	rejected := set.NewSet[dep_graph.BindingKey]()
-	if len(component) <= 1 {
-		return rejected // self-recursion is softer; only mutual recursion is gated
+// fuseOverloadArms records an overload set's arms on its binding var as ONE lower
+// bound, the intersection of every arm's type.
+//
+// A reference from inside the component resolves through the var, so a recursive call
+// records `v <: (args) -> R` as an upper bound on it. The fused bound is what that
+// upper bound is checked against, and `(A -> B) & (C -> D) <: (args) -> R` is settled
+// by the arrow-decomposition rule in constrain_nf.go without any arm being picked.
+// That is what lets an overloaded function in a mutually-recursive group infer with no
+// annotations. Constraining only the first arm would instead check every recursive
+// call in the group against that one arm, which is why the set has to fuse.
+//
+// The fused bound serves resolution INSIDE the component. Phase 3 binds the name from
+// b.arms, generalizing each arm on its own, so the var's coalesced type is never the
+// overload's exported type.
+func (c *checker) fuseOverloadArms(b *componentBinding) {
+	if len(b.arms) == 0 {
+		return // every arm failed to produce a definition
 	}
+	if len(b.arms) == 1 {
+		// Only one arm survived inference, so there is nothing to fuse. Record it on its
+		// own, which is what the non-overloaded path would have done.
+		c.constrain(b.arms[0].decl, b.arms[0].t, b.v)
+		return
+	}
+	types := make([]soltype.Type, len(b.arms))
+	for i, arm := range b.arms {
+		types[i] = arm.t
+	}
+	c.constrain(b.primary, &soltype.IntersectionType{Types: types}, b.v)
+}
+
+// checkOverloadDispatch reports every arm of an overload set that codegen would emit a
+// runtime dispatcher for and that leaves a parameter un-annotated.
+//
+// buildOverloadedFunc in internal/codegen compiles an overload set to one JavaScript
+// function whose if-else chain tests each arm's WRITTEN parameter annotations —
+// `typeof` for a primitive, `===` for a literal, `"k" in o` for an object shape,
+// `instanceof` for a class. An un-annotated parameter leaves nothing to test, so the
+// arm's guard degrades to `true` and swallows every call that reaches it. Requiring the
+// annotation is what keeps dispatch deterministic.
+//
+// The obligation is per arm and covers only arms with a body, since those are the arms
+// the dispatcher routes to. A bodyless `declare fn` arm contributes no branch, so a
+// `.d.ts`-shaped overload set keeps the freedom to leave a parameter un-annotated.
+//
+// Inference itself needs none of this. An overload set enters the lattice as one
+// intersection of arrows (see fuseOverloadArms), so a set that fails here still infers
+// and still binds.
+func (c *checker) checkOverloadDispatch(g *dep_graph.DepGraph, component []dep_graph.BindingKey) {
 	for _, key := range component {
 		funcs := funcOnlyDecls(g, key)
 		if len(funcs) <= 1 {
-			continue // not an overload set (a mixed val/var name is a duplicate, not gated here)
+			continue // not an overload set (a mixed val/var name is a duplicate, not reported here)
 		}
 		for _, fd := range funcs {
-			if !isFullyAnnotated(fd.FuncSig) {
-				c.report(&UnannotatedRecursiveOverloadError{Decl: fd, Name: key.Name()})
-				rejected.Add(key)
-				break // one diagnostic per overloaded binding (blame the first gap)
+			if fd.Body == nil {
+				continue // declare-only: no dispatcher branch to guard
+			}
+			for _, p := range fd.FuncSig.Params {
+				if p.TypeAnn == nil && p.Pattern != nil {
+					c.report(&UndispatchableOverloadError{Param: p.Pattern, Decl: fd, Name: key.Name()})
+					break // one diagnostic per arm (blame the first gap)
+				}
 			}
 		}
 	}
-	return rejected
 }
 
 // funcOnlyDecls returns the FuncDecls bound to key when the name is bound ONLY by
 // FuncDecls, or nil when any `val`/`var` shares the name. A func-only result is a
 // candidate overload set. Its slice may have length 1, so it is not necessarily an
 // overload yet. A mixed result is nil because the clash is a duplicate declaration, not
-// an overload. Shared by the recursion gate and annotatedOverloadArms so both classify
-// a name the same way.
+// an overload. Shared by checkOverloadDispatch, phase 2's fusion test, and
+// annotatedOverloadArms so all three classify a name the same way.
 func funcOnlyDecls(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
 	if key.Kind() != dep_graph.DepKindValue {
 		return nil

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -14,10 +14,23 @@ import (
 // A set whose arms span several files in a lib/ therefore reads top-to-bottom, file by
 // file alphabetically, independent of the order sources reached the parser.
 //
-// Resolution is a phase distinct from constrain. The disjunction "callable in several
-// ways" stays out of the subtype lattice. It is driven by the PR5 probe. Each candidate
-// is trialled under a probe and the losers are rolled back, so a failed trial leaves no
-// bounds on the argument variables and no stray Info or Prov entries.
+// Resolution at a DIRECT call is a phase distinct from constrain. It is driven by the
+// PR5 probe. Each candidate is trialled under a probe and the losers are rolled back,
+// so a failed trial leaves no bounds on the argument variables and no stray Info or
+// Prov entries. Picking an arm is what gives the call that arm's own return type,
+// which is sharper than what the lattice derives.
+//
+// The lattice reads the same set without picking anything. An overload set is the
+// intersection of its arms, and the arrow-decomposition rule in constrain_nf.go settles
+// `(A -> B) & (C -> D) <: (args) -> R` by weighing the arms together. That is the form
+// a reference inside a mutually-recursive group takes, where no arm can be picked
+// because the arms are still being inferred. fuseOverloadArms in module.go records the
+// set in that form.
+//
+// Which arm a direct call resolves to must match which arm the generated dispatcher
+// routes to at runtime, since a call typed with one arm's return type has to reach that
+// arm. codegen.DispatchOrder lays the dispatcher's chain out to match specificityOrder
+// below, and overload_dispatch_test.go measures the two against each other.
 //
 // Specificity ordering is the one documented rule, reused by M4 object-arg and M5 method
 // overloads. When every argument carries type information, meaning none is an
@@ -452,10 +465,9 @@ func overloadDisplayType(b ValueBinding) soltype.Type {
 }
 
 // isFullyAnnotated reports whether a function signature is ground from its annotations
-// alone, with every parameter typed and a return type present. The recursion gate
-// checkOverloadAnnotations requires this of every arm of an overloaded function in a
-// mutually-recursive group, since an un-annotated arm's signature is not known before
-// its body is inferred.
+// alone, with every parameter typed and a return type present. annotatedOverloadArms
+// requires this of every arm of an overload set it pre-binds from signatures, since an
+// un-annotated arm's signature is not known before its body is inferred.
 func isFullyAnnotated(sig ast.FuncSig) bool {
 	if sig.Return == nil {
 		return false

--- a/internal/solver/overload_dispatch_test.go
+++ b/internal/solver/overload_dispatch_test.go
@@ -1,0 +1,243 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/codegen"
+	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// Static resolution and the generated dispatcher must agree on which arm answers a
+// call. The checker picks an arm in resolveOverload, driven by specificityOrder over
+// the inferred arm types. The generated code picks one by running the if-else chain
+// codegen.DispatchOrder lays out, driven by the arms' written parameter annotations.
+// Two rankings derived from two representations can drift, and when they drift a call
+// reaches an arm whose return type is not the one the checker gave it — which is a
+// soundness problem, not a cosmetic one.
+//
+// The rows below are the corpus that measures the two against each other. Each row is
+// an overload set whose arms are told apart by their return type, so naming the arm by
+// its return type names it in both rankings at once. Both orders are computed for the
+// whole set and compared position by position.
+//
+// One key is deliberately not compared. DispatchOrder puts arms with more parameters
+// first, because a guard tests only the parameters its own arm declares, so a
+// one-parameter arm placed first would answer a two-argument call. The checker has no
+// counterpart: tryOverloadArm rejects an arm of the wrong arity before it is ranked at
+// all. So each row's arms share an arity, and TestOverloadDispatchArityIsCheckerOnly
+// covers the mixed-arity case on its own.
+
+func TestOverloadDispatchAgreesWithResolution(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		// want names the arms in the order both rankings must produce, one entry per
+		// arm, written as the arm's return annotation.
+		want []string
+	}{
+		{
+			// The disagreement this corpus exists to catch. A literal admits one value out
+			// of its primitive's set, so the checker ranks `(x: 5)` ahead of `(x: number)`
+			// however they are declared. A dispatcher that kept declaration order would
+			// route f(5) to the number arm and hand back `string` where the checker said
+			// `boolean`.
+			name: "a literal arm outranks its primitive",
+			src: `
+				fn f(x: number) -> string { return "n" }
+				fn f(x: 5) -> boolean { return true }
+			`,
+			want: []string{"boolean", "string"},
+		},
+		{
+			name: "a literal arm declared first keeps its place",
+			src: `
+				fn f(x: 5) -> boolean { return true }
+				fn f(x: number) -> string { return "n" }
+			`,
+			want: []string{"boolean", "string"},
+		},
+		{
+			// Two primitives of different families accept disjoint arguments, so neither
+			// outranks the other and both rankings fall back to declaration order.
+			name: "disjoint primitives keep declaration order",
+			src: `
+				fn f(x: number) -> string { return "n" }
+				fn f(x: string) -> boolean { return true }
+			`,
+			want: []string{"string", "boolean"},
+		},
+		{
+			// An object with more required properties accepts fewer arguments, so it is
+			// tested first. Every `{x, y}` is also an `{x}`, and testing `{x}` first would
+			// swallow both.
+			name: "more required properties outranks fewer",
+			src: `
+				fn f(p: {x: number}) -> string { return "n" }
+				fn f(p: {x: number, y: number}) -> boolean { return true }
+			`,
+			want: []string{"boolean", "string"},
+		},
+		{
+			// An optional property widens an arm rather than narrowing it: `{x, y?}`
+			// accepts everything `{x}` accepts. Counting it would rank the wider arm first.
+			name: "an optional property does not narrow an arm",
+			src: `
+				fn f(p: {x: number}) -> string { return "n" }
+				fn f(p: {x: number, y?: number}) -> boolean { return true }
+			`,
+			want: []string{"string", "boolean"},
+		},
+		{
+			// An exact object accepts no extra properties, so it is narrower than the
+			// inexact one over the same fields. The two emit the SAME guard, which is
+			// exactly why the ranking has to settle which of them answers the call.
+			name: "an exact object outranks an inexact one over the same fields",
+			src: `
+				fn f(p: {x: number, ...}) -> string { return "n" }
+				fn f(p: {x: number}) -> boolean { return true }
+			`,
+			want: []string{"boolean", "string"},
+		},
+		{
+			// A type parameter is untestable at runtime, so its guard is a bare `true` and
+			// the arm accepts every argument that reaches it. Both rankings treat it as the
+			// catch-all and put it last.
+			name: "an untestable arm sorts last",
+			src: `
+				fn f<T>(x: T) -> T { return x }
+				fn f(x: string) -> boolean { return true }
+			`,
+			want: []string{"boolean", "T"},
+		},
+		{
+			// Three arms whose ranking is only a partial order: the two concretes are
+			// incomparable with each other and both beat the catch-all. Ranking by how many
+			// arms dominate each one puts the concretes first, tied in declaration order,
+			// and the catch-all last. Both sides rank this way.
+			name: "two concretes and a catch-all",
+			src: `
+				fn f<T>(x: T) -> T { return x }
+				fn f(x: number) -> string { return "n" }
+				fn f(x: string) -> boolean { return true }
+			`,
+			want: []string{"string", "boolean", "T"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			arms, armType := overloadArmsOf(t, tt.src, "f")
+			require.Len(t, arms, len(tt.want))
+
+			resolution := make([]string, len(arms))
+			for i, idx := range specificityOrderOfArms(armType) {
+				resolution[i] = returnAnnOf(t, arms[idx])
+			}
+			require.Equal(t, tt.want, resolution, "the order resolveOverload trials arms in")
+
+			dispatch := make([]string, len(arms))
+			for i, decl := range codegen.DispatchOrder(arms) {
+				dispatch[i] = returnAnnOf(t, decl)
+			}
+			require.Equal(t, tt.want, dispatch, "the order the generated dispatcher tests arms in")
+		})
+	}
+}
+
+// Parameter count is the one ranking key the dispatcher has and the checker does not.
+// The checker gates arity in tryOverloadArm, so a call only ever reaches arms of its
+// own arity and their relative order is all that matters. The dispatcher has no arity
+// gate, so it must test the arm with the most parameters first. Here that puts the two
+// orders in opposite sequences without either being wrong.
+func TestOverloadDispatchArityIsCheckerOnly(t *testing.T) {
+	src := `
+		fn f(x: string) -> string { return x }
+		fn f(x: string, y: string) -> boolean { return true }
+	`
+	arms, armType := overloadArmsOf(t, src, "f")
+
+	resolution := make([]string, len(arms))
+	for i, idx := range specificityOrderOfArms(armType) {
+		resolution[i] = returnAnnOf(t, arms[idx])
+	}
+	require.Equal(t, []string{"string", "boolean"}, resolution,
+		"arity is not a specificity signal, so the arms stay in declaration order")
+
+	dispatch := make([]string, len(arms))
+	for i, decl := range codegen.DispatchOrder(arms) {
+		dispatch[i] = returnAnnOf(t, decl)
+	}
+	require.Equal(t, []string{"boolean", "string"}, dispatch,
+		"the two-parameter arm is tested first so it is not swallowed by the one-parameter arm")
+
+	// The arity gate is what makes the two orders equivalent for any actual call: each
+	// call reaches exactly one of these arms.
+	values, _, errs := inferSource(t, src+"\nval a = f(\"hi\")\nval b = f(\"hi\", \"there\")")
+	require.Empty(t, errs)
+	require.Equal(t, "string", values["a"])
+	require.Equal(t, "boolean", values["b"])
+}
+
+// overloadArmsOf infers src and returns the declarations of the overload set bound to
+// name, in declaration order, alongside the inferred type of each arm. The two line up
+// by index: arms[i] is the declaration the checker inferred armType[i] from.
+func overloadArmsOf(t *testing.T, src, name string) ([]*ast.FuncDecl, []TypeScheme) {
+	t.Helper()
+	module := parseModule(t, src)
+	c := newChecker()
+	scope := sharedPrelude().Child()
+	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))
+	require.Empty(t, c.errs)
+
+	b, ok := scope.GetValue(name)
+	require.True(t, ok, "no binding named %s", name)
+	require.True(t, b.IsOverloaded(), "%s is not an overload set", name)
+	require.Len(t, b.Sources, len(b.Schemes), "one source per arm")
+
+	decls := make([]*ast.FuncDecl, len(b.Sources))
+	for i, src := range b.Sources {
+		nodeProv, ok := src.(*ast.NodeProvenance)
+		require.True(t, ok, "arm %d has no declaration node", i)
+		fd, ok := nodeProv.Node.(*ast.FuncDecl)
+		require.True(t, ok, "arm %d is not a function declaration", i)
+		decls[i] = fd
+	}
+	return decls, b.Schemes
+}
+
+// specificityOrderOfArms returns the arm indices in the order resolveOverload trials
+// them for a call whose arguments all carry type information, which is what
+// overloadOrder computes for such a call.
+func specificityOrderOfArms(schemes []TypeScheme) []int {
+	cands := make([]soltype.Type, len(schemes))
+	for i, s := range schemes {
+		// Leave a non-function arm's slot a nil interface, the way overloadOrder does, so
+		// specificityOrder ranks it last instead of dereferencing a typed nil.
+		if ft := schemeFunc(s); ft != nil {
+			cands[i] = ft
+		}
+	}
+	return specificityOrder(cands)
+}
+
+// returnAnnOf renders an arm's written return annotation, which is what each row names
+// the arm by. Every arm in this corpus annotates its return.
+func returnAnnOf(t *testing.T, decl *ast.FuncDecl) string {
+	t.Helper()
+	require.NotNil(t, decl.Return, "every arm in this corpus annotates its return")
+	switch ret := decl.Return.(type) {
+	case *ast.StringTypeAnn:
+		return "string"
+	case *ast.NumberTypeAnn:
+		return "number"
+	case *ast.BooleanTypeAnn:
+		return "boolean"
+	case *ast.TypeRefTypeAnn:
+		return ast.QualIdentToString(ret.Name)
+	}
+	t.Fatalf("unhandled return annotation %T", decl.Return)
+	return ""
+}

--- a/internal/solver/overload_dispatch_test.go
+++ b/internal/solver/overload_dispatch_test.go
@@ -1,11 +1,14 @@
 package solver
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/codegen"
 	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/parser"
 	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
@@ -113,6 +116,30 @@ func TestOverloadDispatchAgreesWithResolution(t *testing.T) {
 			want: []string{"boolean", "T"},
 		},
 		{
+			// A union is untestable at runtime, so this arm's guard is a bare `true` — but
+			// it is NOT the catch-all a type parameter is. The checker cannot rank a union
+			// against a primitive either, so both sides leave the pair tied and the union
+			// arm keeps its declared place. Sorting it last on the strength of its `true`
+			// guard would send f(5) to the number arm the checker did not resolve it to.
+			name: "an untestable union arm is not a catch-all",
+			src: `
+				fn f(x: number | string) -> string { return "u" }
+				fn f(x: number) -> boolean { return true }
+			`,
+			want: []string{"string", "boolean"},
+		},
+		{
+			// Required-property counting has to look past a property type neither side can
+			// test. Both arms type `x` as the same union, so the `y` property is what
+			// separates them and the two-property arm is tested first.
+			name: "required properties rank past an untestable property type",
+			src: `
+				fn f(p: {x: number | string}) -> string { return "x" }
+				fn f(p: {x: number | string, y: number}) -> boolean { return true }
+			`,
+			want: []string{"boolean", "string"},
+		},
+		{
 			// Three arms whose ranking is only a partial order: the two concretes are
 			// incomparable with each other and both beat the catch-all. Ranking by how many
 			// arms dominate each one puts the concretes first, tied in declaration order,
@@ -181,12 +208,51 @@ func TestOverloadDispatchArityIsCheckerOnly(t *testing.T) {
 	require.Equal(t, "boolean", values["b"])
 }
 
-// overloadArmsOf infers src and returns the declarations of the overload set bound to
-// name, in declaration order, alongside the inferred type of each arm. The two line up
-// by index: arms[i] is the declaration the checker inferred armType[i] from.
+// Two arms the specificity ranking cannot separate fall back to declaration order, and
+// both sides have to mean the same thing by that. The checker sorts its arms into
+// source-position order before binding the set, so it never sees the order the parser
+// happened to produce; DispatchOrder sorts too, for the same reason. Here the two arms
+// live in separate files handed to the parser in reverse-alphabetical order, so an
+// unsorted dispatcher would test them back to front.
+func TestOverloadDispatchTiebreakIsSourcePosition(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	module, parseErrs := parser.ParseLibFiles(ctx, []*ast.Source{
+		{ID: 0, Path: "a.esc", Contents: `fn f(x: number) -> string { return "n" }`},
+		{ID: 1, Path: "b.esc", Contents: `fn f(x: string) -> boolean { return true }`},
+	})
+	require.Empty(t, parseErrs, "expected no parse errors")
+
+	arms, schemes := overloadArmsOfModule(t, module, "f")
+	resolution := make([]string, len(arms))
+	for i, idx := range specificityOrderOfArms(schemes) {
+		resolution[i] = returnAnnOf(t, arms[idx])
+	}
+	require.Equal(t, []string{"string", "boolean"}, resolution,
+		"the checker reads the arms in source-position order, a.esc before b.esc")
+
+	// Hand DispatchOrder the arms back to front, the way an unsorted dep-graph walk
+	// could. Sorting is what recovers the same order the checker read them in.
+	reversed := []*ast.FuncDecl{arms[1], arms[0]}
+	dispatch := make([]string, len(reversed))
+	for i, decl := range codegen.DispatchOrder(reversed) {
+		dispatch[i] = returnAnnOf(t, decl)
+	}
+	require.Equal(t, []string{"string", "boolean"}, dispatch,
+		"the dispatcher recovers source-position order rather than keeping the order it was handed")
+}
+
+// overloadArmsOf parses and infers src, then returns the overload set bound to name.
 func overloadArmsOf(t *testing.T, src, name string) ([]*ast.FuncDecl, []TypeScheme) {
 	t.Helper()
-	module := parseModule(t, src)
+	return overloadArmsOfModule(t, parseModule(t, src), name)
+}
+
+// overloadArmsOfModule infers module and returns the declarations of the overload set
+// bound to name, in declaration order, alongside the inferred scheme of each arm. The
+// two line up by index: arms[i] is the declaration the checker inferred schemes[i] from.
+func overloadArmsOfModule(t *testing.T, module *ast.Module, name string) ([]*ast.FuncDecl, []TypeScheme) {
+	t.Helper()
 	c := newChecker()
 	scope := sharedPrelude().Child()
 	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))

--- a/internal/solver/overload_dispatch_test.go
+++ b/internal/solver/overload_dispatch_test.go
@@ -17,8 +17,8 @@ import (
 // call. The checker picks an arm in resolveOverload, driven by specificityOrder over
 // the inferred arm types. The generated code picks one by running the if-else chain
 // codegen.DispatchOrder lays out, driven by the arms' written parameter annotations.
-// Two rankings derived from two representations can drift, and when they drift a call
-// reaches an arm whose return type is not the one the checker gave it — which is a
+// The two rankings read different things, so they can drift apart. When they do, a call
+// reaches an arm whose return type is not the one the checker gave it. That is a
 // soundness problem, not a cosmetic one.
 //
 // The rows below are the corpus that measures the two against each other. Each row is
@@ -138,6 +138,18 @@ func TestOverloadDispatchAgreesWithResolution(t *testing.T) {
 				fn f(p: {x: number | string, y: number}) -> boolean { return true }
 			`,
 			want: []string{"boolean", "string"},
+		},
+		{
+			// A declare-only arm gets no branch in the generated chain, but it still takes
+			// part in the ranking on both sides. `{y, w, ...}` outranks `{y, ...}`, which is
+			// what leaves the later `{x, ...}` arm ahead of it.
+			name: "a declare-only arm takes part in the ranking",
+			src: `
+				fn f(p: {y: number, ...}) -> boolean { return true }
+				declare fn f(p: {y: number, w: number, ...}) -> number
+				fn f(p: {x: number, ...}) -> string { return "x" }
+			`,
+			want: []string{"number", "string", "boolean"},
 		},
 		{
 			// Three arms whose ranking is only a partial order: the two concretes are

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -11,23 +11,16 @@ import (
 // soltype.Type binding. A MonoScheme is a value that does not generalize (a
 // parameter, a current-level initializer during inference, a body-level `val`, a prelude
 // operator); a PolyScheme carries a generalize-level so each use can be
-// instantiated with fresh variables (let-polymorphism). The IsAnnotated bit is
-// forward-looking metadata for PR6's overload-recursion gate — PR1 sets it false
-// and never reads it.
+// instantiated with fresh variables (let-polymorphism).
 type TypeScheme interface {
 	isScheme()
-	// IsAnnotated reports whether this scheme came from a user-written signature.
-	// PR1 always returns false; PR6 sets it per overload arm and folds it over a
-	// binding's arms for the mutual-recursion-needs-annotation rule.
-	IsAnnotated() bool
 }
 
 // MonoScheme is a non-generalized type. instantiate returns its Ty unchanged, so
 // every use shares the same variables — the monomorphic discipline M2 had for
 // every binding, now scoped to the bindings that genuinely must not generalize.
 type MonoScheme struct {
-	Ty        soltype.Type
-	Annotated bool // PR6 only — consulted solely for overload arms
+	Ty soltype.Type
 }
 
 // PolyScheme is a generalized type. Body is the RAW (variable-carrying) type so
@@ -36,9 +29,8 @@ type MonoScheme struct {
 // captured from an enclosing scope (shared across uses). Level is the level the
 // binding was generalized at (the SCC component's level).
 type PolyScheme struct {
-	Level     int
-	Body      soltype.Type
-	Annotated bool // PR6 only — set per overload arm; folds for the recursion gate
+	Level int
+	Body  soltype.Type
 
 	// coalesced memoizes the display type. A Body is immutable after
 	// generalization. Later components instantiate fresh copies rather than
@@ -63,9 +55,6 @@ func (sc *PolyScheme) display() soltype.Type {
 	}
 	return sc.coalesced
 }
-
-func (s *MonoScheme) IsAnnotated() bool { return s.Annotated }
-func (s *PolyScheme) IsAnnotated() bool { return s.Annotated }
 
 // monoScheme wraps a raw type as a single-scheme value binding's scheme — the
 // common case for the param/prelude/body-level/raw-def bindings PR1 does not

--- a/planning/ml_struct/06-open-items.md
+++ b/planning/ml_struct/06-open-items.md
@@ -51,7 +51,12 @@ must be scoped, and static resolution must pick the same arm the dispatcher rout
 to (example A is where the two can disagree).
 
 **Residual decision:** the annotation-obligation scope plus the static-vs-runtime
-agreement test. Owned by **PR11 (#1068)**.
+agreement test. Owned by **PR11 (#1068)**, and settled there. The obligation covers
+*parameter* annotations on arms with a body, the arms `buildOverloadedFunc` emits a
+branch for; declare-only arms are exempt and inference carries no obligation at all.
+Agreement is held by construction rather than only measured — `codegen.DispatchOrder`
+lays the dispatcher's chain out to match `specificityOrder` — and
+`internal/solver/overload_dispatch_test.go` is the corpus that measures the two.
 
 ## Finding 4 — `¬Ref` premises hold; the invariant is a construction-site guard (verified)
 


### PR DESCRIPTION
Fixes #1068.

Makes overload types lattice-first (MLstruct adoption trigger 3) and reconciles static resolution with the runtime dispatcher. The through-line from the plan holds: the trigger-3 win is an inference-and-display win, and it does not reach codegen.

## Summary

Under the previous design an overloaded call had to **pick a single arm** to know what to constrain. In a mutually recursive group that choice depends on the inferred types of the other members, which depend on the choices made at *their* recursive calls — a cycle that need not converge under subtyping. The old gate broke it by requiring fully-annotated arms.

PR5's arrow decomposition removes the choice. An overload set now reaches its binding variable as **one lower bound**, the intersection of every arm, so a recursive call inside the group records `v <: (args) -> R` and `(A → B) & (C → D) <: (args) -> R` is settled by weighing the arms together. No arm is picked, so nothing has to be annotated to make the choice possible.

The annotation obligation does not disappear — it moves to where it is actually consumed. `buildTypeGuard` emits `typeof` / `===` / `"k" in o` / `instanceof` guards from each arm's **written parameter annotations**, so an arm with a body must annotate its parameters or its guard degrades to `true` and swallows every call reaching it. An arm may still leave its *return* un-annotated, and a declare-only arm is exempt entirely, which is what keeps `.d.ts`-shaped sets free.

Finally, the two ways an arm gets chosen have to agree: a call the checker types with one arm's return type must reach that arm at runtime. The dispatcher's chain is now laid out to match the checker's `specificityOrder`.

## Key changes

- **`internal/solver/module.go`** — `fuseOverloadArms` records an overload set on its binding variable as the intersection of its arms, after every arm is inferred. `checkOverloadAnnotations` and its `rejected` set are gone; `checkOverloadDispatch` replaces them, reporting every arm that has a body and leaves a parameter un-annotated. Arms are sorted into source-position order before fusing, so an in-component recursive call resolves against the same order the exported binding uses.

- **`internal/solver/errors.go`** — `UnannotatedRecursiveOverloadError` is replaced by `UndispatchableOverloadError`, which blames the un-annotated parameter and relates its arm.

- **`internal/codegen/overload_order.go`** (new) — `DispatchOrder` ranks arms by domination count, mirroring `specificityOrder`. Keys are parameter count descending, then specificity, then source position. Annotation equality is a comparison of the rendered source, so it covers every annotation form rather than only the ones a guard can test.

- **`internal/codegen/builder.go`** — `buildOverloadedFunc` calls `DispatchOrder` over the **whole** set and drops declare-only arms from the result. Ranking only the arms that get a branch would lower the count of every arm a removed arm outranked, reordering arms the checker kept apart. `buildTypeGuard`'s type-reference handling is factored into `nominalGuardName` / `isArrayTypeRef`.

- **`internal/solver/poly.go`** — removes `TypeScheme.IsAnnotated` and the `Annotated` fields, whose only stated purpose was the recursion gate.

## Tests

- **`internal/solver/overload_dispatch_test.go`** (new) — the conformance corpus measuring `specificityOrder` against `DispatchOrder`. Rows cover literal-under-primitive, disjoint primitives, required-property counting, optional properties, exactness, type-parameter catch-alls, untestable unions, and declare-only arms. Separate tests cover the arity key, which is the dispatcher's alone, and the source-position tiebreak.
- **`internal/codegen/overload_order_test.go`** (new) — pins the emitted if-else chain for each ordering rule.
- **`internal/solver/infer_overload_test.go`** — `TestInferOverloadMutualRecursionRequiresAnnotation` becomes `TestInferOverloadMutualRecursionInfersUnannotatedReturns`, joined by tests for per-arm resolution through a recursive group, the dispatch obligation, and the declare-only exemption.

`go build ./...` and `go test ./...` pass. No fixture output changed.

## Known divergences, documented rather than fixed

The two rankings read different things — written annotations on one side, inferred types on the other — so three narrow gaps remain, each documented in `overload_order.go`:

- **Type references.** `annSubsumes` never resolves a reference, so an alias standing for a literal or an object can separate a pair this ties. Two class references are safe, since the checker ties those too.
- **Optional and rest parameters.** The dispatcher has no arity test, so `(x: string, y?: number|string)` can answer a one-argument call the checker gave to `(x: string)`. Pre-existing; closing it needs the dispatcher to test its argument count.
- **Unconstrained call arguments.** `overloadOrder` falls back to declaration order when it cannot rank, so a call through `fn g(y) { return f(y) }` can reach a different arm. That is the MVP limitation #723 tracks, and deferred resolution retires this with it.

One interim note: codegen is still fed by the old `internal/checker`, which resolves overloads by plain first-match. Aligning the dispatcher with `internal/solver` is what this issue asks for and what PR12's flip assumes, but until that flip a program can exist where codegen's order differs from the old checker's pick. No fixture hits it.

Discharges open item 3 in `planning/ml_struct/06-open-items.md`.

https://claude.ai/code/session_01TD84AZescKw86vPYRQMgde

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved overloaded function dispatch so the most specific matching implementation is selected consistently.
  - Added support for more reliable recursive overload inference, including overloads with inferred signatures.
  - Improved handling of array and nominal type checks at runtime.

- **Bug Fixes**
  - Fixed mismatches between compile-time overload resolution and runtime dispatch.
  - Improved diagnostics for overload implementations with missing parameter annotations.
  - Declaration-only overloads are no longer incorrectly treated as requiring implementation annotations.

- **Documentation**
  - Clarified overload resolution, dispatch ordering, and annotation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->