### PR TITLE
Decide a borrow against a primitive through the meet

### DIFF
--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -890,18 +890,15 @@ func (f *knotFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ent
 
 func (f *knotFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
 
-// valueFamily is a set of runtime values no value outside it belongs to. Two
-// atoms drawn from different families are disjoint, so their meet is `never`.
+// valueFamily is a set of runtime values no value outside it belongs to, so two atoms drawn
+// from different families are disjoint and their meet is `never`. Five families cover the
+// primitives and the two absence markers, and a sixth, refCellFamily, covers the borrows no
+// primitive can be.
 //
-// Five families cover the primitives and the two absence markers, the kinds whose
-// disjointness the solver already decides elsewhere. A sixth covers the borrows a
-// primitive can never be. Bare objects, tuples, functions, and class instances are
-// deliberately absent. They are disjoint from a primitive too, but keeping two such
-// atoms separate is already precise, so naming them here would buy nothing.
-//
-// Only cross-family disjointness applies to refCellFamily. The within-family rules
-// meetValueAtoms uses for the primitives read two distinct atoms as disjoint, which
-// is right for `5` and `6` and wrong for two borrows.
+// Objects, tuples, functions, and class instances are deliberately absent. They are disjoint
+// from a primitive too, but keeping two such atoms apart is already precise, so a family for
+// them would buy nothing. refCellFamily uses only the cross-family rule, never the within-family
+// one meetValueAtoms applies to the primitives, since two distinct borrows are not disjoint.
 type valueFamily int
 
 const (
@@ -932,17 +929,15 @@ func valueFamilyOf(t soltype.Type) valueFamily {
 	return notValueAtom
 }
 
-// refCellOrNot returns refCellFamily for a borrow whose carrier settles the values it
-// admits to objects, tuples, or class instances, and notValueAtom for one whose carrier
-// may still rewrite. It reads the carrier because a borrow is only as decided as the
+// refCellOrNot returns refCellFamily for a borrow over an object, a tuple, or a class
+// instance, and notValueAtom for any other carrier, since a borrow is only as decided as the
 // value it points at.
 //
-// The three kinds it admits stay themselves under every rewrite, so a borrow over one
-// admits no primitive and no absence marker. The kinds it turns away can leave the
-// RefInner set, and RefType.Accept peels a borrow whose inner does. A `mut β` whose β
-// inlines to `string` becomes `string`, so reading it as disjoint from `string` would be
-// wrong. A union, an intersection, and an alias can each reduce to a bare primitive the
-// same way.
+// Those three kinds stay themselves under every rewrite, so a borrow over one admits no
+// primitive. The kinds it turns away can leave the RefInner set, and RefType.Accept peels a
+// borrow whose inner does: a `mut β` whose β inlines to `string` becomes `string`, and a
+// union, an intersection, or an alias can reduce to a bare primitive the same way. Reading
+// such a borrow as disjoint from `string` would be wrong.
 func refCellOrNot(carrier soltype.Type) valueFamily {
 	switch carrier.(type) {
 	case *soltype.ObjectType, *soltype.TupleType, *soltype.ClassType:

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -892,11 +892,16 @@ func (f *knotFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type
 
 // valueFamily is a set of runtime values no value outside it belongs to. Two
 // atoms drawn from different families are disjoint, so their meet is `never`.
-// The families cover the primitives and the two absence markers, the kinds whose
-// disjointness the solver already decides elsewhere. Objects, tuples, functions,
-// and class instances are deliberately absent: they are disjoint from a primitive
-// too, but claiming that here would go beyond what this PR needs, and keeping two
-// such atoms separate is precise anyway.
+//
+// Five families cover the primitives and the two absence markers, the kinds whose
+// disjointness the solver already decides elsewhere. A sixth covers the borrows a
+// primitive can never be. Bare objects, tuples, functions, and class instances are
+// deliberately absent. They are disjoint from a primitive too, but keeping two such
+// atoms separate is already precise, so naming them here would buy nothing.
+//
+// Only cross-family disjointness applies to refCellFamily. The within-family rules
+// meetValueAtoms uses for the primitives read two distinct atoms as disjoint, which
+// is right for `5` and `6` and wrong for two borrows.
 type valueFamily int
 
 const (
@@ -906,6 +911,7 @@ const (
 	booleanFamily
 	nullFamily
 	undefinedFamily
+	refCellFamily
 )
 
 // valueFamilyOf returns the family t draws its values from, and notValueAtom for
@@ -920,10 +926,30 @@ func valueFamilyOf(t soltype.Type) valueFamily {
 		return nullFamily
 	case *soltype.UndefinedType:
 		return undefinedFamily
+	case *soltype.RefType:
+		return refCellOrNot(t.Inner)
 	}
 	return notValueAtom
 }
 
+// refCellOrNot returns refCellFamily for a borrow whose carrier settles the values it
+// admits to objects, tuples, or class instances, and notValueAtom for one whose carrier
+// may still rewrite. It reads the carrier because a borrow is only as decided as the
+// value it points at.
+//
+// The three kinds it admits stay themselves under every rewrite, so a borrow over one
+// admits no primitive and no absence marker. The kinds it turns away can leave the
+// RefInner set, and RefType.Accept peels a borrow whose inner does. A `mut β` whose β
+// inlines to `string` becomes `string`, so reading it as disjoint from `string` would be
+// wrong. A union, an intersection, and an alias can each reduce to a bare primitive the
+// same way.
+func refCellOrNot(carrier soltype.Type) valueFamily {
+	switch carrier.(type) {
+	case *soltype.ObjectType, *soltype.TupleType, *soltype.ClassType:
+		return refCellFamily
+	}
+	return notValueAtom
+}
 
 func primFamily(p soltype.Prim) valueFamily {
 	switch p {
@@ -950,9 +976,15 @@ func litFamily(l soltype.Lit) valueFamily {
 }
 
 // meetValueAtoms fuses two atoms drawn from the value families. Different
-// families are disjoint, so the meet is `never`. Within one family a literal is
-// narrower than its primitive, so the literal wins, and two distinct atoms of the
-// family are disjoint.
+// families are disjoint, so the meet is `never`. Within one primitive family a
+// literal is narrower than its primitive, so the literal wins, and two distinct
+// atoms of the family are disjoint.
+//
+// Two borrows are the exception to that last rule, so they are handed back
+// unfused. `mut {x: number}` and `mut {y: string}` are distinct atoms of
+// refCellFamily and are not disjoint, since an object carrying both fields
+// inhabits each. meetAtoms reaches meetRefs once this bails, and meetRefs decides
+// the pair by comparing carriers.
 //
 // Equal atoms are answered here as well as by meetAtoms, which reaches them
 // first. The overlap is deliberate. Without it `"hello"` met with `"hello"` would
@@ -969,6 +1001,9 @@ func meetValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	if equalType(a, b) {
 		return a, true
 	}
+	if fa == refCellFamily {
+		return nil, false
+	}
 	if _, ok := a.(*soltype.PrimType); ok {
 		return b, true
 	}
@@ -983,6 +1018,9 @@ func meetValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 // primitive absorbs a literal of its own family, so `5 | number` is `number`.
 // Anything else keeps both atoms, which is already precise.
 //
+// Two borrows keep both atoms as well. No borrow absorbs another the way a
+// primitive absorbs its literal, so joinRefs decides them once this bails.
+//
 // Equal atoms are answered here too, for the reason meetValueAtoms gives. Without
 // it two equal literals would read as un-fusable and stay two atoms, which is
 // sound but needlessly imprecise.
@@ -993,6 +1031,9 @@ func joinValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	}
 	if equalType(a, b) {
 		return a, true
+	}
+	if fa == refCellFamily {
+		return nil, false
 	}
 	if _, ok := a.(*soltype.PrimType); ok {
 		return a, true

--- a/internal/solver/normal_ref_test.go
+++ b/internal/solver/normal_ref_test.go
@@ -377,3 +377,92 @@ func TestNegationIsNotBorrowable(t *testing.T) {
 	require.False(t, borrowable, "NegationType must not be a RefInner")
 	require.False(t, soltype.BorrowableType(complement))
 }
+
+// TestBorrowDisjointFromValueAtoms pins the disjointness rule that lets a meet decide
+// a borrow against a primitive. A borrow over an object, a tuple, or a class instance
+// admits none of the values a primitive or an absence marker admits, so the two are
+// disjoint and their meet is `never`.
+//
+// The rule is stated as a value family in normal.go, and a family carries two
+// obligations. Cross-family atoms are disjoint, which is the answer this buys. Within
+// one family two distinct atoms are disjoint as well, which is right for `5` and `6`
+// and wrong for two borrows, so the borrow family opts out of that half. The rows
+// below cover both obligations along with the carriers the rule turns away.
+func TestBorrowDisjointFromValueAtoms(t *testing.T) {
+	c := &Context{}
+	c.registerClass("Point", &ClassDef{})
+	obj := parseType(t, "{x: number}").(soltype.RefInner)
+	other := parseType(t, "{y: string}").(soltype.RefInner)
+	tuple := parseType(t, "[number]").(soltype.RefInner)
+
+	tests := []struct {
+		name  string
+		parts []soltype.Type
+		want  string
+	}{
+		// A borrow's carrier decides what values it admits, and none of these carriers
+		// admits a primitive however the borrow is written.
+		{"owned mutable cell against a primitive", []soltype.Type{str(), borrow(true, nil, obj)}, "never"},
+		{"lifetime borrow against a literal", []soltype.Type{numLit(5), borrow(false, c.freshLifetime(0), obj)}, "never"},
+		{"tuple carrier against a primitive", []soltype.Type{str(), borrow(true, nil, tuple)}, "never"},
+		{"class carrier against a primitive", []soltype.Type{num(), borrow(true, nil, cls("Point", false))}, "never"},
+		// The absence markers are families of their own, so they answer the same way.
+		{"null against a borrow", []soltype.Type{&soltype.NullType{}, borrow(true, nil, obj)}, "never"},
+		{"undefined against a borrow", []soltype.Type{&soltype.UndefinedType{}, borrow(true, nil, obj)}, "never"},
+
+		// Two borrows are distinct atoms of one family and are NOT disjoint. An object
+		// carrying both fields inhabits each. The pair is left for meetRefs to decide.
+		{"two borrows stay unfused", []soltype.Type{borrow(true, nil, obj), borrow(true, nil, other)},
+			"mut {x: number} & mut {y: string}"},
+
+		// A bare object is disjoint from a primitive too, but the families do not name it,
+		// so the pair keeps both atoms. That is precise, just less compact.
+		{"a bare object keeps both atoms", []soltype.Type{str(), obj}, "string & {x: number}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			met := newIntersection(nil, tt.parts)
+			require.Equal(t, tt.want, soltype.PrintAsScheme(c.normalizeDeep(met, soltype.Positive)))
+		})
+	}
+}
+
+// TestBorrowOverAnUnsettledCarrierIsNotDisjoint pins the gate the disjointness rule
+// needs to stay sound. RefType.Accept PEELS the wrapper when a rewritten inner leaves
+// the RefInner set, so a borrow over a carrier that can still become a primitive is not
+// yet a borrow of anything.
+//
+// `mut β` is the case. Coalescing it once β inlines to `string` yields a bare `string`,
+// and `string & string` is `string` rather than `never`. Reading the unresolved borrow
+// as disjoint from `string` would therefore answer a meet that later turns out
+// inhabited. A union carrier can reduce to a bare primitive the same way.
+func TestBorrowOverAnUnsettledCarrierIsNotDisjoint(t *testing.T) {
+	c := &Context{}
+	union := newUnion(nil, []soltype.Type{str(), numLit(5)}, false).(soltype.RefInner)
+
+	tests := []struct {
+		name    string
+		carrier soltype.RefInner
+		want    string
+	}{
+		{"a type variable may inline to a primitive", c.freshVar(0), "<T0> (string & mut T0)"},
+		{"a union may reduce to a bare primitive", union, "string & mut (string | 5)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			met := newIntersection(nil, []soltype.Type{str(), borrow(true, nil, tt.carrier)})
+			require.Equal(t, tt.want, soltype.PrintAsScheme(c.normalizeDeep(met, soltype.Positive)))
+		})
+	}
+}
+
+// TestBorrowAndPrimitiveJoinKeepsBothMembers pins the dual. Disjointness makes the MEET
+// empty and says nothing about the join, so a union of the two keeps both members. No
+// borrow absorbs a primitive the way `number` absorbs `5`.
+func TestBorrowAndPrimitiveJoinKeepsBothMembers(t *testing.T) {
+	c := &Context{}
+	obj := parseType(t, "{x: number}").(soltype.RefInner)
+	joined := newUnion(nil, []soltype.Type{str(), borrow(true, nil, obj)}, false)
+	require.Equal(t, "string | mut {x: number}",
+		soltype.PrintAsScheme(c.normalizeDeep(joined, soltype.Positive)))
+}

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -637,7 +637,7 @@ func TestOperatorsOverAMemberlessBoundedUnion(t *testing.T) {
 			Check:   newBoundedUnion(nil, nil, str()),
 			Extends: ref, Then: numLit(1), Else: numLit(2), Distribute: true,
 		}
-		require.Equal(t, `if ... : string : mut {x: number} { 1 } else { 2 }`, soltype.Print(reduceType(cond)))
+		require.Equal(t, `... : 2`, soltype.Print(reduceType(cond)))
 	})
 
 	// A key set that names keys is still enumerable, so the tail changes nothing about how a

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -330,15 +330,11 @@ func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.Union
 func (e *typeEvaluator) condOverTailBound(t *soltype.CondType, bound soltype.Type) soltype.Type {
 	extends := substituteOccurrences(t.Extends, t.Check, bound)
 	// Every value of the bound takes the same branch: all satisfy the check, so every tail member
-	// takes Then, or none do, so every member takes Else. Either way the conditional runs on the
-	// whole bound the way it runs on a named member. Over `"a" | ...string`,
+	// takes Then, or none satisfy it, so every member takes Else. boundDisjointFrom decides the
+	// Else case, reading an empty meet as "no value satisfies". Either way the conditional runs on
+	// the whole bound the way it runs on a named member. Over `"a" | ...string`,
 	// `type Yes<T> = if T : string { "y" } else { "n" }` gives a tail bounded by `"y"`.
-	uniform := e.ctx.condExtends(bound, extends, e.seen)
-	if !uniform && negatableOperand(extends) {
-		// The Else half is decided by `bound <: ¬extends`, the same question excludeFrom asks to
-		// decide that an exclusion takes nothing from a member.
-		uniform = e.ctx.condExtends(bound, soltype.NewNegation(extends), e.seen)
-	}
+	uniform := e.ctx.condExtends(bound, extends, e.seen) || e.boundDisjointFrom(bound, extends)
 	if uniform {
 		return e.reduceCond(&soltype.CondType{
 			Check:   bound,
@@ -382,6 +378,23 @@ func (e *typeEvaluator) condOverTailBound(t *soltype.CondType, bound soltype.Typ
 		e.reduceBranch(substituteOccurrences(t.Then, t.Check, matched)),
 		e.reduceBranch(substituteOccurrences(t.Else, t.Check, unmatched)),
 	}, false)
+}
+
+// boundDisjointFrom reports whether no value the bound admits satisfies the check, which
+// puts every tail member in the Else branch.
+//
+// It asks the question as an empty meet rather than as the subtype check
+// `bound <: ¬extends`. The two agree wherever both apply, and the meet also answers over a
+// check the ¬Ref exclusion invariant forbids naming under a complement. `...string` against
+// `mut {x: number}` is that case. No string is a borrowed object, so
+// `string ∩ mut {x: number}` is `never` and the whole tail takes Else.
+//
+// A `never` bound never reaches here. It is a subtype of every check, so the caller's
+// first test already answers uniform for it.
+func (e *typeEvaluator) boundDisjointFrom(bound, extends soltype.Type) bool {
+	met := newIntersection(nil, []soltype.Type{bound, extends})
+	_, disjoint := e.ctx.normalizeDeep(met, soltype.Positive).(*soltype.NeverType)
+	return disjoint
 }
 
 // substituteOccurrences rewrites every occurrence of the from type inside in to the to type,


### PR DESCRIPTION
Fixes #1132. Refs #1126. Last of six, splitting #1129. Base: #1137.

`string & mut {x: number}` is `never`, since no string is a borrowed object, but nothing said so. `valueFamilyOf` covered the primitives and the absence markers alone, so `meetAtoms` reported the pair unfusable.

Add `refCellFamily` for a borrow whose carrier is an object, a tuple, or a class instance. Only cross-family disjointness applies to it. The rule that reads two distinct atoms of one family as disjoint is right for `5` and `6` and wrong for two borrows — an object carrying both fields inhabits `mut {x: number}` and `mut {y: string}` alike — so `meetValueAtoms` and `joinValueAtoms` hand a borrow pair back to `meetRefs` and `joinRefs` instead.

**The carrier gate is the part worth checking.** `RefType.Accept` peels a borrow whose inner leaves the `RefInner` set, so a `mut β` whose `β` inlines to `string` becomes `string`. Reading that as disjoint from `string` would answer a meet that later turns out inhabited. A borrow over a variable, a union, or an alias is therefore not yet a borrow of anything and stays out of the family. `TestBorrowOverAnUnsettledCarrierIsNotDisjoint` pins both cases.

`condOverTailBound` then asks disjointness as an empty meet rather than as `bound <: ¬extends`. The meet answers over a check the ¬Ref exclusion invariant forbids naming under a complement, so `if (...string) : mut {x: number} { 1 } else { 2 }` reduces to `...2` where it used to stay unreduced — the case #1137 left open.

The meet change stands on its own merits and does not depend on tail bounds; only `boundDisjointFrom`'s use of it does. It could be reordered to the front of the stack if that reads better.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VG4c9M6EgSC672itUpaMDm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type resolution for borrowed object, tuple, and class values.
  - Corrected intersections and joins involving borrows, primitives, null, undefined, and unresolved carriers.
  - Fixed conditional type reduction to select the correct branch when checks are uniformly false.

- **Tests**
  - Added coverage for borrow disjointness, unresolved carriers, and mixed borrow/value joins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->