### PR TITLE
Constrain string literals against string-intrinsic residuals

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -847,6 +847,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			}
 			return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
 		}
+		if sup, ok := super.(*soltype.StringIntrinsicType); ok {
+			return c.constrainStrLitToStringIntrinsic(sub, sup)
+		}
 	case *soltype.SkolemType:
 		// A skolem is a subtype of the same skolem and of its declared upper bound, so an
 		// unconstrained `T` fails against `number` or a distinct `U`, while a `<U: T>` skolem
@@ -1457,6 +1460,29 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		return c.constrain(c.extrude(sub, soltype.Positive, superVar.Level, map[extrudeKey]*soltype.TypeVarType{}), super, seen, mutCtx)
 	}
 
+	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+}
+
+// constrainStrLitToStringIntrinsic checks a string-literal sub against a residual string-operator
+// super whose operand never reduced to a literal, such as `"A" <: Uppercase<string>`. The operator
+// denotes the image of its transform over the operand's inhabitants, and each of the four transforms
+// is idempotent, so its image is exactly the strings the transform leaves unchanged. When the operand
+// is the whole `string` primitive, a string literal lands in that image iff the transform maps it to
+// itself: `Uppercase<string>` accepts `"A"` because `Uppercase("A")` is `"A"`, and rejects `"a"`
+// because `Uppercase("a")` is `"A"`. An operand that is not `string`, such as a type parameter,
+// leaves the operator symbolic, so no literal can be shown to land in its image and the mismatch is
+// reported.
+func (c *Context) constrainStrLitToStringIntrinsic(sub *soltype.LitType, super *soltype.StringIntrinsicType) []SolverError {
+	strLit, ok := sub.Lit.(*soltype.StrLit)
+	if !ok {
+		return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+	}
+	if prim, ok := super.Operand.(*soltype.PrimType); !ok || prim.Prim != soltype.StrPrim {
+		return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+	}
+	if applyStringIntrinsic(super.Kind, strLit.Value) == strLit.Value {
+		return nil
+	}
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 }
 

--- a/internal/solver/infer_template_lit_test.go
+++ b/internal/solver/infer_template_lit_test.go
@@ -222,6 +222,66 @@ func TestInferStringIntrinsicConstraint(t *testing.T) {
 	}
 }
 
+// A string-intrinsic residual over the whole `string` primitive denotes the strings the transform
+// leaves unchanged, since each of the four transforms is idempotent. A string literal satisfies the
+// residual iff the transform maps it to itself: `Uppercase<string>` accepts `"A"` and rejects `"a"`,
+// and Lowercase, Capitalize, and Uncapitalize accept and reject by the same fixed-point test.
+func TestInferStringIntrinsicOverString(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "UppercaseAcceptsUppercase",
+			src:  `val u: Uppercase<string> = "A"`,
+		},
+		{
+			name:    "UppercaseRejectsLowercase",
+			src:     `val u: Uppercase<string> = "a"`,
+			wantErr: `cannot constrain "a" <: Uppercase<string>`,
+		},
+		{
+			name: "LowercaseAcceptsLowercase",
+			src:  `val l: Lowercase<string> = "a"`,
+		},
+		{
+			name:    "LowercaseRejectsUppercase",
+			src:     `val l: Lowercase<string> = "A"`,
+			wantErr: `cannot constrain "A" <: Lowercase<string>`,
+		},
+		{
+			name: "CapitalizeAcceptsLeadingUpper",
+			src:  `val c: Capitalize<string> = "Abc"`,
+		},
+		{
+			name:    "CapitalizeRejectsLeadingLower",
+			src:     `val c: Capitalize<string> = "abc"`,
+			wantErr: `cannot constrain "abc" <: Capitalize<string>`,
+		},
+		{
+			name: "UncapitalizeAcceptsLeadingLower",
+			src:  `val c: Uncapitalize<string> = "aBC"`,
+		},
+		{
+			name:    "UncapitalizeRejectsLeadingUpper",
+			src:     `val c: Uncapitalize<string> = "ABC"`,
+			wantErr: `cannot constrain "ABC" <: Uncapitalize<string>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
 // A string intrinsic nested inside a template interpolation composes: `on${Capitalize<K>}`
 // over `type K = "click"` reduces the inner `Capitalize<K>` to `"Click"`, then folds it into the
 // template to yield `"onClick"`. This is the `EventName<K>` shape the utility-type suite builds on.


### PR DESCRIPTION
Add support for constraining string literals against string-intrinsic types when the operand is the `string` primitive. String intrinsics like `Uppercase<string>` denote the image of their transform over the operand's inhabitants. Since each of the four transforms (Uppercase, Lowercase, Capitalize, Uncapitalize) is idempotent, the image is exactly the strings the transform leaves unchanged. A string literal satisfies such a constraint iff the transform maps it to itself.

**Changes:**

- Add `constrainStrLitToStringIntrinsic` method to check if a string literal satisfies a string-intrinsic constraint by applying the transform and verifying it produces the same value
- Wire the new constraint check into the main `constrain` method for `LitType` cases
- Add comprehensive test cases covering all four string transforms with both accepting and rejecting literals

The implementation correctly rejects constraints where the operand is not the `string` primitive (e.g., type parameters), since those leave the operator symbolic and no literal can be shown to satisfy them.

https://claude.ai/code/session_01XLGXSCR9ePXFiZRW9teF2Q