### PR TITLE
Centralize provenance recording for annotation results

### DIFF
--- a/internal/solver/infer_negation_test.go
+++ b/internal/solver/infer_negation_test.go
@@ -59,13 +59,15 @@ func TestInferNegationTypeAnnResolves(t *testing.T) {
 	}
 }
 
-// newNegation can hand back a pointer that already carries provenance: `¬¬T` folds to the operand's
-// inner, and the lattice-bound folds return the shared zero-size NeverType/UnknownType singletons
-// every instance of which shares one address. resolveNegationTypeAnn records prov only on the first
-// writer, so a second annotation that folds to the same pointer overwrites no earlier blame and does
-// not trip the debugProv unique-pointer guard. Each case resolves two distinct annotations that fold
-// to one shared pointer and asserts the second records nothing new. inferSource leaves debugProv off,
-// so the test drives the resolver directly with the guard on, mirroring the atom-annotation test.
+// newNegation can hand back a pointer that is not freshly minted: `¬¬T` folds to the operand's
+// inner T, which already carries its own blame, and the lattice-bound folds return the shared
+// zero-size NeverType/UnknownType singletons every instance of which shares one address.
+// resolveNegationTypeAnn routes through recordProvForResult, which records neither, so a second
+// annotation that folds to the same pointer overwrites no earlier blame and does not trip the
+// debugProv unique-pointer guard. Each case resolves two distinct annotations that fold to one
+// shared pointer and asserts the second does not panic. TestProvSharedSingletonRecordsNothing
+// asserts the stronger fact that a singleton fold records nothing at all. inferSource leaves
+// debugProv off, so the test drives the resolver directly with the guard on.
 func TestResolveNegationFoldRecordsProvOnce(t *testing.T) {
 	str := func() ast.TypeAnn { return ast.NewLitTypeAnn(ast.NewString("a", testSpan()), testSpan()) }
 	tests := []struct {

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -163,6 +163,7 @@ func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
 //     singletons. The FromAST skip alone would miss them: the first annotation to
 //     fold to a singleton would record against the shared address, and every later
 //     use of that singleton would then resolve its blame to that first annotation.
+//     #1171 weighs making these atoms distinct pointers so they could carry blame.
 //
 // recordProv keeps its strict unique-pointer contract for genuinely-minted types;
 // this wrapper is what the arms that cannot promise a fresh pointer call instead.

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -143,6 +143,48 @@ func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
 	c.prov[t] = FromAST{Node: n, Kind: kind}
 }
 
+// recordProvForResult records provenance for an annotation result whose smart
+// constructor may hand back a pointer that is not freshly minted. It is the one
+// choke point the annotation arms with that property route through, so the
+// may-not-be-fresh rule lives in one documented place instead of being re-derived
+// per arm. It records only when the result can carry blame of its own, and
+// otherwise skips:
+//
+//   - A result that already carries a FromAST origin. newUnion and newIntersection
+//     collapse to an input member's pointer on dedup or subsumption, and newNegation
+//     folds ¬¬T to the operand's inner T. That member or inner keeps its own narrower
+//     child-annotation blame rather than being overwritten by the enclosing
+//     annotation, and re-recording it would trip recordProv's debugProv guard.
+//   - A shared zero-size singleton such as NeverType or UnknownType. Go gives every
+//     &soltype.NeverType{} the same address, and Prov is keyed by pointer identity,
+//     so recording would file every such annotation in the module under one entry.
+//     This also covers newNegation's lattice-bound folds `¬never` ⇒ `unknown`,
+//     `¬unknown` ⇒ `never`, and `¬(open union)` ⇒ `never`, which return those
+//     singletons. The FromAST skip alone would miss them: the first annotation to
+//     fold to a singleton would record against the shared address, and every later
+//     use of that singleton would then resolve its blame to that first annotation.
+//
+// recordProv keeps its strict unique-pointer contract for genuinely-minted types;
+// this wrapper is what the arms that cannot promise a fresh pointer call instead.
+func (c *checker) recordProvForResult(t soltype.Type, n ast.Node, kind ASTOriginKind) {
+	if c.hasProv(t) || sharedSingleton(t) {
+		return
+	}
+	c.recordProv(t, n, kind)
+}
+
+// sharedSingleton reports whether t is one of the zero-size atom types Go gives a
+// shared address. Every &soltype.NeverType{}, &soltype.UnknownType{},
+// &soltype.NullType{}, and &soltype.UndefinedType{} in a module points at one
+// address, so the pointer-keyed Prov table cannot tell two of them apart.
+func sharedSingleton(t soltype.Type) bool {
+	switch t.(type) {
+	case *soltype.NeverType, *soltype.UnknownType, *soltype.NullType, *soltype.UndefinedType:
+		return true
+	}
+	return false
+}
+
 // recordFusionEdge records the FromNormalization interior edge a normal-form
 // fusion mints, installed on Context in newChecker so a fusion in normal.go or
 // classes.go can reach the table the checker owns. fused is the atom the merge

--- a/internal/solver/prov_test.go
+++ b/internal/solver/prov_test.go
@@ -209,6 +209,43 @@ func TestProvCoalescedTypeHasNoEntry(t *testing.T) {
 	require.False(t, ok, "a coalesced type must have no provenance entry")
 }
 
+// A resolver arm whose result is a shared zero-size singleton records no provenance.
+// Every &UnknownType{} shares one address, so an entry would file every such annotation
+// in the module under one node. This is the mis-blame the guarded record path let
+// through for `¬never`: it folds to the shared `unknown` singleton, and the first such
+// annotation would capture the address, after which every later `unknown` — a bare
+// `unknown` annotation included — would resolve its blame to that first `¬never`.
+// recordProvForResult's singleton skip records nothing, so Prov stays empty. debugProv
+// is on so a stray record against a singleton already blamed by an earlier case would
+// also panic.
+func TestProvSharedSingletonRecordsNothing(t *testing.T) {
+	tests := []struct {
+		name string
+		ann  func() ast.TypeAnn
+	}{
+		{"never", func() ast.TypeAnn { return ast.NewNeverTypeAnn(testSpan()) }},
+		{"unknown", func() ast.TypeAnn { return ast.NewUnknownTypeAnn(testSpan()) }},
+		{"¬never folds to unknown", func() ast.TypeAnn {
+			return ast.NewNegationTypeAnn(ast.NewNeverTypeAnn(testSpan()), testSpan())
+		}},
+		{"¬unknown folds to never", func() ast.TypeAnn {
+			return ast.NewNegationTypeAnn(ast.NewUnknownTypeAnn(testSpan()), testSpan())
+		}},
+		{"null", func() ast.TypeAnn { return ast.NewLitTypeAnn(ast.NewNull(testSpan()), testSpan()) }},
+		{"undefined", func() ast.TypeAnn { return ast.NewLitTypeAnn(ast.NewUndefined(testSpan()), testSpan()) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newChecker()
+			c.debugProv = true
+			ty, ok := c.resolveTypeAnn(NewScope(), tt.ann(), 0)
+			require.True(t, ok)
+			require.True(t, sharedSingleton(ty), "result must be a shared zero-size singleton")
+			require.Empty(t, c.prov, "a shared singleton must record no provenance")
+		})
+	}
+}
+
 // The debugProv guard (finding #5) enforces the unique-pointer invariant: recording
 // the SAME type pointer against a DIFFERENT node panics (catching a future
 // interned/coalesced-pointer reuse that would silently mis-blame), while

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -26,23 +26,22 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		// expression names it to drop a field, `{[if K : "id" { never } else { K }]: … }`, which is
 		// how a mapped type filters its key set.
 		//
-		// No provenance is recorded. soltype.NeverType has no fields, so Go gives every
-		// `&soltype.NeverType{}` the same address, and the Prov side table is keyed by pointer
-		// identity. Recording against it would file every `never` annotation in the module under one
-		// entry, so each would report the last one's span as its blame, and the debugProv guard would
-		// panic on the second. A caller that needs a span for a rejected `never` falls back to the
-		// constraint site.
-		return &soltype.NeverType{}, true
+		// recordProvForResult records nothing here: NeverType is a shared zero-size singleton, so
+		// a caller that needs a span for a rejected `never` falls back to the constraint site.
+		t := &soltype.NeverType{}
+		c.recordProvForResult(t, ta, AnnotationType)
+		return t, true
 	case *ast.UnknownTypeAnn:
 		// `unknown` is the top of the lattice. Every type is a subtype of it through
 		// constrain's `_ <: unknown` rule, so it is the bound that admits any type at a
 		// position whose value is never read, as `fn () -> unknown` does in a type
 		// parameter's constraint.
 		//
-		// No provenance is recorded, for the reason the NeverTypeAnn arm above gives:
-		// soltype.UnknownType has no fields, so every `&soltype.UnknownType{}` shares one
-		// address and the pointer-keyed Prov table cannot tell two of them apart.
-		return &soltype.UnknownType{}, true
+		// recordProvForResult records nothing here, for the reason the NeverTypeAnn arm gives:
+		// UnknownType is a shared zero-size singleton.
+		t := &soltype.UnknownType{}
+		c.recordProvForResult(t, ta, AnnotationType)
+		return t, true
 	case *ast.LitTypeAnn:
 		return c.resolveLitTypeAnn(ta)
 	case *ast.TypeRefTypeAnn:
@@ -597,13 +596,10 @@ func (c *checker) resolveUnionTypeAnn(scope *Scope, ta *ast.UnionTypeAnn, lvl in
 	} else {
 		t = newUnion(c.ctx, members, ta.Inexact)
 	}
-	// newUnion can collapse to an input member's pointer (single-member
-	// dedup, or subsumption). Re-recording Prov on a pointer that already
-	// carries it would overwrite the narrower child-annotation blame and
-	// trip the debugProv guard.
-	if !c.hasProv(t) {
-		c.recordProv(t, ta, AnnotationType)
-	}
+	// newUnion can collapse to an input member's pointer on single-member dedup or
+	// subsumption, so the result may already carry that member's blame. recordProvForResult
+	// records only a fresh, uniquely-owned result.
+	c.recordProvForResult(t, ta, AnnotationType)
 	return t, true
 }
 
@@ -618,9 +614,7 @@ func (c *checker) resolveIntersectionTypeAnn(scope *Scope, ta *ast.IntersectionT
 		}
 	}
 	t := newIntersection(c.ctx, members)
-	if !c.hasProv(t) {
-		c.recordProv(t, ta, AnnotationType)
-	}
+	c.recordProvForResult(t, ta, AnnotationType)
 	return t, true
 }
 
@@ -657,14 +651,11 @@ func (c *checker) resolveNegationTypeAnn(scope *Scope, ta *ast.NegationTypeAnn, 
 		return c.report(&NegatedBorrowError{Ann: ta, Borrow: borrow}), false
 	}
 	t := newNegation(operand)
-	// newNegation can return a pointer that already carries prov: `¬¬T` folds to the operand's
-	// inner, and the lattice-bound folds return the shared zero-size NeverType/UnknownType
-	// singletons every `&soltype.NeverType{}` shares an address with. Re-recording would overwrite
-	// the narrower child-annotation blame and trip the debugProv guard, so record only the first
-	// writer, mirroring resolveUnionTypeAnn.
-	if !c.hasProv(t) {
-		c.recordProv(t, ta, AnnotationType)
-	}
+	// newNegation can return a pointer that is not freshly minted: `¬¬T` folds to the
+	// operand's inner T, and the lattice-bound folds return the shared zero-size
+	// NeverType/UnknownType singletons. recordProvForResult skips both the already-blamed
+	// inner and the module-shared singleton, mirroring resolveUnionTypeAnn.
+	c.recordProvForResult(t, ta, AnnotationType)
 	return t, true
 }
 
@@ -675,12 +666,13 @@ func (c *checker) resolveNegationTypeAnn(scope *Scope, ta *ast.NegationTypeAnn, 
 //
 // `null` and `undefined` become the atoms atomLitOf returns. That makes both writable in an
 // annotation, so a binding can be declared `val n: null = null` and `NonNullable<T>` can test
-// its argument against `null | undefined`. The atom returns above the recordProv call below,
-// since neither atom can carry provenance. atomLitOf explains why.
+// its argument against `null | undefined`. recordProvForResult records nothing for either atom,
+// since both are shared zero-size singletons that cannot carry provenance.
 //
 // A literal with no soltype form, such as a regex or a bigint, reports unsupported and recovers.
 func (c *checker) resolveLitTypeAnn(ta *ast.LitTypeAnn) (soltype.Type, bool) {
 	if atom, _, isAtom := atomLitOf(ta.Lit); isAtom {
+		c.recordProvForResult(atom, ta, AnnotationType)
 		return atom, true
 	}
 	lit, ok := c.litTypeOf(ta.Lit)


### PR DESCRIPTION
Introduce `recordProvForResult` to handle provenance recording for type annotation results that may not be freshly minted. This consolidates the logic for skipping provenance on already-blamed pointers and shared zero-size singletons into one documented place, replacing ad-hoc `if !c.hasProv(t)` checks scattered across multiple resolver arms.

**Key changes:**

- Add `recordProvForResult` function in `prov.go` that records provenance only when safe: skips results that already carry `FromAST` blame (from union/intersection/negation collapsing to input members) and shared singleton types (NeverType, UnknownType, NullType, UndefinedType) that cannot carry distinct provenance due to pointer identity sharing.
- Add `sharedSingleton` helper to identify zero-size atom types that Go allocates at a single address per module.
- Replace conditional `if !c.hasProv(t) { c.recordProv(...) }` patterns in `resolveNeverTypeAnn`, `resolveUnknownTypeAnn`, `resolveUnionTypeAnn`, `resolveIntersectionTypeAnn`, `resolveNegationTypeAnn`, and `resolveLitTypeAnn` with calls to `recordProvForResult`.
- Add `TestProvSharedSingletonRecordsNothing` to verify that singleton results (never, unknown, null, undefined, and negation folds to singletons) record no provenance, preventing mis-blame where the first annotation to fold to a singleton would capture the shared address.
- Update `TestResolveNegationFoldRecordsProvOnce` comment to reflect the new routing through `recordProvForResult`.

This change maintains the unique-pointer invariant for genuinely-minted types while centralizing the exception handling for non-fresh results.

https://claude.ai/code/session_01EFXseVPabjAhkMc6TojRQY