### PR TITLE
Add negation type syntax (¬T) for set-theoretic complements

### DIFF
--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -26,6 +26,7 @@ func (*IntersectionTypeAnn) isTypeAnn() {}
 func (*TypeRefTypeAnn) isTypeAnn()      {}
 func (*FuncTypeAnn) isTypeAnn()         {}
 func (*KeyOfTypeAnn) isTypeAnn()        {}
+func (*NegationTypeAnn) isTypeAnn()     {}
 func (*TypeOfTypeAnn) isTypeAnn()       {}
 func (*IndexTypeAnn) isTypeAnn()        {}
 func (*CondTypeAnn) isTypeAnn()         {}
@@ -501,6 +502,24 @@ func NewKeyOfTypeAnn(typ TypeAnn, span Span) *KeyOfTypeAnn {
 	return &KeyOfTypeAnn{Type: typ, span: span, inferredType: nil}
 }
 func (t *KeyOfTypeAnn) Accept(v Visitor) {
+	if v.EnterTypeAnn(t) {
+		t.Type.Accept(v)
+	}
+	v.ExitTypeAnn(t)
+}
+
+// NegationTypeAnn is the prefix `¬T`, the set-theoretic complement admitting every value
+// its operand rejects. It resolves to a soltype.NegationType.
+type NegationTypeAnn struct {
+	Type         TypeAnn
+	span         Span
+	inferredType Type
+}
+
+func NewNegationTypeAnn(typ TypeAnn, span Span) *NegationTypeAnn {
+	return &NegationTypeAnn{Type: typ, span: span, inferredType: nil}
+}
+func (t *NegationTypeAnn) Accept(v Visitor) {
 	if v.EnterTypeAnn(t) {
 		t.Type.Accept(v)
 	}

--- a/internal/ast/type_ann_gen.go
+++ b/internal/ast/type_ann_gen.go
@@ -74,6 +74,10 @@ func (node *KeyOfTypeAnn) Span() Span             { return node.span }
 func (node *KeyOfTypeAnn) InferredType() Type     { return node.inferredType }
 func (node *KeyOfTypeAnn) SetInferredType(t Type) { node.inferredType = t }
 
+func (node *NegationTypeAnn) Span() Span             { return node.span }
+func (node *NegationTypeAnn) InferredType() Type     { return node.inferredType }
+func (node *NegationTypeAnn) SetInferredType(t Type) { node.inferredType = t }
+
 func (node *TypeOfTypeAnn) Span() Span             { return node.span }
 func (node *TypeOfTypeAnn) InferredType() Type     { return node.inferredType }
 func (node *TypeOfTypeAnn) SetInferredType(t Type) { node.inferredType = t }

--- a/internal/checker/infer_type_ann.go
+++ b/internal/checker/infer_type_ann.go
@@ -224,6 +224,16 @@ func (c *Checker) inferTypeAnn(
 		argType, argErrors := c.inferTypeAnn(ctx, typeAnn.Type)
 		errors = slices.Concat(errors, argErrors)
 		t = type_system.NewKeyOfType(provenance, argType)
+	case *ast.NegationTypeAnn:
+		// The complement type lives only in the SimpleSub-based solver, which has a
+		// NegationType this checker's type_system has no counterpart for. Report cleanly
+		// rather than panicking on the default arm so a stray `¬T` can't crash the CLI or LSP,
+		// mirroring the RefTypeAnn arm below.
+		errors = append(errors, &UnimplementedError{
+			message: "negation types are unsupported in the legacy checker",
+			span:    typeAnn.Span(),
+		})
+		t = type_system.NewErrorType(provenance)
 	case *ast.MutableTypeAnn:
 		targetType, targetErrors := c.inferTypeAnn(ctx, typeAnn.Target)
 		errors = slices.Concat(errors, targetErrors)

--- a/internal/interop/twin_rewrite.go
+++ b/internal/interop/twin_rewrite.go
@@ -245,6 +245,9 @@ func (r *twinRewriter) rewrite(t ast.TypeAnn) ast.TypeAnn {
 	case *ast.KeyOfTypeAnn:
 		tt.Type = r.rewrite(tt.Type)
 		return tt
+	case *ast.NegationTypeAnn:
+		tt.Type = r.rewrite(tt.Type)
+		return tt
 	case *ast.IndexTypeAnn:
 		tt.Target = r.rewrite(tt.Target)
 		tt.Index = r.rewrite(tt.Index)

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -2894,3 +2894,93 @@
     },
 }
 ---
+
+[TestParseTypeAnnNoErrors/NegationType - 1]
+&ast.NegationTypeAnn{
+    Type: &ast.TypeRefTypeAnn{
+        Name: &ast.Ident{
+            Name: "T",
+            span: 1:2-1:3,
+        },
+        span: 1:2-1:3,
+    },
+    span: 1:1-1:3,
+}
+---
+
+[TestParseTypeAnnNoErrors/UnionTypeWithNegation - 1]
+&ast.UnionTypeAnn{
+    Types: []ast.TypeAnn{
+        &ast.NegationTypeAnn{
+            Type: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "T",
+                    span: 1:2-1:3,
+                },
+                span: 1:2-1:3,
+            },
+            span: 1:1-1:3,
+        },
+        &ast.TypeRefTypeAnn{
+            Name: &ast.Ident{
+                Name: "U",
+                span: 1:6-1:7,
+            },
+            span: 1:6-1:7,
+        },
+    },
+    span: 1:1-1:7,
+}
+---
+
+[TestParseTypeAnnNoErrors/NegationOfLiteral - 1]
+&ast.NegationTypeAnn{
+    Type: &ast.LitTypeAnn{
+        Lit: &ast.StrLit{
+            Value: "a",
+            span: 1:2-1:5,
+        },
+        span: 1:2-1:5,
+    },
+    span: 1:1-1:5,
+}
+---
+
+[TestParseTypeAnnNoErrors/IntersectionTypeWithNegation - 1]
+&ast.IntersectionTypeAnn{
+    Types: []ast.TypeAnn{
+        &ast.StringTypeAnn{
+            span: 1:1-1:7,
+        },
+        &ast.NegationTypeAnn{
+            Type: &ast.LitTypeAnn{
+                Lit: &ast.StrLit{
+                    Value: "a",
+                    span: 1:11-1:14,
+                },
+                span: 1:11-1:14,
+            },
+            span: 1:10-1:14,
+        },
+    },
+    span: 1:1-1:14,
+}
+---
+
+[TestParseTypeAnnErrorHandling/NegationMissingType - 1]
+&ast.NegationTypeAnn{
+    Type: &ast.ErrorTypeAnn{
+        span: 1:1-1:2,
+    },
+    span: 1:1-1:2,
+}
+---
+
+[TestParseTypeAnnErrorHandling/NegationMissingType - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: 1:1-1:2,
+        Message: "expected a type annotation after '¬'",
+    },
+}
+---

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -338,6 +338,8 @@ func (lexer *Lexer) next() *Token {
 		} else {
 			token = NewToken(Ampersand, "&", ast.Span{Start: start, End: end, SourceID: lexer.source.ID})
 		}
+	case '¬':
+		token = NewToken(Negation, "¬", ast.Span{Start: start, End: end, SourceID: lexer.source.ID})
 	case '`':
 		token = NewToken(BackTick, "`", ast.Span{Start: start, End: end, SourceID: lexer.source.ID})
 	case '?':

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -115,6 +115,9 @@ const (
 	// snapshots record a token's numeric value, so inserting mid-enum renumbers every token
 	// after it.
 	Super
+	// Negation is `¬` (U+00AC), the prefix operator for a complement type. Appended for
+	// the same reason as Super: a token added mid-enum renumbers every token after it.
+	Negation
 )
 
 type Token struct {

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -495,6 +495,17 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 				typ,
 				ast.NewSpan(token.Span.Start, typ.Span().End, p.lexer.source.ID),
 			)
+		case Negation: // ¬T complement type
+			p.lexer.consume() // consume '¬'
+			typ := p.primaryTypeAnn()
+			if typ == nil {
+				p.reportError(token.Span, "expected a type annotation after '¬'")
+				typ = ast.NewErrorTypeAnn(token.Span)
+			}
+			typeAnn = ast.NewNegationTypeAnn(
+				typ,
+				ast.NewSpan(token.Span.Start, typ.Span().End, p.lexer.source.ID),
+			)
 		case Typeof: // typeof value
 			p.lexer.consume() // consume 'typeof'
 			// Parse the identifier that refers to a value

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -210,6 +210,20 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 		"IntersectionTypeWithKeyOf": {
 			input: "keyof T & U",
 		},
+		"NegationType": {
+			input: "¬T",
+		},
+		"NegationOfLiteral": {
+			input: "¬\"a\"",
+		},
+		// `¬` binds tighter than `&`, so this parses as `string & (¬"a")`.
+		"IntersectionTypeWithNegation": {
+			input: "string & ¬\"a\"",
+		},
+		// `¬` binds tighter than `|`, so this parses as `(¬T) | U`.
+		"UnionTypeWithNegation": {
+			input: "¬T | U",
+		},
 		"TypeOfIdent": {
 			input: "typeof x",
 		},
@@ -325,6 +339,9 @@ func TestParseTypeAnnErrorHandling(t *testing.T) {
 		},
 		"KeyofMissingType": {
 			input: "keyof",
+		},
+		"NegationMissingType": {
+			input: "¬",
 		},
 		"FuncTypeMissingReturnType": {
 			input: "fn() ->",

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1412,6 +1412,9 @@ func (p *Printer) printTypeAnn(typ ast.TypeAnn) {
 	case *ast.KeyOfTypeAnn:
 		p.writeString("keyof ")
 		p.printPrefixTypeAnnOperand(t.Type)
+	case *ast.NegationTypeAnn:
+		p.writeString("¬")
+		p.printPrefixTypeAnnOperand(t.Type)
 	case *ast.TypeOfTypeAnn:
 		p.writeString("typeof ")
 		p.printQualIdent(t.Value)
@@ -1630,8 +1633,8 @@ const (
 	precTypeOpenEnded    = 1
 	precTypeUnion        = 2
 	precTypeIntersection = 3
-	// precTypePrefix covers `keyof A`, `mut A`, `&A`, and `infer A`. Each takes the whole
-	// annotation that follows it.
+	// precTypePrefix covers `keyof A`, `mut A`, `&A`, `infer A`, and `¬A`. Each takes the
+	// whole annotation that follows it.
 	precTypePrefix = 4
 	// precTypePrimary is for an annotation that nothing can regroup, such as a type
 	// reference, an object type, a tuple, or an indexed access.
@@ -1647,7 +1650,7 @@ func typeAnnPrecedence(t ast.TypeAnn) int {
 		return precTypeUnion
 	case *ast.IntersectionTypeAnn:
 		return precTypeIntersection
-	case *ast.KeyOfTypeAnn, *ast.MutableTypeAnn, *ast.RefTypeAnn, *ast.InferTypeAnn:
+	case *ast.KeyOfTypeAnn, *ast.MutableTypeAnn, *ast.RefTypeAnn, *ast.InferTypeAnn, *ast.NegationTypeAnn:
 		return precTypePrefix
 	default:
 		return precTypePrimary

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -569,6 +569,13 @@ func TestPrintTypeAnnGrouping(t *testing.T) {
 		{"keyof in union", "keyof A | B", "keyof A | B"},
 		{"union under mut", "mut (A | B)", "mut (A | B)"},
 		{"function type under keyof", "keyof fn () -> A", "keyof fn () -> A"},
+		// `¬` is a prefix like `keyof`, so it takes the whole annotation that follows and
+		// renders with no space before its operand, matching the solver's `¬number`.
+		{"negation of ref", "¬A", "¬A"},
+		{"negation in intersection", "A & ¬B", "A & ¬B"},
+		{"negation in union", "¬A | B", "¬A | B"},
+		{"union under negation", "¬(A | B)", "¬(A | B)"},
+		{"intersection under negation", "¬(A & B)", "¬(A & B)"},
 		// An indexed access reads from a target that binds as tightly as a type
 		// reference, so anything carrying an operator has to be wrapped.
 		{"union as index target", "(A | B)[C]", "(A | B)[C]"},

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1026,8 +1026,8 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		return strings.Join(parts, " & ")
 	case *NegationType:
-		// `¬T`, the standard set-theoretic notation, since Escalier has no surface syntax for a
-		// complement to mirror. The operand prints at precPrefix, so a union renders
+		// `¬T`, the standard set-theoretic notation, matching the `¬` surface syntax the parser
+		// reads and the AST printer writes. The operand prints at precPrefix, so a union renders
 		// `¬(A | B)`, an intersection `¬(A & B)`, a function `¬(fn () -> number)`, and an atom
 		// stays bare as `¬number`.
 		return "¬" + p.printTypeMinPrec(t.Inner, precPrefix)

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -864,6 +864,16 @@ type UnsupportedFeatureError struct {
 	Feature string
 }
 
+// NegatedBorrowError fires when a written `¬T` names a borrow on its operand's spine. A complement
+// may not name a borrow, the ¬Ref exclusion invariant. The outlives lattice a borrow's lifetime
+// lives in has a join and a meet but no complement, so `¬(&'a Point)` names nothing. Borrow is the
+// offending borrow, which may sit under a union or an intersection as in `¬(&'a Point | number)`,
+// not only at the top. The solver enforces the same rule on the complements it builds itself.
+type NegatedBorrowError struct {
+	Ann    *ast.NegationTypeAnn
+	Borrow *soltype.RefType
+}
+
 // BodyDeclNotAllowedError fires when a statement-level declaration in a function
 // body is anything other than a VarDecl. This is a permanent language rule
 // (§3.2), not the temporary subset gate above: body decls are VarDecl-only.
@@ -1219,6 +1229,7 @@ func (*TooManyArgsError) isSolverError()                    {}
 func (*NotEnoughArgsError) isSolverError()                  {}
 func (*UnsupportedNodeError) isSolverError()                {}
 func (*UnsupportedFeatureError) isSolverError()             {}
+func (*NegatedBorrowError) isSolverError()                  {}
 func (*BodyDeclNotAllowedError) isSolverError()             {}
 func (*MissingInitializerError) isSolverError()             {}
 func (*DuplicateDeclarationError) isSolverError()           {}
@@ -2374,6 +2385,15 @@ func (e *UnsupportedFeatureError) Span() ast.Span      { return e.Node.Span() }
 func (e *UnsupportedFeatureError) Related() []ast.Span { return nil }
 func (e *UnsupportedFeatureError) Message() string {
 	return "Unsupported: " + e.Feature
+}
+
+func (e *NegatedBorrowError) Span() ast.Span      { return e.Ann.Span() }
+func (e *NegatedBorrowError) Related() []ast.Span { return nil }
+func (e *NegatedBorrowError) Message() string {
+	// soltype.Print renders the borrow with its `&` and `mut`, so the message names the offending
+	// borrow directly, as `&Point` or `&mut {x: number}`, whether it sat at the top of the operand
+	// or under a union or an intersection.
+	return "cannot negate a borrow: " + soltype.Print(e.Borrow)
 }
 
 func (e *BodyDeclNotAllowedError) Span() ast.Span      { return e.Decl.Span() }

--- a/internal/solver/infer_negation_test.go
+++ b/internal/solver/infer_negation_test.go
@@ -1,0 +1,188 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// A written `¬T` resolves to the complement of its operand. newNegation folds the four operands
+// whose complement the lattice already names — `¬never` to `unknown`, `¬unknown` to `never`, `¬¬T`
+// to `T`, and `¬(open union)` to `never` — and wraps anything else in a NegationType that renders
+// `¬T` the way the source wrote it. Each case asserts the stored `Result` renders as expected.
+func TestInferNegationTypeAnnResolves(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "LiteralOperand",
+			src:  `type Result = ¬"a"`,
+			want: `¬"a"`,
+		},
+		{
+			name: "PrimitiveOperand",
+			src:  "type Result = ¬number",
+			want: "¬number",
+		},
+		{
+			// `¬` binds tighter than `&`, so the intersection keeps the complement as one member.
+			name: "IntersectionMember",
+			src:  `type Result = string & ¬"a"`,
+			want: `string & ¬"a"`,
+		},
+		{
+			name: "NegateNever",
+			src:  "type Result = ¬never",
+			want: "unknown",
+		},
+		{
+			name: "NegateUnknown",
+			src:  "type Result = ¬unknown",
+			want: "never",
+		},
+		{
+			name: "DoubleNegation",
+			src:  "type Result = ¬¬number",
+			want: "number",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, _, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, soltype.Print(nodes["Result"]))
+		})
+	}
+}
+
+// newNegation can hand back a pointer that already carries provenance: `¬¬T` folds to the operand's
+// inner, and the lattice-bound folds return the shared zero-size NeverType/UnknownType singletons
+// every instance of which shares one address. resolveNegationTypeAnn records prov only on the first
+// writer, so a second annotation that folds to the same pointer overwrites no earlier blame and does
+// not trip the debugProv unique-pointer guard. Each case resolves two distinct annotations that fold
+// to one shared pointer and asserts the second records nothing new. inferSource leaves debugProv off,
+// so the test drives the resolver directly with the guard on, mirroring the atom-annotation test.
+func TestResolveNegationFoldRecordsProvOnce(t *testing.T) {
+	str := func() ast.TypeAnn { return ast.NewLitTypeAnn(ast.NewString("a", testSpan()), testSpan()) }
+	tests := []struct {
+		name string
+		ann  func() ast.TypeAnn
+	}{
+		{"¬never folds to unknown", func() ast.TypeAnn {
+			return ast.NewNegationTypeAnn(ast.NewNeverTypeAnn(testSpan()), testSpan())
+		}},
+		{"¬unknown folds to never", func() ast.TypeAnn {
+			return ast.NewNegationTypeAnn(ast.NewUnknownTypeAnn(testSpan()), testSpan())
+		}},
+		{"¬¬T folds to the operand", func() ast.TypeAnn {
+			return ast.NewNegationTypeAnn(ast.NewNegationTypeAnn(str(), testSpan()), testSpan())
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newChecker()
+			c.debugProv = true
+			scope := NewScope()
+
+			_, ok := c.resolveTypeAnn(scope, tt.ann(), 0)
+			require.True(t, ok)
+			require.NotPanics(t, func() { c.resolveTypeAnn(scope, tt.ann(), 0) })
+			require.Empty(t, c.errs)
+		})
+	}
+}
+
+// A bare `¬T` resolves to a NegationType node, not merely a type that prints as `¬T`.
+func TestInferNegationTypeAnnResolvesToNegationType(t *testing.T) {
+	nodes, _, errs := inferTypeNodes(t, `type Result = ¬"a"`)
+	require.Empty(t, errs)
+	require.IsType(t, &soltype.NegationType{}, nodes["Result"])
+}
+
+// A written `¬` flows through constraint solving: constrain reads a complement, so a value the
+// complement admits is accepted and one it excludes is rejected. The excluded case reports the
+// mismatch against the complement `¬"a"` the intersection normalizes to.
+func TestInferNegationTypeAnnConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "AdmittedLiteralAccepted",
+			src:  `val x: ¬"a" = "b"`,
+		},
+		{
+			name:    "ExcludedLiteralRejected",
+			src:     `val x: ¬"a" = "a"`,
+			wantErr: `cannot constrain "a" <: ¬"a"`,
+		},
+		{
+			// `¬` binds tighter than `&`, so the annotation is `string & (¬"a")`, admitting every
+			// string but `"a"`. This is the complement the feature request writes as `string & ¬"a"`.
+			name: "IntersectionAdmitsAllButExcluded",
+			src:  `val x: string & ¬"a" = "b"`,
+		},
+		{
+			name:    "IntersectionRejectsExcluded",
+			src:     `val x: string & ¬"a" = "a"`,
+			wantErr: `cannot constrain "a" <: ¬"a"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// The ¬Ref exclusion invariant forbids a complement from naming a borrow. A written `¬T` routes
+// through the resolver's spine walk, so the diagnostic surfaces at the annotation rather than as a
+// panic deeper in normalization. A borrow reached only under a union or an intersection is caught
+// too, since De Morgan turns `¬(&Point | number)` into `¬(&Point) ∩ ¬number`, which still names the
+// borrow. The message renders the offending borrow with its `&` and `mut`, dropping the lifetime.
+func TestInferNegationOfBorrowRejected(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string
+	}{
+		{
+			name:    "SharedBorrowOfClass",
+			src:     "class Point { x: number }\ntype Bad = ¬&Point",
+			wantErr: "cannot negate a borrow: &Point",
+		},
+		{
+			name:    "MutBorrowOfObject",
+			src:     "type Bad = ¬&mut {x: number}",
+			wantErr: "cannot negate a borrow: &mut {x: number}",
+		},
+		{
+			name:    "BorrowUnderUnion",
+			src:     "class Point { x: number }\ntype Bad = ¬(&Point | number)",
+			wantErr: "cannot negate a borrow: &Point",
+		},
+		{
+			name:    "BorrowUnderIntersection",
+			src:     "class Point { x: number }\ntype Bad = ¬(number & &Point)",
+			wantErr: "cannot negate a borrow: &Point",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}

--- a/internal/solver/infer_negation_test.go
+++ b/internal/solver/infer_negation_test.go
@@ -187,7 +187,8 @@ func TestInferNegationInTemplateLit(t *testing.T) {
 // through the resolver's spine walk, so the diagnostic surfaces at the annotation rather than as a
 // panic deeper in normalization. A borrow reached only under a union or an intersection is caught
 // too, since De Morgan turns `¬(&Point | number)` into `¬(&Point) ∩ ¬number`, which still names the
-// borrow. The message renders the offending borrow with its `&` and `mut`, dropping the lifetime.
+// borrow. The message names the offending borrow with its `&` and `mut`; the plain `soltype.Print`
+// used here carries no lifetime names, so no borrow lifetime appears even when the source wrote one.
 func TestInferNegationOfBorrowRejected(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -212,6 +213,13 @@ func TestInferNegationOfBorrowRejected(t *testing.T) {
 		{
 			name:    "BorrowUnderIntersection",
 			src:     "class Point { x: number }\ntype Bad = ¬(number & &Point)",
+			wantErr: "cannot negate a borrow: &Point",
+		},
+		{
+			// A named lifetime the source wrote is still omitted, since plain soltype.Print
+			// carries no lifetime names.
+			name:    "BorrowWithNamedLifetime",
+			src:     "class Point { x: number }\ntype Bad<'a> = ¬(&'a Point)",
 			wantErr: "cannot negate a borrow: &Point",
 		},
 	}

--- a/internal/solver/infer_negation_test.go
+++ b/internal/solver/infer_negation_test.go
@@ -146,6 +146,43 @@ func TestInferNegationTypeAnnConstraint(t *testing.T) {
 	}
 }
 
+// DISABLED until #1164: a complement written inside a template-literal interpolation only matches
+// once the placeholder matcher gains negation and intersection arms. Today matchInterp in constrain.go
+// handles a string literal, the `string` primitive, and a union of those, so `on${string & ¬"a"}`
+// rejects every value, `"onb"` included. #1164 teaches the matcher to read a complement, after which
+// `on${string & ¬"a"}` admits every `on`-prefixed string but `"ona"`. When #1164 lands, remove the
+// /* */ wrapper.
+func TestInferNegationInTemplateLit(t *testing.T) {
+	/*
+		tests := []struct {
+			name    string
+			src     string
+			wantErr string // "" ⇒ expect no error
+		}{
+			{
+				name: "AdmittedValueAccepted",
+				src:  "val b: `on${string & ¬\"a\"}` = \"onb\"",
+			},
+			{
+				name:    "ExcludedValueRejected",
+				src:     "val a: `on${string & ¬\"a\"}` = \"ona\"",
+				wantErr: "cannot constrain \"ona\" <: `on${string & ¬\"a\"}`",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, _, errs := inferSource(t, tt.src)
+				if tt.wantErr == "" {
+					require.Empty(t, errs)
+					return
+				}
+				require.Len(t, errs, 1)
+				require.Equal(t, tt.wantErr, errs[0].Message())
+			})
+		}
+	*/
+}
+
 // The ¬Ref exclusion invariant forbids a complement from naming a borrow. A written `¬T` routes
 // through the resolver's spine walk, so the diagnostic surfaces at the annotation rather than as a
 // panic deeper in normalization. A borrow reached only under a union or an intersection is caught

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -193,6 +193,8 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.resolveFuncTypeAnn(scope, ta, lvl)
 	case *ast.KeyOfTypeAnn:
 		return c.resolveKeyOfTypeAnn(scope, ta, lvl)
+	case *ast.NegationTypeAnn:
+		return c.resolveNegationTypeAnn(scope, ta, lvl)
 	case *ast.IndexTypeAnn:
 		return c.resolveIndexTypeAnn(scope, ta, lvl)
 	case *ast.TypeOfTypeAnn:
@@ -633,6 +635,36 @@ func (c *checker) resolveKeyOfTypeAnn(scope *Scope, ta *ast.KeyOfTypeAnn, lvl in
 	}
 	t := &soltype.KeyofType{Operand: operand}
 	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveNegationTypeAnn lowers `¬T` to the complement of its operand through newNegation, which
+// folds `¬never` to `unknown`, `¬unknown` to `never`, `¬¬T` to `T`, and `¬(open union)` to `never`.
+// An unsupported operand recovers to a fresh var, cascade-safe like the Promise<bad> recovery.
+//
+// A borrow is the one atom a complement may not name, the ¬Ref exclusion invariant. The outlives
+// lattice a borrow's lifetime lives in has no complement, so `¬(&'a Point)` names nothing. The check
+// reaches a borrow anywhere on the operand's spine, not only at the top, because De Morgan turns
+// `¬(&'a Point | number)` into `¬(&'a Point) ∩ ¬number`, which still names the borrow. The solver
+// enforces this on the complements it builds itself; a written `¬` routes through the same spine walk
+// here so the diagnostic surfaces at the annotation rather than as a panic deeper in normalization.
+func (c *checker) resolveNegationTypeAnn(scope *Scope, ta *ast.NegationTypeAnn, lvl int) (soltype.Type, bool) {
+	operand, ok := c.resolveTypeAnn(scope, ta.Type, lvl)
+	if !ok {
+		operand = c.freshAt(lvl)
+	}
+	if borrow := negatedSpineBorrow(operand); borrow != nil {
+		return c.report(&NegatedBorrowError{Ann: ta, Borrow: borrow}), false
+	}
+	t := newNegation(operand)
+	// newNegation can return a pointer that already carries prov: `¬¬T` folds to the operand's
+	// inner, and the lattice-bound folds return the shared zero-size NeverType/UnknownType
+	// singletons every `&soltype.NeverType{}` shares an address with. Re-recording would overwrite
+	// the narrower child-annotation blame and trip the debugProv guard, so record only the first
+	// writer, mirroring resolveUnionTypeAnn.
+	if !c.hasProv(t) {
+		c.recordProv(t, ta, AnnotationType)
+	}
 	return t, true
 }
 

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -262,10 +262,10 @@ func negatableOperand(t soltype.Type) bool {
 }
 
 // negatedSpineBorrow returns the first borrow on t's lattice spine, the atom the ¬Ref exclusion
-// invariant forbids a complement from naming, or nil when the spine holds none. It walks the same
-// union/intersection/negation spine as negatableOperand, so a caller that reports the violation can
-// name the offending borrow instead of only stating that one is present. See negatableOperand for
-// why the walk stops at the spine and treats a borrow under a second complement as forbidden.
+// invariant forbids a complement from naming, or nil when the spine holds none. negatableOperand's
+// boolean backs this walk, and a caller that reports the violation reads the borrow itself here so
+// it can name it. The walk stops at the spine: a borrow nested inside an atom, as in `¬{a: &'a T}`,
+// is a field of the type the negated part names rather than a negated part itself, so it is allowed.
 func negatedSpineBorrow(t soltype.Type) *soltype.RefType {
 	switch t := t.(type) {
 	case *soltype.RefType:

--- a/internal/solver/typeops_negation.go
+++ b/internal/solver/typeops_negation.go
@@ -258,18 +258,37 @@ func negatableOperands(types []soltype.Type) bool {
 // existing complement around a rewritten operand chooses nothing, which is why soltype.NewNegation
 // draws the same distinction.
 func negatableOperand(t soltype.Type) bool {
+	return negatedSpineBorrow(t) == nil
+}
+
+// negatedSpineBorrow returns the first borrow on t's lattice spine, the atom the ¬Ref exclusion
+// invariant forbids a complement from naming, or nil when the spine holds none. It walks the same
+// union/intersection/negation spine as negatableOperand, so a caller that reports the violation can
+// name the offending borrow instead of only stating that one is present. See negatableOperand for
+// why the walk stops at the spine and treats a borrow under a second complement as forbidden.
+func negatedSpineBorrow(t soltype.Type) *soltype.RefType {
 	switch t := t.(type) {
 	case *soltype.RefType:
-		return false
+		return t
 	case *soltype.UnionType:
-		return negatableOperands(t.Types)
+		return firstSpineBorrow(t.Types)
 	case *soltype.IntersectionType:
-		return negatableOperands(t.Types)
+		return firstSpineBorrow(t.Types)
 	case *soltype.NegationType:
-		return negatableOperand(t.Inner)
+		return negatedSpineBorrow(t.Inner)
 	default:
-		return true
+		return nil
 	}
+}
+
+// firstSpineBorrow returns the first borrow negatedSpineBorrow finds across these types, or nil.
+func firstSpineBorrow(types []soltype.Type) *soltype.RefType {
+	for _, t := range types {
+		if r := negatedSpineBorrow(t); r != nil {
+			return r
+		}
+	}
+	return nil
 }
 
 // nativeDifference rewrites a distributive conditional that filters its own operand into the set

--- a/internal/test_util/test_util.go
+++ b/internal/test_util/test_util.go
@@ -176,6 +176,11 @@ func typeAnnToType(typeAnn ast.TypeAnn) Type {
 		// annotation here is a test mistake. Fail with a clear cause rather
 		// than the generic default below.
 		panic("typeAnnToType: borrow annotations are unsupported in the legacy test helper")
+	case *ast.NegationTypeAnn:
+		// The legacy type system has no complement representation. A NegationType
+		// lives only in the SimpleSub-based solver, so feeding a `¬T` annotation here
+		// is a test mistake. Fail with a clear cause rather than the generic default below.
+		panic("typeAnnToType: negation annotations are unsupported in the legacy test helper")
 	default:
 		panic(fmt.Sprintf("ConvertTypeAnnToType: unsupported type annotation: %T", typeAnn))
 	}


### PR DESCRIPTION
Adds support for the negation type annotation `¬T`, which represents the set-theoretic complement of a type. This allows users to write types that exclude specific values, such as `¬"a"` (all strings except `"a"`) or `string & ¬"a"` (all strings except `"a"`).

## Key changes

- **Parser**: Added `Negation` token for `¬` (U+00AC) and parsing logic in `primaryTypeAnn()` to handle `¬T` as a prefix operator with the same precedence as `keyof` and `mut`.
- **AST**: Added `NegationTypeAnn` node type to represent negation annotations in the syntax tree.
- **Type solver**: Implemented `resolveNegationTypeAnn()` to lower `¬T` to a `soltype.NegationType` through `newNegation()`, which folds special cases (`¬never` → `unknown`, `¬unknown` → `never`, `¬¬T` → `T`, `¬(open union)` → `never`).
- **Constraint checking**: Negation types flow through constraint solving so values the complement admits are accepted and excluded values are rejected.
- **Borrow validation**: Added `negatedSpineBorrow()` to enforce the ¬Ref exclusion invariant — complements may not name borrows anywhere on the operand's spine, since the outlives lattice has no complement. Violations surface as `NegatedBorrowError` at the annotation rather than panicking deeper in normalization.
- **Printer**: Added rendering of `¬T` in both the AST printer and type printer, with correct precedence handling.
- **Legacy checker**: Added a clean error for negation types, which are unsupported in the legacy type system.
- **Tests**: Added comprehensive test coverage for parsing, type inference, constraint checking, and borrow rejection.

## Notable implementation details

- Negation binds tighter than union and intersection, so `string & ¬"a"` parses as `string & (¬"a")` and `¬T | U` parses as `(¬T) | U`.
- `newNegation()` can return a pointer that already carries provenance (from folding `¬¬T` or lattice-bound cases), so `resolveNegationTypeAnn()` only records provenance on the first writer to avoid overwriting narrower child-annotation blame.
- Template literal interpolation with negation is disabled pending #1164, which will teach the placeholder matcher to handle complements.

https://claude.ai/code/session_01RfSgsHw1i3aUMxLHHuPh7A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for complement type annotations using the `¬T` syntax.
  * Supports negation with references, unions, intersections, and nested type expressions.
  * Preserves correct parsing, formatting, precedence, and type resolution.

* **Bug Fixes**
  * Added clear diagnostics when negating borrow types.
  * Improved error recovery for incomplete negation annotations.

* **Tests**
  * Added comprehensive coverage for parsing, printing, inference, constraints, and invalid borrow negation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->