### PR TITLE
Fold overload sets into the lattice as an intersection of arrows

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -909,6 +909,28 @@ type NoMatchingOverloadError struct {
 	Candidates []TypeScheme
 }
 
+// UnannotatedRecursiveOverloadError fires when an overloaded function participates in
+// a mutually-recursive group without annotating the parameters of every arm.
+//
+// An overload set reaches the fixed point as one intersection of arrows, and the
+// arrow-decomposition rule tells its arms apart by which inputs each accepts. Ground
+// domains are what make that separation possible; leave them to inference and every arm
+// widens to the same `unknown` parameter, which says nothing and reports again as a set
+// of indistinguishable arms. Return types carry no such requirement — the fixed point
+// infers those through the same decomposition. Self-recursion is not gated, since a
+// call there resolves against the arm it selects rather than against a fixed point over
+// the whole group.
+//
+// The binding degrades to its first arm so a later reference still resolves.
+//
+// It is a BRIDGE error: born in checkOverloadAnnotations with the offending arm's
+// declaration in hand, so it self-blames (Span() is the first arm with an un-annotated
+// parameter). Name is the overloaded binding's name for the message.
+type UnannotatedRecursiveOverloadError struct {
+	Decl ast.Decl
+	Name string
+}
+
 // DuplicateOverloadError fires when two arms of an overload set (PR6) are
 // indistinguishable for dispatch: they share an arity and have pointwise-equal
 // parameter types, so no call could ever select one over the other. An overload set
@@ -1201,6 +1223,7 @@ func (*BodyDeclNotAllowedError) isSolverError()             {}
 func (*MissingInitializerError) isSolverError()             {}
 func (*DuplicateDeclarationError) isSolverError()           {}
 func (*NoMatchingOverloadError) isSolverError()             {}
+func (*UnannotatedRecursiveOverloadError) isSolverError()   {}
 func (*DuplicateOverloadError) isSolverError()              {}
 func (*AwaitOutsideAsyncError) isSolverError()              {}
 func (*ForAwaitOutsideAsyncError) isSolverError()           {}
@@ -2389,6 +2412,12 @@ func (e *NoMatchingOverloadError) Message() string {
 		sb.WriteString(renderScheme(s))
 	}
 	return sb.String()
+}
+
+func (e *UnannotatedRecursiveOverloadError) Span() ast.Span      { return e.Decl.Span() }
+func (e *UnannotatedRecursiveOverloadError) Related() []ast.Span { return nil }
+func (e *UnannotatedRecursiveOverloadError) Message() string {
+	return "Overloaded function in a recursive group must annotate its parameters: " + e.Name
 }
 
 func (e *DuplicateOverloadError) Span() ast.Span      { return e.Decl.Span() }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -909,20 +909,25 @@ type NoMatchingOverloadError struct {
 	Candidates []TypeScheme
 }
 
-// UnannotatedRecursiveOverloadError fires when an overloaded function participates
-// in a mutually-recursive group (a dep-graph component with more than one binding)
-// without fully-annotated overload signatures (PR6). Fixed-point iteration over
-// overload choices is not guaranteed to converge under subtyping, so the overload
-// set must be ground before the group is inferred; self-recursion (a singleton
-// component) is softer and does not trip this. The binding degrades to its first
-// arm so a later reference still resolves.
+// UndispatchableOverloadError fires when an arm of an overload set has a body and
+// leaves one of its parameters un-annotated.
 //
-// It is a BRIDGE error: born in checkOverloadAnnotations with the offending arm's
-// declaration in hand, so it self-blames (Span() is the first unannotated arm).
-// Name is the overloaded binding's name for the message.
-type UnannotatedRecursiveOverloadError struct {
-	Decl ast.Decl
-	Name string
+// An overload set with bodies compiles to a single JavaScript function whose if-else
+// chain tests each arm's written parameter annotations, so an un-annotated parameter
+// leaves the arm's guard with nothing to test. That guard degrades to `true` and the
+// arm then swallows every call that reaches it. A bodyless `declare fn` arm
+// contributes no branch to the chain and so is not reported.
+//
+// The set still infers and still binds. Inference reads the arms as one intersection of
+// arrows and needs no annotation; only the runtime dispatch does.
+//
+// It is a BRIDGE error: born in checkOverloadDispatch with the offending parameter in
+// hand, so it self-blames (Span() is the un-annotated parameter's pattern) and relates
+// the arm it belongs to. Name is the overloaded binding's name for the message.
+type UndispatchableOverloadError struct {
+	Param ast.Node
+	Decl  ast.Decl
+	Name  string
 }
 
 // DuplicateOverloadError fires when two arms of an overload set (PR6) are
@@ -1217,7 +1222,7 @@ func (*BodyDeclNotAllowedError) isSolverError()             {}
 func (*MissingInitializerError) isSolverError()             {}
 func (*DuplicateDeclarationError) isSolverError()           {}
 func (*NoMatchingOverloadError) isSolverError()             {}
-func (*UnannotatedRecursiveOverloadError) isSolverError()   {}
+func (*UndispatchableOverloadError) isSolverError()         {}
 func (*DuplicateOverloadError) isSolverError()              {}
 func (*AwaitOutsideAsyncError) isSolverError()              {}
 func (*ForAwaitOutsideAsyncError) isSolverError()           {}
@@ -1779,8 +1784,7 @@ func (e *SetterReceiverError) Message() string {
 // signature is pre-declared before its body is walked so a sibling call resolves,
 // but an un-annotated return in a cycle stays an inference variable that the cycle
 // cannot ground on its own. An annotation on any member of the cycle breaks it, so
-// every member reports until one is annotated. This mirrors the recursion gate
-// top-level overloaded functions use (UnannotatedRecursiveOverloadError).
+// every member reports until one is annotated.
 type RecursiveMethodAnnotationError struct {
 	Name  string
 	Elem  *ast.MethodElem
@@ -2409,10 +2413,10 @@ func (e *NoMatchingOverloadError) Message() string {
 	return sb.String()
 }
 
-func (e *UnannotatedRecursiveOverloadError) Span() ast.Span      { return e.Decl.Span() }
-func (e *UnannotatedRecursiveOverloadError) Related() []ast.Span { return nil }
-func (e *UnannotatedRecursiveOverloadError) Message() string {
-	return "Overloaded function in a recursive group must have fully-annotated signatures: " + e.Name
+func (e *UndispatchableOverloadError) Span() ast.Span      { return e.Param.Span() }
+func (e *UndispatchableOverloadError) Related() []ast.Span { return []ast.Span{e.Decl.Span()} }
+func (e *UndispatchableOverloadError) Message() string {
+	return "Overload arm with a body must annotate every parameter to be dispatchable: " + e.Name
 }
 
 func (e *DuplicateOverloadError) Span() ast.Span      { return e.Decl.Span() }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -909,27 +909,6 @@ type NoMatchingOverloadError struct {
 	Candidates []TypeScheme
 }
 
-// UndispatchableOverloadError fires when an arm of an overload set has a body and
-// leaves one of its parameters un-annotated.
-//
-// An overload set with bodies compiles to a single JavaScript function whose if-else
-// chain tests each arm's written parameter annotations, so an un-annotated parameter
-// leaves the arm's guard with nothing to test. That guard degrades to `true` and the
-// arm then swallows every call that reaches it. A bodyless `declare fn` arm
-// contributes no branch to the chain and so is not reported.
-//
-// The set still infers and still binds. Inference reads the arms as one intersection of
-// arrows and needs no annotation; only the runtime dispatch does.
-//
-// It is a BRIDGE error: born in checkOverloadDispatch with the offending parameter in
-// hand, so it self-blames (Span() is the un-annotated parameter's pattern) and relates
-// the arm it belongs to. Name is the overloaded binding's name for the message.
-type UndispatchableOverloadError struct {
-	Param ast.Node
-	Decl  ast.Decl
-	Name  string
-}
-
 // DuplicateOverloadError fires when two arms of an overload set (PR6) are
 // indistinguishable for dispatch: they share an arity and have pointwise-equal
 // parameter types, so no call could ever select one over the other. An overload set
@@ -1222,7 +1201,6 @@ func (*BodyDeclNotAllowedError) isSolverError()             {}
 func (*MissingInitializerError) isSolverError()             {}
 func (*DuplicateDeclarationError) isSolverError()           {}
 func (*NoMatchingOverloadError) isSolverError()             {}
-func (*UndispatchableOverloadError) isSolverError()         {}
 func (*DuplicateOverloadError) isSolverError()              {}
 func (*AwaitOutsideAsyncError) isSolverError()              {}
 func (*ForAwaitOutsideAsyncError) isSolverError()           {}
@@ -2411,12 +2389,6 @@ func (e *NoMatchingOverloadError) Message() string {
 		sb.WriteString(renderScheme(s))
 	}
 	return sb.String()
-}
-
-func (e *UndispatchableOverloadError) Span() ast.Span      { return e.Param.Span() }
-func (e *UndispatchableOverloadError) Related() []ast.Span { return []ast.Span{e.Decl.Span()} }
-func (e *UndispatchableOverloadError) Message() string {
-	return "Overload arm with a body must annotate every parameter to be dispatchable: " + e.Name
 }
 
 func (e *DuplicateOverloadError) Span() ast.Span      { return e.Decl.Span() }

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -856,7 +856,6 @@ func (c *checker) bindSelf(scope *Scope, recv *ast.MethodReceiver, body *soltype
 // before its body is walked so a sibling call resolves, but an un-annotated return in a
 // cycle stays an inference variable the cycle cannot ground on its own, so it collapses to
 // `never` rather than a useful type. An annotation on any member of the cycle breaks it.
-// This mirrors the recursion gate top-level overloaded functions use.
 //
 // The check builds the call graph over instance methods with bodies — an edge from a
 // method arm to each sibling method its body reads through `self` — and inspects each

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -34,13 +34,10 @@ func TestInferOverloadResolvesByArgType(t *testing.T) {
 
 // Resolution dispatches on arity: f(5) hits the 1-param arm, f(5, "hi") the 2-param
 // arm.
-// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
-// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
-// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadDispatchesOnArity(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f<T>(x: T) -> T { return x }
-		fn f<T, U>(x: T, y: U) -> T { return x }
+		fn f(x) { return x }
+		fn f(x, y) { return x }
 		val a = f(5)
 		val b = f(5, "hi")
 	`)
@@ -126,12 +123,9 @@ val r = f(5)`},
 // Specificity beats declaration order: a concrete arm declared AFTER a generic one
 // still wins for a matching concrete argument (most-specific-first). f("hi") picks
 // the string arm even though the generic arm is declared first and would also match.
-// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
-// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
-// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadSpecificityBeatsDeclarationOrder(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f<T>(x: T) -> T { return x }
+		fn f(x) { return x }
 		fn f(x: string) -> boolean { return true }
 		val r = f("hi")
 	`)
@@ -203,55 +197,6 @@ func TestInferOverloadMutualRecursionResolvesPerArm(t *testing.T) {
 	require.Equal(t, "1", values["b"])
 }
 
-// Codegen compiles an overload set with bodies to one function whose if-else chain
-// tests each arm's written parameter annotations, so an arm with a body must annotate
-// every parameter. Each offending arm reports once, blaming its first un-annotated
-// parameter. The set still infers: the report is about dispatch, not about the fixed
-// point. Both arms here also end up with the same parameter type, which is the
-// separate indistinguishable-arms report.
-func TestInferOverloadImplementedArmNeedsParamAnnotation(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f(x) { return g(x) }
-		fn f(y) { return g(y) }
-		fn g(z: number) { return z }
-	`)
-	require.Len(t, errs, 3)
-	require.Equal(t,
-		"2:8-2:9: Overload arm with a body must annotate every parameter to be dispatchable: f",
-		msgWithSpan(errs[0]))
-	require.Equal(t,
-		"3:8-3:9: Overload arm with a body must annotate every parameter to be dispatchable: f",
-		msgWithSpan(errs[1]))
-	require.Equal(t,
-		"3:3-3:26: Overload arms must have distinguishable parameter types: f",
-		msgWithSpan(errs[2]))
-}
-
-// A `declare fn` arm contributes no branch to the generated dispatcher, so a
-// declare-only overload set keeps the freedom to leave a parameter un-annotated. This
-// is the `.d.ts`-shaped set the annotation obligation deliberately does not reach.
-func TestInferOverloadDeclareOnlyArmNeedsNoParamAnnotation(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		declare fn f(x)
-		declare fn f(x: string) -> boolean
-	`)
-	require.Empty(t, errs)
-	require.Equal(t, "(fn (x: unknown) -> undefined) & (fn (x: string) -> boolean)", values["f"])
-}
-
-// The obligation is per ARM, not per set: an implemented arm alongside a declare-only
-// one still has to annotate its parameters, and only the implemented arm reports.
-func TestInferOverloadMixedDeclareAndBodyReportsOnlyTheBody(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		declare fn f(x: string) -> boolean
-		fn f(y) { return y }
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t,
-		"3:8-3:9: Overload arm with a body must annotate every parameter to be dispatchable: f",
-		msgWithSpan(errs[0]))
-}
-
 // A self-recursive fully-annotated overload type-checks: each arm's recursive call
 // resolves against the whole pre-bound overload set (the number arm's f(x) hits the
 // number arm, the string arm's hits the string arm), so neither arm is wrongly
@@ -320,13 +265,10 @@ func TestInferOverloadValuePosition(t *testing.T) {
 // distinct types instead of cross-contaminating to "hi" | true. (Guards the
 // soltype.LevelOf recursion into IntersectionType — without it freshenAbove prunes
 // the level-0 intersection and aliases the arm's type variable across uses.)
-// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
-// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
-// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f<T>(x: T) -> T { return x }
-		fn f<T, U>(x: T, y: U) -> T { return x }
+		fn f(x) { return x }
+		fn f(x, y) { return x }
 		val g = f
 		val a = g("hi")
 		val b = g(true)
@@ -339,12 +281,9 @@ func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 // Value-position resolution uses the SAME specificity order as a direct call: a
 // concrete arm declared after a generic one wins for a matching concrete argument,
 // whether the callee is the overloaded name directly or a let-bound alias.
-// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
-// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
-// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 	direct, _, errs := inferSource(t, `
-		fn f<T>(x: T) -> T { return x }
+		fn f(x) { return x }
 		fn f(x: string) -> boolean { return true }
 		val r = f("hi")
 	`)
@@ -352,7 +291,7 @@ func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 	require.Equal(t, "boolean", direct["r"], "direct call picks the more specific arm")
 
 	binding, _, errs := inferSource(t, `
-		fn f<T>(x: T) -> T { return x }
+		fn f(x) { return x }
 		fn f(x: string) -> boolean { return true }
 		val g = f
 		val r = g("hi")
@@ -364,12 +303,9 @@ func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 // Three mixed arms (concrete-literal-ish, concrete-prim, generic) rank by specificity
 // without relying on a non-transitive comparator: each call with a concrete argument
 // selects the arm that accepts it, most-specific-first with declaration-order tiebreak.
-// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
-// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
-// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadThreeArmSpecificity(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f<T>(x: T) -> T { return x }
+		fn f(x) { return x }
 		fn f(x: number) -> boolean { return true }
 		fn f(x: string) -> string { return x }
 		val p = f(5)

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -34,6 +34,9 @@ func TestInferOverloadResolvesByArgType(t *testing.T) {
 
 // Resolution dispatches on arity: f(5) hits the 1-param arm, f(5, "hi") the 2-param
 // arm.
+// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
+// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
+// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadDispatchesOnArity(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f<T>(x: T) -> T { return x }
@@ -123,6 +126,9 @@ val r = f(5)`},
 // Specificity beats declaration order: a concrete arm declared AFTER a generic one
 // still wins for a matching concrete argument (most-specific-first). f("hi") picks
 // the string arm even though the generic arm is declared first and would also match.
+// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
+// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
+// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadSpecificityBeatsDeclarationOrder(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f<T>(x: T) -> T { return x }
@@ -314,6 +320,9 @@ func TestInferOverloadValuePosition(t *testing.T) {
 // distinct types instead of cross-contaminating to "hi" | true. (Guards the
 // soltype.LevelOf recursion into IntersectionType — without it freshenAbove prunes
 // the level-0 intersection and aliases the arm's type variable across uses.)
+// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
+// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
+// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f<T>(x: T) -> T { return x }
@@ -330,6 +339,9 @@ func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 // Value-position resolution uses the SAME specificity order as a direct call: a
 // concrete arm declared after a generic one wins for a matching concrete argument,
 // whether the callee is the overloaded name directly or a let-bound alias.
+// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
+// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
+// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 	direct, _, errs := inferSource(t, `
 		fn f<T>(x: T) -> T { return x }
@@ -352,6 +364,9 @@ func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 // Three mixed arms (concrete-literal-ish, concrete-prim, generic) rank by specificity
 // without relying on a non-transitive comparator: each call with a concrete argument
 // selects the arm that accepts it, most-specific-first with declaration-order tiebreak.
+// TODO(#1152): drop the explicit type parameters once codegen builds its guards from
+// inferred types. They are here only to satisfy checkOverloadDispatch. An un-annotated
+// `fn f(x)` infers identically, and that is the shape this test was written to exercise.
 func TestInferOverloadThreeArmSpecificity(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f<T>(x: T) -> T { return x }

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -32,13 +32,12 @@ func TestInferOverloadResolvesByArgType(t *testing.T) {
 	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"])
 }
 
-// Unannotated overloads are allowed when NOT recursive — arms are inferred
-// independently and resolution dispatches on arity: f(5) hits the 1-param arm,
-// f(5, "hi") the 2-param arm.
+// Resolution dispatches on arity: f(5) hits the 1-param arm, f(5, "hi") the 2-param
+// arm.
 func TestInferOverloadDispatchesOnArity(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { return x }
-		fn f(x, y) { return x }
+		fn f<T>(x: T) -> T { return x }
+		fn f<T, U>(x: T, y: U) -> T { return x }
 		val a = f(5)
 		val b = f(5, "hi")
 	`)
@@ -126,7 +125,7 @@ val r = f(5)`},
 // the string arm even though the generic arm is declared first and would also match.
 func TestInferOverloadSpecificityBeatsDeclarationOrder(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { return x }
+		fn f<T>(x: T) -> T { return x }
 		fn f(x: string) -> boolean { return true }
 		val r = f("hi")
 	`)
@@ -163,18 +162,87 @@ func TestInferOverloadNoMatch(t *testing.T) {
 		msgWithSpan(errs[0]))
 }
 
-// A mutually-recursive group containing an overloaded function with un-annotated
-// arms is rejected: the overload set must be ground before the group's bodies are
-// inferred. The error blames the offending overloaded participant.
-func TestInferOverloadMutualRecursionRequiresAnnotation(t *testing.T) {
+// An overloaded function in a mutually-recursive group infers without a return
+// annotation on any arm. The set reaches its binding variable as the single lower
+// bound `(number -> R1) & (string -> R2)`, and the recursive `f("hi")` inside g
+// records `v <: (string) -> R` against it. The arrow-decomposition rule settles that
+// by weighing both arms together, so nothing has to pick an arm before the group's
+// bodies are inferred and nothing has to be annotated to make that choice possible.
+func TestInferOverloadMutualRecursionInfersUnannotatedReturns(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) { return g(x) }
+		fn f(x: string) { return x }
+		fn g(n: number) { return f("hi") }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: number) -> string) & (fn (x: string) -> string)", values["f"])
+	require.Equal(t, "fn (n: number) -> string", values["g"])
+}
+
+// The same relaxation across a group whose recursion runs through BOTH arms: the
+// number arm returns a literal, the string arm recurses through g, and g calls back
+// into the number arm. Each call site reads its own arm's return type out of the
+// decomposition.
+func TestInferOverloadMutualRecursionResolvesPerArm(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) { return 1 }
+		fn f(x: string) { return g(x) }
+		fn g(s: string) { return f(1) }
+		val a = f(5)
+		val b = f("hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: number) -> 1) & (fn (x: string) -> 1)", values["f"])
+	require.Equal(t, "1", values["a"])
+	require.Equal(t, "1", values["b"])
+}
+
+// Codegen compiles an overload set with bodies to one function whose if-else chain
+// tests each arm's written parameter annotations, so an arm with a body must annotate
+// every parameter. Each offending arm reports once, blaming its first un-annotated
+// parameter. The set still infers: the report is about dispatch, not about the fixed
+// point. Both arms here also end up with the same parameter type, which is the
+// separate indistinguishable-arms report.
+func TestInferOverloadImplementedArmNeedsParamAnnotation(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		fn f(x) { g(x) }
-		fn f(y) { g(y) }
-		fn g(z) { f(z) }
+		fn f(x) { return g(x) }
+		fn f(y) { return g(y) }
+		fn g(z: number) { return z }
+	`)
+	require.Len(t, errs, 3)
+	require.Equal(t,
+		"2:8-2:9: Overload arm with a body must annotate every parameter to be dispatchable: f",
+		msgWithSpan(errs[0]))
+	require.Equal(t,
+		"3:8-3:9: Overload arm with a body must annotate every parameter to be dispatchable: f",
+		msgWithSpan(errs[1]))
+	require.Equal(t,
+		"3:3-3:26: Overload arms must have distinguishable parameter types: f",
+		msgWithSpan(errs[2]))
+}
+
+// A `declare fn` arm contributes no branch to the generated dispatcher, so a
+// declare-only overload set keeps the freedom to leave a parameter un-annotated. This
+// is the `.d.ts`-shaped set the annotation obligation deliberately does not reach.
+func TestInferOverloadDeclareOnlyArmNeedsNoParamAnnotation(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		declare fn f(x)
+		declare fn f(x: string) -> boolean
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: unknown) -> undefined) & (fn (x: string) -> boolean)", values["f"])
+}
+
+// The obligation is per ARM, not per set: an implemented arm alongside a declare-only
+// one still has to annotate its parameters, and only the implemented arm reports.
+func TestInferOverloadMixedDeclareAndBodyReportsOnlyTheBody(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		declare fn f(x: string) -> boolean
+		fn f(y) { return y }
 	`)
 	require.Len(t, errs, 1)
 	require.Equal(t,
-		"2:3-2:19: Overloaded function in a recursive group must have fully-annotated signatures: f",
+		"3:8-3:9: Overload arm with a body must annotate every parameter to be dispatchable: f",
 		msgWithSpan(errs[0]))
 }
 
@@ -248,8 +316,8 @@ func TestInferOverloadValuePosition(t *testing.T) {
 // the level-0 intersection and aliases the arm's type variable across uses.)
 func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { return x }
-		fn f(x, y) { return x }
+		fn f<T>(x: T) -> T { return x }
+		fn f<T, U>(x: T, y: U) -> T { return x }
 		val g = f
 		val a = g("hi")
 		val b = g(true)
@@ -264,7 +332,7 @@ func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 // whether the callee is the overloaded name directly or a let-bound alias.
 func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 	direct, _, errs := inferSource(t, `
-		fn f(x) { return x }
+		fn f<T>(x: T) -> T { return x }
 		fn f(x: string) -> boolean { return true }
 		val r = f("hi")
 	`)
@@ -272,7 +340,7 @@ func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 	require.Equal(t, "boolean", direct["r"], "direct call picks the more specific arm")
 
 	binding, _, errs := inferSource(t, `
-		fn f(x) { return x }
+		fn f<T>(x: T) -> T { return x }
 		fn f(x: string) -> boolean { return true }
 		val g = f
 		val r = g("hi")
@@ -286,7 +354,7 @@ func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 // selects the arm that accepts it, most-specific-first with declaration-order tiebreak.
 func TestInferOverloadThreeArmSpecificity(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { return x }
+		fn f<T>(x: T) -> T { return x }
 		fn f(x: number) -> boolean { return true }
 		fn f(x: string) -> string { return x }
 		val p = f(5)

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -162,6 +162,23 @@ func TestInferOverloadNoMatch(t *testing.T) {
 		msgWithSpan(errs[0]))
 }
 
+// An overloaded function in a mutually-recursive group must annotate the parameters of
+// every arm. The fixed point tells the arms apart by their domains, so leaving those to
+// inference collapses every arm onto the same `unknown` parameter. The error blames the
+// first arm with an un-annotated parameter, and the binding degrades to that arm, which
+// is why the indistinguishable-arms check does not also fire.
+func TestInferOverloadMutualRecursionRequiresAnnotation(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(x) { g(x) }
+		fn f(y) { g(y) }
+		fn g(z) { f(z) }
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"2:3-2:19: Overloaded function in a recursive group must annotate its parameters: f",
+		msgWithSpan(errs[0]))
+}
+
 // An overloaded function in a mutually-recursive group infers without a return
 // annotation on any arm. The set reaches its binding variable as the single lower
 // bound `(number -> R1) & (string -> R2)`, and the recursive `f("hi")` inside g

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -161,12 +161,6 @@ func (c *checker) inferComponent(
 ) {
 	inner := lvl + 1
 
-	// Every arm of an overload set that codegen emits a runtime dispatcher for must
-	// annotate its parameters, since the dispatcher tests those annotations. This is a
-	// codegen obligation, not a recursion one: inference itself needs no annotation,
-	// because an overload set enters the lattice as one intersection of arrows.
-	c.checkOverloadDispatch(g, component)
-
 	// Phase 1: a fresh var per value binding, all defined before any body so a
 	// mutually-recursive reference resolves through the var. M2 only infers value
 	// bindings; type-sort keys are handled (as unsupported) after the value walk.
@@ -747,53 +741,12 @@ func (c *checker) fuseOverloadArms(b *componentBinding) {
 	c.constrain(b.primary, &soltype.IntersectionType{Types: types}, b.v)
 }
 
-// checkOverloadDispatch reports every arm of an overload set that codegen would emit a
-// runtime dispatcher for and that leaves a parameter un-annotated.
-//
-// buildOverloadedFunc in internal/codegen compiles an overload set to one JavaScript
-// function whose if-else chain tests each arm's WRITTEN parameter annotations —
-// `typeof` for a primitive, `===` for a literal, `"k" in o` for an object shape,
-// `instanceof` for a class. An un-annotated parameter leaves nothing to test, so the
-// arm's guard degrades to `true` and swallows every call that reaches it. Requiring the
-// annotation is what keeps dispatch deterministic.
-//
-// The obligation is per arm and covers only arms with a body, since those are the arms
-// the dispatcher routes to. A bodyless `declare fn` arm contributes no branch, so a
-// `.d.ts`-shaped overload set keeps the freedom to leave a parameter un-annotated.
-//
-// Inference itself needs none of this. An overload set enters the lattice as one
-// intersection of arrows, the form fuseOverloadArms records, so a set that fails here
-// still infers and still binds.
-func (c *checker) checkOverloadDispatch(g *dep_graph.DepGraph, component []dep_graph.BindingKey) {
-	for _, key := range component {
-		funcs := funcOnlyDecls(g, key)
-		if len(funcs) <= 1 {
-			// Not an overload set. A name a `val`/`var` shares with a function is a
-			// duplicate declaration, reported in phase 2 rather than here.
-			continue
-		}
-		for _, fd := range funcs {
-			if fd.Body == nil {
-				continue // a declare-only arm gets no branch, so it has no guard to write
-			}
-			for _, p := range fd.FuncSig.Params {
-				if p.TypeAnn == nil && p.Pattern != nil {
-					c.report(&UndispatchableOverloadError{Param: p.Pattern, Decl: fd, Name: key.Name()})
-					// One diagnostic per arm, blaming the first parameter that is missing an
-					// annotation. Each arm is fixed on its own.
-					break
-				}
-			}
-		}
-	}
-}
-
 // funcOnlyDecls returns the FuncDecls bound to key when the name is bound ONLY by
 // FuncDecls, or nil when any `val`/`var` shares the name. A func-only result is a
 // candidate overload set. Its slice may have length 1, so it is not necessarily an
 // overload yet. A mixed result is nil because the clash is a duplicate declaration, not
-// an overload. Shared by checkOverloadDispatch, phase 2's fusion test, and
-// annotatedOverloadArms so all three classify a name the same way.
+// an overload. Shared by phase 2's fusion test and annotatedOverloadArms so both
+// classify a name the same way.
 func funcOnlyDecls(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
 	if key.Kind() != dep_graph.DepKindValue {
 		return nil

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -787,7 +787,7 @@ func (c *checker) checkOverloadAnnotations(
 			continue
 		}
 		for _, fd := range funcs {
-			if !hasAnnotatedParams(fd.FuncSig) {
+			if !allParamsAnnotated(fd.FuncSig) {
 				c.report(&UnannotatedRecursiveOverloadError{Decl: fd, Name: key.Name()})
 				rejected.Add(key)
 				break // one diagnostic per overloaded binding, blaming the first gap

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -79,12 +79,10 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 }
 
 // overloadArm is one collected arm of an overload set (PR6): a top-level FuncDecl's
-// raw inferred type plus whether its signature is fully annotated (the recursion
-// gate) and the decl itself (for per-arm Info recording in phase 3).
+// raw inferred type alongside the decl itself, which phase 3 records per-arm Info on.
 type overloadArm struct {
-	decl      *ast.FuncDecl
-	t         soltype.Type // the arm's RAW (variable-carrying) inferred FuncType
-	annotated bool
+	decl *ast.FuncDecl
+	t    soltype.Type // the arm's RAW (variable-carrying) inferred FuncType
 }
 
 // componentBinding tracks the in-flight state of one value binding while its
@@ -120,13 +118,13 @@ type componentBinding struct {
 	// FuncDecl's entry in sources.
 	arms []overloadArm
 	// signatureBound marks an overload set whose arms are ALL fully annotated, so phase
-	// 1 could build their signatures (body-free) and pre-bind the whole set in scope
-	// (b.arms holds the signature types). References WITHIN the component — recursive
-	// calls and value captures — then resolve against the set rather than a single
-	// first-arm var; phase 2 only checks each arm's body. An overload with any
-	// un-annotated arm cannot be signature-bound (its signature isn't known without
-	// inferring the body), so it stays on the ordinary group-var path and cannot be
-	// mutually recursive (the gate forbids it). See checkOverloadAnnotations / annotatedOverloadArms.
+	// 1 could build their signatures body-free and pre-bind the whole set in scope.
+	// b.arms then holds those signature types. A reference WITHIN the component — a
+	// recursive call or a value capture — resolves against the set rather than against a
+	// single first-arm var, and phase 2 only checks each arm's body. A set with any
+	// un-annotated arm has no signature to build without inferring the body, so it stays
+	// on the group-var path, where fuseOverloadArms records the whole set as one lower
+	// bound on that var. See annotatedOverloadArms.
 	signatureBound bool
 }
 
@@ -163,14 +161,11 @@ func (c *checker) inferComponent(
 ) {
 	inner := lvl + 1
 
-	// Recursion gate (PR6): an overloaded function in a mutually-recursive component
-	// (more than one binding) must have fully-annotated arms, since the overload set
-	// has to be ground before bodies are inferred — fixed-point iteration over
-	// overload choices is not guaranteed to converge under subtyping. The gate reports
-	// the offending participants and returns the set of keys to degrade to a single
-	// arm (so a later reference still resolves). Self-recursion (a singleton
-	// component) is softer and is not gated.
-	rejected := c.checkOverloadAnnotations(g, component)
+	// Every arm of an overload set that codegen emits a runtime dispatcher for must
+	// annotate its parameters, since the dispatcher tests those annotations. This is a
+	// codegen obligation, not a recursion one: inference itself needs no annotation,
+	// because an overload set enters the lattice as one intersection of arrows.
+	c.checkOverloadDispatch(g, component)
 
 	// Phase 1: a fresh var per value binding, all defined before any body so a
 	// mutually-recursive reference resolves through the var. M2 only infers value
@@ -184,29 +179,28 @@ func (c *checker) inferComponent(
 		// arm signatures alone (body-free), so references within the component resolve
 		// against every arm via resolveOverload instead of seeing only a single
 		// first-arm binding var (which would make a recursive arm — or a value capture —
-		// type-check against the wrong overload). The recursion gate guarantees a
-		// mutually-recursive overload IS fully annotated, so this is exactly the set it
-		// requires to be ground before bodies are inferred.
-		if !rejected.Contains(key) {
-			if armDecls := annotatedOverloadArms(g, key); armDecls != nil {
-				sortArmDecls(module, armDecls)
-				arms := make([]overloadArm, len(armDecls))
-				schemes := make([]TypeScheme, len(armDecls))
-				for i, fd := range armDecls {
-					// Build the signature body-free under a discarded probe: the arm is fully
-					// annotated, so the signature is concrete (no bounds to roll back), and
-					// discarding keeps phase 2's inferFunc — which re-derives the signature
-					// while checking the body — the single reporter of any signature error.
-					p := c.openProbe()
-					sig := c.inferFunc(scope, inner, fd.FuncSig, nil, fd, true)
-					c.closeProbe(p, false)
-					arms[i] = overloadArm{decl: fd, t: sig, annotated: true}
-					schemes[i] = monoScheme(sig)
-				}
-				bindings[key] = &componentBinding{arms: arms, bound: true, signatureBound: true}
-				scope.defineValue(key.Name(), ValueBinding{Schemes: schemes})
-				continue
+		// type-check against the wrong overload). Each recursive call then picks an arm
+		// and gets that arm's own return type, which is sharper than what the fused
+		// lower bound below derives. A set with any un-annotated arm cannot be built
+		// body-free, so it takes the fused path instead.
+		if armDecls := annotatedOverloadArms(g, key); armDecls != nil {
+			sortArmDecls(module, armDecls)
+			arms := make([]overloadArm, len(armDecls))
+			schemes := make([]TypeScheme, len(armDecls))
+			for i, fd := range armDecls {
+				// Build the signature body-free under a discarded probe: the arm is fully
+				// annotated, so the signature is concrete (no bounds to roll back), and
+				// discarding keeps phase 2's inferFunc — which re-derives the signature
+				// while checking the body — the single reporter of any signature error.
+				p := c.openProbe()
+				sig := c.inferFunc(scope, inner, fd.FuncSig, nil, fd, true)
+				c.closeProbe(p, false)
+				arms[i] = overloadArm{decl: fd, t: sig}
+				schemes[i] = monoScheme(sig)
 			}
+			bindings[key] = &componentBinding{arms: arms, bound: true, signatureBound: true}
+			scope.defineValue(key.Name(), ValueBinding{Schemes: schemes})
+			continue
 		}
 		v := c.freshAt(inner)
 		bindings[key] = &componentBinding{v: v}
@@ -363,6 +357,9 @@ func (c *checker) inferComponent(
 			}
 			continue
 		}
+		// An overload set reaches the binding var as ONE lower bound, the intersection of
+		// its arms, recorded after every arm is inferred. See fuseOverloadArms.
+		fused := len(funcOnlyDecls(g, key)) > 1
 		for _, d := range g.GetDecls(key) {
 			// M4 E3: a top-level destructuring `val [a, b] = …` / `val {x, y} = …`
 			// registers one decl under one leaf key per bound name. Bind it per key it
@@ -407,7 +404,11 @@ func (c *checker) inferComponent(
 			}
 			fd, isFunc := d.(*ast.FuncDecl)
 			if !b.bound {
-				c.constrain(d, t, b.v)
+				// An overload set's lower bound is the fusion of every arm, so the first arm
+				// is collected here and constrained after the loop rather than on its own.
+				if !fused {
+					c.constrain(d, t, b.v)
+				}
 				b.primary = d
 				b.bound = true
 				vd, isVarDecl := d.(*ast.VarDecl)
@@ -437,7 +438,7 @@ func (c *checker) inferComponent(
 				// more FuncDecls follow under this name it becomes an overload set; otherwise
 				// it stays a lone function.
 				if isFunc {
-					b.arms = append(b.arms, overloadArm{decl: fd, t: t, annotated: isFullyAnnotated(fd.FuncSig)})
+					b.arms = append(b.arms, overloadArm{decl: fd, t: t})
 				}
 				continue
 			}
@@ -448,7 +449,7 @@ func (c *checker) inferComponent(
 			// reports a duplicate — a second `val`/`var`, or a FuncDecl colliding with a
 			// variable binding, since a value cannot be overloaded.
 			if isFunc && !b.isVarDecl {
-				b.arms = append(b.arms, overloadArm{decl: fd, t: t, annotated: isFullyAnnotated(fd.FuncSig)})
+				b.arms = append(b.arms, overloadArm{decl: fd, t: t})
 				continue
 			}
 			c.report(&DuplicateDeclarationError{
@@ -456,6 +457,14 @@ func (c *checker) inferComponent(
 				Previous: b.primary,
 				Name:     key.Name(),
 			})
+		}
+		if fused {
+			// Sort before fusing, not only in phase 3. The fused bound is what an
+			// in-component recursive call is checked against, and specificityOrder settles a
+			// tie by position in the list it is handed, so an unsorted fusion would resolve
+			// such a call against a different arm order than the exported binding uses.
+			sortArms(module, b.arms)
+			c.fuseOverloadArms(b)
 		}
 	}
 
@@ -478,12 +487,9 @@ func (c *checker) inferComponent(
 			scope.removeValue(key.Name())
 			continue
 		}
-		// A PR6 overload set is a name with more than one FuncDecl arm. This branch binds
-		// such a set when the recursion gate did not reject it. A rejected set is a
-		// mutually-recursive unannotated overload. It is excluded here and degrades to its
-		// first arm below.
+		// A PR6 overload set is a name with more than one FuncDecl arm.
 		//
-		// Binding an accepted set takes four steps, each detailed at its block below:
+		// Binding a set takes four steps, each detailed at its block below:
 		//
 		//  1. sort the arms into source-position order;
 		//  2. reject any two arms with indistinguishable parameter types;
@@ -494,7 +500,7 @@ func (c *checker) inferComponent(
 		// the arm at arms[i], and Sources[i] all line up. b.sources also carries any
 		// rejected duplicate-declaration decls, which would desync the per-scheme index
 		// that a multi-target go-to-definition relies on.
-		if len(b.arms) > 1 && !rejected.Contains(key) {
+		if len(b.arms) > 1 {
 			// A signature-bound set was already sorted in phase 1, so this stable re-sort is
 			// a no-op for it. It also orders the ordinary group-var path's arms the same way.
 			sortArms(module, b.arms)
@@ -527,9 +533,6 @@ func (c *checker) inferComponent(
 			srcs := make([]provenance.Provenance, len(b.arms))
 			for i, arm := range b.arms {
 				sc := c.generalize(arm.t, lvl)
-				if ps, ok := sc.(*PolyScheme); ok {
-					ps.Annotated = arm.annotated
-				}
 				schemes[i] = sc
 				srcs[i] = &ast.NodeProvenance{Node: arm.decl}
 				if arm.decl.Name != nil {
@@ -542,8 +545,7 @@ func (c *checker) inferComponent(
 		// Generalize the binding var at the component's level (was: coalesce to a
 		// monotype). Every variable at Level > lvl becomes a quantified type
 		// parameter, captured outer variables do not — turning M2's monomorphic
-		// freeze into real let-polymorphism (PR1). A rejected overload degrades here to
-		// its first arm: b.v carries only the primary (first arm) definition.
+		// freeze into real let-polymorphism (PR1).
 		//
 		// PR8: a binding whose definition was wholly the ErrorType sentinel left its
 		// binding var with no bound (ErrorType absorbs in constrain), so generalizing it
@@ -714,42 +716,84 @@ func leafName(g *dep_graph.DepGraph, key dep_graph.BindingKey) string {
 	return name
 }
 
-// checkOverloadAnnotations enforces the PR6 recursion gate. It returns the set of
-// overloaded keys that failed the gate; phase 3 degrades each of them to its first arm.
-// A singleton component is never gated, since self-recursion is softer. Only a
-// genuinely mutually-recursive group of more than one binding requires its overloaded
-// members to have fully-annotated arms. For each overloaded member whose arms are not
-// all annotated, it reports an UnannotatedRecursiveOverloadError blaming the first
-// unannotated arm.
-func (c *checker) checkOverloadAnnotations(
-	g *dep_graph.DepGraph, component []dep_graph.BindingKey,
-) set.Set[dep_graph.BindingKey] {
-	rejected := set.NewSet[dep_graph.BindingKey]()
-	if len(component) <= 1 {
-		return rejected // self-recursion is softer; only mutual recursion is gated
+// fuseOverloadArms records an overload set's arms on its binding var as ONE lower
+// bound, the intersection of every arm's type.
+//
+// A reference from inside the component resolves through the var, so a recursive call
+// records `v <: (args) -> R` as an upper bound on it. The fused bound is what that
+// upper bound is checked against, and `(A -> B) & (C -> D) <: (args) -> R` is settled
+// by the arrow-decomposition rule in constrain_nf.go without any arm being picked.
+// That is what lets an overloaded function in a mutually-recursive group infer with no
+// annotations. Constraining only the first arm would instead check every recursive
+// call in the group against that one arm, which is why the set has to fuse.
+//
+// The fused bound serves resolution INSIDE the component. Phase 3 binds the name from
+// b.arms, generalizing each arm on its own, so the var's coalesced type is never the
+// overload's exported type.
+func (c *checker) fuseOverloadArms(b *componentBinding) {
+	if len(b.arms) == 0 {
+		return // every arm failed to produce a definition
 	}
+	if len(b.arms) == 1 {
+		// Only one arm survived inference, so there is nothing to fuse. Record it on its
+		// own, which is what the non-overloaded path would have done.
+		c.constrain(b.arms[0].decl, b.arms[0].t, b.v)
+		return
+	}
+	types := make([]soltype.Type, len(b.arms))
+	for i, arm := range b.arms {
+		types[i] = arm.t
+	}
+	c.constrain(b.primary, &soltype.IntersectionType{Types: types}, b.v)
+}
+
+// checkOverloadDispatch reports every arm of an overload set that codegen would emit a
+// runtime dispatcher for and that leaves a parameter un-annotated.
+//
+// buildOverloadedFunc in internal/codegen compiles an overload set to one JavaScript
+// function whose if-else chain tests each arm's WRITTEN parameter annotations —
+// `typeof` for a primitive, `===` for a literal, `"k" in o` for an object shape,
+// `instanceof` for a class. An un-annotated parameter leaves nothing to test, so the
+// arm's guard degrades to `true` and swallows every call that reaches it. Requiring the
+// annotation is what keeps dispatch deterministic.
+//
+// The obligation is per arm and covers only arms with a body, since those are the arms
+// the dispatcher routes to. A bodyless `declare fn` arm contributes no branch, so a
+// `.d.ts`-shaped overload set keeps the freedom to leave a parameter un-annotated.
+//
+// Inference itself needs none of this. An overload set enters the lattice as one
+// intersection of arrows, the form fuseOverloadArms records, so a set that fails here
+// still infers and still binds.
+func (c *checker) checkOverloadDispatch(g *dep_graph.DepGraph, component []dep_graph.BindingKey) {
 	for _, key := range component {
 		funcs := funcOnlyDecls(g, key)
 		if len(funcs) <= 1 {
-			continue // not an overload set (a mixed val/var name is a duplicate, not gated here)
+			// Not an overload set. A name a `val`/`var` shares with a function is a
+			// duplicate declaration, reported in phase 2 rather than here.
+			continue
 		}
 		for _, fd := range funcs {
-			if !isFullyAnnotated(fd.FuncSig) {
-				c.report(&UnannotatedRecursiveOverloadError{Decl: fd, Name: key.Name()})
-				rejected.Add(key)
-				break // one diagnostic per overloaded binding (blame the first gap)
+			if fd.Body == nil {
+				continue // a declare-only arm gets no branch, so it has no guard to write
+			}
+			for _, p := range fd.FuncSig.Params {
+				if p.TypeAnn == nil && p.Pattern != nil {
+					c.report(&UndispatchableOverloadError{Param: p.Pattern, Decl: fd, Name: key.Name()})
+					// One diagnostic per arm, blaming the first parameter that is missing an
+					// annotation. Each arm is fixed on its own.
+					break
+				}
 			}
 		}
 	}
-	return rejected
 }
 
 // funcOnlyDecls returns the FuncDecls bound to key when the name is bound ONLY by
 // FuncDecls, or nil when any `val`/`var` shares the name. A func-only result is a
 // candidate overload set. Its slice may have length 1, so it is not necessarily an
 // overload yet. A mixed result is nil because the clash is a duplicate declaration, not
-// an overload. Shared by the recursion gate and annotatedOverloadArms so both classify
-// a name the same way.
+// an overload. Shared by checkOverloadDispatch, phase 2's fusion test, and
+// annotatedOverloadArms so all three classify a name the same way.
 func funcOnlyDecls(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
 	if key.Kind() != dep_graph.DepKindValue {
 		return nil

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -161,6 +161,11 @@ func (c *checker) inferComponent(
 ) {
 	inner := lvl + 1
 
+	// An overloaded function in a mutually-recursive group must annotate its parameters,
+	// since the fixed point tells its arms apart by their domains. See
+	// checkOverloadAnnotations for what a set that fails this infers instead.
+	rejected := c.checkOverloadAnnotations(g, component)
+
 	// Phase 1: a fresh var per value binding, all defined before any body so a
 	// mutually-recursive reference resolves through the var. M2 only infers value
 	// bindings; type-sort keys are handled (as unsupported) after the value walk.
@@ -352,8 +357,10 @@ func (c *checker) inferComponent(
 			continue
 		}
 		// An overload set reaches the binding var as ONE lower bound, the intersection of
-		// its arms, recorded after every arm is inferred. See fuseOverloadArms.
-		fused := len(funcOnlyDecls(g, key)) > 1
+		// its arms, recorded after every arm is inferred. See fuseOverloadArms. A set the
+		// annotation gate rejected does not fuse: it degrades to its first arm, which is
+		// the recovery phase 3 binds it at.
+		fused := len(funcOnlyDecls(g, key)) > 1 && !rejected.Contains(key)
 		for _, d := range g.GetDecls(key) {
 			// M4 E3: a top-level destructuring `val [a, b] = …` / `val {x, y} = …`
 			// registers one decl under one leaf key per bound name. Bind it per key it
@@ -494,7 +501,7 @@ func (c *checker) inferComponent(
 		// the arm at arms[i], and Sources[i] all line up. b.sources also carries any
 		// rejected duplicate-declaration decls, which would desync the per-scheme index
 		// that a multi-target go-to-definition relies on.
-		if len(b.arms) > 1 {
+		if len(b.arms) > 1 && !rejected.Contains(key) {
 			// A signature-bound set was already sorted in phase 1, so this stable re-sort is
 			// a no-op for it. It also orders the ordinary group-var path's arms the same way.
 			sortArms(module, b.arms)
@@ -739,6 +746,55 @@ func (c *checker) fuseOverloadArms(b *componentBinding) {
 		types[i] = arm.t
 	}
 	c.constrain(b.primary, &soltype.IntersectionType{Types: types}, b.v)
+}
+
+// checkOverloadAnnotations requires every arm of an overloaded function in a
+// mutually-recursive group to annotate its parameters. It returns the keys that failed,
+// which phase 2 and phase 3 degrade to the binding's first arm so a later reference
+// still resolves.
+//
+// The requirement is about DOMAINS, not about whole signatures. An overload set reaches
+// the fixed point as one intersection of arrows, and the arrow-decomposition rule tells
+// its arms apart by which inputs each one accepts. Ground domains are what make that
+// separation possible. Leave them to inference and every arm of
+//
+//	fn f(x) { g(x) }
+//	fn f(y) { g(y) }
+//	fn g(z) { f(z) }
+//
+// widens to the same `(x: unknown) -> undefined`, with g inferring the vacuous
+// `μX0.(X0 | X0)`. The arms are then indistinguishable, which is a second diagnostic on
+// top of a set that says nothing.
+//
+// Return types carry no such requirement. They are outputs the body determines, and the
+// fixed point infers them through the same decomposition — see
+// TestInferOverloadMutualRecursionInfersUnannotatedReturns.
+//
+// A singleton component is never gated. Self-recursion resolves against the arm the
+// call selects rather than against a fixed point over the whole group.
+func (c *checker) checkOverloadAnnotations(
+	g *dep_graph.DepGraph, component []dep_graph.BindingKey,
+) set.Set[dep_graph.BindingKey] {
+	rejected := set.NewSet[dep_graph.BindingKey]()
+	if len(component) <= 1 {
+		return rejected
+	}
+	for _, key := range component {
+		funcs := funcOnlyDecls(g, key)
+		if len(funcs) <= 1 {
+			// Not an overload set. A name a `val`/`var` shares with a function is a
+			// duplicate declaration, reported in phase 2 rather than here.
+			continue
+		}
+		for _, fd := range funcs {
+			if !hasAnnotatedParams(fd.FuncSig) {
+				c.report(&UnannotatedRecursiveOverloadError{Decl: fd, Name: key.Name()})
+				rejected.Add(key)
+				break // one diagnostic per overloaded binding, blaming the first gap
+			}
+		}
+	}
+	return rejected
 }
 
 // funcOnlyDecls returns the FuncDecls bound to key when the name is bound ONLY by

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -720,17 +720,12 @@ func leafName(g *dep_graph.DepGraph, key dep_graph.BindingKey) string {
 // fuseOverloadArms records an overload set's arms on its binding var as ONE lower
 // bound, the intersection of every arm's type.
 //
-// A reference from inside the component resolves through the var, so a recursive call
-// records `v <: (args) -> R` as an upper bound on it. The fused bound is what that
-// upper bound is checked against, and `(A -> B) & (C -> D) <: (args) -> R` is settled
-// by the arrow-decomposition rule in constrain_nf.go without any arm being picked.
-// That is what lets an overloaded function in a mutually-recursive group infer with no
-// annotations. Constraining only the first arm would instead check every recursive
-// call in the group against that one arm, which is why the set has to fuse.
+// A recursive call inside the component records `v <: (args) -> R` as an upper bound on
+// the var, and the arrow-decomposition rule in constrain_nf.go settles that against the
+// fused bound by weighing the arms together rather than picking one.
 //
-// The fused bound serves resolution INSIDE the component. Phase 3 binds the name from
-// b.arms, generalizing each arm on its own, so the var's coalesced type is never the
-// overload's exported type.
+// The bound serves resolution INSIDE the component only. Phase 3 binds the name from
+// b.arms, so the var's coalesced type is never the overload's exported type.
 func (c *checker) fuseOverloadArms(b *componentBinding) {
 	if len(b.arms) == 0 {
 		return // every arm failed to produce a definition
@@ -750,28 +745,15 @@ func (c *checker) fuseOverloadArms(b *componentBinding) {
 
 // checkOverloadAnnotations requires every arm of an overloaded function in a
 // mutually-recursive group to annotate its parameters. It returns the keys that failed,
-// which phase 2 and phase 3 degrade to the binding's first arm so a later reference
-// still resolves.
+// which phases 2 and 3 degrade to the binding's first arm so a later reference still
+// resolves. A singleton component is not gated, since self-recursion resolves against
+// the arm the call selects rather than against a fixed point over the group.
 //
-// The requirement is about DOMAINS, not about whole signatures. An overload set reaches
-// the fixed point as one intersection of arrows, and the arrow-decomposition rule tells
-// its arms apart by which inputs each one accepts. Ground domains are what make that
-// separation possible. Leave them to inference and every arm of
-//
-//	fn f(x) { g(x) }
-//	fn f(y) { g(y) }
-//	fn g(z) { f(z) }
-//
-// widens to the same `(x: unknown) -> undefined`, with g inferring the vacuous
-// `μX0.(X0 | X0)`. The arms are then indistinguishable, which is a second diagnostic on
-// top of a set that says nothing.
-//
-// Return types carry no such requirement. They are outputs the body determines, and the
-// fixed point infers them through the same decomposition — see
-// TestInferOverloadMutualRecursionInfersUnannotatedReturns.
-//
-// A singleton component is never gated. Self-recursion resolves against the arm the
-// call selects rather than against a fixed point over the whole group.
+// The requirement is on DOMAINS, not whole signatures. The arrow-decomposition rule
+// tells a fused set's arms apart by which inputs each accepts, so leaving the parameters
+// to inference widens every arm onto the same `unknown` and infers nothing useful for
+// the group. Return types are outputs the same decomposition infers, which is the
+// relaxation this rule is scoped around.
 func (c *checker) checkOverloadAnnotations(
 	g *dep_graph.DepGraph, component []dep_graph.BindingKey,
 ) set.Set[dep_graph.BindingKey] {

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -459,6 +459,22 @@ func overloadDisplayType(b ValueBinding) soltype.Type {
 	return &soltype.IntersectionType{Types: arms}
 }
 
+// hasAnnotatedParams reports whether every parameter of a signature carries a type
+// annotation, so the function's DOMAIN is ground from what was written. The return type
+// is not consulted: it is an output the body determines, and the fixed point infers it.
+//
+// checkOverloadAnnotations requires this of every arm of an overloaded function in a
+// mutually-recursive group. Domains are what tell one arm of a fused overload set from
+// another, so an un-annotated one leaves the set indistinguishable to itself.
+func hasAnnotatedParams(sig ast.FuncSig) bool {
+	for _, p := range sig.Params {
+		if p.TypeAnn == nil {
+			return false
+		}
+	}
+	return true
+}
+
 // isFullyAnnotated reports whether a function signature is ground from its annotations
 // alone, with every parameter typed and a return type present. annotatedOverloadArms
 // requires this of every arm of an overload set it pre-binds from signatures, since an

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -14,10 +14,18 @@ import (
 // A set whose arms span several files in a lib/ therefore reads top-to-bottom, file by
 // file alphabetically, independent of the order sources reached the parser.
 //
-// Resolution is a phase distinct from constrain. The disjunction "callable in several
-// ways" stays out of the subtype lattice. It is driven by the PR5 probe. Each candidate
-// is trialled under a probe and the losers are rolled back, so a failed trial leaves no
-// bounds on the argument variables and no stray Info or Prov entries.
+// Resolution at a DIRECT call is a phase distinct from constrain. It is driven by the
+// PR5 probe. Each candidate is trialled under a probe and the losers are rolled back,
+// so a failed trial leaves no bounds on the argument variables and no stray Info or
+// Prov entries. Picking an arm is what gives the call that arm's own return type,
+// which is sharper than what the lattice derives.
+//
+// The lattice reads the same set without picking anything. An overload set is the
+// intersection of its arms, and the arrow-decomposition rule in constrain_nf.go settles
+// `(A -> B) & (C -> D) <: (args) -> R` by weighing the arms together. That is the form
+// a reference inside a mutually-recursive group takes, where no arm can be picked
+// because the arms are still being inferred. fuseOverloadArms in module.go records the
+// set in that form.
 //
 // Specificity ordering is the one documented rule, reused by M4 object-arg and M5 method
 // overloads. When every argument carries type information, meaning none is an
@@ -452,10 +460,9 @@ func overloadDisplayType(b ValueBinding) soltype.Type {
 }
 
 // isFullyAnnotated reports whether a function signature is ground from its annotations
-// alone, with every parameter typed and a return type present. The recursion gate
-// checkOverloadAnnotations requires this of every arm of an overloaded function in a
-// mutually-recursive group, since an un-annotated arm's signature is not known before
-// its body is inferred.
+// alone, with every parameter typed and a return type present. annotatedOverloadArms
+// requires this of every arm of an overload set it pre-binds from signatures, since an
+// un-annotated arm's signature is not known before its body is inferred.
 func isFullyAnnotated(sig ast.FuncSig) bool {
 	if sig.Return == nil {
 		return false

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -14,11 +14,11 @@ import (
 // A set whose arms span several files in a lib/ therefore reads top-to-bottom, file by
 // file alphabetically, independent of the order sources reached the parser.
 //
-// Resolution at a DIRECT call is a phase distinct from constrain. It is driven by the
-// PR5 probe. Each candidate is trialled under a probe and the losers are rolled back,
-// so a failed trial leaves no bounds on the argument variables and no stray Info or
-// Prov entries. Picking an arm is what gives the call that arm's own return type,
-// which is sharper than what the lattice derives.
+// Resolution at a DIRECT call is a phase distinct from constrain. Each candidate is
+// trialled under a probe and the losers are rolled back, so a failed trial leaves no
+// bounds on the argument variables and no stray Info or Prov entries. Picking an arm is
+// what gives the call that arm's own return type, which is sharper than what the
+// lattice derives.
 //
 // The lattice reads the same set without picking anything. An overload set is the
 // intersection of its arms, and the arrow-decomposition rule in constrain_nf.go settles

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -459,14 +459,16 @@ func overloadDisplayType(b ValueBinding) soltype.Type {
 	return &soltype.IntersectionType{Types: arms}
 }
 
-// hasAnnotatedParams reports whether every parameter of a signature carries a type
-// annotation, so the function's DOMAIN is ground from what was written. The return type
-// is not consulted: it is an output the body determines, and the fixed point infers it.
+// allParamsAnnotated reports whether EVERY parameter of a signature carries a type
+// annotation. One un-annotated parameter is enough to make it false. The return type is
+// not consulted: it is an output the body determines, and the fixed point infers it.
 //
-// checkOverloadAnnotations requires this of every arm of an overloaded function in a
+// A signature it accepts has a ground domain, meaning the set of arguments the function
+// takes is fixed by what was written rather than left to inference.
+// checkOverloadAnnotations requires that of every arm of an overloaded function in a
 // mutually-recursive group. Domains are what tell one arm of a fused overload set from
 // another, so an un-annotated one leaves the set indistinguishable to itself.
-func hasAnnotatedParams(sig ast.FuncSig) bool {
+func allParamsAnnotated(sig ast.FuncSig) bool {
 	for _, p := range sig.Params {
 		if p.TypeAnn == nil {
 			return false

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -11,23 +11,16 @@ import (
 // soltype.Type binding. A MonoScheme is a value that does not generalize (a
 // parameter, a current-level initializer during inference, a body-level `val`, a prelude
 // operator); a PolyScheme carries a generalize-level so each use can be
-// instantiated with fresh variables (let-polymorphism). The IsAnnotated bit is
-// forward-looking metadata for PR6's overload-recursion gate — PR1 sets it false
-// and never reads it.
+// instantiated with fresh variables (let-polymorphism).
 type TypeScheme interface {
 	isScheme()
-	// IsAnnotated reports whether this scheme came from a user-written signature.
-	// PR1 always returns false; PR6 sets it per overload arm and folds it over a
-	// binding's arms for the mutual-recursion-needs-annotation rule.
-	IsAnnotated() bool
 }
 
 // MonoScheme is a non-generalized type. instantiate returns its Ty unchanged, so
 // every use shares the same variables — the monomorphic discipline M2 had for
 // every binding, now scoped to the bindings that genuinely must not generalize.
 type MonoScheme struct {
-	Ty        soltype.Type
-	Annotated bool // PR6 only — consulted solely for overload arms
+	Ty soltype.Type
 }
 
 // PolyScheme is a generalized type. Body is the RAW (variable-carrying) type so
@@ -36,9 +29,8 @@ type MonoScheme struct {
 // captured from an enclosing scope (shared across uses). Level is the level the
 // binding was generalized at (the SCC component's level).
 type PolyScheme struct {
-	Level     int
-	Body      soltype.Type
-	Annotated bool // PR6 only — set per overload arm; folds for the recursion gate
+	Level int
+	Body  soltype.Type
 
 	// coalesced memoizes the display type. A Body is immutable after
 	// generalization. Later components instantiate fresh copies rather than
@@ -63,9 +55,6 @@ func (sc *PolyScheme) display() soltype.Type {
 	}
 	return sc.coalesced
 }
-
-func (s *MonoScheme) IsAnnotated() bool { return s.Annotated }
-func (s *PolyScheme) IsAnnotated() bool { return s.Annotated }
 
 // monoScheme wraps a raw type as a single-scheme value binding's scheme — the
 // common case for the param/prelude/body-level/raw-def bindings PR1 does not

--- a/planning/ml_struct/06-open-items.md
+++ b/planning/ml_struct/06-open-items.md
@@ -51,21 +51,22 @@ must be scoped, and static resolution must pick the same arm the dispatcher rout
 to (example A is where the two can disagree).
 
 **Residual decision:** the annotation-obligation scope plus the static-vs-runtime
-agreement test. Owned by **PR11 (#1068)**, and half settled there. The obligation
-covers *parameter* annotations on arms with a body, the arms `buildOverloadedFunc`
-emits a branch for; `checkOverloadDispatch` reports the rest. Declare-only arms are
-exempt, and inference carries no obligation at all, because `fuseOverloadArms` hands
-the whole set to the lattice as one intersection of arrows.
+agreement test. Owned by **PR11 (#1068)**, which delivered the inference half and
+deferred both decisions.
 
-The agreement half is deferred until the new checker feeds codegen, which is the **M12
-flip** in milestone 1 rather than anything MLstruct owns. `internal/codegen` reads the
-old `internal/checker`, which resolves overloads by first-match rather than by
-specificity, and nothing outside `internal/solver` imports the new checker. An ordering
-built to match `specificityOrder` would therefore disagree with the checker actually
-feeding codegen. Reconcile the two once the flip makes them one checker, reading
-inferred types rather than written annotations (#1152). **PR12 (#1069)** assumes the
-new checker is at or near default, so its rollout is the natural place for this to
-land.
+What PR11 settled is that the dispatcher's artifact is no longer what inference needs.
+`fuseOverloadArms` hands an overload set to the lattice as one intersection of arrows,
+so a recursive-group overload infers with no annotation on any arm. The obligation that
+used to stand in for that choice is gone from the checker.
+
+What PR11 deferred is everything that touches codegen, because `internal/codegen` reads
+the old `internal/checker` and nothing outside `internal/solver` imports the new one. An
+obligation reported by the new checker reaches no build, and an arm ordering built to
+match `specificityOrder` would disagree with the checker actually feeding codegen, which
+resolves overloads by first-match. Both wait for the **M12 flip** in milestone 1, when
+the two become one checker. #1152 tracks the shape they should take then: guards built
+from inferred types rather than written annotations, with the arm order derived from the
+checker's own ranking rather than mirrored over annotations.
 
 ## Finding 4 — `¬Ref` premises hold; the invariant is a construction-site guard (verified)
 

--- a/planning/ml_struct/06-open-items.md
+++ b/planning/ml_struct/06-open-items.md
@@ -51,7 +51,21 @@ must be scoped, and static resolution must pick the same arm the dispatcher rout
 to (example A is where the two can disagree).
 
 **Residual decision:** the annotation-obligation scope plus the static-vs-runtime
-agreement test. Owned by **PR11 (#1068)**.
+agreement test. Owned by **PR11 (#1068)**, and half settled there. The obligation
+covers *parameter* annotations on arms with a body, the arms `buildOverloadedFunc`
+emits a branch for; `checkOverloadDispatch` reports the rest. Declare-only arms are
+exempt, and inference carries no obligation at all, because `fuseOverloadArms` hands
+the whole set to the lattice as one intersection of arrows.
+
+The agreement half is deferred until the new checker feeds codegen, which is the **M12
+flip** in milestone 1 rather than anything MLstruct owns. `internal/codegen` reads the
+old `internal/checker`, which resolves overloads by first-match rather than by
+specificity, and nothing outside `internal/solver` imports the new checker. An ordering
+built to match `specificityOrder` would therefore disagree with the checker actually
+feeding codegen. Reconcile the two once the flip makes them one checker, reading
+inferred types rather than written annotations (#1152). **PR12 (#1069)** assumes the
+new checker is at or near default, so its rollout is the natural place for this to
+land.
 
 ## Finding 4 — `¬Ref` premises hold; the invariant is a construction-site guard (verified)
 

--- a/planning/ml_struct/06-open-items.md
+++ b/planning/ml_struct/06-open-items.md
@@ -51,22 +51,24 @@ must be scoped, and static resolution must pick the same arm the dispatcher rout
 to (example A is where the two can disagree).
 
 **Residual decision:** the annotation-obligation scope plus the static-vs-runtime
-agreement test. Owned by **PR11 (#1068)**, which delivered the inference half and
-deferred both decisions.
+agreement test. Owned by **PR11 (#1068)**, which scoped the obligation and deferred the
+agreement.
 
-What PR11 settled is that the dispatcher's artifact is no longer what inference needs.
-`fuseOverloadArms` hands an overload set to the lattice as one intersection of arrows,
-so a recursive-group overload infers with no annotation on any arm. The obligation that
-used to stand in for that choice is gone from the checker.
+The obligation is scoped to **parameters**, and it is an inference requirement rather
+than the codegen one this finding anticipated. An overload set reaches the fixed point
+as one intersection of arrows, and the arrow-decomposition rule tells its arms apart by
+their domains, so a mutually-recursive group needs those ground. Return types do not:
+the same decomposition infers them, which is the trigger-3 win. `checkOverloadAnnotations`
+enforces the narrowed rule; `fuseOverloadArms` delivers the relaxation.
 
-What PR11 deferred is everything that touches codegen, because `internal/codegen` reads
-the old `internal/checker` and nothing outside `internal/solver` imports the new one. An
-obligation reported by the new checker reaches no build, and an arm ordering built to
-match `specificityOrder` would disagree with the checker actually feeding codegen, which
-resolves overloads by first-match. Both wait for the **M12 flip** in milestone 1, when
-the two become one checker. #1152 tracks the shape they should take then: guards built
-from inferred types rather than written annotations, with the arm order derived from the
-checker's own ranking rather than mirrored over annotations.
+The agreement is deferred, along with any obligation stated on codegen's behalf.
+`internal/codegen` reads the old `internal/checker`, and nothing outside
+`internal/solver` imports the new one, so a rule reported by the new checker reaches no
+build and an arm ordering built to match `specificityOrder` would disagree with the
+checker actually feeding codegen, which resolves overloads by first-match. Both wait for
+the **M12 flip** in milestone 1. #1152 tracks the shape they should take then: guards
+built from inferred types rather than written annotations, with the arm order derived
+from the checker's own ranking rather than mirrored over annotations.
 
 ## Finding 4 — `¬Ref` premises hold; the invariant is a construction-site guard (verified)
 


### PR DESCRIPTION
Refs #1068 — this settles the inference half; see "What this does not do". Stacked on #1145.

MLstruct adoption trigger 3: making overload types lattice-first. Solver only.

## The relaxation

Under the previous design an overloaded call had to **pick a single arm** to know what to constrain. In a mutually recursive group that choice depends on the inferred types of the other members, which depend on the choices made at *their* recursive calls — a cycle that need not converge under subtyping. The old gate broke it by requiring **fully-annotated** arms.

PR5's arrow decomposition removes the choice. `fuseOverloadArms` records an overload set on its binding variable as **one lower bound**, the intersection of every arm, once every arm is inferred. A recursive call inside the group records `v <: (args) -> R` against it, and `(A → B) & (C → D) <: (args) -> R` is settled by weighing the arms together:

```
fn f(x: number) { return g(x) }
fn f(x: string) { return x }
fn g(n: number) { return f("hi") }
```

now infers `f: (fn (x: number) -> string) & (fn (x: string) -> string)`. No arm is picked, and no return type is written.

The fused bound serves resolution *inside* the component only. Phase 3 still binds the name from the arms, generalizing each on its own, so the variable's own coalesced type is never the overload's exported type. Arms are sorted into source-position order before fusing, so an in-component recursive call resolves against the same order the exported binding uses.

## What survives, narrowed

`UnannotatedRecursiveOverloadError` stays, scoped from whole signatures down to **parameters**. The two halves of the old rule turn out to be different in kind:

- **Domains must be ground.** The decomposition tells arms apart by which inputs each accepts. Leave the parameters to inference and every arm of a recursive group widens onto the same `unknown`, with the group itself inferring a vacuous `μX0.(X0 | X0)`. So this half is a genuine *inference* requirement, and it reports from the checker because the checker is what it protects.
- **Return types need not be.** They are outputs the same decomposition infers. This half is the trigger-3 win, and it is what the relaxation delivers.

`TestInferOverloadMutualRecursionRequiresAnnotation` and `TestInferOverloadMutualRecursionInfersUnannotatedReturns` sit side by side and pin exactly this line.

## What this does not do

#1068 also asks for an annotation obligation wherever a *dispatcher* is generated, and for static resolution to agree with the arm that dispatcher routes to. **Both are deferred**, and #1068 stays open.

An earlier revision carried the dispatcher obligation as `checkOverloadDispatch`. It is removed: `internal/codegen` reads the old `internal/checker`, and nothing outside `internal/solver` imports the new one, so the error reached no build while forcing existing tests to annotate arms inference handles fine. The reconciliation was also written (#1147) and measured (#1148); both are closed, because an ordering matching the new solver disagrees with the checker actually feeding codegen, which resolves by first-match.

All of it is tracked in #1152 and gated on the M12 flip. `planning/ml_struct/06-open-items.md` records the split.

## Also here

`TypeScheme.IsAnnotated` and the `Annotated` fields are removed. Nothing read them, and their only stated purpose was the old gate's fully-annotated form.

## Tests

`TestInferOverloadMutualRecursionRequiresAnnotation` keeps its original source and asserts the narrowed message. Joining it: `TestInferOverloadMutualRecursionInfersUnannotatedReturns` for the relaxation, and `TestInferOverloadMutualRecursionResolvesPerArm` for a group whose recursion runs through both arms, where each call site reads its own arm's return type out of the decomposition.

No existing test's source changed.

`go build ./...` and `go test ./...` pass. No fixture output changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TD84AZescKw86vPYRQMgde