### PR TITLE
Extract the type-reference guard helpers from buildTypeGuard

### DIFF
--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -1449,56 +1449,22 @@ func (b *Builder) buildTypeGuard(valueExpr Expr, typeAnn ast.TypeAnn) Expr {
 		// Check if it's an array
 		return buildArrayIsArrayCheck(valueExpr, nil)
 	case *ast.TypeRefTypeAnn:
-		// For type references, expand the type and check if it's a nominal type
-		inferredType := t.InferredType()
-		if inferredType != nil {
-			// Prune type variables to get the actual type
-			prunedType := type_system.Prune(inferredType)
-
-			// Check if it's a TypeRefType with a TypeAlias
-			if typeRef, ok := prunedType.(*type_system.TypeRefType); ok {
-				if typeRef.TypeAlias != nil {
-					// Get the aliased type
-					aliasedType := type_system.Prune(typeRef.TypeAlias.Type)
-
-					// Check if the aliased type is a nominal object type
-					if objType, ok := aliasedType.(*type_system.ObjectType); ok && objType.Nominal {
-						// Generate instanceof check for nominal types
-						typeName := ast.QualIdentToString(t.Name)
-						return NewBinaryExpr(
-							valueExpr,
-							InstanceOf,
-							NewIdentExpr(typeName, "", nil),
-							nil,
-						)
-					}
-				}
-			}
-
-			// Check if it's directly an object type (not aliased)
-			if objType, ok := prunedType.(*type_system.ObjectType); ok && objType.Nominal {
-				// Generate instanceof check for nominal types
-				typeName := ast.QualIdentToString(t.Name)
-				return NewBinaryExpr(
-					valueExpr,
-					InstanceOf,
-					NewIdentExpr(typeName, "", nil),
-					nil,
-				)
-			}
-
-			// TODO(#289): handle non-object types
-			// TODO(#289): handle structural object types
+		// A reference to a nominal type is tested with `instanceof` against the class
+		// name. nominalGuardName resolves the reference through its inferred type, either
+		// directly or through a type alias.
+		//
+		// TODO(#289): handle non-object types
+		// TODO(#289): handle structural object types
+		if typeName, nominal := nominalGuardName(t); nominal {
+			return NewBinaryExpr(
+				valueExpr,
+				InstanceOf,
+				NewIdentExpr(typeName, "", nil),
+				nil,
+			)
 		}
-
-		// For type references like Array<T>, try to infer the check
-		if t.Name != nil {
-			// Get the simple name from QualIdent
-			name := ast.QualIdentToString(t.Name)
-			switch name {
-			case "Array":
-				return buildArrayIsArrayCheck(valueExpr, nil)
-			}
+		if isArrayTypeRef(t) {
+			return buildArrayIsArrayCheck(valueExpr, nil)
 		}
 		// Default: accept anything
 		return NewLitExpr(NewBoolLit(true, nil), nil)
@@ -1506,6 +1472,32 @@ func (b *Builder) buildTypeGuard(valueExpr Expr, typeAnn ast.TypeAnn) Expr {
 		// For complex types we can't easily check at runtime, accept anything
 		return NewLitExpr(NewBoolLit(true, nil), nil)
 	}
+}
+
+// nominalGuardName returns the class name an `x instanceof C` guard tests for a
+// reference to a nominal type, and reports whether the reference is one. A reference
+// resolves through its inferred type, either directly or through a type alias.
+func nominalGuardName(t *ast.TypeRefTypeAnn) (string, bool) {
+	inferred := t.InferredType()
+	if inferred == nil {
+		return "", false
+	}
+	pruned := type_system.Prune(inferred)
+	if typeRef, ok := pruned.(*type_system.TypeRefType); ok && typeRef.TypeAlias != nil {
+		if obj, ok := type_system.Prune(typeRef.TypeAlias.Type).(*type_system.ObjectType); ok && obj.Nominal {
+			return ast.QualIdentToString(t.Name), true
+		}
+	}
+	if obj, ok := pruned.(*type_system.ObjectType); ok && obj.Nominal {
+		return ast.QualIdentToString(t.Name), true
+	}
+	return "", false
+}
+
+// isArrayTypeRef reports whether a reference is the `Array` the guard tests with
+// `Array.isArray`.
+func isArrayTypeRef(t *ast.TypeRefTypeAnn) bool {
+	return t.Name != nil && ast.QualIdentToString(t.Name) == "Array"
 }
 
 func (b *Builder) buildExpr(expr ast.Expr, parent ast.Expr) (Expr, []Stmt) {


### PR DESCRIPTION
Refs #1068. First of two PRs; #1146 stacks on it.

`buildTypeGuard`'s `TypeRefTypeAnn` case inlined two decisions behind a nested chain of type assertions and `type_system.Prune` calls: whether the reference resolves to a nominal type, so the guard is `x instanceof C`, and whether it is `Array`, so the guard is `Array.isArray(x)`. Both are now named helpers, `nominalGuardName` and `isArrayTypeRef`, which flattens roughly forty lines into two.

Behavior is unchanged — same guards, same fallback to `true` for a reference that is neither.

One note on provenance: this was originally split out to give an arm-ordering pass something to consult. That ordering has since been dropped from the stack (see #1147), and it turned out not to consult these helpers anyway. So this now stands on its own as a readability change to `buildTypeGuard`, and it is fine to drop if you would rather not carry it.

`go build ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TD84AZescKw86vPYRQMgde