### PR TITLE
Extend object member fusion to methods, accessors, and constructors

### DIFF
--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -738,6 +738,9 @@ func compareObjElem(a, b soltype.ObjTypeElem) int {
 		if a.Optional != b.Optional {
 			return boolOrder(a.Optional) - boolOrder(b.Optional)
 		}
+		if a.Readonly != b.Readonly {
+			return boolOrder(a.Readonly) - boolOrder(b.Readonly)
+		}
 		return compareType(a.Type, b.Type)
 	case *soltype.MethodElem:
 		b := b.(*soltype.MethodElem)

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -695,42 +695,129 @@ func compareFuncParam(a, b *soltype.FuncParam) int {
 	return compareType(a.Type, b.Type)
 }
 
-// compareObjectFields orders two objects by property name, then by each
-// property's optional flag and type. Property order in the slice is
-// presentation only, so the comparator walks both objects in name-sorted
-// order.
+// compareObjectFields orders two objects member against member. Element order in
+// the slice is presentation only, so each object's members are sorted by
+// compareObjElem first, then compared position by position.
 func compareObjectFields(a, b *soltype.ObjectType) int {
 	if c := len(a.Elems) - len(b.Elems); c != 0 {
 		return c
 	}
-	an := sortedPropertyNames(a)
-	bn := sortedPropertyNames(b)
-	for i := range an {
-		if c := stringCompare(an[i], bn[i]); c != 0 {
-			return c
-		}
-		ap, _ := a.Prop(an[i])
-		bp, _ := b.Prop(bn[i])
-		if ap.Optional != bp.Optional {
-			return boolOrder(ap.Optional) - boolOrder(bp.Optional)
-		}
-		if c := compareType(ap.Type, bp.Type); c != 0 {
+	ae := sortedObjElems(a.Elems)
+	be := sortedObjElems(b.Elems)
+	for i := range ae {
+		if c := compareObjElem(ae[i], be[i]); c != 0 {
 			return c
 		}
 	}
 	return 0
 }
 
-func sortedPropertyNames(o *soltype.ObjectType) []string {
-	// A residual object's members are a spread or a mapped member, neither of which names a field.
-	// soltype.ObjElemName returns "" for both, so they sort together and compare equal, which leaves
-	// the caller's ordering decided by the members that do name something.
-	names := make([]string, len(o.Elems))
-	for i, e := range o.Elems {
-		names[i] = soltype.ObjElemName(e)
+// sortedObjElems returns a copy of the members ordered by compareObjElem, so a
+// comparison reads both objects in one canonical order without mutating either.
+func sortedObjElems(elems []soltype.ObjTypeElem) []soltype.ObjTypeElem {
+	out := append([]soltype.ObjTypeElem(nil), elems...)
+	sort.SliceStable(out, func(i, j int) bool {
+		return compareObjElem(out[i], out[j]) < 0
+	})
+	return out
+}
+
+// compareObjElem orders two object members by name, then by kind, then by the
+// fields of that kind. Ordering a member by kind lets a getter and a setter that
+// share one name sort into a fixed order, which the name alone cannot settle.
+func compareObjElem(a, b soltype.ObjTypeElem) int {
+	if c := stringCompare(soltype.ObjElemName(a), soltype.ObjElemName(b)); c != 0 {
+		return c
 	}
-	sort.Strings(names)
-	return names
+	if c := objElemKindOrder(a) - objElemKindOrder(b); c != 0 {
+		return c
+	}
+	switch a := a.(type) {
+	case *soltype.PropertyElem:
+		b := b.(*soltype.PropertyElem)
+		if a.Optional != b.Optional {
+			return boolOrder(a.Optional) - boolOrder(b.Optional)
+		}
+		return compareType(a.Type, b.Type)
+	case *soltype.MethodElem:
+		b := b.(*soltype.MethodElem)
+		if a.Static != b.Static {
+			return boolOrder(a.Static) - boolOrder(b.Static)
+		}
+		if c := len(a.Signatures) - len(b.Signatures); c != 0 {
+			return c
+		}
+		for i := range a.Signatures {
+			if c := compareType(a.Signatures[i], b.Signatures[i]); c != 0 {
+				return c
+			}
+		}
+		return 0
+	case *soltype.GetterElem:
+		b := b.(*soltype.GetterElem)
+		if c := compareSelfParam(a.SelfParam, b.SelfParam); c != 0 {
+			return c
+		}
+		if c := compareType(a.Type, b.Type); c != 0 {
+			return c
+		}
+		// ThrowsOrNever reads both sides through the nil-is-never collapse, so two
+		// getters differing only in whether the clause was written compare equal.
+		return compareType(a.ThrowsOrNever(), b.ThrowsOrNever())
+	case *soltype.SetterElem:
+		b := b.(*soltype.SetterElem)
+		if c := compareSelfParam(a.SelfParam, b.SelfParam); c != 0 {
+			return c
+		}
+		if c := compareType(a.Param, b.Param); c != 0 {
+			return c
+		}
+		return compareType(a.ThrowsOrNever(), b.ThrowsOrNever())
+	case *soltype.ConstructorElem:
+		return compareType(a.Fn, b.(*soltype.ConstructorElem).Fn)
+	case *soltype.SpreadElem:
+		return compareType(a.Type, b.(*soltype.SpreadElem).Type)
+	case *soltype.MappedElem:
+		// A mapped member computes the whole member list rather than naming one field.
+		// Ordering by its value type gives a stable key, and equalObjElem settles whether
+		// two are truly equal.
+		return compareType(a.Value, b.(*soltype.MappedElem).Value)
+	}
+	return 0
+}
+
+// objElemKindOrder ranks the member kinds so compareObjElem can order two members
+// that share a name but not a kind.
+func objElemKindOrder(e soltype.ObjTypeElem) int {
+	switch e.(type) {
+	case *soltype.PropertyElem:
+		return 0
+	case *soltype.MethodElem:
+		return 1
+	case *soltype.GetterElem:
+		return 2
+	case *soltype.SetterElem:
+		return 3
+	case *soltype.ConstructorElem:
+		return 4
+	case *soltype.SpreadElem:
+		return 5
+	case *soltype.MappedElem:
+		return 6
+	}
+	return 7
+}
+
+// compareSelfParam orders two method or accessor receivers. A missing receiver
+// sorts before a present one, and two present receivers order by compareFuncParam.
+func compareSelfParam(a, b *soltype.FuncParam) int {
+	if (a == nil) != (b == nil) {
+		return boolOrder(a != nil) - boolOrder(b != nil)
+	}
+	if a == nil {
+		return 0
+	}
+	return compareFuncParam(a, b)
 }
 
 func stringCompare(a, b string) int {

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -796,7 +796,7 @@ func (c *Context) joinAtoms(a, b soltype.Type) (soltype.Type, bool) {
 // structural equality, and it keeps the test in step with equalType as kinds gain
 // fields.
 //
-// An UNREDUCED atom is left alone, which is the same refusal plainProps and
+// An UNREDUCED atom is left alone, which is the same refusal mergeableElems and
 // comparableTuples make. A `{...S}` does not know its own field names and a
 // `[...P]` does not know its own positions, so neither supports the claim that the
 // exact side caps what the inexact side leaves open. The constraint rules treat
@@ -1073,70 +1073,77 @@ func joinValueAtoms(a, b soltype.Type) (soltype.Type, bool) {
 //
 // The meet is exact when either side is, since one cap is enough to close the key
 // set.
+//
+// A member the two objects share is fused member against member by meetObjElem,
+// which bails on any pair it cannot fuse exactly, so a method or accessor whose
+// merge is not expressible keeps the two objects apart the same way a readonly
+// clash does.
 func (c *Context) meetObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
-	pa, ok := plainProps(a)
+	ea, ok := mergeableElems(a)
 	if !ok {
 		return nil, false
 	}
-	pb, ok := plainProps(b)
+	eb, ok := mergeableElems(b)
 	if !ok {
 		return nil, false
 	}
-	if !requiredFieldsWithin(pa, pb, b.Inexact) || !requiredFieldsWithin(pb, pa, a.Inexact) {
+	if !requiredMembersWithin(ea, eb, b.Inexact) || !requiredMembersWithin(eb, ea, a.Inexact) {
 		return &soltype.NeverType{}, true
 	}
-	elems := make([]soltype.ObjTypeElem, 0, len(pa)+len(pb))
-	for _, p := range pa {
-		q, shared := propNamed(pb, p.Name)
+	elems := make([]soltype.ObjTypeElem, 0, len(ea)+len(eb))
+	for _, e := range ea {
+		q, shared := elemNamed(eb, soltype.ObjElemName(e))
 		if !shared {
 			if !b.Inexact {
 				continue
 			}
-			elems = append(elems, p)
+			elems = append(elems, e)
 			continue
 		}
-		// A readonly field and a writable one constrain what a holder may do rather
-		// than which values inhabit the type, and no rule says which marker the fused
-		// field should carry, so the two atoms stay separate.
-		if p.Readonly != q.Readonly {
+		merged, ok := c.meetObjElem(e, q)
+		if !ok {
 			return nil, false
 		}
-		elems = append(elems, &soltype.PropertyElem{
-			Name:     p.Name,
-			Type:     c.meetTypes(p.Type, q.Type),
-			Optional: p.Optional && q.Optional,
-			Readonly: p.Readonly,
-		})
+		elems = append(elems, merged)
 	}
-	for _, q := range pb {
-		if _, shared := propNamed(pa, q.Name); shared {
+	for _, e := range eb {
+		if _, shared := elemNamed(ea, soltype.ObjElemName(e)); shared {
 			continue
 		}
 		if !a.Inexact {
 			continue
 		}
-		elems = append(elems, q)
+		elems = append(elems, e)
 	}
 	return &soltype.ObjectType{Elems: sortedByName(elems), Inexact: a.Inexact && b.Inexact}, true
 }
 
-// requiredFieldsWithin reports whether every field props REQUIRES is one the
-// allowed list names. Pass open as true when allowed came off an inexact object.
-// Such an object caps nothing, so it admits any field name and the check passes
-// without reading either list.
-func requiredFieldsWithin(props, allowed []*soltype.PropertyElem, open bool) bool {
+// requiredMembersWithin reports whether the allowed list names every member that
+// `members` requires. A member is required unless it is an optional property, so a
+// method, accessor, or constructor always counts. Pass open as true when allowed
+// came off an inexact object. Such an object caps nothing, so it admits any member
+// name and the check passes without reading either list.
+func requiredMembersWithin(members, allowed []soltype.ObjTypeElem, open bool) bool {
 	if open {
 		return true
 	}
-	for _, p := range props {
-		if p.Optional {
+	for _, e := range members {
+		if optionalProperty(e) {
 			continue
 		}
-		if _, ok := propNamed(allowed, p.Name); !ok {
+		if _, ok := elemNamed(allowed, soltype.ObjElemName(e)); !ok {
 			return false
 		}
 	}
 	return true
+}
+
+// optionalProperty reports whether a member is an `x?: T` property, the only member
+// kind that does not add to an object's required floor. A method, accessor, or
+// constructor is always present, so none is ever optional.
+func optionalProperty(e soltype.ObjTypeElem) bool {
+	p, ok := e.(*soltype.PropertyElem)
+	return ok && p.Optional
 }
 
 // joinObjects fuses two object atoms under a union. One object denotes their union
@@ -1160,43 +1167,43 @@ func requiredFieldsWithin(props, allowed []*soltype.PropertyElem, open bool) boo
 // second field, and only the exact member admits an x from A. The pair that would
 // fuse is the one whose fields also agree, and joinAtoms answers that one through
 // widerByExactness before reaching here.
+//
+// The one member that differs is fused by joinObjElem, which bails on any pair it
+// cannot fuse exactly. A method, setter, or constructor carries a contravariant
+// input or a per-call output, neither of which a union folds into one member, so
+// only a property or a getter ever widens.
 func (c *Context) joinObjects(a, b *soltype.ObjectType) (soltype.Type, bool) {
 	if a.Inexact != b.Inexact {
 		return nil, false
 	}
-	pa, ok := plainProps(a)
+	ea, ok := mergeableElems(a)
 	if !ok {
 		return nil, false
 	}
-	pb, ok := plainProps(b)
+	eb, ok := mergeableElems(b)
 	if !ok {
 		return nil, false
 	}
-	if !sameFieldNames(pa, pb) {
+	if !sameMemberNames(ea, eb) {
 		return nil, false
 	}
-	elems := make([]soltype.ObjTypeElem, 0, len(pa))
+	elems := make([]soltype.ObjTypeElem, 0, len(ea))
 	widened := 0
-	for _, p := range pa {
-		q, _ := propNamed(pb, p.Name)
-		// Readonly stays a bail, for the reason meetObjects gives.
-		if p.Readonly != q.Readonly {
-			return nil, false
-		}
-		if p.Optional == q.Optional && equalType(p.Type, q.Type) {
-			elems = append(elems, p)
+	for _, e := range ea {
+		q, _ := elemNamed(eb, soltype.ObjElemName(e))
+		if equalMember(e, q) {
+			elems = append(elems, e)
 			continue
 		}
 		widened++
 		if widened > 1 {
 			return nil, false
 		}
-		elems = append(elems, &soltype.PropertyElem{
-			Name:     p.Name,
-			Type:     c.joinTypes(p.Type, q.Type),
-			Optional: p.Optional || q.Optional,
-			Readonly: p.Readonly,
-		})
+		merged, ok := c.joinObjElem(e, q)
+		if !ok {
+			return nil, false
+		}
+		elems = append(elems, merged)
 	}
 	return &soltype.ObjectType{Elems: sortedByName(elems), Inexact: a.Inexact}, true
 }
@@ -1544,10 +1551,7 @@ func sameThrows(a, b *soltype.FuncType) bool {
 // non-throwing arrows yields a third whose Throws stays nil rather than an explicit
 // `never` the printer would have to suppress.
 func (c *Context) meetThrows(a, b *soltype.FuncType) soltype.Type {
-	if sameThrows(a, b) {
-		return a.Throws
-	}
-	return c.meetTypes(a.ThrowsOrNever(), b.ThrowsOrNever())
+	return c.meetThrowsTypes(a.Throws, b.Throws)
 }
 
 func equalParamTypes(a, b *soltype.FuncType) bool {
@@ -1579,30 +1583,278 @@ func (c *Context) joinTypes(a, b soltype.Type) soltype.Type {
 	return c.mkDNF(newUnion(nil, []soltype.Type{a, b}, false), soltype.Positive).toType()
 }
 
-// plainProps returns an object's members as properties, and ok is false when the
-// object carries any other member kind, which keeps that object an unfused atom.
-// The two reasons for refusing differ.
+// mergeableElems returns an object's members for a field-by-field merge, and ok is
+// false when the object cannot take part in one. The two refusals differ.
 //
-// A spread or a mapped member makes the object an unreduced residual whose real
-// member list is not known yet, so there is nothing to fuse field by field until
-// the evaluator settles it. See soltype.HasResidualElem. Refusing those two is
-// required, not a choice.
+// A member that is not a property, method, accessor, or constructor is refused. A
+// spread or a mapped member, an index signature included, stands for a member list
+// the merge cannot take apart field by field, so an object carrying one is kept
+// whole.
 //
-// A method, an accessor, and a constructor could fuse under a rule of their own,
-// since each carries a FuncType that could meet the way meetFuncs meets an arrow
-// atom. No such rule exists, and none is needed: an unfused atom denotes the meet
-// or the join just as precisely, so writing one would only shrink the normal form.
-// TODO(#1103).
-func plainProps(o *soltype.ObjectType) ([]*soltype.PropertyElem, bool) {
-	props := make([]*soltype.PropertyElem, 0, len(o.Elems))
+// A repeated member name is refused so the merge can pair members by name with at
+// most one hit per side. The only source of a repeat is a `get x` and `set x`
+// accessor pair sharing one name. Keeping such an object unfused costs an atom and
+// no precision, which is the trade this whole file is built on.
+func mergeableElems(o *soltype.ObjectType) ([]soltype.ObjTypeElem, bool) {
 	for _, e := range o.Elems {
-		p, ok := e.(*soltype.PropertyElem)
+		if !fusableMember(e) {
+			return nil, false
+		}
+	}
+	if hasRepeatedName(o.Elems) {
+		return nil, false
+	}
+	return o.Elems, true
+}
+
+// fusableMember reports whether a member has a per-kind merge rule. A spread and a
+// mapped member do not, so an object carrying either stays an unfused atom.
+func fusableMember(e soltype.ObjTypeElem) bool {
+	switch e.(type) {
+	case *soltype.PropertyElem, *soltype.MethodElem, *soltype.GetterElem,
+		*soltype.SetterElem, *soltype.ConstructorElem:
+		return true
+	}
+	return false
+}
+
+// hasRepeatedName reports whether two members of one object share a name. Its
+// callers rule out spread and mapped members first, so a constructor is the only
+// member that names the empty string, and an object holds at most one. The empty
+// key therefore never collides with itself here.
+func hasRepeatedName(elems []soltype.ObjTypeElem) bool {
+	seen := set.NewSet[string]()
+	for _, e := range elems {
+		name := soltype.ObjElemName(e)
+		if seen.Contains(name) {
+			return true
+		}
+		seen.Add(name)
+	}
+	return false
+}
+
+// meetObjElem fuses two members that share a name into the one member a value of
+// both objects carries, and ok is false when no single member denotes the meet.
+// Equal members fuse to themselves, which is what lets two objects sharing an
+// identical overloaded method fuse without meetMethods having to meet the overload
+// sets. A pair of different kinds never fuses.
+func (c *Context) meetObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bool) {
+	if equalMember(a, b) {
+		return a, true
+	}
+	switch a := a.(type) {
+	case *soltype.PropertyElem:
+		b, ok := b.(*soltype.PropertyElem)
 		if !ok {
 			return nil, false
 		}
-		props = append(props, p)
+		// A readonly field and a writable one constrain what a holder may do rather
+		// than which values inhabit the type, and no rule says which marker the fused
+		// field should carry, so the two atoms stay separate.
+		if a.Readonly != b.Readonly {
+			return nil, false
+		}
+		return &soltype.PropertyElem{
+			Name:     a.Name,
+			Type:     c.meetTypes(a.Type, b.Type),
+			Optional: a.Optional && b.Optional,
+			Readonly: a.Readonly,
+		}, true
+	case *soltype.MethodElem:
+		b, ok := b.(*soltype.MethodElem)
+		if !ok {
+			return nil, false
+		}
+		return c.meetMethods(a, b)
+	case *soltype.GetterElem:
+		b, ok := b.(*soltype.GetterElem)
+		if !ok {
+			return nil, false
+		}
+		if !equalSelfParam(a.SelfParam, b.SelfParam, &alphaCtx{}) {
+			return nil, false
+		}
+		// A getter reads its property, so both Type and Throws are covariant outputs
+		// that meet the way a function's codomain does.
+		return &soltype.GetterElem{
+			Name:      a.Name,
+			SelfParam: a.SelfParam,
+			Type:      c.meetTypes(a.Type, b.Type),
+			Throws:    c.meetThrowsTypes(a.Throws, b.Throws),
+		}, true
+	case *soltype.SetterElem:
+		b, ok := b.(*soltype.SetterElem)
+		if !ok {
+			return nil, false
+		}
+		return c.meetSetters(a, b)
+	case *soltype.ConstructorElem:
+		b, ok := b.(*soltype.ConstructorElem)
+		if !ok {
+			return nil, false
+		}
+		fused, ok := c.meetFuncs(a.Fn, b.Fn)
+		if !ok {
+			return nil, false
+		}
+		fn, ok := fused.(*soltype.FuncType)
+		if !ok {
+			return nil, false
+		}
+		return &soltype.ConstructorElem{Fn: fn}, true
 	}
-	return props, true
+	return nil, false
+}
+
+// joinObjElem fuses the one member two objects differ in into the member their
+// union carries, and ok is false when no single member denotes the join. Only a
+// property and a getter can widen. Each reads a single value, so the union of the
+// two members reads a value from the union of the two types, which one member
+// states. A method, setter, or constructor carries a contravariant input or a
+// per-call output that no single member folds a union into, so each bails.
+func (c *Context) joinObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bool) {
+	switch a := a.(type) {
+	case *soltype.PropertyElem:
+		b, ok := b.(*soltype.PropertyElem)
+		if !ok {
+			return nil, false
+		}
+		// Readonly stays a bail, for the reason meetObjElem gives.
+		if a.Readonly != b.Readonly {
+			return nil, false
+		}
+		return &soltype.PropertyElem{
+			Name:     a.Name,
+			Type:     c.joinTypes(a.Type, b.Type),
+			Optional: a.Optional || b.Optional,
+			Readonly: a.Readonly,
+		}, true
+	case *soltype.GetterElem:
+		b, ok := b.(*soltype.GetterElem)
+		if !ok {
+			return nil, false
+		}
+		if !equalSelfParam(a.SelfParam, b.SelfParam, &alphaCtx{}) {
+			return nil, false
+		}
+		return &soltype.GetterElem{
+			Name:      a.Name,
+			SelfParam: a.SelfParam,
+			Type:      c.joinTypes(a.Type, b.Type),
+			Throws:    c.joinThrowsTypes(a.Throws, b.Throws),
+		}, true
+	}
+	return nil, false
+}
+
+// meetMethods fuses two methods that share a name. An overloaded method fuses only
+// when the two overload sets are identical, which meetObjElem's equal-member check
+// already answered before reaching here, so a set that is not a single signature
+// keeps the objects apart. Static-ness must agree, since a static method lives on
+// the constructor value and an instance method on the instance, so the two are not
+// the same member.
+func (c *Context) meetMethods(a, b *soltype.MethodElem) (soltype.ObjTypeElem, bool) {
+	if a.Static != b.Static {
+		return nil, false
+	}
+	if len(a.Signatures) != 1 || len(b.Signatures) != 1 {
+		return nil, false
+	}
+	fused, ok := c.meetMethodSig(a.Signatures[0], b.Signatures[0])
+	if !ok {
+		return nil, false
+	}
+	return &soltype.MethodElem{Name: a.Name, Signatures: []*soltype.FuncType{fused}, Static: a.Static}, true
+}
+
+// meetSetters fuses two setters that share a name. A setter is a one-input arrow
+// whose Throws is its only output, so its meet follows the two arrow cases
+// meetFuncs uses. When the written values agree the outputs meet, and when the
+// raises agree the written values join. A pair that agrees on neither has no single
+// setter that states both, the same reason meetFuncs keeps two arrows apart, so it
+// bails. The receivers must be equal, since one setter cannot say which it takes.
+func (c *Context) meetSetters(a, b *soltype.SetterElem) (soltype.ObjTypeElem, bool) {
+	if !equalSelfParam(a.SelfParam, b.SelfParam, &alphaCtx{}) {
+		return nil, false
+	}
+	if equalType(a.Param, b.Param) {
+		return &soltype.SetterElem{
+			Name:      a.Name,
+			SelfParam: a.SelfParam,
+			Param:     a.Param,
+			Throws:    c.meetThrowsTypes(a.Throws, b.Throws),
+		}, true
+	}
+	if equalType(orNever(a.Throws), orNever(b.Throws)) {
+		return &soltype.SetterElem{
+			Name:      a.Name,
+			SelfParam: a.SelfParam,
+			Param:     c.joinTypes(a.Param, b.Param),
+			Throws:    a.Throws,
+		}, true
+	}
+	return nil, false
+}
+
+// meetMethodSig meets two method signatures, which carry a self receiver that
+// meetFuncs does not handle. The receivers must be equal, since one signature
+// cannot say which receiver it takes. With the receiver set aside the rest meets as
+// an arrow, and the shared receiver is written back onto the result.
+func (c *Context) meetMethodSig(a, b *soltype.FuncType) (*soltype.FuncType, bool) {
+	if !equalSelfParam(a.SelfParam, b.SelfParam, &alphaCtx{}) {
+		return nil, false
+	}
+	da := *a
+	da.SelfParam = nil
+	db := *b
+	db.SelfParam = nil
+	fused, ok := c.meetFuncs(&da, &db)
+	if !ok {
+		return nil, false
+	}
+	fn, ok := fused.(*soltype.FuncType)
+	if !ok {
+		return nil, false
+	}
+	fn.SelfParam = a.SelfParam
+	return fn, true
+}
+
+// meetThrowsTypes meets two throws clauses, each read through the nil-is-never
+// shorthand. It keeps the clause unwritten when both agree, so fusing two members
+// whose Throws is nil leaves the result's Throws nil rather than an explicit
+// `never` the printer would suppress. It is the member twin of meetThrows.
+func (c *Context) meetThrowsTypes(a, b soltype.Type) soltype.Type {
+	if equalType(orNever(a), orNever(b)) {
+		return a
+	}
+	return c.meetTypes(orNever(a), orNever(b))
+}
+
+// joinThrowsTypes is the join twin of meetThrowsTypes, written for a widening
+// getter whose two Throws clauses join the way its returned value does.
+func (c *Context) joinThrowsTypes(a, b soltype.Type) soltype.Type {
+	if equalType(orNever(a), orNever(b)) {
+		return a
+	}
+	return c.joinTypes(orNever(a), orNever(b))
+}
+
+// orNever resolves the nil-is-never shorthand a throws clause uses, so a caller
+// comparing or merging two clauses reads a concrete type in either slot.
+func orNever(t soltype.Type) soltype.Type {
+	if t == nil {
+		return &soltype.NeverType{}
+	}
+	return t
+}
+
+// equalMember reports whether two object members are structurally equal, so a
+// merge can keep one unchanged instead of rebuilding it. It compares under a fresh
+// binder pairing, which two members carrying no bound name never consult.
+func equalMember(a, b soltype.ObjTypeElem) bool {
+	return equalObjElem(a, b, &alphaCtx{})
 }
 
 // sortedByName orders a fused object's members by field name. A fused object is
@@ -1618,23 +1870,24 @@ func sortedByName(elems []soltype.ObjTypeElem) []soltype.ObjTypeElem {
 	return elems
 }
 
-func propNamed(props []*soltype.PropertyElem, name string) (*soltype.PropertyElem, bool) {
-	for _, p := range props {
-		if p.Name == name {
-			return p, true
+func elemNamed(elems []soltype.ObjTypeElem, name string) (soltype.ObjTypeElem, bool) {
+	for _, e := range elems {
+		if soltype.ObjElemName(e) == name {
+			return e, true
 		}
 	}
 	return nil, false
 }
 
-// sameFieldNames reports whether two property lists name the same fields. Order is
-// irrelevant, since an object's element order is presentation only.
-func sameFieldNames(a, b []*soltype.PropertyElem) bool {
+// sameMemberNames reports whether two member lists name the same members. Order is
+// irrelevant, since an object's element order is presentation only. A repeated name
+// is ruled out before this runs, so equal lengths plus one-way containment settle it.
+func sameMemberNames(a, b []soltype.ObjTypeElem) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for _, p := range a {
-		if _, ok := propNamed(b, p.Name); !ok {
+	for _, e := range a {
+		if _, ok := elemNamed(b, soltype.ObjElemName(e)); !ok {
 			return false
 		}
 	}

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1748,12 +1748,13 @@ func (c *Context) joinObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bo
 	return nil, false
 }
 
-// meetMethods fuses two methods that share a name. An overloaded method fuses only
-// when the two overload sets are identical, which meetObjElem's equal-member check
-// already answered before reaching here, so a set that is not a single signature
-// keeps the objects apart. Static-ness must agree, since a static method lives on
-// the constructor value and an instance method on the instance, so the two are not
-// the same member.
+// meetMethods fuses two methods that share a name by meeting their signatures. It
+// fuses only single-signature methods, bailing when either carries an overload set.
+// Two identical methods never reach here, since meetObjElem's equal-member check
+// returns one of them first, so the overload sets that do reach here always differ,
+// and meeting two differing overload sets exactly is not attempted. Static-ness must
+// agree, since a static method lives on the constructor value and an instance method
+// on the instance, so the two are not the same member.
 func (c *Context) meetMethods(a, b *soltype.MethodElem) (soltype.ObjTypeElem, bool) {
 	if a.Static != b.Static {
 		return nil, false

--- a/internal/solver/normal_member_merge_test.go
+++ b/internal/solver/normal_member_merge_test.go
@@ -84,6 +84,11 @@ func TestObjectMemberMeet(t *testing.T) {
 			want: "{foo: number} & {foo(self) -> number}",
 		},
 		{
+			name: "a readonly and a writable field of one name keep both atoms",
+			in:   "{readonly x: number} & {x: number}",
+			want: "{x: number} & {readonly x: number}",
+		},
+		{
 			name: "an exact object meets an exact object lacking its method: never",
 			in:   "{foo(self) -> number} & {bar(self) -> number}",
 			want: "never",
@@ -146,6 +151,11 @@ func TestObjectMemberJoin(t *testing.T) {
 			in:   "{new () -> number} | {new () -> string}",
 			want: "{new () -> number} | {new () -> string}",
 		},
+		{
+			name: "a readonly and a writable field of one name keep both atoms",
+			in:   "{readonly x: number} | {x: string}",
+			want: "{x: string} | {readonly x: number}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -172,4 +182,20 @@ func TestIndexSignatureObjectStaysUnfused(t *testing.T) {
 	require.False(t, ok, "meetObjects keeps an index-signature object unfused")
 	_, ok = c.joinObjects(withIndexSig(), withIndexSig())
 	require.False(t, ok, "joinObjects keeps an index-signature object unfused")
+}
+
+// TestStaticMethodMismatchStaysUnfused covers meetMethods' Static bail. A static
+// method lives on the constructor value and an instance method on the instance, so
+// two methods of one name that disagree on Static are not the same member and the
+// objects stay apart. Object type annotations have no static-member syntax, so this
+// builds the objects directly.
+func TestStaticMethodMismatchStaysUnfused(t *testing.T) {
+	c := &Context{}
+	method := func(static bool) *soltype.ObjectType {
+		return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.MethodElem{Name: "foo", Static: static, Signatures: []*soltype.FuncType{{Ret: num()}}},
+		}}
+	}
+	_, ok := c.meetObjects(method(true), method(false))
+	require.False(t, ok, "a static and an instance method of one name keep both atoms")
 }

--- a/internal/solver/normal_member_merge_test.go
+++ b/internal/solver/normal_member_merge_test.go
@@ -63,6 +63,22 @@ func TestObjectMemberMeet(t *testing.T) {
 			want: "{a: number, b: number, foo(self, x: number) -> number; foo(self, x: string) -> string, ...}",
 		},
 		{
+			name: "an exact object meets an inexact one requiring a member it caps out: never",
+			in:   "{foo(self) -> number} & {bar(self) -> number, ...}",
+			want: "never",
+		},
+		{
+			name: "an exact object meeting an inexact subset closes the result",
+			in:   "{bar(self) -> number, foo(self) -> number} & {foo(self) -> number, ...}",
+			want: "{bar(self) -> number, foo(self) -> number}",
+		},
+		{
+			name: "two inexact objects meet a shared method and keep disjoint fields open",
+			in: "{a: number, foo(self) -> number | string, ...} & " +
+				"{b: number, foo(self) -> string | boolean, ...}",
+			want: "{a: number, b: number, foo(self) -> string, ...}",
+		},
+		{
 			name: "a method and a property sharing a name keep both atoms",
 			in:   "{foo(self) -> number} & {foo: number}",
 			want: "{foo: number} & {foo(self) -> number}",
@@ -104,6 +120,16 @@ func TestObjectMemberJoin(t *testing.T) {
 			name: "objects differing only in a getter widen it",
 			in:   "{get x(self) -> number, foo(self) -> number} | {get x(self) -> string, foo(self) -> number}",
 			want: "{foo(self) -> number, get x(self) -> number | string}",
+		},
+		{
+			name: "two inexact objects differing in one property widen it and stay open",
+			in:   "{x: number, foo(self) -> number, ...} | {x: string, foo(self) -> number, ...}",
+			want: "{foo(self) -> number, x: number | string, ...}",
+		},
+		{
+			name: "a method-carrying object absorbs its own open version at the open one",
+			in:   "{foo(self) -> number} | {foo(self) -> number, ...}",
+			want: "{foo(self) -> number, ...}",
 		},
 		{
 			name: "objects differing in a method keep both atoms",

--- a/internal/solver/normal_member_merge_test.go
+++ b/internal/solver/normal_member_merge_test.go
@@ -1,0 +1,209 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// The rows here cover fusing objects that carry a method, an accessor, or a
+// constructor. parseType lowers only property members, so each case builds its
+// objects with the helpers below and combines them through newIntersection or
+// newUnion, the same combine path the production solver takes. normDNF then renders
+// the fused normal form a row asserts on.
+
+// selfRecv is a method or accessor receiver. printSelfReceiver renders any
+// non-borrow receiver as `self`, and both operands of a case share this type so
+// their receivers compare equal.
+func selfRecv() *soltype.FuncParam {
+	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}, Type: &soltype.ClassType{Name: "Self"}}
+}
+
+// methodElem builds a one-signature instance method `name(self, params) -> ret`.
+func methodElem(name string, ret soltype.Type, params ...*soltype.FuncParam) *soltype.MethodElem {
+	sig := &soltype.FuncType{SelfParam: selfRecv(), Params: params, Ret: ret}
+	return &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}}
+}
+
+// overloadElem builds a method holding several signatures, an overload set.
+func overloadElem(name string, sigs ...*soltype.FuncType) *soltype.MethodElem {
+	for _, s := range sigs {
+		s.SelfParam = selfRecv()
+	}
+	return &soltype.MethodElem{Name: name, Signatures: sigs}
+}
+
+// getterElem builds an instance getter `get name(self) -> t`.
+func getterElem(name string, t soltype.Type) *soltype.GetterElem {
+	return &soltype.GetterElem{Name: name, SelfParam: selfRecv(), Type: t}
+}
+
+// setterElem builds an instance setter `set name(self, value: t)`.
+func setterElem(name string, t soltype.Type) *soltype.SetterElem {
+	return &soltype.SetterElem{Name: name, SelfParam: selfRecv(), Param: t}
+}
+
+// setterThrows builds an instance setter that raises on write, `set name(self,
+// value: t) throws e`.
+func setterThrows(name string, t, e soltype.Type) *soltype.SetterElem {
+	return &soltype.SetterElem{Name: name, SelfParam: selfRecv(), Param: t, Throws: e}
+}
+
+// ctorElem builds a constructor `new (params) -> ret`.
+func ctorElem(ret soltype.Type, params ...*soltype.FuncParam) *soltype.ConstructorElem {
+	return &soltype.ConstructorElem{Fn: &soltype.FuncType{Params: params, Ret: ret}}
+}
+
+func TestObjectMemberMeet(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *soltype.ObjectType
+		b    *soltype.ObjectType
+		want string
+	}{
+		{
+			name: "objects sharing an identical method fuse their disjoint fields",
+			a:    inexactObj(propElem("a", num()), methodElem("foo", num())),
+			b:    inexactObj(propElem("b", num()), methodElem("foo", num())),
+			want: "{a: number, b: number, foo(self) -> number, ...}",
+		},
+		{
+			name: "a shared method with agreeing domains meets its codomains",
+			a:    exactObj(methodElem("foo", newUnion(nil, []soltype.Type{num(), str()}, false), identParam("x", num()))),
+			b:    exactObj(methodElem("foo", newUnion(nil, []soltype.Type{str(), boolT()}, false), identParam("x", num()))),
+			want: "{foo(self, x: number) -> string}",
+		},
+		{
+			name: "a shared getter meets its returned value",
+			a:    exactObj(getterElem("x", newUnion(nil, []soltype.Type{num(), str()}, false))),
+			b:    exactObj(getterElem("x", newUnion(nil, []soltype.Type{str(), boolT()}, false))),
+			want: "{get x(self) -> string}",
+		},
+		{
+			name: "a shared setter with equal raises joins the value it accepts",
+			a:    exactObj(setterElem("x", num())),
+			b:    exactObj(setterElem("x", str())),
+			want: "{set x(self, value: number | string)}",
+		},
+		{
+			name: "a shared setter with an equal written value meets its raises",
+			a:    exactObj(setterThrows("x", num(), newUnion(nil, []soltype.Type{strLit("a"), strLit("b")}, false))),
+			b:    exactObj(setterThrows("x", num(), newUnion(nil, []soltype.Type{strLit("b"), strLit("c")}, false))),
+			want: `{set x(self, value: number) throws "b"}`,
+		},
+		{
+			name: "a shared setter differing in both value and raises keeps both atoms",
+			a:    exactObj(setterThrows("x", num(), strLit("a"))),
+			b:    exactObj(setterThrows("x", str(), strLit("b"))),
+			want: `{set x(self, value: number) throws "a"} & {set x(self, value: string) throws "b"}`,
+		},
+		{
+			name: "a shared constructor joins its domain over a shared return",
+			a:    exactObj(ctorElem(boolT(), identParam("x", num()))),
+			b:    exactObj(ctorElem(boolT(), identParam("x", str()))),
+			want: "{new (x: number | string) -> boolean}",
+		},
+		{
+			name: "an identical overload set fuses without meeting the arms",
+			a: inexactObj(propElem("a", num()), overloadElem("foo",
+				exactFn(num(), identParam("x", num())),
+				exactFn(str(), identParam("x", str())))),
+			b: inexactObj(propElem("b", num()), overloadElem("foo",
+				exactFn(num(), identParam("x", num())),
+				exactFn(str(), identParam("x", str())))),
+			want: "{a: number, b: number, foo(self, x: number) -> number; foo(self, x: string) -> string, ...}",
+		},
+		{
+			name: "a method and a property sharing a name keep both atoms",
+			a:    exactObj(methodElem("foo", num())),
+			b:    exactObj(propElem("foo", num())),
+			want: "{foo: number} & {foo(self) -> number}",
+		},
+		{
+			name: "an exact object meets an exact object lacking its method: never",
+			a:    exactObj(methodElem("foo", num())),
+			b:    exactObj(methodElem("bar", num())),
+			want: "never",
+		},
+		{
+			name: "a get/set accessor pair keeps both atoms unfused",
+			a:    exactObj(propElem("a", num()), getterElem("x", num()), setterElem("x", num())),
+			b:    exactObj(propElem("b", num()), getterElem("x", num()), setterElem("x", num())),
+			want: "{a: number, get x(self) -> number, set x(self, value: number)} & " +
+				"{b: number, get x(self) -> number, set x(self, value: number)}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			got := normDNF(c, newIntersection(nil, []soltype.Type{tt.a, tt.b}))
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestIndexSignatureObjectStaysUnfused guards the scope line of #1103: a mapped
+// member such as an index signature has no per-member merge rule, so an object
+// carrying one is kept as its own atom. A settled index signature is not a residual,
+// so this checks fusableMember rather than the residual test alone keeps it out.
+func TestIndexSignatureObjectStaysUnfused(t *testing.T) {
+	c := &Context{}
+	withIndexSig := func() *soltype.ObjectType {
+		return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			propElem("a", num()),
+			&soltype.MappedElem{Key: &soltype.MappedKeyType{ID: 0, Name: "K"}, Keys: str(), Value: num()},
+		}}
+	}
+	_, ok := c.meetObjects(withIndexSig(), withIndexSig())
+	require.False(t, ok, "meetObjects keeps an index-signature object unfused")
+	_, ok = c.joinObjects(withIndexSig(), withIndexSig())
+	require.False(t, ok, "joinObjects keeps an index-signature object unfused")
+}
+
+func TestObjectMemberJoin(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *soltype.ObjectType
+		b    *soltype.ObjectType
+		want string
+	}{
+		{
+			name: "objects agreeing but for one property widen it, keeping shared methods",
+			a:    exactObj(propElem("x", num()), methodElem("foo", num())),
+			b:    exactObj(propElem("x", str()), methodElem("foo", num())),
+			want: "{foo(self) -> number, x: number | string}",
+		},
+		{
+			name: "objects differing only in a getter widen it",
+			a:    exactObj(getterElem("x", num()), methodElem("foo", num())),
+			b:    exactObj(getterElem("x", str()), methodElem("foo", num())),
+			want: "{foo(self) -> number, get x(self) -> number | string}",
+		},
+		{
+			name: "objects differing in a method keep both atoms",
+			a:    exactObj(methodElem("foo", num())),
+			b:    exactObj(methodElem("foo", str())),
+			want: "{foo(self) -> number} | {foo(self) -> string}",
+		},
+		{
+			name: "objects differing in a setter keep both atoms",
+			a:    exactObj(setterElem("x", num())),
+			b:    exactObj(setterElem("x", str())),
+			want: "{set x(self, value: number)} | {set x(self, value: string)}",
+		},
+		{
+			name: "objects differing in a constructor keep both atoms",
+			a:    exactObj(ctorElem(num())),
+			b:    exactObj(ctorElem(str())),
+			want: "{new () -> number} | {new () -> string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			got := normDNF(c, newUnion(nil, []soltype.Type{tt.a, tt.b}, false))
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/solver/normal_member_merge_test.go
+++ b/internal/solver/normal_member_merge_test.go
@@ -7,129 +7,75 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The rows here cover fusing objects that carry a method, an accessor, or a
-// constructor. parseType lowers only property members, so each case builds its
-// objects with the helpers below and combines them through newIntersection or
-// newUnion, the same combine path the production solver takes. normDNF then renders
-// the fused normal form a row asserts on.
+// These tests cover fusing objects that carry a method, an accessor, or a
+// constructor. Each case states its input as an intersection or a union of object
+// types written in Escalier source, which parseType lowers, and asserts the normal
+// form the merge produces.
 
-// selfRecv is a method or accessor receiver. printSelfReceiver renders any
-// non-borrow receiver as `self`, and both operands of a case share this type so
-// their receivers compare equal.
-func selfRecv() *soltype.FuncParam {
-	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}, Type: &soltype.ClassType{Name: "Self"}}
-}
-
-// methodElem builds a one-signature instance method `name(self, params) -> ret`.
-func methodElem(name string, ret soltype.Type, params ...*soltype.FuncParam) *soltype.MethodElem {
-	sig := &soltype.FuncType{SelfParam: selfRecv(), Params: params, Ret: ret}
-	return &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}}
-}
-
-// overloadElem builds a method holding several signatures, an overload set.
-func overloadElem(name string, sigs ...*soltype.FuncType) *soltype.MethodElem {
-	for _, s := range sigs {
-		s.SelfParam = selfRecv()
-	}
-	return &soltype.MethodElem{Name: name, Signatures: sigs}
-}
-
-// getterElem builds an instance getter `get name(self) -> t`.
-func getterElem(name string, t soltype.Type) *soltype.GetterElem {
-	return &soltype.GetterElem{Name: name, SelfParam: selfRecv(), Type: t}
-}
-
-// setterElem builds an instance setter `set name(self, value: t)`.
-func setterElem(name string, t soltype.Type) *soltype.SetterElem {
-	return &soltype.SetterElem{Name: name, SelfParam: selfRecv(), Param: t}
-}
-
-// setterThrows builds an instance setter that raises on write, `set name(self,
-// value: t) throws e`.
-func setterThrows(name string, t, e soltype.Type) *soltype.SetterElem {
-	return &soltype.SetterElem{Name: name, SelfParam: selfRecv(), Param: t, Throws: e}
-}
-
-// ctorElem builds a constructor `new (params) -> ret`.
-func ctorElem(ret soltype.Type, params ...*soltype.FuncParam) *soltype.ConstructorElem {
-	return &soltype.ConstructorElem{Fn: &soltype.FuncType{Params: params, Ret: ret}}
-}
-
+// TestObjectMemberMeet exercises meetObjects over member-carrying objects.
 func TestObjectMemberMeet(t *testing.T) {
 	tests := []struct {
 		name string
-		a    *soltype.ObjectType
-		b    *soltype.ObjectType
+		in   string
 		want string
 	}{
 		{
 			name: "objects sharing an identical method fuse their disjoint fields",
-			a:    inexactObj(propElem("a", num()), methodElem("foo", num())),
-			b:    inexactObj(propElem("b", num()), methodElem("foo", num())),
+			in:   "{a: number, foo(self) -> number, ...} & {b: number, foo(self) -> number, ...}",
 			want: "{a: number, b: number, foo(self) -> number, ...}",
 		},
 		{
 			name: "a shared method with agreeing domains meets its codomains",
-			a:    exactObj(methodElem("foo", newUnion(nil, []soltype.Type{num(), str()}, false), identParam("x", num()))),
-			b:    exactObj(methodElem("foo", newUnion(nil, []soltype.Type{str(), boolT()}, false), identParam("x", num()))),
+			in:   "{foo(self, x: number) -> number | string} & {foo(self, x: number) -> string | boolean}",
 			want: "{foo(self, x: number) -> string}",
 		},
 		{
 			name: "a shared getter meets its returned value",
-			a:    exactObj(getterElem("x", newUnion(nil, []soltype.Type{num(), str()}, false))),
-			b:    exactObj(getterElem("x", newUnion(nil, []soltype.Type{str(), boolT()}, false))),
+			in:   "{get x(self) -> number | string} & {get x(self) -> string | boolean}",
 			want: "{get x(self) -> string}",
 		},
 		{
 			name: "a shared setter with equal raises joins the value it accepts",
-			a:    exactObj(setterElem("x", num())),
-			b:    exactObj(setterElem("x", str())),
+			in:   "{set x(self, v: number) -> undefined} & {set x(self, v: string) -> undefined}",
 			want: "{set x(self, value: number | string)}",
 		},
 		{
 			name: "a shared setter with an equal written value meets its raises",
-			a:    exactObj(setterThrows("x", num(), newUnion(nil, []soltype.Type{strLit("a"), strLit("b")}, false))),
-			b:    exactObj(setterThrows("x", num(), newUnion(nil, []soltype.Type{strLit("b"), strLit("c")}, false))),
+			in: `{set x(self, v: number) -> undefined throws "a" | "b"} & ` +
+				`{set x(self, v: number) -> undefined throws "b" | "c"}`,
 			want: `{set x(self, value: number) throws "b"}`,
 		},
 		{
 			name: "a shared setter differing in both value and raises keeps both atoms",
-			a:    exactObj(setterThrows("x", num(), strLit("a"))),
-			b:    exactObj(setterThrows("x", str(), strLit("b"))),
+			in: `{set x(self, v: number) -> undefined throws "a"} & ` +
+				`{set x(self, v: string) -> undefined throws "b"}`,
 			want: `{set x(self, value: number) throws "a"} & {set x(self, value: string) throws "b"}`,
 		},
 		{
 			name: "a shared constructor joins its domain over a shared return",
-			a:    exactObj(ctorElem(boolT(), identParam("x", num()))),
-			b:    exactObj(ctorElem(boolT(), identParam("x", str()))),
+			in:   "{new (x: number) -> boolean} & {new (x: string) -> boolean}",
 			want: "{new (x: number | string) -> boolean}",
 		},
 		{
 			name: "an identical overload set fuses without meeting the arms",
-			a: inexactObj(propElem("a", num()), overloadElem("foo",
-				exactFn(num(), identParam("x", num())),
-				exactFn(str(), identParam("x", str())))),
-			b: inexactObj(propElem("b", num()), overloadElem("foo",
-				exactFn(num(), identParam("x", num())),
-				exactFn(str(), identParam("x", str())))),
+			in: "{a: number, foo(self, x: number) -> number, foo(self, x: string) -> string, ...} & " +
+				"{b: number, foo(self, x: number) -> number, foo(self, x: string) -> string, ...}",
 			want: "{a: number, b: number, foo(self, x: number) -> number; foo(self, x: string) -> string, ...}",
 		},
 		{
 			name: "a method and a property sharing a name keep both atoms",
-			a:    exactObj(methodElem("foo", num())),
-			b:    exactObj(propElem("foo", num())),
+			in:   "{foo(self) -> number} & {foo: number}",
 			want: "{foo: number} & {foo(self) -> number}",
 		},
 		{
 			name: "an exact object meets an exact object lacking its method: never",
-			a:    exactObj(methodElem("foo", num())),
-			b:    exactObj(methodElem("bar", num())),
+			in:   "{foo(self) -> number} & {bar(self) -> number}",
 			want: "never",
 		},
 		{
 			name: "a get/set accessor pair keeps both atoms unfused",
-			a:    exactObj(propElem("a", num()), getterElem("x", num()), setterElem("x", num())),
-			b:    exactObj(propElem("b", num()), getterElem("x", num()), setterElem("x", num())),
+			in: "{a: number, get x(self) -> number, set x(self, v: number) -> undefined} & " +
+				"{b: number, get x(self) -> number, set x(self, v: number) -> undefined}",
 			want: "{a: number, get x(self) -> number, set x(self, value: number)} & " +
 				"{b: number, get x(self) -> number, set x(self, value: number)}",
 		},
@@ -137,15 +83,56 @@ func TestObjectMemberMeet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Context{}
-			got := normDNF(c, newIntersection(nil, []soltype.Type{tt.a, tt.b}))
-			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want, normDNF(c, parseType(t, tt.in)))
+		})
+	}
+}
+
+// TestObjectMemberJoin exercises joinObjects over member-carrying objects.
+func TestObjectMemberJoin(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "objects agreeing but for one property widen it, keeping shared methods",
+			in:   "{x: number, foo(self) -> number} | {x: string, foo(self) -> number}",
+			want: "{foo(self) -> number, x: number | string}",
+		},
+		{
+			name: "objects differing only in a getter widen it",
+			in:   "{get x(self) -> number, foo(self) -> number} | {get x(self) -> string, foo(self) -> number}",
+			want: "{foo(self) -> number, get x(self) -> number | string}",
+		},
+		{
+			name: "objects differing in a method keep both atoms",
+			in:   "{foo(self) -> number} | {foo(self) -> string}",
+			want: "{foo(self) -> number} | {foo(self) -> string}",
+		},
+		{
+			name: "objects differing in a setter keep both atoms",
+			in:   "{set x(self, v: number) -> undefined} | {set x(self, v: string) -> undefined}",
+			want: "{set x(self, value: number)} | {set x(self, value: string)}",
+		},
+		{
+			name: "objects differing in a constructor keep both atoms",
+			in:   "{new () -> number} | {new () -> string}",
+			want: "{new () -> number} | {new () -> string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, normDNF(c, parseType(t, tt.in)))
 		})
 	}
 }
 
 // TestIndexSignatureObjectStaysUnfused guards the scope line of #1103: a mapped
 // member such as an index signature has no per-member merge rule, so an object
-// carrying one is kept as its own atom. A settled index signature is not a residual,
+// carrying one is kept as its own atom. parseType does not lower a mapped member,
+// so this builds the object directly. A settled index signature is not a residual,
 // so this checks fusableMember rather than the residual test alone keeps it out.
 func TestIndexSignatureObjectStaysUnfused(t *testing.T) {
 	c := &Context{}
@@ -159,51 +146,4 @@ func TestIndexSignatureObjectStaysUnfused(t *testing.T) {
 	require.False(t, ok, "meetObjects keeps an index-signature object unfused")
 	_, ok = c.joinObjects(withIndexSig(), withIndexSig())
 	require.False(t, ok, "joinObjects keeps an index-signature object unfused")
-}
-
-func TestObjectMemberJoin(t *testing.T) {
-	tests := []struct {
-		name string
-		a    *soltype.ObjectType
-		b    *soltype.ObjectType
-		want string
-	}{
-		{
-			name: "objects agreeing but for one property widen it, keeping shared methods",
-			a:    exactObj(propElem("x", num()), methodElem("foo", num())),
-			b:    exactObj(propElem("x", str()), methodElem("foo", num())),
-			want: "{foo(self) -> number, x: number | string}",
-		},
-		{
-			name: "objects differing only in a getter widen it",
-			a:    exactObj(getterElem("x", num()), methodElem("foo", num())),
-			b:    exactObj(getterElem("x", str()), methodElem("foo", num())),
-			want: "{foo(self) -> number, get x(self) -> number | string}",
-		},
-		{
-			name: "objects differing in a method keep both atoms",
-			a:    exactObj(methodElem("foo", num())),
-			b:    exactObj(methodElem("foo", str())),
-			want: "{foo(self) -> number} | {foo(self) -> string}",
-		},
-		{
-			name: "objects differing in a setter keep both atoms",
-			a:    exactObj(setterElem("x", num())),
-			b:    exactObj(setterElem("x", str())),
-			want: "{set x(self, value: number)} | {set x(self, value: string)}",
-		},
-		{
-			name: "objects differing in a constructor keep both atoms",
-			a:    exactObj(ctorElem(num())),
-			b:    exactObj(ctorElem(str())),
-			want: "{new () -> number} | {new () -> string}",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &Context{}
-			got := normDNF(c, newUnion(nil, []soltype.Type{tt.a, tt.b}, false))
-			require.Equal(t, tt.want, got)
-		})
-	}
 }

--- a/internal/solver/normal_member_merge_test.go
+++ b/internal/solver/normal_member_merge_test.go
@@ -172,12 +172,18 @@ func TestObjectMemberJoin(t *testing.T) {
 // so this checks fusableMember rather than the residual test alone keeps it out.
 func TestIndexSignatureObjectStaysUnfused(t *testing.T) {
 	c := &Context{}
+	// A settled index signature is `[K: string]?: number`, an optional member over an
+	// uncountable key set. MappedElemSettled recognizes it only when Optional is ModAdd.
+	// The non-optional `[K: string]: number` is uninhabited, so it stays an unsettled
+	// residual instead, which the residual check already keeps out.
 	withIndexSig := func() *soltype.ObjectType {
 		return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
 			propElem("a", num()),
-			&soltype.MappedElem{Key: &soltype.MappedKeyType{ID: 0, Name: "K"}, Keys: str(), Value: num()},
+			&soltype.MappedElem{Key: &soltype.MappedKeyType{ID: 0, Name: "K"}, Keys: str(), Value: num(), Optional: soltype.ModAdd},
 		}}
 	}
+	require.True(t, soltype.MappedElemSettled(withIndexSig().Elems[1].(*soltype.MappedElem)),
+		"the index signature must be settled for this test to exercise fusableMember")
 	_, ok := c.meetObjects(withIndexSig(), withIndexSig())
 	require.False(t, ok, "meetObjects keeps an index-signature object unfused")
 	_, ok = c.joinObjects(withIndexSig(), withIndexSig())

--- a/internal/solver/normal_member_merge_test.go
+++ b/internal/solver/normal_member_merge_test.go
@@ -167,20 +167,18 @@ func TestObjectMemberJoin(t *testing.T) {
 
 // TestIndexSignatureObjectStaysUnfused guards the scope line of #1103: a mapped
 // member such as an index signature has no per-member merge rule, so an object
-// carrying one is kept as its own atom. parseType does not lower a mapped member,
-// so this builds the object directly. A settled index signature is not a residual,
-// so this checks fusableMember rather than the residual test alone keeps it out.
+// carrying one is kept as its own atom.
+//
+// The member is a settled index signature, `[K: string]?: number`. Settled means
+// not a residual, so this checks that fusableMember keeps it out rather than the
+// residual test alone. MappedElemSettled recognizes the settled form only when the
+// optional marker is present; the non-optional `[K: string]: number` is
+// uninhabited and stays an unsettled residual, which the residual test already
+// keeps out. The assertion pins that the source lowers to the settled form.
 func TestIndexSignatureObjectStaysUnfused(t *testing.T) {
 	c := &Context{}
-	// A settled index signature is `[K: string]?: number`, an optional member over an
-	// uncountable key set. MappedElemSettled recognizes it only when Optional is ModAdd.
-	// The non-optional `[K: string]: number` is uninhabited, so it stays an unsettled
-	// residual instead, which the residual check already keeps out.
 	withIndexSig := func() *soltype.ObjectType {
-		return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
-			propElem("a", num()),
-			&soltype.MappedElem{Key: &soltype.MappedKeyType{ID: 0, Name: "K"}, Keys: str(), Value: num(), Optional: soltype.ModAdd},
-		}}
+		return parseType(t, "{a: number, [K: string]?: number}").(*soltype.ObjectType)
 	}
 	require.True(t, soltype.MappedElemSettled(withIndexSig().Elems[1].(*soltype.MappedElem)),
 		"the index signature must be settled for this test to exercise fusableMember")

--- a/internal/solver/parse_type_test.go
+++ b/internal/solver/parse_type_test.go
@@ -194,27 +194,98 @@ func envLookup(t *testing.T, env map[string]soltype.Type, ta *ast.TypeRefTypeAnn
 	return bound
 }
 
-// objectToSoltype lowers an ObjectTypeAnn into a soltype.ObjectType. Only
-// property elements (`name: T`, `name?: T`) are accepted, mirroring the
-// production resolveObjectTypeAnn arm. Method, getter, setter, index, and
-// spread elements fail the test since the lattice tests do not need them.
+// objectToSoltype lowers an ObjectTypeAnn into a soltype.ObjectType. It accepts
+// property, method, getter, setter, and constructor elements, mirroring the
+// production resolveObjectTypeAnn arm for each. A method written more than once
+// under one name folds into a single MethodElem holding an overload set, the way
+// the production overload merge collapses repeated signatures. An index signature,
+// a spread, and a callable element fail the test, since the lattice tests do not
+// author them.
 func objectToSoltype(t *testing.T, env map[string]soltype.Type, ta *ast.ObjectTypeAnn) *soltype.ObjectType {
 	t.Helper()
 	elems := make([]soltype.ObjTypeElem, 0, len(ta.Elems))
 	for _, e := range ta.Elems {
-		prop, ok := e.(*ast.PropertyTypeAnn)
-		require.True(t, ok, "parseType: unsupported object element %T", e)
-		name, ok := objKeyName(prop.Name)
-		require.True(t, ok, "parseType: unsupported object key %T", prop.Name)
-		var ft soltype.Type
-		if prop.Value != nil {
-			ft = toSoltype(t, env, prop.Value)
-		} else {
-			ft = &soltype.UnknownType{}
+		switch e := e.(type) {
+		case *ast.PropertyTypeAnn:
+			name, ok := objKeyName(e.Name)
+			require.True(t, ok, "parseType: unsupported object key %T", e.Name)
+			var ft soltype.Type
+			if e.Value != nil {
+				ft = toSoltype(t, env, e.Value)
+			} else {
+				ft = &soltype.UnknownType{}
+			}
+			elems = append(elems, &soltype.PropertyElem{Name: name, Type: ft, Optional: e.Optional})
+		case *ast.MethodTypeAnn:
+			fn := methodFuncToSoltype(t, env, e.Fn, e.Receiver)
+			elems = append(elems, &soltype.MethodElem{Name: objKeyNameReq(t, e.Name), Signatures: []*soltype.FuncType{fn}})
+		case *ast.GetterTypeAnn:
+			// A getter's Fn is `(self) -> T throws E`, so its return and throws are the
+			// value read and what reading raises.
+			fn := methodFuncToSoltype(t, env, e.Fn, e.Receiver)
+			elems = append(elems, &soltype.GetterElem{Name: objKeyNameReq(t, e.Name), SelfParam: fn.SelfParam, Type: fn.Ret, Throws: fn.Throws})
+		case *ast.SetterTypeAnn:
+			// A setter's Fn is `(self, value: T) -> undefined throws E`, so its one value
+			// parameter is what the setter accepts and its throws is what writing raises.
+			fn := methodFuncToSoltype(t, env, e.Fn, e.Receiver)
+			require.Len(t, fn.Params, 1, "parseType: a setter takes one value parameter")
+			elems = append(elems, &soltype.SetterElem{Name: objKeyNameReq(t, e.Name), SelfParam: fn.SelfParam, Param: fn.Params[0].Type, Throws: fn.Throws})
+		case *ast.ConstructorTypeAnn:
+			elems = append(elems, &soltype.ConstructorElem{Fn: funcToSoltype(t, env, e.Fn)})
+		default:
+			t.Fatalf("parseType: unsupported object element %T", e)
 		}
-		elems = append(elems, &soltype.PropertyElem{Name: name, Type: ft, Optional: prop.Optional})
 	}
-	return &soltype.ObjectType{Elems: elems, Inexact: ta.Inexact}
+	return &soltype.ObjectType{Elems: mergeMethodOverloads(elems), Inexact: ta.Inexact}
+}
+
+// objKeyNameReq lowers an object key to its name, failing the test on a computed or
+// otherwise unsupported key. It is the must-succeed form of objKeyName, used where
+// only a named member is expected.
+func objKeyNameReq(t *testing.T, key ast.ObjKey) string {
+	t.Helper()
+	name, ok := objKeyName(key)
+	require.True(t, ok, "parseType: unsupported object key %T", key)
+	return name
+}
+
+// methodFuncToSoltype lowers a method, getter, or setter signature, attaching the
+// `self` receiver the FuncTypeAnn does not carry. The receiver's type is the same
+// marker on every member, so two members compare equal on their receiver the way
+// two instance members of one class body do.
+func methodFuncToSoltype(t *testing.T, env map[string]soltype.Type, fnAnn *ast.FuncTypeAnn, recv *ast.MethodReceiver) *soltype.FuncType {
+	t.Helper()
+	fn := funcToSoltype(t, env, fnAnn)
+	if recv != nil {
+		require.False(t, recv.Mut, "parseType: mut receiver")
+		require.Nil(t, recv.Lifetime, "parseType: receiver lifetime")
+		fn.SelfParam = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}, Type: &soltype.ClassType{Name: "Self"}}
+	}
+	return fn
+}
+
+// mergeMethodOverloads folds methods that repeat one name into a single MethodElem
+// whose Signatures slice carries every arm in source order, mirroring the production
+// overload merge. Members of other kinds pass through untouched. Two methods merge
+// only when their Static markers agree, since a static and an instance member are
+// distinct.
+func mergeMethodOverloads(elems []soltype.ObjTypeElem) []soltype.ObjTypeElem {
+	out := make([]soltype.ObjTypeElem, 0, len(elems))
+	byName := map[string]*soltype.MethodElem{}
+	for _, e := range elems {
+		m, ok := e.(*soltype.MethodElem)
+		if !ok {
+			out = append(out, e)
+			continue
+		}
+		if prev, seen := byName[m.Name]; seen && prev.Static == m.Static {
+			prev.Signatures = append(prev.Signatures, m.Signatures...)
+			continue
+		}
+		byName[m.Name] = m
+		out = append(out, m)
+	}
+	return out
 }
 
 // TestParseTypeHelperSmoke confirms parseType round-trips a variety of

--- a/internal/solver/parse_type_test.go
+++ b/internal/solver/parse_type_test.go
@@ -215,7 +215,7 @@ func objectToSoltype(t *testing.T, env map[string]soltype.Type, ta *ast.ObjectTy
 			} else {
 				ft = &soltype.UnknownType{}
 			}
-			elems = append(elems, &soltype.PropertyElem{Name: name, Type: ft, Optional: e.Optional})
+			elems = append(elems, &soltype.PropertyElem{Name: name, Type: ft, Optional: e.Optional, Readonly: e.Readonly})
 		case *ast.MethodTypeAnn:
 			fn := methodFuncToSoltype(t, env, e.Fn, e.Receiver)
 			elems = append(elems, &soltype.MethodElem{Name: objKeyNameReq(t, e.Name), Signatures: []*soltype.FuncType{fn}})

--- a/internal/solver/parse_type_test.go
+++ b/internal/solver/parse_type_test.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/ast"
@@ -195,12 +196,11 @@ func envLookup(t *testing.T, env map[string]soltype.Type, ta *ast.TypeRefTypeAnn
 }
 
 // objectToSoltype lowers an ObjectTypeAnn into a soltype.ObjectType. It accepts
-// property, method, getter, setter, and constructor elements, mirroring the
+// property, method, getter, setter, constructor, and mapped members, mirroring the
 // production resolveObjectTypeAnn arm for each. A method written more than once
 // under one name folds into a single MethodElem holding an overload set, the way
-// the production overload merge collapses repeated signatures. An index signature,
-// a spread, and a callable element fail the test, since the lattice tests do not
-// author them.
+// the production overload merge collapses repeated signatures. A spread and a
+// callable element fail the test, since the lattice tests do not author them.
 func objectToSoltype(t *testing.T, env map[string]soltype.Type, ta *ast.ObjectTypeAnn) *soltype.ObjectType {
 	t.Helper()
 	elems := make([]soltype.ObjTypeElem, 0, len(ta.Elems))
@@ -232,11 +232,61 @@ func objectToSoltype(t *testing.T, env map[string]soltype.Type, ta *ast.ObjectTy
 			elems = append(elems, &soltype.SetterElem{Name: objKeyNameReq(t, e.Name), SelfParam: fn.SelfParam, Param: fn.Params[0].Type, Throws: fn.Throws})
 		case *ast.ConstructorTypeAnn:
 			elems = append(elems, &soltype.ConstructorElem{Fn: funcToSoltype(t, env, e.Fn)})
+		case *ast.MappedTypeAnn:
+			elems = append(elems, mappedToSoltype(t, env, e))
 		default:
 			t.Fatalf("parseType: unsupported object element %T", e)
 		}
 	}
 	return &soltype.ObjectType{Elems: mergeMethodOverloads(elems), Inexact: ta.Inexact}
+}
+
+// mappedKeyCounter mints the ids mappedToSoltype gives each mapped key, so a nested
+// mapped type's key stays distinct from the enclosing one's when both are written K,
+// the way freshMappedKey draws from the Context's counter in production.
+var mappedKeyCounter atomic.Int64
+
+// mappedToSoltype lowers a `[K: Keys]: V` mapped member to a soltype.MappedElem,
+// mirroring the production resolveMappedElem. The `for K in Keys` clause binds K, so
+// the value and the optional key-remapping and filter operands resolve in an
+// environment where K names the minted key. The `?` and `readonly` markers carry
+// through mappedModifier, which is what decides whether an index signature is
+// settled.
+func mappedToSoltype(t *testing.T, env map[string]soltype.Type, m *ast.MappedTypeAnn) *soltype.MappedElem {
+	t.Helper()
+	var keys soltype.Type = &soltype.UnknownType{}
+	if m.TypeParam.Constraint != nil {
+		keys = toSoltype(t, env, m.TypeParam.Constraint)
+	}
+	key := &soltype.MappedKeyType{ID: int(mappedKeyCounter.Add(1)), Name: m.TypeParam.Name}
+	inner := env
+	if m.TypeParam.Name != "" {
+		inner = make(map[string]soltype.Type, len(env)+1)
+		for name, ty := range env {
+			inner[name] = ty
+		}
+		inner[m.TypeParam.Name] = key
+	}
+	var name, check, extends soltype.Type
+	if m.Name != nil {
+		name = toSoltype(t, inner, m.Name)
+	}
+	// The parser fills Check and Extends together or leaves both nil, so a filter is
+	// resolved only when both halves are present.
+	if m.Check != nil && m.Extends != nil {
+		check = toSoltype(t, inner, m.Check)
+		extends = toSoltype(t, inner, m.Extends)
+	}
+	return &soltype.MappedElem{
+		Key:      key,
+		Keys:     keys,
+		Value:    toSoltype(t, inner, m.Value),
+		Name:     name,
+		Check:    check,
+		Extends:  extends,
+		Optional: mappedModifier(m.Optional),
+		Readonly: mappedModifier(m.ReadOnly),
+	}
 }
 
 // objKeyNameReq lowers an object key to its name, failing the test on a computed or


### PR DESCRIPTION
Generalizes the solver's object type merging to handle methods, getters, setters, and constructors in addition to properties. Previously, `meetObjects` and `joinObjects` only fused property members and kept objects with other member kinds as separate atoms. This change adds per-kind merge rules so that objects sharing methods or accessors can fuse their disjoint fields and merge shared members.

**Key changes:**

- Renamed `plainProps` to `mergeableElems` and extended it to accept methods, getters, setters, and constructors. Objects carrying spreads, mapped members, or repeated member names are still kept unfused.
- Added `meetObjElem` and `joinObjElem` to fuse individual members by kind. Properties meet by intersecting their types (with readonly agreement required). Getters meet by intersecting their return types. Setters meet by joining their parameter types when throws clauses agree, or meeting throws when parameters agree. Methods and constructors meet via their function types. Only properties and getters can widen under union.
- Added `meetMethods`, `meetSetters`, and `meetMethodSig` to handle method and setter fusion, which require static-ness and receiver agreement respectively.
- Added `meetThrowsTypes` and `joinThrowsTypes` to merge throws clauses while preserving the nil-is-never shorthand (so two members with `Throws: nil` fuse to `Throws: nil` rather than an explicit `never`).
- Refactored `requiredFieldsWithin` to `requiredMembersWithin` and added `optionalProperty` to distinguish optional properties from always-present methods and accessors.
- Updated `compareObjectFields` in lattice.go to order members by kind in addition to name, so getters and setters sharing one name sort into a fixed order.
- Added comprehensive test coverage in `normal_member_merge_test.go` for method, getter, setter, and constructor fusion under both meet and join.

The change preserves the existing behavior for property-only objects and keeps objects with incompatible member kinds (e.g., a method and a property sharing a name) as separate atoms.

https://claude.ai/code/session_01HMrn2XTmkxs3XzTBC2Rtwo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for object methods, getters, setters, constructors, and overloads during type analysis.
  * Object type comparisons now account for all supported member kinds, including receiver details.
  * Object type merging now handles compatible members more accurately while preserving conflicting or unsupported structures.

* **Bug Fixes**
  * Prevented objects with index signatures from being incorrectly combined.
  * Preserved omitted `never` clauses and static/instance distinctions during type conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->