### PR TITLE
Document guidelines for writing agent-facing docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,29 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
 - While iterating on a PR, commit locally but don't `git push` until I explicitly ask.
 - Still push at the end of a session so nothing is lost.
 
+## Writing agent-facing docs
+
+This covers the files an agent reads to work here: `CLAUDE.md`, the skills under
+`.claude/skills/`, and any reference file they point to. `CLAUDE.md` loads on
+every turn, so treat its length as a running cost and keep only lines that change
+what the agent does.
+
+- State each rule once. When another section needs the same rule, link to the one
+  place that states it. A rule copied into two spots drifts when one copy changes.
+- Cut instructions that only restate a default. Spelling out behavior the agent
+  already does spends tokens without changing the outcome.
+- Inline what every task needs and push branch-specific detail into a separate
+  file, then point to that file. The repo-layout list does this: it names each
+  subsystem with a one-line gloss and a link instead of inlining the details.
+  Word the pointer so it says what the file is and which cases it covers, since
+  that wording is what prompts the agent to open it.
+- Give each instruction a clear done condition. "Re-run with both vars set so
+  snapshots and fixtures stay in sync" marks when the step is finished; "update
+  the snapshots" leaves the boundary vague.
+- Prefer naming the action to take over the action to avoid. "Use the `Set` ADT"
+  points at the target directly, where "don't use a raw map" only rules one path
+  out. Keep a prohibition when the wrong path is the tempting one.
+
 # Writing Prose
 
 The guidance in this section applies to every kind of prose you write: code


### PR DESCRIPTION
Add a new section to CLAUDE.md covering best practices for writing documentation that agents read, including `CLAUDE.md` itself, skill files, and reference materials.

The guidance emphasizes token efficiency and clarity:
- State each rule once and link to it rather than duplicating across sections
- Cut instructions that only restate defaults
- Inline what every task needs; push branch-specific detail into separate files with clear pointers
- Give each instruction a clear done condition so the agent knows when it's finished
- Name the action to take rather than the action to avoid, keeping prohibitions only when the wrong path is tempting

This reflects the principle that `CLAUDE.md` loads on every turn, so its length is a running cost.

https://claude.ai/code/session_01SZWQ3ZxHxZPZadVkHfZxGv