### PR TITLE
Add `: R` syntax for bounded union tail bounds

### DIFF
--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -373,7 +373,7 @@ type UnionTypeAnn struct {
 	Types   []TypeAnn
 	Inexact bool // trailing `...` marker: `A | B | ...` tolerates an unknown tail
 	// TailBound names the type the tail's unknown members are drawn from, as in
-	// `A | ...string`. It is nil when the tail is unbounded (`A | ...`) or the union exact.
+	// `A | ... : string`. It is nil when the tail is unbounded (`A | ...`) or the union exact.
 	TailBound    TypeAnn
 	span         Span
 	inferredType Type

--- a/internal/parser/inexact_test.go
+++ b/internal/parser/inexact_test.go
@@ -106,13 +106,14 @@ func TestParseExactAndRestAreNotInexact(t *testing.T) {
 	})
 }
 
-// A `...R` tail bounds the open tail: `A | ...string` stores string on TailBound. A bound
-// also makes a tail meaningful after a single member, which the bare `...` marker rejects.
+// A `... : R` tail bounds the open tail: `A | ... : string` stores string on TailBound. A
+// bound also makes a tail meaningful after a single member, which the bare `...` marker
+// rejects. The bound sits behind a `:` so `...T` stays a tuple spread alone.
 func TestParseBoundedUnionTail(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("bound after several members", func(t *testing.T) {
-		ta, errs := ParseTypeAnn(ctx, `"a" | "b" | ...string`)
+		ta, errs := ParseTypeAnn(ctx, `"a" | "b" | ... : string`)
 		require.Empty(t, errs)
 		u, ok := ta.(*ast.UnionTypeAnn)
 		require.True(t, ok)
@@ -125,7 +126,7 @@ func TestParseBoundedUnionTail(t *testing.T) {
 	})
 
 	t.Run("bound after a single member wraps in a one-member union", func(t *testing.T) {
-		ta, errs := ParseTypeAnn(ctx, `"a" | ...string`)
+		ta, errs := ParseTypeAnn(ctx, `"a" | ... : string`)
 		require.Empty(t, errs)
 		u, ok := ta.(*ast.UnionTypeAnn)
 		require.True(t, ok)
@@ -135,7 +136,7 @@ func TestParseBoundedUnionTail(t *testing.T) {
 	})
 
 	t.Run("a parenthesized bound is a full type", func(t *testing.T) {
-		ta, errs := ParseTypeAnn(ctx, `"a" | ...(string | number)`)
+		ta, errs := ParseTypeAnn(ctx, `"a" | ... : (string | number)`)
 		require.Empty(t, errs)
 		u, ok := ta.(*ast.UnionTypeAnn)
 		require.True(t, ok)
@@ -151,6 +152,12 @@ func TestParseBoundedUnionTail(t *testing.T) {
 		require.True(t, ok)
 		require.True(t, u.Inexact)
 		require.Nil(t, u.TailBound)
+	})
+
+	t.Run("a `... :` with no type after it is an error", func(t *testing.T) {
+		_, errs := ParseTypeAnn(ctx, `"a" | "b" | ... :`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "expected a type annotation after `... :`", errs[0].Message)
 	})
 
 	t.Run("a single member with no bound is still an error", func(t *testing.T) {

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -132,11 +132,21 @@ loop:
 		// union below, or reported as an error when no union was built.
 		if nextOp.Kind == Union && p.lexer.peek().Type == DotDotDot {
 			unionInexactSpan = p.lexer.peek().Span
-			p.lexer.consume()
+			p.lexer.consume() // consume '...'
 			unionInexact = true
-			// A primary type after the `...` bounds the tail, as in `A | ...string`.
-			// primaryTypeAnn returns nil without consuming when none follows, leaving `A | ...`.
-			unionTailBound = p.primaryTypeAnn()
+			// A `... : R` bounds the tail: the union holds its named members plus
+			// unknown values drawn from R, as in `"a" | ... : string`. The bound sits
+			// behind a `:` so `...T` stays a tuple spread and only a tuple spread. A
+			// bare `... ` with no `:` leaves the tail unbounded.
+			if p.lexer.peek().Type == Colon {
+				p.lexer.consume() // consume ':'
+				unionTailBound = p.primaryTypeAnn()
+				if unionTailBound == nil {
+					token := p.lexer.peek()
+					p.reportError(token.Span, "expected a type annotation after `... :`")
+					unionTailBound = ast.NewErrorTypeAnn(token.Span)
+				}
+			}
 			break loop
 		}
 
@@ -230,9 +240,9 @@ loop:
 			result = boundedUnionTypeAnn(u.Types, unionTailBound)
 		case unionTailBound != nil:
 			// A lone member followed by a bounded tail, where the member is not itself a
-			// union: a primary as in `"a" | ...string`, or a higher-precedence compound as in
-			// `number & string | ...string`. The bound makes the tail meaningful with one
-			// member, so wrap it rather than rejecting the marker.
+			// union: a primary as in `"a" | ... : string`, or a higher-precedence compound as
+			// in `number & string | ... : string`. The bound makes the tail meaningful with
+			// one member, so wrap it rather than rejecting the marker.
 			result = boundedUnionTypeAnn([]ast.TypeAnn{result}, unionTailBound)
 		default:
 			// An unbounded `...` after a single member carries no union to mark.
@@ -242,8 +252,8 @@ loop:
 	return result
 }
 
-// boundedUnionTypeAnn builds an inexact union carrying a `...R` tail bound, spanning from the
-// first member through the bound.
+// boundedUnionTypeAnn builds an inexact union carrying a `... : R` tail bound, spanning from
+// the first member through the bound.
 func boundedUnionTypeAnn(types []ast.TypeAnn, bound ast.TypeAnn) *ast.UnionTypeAnn {
 	u := ast.NewUnionTypeAnn(types, ast.MergeSpans(types[0].Span(), bound.Span()))
 	u.Inexact = true

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1676,6 +1676,20 @@ func (p *Printer) printUnionTypeAnn(typ *ast.UnionTypeAnn) {
 		}
 		p.printTypeAnnAt(t, precTypeUnion)
 	}
+	// An inexact union renders a trailing `...` entry, so `A | B | ...` round-trips. A
+	// bounded tail renders its bound after a `:`, as in `A | ... : string`. The bound
+	// prints at precTypePrefix, so a looser bound such as a union or intersection is
+	// parenthesized, matching the primary the parser reads after the `:`.
+	if typ.Inexact {
+		if len(typ.Types) > 0 {
+			p.writeString(" | ")
+		}
+		p.writeString("...")
+		if typ.TailBound != nil {
+			p.writeString(" : ")
+			p.printTypeAnnAt(typ.TailBound, precTypePrefix)
+		}
+	}
 }
 
 func (p *Printer) printIntersectionTypeAnn(typ *ast.IntersectionTypeAnn) {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -142,6 +142,30 @@ func TestPrintInexactObjectAndTupleAnnotations(t *testing.T) {
 	})
 }
 
+// A union's trailing `...` marker and its `... : R` tail bound round-trip through the
+// printer, so a rendered inexact or bounded union reparses to the same annotation.
+func TestPrintUnionTailAnnotations(t *testing.T) {
+	opts := DefaultOptions()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"exact union unchanged", `"a" | "b"`, `"a" | "b"`},
+		{"unbounded tail", `"a" | "b" | ...`, `"a" | "b" | ...`},
+		{"bounded tail after several members", `"a" | "b" | ... : string`, `"a" | "b" | ... : string`},
+		{"bounded tail after one member", `"a" | ... : string`, `"a" | ... : string`},
+		{"parenthesized union bound", `"a" | ... : (string | number)`, `"a" | ... : (string | number)`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Print(parseTypeAnn(t, tt.input), opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestPrintInexactFunctions(t *testing.T) {
 	opts := DefaultOptions()
 

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1002,15 +1002,11 @@ func (p *namedPrinter) printType(t Type) string {
 		// `A | B | ...` round-trips to surface syntax. The inexact tuple,
 		// object, and function arms render their flag the same way.
 		//
-		// A bounded tail renders its bound after the marker, so `"a" | ...string`
+		// A bounded tail renders its bound after a `:`, so `"a" | ... : string`
 		// says the unnamed members are strings. The bound prints at precPrefix, so a
-		// looser bound such as an intersection is parenthesized under the `...`.
-		//
-		// The bounded form does not round-trip. No surface syntax writes a bound, so
-		// only the type operators mint one and the parser rejects what this renders.
-		// The rendering exists for diagnostics and for reading inferred types, where
-		// the bound is the reason a constraint held or failed. escalier-lang/escalier#1126
-		// tracks the syntax.
+		// looser bound such as an intersection is parenthesized: `"a" | ... : (string & ¬"a")`.
+		// The `... : R` form round-trips through the parser, which reads the bound as
+		// a primary type after the `:`.
 		parts := make([]string, 0, len(t.Types)+1)
 		for _, m := range t.Types {
 			parts = append(parts, p.printTypeMinPrec(m, precUnion))
@@ -1018,7 +1014,7 @@ func (p *namedPrinter) printType(t Type) string {
 		if t.Inexact {
 			marker := "..."
 			if t.TailBound != nil {
-				marker += p.printTypeMinPrec(t.TailBound, precPrefix)
+				marker += " : " + p.printTypeMinPrec(t.TailBound, precPrefix)
 			}
 			parts = append(parts, marker)
 		}

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -171,12 +171,12 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"union triple", &UnionType{Types: []Type{numP(), strP(), boolP()}}, "number | string | boolean"},
 		// An inexact union renders a trailing `...` entry.
 		{"inexact union", &UnionType{Types: []Type{numP(), strP()}, Inexact: true}, "number | string | ..."},
-		// A bounded tail renders its bound after the marker. The bound prints at precPrefix,
-		// so an atom stays bare and an intersection is parenthesized under the `...`.
+		// A bounded tail renders its bound after a `:`. The bound prints at precPrefix,
+		// so an atom stays bare and an intersection is parenthesized after the `... :`.
 		{
 			"bounded tail",
 			&UnionType{Types: []Type{numP()}, Inexact: true, TailBound: strP()},
-			"number | ...string",
+			"number | ... : string",
 		},
 		{
 			"bounded tail over a compound bound",
@@ -185,21 +185,21 @@ func TestPrintRoundTrips(t *testing.T) {
 				Inexact:   true,
 				TailBound: &IntersectionType{Types: []Type{strP(), &NegationType{Inner: strP()}}},
 			},
-			"number | ...(string & ¬string)",
+			"number | ... : (string & ¬string)",
 		},
 		// A bounded tail with no named member is the whole union, which is what a set
 		// difference that excludes every named member leaves.
 		{
 			"bounded tail with no named member",
 			&UnionType{Inexact: true, TailBound: strP()},
-			"...string",
+			"... : string",
 		},
 		// LevelOf reads the bound too, so a variable reachable only through it lifts the
 		// union's level and the freshener descends to it.
 		{
 			"a variable in the bound lifts the level",
 			&UnionType{Types: []Type{numP()}, Inexact: true, TailBound: &TypeVarType{ID: 1, Level: 2}},
-			"number | ...t1",
+			"number | ... : t1",
 		},
 		// NullType renders as `null`. It is a distinct atomic kind from UndefinedType.
 		{"null atom", &NullType{}, "null"},
@@ -401,7 +401,7 @@ func TestPrintConstructorElem(t *testing.T) {
 func TestFreeTypeVarsUnionTailBound(t *testing.T) {
 	a := &TypeVarType{ID: 1, Level: 3}
 	u := &UnionType{Types: []Type{numP()}, Inexact: true, TailBound: a}
-	require.Equal(t, "<T0> (number | ...T0)", PrintAsScheme(u))
+	require.Equal(t, "<T0> (number | ... : T0)", PrintAsScheme(u))
 	require.Equal(t, 3, LevelOf(u))
 	// A nil bound is the childless case, which reads as level 0 rather than panicking.
 	require.Equal(t, 0, LevelOf(&UnionType{Types: []Type{numP()}, Inexact: true}))

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -892,13 +892,13 @@ type UnionType struct {
 	// Inexact tracks the trailing `...` marker. The zero value is exact.
 	Inexact bool
 	// TailBound names the type the tail's unnamed members are drawn from, so
-	// `"a" | ...string` reads as `"a"` together with some unknown set of strings.
+	// `"a" | ... : string` reads as `"a"` together with some unknown set of strings.
 	// It is nil on an exact union and may be nil on an inexact one, which leaves
 	// the tail unbounded. An unbounded tail admits every value, which makes the
 	// whole union the top of the subtype lattice.
 	//
 	// A bound keeps the named members enumerable while still saying what the rest
-	// can be. `keyof {a: X, ...}` is `"a" | ...string`, so a mapped type still has
+	// can be. `keyof {a: X, ...}` is `"a" | ... : string`, so a mapped type still has
 	// "a" to iterate and the key set still rejects `5`. Flattening the bound into
 	// the member list instead would give `"a" | string`, which subsumes to `string`
 	// and loses both.

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1500,8 +1500,8 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		// Inexact flags must match, since an open union never equals a closed
-		// one, and so must the tails' bounds, since `"a" | ...string` admits values
-		// `"a" | ...number` rejects. newUnion imposes canonical member order at
+		// one, and so must the tails' bounds, since `"a" | ... : string` admits values
+		// `"a" | ... : number` rejects. newUnion imposes canonical member order at
 		// construction, so the positional equalTypeSliceWith is order-stable and two
 		// unions over the same member set compare equal whatever order their members
 		// were minted in.

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -691,7 +691,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				// absorb it and the mismatch is reported once for the whole union.
 				// Only a super whose own tail is unbounded can absorb this one, since a
 				// bounded tail admits just its bound and an unbounded sub tail may hold
-				// anything. `("a" | ...) <: ("a" | "b" | ...string)` is therefore rejected.
+				// anything. `("a" | ...) <: ("a" | "b" | ... : string)` is therefore rejected.
 				closed := true
 				if s, ok := super.(*soltype.UnionType); ok {
 					closed = !s.Inexact || s.TailBound != nil
@@ -706,7 +706,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			if subU.TailBound != nil {
 				// A bounded tail holds only values of its bound, so the super absorbs the
 				// whole tail exactly when it absorbs that bound. Checking it is what makes
-				// `("a" | ...string) <: string` hold and `("a" | ...string) <: ("a" | ...number)`
+				// `("a" | ... : string) <: string` hold and `("a" | ... : string) <: ("a" | ... : number)`
 				// fail, the latter because the sub's tail may hold a string the super rejects.
 				errs = append(errs, c.constrain(subU.TailBound, super, seen, mutCtx)...)
 			}

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -1214,7 +1214,7 @@ func TestDescribeNegation(t *testing.T) {
 }
 
 // A diagnostic naming an inexact union has to say what its tail admits, since the bound is
-// the reason the constraint failed. `5 <: ("a" | ...string)` is rejected where
+// the reason the constraint failed. `5 <: ("a" | ... : string)` is rejected where
 // `5 <: ("a" | ...)` holds, and a message rendering both as `"a" | ...` leaves the reader
 // with no way to tell which rule fired.
 func TestDescribeOpenUnionTail(t *testing.T) {
@@ -1231,7 +1231,7 @@ func TestDescribeOpenUnionTail(t *testing.T) {
 		{
 			"bounded tail",
 			&soltype.UnionType{Types: []soltype.Type{strLit("a")}, Inexact: true, TailBound: str()},
-			`"a" | ...string`,
+			`"a" | ... : string`,
 		},
 		{
 			// An intersection bound is parenthesized, so its `&` does not read as binding
@@ -1242,14 +1242,14 @@ func TestDescribeOpenUnionTail(t *testing.T) {
 				Inexact:   true,
 				TailBound: &soltype.IntersectionType{Types: []soltype.Type{str(), num()}},
 			},
-			`"a" | ...(string & number)`,
+			`"a" | ... : (string & number)`,
 		},
 		{
 			// The shape a set difference leaves when it excludes every named member. A
 			// leading `" | "` would read as an empty first member, so the marker stands alone.
 			"bounded tail with no named member",
 			&soltype.UnionType{Inexact: true, TailBound: str()},
-			"...string",
+			"... : string",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -3006,23 +3006,23 @@ func describe(t soltype.Type) string {
 		}
 		// An inexact union has an open tail. The marker follows the members so a
 		// diagnostic naming the union matches the printer's surface form. The tail's
-		// bound follows the marker, since the bound is what decides the constraint.
-		// `"a" | ...string` rejects `5` where `"a" | ...` accepts it, and a message
-		// rendering both the same way leaves the reader no way to tell which rule
-		// fired. A union with no named member renders as the marker alone, since a
+		// bound follows the marker after a `:`, since the bound is what decides the
+		// constraint. `"a" | ... : string` rejects `5` where `"a" | ...` accepts it, and
+		// a message rendering both the same way leaves the reader no way to tell which
+		// rule fired. A union with no named member renders as the marker alone, since a
 		// leading `" | "` would read as an empty first member.
 		marker := "..."
 		if t.TailBound != nil {
 			// A union or intersection bound is parenthesized, since its `|` or `&` would
-			// otherwise bind past the `...` and `...string & ¬"a"` read back as a member
-			// of the enclosing union. The NegationType arm below parenthesizes for the
-			// same reason.
+			// otherwise bind past the `... :` and `... : string & ¬"a"` read back as a
+			// member of the enclosing union. The NegationType arm below parenthesizes for
+			// the same reason.
 			bound := describe(t.TailBound)
 			switch t.TailBound.(type) {
 			case *soltype.UnionType, *soltype.IntersectionType:
 				bound = "(" + bound + ")"
 			}
-			marker += bound
+			marker += " : " + bound
 		}
 		if len(t.Types) == 0 {
 			return marker

--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -39,7 +39,7 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 				type Result = keyof Tup
 			`,
 			wantSymbolic: "keyof Tup",
-			wantExpanded: "0 | 1 | ...number",
+			wantExpanded: "0 | 1 | ... : number",
 		},
 		{
 			// `T[keyof T]` over an exact object reads every key the object declares, and those are
@@ -170,7 +170,7 @@ func TestInferOperatorExactnessPropagates(t *testing.T) {
 				type Result = keyof I
 			`,
 			wantSymbolic: "keyof I",
-			wantExpanded: `"a" | "b" | ...string`,
+			wantExpanded: `"a" | "b" | ... : string`,
 		},
 		{
 			// `Exact` and `Inexact` are the two operators that run the other way. Every case above
@@ -444,7 +444,7 @@ func TestInferExactnessIntrinsics(t *testing.T) {
 				type Result = keyof Inexact<Obj>
 			`,
 			wantSymbolic: "keyof Inexact<Obj>",
-			wantExpanded: `"a" | "b" | ...string`,
+			wantExpanded: `"a" | "b" | ... : string`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -106,11 +106,11 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 				type Result = keyof Obj
 			`,
 			wantSymbolic: "keyof Obj",
-			wantExpanded: `"x" | "y" | ...string`,
+			wantExpanded: `"x" | "y" | ... : string`,
 		},
 		{
 			// A single-key inexact object keeps the union wrapper rather than collapsing to the lone
-			// literal, since the open tail makes `"only" | ...string` strictly weaker than bare
+			// literal, since the open tail makes `"only" | ... : string` strictly weaker than bare
 			// `"only"`.
 			name: "InexactSingleKeyObject",
 			src: `
@@ -118,7 +118,7 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 				type Result = keyof Obj
 			`,
 			wantSymbolic: "keyof Obj",
-			wantExpanded: `"only" | ...string`,
+			wantExpanded: `"only" | ... : string`,
 		},
 		{
 			// A key is readable from a union only when every member carries it, so the members'
@@ -194,7 +194,7 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 				type Result = keyof U
 			`,
 			wantSymbolic: "keyof U",
-			wantExpanded: `"shared" | ...string`,
+			wantExpanded: `"shared" | ... : string`,
 		},
 		{
 			// An inexact union has an unlisted member whose keys are unknown, so it cannot close
@@ -295,7 +295,7 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 		},
 		{
 			// A non-final class projects to an inexact instance body, since a subclass may add
-			// members, so its key union is open: `"x" | "y" | ...string`.
+			// members, so its key union is open: `"x" | "y" | ... : string`.
 			name: "Class",
 			src: `
 				class Point {
@@ -305,7 +305,7 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 				type Result = keyof Point
 			`,
 			wantSymbolic: "keyof Point",
-			wantExpanded: `"x" | "y" | ...string`,
+			wantExpanded: `"x" | "y" | ... : string`,
 		},
 		{
 			// A final class has no subclasses to widen it, so its instance body is exact and its

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -32,7 +32,7 @@ func newUnion(c *Context, parts []soltype.Type, inexact bool) soltype.Type {
 	return newUnionWithTail(c, parts, unionTail{open: inexact})
 }
 
-// newBoundedUnion mints `A | ...R`, an inexact union whose tail members are drawn from
+// newBoundedUnion mints `A | ... : R`, an inexact union whose tail members are drawn from
 // bound. A nil bound leaves the tail unbounded, which is what newUnion's inexact form
 // mints, so a caller that computes a bound and may come up empty needs no branch.
 func newBoundedUnion(c *Context, parts []soltype.Type, bound soltype.Type) soltype.Type {
@@ -68,7 +68,7 @@ func tailOf(u *soltype.UnionType) unionTail {
 
 // merge folds another tail into t, the rule flattenUnion applies when it splices a
 // nested union's members into the outer list. Two bounded tails join their bounds,
-// since `...string | ...number` may hold a member of either. An unbounded tail absorbs
+// since `... : string | ... : number` may hold a member of either. An unbounded tail absorbs
 // a bounded one, since nothing says what the unbounded one holds.
 //
 // keyofUnion is the other caller, and the join is wider than that reduction wants, since
@@ -115,7 +115,7 @@ func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 //   - `¬(A | B | ...)` is `never`. A union whose open tail carries no bound is the
 //     top of the subtype lattice, since that tail accepts every value, so its
 //     complement admits none. TestOpenUnionIsTopForSubtypingOnly pins that reading.
-//     A bounded tail is not top and gets no fold. `¬("a" | ...string)` rejects every
+//     A bounded tail is not top and gets no fold. `¬("a" | ... : string)` rejects every
 //     string and admits `5`, so it wraps like any other operand.
 //   - `¬¬T` is T, since complementing twice returns the original set.
 //
@@ -287,13 +287,13 @@ func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype
 }
 
 // narrowTailBound removes from a tail's bound every value the union's named members already
-// admit, and returns nil once nothing is left. A nil result drops the tail, so `"y" | ..."y"`
-// is exactly `"y"`. A partial overlap narrows instead: `1 | ...(1 | 2)` becomes `1 | ...2`,
+// admit, and returns nil once nothing is left. A nil result drops the tail, so `"y" | ... : "y"`
+// is exactly `"y"`. A partial overlap narrows instead: `1 | ... : (1 | 2)` becomes `1 | ... : 2`,
 // which reads tighter and denotes the same thing, since both admit `1` alone or `1 | 2`.
 //
 // Equality decides membership rather than a subtype test, so this needs no Context and runs on
 // every mint. A bound that is a subtype of the named members by some other route, such as
-// `string | ..."a"`, goes undetected. An inexact union bound is left alone, since its own tail
+// `string | ... : "a"`, goes undetected. An inexact union bound is left alone, since its own tail
 // says nothing about what it holds, and a `never` bound holds nothing and drops.
 //
 // An unchanged bound comes back as the same pointer, which is how finalSubsumer tells whether
@@ -354,9 +354,9 @@ func collapseUnion(pruned []soltype.Type, tail unionTail, hadError bool) soltype
 		// makes it strictly weaker than the bare T.
 		return pruned[0]
 	}
-	// A bounded tail with no named member survives as `...R`, a union naming no member
-	// and drawing every one it has from R. `("a" | ...string) ∩ ¬"a"` reduces to
-	// `...(string & ¬"a")`, the string keys other than "a", which has no other spelling.
+	// A bounded tail with no named member survives as `... : R`, a union naming no member
+	// and drawing every one it has from R. `("a" | ... : string) ∩ ¬"a"` reduces to
+	// `... : (string & ¬"a")`, the string keys other than "a", which has no other spelling.
 	return &soltype.UnionType{Types: pruned, Inexact: tail.open, TailBound: tail.bound}
 }
 
@@ -499,7 +499,7 @@ func (s *finalSubsumer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 // the bound before the union itself. A bound that folds to `never` on the way up
 // leaves a tail holding nothing, and a bound that folds to a named member leaves
 // one contributing nothing. Neither drops a member, so a member count alone would
-// miss both and render `...never` or `"y" | ..."y"`.
+// miss both and render `... : never` or `"y" | ... : "y"`.
 func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.UnionType:

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -225,14 +225,14 @@ func TestFlattenUnionMergesTailBounds(t *testing.T) {
 			// A nested bounded tail with no other tail to meet comes through as written.
 			name:  "a lone bounded tail carries out",
 			parts: []soltype.Type{numLit(1), strTail(strLit("a"))},
-			want:  `1 | "a" | ...string`,
+			want:  `1 | "a" | ... : string`,
 		},
 		{
 			// Two bounded tails join their bounds, since a member of either could be in the
 			// result.
 			name:  "two bounded tails join their bounds",
 			parts: []soltype.Type{strTail(strLit("a")), numTail(numLit(1))},
-			want:  `1 | "a" | ...(number | string)`,
+			want:  `1 | "a" | ... : (number | string)`,
 		},
 		{
 			// Nothing says what an unbounded tail holds, so meeting one loses the bound.
@@ -244,7 +244,7 @@ func TestFlattenUnionMergesTailBounds(t *testing.T) {
 			// An exact nested union brings no tail, so the outer one is untouched.
 			name:  "an exact nested union leaves the tail alone",
 			parts: []soltype.Type{strTail(strLit("a")), unionT(numLit(1), numLit(2))},
-			want:  `1 | 2 | "a" | ...string`,
+			want:  `1 | 2 | "a" | ... : string`,
 		},
 	}
 	for _, tt := range tests {
@@ -273,7 +273,7 @@ func TestCollapseUnionDropsASubsumedTail(t *testing.T) {
 			want:  `"y"`,
 		},
 		{
-			// `string | ...string`, the same rule over a primitive.
+			// `string | ... : string`, the same rule over a primitive.
 			name:  "a bound equal to a primitive member closes the union",
 			build: func() soltype.Type { return newBoundedUnion(nil, []soltype.Type{str()}, str()) },
 			want:  "string",
@@ -299,14 +299,14 @@ func TestCollapseUnionDropsASubsumedTail(t *testing.T) {
 		},
 		{
 			// A bound that only partly overlaps the named members is narrowed to the part the
-			// union does not already admit. `1 | ...(1 | 2)` and `1 | ...2` both admit `1`
+			// union does not already admit. `1 | ... : (1 | 2)` and `1 | ... : 2` both admit `1`
 			// alone or `1 | 2`, so this tightens how the type reads without changing what it
 			// denotes.
 			name: "a union bound is narrowed to its unnamed members",
 			build: func() soltype.Type {
 				return newBoundedUnion(nil, []soltype.Type{numLit(1)}, unionT(numLit(1), numLit(2)))
 			},
-			want: "1 | ...2",
+			want: "1 | ... : 2",
 		},
 		{
 			// Narrowing down to a single member leaves that member as the bound rather than a
@@ -316,19 +316,19 @@ func TestCollapseUnionDropsASubsumedTail(t *testing.T) {
 				return newBoundedUnion(nil, []soltype.Type{numLit(1), numLit(2)},
 					unionT(numLit(1), numLit(2), numLit(3)))
 			},
-			want: "1 | 2 | ...3",
+			want: "1 | 2 | ... : 3",
 		},
 		{
 			// A bound naming values no member does is not subsumed, so the tail stays.
 			name:  "an unrelated bound is kept",
 			build: func() soltype.Type { return newBoundedUnion(nil, []soltype.Type{strLit("y")}, str()) },
-			want:  `"y" | ...string`,
+			want:  `"y" | ... : string`,
 		},
 		{
 			// Subsumption needs a member to be subsumed by. A tail with none stays whole.
 			name:  "a member-less tail is kept",
 			build: func() soltype.Type { return newBoundedUnion(nil, nil, str()) },
-			want:  "...string",
+			want:  "... : string",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -202,7 +202,7 @@ func (c *Context) mkDNF(t soltype.Type, pol soltype.Polarity) DNF {
 			// A bounded tail holds some unknown set of the bound's values, so no value
 			// outside the bound reaches the union and every value inside it might. That
 			// makes the bound one more disjunct for a decision about which values the
-			// union admits. `5 <: ("a" | ...string)` fails and `"z" <: ("a" | ...string)`
+			// union admits. `5 <: ("a" | ... : string)` fails and `"z" <: ("a" | ... : string)`
 			// holds, both by the ordinary union rule once the bound joins the members.
 			//
 			// The bound joins the DNF rather than the member list, so the named members

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -244,12 +244,12 @@ func TestNewNegation(t *testing.T) {
 		{"primitive", str(), "¬string"},
 		// A closed union bounds its members, so its complement is a real type.
 		{"closed union", unionT(str(), num()), "¬(number | string)"},
-		// So does a bounded tail. `¬("a" | ...string)` admits `5`, which is exactly what the
+		// So does a bounded tail. `¬("a" | ... : string)` admits `5`, which is exactly what the
 		// fold above would have thrown away.
 		{
 			"bounded open union",
 			newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()),
-			`¬("a" | ...string)`,
+			`¬("a" | ... : string)`,
 		},
 	}
 	for _, tt := range tests {
@@ -320,14 +320,14 @@ func TestOpenUnionIsTopForSubtypingOnly(t *testing.T) {
 }
 
 // Writing a bound on the open tail takes the union out of the top position
-// TestOpenUnionIsTopForSubtypingOnly pins. `"a" | ...string` names "a" and draws every
+// TestOpenUnionIsTopForSubtypingOnly pins. `"a" | ... : string` names "a" and draws every
 // other member it has from `string`, so a value outside `string` is outside the union.
 //
 // Each probe below has a counterpart in that test that answers the other way, which is
 // what makes the bound the thing that changed rather than some difference in the shapes.
 func TestBoundedTailIsNotTop(t *testing.T) {
 	c := newChecker()
-	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()) // "a" | ...string
+	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str()) // "a" | ... : string
 
 	t.Run("the bound decides what is a subtype of the union", func(t *testing.T) {
 		probes := []struct {
@@ -428,7 +428,7 @@ func TestSimplifyNegationsEmptiesABoundedTail(t *testing.T) {
 	c := newChecker()
 	bounded := newBoundedUnion(nil, []soltype.Type{strLit("a")}, str())
 
-	// `("a" | ...string) & ¬string`. Both the named member and every value the tail could
+	// `("a" | ... : string) & ¬string`. Both the named member and every value the tail could
 	// hold is a string, so nothing survives.
 	kept, changed, provedEmpty := simplifyNegations(c.ctx, []soltype.Type{bounded, negT(str())})
 	require.True(t, provedEmpty)
@@ -453,7 +453,7 @@ func TestKeyofBoundsItsOpenTail(t *testing.T) {
 			type Obj = {a: number, ...}
 			type Result = keyof Obj
 		`)
-		require.Equal(t, `"a" | ...string`, soltype.Print(keys))
+		require.Equal(t, `"a" | ... : string`, soltype.Print(keys))
 		// `5` is plainly not a key of that object, which an unbounded tail could not say.
 		require.False(t, subtypeHolds(c.ctx, numLit(5), keys))
 		require.True(t, subtypeHolds(c.ctx, strLit("b"), keys))
@@ -464,7 +464,7 @@ func TestKeyofBoundsItsOpenTail(t *testing.T) {
 			type Tup = [number, ...]
 			type Result = keyof Tup
 		`)
-		require.Equal(t, "0 | ...number", soltype.Print(keys))
+		require.Equal(t, "0 | ... : number", soltype.Print(keys))
 		require.False(t, subtypeHolds(c.ctx, strLit("a"), keys))
 		require.True(t, subtypeHolds(c.ctx, numLit(1), keys))
 	})

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -569,7 +569,7 @@ func (c *checker) resolveTupleTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, lvl in
 // resolveUnionTypeAnn lowers `A | B | …` through newUnion. An unsupported
 // member recovers to a fresh var so the union shape survives, mirroring the
 // Promise<bad> and object/tuple cascade-safe recovery. A trailing `...` in the
-// source sets ta.Inexact, which carries onto the resolved union, and a `...R`
+// source sets ta.Inexact, which carries onto the resolved union, and a `... : R`
 // tail sets ta.TailBound, which bounds it through newBoundedUnion.
 func (c *checker) resolveUnionTypeAnn(scope *Scope, ta *ast.UnionTypeAnn, lvl int) (soltype.Type, bool) {
 	members := make([]soltype.Type, len(ta.Types))

--- a/internal/solver/type_ann_tail_test.go
+++ b/internal/solver/type_ann_tail_test.go
@@ -7,18 +7,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The surface syntax `A | ...R` resolves to a bounded tail and `A | B | ...` to an unbounded
-// one, so a test can write the source directly rather than minting the union by hand.
+// The surface syntax `A | ... : R` resolves to a bounded tail and `A | B | ...` to an
+// unbounded one, so a test can write the source directly rather than minting the union by
+// hand. Each printed form reparses to the same type, which is the round-trip the bounded
+// tail syntax exists to establish.
 func TestResolveUnionTailSyntax(t *testing.T) {
 	tests := []struct {
 		name string
 		src  string
 		want string
 	}{
-		{"a bounded tail after several members", `type Result = "a" | "b" | ...string`, `"a" | "b" | ...string`},
-		{"a bounded tail after one member", `type Result = "a" | ...string`, `"a" | ...string`},
-		{"a numeric bound", `type Result = 0 | ...number`, "0 | ...number"},
-		{"a parenthesized union bound", `type Result = "a" | ...(number | string)`, `"a" | ...(number | string)`},
+		{"a bounded tail after several members", `type Result = "a" | "b" | ... : string`, `"a" | "b" | ... : string`},
+		{"a bounded tail after one member", `type Result = "a" | ... : string`, `"a" | ... : string`},
+		{"a numeric bound", `type Result = 0 | ... : number`, "0 | ... : number"},
+		{"a parenthesized union bound", `type Result = "a" | ... : (number | string)`, `"a" | ... : (number | string)`},
 		{"an unbounded tail", `type Result = "a" | "b" | ...`, `"a" | "b" | ...`},
 	}
 	for _, tt := range tests {

--- a/internal/solver/type_ann_tail_test.go
+++ b/internal/solver/type_ann_tail_test.go
@@ -31,3 +31,107 @@ func TestResolveUnionTailSyntax(t *testing.T) {
 		})
 	}
 }
+
+// A tail bound written in source drives subtyping the same way a hand-built bounded union
+// does, so the parser and lowering together produce a semantically live bound rather than a
+// shape that only prints. Each probe mirrors one in TestBoundedTailIsNotTop, which builds the
+// union with newBoundedUnion instead of parsing it.
+func TestResolveUnionTailSyntaxSubtyping(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Bounded = "a" | ... : string
+		type NumberTail = "a" | ... : number
+	`)
+	require.Empty(t, errs)
+	bounded := expandAliasResidual(ctx, nodes["Bounded"])
+	numberTail := expandAliasResidual(ctx, nodes["NumberTail"])
+
+	probes := []struct {
+		name     string
+		sub, sup soltype.Type
+		want     bool
+	}{
+		// The bound decides what is a subtype of the union: a value it admits may be one of
+		// the tail's members, and a value it rejects cannot be.
+		{"a named member is a subtype of it", strLit("a"), bounded, true},
+		{"another string is a subtype of it", strLit("z"), bounded, true},
+		{"the bound itself is a subtype of it", str(), bounded, true},
+		{"a number literal is not a subtype of it", numLit(5), bounded, false},
+		{"a number is not a subtype of it", num(), bounded, false},
+		// The bound also decides what the union is a subtype of, carrying the tail into a
+		// supertype: every member is a string, so `string` absorbs the whole union, but a
+		// `number` tail rejects the string tail's members.
+		{"a bounded tail is a subtype of its own bound", bounded, str(), true},
+		{"a string tail is not a subtype of a number tail", bounded, numberTail, false},
+	}
+	for _, p := range probes {
+		require.Equal(t, p.want, subtypeHolds(ctx, p.sub, p.sup), p.name)
+	}
+}
+
+// An unbounded tail written in source resolves to the open union that is top for subtyping,
+// so every value is a subtype of it. These probes answer the other way from their bounded
+// counterparts in TestResolveUnionTailSyntaxSubtyping, which is what makes the missing bound
+// the thing that changed. The hand-built counterpart is TestOpenUnionIsTopForSubtypingOnly.
+func TestResolveUnionTailSyntaxUnboundedSubtyping(t *testing.T) {
+	// The unbounded marker needs two or more named members, unlike a bounded tail, which a
+	// lone member can carry. TestParseInexactUnionMarkerRequiresUnion pins that rule.
+	nodes, ctx, errs := inferTypeNodes(t, `type Open = "a" | "b" | ...`)
+	require.Empty(t, errs)
+	open := expandAliasResidual(ctx, nodes["Open"])
+
+	probes := []struct {
+		name string
+		sub  soltype.Type
+		want bool
+	}{
+		// An unbounded tail admits every value, so a number the bounded tail rejects is a
+		// subtype here.
+		{"a named member is a subtype of it", strLit("a"), true},
+		{"a number literal is a subtype of it", numLit(5), true},
+		{"a number is a subtype of it", num(), true},
+		{"unknown is a subtype of it", &soltype.UnknownType{}, true},
+	}
+	for _, p := range probes {
+		require.Equal(t, p.want, subtypeHolds(ctx, p.sub, open), p.name)
+	}
+}
+
+// The bounded tail earns its syntax on the conditional-type examples #1131 raises: a check
+// against `"a" | ... : infer U` binds U to the operand's own tail bound, and a check against a
+// concrete tail bound selects the then branch only when the bounds agree. Each case is the
+// source form of a CondType those examples built by hand.
+func TestResolveUnionTailSyntaxUnderConditional(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			"infer binds U to the tail bound",
+			`type Result = if ("a" | ... : string) : ("a" | ... : infer U) { U } else { boolean }`,
+			"string",
+		},
+		{
+			"the inferred bound flows into the then branch",
+			`type Result = if ("a" | ... : string) : ("a" | ... : infer U) { [U] } else { boolean }`,
+			"[string]",
+		},
+		{
+			"a matching concrete bound selects the then branch",
+			`type Result = if ("a" | ... : string) : ("a" | ... : string) { 9 } else { boolean }`,
+			"9",
+		},
+		{
+			"a non-matching bound selects the else branch",
+			`type Result = if ("a" | ... : string) : ("a" | ... : number) { 9 } else { boolean }`,
+			"boolean",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1189,7 +1189,7 @@ func aliasItself(op *soltype.AliasType) soltype.Type { return op }
 // for no members.
 //
 // An inexact object carries an unknown-keyed tail, so its key set is open:
-// `keyof {a: number, ...}` is `"a" | ...string`, an inexact union whose members are the known keys
+// `keyof {a: number, ...}` is `"a" | ... : string`, an inexact union whose members are the known keys
 // and whose tail stands for the unlisted ones. keyofObject seeds the union's exactness from the
 // object's, so an exact object yields an exact key union and an inexact object an inexact one.
 //
@@ -1228,7 +1228,7 @@ func (e *typeEvaluator) keyofObject(obj *soltype.ObjectType) soltype.Type {
 // TODO: decide how keyof should account for inherited prototype members once interop is designed.
 //
 // An inexact tuple has unknown trailing positions, so its index set is open the same way an inexact
-// object's key set is. `keyof [number, string, ...]` reduces to `0 | 1 | ...number`, where the tail
+// object's key set is. `keyof [number, string, ...]` reduces to `0 | 1 | ... : number`, where the tail
 // stands for the indices those unknown positions occupy (exact-types §7.1). The bound is `number`
 // rather than the `string` an object's tail takes, since an index is a position and not a name.
 func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
@@ -1250,7 +1250,7 @@ func (e *typeEvaluator) keyofTuple(tup *soltype.TupleType) soltype.Type {
 // An inexact key set is open, so it can carry keys its written members do not name. That makes
 // the result inexact whenever the operand union is inexact or any member's key set is. Take
 // `keyof ({a: number, shared: string} | {b: boolean, shared: string, ...})`, which reduces to
-// `"shared" | ...string`. Only "shared" is written on both members, so only "shared" is definitely
+// `"shared" | ... : string`. Only "shared" is written on both members, so only "shared" is definitely
 // a key, but the second member's open tail may carry "a" too. Intersecting the written keys keeps
 // every key the result names one that every member definitely carries, and the trailing `...`
 // records that the true key set may be larger.


### PR DESCRIPTION
This PR adds surface syntax for bounded union tail bounds, allowing `A | ... : R` to denote an inexact union whose unnamed members are drawn from type `R`. Previously, bounded tails existed only in the type system (minted by type operators like `keyof`), with no way to write them in source.

The syntax change:
- Parser now recognizes `... : R` after a union, where `R` is a primary type annotation
- A bare `...` with no `:` leaves the tail unbounded, as before
- The `:` ensures `...T` remains a tuple spread and only a tuple spread
- Printer renders bounded tails as `... : R` to round-trip through the parser

Key changes:
- **internal/parser/type_ann.go**: Updated union tail parsing to look for an optional `:` after `...`, consuming a primary type as the bound. Added error reporting when `... :` appears with no type following.
- **internal/printer/printer.go**: Added rendering of `Inexact` flag and `TailBound` field in union type annotations, printing `... : R` format.
- **internal/soltype/print.go**: Updated type printing to render bounded tails as `... : R` instead of `...R`.
- **internal/solver/errors.go**: Updated error descriptions to use `... : R` syntax.
- **internal/ast/type_ann.go**: Updated `UnionTypeAnn` documentation to reflect the new syntax.
- **Tests**: Updated all test cases and comments throughout the codebase to use the new `... : R` syntax instead of `...R`.

The bounded tail syntax now round-trips: a rendered inexact or bounded union reparses to the same annotation, which is verified by new printer tests.

https://claude.ai/code/session_016RcAYbzDtXvkkurM4eZaGV