### PR TITLE
Bind the caught value as unknown (2/5)

### DIFF
--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -3539,13 +3539,14 @@ func (c *checker) inferTryCatch(scope *Scope, lvl int, e *ast.TryCatchExpr) solt
 		branches = append(branches, tryT)
 	}
 
-	// The caught type is this walk's scrutinee, and the arms are typed exactly as a `match`
-	// expression's are. It is already concrete, so it serves as both the narrowing shape and
-	// the bind target.
-	caught := c.caughtType(collected)
+	// A catch can catch any value the runtime throws, whatever the block's signature named, so the
+	// caught value is `unknown`. That is this walk's scrutinee, serving as both the narrowing shape
+	// and the bind target, and the arms are typed exactly as a `match` expression's are. The
+	// block's known throws drive rethrowUnhandled instead.
+	caught := soltype.Type(&soltype.UnknownType{})
 	branches = append(branches, c.inferMatchArms(scope, lvl, e, e.Catch, caught, caught, res)...)
 	c.checkUniformOwnership(e, branches)
-	c.rethrowUnhandled(scope, e, caught, enclosing)
+	c.rethrowUnhandled(scope, e, collected, enclosing)
 	c.recordType(e, res)
 	return res
 }
@@ -3569,58 +3570,37 @@ func (c *checker) walkTryBlock(scope *Scope, lvl int, b *ast.Block, sink soltype
 	return t, diverges
 }
 
-// caughtType returns the type a catch arm's pattern binds against: what the try block
-// raised, reopened with a trailing `...`. The tail is there because a clause is a floor
-// rather than a ceiling, so a call can raise something its signature did not name. A block
-// with no known exceptional exit yields `unknown`, the tail on its own, since an inexact
-// union with no members carries no value to bind against.
-func (c *checker) caughtType(collected soltype.Type) soltype.Type {
-	shape := coalesce(collected, soltype.Positive)
-	if isNeverType(shape) {
-		return &soltype.UnknownType{}
-	}
-	return newUnion(c.ctx, []soltype.Type{shape}, true)
-}
-
-// rethrowUnhandled sends the part of the caught union no arm covers into the enclosing
+// rethrowUnhandled sends the part of the block's known throws no arm covers into the enclosing
 // throws sink. A value matching no arm is re-raised at runtime, so uncovered members draw a
-// rethrow rather than the non-exhaustiveness error the equivalent `match` would draw.
+// rethrow rather than the non-exhaustiveness error the equivalent `match` would draw. collected is
+// what the try block raised, before coalescing.
 //
-// What escapes is the set difference `caught ∩ ¬handled`, where handled is the type the arms
-// catch. The difference is taken one member at a time, which is exact because meeting a
-// complement distributes over a union: `(A | B) ∩ ¬H` is `(A ∩ ¬H) | (B ∩ ¬H)`. A member
-// survives when the meet still holds a value, which memberCaught decides.
+// What escapes is the set difference `known ∩ ¬handled`, where handled is the type the arms catch.
+// The difference is taken one member at a time, which is exact because meeting a complement
+// distributes over a union: `(A | B) ∩ ¬H` is `(A ∩ ¬H) | (B ∩ ¬H)`. A member survives when the
+// meet still holds a value, which memberCaught decides.
 //
-// A guarded arm can fail its guard, so it catches nothing and contributes nothing to handled.
-// An unguarded catch-all catches every value and is answered before the difference is taken.
-// Only the MEMBERS are rethrown: every throws type is open already, and only `unknown` could
-// carry the tail, so adding it would erase the named types the clause had.
-func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, caught, enclosing soltype.Type) {
+// A guarded arm can fail its guard, so it catches nothing and contributes nothing to handled. An
+// unguarded catch-all catches every value and is answered before the difference is taken. Only the
+// named throws are weighed: a value outside them can still be thrown and rethrown at runtime, but
+// no signature named its type, so recording it would widen the clause to `unknown`.
+func (c *checker) rethrowUnhandled(scope *Scope, e *ast.TryCatchExpr, collected, enclosing soltype.Type) {
 	if ast.HasUnguardedCatchAll(e.Catch) {
 		return
 	}
 	handled := c.armsCatchType(scope, e.Catch)
-	// A non-union `caught` carries no named member to rethrow. It is `unknown`, the bare
-	// open tail caughtType renders for a block that raises nothing known, or the ErrorType
-	// recovery placeholder. Neither leaves anything for the enclosing clause to record.
-	var rethrown soltype.Type = &soltype.NeverType{}
-	if u, isUnion := caught.(*soltype.UnionType); isUnion {
-		uncovered := make([]soltype.Type, 0, len(u.Types))
-		for _, m := range u.Types {
-			for _, part := range c.caughtMembers(m) {
-				if c.memberCaught(part, handled, e.Catch) {
-					continue
-				}
-				uncovered = append(uncovered, part)
-			}
+	uncovered := make([]soltype.Type, 0)
+	for _, part := range c.caughtMembers(coalesce(collected, soltype.Positive)) {
+		if c.memberCaught(part, handled, e.Catch) {
+			continue
 		}
-		rethrown = newUnion(c.ctx, uncovered, false)
+		uncovered = append(uncovered, part)
 	}
+	rethrown := newUnion(c.ctx, uncovered, false)
 	if isNeverType(rethrown) {
-		// Every member an arm could name is covered. Codegen still emits a runtime rethrow
-		// for a value that matches no arm, but such a value came from the open tail, so no
-		// signature named its type. Recording it would mean widening the clause to
-		// `unknown` to state what is already true of every clause.
+		// Every known throw is covered. Codegen still emits a runtime rethrow for a value that
+		// matches no arm, but no signature named its type, so recording it would mean widening the
+		// clause to `unknown` to state what is already true of every clause.
 		return
 	}
 	// The engine runs directly rather than through c.constrain, so its errors are dropped

--- a/internal/solver/infer_try_catch_test.go
+++ b/internal/solver/infer_try_catch_test.go
@@ -51,17 +51,18 @@ func TestInferTryCatchHandlesWithACatchAll(t *testing.T) {
 // This is the one place the tail is rendered. A rethrow drops it, since a throws clause is
 // open already and would gain nothing from carrying it, but a catch arm matches an actual
 // value and has to reckon with one the block did not predict.
-func TestInferTryCatchBindsAnInexactUnion(t *testing.T) {
+func TestInferTryCatchBindsUnknown(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
-			// The arm returns the caught binding, so the function's return type is the
-			// caught type.
-			name: "CaughtBindingCarriesAnOpenTail",
+			// The arm returns the caught binding, so the function's return type is the caught
+			// type. A catch can catch any value the runtime throws, so the caught value is
+			// `unknown` whatever the block's signature named.
+			name: "CaughtBindingIsUnknown",
 			src:  `fn f() { try { throw "boom" } catch { e => { return e } } }`,
-			want: `fn () -> "boom" | ...`,
+			want: `fn () -> unknown`,
 		},
 		{
-			name: "CaughtBindingUnionsEveryRaisedType",
+			name: "CaughtBindingIsUnknownWhateverIsRaised",
 			src: `
 				fn f(c: boolean) {
 					try {
@@ -71,11 +72,11 @@ func TestInferTryCatchBindsAnInexactUnion(t *testing.T) {
 					}
 				}
 			`,
-			want: `fn (c: boolean) -> 5 | "boom" | ...`,
+			want: `fn (c: boolean) -> unknown`,
 		},
 		{
-			// A block with no known exceptional exit still binds something, since the tail
-			// is what remains. `unknown` is that tail on its own.
+			// A block with no known exceptional exit binds `unknown` too, the same as one that
+			// raises a known type.
 			name: "CaughtBindingOfAQuietBlockIsUnknown",
 			src: `
 				fn f() {
@@ -91,16 +92,14 @@ func TestInferTryCatchBindsAnInexactUnion(t *testing.T) {
 	})
 }
 
-// Without a catch-all the arms leave part of the caught union unhandled, and the compiler
-// rethrows it rather than reporting the arms non-exhaustive. What reaches the enclosing
-// clause is the members no arm covers.
+// Without a catch-all the arms leave part of the block's known throws unhandled, and the
+// compiler rethrows it rather than reporting the arms non-exhaustive. What reaches the
+// enclosing clause is the members no arm covers.
 //
-// The caught union's open tail is NOT among them, even though no arm short of a catch-all
-// covers it. Every throws type is already open, since any call can raise something its
-// signature did not name, so carrying the tail into the clause would re-state that once per
-// `try` and, since only `unknown` can hold it, erase every named type the clause had. The
-// tail stays where it is observable, on the caught binding, which
-// TestInferTryCatchBindsAnInexactUnion covers.
+// Only the known throws are weighed. A value outside them can still be thrown and rethrown at
+// runtime, but no signature named its type, so recording it would widen the clause to
+// `unknown`. The caught binding, which the arms narrow, is `unknown`, which
+// TestInferTryCatchBindsUnknown covers.
 func TestInferTryCatchRethrowsWhatTheArmsLeave(t *testing.T) {
 	runThrowsCases(t, []throwsCase{
 		{
@@ -220,25 +219,25 @@ func TestInferTryCatchAtModuleTopLevel(t *testing.T) {
 		want map[string]string
 	}{
 		{
-			name: "CaughtBindingCollectsTheBlocksThrows",
+			name: "CaughtBindingIsUnknown",
 			src:  `val caught = try { throw "fail" } catch { msg => msg }`,
-			want: map[string]string{"caught": `"fail" | ...`},
+			want: map[string]string{"caught": `unknown`},
 		},
 		{
 			// The install is undone when the block finishes, so a later `try` over a quiet
-			// block collects nothing rather than inheriting the earlier block's throws.
+			// block collects nothing rather than inheriting the earlier block's throws. Both
+			// caught bindings read `unknown`, whatever the block raised.
 			name: "TheSinkDoesNotLeakBetweenDecls",
 			src: `
 				val a = try { throw "one" } catch { e => e }
 				val b = try { val q = 1 } catch { e => e }
 			`,
-			want: map[string]string{"a": `"one" | ...`, "b": "unknown"},
+			want: map[string]string{"a": `unknown`, "b": "unknown"},
 		},
 		{
 			// throwsSink reads the module-level sink only when there is no funcCtx, so a
-			// function declared inside the block collects into its own signature. The block
-			// diverges, so the binding is the caught type alone, and `"inner"` is absent
-			// from it while the block's own `"outer"` is there.
+			// function declared inside the block collects into its own signature rather than
+			// the block's. The caught binding is `unknown` regardless.
 			name: "ANestedFunctionKeepsItsOwnSink",
 			src: `
 				val caught = try {
@@ -246,7 +245,7 @@ func TestInferTryCatchAtModuleTopLevel(t *testing.T) {
 					throw "outer"
 				} catch { e => e }
 			`,
-			want: map[string]string{"caught": `"outer" | ...`},
+			want: map[string]string{"caught": `unknown`},
 		},
 	}
 	for _, test := range tests {
@@ -279,7 +278,7 @@ func TestInferTryCatchNests(t *testing.T) {
 					}
 				}
 			`,
-			want: `fn (c: boolean) -> "boom" | ...`,
+			want: `fn (c: boolean) -> unknown`,
 		},
 		{
 			// The outer catch-all closes what the inner form left over, so the function
@@ -581,17 +580,13 @@ func TestInferTryCatchExpandsAliasedErrorTypes(t *testing.T) {
 	})
 }
 
-// A catch arm is a refutable context, so a structural pattern over a union of caught types
-// binds against only the members it can destructure. `[a, b]` keeps `[number, number]` and
-// drops `[string]`, which is what stops the arm from reporting a length mismatch against a
-// member it was never meant to match. One diagnostic remains. It comes from the open `...`
-// tail caughtType puts on every caught type, not from the dropped member. A fixed-arity tuple
-// pattern cannot destructure that tail, so `[a, b]` still fails against
-// `[number, number] | ...`.
+// The caught value is `unknown`, since a catch can catch any value the runtime throws. A
+// fixed-arity tuple pattern cannot destructure `unknown`, so `[a, b]` fails against it. The
+// catch-all arm below still binds the value, so only the tuple arm's diagnostic remains.
 func TestInferTryCatchArmNarrowsItsScrutinee(t *testing.T) {
 	runThrowsErrCases(t, []throwsErrCase{
 		{
-			name: "TuplePatternKeepsOnlyTheMembersItDestructures",
+			name: "TuplePatternCannotDestructureUnknown",
 			src: `
 				fn f(b: boolean) {
 					return try {
@@ -603,7 +598,7 @@ func TestInferTryCatchArmNarrowsItsScrutinee(t *testing.T) {
 				}
 			`,
 			wantErrs: []string{
-				"6:7-6:13: cannot constrain tuple | ... <: tuple",
+				"6:7-6:13: cannot constrain unknown <: tuple",
 			},
 		},
 	})


### PR DESCRIPTION
Part 2 of 5 of removing inexact union types (#1176).

A catch can catch any value the runtime throws, whatever the block's signature named, so the caught value is `unknown` rather than an inexact union of the known throws. `rethrowUnhandled` now sources the block's known throws from `collected` directly, so throws-propagation is unchanged: uncovered known members are still rethrown into the enclosing clause, and a catch without a catch-all is still non-exhaustive because `unknown` has infinitely many inhabitants (#1175).

This removes the try/catch construct as a producer of inexact unions.

## The stack

Stacked on #1180. The principle: stop every producer of inexact unions first, keeping the `soltype.UnionType` fields as dead storage, then delete the fields last.

1. #1180 — Remove the inexact/bounded union syntax
2. **#1181 — Bind the caught value as `unknown`** ← this PR
3. #1182 — Reduce `keyof` and indexed access to domain primitives
4. #1183 — Stop the remaining producers of inexact unions
5. #1184 — Remove the union exactness fields and the dead tail machinery

Refs #1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)