### PR TITLE
Stop the remaining producers of inexact unions (4/5)

### DIFF
--- a/internal/solver/infer_exactness_ops_test.go
+++ b/internal/solver/infer_exactness_ops_test.go
@@ -298,18 +298,18 @@ func TestInferExactnessIntrinsics(t *testing.T) {
 			wantExpanded: "fn (a: number, ...) -> string",
 		},
 		{
-			// `Inexact` over a union opens it: the marker rides the union node until later work
-			// removes union exactness.
+			// A union carries no exactness marker, so `Inexact` over one is the identity. Openness
+			// is a `string`, `number`, or `unknown` member written in, not a flag the operator flips.
 			name: "InexactUnion",
 			src: `
 				type Color = "red" | "green" | "blue"
 				type Result = Inexact<Color>
 			`,
 			wantSymbolic: "Inexact<Color>",
-			wantExpanded: `"blue" | "green" | "red" | ...`,
+			wantExpanded: `"blue" | "green" | "red"`,
 		},
 		{
-			// `Exact` over a union is the identity.
+			// `Exact` over a union is likewise the identity.
 			name: "ExactUnion",
 			src: `
 				type Color = "red" | "green" | "blue"

--- a/internal/solver/infer_for_in.go
+++ b/internal/solver/infer_for_in.go
@@ -183,12 +183,9 @@ func (c *checker) asyncElemType(t soltype.Type) (soltype.Type, bool) {
 // generator yields its Yield slot. Every other type — a primitive, an object, a
 // class instance without the M7 iterator protocol — is not iterable.
 //
-// Inexactness carries through. An inexact tuple `[number, ...]` has an open tail
-// of unknown additional elements, and an inexact union `[number] | ...` an open
-// tail of unknown additional branches, so either yields an inexact element union:
-// the loop variable may also be some unlisted element, so `[number, ...]` yields
-// `number | ...` rather than a bare `number`. The precise type of the tail needs
-// the Array<T> the tuple approximates, which lands in M7.
+// An inexact tuple `[number, ...]` has an open tail of unknown additional elements, so its
+// element type is the join of its listed elements with that unknown tail, which is `unknown`.
+// The precise type of the tail needs the Array<T> the tuple approximates, which lands in M7.
 func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
 	t = groundedCarrier(t)
 	switch t := t.(type) {
@@ -200,7 +197,10 @@ func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
 		}
 		return t.Yield, true
 	case *soltype.TupleType:
-		return newUnion(c.ctx, t.Elems, t.Inexact), true
+		if t.Inexact {
+			return &soltype.UnknownType{}, true
+		}
+		return newUnion(c.ctx, t.Elems, false), true
 	case *soltype.UnionType:
 		elems := make([]soltype.Type, 0, len(t.Types))
 		for _, branch := range t.Types {

--- a/internal/solver/infer_for_in_test.go
+++ b/internal/solver/infer_for_in_test.go
@@ -55,10 +55,10 @@ func TestInferForInElementType(t *testing.T) {
 			`,
 			want: map[string]string{"f": "fn (xs: [number, string]) -> number | string"},
 		},
-		// An inexact tuple `[number, ...]` has an open tail of unknown extra elements, so
-		// its element union stays inexact — `number | ...`, not a bare `number` — since
-		// the loop variable may also be some unlisted tail element.
-		"InexactTupleElementUnionInexact": {
+		// An inexact tuple `[number, ...]` has an open tail of unknown extra elements, so its
+		// element type is the join of its listed elements with that unknown tail, which is
+		// `unknown`, since the loop variable may also be some unlisted tail element.
+		"InexactTupleElementIsUnknown": {
 			src: `
 				fn f(xs: [number, ...]) {
 					for x in xs {
@@ -66,7 +66,7 @@ func TestInferForInElementType(t *testing.T) {
 					}
 				}
 			`,
-			want: map[string]string{"f": "fn (xs: [number, ...]) -> number | ..."},
+			want: map[string]string{"f": "fn (xs: [number, ...]) -> unknown"},
 		},
 		// The empty tuple has no elements, so nothing can be bound to the loop variable
 		// and the body is statically unreachable. The `return x` never runs, so the

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -2055,17 +2055,9 @@ func (e *typeEvaluator) reduceExactness(kind soltype.ExactnessKind, operand solt
 		rewritten.Inexact = inexact
 		return &rewritten
 	case *soltype.UnionType:
-		// newUnionWithTail rather than a direct rebuild, so clearing the marker on a one-member
-		// union collapses it to that member: `Exact<"only" | ...>` reduces to `"only"`.
-		//
-		// Opening a union keeps whatever bound the operand's tail carried, so `Inexact<T>` over
-		// an already-inexact T is the identity `Inexact<keyof {a: X, ...}>` needs. Dropping the
-		// bound would widen `"a" | ...string` to `"a" | ...`, which is top.
-		tail := unionTail{open: inexact}
-		if inexact {
-			tail.bound = op.TailBound
-		}
-		return newUnionWithTail(nil, op.Types, tail)
+		// A union carries no exactness marker to rewrite, so the operator is the identity over one.
+		// Its openness is a member of its own, a `string` or `number` written in, not a flag.
+		return op
 	case *soltype.IntersectionType:
 		// An intersection's exactness is its members', so the operator reaches each of them (§7.7).
 		parts := make([]soltype.Type, len(op.Types))


### PR DESCRIPTION
Part 4 of 5 of removing inexact union types (#1176).

The last two root producers:

- `Exact<T>` and `Inexact<T>` over a union are the identity, the same way they are over `never` or `unknown`, since a union carries no exactness marker.
- Iterating an inexact tuple yields `unknown`, the join of its listed elements with the unknown tail.

After this PR no code path mints an inexact union. Everything that still reads the `Inexact`/`TailBound` fields is now unreachable; part 5 deletes it.

## The stack

Stacked on #1182. The principle: stop every producer of inexact unions first, keeping the `soltype.UnionType` fields as dead storage, then delete the fields last.

1. #1180 — Remove the inexact/bounded union syntax
2. #1181 — Bind the caught value as `unknown`
3. #1182 — Reduce `keyof` and indexed access to domain primitives
4. **#1183 — Stop the remaining producers of inexact unions** ← this PR
5. #1184 — Remove the union exactness fields and the dead tail machinery

Refs #1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)