### PR TITLE
Add a bound beside an inexact union's open tail

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -594,6 +594,9 @@ func freeTypeVars(t Type) []*TypeVarType {
 			for _, m := range t.Types {
 				walk(m)
 			}
+			if t.TailBound != nil {
+				walk(t.TailBound)
+			}
 		case *IntersectionType:
 			for _, m := range t.Types {
 				walk(m)
@@ -998,12 +1001,26 @@ func (p *namedPrinter) printType(t Type) string {
 		// An inexact union renders a trailing `...` entry, so a union typed
 		// `A | B | ...` round-trips to surface syntax. The inexact tuple,
 		// object, and function arms render their flag the same way.
+		//
+		// A bounded tail renders its bound after the marker, so `"a" | ...string`
+		// says the unnamed members are strings. The bound prints at precPrefix, so a
+		// looser bound such as an intersection is parenthesized under the `...`.
+		//
+		// The bounded form does not round-trip. No surface syntax writes a bound, so
+		// only the type operators mint one and the parser rejects what this renders.
+		// The rendering exists for diagnostics and for reading inferred types, where
+		// the bound is the reason a constraint held or failed. escalier-lang/escalier#1126
+		// tracks the syntax.
 		parts := make([]string, 0, len(t.Types)+1)
 		for _, m := range t.Types {
 			parts = append(parts, p.printTypeMinPrec(m, precUnion))
 		}
 		if t.Inexact {
-			parts = append(parts, "...")
+			marker := "..."
+			if t.TailBound != nil {
+				marker += p.printTypeMinPrec(t.TailBound, precPrefix)
+			}
+			parts = append(parts, marker)
 		}
 		return strings.Join(parts, " | ")
 	case *IntersectionType:

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -171,6 +171,36 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"union triple", &UnionType{Types: []Type{numP(), strP(), boolP()}}, "number | string | boolean"},
 		// An inexact union renders a trailing `...` entry.
 		{"inexact union", &UnionType{Types: []Type{numP(), strP()}, Inexact: true}, "number | string | ..."},
+		// A bounded tail renders its bound after the marker. The bound prints at precPrefix,
+		// so an atom stays bare and an intersection is parenthesized under the `...`.
+		{
+			"bounded tail",
+			&UnionType{Types: []Type{numP()}, Inexact: true, TailBound: strP()},
+			"number | ...string",
+		},
+		{
+			"bounded tail over a compound bound",
+			&UnionType{
+				Types:     []Type{numP()},
+				Inexact:   true,
+				TailBound: &IntersectionType{Types: []Type{strP(), &NegationType{Inner: strP()}}},
+			},
+			"number | ...(string & ¬string)",
+		},
+		// A bounded tail with no named member is the whole union, which is what a set
+		// difference that excludes every named member leaves.
+		{
+			"bounded tail with no named member",
+			&UnionType{Inexact: true, TailBound: strP()},
+			"...string",
+		},
+		// LevelOf reads the bound too, so a variable reachable only through it lifts the
+		// union's level and the freshener descends to it.
+		{
+			"a variable in the bound lifts the level",
+			&UnionType{Types: []Type{numP()}, Inexact: true, TailBound: &TypeVarType{ID: 1, Level: 2}},
+			"number | ...t1",
+		},
 		// NullType renders as `null`. It is a distinct atomic kind from UndefinedType.
 		{"null atom", &NullType{}, "null"},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
@@ -363,6 +393,18 @@ func TestPrintConstructorElem(t *testing.T) {
 	// Accept with an identity visitor preserves the node, so a constructor member
 	// survives every rewriting pass built on Accept.
 	require.Same(t, obj, obj.Accept(identityVisitor{}, Positive))
+}
+
+// freeTypeVars and LevelOf descend a union's tail bound, so a variable reachable only through
+// it is named as a quantified parameter and lifts the union's level. Both are hand-rolled walks
+// rather than rides on Accept, so each needs the bound added by name.
+func TestFreeTypeVarsUnionTailBound(t *testing.T) {
+	a := &TypeVarType{ID: 1, Level: 3}
+	u := &UnionType{Types: []Type{numP()}, Inexact: true, TailBound: a}
+	require.Equal(t, "<T0> (number | ...T0)", PrintAsScheme(u))
+	require.Equal(t, 3, LevelOf(u))
+	// A nil bound is the childless case, which reads as level 0 rather than panicking.
+	require.Equal(t, 0, LevelOf(&UnionType{Types: []Type{numP()}, Inexact: true}))
 }
 
 // freeTypeVars descends a constructor's signature, so a variable reachable only through

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -880,15 +880,29 @@ type UnknownType struct{}
 //
 // UnionType.Inexact flags whether the union is open. A bare `A | B` is
 // exact, so its inhabitants are exactly A ∪ B. An `A | B | ...` written with
-// a trailing `...` is inexact: at least these, with an unknown-typed tail.
-// The flag is Inexact rather than Exact so the zero value is exact, matching
-// the ObjectType, TupleType, and FuncType convention. IntersectionType
-// carries no exactness flag, since exactness is a property of the result
-// rather than the meet. The flag and the smart constructors land with M6 PR1.
+// a trailing `...` is inexact: at least these, with an open tail standing for
+// members the type does not name. The flag is Inexact rather than Exact so the
+// zero value is exact, matching the ObjectType, TupleType, and FuncType
+// convention. IntersectionType carries no exactness flag, since exactness is a
+// property of the result rather than the meet.
+//
+// TailBound says what the tail's unnamed members may be. See the field comment.
 type UnionType struct {
 	Types []Type
 	// Inexact tracks the trailing `...` marker. The zero value is exact.
 	Inexact bool
+	// TailBound names the type the tail's unnamed members are drawn from, so
+	// `"a" | ...string` reads as `"a"` together with some unknown set of strings.
+	// It is nil on an exact union and may be nil on an inexact one, which leaves
+	// the tail unbounded. An unbounded tail admits every value, which makes the
+	// whole union the top of the subtype lattice.
+	//
+	// A bound keeps the named members enumerable while still saying what the rest
+	// can be. `keyof {a: X, ...}` is `"a" | ...string`, so a mapped type still has
+	// "a" to iterate and the key set still rejects `5`. Flattening the bound into
+	// the member list instead would give `"a" | string`, which subsumes to `string`
+	// and loses both.
+	TailBound Type
 }
 type IntersectionType struct{ Types []Type }
 
@@ -1467,7 +1481,9 @@ func LevelOf(t Type) int {
 	// union annotation). Coalesced-output unions/intersections hold no live vars, so
 	// both arms still return 0 for them.
 	case *UnionType:
-		return maxMemberLevel(t.Types)
+		// The tail's bound is a member the union does not list, so it counts toward the
+		// level the same way a written member does.
+		return max(maxMemberLevel(t.Types), LevelOf(t.TailBound))
 	case *IntersectionType:
 		return maxMemberLevel(t.Types)
 	case *NegationType:

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -442,9 +442,16 @@ func (t *UnionType) Accept(v TypeVisitor, pol Polarity) Type {
 	}
 	cur := descendReplacement(t, e)
 	types, changed := acceptTypes(cur.Types, v, pol)
+	// The tail's unnamed members are members of the union, so its bound is visited at
+	// the union's own polarity, the same as a written member.
+	bound := cur.TailBound
+	if bound != nil {
+		bound = bound.Accept(v, pol)
+		changed = changed || bound != cur.TailBound
+	}
 	out := cur
 	if changed {
-		out = &UnionType{Types: types, Inexact: cur.Inexact}
+		out = &UnionType{Types: types, Inexact: cur.Inexact, TailBound: bound}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -306,6 +306,31 @@ func TestAcceptUnionIdentityPreservation(t *testing.T) {
 	require.Same(t, u, u.Accept(identityVisitor{}, Positive), "an unchanged UnionType keeps its pointer")
 }
 
+// A tail's bound is a member the union does not list, so Accept walks it like a written one.
+// Every rewriter and every predicate that rides Accept reaches the bound through this, so a
+// walk that stopped at the member list would silently leave a variable in the bound
+// unsubstituted rather than fail anywhere visible.
+func TestAcceptUnionWalksTheTailBound(t *testing.T) {
+	a := &TypeVarType{ID: 1}
+	num := &PrimType{Prim: NumPrim}
+	str := &PrimType{Prim: StrPrim}
+
+	t.Run("a replacement in the bound rebuilds the union", func(t *testing.T) {
+		u := &UnionType{Types: []Type{num}, Inexact: true, TailBound: a}
+		got := u.Accept(&replaceVar{target: a, repl: str}, Positive).(*UnionType)
+
+		require.NotSame(t, u, got, "a changed bound forces a new union")
+		require.True(t, got.Inexact, "the rebuilt union keeps its Inexact marker")
+		require.Same(t, str, got.TailBound, "the bound took the replacement")
+		require.Same(t, num, got.Types[0], "the unchanged member keeps its pointer")
+	})
+
+	t.Run("an unchanged bound keeps the union's pointer", func(t *testing.T) {
+		u := &UnionType{Types: []Type{num}, Inexact: true, TailBound: str}
+		require.Same(t, u, u.Accept(identityVisitor{}, Positive), "copy-on-write covers the bound")
+	})
+}
+
 // Accept walks a complement's operand at the flipped polarity, and that flip composes with
 // the one a function's parameters get. So a parameter under a negation is covariant and a
 // second negation flips back, while a tuple's elements stay covariant.

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1500,10 +1500,18 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		// Inexact flags must match, since an open union never equals a closed
-		// one. newUnion imposes canonical member order at construction, so the
-		// positional equalTypeSliceWith is order-stable and two unions over the
-		// same member set compare equal whatever order their members were minted in.
-		return ok && a.Inexact == b.Inexact && equalTypeSliceWith(a.Types, b.Types, ctx)
+		// one, and so must the tails' bounds, since `"a" | ...string` admits values
+		// `"a" | ...number` rejects. newUnion imposes canonical member order at
+		// construction, so the positional equalTypeSliceWith is order-stable and two
+		// unions over the same member set compare equal whatever order their members
+		// were minted in.
+		if !ok || a.Inexact != b.Inexact || (a.TailBound == nil) != (b.TailBound == nil) {
+			return false
+		}
+		if a.TailBound != nil && !equalTypeWith(a.TailBound, b.TailBound, ctx) {
+			return false
+		}
+		return equalTypeSliceWith(a.Types, b.Types, ctx)
 	case *soltype.IntersectionType:
 		b, ok := b.(*soltype.IntersectionType)
 		return ok && equalTypeSliceWith(a.Types, b.Types, ctx)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -746,7 +746,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			// keeps a nested tail from putting the flag straight back.
 			named := super
 			if supU.Inexact {
-				flat, _ := flattenUnion(supU.Types, false)
+				flat, _ := flattenUnion(supU.Types, unionTail{})
 				named = newUnion(nil, flat, false)
 			}
 			decision := c.constrainNF(sub, named, seen, mutCtx)

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -1213,6 +1213,52 @@ func TestDescribeNegation(t *testing.T) {
 	}
 }
 
+// A diagnostic naming an inexact union has to say what its tail admits, since the bound is
+// the reason the constraint failed. `5 <: ("a" | ...string)` is rejected where
+// `5 <: ("a" | ...)` holds, and a message rendering both as `"a" | ...` leaves the reader
+// with no way to tell which rule fired.
+func TestDescribeOpenUnionTail(t *testing.T) {
+	tests := []struct {
+		name string
+		in   soltype.Type
+		want string
+	}{
+		{
+			"unbounded tail",
+			&soltype.UnionType{Types: []soltype.Type{strLit("a")}, Inexact: true},
+			`"a" | ...`,
+		},
+		{
+			"bounded tail",
+			&soltype.UnionType{Types: []soltype.Type{strLit("a")}, Inexact: true, TailBound: str()},
+			`"a" | ...string`,
+		},
+		{
+			// An intersection bound is parenthesized, so its `&` does not read as binding
+			// past the `...` into the enclosing union.
+			"compound bound is parenthesized",
+			&soltype.UnionType{
+				Types:     []soltype.Type{strLit("a")},
+				Inexact:   true,
+				TailBound: &soltype.IntersectionType{Types: []soltype.Type{str(), num()}},
+			},
+			`"a" | ...(string & number)`,
+		},
+		{
+			// The shape a set difference leaves when it excludes every named member. A
+			// leading `" | "` would read as an empty first member, so the marker stands alone.
+			"bounded tail with no named member",
+			&soltype.UnionType{Inexact: true, TailBound: str()},
+			"...string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, describe(tt.in))
+		})
+	}
+}
+
 // --- The coinductive seen-set's two records ---
 
 // nestedRecursiveObj builds the cyclic object type `{p: pt, next: {q: <the outer object>}}` and

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2996,12 +2996,33 @@ func describe(t soltype.Type) string {
 		return "error"
 	case *soltype.UnionType:
 		s := joinDescribe(t.Types, " | ")
-		if t.Inexact {
-			// An inexact union has an open tail. Append the marker so a
-			// diagnostic naming the union matches the printer's surface form.
-			return s + " | ..."
+		if !t.Inexact {
+			return s
 		}
-		return s
+		// An inexact union has an open tail. The marker follows the members so a
+		// diagnostic naming the union matches the printer's surface form. The tail's
+		// bound follows the marker, since the bound is what decides the constraint.
+		// `"a" | ...string` rejects `5` where `"a" | ...` accepts it, and a message
+		// rendering both the same way leaves the reader no way to tell which rule
+		// fired. A union with no named member renders as the marker alone, since a
+		// leading `" | "` would read as an empty first member.
+		marker := "..."
+		if t.TailBound != nil {
+			// A union or intersection bound is parenthesized, since its `|` or `&` would
+			// otherwise bind past the `...` and `...string & ¬"a"` read back as a member
+			// of the enclosing union. The NegationType arm below parenthesizes for the
+			// same reason.
+			bound := describe(t.TailBound)
+			switch t.TailBound.(type) {
+			case *soltype.UnionType, *soltype.IntersectionType:
+				bound = "(" + bound + ")"
+			}
+			marker += bound
+		}
+		if len(t.Types) == 0 {
+			return marker
+		}
+		return s + " | " + marker
 	case *soltype.IntersectionType:
 		return joinDescribe(t.Types, " & ")
 	case *soltype.NegationType:

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/escalier-lang/escalier/internal/set"
@@ -28,14 +29,61 @@ import (
 // so `number | string` and `string | number` print identically, and it lets
 // the canonical type serve as a stable key for caching.
 func newUnion(c *Context, parts []soltype.Type, inexact bool) soltype.Type {
-	flat, inexact := flattenUnion(parts, inexact)
+	return newUnionWithTail(c, parts, unionTail{open: inexact})
+}
+
+// newBoundedUnion mints `A | ...R`, an inexact union whose tail members are drawn from
+// bound. A nil bound leaves the tail unbounded, which is what newUnion's inexact form
+// mints, so a caller that computes a bound and may come up empty needs no branch.
+func newBoundedUnion(c *Context, parts []soltype.Type, bound soltype.Type) soltype.Type {
+	return newUnionWithTail(c, parts, unionTail{open: true, bound: bound})
+}
+
+// newUnionWithTail is the core newUnion and newBoundedUnion share. It runs the same
+// normalization for either and differs only in the tail it carries through.
+func newUnionWithTail(c *Context, parts []soltype.Type, tail unionTail) soltype.Type {
+	flat, tail := flattenUnion(parts, tail)
 	pruned, hadError := pruneUnion(flat)
 	pruned = dedup(pruned)
 	if c != nil {
 		pruned = subsumeMembers(c, pruned, unionDrops)
 	}
 	sortTypes(pruned)
-	return collapseUnion(pruned, inexact, hadError)
+	return collapseUnion(pruned, tail, hadError)
+}
+
+// unionTail is a union's open-tail marker as it moves through the mint pipeline. open
+// says a trailing `...` is present. bound names the type the tail's unnamed members are
+// drawn from, and a nil bound leaves them unbounded, so the tail admits every value.
+// The zero value is the exact union's tail, which is no tail at all.
+type unionTail struct {
+	open  bool
+	bound soltype.Type
+}
+
+// tailOf reads a union's tail back out, the inverse of what collapseUnion writes.
+func tailOf(u *soltype.UnionType) unionTail {
+	return unionTail{open: u.Inexact, bound: u.TailBound}
+}
+
+// merge folds another tail into t, the rule flattenUnion applies when it splices a
+// nested union's members into the outer list. Two bounded tails join their bounds,
+// since `...string | ...number` may hold a member of either. An unbounded tail absorbs
+// a bounded one, since nothing says what the unbounded one holds.
+//
+// keyofUnion is the other caller, and the join is wider than that reduction wants, since
+// a key set of a union is a meet. The doc comment there records the gap.
+func (t unionTail) merge(other unionTail) unionTail {
+	if !other.open {
+		return t
+	}
+	if !t.open {
+		return other
+	}
+	if t.bound == nil || other.bound == nil {
+		return unionTail{open: true}
+	}
+	return unionTail{open: true, bound: newUnion(nil, []soltype.Type{t.bound, other.bound}, false)}
 }
 
 // newIntersection is the meet twin of newUnion. An IntersectionType carries
@@ -64,9 +112,11 @@ func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 //   - `¬never` is `unknown`, since `never` admits no value and `unknown` admits
 //     every one.
 //   - `¬unknown` is `never`, the same identity read the other way.
-//   - `¬(A | B | ...)` is `never`. An inexact union is the top of the subtype
-//     lattice, since its open tail accepts every value, so its complement admits
-//     none. TestOpenUnionIsTopForSubtypingOnly pins that reading.
+//   - `¬(A | B | ...)` is `never`. A union whose open tail carries no bound is the
+//     top of the subtype lattice, since that tail accepts every value, so its
+//     complement admits none. TestOpenUnionIsTopForSubtypingOnly pins that reading.
+//     A bounded tail is not top and gets no fold. `¬("a" | ...string)` rejects every
+//     string and admits `5`, so it wraps like any other operand.
 //   - `¬¬T` is T, since complementing twice returns the original set.
 //
 // It does NOT push the complement through a union or an intersection. `¬(A | B)`
@@ -83,7 +133,7 @@ func newNegation(inner soltype.Type) soltype.Type {
 	case *soltype.UnknownType:
 		return &soltype.NeverType{}
 	case *soltype.UnionType:
-		if inner.Inexact {
+		if inner.Inexact && inner.TailBound == nil {
 			return &soltype.NeverType{}
 		}
 	case *soltype.NegationType:
@@ -93,12 +143,12 @@ func newNegation(inner soltype.Type) soltype.Type {
 }
 
 // flattenUnion splices nested UnionType members into the outer member list
-// and carries an inner inexact flag out to the caller. The splice is
-// recursive, so a UnionType whose members include another UnionType is fully
-// unwrapped in one pass. An inexact nested member at any depth makes the
-// outer union inexact, since `... | (A | ...)` collapses to `A | ...`. When
-// no member nests, the input slice is reused, so the common case pays no
-// allocation.
+// and carries an inner tail out to the caller. The splice is recursive, so a
+// UnionType whose members include another UnionType is fully unwrapped in one
+// pass. An inexact nested member at any depth makes the outer union inexact,
+// since `... | (A | ...)` collapses to `A | ...`, and unionTail.merge decides
+// what bounds the result. When no member nests, the input slice is reused, so
+// the common case pays no allocation.
 //
 // Recursion matters when a caller hands flatten an unnormalized member, such
 // as a raw `&UnionType{Types: [...]}` constructed in a test or rebuilt by a
@@ -106,9 +156,9 @@ func newNegation(inner soltype.Type) soltype.Type {
 // always flat, so a chain of normal newUnion calls would never trigger the
 // recursive case, but the recursion keeps the flatness invariant true for
 // every input.
-func flattenUnion(parts []soltype.Type, inexact bool) ([]soltype.Type, bool) {
+func flattenUnion(parts []soltype.Type, tail unionTail) ([]soltype.Type, unionTail) {
 	if !anyUnion(parts) {
-		return parts, inexact
+		return parts, tail
 	}
 	flat := make([]soltype.Type, 0, len(parts))
 	var splice func(p soltype.Type)
@@ -118,9 +168,7 @@ func flattenUnion(parts []soltype.Type, inexact bool) ([]soltype.Type, bool) {
 			flat = append(flat, p)
 			return
 		}
-		if u.Inexact {
-			inexact = true
-		}
+		tail = tail.merge(tailOf(u))
 		for _, m := range u.Types {
 			splice(m)
 		}
@@ -128,7 +176,7 @@ func flattenUnion(parts []soltype.Type, inexact bool) ([]soltype.Type, bool) {
 	for _, p := range parts {
 		splice(p)
 	}
-	return flat, inexact
+	return flat, tail
 }
 
 // flattenIntersection is the meet twin of flattenUnion. The splice is
@@ -238,24 +286,70 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 	return out
 }
 
-func collapseUnion(pruned []soltype.Type, inexact, hadError bool) soltype.Type {
+// tailSubsumed reports whether every value a tail's bound admits is one the union's named
+// members already admit, which makes the tail contribute nothing and the union exactly its
+// named side. `"y" | ..."y"` is exactly `"y"`, `string | ...string` exactly `string`, and
+// `1 | 2 | ...(1 | 2)` exactly `1 | 2`.
+//
+// This is subsumption applied to the tail rather than to a member. Equality decides it rather
+// than a subtype test, so it needs no Context and runs on every mint. Two shapes qualify: a
+// bound equal to a named member, and an exact union whose every member is. A bound that is a
+// subtype of the named members by some other route, such as `string | ..."a"`, is subsumed too
+// but goes undetected. An inexact union bound never qualifies, since its own tail says nothing about
+// what it holds.
+//
+// A tail drawn from `never` holds nothing, so it drops however that emptiness is spelled. A
+// bare `never` is one spelling and an exact union naming no member is the other, which the
+// loop below passes vacuously.
+func tailSubsumed(pruned []soltype.Type, bound soltype.Type) bool {
+	if bound == nil {
+		return false
+	}
+	if _, empty := bound.(*soltype.NeverType); empty {
+		return true
+	}
+	named := func(t soltype.Type) bool {
+		return slices.ContainsFunc(pruned, func(m soltype.Type) bool { return equalType(m, t) })
+	}
+	if u, ok := bound.(*soltype.UnionType); ok && !u.Inexact {
+		for _, m := range u.Types {
+			if !named(m) {
+				return false
+			}
+		}
+		return true
+	}
+	return named(bound)
+}
+
+func collapseUnion(pruned []soltype.Type, tail unionTail, hadError bool) soltype.Type {
+	if tailSubsumed(pruned, tail.bound) {
+		tail = unionTail{}
+	}
 	if len(pruned) == 0 {
+		// ErrorType absorbs, so a union whose every other member was pruned comes back
+		// as the sole surviving error whatever its tail says.
 		if hadError {
 			return &soltype.ErrorType{}
 		}
-		// Empty union ⇒ never, the identity of |. An inexact-but-empty union is
-		// still never, since the inexactness flag has no carrier without
-		// members. A caller that needs a union whose only content is the open
-		// tail should write unknown directly.
-		return &soltype.NeverType{}
+		if !tail.open || tail.bound == nil {
+			// Empty union ⇒ never, the identity of |. An empty union with an unbounded
+			// tail is still never, since that tail says nothing a member could stand
+			// for. A caller that needs a union whose only content is an unbounded tail
+			// should write unknown directly.
+			return &soltype.NeverType{}
+		}
 	}
-	if len(pruned) == 1 && !inexact {
+	if len(pruned) == 1 && !tail.open {
 		// A single exact-union member collapses to that member. An inexact
 		// single-member union keeps its wrapper, since the `... | T` tail
 		// makes it strictly weaker than the bare T.
 		return pruned[0]
 	}
-	return &soltype.UnionType{Types: pruned, Inexact: inexact}
+	// A bounded tail with no named member survives as `...R`, a union naming no member
+	// and drawing every one it has from R. `("a" | ...string) ∩ ¬"a"` reduces to
+	// `...(string & ¬"a")`, the string keys other than "a", which has no other spelling.
+	return &soltype.UnionType{Types: pruned, Inexact: tail.open, TailBound: tail.bound}
 }
 
 func collapseIntersection(pruned []soltype.Type, hadError bool) soltype.Type {
@@ -384,21 +478,27 @@ func (s *finalSubsumer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 	return soltype.EnterResult{}
 }
 
-// ExitType subsumes a lattice node's members and rebuilds it only when a member
-// was dropped. The input is a coalesced display type, so it is already flattened,
+// ExitType subsumes a lattice node's members and rebuilds it only when something
+// changed. The input is a coalesced display type, so it is already flattened,
 // pruned, deduped, and canonically ordered — newUnion's other normalization steps
 // would be no-ops here, so only subsumeMembers runs. subsumeMembers only ever
 // removes members, so a length drop is an O(1) signal that the node changed, which
-// avoids a structural re-comparison. When nothing dropped the original node is
+// avoids a structural re-comparison. When nothing changed the original node is
 // returned, preserving pointer identity up the spine.
+//
+// A union asks about its tail as well as its members, because this walk rewrites
+// the bound before the union itself. A bound that folds to `never` on the way up
+// leaves a tail holding nothing, and a bound that folds to a named member leaves
+// one contributing nothing. Neither drops a member, so a member count alone would
+// miss both and render `...never` or `"y" | ..."y"`.
 func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.UnionType:
 		kept := subsumeMembers(s.ctx, t.Types, unionDrops)
-		if len(kept) == len(t.Types) {
+		if len(kept) == len(t.Types) && !tailSubsumed(kept, t.TailBound) {
 			return t
 		}
-		return collapseUnion(kept, t.Inexact, false)
+		return collapseUnion(kept, tailOf(t), false)
 	case *soltype.IntersectionType:
 		members, changed, provedEmpty := simplifyNegations(s.ctx, t.Types)
 		if provedEmpty {
@@ -534,6 +634,16 @@ func compareSameKind(a, b soltype.Type) int {
 		b := b.(*soltype.UnionType)
 		if a.Inexact != b.Inexact {
 			return boolOrder(a.Inexact) - boolOrder(b.Inexact)
+		}
+		// An unbounded tail sorts before a bounded one, so two unions over the same
+		// members order by what their tails admit.
+		if (a.TailBound == nil) != (b.TailBound == nil) {
+			return boolOrder(a.TailBound != nil) - boolOrder(b.TailBound != nil)
+		}
+		if a.TailBound != nil {
+			if c := compareType(a.TailBound, b.TailBound); c != 0 {
+				return c
+			}
 		}
 		if c := len(a.Types) - len(b.Types); c != 0 {
 			return c

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -286,45 +286,53 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 	return out
 }
 
-// tailSubsumed reports whether every value a tail's bound admits is one the union's named
-// members already admit, which makes the tail contribute nothing and the union exactly its
-// named side. `"y" | ..."y"` is exactly `"y"`, `string | ...string` exactly `string`, and
-// `1 | 2 | ...(1 | 2)` exactly `1 | 2`.
+// narrowTailBound removes from a tail's bound every value the union's named members already
+// admit, and returns nil once nothing is left. A nil result drops the tail, so `"y" | ..."y"`
+// is exactly `"y"`. A partial overlap narrows instead: `1 | ...(1 | 2)` becomes `1 | ...2`,
+// which reads tighter and denotes the same thing, since both admit `1` alone or `1 | 2`.
 //
-// This is subsumption applied to the tail rather than to a member. Equality decides it rather
-// than a subtype test, so it needs no Context and runs on every mint. Two shapes qualify: a
-// bound equal to a named member, and an exact union whose every member is. A bound that is a
-// subtype of the named members by some other route, such as `string | ..."a"`, is subsumed too
-// but goes undetected. An inexact union bound never qualifies, since its own tail says nothing about
-// what it holds.
+// Equality decides membership rather than a subtype test, so this needs no Context and runs on
+// every mint. A bound that is a subtype of the named members by some other route, such as
+// `string | ..."a"`, goes undetected. An inexact union bound is left alone, since its own tail
+// says nothing about what it holds, and a `never` bound holds nothing and drops.
 //
-// A tail drawn from `never` holds nothing, so it drops however that emptiness is spelled. A
-// bare `never` is one spelling and an exact union naming no member is the other, which the
-// loop below passes vacuously.
-func tailSubsumed(pruned []soltype.Type, bound soltype.Type) bool {
+// An unchanged bound comes back as the same pointer, which is how finalSubsumer tells whether
+// the walk changed anything.
+func narrowTailBound(pruned []soltype.Type, bound soltype.Type) soltype.Type {
 	if bound == nil {
-		return false
+		return nil
 	}
 	if _, empty := bound.(*soltype.NeverType); empty {
-		return true
-	}
-	named := func(t soltype.Type) bool {
-		return slices.ContainsFunc(pruned, func(m soltype.Type) bool { return equalType(m, t) })
+		return nil
 	}
 	if u, ok := bound.(*soltype.UnionType); ok && !u.Inexact {
-		for _, m := range u.Types {
-			if !named(m) {
-				return false
+		kept := make([]soltype.Type, 0, len(u.Types))
+		for _, member := range u.Types {
+			if !slices.ContainsFunc(pruned, func(p soltype.Type) bool { return equalType(p, member) }) {
+				kept = append(kept, member)
 			}
 		}
-		return true
+		switch {
+		case len(kept) == 0:
+			return nil
+		case len(kept) == len(u.Types):
+			return bound
+		}
+		// The filtered members carry no tail of their own, so this mint reaches collapseUnion
+		// with a nil bound and does not come back here.
+		return newUnion(nil, kept, false)
 	}
-	return named(bound)
+	if slices.ContainsFunc(pruned, func(p soltype.Type) bool { return equalType(p, bound) }) {
+		return nil
+	}
+	return bound
 }
 
 func collapseUnion(pruned []soltype.Type, tail unionTail, hadError bool) soltype.Type {
-	if tailSubsumed(pruned, tail.bound) {
-		tail = unionTail{}
+	if tail.bound != nil {
+		if tail.bound = narrowTailBound(pruned, tail.bound); tail.bound == nil {
+			tail = unionTail{}
+		}
 	}
 	if len(pruned) == 0 {
 		// ErrorType absorbs, so a union whose every other member was pruned comes back
@@ -480,11 +488,12 @@ func (s *finalSubsumer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 
 // ExitType subsumes a lattice node's members and rebuilds it only when something
 // changed. The input is a coalesced display type, so it is already flattened,
-// pruned, deduped, and canonically ordered — newUnion's other normalization steps
-// would be no-ops here, so only subsumeMembers runs. subsumeMembers only ever
-// removes members, so a length drop is an O(1) signal that the node changed, which
-// avoids a structural re-comparison. When nothing changed the original node is
-// returned, preserving pointer identity up the spine.
+// pruned, deduped, and canonically ordered. newUnion's other normalization steps
+// would be no-ops here, so only subsumeMembers runs. It removes members and never
+// rewrites one, so comparing how many members came back against how many went in
+// says whether anything changed, and the members themselves need no comparison.
+// When nothing changed the original node is returned, preserving pointer identity
+// up the spine.
 //
 // A union asks about its tail as well as its members, because this walk rewrites
 // the bound before the union itself. A bound that folds to `never` on the way up
@@ -495,7 +504,7 @@ func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.T
 	switch t := t.(type) {
 	case *soltype.UnionType:
 		kept := subsumeMembers(s.ctx, t.Types, unionDrops)
-		if len(kept) == len(t.Types) && !tailSubsumed(kept, t.TailBound) {
+		if len(kept) == len(t.Types) && narrowTailBound(kept, t.TailBound) == t.TailBound {
 			return t
 		}
 		return collapseUnion(kept, tailOf(t), false)

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -209,6 +209,152 @@ func TestNewUnionInexactPrintRoundTrip(t *testing.T) {
 	require.Equal(t, "number | string | ...", soltype.Print(u))
 }
 
+// Splicing a nested union carries its tail out to the outer union, and the two tails
+// merge. The bound says what the tail's unnamed members may be, so a union that swallows
+// another inherits whatever the swallowed one could hold.
+func TestFlattenUnionMergesTailBounds(t *testing.T) {
+	strTail := func(parts ...soltype.Type) soltype.Type { return newBoundedUnion(nil, parts, str()) }
+	numTail := func(parts ...soltype.Type) soltype.Type { return newBoundedUnion(nil, parts, num()) }
+
+	tests := []struct {
+		name  string
+		parts []soltype.Type
+		want  string
+	}{
+		{
+			// A nested bounded tail with no other tail to meet comes through as written.
+			name:  "a lone bounded tail carries out",
+			parts: []soltype.Type{numLit(1), strTail(strLit("a"))},
+			want:  `1 | "a" | ...string`,
+		},
+		{
+			// Two bounded tails join their bounds, since a member of either could be in the
+			// result.
+			name:  "two bounded tails join their bounds",
+			parts: []soltype.Type{strTail(strLit("a")), numTail(numLit(1))},
+			want:  `1 | "a" | ...(number | string)`,
+		},
+		{
+			// Nothing says what an unbounded tail holds, so meeting one loses the bound.
+			name:  "an unbounded tail absorbs a bounded one",
+			parts: []soltype.Type{strTail(strLit("a")), newUnion(nil, []soltype.Type{numLit(1)}, true)},
+			want:  `1 | "a" | ...`,
+		},
+		{
+			// An exact nested union brings no tail, so the outer one is untouched.
+			name:  "an exact nested union leaves the tail alone",
+			parts: []soltype.Type{strTail(strLit("a")), unionT(numLit(1), numLit(2))},
+			want:  `1 | 2 | "a" | ...string`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, soltype.Print(newUnion(nil, tt.parts, false)))
+		})
+	}
+}
+
+// A tail whose bound the union already names as a member contributes no value that member
+// does not, so it drops and the union closes. This is subsumption applied to the tail rather
+// than to a member, and equality decides it, so no Context is needed.
+func TestCollapseUnionDropsASubsumedTail(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func() soltype.Type
+		want  string
+	}{
+		{
+			// `"y" | ..."y"`. Every value the tail could hold is a `"y"`, which the named
+			// member already admits, so the union is exactly `"y"` and collapses to it. This
+			// is what a distributive conditional leaves when every member and the bound
+			// select the same branch.
+			name:  "a bound equal to the only member closes the union",
+			build: func() soltype.Type { return newBoundedUnion(nil, []soltype.Type{strLit("y")}, strLit("y")) },
+			want:  `"y"`,
+		},
+		{
+			// `string | ...string`, the same rule over a primitive.
+			name:  "a bound equal to a primitive member closes the union",
+			build: func() soltype.Type { return newBoundedUnion(nil, []soltype.Type{str()}, str()) },
+			want:  "string",
+		},
+		{
+			// The tail drops but other members remain, so the union stays a union and only
+			// loses its `...`.
+			name: "the union keeps its other members",
+			build: func() soltype.Type {
+				return newBoundedUnion(nil, []soltype.Type{strLit("y"), numLit(1)}, strLit("y"))
+			},
+			want: `1 | "y"`,
+		},
+		{
+			// A union bound is subsumed when every one of its members is named, which is the
+			// shape a conditional that reaches both branches leaves behind.
+			name: "a union bound whose every member is named closes the union",
+			build: func() soltype.Type {
+				return newBoundedUnion(nil, []soltype.Type{numLit(1), numLit(2)},
+					unionT(numLit(1), numLit(2)))
+			},
+			want: "1 | 2",
+		},
+		{
+			// One unnamed member in the bound is enough to keep the tail, since the union does
+			// not otherwise admit it.
+			name: "a union bound with an unnamed member is kept",
+			build: func() soltype.Type {
+				return newBoundedUnion(nil, []soltype.Type{numLit(1)}, unionT(numLit(1), numLit(2)))
+			},
+			want: "1 | ...(1 | 2)",
+		},
+		{
+			// A bound naming values no member does is not subsumed, so the tail stays.
+			name:  "an unrelated bound is kept",
+			build: func() soltype.Type { return newBoundedUnion(nil, []soltype.Type{strLit("y")}, str()) },
+			want:  `"y" | ...string`,
+		},
+		{
+			// Subsumption needs a member to be subsumed by. A tail with none stays whole.
+			name:  "a member-less tail is kept",
+			build: func() soltype.Type { return newBoundedUnion(nil, nil, str()) },
+			want:  "...string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, soltype.Print(tt.build()))
+		})
+	}
+}
+
+// A bound is part of a union's identity, so two unions that differ only in what their
+// tails admit are neither equal nor deduped into one, and they hold a stable place in
+// canonical order. compareType is what sortTypes consults, so an unstable answer there
+// would let one member list render two ways.
+func TestBoundedTailsCompareByTheirBound(t *testing.T) {
+	strBound := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())
+	numBound := newBoundedUnion(nil, []soltype.Type{strLit("a")}, num())
+	unbounded := newUnion(nil, []soltype.Type{strLit("a")}, true)
+
+	t.Run("equality reads the bound", func(t *testing.T) {
+		require.True(t, equalType(strBound, newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())))
+		require.False(t, equalType(strBound, numBound))
+		require.False(t, equalType(strBound, unbounded))
+		require.False(t, equalType(strBound, unionT(strLit("a"))))
+	})
+
+	t.Run("canonical order reads the bound", func(t *testing.T) {
+		// An unbounded tail sorts before a bounded one, so the two never compare equal and
+		// whichever way a caller hands them over they come back in one order.
+		require.Equal(t, -1, compareType(unbounded, strBound))
+		require.Equal(t, 1, compareType(strBound, unbounded))
+		// Two bounded tails order by their bounds, `number` before `string`.
+		require.Equal(t, 1, compareType(strBound, numBound))
+		require.Equal(t, -1, compareType(numBound, strBound))
+		// Identical bounds tie, which is what lets dedup drop one of them.
+		require.Equal(t, 0, compareType(strBound, newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())))
+	})
+}
+
 // TestNewUnionSubsumeWithContext covers the Context-gated subsumption step.
 // A member that is a subtype of another member is dropped, so `number | 1`
 // reduces to `number`.

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -298,13 +298,25 @@ func TestCollapseUnionDropsASubsumedTail(t *testing.T) {
 			want: "1 | 2",
 		},
 		{
-			// One unnamed member in the bound is enough to keep the tail, since the union does
-			// not otherwise admit it.
-			name: "a union bound with an unnamed member is kept",
+			// A bound that only partly overlaps the named members is narrowed to the part the
+			// union does not already admit. `1 | ...(1 | 2)` and `1 | ...2` both admit `1`
+			// alone or `1 | 2`, so this tightens how the type reads without changing what it
+			// denotes.
+			name: "a union bound is narrowed to its unnamed members",
 			build: func() soltype.Type {
 				return newBoundedUnion(nil, []soltype.Type{numLit(1)}, unionT(numLit(1), numLit(2)))
 			},
-			want: "1 | ...(1 | 2)",
+			want: "1 | ...2",
+		},
+		{
+			// Narrowing down to a single member leaves that member as the bound rather than a
+			// one-member union, since newUnion collapses it.
+			name: "a bound narrowed to one member drops its union wrapper",
+			build: func() soltype.Type {
+				return newBoundedUnion(nil, []soltype.Type{numLit(1), numLit(2)},
+					unionT(numLit(1), numLit(2), numLit(3)))
+			},
+			want: "1 | 2 | ...3",
 		},
 		{
 			// A bound naming values no member does is not subsumed, so the tail stays.

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -613,5 +613,5 @@ func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
 	}
 	// collapseUnion returns `never` for an empty arm list, which is the caller's
 	// signal that the whole meet is uninhabited.
-	return collapseUnion(arms, u.Inexact, false), true
+	return collapseUnion(arms, unionTail{open: u.Inexact}, false), true
 }

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -238,11 +238,19 @@ func TestNewNegation(t *testing.T) {
 		{"never", &soltype.NeverType{}, "unknown"},
 		{"unknown", &soltype.UnknownType{}, "never"},
 		{"double complement", negT(str()), "string"},
-		// An inexact union accepts every value, so its complement accepts none.
+		// A union whose open tail carries no bound accepts every value, so its complement
+		// accepts none.
 		{"open union", newUnion(nil, []soltype.Type{boolT(), str()}, true), "never"},
 		{"primitive", str(), "¬string"},
 		// A closed union bounds its members, so its complement is a real type.
 		{"closed union", unionT(str(), num()), "¬(number | string)"},
+		// So does a bounded tail. `¬("a" | ...string)` admits `5`, which is exactly what the
+		// fold above would have thrown away.
+		{
+			"bounded open union",
+			newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()),
+			`¬("a" | ...string)`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -251,10 +259,13 @@ func TestNewNegation(t *testing.T) {
 	}
 }
 
-// An inexact union is the top of the subtype lattice, and two passes now depend on that.
-// newNegation folds `¬(A | B | ...)` to `never`, and simplifyNegations collapses a meet
-// carrying such a complement. Both rest on the probes below, so they are pinned here
-// rather than left to a comment.
+// A union whose open tail carries no bound is the top of the subtype lattice, and two
+// passes depend on that. newNegation folds `¬(A | B | ...)` to `never`, and
+// simplifyNegations collapses a meet carrying such a complement. Both rest on the probes
+// below, so they are pinned here rather than left to a comment.
+//
+// TestBoundedTailIsNotTop is the counterpart. Writing a bound on the tail is what takes
+// the union out of the top position these probes put it in.
 //
 // The second subtest is the step from top-ness to the fold: if `boolean | ...` accepts
 // every value then nothing satisfies `¬(boolean | ...)`.
@@ -368,4 +379,40 @@ func printedBounds(bounds []soltype.Type) []string {
 		out[i] = soltype.Print(b)
 	}
 	return out
+}
+
+// subsumeFinal rewrites a union's tail bound before the union itself, so a bound that only
+// becomes droppable on the way up still has to be noticed. Neither case below drops a member,
+// which is what makes them the cases a member count alone would miss.
+func TestFinalSubsumptionRereadsARewrittenTailBound(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []soltype.Type
+		bound soltype.Type
+		want  string
+	}{
+		{
+			// `¬string` admits nothing a `string` admits, so the meet is empty and the tail
+			// is drawn from `never`. A tail holding nothing leaves the union its named side,
+			// and there is none, so the answer is `never` rather than `...never`.
+			name:  "a bound that folds to never empties the union",
+			bound: newIntersection(nil, []soltype.Type{str(), not(str())}),
+			want:  "never",
+		},
+		{
+			// The bound folds to `"y"`, which the union already names. The tail then draws
+			// only members the union lists, so it contributes nothing and drops.
+			name:  "a bound that folds to a named member drops the tail",
+			parts: []soltype.Type{strLit("y")},
+			bound: newIntersection(nil, []soltype.Type{strLit("y"), not(strLit("n"))}),
+			want:  `"y"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newChecker()
+			in := &soltype.UnionType{Types: tt.parts, Inexact: true, TailBound: tt.bound}
+			require.Equal(t, tt.want, soltype.Print(c.subsumeFinal(in)))
+		})
+	}
 }


### PR DESCRIPTION
Refs #1126. First of six, splitting #1129 into reviewable pieces. Base: `main`.

`A | ...` says a union has unnamed members without saying what they may be, which leaves it admitting every value. This gives the tail an optional bound naming the type its unnamed members are drawn from, so `"a" | ...string` reads as `"a"` together with some unknown set of strings.

**This PR adds the representation and nothing else.** Nothing mints a bound, and every rule that reads one is guarded on its absence, so a union built anywhere in the compiler comes back exactly as it did before. That is the property to check while reviewing: the plumbing should be *total*, reaching every site that rebuilds a union. The tests construct bounded unions directly, since no in-tree caller produces one yet.

What the bound has to reach:

- `LevelOf` and the visitor walk it, the visitor at the union's own polarity, since a tail member is a member.
- The printer renders `...R`, and `freeTypeVars` collects a variable reachable only through it.
- The lattice constructors thread it as a `unionTail` through flatten, merge, prune, and collapse. Merging two tails joins their bounds, and an unbounded tail absorbs.
- `narrowTailBound` removes from a bound every value the union already names, so `"y" | ..."y"` is exactly `"y"` and `1 | ...(1 | 2)` is `1 | ...2`. An emptied bound drops the tail. Equality decides it, so it needs no `Context` and runs on every mint; a bound that is a subtype of the named members by some other route, such as `string | ..."a"`, goes undetected.
- `equalTypeWith` compares it, since `"a" | ...string` admits values `"a" | ...number` rejects.
- `describe` renders it in diagnostics.

The bounded form has no surface syntax, so it does not round-trip through the printer. #1131 tracks adding one.

Full suite passes; no snapshot or fixture movement, which is what "behavior-preserving" means here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bounded open unions, allowing unnamed union members to be constrained by a type bound.
  * Preserved and merged union tail bounds during type simplification and inference.
  * Improved type diagnostics to display bounded tails, including compound bounds.

* **Bug Fixes**
  * Corrected union equality, traversal, variable collection, ordering, and negation for bounded tails.
  * Prevented bounded open unions from incorrectly collapsing to `never`.
  * Added handling for empty named-member unions and nil bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->