### PR TITLE
Bound the tail keyof mints for an inexact operand

### DIFF
--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -31,14 +31,15 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 		},
 		{
 			// An inexact tuple has unknown trailing positions, so its index set is open and carries
-			// the indices those positions occupy in a trailing `...`.
+			// the indices those positions occupy in a trailing `...`. Those indices are positions,
+			// so the tail is bounded by `number`.
 			name: "KeyofInexactTuple",
 			src: `
 				type Tup = [number, string, ...]
 				type Result = keyof Tup
 			`,
 			wantSymbolic: "keyof Tup",
-			wantExpanded: "0 | 1 | ...",
+			wantExpanded: "0 | 1 | ...number",
 		},
 		{
 			// `T[keyof T]` over an exact object reads every key the object declares, and those are
@@ -161,14 +162,15 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 		},
 		{
 			// An intersection carries both operands' members, so its key sets union. An inexact
-			// operand's open key set leaves the whole union open.
+			// operand's open key set leaves the whole union open, bounded by `string` because the
+			// keys it did not list are still property names.
 			name: "KeyofIntersectionWithInexactMember",
 			src: `
 				type I = {a: number} & {b: string, ...}
 				type Result = keyof I
 			`,
 			wantSymbolic: "keyof I",
-			wantExpanded: `"a" | "b" | ...`,
+			wantExpanded: `"a" | "b" | ...string`,
 		},
 		{
 			// `Exact` and `Inexact` are the two operators that run the other way. Every case above
@@ -442,7 +444,7 @@ func TestInferExactnessIntrinsics(t *testing.T) {
 				type Result = keyof Inexact<Obj>
 			`,
 			wantSymbolic: "keyof Inexact<Obj>",
-			wantExpanded: `"a" | "b" | ...`,
+			wantExpanded: `"a" | "b" | ...string`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -97,26 +97,28 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 			wantExpanded: `"only"`,
 		},
 		{
-			// An inexact object's key union is inexact too: the known
-			// keys plus a trailing `...` standing for the unlisted ones.
+			// An inexact object's key union is inexact too: the known keys plus a trailing `...`
+			// standing for the unlisted ones. The tail is bounded by `string`, since a key the
+			// object did not list is still a property name.
 			name: "InexactObject",
 			src: `
 				type Obj = {x: number, y: string, ...}
 				type Result = keyof Obj
 			`,
 			wantSymbolic: "keyof Obj",
-			wantExpanded: `"x" | "y" | ...`,
+			wantExpanded: `"x" | "y" | ...string`,
 		},
 		{
 			// A single-key inexact object keeps the union wrapper rather than collapsing to the lone
-			// literal, since the open tail makes `"only" | ...` strictly weaker than bare `"only"`.
+			// literal, since the open tail makes `"only" | ...string` strictly weaker than bare
+			// `"only"`.
 			name: "InexactSingleKeyObject",
 			src: `
 				type Obj = {only: number, ...}
 				type Result = keyof Obj
 			`,
 			wantSymbolic: "keyof Obj",
-			wantExpanded: `"only" | ...`,
+			wantExpanded: `"only" | ...string`,
 		},
 		{
 			// A key is readable from a union only when every member carries it, so the members'
@@ -184,14 +186,15 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 		},
 		{
 			// An inexact member's open key set may carry "a" as well, so the intersection cannot
-			// rule "a" out. The written keys intersect to "shared" and the result stays open.
+			// rule "a" out. The written keys intersect to "shared" and the result stays open,
+			// carrying the `string` bound that member's own key set had.
 			name: "UnionInexactMember",
 			src: `
 				type U = {a: number, shared: string} | {b: boolean, shared: string, ...}
 				type Result = keyof U
 			`,
 			wantSymbolic: "keyof U",
-			wantExpanded: `"shared" | ...`,
+			wantExpanded: `"shared" | ...string`,
 		},
 		{
 			// An inexact union has an unlisted member whose keys are unknown, so it cannot close
@@ -292,7 +295,7 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 		},
 		{
 			// A non-final class projects to an inexact instance body, since a subclass may add
-			// members, so its key union is open: `"x" | "y" | ...`.
+			// members, so its key union is open: `"x" | "y" | ...string`.
 			name: "Class",
 			src: `
 				class Point {
@@ -302,7 +305,7 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 				type Result = keyof Point
 			`,
 			wantSymbolic: "keyof Point",
-			wantExpanded: `"x" | "y" | ...`,
+			wantExpanded: `"x" | "y" | ...string`,
 		},
 		{
 			// A final class has no subclasses to widen it, so its instance body is exact and its

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -436,6 +436,40 @@ func TestSimplifyNegationsEmptiesABoundedTail(t *testing.T) {
 	require.Empty(t, kept)
 }
 
+// keyof over an inexact object or tuple is the one site that mints a bounded tail today,
+// and the bound is decided by what kind of key the operand has. An object's unlisted keys
+// are property names and a tuple's are positions, so the two take different bounds.
+func TestKeyofBoundsItsOpenTail(t *testing.T) {
+	c := newChecker()
+	keysOf := func(t *testing.T, src string) soltype.Type {
+		t.Helper()
+		nodes, ctx, errs := inferTypeNodes(t, src)
+		require.Empty(t, errs)
+		return expandAliasResidual(ctx, nodes["Result"])
+	}
+
+	t.Run("an object's tail is bounded by string", func(t *testing.T) {
+		keys := keysOf(t, `
+			type Obj = {a: number, ...}
+			type Result = keyof Obj
+		`)
+		require.Equal(t, `"a" | ...string`, soltype.Print(keys))
+		// `5` is plainly not a key of that object, which an unbounded tail could not say.
+		require.False(t, subtypeHolds(c.ctx, numLit(5), keys))
+		require.True(t, subtypeHolds(c.ctx, strLit("b"), keys))
+	})
+
+	t.Run("a tuple's tail is bounded by number", func(t *testing.T) {
+		keys := keysOf(t, `
+			type Tup = [number, ...]
+			type Result = keyof Tup
+		`)
+		require.Equal(t, "0 | ...number", soltype.Print(keys))
+		require.False(t, subtypeHolds(c.ctx, strLit("a"), keys))
+		require.True(t, subtypeHolds(c.ctx, numLit(1), keys))
+	})
+}
+
 // The two routes a complement can take past a variable, which the section comment above
 // simplifyNegations describes. They go opposite ways, and only the first leaves a
 // complement behind for that pass to find.

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1188,10 +1188,15 @@ func aliasItself(op *soltype.AliasType) soltype.Type { return op }
 // and unions them. An empty projection collapses to `never`, the union identity newUnion returns
 // for no members.
 //
-// An inexact object carries an unknown-keyed tail, so its key set is open: `keyof {a: number, ...}`
-// is `"a" | ...`, an inexact union whose members are the known keys and whose tail stands for the
-// unlisted ones. keyofObject seeds the union's exactness from the object's, so an exact object
-// yields an exact key union and an inexact object an inexact one.
+// An inexact object carries an unknown-keyed tail, so its key set is open:
+// `keyof {a: number, ...}` is `"a" | ...string`, an inexact union whose members are the known keys
+// and whose tail stands for the unlisted ones. keyofObject seeds the union's exactness from the
+// object's, so an exact object yields an exact key union and an inexact object an inexact one.
+//
+// The tail is bounded by `string`, since the unlisted keys are property names whatever else is
+// unknown about them. That one fact is what makes the tail tractable. `¬keyof {a: number, ...}`
+// rejects every string and admits `5`, where an unbounded tail would be top and leave the
+// complement empty.
 //
 // It omits methods, which is correct for a class instance whose methods live on the prototype
 // and so are absent from Object.keys, but wrong for a bare object whose methods are own
@@ -1210,7 +1215,10 @@ func (e *typeEvaluator) keyofObject(obj *soltype.ObjectType) soltype.Type {
 			keys = append(keys, strLitType(elem.Name))
 		}
 	}
-	return newUnion(nil, keys, obj.Inexact)
+	if obj.Inexact {
+		return newBoundedUnion(nil, keys, &soltype.PrimType{Prim: soltype.StrPrim})
+	}
+	return newUnion(nil, keys, false)
 }
 
 // keyofTuple yields a tuple's own keys: one number-literal type per positional element, the
@@ -1220,14 +1228,18 @@ func (e *typeEvaluator) keyofObject(obj *soltype.ObjectType) soltype.Type {
 // TODO: decide how keyof should account for inherited prototype members once interop is designed.
 //
 // An inexact tuple has unknown trailing positions, so its index set is open the same way an inexact
-// object's key set is. `keyof [number, string, ...]` reduces to `0 | 1 | ...`, where the tail stands
-// for the indices those unknown positions occupy (exact-types §7.1).
+// object's key set is. `keyof [number, string, ...]` reduces to `0 | 1 | ...number`, where the tail
+// stands for the indices those unknown positions occupy (exact-types §7.1). The bound is `number`
+// rather than the `string` an object's tail takes, since an index is a position and not a name.
 func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
 	keys := make([]soltype.Type, 0, len(tup.Elems))
 	for i := range tup.Elems {
 		keys = append(keys, &soltype.LitType{Lit: &soltype.NumLit{Value: float64(i)}})
 	}
-	return newUnion(nil, keys, tup.Inexact)
+	if tup.Inexact {
+		return newBoundedUnion(nil, keys, &soltype.PrimType{Prim: soltype.NumPrim})
+	}
+	return newUnion(nil, keys, false)
 }
 
 // keyofUnion intersects the keys of a union operand's members. A value typed `A | B` is either
@@ -1238,10 +1250,18 @@ func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
 // An inexact key set is open, so it can carry keys its written members do not name. That makes
 // the result inexact whenever the operand union is inexact or any member's key set is. Take
 // `keyof ({a: number, shared: string} | {b: boolean, shared: string, ...})`, which reduces to
-// `"shared" | ...`. Only "shared" is written on both members, so only "shared" is definitely a
-// key, but the second member's open tail may carry "a" too. Intersecting the written keys keeps
+// `"shared" | ...string`. Only "shared" is written on both members, so only "shared" is definitely
+// a key, but the second member's open tail may carry "a" too. Intersecting the written keys keeps
 // every key the result names one that every member definitely carries, and the trailing `...`
 // records that the true key set may be larger.
+//
+// The tail's bound is wider than the operand allows. This reduction is a MEET of key sets, so an
+// unnamed shared key has to be a key of every member. The example above bounds its tail by
+// `string` where only "a" is possible. Its first member is exact, so no key outside "a" and
+// "shared" is a key of that member, and "shared" is already named. Bounding the tail by the exact
+// members' key sets is what would close the gap. The bound still admits less than the unbounded
+// tail the reduction leaves without it, which admits every value at all, so this is an imprecise
+// answer rather than a useless one. escalier-lang/escalier#1126 tracks tightening it.
 //
 // Some members have no key set to enumerate. A type parameter is one, and so is an operator whose
 // own operands are not ground. Such a member reduces to a `keyof` residual, and the rule this whole
@@ -1257,17 +1277,21 @@ func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.
 	var shared []soltype.Type
 	var residuals []soltype.Type
 	seeded := false
-	sharedInexact := op.Inexact
+	// The result's tail is open when the operand union's is, since an unlisted member
+	// carries keys the reduction cannot read. It takes no bound from that member. The
+	// operand's own bound is over VALUES where this tail is over KEYS, and an unlisted
+	// member could be an object or a tuple, so nothing says whether its keys are names
+	// or positions. Each member's own key set then merges in, and a member that is an
+	// inexact object brings the `string` bound its keys carry.
+	sharedTail := unionTail{open: op.Inexact}
 	for _, m := range op.Types {
 		reduced := e.reduceKeyof(m, inexact)
-		keys, memberInexact, ok := literalKeys(reduced)
+		keys, memberTail, ok := literalKeys(reduced)
 		if !ok {
 			residuals = append(residuals, reduced)
 			continue
 		}
-		if memberInexact {
-			sharedInexact = true
-		}
+		sharedTail = sharedTail.merge(memberTail)
 		if seeded {
 			shared = intersectTypes(shared, keys)
 		} else {
@@ -1285,44 +1309,44 @@ func (e *typeEvaluator) keyofUnion(op *soltype.UnionType, inexact bool) soltype.
 		}
 	}
 	if len(residuals) == 0 {
-		return newUnion(nil, shared, sharedInexact)
+		return newUnionWithTail(nil, shared, sharedTail)
 	}
 	if !seeded {
 		// Every member left a residual, so there are no literal keys to meet them with. An
 		// intersection carries no exactness marker, and with no key union among its members there
 		// is nothing to hang the open tail on, so an open key set keeps the whole operator
 		// symbolic rather than dropping what the tail stands for.
-		if sharedInexact {
+		if sharedTail.open {
 			return &soltype.KeyofType{Operand: op, Inexact: inexact}
 		}
 		return newIntersection(nil, residuals)
 	}
-	return newIntersection(nil, append([]soltype.Type{newUnion(nil, shared, sharedInexact)}, residuals...))
+	return newIntersection(nil, append([]soltype.Type{newUnionWithTail(nil, shared, sharedTail)}, residuals...))
 }
 
-// literalKeys decomposes a reduced `keyof` result into the literal keys it names and whether its
-// key set is inexact. It reports false for a result that names no enumerable key set, such as the
+// literalKeys decomposes a reduced `keyof` result into the literal keys it names and the open tail
+// carrying the rest. It reports false for a result that names no enumerable key set, such as the
 // `keyof T` residual over a type parameter, so a caller that needs the keys can fall back to
 // leaving its own operator symbolic.
 //
 // `never` decomposes to an empty exact set, a lone literal to that one key, and a union to its
-// members with the union's own exactness. A union carrying a non-literal member is not a key set
+// members under the union's own tail. A union carrying a non-literal member is not a key set
 // the reduction produced, so it reports false rather than silently dropping that member.
-func literalKeys(reduced soltype.Type) (keys []soltype.Type, inexact bool, ok bool) {
+func literalKeys(reduced soltype.Type) (keys []soltype.Type, tail unionTail, ok bool) {
 	switch t := reduced.(type) {
 	case *soltype.NeverType:
-		return nil, false, true
+		return nil, unionTail{}, true
 	case *soltype.LitType:
-		return []soltype.Type{t}, false, true
+		return []soltype.Type{t}, unionTail{}, true
 	case *soltype.UnionType:
 		for _, m := range t.Types {
 			if _, isLit := m.(*soltype.LitType); !isLit {
-				return nil, false, false
+				return nil, unionTail{}, false
 			}
 		}
-		return t.Types, t.Inexact, true
+		return t.Types, tailOf(t), true
 	default:
-		return nil, false, false
+		return nil, unionTail{}, false
 	}
 }
 

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -90,8 +90,8 @@ func meetKeySets(members []soltype.Type) (soltype.Type, bool) {
 	}
 	var shared []soltype.Type
 	for i, m := range members {
-		keys, inexact, ok := literalKeys(m)
-		if !ok || inexact {
+		keys, tail, ok := literalKeys(m)
+		if !ok || tail.open {
 			return nil, false
 		}
 		if i == 0 {


### PR DESCRIPTION
Refs #1126. Third of six, splitting #1129. Base: #1134.

`keyof {a: number, ...}` names the key `"a"` and leaves a tail for the keys the object does not list. Those keys are strings, so the tail is bounded by `string` and the operator answers `"a" | ...string`.

**This is the first bound anything mints**, so it is where #1133 and #1134 start to show. `keyof` over an inexact object or tuple stops being the top of the subtype lattice: a `5` is no longer one of its keys, while an unlisted string key still is. A tuple's unlisted keys are indices, so `keyofTuple` bounds its tail by `number`.

`keyofUnion` takes the meet of its members' key sets and seeds a shared tail from their exactness alone. A bound drawn from one member's value domain would not answer for the others, and the join it would take is wider than the meet `keyof (A | B)` denotes. That is a known imprecision rather than an oversight.

Small diff, but this is the one that moves observable behavior, so the test-expectation changes in `infer_exactness_ops_test.go` and `infer_typeops_test.go` are the interesting part of the review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VG4c9M6EgSC672itUpaMDm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `keyof` results for open object and tuple key sets.
  * Object key sets now clearly indicate additional string keys.
  * Tuple key sets now clearly indicate additional numeric keys.
  * Improved handling of key unions and subtype checks involving open key sets.

* **Tests**
  * Added coverage for bounded open tails and valid or invalid key values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->