### PR TITLE
Carry the tail's bound through the type operators

### DIFF
--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -131,13 +131,15 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 		},
 		{
 			// An interpolation naming an open set of choices produces an open set of strings.
+			// The tail is bounded by `string` rather than left open, because a template
+			// produces a string whatever it interpolates. An open tail would accept a `5`.
 			name: "TemplateLitInexactInterp",
 			src: `
 				type Side = "left" | "right" | ...
 				type Result = ` + "`pad-${Side}`" + `
 			`,
 			wantSymbolic: "`pad-${Side}`",
-			wantExpanded: `"pad-left" | "pad-right" | ...`,
+			wantExpanded: `"pad-left" | "pad-right" | ... : string`,
 		},
 		{
 			// A string intrinsic maps each member of a closed operand union, and that is every

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -984,6 +984,10 @@ func hasBorrowShape(t soltype.Type) bool {
 				return true
 			}
 		}
+		// The tail's bound is an unlisted member, and peelBorrows peels it, so a borrow
+		// held only there has to count too. Without this readCarrier would peel the lower
+		// bound and then discard the peeled result, re-borrowing what the read had freed.
+		return t.TailBound != nil && hasBorrowShape(t.TailBound)
 	}
 	return false
 }
@@ -3962,19 +3966,24 @@ func narrowUnionMembers(shape soltype.Type, keep func(soltype.Type) bool) (solty
 			kept = append(kept, m)
 		}
 	}
-	if len(kept) == 0 || len(kept) == len(u.Types) {
-		return nil, false
-	}
 	// An inexact union keeps its open `...` tail through narrowing. A tail member may carry
 	// the tested fields at any type, so the tail is retained and the field-read rule (D4)
 	// reads a narrowed inexact member's fields as `... | unknown`, i.e. `unknown`. An exact
 	// union narrows to precisely the members that matched.
 	tail := tailOf(u)
+	tailDropped := false
 	if tail.bound != nil && closedShape(tail.bound) && !keep(tail.bound) {
 		// No value the bound admits has the shape the test asks for, so the tail contributes
 		// no member to this branch and goes. See closedShape for which bounds may be decided
 		// this way: those whose own keys or arity pin every member drawn from them.
 		tail = unionTail{}
+		tailDropped = true
+	}
+	// Dropping the tail is narrowing even when every listed member matched, so the no-op
+	// return has to weigh it. `{a: number} | ...string` narrowed by `{a}` keeps its one
+	// member and sheds the string tail, which would be missed by a member count alone.
+	if len(kept) == 0 || (len(kept) == len(u.Types) && !tailDropped) {
+		return nil, false
 	}
 	if len(kept) == 1 && !tail.open {
 		return kept[0], true
@@ -3986,28 +3995,16 @@ func narrowUnionMembers(shape soltype.Type, keep func(soltype.Type) bool) (solty
 	return &soltype.UnionType{Types: kept, Inexact: tail.open, TailBound: tail.bound}, true
 }
 
-// closedShape reports whether t's key set or arity is fully determined by t itself, so a
-// `keep` test — which inspects only keys and arity, never field values — answers the same for
-// every value t admits. Four shapes qualify:
-//
-//   - A primitive or a literal: a string is a string however it was written, and neither
-//     carries object keys a test could find that t does not already show.
-//   - An exact object: exactness forbids extra fields, so its inhabitants all carry exactly
-//     t's keys. `{c: boolean}` lacking key "a" means no value it admits has "a".
-//   - An exact tuple with no rest element: its inhabitants all have exactly t's length.
-//
-// An inexact object or tuple does not qualify: `{c: boolean, ...}` admits `{c: boolean, a: ...}`,
-// which carries a key the bound does not name, so the bound failing a key test does not settle
-// the members drawn from it. A union bound fails every object test while its members need not.
-// Deciding those needs a disjointness question, a subtype check narrowUnionMembers holds no
-// Context to ask, so it keeps such a tail — the wider, safe answer.
-//
-// The gate is what keeps narrowUnionMembers from over-narrowing. Its `keep` predicates are
-// shape tests over one MEMBER, and a bound is not a member but the set its members are drawn
-// from. Reading a bound's own failure as every member's is sound only where t's shape pins
-// every member's keys, which is exactly what closedShape reports.
+// closedShape reports whether a `keep` test — which inspects only keys and arity, never field
+// values — answers the same for every value the bound admits, so the bound's own result settles
+// every member drawn from it. It reads through a borrow to the carrier first, matching how `keep`
+// peels one via CarrierOf. A primitive, a literal, an exact object, or an exact tuple qualifies:
+// each pins its members' keys exactly, so `{c: boolean}` lacking "a" means none of its inhabitants
+// has "a". An inexact object or tuple, a union, or a bare type variable does not, since a member
+// may carry a key the bound omits; deciding those needs a disjointness check narrowUnionMembers has
+// no Context to run, so it keeps the tail — the wider, safe answer.
 func closedShape(t soltype.Type) bool {
-	switch t := t.(type) {
+	switch t := soltype.CarrierOf(t).(type) {
 	case *soltype.PrimType, *soltype.LitType:
 		return true
 	case *soltype.ObjectType:

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -960,7 +960,13 @@ func peelBorrows(t soltype.Type) soltype.Type {
 		for i, m := range t.Types {
 			members[i] = peelBorrows(m)
 		}
-		return newUnion(nil, members, t.Inexact)
+		// The tail's bound is a member the union does not list, so it peels too. Dropping it
+		// would leave the peeled union unbounded, which is top.
+		tail := tailOf(t)
+		if tail.bound != nil {
+			tail.bound = peelBorrows(tail.bound)
+		}
+		return newUnionWithTail(nil, members, tail)
 	}
 	return t
 }
@@ -3963,14 +3969,54 @@ func narrowUnionMembers(shape soltype.Type, keep func(soltype.Type) bool) (solty
 	// the tested fields at any type, so the tail is retained and the field-read rule (D4)
 	// reads a narrowed inexact member's fields as `... | unknown`, i.e. `unknown`. An exact
 	// union narrows to precisely the members that matched.
-	if len(kept) == 1 && !u.Inexact {
+	tail := tailOf(u)
+	if tail.bound != nil && closedShape(tail.bound) && !keep(tail.bound) {
+		// No value the bound admits has the shape the test asks for, so the tail contributes
+		// no member to this branch and goes. See closedShape for which bounds may be decided
+		// this way: those whose own keys or arity pin every member drawn from them.
+		tail = unionTail{}
+	}
+	if len(kept) == 1 && !tail.open {
 		return kept[0], true
 	}
 	// Keep the structured inexact union rather than returning `unknown`. It is the bind
 	// target for the branch's leaves, and constrainUnionFieldRead needs the listed members to
 	// read each field before the tail widens it. Binding against bare `unknown` would leave
 	// nothing to destructure.
-	return &soltype.UnionType{Types: kept, Inexact: u.Inexact}, true
+	return &soltype.UnionType{Types: kept, Inexact: tail.open, TailBound: tail.bound}, true
+}
+
+// closedShape reports whether t's key set or arity is fully determined by t itself, so a
+// `keep` test — which inspects only keys and arity, never field values — answers the same for
+// every value t admits. Four shapes qualify:
+//
+//   - A primitive or a literal: a string is a string however it was written, and neither
+//     carries object keys a test could find that t does not already show.
+//   - An exact object: exactness forbids extra fields, so its inhabitants all carry exactly
+//     t's keys. `{c: boolean}` lacking key "a" means no value it admits has "a".
+//   - An exact tuple with no rest element: its inhabitants all have exactly t's length.
+//
+// An inexact object or tuple does not qualify: `{c: boolean, ...}` admits `{c: boolean, a: ...}`,
+// which carries a key the bound does not name, so the bound failing a key test does not settle
+// the members drawn from it. A union bound fails every object test while its members need not.
+// Deciding those needs a disjointness question, a subtype check narrowUnionMembers holds no
+// Context to ask, so it keeps such a tail — the wider, safe answer.
+//
+// The gate is what keeps narrowUnionMembers from over-narrowing. Its `keep` predicates are
+// shape tests over one MEMBER, and a bound is not a member but the set its members are drawn
+// from. Reading a bound's own failure as every member's is sound only where t's shape pins
+// every member's keys, which is exactly what closedShape reports.
+func closedShape(t soltype.Type) bool {
+	switch t := t.(type) {
+	case *soltype.PrimType, *soltype.LitType:
+		return true
+	case *soltype.ObjectType:
+		return !t.Inexact
+	case *soltype.TupleType:
+		return !t.Inexact && !hasRestSpread(t.Elems)
+	default:
+		return false
+	}
 }
 
 // structuralInexact returns the Inexact flag of an object or tuple type and whether

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -399,6 +399,57 @@ func TestBoundedTailIsNotTop(t *testing.T) {
 	})
 }
 
+// A type operator that rebuilds a union has to carry the tail's bound through, or the result
+// lands back at the top of the lattice the bound took it off. Each case runs an operator over
+// `keyof {a: number, b: string, ...}`, whose tail is bounded by `string`.
+func TestOperatorsCarryTheTailBound(t *testing.T) {
+	tests := []struct {
+		name string
+		// decl is a type declaration appended to the shared Obj alias, binding Result.
+		decl string
+		want string
+	}{
+		{
+			// The key set the operator starts from.
+			name: "Keyof",
+			decl: `type Result = keyof Obj`,
+			want: `"a" | "b" | ... : string`,
+		},
+		{
+			// `Inexact` over an already-open union is the identity, so the bound has to
+			// survive the rewrite rather than being reset to unbounded.
+			name: "InexactIsTheIdentityOnAnOpenUnion",
+			decl: `type Result = Inexact<keyof Obj>`,
+			want: `"a" | "b" | ... : string`,
+		},
+		{
+			// `Exact` closes the union, and a closed union has no tail to bound.
+			name: "ExactDropsTheTail",
+			decl: `type Result = Exact<keyof Obj>`,
+			want: `"a" | "b"`,
+		},
+		{
+			// A string intrinsic transforms the bound alongside the named members. Only a
+			// literal has a case to change, so transforming `string` yields the unreduced
+			// `Uppercase<string>`, which is widened to `string`. A union carrying an
+			// unreduced operator anywhere reads as residual, and constraint solving then
+			// decides against the operator instead of the union it belongs to.
+			name: "StringIntrinsic",
+			decl: `type Result = Uppercase<keyof Obj>`,
+			want: `"A" | "B" | ... : string`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, `
+				type Obj = {a: number, b: string, ...}
+			`+tt.decl)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
 // The normalization layer reads a bounded tail as one more disjunct, so a decision about
 // which values the union admits sees the bound alongside the named members. The two probes
 // below are the two directions that reading is consulted from.
@@ -434,6 +485,66 @@ func TestSimplifyNegationsEmptiesABoundedTail(t *testing.T) {
 	require.True(t, provedEmpty)
 	require.True(t, changed)
 	require.Empty(t, kept)
+}
+
+// peelBorrows strips the borrow wrapper off every member a union has, and the tail's bound is
+// one of them. A dropped bound would leave the peeled union unbounded, which is top.
+func TestPeelBorrowsReachesTheTailBound(t *testing.T) {
+	inner := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("x", num())}}
+	peeled := peelBorrows(newBoundedUnion(nil, []soltype.Type{num()}, &soltype.RefType{Inner: inner}))
+	require.Equal(t, "number | ... : {x: number}", soltype.Print(peeled))
+}
+
+// Narrowing a union to the members a pattern can destructure weighs the tail's bound too, but
+// only where the bound answers for every member drawn from it. The `keep` predicate is a shape
+// test over one member, and a bound is the set its members come from, so the two coincide for
+// an atomic bound and part ways for a structured one.
+func TestNarrowUnionMembersWeighsTheTailBound(t *testing.T) {
+	objA := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("a", num())}}
+	objB := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("b", str())}}
+	// keepA stands for an object pattern `{a}`: it accepts a member carrying the key "a".
+	keepA := func(m soltype.Type) bool { return objectMemberHasKeys(m, []string{"a"}) }
+
+	t.Run("an atomic bound no member of which fits is dropped", func(t *testing.T) {
+		// `{a: number} | {b: string} | ...string`. Every value the tail holds is a string, and
+		// no string carries the key "a", so the tail contributes nothing to this branch.
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, str())
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number}", soltype.Print(narrowed))
+	})
+
+	t.Run("an exact object bound no member of which fits is dropped", func(t *testing.T) {
+		// `{a: number} | {b: string} | ...{c: boolean}`. The bound is exact, so its inhabitants
+		// carry exactly the key "c" and none carries "a". A key test over the bound settles every
+		// member drawn from it, exactly as it does for a primitive, so the tail drops.
+		objC := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("c", boolT())}}
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, objC)
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number}", soltype.Print(narrowed))
+	})
+
+	t.Run("an inexact object bound is kept", func(t *testing.T) {
+		// `{a: number} | {b: string} | ...{c: boolean, ...}`. The inexact bound admits a member
+		// such as `{c: boolean, a: number}` that carries "a", so the bound failing the key test
+		// does not settle the members drawn from it. Deciding the tail needs a disjointness
+		// question narrowUnionMembers cannot ask, so it keeps the tail — the wider answer.
+		objC := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("c", boolT())}, Inexact: true}
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, objC)
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number} | ... : {c: boolean, ...}", soltype.Print(narrowed))
+	})
+
+	t.Run("an unbounded tail is kept", func(t *testing.T) {
+		// Nothing says what the tail holds, so it survives every narrowing, which is the rule
+		// the field-read path already depends on.
+		u := newUnion(nil, []soltype.Type{objA, objB}, true)
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number} | ...", soltype.Print(narrowed))
+	})
 }
 
 // keyof over an inexact object or tuple is the one site that mints a bounded tail today,
@@ -566,4 +677,58 @@ func TestFinalSubsumptionRereadsARewrittenTailBound(t *testing.T) {
 			require.Equal(t, tt.want, soltype.Print(c.subsumeFinal(in)))
 		})
 	}
+}
+
+// An operator over a bounded tail has to hand back a union that is still usable as a type. Two
+// ways it can fail are invisible in the printed form, so each case here checks what the result
+// accepts rather than only how it renders.
+func TestOperatorResultsOverABoundedTailStayUsable(t *testing.T) {
+	// A template produces a string whatever it interpolates, so its tail is bounded by
+	// `string`. An unbounded tail admits every value, which would let a number pass for a
+	// string the template could have produced.
+	t.Run("a template over an open key set still rejects a non-string", func(t *testing.T) {
+		nodes, ctx, errs := inferTypeNodes(t, `
+			type Obj = {a: number, ...}
+			type Result = `+"`on${keyof Obj}`"+`
+		`)
+		require.Empty(t, errs)
+		result := expandAliasResidual(ctx, nodes["Result"])
+		require.Equal(t, "\"ona\" | ... : string", soltype.Print(result))
+
+		c := newChecker()
+		require.False(t, subtypeHolds(c.ctx, numLit(5), result), "a template never produces a number")
+		require.False(t, subtypeHolds(c.ctx, &soltype.LitType{Lit: &soltype.BoolLit{Value: true}}, result), "nor a boolean")
+		require.True(t, subtypeHolds(c.ctx, strLit("ona"), result), "the named string is a member")
+		require.True(t, subtypeHolds(c.ctx, strLit("onb"), result), "so is one the tail may hold")
+	})
+
+	// A bound the intrinsic cannot fold comes back as an unreduced operator, and a union
+	// carrying one anywhere reads as residual. Constraint solving would then decide against
+	// the operator rather than the union, rejecting a string the union plainly names.
+	t.Run("an intrinsic over an open key set still accepts its own member", func(t *testing.T) {
+		nodes, ctx, errs := inferTypeNodes(t, `
+			type Obj = {a: number, ...}
+			type Result = Uppercase<keyof Obj>
+		`)
+		require.Empty(t, errs)
+		result := expandAliasResidual(ctx, nodes["Result"])
+		require.Equal(t, `"A" | ... : string`, soltype.Print(result))
+
+		c := newChecker()
+		require.False(t, containsResidualOp(result), "a residual union is decided against the operator")
+		require.True(t, subtypeHolds(c.ctx, strLit("A"), result), "the transformed key is a member")
+		require.False(t, subtypeHolds(c.ctx, numLit(5), result), "the bound still rules out a non-string")
+	})
+
+	// An index read that cannot ground the bound has no answer to commit to. Answering anyway
+	// would produce `number | ...string["x"]`, a union whose bound is an unreduced access, and
+	// a union carrying an unreduced operator anywhere is decided against that operator rather
+	// than against the union. The whole access stays symbolic instead, so it reduces once the
+	// target grounds.
+	t.Run("an ungrounded index read over a bounded tail stays symbolic", func(t *testing.T) {
+		obj := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("x", num())}}
+		target := &soltype.UnionType{Types: []soltype.Type{obj}, Inexact: true, TailBound: str()}
+		got := reduceType(&soltype.IndexType{Target: target, Index: strLit("x")})
+		require.Equal(t, `({x: number} | ... : string)["x"]`, soltype.Print(got))
+	})
 }

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -514,6 +514,17 @@ func TestNarrowUnionMembersWeighsTheTailBound(t *testing.T) {
 		require.Equal(t, "{a: number}", soltype.Print(narrowed))
 	})
 
+	t.Run("every member matches and the atomic tail still drops", func(t *testing.T) {
+		// `{a: number} | ...string` narrowed by `{a}`. The one listed member matches, so a
+		// member count alone reads it as unchanged, but the string tail cannot carry "a" and
+		// goes. Weighing the tail before the no-op return is what narrows this to `{a: number}`
+		// rather than keeping the whole inexact union.
+		u := newBoundedUnion(nil, []soltype.Type{objA}, str())
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number}", soltype.Print(narrowed))
+	})
+
 	t.Run("an exact object bound no member of which fits is dropped", func(t *testing.T) {
 		// `{a: number} | {b: string} | ...{c: boolean}`. The bound is exact, so its inhabitants
 		// carry exactly the key "c" and none carries "a". A key test over the bound settles every
@@ -535,6 +546,51 @@ func TestNarrowUnionMembersWeighsTheTailBound(t *testing.T) {
 		narrowed, ok := narrowUnionMembers(u, keepA)
 		require.True(t, ok)
 		require.Equal(t, "{a: number} | ... : {c: boolean, ...}", soltype.Print(narrowed))
+	})
+
+	t.Run("an exact tuple bound no member of which fits is dropped", func(t *testing.T) {
+		// `{a: number} | {b: string} | ...[boolean, boolean]`. The bound is an exact tuple, so
+		// its inhabitants are all length-two tuples and none carries the object key "a". Arity
+		// pins every member drawn from it, exactly as an exact object's keys do, so the tail drops.
+		tup := &soltype.TupleType{Elems: []soltype.Type{boolT(), boolT()}}
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, tup)
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number}", soltype.Print(narrowed))
+	})
+
+	t.Run("a borrow of an exact object bound is dropped", func(t *testing.T) {
+		// `{a: number} | {b: string} | ...&mut {x: number}`. closedShape reads through the borrow
+		// to its carrier the way `keep` does through CarrierOf. The carrier is an exact object
+		// with no "a", and a borrow of an exact object admits only borrows of that same object, so
+		// no member drawn from the tail carries "a" and the tail drops.
+		ref := &soltype.RefType{Mut: true, Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("x", num())}}}
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, ref)
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number}", soltype.Print(narrowed))
+	})
+
+	t.Run("a borrow of an inexact object bound is kept", func(t *testing.T) {
+		// `{a: number} | {b: string} | ...&mut {x: number, ...}`. The carrier under the borrow is
+		// inexact, so it admits an object carrying "a", and the tail is kept just as a bare inexact
+		// object bound is.
+		ref := &soltype.RefType{Mut: true, Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("x", num())}, Inexact: true}}
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, ref)
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number} | ... : mut {x: number, ...}", soltype.Print(narrowed))
+	})
+
+	t.Run("a type-variable bound is kept", func(t *testing.T) {
+		// `{a: number} | {b: string} | ...t1`. A bare type variable stands for a carrier not yet
+		// known, so closedShape cannot settle whether a member drawn from it carries "a", and the
+		// tail is kept — the undecidable case CarrierOf leaves in place.
+		v := &soltype.TypeVarType{ID: 1, Level: 1}
+		u := newBoundedUnion(nil, []soltype.Type{objA, objB}, v)
+		narrowed, ok := narrowUnionMembers(u, keepA)
+		require.True(t, ok)
+		require.Equal(t, "{a: number} | ... : t1", soltype.Print(narrowed))
 	})
 
 	t.Run("an unbounded tail is kept", func(t *testing.T) {
@@ -731,4 +787,27 @@ func TestOperatorResultsOverABoundedTailStayUsable(t *testing.T) {
 		got := reduceType(&soltype.IndexType{Target: target, Index: strLit("x")})
 		require.Equal(t, `({x: number} | ... : string)["x"]`, soltype.Print(got))
 	})
+}
+
+// readCarrier peels a borrow held in a receiver variable's lower bounds so a field read does
+// not trip the borrow-escape guard. hasBorrowShape decides whether a lower bound carries a
+// borrow at all, and a bound whose only borrow sits in its open tail counts, since peelBorrows
+// peels that tail. Without it readCarrier would peel the bound and then hand back the bare
+// variable, re-borrowing what the read had freed.
+func TestReadCarrierPeelsATailOnlyBorrow(t *testing.T) {
+	c := newChecker()
+	ref := &soltype.RefType{Mut: true, Inner: &soltype.ObjectType{
+		Elems: []soltype.ObjTypeElem{propElem("x", num())},
+	}}
+	// `{y: number} | ...&mut {x: number}`: no listed member is a borrow, only the tail bound is.
+	lb := newBoundedUnion(nil, []soltype.Type{
+		&soltype.ObjectType{Elems: []soltype.ObjTypeElem{propElem("y", num())}},
+	}, ref)
+	v := c.ctx.freshVar(0)
+	v.LowerBounds = []soltype.Type{lb}
+
+	carrier := readCarrier(v)
+	require.NotSame(t, soltype.Type(v), carrier, "a tail-only borrow must divert to the peeled carrier")
+	require.Equal(t, "{y: number} | ... : {x: number}", soltype.Print(carrier))
+	require.True(t, hasBorrowShape(lb), "the tail bound's borrow is a borrow shape")
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -822,18 +822,18 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 	if !condOperandGround(keys) {
 		return reduced, nil, false, false
 	}
-	if soltype.UncountableKeys(keys) {
-		// An uncountable key set has no keys to enumerate, so the member stays unexpanded and is
-		// itself the index signature. The required form over such a key set is uninhabited and is
-		// rejected. A rename or filter over one has no enumerable keys to run over, so it stays
-		// symbolic with no diagnostic. That gap is #930.
+	if hasNoEnumerableKeys(keys) {
+		// A key set with nothing to enumerate leaves the member unexpanded, so it is itself the
+		// index signature. The required form over such a key set is uninhabited and is rejected.
+		// A rename or filter over one has no enumerable keys to run over, so it stays symbolic
+		// with no diagnostic. That gap is #930.
 		if soltype.IsIndexSignature(reduced) && reduced.Optional != soltype.ModAdd {
 			e.errs = append(e.errs, &RequiredUncountableKeysError{Mapped: reduced})
 		}
 		return reduced, nil, false, false
 	}
 	source, homomorphic := e.homomorphicSource(t.Keys)
-	members, inexactKeys := unionMembers(keys)
+	members, keyTail := unionMembers(keys)
 	pos := make(map[string]int, len(members))
 	for _, member := range members {
 		built, ok := e.mappedFields(t, member, source, homomorphic)
@@ -849,24 +849,38 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 			fields = append(fields, field)
 		}
 	}
-	return reduced, fields, inexactKeys, true
+	return reduced, fields, keyTail.open, true
 }
 
-// unionMembers splits a reduced type into the members a rule runs over one at a time, and reports
-// whether the set they make up is inexact. A union contributes its members and carries its own
-// inexact marker through; `never` is the empty set, so it contributes none; any other type is a
-// single member.
+// hasNoEnumerableKeys reports whether a mapped type's key set has no key to emit a field for at
+// all: an uncountable set such as `string`, or an open set naming no key of its own, such as the
+// `...(string & ¬"a")` a difference leaves after excluding every named key. Its bound says what
+// the keys are drawn from, not which the set holds. A set that DOES name a key is not this, even
+// with an open tail: each named key gets a field and the tail becomes the result's own inexactness
+// marker, so `{[K]: T[K] for K in keyof {x: X, ...}}` expands to `{x: X, ...}`.
+func hasNoEnumerableKeys(keys soltype.Type) bool {
+	if soltype.UncountableKeys(keys) {
+		return true
+	}
+	u, ok := keys.(*soltype.UnionType)
+	return ok && len(u.Types) == 0 && u.TailBound != nil
+}
+
+// unionMembers splits a reduced type into the members a rule runs over one at a time, and returns
+// the open tail holding whatever it could not enumerate. A union contributes its members and
+// carries its own tail through; `never` is the empty set, so it contributes none; any other type is
+// a single member under no tail.
 //
 // A mapped type splits its key set this way to emit one field per key, and a set difference splits
 // its positive side this way to settle one member at a time against what is excluded.
-func unionMembers(t soltype.Type) ([]soltype.Type, bool) {
+func unionMembers(t soltype.Type) ([]soltype.Type, unionTail) {
 	switch t := t.(type) {
 	case *soltype.UnionType:
-		return t.Types, t.Inexact
+		return t.Types, tailOf(t)
 	case *soltype.NeverType:
-		return nil, false
+		return nil, unionTail{}
 	default:
-		return []soltype.Type{t}, false
+		return []soltype.Type{t}, unionTail{}
 	}
 }
 
@@ -1409,10 +1423,22 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 	// what carries an inexact object's openness into `T[keyof T]`. Over `type Obj = {a: number, ...}`,
 	// `keyof Obj` reduces to `"a" | ...` and `Obj[keyof Obj]` to `number | ...`.
 	if u, ok := idx.(*soltype.UnionType); ok {
+		// TODO(#1155): reduce `T[...R]` to the values the target stores at the keys in R
+		// rather than leaving the access symbolic.
+		if len(u.Types) == 0 {
+			// An open key set naming no key of its own, such as the `...string` a set
+			// difference leaves when it excludes every named key. There is no key to read
+			// the target at, so the access stays symbolic. Distributing over no member
+			// would answer `never`, claiming the key set is empty when it is only unread.
+			return &soltype.IndexType{Target: target, Index: idx, Inexact: inexact}
+		}
 		parts := make([]soltype.Type, len(u.Types))
 		for i, m := range u.Types {
 			parts[i] = e.reduceIndex(target, m, inexact)
 		}
+		// The result's tail stays unbounded whatever bounds the key tail. The bound says
+		// what the unread KEYS are, and this union holds the VALUES stored at them, which
+		// nothing here has read.
 		return newUnion(nil, parts, u.Inexact)
 	}
 	switch tgt := target.(type) {
@@ -1461,13 +1487,26 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 		// lacking it records its own absence diagnostic through reduceIndex. Each member indexes
 		// with the same reduced key.
 		//
-		// An inexact target union has unlisted members, and the value each holds at K is not among
-		// the ones the access read, so the result union is open too (exact-types §7.6).
+		// An inexact target union has unlisted members whose value at K the access did not read,
+		// so the result is open too (exact-types §7.6). A bounded tail says what those members are,
+		// so reading K off the bound reads it off all of them at once and the result's tail keeps
+		// that. A target naming no member of its own has only the bound to read.
 		parts := make([]soltype.Type, len(tgt.Types))
 		for i, m := range tgt.Types {
 			parts[i] = e.reduceIndex(m, idx, inexact)
 		}
-		return newUnion(nil, parts, tgt.Inexact)
+		tail := tailOf(tgt)
+		if tail.bound != nil {
+			tail.bound = e.reduceIndex(tail.bound, idx, inexact)
+			if containsResidualOp(tail.bound) {
+				// The read off the bound did not ground, so it comes back as an unreduced
+				// access. A union carrying one reads as residual and would be decided against
+				// the operator rather than the union, and an access has no wider bound to fall
+				// back on. Stay symbolic and reduce once the target grounds.
+				return &soltype.IndexType{Target: target, Index: idx, Inexact: inexact}
+			}
+		}
+		return newUnionWithTail(nil, parts, tail)
 	case *soltype.IntersectionType:
 		return e.reduceIndexIntersection(tgt, idx, inexact)
 	default:
@@ -1624,6 +1663,14 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, i
 // The result is exact only when every interpolation is, since an interpolation that names an open
 // set of choices produces an open set of strings (exact-types §5.6). `on${"a" | "b"}` reduces to
 // the exact `"ona" | "onb"`, while `on${"a" | "b" | ...}` reduces to `"ona" | "onb" | ...`.
+//
+// A tail's bound is not folded into the result. The bound says the tail's choices are strings
+// without saying which, so no segment can absorb them. The result's tail is bounded by `string`
+// all the same, since a template produces a string whatever it interpolates. Leaving it unbounded
+// would make the result the top of the subtype lattice, so a template interpolating
+// `keyof {a: number, ...}` would accept a `5`.
+// An interpolation that names no choice at all, which is the shape a set difference leaves when it
+// excludes every named one, has nothing to run the product over and keeps the template symbolic.
 func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Type {
 	interpChoices := make([][]soltype.Type, len(t.Interps))
 	combinations := 1
@@ -1632,6 +1679,14 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 		reduced := e.groundOperand(interp)
 		if u, ok := reduced.(*soltype.UnionType); ok {
 			openChoices = openChoices || u.Inexact
+			if len(u.Types) == 0 {
+				// An interpolation naming no choice of its own, such as the `...string` a set
+				// difference leaves when it excludes every named key. Its bound says the
+				// choices are strings without saying which, so there is nothing to fold into
+				// the surrounding segments and the template stays symbolic. Running the
+				// product over no choice would empty it and answer `never`.
+				return &soltype.TemplateLitType{Quasis: t.Quasis, Interps: t.Interps}
+			}
 			// Ground each union member too, so a reducible member — an alias to a literal, or a
 			// nested operator such as `keyof O` — collapses to its string literal before the product
 			// rather than surviving as a residual interpolation.
@@ -1656,7 +1711,10 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 	for _, combo := range combos {
 		parts = append(parts, foldTemplatePart(t.Quasis, combo))
 	}
-	return newUnion(nil, parts, openChoices)
+	if openChoices {
+		return newBoundedUnion(nil, parts, &soltype.PrimType{Prim: soltype.StrPrim})
+	}
+	return newUnion(nil, parts, false)
 }
 
 // foldTemplatePart folds one cartesian-product combination into a single template result. It
@@ -1751,7 +1809,26 @@ func (e *typeEvaluator) reduceStringIntrinsic(kind soltype.StringIntrinsicKind, 
 		for i, m := range op.Types {
 			parts[i] = e.reduceStringIntrinsic(kind, m)
 		}
-		return newUnion(nil, parts, op.Inexact)
+		// The intrinsic reaches the tail's bound too, since the tail's unnamed members are
+		// drawn from it and each is transformed the way a named member is. A bound of `"a"`
+		// becomes `"A"` exactly as a named member does.
+		//
+		// Only a string LITERAL has a case to change, so a bound the transform cannot fold
+		// comes back as an unreduced operator. `Uppercase<string>` is one. Such a bound is
+		// widened to `string` rather than kept, because a bound is part of the union and a
+		// union carrying an unreduced operator anywhere reads as residual. Constraint
+		// solving then decides against the opaque operator and rejects
+		// `val u: Uppercase<keyof {a: number, ...}> = "A"`. Widening is sound, since the
+		// intrinsic maps strings to strings, and it keeps the tail bounded where dropping it
+		// would leave the union at the top of the lattice.
+		tail := tailOf(op)
+		if tail.bound != nil {
+			tail.bound = e.reduceStringIntrinsic(kind, tail.bound)
+			if containsResidualOp(tail.bound) {
+				tail.bound = &soltype.PrimType{Prim: soltype.StrPrim}
+			}
+		}
+		return newUnionWithTail(nil, parts, tail)
 	case *soltype.LitType:
 		if s, ok := op.Lit.(*soltype.StrLit); ok {
 			return strLitType(applyStringIntrinsic(kind, s.Value))
@@ -1787,9 +1864,17 @@ func (e *typeEvaluator) reduceExactness(kind soltype.ExactnessKind, operand solt
 		rewritten.Inexact = inexact
 		return &rewritten
 	case *soltype.UnionType:
-		// newUnion rather than a direct rebuild, so clearing the marker on a one-member union
-		// collapses it to that member: `Exact<"only" | ...>` reduces to `"only"`.
-		return newUnion(nil, op.Types, inexact)
+		// newUnionWithTail rather than a direct rebuild, so clearing the marker on a one-member
+		// union collapses it to that member: `Exact<"only" | ...>` reduces to `"only"`.
+		//
+		// Opening a union keeps whatever bound the operand's tail carried, so `Inexact<T>` over
+		// an already-inexact T is the identity `Inexact<keyof {a: X, ...}>` needs. Dropping the
+		// bound would widen `"a" | ...string` to `"a" | ...`, which is top.
+		tail := unionTail{open: inexact}
+		if inexact {
+			tail.bound = op.TailBound
+		}
+		return newUnionWithTail(nil, op.Types, tail)
 	case *soltype.IntersectionType:
 		// An intersection's exactness is its members', so the operator reaches each of them (§7.7).
 		parts := make([]soltype.Type, len(op.Types))

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -127,17 +127,16 @@ func meetKeySets(members []soltype.Type) (soltype.Type, bool) {
 // operand grounds. That residual is the `∩ ¬` form itself rather than a stuck operator, which is
 // what a caller such as a mapped-type key set or a constraint reads.
 //
-// An inexact positive side names only some of its members. The rest sit in an open tail that the
-// reduction cannot enumerate, so what the exclusion takes from them cannot be worked out. The
-// result union keeps the tail, which stands for whatever those undecided members contribute, so
-// `("a" | "b" | ...) ∩ ¬"a"` reduces to `"b" | ...`.
+// An inexact positive side names only some members; the rest sit in an open tail, and what the
+// exclusion takes from them depends on the tail's bound.
 //
-// When no named member survives, the difference stays as it stands, since neither answer available
-// is the one the reduction means. `newUnion` over an empty member list is `never` however the
-// marker is set, which would claim the tail is empty too. Reading the open union as `unknown` —
-// which is what it is for subtyping, since its tail accepts every value — would answer `¬X`, and
-// that is wrong for the key sets this reduction mostly serves. `keyof {a: X, ...}` is `"a" | ...`,
-// where the tail stands for the keys the object did not name, not for every key there is.
+// An unbounded tail says nothing about its members, so the exclusion cannot be worked out. The
+// result keeps the tail, so `("a" | "b" | ...) ∩ ¬"a"` reduces to `"b" | ...`. With no named member
+// surviving either, the difference stays as it arrived rather than collapsing to `never`.
+//
+// A bounded tail draws its members from its bound, so excluding from the bound excludes from every
+// member at once. `keyof {a: X, ...}` is `"a" | ...string`, so `∩ ¬"a"` reduces to
+// `...(string & ¬"a")`. A bound the exclusion empties leaves an exact union of the survivors.
 func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
 	positives := make([]soltype.Type, 0, len(members))
 	var excluded []soltype.Type
@@ -159,16 +158,24 @@ func (e *typeEvaluator) reduceDifference(members []soltype.Type) soltype.Type {
 		base = newIntersection(nil, positives)
 	}
 	if groundDifference(base, excluded) {
-		baseMembers, inexact := unionMembers(base)
+		baseMembers, tail := unionMembers(base)
 		survivors := make([]soltype.Type, 0, len(baseMembers))
 		for _, m := range baseMembers {
 			if narrowed, keep := e.excludeFrom(m, excluded); keep {
 				survivors = append(survivors, narrowed)
 			}
 		}
-		// A tail with no surviving member to ride on falls through to the residual below.
-		if len(survivors) > 0 || !inexact {
-			return newUnion(nil, survivors, inexact)
+		if tail.bound != nil && condOperandGround(tail.bound) {
+			if narrowed, keep := e.excludeFrom(tail.bound, excluded); keep {
+				tail.bound = narrowed
+			} else {
+				tail = unionTail{}
+			}
+		}
+		// An unbounded tail with no surviving member to ride on falls through to the residual
+		// below. A bounded one needs no member, since its bound says what it holds.
+		if len(survivors) > 0 || !tail.open || tail.bound != nil {
+			return newUnionWithTail(nil, survivors, tail)
 		}
 	}
 	return newIntersection(nil, append([]soltype.Type{base}, complementsOf(excluded)...))

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -128,6 +128,35 @@ func TestReduceSetDifference(t *testing.T) {
 			want: `("a" | ...) & ¬"a"`,
 		},
 		{
+			// `("a" | "b" | ...string) & ¬"a"`
+			//
+			// A bounded tail draws its members from `string`, so the exclusion applies to that
+			// bound the same way it applies to a named member. The tail comes through narrowed
+			// rather than undecided.
+			name: "BoundedTailNarrowsWithTheNamedMembers",
+			diff: meet(newBoundedUnion(nil, []soltype.Type{strLit("a"), strLit("b")}, str()), negate(strLit("a"))),
+			want: `"b" | ... : (string & ¬"a")`,
+		},
+		{
+			// `("a" | ...string) & ¬"a"`
+			//
+			// The case InexactPositiveSideWithNoSurvivorsStays leaves standing, settled. The
+			// answer is the string keys other than "a", a union naming no member and drawing
+			// every one it has from `string & ¬"a"`.
+			name: "BoundedTailSurvivesWithNoNamedMember",
+			diff: meet(newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()), negate(strLit("a"))),
+			want: `... : (string & ¬"a")`,
+		},
+		{
+			// `("a" | ...string) & ¬string`
+			//
+			// The exclusion empties the bound, so the tail contributes nothing, and it excludes
+			// the one named member too. Nothing is left.
+			name: "BoundedTailEmptiedByItsOwnBound",
+			diff: meet(newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()), negate(str())),
+			want: "never",
+		},
+		{
 			// `(("a" | "b") & ¬"a") & ¬"b"`
 			//
 			// Nested complements reduce as one difference, since newIntersection flattens the


### PR DESCRIPTION
Refs #1126. Fourth of six, splitting #1129. Base: #1135.

The largest diff of the series but the shallowest. Each operator gets one independent rule, so it reads as a checklist rather than an argument.

An operator over a bounded union has to answer for the tail as well as the named members, since the bound says what those unnamed members are. Each rule reads the bound the way it reads a member.

- `Exact` drops the tail outright, and `Inexact` leaves a bounded one alone.
- A string intrinsic transforms the bound alongside the members, so `Uppercase&lt;"a" | ...string&gt;` is `"A" | ...string`. A bound the transform cannot fold comes back as an unreduced operator, and a union carrying one anywhere reads as residual, so it widens to `string` instead. The intrinsic maps strings to strings, which makes that sound.
- A template literal bounds its result by `string`, since a template produces a string whatever it interpolates.
- An index read reaches the bound on the target axis. A read that does not ground leaves the whole access symbolic rather than committing to a union whose bound is an unreduced access.
- `reduceDifference` narrows the bound through `excludeFrom`, so an exclusion cuts inside the tail rather than dropping it.
- `peelBorrows` peels the bound, since dropping it would leave the peeled union unbounded.
- A mapped type reads a bounded tail as unenumerable, so it keeps its index signature rather than expanding over the members it can see.

Two of these fix soundness holes rather than adding precision:

- Leaving a template literal's tail unbounded made the result top, so a template interpolating `keyof {a: number, ...}` accepted a number and a boolean.
- Putting an unreduced operator in a bound made the union read as residual, so constraint solving decided against the operator and rejected `val u: Uppercase&lt;keyof {a: number, ...}&gt; = "A"`.

`narrowUnionMembers` weighs the bound only where the bound answers for every member drawn from it. Its `keep` predicate is a shape test over one member, and a bound is the set members come from, so the two coincide for a primitive or a literal and part ways for a structured bound, which is kept. `atomicShape` is that gate.

The end-to-end tests for `reduceDifference` over a bound live in #1137, since reaching it needs the conditional rule that PR lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for unions with bounded open-ended values.
  * Preserved and correctly narrowed bounds across indexed access, mapped types, template literals, negation, and exactness operations.
  * Improved handling of symbolic results when values cannot be fully enumerated.
  * Correctly reports impossible exclusions and reduces emptied bounds to `never`.

* **Tests**
  * Added coverage for bounded-tail preservation, narrowing, subtype checks, and operator results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->