### PR TITLE
Support string intrinsics in template literal matching

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1555,8 +1555,9 @@ func templateMatchesString(s string, quasis []string, interps []soltype.Type) bo
 // matchInterp reports whether some prefix of s is a value interp admits and the leftover matches the
 // rest of the template, quasis and interps. A string literal or a literal that renders as a string
 // consumes exactly its own characters. The `string` primitive consumes any prefix, so each split point
-// is tried until one lets the rest match. A union admits a prefix any member does. Any other
-// interpolation type is left undecided and fails the match.
+// is tried until one lets the rest match. A residual string intrinsic over `string`, such as
+// `Uppercase<string>`, consumes a prefix its transform leaves unchanged. A union admits a prefix any
+// member does. Any other interpolation type is left undecided and fails the match.
 func matchInterp(s string, interp soltype.Type, quasis []string, interps []soltype.Type) bool {
 	switch it := interp.(type) {
 	case *soltype.LitType:
@@ -1574,6 +1575,23 @@ func matchInterp(s string, interp soltype.Type, quasis []string, interps []solty
 		}
 		for k := 0; k <= len(s); k++ {
 			if templateMatchesString(s[k:], quasis, interps) {
+				return true
+			}
+		}
+		return false
+	case *soltype.StringIntrinsicType:
+		// A residual intrinsic such as `Uppercase<string>` denotes the strings its transform
+		// leaves unchanged, since each of the four transforms is idempotent, so its image over
+		// `string` is exactly its fixed points. Try each split point and admit the prefix when
+		// the transform maps it to itself, the same fixed-point rule
+		// constrainStrLitToStringIntrinsic uses for the direct `"A" <: Uppercase<string>` path.
+		// An operand that is not `string`, such as a type parameter, leaves the operator symbolic,
+		// so no prefix lands in its image and the placeholder matches nothing.
+		if prim, ok := it.Operand.(*soltype.PrimType); !ok || prim.Prim != soltype.StrPrim {
+			return false
+		}
+		for k := 0; k <= len(s); k++ {
+			if applyStringIntrinsic(it.Kind, s[:k]) == s[:k] && templateMatchesString(s[k:], quasis, interps) {
 				return true
 			}
 		}

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -50,6 +50,12 @@ func boolT() *soltype.PrimType { return &soltype.PrimType{Prim: soltype.BoolPrim
 func numLit(v float64) *soltype.LitType { return &soltype.LitType{Lit: &soltype.NumLit{Value: v}} }
 func strLit(v string) *soltype.LitType  { return &soltype.LitType{Lit: &soltype.StrLit{Value: v}} }
 
+// upperOverStr is the residual `Uppercase<string>`, the intrinsic placeholder a template such as
+// `on${Uppercase}` leaves symbolic over `string`.
+func upperOverStr() *soltype.StringIntrinsicType {
+	return &soltype.StringIntrinsicType{Kind: soltype.Uppercase, Operand: str()}
+}
+
 func identParam(name string, t soltype.Type) *soltype.FuncParam {
 	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: t}
 }

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -50,10 +50,10 @@ func boolT() *soltype.PrimType { return &soltype.PrimType{Prim: soltype.BoolPrim
 func numLit(v float64) *soltype.LitType { return &soltype.LitType{Lit: &soltype.NumLit{Value: v}} }
 func strLit(v string) *soltype.LitType  { return &soltype.LitType{Lit: &soltype.StrLit{Value: v}} }
 
-// upperOverStr is the residual `Uppercase<string>`, the intrinsic placeholder a template such as
+// intrinsicOverStr is the residual `Kind<string>`, the intrinsic placeholder a template such as
 // `on${Uppercase}` leaves symbolic over `string`.
-func upperOverStr() *soltype.StringIntrinsicType {
-	return &soltype.StringIntrinsicType{Kind: soltype.Uppercase, Operand: str()}
+func intrinsicOverStr(kind soltype.StringIntrinsicKind) *soltype.StringIntrinsicType {
+	return &soltype.StringIntrinsicType{Kind: kind, Operand: str()}
 }
 
 func identParam(name string, t soltype.Type) *soltype.FuncParam {

--- a/internal/solver/infer_template_lit_test.go
+++ b/internal/solver/infer_template_lit_test.go
@@ -125,6 +125,44 @@ func TestInferTemplateLitConstraint(t *testing.T) {
 	}
 }
 
+// A template whose interpolation is a residual intrinsic over `string`, such as
+// `on${Uppercase<string>}`, stays symbolic and is decided by templateMatchesString. A literal
+// satisfies it iff its interpolated span is a fixed point of the transform: `"onA"` and `"on5"`
+// hold because Uppercase leaves them unchanged, while `"onb"` is rejected because Uppercase maps
+// it to `"onB"`.
+func TestInferTemplateLitOverStringIntrinsic(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "UppercaseSpanAccepted",
+			src:  "val u: `on${Uppercase<string>}` = \"onA\"",
+		},
+		{
+			name: "CaselessSpanAccepted",
+			src:  "val u: `on${Uppercase<string>}` = \"on5\"",
+		},
+		{
+			name:    "LowercaseSpanRejected",
+			src:     "val u: `on${Uppercase<string>}` = \"onb\"",
+			wantErr: "cannot constrain \"onb\" <: `on${Uppercase<string>}`",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
 // An intrinsic string operator `Uppercase<T>` and its three siblings are stored as residuals and
 // reduced over a string-literal operand. Each case asserts the stored `Result` renders the way the
 // source wrote it, then asserts that reducing it maps the operand's characters, distributing over a
@@ -353,6 +391,12 @@ func TestTemplateMatchesString(t *testing.T) {
 		{"a union interp rejects a non-member", "onc", []string{"on", ""}, []soltype.Type{newUnion(nil, []soltype.Type{strLit("a"), strLit("b")}, false)}, false},
 		{"a type-variable interp is left undecided", "onx", []string{"on", ""}, []soltype.Type{&soltype.TypeVarType{ID: 1, Level: 1}}, false},
 		{"two string interps backtrack to a split", "a-b", []string{"", "-", ""}, []soltype.Type{str(), str()}, true},
+		{"an Uppercase<string> interp admits an uppercase span", "onA", []string{"on", ""}, []soltype.Type{upperOverStr()}, true},
+		{"an Uppercase<string> interp admits a caseless span", "on5", []string{"on", ""}, []soltype.Type{upperOverStr()}, true},
+		{"an Uppercase<string> interp rejects a lowercase span", "onb", []string{"on", ""}, []soltype.Type{upperOverStr()}, false},
+		{"an Uppercase<string> interp allows an empty middle", "on", []string{"on", ""}, []soltype.Type{upperOverStr()}, true},
+		{"an Uppercase<string> interp matches up to a trailing quasi", "onAz", []string{"on", "z"}, []soltype.Type{upperOverStr()}, true},
+		{"an intrinsic over a type variable is left undecided", "onA", []string{"on", ""}, []soltype.Type{&soltype.StringIntrinsicType{Kind: soltype.Uppercase, Operand: &soltype.TypeVarType{ID: 1, Level: 1}}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/solver/infer_template_lit_test.go
+++ b/internal/solver/infer_template_lit_test.go
@@ -127,9 +127,10 @@ func TestInferTemplateLitConstraint(t *testing.T) {
 
 // A template whose interpolation is a residual intrinsic over `string`, such as
 // `on${Uppercase<string>}`, stays symbolic and is decided by templateMatchesString. A literal
-// satisfies it iff its interpolated span is a fixed point of the transform: `"onA"` and `"on5"`
-// hold because Uppercase leaves them unchanged, while `"onb"` is rejected because Uppercase maps
-// it to `"onB"`.
+// satisfies it iff its interpolated span is a fixed point of the transform. Each of the four
+// intrinsics is idempotent, so all decide by the same fixed-point test: `"onA"` and `"on5"` hold
+// against Uppercase because it leaves them unchanged, while `"onb"` is rejected because Uppercase
+// maps it to `"onB"`.
 func TestInferTemplateLitOverStringIntrinsic(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -145,9 +146,36 @@ func TestInferTemplateLitOverStringIntrinsic(t *testing.T) {
 			src:  "val u: `on${Uppercase<string>}` = \"on5\"",
 		},
 		{
-			name:    "LowercaseSpanRejected",
+			name:    "UppercaseLowercaseSpanRejected",
 			src:     "val u: `on${Uppercase<string>}` = \"onb\"",
 			wantErr: "cannot constrain \"onb\" <: `on${Uppercase<string>}`",
+		},
+		{
+			name: "LowercaseSpanAccepted",
+			src:  "val u: `on${Lowercase<string>}` = \"onb\"",
+		},
+		{
+			name:    "LowercaseUppercaseSpanRejected",
+			src:     "val u: `on${Lowercase<string>}` = \"onA\"",
+			wantErr: "cannot constrain \"onA\" <: `on${Lowercase<string>}`",
+		},
+		{
+			name: "CapitalizeSpanAccepted",
+			src:  "val u: `on${Capitalize<string>}` = \"onAbc\"",
+		},
+		{
+			name:    "CapitalizeLeadingLowerRejected",
+			src:     "val u: `on${Capitalize<string>}` = \"onaBC\"",
+			wantErr: "cannot constrain \"onaBC\" <: `on${Capitalize<string>}`",
+		},
+		{
+			name: "UncapitalizeSpanAccepted",
+			src:  "val u: `on${Uncapitalize<string>}` = \"onaBC\"",
+		},
+		{
+			name:    "UncapitalizeLeadingUpperRejected",
+			src:     "val u: `on${Uncapitalize<string>}` = \"onAbc\"",
+			wantErr: "cannot constrain \"onAbc\" <: `on${Uncapitalize<string>}`",
 		},
 	}
 	for _, tt := range tests {
@@ -391,11 +419,17 @@ func TestTemplateMatchesString(t *testing.T) {
 		{"a union interp rejects a non-member", "onc", []string{"on", ""}, []soltype.Type{newUnion(nil, []soltype.Type{strLit("a"), strLit("b")}, false)}, false},
 		{"a type-variable interp is left undecided", "onx", []string{"on", ""}, []soltype.Type{&soltype.TypeVarType{ID: 1, Level: 1}}, false},
 		{"two string interps backtrack to a split", "a-b", []string{"", "-", ""}, []soltype.Type{str(), str()}, true},
-		{"an Uppercase<string> interp admits an uppercase span", "onA", []string{"on", ""}, []soltype.Type{upperOverStr()}, true},
-		{"an Uppercase<string> interp admits a caseless span", "on5", []string{"on", ""}, []soltype.Type{upperOverStr()}, true},
-		{"an Uppercase<string> interp rejects a lowercase span", "onb", []string{"on", ""}, []soltype.Type{upperOverStr()}, false},
-		{"an Uppercase<string> interp allows an empty middle", "on", []string{"on", ""}, []soltype.Type{upperOverStr()}, true},
-		{"an Uppercase<string> interp matches up to a trailing quasi", "onAz", []string{"on", "z"}, []soltype.Type{upperOverStr()}, true},
+		{"an Uppercase<string> interp admits an uppercase span", "onA", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Uppercase)}, true},
+		{"an Uppercase<string> interp admits a caseless span", "on5", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Uppercase)}, true},
+		{"an Uppercase<string> interp rejects a lowercase span", "onb", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Uppercase)}, false},
+		{"an Uppercase<string> interp allows an empty middle", "on", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Uppercase)}, true},
+		{"an Uppercase<string> interp matches up to a trailing quasi", "onAz", []string{"on", "z"}, []soltype.Type{intrinsicOverStr(soltype.Uppercase)}, true},
+		{"a Lowercase<string> interp admits a lowercase span", "onb", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Lowercase)}, true},
+		{"a Lowercase<string> interp rejects an uppercase span", "onA", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Lowercase)}, false},
+		{"a Capitalize<string> interp admits a leading-upper span", "onAbc", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Capitalize)}, true},
+		{"a Capitalize<string> interp rejects a leading-lower span", "onaBC", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Capitalize)}, false},
+		{"an Uncapitalize<string> interp admits a leading-lower span", "onaBC", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Uncapitalize)}, true},
+		{"an Uncapitalize<string> interp rejects a leading-upper span", "onAbc", []string{"on", ""}, []soltype.Type{intrinsicOverStr(soltype.Uncapitalize)}, false},
 		{"an intrinsic over a type variable is left undecided", "onA", []string{"on", ""}, []soltype.Type{&soltype.StringIntrinsicType{Kind: soltype.Uppercase, Operand: &soltype.TypeVarType{ID: 1, Level: 1}}}, false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Extends template literal constraint solving to handle residual string intrinsics (like `Uppercase<string>`) in interpolations. Previously, intrinsics over `string` were left undecided; now they're resolved by checking if a candidate span is a fixed point of the transform.

**Key changes:**

- Added `matchInterp` case for `StringIntrinsicType` that admits a prefix only if applying the intrinsic's transform leaves it unchanged (the fixed-point rule). This mirrors the existing `constrainStrLitToStringIntrinsic` logic for direct literal-to-intrinsic constraints.
- Intrinsics over non-`string` operands (e.g., type variables) remain undecided and fail the match, preserving symbolic behavior.
- Added comprehensive test coverage in `TestInferTemplateLitOverStringIntrinsic` for the three cases: uppercase spans accepted, caseless spans accepted, lowercase spans rejected.
- Extended `TestTemplateMatchesString` with six new cases covering uppercase/caseless/lowercase spans, empty middles, trailing quasis, and intrinsics over type variables.

**Implementation details:**

The fix recognizes that string intrinsics are idempotent, so their image over `string` is exactly their fixed points. The `matchInterp` function now tries each split point and admits the prefix when `applyStringIntrinsic(kind, prefix) == prefix`, reusing the existing intrinsic application logic.

https://claude.ai/code/session_01XzQNebMwvej9v8LgCt3VPG