### PR TITLE
Keep an intrinsic's residual bound on an inexact union's tail

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -441,10 +441,34 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen *seenPairs) (soltype.Typ
 func (c *Context) reduceResidual(t soltype.Type, seen *seenPairs) (soltype.Type, []SolverError, bool) {
 	e := newTypeEvaluator(c, seen)
 	reduced := e.reduce(t)
+	if u, ok := reduced.(*soltype.UnionType); ok {
+		// A union grounds even when its tail bound is a residual such as `Uppercase<string>`,
+		// the shape `Uppercase<keyof {a: number, ...}>` reduces to. The bound reduces at its own
+		// site: constraint solving folds it in as a disjunct and decides a value against it there
+		// through the fixed-point test, the same way the object and tuple arms ground with a
+		// residual field or element. Only a residual among the named members keeps the union
+		// symbolic, since such a member never settled to a value the union can offer.
+		if anyMemberResidual(u) {
+			return nil, nil, false
+		}
+		return reduced, e.errs, true
+	}
 	if containsResidualOp(reduced) {
 		return nil, nil, false
 	}
 	return reduced, e.errs, true
+}
+
+// anyMemberResidual reports whether a named member of u carries an unreduced operator. It reads the
+// named members only, since a union's tail bound is allowed to stay residual and reduces where a
+// value is decided against it.
+func anyMemberResidual(u *soltype.UnionType) bool {
+	for _, member := range u.Types {
+		if containsResidualOp(member) {
+			return true
+		}
+	}
+	return false
 }
 
 // maxUnwrapDepth caps how many type operators constrain may evaluate along one constraint path.

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"maps"
 	"math"
+	"strings"
 
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -874,6 +875,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		if sup, ok := super.(*soltype.StringIntrinsicType); ok {
 			return c.constrainStrLitToStringIntrinsic(sub, sup)
 		}
+		if sup, ok := super.(*soltype.TemplateLitType); ok {
+			return c.constrainStrLitToTemplateLit(sub, sup)
+		}
 	case *soltype.SkolemType:
 		// A skolem is a subtype of the same skolem and of its declared upper bound, so an
 		// unconstrained `T` fails against `number` or a distinct `U`, while a `<U: T>` skolem
@@ -1508,6 +1512,82 @@ func (c *Context) constrainStrLitToStringIntrinsic(sub *soltype.LitType, super *
 		return nil
 	}
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+}
+
+// constrainStrLitToTemplateLit checks a string-literal sub against a template-literal super, such as
+// `"onb" <: `on${string}``. A template denotes the strings its fixed quasi segments and its
+// interpolations spell out, so the literal is a subtype iff its characters match that pattern. The
+// match reads the literal left to right: each quasi must appear in order, and each interpolation
+// consumes a span the interpolation type admits. `"onb"` matches ``on${string}`` because it starts
+// with `on` and `b` is a string; `"xyz"` does not, since it lacks the `on` prefix. An interpolation
+// type templateMatchesString cannot decide — anything but a string literal, the `string` primitive,
+// or a union of those — makes the whole match fail, which reports the mismatch rather than guessing.
+func (c *Context) constrainStrLitToTemplateLit(sub *soltype.LitType, super *soltype.TemplateLitType) []SolverError {
+	strLit, ok := sub.Lit.(*soltype.StrLit)
+	if !ok {
+		return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+	}
+	if templateMatchesString(strLit.Value, super.Quasis, super.Interps) {
+		return nil
+	}
+	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+}
+
+// templateMatchesString reports whether s is one of the strings the template spells out. quasis holds
+// the fixed segments and interps the interpolations between them, so quasis is one longer than interps.
+// s must begin with the leading quasi; what remains is handed to the first interpolation, which peels
+// off the span it admits before the next quasi is matched. With no interpolations left, s matches only
+// when it has been consumed down to the empty string.
+func templateMatchesString(s string, quasis []string, interps []soltype.Type) bool {
+	if len(quasis) == 0 {
+		return false
+	}
+	if !strings.HasPrefix(s, quasis[0]) {
+		return false
+	}
+	rest := s[len(quasis[0]):]
+	if len(interps) == 0 {
+		return rest == ""
+	}
+	return matchInterp(rest, interps[0], quasis[1:], interps[1:])
+}
+
+// matchInterp reports whether some prefix of s is a value interp admits and the leftover matches the
+// rest of the template, quasis and interps. A string literal or a literal that renders as a string
+// consumes exactly its own characters. The `string` primitive consumes any prefix, so each split point
+// is tried until one lets the rest match. A union admits a prefix any member does. Any other
+// interpolation type is left undecided and fails the match.
+func matchInterp(s string, interp soltype.Type, quasis []string, interps []soltype.Type) bool {
+	switch it := interp.(type) {
+	case *soltype.LitType:
+		lit, ok := it.Lit.(*soltype.StrLit)
+		if !ok {
+			return false
+		}
+		if !strings.HasPrefix(s, lit.Value) {
+			return false
+		}
+		return templateMatchesString(s[len(lit.Value):], quasis, interps)
+	case *soltype.PrimType:
+		if it.Prim != soltype.StrPrim {
+			return false
+		}
+		for k := 0; k <= len(s); k++ {
+			if templateMatchesString(s[k:], quasis, interps) {
+				return true
+			}
+		}
+		return false
+	case *soltype.UnionType:
+		for _, member := range it.Types {
+			if matchInterp(s, member, quasis, interps) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
 }
 
 // ambiguousAlternate returns a union member, other than the one the decision committed to,

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -133,15 +133,16 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 		},
 		{
 			// An interpolation naming an open set of choices produces an open set of strings.
-			// The tail is bounded by `string` rather than left open, because a template
-			// produces a string whatever it interpolates. An open tail would accept a `5`.
+			// The tail is bounded by the template applied to the interpolation's own bound —
+			// `string` for an unbounded `...` — so it holds only strings the template can spell,
+			// `pad-${string}`, rather than every `string`. An open tail would accept a `5`.
 			name: "TemplateLitInexactInterp",
 			src: `
 				type Side = "left" | "right" | ...
 				type Result = ` + "`pad-${Side}`" + `
 			`,
 			wantSymbolic: "`pad-${Side}`",
-			wantExpanded: `"pad-left" | "pad-right" | ... : string`,
+			wantExpanded: `"pad-left" | "pad-right" | ... : ` + "`pad-${string}`",
 		},
 		{
 			// A string intrinsic maps each member of a closed operand union, and that is every

--- a/internal/solver/infer_template_lit_test.go
+++ b/internal/solver/infer_template_lit_test.go
@@ -322,3 +322,60 @@ func TestInferTemplateLitTooComplex(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, "template literal type `${D}${D}${D}` is too complex to reduce; it expands to more than 10000 members", errs[0].Message())
 }
+
+// templateMatchesString decides a string literal against a template pattern character by character,
+// matching each quasi in order and letting each interpolation consume a span its type admits. It is
+// the rule behind `"onb" <: `on${string}``, and the cases below drive every interpolation kind it
+// reads: a literal that must appear verbatim, the `string` primitive that consumes any span, a union
+// that matches when a member does, and the kinds it leaves undecided — a non-string primitive and a
+// bare type variable — which fail the match rather than guess.
+func TestTemplateMatchesString(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       string
+		quasis  []string
+		interps []soltype.Type
+		want    bool
+	}{
+		{"no quasis is not a template", "x", nil, nil, false},
+		{"a bare segment matches exactly", "hi", []string{"hi"}, nil, true},
+		{"a bare segment rejects a longer string", "hix", []string{"hi"}, nil, false},
+		{"a string interp takes any middle", "onb", []string{"on", ""}, []soltype.Type{str()}, true},
+		{"a string interp needs the prefix", "xyz", []string{"on", ""}, []soltype.Type{str()}, false},
+		{"a string interp allows an empty middle", "on", []string{"on", ""}, []soltype.Type{str()}, true},
+		{"a string interp matches up to a trailing quasi", "onbz", []string{"on", "z"}, []soltype.Type{str()}, true},
+		{"a literal interp matches its own text", "onax", []string{"on", "x"}, []soltype.Type{strLit("a")}, true},
+		{"a literal interp rejects other text", "onbx", []string{"on", "x"}, []soltype.Type{strLit("a")}, false},
+		{"a non-string literal interp is left undecided", "on5", []string{"on", ""}, []soltype.Type{numLit(5)}, false},
+		{"a number interp is left undecided", "n5", []string{"n", ""}, []soltype.Type{num()}, false},
+		{"a union interp matches through its string member", "onb", []string{"on", ""}, []soltype.Type{newUnion(nil, []soltype.Type{strLit("a"), str()}, false)}, true},
+		{"a union interp matches a literal member", "onb", []string{"on", ""}, []soltype.Type{newUnion(nil, []soltype.Type{strLit("a"), strLit("b")}, false)}, true},
+		{"a union interp rejects a non-member", "onc", []string{"on", ""}, []soltype.Type{newUnion(nil, []soltype.Type{strLit("a"), strLit("b")}, false)}, false},
+		{"a type-variable interp is left undecided", "onx", []string{"on", ""}, []soltype.Type{&soltype.TypeVarType{ID: 1, Level: 1}}, false},
+		{"two string interps backtrack to a split", "a-b", []string{"", "-", ""}, []soltype.Type{str(), str()}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, templateMatchesString(tt.s, tt.quasis, tt.interps))
+		})
+	}
+}
+
+// A template with two open interpolations builds a tail bound where each interp ranges over its named
+// choices and its bound, since a tail string may pair one interp's named choice with the other's
+// bound. `${keyof Obj}-${keyof Obj}` over `{a: number, ...}` keeps the named "a-a" and bounds the tail
+// by the three combinations that draw at least one side from `string`.
+func TestTemplateOverTwoOpenInterpsBoundsEachSide(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Obj = {a: number, ...}
+		type Result = `+"`${keyof Obj}-${keyof Obj}`"+`
+	`)
+	require.Empty(t, errs)
+	result := expandAliasResidual(ctx, nodes["Result"])
+	require.Equal(t, "\"a-a\" | ... : (`${string}-${string}` | `${string}-a` | `a-${string}`)", soltype.Print(result))
+
+	require.True(t, subtypeHolds(ctx, strLit("a-a"), result), "the named pairing is a member")
+	require.True(t, subtypeHolds(ctx, strLit("b-c"), result), "so is a pairing the tail bounds")
+	require.True(t, subtypeHolds(ctx, strLit("b-a"), result), "and one pairing a name with a bound string")
+	require.False(t, subtypeHolds(ctx, strLit("xyz"), result), "a string the template cannot spell is not")
+}

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -1074,20 +1074,23 @@ func TestOperatorResultsOverABoundedTailStayUsable(t *testing.T) {
 	// A template produces a string whatever it interpolates, so its tail is bounded by
 	// `string`. An unbounded tail admits every value, which would let a number pass for a
 	// string the template could have produced.
-	t.Run("a template over an open key set still rejects a non-string", func(t *testing.T) {
+	t.Run("a template over an open key set keeps its prefix in the tail bound", func(t *testing.T) {
 		nodes, ctx, errs := inferTypeNodes(t, `
 			type Obj = {a: number, ...}
 			type Result = `+"`on${keyof Obj}`"+`
 		`)
 		require.Empty(t, errs)
 		result := expandAliasResidual(ctx, nodes["Result"])
-		require.Equal(t, "\"ona\" | ... : string", soltype.Print(result))
+		require.Equal(t, "\"ona\" | ... : `on${string}`", soltype.Print(result))
 
-		c := newChecker()
-		require.False(t, subtypeHolds(c.ctx, numLit(5), result), "a template never produces a number")
-		require.False(t, subtypeHolds(c.ctx, &soltype.LitType{Lit: &soltype.BoolLit{Value: true}}, result), "nor a boolean")
-		require.True(t, subtypeHolds(c.ctx, strLit("ona"), result), "the named string is a member")
-		require.True(t, subtypeHolds(c.ctx, strLit("onb"), result), "so is one the tail may hold")
+		// The tail bound is the template applied to the operand's `string` bound, so the tail holds
+		// only strings the template can spell. Widening it to `string` would have admitted a bare
+		// "xyz" the original never produced.
+		require.False(t, subtypeHolds(ctx, numLit(5), result), "a template never produces a number")
+		require.False(t, subtypeHolds(ctx, &soltype.LitType{Lit: &soltype.BoolLit{Value: true}}, result), "nor a boolean")
+		require.False(t, subtypeHolds(ctx, strLit("xyz"), result), "nor a string outside the template's shape")
+		require.True(t, subtypeHolds(ctx, strLit("ona"), result), "the named string is a member")
+		require.True(t, subtypeHolds(ctx, strLit("onb"), result), "so is one the tail may hold")
 	})
 
 	// A bound the intrinsic cannot fold comes back as an unreduced operator such as

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -469,12 +469,12 @@ func TestOperatorsCarryTheTailBound(t *testing.T) {
 		{
 			// A string intrinsic transforms the bound alongside the named members. Only a
 			// literal has a case to change, so transforming `string` yields the unreduced
-			// `Uppercase<string>`, which is widened to `string`. A union carrying an
-			// unreduced operator anywhere reads as residual, and constraint solving then
-			// decides against the operator instead of the union it belongs to.
+			// `Uppercase<string>`, kept as the tail's bound. It names the exact set the tail
+			// draws from, and constraint solving folds it in as a disjunct and decides a
+			// literal against it through the fixed-point test.
 			name: "StringIntrinsic",
 			decl: `type Result = Uppercase<keyof Obj>`,
-			want: `"A" | "B" | ... : string`,
+			want: `"A" | "B" | ... : Uppercase<string>`,
 		},
 	}
 	for _, tt := range tests {
@@ -1090,22 +1090,27 @@ func TestOperatorResultsOverABoundedTailStayUsable(t *testing.T) {
 		require.True(t, subtypeHolds(c.ctx, strLit("onb"), result), "so is one the tail may hold")
 	})
 
-	// A bound the intrinsic cannot fold comes back as an unreduced operator, and a union
-	// carrying one anywhere reads as residual. Constraint solving would then decide against
-	// the operator rather than the union, rejecting a string the union plainly names.
+	// A bound the intrinsic cannot fold comes back as an unreduced operator such as
+	// `Uppercase<string>`, kept as the tail's bound. It names the exact set the tail draws from,
+	// the strings a round trip through the intrinsic leaves unchanged. Constraint solving folds
+	// the bound in as a disjunct and decides a literal against it through the fixed-point test,
+	// so the union accepts `"A"` and rejects `"a"`.
 	t.Run("an intrinsic over an open key set still accepts its own member", func(t *testing.T) {
 		nodes, ctx, errs := inferTypeNodes(t, `
 			type Obj = {a: number, ...}
 			type Result = Uppercase<keyof Obj>
 		`)
 		require.Empty(t, errs)
-		result := expandAliasResidual(ctx, nodes["Result"])
-		require.Equal(t, `"A" | ... : string`, soltype.Print(result))
+		require.Equal(t, `"A" | ... : Uppercase<string>`, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
 
-		c := newChecker()
-		require.False(t, containsResidualOp(result), "a residual union is decided against the operator")
-		require.True(t, subtypeHolds(c.ctx, strLit("A"), result), "the transformed key is a member")
-		require.False(t, subtypeHolds(c.ctx, numLit(5), result), "the bound still rules out a non-string")
+		// Constrain against the un-expanded alias inside the inference context, the path a
+		// `val u: Uppercase<keyof Obj> = "A"` annotation takes. The intrinsic super reduces to
+		// the union, whose residual tail bound grounds because only its named members must
+		// settle, and the literal decides against the bound as a folded disjunct.
+		raw := nodes["Result"]
+		require.True(t, subtypeHolds(ctx, strLit("A"), raw), "the transformed key is a member")
+		require.False(t, subtypeHolds(ctx, strLit("a"), raw), "the bound admits only uppercase-invariant strings")
+		require.False(t, subtypeHolds(ctx, numLit(5), raw), "the bound still rules out a non-string")
 	})
 
 	// An index read that cannot ground the bound has no answer to commit to. Answering anyway

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -1125,6 +1125,21 @@ func TestOperatorResultsOverABoundedTailStayUsable(t *testing.T) {
 		require.Equal(t, `({x: number} | ... : string)["x"]`, soltype.Print(got))
 	})
 
+	// A residual tail bound lets a union ground, since the bound decides at its own site. A
+	// residual named member does not: `Uppercase<"a" | keyof T>` reduces to
+	// `"A" | Uppercase<keyof T>`, whose second member never settles while `T` is abstract. A
+	// union offering a member it cannot name stays symbolic, so no literal can be decided
+	// against it and the whole intrinsic reduces once `T` grounds.
+	t.Run("an intrinsic over a union with a residual member stays symbolic", func(t *testing.T) {
+		c := newChecker()
+		v := c.ctx.freshVar(0)
+		intrinsic := &soltype.StringIntrinsicType{
+			Kind:    soltype.Uppercase,
+			Operand: &soltype.UnionType{Types: []soltype.Type{strLit("a"), &soltype.KeyofType{Operand: v}}},
+		}
+		require.False(t, subtypeHolds(c.ctx, strLit("A"), intrinsic), "an unsettled member blocks a decision")
+	})
+
 	// Keeping only the named key leaves a tail drawn from `string ∩ "a"`, which is `"a"` — a key
 	// the union already names. An unfused meet would hide that and leave the tail standing,
 	// which makes the union inexact and stops it satisfying an exact object.

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1934,19 +1934,15 @@ func (e *typeEvaluator) reduceStringIntrinsic(kind soltype.StringIntrinsicKind, 
 		// becomes `"A"` exactly as a named member does.
 		//
 		// Only a string LITERAL has a case to change, so a bound the transform cannot fold
-		// comes back as an unreduced operator. `Uppercase<string>` is one. Such a bound is
-		// widened to `string` rather than kept, because a bound is part of the union and a
-		// union carrying an unreduced operator anywhere reads as residual. Constraint
-		// solving then decides against the opaque operator and rejects
-		// `val u: Uppercase<keyof {a: number, ...}> = "A"`. Widening is sound, since the
-		// intrinsic maps strings to strings, and it keeps the tail bounded where dropping it
-		// would leave the union at the top of the lattice.
+		// comes back as an unreduced operator. `Uppercase<string>` is one, and it is kept as
+		// the tail's bound rather than widened. It names the exact set the tail draws from,
+		// the strings a round trip through the intrinsic leaves unchanged, so
+		// `val u: Uppercase<keyof {a: number, ...}> = "A"` holds and `= "a"` is rejected.
+		// Constraint solving folds the bound in as a disjunct and decides a literal against
+		// it through the fixed-point test `applyStringIntrinsic(kind, v) == v`.
 		tail := tailOf(op)
 		if tail.bound != nil {
 			tail.bound = e.reduceStringIntrinsic(kind, tail.bound)
-			if containsResidualOp(tail.bound) {
-				tail.bound = &soltype.PrimType{Prim: soltype.StrPrim}
-			}
 		}
 		return newUnionWithTail(nil, parts, tail)
 	case *soltype.LitType:

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -1784,15 +1785,16 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, i
 // set of choices produces an open set of strings (exact-types §5.6). `on${"a" | "b"}` reduces to
 // the exact `"ona" | "onb"`, while `on${"a" | "b" | ...}` reduces to `"ona" | "onb" | ...`.
 //
-// A tail's bound is not folded into the result. The bound says the tail's choices are strings
-// without saying which, so no segment can absorb them. The result's tail is bounded by `string`
-// all the same, since a template produces a string whatever it interpolates. Leaving it unbounded
-// would make the result the top of the subtype lattice, so a template interpolating
-// `keyof {a: number, ...}` would accept a `5`.
-// An interpolation that names no choice at all, which is the shape a set difference leaves when it
-// excludes every named one, has nothing to run the product over and keeps the template symbolic.
+// A tail's bound is not folded into a named result string, since it says the tail's choices are
+// strings without saying which, so no segment can absorb them. It becomes the result's own tail
+// bound instead, transformed by the same template: `on${"a" | ...string}` reduces to
+// `"ona" | ...`on${string}``, keeping the result to strings the template can spell rather than
+// widening to every `string`. templateTailBound assembles that bound. An interpolation that names
+// no choice at all, which is the shape a set difference leaves when it excludes every named one,
+// has nothing to run the product over and keeps the template symbolic.
 func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Type {
 	interpChoices := make([][]soltype.Type, len(t.Interps))
+	interpBound := make([]soltype.Type, len(t.Interps))
 	combinations := 1
 	openChoices := false
 	for i, interp := range t.Interps {
@@ -1815,6 +1817,17 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 				members[j] = e.groundOperand(m)
 			}
 			interpChoices[i] = members
+			if u.Inexact {
+				// The interp has unnamed choices the tail draws from, so record the bound they come
+				// from; a non-nil entry marks this interp open. A bounded tail says which strings
+				// those are; an unbounded `...` says only that they are strings, so the bound is
+				// `string`. Either way the result's tail ranges over the template applied to it.
+				if u.TailBound != nil {
+					interpBound[i] = e.groundOperand(u.TailBound)
+				} else {
+					interpBound[i] = &soltype.PrimType{Prim: soltype.StrPrim}
+				}
+			}
 		} else {
 			interpChoices[i] = []soltype.Type{reduced}
 		}
@@ -1832,9 +1845,31 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 		parts = append(parts, foldTemplatePart(t.Quasis, combo))
 	}
 	if openChoices {
-		return newBoundedUnion(nil, parts, &soltype.PrimType{Prim: soltype.StrPrim})
+		return newBoundedUnion(nil, parts, e.templateTailBound(t.Quasis, interpChoices, interpBound))
 	}
 	return newUnion(nil, parts, false)
+}
+
+// templateTailBound builds the bound on an open template's tail: the strings a combination drawing at
+// least one interpolation from an open interp's bound can spell. It is a template whose interpolations
+// range over each interp's full set of choices — its named ones, and its bound where the interp is
+// open, marked by a non-nil bound[i]. A tail string may pair one interp's named choice with another's
+// bound, so both are kept. Reducing the assembled template enumerates every combination, the all-named
+// one included; newBoundedUnion's narrowing then strips the combinations the outer union already lists
+// as members, leaving just what the tail adds — `on${string}` for a lone open interp, and the cross
+// combinations when several are open. A `string` interpolation stays symbolic through the reduction,
+// which the literal-vs-template subtyping rule then decides a member against.
+func (e *typeEvaluator) templateTailBound(quasis []string, choices [][]soltype.Type, bound []soltype.Type) soltype.Type {
+	interps := make([]soltype.Type, len(choices))
+	for i := range choices {
+		reps := choices[i]
+		if bound[i] != nil {
+			reps = append(slices.Clone(choices[i]), bound[i])
+		}
+		// newUnion collapses a lone choice to itself, so a closed interp keeps its single value.
+		interps[i] = newUnion(nil, reps, false)
+	}
+	return e.reduceTemplateLit(&soltype.TemplateLitType{Quasis: quasis, Interps: interps})
 }
 
 // foldTemplatePart folds one cartesian-product combination into a single template result. It


### PR DESCRIPTION
Refs #1126. Implements "Tier 2" of the `Uppercase<keyof {...}>` discussion, building on the literal-vs-intrinsic subtyping rule merged as #1144 ("Tier 1").

Stacked on top of #1138. Review only the final commit here; the earlier ones belong to #1136 → #1137 → #1138.

## What changed

`Uppercase<keyof {a: number, ...}>` reduces to a bounded union. The named key `a` transforms to `"A"`, and the tail draws from the operand union's own bound, `string`, transformed the same way. `Uppercase<string>` has no literal case to fold, so it comes back as an unreduced operator.

Previously that residual bound was **widened to `string`**, giving `"A" | ...string`. That admitted lowercase strings the original key set never held, so `val u: Uppercase<keyof {a: number, ...}> = "a"` was wrongly accepted.

This PR **keeps the bound** as `Uppercase<string>`, giving `"A" | ...Uppercase<string>`. The bound names the exact set the tail draws from, the strings a round trip through the intrinsic leaves unchanged. Constraint solving folds the bound in as a disjunct and decides a literal against it through the fixed-point test `applyStringIntrinsic(kind, v) == v` that #1144 added. The result:

- `val u: Uppercase<keyof {a: number, ...}> = "A"` holds
- `val u: Uppercase<keyof {a: number, ...}> = "a"` is rejected

## Two edits

1. **`reduceStringIntrinsic`** (`typeops.go`): drop the widening that replaced a residual tail bound with `string`.
2. **`reduceResidual`** (`constrain.go`): ground a union when only its tail bound is residual. The old code bailed whenever the reduced type carried any residual operator anywhere, which a residual tail bound trips, leaving the whole intrinsic symbolic so no literal could be decided against it. A union whose named members have all settled is a real union — its tail bound reduces at its own site during constraint folding, mirroring the object and tuple arms that already ground with a residual field or element. Only a residual among the **named** members keeps the union symbolic.

## Tests

`TestOperatorResultsOverABoundedTailStayUsable/an intrinsic over an open key set still accepts its own member` now asserts the un-widened bound and constrains a literal against the **un-expanded alias inside the inference context** — the path a real `val u: Uppercase<keyof Obj> = "A"` annotation takes, which is what exercises the `reduceResidual` gate. `TestOperatorsCarryTheTailBound/StringIntrinsic` updates its expected reduction from `"A" | "B" | ...string` to `"A" | "B" | ...Uppercase<string>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VG4c9M6EgSC672itUpaMDm)_