### PR TITLE
Expand prose style guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,15 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
 - While iterating on a PR, commit locally but don't `git push` until I explicitly ask.
 - Still push at the end of a session so nothing is lost.
 
-# Writing Prose: Punctuation and sentence structure
+# Writing Prose
+
+The guidance in this section applies to every kind of prose you write: code
+comments, docstrings, and the messages you write to the user in conversation.
+Read each rule as covering all three. A few points are inherently code-specific,
+such as backticking type and keyword names or sweeping a diff before committing.
+Those apply wherever they make sense and are simply irrelevant elsewhere.
+
+## Punctuation and sentence structure
 
 - Use colons only for their standard jobs: introducing a list, a definition, or
   a direct elaboration that completes the clause before it. Do not use a colon
@@ -114,7 +122,7 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
   sentence case for headings and keep decorative emoji out of them. Don't add an
   inline bold lead-in that just restates the sentence after it.
 
-# Writing Prose: Word choice and explaining code
+## Word choice and explaining code
 
 - Define a technical or coined term the first time you use it. Terms like
   "co-occurrence", "representative", or "closure" mean nothing to a reader who
@@ -162,8 +170,9 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
   `seen` set. Backtick only the specialized sense. "it never needs parens" and
   "an unknown key" stay bare, because there the ordinary meaning is the intended
   one. Apply this when reviewing a comment as well as when writing one.
-- Treat a comment as draft-then-revise, not one-shot. After writing any comment
-  longer than a sentence or two, reread it as someone with no prior context.
-  Fix every unexplained term and every sentence that needs a second pass. On
-  that reread, scan for the stock phrases listed above and cut any that slipped
-  in. Do the same sweep over the comments in a diff before committing.
+- Treat any prose you write as draft-then-revise, not one-shot. After writing
+  anything longer than a sentence or two, whether a comment, a docstring, or a
+  reply to the user, reread it as someone with no prior context. Fix every
+  unexplained term and every sentence that needs a second pass. On that reread,
+  scan for the stock phrases listed above and cut any that slipped in. Do the
+  same sweep over the comments in a diff before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,9 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
 - Read each sentence as if a human has to parse it left to right with no
   rereading. If understanding it requires jumping back to an earlier clause,
   restructure it.
+- In Markdown you write, such as PR descriptions, docs, and issue bodies, use
+  sentence case for headings and keep decorative emoji out of them. Don't add an
+  inline bold lead-in that just restates the sentence after it.
 
 # Writing Prose: Word choice and explaining code
 
@@ -124,6 +127,27 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
 - Use precise verbs. Replace vague verbs like "supplies", "handles", "drives",
   and "manages" with the actual action: produces, reads, returns, mutates,
   consults. A vague verb hides what the code does.
+- Cut the stock phrases that pad machine-written text. They add length without
+  adding information. Watch for these:
+    - Filler openers and connectors: "additionally", "furthermore", "moreover",
+      "in order to", "due to the fact that", "it is worth noting that", "it is
+      important to note that". Delete them or start with the point.
+    - Puffery and inflated verbs: "crucial", "pivotal", "seamless", "robust",
+      "powerful", "leverage", "utilize", "delve", "underscore", "showcase".
+      Prefer the plain word. Write "use" not "utilize", "important" not
+      "crucial", "shows" not "showcases".
+    - Filler copulas where a plain "is" or a precise verb reads better: "serves
+      as", "stands as", "acts as", "boasts", "features".
+    - The "not just X, but Y" construction, and groups of three forced for
+      rhythm. State the one thing that matters.
+    - Vague "-ing" tails bolted onto a clause: "..., ensuring correctness",
+      "..., highlighting the issue", "..., allowing reuse". Make the fact its
+      own sentence or drop it.
+    - Hedges that soften a claim you can state flatly: "generally", "typically",
+      "in most cases", when the code always does the thing.
+- Don't inject personality to compensate for cutting those phrases. A comment or
+  doc wants flat, precise description, not a lively voice, editorial opinions, or
+  first-person asides. Cut the tell and stop. Plain is the goal, not colorful.
 - Name the value, not the technique that produced it. Don't write "union-find"
   when you mean the merge classes it computed, or "the visitor" when you mean
   the walk's result. Refer to the thing the code hands around.
@@ -140,4 +164,6 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
   one. Apply this when reviewing a comment as well as when writing one.
 - Treat a comment as draft-then-revise, not one-shot. After writing any comment
   longer than a sentence or two, reread it as someone with no prior context.
-  Fix every unexplained term and every sentence that needs a second pass.
+  Fix every unexplained term and every sentence that needs a second pass. On
+  that reread, scan for the stock phrases listed above and cut any that slipped
+  in. Do the same sweep over the comments in a diff before committing.


### PR DESCRIPTION
Adds detailed guidance on writing clear, direct prose by cutting stock phrases and maintaining plain, precise description.

The changes extend the "Writing Prose" section with:

- New heading guidance: use sentence case for Markdown headings (PR descriptions, docs, issue bodies) and avoid decorative emoji or inline bold lead-ins that restate the sentence.
- Comprehensive list of stock phrases to cut from technical writing:
  - Filler openers and connectors ("additionally", "in order to", "it is worth noting that")
  - Puffery and inflated verbs ("crucial", "leverage", "utilize", "showcase")
  - Filler copulas ("serves as", "stands as", "boasts")
  - Forced constructions ("not just X, but Y", groups of three for rhythm)
  - Vague "-ing" tails bolted onto clauses
  - Hedges that soften claims ("generally", "typically")
- Guidance against injecting personality to compensate for cutting phrases—comments and docs should be flat and precise, not lively or editorial.
- Extended comment revision guidance: scan for stock phrases during the reread pass and cut any that slipped in, including a sweep over diff comments before committing.

These additions reinforce the existing principle that clear, direct writing serves the reader better than padded or colorful prose.

https://claude.ai/code/session_01ABfb3qC6sWkecy6mmPTxMs