### PR TITLE
Read the tail's bound when deciding subtyping

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -686,10 +686,15 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				return errs
 			}
 			var errs []SolverError
-			if subU.Inexact {
+			if subU.Inexact && subU.TailBound == nil {
+				// Nothing says what an unbounded tail holds, so a closed super cannot
+				// absorb it and the mismatch is reported once for the whole union.
+				// Only a super whose own tail is unbounded can absorb this one, since a
+				// bounded tail admits just its bound and an unbounded sub tail may hold
+				// anything. `("a" | ...) <: ("a" | "b" | ...string)` is therefore rejected.
 				closed := true
 				if s, ok := super.(*soltype.UnionType); ok {
-					closed = !s.Inexact
+					closed = !s.Inexact || s.TailBound != nil
 				}
 				if closed {
 					errs = append(errs, &InexactUnionIntoExactError{Sub: subU, Super: super})
@@ -697,6 +702,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			}
 			for _, m := range subU.Types {
 				errs = append(errs, c.constrain(m, super, seen, mutCtx)...)
+			}
+			if subU.TailBound != nil {
+				// A bounded tail holds only values of its bound, so the super absorbs the
+				// whole tail exactly when it absorbs that bound. Checking it is what makes
+				// `("a" | ...string) <: string` hold and `("a" | ...string) <: ("a" | ...number)`
+				// fail, the latter because the sub's tail may hold a string the super rejects.
+				errs = append(errs, c.constrain(subU.TailBound, super, seen, mutCtx)...)
 			}
 			return errs
 		}
@@ -738,14 +750,24 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 	// commits `number` and never touches T. `"hi" <: (T | number)` finds no concrete
 	// match and falls through to `"hi" <: T`, recording "hi" as T's lower bound.
 	if supU, ok := super.(*soltype.UnionType); ok {
-		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && len(supU.Types) > 0 {
-			// An open tail has no atom to stand for it, so the layer hands a union that
-			// carries one straight back and weighs no member at all. The decision runs
-			// against the members with the tail dropped, and the tail rule below catches
-			// what they miss. Splicing the members out of any nested union first is what
-			// keeps a nested tail from putting the flag straight back.
+		// The second disjunct is what admits a union naming no member of its own. `...string`
+		// still has something to weigh, since its bound admits every string. A union that does
+		// name members enters through the first disjunct, and constrainNF weighs its bound
+		// alongside those members either way.
+		hasCandidate := len(supU.Types) > 0 || supU.TailBound != nil
+		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && hasCandidate {
+			// An unbounded tail has no atom to stand for it, so normalization keeps such a
+			// union whole rather than splitting it into its members. The only pair the layer
+			// could form is then the original goal against itself, which pairPlan skips as
+			// circular, so it returns having weighed nothing. Dropping the tail first gives
+			// the layer an exact union whose members it does take apart, and the tail rule
+			// below covers a sub that matches none of them. Splicing the members out of any
+			// nested union is what keeps a nested tail from putting the flag straight back.
+			//
+			// A bounded tail stays on, since the normal-form layer takes it apart into one
+			// more disjunct and so decides the whole union in one go.
 			named := super
-			if supU.Inexact {
+			if supU.Inexact && supU.TailBound == nil {
 				flat, _ := flattenUnion(supU.Types, unionTail{})
 				named = newUnion(nil, flat, false)
 			}
@@ -778,11 +800,15 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				}
 				return diags
 			}
-			if supU.Inexact {
-				// An inexact union super has an open, unknown-typed tail. A sub that
-				// matches no named member is subsumed by that tail, so accept it. This
-				// is the dual of the union-sub arm above, which rejects an inexact sub
-				// into a closed super because that open tail can't be absorbed.
+			if supU.Inexact && supU.TailBound == nil {
+				// An unbounded tail admits every value, so a sub that matches no named
+				// member is subsumed by that tail and the constraint holds. This is the
+				// dual of the union-sub arm above, which rejects an inexact sub into a
+				// closed super because that open tail can't be absorbed.
+				//
+				// A bounded tail admits only what its bound does, and the decision above
+				// already weighed the bound, so a sub that got here is outside it. Fall
+				// through to the error.
 				return nil
 			}
 			// No candidate holds, the var members included, and the decomposition's own

--- a/internal/solver/constrain_nf.go
+++ b/internal/solver/constrain_nf.go
@@ -409,7 +409,7 @@ func orderedPairs(subCands, superCands []soltype.Type, origSub, origSuper soltyp
 			continue
 		}
 		for _, i := range subOrder {
-			if isInexactUnion(superCands[j]) && equalType(subCands[i], origSub) && equalType(superCands[j], origSuper) {
+			if hasUnboundedTail(superCands[j]) && equalType(subCands[i], origSub) && equalType(superCands[j], origSuper) {
 				continue
 			}
 			pairs = append(pairs, nfPair{sub: subCands[i], super: superCands[j]})
@@ -492,9 +492,10 @@ func isNegation(t soltype.Type) bool {
 	return ok
 }
 
-// isInexactUnion reports whether t is a union with an open tail, the one supertype
-// normalization hands back whole.
-func isInexactUnion(t soltype.Type) bool {
+// hasUnboundedTail reports whether t is a union carrying an open tail that nothing bounds,
+// the one supertype normalization hands back whole. A bounded tail contributes its bound as
+// one more disjunct, so such a union is taken apart and never reaches a candidate list.
+func hasUnboundedTail(t soltype.Type) bool {
 	u, ok := t.(*soltype.UnionType)
-	return ok && u.Inexact
+	return ok && u.Inexact && u.TailBound == nil
 }

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -177,8 +177,8 @@ func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
 	case *soltype.UnknownType:
 		return dnfTop()
 	case *soltype.UnionType:
-		if t.Inexact {
-			// `A | B | ...` names A, B, and an open tail of unknown content. The tail has
+		if t.Inexact && t.TailBound == nil {
+			// `A | B | ...` names A, B, and an open tail nothing bounds. The tail has
 			// no atom to stand for it, so taking the union apart would drop it and hand
 			// back a type narrower than the source wrote. The whole node stays one atom,
 			// which round-trips exactly and keeps the flag.
@@ -197,6 +197,18 @@ func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
 		out := DNF{Conjuncts: nil}
 		for _, m := range t.Types {
 			out = dnfOr(out, c.mkDNF(m, pol))
+		}
+		if t.TailBound != nil {
+			// A bounded tail holds some unknown set of the bound's values, so no value
+			// outside the bound reaches the union and every value inside it might. That
+			// makes the bound one more disjunct for a decision about which values the
+			// union admits. `5 <: ("a" | ...string)` fails and `"z" <: ("a" | ...string)`
+			// holds, both by the ordinary union rule once the bound joins the members.
+			//
+			// The bound joins the DNF rather than the member list, so the named members
+			// stay enumerable for keyof and mapped types. Adding it to the members would
+			// let subsumption drop `"a"` against `string` and leave nothing to iterate.
+			out = dnfOr(out, c.mkDNF(t.TailBound, pol))
 		}
 		return DNF{Conjuncts: c.canonicalConjuncts(out.Conjuncts)}
 	case *soltype.IntersectionType:
@@ -241,13 +253,17 @@ func (c *Context) mkCNF(t soltype.Type, pol soltype.Polarity) CNF {
 		}
 		return CNF{Disjuncts: c.canonicalDisjuncts(out.Disjuncts)}
 	case *soltype.UnionType:
-		if t.Inexact {
-			// The open tail has no atom to stand for it; see the mkDNF arm.
+		if t.Inexact && t.TailBound == nil {
+			// An unbounded tail has no atom to stand for it; see the mkDNF arm.
 			return cnfAtom(t)
 		}
 		out := cnfBot()
 		for _, m := range t.Types {
 			out = cnfOr(out, c.mkCNF(m, pol))
+		}
+		if t.TailBound != nil {
+			// A bounded tail contributes its bound; see the mkDNF arm.
+			out = cnfOr(out, c.mkCNF(t.TailBound, pol))
 		}
 		return CNF{Disjuncts: c.canonicalDisjuncts(out.Disjuncts)}
 	case *soltype.NegationType:
@@ -907,6 +923,7 @@ func valueFamilyOf(t soltype.Type) valueFamily {
 	}
 	return notValueAtom
 }
+
 
 func primFamily(p soltype.Prim) valueFamily {
 	switch p {

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -588,8 +588,12 @@ func simplifyNegations(c *Context, members []soltype.Type) (kept []soltype.Type,
 // since meeting such an arm with ¬n leaves no value. A non-union p that is itself a
 // subtype of n leaves nothing at all, which excludeArms returns as `never`.
 //
-// An INEXACT union in p is left as written. It is top, so none of its arms bounds the
-// type and dropping one would discard a named member for no gain.
+// A union whose open tail carries no bound is left as written. It is top, so none of
+// its arms bounds the type and dropping one would discard a named member for no gain.
+//
+// A bounded tail does bound the type, so it is weighed like an arm. The tail goes away
+// when ¬n rules out every value its bound admits, and otherwise stays as written, since
+// excludeArms only ever drops parts.
 func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
 	u, isUnion := p.(*soltype.UnionType)
 	if !isUnion {
@@ -598,7 +602,7 @@ func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
 		}
 		return p, false
 	}
-	if u.Inexact {
+	if u.Inexact && u.TailBound == nil {
 		return p, false
 	}
 	arms := make([]soltype.Type, 0, len(u.Types))
@@ -608,10 +612,14 @@ func excludeArms(c *Context, p, n soltype.Type) (soltype.Type, bool) {
 		}
 		arms = append(arms, arm)
 	}
-	if len(arms) == len(u.Types) {
+	tail := tailOf(u)
+	if tail.bound != nil && concreteMember(tail.bound) && subtypeHolds(c, tail.bound, n) {
+		tail = unionTail{}
+	}
+	if len(arms) == len(u.Types) && tail.open == u.Inexact {
 		return p, false
 	}
-	// collapseUnion returns `never` for an empty arm list, which is the caller's
-	// signal that the whole meet is uninhabited.
-	return collapseUnion(arms, unionTail{open: u.Inexact}, false), true
+	// collapseUnion returns `never` for an empty arm list under a tail that dropped,
+	// which is the caller's signal that the whole meet is uninhabited.
+	return collapseUnion(arms, tail, false), true
 }

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -319,6 +319,123 @@ func TestOpenUnionIsTopForSubtypingOnly(t *testing.T) {
 	})
 }
 
+// Writing a bound on the open tail takes the union out of the top position
+// TestOpenUnionIsTopForSubtypingOnly pins. `"a" | ...string` names "a" and draws every
+// other member it has from `string`, so a value outside `string` is outside the union.
+//
+// Each probe below has a counterpart in that test that answers the other way, which is
+// what makes the bound the thing that changed rather than some difference in the shapes.
+func TestBoundedTailIsNotTop(t *testing.T) {
+	c := newChecker()
+	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()) // "a" | ...string
+
+	t.Run("the bound decides what is a subtype of the union", func(t *testing.T) {
+		probes := []struct {
+			name     string
+			sub, sup soltype.Type
+			want     bool
+		}{
+			// A value the bound admits may be one of the tail's members.
+			{"a named member is a subtype of it", strLit("a"), bounded, true},
+			{"another string is a subtype of it", strLit("z"), bounded, true},
+			{"the bound itself is a subtype of it", str(), bounded, true},
+			// A value the bound rejects cannot be, which is where the unbounded tail
+			// answered true for every sub.
+			{"a number literal is not a subtype of it", numLit(5), bounded, false},
+			{"a number is not a subtype of it", num(), bounded, false},
+			{"unknown is not a subtype of it", &soltype.UnknownType{}, bounded, false},
+		}
+		for _, p := range probes {
+			require.Equal(t, p.want, subtypeHolds(c.ctx, p.sub, p.sup), p.name)
+		}
+	})
+
+	// The complement is inhabited, so newNegation has something to wrap. `5` is not a key of
+	// the object, so it satisfies `¬keyof {a: X, ...}`, while a string that could be one does
+	// not. An unbounded tail folds the whole complement to `never`, which nothing satisfies.
+	t.Run("its complement is inhabited", func(t *testing.T) {
+		require.True(t, subtypeHolds(c.ctx, numLit(5), negT(bounded)))
+		require.False(t, subtypeHolds(c.ctx, strLit("z"), negT(bounded)))
+	})
+
+	// The bound also decides what the union is a subtype of, which is the direction that
+	// carries the tail into a supertype rather than out of one. An unbounded tail is a
+	// subtype of nothing but `unknown`, since no closed type absorbs a tail that may hold
+	// anything.
+	t.Run("the bound decides what the union is a subtype of", func(t *testing.T) {
+		probes := []struct {
+			name     string
+			sub, sup soltype.Type
+			want     bool
+		}{
+			// Every member is a string, the named one included, so `string` absorbs the
+			// whole union.
+			{"a bounded tail is a subtype of its own bound", bounded, str(), true},
+			// The sub's tail may hold "zz", which the super's `number` tail rejects.
+			{
+				"a string tail is not a subtype of a number tail",
+				bounded, newBoundedUnion(nil, []soltype.Type{strLit("a")}, num()), false,
+			},
+			// The super's tail admits every string, so it absorbs the sub's whole tail.
+			{
+				"a narrower bound is a subtype of a wider one",
+				newBoundedUnion(nil, []soltype.Type{strLit("a")}, strLit("z")), bounded, true,
+			},
+			{"a bounded tail is not a subtype of a lone member", bounded, strLit("a"), false},
+			// The unbounded sub is top, so no bounded super absorbs it. This is the one
+			// pair where both operands carry a tail and only the sub's is unbounded.
+			{
+				"an unbounded tail is not a subtype of a bounded one",
+				newUnion(nil, []soltype.Type{strLit("a")}, true), bounded, false,
+			},
+			{
+				"a bounded tail is a subtype of an unbounded one",
+				bounded, newUnion(nil, []soltype.Type{strLit("a")}, true), true,
+			},
+		}
+		for _, p := range probes {
+			require.Equal(t, p.want, subtypeHolds(c.ctx, p.sub, p.sup), p.name)
+		}
+	})
+}
+
+// The normalization layer reads a bounded tail as one more disjunct, so a decision about
+// which values the union admits sees the bound alongside the named members. The two probes
+// below are the two directions that reading is consulted from.
+func TestNormalizationReadsTheTailBound(t *testing.T) {
+	c := newChecker()
+	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())
+
+	// `"a"` is one of the strings the bound admits, so the two fuse and the whole union
+	// normalizes to `string`. An unbounded tail has no atom to fuse and stays whole.
+	t.Run("a bounded tail joins the disjuncts", func(t *testing.T) {
+		require.Equal(t, "string", soltype.Print(c.ctx.mkCNF(bounded, soltype.Positive).toType()))
+		require.Equal(t, "string", soltype.Print(c.ctx.mkDNF(bounded, soltype.Positive).toType()))
+	})
+
+	t.Run("an unbounded tail stays one atom", func(t *testing.T) {
+		// mkDNF and mkCNF each carry their own unbounded-tail guard, so both are probed.
+		open := newUnion(nil, []soltype.Type{strLit("a")}, true)
+		require.Equal(t, `"a" | ...`, soltype.Print(c.ctx.mkCNF(open, soltype.Positive).toType()))
+		require.Equal(t, `"a" | ...`, soltype.Print(c.ctx.mkDNF(open, soltype.Positive).toType()))
+	})
+}
+
+// simplifyNegations weighs a bounded tail the way it weighs a named arm, so a complement that
+// rules out everything the bound admits empties the meet. An unbounded tail is top and no
+// complement can empty it, which TestSimplifyNegationsRefusesToCollapse pins on the other side.
+func TestSimplifyNegationsEmptiesABoundedTail(t *testing.T) {
+	c := newChecker()
+	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())
+
+	// `("a" | ...string) & ¬string`. Both the named member and every value the tail could
+	// hold is a string, so nothing survives.
+	kept, changed, provedEmpty := simplifyNegations(c.ctx, []soltype.Type{bounded, negT(str())})
+	require.True(t, provedEmpty)
+	require.True(t, changed)
+	require.Empty(t, kept)
+}
+
 // The two routes a complement can take past a variable, which the section comment above
 // simplifyNegations describes. They go opposite ways, and only the first leaves a
 // complement behind for that pass to find.


### PR DESCRIPTION
Refs #1126. Second of six, splitting #1129. Base: #1133.

This is the semantic core of the series and the one worth reading slowly. Everything else is plumbing around the rule stated here.

A bounded tail says what the union's unnamed members may be, so it answers questions an unbounded one cannot. `X &lt;: (A | ...R)` holds when `X` is a subtype of `A` or of `R`, since a tail member is drawn from `R`. That makes a bounded union an ordinary supertype rather than the top of the lattice.

Normalization is where the reading lives. `mkDNF` and `mkCNF` keep an unbounded tail as one opaque atom, because no type names what it holds. A bounded tail instead contributes its bound as one more disjunct, so every rule downstream weighs the tail alongside the named members without knowing about tails at all.

## What changes in the constraint arms

A union can sit on either side of `sub <: super`, and each side gets its own rule.

**Union on the right —** `X <: (A | ...R)`

An unbounded tail supports a shortcut: if `X` matched no named member, constrain returned success outright, since a tail that says nothing about its contents admits everything. A bound makes that wrong. The union now goes to `constrainNF`, the normal-form layer, with its bound still attached, and that layer folds the bound in as one extra disjunct and weighs it alongside the named members in a single pass. Matching nothing is a real error again.

```
5   <: ("a" | ...)          holds   — the blanket accept
5   <: ("a" | ...string)    fails   — 5 is neither "a" nor a string
"b" <: ("a" | ...string)    holds   — the bound absorbs it
```

**Union on the left —** `(A | ...R) <: Y`

Each named member is constrained against `Y` as before. The bound is now constrained too, exactly as if it were one more member. That is sound because every tail member is drawn from `R`, so `Y` absorbs the whole tail precisely when it absorbs `R`.

```
("a" | ...string) <: string              holds  — "a" <: string, and string <: string
("a" | ...string) <: ("a" | ...number)   fails  — the bound check string <: ("a" | ...number) fails
```

Together the two rules give an asymmetry that is a good sanity check while reviewing:

```
("a" | ...)       <: ("a" | ...string)   fails  — an unbounded tail may hold anything,
                                                  so only an unbounded super can absorb it
("a" | ...string) <: ("a" | ...)         holds  — the unbounded super absorbs everything
```

## Elsewhere

`excludeArms` weighs a bounded tail as an arm, so a complement that rules out every value the bound admits empties the meet. `isInexactUnion` is renamed `hasUnboundedTail`, since it now asks about the tail's bound rather than the union's exactness.

Nothing mints a bound yet, so behavior is unchanged and the tests construct bounded unions directly. #1135 is where the first one appears.