### PR TITLE
Order the generated dispatcher to match static resolution

### DIFF
--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -1129,66 +1129,24 @@ func (b *Builder) buildOverloadedFunc(overloads []*ast.FuncDecl, nsName string) 
 	// All overloads should have the same name
 	funcName := overloads[0].Name.Name
 
-	// Filter out declare-only functions (they have no body)
+	// Order the arms so the chain tests the most specific first, matching the order the
+	// checker resolves a call in. See overload_order.go.
+	//
+	// The WHOLE set is ranked and the declare-only arms are dropped from the result,
+	// rather than dropped first and the rest ranked on their own. DispatchOrder ranks an
+	// arm by how many OTHER arms outrank it, so an arm removed before the ranking lowers
+	// the count of every arm it outranked. That can reorder two arms the checker, which
+	// ranks the whole set, kept apart.
 	var implementedOverloads []*ast.FuncDecl
-	for _, overload := range overloads {
+	for _, overload := range DispatchOrder(overloads) {
+		// A declare-only arm has no body to dispatch to, so it contributes no branch.
 		if overload.Body != nil {
 			implementedOverloads = append(implementedOverloads, overload)
 		}
 	}
-
-	// If all overloads are declare-only, skip codegen
 	if len(implementedOverloads) == 0 {
 		return []Stmt{}
 	}
-
-	// Helper function to count the specificity of a parameter type
-	// For object types, count the number of required properties
-	countTypeSpecificity := func(param *ast.Param) int {
-		if param.TypeAnn == nil {
-			return 0
-		}
-		switch typeAnn := param.TypeAnn.(type) {
-		case *ast.ObjectTypeAnn:
-			// Count required properties (non-optional)
-			count := 0
-			for _, elem := range typeAnn.Elems {
-				if propType, ok := elem.(*ast.PropertyTypeAnn); ok {
-					if !propType.Optional {
-						count++
-					}
-				}
-			}
-			return count
-		default:
-			return 1 // Default specificity for other types
-		}
-	}
-
-	// Sort overloads by specificity (descending) so that more specific overloads
-	// are checked first. This is necessary because without arity checks, function
-	// subtyping allows less specific functions to match more specific calls.
-	// We sort by: 1) parameter count (more first), 2) type specificity (more first)
-	slices.SortFunc(implementedOverloads, func(a, b *ast.FuncDecl) int {
-		// First, compare by parameter count
-		if len(a.Params) != len(b.Params) {
-			return len(b.Params) - len(a.Params) // Descending order
-		}
-
-		// If same parameter count, compare by type specificity
-		// Calculate total specificity for each overload
-		aSpecificity := 0
-		for _, param := range a.Params {
-			aSpecificity += countTypeSpecificity(param)
-		}
-
-		bSpecificity := 0
-		for _, param := range b.Params {
-			bSpecificity += countTypeSpecificity(param)
-		}
-
-		return bSpecificity - aSpecificity // Descending order
-	})
 
 	// Collect all unique parameter names across overloads
 	// We'll use the maximum parameter count and give them generic names

--- a/internal/codegen/overload_order.go
+++ b/internal/codegen/overload_order.go
@@ -17,7 +17,10 @@ import (
 // with one arm's return type must reach that arm at runtime. This file derives the
 // dispatcher's order so it matches the checker's.
 //
-// The order has three keys, applied in turn.
+// # The three ranking keys
+//
+// They are applied in turn: an arm's parameter count decides first, its specificity
+// breaks a tie there, and its source position breaks a tie in that.
 //
 //  1. Parameter count, descending. A guard tests only the parameters its own arm
 //     declares, so a one-parameter arm placed first would answer a two-argument call
@@ -38,16 +41,16 @@ import (
 // Key 2 ranks what the arm WROTE, while the checker ranks what it INFERRED. Three gaps
 // follow. Each is narrow, and each is documented at the code that leaves it.
 //
-//   - A parameter annotated with a type reference. annSubsumes reads the name and never
+//  1. A parameter annotated with a type reference. annSubsumes reads the name and never
 //     resolves it, so two references tie unless they were spelled the same way. The
 //     checker ranks the type the reference resolves to. An alias for a literal or for an
 //     object can therefore separate a pair this ties. Two class references are safe,
 //     because the checker ties those as well.
-//   - Key 3 orders by source id where armPosLess orders by file path. The compiler
+//  2. Key 3 orders by source id where armPosLess orders by file path. The compiler
 //     assigns ids by walking the source tree in lexical order, so the two agree for
 //     every program it builds. Only a caller that hands the parser sources in some other
 //     order can separate them.
-//   - Key 1's own gap. An optional or rest parameter widens the argument counts an arm
+//  3. Key 1's own gap. An optional or rest parameter widens the argument counts an arm
 //     accepts, so `(x: string, y?: number|string)` and `(x: string)` both accept a
 //     one-argument call. The checker ranks a pair of different arities by declaration
 //     order, while key 1 tests the longer arm first. A union is untestable, so that

--- a/internal/codegen/overload_order.go
+++ b/internal/codegen/overload_order.go
@@ -1,0 +1,368 @@
+package codegen
+
+import (
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/printer"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// The order the generated dispatcher tests overload arms in.
+//
+// buildOverloadedFunc compiles an overload set to one function whose if-else chain
+// runs each arm's guard in turn, so the order decides which arm answers a call two
+// arms both accept. The checker answers the same question statically in
+// internal/solver's resolveOverload. The two have to agree: a call the checker types
+// with one arm's return type must reach that arm at runtime. This file derives the
+// dispatcher's order so it matches the checker's.
+//
+// The order has three keys, applied in turn.
+//
+//  1. Parameter count, descending. A guard tests only the parameters its own arm
+//     declares, so a one-parameter arm placed first would answer a two-argument call
+//     the two-parameter arm was written for. The checker has no matching rule because
+//     it gates arity separately, in tryOverloadArm, before an arm is ranked at all. So
+//     this key is invisible to the checker rather than in conflict with it.
+//  2. Specificity, most specific first, mirroring the checker's specificityOrder. An
+//     arm is more specific than another when each of its parameters admits no more
+//     values than the matching parameter, and at least one admits strictly fewer. So
+//     `(x: 5)` is tested before `(x: number)`, and `({x, y})` before `({x})`.
+//  3. Source position — source id, then line, then column. This is the declaration
+//     order the checker's armPosLess pins. It settles every pair the first two keys
+//     leave tied. Sorting is what makes the two tiebreaks the same, since the dep graph
+//     hands its declarations back in the order they were registered.
+//
+// # Where the two orders can still differ
+//
+// Key 2 ranks what the arm WROTE, while the checker ranks what it INFERRED. Three gaps
+// follow. Each is narrow, and each is documented at the code that leaves it.
+//
+//   - A parameter annotated with a type reference. annSubsumes reads the name and never
+//     resolves it, so two references tie unless they were spelled the same way. The
+//     checker ranks the type the reference resolves to. An alias for a literal or for an
+//     object can therefore separate a pair this ties. Two class references are safe,
+//     because the checker ties those as well.
+//   - Key 3 orders by source id where armPosLess orders by file path. The compiler
+//     assigns ids by walking the source tree in lexical order, so the two agree for
+//     every program it builds. Only a caller that hands the parser sources in some other
+//     order can separate them.
+//   - Key 1's own gap. An optional or rest parameter widens the argument counts an arm
+//     accepts, so `(x: string, y?: number|string)` and `(x: string)` both accept a
+//     one-argument call. The checker ranks a pair of different arities by declaration
+//     order, while key 1 tests the longer arm first. A union is untestable, so that
+//     arm's `y` guard is a bare `true` and it answers a call the checker gave to the
+//     shorter arm. Closing this needs the dispatcher to test how many arguments it was
+//     called with, which it does not do.
+//
+// One further divergence lives on the checker's side rather than here. When a call
+// argument is a still-unconstrained variable, overloadOrder cannot rank the arms and
+// falls back to plain declaration order. So `fn g(y) { return f(y) }` pins y to the
+// FIRST arm rather than to the one specificity would choose, and a call through g can
+// reach a different arm than the one g was typed with. That fallback is the MVP
+// limitation #723 tracks, and deferred resolution retires this divergence with it.
+
+// DispatchOrder returns overloads in the order the generated if-else chain tests them.
+// The input is left untouched.
+//
+// It is exported so the checker's conformance corpus can measure its own resolution
+// order against this one. Nothing outside that check and buildOverloadedFunc should
+// need it.
+func DispatchOrder(overloads []*ast.FuncDecl) []*ast.FuncDecl {
+	ordered := make([]*ast.FuncDecl, len(overloads))
+	copy(ordered, overloads)
+	// Rank each arm by its DOMINATION COUNT — how many other arms are strictly more
+	// specific than it. Sorting on that integer rather than on the specificity relation
+	// itself is what keeps the sort well-defined. Specificity is only a partial order:
+	// `(x: number)` and `(x: string)` are incomparable, and incomparability is not
+	// transitive, so feeding the relation to a sort would break the strict-weak-ordering
+	// contract sort.SliceStable requires. A count is a total order on integers. An arm
+	// nothing dominates gets 0 and sorts first; the catch-all every other arm beats sorts
+	// last. internal/solver's specificityOrder ranks the same way.
+	dominators := make([]int, len(ordered))
+	for i := range ordered {
+		for j := range ordered {
+			if i == j || len(ordered[i].Params) != len(ordered[j].Params) {
+				continue
+			}
+			if armSpecificity(ordered[j], ordered[i]) < 0 {
+				dominators[i]++
+			}
+		}
+	}
+	order := make([]int, len(ordered))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(x, y int) bool {
+		a, b := order[x], order[y]
+		if len(ordered[a].Params) != len(ordered[b].Params) {
+			return len(ordered[a].Params) > len(ordered[b].Params)
+		}
+		if dominators[a] != dominators[b] {
+			return dominators[a] < dominators[b]
+		}
+		return earlierInSource(ordered[a], ordered[b])
+	})
+	sorted := make([]*ast.FuncDecl, len(ordered))
+	for i, idx := range order {
+		sorted[i] = ordered[idx]
+	}
+	return sorted
+}
+
+// earlierInSource reports whether a is declared before b, by source id, then line, then
+// column. It is the tiebreak internal/solver's armPosLess applies, with one difference.
+// armPosLess orders by file path where this orders by source id. The compiler assigns
+// ids by walking the source tree in lexical order, so id order is path order for every
+// program it builds.
+//
+// Ordering here at all is what matters most. The dep graph hands its declarations back
+// in the order they were registered, and no rule pins that order.
+func earlierInSource(a, b *ast.FuncDecl) bool {
+	as, bs := a.Span(), b.Span()
+	if as.SourceID != bs.SourceID {
+		return as.SourceID < bs.SourceID
+	}
+	if as.Start.Line != bs.Start.Line {
+		return as.Start.Line < bs.Start.Line
+	}
+	return as.Start.Column < bs.Start.Column
+}
+
+// armSpecificity compares two overload arms parameter by parameter. It returns -1 when
+// a is strictly more specific than b, +1 when b is, and 0 when neither is — either
+// because they are incomparable or because they admit the same arguments. Arms of
+// different arity are a 0 here; DispatchOrder separates those by parameter count
+// instead. This mirrors moreSpecific in internal/solver.
+func armSpecificity(a, b *ast.FuncDecl) int {
+	if len(a.Params) != len(b.Params) {
+		return 0
+	}
+	aParams := armParams(a)
+	bParams := armParams(b)
+	aSubB, bSubA := true, true
+	for i := range aParams {
+		if aSubB && !annSubsumes(aParams[i], bParams[i]) {
+			aSubB = false
+		}
+		if bSubA && !annSubsumes(bParams[i], aParams[i]) {
+			bSubA = false
+		}
+		if !aSubB && !bSubA {
+			return 0
+		}
+	}
+	if aSubB && !bSubA {
+		return -1
+	}
+	if bSubA && !aSubB {
+		return 1
+	}
+	return 0
+}
+
+// armParam is one parameter of an arm as the ordering reads it: the written annotation
+// plus whether that annotation admits every value.
+type armParam struct {
+	ann ast.TypeAnn
+	// top marks a parameter that accepts anything, so every other parameter is at least
+	// as specific as it. Two cases qualify, and they are the two the checker's
+	// structuralSubtype treats as the top of its own ordering by seeing a type variable:
+	// a parameter with no annotation, whose type is a fresh inference variable, and one
+	// annotated with the arm's own type parameter.
+	top bool
+}
+
+// armParams describes each of decl's parameters for the ordering.
+func armParams(decl *ast.FuncDecl) []armParam {
+	// The arm's own type parameters are the names that stand for a type variable rather
+	// than for a type. A signature with no `<…>` list allocates nothing.
+	var vars set.Set[string]
+	if len(decl.TypeParams) > 0 {
+		vars = set.NewSet[string]()
+		for _, tp := range decl.TypeParams {
+			vars.Add(tp.Name)
+		}
+	}
+	params := make([]armParam, len(decl.Params))
+	for i, p := range decl.Params {
+		params[i] = armParam{ann: p.TypeAnn, top: isTopAnn(p.TypeAnn, vars)}
+	}
+	return params
+}
+
+// isTopAnn reports whether ann admits every value: either there is no annotation, or it
+// names one of vars, the enclosing arm's own type parameters.
+func isTopAnn(ann ast.TypeAnn, vars set.Set[string]) bool {
+	if ann == nil {
+		return true
+	}
+	ref, ok := ann.(*ast.TypeRefTypeAnn)
+	if !ok || ref.Name == nil || vars == nil {
+		return false
+	}
+	return vars.Contains(ast.QualIdentToString(ref.Name))
+}
+
+// annSubsumes reports whether the values a admits are a subset of those b admits. It is
+// the dispatch-order counterpart of structuralSubtype in internal/solver, reading the
+// annotations the source wrote rather than the types the checker inferred. It is
+// deliberately partial in the same way. A pair it cannot rank returns false in both
+// directions, which armSpecificity reads as a tie and DispatchOrder settles by source
+// position.
+//
+// An annotation buildTypeGuard cannot test at runtime, such as a union or a function
+// type, is NOT top here. The checker does not treat one as top either, so such an arm
+// ties with everything and keeps its declared place. Its guard is still a bare `true`,
+// so an untestable arm declared first answers every call that reaches it. The checker's
+// resolution picks that same arm, which is the agreement this ordering is for, even
+// though the program would be better written with a testable annotation.
+func annSubsumes(a, b armParam) bool {
+	if b.top {
+		return true
+	}
+	if a.top {
+		return false
+	}
+	if sameAnn(a.ann, b.ann) {
+		return true
+	}
+	// A literal is one value out of its primitive's set, so `5` is more specific than
+	// `number`. The checker ranks a LitType under its PrimType the same way.
+	if lit, ok := a.ann.(*ast.LitTypeAnn); ok {
+		return litUnderPrimitive(lit.Lit, b.ann)
+	}
+	if ao, ok := a.ann.(*ast.ObjectTypeAnn); ok {
+		if bo, ok := b.ann.(*ast.ObjectTypeAnn); ok {
+			return objectAnnSubsumes(ao, bo)
+		}
+	}
+	return false
+}
+
+// sameAnn reports whether two annotations were written the same way, by rendering each
+// back to source and comparing the text. It stands in for the alpha-equality the
+// checker's structuralSubtype tests first, and covers every annotation form rather than
+// the handful the guard builder can test, so `{x: number | string}` compares equal to
+// itself even though no guard tests a union.
+//
+// Two annotations naming the same type through different spellings — an alias and its
+// expansion, a qualified and an unqualified reference — read as different here and rank
+// as a tie. The checker sees one type and ranks them equal, which is also a tie.
+func sameAnn(a, b ast.TypeAnn) bool {
+	aText, aOK := annText(a)
+	bText, bOK := annText(b)
+	return aOK && bOK && aText == bText
+}
+
+// annText renders an annotation back to Escalier source, reporting false for a nil
+// annotation or one the printer cannot render.
+func annText(ann ast.TypeAnn) (string, bool) {
+	if ann == nil {
+		return "", false
+	}
+	text, err := printer.Print(ann, printer.CompactOptions())
+	if err != nil {
+		return "", false
+	}
+	return text, true
+}
+
+// litUnderPrimitive reports whether lit is one of the values the primitive annotation
+// prim admits, the `5` under `number` case.
+func litUnderPrimitive(lit ast.Lit, prim ast.TypeAnn) bool {
+	switch lit.(type) {
+	case *ast.NumLit:
+		_, ok := prim.(*ast.NumberTypeAnn)
+		return ok
+	case *ast.StrLit:
+		_, ok := prim.(*ast.StringTypeAnn)
+		return ok
+	case *ast.BoolLit:
+		_, ok := prim.(*ast.BooleanTypeAnn)
+		return ok
+	}
+	return false
+}
+
+// objectAnnSubsumes reports whether object annotation a accepts a subset of what b
+// accepts. It ranks two axes and ignores a third, exactly as objectSubsumes does.
+//
+//   - Required-property count. The guard tests that each required property is present
+//     and that its value passes the property's own guard, so a is narrower when its
+//     required properties are a strict superset of b's. `{x: number, y: number}` is
+//     more specific than `{x: number}`. Every required property of b must appear in a
+//     as required and with the same property type; a property a is missing, has as
+//     optional, or types differently leaves the two incomparable and returns false.
+//   - The trailing `...` marker, consulted only when the required sets match. An exact
+//     `{x: number}` is more specific than an inexact `{x: number, ...}`, since it
+//     accepts no extra properties. The two emit the SAME guard, so this is the ranking
+//     that decides which of them answers a call both accept.
+//
+// Property types are NOT ranked. Two arms whose shared properties differ in type tie
+// here and fall back to source position.
+//
+// An optional property is never tested and widens the arm rather than narrowing it, so
+// it is not counted: `{x, y?}` accepts everything `{x}` accepts.
+func objectAnnSubsumes(a, b *ast.ObjectTypeAnn) bool {
+	requiredB := 0
+	for _, elem := range b.Elems {
+		prop, ok := elem.(*ast.PropertyTypeAnn)
+		if !ok {
+			return false // a non-property member is outside what the guard tests
+		}
+		if prop.Optional {
+			continue
+		}
+		requiredB++
+		match, found := lookupProp(a, propAnnName(prop))
+		if !found || match.Optional || !sameAnn(match.Value, prop.Value) {
+			return false
+		}
+	}
+	requiredA := 0
+	for _, elem := range a.Elems {
+		prop, ok := elem.(*ast.PropertyTypeAnn)
+		if !ok {
+			return false
+		}
+		if !prop.Optional {
+			requiredA++
+		}
+	}
+	if requiredA > requiredB {
+		return true
+	}
+	return !a.Inexact && b.Inexact
+}
+
+// lookupProp returns obj's property named name. A computed key has no name the guard
+// can test, so it never matches.
+func lookupProp(obj *ast.ObjectTypeAnn, name string) (*ast.PropertyTypeAnn, bool) {
+	if name == "" {
+		return nil, false
+	}
+	for _, elem := range obj.Elems {
+		prop, ok := elem.(*ast.PropertyTypeAnn)
+		if !ok {
+			continue
+		}
+		if propAnnName(prop) == name {
+			return prop, true
+		}
+	}
+	return nil, false
+}
+
+// propAnnName returns the property name the `"k" in o` guard tests, or "" for a
+// computed key buildTypeGuard skips.
+func propAnnName(prop *ast.PropertyTypeAnn) string {
+	switch key := prop.Name.(type) {
+	case *ast.IdentExpr:
+		return key.Name
+	case *ast.StrLit:
+		return key.Value
+	}
+	return ""
+}

--- a/internal/codegen/overload_order_test.go
+++ b/internal/codegen/overload_order_test.go
@@ -1,0 +1,149 @@
+package codegen
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// The dispatcher's if-else chain tests arms in the order DispatchOrder computes, so
+// the emitted chain is where that order is visible. Each case below writes an overload
+// set whose arms return different strings, so the order the guards appear in — and the
+// body each guard carries — names the order the arms are tested in.
+//
+// The checker ranks the same sets the same way; internal/solver's
+// TestOverloadDispatchAgreesWithResolution measures the two against each other.
+func TestBuildOverloadedFuncDispatchOrder(t *testing.T) {
+	tests := map[string]struct {
+		src      string
+		expected string
+	}{
+		// A literal admits one value out of its primitive's set, so its guard has to run
+		// before the primitive's. Testing `typeof param0 === "number"` first would swallow
+		// f(5) into the primitive arm, which is the arm the checker did NOT resolve it to.
+		"LiteralBeforeItsPrimitive": {
+			src: `fn f(x: number) -> string { return "n" }
+fn f(x: 5) -> string { return "five" }`,
+			expected: `export function f(param0) {
+  if (param0 === 5) {
+    const x = param0;
+    return "five";
+  } else if (typeof param0 === "number") {
+    const x = param0;
+    return "n";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+		// An object with more required properties accepts fewer arguments, so its guard
+		// runs first. Every `{x, y}` is also an `{x}`.
+		"MoreRequiredPropertiesFirst": {
+			src: `fn f(p: {x: number}) -> string { return "x" }
+fn f(p: {x: number, y: number}) -> string { return "xy" }`,
+			expected: `export function f(param0) {
+  if (param0 !== null && typeof param0 === "object" && "x" in param0 && typeof param0.x === "number" && "y" in param0 && typeof param0.y === "number") {
+    const p = param0;
+    return "xy";
+  } else if (param0 !== null && typeof param0 === "object" && "x" in param0 && typeof param0.x === "number") {
+    const p = param0;
+    return "x";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+		// A type parameter cannot be tested at runtime, so its guard is a bare `true`.
+		// Placed first it would answer every call, so it has to run last.
+		"UntestableArmLast": {
+			src: `fn f<T>(x: T) -> string { return "any" }
+fn f(x: string) -> string { return "s" }`,
+			expected: `export function f(param0) {
+  if (typeof param0 === "string") {
+    const x = param0;
+    return "s";
+  } else if (true) {
+    const x = param0;
+    return "any";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+		// Two primitives of different families accept disjoint arguments, so neither
+		// outranks the other and the chain keeps declaration order.
+		"DisjointPrimitivesKeepDeclarationOrder": {
+			src: `fn f(x: number) -> string { return "n" }
+fn f(x: string) -> string { return "s" }`,
+			expected: `export function f(param0) {
+  if (typeof param0 === "number") {
+    const x = param0;
+    return "n";
+  } else if (typeof param0 === "string") {
+    const x = param0;
+    return "s";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+		// A declare-only arm gets no branch of its own, but it still takes part in the
+		// ranking, because the checker ranks it too. Here `{y, w, ...}` outranks
+		// `{y, ...}`, which is what leaves the later `{x, ...}` arm ahead of it. Ranking
+		// only the arms that get a branch would drop that and put `{y, ...}` first, so
+		// f({x: 1, y: 2}) would return true where the checker typed it as a number.
+		"DeclareOnlyArmParticipatesInRanking": {
+			src: `fn f(p: {y: number, ...}) -> boolean { return true }
+declare fn f(p: {y: number, w: number, ...}) -> string
+fn f(p: {x: number, ...}) -> number { return 1 }`,
+			expected: `export function f(param0) {
+  if (param0 !== null && typeof param0 === "object" && "x" in param0 && typeof param0.x === "number") {
+    const p = param0;
+    return 1;
+  } else if (param0 !== null && typeof param0 === "object" && "y" in param0 && typeof param0.y === "number") {
+    const p = param0;
+    return true;
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+		// A guard tests only the parameters its own arm declares, so the arm with more
+		// parameters runs first. Otherwise `typeof param0 === "string"` alone would answer
+		// a two-argument call.
+		"MoreParametersFirst": {
+			src: `fn f(x: string) -> string { return "one" }
+fn f(x: string, y: string) -> string { return "two" }`,
+			expected: `export function f(param0, param1) {
+  if (typeof param0 === "string" && typeof param1 === "string") {
+    const x = param0;
+    const y = param1;
+    return "two";
+  } else if (typeof param0 === "string") {
+    const x = param0;
+    return "one";
+  } else throw new TypeError("No overload matches the provided arguments for function 'f'");
+}`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			module, parseErrs := parser.ParseLibFiles(ctx, []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: test.src},
+			})
+			require.Empty(t, parseErrs, "expected no parse errors")
+
+			depGraph := dep_graph.BuildDepGraph(module)
+			builder := &Builder{tempId: 0, depGraph: depGraph}
+			out := builder.BuildTopLevelDecls(depGraph)
+
+			printer := NewPrinter()
+			for i, stmt := range out.Stmts {
+				if i > 0 {
+					printer.NewLine()
+				}
+				printer.PrintStmt(stmt)
+			}
+			require.Equal(t, test.expected, printer.Output)
+		})
+	}
+}


### PR DESCRIPTION
Refs #1068. Third of four PRs splitting #1128 up, stacked on #1146.

An overload set with bodies compiles to one JavaScript function whose if-else chain runs each arm's guard in turn, so the order decides which arm answers a call two arms both accept. The checker settles the same question in `resolveOverload`, ranking by `specificityOrder`. When the two disagree, a call reaches an arm whose return type is not the one the checker gave it — soundness-adjacent, not cosmetic.

`DispatchOrder` in the new `internal/codegen/overload_order.go` derives the chain's order to match. It ranks by:

1. **Parameter count, descending.** A guard tests only the parameters its own arm declares. The checker has no counterpart because `tryOverloadArm` gates arity before an arm is ranked at all, so this key is invisible to the checker rather than in conflict with it.
2. **Specificity**, through a domination count — how many other arms outrank each one. Projecting onto an integer is what keeps the sort well-defined, since specificity is only a partial order and incomparability is not transitive. `specificityOrder` ranks the same way.
3. **Source position**, which settles what the first two leave tied. The dep graph hands its declarations back in registration order, which no rule pins.

Specificity reads the written parameter annotations: a literal under its primitive, an object whose required properties are a strict superset, an exact object over an inexact one with the same fields, and a type parameter or missing annotation as the catch-all that sorts last. Annotation equality is a comparison of the rendered source, so it covers forms no guard can test — `{x: number | string}` compares equal to itself even though nothing tests a union.

The ad-hoc sort this replaces counted required properties only, so it tested `(x: number)` before `(x: 5)` and kept declaration order for exactness. It also used an unstable sort, so ties were not pinned at all.

Two details worth a look in review:

- The **whole** set is ranked and declare-only arms are dropped from the result, not dropped first. An arm removed before the ranking lowers the count of every arm it outranked, which can reorder two arms the checker kept apart.
- An untestable-but-written annotation such as a union is **not** treated as the top of the ordering, because the checker does not treat it as top either. Its guard is still a bare `true`, so such an arm declared first answers every call reaching it — and the checker picks that same arm, which is the agreement this is for.

## Known divergences, documented rather than fixed

Three gaps remain, each documented at the code that leaves it:

- **Type references.** `annSubsumes` never resolves a reference, so an alias standing for a literal or an object can separate a pair this ties. Two class references are safe, since the checker ties those too.
- **Optional and rest parameters.** The dispatcher has no arity test, so `(x: string, y?: number|string)` can answer a one-argument call the checker gave to `(x: string)`. Pre-existing; closing it needs the dispatcher to test its argument count.
- **Unconstrained call arguments.** `overloadOrder` falls back to declaration order when it cannot rank, so a call through `fn g(y) { return f(y) }` can reach a different arm. That is the MVP limitation #723 tracks, and deferred resolution retires this with it.

One interim note: codegen is still fed by the old `internal/checker`, which resolves overloads by plain first-match. Aligning the dispatcher with `internal/solver` is what #1068 asks for and what PR12's flip assumes, but until that flip a program can exist where codegen's order differs from the old checker's pick. No fixture hits it — fixture output is unchanged by this PR.

The test that measures the two orders against each other lands in the next PR of the stack; `internal/codegen/overload_order_test.go` here pins the emitted chain for each rule.

`go build ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TD84AZescKw86vPYRQMgde

---
_Generated by [Claude Code](https://claude.ai/code/session_01TD84AZescKw86vPYRQMgde)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overload dispatch ordering for more predictable behavior.
  * Ensured more specific overloads and overloads with additional parameters are selected appropriately.
  * Improved handling of literal values, object properties, type parameters, and declare-only overloads.

* **Tests**
  * Added comprehensive coverage for overload dispatch scenarios, including ambiguous and disjoint types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->