### PR TITLE
Record FromNormalization provenance edges for type fusions

### DIFF
--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -120,6 +120,24 @@ type Context struct {
 	// records T → (T | number). A later constraint that forces an incompatible bound onto the
 	// var reads this to breadcrumb the failure back to that union choice.
 	unionCommits map[*soltype.TypeVarType]*soltype.UnionType
+
+	// recordFusion records the interior provenance edge a normal-form fusion mints:
+	// fused was produced by merging the atoms in from. The engine's fusion sites live
+	// on *Context, while the Prov table lives on the checker carrier, so the carrier
+	// installs this hook in newChecker to bridge the two. It is nil on a Context that
+	// carries no such table, where a fusion records nothing. See recordFusionEdge for
+	// what an installed recorder writes.
+	recordFusion func(fused soltype.Type, from []soltype.Type)
+}
+
+// recordNorm records that fused came from merging the atoms in from, when a carrier
+// installed a recorder. A fusion helper in normal.go or classes.go calls it at the
+// fresh node it allocates, so the interior FromNormalization edge is minted at the
+// one place that knows the two source atoms. A no-op when no recorder is installed.
+func (c *Context) recordNorm(fused soltype.Type, from ...soltype.Type) {
+	if c.recordFusion != nil {
+		c.recordFusion(fused, from)
+	}
 }
 
 // tagUnionCommit records that committing union u pinned v, so a later failure on v can name

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -121,22 +121,24 @@ type Context struct {
 	// var reads this to breadcrumb the failure back to that union choice.
 	unionCommits map[*soltype.TypeVarType]*soltype.UnionType
 
-	// recordFusion records the interior provenance edge a normal-form fusion mints:
-	// fused was produced by merging the atoms in from. The engine's fusion sites live
-	// on *Context, while the Prov table lives on the checker carrier, so the carrier
+	// fusionRecorder records the interior provenance edge a fusion mints: fused was
+	// produced by merging the atoms in from. The engine's fusion sites live on
+	// *Context, while the Prov table lives on the checker carrier, so the carrier
 	// installs this hook in newChecker to bridge the two. It is nil on a Context that
 	// carries no such table, where a fusion records nothing. See recordFusionEdge for
 	// what an installed recorder writes.
-	recordFusion func(fused soltype.Type, from []soltype.Type)
+	fusionRecorder func(fused soltype.Type, from []soltype.Type)
 }
 
-// recordNorm records that fused came from merging the atoms in from, when a carrier
+// recordFusion records that fused came from merging the atoms in from, when a carrier
 // installed a recorder. A fusion helper in normal.go or classes.go calls it at the
 // fresh node it allocates, so the interior FromNormalization edge is minted at the
-// one place that knows the two source atoms. A no-op when no recorder is installed.
-func (c *Context) recordNorm(fused soltype.Type, from ...soltype.Type) {
-	if c.recordFusion != nil {
-		c.recordFusion(fused, from)
+// one place that knows the two source atoms. A no-op when no recorder is installed,
+// which is every Context built outside newChecker, such as the bare `&Context{}` the
+// engine-level tests use.
+func (c *Context) recordFusion(fused soltype.Type, from ...soltype.Type) {
+	if c.fusionRecorder != nil {
+		c.fusionRecorder(fused, from)
 	}
 }
 

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -469,6 +469,7 @@ func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
 // method returns.
 func newChecker() *checker {
 	c := &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}, varIDCounter: 1}
+	c.ctx.recordFusion = c.recordFusionEdge
 	registerIteratorResultAliases(c.ctx)
 	return c
 }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -469,7 +469,7 @@ func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
 // method returns.
 func newChecker() *checker {
 	c := &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}, varIDCounter: 1}
-	c.ctx.recordFusion = c.recordFusionEdge
+	c.ctx.fusionRecorder = c.recordFusionEdge
 	registerIteratorResultAliases(c.ctx)
 	return c
 }

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -712,7 +712,7 @@ func equalAtomLists(a, b []soltype.Type) bool {
 func (c *Context) meetAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	fused, ok := c.meetFusedAtoms(a, b)
 	if ok {
-		c.recordNorm(fused, a, b)
+		c.recordFusion(fused, a, b)
 	}
 	return fused, ok
 }
@@ -763,7 +763,7 @@ func (c *Context) meetFusedAtoms(a, b soltype.Type) (soltype.Type, bool) {
 func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	fused, ok := c.joinFusedAtoms(a, b)
 	if ok {
-		c.recordNorm(fused, a, b)
+		c.recordFusion(fused, a, b)
 	}
 	return fused, ok
 }
@@ -1600,7 +1600,7 @@ func equalParamTypes(a, b *soltype.FuncType) bool {
 // is Positive because a shallow normalization reads the same at either one.
 func (c *Context) meetTypes(a, b soltype.Type) soltype.Type {
 	met := c.mkDNF(newIntersection(nil, []soltype.Type{a, b}), soltype.Positive).toType()
-	c.recordNorm(met, a, b)
+	c.recordFusion(met, a, b)
 	return met
 }
 
@@ -1608,7 +1608,7 @@ func (c *Context) meetTypes(a, b soltype.Type) soltype.Type {
 // widened record field are written from.
 func (c *Context) joinTypes(a, b soltype.Type) soltype.Type {
 	joined := c.mkDNF(newUnion(nil, []soltype.Type{a, b}, false), soltype.Positive).toType()
-	c.recordNorm(joined, a, b)
+	c.recordFusion(joined, a, b)
 	return joined
 }
 

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -698,9 +698,27 @@ func equalAtomLists(a, b []soltype.Type) bool {
 // fusion exists, which tells the caller to keep both atoms. A returned `never`
 // means the two atoms are disjoint, so the enclosing conjunct is uninhabited.
 //
-// The kinds not named below never fuse. That costs nothing: a two-atom list is
-// already the precise meet, and only the atom count grows.
+// The kinds not named in meetFusedAtoms never fuse. That costs nothing: a two-atom
+// list is already the precise meet, and only the atom count grows.
+//
+// Every fusion mints one FromNormalization provenance edge here, at the single point
+// each merge passes through, rather than in the per-kind helpers. The edge names a
+// and b, the two atoms the merge combined. An identity or absorption result is one
+// of the sources. `A & A` is `A` and `5 & number` is `5`, and recordFusionEdge skips
+// such a result so the source keeps its own leaf origin. glbClass's meetClassArgs
+// also runs from instanceBelow, which fuses two tags only to test a relation and
+// discards the result. That call does not pass through here, so a throwaway tag meet
+// mints no edge for the fused tag.
 func (c *Context) meetAtoms(a, b soltype.Type) (soltype.Type, bool) {
+	fused, ok := c.meetFusedAtoms(a, b)
+	if ok {
+		c.recordNorm(fused, a, b)
+	}
+	return fused, ok
+}
+
+// meetFusedAtoms computes the meet of two atoms without recording provenance.
+func (c *Context) meetFusedAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	if equalType(a, b) {
 		return a, true
 	}
@@ -740,7 +758,18 @@ func (c *Context) meetAtoms(a, b soltype.Type) (soltype.Type, bool) {
 // `{x: number} | {y: number}` stays two members: two records with different field
 // names have no single record that stands for their union, so the merge bails and
 // the union keeps both.
+//
+// It mints the FromNormalization edge naming a and b the way meetAtoms does.
 func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
+	fused, ok := c.joinFusedAtoms(a, b)
+	if ok {
+		c.recordNorm(fused, a, b)
+	}
+	return fused, ok
+}
+
+// joinFusedAtoms computes the join of two atoms without recording provenance.
+func (c *Context) joinFusedAtoms(a, b soltype.Type) (soltype.Type, bool) {
 	if equalType(a, b) {
 		return a, true
 	}
@@ -1570,13 +1599,17 @@ func equalParamTypes(a, b *soltype.FuncType) bool {
 // and a borrow — are opaque atoms that no merge takes apart. The polarity passed
 // is Positive because a shallow normalization reads the same at either one.
 func (c *Context) meetTypes(a, b soltype.Type) soltype.Type {
-	return c.mkDNF(newIntersection(nil, []soltype.Type{a, b}), soltype.Positive).toType()
+	met := c.mkDNF(newIntersection(nil, []soltype.Type{a, b}), soltype.Positive).toType()
+	c.recordNorm(met, a, b)
+	return met
 }
 
 // joinTypes is the join twin of meetTypes, the one a fused arrow's domain and a
 // widened record field are written from.
 func (c *Context) joinTypes(a, b soltype.Type) soltype.Type {
-	return c.mkDNF(newUnion(nil, []soltype.Type{a, b}, false), soltype.Positive).toType()
+	joined := c.mkDNF(newUnion(nil, []soltype.Type{a, b}, false), soltype.Positive).toType()
+	c.recordNorm(joined, a, b)
+	return joined
 }
 
 // plainProps returns an object's members as properties, and ok is false when the

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -19,8 +19,9 @@ import (
 // variant rather than changing the map's value type.
 type Prov map[soltype.Type]Origin
 
-// Origin is a tagged sum naming the kind of hop that minted a type. M2.5 shipped
-// the FromAST leaf; M3 adds FromInstantiation; the rest are deferred.
+// Origin is a tagged sum naming the kind of hop that minted a type. FromAST is the
+// leaf; FromInstantiation and FromNormalization are interior edges; the rest are
+// deferred.
 type Origin interface{ isOrigin() }
 
 // FromAST is the leaf: a direct AST cause for a freshly-minted type.
@@ -41,6 +42,24 @@ type FromInstantiation struct {
 }
 
 func (FromInstantiation) isOrigin() {}
+
+// FromNormalization is the interior edge a normal-form fusion mints: the atom the
+// merge produced came from the atoms it merged. `((x: number) -> boolean) &
+// ((x: string) -> boolean)` reaches the solver as the one arrow
+// `(x: number | string) -> boolean`, and neither the fused arrow nor its fused
+// domain `number | string` was written by an AST node, so without this edge both
+// resolve to nothing and a diagnostic naming one falls back to the constraint
+// site's span.
+//
+// From holds the two atoms the fusion combined, in the order the merge received
+// them. It carries no AST node of its own. The renderer that chases From back to
+// its AST leaves is M11.5's multi-hop provenance renderer, so NodeFor still
+// resolves only FromAST. This mints the edge; nothing reads it yet.
+type FromNormalization struct {
+	From []soltype.Type
+}
+
+func (FromNormalization) isOrigin() {}
 
 // ASTOriginKind tags WHY a node minted a type, so a renderer/LSP can phrase blame
 // ("the literal here", "this argument", "field `x`") without re-deriving it from
@@ -124,11 +143,39 @@ func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
 	c.prov[t] = FromAST{Node: n, Kind: kind}
 }
 
+// recordFusionEdge records the FromNormalization interior edge a normal-form
+// fusion mints, installed on Context in newChecker so a fusion in normal.go or
+// classes.go can reach the table the checker owns. fused is the atom the merge
+// produced; from names the atoms it merged.
+//
+// It writes nothing when fused already carries an origin, or when fused is one of
+// its own sources. An identity or absorption merge returns a source unchanged.
+// `A & A` is `A` and `5 & number` is `5`, so that source keeps its own leaf origin
+// rather than gaining a self-referential edge. A genuinely fresh fused node is a
+// distinct pointer with no entry, so it records.
+//
+// The write routes through snapshotProv so a discarded speculative trial rolls the
+// entry back, the same discipline recordProv and recordInstantiation follow. It
+// does not consult debugProv, since a fused pointer can legitimately already carry
+// an origin through interning. A re-record is skipped rather than crashing.
+func (c *checker) recordFusionEdge(fused soltype.Type, from []soltype.Type) {
+	if _, ok := c.prov[fused]; ok {
+		return
+	}
+	for _, src := range from {
+		if src == fused {
+			return
+		}
+	}
+	c.snapshotProv(fused)
+	c.prov[fused] = FromNormalization{From: from}
+}
+
 // snapshotProv registers a probe rollback for a pending write to t's Prov entry,
 // so a discarded speculative trial leaves Prov exactly as it was. A no-op when no
-// probe is open. Shared by both Prov writers (recordProv, recordInstantiation) so
-// every speculative side-table write is reversible; delegates to the same
-// snapshotMapEntry helper as recordType's Info write.
+// probe is open. recordProv, recordInstantiation, and recordFusionEdge all route
+// through it, so each speculative side-table write is reversible. It delegates to
+// the same snapshotMapEntry helper as recordType's Info write.
 func (c *checker) snapshotProv(t soltype.Type) {
 	snapshotMapEntry(c, c.prov, t)
 }

--- a/internal/solver/prov_test.go
+++ b/internal/solver/prov_test.go
@@ -20,6 +20,80 @@ func requireOrigin(t *testing.T, c *checker, ty soltype.Type, node ast.Node, kin
 	require.Equal(t, kind, fa.Kind, "origin kind")
 }
 
+// requireFromNormalization asserts the Prov table records ty as a fused atom minted
+// by normalization from exactly sources, in order. It reads prov directly rather
+// than through NodeFor, since NodeFor resolves only the FromAST leaf and the
+// renderer that chases a FromNormalization edge to its AST leaves is deferred to
+// M11.5.
+func requireFromNormalization(t *testing.T, c *checker, ty soltype.Type, sources ...soltype.Type) {
+	t.Helper()
+	o, ok := c.prov[ty]
+	require.True(t, ok, "expected a Prov entry for the fused atom")
+	fn, ok := o.(FromNormalization)
+	require.True(t, ok, "expected a FromNormalization origin")
+	require.Len(t, fn.From, len(sources), "fused-atom source count")
+	for i, src := range sources {
+		require.Same(t, src, fn.From[i], "fused-atom source %d", i)
+	}
+}
+
+// A fused arrow and its fused domain each carry a FromNormalization edge naming the
+// two atoms the merge combined. `(fn (x: number) -> boolean) &
+// (fn (x: string) -> boolean)` fuses to the one arrow
+// `fn (x: number | string) -> boolean`. The arrow came from the two source arrows,
+// and its domain `number | string` from the two source domains. Neither node was
+// written by an AST node, so without the edge a diagnostic naming one falls back to
+// the constraint site's span.
+func TestProvFusedArrowAndDomain(t *testing.T) {
+	c := newChecker()
+	a := parseType(t, "fn (x: number) -> boolean")
+	b := parseType(t, "fn (x: string) -> boolean")
+
+	fused, ok := c.ctx.meetAtoms(a, b)
+	require.True(t, ok, "the two arrows fuse")
+	requireFromNormalization(t, c, fused, a, b)
+
+	ft, ok := fused.(*soltype.FuncType)
+	require.True(t, ok, "the fused atom is an arrow")
+	aDomain := a.(*soltype.FuncType).Params[0].Type
+	bDomain := b.(*soltype.FuncType).Params[0].Type
+	requireFromNormalization(t, c, ft.Params[0].Type, aDomain, bDomain)
+}
+
+// A fused record and each field the merge rebuilds carry a FromNormalization edge.
+// `{x: number, ...} & {x: string, ...}` fuses field by field to `{x: never, ...}`.
+// The record came from the two source records, and the field `never` from the meet
+// of the two source field types.
+func TestProvFusedRecordAndField(t *testing.T) {
+	c := newChecker()
+	a := parseType(t, "{x: number, ...}")
+	b := parseType(t, "{x: string, ...}")
+
+	fused, ok := c.ctx.meetAtoms(a, b)
+	require.True(t, ok, "the two records fuse")
+	requireFromNormalization(t, c, fused, a, b)
+
+	fusedField := fused.(*soltype.ObjectType).Elems[0].(*soltype.PropertyElem).Type
+	aField := a.(*soltype.ObjectType).Elems[0].(*soltype.PropertyElem).Type
+	bField := b.(*soltype.ObjectType).Elems[0].(*soltype.PropertyElem).Type
+	requireFromNormalization(t, c, fusedField, aField, bField)
+}
+
+// A disjoint meet mints an edge for the `never` it produces, so a later renderer can
+// still reach the two atoms whose intersection is uninhabited. `5 & 6` fuses to
+// `never` naming the two literals.
+func TestProvFusedNeverNamesSources(t *testing.T) {
+	c := newChecker()
+	a := parseType(t, "5")
+	b := parseType(t, "6")
+
+	fused, ok := c.ctx.meetAtoms(a, b)
+	require.True(t, ok, "two disjoint literals meet to never")
+	_, isNever := fused.(*soltype.NeverType)
+	require.True(t, isNever, "the meet is never")
+	requireFromNormalization(t, c, fused, a, b)
+}
+
 // A literal mints a LitType recorded against its LiteralExpr.
 func TestProvLiteralInference(t *testing.T) {
 	c := newChecker()

--- a/planning/ml_struct/05-feature-interactions.md
+++ b/planning/ml_struct/05-feature-interactions.md
@@ -196,6 +196,45 @@ not reach codegen.**
 
 ---
 
+## Diagnostics and blame
+
+Normalization mints types no AST node minted. A structural merge fuses two atoms
+into one — two records field by field, two arrows into one, two tags of one class —
+and the fused node is a pointer nobody wrote. `Prov`, the side table that maps a
+type back to its origin, is keyed by pointer identity, so a fused node resolves to
+nothing and a diagnostic naming it falls back to the constraint site's span rather
+than the narrower node it would otherwise blame.
+
+The rule for the minting side is settled here so a later PR in the epic follows one
+convention. Every fusion records a `FromNormalization` interior edge naming the two
+atoms it merged. `Origin` is an interface, so the edge is an addition rather than a
+change to the table's value type, alongside the `FromAST` leaf and the
+`FromInstantiation` edge.
+
+The two atom-merge dispatchers `meetAtoms` and `joinAtoms` in
+`internal/solver/normal.go` mint the edge for every fusion they perform — a
+structural merge of two records, tuples, arrows, borrows, or class tags; a
+value-atom absorption; or a `never` from two disjoint atoms — naming the two atoms
+combined. The field-level `meetTypes` and `joinTypes` each record the member node
+they build as well, since a rebuilt arrow domain such as `number | string` or a
+field that collapses to `never` does not itself pass back through a dispatcher. An
+identity or absorption merge returns a source unchanged, `A & A` is `A` and
+`5 & number` is `5`, and keeps that source's own leaf origin rather than gaining a
+self-referential edge. `meetClassArgs` also runs from `instanceBelow`, which fuses
+two tags only to test a subtype relation and discards the result; that path bypasses
+the dispatchers, so a throwaway meet does not mint a container edge.
+
+The rendering side is deferred to M11.5, the multi-hop provenance renderer in
+`planning/simple_sub/01-milestones.md`. `NodeFor` resolves only the `FromAST` leaf
+today, so a `FromNormalization` edge is minted-but-unread and no diagnostic moves
+until that renderer chases the edge to its AST leaves. A fused atom has more than
+one source, which the single-source `FromAST` and `FromInstantiation` edges never
+do, so the renderer needs a rule the others do not. Two candidates: blame the
+nearest common ancestor of the leaves, or attach every leaf as a related span. The
+choice belongs with the renderer and is recorded here when it is made.
+
+---
+
 ## The cross-cutting theme
 
 Negation upgrades **every set-difference in the language at once**: type-level
@@ -214,3 +253,4 @@ inference win does not reach codegen, so MLstruct complicates rather than upgrad
 | Exact / inexact | Flag threads through; the merge must stay exactness-aware (exact `{x} & {y}` is `never`, not `{x, y}`) by reusing `newIntersection`. Exact unions + tag negation give `match` exhaustiveness. |
 | `throws` | Rides parallel to `Ret` as a covariant field. **Upgrade** — try/catch narrowing becomes native `body_throws & ¬caught`, resolving M9's open question. |
 | Function overloading | **Complication** — trigger 3 infers recursive-group overloads without annotations, but the set-theoretic type does not round-trip to a TS overload table and the inference win does not reach codegen. Implemented overloads still need per-arm annotations for deterministic dispatch. |
+| Diagnostics / blame | **Precision cost** — a structural merge mints a fused node no AST node wrote, so `Prov` resolves it to nothing and blame widens to the constraint site. Each merge records a `FromNormalization` edge naming the atoms it fused; the renderer that chases it to AST leaves is deferred to M11.5. |


### PR DESCRIPTION
Mints `FromNormalization` interior provenance edges when structural merges fuse two atoms into one, so diagnostics can later trace fused types back to their source atoms.

When the solver normalizes types, it fuses atoms structurally: two records merge field-by-field, two arrows merge into one, two disjoint literals produce `never`. These fused nodes are pointers the AST never wrote, so `Prov` (the side table mapping types to their origins) resolves them to nothing and diagnostics fall back to the constraint site's span rather than the narrower node they would otherwise blame.

This PR records a `FromNormalization` edge at every fusion point, naming the two atoms combined. The rendering side that chases these edges to AST leaves is deferred to M11.5; `NodeFor` still resolves only `FromAST` today, so the edges are minted-but-unread. The minting rule is settled here so later PRs in the epic follow one convention.

**Key changes:**

- Add `FromNormalization` origin type in `prov.go` alongside `FromAST` and `FromInstantiation`
- Install `recordFusion` hook on `Context` in `newChecker` to bridge fusion sites in the engine with the `Prov` table on the checker
- Call `recordNorm` from `meetAtoms`, `joinAtoms`, `meetTypes`, and `joinTypes` in `normal.go` to record edges at each fusion
- Extract `meetFusedAtoms` and `joinFusedAtoms` helpers to separate the fusion logic from provenance recording
- Add `recordFusionEdge` method to skip self-referential edges (identity and absorption merges keep their source's leaf origin)
- Add three test cases in `prov_test.go` covering fused arrows with domains, fused records with fields, and disjoint literals producing `never`
- Document the minting rule and deferred rendering in `planning/ml_struct/05-feature-interactions.md`

https://claude.ai/code/session_01S3p23US9qmm8LBzJXDTs5Y