### PR TITLE
Parse a bounded tail in a union type annotation

### DIFF
--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -370,8 +370,12 @@ func (t *TupleTypeAnn) Accept(v Visitor) {
 }
 
 type UnionTypeAnn struct {
-	Types        []TypeAnn
-	Inexact      bool // trailing `...` marker: `A | B | ...` tolerates an unknown tail
+	Types   []TypeAnn
+	Inexact bool // trailing `...` marker: `A | B | ...` tolerates an unknown tail
+	// TailBound names the type the tail's unknown members are drawn from, set by a
+	// `...R` tail as in `A | ...string`. It is nil on an exact union and may be nil on
+	// an inexact one, which leaves the tail unbounded as `A | ...`.
+	TailBound    TypeAnn
 	span         Span
 	inferredType Type
 }
@@ -383,6 +387,9 @@ func (t *UnionTypeAnn) Accept(v Visitor) {
 	if v.EnterTypeAnn(t) {
 		for _, typ := range t.Types {
 			typ.Accept(v)
+		}
+		if t.TailBound != nil {
+			t.TailBound.Accept(v)
 		}
 	}
 	v.ExitTypeAnn(t)

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -372,9 +372,8 @@ func (t *TupleTypeAnn) Accept(v Visitor) {
 type UnionTypeAnn struct {
 	Types   []TypeAnn
 	Inexact bool // trailing `...` marker: `A | B | ...` tolerates an unknown tail
-	// TailBound names the type the tail's unknown members are drawn from, set by a
-	// `...R` tail as in `A | ...string`. It is nil on an exact union and may be nil on
-	// an inexact one, which leaves the tail unbounded as `A | ...`.
+	// TailBound names the type the tail's unknown members are drawn from, as in
+	// `A | ...string`. It is nil when the tail is unbounded (`A | ...`) or the union exact.
 	TailBound    TypeAnn
 	span         Span
 	inferredType Type

--- a/internal/parser/inexact_test.go
+++ b/internal/parser/inexact_test.go
@@ -106,9 +106,8 @@ func TestParseExactAndRestAreNotInexact(t *testing.T) {
 	})
 }
 
-// A `...R` tail bounds the open tail: `A | ...string` draws its unknown members from
-// string. The bound is parsed as a primary type and stored on TailBound, and it makes a
-// tail meaningful even after a single member, which the bare `...` marker rejects.
+// A `...R` tail bounds the open tail: `A | ...string` stores string on TailBound. A bound
+// also makes a tail meaningful after a single member, which the bare `...` marker rejects.
 func TestParseBoundedUnionTail(t *testing.T) {
 	ctx := context.Background()
 
@@ -121,6 +120,8 @@ func TestParseBoundedUnionTail(t *testing.T) {
 		require.Len(t, u.Types, 2)
 		_, ok = u.TailBound.(*ast.StringTypeAnn)
 		require.True(t, ok)
+		// The union's span reaches through the bound, so it ends at the end of `string`.
+		require.Equal(t, u.TailBound.Span().End, u.Span().End)
 	})
 
 	t.Run("bound after a single member wraps in a one-member union", func(t *testing.T) {

--- a/internal/parser/inexact_test.go
+++ b/internal/parser/inexact_test.go
@@ -105,3 +105,56 @@ func TestParseExactAndRestAreNotInexact(t *testing.T) {
 		require.False(t, u.Inexact)
 	})
 }
+
+// A `...R` tail bounds the open tail: `A | ...string` draws its unknown members from
+// string. The bound is parsed as a primary type and stored on TailBound, and it makes a
+// tail meaningful even after a single member, which the bare `...` marker rejects.
+func TestParseBoundedUnionTail(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("bound after several members", func(t *testing.T) {
+		ta, errs := ParseTypeAnn(ctx, `"a" | "b" | ...string`)
+		require.Empty(t, errs)
+		u, ok := ta.(*ast.UnionTypeAnn)
+		require.True(t, ok)
+		require.True(t, u.Inexact)
+		require.Len(t, u.Types, 2)
+		_, ok = u.TailBound.(*ast.StringTypeAnn)
+		require.True(t, ok)
+	})
+
+	t.Run("bound after a single member wraps in a one-member union", func(t *testing.T) {
+		ta, errs := ParseTypeAnn(ctx, `"a" | ...string`)
+		require.Empty(t, errs)
+		u, ok := ta.(*ast.UnionTypeAnn)
+		require.True(t, ok)
+		require.True(t, u.Inexact)
+		require.Len(t, u.Types, 1)
+		require.NotNil(t, u.TailBound)
+	})
+
+	t.Run("a parenthesized bound is a full type", func(t *testing.T) {
+		ta, errs := ParseTypeAnn(ctx, `"a" | ...(string | number)`)
+		require.Empty(t, errs)
+		u, ok := ta.(*ast.UnionTypeAnn)
+		require.True(t, ok)
+		require.True(t, u.Inexact)
+		_, ok = u.TailBound.(*ast.UnionTypeAnn)
+		require.True(t, ok)
+	})
+
+	t.Run("an unbounded tail leaves TailBound nil", func(t *testing.T) {
+		ta, errs := ParseTypeAnn(ctx, `"a" | "b" | ...`)
+		require.Empty(t, errs)
+		u, ok := ta.(*ast.UnionTypeAnn)
+		require.True(t, ok)
+		require.True(t, u.Inexact)
+		require.Nil(t, u.TailBound)
+	})
+
+	t.Run("a single member with no bound is still an error", func(t *testing.T) {
+		_, errs := ParseTypeAnn(ctx, `number | ...`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "a trailing `...` must follow two or more union members, as in `A | B | ...`", errs[0].Message)
+	})
+}

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -134,9 +134,8 @@ loop:
 			unionInexactSpan = p.lexer.peek().Span
 			p.lexer.consume()
 			unionInexact = true
-			// A primary type after the `...` bounds the tail: `A | ...string` draws the
-			// tail's unknown members from string. primaryTypeAnn returns nil without
-			// consuming when no type follows, which leaves the tail unbounded as `A | ...`.
+			// A primary type after the `...` bounds the tail, as in `A | ...string`.
+			// primaryTypeAnn returns nil without consuming when none follows, leaving `A | ...`.
 			unionTailBound = p.primaryTypeAnn()
 			break loop
 		}
@@ -222,26 +221,32 @@ loop:
 	}
 	result := typeAnns.Pop()
 	if unionInexact {
-		if u, ok := result.(*ast.UnionTypeAnn); ok {
+		u, isUnion := result.(*ast.UnionTypeAnn)
+		switch {
+		case isUnion && unionTailBound == nil:
 			u.Inexact = true
-			u.TailBound = unionTailBound
-		} else if unionTailBound != nil {
-			// A single named member with a bounded tail, as in `"a" | ...string`. The bound
-			// makes the tail meaningful with one member, so wrap the member in a one-member
-			// inexact union carrying it rather than rejecting the marker.
-			span := ast.MergeSpans(result.Span(), unionTailBound.Span())
-			u := ast.NewUnionTypeAnn([]ast.TypeAnn{result}, span)
-			u.Inexact = true
-			u.TailBound = unionTailBound
-			result = u
-		} else {
-			// The `...` followed a single member or a non-union top operator with no bound,
-			// so no UnionTypeAnn was built to carry the flag. An unbounded trailing `...` is
-			// only meaningful on a union of two or more members.
+		case isUnion:
+			// A bounded tail rebuilds the union so its span reaches through the bound.
+			result = boundedUnionTypeAnn(u.Types, unionTailBound)
+		case unionTailBound != nil:
+			// A bound makes a single-member tail meaningful, as in `"a" | ...string`, so wrap
+			// the member rather than rejecting the marker.
+			result = boundedUnionTypeAnn([]ast.TypeAnn{result}, unionTailBound)
+		default:
+			// An unbounded `...` after a single member carries no union to mark.
 			p.reportError(unionInexactSpan, "a trailing `...` must follow two or more union members, as in `A | B | ...`")
 		}
 	}
 	return result
+}
+
+// boundedUnionTypeAnn builds an inexact union carrying a `...R` tail bound, spanning from the
+// first member through the bound.
+func boundedUnionTypeAnn(types []ast.TypeAnn, bound ast.TypeAnn) *ast.UnionTypeAnn {
+	u := ast.NewUnionTypeAnn(types, ast.MergeSpans(types[0].Span(), bound.Span()))
+	u.Inexact = true
+	u.TailBound = bound
+	return u
 }
 
 // funcTypeAnnTail parses a function signature once its leading keyword has been consumed:

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -229,8 +229,10 @@ loop:
 			// A bounded tail rebuilds the union so its span reaches through the bound.
 			result = boundedUnionTypeAnn(u.Types, unionTailBound)
 		case unionTailBound != nil:
-			// A bound makes a single-member tail meaningful, as in `"a" | ...string`, so wrap
-			// the member rather than rejecting the marker.
+			// A lone member followed by a bounded tail, where the member is not itself a
+			// union: a primary as in `"a" | ...string`, or a higher-precedence compound as in
+			// `number & string | ...string`. The bound makes the tail meaningful with one
+			// member, so wrap it rather than rejecting the marker.
 			result = boundedUnionTypeAnn([]ast.TypeAnn{result}, unionTailBound)
 		default:
 			// An unbounded `...` after a single member carries no union to mark.

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -71,6 +71,7 @@ func (p *Parser) typeAnn() ast.TypeAnn {
 	ops := NewStack[*TypeAnnOp]()
 	unionInexact := false
 	var unionInexactSpan ast.Span
+	var unionTailBound ast.TypeAnn
 
 	token := p.lexer.peek()
 	//nolint: exhaustive
@@ -133,6 +134,10 @@ loop:
 			unionInexactSpan = p.lexer.peek().Span
 			p.lexer.consume()
 			unionInexact = true
+			// A primary type after the `...` bounds the tail: `A | ...string` draws the
+			// tail's unknown members from string. primaryTypeAnn returns nil without
+			// consuming when no type follows, which leaves the tail unbounded as `A | ...`.
+			unionTailBound = p.primaryTypeAnn()
 			break loop
 		}
 
@@ -219,9 +224,19 @@ loop:
 	if unionInexact {
 		if u, ok := result.(*ast.UnionTypeAnn); ok {
 			u.Inexact = true
+			u.TailBound = unionTailBound
+		} else if unionTailBound != nil {
+			// A single named member with a bounded tail, as in `"a" | ...string`. The bound
+			// makes the tail meaningful with one member, so wrap the member in a one-member
+			// inexact union carrying it rather than rejecting the marker.
+			span := ast.MergeSpans(result.Span(), unionTailBound.Span())
+			u := ast.NewUnionTypeAnn([]ast.TypeAnn{result}, span)
+			u.Inexact = true
+			u.TailBound = unionTailBound
+			result = u
 		} else {
-			// The `...` followed a single member or a non-union top operator, so
-			// no UnionTypeAnn was built to carry the flag. A trailing `...` is
+			// The `...` followed a single member or a non-union top operator with no bound,
+			// so no UnionTypeAnn was built to carry the flag. An unbounded trailing `...` is
 			// only meaningful on a union of two or more members.
 			p.reportError(unionInexactSpan, "a trailing `...` must follow two or more union members, as in `A | B | ...`")
 		}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -569,7 +569,8 @@ func (c *checker) resolveTupleTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, lvl in
 // resolveUnionTypeAnn lowers `A | B | …` through newUnion. An unsupported
 // member recovers to a fresh var so the union shape survives, mirroring the
 // Promise<bad> and object/tuple cascade-safe recovery. A trailing `...` in the
-// source sets ta.Inexact, which carries onto the resolved union.
+// source sets ta.Inexact, which carries onto the resolved union, and a `...R`
+// tail sets ta.TailBound, which bounds it through newBoundedUnion.
 func (c *checker) resolveUnionTypeAnn(scope *Scope, ta *ast.UnionTypeAnn, lvl int) (soltype.Type, bool) {
 	members := make([]soltype.Type, len(ta.Types))
 	for i, m := range ta.Types {
@@ -582,7 +583,18 @@ func (c *checker) resolveUnionTypeAnn(scope *Scope, ta *ast.UnionTypeAnn, lvl in
 			members[i] = c.freshAt(lvl)
 		}
 	}
-	t := newUnion(c.ctx, members, ta.Inexact)
+	var t soltype.Type
+	if ta.TailBound != nil {
+		bound, ok := c.resolveTypeAnn(scope, ta.TailBound, lvl)
+		if !ok {
+			// An unsupported bound recovers to a fresh var, the same as an
+			// unsupported member, so the bounded shape survives.
+			bound = c.freshAt(lvl)
+		}
+		t = newBoundedUnion(c.ctx, members, bound)
+	} else {
+		t = newUnion(c.ctx, members, ta.Inexact)
+	}
 	// newUnion can collapse to an input member's pointer (single-member
 	// dedup, or subsumption). Re-recording Prov on a pointer that already
 	// carries it would overwrite the narrower child-annotation blame and

--- a/internal/solver/type_ann_tail_test.go
+++ b/internal/solver/type_ann_tail_test.go
@@ -7,10 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The surface syntax `A | ...R` resolves to a bounded tail, and `A | B | ...` to an
-// unbounded one, so a test can write the source directly instead of minting the union by
-// hand. resolveUnionTypeAnn reads UnionTypeAnn.TailBound and lowers it through
-// newBoundedUnion, or leaves the tail unbounded when the source wrote a bare `...`.
+// The surface syntax `A | ...R` resolves to a bounded tail and `A | B | ...` to an unbounded
+// one, so a test can write the source directly rather than minting the union by hand.
 func TestResolveUnionTailSyntax(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/solver/type_ann_tail_test.go
+++ b/internal/solver/type_ann_tail_test.go
@@ -1,0 +1,33 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// The surface syntax `A | ...R` resolves to a bounded tail, and `A | B | ...` to an
+// unbounded one, so a test can write the source directly instead of minting the union by
+// hand. resolveUnionTypeAnn reads UnionTypeAnn.TailBound and lowers it through
+// newBoundedUnion, or leaves the tail unbounded when the source wrote a bare `...`.
+func TestResolveUnionTailSyntax(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"a bounded tail after several members", `type Result = "a" | "b" | ...string`, `"a" | "b" | ...string`},
+		{"a bounded tail after one member", `type Result = "a" | ...string`, `"a" | ...string`},
+		{"a numeric bound", `type Result = 0 | ...number`, "0 | ...number"},
+		{"a parenthesized union bound", `type Result = "a" | ...(number | string)`, `"a" | ...(number | string)`},
+		{"an unbounded tail", `type Result = "a" | "b" | ...`, `"a" | "b" | ...`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}


### PR DESCRIPTION
Refs #1126, #1131. Inserted into the bounded-tail stack between #1133 (representation) and #1134 (subtyping), so the PRs above it can write their test inputs as Escalier source instead of minting unions by hand. Base: #1133.

`A | ...` already parses as an inexact union and the solver resolves it to an unbounded tail. This adds the bounded form `A | ...R`, which draws the tail's unknown members from `R`, so `"a" | ...string` reads as `"a"` together with some unknown set of strings.

**What changes**

- `UnionTypeAnn` gains a `TailBound TypeAnn` field, visited by `Accept`.
- After a union's `...` marker the parser reads an optional primary type as the bound. `primaryTypeAnn` returns nil without consuming when no type follows, so a bare `...` still leaves the tail unbounded, and `...(string | number)` takes a parenthesized type.
- A bound makes a single-member tail meaningful, so `"a" | ...string` wraps its one member in an inexact union rather than being rejected. An unbounded single-member `A | ...` stays an error, exactly as before — `TestParseInexactUnionMarkerRequiresUnion` is unchanged.
- `resolveUnionTypeAnn` lowers a bound through `newBoundedUnion`, recovering an unsupported bound to a fresh var the same way it recovers an unsupported member.

**Scope**

This is the parse and resolve path only. The old `internal/checker` already ignores the `...` inexact marker on a union annotation, and it ignores the bound the same way; the bounded-tail feature lives entirely in `internal/solver`. The AST-to-source printer is unchanged, so this does not add round-trip printing of the marker, which it never did for `...` either.

**Tests**

- `internal/parser/inexact_test.go`: `TestParseBoundedUnionTail` covers a bound after several members, after one member, a parenthesized bound, an unbounded tail leaving `TailBound` nil, and the preserved single-member-no-bound error.
- `internal/solver/type_ann_tail_test.go`: `TestResolveUnionTailSyntax` asserts each source form resolves to the expected soltype, e.g. `type Result = "a" | ...string` → `"a" | ...string`.

Full suite passes; no snapshot or fixture movement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VG4c9M6EgSC672itUpaMDm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bounded inexact union types using trailing syntax such as `A | ...string`.
  * Supports multiple union members, single-member unions, numeric and parenthesized bounds.
  * Preserves existing behavior for unbounded inexact unions.

* **Bug Fixes**
  * Improved validation and error handling for unsupported or invalid unbounded union syntax.

* **Tests**
  * Added coverage for parsing and resolving bounded and unbounded union tails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->