### PR TITLE
Bound open union tails to track what unnamed members may be

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -998,12 +998,20 @@ func (p *namedPrinter) printType(t Type) string {
 		// An inexact union renders a trailing `...` entry, so a union typed
 		// `A | B | ...` round-trips to surface syntax. The inexact tuple,
 		// object, and function arms render their flag the same way.
+		//
+		// A bounded tail renders its bound after the marker, so `"a" | ...string`
+		// says the unnamed members are strings. The bound prints at precPrefix, so a
+		// looser bound such as an intersection is parenthesized under the `...`.
 		parts := make([]string, 0, len(t.Types)+1)
 		for _, m := range t.Types {
 			parts = append(parts, p.printTypeMinPrec(m, precUnion))
 		}
 		if t.Inexact {
-			parts = append(parts, "...")
+			marker := "..."
+			if t.TailBound != nil {
+				marker += p.printTypeMinPrec(t.TailBound, precPrefix)
+			}
+			parts = append(parts, marker)
 		}
 		return strings.Join(parts, " | ")
 	case *IntersectionType:

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -594,6 +594,9 @@ func freeTypeVars(t Type) []*TypeVarType {
 			for _, m := range t.Types {
 				walk(m)
 			}
+			if t.TailBound != nil {
+				walk(t.TailBound)
+			}
 		case *IntersectionType:
 			for _, m := range t.Types {
 				walk(m)

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1005,6 +1005,12 @@ func (p *namedPrinter) printType(t Type) string {
 		// A bounded tail renders its bound after the marker, so `"a" | ...string`
 		// says the unnamed members are strings. The bound prints at precPrefix, so a
 		// looser bound such as an intersection is parenthesized under the `...`.
+		//
+		// The bounded form does not round-trip. No surface syntax writes a bound, so
+		// only the type operators mint one and the parser rejects what this renders.
+		// The rendering exists for diagnostics and for reading inferred types, where
+		// the bound is the reason a constraint held or failed. escalier-lang/escalier#1126
+		// tracks the syntax.
 		parts := make([]string, 0, len(t.Types)+1)
 		for _, m := range t.Types {
 			parts = append(parts, p.printTypeMinPrec(m, precUnion))

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -171,6 +171,29 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"union triple", &UnionType{Types: []Type{numP(), strP(), boolP()}}, "number | string | boolean"},
 		// An inexact union renders a trailing `...` entry.
 		{"inexact union", &UnionType{Types: []Type{numP(), strP()}, Inexact: true}, "number | string | ..."},
+		// A bounded tail renders its bound after the marker. The bound prints at precPrefix,
+		// so an atom stays bare and an intersection is parenthesized under the `...`.
+		{
+			"bounded tail",
+			&UnionType{Types: []Type{numP()}, Inexact: true, TailBound: strP()},
+			"number | ...string",
+		},
+		{
+			"bounded tail over a compound bound",
+			&UnionType{
+				Types:     []Type{numP()},
+				Inexact:   true,
+				TailBound: &IntersectionType{Types: []Type{strP(), &NegationType{Inner: strP()}}},
+			},
+			"number | ...(string & ¬string)",
+		},
+		// A bounded tail with no named member is the whole union, which is what a set
+		// difference that excludes every named member leaves.
+		{
+			"bounded tail with no named member",
+			&UnionType{Inexact: true, TailBound: strP()},
+			"...string",
+		},
 		// NullType renders as `null`. It is a distinct atomic kind from UndefinedType.
 		{"null atom", &NullType{}, "null"},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -194,6 +194,13 @@ func TestPrintRoundTrips(t *testing.T) {
 			&UnionType{Inexact: true, TailBound: strP()},
 			"...string",
 		},
+		// LevelOf reads the bound too, so a variable reachable only through it lifts the
+		// union's level and the freshener descends to it.
+		{
+			"a variable in the bound lifts the level",
+			&UnionType{Types: []Type{numP()}, Inexact: true, TailBound: &TypeVarType{ID: 1, Level: 2}},
+			"number | ...t1",
+		},
 		// NullType renders as `null`. It is a distinct atomic kind from UndefinedType.
 		{"null atom", &NullType{}, "null"},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
@@ -386,6 +393,18 @@ func TestPrintConstructorElem(t *testing.T) {
 	// Accept with an identity visitor preserves the node, so a constructor member
 	// survives every rewriting pass built on Accept.
 	require.Same(t, obj, obj.Accept(identityVisitor{}, Positive))
+}
+
+// freeTypeVars and LevelOf descend a union's tail bound, so a variable reachable only through
+// it is named as a quantified parameter and lifts the union's level. Both are hand-rolled walks
+// rather than rides on Accept, so each needs the bound added by name.
+func TestFreeTypeVarsUnionTailBound(t *testing.T) {
+	a := &TypeVarType{ID: 1, Level: 3}
+	u := &UnionType{Types: []Type{numP()}, Inexact: true, TailBound: a}
+	require.Equal(t, "<T0> (number | ...T0)", PrintAsScheme(u))
+	require.Equal(t, 3, LevelOf(u))
+	// A nil bound is the childless case, which reads as level 0 rather than panicking.
+	require.Equal(t, 0, LevelOf(&UnionType{Types: []Type{numP()}, Inexact: true}))
 }
 
 // freeTypeVars descends a constructor's signature, so a variable reachable only through

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -899,9 +899,9 @@ type UnionType struct {
 	//
 	// A bound keeps the named members enumerable while still saying what the rest
 	// can be. `keyof {a: X, ...}` is `"a" | ...string`, so a mapped type still has
-	// "a" to iterate and `¬keyof {a: X, ...}` still rejects `5`. Flattening the
-	// bound into the member list instead would give `"a" | string`, which subsumes
-	// to `string` and loses both.
+	// "a" to iterate and the key set still rejects `5`. Flattening the bound into
+	// the member list instead would give `"a" | string`, which subsumes to `string`
+	// and loses both.
 	TailBound Type
 }
 type IntersectionType struct{ Types []Type }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -1482,7 +1482,9 @@ func LevelOf(t Type) int {
 	// union annotation). Coalesced-output unions/intersections hold no live vars, so
 	// both arms still return 0 for them.
 	case *UnionType:
-		return maxMemberLevel(t.Types)
+		// The tail's bound is a member the union does not list, so it counts toward the
+		// level the same way a written member does.
+		return max(maxMemberLevel(t.Types), LevelOf(t.TailBound))
 	case *IntersectionType:
 		return maxMemberLevel(t.Types)
 	case *NegationType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -884,8 +884,7 @@ type UnknownType struct{}
 // members the type does not name. The flag is Inexact rather than Exact so the
 // zero value is exact, matching the ObjectType, TupleType, and FuncType
 // convention. IntersectionType carries no exactness flag, since exactness is a
-// property of the result rather than the meet. The flag and the smart
-// constructors land with M6 PR1.
+// property of the result rather than the meet.
 //
 // TailBound says what the tail's unnamed members may be. See the field comment.
 type UnionType struct {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -880,15 +880,30 @@ type UnknownType struct{}
 //
 // UnionType.Inexact flags whether the union is open. A bare `A | B` is
 // exact, so its inhabitants are exactly A ∪ B. An `A | B | ...` written with
-// a trailing `...` is inexact: at least these, with an unknown-typed tail.
-// The flag is Inexact rather than Exact so the zero value is exact, matching
-// the ObjectType, TupleType, and FuncType convention. IntersectionType
-// carries no exactness flag, since exactness is a property of the result
-// rather than the meet. The flag and the smart constructors land with M6 PR1.
+// a trailing `...` is inexact: at least these, with an open tail standing for
+// members the type does not name. The flag is Inexact rather than Exact so the
+// zero value is exact, matching the ObjectType, TupleType, and FuncType
+// convention. IntersectionType carries no exactness flag, since exactness is a
+// property of the result rather than the meet. The flag and the smart
+// constructors land with M6 PR1.
+//
+// TailBound says what the tail's unnamed members may be. See the field comment.
 type UnionType struct {
 	Types []Type
 	// Inexact tracks the trailing `...` marker. The zero value is exact.
 	Inexact bool
+	// TailBound names the type the tail's unnamed members are drawn from, so
+	// `"a" | ...string` reads as `"a"` together with some unknown set of strings.
+	// It is nil on an exact union and may be nil on an inexact one, which leaves
+	// the tail unbounded. An unbounded tail admits every value, which makes the
+	// whole union the top of the subtype lattice.
+	//
+	// A bound keeps the named members enumerable while still saying what the rest
+	// can be. `keyof {a: X, ...}` is `"a" | ...string`, so a mapped type still has
+	// "a" to iterate and `¬keyof {a: X, ...}` still rejects `5`. Flattening the
+	// bound into the member list instead would give `"a" | string`, which subsumes
+	// to `string` and loses both.
+	TailBound Type
 }
 type IntersectionType struct{ Types []Type }
 

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -442,9 +442,16 @@ func (t *UnionType) Accept(v TypeVisitor, pol Polarity) Type {
 	}
 	cur := descendReplacement(t, e)
 	types, changed := acceptTypes(cur.Types, v, pol)
+	// The tail's unnamed members are members of the union, so its bound is visited at
+	// the union's own polarity, the same as a written member.
+	bound := cur.TailBound
+	if bound != nil {
+		bound = bound.Accept(v, pol)
+		changed = changed || bound != cur.TailBound
+	}
 	out := cur
 	if changed {
-		out = &UnionType{Types: types, Inexact: cur.Inexact}
+		out = &UnionType{Types: types, Inexact: cur.Inexact, TailBound: bound}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -306,6 +306,31 @@ func TestAcceptUnionIdentityPreservation(t *testing.T) {
 	require.Same(t, u, u.Accept(identityVisitor{}, Positive), "an unchanged UnionType keeps its pointer")
 }
 
+// A tail's bound is a member the union does not list, so Accept walks it like a written one.
+// Every rewriter and every predicate that rides Accept reaches the bound through this, so a
+// walk that stopped at the member list would silently leave a variable in the bound
+// unsubstituted rather than fail anywhere visible.
+func TestAcceptUnionWalksTheTailBound(t *testing.T) {
+	a := &TypeVarType{ID: 1}
+	num := &PrimType{Prim: NumPrim}
+	str := &PrimType{Prim: StrPrim}
+
+	t.Run("a replacement in the bound rebuilds the union", func(t *testing.T) {
+		u := &UnionType{Types: []Type{num}, Inexact: true, TailBound: a}
+		got := u.Accept(&replaceVar{target: a, repl: str}, Positive).(*UnionType)
+
+		require.NotSame(t, u, got, "a changed bound forces a new union")
+		require.True(t, got.Inexact, "the rebuilt union keeps its Inexact marker")
+		require.Same(t, str, got.TailBound, "the bound took the replacement")
+		require.Same(t, num, got.Types[0], "the unchanged member keeps its pointer")
+	})
+
+	t.Run("an unchanged bound keeps the union's pointer", func(t *testing.T) {
+		u := &UnionType{Types: []Type{num}, Inexact: true, TailBound: str}
+		require.Same(t, u, u.Accept(identityVisitor{}, Positive), "copy-on-write covers the bound")
+	})
+}
+
 // Accept walks a complement's operand at the flipped polarity, and that flip composes with
 // the one a function's parameters get. So a parameter under a negation is covariant and a
 // second negation flips back, while a tuple's elements stay covariant.

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1500,10 +1500,18 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		// Inexact flags must match, since an open union never equals a closed
-		// one. newUnion imposes canonical member order at construction, so the
-		// positional equalTypeSliceWith is order-stable and two unions over the
-		// same member set compare equal whatever order their members were minted in.
-		return ok && a.Inexact == b.Inexact && equalTypeSliceWith(a.Types, b.Types, ctx)
+		// one, and so must the tails' bounds, since `"a" | ...string` admits values
+		// `"a" | ...number` rejects. newUnion imposes canonical member order at
+		// construction, so the positional equalTypeSliceWith is order-stable and two
+		// unions over the same member set compare equal whatever order their members
+		// were minted in.
+		if !ok || a.Inexact != b.Inexact || (a.TailBound == nil) != (b.TailBound == nil) {
+			return false
+		}
+		if a.TailBound != nil && !equalTypeWith(a.TailBound, b.TailBound, ctx) {
+			return false
+		}
+		return equalTypeSliceWith(a.Types, b.Types, ctx)
 	case *soltype.IntersectionType:
 		b, ok := b.(*soltype.IntersectionType)
 		return ok && equalTypeSliceWith(a.Types, b.Types, ctx)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -686,7 +686,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				return errs
 			}
 			var errs []SolverError
-			if subU.Inexact {
+			if subU.Inexact && subU.TailBound == nil {
+				// Nothing says what an unbounded tail holds, so a closed super cannot
+				// absorb it and the mismatch is reported once for the whole union.
 				closed := true
 				if s, ok := super.(*soltype.UnionType); ok {
 					closed = !s.Inexact
@@ -697,6 +699,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			}
 			for _, m := range subU.Types {
 				errs = append(errs, c.constrain(m, super, seen, mutCtx)...)
+			}
+			if subU.TailBound != nil {
+				// A bounded tail holds only values of its bound, so the super absorbs the
+				// whole tail exactly when it absorbs that bound. Checking it is what makes
+				// `("a" | ...string) <: string` hold and `("a" | ...string) <: ("a" | ...number)`
+				// fail, the latter because the sub's tail may hold a string the super rejects.
+				errs = append(errs, c.constrain(subU.TailBound, super, seen, mutCtx)...)
 			}
 			return errs
 		}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -738,15 +738,21 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 	// commits `number` and never touches T. `"hi" <: (T | number)` finds no concrete
 	// match and falls through to `"hi" <: T`, recording "hi" as T's lower bound.
 	if supU, ok := super.(*soltype.UnionType); ok {
-		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && len(supU.Types) > 0 {
-			// An open tail has no atom to stand for it, so the layer hands a union that
-			// carries one straight back and weighs no member at all. The decision runs
-			// against the members with the tail dropped, and the tail rule below catches
-			// what they miss. Splicing the members out of any nested union first is what
-			// keeps a nested tail from putting the flag straight back.
+		// A bounded tail is weighed even with no named member beside it, since `...string`
+		// admits every string on the tail's strength alone.
+		hasCandidate := len(supU.Types) > 0 || supU.TailBound != nil
+		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && hasCandidate {
+			// An unbounded tail has no atom to stand for it, so the layer hands a union
+			// that carries one straight back and weighs no member at all. The decision
+			// runs against the members with the tail dropped, and the tail rule below
+			// catches what they miss. Splicing the members out of any nested union first
+			// is what keeps a nested tail from putting the flag straight back.
+			//
+			// A bounded tail stays on, since the normal-form layer takes it apart into one
+			// more disjunct and so decides the whole union in one go.
 			named := super
-			if supU.Inexact {
-				flat, _ := flattenUnion(supU.Types, false)
+			if supU.Inexact && supU.TailBound == nil {
+				flat, _ := flattenUnion(supU.Types, unionTail{})
 				named = newUnion(nil, flat, false)
 			}
 			decision := c.constrainNF(sub, named, seen, mutCtx)
@@ -778,11 +784,15 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				}
 				return diags
 			}
-			if supU.Inexact {
-				// An inexact union super has an open, unknown-typed tail. A sub that
-				// matches no named member is subsumed by that tail, so accept it. This
-				// is the dual of the union-sub arm above, which rejects an inexact sub
-				// into a closed super because that open tail can't be absorbed.
+			if supU.Inexact && supU.TailBound == nil {
+				// An unbounded tail admits every value, so a sub that matches no named
+				// member is subsumed by that tail and the constraint holds. This is the
+				// dual of the union-sub arm above, which rejects an inexact sub into a
+				// closed super because that open tail can't be absorbed.
+				//
+				// A bounded tail admits only what its bound does, and the decision above
+				// already weighed the bound, so a sub that got here is outside it. Fall
+				// through to the error.
 				return nil
 			}
 			// No candidate holds, the var members included, and the decomposition's own

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -689,9 +689,12 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			if subU.Inexact && subU.TailBound == nil {
 				// Nothing says what an unbounded tail holds, so a closed super cannot
 				// absorb it and the mismatch is reported once for the whole union.
+				// Only a super whose own tail is unbounded can absorb this one, since a
+				// bounded tail admits just its bound and an unbounded sub tail may hold
+				// anything. `("a" | ...) <: ("a" | "b" | ...string)` is therefore rejected.
 				closed := true
 				if s, ok := super.(*soltype.UnionType); ok {
-					closed = !s.Inexact
+					closed = !s.Inexact || s.TailBound != nil
 				}
 				if closed {
 					errs = append(errs, &InexactUnionIntoExactError{Sub: subU, Super: super})

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -409,7 +409,7 @@ func orderedPairs(subCands, superCands []soltype.Type, origSub, origSuper soltyp
 			continue
 		}
 		for _, i := range subOrder {
-			if isInexactUnion(superCands[j]) && equalType(subCands[i], origSub) && equalType(superCands[j], origSuper) {
+			if hasUnboundedTail(superCands[j]) && equalType(subCands[i], origSub) && equalType(superCands[j], origSuper) {
 				continue
 			}
 			pairs = append(pairs, nfPair{sub: subCands[i], super: superCands[j]})
@@ -492,10 +492,10 @@ func isNegation(t soltype.Type) bool {
 	return ok
 }
 
-// isInexactUnion reports whether t is a union with an unbounded open tail, the one
-// supertype normalization hands back whole. A bounded tail contributes its bound as one
-// more disjunct, so such a union is taken apart and never reaches a candidate list.
-func isInexactUnion(t soltype.Type) bool {
+// hasUnboundedTail reports whether t is a union carrying an open tail that nothing bounds,
+// the one supertype normalization hands back whole. A bounded tail contributes its bound as
+// one more disjunct, so such a union is taken apart and never reaches a candidate list.
+func hasUnboundedTail(t soltype.Type) bool {
 	u, ok := t.(*soltype.UnionType)
 	return ok && u.Inexact && u.TailBound == nil
 }

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -492,9 +492,10 @@ func isNegation(t soltype.Type) bool {
 	return ok
 }
 
-// isInexactUnion reports whether t is a union with an open tail, the one supertype
-// normalization hands back whole.
+// isInexactUnion reports whether t is a union with an unbounded open tail, the one
+// supertype normalization hands back whole. A bounded tail contributes its bound as one
+// more disjunct, so such a union is taken apart and never reaches a candidate list.
 func isInexactUnion(t soltype.Type) bool {
 	u, ok := t.(*soltype.UnionType)
-	return ok && u.Inexact
+	return ok && u.Inexact && u.TailBound == nil
 }

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -1213,6 +1213,52 @@ func TestDescribeNegation(t *testing.T) {
 	}
 }
 
+// A diagnostic naming an inexact union has to say what its tail admits, since the bound is
+// the reason the constraint failed. `5 <: ("a" | ...string)` is rejected where
+// `5 <: ("a" | ...)` holds, and a message rendering both as `"a" | ...` leaves the reader
+// with no way to tell which rule fired.
+func TestDescribeOpenUnionTail(t *testing.T) {
+	tests := []struct {
+		name string
+		in   soltype.Type
+		want string
+	}{
+		{
+			"unbounded tail",
+			&soltype.UnionType{Types: []soltype.Type{strLit("a")}, Inexact: true},
+			`"a" | ...`,
+		},
+		{
+			"bounded tail",
+			&soltype.UnionType{Types: []soltype.Type{strLit("a")}, Inexact: true, TailBound: str()},
+			`"a" | ...string`,
+		},
+		{
+			// An intersection bound is parenthesized, so its `&` does not read as binding
+			// past the `...` into the enclosing union.
+			"compound bound is parenthesized",
+			&soltype.UnionType{
+				Types:     []soltype.Type{strLit("a")},
+				Inexact:   true,
+				TailBound: &soltype.IntersectionType{Types: []soltype.Type{str(), num()}},
+			},
+			`"a" | ...(string & number)`,
+		},
+		{
+			// The shape a set difference leaves when it excludes every named member. A
+			// leading `" | "` would read as an empty first member, so the marker stands alone.
+			"bounded tail with no named member",
+			&soltype.UnionType{Inexact: true, TailBound: str()},
+			"...string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, describe(tt.in))
+		})
+	}
+}
+
 // --- The coinductive seen-set's two records ---
 
 // nestedRecursiveObj builds the cyclic object type `{p: pt, next: {q: <the outer object>}}` and

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2996,12 +2996,32 @@ func describe(t soltype.Type) string {
 		return "error"
 	case *soltype.UnionType:
 		s := joinDescribe(t.Types, " | ")
-		if t.Inexact {
-			// An inexact union has an open tail. Append the marker so a
-			// diagnostic naming the union matches the printer's surface form.
-			return s + " | ..."
+		if !t.Inexact {
+			return s
 		}
-		return s
+		// An inexact union has an open tail. Append the marker so a diagnostic naming
+		// the union matches the printer's surface form, and append the tail's bound
+		// after it so a diagnostic distinguishes `"a" | ...string`, which rejects `5`,
+		// from the `"a" | ...` that would have accepted it. A union with no named
+		// member renders as the marker alone, since a leading `" | "` would read as an
+		// empty first member.
+		marker := "..."
+		if t.TailBound != nil {
+			// A union or intersection bound is parenthesized, since its `|` or `&` would
+			// otherwise bind past the `...` and `...string & ¬"a"` read back as a member
+			// of the enclosing union. The NegationType arm below parenthesizes for the
+			// same reason.
+			bound := describe(t.TailBound)
+			switch t.TailBound.(type) {
+			case *soltype.UnionType, *soltype.IntersectionType:
+				bound = "(" + bound + ")"
+			}
+			marker += bound
+		}
+		if len(t.Types) == 0 {
+			return marker
+		}
+		return s + " | " + marker
 	case *soltype.IntersectionType:
 		return joinDescribe(t.Types, " & ")
 	case *soltype.NegationType:

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2999,12 +2999,13 @@ func describe(t soltype.Type) string {
 		if !t.Inexact {
 			return s
 		}
-		// An inexact union has an open tail. Append the marker so a diagnostic naming
-		// the union matches the printer's surface form, and append the tail's bound
-		// after it so a diagnostic distinguishes `"a" | ...string`, which rejects `5`,
-		// from the `"a" | ...` that would have accepted it. A union with no named
-		// member renders as the marker alone, since a leading `" | "` would read as an
-		// empty first member.
+		// An inexact union has an open tail. The marker follows the members so a
+		// diagnostic naming the union matches the printer's surface form. The tail's
+		// bound follows the marker, since the bound is what decides the constraint.
+		// `"a" | ...string` rejects `5` where `"a" | ...` accepts it, and a message
+		// rendering both the same way leaves the reader no way to tell which rule
+		// fired. A union with no named member renders as the marker alone, since a
+		// leading `" | "` would read as an empty first member.
 		marker := "..."
 		if t.TailBound != nil {
 			// A union or intersection bound is parenthesized, since its `|` or `&` would

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -31,14 +31,15 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 		},
 		{
 			// An inexact tuple has unknown trailing positions, so its index set is open and carries
-			// the indices those positions occupy in a trailing `...`.
+			// the indices those positions occupy in a trailing `...`. Those indices are positions,
+			// so the tail is bounded by `number`.
 			name: "KeyofInexactTuple",
 			src: `
 				type Tup = [number, string, ...]
 				type Result = keyof Tup
 			`,
 			wantSymbolic: "keyof Tup",
-			wantExpanded: "0 | 1 | ...",
+			wantExpanded: "0 | 1 | ...number",
 		},
 		{
 			// `T[keyof T]` over an exact object reads every key the object declares, and those are
@@ -161,14 +162,15 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 		},
 		{
 			// An intersection carries both operands' members, so its key sets union. An inexact
-			// operand's open key set leaves the whole union open.
+			// operand's open key set leaves the whole union open, bounded by `string` because the
+			// keys it did not list are still property names.
 			name: "KeyofIntersectionWithInexactMember",
 			src: `
 				type I = {a: number} & {b: string, ...}
 				type Result = keyof I
 			`,
 			wantSymbolic: "keyof I",
-			wantExpanded: `"a" | "b" | ...`,
+			wantExpanded: `"a" | "b" | ...string`,
 		},
 		{
 			// `Exact` and `Inexact` are the two operators that run the other way. Every case above
@@ -442,7 +444,7 @@ func TestInferExactnessIntrinsics(t *testing.T) {
 				type Result = keyof Inexact<Obj>
 			`,
 			wantSymbolic: "keyof Inexact<Obj>",
-			wantExpanded: `"a" | "b" | ...`,
+			wantExpanded: `"a" | "b" | ...string`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -131,13 +131,15 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 		},
 		{
 			// An interpolation naming an open set of choices produces an open set of strings.
+			// The tail is bounded by `string` rather than left open, because a template
+			// produces a string whatever it interpolates. An open tail would accept a `5`.
 			name: "TemplateLitInexactInterp",
 			src: `
 				type Side = "left" | "right" | ...
 				type Result = ` + "`pad-${Side}`" + `
 			`,
 			wantSymbolic: "`pad-${Side}`",
-			wantExpanded: `"pad-left" | "pad-right" | ...`,
+			wantExpanded: `"pad-left" | "pad-right" | ...string`,
 		},
 		{
 			// A string intrinsic maps each member of a closed operand union, and that is every

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3970,7 +3970,7 @@ func narrowUnionMembers(shape soltype.Type, keep func(soltype.Type) bool) (solty
 	// target for the branch's leaves, and constrainUnionFieldRead needs the listed members to
 	// read each field before the tail widens it. Binding against bare `unknown` would leave
 	// nothing to destructure.
-	return &soltype.UnionType{Types: kept, Inexact: u.Inexact}, true
+	return &soltype.UnionType{Types: kept, Inexact: u.Inexact, TailBound: u.TailBound}, true
 }
 
 // structuralInexact returns the Inexact flag of an object or tuple type and whether

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3969,14 +3969,43 @@ func narrowUnionMembers(shape soltype.Type, keep func(soltype.Type) bool) (solty
 	// the tested fields at any type, so the tail is retained and the field-read rule (D4)
 	// reads a narrowed inexact member's fields as `... | unknown`, i.e. `unknown`. An exact
 	// union narrows to precisely the members that matched.
-	if len(kept) == 1 && !u.Inexact {
+	tail := tailOf(u)
+	if tail.bound != nil && atomicShape(tail.bound) && !keep(tail.bound) {
+		// No value the bound admits has the shape the test asks for, so the tail contributes
+		// no member to this branch and goes. See atomicShape for why only an atomic bound may
+		// be decided this way.
+		tail = unionTail{}
+	}
+	if len(kept) == 1 && !tail.open {
 		return kept[0], true
 	}
 	// Keep the structured inexact union rather than returning `unknown`. It is the bind
 	// target for the branch's leaves, and constrainUnionFieldRead needs the listed members to
 	// read each field before the tail widens it. Binding against bare `unknown` would leave
 	// nothing to destructure.
-	return &soltype.UnionType{Types: kept, Inexact: u.Inexact, TailBound: u.TailBound}, true
+	return &soltype.UnionType{Types: kept, Inexact: tail.open, TailBound: tail.bound}, true
+}
+
+// atomicShape reports whether every value t admits has t's own shape, so a shape test over t
+// answers for each of those values at once. A primitive and a literal are the two, since a
+// string is a string however it was written.
+//
+// Nothing else qualifies, and the gate is what keeps narrowUnionMembers from over-narrowing.
+// The `keep` predicates it takes are shape tests over one MEMBER, and a bound is not a member
+// but the set its members are drawn from. Reading a bound's own failure as every member's
+// would be wrong for a bound whose members can differ in shape from it. A bound of
+// `{kind: string}` fails an object test for some other key while a member drawn from it may
+// carry that key, and a union bound fails every object test while its members need not.
+// Deciding those needs a disjointness question, which is a subtype check, and
+// narrowUnionMembers holds no Context to ask one. Such a tail is kept, which is the wider
+// answer and the safe one.
+func atomicShape(t soltype.Type) bool {
+	switch t.(type) {
+	case *soltype.PrimType, *soltype.LitType:
+		return true
+	default:
+		return false
+	}
 }
 
 // structuralInexact returns the Inexact flag of an object or tuple type and whether

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -960,7 +960,13 @@ func peelBorrows(t soltype.Type) soltype.Type {
 		for i, m := range t.Types {
 			members[i] = peelBorrows(m)
 		}
-		return newUnion(nil, members, t.Inexact)
+		// The tail's bound is a member the union does not list, so it peels too. Dropping it
+		// would leave the peeled union unbounded, which is top.
+		tail := tailOf(t)
+		if tail.bound != nil {
+			tail.bound = peelBorrows(tail.bound)
+		}
+		return newUnionWithTail(nil, members, tail)
 	}
 	return t
 }

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -97,26 +97,28 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 			wantExpanded: `"only"`,
 		},
 		{
-			// An inexact object's key union is inexact too: the known
-			// keys plus a trailing `...` standing for the unlisted ones.
+			// An inexact object's key union is inexact too: the known keys plus a trailing `...`
+			// standing for the unlisted ones. The tail is bounded by `string`, since a key the
+			// object did not list is still a property name.
 			name: "InexactObject",
 			src: `
 				type Obj = {x: number, y: string, ...}
 				type Result = keyof Obj
 			`,
 			wantSymbolic: "keyof Obj",
-			wantExpanded: `"x" | "y" | ...`,
+			wantExpanded: `"x" | "y" | ...string`,
 		},
 		{
 			// A single-key inexact object keeps the union wrapper rather than collapsing to the lone
-			// literal, since the open tail makes `"only" | ...` strictly weaker than bare `"only"`.
+			// literal, since the open tail makes `"only" | ...string` strictly weaker than bare
+			// `"only"`.
 			name: "InexactSingleKeyObject",
 			src: `
 				type Obj = {only: number, ...}
 				type Result = keyof Obj
 			`,
 			wantSymbolic: "keyof Obj",
-			wantExpanded: `"only" | ...`,
+			wantExpanded: `"only" | ...string`,
 		},
 		{
 			// A key is readable from a union only when every member carries it, so the members'
@@ -184,14 +186,15 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 		},
 		{
 			// An inexact member's open key set may carry "a" as well, so the intersection cannot
-			// rule "a" out. The written keys intersect to "shared" and the result stays open.
+			// rule "a" out. The written keys intersect to "shared" and the result stays open,
+			// carrying the `string` bound that member's own key set had.
 			name: "UnionInexactMember",
 			src: `
 				type U = {a: number, shared: string} | {b: boolean, shared: string, ...}
 				type Result = keyof U
 			`,
 			wantSymbolic: "keyof U",
-			wantExpanded: `"shared" | ...`,
+			wantExpanded: `"shared" | ...string`,
 		},
 		{
 			// An inexact union has an unlisted member whose keys are unknown, so it cannot close
@@ -292,7 +295,7 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 		},
 		{
 			// A non-final class projects to an inexact instance body, since a subclass may add
-			// members, so its key union is open: `"x" | "y" | ...`.
+			// members, so its key union is open: `"x" | "y" | ...string`.
 			name: "Class",
 			src: `
 				class Point {
@@ -302,7 +305,7 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 				type Result = keyof Point
 			`,
 			wantSymbolic: "keyof Point",
-			wantExpanded: `"x" | "y" | ...`,
+			wantExpanded: `"x" | "y" | ...string`,
 		},
 		{
 			// A final class has no subclasses to widen it, so its instance body is exact and its

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -298,11 +298,15 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 // undetected. An inexact union bound never qualifies, since its own tail says nothing about
 // what it holds.
 //
-// An exact union bound naming no member denotes `never`, so the loop below passes it vacuously
-// and the tail drops. A tail drawn from `never` holds nothing, which is the answer that wants.
+// A tail drawn from `never` holds nothing, so it drops however that emptiness is spelled. A
+// bare `never` is one spelling and an exact union naming no member is the other, which the
+// loop below passes vacuously.
 func tailSubsumed(pruned []soltype.Type, bound soltype.Type) bool {
 	if bound == nil {
 		return false
+	}
+	if _, empty := bound.(*soltype.NeverType); empty {
+		return true
 	}
 	named := func(t soltype.Type) bool {
 		return slices.ContainsFunc(pruned, func(m soltype.Type) bool { return equalType(m, t) })
@@ -474,18 +478,24 @@ func (s *finalSubsumer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 	return soltype.EnterResult{}
 }
 
-// ExitType subsumes a lattice node's members and rebuilds it only when a member
-// was dropped. The input is a coalesced display type, so it is already flattened,
+// ExitType subsumes a lattice node's members and rebuilds it only when something
+// changed. The input is a coalesced display type, so it is already flattened,
 // pruned, deduped, and canonically ordered — newUnion's other normalization steps
 // would be no-ops here, so only subsumeMembers runs. subsumeMembers only ever
 // removes members, so a length drop is an O(1) signal that the node changed, which
-// avoids a structural re-comparison. When nothing dropped the original node is
+// avoids a structural re-comparison. When nothing changed the original node is
 // returned, preserving pointer identity up the spine.
+//
+// A union asks about its tail as well as its members, because this walk rewrites
+// the bound before the union itself. A bound that folds to `never` on the way up
+// leaves a tail holding nothing, and a bound that folds to a named member leaves
+// one contributing nothing. Neither drops a member, so a member count alone would
+// miss both and render `...never` or `"y" | ..."y"`.
 func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.UnionType:
 		kept := subsumeMembers(s.ctx, t.Types, unionDrops)
-		if len(kept) == len(t.Types) {
+		if len(kept) == len(t.Types) && !tailSubsumed(kept, t.TailBound) {
 			return t
 		}
 		return collapseUnion(kept, tailOf(t), false)

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -293,9 +293,9 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 //
 // This is subsumption applied to the tail rather than to a member. Equality decides it rather
 // than a subtype test, so it needs no Context and runs on every mint. Two shapes qualify: a
-// bound equal to a named member, and an exact union whose every member is. A bound merely BELOW
-// the named members by some other route, such as `string | ..."a"`, is subsumed too but goes
-// undetected. An inexact union bound never qualifies, since its own tail says nothing about
+// bound equal to a named member, and an exact union whose every member is. A bound that is a
+// subtype of the named members by some other route, such as `string | ..."a"`, is subsumed too
+// but goes undetected. An inexact union bound never qualifies, since its own tail says nothing about
 // what it holds.
 //
 // A tail drawn from `never` holds nothing, so it drops however that emptiness is spelled. A

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -297,6 +297,9 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 // the named members by some other route, such as `string | ..."a"`, is subsumed too but goes
 // undetected. An inexact union bound never qualifies, since its own tail says nothing about
 // what it holds.
+//
+// An exact union bound naming no member denotes `never`, so the loop below passes it vacuously
+// and the tail drops. A tail drawn from `never` holds nothing, which is the answer that wants.
 func tailSubsumed(pruned []soltype.Type, bound soltype.Type) bool {
 	if bound == nil {
 		return false
@@ -305,9 +308,6 @@ func tailSubsumed(pruned []soltype.Type, bound soltype.Type) bool {
 		return slices.ContainsFunc(pruned, func(m soltype.Type) bool { return equalType(m, t) })
 	}
 	if u, ok := bound.(*soltype.UnionType); ok && !u.Inexact {
-		if len(u.Types) == 0 {
-			return false
-		}
 		for _, m := range u.Types {
 			if !named(m) {
 				return false

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -286,18 +286,40 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 	return out
 }
 
+// tailSubsumed reports whether every value a tail's bound admits is one the union's named
+// members already admit, which makes the tail contribute nothing and the union exactly its
+// named side. `"y" | ..."y"` is exactly `"y"`, `string | ...string` exactly `string`, and
+// `1 | 2 | ...(1 | 2)` exactly `1 | 2`.
+//
+// This is subsumption applied to the tail rather than to a member. Equality decides it rather
+// than a subtype test, so it needs no Context and runs on every mint. Two shapes qualify: a
+// bound equal to a named member, and an exact union whose every member is. A bound merely BELOW
+// the named members by some other route, such as `string | ..."a"`, is subsumed too but goes
+// undetected. An inexact union bound never qualifies, since its own tail says nothing about
+// what it holds.
+func tailSubsumed(pruned []soltype.Type, bound soltype.Type) bool {
+	if bound == nil {
+		return false
+	}
+	named := func(t soltype.Type) bool {
+		return slices.ContainsFunc(pruned, func(m soltype.Type) bool { return equalType(m, t) })
+	}
+	if u, ok := bound.(*soltype.UnionType); ok && !u.Inexact {
+		if len(u.Types) == 0 {
+			return false
+		}
+		for _, m := range u.Types {
+			if !named(m) {
+				return false
+			}
+		}
+		return true
+	}
+	return named(bound)
+}
+
 func collapseUnion(pruned []soltype.Type, tail unionTail, hadError bool) soltype.Type {
-	if tail.bound != nil && slices.ContainsFunc(pruned, func(m soltype.Type) bool {
-		return equalType(m, tail.bound)
-	}) {
-		// The tail draws its members from a type the union already names, so every value the
-		// tail could hold is one that member already admits and the tail adds nothing. Both
-		// `"y" | ..."y"` and `string | ...string` are exactly their named side.
-		//
-		// This is subsumption applied to the tail rather than to a member, and it is decided
-		// by equality rather than by a subtype test, so it needs no Context and runs on every
-		// mint. A bound merely BELOW the named members, as in `"a" | "b" | ...("a" | "b")`,
-		// is subsumed too but goes undetected here.
+	if tailSubsumed(pruned, tail.bound) {
 		tail = unionTail{}
 	}
 	if len(pruned) == 0 {

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/escalier-lang/escalier/internal/set"
@@ -286,6 +287,19 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 }
 
 func collapseUnion(pruned []soltype.Type, tail unionTail, hadError bool) soltype.Type {
+	if tail.bound != nil && slices.ContainsFunc(pruned, func(m soltype.Type) bool {
+		return equalType(m, tail.bound)
+	}) {
+		// The tail draws its members from a type the union already names, so every value the
+		// tail could hold is one that member already admits and the tail adds nothing. Both
+		// `"y" | ..."y"` and `string | ...string` are exactly their named side.
+		//
+		// This is subsumption applied to the tail rather than to a member, and it is decided
+		// by equality rather than by a subtype test, so it needs no Context and runs on every
+		// mint. A bound merely BELOW the named members, as in `"a" | "b" | ...("a" | "b")`,
+		// is subsumed too but goes undetected here.
+		tail = unionTail{}
+	}
 	if len(pruned) == 0 {
 		// ErrorType absorbs, so a union whose every other member was pruned comes back
 		// as the sole surviving error whatever its tail says.

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -283,15 +283,19 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 }
 
 func collapseUnion(pruned []soltype.Type, tail unionTail, hadError bool) soltype.Type {
-	if len(pruned) == 0 && (!tail.open || tail.bound == nil) {
+	if len(pruned) == 0 {
+		// ErrorType absorbs, so a union whose every other member was pruned comes back
+		// as the sole surviving error whatever its tail says.
 		if hadError {
 			return &soltype.ErrorType{}
 		}
-		// Empty union ⇒ never, the identity of |. An empty union with an unbounded
-		// tail is still never, since that tail says nothing a member could stand
-		// for. A caller that needs a union whose only content is an unbounded tail
-		// should write unknown directly.
-		return &soltype.NeverType{}
+		if !tail.open || tail.bound == nil {
+			// Empty union ⇒ never, the identity of |. An empty union with an unbounded
+			// tail is still never, since that tail says nothing a member could stand
+			// for. A caller that needs a union whose only content is an unbounded tail
+			// should write unknown directly.
+			return &soltype.NeverType{}
+		}
 	}
 	if len(pruned) == 1 && !tail.open {
 		// A single exact-union member collapses to that member. An inexact

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -28,14 +28,58 @@ import (
 // so `number | string` and `string | number` print identically, and it lets
 // the canonical type serve as a stable key for caching.
 func newUnion(c *Context, parts []soltype.Type, inexact bool) soltype.Type {
-	flat, inexact := flattenUnion(parts, inexact)
+	return newUnionWithTail(c, parts, unionTail{open: inexact})
+}
+
+// newBoundedUnion mints `A | ...R`, an inexact union whose tail members are drawn from
+// bound. A nil bound leaves the tail unbounded, which is what newUnion's inexact form
+// mints, so a caller that computes a bound and may come up empty needs no branch.
+func newBoundedUnion(c *Context, parts []soltype.Type, bound soltype.Type) soltype.Type {
+	return newUnionWithTail(c, parts, unionTail{open: true, bound: bound})
+}
+
+// newUnionWithTail is the core newUnion and newBoundedUnion share. It runs the same
+// normalization for either and differs only in the tail it carries through.
+func newUnionWithTail(c *Context, parts []soltype.Type, tail unionTail) soltype.Type {
+	flat, tail := flattenUnion(parts, tail)
 	pruned, hadError := pruneUnion(flat)
 	pruned = dedup(pruned)
 	if c != nil {
 		pruned = subsumeMembers(c, pruned, unionDrops)
 	}
 	sortTypes(pruned)
-	return collapseUnion(pruned, inexact, hadError)
+	return collapseUnion(pruned, tail, hadError)
+}
+
+// unionTail is a union's open-tail marker as it moves through the mint pipeline. open
+// says a trailing `...` is present. bound names the type the tail's unnamed members are
+// drawn from, and a nil bound leaves them unbounded, so the tail admits every value.
+// The zero value is the exact union's tail, which is no tail at all.
+type unionTail struct {
+	open  bool
+	bound soltype.Type
+}
+
+// tailOf reads a union's tail back out, the inverse of what collapseUnion writes.
+func tailOf(u *soltype.UnionType) unionTail {
+	return unionTail{open: u.Inexact, bound: u.TailBound}
+}
+
+// merge folds another tail into t, the rule flattenUnion applies when it splices a
+// nested union's members into the outer list. Two bounded tails join their bounds,
+// since `...string | ...number` may hold a member of either. An unbounded tail absorbs
+// a bounded one, since nothing says what the unbounded one holds.
+func (t unionTail) merge(other unionTail) unionTail {
+	if !other.open {
+		return t
+	}
+	if !t.open {
+		return other
+	}
+	if t.bound == nil || other.bound == nil {
+		return unionTail{open: true}
+	}
+	return unionTail{open: true, bound: newUnion(nil, []soltype.Type{t.bound, other.bound}, false)}
 }
 
 // newIntersection is the meet twin of newUnion. An IntersectionType carries
@@ -64,9 +108,11 @@ func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 //   - `¬never` is `unknown`, since `never` admits no value and `unknown` admits
 //     every one.
 //   - `¬unknown` is `never`, the same identity read the other way.
-//   - `¬(A | B | ...)` is `never`. An inexact union is the top of the subtype
-//     lattice, since its open tail accepts every value, so its complement admits
-//     none. TestOpenUnionIsTopForSubtypingOnly pins that reading.
+//   - `¬(A | B | ...)` is `never`. A union whose open tail carries no bound is the
+//     top of the subtype lattice, since that tail accepts every value, so its
+//     complement admits none. TestOpenUnionIsTopForSubtypingOnly pins that reading.
+//     A bounded tail is not top and gets no fold. `¬("a" | ...string)` rejects every
+//     string and admits `5`, so it wraps like any other operand.
 //   - `¬¬T` is T, since complementing twice returns the original set.
 //
 // It does NOT push the complement through a union or an intersection. `¬(A | B)`
@@ -83,7 +129,7 @@ func newNegation(inner soltype.Type) soltype.Type {
 	case *soltype.UnknownType:
 		return &soltype.NeverType{}
 	case *soltype.UnionType:
-		if inner.Inexact {
+		if inner.Inexact && inner.TailBound == nil {
 			return &soltype.NeverType{}
 		}
 	case *soltype.NegationType:
@@ -93,12 +139,12 @@ func newNegation(inner soltype.Type) soltype.Type {
 }
 
 // flattenUnion splices nested UnionType members into the outer member list
-// and carries an inner inexact flag out to the caller. The splice is
-// recursive, so a UnionType whose members include another UnionType is fully
-// unwrapped in one pass. An inexact nested member at any depth makes the
-// outer union inexact, since `... | (A | ...)` collapses to `A | ...`. When
-// no member nests, the input slice is reused, so the common case pays no
-// allocation.
+// and carries an inner tail out to the caller. The splice is recursive, so a
+// UnionType whose members include another UnionType is fully unwrapped in one
+// pass. An inexact nested member at any depth makes the outer union inexact,
+// since `... | (A | ...)` collapses to `A | ...`, and unionTail.merge decides
+// what bounds the result. When no member nests, the input slice is reused, so
+// the common case pays no allocation.
 //
 // Recursion matters when a caller hands flatten an unnormalized member, such
 // as a raw `&UnionType{Types: [...]}` constructed in a test or rebuilt by a
@@ -106,9 +152,9 @@ func newNegation(inner soltype.Type) soltype.Type {
 // always flat, so a chain of normal newUnion calls would never trigger the
 // recursive case, but the recursion keeps the flatness invariant true for
 // every input.
-func flattenUnion(parts []soltype.Type, inexact bool) ([]soltype.Type, bool) {
+func flattenUnion(parts []soltype.Type, tail unionTail) ([]soltype.Type, unionTail) {
 	if !anyUnion(parts) {
-		return parts, inexact
+		return parts, tail
 	}
 	flat := make([]soltype.Type, 0, len(parts))
 	var splice func(p soltype.Type)
@@ -118,9 +164,7 @@ func flattenUnion(parts []soltype.Type, inexact bool) ([]soltype.Type, bool) {
 			flat = append(flat, p)
 			return
 		}
-		if u.Inexact {
-			inexact = true
-		}
+		tail = tail.merge(tailOf(u))
 		for _, m := range u.Types {
 			splice(m)
 		}
@@ -128,7 +172,7 @@ func flattenUnion(parts []soltype.Type, inexact bool) ([]soltype.Type, bool) {
 	for _, p := range parts {
 		splice(p)
 	}
-	return flat, inexact
+	return flat, tail
 }
 
 // flattenIntersection is the meet twin of flattenUnion. The splice is
@@ -238,24 +282,27 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 	return out
 }
 
-func collapseUnion(pruned []soltype.Type, inexact, hadError bool) soltype.Type {
-	if len(pruned) == 0 {
+func collapseUnion(pruned []soltype.Type, tail unionTail, hadError bool) soltype.Type {
+	if len(pruned) == 0 && (!tail.open || tail.bound == nil) {
 		if hadError {
 			return &soltype.ErrorType{}
 		}
-		// Empty union ⇒ never, the identity of |. An inexact-but-empty union is
-		// still never, since the inexactness flag has no carrier without
-		// members. A caller that needs a union whose only content is the open
-		// tail should write unknown directly.
+		// Empty union ⇒ never, the identity of |. An empty union with an unbounded
+		// tail is still never, since that tail says nothing a member could stand
+		// for. A caller that needs a union whose only content is an unbounded tail
+		// should write unknown directly.
 		return &soltype.NeverType{}
 	}
-	if len(pruned) == 1 && !inexact {
+	if len(pruned) == 1 && !tail.open {
 		// A single exact-union member collapses to that member. An inexact
 		// single-member union keeps its wrapper, since the `... | T` tail
 		// makes it strictly weaker than the bare T.
 		return pruned[0]
 	}
-	return &soltype.UnionType{Types: pruned, Inexact: inexact}
+	// A bounded tail with no named member survives as `...R`, a union naming no member
+	// and drawing every one it has from R. `("a" | ...string) ∩ ¬"a"` reduces to
+	// `...(string & ¬"a")`, the string keys other than "a", which has no other spelling.
+	return &soltype.UnionType{Types: pruned, Inexact: tail.open, TailBound: tail.bound}
 }
 
 func collapseIntersection(pruned []soltype.Type, hadError bool) soltype.Type {
@@ -398,7 +445,7 @@ func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.T
 		if len(kept) == len(t.Types) {
 			return t
 		}
-		return collapseUnion(kept, t.Inexact, false)
+		return collapseUnion(kept, tailOf(t), false)
 	case *soltype.IntersectionType:
 		members, changed, provedEmpty := simplifyNegations(s.ctx, t.Types)
 		if provedEmpty {
@@ -534,6 +581,16 @@ func compareSameKind(a, b soltype.Type) int {
 		b := b.(*soltype.UnionType)
 		if a.Inexact != b.Inexact {
 			return boolOrder(a.Inexact) - boolOrder(b.Inexact)
+		}
+		// An unbounded tail sorts before a bounded one, so two unions over the same
+		// members order by what their tails admit.
+		if (a.TailBound == nil) != (b.TailBound == nil) {
+			return boolOrder(a.TailBound != nil) - boolOrder(b.TailBound != nil)
+		}
+		if a.TailBound != nil {
+			if c := compareType(a.TailBound, b.TailBound); c != 0 {
+				return c
+			}
 		}
 		if c := len(a.Types) - len(b.Types); c != 0 {
 			return c

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -69,6 +69,9 @@ func tailOf(u *soltype.UnionType) unionTail {
 // nested union's members into the outer list. Two bounded tails join their bounds,
 // since `...string | ...number` may hold a member of either. An unbounded tail absorbs
 // a bounded one, since nothing says what the unbounded one holds.
+//
+// keyofUnion is the other caller, and the join is wider than that reduction wants, since
+// a key set of a union is a meet. The doc comment there records the gap.
 func (t unionTail) merge(other unionTail) unionTail {
 	if !other.open {
 		return t

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -209,6 +209,64 @@ func TestNewUnionInexactPrintRoundTrip(t *testing.T) {
 	require.Equal(t, "number | string | ...", soltype.Print(u))
 }
 
+// Splicing a nested union carries its tail out to the outer union, and the two tails
+// merge. The bound says what the tail's unnamed members may be, so a union that swallows
+// another inherits whatever the swallowed one could hold.
+func TestFlattenUnionMergesTailBounds(t *testing.T) {
+	strTail := func(parts ...soltype.Type) soltype.Type { return newBoundedUnion(nil, parts, str()) }
+	numTail := func(parts ...soltype.Type) soltype.Type { return newBoundedUnion(nil, parts, num()) }
+
+	tests := []struct {
+		name  string
+		parts []soltype.Type
+		want  string
+	}{
+		{
+			// A nested bounded tail with no other tail to meet comes through as written.
+			name:  "a lone bounded tail carries out",
+			parts: []soltype.Type{numLit(1), strTail(strLit("a"))},
+			want:  `1 | "a" | ...string`,
+		},
+		{
+			// Two bounded tails join their bounds, since a member of either could be in the
+			// result.
+			name:  "two bounded tails join their bounds",
+			parts: []soltype.Type{strTail(strLit("a")), numTail(numLit(1))},
+			want:  `1 | "a" | ...(number | string)`,
+		},
+		{
+			// Nothing says what an unbounded tail holds, so meeting one loses the bound.
+			name:  "an unbounded tail absorbs a bounded one",
+			parts: []soltype.Type{strTail(strLit("a")), newUnion(nil, []soltype.Type{numLit(1)}, true)},
+			want:  `1 | "a" | ...`,
+		},
+		{
+			// An exact nested union brings no tail, so the outer one is untouched.
+			name:  "an exact nested union leaves the tail alone",
+			parts: []soltype.Type{strTail(strLit("a")), unionT(numLit(1), numLit(2))},
+			want:  `1 | 2 | "a" | ...string`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, soltype.Print(newUnion(nil, tt.parts, false)))
+		})
+	}
+}
+
+// A bound is part of a union's identity, so two unions that differ only in what their
+// tails admit are neither equal nor deduped into one.
+func TestBoundedTailsCompareByTheirBound(t *testing.T) {
+	strBound := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())
+	numBound := newBoundedUnion(nil, []soltype.Type{strLit("a")}, num())
+	unbounded := newUnion(nil, []soltype.Type{strLit("a")}, true)
+
+	require.True(t, equalType(strBound, newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())))
+	require.False(t, equalType(strBound, numBound))
+	require.False(t, equalType(strBound, unbounded))
+	require.False(t, equalType(strBound, unionT(strLit("a"))))
+}
+
 // TestNewUnionSubsumeWithContext covers the Context-gated subsumption step.
 // A member that is a subtype of another member is dropped, so `number | 1`
 // reduces to `number`.

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -288,6 +288,25 @@ func TestCollapseUnionDropsASubsumedTail(t *testing.T) {
 			want: `1 | "y"`,
 		},
 		{
+			// A union bound is subsumed when every one of its members is named, which is the
+			// shape a conditional that reaches both branches leaves behind.
+			name: "a union bound whose every member is named closes the union",
+			build: func() soltype.Type {
+				return newBoundedUnion(nil, []soltype.Type{numLit(1), numLit(2)},
+					unionT(numLit(1), numLit(2)))
+			},
+			want: "1 | 2",
+		},
+		{
+			// One unnamed member in the bound is enough to keep the tail, since the union does
+			// not otherwise admit it.
+			name: "a union bound with an unnamed member is kept",
+			build: func() soltype.Type {
+				return newBoundedUnion(nil, []soltype.Type{numLit(1)}, unionT(numLit(1), numLit(2)))
+			},
+			want: "1 | ...(1 | 2)",
+		},
+		{
 			// A bound naming values no member does is not subsumed, so the tail stays.
 			name:  "an unrelated bound is kept",
 			build: func() soltype.Type { return newBoundedUnion(nil, []soltype.Type{strLit("y")}, str()) },

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -255,16 +255,32 @@ func TestFlattenUnionMergesTailBounds(t *testing.T) {
 }
 
 // A bound is part of a union's identity, so two unions that differ only in what their
-// tails admit are neither equal nor deduped into one.
+// tails admit are neither equal nor deduped into one, and they hold a stable place in
+// canonical order. compareType is what sortTypes consults, so an unstable answer there
+// would let one member list render two ways.
 func TestBoundedTailsCompareByTheirBound(t *testing.T) {
 	strBound := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())
 	numBound := newBoundedUnion(nil, []soltype.Type{strLit("a")}, num())
 	unbounded := newUnion(nil, []soltype.Type{strLit("a")}, true)
 
-	require.True(t, equalType(strBound, newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())))
-	require.False(t, equalType(strBound, numBound))
-	require.False(t, equalType(strBound, unbounded))
-	require.False(t, equalType(strBound, unionT(strLit("a"))))
+	t.Run("equality reads the bound", func(t *testing.T) {
+		require.True(t, equalType(strBound, newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())))
+		require.False(t, equalType(strBound, numBound))
+		require.False(t, equalType(strBound, unbounded))
+		require.False(t, equalType(strBound, unionT(strLit("a"))))
+	})
+
+	t.Run("canonical order reads the bound", func(t *testing.T) {
+		// An unbounded tail sorts before a bounded one, so the two never compare equal and
+		// whichever way a caller hands them over they come back in one order.
+		require.Equal(t, -1, compareType(unbounded, strBound))
+		require.Equal(t, 1, compareType(strBound, unbounded))
+		// Two bounded tails order by their bounds, `number` before `string`.
+		require.Equal(t, 1, compareType(strBound, numBound))
+		require.Equal(t, -1, compareType(numBound, strBound))
+		// Identical bounds tie, which is what lets dedup drop one of them.
+		require.Equal(t, 0, compareType(strBound, newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())))
+	})
 }
 
 // TestNewUnionSubsumeWithContext covers the Context-gated subsumption step.

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -254,6 +254,59 @@ func TestFlattenUnionMergesTailBounds(t *testing.T) {
 	}
 }
 
+// A tail whose bound the union already names as a member contributes no value that member
+// does not, so it drops and the union closes. This is subsumption applied to the tail rather
+// than to a member, and equality decides it, so no Context is needed.
+func TestCollapseUnionDropsASubsumedTail(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func() soltype.Type
+		want  string
+	}{
+		{
+			// `"y" | ..."y"`. Every value the tail could hold is a `"y"`, which the named
+			// member already admits, so the union is exactly `"y"` and collapses to it. This
+			// is what a distributive conditional leaves when every member and the bound
+			// select the same branch.
+			name:  "a bound equal to the only member closes the union",
+			build: func() soltype.Type { return newBoundedUnion(nil, []soltype.Type{strLit("y")}, strLit("y")) },
+			want:  `"y"`,
+		},
+		{
+			// `string | ...string`, the same rule over a primitive.
+			name:  "a bound equal to a primitive member closes the union",
+			build: func() soltype.Type { return newBoundedUnion(nil, []soltype.Type{str()}, str()) },
+			want:  "string",
+		},
+		{
+			// The tail drops but other members remain, so the union stays a union and only
+			// loses its `...`.
+			name: "the union keeps its other members",
+			build: func() soltype.Type {
+				return newBoundedUnion(nil, []soltype.Type{strLit("y"), numLit(1)}, strLit("y"))
+			},
+			want: `1 | "y"`,
+		},
+		{
+			// A bound naming values no member does is not subsumed, so the tail stays.
+			name:  "an unrelated bound is kept",
+			build: func() soltype.Type { return newBoundedUnion(nil, []soltype.Type{strLit("y")}, str()) },
+			want:  `"y" | ...string`,
+		},
+		{
+			// Subsumption needs a member to be subsumed by. A tail with none stays whole.
+			name:  "a member-less tail is kept",
+			build: func() soltype.Type { return newBoundedUnion(nil, nil, str()) },
+			want:  "...string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, soltype.Print(tt.build()))
+		})
+	}
+}
+
 // A bound is part of a union's identity, so two unions that differ only in what their
 // tails admit are neither equal nor deduped into one, and they hold a stable place in
 // canonical order. compareType is what sortTypes consults, so an unstable answer there

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -892,11 +892,16 @@ func (f *knotFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type
 
 // valueFamily is a set of runtime values no value outside it belongs to. Two
 // atoms drawn from different families are disjoint, so their meet is `never`.
-// The families cover the primitives and the two absence markers, the kinds whose
-// disjointness the solver already decides elsewhere. Objects, tuples, functions,
-// and class instances are deliberately absent: they are disjoint from a primitive
-// too, but claiming that here would go beyond what this PR needs, and keeping two
-// such atoms separate is precise anyway.
+//
+// Five families cover the primitives and the two absence markers, the kinds whose
+// disjointness the solver already decides elsewhere. A sixth covers the borrows a
+// primitive can never be. Bare objects, tuples, functions, and class instances are
+// deliberately absent. They are disjoint from a primitive too, but keeping two such
+// atoms separate is already precise, so naming them here would buy nothing.
+//
+// Only cross-family disjointness applies to refCellFamily. The within-family rules
+// meetValueAtoms uses for the primitives read two distinct atoms as disjoint, which
+// is right for `5` and `6` and wrong for two borrows.
 type valueFamily int
 
 const (
@@ -906,6 +911,7 @@ const (
 	booleanFamily
 	nullFamily
 	undefinedFamily
+	refCellFamily
 )
 
 // valueFamilyOf returns the family t draws its values from, and notValueAtom for
@@ -920,6 +926,27 @@ func valueFamilyOf(t soltype.Type) valueFamily {
 		return nullFamily
 	case *soltype.UndefinedType:
 		return undefinedFamily
+	case *soltype.RefType:
+		return refCellOrNot(t.Inner)
+	}
+	return notValueAtom
+}
+
+// refCellOrNot returns refCellFamily for a borrow whose carrier settles the values it
+// admits to objects, tuples, or class instances, and notValueAtom for one whose carrier
+// may still rewrite. It reads the carrier because a borrow is only as decided as the
+// value it points at.
+//
+// The three kinds it admits stay themselves under every rewrite, so a borrow over one
+// admits no primitive and no absence marker. The kinds it turns away can leave the
+// RefInner set, and RefType.Accept peels a borrow whose inner does. A `mut β` whose β
+// inlines to `string` becomes `string`, so reading it as disjoint from `string` would be
+// wrong. A union, an intersection, and an alias can each reduce to a bare primitive the
+// same way.
+func refCellOrNot(carrier soltype.Type) valueFamily {
+	switch carrier.(type) {
+	case *soltype.ObjectType, *soltype.TupleType, *soltype.ClassType:
+		return refCellFamily
 	}
 	return notValueAtom
 }
@@ -949,9 +976,15 @@ func litFamily(l soltype.Lit) valueFamily {
 }
 
 // meetValueAtoms fuses two atoms drawn from the value families. Different
-// families are disjoint, so the meet is `never`. Within one family a literal is
-// narrower than its primitive, so the literal wins, and two distinct atoms of the
-// family are disjoint.
+// families are disjoint, so the meet is `never`. Within one primitive family a
+// literal is narrower than its primitive, so the literal wins, and two distinct
+// atoms of the family are disjoint.
+//
+// Two borrows are the exception to that last rule, so they are handed back
+// unfused. `mut {x: number}` and `mut {y: string}` are distinct atoms of
+// refCellFamily and are not disjoint, since an object carrying both fields
+// inhabits each. meetAtoms reaches meetRefs once this bails, and meetRefs decides
+// the pair by comparing carriers.
 //
 // Equal atoms are answered here as well as by meetAtoms, which reaches them
 // first. The overlap is deliberate. Without it `"hello"` met with `"hello"` would
@@ -968,6 +1001,9 @@ func meetValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	if equalType(a, b) {
 		return a, true
 	}
+	if fa == refCellFamily {
+		return nil, false
+	}
 	if _, ok := a.(*soltype.PrimType); ok {
 		return b, true
 	}
@@ -982,6 +1018,9 @@ func meetValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 // primitive absorbs a literal of its own family, so `5 | number` is `number`.
 // Anything else keeps both atoms, which is already precise.
 //
+// Two borrows keep both atoms as well. No borrow absorbs another the way a
+// primitive absorbs its literal, so joinRefs decides them once this bails.
+//
 // Equal atoms are answered here too, for the reason meetValueAtoms gives. Without
 // it two equal literals would read as un-fusable and stay two atoms, which is
 // sound but needlessly imprecise.
@@ -992,6 +1031,9 @@ func joinValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	}
 	if equalType(a, b) {
 		return a, true
+	}
+	if fa == refCellFamily {
+		return nil, false
 	}
 	if _, ok := a.(*soltype.PrimType); ok {
 		return a, true

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -177,8 +177,8 @@ func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
 	case *soltype.UnknownType:
 		return dnfTop()
 	case *soltype.UnionType:
-		if t.Inexact {
-			// `A | B | ...` names A, B, and an open tail of unknown content. The tail has
+		if t.Inexact && t.TailBound == nil {
+			// `A | B | ...` names A, B, and an open tail nothing bounds. The tail has
 			// no atom to stand for it, so taking the union apart would drop it and hand
 			// back a type narrower than the source wrote. The whole node stays one atom,
 			// which round-trips exactly and keeps the flag.
@@ -197,6 +197,18 @@ func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
 		out := DNF{Conjuncts: nil}
 		for _, m := range t.Types {
 			out = dnfOr(out, c.mkDNF(m, pol))
+		}
+		if t.TailBound != nil {
+			// A bounded tail holds some unknown set of the bound's values, so no value
+			// outside the bound reaches the union and every value inside it might. That
+			// makes the bound one more disjunct for a decision about which values the
+			// union admits. `5 <: ("a" | ...string)` fails and `"z" <: ("a" | ...string)`
+			// holds, both by the ordinary union rule once the bound joins the members.
+			//
+			// The bound joins the DNF rather than the member list, so the named members
+			// stay enumerable for keyof and mapped types. Adding it to the members would
+			// let subsumption drop `"a"` against `string` and leave nothing to iterate.
+			out = dnfOr(out, c.mkDNF(t.TailBound, pol))
 		}
 		return DNF{Conjuncts: c.canonicalConjuncts(out.Conjuncts)}
 	case *soltype.IntersectionType:
@@ -241,13 +253,17 @@ func (c *Context) mkCNF(t soltype.Type, pol soltype.Polarity) CNF {
 		}
 		return CNF{Disjuncts: c.canonicalDisjuncts(out.Disjuncts)}
 	case *soltype.UnionType:
-		if t.Inexact {
-			// The open tail has no atom to stand for it; see the mkDNF arm.
+		if t.Inexact && t.TailBound == nil {
+			// An unbounded tail has no atom to stand for it; see the mkDNF arm.
 			return cnfAtom(t)
 		}
 		out := cnfBot()
 		for _, m := range t.Types {
 			out = cnfOr(out, c.mkCNF(m, pol))
+		}
+		if t.TailBound != nil {
+			// A bounded tail contributes its bound; see the mkDNF arm.
+			out = cnfOr(out, c.mkCNF(t.TailBound, pol))
 		}
 		return CNF{Disjuncts: c.canonicalDisjuncts(out.Disjuncts)}
 	case *soltype.NegationType:

--- a/internal/solver/normal_ref_test.go
+++ b/internal/solver/normal_ref_test.go
@@ -410,7 +410,7 @@ func TestBorrowDisjointFromValueAtoms(t *testing.T) {
 		{"null against a borrow", []soltype.Type{&soltype.NullType{}, borrow(true, nil, obj)}, "never"},
 		{"undefined against a borrow", []soltype.Type{&soltype.UndefinedType{}, borrow(true, nil, obj)}, "never"},
 
-		// Two borrows are distinct atoms of one family and are NOT disjoint: an object
+		// Two borrows are distinct atoms of one family and are NOT disjoint. An object
 		// carrying both fields inhabits each. The pair is left for meetRefs to decide.
 		{"two borrows stay unfused", []soltype.Type{borrow(true, nil, obj), borrow(true, nil, other)},
 			"mut {x: number} & mut {y: string}"},

--- a/internal/solver/normal_ref_test.go
+++ b/internal/solver/normal_ref_test.go
@@ -377,3 +377,92 @@ func TestNegationIsNotBorrowable(t *testing.T) {
 	require.False(t, borrowable, "NegationType must not be a RefInner")
 	require.False(t, soltype.BorrowableType(complement))
 }
+
+// TestBorrowDisjointFromValueAtoms pins the disjointness rule that lets a meet decide
+// a borrow against a primitive. A borrow over an object, a tuple, or a class instance
+// admits none of the values a primitive or an absence marker admits, so the two are
+// disjoint and their meet is `never`.
+//
+// The rule is stated as a value family in normal.go, and a family carries two
+// obligations. Cross-family atoms are disjoint, which is the answer this buys. Within
+// one family two distinct atoms are disjoint as well, which is right for `5` and `6`
+// and wrong for two borrows, so the borrow family opts out of that half. The rows
+// below cover both obligations along with the carriers the rule turns away.
+func TestBorrowDisjointFromValueAtoms(t *testing.T) {
+	c := &Context{}
+	c.registerClass("Point", &ClassDef{})
+	obj := parseType(t, "{x: number}").(soltype.RefInner)
+	other := parseType(t, "{y: string}").(soltype.RefInner)
+	tuple := parseType(t, "[number]").(soltype.RefInner)
+
+	tests := []struct {
+		name  string
+		parts []soltype.Type
+		want  string
+	}{
+		// A borrow's carrier decides what values it admits, and none of these carriers
+		// admits a primitive however the borrow is written.
+		{"owned mutable cell against a primitive", []soltype.Type{str(), borrow(true, nil, obj)}, "never"},
+		{"lifetime borrow against a literal", []soltype.Type{numLit(5), borrow(false, c.freshLifetime(0), obj)}, "never"},
+		{"tuple carrier against a primitive", []soltype.Type{str(), borrow(true, nil, tuple)}, "never"},
+		{"class carrier against a primitive", []soltype.Type{num(), borrow(true, nil, cls("Point", false))}, "never"},
+		// The absence markers are families of their own, so they answer the same way.
+		{"null against a borrow", []soltype.Type{&soltype.NullType{}, borrow(true, nil, obj)}, "never"},
+		{"undefined against a borrow", []soltype.Type{&soltype.UndefinedType{}, borrow(true, nil, obj)}, "never"},
+
+		// Two borrows are distinct atoms of one family and are NOT disjoint: an object
+		// carrying both fields inhabits each. The pair is left for meetRefs to decide.
+		{"two borrows stay unfused", []soltype.Type{borrow(true, nil, obj), borrow(true, nil, other)},
+			"mut {x: number} & mut {y: string}"},
+
+		// A bare object is disjoint from a primitive too, but the families do not name it,
+		// so the pair keeps both atoms. That is precise, just less compact.
+		{"a bare object keeps both atoms", []soltype.Type{str(), obj}, "string & {x: number}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			met := newIntersection(nil, tt.parts)
+			require.Equal(t, tt.want, soltype.PrintAsScheme(c.normalizeDeep(met, soltype.Positive)))
+		})
+	}
+}
+
+// TestBorrowOverAnUnsettledCarrierIsNotDisjoint pins the gate the disjointness rule
+// needs to stay sound. RefType.Accept PEELS the wrapper when a rewritten inner leaves
+// the RefInner set, so a borrow over a carrier that can still become a primitive is not
+// yet a borrow of anything.
+//
+// `mut β` is the case. Coalescing it once β inlines to `string` yields a bare `string`,
+// and `string & string` is `string` rather than `never`. Reading the unresolved borrow
+// as disjoint from `string` would therefore answer a meet that later turns out
+// inhabited. A union carrier can reduce to a bare primitive the same way.
+func TestBorrowOverAnUnsettledCarrierIsNotDisjoint(t *testing.T) {
+	c := &Context{}
+	union := newUnion(nil, []soltype.Type{str(), numLit(5)}, false).(soltype.RefInner)
+
+	tests := []struct {
+		name    string
+		carrier soltype.RefInner
+		want    string
+	}{
+		{"a type variable may inline to a primitive", c.freshVar(0), "<T0> (string & mut T0)"},
+		{"a union may reduce to a bare primitive", union, "string & mut (string | 5)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			met := newIntersection(nil, []soltype.Type{str(), borrow(true, nil, tt.carrier)})
+			require.Equal(t, tt.want, soltype.PrintAsScheme(c.normalizeDeep(met, soltype.Positive)))
+		})
+	}
+}
+
+// TestBorrowAndPrimitiveJoinKeepsBothMembers pins the dual. Disjointness makes the MEET
+// empty and says nothing about the join, so a union of the two keeps both members. No
+// borrow absorbs a primitive the way `number` absorbs `5`.
+func TestBorrowAndPrimitiveJoinKeepsBothMembers(t *testing.T) {
+	c := &Context{}
+	obj := parseType(t, "{x: number}").(soltype.RefInner)
+	joined := newUnion(nil, []soltype.Type{str(), borrow(true, nil, obj)}, false)
+	require.Equal(t, "string | mut {x: number}",
+		soltype.PrintAsScheme(c.normalizeDeep(joined, soltype.Positive)))
+}

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -588,8 +588,12 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 // since meeting such an arm with ¬n leaves no value. A non-union p that is itself a
 // subtype of n leaves nothing at all, which excludeArms returns as `never`.
 //
-// An INEXACT union in p is left as written. It is top, so none of its arms bounds the
-// type and dropping one would discard a named member for no gain.
+// A union whose open tail carries no bound is left as written. It is top, so none of
+// its arms bounds the type and dropping one would discard a named member for no gain.
+//
+// A bounded tail does bound the type, so it is weighed like an arm. The tail goes away
+// when ¬n rules out every value its bound admits, and otherwise stays as written, since
+// excludeArms only ever drops parts.
 func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
 	u, isUnion := p.(*soltype.UnionType)
 	if !isUnion {
@@ -598,7 +602,7 @@ func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
 		}
 		return p, false
 	}
-	if u.Inexact {
+	if u.Inexact && u.TailBound == nil {
 		return p, false
 	}
 	arms := make([]soltype.Type, 0, len(u.Types))
@@ -608,10 +612,14 @@ func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
 		}
 		arms = append(arms, arm)
 	}
-	if len(arms) == len(u.Types) {
+	tail := tailOf(u)
+	if tail.bound != nil && concreteMember(tail.bound) && subtypeHolds(c, tail.bound, n) {
+		tail = unionTail{}
+	}
+	if len(arms) == len(u.Types) && tail.open == u.Inexact {
 		return p, false
 	}
-	// collapseUnion returns `never` for an empty arm list, which is the caller's
-	// signal that the whole meet is uninhabited.
-	return collapseUnion(arms, u.Inexact, false), true
+	// collapseUnion returns `never` for an empty arm list under a tail that dropped,
+	// which is the caller's signal that the whole meet is uninhabited.
+	return collapseUnion(arms, tail, false), true
 }

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -747,13 +747,42 @@ func TestIndexOverAMemberlessBoundedUnion(t *testing.T) {
 func TestVisitorRidersReachTheTailBound(t *testing.T) {
 	binder := &soltype.InferType{ID: 7, Name: "U", Binder: true}
 
-	t.Run("an infer binder in the bound is found and filled", func(t *testing.T) {
-		pattern := newBoundedUnion(nil, []soltype.Type{strLit("a")}, binder)
-		require.Equal(t, `"a" | ...infer U`, soltype.Print(pattern))
-		require.True(t, containsInfer(pattern))
-		require.Equal(t, []int{7}, inferDeclIDs(pattern))
-		filled := substituteInfer(pattern, map[int]soltype.Type{7: str()})
-		require.Equal(t, `"a" | ...string`, soltype.Print(filled))
+	// `if ("a" | ...string) : ("a" | ...B) { then } else { boolean }`, the shape every binder
+	// case below runs. The check's bound is `string` and its only named member is `"a"`, so a
+	// capture of `string` can only have come from the bound.
+	//
+	// An `infer` binder means nothing outside a conditional, so these run one rather than
+	// calling the infer machinery on a bare pattern. reduceCondInfer drives inferDeclIDs,
+	// substituteInfer, and the trial constraint in turn, and each rides the visitor, so a walk
+	// that stopped at the member list would leave U undeclared and take the Else branch.
+	match := func(patternBound, then soltype.Type) string {
+		return soltype.Print(reduceType(&soltype.CondType{
+			Check:   newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()),
+			Extends: newBoundedUnion(nil, []soltype.Type{strLit("a")}, patternBound),
+			Then:    then,
+			Else:    boolT(),
+		}))
+	}
+
+	t.Run("a binder in the bound captures the check's bound", func(t *testing.T) {
+		require.Equal(t, "string", match(binder, binder))
+	})
+
+	t.Run("the capture reaches a compound branch", func(t *testing.T) {
+		// Then is `[U]`, so the answer shows substituteInfer filling a position inside the
+		// branch rather than the branch being the binder itself.
+		require.Equal(t, "[string]", match(binder, &soltype.TupleType{Elems: []soltype.Type{binder}}))
+	})
+
+	t.Run("a concrete bound the check fits takes the Then branch", func(t *testing.T) {
+		// No binder anywhere. The bounds still have to meet for the branch to be selected, so
+		// this and the case below are what show the bound is matched against rather than
+		// carried along.
+		require.Equal(t, "9", match(str(), numLit(9)))
+	})
+
+	t.Run("a bound the check does not fit takes the Else branch", func(t *testing.T) {
+		require.Equal(t, "boolean", match(num(), binder))
 	})
 
 	t.Run("a residual operator in the bound leaves the union ungrounded", func(t *testing.T) {
@@ -768,18 +797,6 @@ func TestVisitorRidersReachTheTailBound(t *testing.T) {
 	t.Run("a free variable in the bound is found", func(t *testing.T) {
 		u := newBoundedUnion(nil, []soltype.Type{strLit("a")}, &soltype.TypeVarType{ID: 2, Level: 1})
 		require.True(t, containsFreeVar(u))
-	})
-
-	// End to end: the capture comes from the subtype check that decides the branch, so a binder
-	// in the bound is filled by the same route a binder in a written member is.
-	t.Run("a conditional captures from the bound", func(t *testing.T) {
-		cond := &soltype.CondType{
-			Check:   newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()),
-			Extends: newBoundedUnion(nil, []soltype.Type{strLit("a")}, binder),
-			Then:    binder,
-			Else:    boolT(),
-		}
-		require.Equal(t, "string", soltype.Print(reduceType(cond)))
 	})
 }
 

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -535,6 +535,33 @@ func TestOperatorsOverAMemberlessBoundedUnion(t *testing.T) {
 		})
 	}
 
+	// A conditional over such a union runs entirely on the bound, since the bound is the only
+	// thing the union says. Whether it has an answer decides whether the conditional reduces
+	// at all, so both outcomes are stated here as solver types rather than as source, which
+	// has no syntax for a bounded tail to write the operand with.
+	t.Run("a check the bound answers uniformly reduces", func(t *testing.T) {
+		// `if (...string) : string { 1 } else { 2 }`. Every value the tail could hold is a
+		// string, so every member takes Then and the result's tail is bounded by `1`.
+		cond := &soltype.CondType{
+			Check:   newBoundedUnion(nil, nil, str()),
+			Extends: str(), Then: numLit(1), Else: numLit(2), Distribute: true,
+		}
+		require.Equal(t, "...1", soltype.Print(reduceType(cond)))
+	})
+
+	t.Run("a check that splits the bound with no difference form stays symbolic", func(t *testing.T) {
+		// `if (...string) : "b" { 1 } else { 2 }`. Some strings are "b" and some are not, so
+		// the members do not agree on a branch. The conditional keeps neither branch and does
+		// not denote a set difference, so there is no answer to give and it stays as written.
+		// Unbounding the tail would leave a union with neither member nor bound, which
+		// collapses to `never`.
+		cond := &soltype.CondType{
+			Check:   newBoundedUnion(nil, nil, str()),
+			Extends: strLit("b"), Then: numLit(1), Else: numLit(2), Distribute: true,
+		}
+		require.Equal(t, `if ...string : "b" { 1 } else { 2 }`, soltype.Print(reduceType(cond)))
+	})
+
 	// A key set that names keys is still enumerable, so the tail changes nothing about how a
 	// mapped type over it expands. This is the case the rules above must not catch.
 	t.Run("a named key still gets a field", func(t *testing.T) {
@@ -545,6 +572,49 @@ func TestOperatorsOverAMemberlessBoundedUnion(t *testing.T) {
 		require.Empty(t, errs)
 		require.Equal(t, "{a: boolean, ...}", soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
 	})
+}
+
+// The normalization layer reads a bounded tail as one more disjunct, so a decision about
+// which values the union admits sees the bound alongside the named members. The two probes
+// below are the two directions that reading is consulted from.
+func TestNormalizationReadsTheTailBound(t *testing.T) {
+	c := newChecker()
+	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())
+
+	// `"a"` is one of the strings the bound admits, so the two fuse and the whole union
+	// normalizes to `string`. An unbounded tail has no atom to fuse and stays whole.
+	t.Run("a bounded tail joins the disjuncts", func(t *testing.T) {
+		require.Equal(t, "string", soltype.Print(c.ctx.mkCNF(bounded, soltype.Positive).toType()))
+		require.Equal(t, "string", soltype.Print(c.ctx.mkDNF(bounded, soltype.Positive).toType()))
+	})
+
+	t.Run("an unbounded tail stays one atom", func(t *testing.T) {
+		open := newUnion(nil, []soltype.Type{strLit("a")}, true)
+		require.Equal(t, `"a" | ...`, soltype.Print(c.ctx.mkCNF(open, soltype.Positive).toType()))
+	})
+}
+
+// simplifyNegations weighs a bounded tail the way it weighs a named arm, so a complement that
+// rules out everything the bound admits empties the meet. An unbounded tail is top and no
+// complement can empty it, which TestSimplifyNegationsRefusesToCollapse pins on the other side.
+func TestSimplifyNegationsEmptiesABoundedTail(t *testing.T) {
+	c := newChecker()
+	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())
+
+	// `("a" | ...string) & ¬string`. Both the named member and every value the tail could
+	// hold is a string, so nothing survives.
+	kept, changed, provedEmpty := simplifyNegations(c.ctx, []soltype.Type{bounded, negT(str())})
+	require.True(t, provedEmpty)
+	require.True(t, changed)
+	require.Empty(t, kept)
+}
+
+// peelBorrows strips the borrow wrapper off every member a union has, and the tail's bound is
+// one of them. A dropped bound would leave the peeled union unbounded, which is top.
+func TestPeelBorrowsReachesTheTailBound(t *testing.T) {
+	inner := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("x", num())}}
+	peeled := peelBorrows(newBoundedUnion(nil, []soltype.Type{num()}, &soltype.RefType{Inner: inner}))
+	require.Equal(t, "number | ...{x: number}", soltype.Print(peeled))
 }
 
 // An indexed access over a key set or a target that names no member of its own. Both shapes

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -350,8 +350,9 @@ func TestBoundedTailIsNotTop(t *testing.T) {
 		}
 	})
 
-	// The complement is inhabited, so newNegation has something to wrap. This is the probe
-	// behind `¬keyof {a: X, ...}` rejecting `5` rather than reducing to `never`.
+	// The complement is inhabited, so newNegation has something to wrap. `5` is not a key of
+	// the object, so it satisfies `¬keyof {a: X, ...}`, while a string that could be one does
+	// not. An unbounded tail folds the whole complement to `never`, which nothing satisfies.
 	t.Run("its complement is inhabited", func(t *testing.T) {
 		require.True(t, subtypeHolds(c.ctx, numLit(5), negT(bounded)))
 		require.False(t, subtypeHolds(c.ctx, strLit("z"), negT(bounded)))

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -1035,6 +1035,18 @@ func TestOperatorResultsOverABoundedTailStayUsable(t *testing.T) {
 		require.False(t, subtypeHolds(c.ctx, numLit(5), result), "the bound still rules out a non-string")
 	})
 
+	// An index read that cannot ground the bound has no answer to commit to. Answering anyway
+	// would produce `number | ...string["x"]`, a union whose bound is an unreduced access, and
+	// a union carrying an unreduced operator anywhere is decided against that operator rather
+	// than against the union. The whole access stays symbolic instead, so it reduces once the
+	// target grounds.
+	t.Run("an ungrounded index read over a bounded tail stays symbolic", func(t *testing.T) {
+		obj := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("x", num())}}
+		target := &soltype.UnionType{Types: []soltype.Type{obj}, Inexact: true, TailBound: str()}
+		got := reduceType(&soltype.IndexType{Target: target, Index: strLit("x")})
+		require.Equal(t, `({x: number} | ...string)["x"]`, soltype.Print(got))
+	})
+
 	// Keeping only the named key leaves a tail drawn from `string ∩ "a"`, which is `"a"` — a key
 	// the union already names. An unfused meet would hide that and leave the tail standing,
 	// which makes the union inexact and stops it satisfying an exact object.

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -589,8 +589,10 @@ func TestNormalizationReadsTheTailBound(t *testing.T) {
 	})
 
 	t.Run("an unbounded tail stays one atom", func(t *testing.T) {
+		// mkDNF and mkCNF each carry their own unbounded-tail guard, so both are probed.
 		open := newUnion(nil, []soltype.Type{strLit("a")}, true)
 		require.Equal(t, `"a" | ...`, soltype.Print(c.ctx.mkCNF(open, soltype.Positive).toType()))
+		require.Equal(t, `"a" | ...`, soltype.Print(c.ctx.mkDNF(open, soltype.Positive).toType()))
 	})
 }
 
@@ -615,6 +617,45 @@ func TestPeelBorrowsReachesTheTailBound(t *testing.T) {
 	inner := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("x", num())}}
 	peeled := peelBorrows(newBoundedUnion(nil, []soltype.Type{num()}, &soltype.RefType{Inner: inner}))
 	require.Equal(t, "number | ...{x: number}", soltype.Print(peeled))
+}
+
+// Narrowing a union to the members a pattern can destructure weighs the tail's bound too, but
+// only where the bound answers for every member drawn from it. The `keep` predicate is a shape
+// test over one member, and a bound is the set its members come from, so the two coincide for
+// an atomic bound and part ways for a structured one.
+func TestNarrowUnionMembersWeighsTheTailBound(t *testing.T) {
+	objA := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("a", num())}}
+	objB := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("b", str())}}
+	// keepA stands for an object pattern `{a}`: it accepts a member carrying the key "a".
+	keepA := func(m soltype.Type) bool { return objectMemberHasKeys(m, []string{"a"}) }
+
+	t.Run("an atomic bound no member of which fits is dropped", func(t *testing.T) {
+		// `{a: number} | {b: string} | ...string`. Every value the tail holds is a string, and
+		// no string carries the key "a", so the tail contributes nothing to this branch.
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, str())
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number}", soltype.Print(narrowed))
+	})
+
+	t.Run("a structured bound is kept", func(t *testing.T) {
+		// `{a: number} | {b: string} | ...{b: string}`. The bound itself carries no "a", but a
+		// member drawn from it may, so deciding the tail needs a disjointness question
+		// narrowUnionMembers cannot ask. It keeps the tail, which is the wider answer.
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, objB)
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number} | ...{b: string}", soltype.Print(narrowed))
+	})
+
+	t.Run("an unbounded tail is kept", func(t *testing.T) {
+		// Nothing says what the tail holds, so it survives every narrowing, which is the rule
+		// the field-read path already depends on.
+		u := newUnion(nil, []soltype.Type{objA, objB}, true)
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number} | ...", soltype.Print(narrowed))
+	})
 }
 
 // An indexed access over a key set or a target that names no member of its own. Both shapes

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -469,7 +469,7 @@ func TestOperatorsCarryTheTailBound(t *testing.T) {
 }
 
 // Excluding the one key an inexact object names leaves a key set with no named member, so what
-// the tail admits is the whole answer. The bound is where the exclusion has to land: a tail that
+// the tail admits is the whole answer. The bound is where the exclusion has to land. A tail that
 // kept `string` whole would take back the very key the exclusion removed.
 func TestExcludingEveryNamedKeyStillRejectsIt(t *testing.T) {
 	nodes, ctx, errs := inferTypeNodes(t, `
@@ -487,10 +487,10 @@ func TestExcludingEveryNamedKeyStillRejectsIt(t *testing.T) {
 	require.False(t, subtypeHolds(c.ctx, numLit(5), rest), "the bound still rules out a non-string")
 }
 
-// A union that names no member and bounds its tail is a shape only the type operators mint,
-// and every rule that runs over a union's members has to notice that the members it can see
-// are not all there are. Reading the empty list as "nothing" answers `never` or `{}`, both of
-// which claim the union is empty when it is only unenumerated.
+// A union that names no member and bounds its tail is a shape only the type operators mint.
+// Every rule that runs over a union's members has to notice that the members it can see are
+// not all there are. Reading the empty list as "nothing" answers `never` or `{}`, and both
+// claim the union is empty when it is only unenumerated.
 //
 // Each case here reduces such a union through a different operator. `Drop<keyof Obj, "a">` is
 // `...(string & ¬"a")`, the string keys of an inexact one-key object other than the one it names.

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -430,12 +430,14 @@ func TestOperatorsCarryTheTailBound(t *testing.T) {
 		{
 			// A check every value of the bound satisfies takes the same branch for every tail
 			// member, so the conditional runs on the bound the way it runs on a named member.
+			// Every member and the bound alike select `"y"`, and a tail drawn from a type the
+			// union already names adds nothing, so the whole result closes to `"y"`.
 			name: "DistributiveConditionalUniformOverTheBound",
 			decl: `
 				type Yes<T> = if T : string { "y" } else { "n" }
 				type Result = Yes<keyof Obj>
 			`,
-			want: `"y" | ..."y"`,
+			want: `"y"`,
 		},
 		{
 			// `Inexact` over an already-open union is the identity, so the bound has to
@@ -641,13 +643,17 @@ func TestNarrowUnionMembersWeighsTheTailBound(t *testing.T) {
 	})
 
 	t.Run("a structured bound is kept", func(t *testing.T) {
-		// `{a: number} | {b: string} | ...{b: string}`. The bound itself carries no "a", but a
+		// `{a: number} | {b: string} | ...{c: boolean}`. The bound itself carries no "a", but a
 		// member drawn from it may, so deciding the tail needs a disjointness question
 		// narrowUnionMembers cannot ask. It keeps the tail, which is the wider answer.
-		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, objB)
+		//
+		// The bound names a shape no member of the union does. A bound equal to a named member
+		// is subsumed by it and drops at construction, which would leave nothing to narrow.
+		objC := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("c", boolT())}}
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, objC)
 		narrowed, ok := narrowUnionMembers(u, keepA)
 		require.True(t, ok)
-		require.Equal(t, "{a: number} | ...{b: string}", soltype.Print(narrowed))
+		require.Equal(t, "{a: number} | ...{c: boolean}", soltype.Print(narrowed))
 	})
 
 	t.Run("an unbounded tail is kept", func(t *testing.T) {

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -380,11 +380,81 @@ func TestBoundedTailIsNotTop(t *testing.T) {
 				newBoundedUnion(nil, []soltype.Type{strLit("a")}, strLit("z")), bounded, true,
 			},
 			{"a bounded tail is not below a lone member", bounded, strLit("a"), false},
+			// The unbounded sub is top, so no bounded super absorbs it. This is the one
+			// pair where both operands carry a tail and only the sub's is unbounded.
+			{
+				"an unbounded tail is not below a bounded one",
+				newUnion(nil, []soltype.Type{strLit("a")}, true), bounded, false,
+			},
+			{
+				"a bounded tail is below an unbounded one",
+				bounded, newUnion(nil, []soltype.Type{strLit("a")}, true), true,
+			},
 		}
 		for _, p := range probes {
 			require.Equal(t, p.want, subtypeHolds(c.ctx, p.sub, p.sup), p.name)
 		}
 	})
+}
+
+// A type operator that rebuilds a union has to carry the tail's bound through, or the result
+// lands back at the top of the lattice the bound took it off. Each case runs an operator over
+// `keyof {a: number, b: string, ...}`, whose tail is bounded by `string`.
+func TestOperatorsCarryTheTailBound(t *testing.T) {
+	tests := []struct {
+		name string
+		// decl is a type declaration appended to the shared Obj alias, binding Result.
+		decl string
+		want string
+	}{
+		{
+			// The key set the operator starts from.
+			name: "Keyof",
+			decl: `type Result = keyof Obj`,
+			want: `"a" | "b" | ...string`,
+		},
+		{
+			// A distributive conditional reaches the bound the way it reaches a named member,
+			// so `Exclude` over an inexact object's keys stays a key set rather than widening
+			// to top. This is what leaves `Omit` a bounded tail to map over.
+			name: "DistributiveConditional",
+			decl: `
+				type Drop<T, U> = if T : U { never } else { T }
+				type Result = Drop<keyof Obj, "a">
+			`,
+			want: `"b" | ...string`,
+		},
+		{
+			// `Inexact` over an already-open union is the identity, so the bound has to
+			// survive the rewrite rather than being reset to unbounded.
+			name: "InexactIsTheIdentityOnAnOpenUnion",
+			decl: `type Result = Inexact<keyof Obj>`,
+			want: `"a" | "b" | ...string`,
+		},
+		{
+			// `Exact` closes the union, and a closed union has no tail to bound.
+			name: "ExactDropsTheTail",
+			decl: `type Result = Exact<keyof Obj>`,
+			want: `"a" | "b"`,
+		},
+		{
+			// A string intrinsic transforms the bound alongside the named members. Only a
+			// literal has a case to change, so the bound comes back symbolic, but it still
+			// says the tail holds strings.
+			name: "StringIntrinsic",
+			decl: `type Result = Uppercase<keyof Obj>`,
+			want: `"A" | "B" | ...Uppercase<string>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, `
+				type Obj = {a: number, b: string, ...}
+			`+tt.decl)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
 }
 
 // keyof over an inexact object or tuple is the one site that mints a bounded tail today,

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -487,6 +487,66 @@ func TestExcludingEveryNamedKeyStillRejectsIt(t *testing.T) {
 	require.False(t, subtypeHolds(c.ctx, numLit(5), rest), "the bound still rules out a non-string")
 }
 
+// A union that names no member and bounds its tail is a shape only the type operators mint,
+// and every rule that runs over a union's members has to notice that the members it can see
+// are not all there are. Reading the empty list as "nothing" answers `never` or `{}`, both of
+// which claim the union is empty when it is only unenumerated.
+//
+// Each case here reduces such a union through a different operator. `Drop<keyof Obj, "a">` is
+// `...(string & ¬"a")`, the string keys of an inexact one-key object other than the one it names.
+func TestOperatorsOverAMemberlessBoundedUnion(t *testing.T) {
+	tests := []struct {
+		name string
+		decl string
+		want string
+	}{
+		{
+			// A mapped type has no key to emit a field for, so the member stays the index
+			// signature it was written as. Expanding over no key would give `{}`, and the
+			// inexactness marker alone would give `{...}`, which accepts a field of any type.
+			name: "MappedTypeStaysAnIndexSignature",
+			decl: `type Result = {[K]: boolean for K in Drop<keyof Obj, "a">}`,
+			want: `{[K: ...(string & ¬"a")]: boolean}`,
+		},
+		{
+			// A template literal has no choice to fold into its segments, so it stays
+			// symbolic. The cartesian product over no choice is empty, which would answer
+			// `never`.
+			name: "TemplateLiteralStaysSymbolic",
+			decl: "type Result = `on${Drop<keyof Obj, \"a\">}`",
+			want: "`on${Drop<keyof Obj, \"a\">}`",
+		},
+		{
+			// A second exclusion over the same key set has no named member to filter and no
+			// filter answer for the bound, so it stays a meet rather than collapsing.
+			name: "SecondExclusionStaysAMeet",
+			decl: `type Result = Drop<Drop<keyof Obj, "a">, "b">`,
+			want: `¬"b" & Drop<keyof Obj, "a">`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, `
+				type Obj = {a: number, ...}
+				type Drop<T, U> = if T : U { never } else { T }
+			`+tt.decl)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+
+	// A key set that names keys is still enumerable, so the tail changes nothing about how a
+	// mapped type over it expands. This is the case the rules above must not catch.
+	t.Run("a named key still gets a field", func(t *testing.T) {
+		nodes, ctx, errs := inferTypeNodes(t, `
+			type Obj = {a: number, ...}
+			type Result = {[K]: boolean for K in keyof Obj}
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "{a: boolean, ...}", soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+	})
+}
+
 // An indexed access over a key set or a target that names no member of its own. Both shapes
 // arrive from a set difference that excluded every named member, and neither may be read as
 // `never`, which would claim the union is empty when it is only unenumerated.

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -356,6 +356,35 @@ func TestBoundedTailIsNotTop(t *testing.T) {
 		require.True(t, subtypeHolds(c.ctx, numLit(5), negT(bounded)))
 		require.False(t, subtypeHolds(c.ctx, strLit("z"), negT(bounded)))
 	})
+
+	// The bound also decides what the union is below, which is the direction that carries
+	// the tail into a supertype rather than out of one. An unbounded tail is below nothing
+	// but `unknown`, since no closed type absorbs a tail that may hold anything.
+	t.Run("the bound decides what the union is below", func(t *testing.T) {
+		probes := []struct {
+			name     string
+			sub, sup soltype.Type
+			want     bool
+		}{
+			// Every member is a string, the named one included, so `string` absorbs the
+			// whole union.
+			{"a bounded tail is below its own bound", bounded, str(), true},
+			// The sub's tail may hold "zz", which the super's `number` tail rejects.
+			{
+				"a string tail is not below a number tail",
+				bounded, newBoundedUnion(nil, []soltype.Type{strLit("a")}, num()), false,
+			},
+			// The super's tail admits every string, so it absorbs the sub's whole tail.
+			{
+				"a narrower bound is below a wider one",
+				newBoundedUnion(nil, []soltype.Type{strLit("a")}, strLit("z")), bounded, true,
+			},
+			{"a bounded tail is not below a lone member", bounded, strLit("a"), false},
+		}
+		for _, p := range probes {
+			require.Equal(t, p.want, subtypeHolds(c.ctx, p.sub, p.sup), p.name)
+		}
+	})
 }
 
 // keyof over an inexact object or tuple is the one site that mints a bounded tail today,

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -414,15 +414,26 @@ func TestOperatorsCarryTheTailBound(t *testing.T) {
 			want: `"a" | "b" | ...string`,
 		},
 		{
-			// A distributive conditional reaches the bound the way it reaches a named member,
-			// so `Exclude` over an inexact object's keys stays a key set rather than widening
-			// to top. This is what leaves `Omit` a bounded tail to map over.
-			name: "DistributiveConditional",
+			// A filtering conditional splits the bound rather than keeping or dropping it
+			// whole, since `"a"` is one of the strings the bound admits. The tail comes back
+			// cut by the same exclusion the named members took, which is the answer
+			// reduceDifference computes for this set through the `∩ ¬` form.
+			name: "DistributiveConditionalSplitsTheBound",
 			decl: `
 				type Drop<T, U> = if T : U { never } else { T }
 				type Result = Drop<keyof Obj, "a">
 			`,
-			want: `"b" | ...string`,
+			want: `"b" | ...(string & ¬"a")`,
+		},
+		{
+			// A check every value of the bound satisfies takes the same branch for every tail
+			// member, so the conditional runs on the bound the way it runs on a named member.
+			name: "DistributiveConditionalUniformOverTheBound",
+			decl: `
+				type Yes<T> = if T : string { "y" } else { "n" }
+				type Result = Yes<keyof Obj>
+			`,
+			want: `"y" | ..."y"`,
 		},
 		{
 			// `Inexact` over an already-open union is the identity, so the bound has to
@@ -455,6 +466,46 @@ func TestOperatorsCarryTheTailBound(t *testing.T) {
 			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
 		})
 	}
+}
+
+// Excluding the one key an inexact object names leaves a key set with no named member, so what
+// the tail admits is the whole answer. The bound is where the exclusion has to land: a tail that
+// kept `string` whole would take back the very key the exclusion removed.
+func TestExcludingEveryNamedKeyStillRejectsIt(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Obj = {a: number, ...}
+		type Drop<T, U> = if T : U { never } else { T }
+		type Result = Drop<keyof Obj, "a">
+	`)
+	require.Empty(t, errs)
+	rest := expandAliasResidual(ctx, nodes["Result"])
+	require.Equal(t, `...(string & ¬"a")`, soltype.Print(rest))
+
+	c := newChecker()
+	require.False(t, subtypeHolds(c.ctx, strLit("a"), rest), "the excluded key is not a member")
+	require.True(t, subtypeHolds(c.ctx, strLit("b"), rest), "another key may be one of the unlisted members")
+	require.False(t, subtypeHolds(c.ctx, numLit(5), rest), "the bound still rules out a non-string")
+}
+
+// An indexed access over a key set or a target that names no member of its own. Both shapes
+// arrive from a set difference that excluded every named member, and neither may be read as
+// `never`, which would claim the union is empty when it is only unenumerated.
+func TestIndexOverAMemberlessBoundedUnion(t *testing.T) {
+	obj := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("x", num())}, Inexact: true}
+
+	t.Run("a member-less key set leaves the access symbolic", func(t *testing.T) {
+		// There is no key to read the target at, since the bound says the keys are strings
+		// without saying which.
+		idx := &soltype.IndexType{Target: obj, Index: newBoundedUnion(nil, nil, str())}
+		require.Equal(t, `{x: number, ...}[...string]`, soltype.Print(reduceType(idx)))
+	})
+
+	t.Run("a member-less target reads the key off its bound", func(t *testing.T) {
+		// The bound names every member the target has, so reading "x" off it reads "x" off
+		// all of them at once.
+		idx := &soltype.IndexType{Target: newBoundedUnion(nil, nil, obj), Index: strLit("x")}
+		require.Equal(t, "...number", soltype.Print(reduceType(idx)))
+	})
 }
 
 // keyof over an inexact object or tuple is the one site that mints a bounded tail today,

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -765,16 +765,21 @@ func TestVisitorRidersReachTheTailBound(t *testing.T) {
 	}
 
 	t.Run("a binder in the bound captures the check's bound", func(t *testing.T) {
+		// if ("a" | ...string) : ("a" | ...infer U) { U } else { boolean }  ⇒  string
 		require.Equal(t, "string", match(binder, binder))
 	})
 
 	t.Run("the capture reaches a compound branch", func(t *testing.T) {
-		// Then is `[U]`, so the answer shows substituteInfer filling a position inside the
-		// branch rather than the branch being the binder itself.
+		// if ("a" | ...string) : ("a" | ...infer U) { [U] } else { boolean }  ⇒  [string]
+		//
+		// The answer shows substituteInfer filling a position inside the branch rather than
+		// the branch being the binder itself.
 		require.Equal(t, "[string]", match(binder, &soltype.TupleType{Elems: []soltype.Type{binder}}))
 	})
 
 	t.Run("a concrete bound the check fits takes the Then branch", func(t *testing.T) {
+		// if ("a" | ...string) : ("a" | ...string) { 9 } else { boolean }  ⇒  9
+		//
 		// No binder anywhere. The bounds still have to meet for the branch to be selected, so
 		// this and the case below are what show the bound is matched against rather than
 		// carried along.
@@ -782,10 +787,13 @@ func TestVisitorRidersReachTheTailBound(t *testing.T) {
 	})
 
 	t.Run("a bound the check does not fit takes the Else branch", func(t *testing.T) {
-		require.Equal(t, "boolean", match(num(), binder))
+		// if ("a" | ...string) : ("a" | ...number) { 9 } else { boolean }  ⇒  boolean
+		require.Equal(t, "boolean", match(num(), numLit(9)))
 	})
 
 	t.Run("a residual operator in the bound leaves the union ungrounded", func(t *testing.T) {
+		// "a" | ...keyof T
+		//
 		// condOperandGround reads containsResidualOp, so a `keyof` reachable only through the
 		// bound has to keep a conditional over this union symbolic.
 		u := newBoundedUnion(nil, []soltype.Type{strLit("a")},
@@ -795,6 +803,7 @@ func TestVisitorRidersReachTheTailBound(t *testing.T) {
 	})
 
 	t.Run("a free variable in the bound is found", func(t *testing.T) {
+		// "a" | ...T
 		u := newBoundedUnion(nil, []soltype.Type{strLit("a")}, &soltype.TypeVarType{ID: 2, Level: 1})
 		require.True(t, containsFreeVar(u))
 	})

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -238,11 +238,19 @@ func TestNewNegation(t *testing.T) {
 		{"never", &soltype.NeverType{}, "unknown"},
 		{"unknown", &soltype.UnknownType{}, "never"},
 		{"double complement", negT(str()), "string"},
-		// An inexact union accepts every value, so its complement accepts none.
+		// A union whose open tail carries no bound accepts every value, so its complement
+		// accepts none.
 		{"open union", newUnion(nil, []soltype.Type{boolT(), str()}, true), "never"},
 		{"primitive", str(), "¬string"},
 		// A closed union bounds its members, so its complement is a real type.
 		{"closed union", unionT(str(), num()), "¬(number | string)"},
+		// So does a bounded tail. `¬("a" | ...string)` admits `5`, which is exactly what the
+		// fold above would have thrown away.
+		{
+			"bounded open union",
+			newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()),
+			`¬("a" | ...string)`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -251,10 +259,13 @@ func TestNewNegation(t *testing.T) {
 	}
 }
 
-// An inexact union is the top of the subtype lattice, and two passes now depend on that.
-// newNegation folds `¬(A | B | ...)` to `never`, and simplifyNegations collapses a meet
-// carrying such a complement. Both rest on the probes below, so they are pinned here
-// rather than left to a comment.
+// A union whose open tail carries no bound is the top of the subtype lattice, and two
+// passes depend on that. newNegation folds `¬(A | B | ...)` to `never`, and
+// simplifyNegations collapses a meet carrying such a complement. Both rest on the probes
+// below, so they are pinned here rather than left to a comment.
+//
+// TestBoundedTailIsNotTop is the counterpart. Writing a bound on the tail is what takes
+// the union out of the top position these probes put it in.
 //
 // The second subtest is the step from top-ness to the fold: if `boolean | ...` accepts
 // every value then nothing satisfies `¬(boolean | ...)`.
@@ -305,6 +316,79 @@ func TestOpenUnionIsTopForSubtypingOnly(t *testing.T) {
 
 		_, _, errs = inferSource(t, `fn g(u: unknown) { return u.x }`)
 		require.Equal(t, []string{"1:27-1:30: cannot constrain unknown <: object"}, messagesWithSpan(errs))
+	})
+}
+
+// Writing a bound on the open tail takes the union out of the top position
+// TestOpenUnionIsTopForSubtypingOnly pins. `"a" | ...string` names "a" and draws every
+// other member it has from `string`, so a value outside `string` is outside the union.
+//
+// Each probe below has a counterpart in that test that answers the other way, which is
+// what makes the bound the thing that changed rather than some difference in the shapes.
+func TestBoundedTailIsNotTop(t *testing.T) {
+	c := newChecker()
+	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()) // "a" | ...string
+
+	t.Run("the bound decides what is below the union", func(t *testing.T) {
+		probes := []struct {
+			name     string
+			sub, sup soltype.Type
+			want     bool
+		}{
+			// A value the bound admits may be one of the tail's members.
+			{"a named member is below it", strLit("a"), bounded, true},
+			{"another string is below it", strLit("z"), bounded, true},
+			{"the bound itself is below it", str(), bounded, true},
+			// A value the bound rejects cannot be, which is where the unbounded tail
+			// answered true for every sub.
+			{"a number literal is not below it", numLit(5), bounded, false},
+			{"a number is not below it", num(), bounded, false},
+			{"unknown is not below it", &soltype.UnknownType{}, bounded, false},
+		}
+		for _, p := range probes {
+			require.Equal(t, p.want, subtypeHolds(c.ctx, p.sub, p.sup), p.name)
+		}
+	})
+
+	// The complement is inhabited, so newNegation has something to wrap. This is the probe
+	// behind `¬keyof {a: X, ...}` rejecting `5` rather than reducing to `never`.
+	t.Run("its complement is inhabited", func(t *testing.T) {
+		require.True(t, subtypeHolds(c.ctx, numLit(5), negT(bounded)))
+		require.False(t, subtypeHolds(c.ctx, strLit("z"), negT(bounded)))
+	})
+}
+
+// keyof over an inexact object or tuple is the one site that mints a bounded tail today,
+// and the bound is decided by what kind of key the operand has. An object's unlisted keys
+// are property names and a tuple's are positions, so the two take different bounds.
+func TestKeyofBoundsItsOpenTail(t *testing.T) {
+	c := newChecker()
+	keysOf := func(t *testing.T, src string) soltype.Type {
+		t.Helper()
+		nodes, ctx, errs := inferTypeNodes(t, src)
+		require.Empty(t, errs)
+		return expandAliasResidual(ctx, nodes["Result"])
+	}
+
+	t.Run("an object's tail is bounded by string", func(t *testing.T) {
+		keys := keysOf(t, `
+			type Obj = {a: number, ...}
+			type Result = keyof Obj
+		`)
+		require.Equal(t, `"a" | ...string`, soltype.Print(keys))
+		// `5` is plainly not a key of that object, which an unbounded tail could not say.
+		require.False(t, subtypeHolds(c.ctx, numLit(5), keys))
+		require.True(t, subtypeHolds(c.ctx, strLit("b"), keys))
+	})
+
+	t.Run("a tuple's tail is bounded by number", func(t *testing.T) {
+		keys := keysOf(t, `
+			type Tup = [number, ...]
+			type Result = keyof Tup
+		`)
+		require.Equal(t, "0 | ...number", soltype.Print(keys))
+		require.False(t, subtypeHolds(c.ctx, strLit("a"), keys))
+		require.True(t, subtypeHolds(c.ctx, numLit(1), keys))
 	})
 }
 

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -440,6 +440,20 @@ func TestOperatorsCarryTheTailBound(t *testing.T) {
 			want: `"y"`,
 		},
 		{
+			// A check that splits the bound and drops neither branch reaches both, so the tail
+			// is bounded by what the two produce together. Here that is `1 | 2`, which the named
+			// members already are, so the tail is subsumed and the whole result closes.
+			//
+			// Without the split the tail would come back unbounded, putting the result at the
+			// top of the lattice where `"zz"` and `5` alike would satisfy it.
+			name: "DistributiveConditionalSplitsWithoutFiltering",
+			decl: `
+				type Pick2<T> = if T : "b" { 1 } else { 2 }
+				type Result = Pick2<keyof Obj>
+			`,
+			want: "1 | 2",
+		},
+		{
 			// `Inexact` over an already-open union is the identity, so the bound has to
 			// survive the rewrite rather than being reset to unbounded.
 			name: "InexactIsTheIdentityOnAnOpenUnion",
@@ -553,17 +567,52 @@ func TestOperatorsOverAMemberlessBoundedUnion(t *testing.T) {
 		require.Equal(t, "...1", soltype.Print(reduceType(cond)))
 	})
 
-	t.Run("a check that splits the bound with no difference form stays symbolic", func(t *testing.T) {
+	t.Run("a check that splits the bound takes both branches", func(t *testing.T) {
 		// `if (...string) : "b" { 1 } else { 2 }`. Some strings are "b" and some are not, so
-		// the members do not agree on a branch. The conditional keeps neither branch and does
-		// not denote a set difference, so there is no answer to give and it stays as written.
-		// Unbounding the tail would leave a union with neither member nor bound, which
-		// collapses to `never`.
+		// the members do not agree on a branch and neither branch is dropped. The tail may hold
+		// a "b", a string that is not one, both, or neither, so what it produces is somewhere
+		// inside `1 | 2`.
+		//
+		// `1 | 2` on its own would be the wrong answer, since it claims both branches are
+		// reached. The marker is what withholds that.
 		cond := &soltype.CondType{
 			Check:   newBoundedUnion(nil, nil, str()),
 			Extends: strLit("b"), Then: numLit(1), Else: numLit(2), Distribute: true,
 		}
-		require.Equal(t, `if ...string : "b" { 1 } else { 2 }`, soltype.Print(reduceType(cond)))
+		require.Equal(t, "...(1 | 2)", soltype.Print(reduceType(cond)))
+	})
+
+	t.Run("the split reaches a branch that names the distributed parameter", func(t *testing.T) {
+		// `if (...string) : "b" { [T] } else { T }`, where T is the parameter the conditional
+		// distributes over. Each branch sees its own half of the split rather than the whole
+		// bound, so Then wraps the part that matched and Else keeps the part that did not.
+		//
+		// The branches name the Check itself, since that is the pointer an alias expansion
+		// installs at every occurrence of the parameter and the one substituteOccurrences
+		// matches on.
+		check := newBoundedUnion(nil, nil, str())
+		cond := &soltype.CondType{
+			Check:      check,
+			Extends:    strLit("b"),
+			Then:       &soltype.TupleType{Elems: []soltype.Type{check}},
+			Else:       check,
+			Distribute: true,
+		}
+		require.Equal(t, `...([string & "b"] | string & ¬"b")`, soltype.Print(reduceType(cond)))
+	})
+
+	t.Run("an unnegatable check leaves the tail unbounded", func(t *testing.T) {
+		// The Else half is the values `¬extends` names, and a borrow is the one operand no
+		// complement may name, so the split has no half to give it. With no named member to
+		// carry a result the conditional stays as written rather than answering from Then alone.
+		ref := &soltype.RefType{Mut: true, Inner: &soltype.ObjectType{
+			Elems: []soltype.ObjTypeElem{propElem("x", num())},
+		}}
+		cond := &soltype.CondType{
+			Check:   newBoundedUnion(nil, nil, str()),
+			Extends: ref, Then: numLit(1), Else: numLit(2), Distribute: true,
+		}
+		require.Equal(t, `if ...string : mut {x: number} { 1 } else { 2 }`, soltype.Print(reduceType(cond)))
 	})
 
 	// A key set that names keys is still enumerable, so the tail changes nothing about how a

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -603,8 +603,16 @@ func TestOperatorsOverAMemberlessBoundedUnion(t *testing.T) {
 
 	t.Run("an unnegatable check leaves the tail unbounded", func(t *testing.T) {
 		// The Else half is the values `¬extends` names, and a borrow is the one operand no
-		// complement may name, so the split has no half to give it. With no named member to
-		// carry a result the conditional stays as written rather than answering from Then alone.
+		// complement may name, so the split has no half to give it. Neither does the
+		// uniform-Else test above, which asks the same complement question. With no named
+		// member to carry a result the conditional stays as written.
+		//
+		// `...2` is the better answer and is not reached. No string is a borrow, so every
+		// tail member takes Else, which the per-member path gets right: the same conditional
+		// over the named member `"a"` reduces to `2`. A bound needs disjointness where a
+		// member needs only "not a subtype", and no oracle here decides a primitive disjoint
+		// from a borrow. meetAtoms reports the pair unfusable rather than `never`, since
+		// valueFamily covers the primitives and the absence markers alone. See #1132.
 		ref := &soltype.RefType{Mut: true, Inner: &soltype.ObjectType{
 			Elems: []soltype.ObjTypeElem{propElem("x", num())},
 		}}

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -329,21 +329,21 @@ func TestBoundedTailIsNotTop(t *testing.T) {
 	c := newChecker()
 	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()) // "a" | ...string
 
-	t.Run("the bound decides what is below the union", func(t *testing.T) {
+	t.Run("the bound decides what is a subtype of the union", func(t *testing.T) {
 		probes := []struct {
 			name     string
 			sub, sup soltype.Type
 			want     bool
 		}{
 			// A value the bound admits may be one of the tail's members.
-			{"a named member is below it", strLit("a"), bounded, true},
-			{"another string is below it", strLit("z"), bounded, true},
-			{"the bound itself is below it", str(), bounded, true},
+			{"a named member is a subtype of it", strLit("a"), bounded, true},
+			{"another string is a subtype of it", strLit("z"), bounded, true},
+			{"the bound itself is a subtype of it", str(), bounded, true},
 			// A value the bound rejects cannot be, which is where the unbounded tail
 			// answered true for every sub.
-			{"a number literal is not below it", numLit(5), bounded, false},
-			{"a number is not below it", num(), bounded, false},
-			{"unknown is not below it", &soltype.UnknownType{}, bounded, false},
+			{"a number literal is not a subtype of it", numLit(5), bounded, false},
+			{"a number is not a subtype of it", num(), bounded, false},
+			{"unknown is not a subtype of it", &soltype.UnknownType{}, bounded, false},
 		}
 		for _, p := range probes {
 			require.Equal(t, p.want, subtypeHolds(c.ctx, p.sub, p.sup), p.name)
@@ -358,10 +358,11 @@ func TestBoundedTailIsNotTop(t *testing.T) {
 		require.False(t, subtypeHolds(c.ctx, strLit("z"), negT(bounded)))
 	})
 
-	// The bound also decides what the union is below, which is the direction that carries
-	// the tail into a supertype rather than out of one. An unbounded tail is below nothing
-	// but `unknown`, since no closed type absorbs a tail that may hold anything.
-	t.Run("the bound decides what the union is below", func(t *testing.T) {
+	// The bound also decides what the union is a subtype of, which is the direction that
+	// carries the tail into a supertype rather than out of one. An unbounded tail is a
+	// subtype of nothing but `unknown`, since no closed type absorbs a tail that may hold
+	// anything.
+	t.Run("the bound decides what the union is a subtype of", func(t *testing.T) {
 		probes := []struct {
 			name     string
 			sub, sup soltype.Type
@@ -369,26 +370,26 @@ func TestBoundedTailIsNotTop(t *testing.T) {
 		}{
 			// Every member is a string, the named one included, so `string` absorbs the
 			// whole union.
-			{"a bounded tail is below its own bound", bounded, str(), true},
+			{"a bounded tail is a subtype of its own bound", bounded, str(), true},
 			// The sub's tail may hold "zz", which the super's `number` tail rejects.
 			{
-				"a string tail is not below a number tail",
+				"a string tail is not a subtype of a number tail",
 				bounded, newBoundedUnion(nil, []soltype.Type{strLit("a")}, num()), false,
 			},
 			// The super's tail admits every string, so it absorbs the sub's whole tail.
 			{
-				"a narrower bound is below a wider one",
+				"a narrower bound is a subtype of a wider one",
 				newBoundedUnion(nil, []soltype.Type{strLit("a")}, strLit("z")), bounded, true,
 			},
-			{"a bounded tail is not below a lone member", bounded, strLit("a"), false},
+			{"a bounded tail is not a subtype of a lone member", bounded, strLit("a"), false},
 			// The unbounded sub is top, so no bounded super absorbs it. This is the one
 			// pair where both operands carry a tail and only the sub's is unbounded.
 			{
-				"an unbounded tail is not below a bounded one",
+				"an unbounded tail is not a subtype of a bounded one",
 				newUnion(nil, []soltype.Type{strLit("a")}, true), bounded, false,
 			},
 			{
-				"a bounded tail is below an unbounded one",
+				"a bounded tail is a subtype of an unbounded one",
 				bounded, newUnion(nil, []soltype.Type{strLit("a")}, true), true,
 			},
 		}

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -468,11 +468,13 @@ func TestOperatorsCarryTheTailBound(t *testing.T) {
 		},
 		{
 			// A string intrinsic transforms the bound alongside the named members. Only a
-			// literal has a case to change, so the bound comes back symbolic, but it still
-			// says the tail holds strings.
+			// literal has a case to change, so transforming `string` yields the unreduced
+			// `Uppercase<string>`, which is widened to `string`. A union carrying an
+			// unreduced operator anywhere reads as residual, and constraint solving then
+			// decides against the operator instead of the union it belongs to.
 			name: "StringIntrinsic",
 			decl: `type Result = Uppercase<keyof Obj>`,
-			want: `"A" | "B" | ...Uppercase<string>`,
+			want: `"A" | "B" | ...string`,
 		},
 	}
 	for _, tt := range tests {
@@ -601,18 +603,16 @@ func TestOperatorsOverAMemberlessBoundedUnion(t *testing.T) {
 		require.Equal(t, `...([string & "b"] | string & ¬"b")`, soltype.Print(reduceType(cond)))
 	})
 
-	t.Run("an unnegatable check leaves the tail unbounded", func(t *testing.T) {
-		// The Else half is the values `¬extends` names, and a borrow is the one operand no
-		// complement may name, so the split has no half to give it. Neither does the
-		// uniform-Else test above, which asks the same complement question. With no named
-		// member to carry a result the conditional stays as written.
+	// `if (...string) : mut {x: number} { 1 } else { 2 }`, using the syntax #1131 asks for.
+	t.Run("an unnegatable check still decides a disjoint bound", func(t *testing.T) {
+		// No string is a borrowed object, so every value the bound admits takes Else and the
+		// tail is bounded by `2`. The uniform-Else test reaches that answer through the meet
+		// `string ∩ mut {x: number}`, which normalization reports `never`.
 		//
-		// `...2` is the better answer and is not reached. No string is a borrow, so every
-		// tail member takes Else, which the per-member path gets right: the same conditional
-		// over the named member `"a"` reduces to `2`. A bound needs disjointness where a
-		// member needs only "not a subtype", and no oracle here decides a primitive disjoint
-		// from a borrow. meetAtoms reports the pair unfusable rather than `never`, since
-		// valueFamily covers the primitives and the absence markers alone. See #1132.
+		// The complement `¬(mut {x: number})` would answer the same question, and the ¬Ref
+		// exclusion invariant forbids writing it. Asking through the meet is what keeps this
+		// case decidable, and it also spares the split below, which has no Else half to give
+		// an operand no complement may name.
 		ref := &soltype.RefType{Mut: true, Inner: &soltype.ObjectType{
 			Elems: []soltype.ObjTypeElem{propElem("x", num())},
 		}}
@@ -620,7 +620,7 @@ func TestOperatorsOverAMemberlessBoundedUnion(t *testing.T) {
 			Check:   newBoundedUnion(nil, nil, str()),
 			Extends: ref, Then: numLit(1), Else: numLit(2), Distribute: true,
 		}
-		require.Equal(t, `if ...string : mut {x: number} { 1 } else { 2 }`, soltype.Print(reduceType(cond)))
+		require.Equal(t, `...2`, soltype.Print(reduceType(cond)))
 	})
 
 	// A key set that names keys is still enumerable, so the tail changes nothing about how a
@@ -911,4 +911,140 @@ func printedBounds(bounds []soltype.Type) []string {
 		out[i] = soltype.Print(b)
 	}
 	return out
+}
+
+// A bound the conditional cannot decide must not be dropped. An unbounded tail admits every
+// value, so a union that loses its bound becomes the top of the subtype lattice, which is a
+// wider answer than the operand the conditional started from. Staying symbolic keeps the
+// operand's own bound reachable and lets the reduction run again once it grounds.
+//
+// A borrow is the check that reaches this. The ¬Ref exclusion invariant forbids naming one
+// under a complement, so the split has no Else half to give it, and the bound `string` is not
+// disjoint from a borrow over an object either, so the uniform tests do not answer.
+func TestAnUndecidableBoundKeepsTheConditionalSymbolic(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Point = {x: number}
+		type Obj = {a: number, ...}
+		type Drop<T, U> = if T : U { never } else { T }
+		type Direct = Drop<keyof Obj, mut Point>
+		type Named = Drop<keyof Obj, Handle>
+		type Handle = mut Point
+	`)
+	require.Empty(t, errs)
+
+	for _, name := range []string{"Direct", "Named"} {
+		t.Run(name, func(t *testing.T) {
+			rest := expandAliasResidual(ctx, nodes[name])
+			c := newChecker()
+			require.False(t, subtypeHolds(c.ctx, numLit(5), rest),
+				"a lost bound would leave the tail unbounded, which accepts every value")
+			require.NotContains(t, soltype.Print(rest), "¬",
+				"no complement may name a borrow, however the check spells it")
+		})
+	}
+}
+
+// Excluding the whole bound leaves a tail drawn from `never`, which holds nothing. The union
+// names no member either, so the answer is `never` rather than a union with an empty tail.
+// `...never` would read as a union with unlisted members and keep every rule that consults a
+// tail from seeing that there is nothing left.
+func TestExcludingTheWholeBoundEmptiesTheUnion(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Obj = {a: number, ...}
+		type Drop<T, U> = if T : U { never } else { T }
+		type Result = Drop<keyof Obj, string>
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `never`, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+}
+
+// subsumeFinal rewrites a union's tail bound before the union itself, so a bound that only
+// becomes droppable on the way up still has to be noticed. Neither case below drops a member,
+// which is what makes them the cases a member count alone would miss.
+func TestFinalSubsumptionRereadsARewrittenTailBound(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []soltype.Type
+		bound soltype.Type
+		want  string
+	}{
+		{
+			// `¬string` admits nothing a `string` admits, so the meet is empty and the tail
+			// is drawn from `never`. A tail holding nothing leaves the union its named side,
+			// and there is none, so the answer is `never` rather than `...never`.
+			name:  "a bound that folds to never empties the union",
+			bound: newIntersection(nil, []soltype.Type{str(), not(str())}),
+			want:  "never",
+		},
+		{
+			// The bound folds to `"y"`, which the union already names. The tail then draws
+			// only members the union lists, so it contributes nothing and drops.
+			name:  "a bound that folds to a named member drops the tail",
+			parts: []soltype.Type{strLit("y")},
+			bound: newIntersection(nil, []soltype.Type{strLit("y"), not(strLit("n"))}),
+			want:  `"y"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newChecker()
+			in := &soltype.UnionType{Types: tt.parts, Inexact: true, TailBound: tt.bound}
+			require.Equal(t, tt.want, soltype.Print(c.subsumeFinal(in)))
+		})
+	}
+}
+
+// An operator over a bounded tail has to hand back a union that is still usable as a type. Two
+// ways it can fail are invisible in the printed form, so each case here checks what the result
+// accepts rather than only how it renders.
+func TestOperatorResultsOverABoundedTailStayUsable(t *testing.T) {
+	// A template produces a string whatever it interpolates, so its tail is bounded by
+	// `string`. An unbounded tail admits every value, which would let a number pass for a
+	// string the template could have produced.
+	t.Run("a template over an open key set still rejects a non-string", func(t *testing.T) {
+		nodes, ctx, errs := inferTypeNodes(t, `
+			type Obj = {a: number, ...}
+			type Result = `+"`on${keyof Obj}`"+`
+		`)
+		require.Empty(t, errs)
+		result := expandAliasResidual(ctx, nodes["Result"])
+		require.Equal(t, "\"ona\" | ...string", soltype.Print(result))
+
+		c := newChecker()
+		require.False(t, subtypeHolds(c.ctx, numLit(5), result), "a template never produces a number")
+		require.False(t, subtypeHolds(c.ctx, &soltype.LitType{Lit: &soltype.BoolLit{Value: true}}, result), "nor a boolean")
+		require.True(t, subtypeHolds(c.ctx, strLit("ona"), result), "the named string is a member")
+		require.True(t, subtypeHolds(c.ctx, strLit("onb"), result), "so is one the tail may hold")
+	})
+
+	// A bound the intrinsic cannot fold comes back as an unreduced operator, and a union
+	// carrying one anywhere reads as residual. Constraint solving would then decide against
+	// the operator rather than the union, rejecting a string the union plainly names.
+	t.Run("an intrinsic over an open key set still accepts its own member", func(t *testing.T) {
+		nodes, ctx, errs := inferTypeNodes(t, `
+			type Obj = {a: number, ...}
+			type Result = Uppercase<keyof Obj>
+		`)
+		require.Empty(t, errs)
+		result := expandAliasResidual(ctx, nodes["Result"])
+		require.Equal(t, `"A" | ...string`, soltype.Print(result))
+
+		c := newChecker()
+		require.False(t, containsResidualOp(result), "a residual union is decided against the operator")
+		require.True(t, subtypeHolds(c.ctx, strLit("A"), result), "the transformed key is a member")
+		require.False(t, subtypeHolds(c.ctx, numLit(5), result), "the bound still rules out a non-string")
+	})
+
+	// Keeping only the named key leaves a tail drawn from `string ∩ "a"`, which is `"a"` — a key
+	// the union already names. An unfused meet would hide that and leave the tail standing,
+	// which makes the union inexact and stops it satisfying an exact object.
+	t.Run("keeping one key drops the tail it already names", func(t *testing.T) {
+		nodes, ctx, errs := inferTypeNodes(t, `
+			type Obj = {a: number, ...}
+			type Keep<T, U> = if T : U { T } else { never }
+			type Result = Keep<keyof Obj, "a">
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, `"a"`, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+	})
 }

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -687,6 +687,53 @@ func TestIndexOverAMemberlessBoundedUnion(t *testing.T) {
 	})
 }
 
+// Five predicates and rewriters reach a union's members through soltype's visitor, so each
+// reaches the tail's bound too. None of them names the bound itself, which is what makes a walk
+// that stopped at the member list invisible: `condOperandGround` would call an ungrounded union
+// ground, and a capture written in the bound would never be filled.
+//
+// No surface syntax writes a bound, so an `infer` cannot reach one from source today. The
+// machinery still has to hold, since the bound is an ordinary type position and every one of
+// these rides the same walk.
+func TestVisitorRidersReachTheTailBound(t *testing.T) {
+	binder := &soltype.InferType{ID: 7, Name: "U", Binder: true}
+
+	t.Run("an infer binder in the bound is found and filled", func(t *testing.T) {
+		pattern := newBoundedUnion(nil, []soltype.Type{strLit("a")}, binder)
+		require.Equal(t, `"a" | ...infer U`, soltype.Print(pattern))
+		require.True(t, containsInfer(pattern))
+		require.Equal(t, []int{7}, inferDeclIDs(pattern))
+		filled := substituteInfer(pattern, map[int]soltype.Type{7: str()})
+		require.Equal(t, `"a" | ...string`, soltype.Print(filled))
+	})
+
+	t.Run("a residual operator in the bound leaves the union ungrounded", func(t *testing.T) {
+		// condOperandGround reads containsResidualOp, so a `keyof` reachable only through the
+		// bound has to keep a conditional over this union symbolic.
+		u := newBoundedUnion(nil, []soltype.Type{strLit("a")},
+			&soltype.KeyofType{Operand: &soltype.TypeVarType{ID: 1, Level: 1}})
+		require.True(t, containsResidualOp(u))
+		require.False(t, condOperandGround(u))
+	})
+
+	t.Run("a free variable in the bound is found", func(t *testing.T) {
+		u := newBoundedUnion(nil, []soltype.Type{strLit("a")}, &soltype.TypeVarType{ID: 2, Level: 1})
+		require.True(t, containsFreeVar(u))
+	})
+
+	// End to end: the capture comes from the subtype check that decides the branch, so a binder
+	// in the bound is filled by the same route a binder in a written member is.
+	t.Run("a conditional captures from the bound", func(t *testing.T) {
+		cond := &soltype.CondType{
+			Check:   newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()),
+			Extends: newBoundedUnion(nil, []soltype.Type{strLit("a")}, binder),
+			Then:    binder,
+			Else:    boolT(),
+		}
+		require.Equal(t, "string", soltype.Print(reduceType(cond)))
+	})
+}
+
 // keyof over an inexact object or tuple is the one site that mints a bounded tail today,
 // and the bound is decided by what kind of key the operand has. An object's unlisted keys
 // are property names and a tuple's are positions, so the two take different bounds.

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1774,8 +1774,8 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, i
 // A tail's bound is not folded into the result. The bound says the tail's choices are strings
 // without saying which, so no segment can absorb them. The result's tail is bounded by `string`
 // all the same, since a template produces a string whatever it interpolates. Leaving it unbounded
-// would make the result the top of the subtype lattice, and `` `on${keyof {a: number, ...}}` ``
-// would accept a `5`.
+// would make the result the top of the subtype lattice, so a template interpolating
+// `keyof {a: number, ...}` would accept a `5`.
 // An interpolation that names no choice at all, which is the shape a set difference leaves when it
 // excludes every named one, has nothing to run the product over and keeps the template symbolic.
 func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Type {

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1330,12 +1330,12 @@ func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
 // records that the true key set may be larger.
 //
 // The tail's bound is wider than the operand allows. This reduction is a MEET of key sets, so an
-// unnamed shared key has to be a key of every member, and the example above bounds its tail by
-// `string` where only "a" is possible: the first member is exact, so no key outside {"a", "shared"}
-// is a key of it. Bounding the tail by the exact members' key sets is what would close that gap.
-// The bound is still narrower than the unbounded tail the reduction would otherwise leave, which
-// admits every value, so `"zz"` reads as a possible key here where before it read as a possible
-// anything. escalier-lang/escalier#1126 tracks tightening it.
+// unnamed shared key has to be a key of every member. The example above bounds its tail by
+// `string` where only "a" is possible. Its first member is exact, so no key outside "a" and
+// "shared" is a key of that member, and "shared" is already named. Bounding the tail by the exact
+// members' key sets is what would close the gap. The bound still admits less than the unbounded
+// tail the reduction leaves without it, which admits every value at all, so this is an imprecise
+// answer rather than a useless one. escalier-lang/escalier#1126 tracks tightening it.
 //
 // Some members have no key set to enumerate. A type parameter is one, and so is an operator whose
 // own operands are not ground. Such a member reduces to a `keyof` residual, and the rule this whole
@@ -1352,8 +1352,8 @@ func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.
 	var residuals []soltype.Type
 	seeded := false
 	// The result's tail is open when the operand union's is, since an unlisted member
-	// carries keys the reduction cannot read. It takes no bound from that member: the
-	// operand's own bound is over VALUES and this tail is over KEYS, and an unlisted
+	// carries keys the reduction cannot read. It takes no bound from that member. The
+	// operand's own bound is over VALUES where this tail is over KEYS, and an unlisted
 	// member could be an object or a tuple, so nothing says whether its keys are names
 	// or positions. Each member's own key set then merges in, and a member that is an
 	// inexact object brings the `string` bound its keys carry.

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -282,20 +282,52 @@ func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.Union
 			Else:    substituteOccurrences(t.Else, t.Check, member),
 		})
 	}
-	// The conditional reaches the tail's bound as well, since the tail's unnamed members are
-	// drawn from it and each one selects a branch the same way a named member does. This is
-	// what keeps `Exclude<keyof {a: X, ...}, "a">` off the top of the lattice: without it the
-	// result's tail would come back unbounded and accept every value.
 	tail := tailOf(check)
 	if tail.bound != nil {
-		tail.bound = e.reduceCond(&soltype.CondType{
-			Check:   tail.bound,
-			Extends: substituteOccurrences(t.Extends, t.Check, tail.bound),
-			Then:    substituteOccurrences(t.Then, t.Check, tail.bound),
-			Else:    substituteOccurrences(t.Else, t.Check, tail.bound),
-		})
+		tail.bound = e.condOverTailBound(t, tail.bound)
 	}
 	return newUnionWithTail(nil, parts, tail)
+}
+
+// condOverTailBound applies a distributive conditional to a tail's bound and returns the bound
+// the result's tail takes, nil when the conditional has no answer over it.
+//
+// A bound stands for a SET of members rather than one, so the member-at-a-time rule the named
+// members take does not carry over. Running the conditional once over the whole bound would
+// answer as though every value the bound admits took the same branch, and a check that some
+// satisfy and others do not splits it instead.
+//
+// Three cases, tried in order.
+//
+//  1. Every value of the bound satisfies the check, so every tail member takes Then. The
+//     conditional runs on the bound the way it runs on a named member. Over `"a" | ...string`,
+//     `type Yes<T> = if T : string { "y" } else { "n" }` gives a tail bounded by `"y"`.
+//  2. No value satisfies it, so every tail member takes Else, and the same run answers.
+//  3. The check splits the bound. A filtering conditional denotes a set difference, which cuts
+//     inside the bound and answers exactly. `Exclude<"a" | ...string, "a">` gives a tail
+//     bounded by `string & ¬"a"`, the same answer reduceDifference computes for that set, so
+//     the filter and the difference agree on this operand as the file header requires. A
+//     conditional of any other shape has no answer here, so the tail comes back unbounded.
+func (e *typeEvaluator) condOverTailBound(t *soltype.CondType, bound soltype.Type) soltype.Type {
+	extends := substituteOccurrences(t.Extends, t.Check, bound)
+	uniform := e.ctx.condExtends(bound, extends, e.seen)
+	if !uniform && negatableOperand(extends) {
+		// Disjointness is the check `bound <: ¬extends`, the same question excludeFrom asks to
+		// decide that an exclusion takes nothing from a member.
+		uniform = e.ctx.condExtends(bound, soltype.NewNegation(extends), e.seen)
+	}
+	if uniform {
+		return e.reduceCond(&soltype.CondType{
+			Check:   bound,
+			Extends: extends,
+			Then:    substituteOccurrences(t.Then, t.Check, bound),
+			Else:    substituteOccurrences(t.Else, t.Check, bound),
+		})
+	}
+	if diff, ok := e.nativeDifference(t, bound, extends); ok {
+		return e.reduce(diff)
+	}
+	return nil
 }
 
 // substituteOccurrences rewrites every occurrence of the from type inside in to the to type,
@@ -1477,12 +1509,25 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 		// with the same reduced key.
 		//
 		// An inexact target union has unlisted members, and the value each holds at K is not among
-		// the ones the access read, so the result union is open too (exact-types §7.6).
+		// the ones the access read, so the result union is open too (exact-types §7.6). A bounded
+		// tail says what those unlisted members are, so reading K off the bound reads it off every
+		// one of them at once, and the result's tail keeps whatever that read yields. A target
+		// naming no member of its own has only the bound to read.
 		parts := make([]soltype.Type, len(tgt.Types))
 		for i, m := range tgt.Types {
 			parts[i] = e.reduceIndex(m, idx, inexact)
 		}
-		return newUnion(nil, parts, tgt.Inexact)
+		tail := tailOf(tgt)
+		if tail.bound != nil {
+			tail.bound = e.reduceIndex(tail.bound, idx, inexact)
+		}
+		if len(parts) == 0 && tail.bound == nil {
+			// An open target naming no member and bounding none. There is nothing to read K
+			// off, so the access stays symbolic rather than distributing over no member and
+			// answering `never`.
+			return &soltype.IndexType{Target: target, Index: idx, Inexact: inexact}
+		}
+		return newUnionWithTail(nil, parts, tail)
 	case *soltype.IntersectionType:
 		return e.reduceIndexIntersection(tgt, idx, inexact)
 	default:

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1269,11 +1269,13 @@ func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.
 	var shared []soltype.Type
 	var residuals []soltype.Type
 	seeded := false
-	// The result's tail starts as the operand union's own. An unlisted member of the
-	// operand could be an object or a tuple, so nothing bounds the keys it contributes.
-	// Each member's own key set then merges in, and a member that is an inexact object
-	// brings the `string` bound its keys carry.
-	sharedTail := tailOf(op)
+	// The result's tail is open when the operand union's is, since an unlisted member
+	// carries keys the reduction cannot read. It takes no bound from that member: the
+	// operand's own bound is over VALUES and this tail is over KEYS, and an unlisted
+	// member could be an object or a tuple, so nothing says whether its keys are names
+	// or positions. Each member's own key set then merges in, and a member that is an
+	// inexact object brings the `string` bound its keys carry.
+	sharedTail := unionTail{open: op.Inexact}
 	for _, m := range op.Types {
 		reduced := e.reduceKeyof(m, inexact)
 		keys, memberTail, ok := literalKeys(reduced)

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -306,17 +306,27 @@ func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.Union
 // answer as though every value the bound admits took the same branch, and a check that some
 // satisfy and others do not splits it instead.
 //
-// Three cases, tried in order.
+// Four cases, tried in order.
 //
 //  1. Every value of the bound satisfies the check, so every tail member takes Then. The
 //     conditional runs on the bound the way it runs on a named member. Over `"a" | ...string`,
 //     `type Yes<T> = if T : string { "y" } else { "n" }` gives a tail bounded by `"y"`.
 //  2. No value satisfies it, so every tail member takes Else, and the same run answers.
-//  3. The check splits the bound. A filtering conditional denotes a set difference, which cuts
-//     inside the bound and answers exactly. `Exclude<"a" | ...string, "a">` gives a tail
-//     bounded by `string & ¬"a"`, the same answer reduceDifference computes for that set, so
-//     the filter and the difference agree on this operand as the file header requires. A
-//     conditional of any other shape has no answer here, so the tail comes back unbounded.
+//  3. The check splits the bound and the conditional is a filter, which denotes a set
+//     difference. That cuts inside the bound and answers exactly. `Exclude<"a" | ...string, "a">`
+//     gives a tail bounded by `string & ¬"a"`, the same answer reduceDifference computes for
+//     that set, so the filter and the difference agree on this operand as the file header
+//     requires.
+//  4. The check splits the bound and the conditional is not a filter. Each part of the split
+//     takes its own branch, and the bound is what the two branches produce together.
+//     `if (...string) : "b" { 1 } else { 2 }` gives a tail bounded by `1 | 2`, since the tail
+//     may hold a "b", a string that is not one, both, or neither.
+//
+// The split bounds rather than enumerates. A tail member is somewhere in `bound ∩ Extends` or in
+// `bound ∩ ¬Extends`, so what it produces is inside what those two parts produce, which is what
+// makes case 4 sound. It also subsumes case 3, since a filter's branches are `never` and the
+// check itself, leaving `never | (bound ∩ ¬Extends)`. Case 3 runs first anyway, because
+// nativeDifference returns the `∩ ¬` form that reduceDifference recognizes.
 func (e *typeEvaluator) condOverTailBound(t *soltype.CondType, bound soltype.Type) soltype.Type {
 	extends := substituteOccurrences(t.Extends, t.Check, bound)
 	uniform := e.ctx.condExtends(bound, extends, e.seen)
@@ -336,7 +346,17 @@ func (e *typeEvaluator) condOverTailBound(t *soltype.CondType, bound soltype.Typ
 	if diff, ok := e.nativeDifference(t, bound, extends); ok {
 		return e.reduce(diff)
 	}
-	return nil
+	if !negatableOperand(extends) {
+		// The Else half is the values `¬extends` names, and an operand no complement may name
+		// has no such half. The tail comes back unbounded rather than half-decided.
+		return nil
+	}
+	matched := newIntersection(nil, []soltype.Type{bound, extends})
+	unmatched := newIntersection(nil, []soltype.Type{bound, newNegation(extends)})
+	return newUnion(nil, []soltype.Type{
+		e.reduceBranch(substituteOccurrences(t.Then, t.Check, matched)),
+		e.reduceBranch(substituteOccurrences(t.Else, t.Check, unmatched)),
+	}, false)
 }
 
 // substituteOccurrences rewrites every occurrence of the from type inside in to the to type,

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1549,7 +1549,8 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 		// the ones the access read, so the result union is open too (exact-types §7.6). A bounded
 		// tail says what those unlisted members are, so reading K off the bound reads it off every
 		// one of them at once, and the result's tail keeps whatever that read yields. A target
-		// naming no member of its own has only the bound to read.
+		// naming no member of its own has only the bound to read, and is the shape a set
+		// difference leaves when it excludes every named member.
 		parts := make([]soltype.Type, len(tgt.Types))
 		for i, m := range tgt.Types {
 			parts[i] = e.reduceIndex(m, idx, inexact)
@@ -1557,12 +1558,6 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 		tail := tailOf(tgt)
 		if tail.bound != nil {
 			tail.bound = e.reduceIndex(tail.bound, idx, inexact)
-		}
-		if len(parts) == 0 && tail.bound == nil {
-			// An open target naming no member and bounding none. There is nothing to read K
-			// off, so the access stays symbolic rather than distributing over no member and
-			// answering `never`.
-			return &soltype.IndexType{Target: target, Index: idx, Inexact: inexact}
 		}
 		return newUnionWithTail(nil, parts, tail)
 	case *soltype.IntersectionType:

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -285,11 +285,13 @@ func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.Union
 	tail := tailOf(check)
 	if tail.bound != nil {
 		tail.bound = e.condOverTailBound(t, tail.bound)
-		if tail.bound == nil && len(parts) == 0 {
-			// The check union names no member of its own, so the tail was the whole operand
-			// and the conditional just failed to answer over it. Unbounding the tail would
-			// leave a union with neither member nor bound, which collapses to `never` and
-			// claims the operand was empty. Stay symbolic instead.
+		if tail.bound == nil {
+			// The conditional failed to answer over the bound. Carrying on would drop the
+			// bound and leave the tail unbounded, and an unbounded tail admits every value,
+			// which makes the whole result the top of the subtype lattice. That is a wider
+			// answer than the operand the conditional started from, so
+			// `Exclude<keyof {a: number, ...}, R>` would accept a `5`. Stay symbolic
+			// instead, and reduce once the bound grounds enough to decide.
 			return &soltype.CondType{
 				Check: check, Extends: t.Extends, Then: t.Then, Else: t.Else, Distribute: t.Distribute,
 			}
@@ -312,6 +314,7 @@ func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.Union
 //     conditional runs on the bound the way it runs on a named member. Over `"a" | ...string`,
 //     `type Yes<T> = if T : string { "y" } else { "n" }` gives a tail bounded by `"y"`.
 //  2. No value satisfies it, so every tail member takes Else, and the same run answers.
+//     boundDisjointFrom decides that, reading an empty meet as "no value satisfies".
 //  3. The check splits the bound and the conditional is a filter, which denotes a set
 //     difference. That cuts inside the bound and answers exactly. `Exclude<"a" | ...string, "a">`
 //     gives a tail bounded by `string & ¬"a"`, the same answer reduceDifference computes for
@@ -329,12 +332,7 @@ func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.Union
 // nativeDifference returns the `∩ ¬` form that reduceDifference recognizes.
 func (e *typeEvaluator) condOverTailBound(t *soltype.CondType, bound soltype.Type) soltype.Type {
 	extends := substituteOccurrences(t.Extends, t.Check, bound)
-	uniform := e.ctx.condExtends(bound, extends, e.seen)
-	if !uniform && negatableOperand(extends) {
-		// Disjointness is the check `bound <: ¬extends`, the same question excludeFrom asks to
-		// decide that an exclusion takes nothing from a member.
-		uniform = e.ctx.condExtends(bound, soltype.NewNegation(extends), e.seen)
-	}
+	uniform := e.ctx.condExtends(bound, extends, e.seen) || e.boundDisjointFrom(bound, extends)
 	if uniform {
 		return e.reduceCond(&soltype.CondType{
 			Check:   bound,
@@ -344,11 +342,21 @@ func (e *typeEvaluator) condOverTailBound(t *soltype.CondType, bound soltype.Typ
 		})
 	}
 	if diff, ok := e.nativeDifference(t, bound, extends); ok {
-		return e.reduce(diff)
+		// The difference is a meet, and nothing downstream normalizes one built here. The
+		// `Extract` shape leaves `bound ∩ extends`, so `Extract<"a" | ...string, "a">` would
+		// keep a tail bounded by `string & "a"` and never notice that it is just `"a"`, which
+		// the union already names. Normalizing fuses the meet so tailSubsumed can see it.
+		return e.ctx.normalizeDeep(e.reduce(diff), soltype.Positive)
 	}
-	if !negatableOperand(extends) {
+	if !negatableOperand(e.groundReduced(extends)) {
 		// The Else half is the values `¬extends` names, and an operand no complement may name
 		// has no such half. The tail comes back unbounded rather than half-decided.
+		//
+		// The check is asked of the grounded operand, because a name reveals nothing about
+		// what it stands for. `type Handle = &'static Point` is an AliasType, which
+		// negatableOperand reads as negatable, while the borrow its body names is the one
+		// thing a complement may not hold. nativeDifference grounds the same question for
+		// the same reason.
 		return nil
 	}
 	matched := newIntersection(nil, []soltype.Type{bound, extends})
@@ -357,6 +365,23 @@ func (e *typeEvaluator) condOverTailBound(t *soltype.CondType, bound soltype.Typ
 		e.reduceBranch(substituteOccurrences(t.Then, t.Check, matched)),
 		e.reduceBranch(substituteOccurrences(t.Else, t.Check, unmatched)),
 	}, false)
+}
+
+// boundDisjointFrom reports whether no value the bound admits satisfies the check, which
+// puts every tail member in the Else branch.
+//
+// It asks the question as an empty meet rather than as the subtype check
+// `bound <: ¬extends`. The two agree wherever both apply, and the meet also answers over a
+// check the ¬Ref exclusion invariant forbids naming under a complement. `...string` against
+// `mut {x: number}` is that case: no string is a borrowed object, so
+// `string ∩ mut {x: number}` is `never` and the whole tail takes Else.
+//
+// A `never` bound never reaches here. It is a subtype of every check, so the caller's
+// first test already answers uniform for it.
+func (e *typeEvaluator) boundDisjointFrom(bound, extends soltype.Type) bool {
+	met := newIntersection(nil, []soltype.Type{bound, extends})
+	_, disjoint := e.ctx.normalizeDeep(met, soltype.Positive).(*soltype.NeverType)
+	return disjoint
 }
 
 // substituteOccurrences rewrites every occurrence of the from type inside in to the to type,
@@ -1578,6 +1603,15 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 		tail := tailOf(tgt)
 		if tail.bound != nil {
 			tail.bound = e.reduceIndex(tail.bound, idx, inexact)
+			if containsResidualOp(tail.bound) {
+				// The read off the bound did not ground, so the bound comes back as an
+				// unreduced access. A union carrying an unreduced operator anywhere reads as
+				// residual, and constraint solving would decide against that operator rather
+				// than against the union. Unlike a string intrinsic there is no wider bound
+				// to fall back on, since an access yields whatever the field holds. Stay
+				// symbolic and reduce once the target grounds.
+				return &soltype.IndexType{Target: target, Index: idx, Inexact: inexact}
+			}
 		}
 		return newUnionWithTail(nil, parts, tail)
 	case *soltype.IntersectionType:
@@ -1738,7 +1772,10 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, i
 // the exact `"ona" | "onb"`, while `on${"a" | "b" | ...}` reduces to `"ona" | "onb" | ...`.
 //
 // A tail's bound is not folded into the result. The bound says the tail's choices are strings
-// without saying which, so no segment can absorb them and the result's tail stays unbounded.
+// without saying which, so no segment can absorb them. The result's tail is bounded by `string`
+// all the same, since a template produces a string whatever it interpolates. Leaving it unbounded
+// would make the result the top of the subtype lattice, and `` `on${keyof {a: number, ...}}` ``
+// would accept a `5`.
 // An interpolation that names no choice at all, which is the shape a set difference leaves when it
 // excludes every named one, has nothing to run the product over and keeps the template symbolic.
 func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Type {
@@ -1781,7 +1818,10 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 	for _, combo := range combos {
 		parts = append(parts, foldTemplatePart(t.Quasis, combo))
 	}
-	return newUnion(nil, parts, openChoices)
+	if openChoices {
+		return newBoundedUnion(nil, parts, &soltype.PrimType{Prim: soltype.StrPrim})
+	}
+	return newUnion(nil, parts, false)
 }
 
 // foldTemplatePart folds one cartesian-product combination into a single template result. It
@@ -1877,14 +1917,23 @@ func (e *typeEvaluator) reduceStringIntrinsic(kind soltype.StringIntrinsicKind, 
 			parts[i] = e.reduceStringIntrinsic(kind, m)
 		}
 		// The intrinsic reaches the tail's bound too, since the tail's unnamed members are
-		// drawn from it and each is transformed the way a named member is.
-		// `Uppercase<"a" | ...string>` is `"A" | ...Uppercase<string>`. The bound stays
-		// symbolic there, since only a string LITERAL has a case to change, but it still
-		// says the tail holds strings where dropping it would leave the union at the top of
-		// the lattice.
+		// drawn from it and each is transformed the way a named member is. A bound of `"a"`
+		// becomes `"A"` exactly as a named member does.
+		//
+		// Only a string LITERAL has a case to change, so a bound the transform cannot fold
+		// comes back as an unreduced operator. `Uppercase<string>` is one. Such a bound is
+		// widened to `string` rather than kept, because a bound is part of the union and a
+		// union carrying an unreduced operator anywhere reads as residual. Constraint
+		// solving then decides against the opaque operator and rejects
+		// `val u: Uppercase<keyof {a: number, ...}> = "A"`. Widening is sound, since the
+		// intrinsic maps strings to strings, and it keeps the tail bounded where dropping it
+		// would leave the union at the top of the lattice.
 		tail := tailOf(op)
 		if tail.bound != nil {
 			tail.bound = e.reduceStringIntrinsic(kind, tail.bound)
+			if containsResidualOp(tail.bound) {
+				tail.bound = &soltype.PrimType{Prim: soltype.StrPrim}
+			}
 		}
 		return newUnionWithTail(nil, parts, tail)
 	case *soltype.LitType:

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -833,7 +833,7 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 		return reduced, nil, false, false
 	}
 	source, homomorphic := e.homomorphicSource(t.Keys)
-	members, inexactKeys := unionMembers(keys)
+	members, keyTail := unionMembers(keys)
 	pos := make(map[string]int, len(members))
 	for _, member := range members {
 		built, ok := e.mappedFields(t, member, source, homomorphic)
@@ -849,24 +849,24 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 			fields = append(fields, field)
 		}
 	}
-	return reduced, fields, inexactKeys, true
+	return reduced, fields, keyTail.open, true
 }
 
-// unionMembers splits a reduced type into the members a rule runs over one at a time, and reports
-// whether the set they make up is inexact. A union contributes its members and carries its own
-// inexact marker through; `never` is the empty set, so it contributes none; any other type is a
-// single member.
+// unionMembers splits a reduced type into the members a rule runs over one at a time, and returns
+// the open tail holding whatever it could not enumerate. A union contributes its members and
+// carries its own tail through; `never` is the empty set, so it contributes none; any other type is
+// a single member under no tail.
 //
 // A mapped type splits its key set this way to emit one field per key, and a set difference splits
 // its positive side this way to settle one member at a time against what is excluded.
-func unionMembers(t soltype.Type) ([]soltype.Type, bool) {
+func unionMembers(t soltype.Type) ([]soltype.Type, unionTail) {
 	switch t := t.(type) {
 	case *soltype.UnionType:
-		return t.Types, t.Inexact
+		return t.Types, tailOf(t)
 	case *soltype.NeverType:
-		return nil, false
+		return nil, unionTail{}
 	default:
-		return []soltype.Type{t}, false
+		return []soltype.Type{t}, unionTail{}
 	}
 }
 
@@ -1188,10 +1188,15 @@ func aliasItself(op *soltype.AliasType) soltype.Type { return op }
 // and unions them. An empty projection collapses to `never`, the union identity newUnion returns
 // for no members.
 //
-// An inexact object carries an unknown-keyed tail, so its key set is open: `keyof {a: number, ...}`
-// is `"a" | ...`, an inexact union whose members are the known keys and whose tail stands for the
-// unlisted ones. keyofObject seeds the union's exactness from the object's, so an exact object
-// yields an exact key union and an inexact object an inexact one.
+// An inexact object carries an unknown-keyed tail, so its key set is open:
+// `keyof {a: number, ...}` is `"a" | ...string`, an inexact union whose members are the known keys
+// and whose tail stands for the unlisted ones. keyofObject seeds the union's exactness from the
+// object's, so an exact object yields an exact key union and an inexact object an inexact one.
+//
+// The tail is bounded by `string`, since the unlisted keys are property names whatever else is
+// unknown about them. That one fact is what makes the tail tractable. `¬keyof {a: number, ...}`
+// rejects every string and admits `5`, where an unbounded tail would be top and leave the
+// complement empty.
 //
 // It omits methods, which is correct for a class instance whose methods live on the prototype
 // and so are absent from Object.keys, but wrong for a bare object whose methods are own
@@ -1210,7 +1215,10 @@ func (e *typeEvaluator) keyofObject(obj *soltype.ObjectType) soltype.Type {
 			keys = append(keys, strLitType(elem.Name))
 		}
 	}
-	return newUnion(nil, keys, obj.Inexact)
+	if obj.Inexact {
+		return newBoundedUnion(nil, keys, &soltype.PrimType{Prim: soltype.StrPrim})
+	}
+	return newUnion(nil, keys, false)
 }
 
 // keyofTuple yields a tuple's own keys: one number-literal type per positional element, the
@@ -1220,14 +1228,18 @@ func (e *typeEvaluator) keyofObject(obj *soltype.ObjectType) soltype.Type {
 // TODO: decide how keyof should account for inherited prototype members once interop is designed.
 //
 // An inexact tuple has unknown trailing positions, so its index set is open the same way an inexact
-// object's key set is. `keyof [number, string, ...]` reduces to `0 | 1 | ...`, where the tail stands
-// for the indices those unknown positions occupy (exact-types §7.1).
+// object's key set is. `keyof [number, string, ...]` reduces to `0 | 1 | ...number`, where the tail
+// stands for the indices those unknown positions occupy (exact-types §7.1). The bound is `number`
+// rather than the `string` an object's tail takes, since an index is a position and not a name.
 func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
 	keys := make([]soltype.Type, 0, len(tup.Elems))
 	for i := range tup.Elems {
 		keys = append(keys, &soltype.LitType{Lit: &soltype.NumLit{Value: float64(i)}})
 	}
-	return newUnion(nil, keys, tup.Inexact)
+	if tup.Inexact {
+		return newBoundedUnion(nil, keys, &soltype.PrimType{Prim: soltype.NumPrim})
+	}
+	return newUnion(nil, keys, false)
 }
 
 // keyofUnion intersects the keys of a union operand's members. A value typed `A | B` is either
@@ -1257,17 +1269,19 @@ func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.
 	var shared []soltype.Type
 	var residuals []soltype.Type
 	seeded := false
-	sharedInexact := op.Inexact
+	// The result's tail starts as the operand union's own. An unlisted member of the
+	// operand could be an object or a tuple, so nothing bounds the keys it contributes.
+	// Each member's own key set then merges in, and a member that is an inexact object
+	// brings the `string` bound its keys carry.
+	sharedTail := tailOf(op)
 	for _, m := range op.Types {
 		reduced := e.reduceKeyof(m, inexact)
-		keys, memberInexact, ok := literalKeys(reduced)
+		keys, memberTail, ok := literalKeys(reduced)
 		if !ok {
 			residuals = append(residuals, reduced)
 			continue
 		}
-		if memberInexact {
-			sharedInexact = true
-		}
+		sharedTail = sharedTail.merge(memberTail)
 		if seeded {
 			shared = intersectTypes(shared, keys)
 		} else {
@@ -1285,44 +1299,44 @@ func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.
 		}
 	}
 	if len(residuals) == 0 {
-		return newUnion(nil, shared, sharedInexact)
+		return newUnionWithTail(nil, shared, sharedTail)
 	}
 	if !seeded {
 		// Every member left a residual, so there are no literal keys to meet them with. An
 		// intersection carries no exactness marker, and with no key union among its members there
 		// is nothing to hang the open tail on, so an open key set keeps the whole operator
 		// symbolic rather than dropping what the tail stands for.
-		if sharedInexact {
+		if sharedTail.open {
 			return &soltype.KeyofType{Operand: op, Inexact: inexact}
 		}
 		return newIntersection(nil, residuals)
 	}
-	return newIntersection(nil, append([]soltype.Type{newUnion(nil, shared, sharedInexact)}, residuals...))
+	return newIntersection(nil, append([]soltype.Type{newUnionWithTail(nil, shared, sharedTail)}, residuals...))
 }
 
-// literalKeys decomposes a reduced `keyof` result into the literal keys it names and whether its
-// key set is inexact. It reports false for a result that names no enumerable key set, such as the
+// literalKeys decomposes a reduced `keyof` result into the literal keys it names and the open tail
+// carrying the rest. It reports false for a result that names no enumerable key set, such as the
 // `keyof T` residual over a type parameter, so a caller that needs the keys can fall back to
 // leaving its own operator symbolic.
 //
 // `never` decomposes to an empty exact set, a lone literal to that one key, and a union to its
-// members with the union's own exactness. A union carrying a non-literal member is not a key set
+// members under the union's own tail. A union carrying a non-literal member is not a key set
 // the reduction produced, so it reports false rather than silently dropping that member.
-func literalKeys(reduced soltype.Type) (keys []soltype.Type, inexact bool, ok bool) {
+func literalKeys(reduced soltype.Type) (keys []soltype.Type, tail unionTail, ok bool) {
 	switch t := reduced.(type) {
 	case *soltype.NeverType:
-		return nil, false, true
+		return nil, unionTail{}, true
 	case *soltype.LitType:
-		return []soltype.Type{t}, false, true
+		return []soltype.Type{t}, unionTail{}, true
 	case *soltype.UnionType:
 		for _, m := range t.Types {
 			if _, isLit := m.(*soltype.LitType); !isLit {
-				return nil, false, false
+				return nil, unionTail{}, false
 			}
 		}
-		return t.Types, t.Inexact, true
+		return t.Types, tailOf(t), true
 	default:
-		return nil, false, false
+		return nil, unionTail{}, false
 	}
 }
 

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -282,7 +282,20 @@ func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.Union
 			Else:    substituteOccurrences(t.Else, t.Check, member),
 		})
 	}
-	return newUnion(nil, parts, check.Inexact)
+	// The conditional reaches the tail's bound as well, since the tail's unnamed members are
+	// drawn from it and each one selects a branch the same way a named member does. This is
+	// what keeps `Exclude<keyof {a: X, ...}, "a">` off the top of the lattice: without it the
+	// result's tail would come back unbounded and accept every value.
+	tail := tailOf(check)
+	if tail.bound != nil {
+		tail.bound = e.reduceCond(&soltype.CondType{
+			Check:   tail.bound,
+			Extends: substituteOccurrences(t.Extends, t.Check, tail.bound),
+			Then:    substituteOccurrences(t.Then, t.Check, tail.bound),
+			Else:    substituteOccurrences(t.Else, t.Check, tail.bound),
+		})
+	}
+	return newUnionWithTail(nil, parts, tail)
 }
 
 // substituteOccurrences rewrites every occurrence of the from type inside in to the to type,
@@ -1401,10 +1414,20 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 	// what carries an inexact object's openness into `T[keyof T]`. Over `type Obj = {a: number, ...}`,
 	// `keyof Obj` reduces to `"a" | ...` and `Obj[keyof Obj]` to `number | ...`.
 	if u, ok := idx.(*soltype.UnionType); ok {
+		if len(u.Types) == 0 {
+			// An open key set naming no key of its own, such as the `...string` a set
+			// difference leaves when it excludes every named key. There is no key to read
+			// the target at, so the access stays symbolic. Distributing over no member
+			// would answer `never`, claiming the key set is empty when it is only unread.
+			return &soltype.IndexType{Target: target, Index: idx, Inexact: inexact}
+		}
 		parts := make([]soltype.Type, len(u.Types))
 		for i, m := range u.Types {
 			parts[i] = e.reduceIndex(target, m, inexact)
 		}
+		// The result's tail stays unbounded whatever bounds the key tail. The bound says
+		// what the unread KEYS are, and this union holds the VALUES stored at them, which
+		// nothing here has read.
 		return newUnion(nil, parts, u.Inexact)
 	}
 	switch tgt := target.(type) {
@@ -1743,7 +1766,17 @@ func (e *typeEvaluator) reduceStringIntrinsic(kind soltype.StringIntrinsicKind, 
 		for i, m := range op.Types {
 			parts[i] = e.reduceStringIntrinsic(kind, m)
 		}
-		return newUnion(nil, parts, op.Inexact)
+		// The intrinsic reaches the tail's bound too, since the tail's unnamed members are
+		// drawn from it and each is transformed the way a named member is.
+		// `Uppercase<"a" | ...string>` is `"A" | ...Uppercase<string>`. The bound stays
+		// symbolic there, since only a string LITERAL has a case to change, but it still
+		// says the tail holds strings where dropping it would leave the union at the top of
+		// the lattice.
+		tail := tailOf(op)
+		if tail.bound != nil {
+			tail.bound = e.reduceStringIntrinsic(kind, tail.bound)
+		}
+		return newUnionWithTail(nil, parts, tail)
 	case *soltype.LitType:
 		if s, ok := op.Lit.(*soltype.StrLit); ok {
 			return strLitType(applyStringIntrinsic(kind, s.Value))
@@ -1779,9 +1812,17 @@ func (e *typeEvaluator) reduceExactness(kind soltype.ExactnessKind, operand solt
 		rewritten.Inexact = inexact
 		return &rewritten
 	case *soltype.UnionType:
-		// newUnion rather than a direct rebuild, so clearing the marker on a one-member union
-		// collapses it to that member: `Exact<"only" | ...>` reduces to `"only"`.
-		return newUnion(nil, op.Types, inexact)
+		// newUnionWithTail rather than a direct rebuild, so clearing the marker on a one-member
+		// union collapses it to that member: `Exact<"only" | ...>` reduces to `"only"`.
+		//
+		// Opening a union keeps whatever bound the operand's tail carried, so `Inexact<T>` over
+		// an already-inexact T is the identity `Inexact<keyof {a: X, ...}>` needs. Dropping the
+		// bound would widen `"a" | ...string` to `"a" | ...`, which is top.
+		tail := unionTail{open: inexact}
+		if inexact {
+			tail.bound = op.TailBound
+		}
+		return newUnionWithTail(nil, op.Types, tail)
 	case *soltype.IntersectionType:
 		// An intersection's exactness is its members', so the operator reaches each of them (§7.7).
 		parts := make([]soltype.Type, len(op.Types))

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -285,6 +285,15 @@ func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.Union
 	tail := tailOf(check)
 	if tail.bound != nil {
 		tail.bound = e.condOverTailBound(t, tail.bound)
+		if tail.bound == nil && len(parts) == 0 {
+			// The check union names no member of its own, so the tail was the whole operand
+			// and the conditional just failed to answer over it. Unbounding the tail would
+			// leave a union with neither member nor bound, which collapses to `never` and
+			// claims the operand was empty. Stay symbolic instead.
+			return &soltype.CondType{
+				Check: check, Extends: t.Extends, Then: t.Then, Else: t.Else, Distribute: t.Distribute,
+			}
+		}
 	}
 	return newUnionWithTail(nil, parts, tail)
 }
@@ -867,11 +876,11 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 	if !condOperandGround(keys) {
 		return reduced, nil, false, false
 	}
-	if soltype.UncountableKeys(keys) {
-		// An uncountable key set has no keys to enumerate, so the member stays unexpanded and is
-		// itself the index signature. The required form over such a key set is uninhabited and is
-		// rejected. A rename or filter over one has no enumerable keys to run over, so it stays
-		// symbolic with no diagnostic. That gap is #930.
+	if unenumerableKeys(keys) {
+		// A key set with nothing to enumerate leaves the member unexpanded, so it is itself the
+		// index signature. The required form over such a key set is uninhabited and is rejected.
+		// A rename or filter over one has no enumerable keys to run over, so it stays symbolic
+		// with no diagnostic. That gap is #930.
 		if soltype.IsIndexSignature(reduced) && reduced.Optional != soltype.ModAdd {
 			e.errs = append(e.errs, &RequiredUncountableKeysError{Mapped: reduced})
 		}
@@ -895,6 +904,26 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 		}
 	}
 	return reduced, fields, keyTail.open, true
+}
+
+// unenumerableKeys reports whether a mapped type's key set gives it no key to emit a field for.
+// Two shapes do.
+//
+//   - An uncountable key set such as `string` names more keys than any object could list.
+//   - An open key set naming no key of its own, such as the `...(string & ¬"a")` a set difference
+//     leaves after excluding every named key. Its bound says what the keys are drawn from without
+//     saying which of them the set holds, so no field follows from it whether the bound is
+//     infinite or not.
+//
+// An open key set that DOES name keys is enumerable. Each named key gets a field and the tail
+// becomes the result object's own inexactness marker, so `{[K]: T[K] for K in keyof {x: X, ...}}`
+// expands to `{x: X, ...}` rather than collapsing to an index signature.
+func unenumerableKeys(keys soltype.Type) bool {
+	if soltype.UncountableKeys(keys) {
+		return true
+	}
+	u, ok := keys.(*soltype.UnionType)
+	return ok && len(u.Types) == 0 && u.TailBound != nil
 }
 
 // unionMembers splits a reduced type into the members a rule runs over one at a time, and returns
@@ -1295,10 +1324,18 @@ func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
 // An inexact key set is open, so it can carry keys its written members do not name. That makes
 // the result inexact whenever the operand union is inexact or any member's key set is. Take
 // `keyof ({a: number, shared: string} | {b: boolean, shared: string, ...})`, which reduces to
-// `"shared" | ...`. Only "shared" is written on both members, so only "shared" is definitely a
-// key, but the second member's open tail may carry "a" too. Intersecting the written keys keeps
+// `"shared" | ...string`. Only "shared" is written on both members, so only "shared" is definitely
+// a key, but the second member's open tail may carry "a" too. Intersecting the written keys keeps
 // every key the result names one that every member definitely carries, and the trailing `...`
 // records that the true key set may be larger.
+//
+// The tail's bound is wider than the operand allows. This reduction is a MEET of key sets, so an
+// unnamed shared key has to be a key of every member, and the example above bounds its tail by
+// `string` where only "a" is possible: the first member is exact, so no key outside {"a", "shared"}
+// is a key of it. Bounding the tail by the exact members' key sets is what would close that gap.
+// The bound is still narrower than the unbounded tail the reduction would otherwise leave, which
+// admits every value, so `"zz"` reads as a possible key here where before it read as a possible
+// anything. escalier-lang/escalier#1126 tracks tightening it.
 //
 // Some members have no key set to enumerate. A type parameter is one, and so is an operator whose
 // own operands are not ground. Such a member reduces to a `keyof` residual, and the rule this whole
@@ -1684,6 +1721,11 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, i
 // The result is exact only when every interpolation is, since an interpolation that names an open
 // set of choices produces an open set of strings (exact-types §5.6). `on${"a" | "b"}` reduces to
 // the exact `"ona" | "onb"`, while `on${"a" | "b" | ...}` reduces to `"ona" | "onb" | ...`.
+//
+// A tail's bound is not folded into the result. The bound says the tail's choices are strings
+// without saying which, so no segment can absorb them and the result's tail stays unbounded.
+// An interpolation that names no choice at all, which is the shape a set difference leaves when it
+// excludes every named one, has nothing to run the product over and keeps the template symbolic.
 func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Type {
 	interpChoices := make([][]soltype.Type, len(t.Interps))
 	combinations := 1
@@ -1692,6 +1734,14 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 		reduced := e.groundOperand(interp)
 		if u, ok := reduced.(*soltype.UnionType); ok {
 			openChoices = openChoices || u.Inexact
+			if len(u.Types) == 0 {
+				// An interpolation naming no choice of its own, such as the `...string` a set
+				// difference leaves when it excludes every named key. Its bound says the
+				// choices are strings without saying which, so there is nothing to fold into
+				// the surrounding segments and the template stays symbolic. Running the
+				// product over no choice would empty it and answer `never`.
+				return &soltype.TemplateLitType{Quasis: t.Quasis, Interps: t.Interps}
+			}
 			// Ground each union member too, so a reducible member — an alias to a literal, or a
 			// nested operator such as `keyof O` — collapses to its string literal before the product
 			// rather than surviving as a residual interpolation.

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -373,7 +373,7 @@ func (e *typeEvaluator) condOverTailBound(t *soltype.CondType, bound soltype.Typ
 // It asks the question as an empty meet rather than as the subtype check
 // `bound <: ¬extends`. The two agree wherever both apply, and the meet also answers over a
 // check the ¬Ref exclusion invariant forbids naming under a complement. `...string` against
-// `mut {x: number}` is that case: no string is a borrowed object, so
+// `mut {x: number}` is that case. No string is a borrowed object, so
 // `string ∩ mut {x: number}` is `never` and the whole tail takes Else.
 //
 // A `never` bound never reaches here. It is a subtype of every check, so the caller's

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -90,8 +90,8 @@ func meetKeySets(members []soltype.Type) (soltype.Type, bool) {
 	}
 	var shared []soltype.Type
 	for i, m := range members {
-		keys, inexact, ok := literalKeys(m)
-		if !ok || inexact {
+		keys, tail, ok := literalKeys(m)
+		if !ok || tail.open {
 			return nil, false
 		}
 		if i == 0 {
@@ -127,17 +127,24 @@ func meetKeySets(members []soltype.Type) (soltype.Type, bool) {
 // operand grounds. That residual is the `∩ ¬` form itself rather than a stuck operator, which is
 // what a caller such as a mapped-type key set or a constraint reads.
 //
-// An inexact positive side names only some of its members. The rest sit in an open tail that the
-// reduction cannot enumerate, so what the exclusion takes from them cannot be worked out. The
-// result union keeps the tail, which stands for whatever those undecided members contribute, so
-// `("a" | "b" | ...) ∩ ¬"a"` reduces to `"b" | ...`.
+// An inexact positive side names only some of its members. The rest sit in an open tail the
+// reduction cannot enumerate, and what the exclusion takes from them depends on what the tail is
+// bounded by.
 //
-// When no named member survives, the difference stays as it stands, since neither answer available
-// is the one the reduction means. `newUnion` over an empty member list is `never` however the
-// marker is set, which would claim the tail is empty too. Reading the open union as `unknown` —
-// which is what it is for subtyping, since its tail accepts every value — would answer `¬X`, and
-// that is wrong for the key sets this reduction mostly serves. `keyof {a: X, ...}` is `"a" | ...`,
-// where the tail stands for the keys the object did not name, not for every key there is.
+// An unbounded tail says nothing about its members, so what the exclusion takes from them cannot be
+// worked out. The result union keeps the tail, which stands for whatever those undecided members
+// contribute, so `("a" | "b" | ...) ∩ ¬"a"` reduces to `"b" | ...`. When no named member survives
+// either, the difference stays as it stands, since neither answer available is the one the
+// reduction means. `newUnion` over an empty member list is `never`, which would claim the tail is
+// empty too. Reading the open union as `unknown` — which is what it is for subtyping, since an
+// unbounded tail accepts every value — would answer `¬X`, and that is wrong for the key sets this
+// reduction mostly serves.
+//
+// A bounded tail draws its members from its bound, so excluding from the bound excludes from every
+// member at once and the tail narrows along with the named ones. `keyof {a: X, ...}` is
+// `"a" | ...string`, so `keyof {a: X, ...} ∩ ¬"a"` reduces to `...(string & ¬"a")`, the string keys
+// other than "a". A bound the exclusion empties leaves an exact union of whatever named members
+// survived.
 func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
 	positives := make([]soltype.Type, 0, len(members))
 	var excluded []soltype.Type
@@ -159,16 +166,24 @@ func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
 		base = newIntersection(nil, positives)
 	}
 	if groundDifference(base, excluded) {
-		baseMembers, inexact := unionMembers(base)
+		baseMembers, tail := unionMembers(base)
 		survivors := make([]soltype.Type, 0, len(baseMembers))
 		for _, m := range baseMembers {
 			if narrowed, keep := e.excludeFrom(m, excluded); keep {
 				survivors = append(survivors, narrowed)
 			}
 		}
-		// A tail with no surviving member to ride on falls through to the residual below.
-		if len(survivors) > 0 || !inexact {
-			return newUnion(nil, survivors, inexact)
+		if tail.bound != nil && condOperandGround(tail.bound) {
+			if narrowed, keep := e.excludeFrom(tail.bound, excluded); keep {
+				tail.bound = narrowed
+			} else {
+				tail = unionTail{}
+			}
+		}
+		// An unbounded tail with no surviving member to ride on falls through to the residual
+		// below. A bounded one needs no member, since its bound says what it holds.
+		if len(survivors) > 0 || !tail.open || tail.bound != nil {
+			return newUnionWithTail(nil, survivors, tail)
 		}
 	}
 	return newIntersection(nil, append([]soltype.Type{base}, complementsOf(excluded)...))

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -136,8 +136,8 @@ func meetKeySets(members []soltype.Type) (soltype.Type, bool) {
 // contribute, so `("a" | "b" | ...) ∩ ¬"a"` reduces to `"b" | ...`. When no named member survives
 // either, the difference stays as it stands, since neither answer available is the one the
 // reduction means. `newUnion` over an empty member list is `never`, which would claim the tail is
-// empty too. Reading the open union as `unknown` — which is what it is for subtyping, since an
-// unbounded tail accepts every value — would answer `¬X`, and that is wrong for the key sets this
+// empty too. For subtyping the open union is `unknown`, since an unbounded tail accepts every
+// value. Reading it that way here would answer `¬X`, and that is wrong for the key sets this
 // reduction mostly serves.
 //
 // A bounded tail draws its members from its bound, so excluding from the bound excludes from every

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -128,6 +128,35 @@ func TestReduceSetDifference(t *testing.T) {
 			want: `("a" | ...) & ¬"a"`,
 		},
 		{
+			// `("a" | "b" | ...string) & ¬"a"`
+			//
+			// A bounded tail draws its members from `string`, so the exclusion applies to that
+			// bound the same way it applies to a named member. The tail comes through narrowed
+			// rather than undecided.
+			name: "BoundedTailNarrowsWithTheNamedMembers",
+			diff: meet(newBoundedUnion(nil, []soltype.Type{strLit("a"), strLit("b")}, str()), negate(strLit("a"))),
+			want: `"b" | ...(string & ¬"a")`,
+		},
+		{
+			// `("a" | ...string) & ¬"a"`
+			//
+			// The case InexactPositiveSideWithNoSurvivorsStays leaves standing, settled. The
+			// answer is the string keys other than "a", a union naming no member and drawing
+			// every one it has from `string & ¬"a"`.
+			name: "BoundedTailSurvivesWithNoNamedMember",
+			diff: meet(newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()), negate(strLit("a"))),
+			want: `...(string & ¬"a")`,
+		},
+		{
+			// `("a" | ...string) & ¬string`
+			//
+			// The exclusion empties the bound, so the tail contributes nothing, and it excludes
+			// the one named member too. Nothing is left.
+			name: "BoundedTailEmptiedByItsOwnBound",
+			diff: meet(newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()), negate(str())),
+			want: "never",
+		},
+		{
 			// `(("a" | "b") & ¬"a") & ¬"b"`
 			//
 			// Nested complements reduce as one difference, since newIntersection flattens the


### PR DESCRIPTION
Refs #1126.

An open union's tail represents members the type does not name. Previously, an unbounded tail accepted every value, making the union top of the subtype lattice. This change adds a `TailBound` field to `UnionType` to track what the tail's unnamed members are drawn from, taking unions off the top when the bound is set.

This is the `keyof` slice of #1126, with the bound carried in the representation from the start. The `throws` case and the surface syntax for writing a bound are not part of it.

**Key changes:**

- Added `TailBound` field to `soltype.UnionType` to record the bound of an open tail (e.g., `"a" | ...string` has tail bound `string`). A nil bound is the unbounded tail, so every existing type keeps its meaning
- Introduced `newBoundedUnion` constructor and `unionTail` struct to thread bounds through the type-minting pipeline
- Updated `keyofObject` and `keyofTuple` to mint bounded tails: object keys are bounded by `string`, tuple indices by `number`
- Modified `newNegation` to only fold `¬(A | B | ...)` to `never` when the tail is unbounded; bounded tails wrap normally, so `¬keyof {a: X, ...}` admits `5`
- Updated constraint checking to verify bounded tails against supertypes, so `("a" | ...string) <: string` holds but `("a" | ...string) <: ("a" | ...number)` fails
- Modified distributive conditionals to apply over tail bounds, narrowing them when the check splits the bound (e.g., `Exclude<"a" | "b" | ...string, "a">` yields `"b" | ...(string & ¬"a")`)
- Updated set difference reduction to narrow bounded tails rather than leaving them undecided
- Added `unenumerableKeys` to distinguish uncountable key sets from member-less bounded unions (which should not collapse to `never`)
- Updated diagnostic rendering to include tail bounds in union descriptions so `"a" | ...string` and `"a" | ...` are visually distinct

**Implementation details:**

The bound flows through type operators via `unionTail.merge`, which joins two bounded tails by unioning their bounds (since either could contribute members) and absorbs a bounded tail into an unbounded one (since unbounded admits everything). Operators like mapped types and template literals stay symbolic when given a member-less bounded union, since the bound says what the members are drawn from without saying which ones the set holds.

**Known imprecision:** `keyofUnion` bounds its tail by joining the members' bounds, but `keyof (A | B)` is a meet of key sets, so an exact member's key set should cap the tail and does not. The bound is still narrower than the unbounded tail the reduction left before, so this is an imprecision rather than a regression; the comment at that site records what would close it.

**No surface syntax:** the bounded form does not round-trip through the parser. Only the type operators mint a bound, so the rendering serves diagnostics and inferred types.

https://claude.ai/code/session_01VG4c9M6EgSC672itUpaMDm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bounded open union tails, improving type checking, inference, normalization, and type operations.
  * Diagnostic output now displays tail bounds, such as `...string` or `...(number | boolean)`.
  * Bounded tails are preserved through unions, negation, indexing, `keyof`, templates, and exactness operations.

* **Bug Fixes**
  * Improved subtype comparisons and simplification for bounded and unbounded union tails.
  * Updated open-object and tuple key representations to include their bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->