### PR TITLE
Emit an internal bundle plus a thin public wrapper

### DIFF
--- a/cmd/escalier/build.go
+++ b/cmd/escalier/build.go
@@ -112,9 +112,20 @@ func formatTypeError(err checker.Error, source *ast.Source) string {
 	return message.String()
 }
 
-// writeOutputFile writes content to a file in the build directory with the given extension
+// writeOutputFile writes content to a file in the build directory with the given extension.
+// Empty content means the module has nothing of that kind to say, so the file is removed
+// rather than written. That also clears one left by an earlier build, which this command does
+// not otherwise clean.
 func writeOutputFile(stderr io.Writer, moduleName, extension, content string) error {
 	filePath := filepath.Join("build", moduleName+extension)
+
+	if content == "" {
+		if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove stale %s file", extension)
+		}
+		return nil
+	}
+
 	file, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create %s file", extension)
@@ -129,7 +140,10 @@ func writeOutputFile(stderr io.Writer, moduleName, extension, content string) er
 	return nil
 }
 
-// writeModuleOutputs writes all module outputs (JS, DTS, sourcemap) to the build directory
+// writeModuleOutputs writes all module outputs (JS, DTS, sourcemap) to the build directory.
+// A package that exports nothing gets no public entry point, and a module with no definitions
+// gets no .d.ts. TypeScript reads a sibling .d.ts in place of the .js it sits next to, so an
+// empty one would describe the module as exporting nothing.
 func writeModuleOutputs(stderr io.Writer, moduleName string, output compiler.CompUnitOutput) error {
 	// Create directory structure
 	dir := filepath.Join("build", filepath.Dir(moduleName))

--- a/cmd/escalier/build.go
+++ b/cmd/escalier/build.go
@@ -114,8 +114,8 @@ func formatTypeError(err checker.Error, source *ast.Source) string {
 
 // writeOutputFile writes content to a file in the build directory with the given extension.
 // Empty content means the module has nothing of that kind to say, so the file is removed
-// rather than written. That also clears one left by an earlier build, which this command does
-// not otherwise clean.
+// rather than written. A module that stops producing one kind of output keeps no stale file
+// for it.
 func writeOutputFile(stderr io.Writer, moduleName, extension, content string) error {
 	filePath := filepath.Join("build", moduleName+extension)
 

--- a/cmd/lsp-server/workspace.go
+++ b/cmd/lsp-server/workspace.go
@@ -95,18 +95,24 @@ func (s *Server) compilePackage() (any, error) {
 			return nil, fmt.Errorf("failed to create directory: %v", err)
 		}
 
-		// Write .js
-		if err := os.WriteFile(jsPath, []byte(module.JS), 0644); err != nil {
-			return nil, fmt.Errorf("failed to write %s: %v", jsPath, err)
+		// Write .js. A package that exports nothing has no public entry point, so the
+		// wrapper comes back empty and gets no file.
+		if module.JS != "" {
+			if err := os.WriteFile(jsPath, []byte(module.JS), 0644); err != nil {
+				return nil, fmt.Errorf("failed to write %s: %v", jsPath, err)
+			}
 		}
 
-		// Write .js.map (pretty-printed)
-		var prettyMap bytes.Buffer
-		if err := json.Indent(&prettyMap, []byte(module.SourceMap), "", "  "); err != nil {
-			prettyMap.WriteString(module.SourceMap)
-		}
-		if err := os.WriteFile(mapPath, prettyMap.Bytes(), 0644); err != nil {
-			return nil, fmt.Errorf("failed to write %s: %v", mapPath, err)
+		// Write .js.map (pretty-printed). The wrapper is generated code with nothing to
+		// map back to, so it carries no source map.
+		if module.SourceMap != "" {
+			var prettyMap bytes.Buffer
+			if err := json.Indent(&prettyMap, []byte(module.SourceMap), "", "  "); err != nil {
+				prettyMap.WriteString(module.SourceMap)
+			}
+			if err := os.WriteFile(mapPath, prettyMap.Bytes(), 0644); err != nil {
+				return nil, fmt.Errorf("failed to write %s: %v", mapPath, err)
+			}
 		}
 
 		// Write .d.ts for lib/ modules only

--- a/internal/codegen/ast.go
+++ b/internal/codegen/ast.go
@@ -556,6 +556,7 @@ func (*InterfaceDecl) isDecl() {}
 func (*NamespaceDecl) isDecl() {}
 func (*ClassDecl) isDecl()     {}
 func (*ImportDecl) isDecl()    {}
+func (*ReExportDecl) isDecl()  {}
 
 type VariableKind int
 
@@ -1015,23 +1016,43 @@ func (d *ClassDecl) Span() *Span        { return d.span }
 func (d *ClassDecl) SetSpan(span *Span) { d.span = span }
 func (d *ClassDecl) Source() ast.Node   { return d.source }
 
+// ImportDecl is a named import when Specifiers is set and a namespace import when
+// NamespaceAlias is set. Exactly one of the two is non-empty.
 type ImportDecl struct {
 	Specifiers []string // Named imports, e.g., ["InvokeCustomMatcherOrThrow"]
-	Path       string   // The module path, e.g., "escalier/runtime"
-	export     bool
-	declare    bool
-	span       *Span
-	source     ast.Node
+	// NamespaceAlias names the single binding a namespace import introduces, so
+	// "internal" prints as `import * as internal from "./internal.js";`. It is
+	// empty for a named import.
+	NamespaceAlias string
+	Path           string // The module path, e.g., "escalier/runtime"
+	export         bool
+	declare        bool
+	span           *Span
+	source         ast.Node
 }
 
 func NewImportDecl(specifiers []string, path string, source ast.Node) *ImportDecl {
 	return &ImportDecl{
-		Specifiers: specifiers,
-		Path:       path,
-		export:     false,
-		declare:    false,
-		source:     source,
-		span:       nil,
+		Specifiers:     specifiers,
+		NamespaceAlias: "",
+		Path:           path,
+		export:         false,
+		declare:        false,
+		source:         source,
+		span:           nil,
+	}
+}
+
+// NewNamespaceImportDecl builds `import * as <alias> from "<path>";`.
+func NewNamespaceImportDecl(alias, path string, source ast.Node) *ImportDecl {
+	return &ImportDecl{
+		Specifiers:     nil,
+		NamespaceAlias: alias,
+		Path:           path,
+		export:         false,
+		declare:        false,
+		source:         source,
+		span:           nil,
 	}
 }
 
@@ -1040,6 +1061,34 @@ func (d *ImportDecl) Declare() bool      { return d.declare }
 func (d *ImportDecl) Span() *Span        { return d.span }
 func (d *ImportDecl) SetSpan(span *Span) { d.span = span }
 func (d *ImportDecl) Source() ast.Node   { return d.source }
+
+// ReExportDecl forwards names from another module, printing as
+// `export { a, b } from "./internal.js";`. The names it forwards stay live bindings, so a
+// consumer reading one sees whatever the other module last assigned to it.
+type ReExportDecl struct {
+	Specifiers []string // The names to forward, e.g., ["rootPub"]
+	Path       string   // The module path, e.g., "./internal.js"
+	span       *Span
+	source     ast.Node
+}
+
+func NewReExportDecl(specifiers []string, path string, source ast.Node) *ReExportDecl {
+	return &ReExportDecl{
+		Specifiers: specifiers,
+		Path:       path,
+		source:     source,
+		span:       nil,
+	}
+}
+
+// Export reports false because the statement prints its own `export` keyword. PrintDecl
+// prepends the keyword for a declaration that carries a name of its own, and a forwarding
+// statement declares nothing.
+func (d *ReExportDecl) Export() bool       { return false }
+func (d *ReExportDecl) Declare() bool      { return false }
+func (d *ReExportDecl) Span() *Span        { return d.span }
+func (d *ReExportDecl) SetSpan(span *Span) { d.span = span }
+func (d *ReExportDecl) Source() ast.Node   { return d.source }
 
 //sumtype:decl
 type ClassElem interface {

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -135,7 +135,13 @@ func (b *Builder) BuildTopLevelDecls(depGraph *dep_graph.DepGraph) *Module {
 
 				if allFuncs && len(funcDecls) > 0 {
 					// Build overloaded function dispatch
-					stmts = slices.Concat(stmts, b.buildOverloadedFunc(funcDecls, nsName))
+					dispatchStmts := b.buildOverloadedFunc(funcDecls, nsName)
+					stmts = slices.Concat(stmts, dispatchStmts)
+					// An overload set with no implemented overload emits no dispatch
+					// function, so there is no mangled name to assign from.
+					if len(dispatchStmts) > 0 {
+						stmts = slices.Concat(stmts, b.nsMemberAssignment(key, funcDecls[0]))
+					}
 					continue
 				}
 
@@ -153,35 +159,17 @@ func (b *Builder) BuildTopLevelDecls(depGraph *dep_graph.DepGraph) *Module {
 				stmts = slices.Concat(stmts, b.buildDeclWithNamespace(decl, nsName))
 			}
 
-			// Handle namespace assignment for namespaced bindings
-			// This needs to happen for EVERY binding, even if the declaration was already processed
-			// For example, with `val {x, y} = getPoint()` in namespace "coords", we need both:
+			// The assignment happens for EVERY binding, even when the declaration was
+			// already processed. For example, with `val {x, y} = getPoint()` in namespace
+			// "coords", we need both:
 			//   coords.x = coords__x
 			//   coords.y = coords__y
 			//
-			// A member the source did not mark `export` is left off the namespace object. The
-			// object is the module's export for the namespace, so a property on it is reachable
-			// by any consumer. Code elsewhere in the module still reaches the member, because
-			// unexportedNsMember rewrites a reference such as `constants.PI` to the mangled
-			// name `constants__PI`.
-			bindingName := key.Name()
-			if strings.Contains(bindingName, ".") && decl.Export() {
-				parts := strings.Split(bindingName, ".")
-				dunderName := strings.Join(parts, "__")
-
-				// Create assignment: namespace.member = dunderName
-				assignExpr := NewBinaryExpr(
-					NewIdentExpr(bindingName, "", nil),
-					Assign,
-					NewIdentExpr(dunderName, "", nil),
-					nil,
-				)
-
-				stmts = append(stmts, &ExprStmt{
-					Expr:   assignExpr,
-					span:   nil,
-					source: decl,
-				})
+			// An ambient declaration binds a name the runtime already provides, and
+			// buildDeclWithNamespace emits nothing for it, so there is no mangled name to
+			// assign from.
+			if !decl.Declare() {
+				stmts = slices.Concat(stmts, b.nsMemberAssignment(key, decl))
 			}
 		}
 	}
@@ -238,6 +226,57 @@ func (b *Builder) BuildTopLevelDecls(depGraph *dep_graph.DepGraph) *Module {
 	return &Module{
 		Stmts: stmts,
 	}
+}
+
+// bindsUnderExpectedName reports whether the declaration leaves its bindings where the rest of
+// codegen looks for them. A root declaration is expected as an export of the module. A
+// namespace member is expected under a mangled name, so `val PI = 3.14` in namespace
+// `constants` is emitted as `const constants__PI = 3.14;`.
+//
+// Two VarDecl forms land elsewhere. A declaration whose initializer throws introduces no
+// binding at all. `val pat = init else { … }` binds through buildPatternCondition, which names
+// the bindings as the source spells them and marks none of them `export`. Neither leaves
+// anything for the namespace object to read or for the public wrapper to forward.
+func bindsUnderExpectedName(decl ast.Decl) bool {
+	varDecl, ok := decl.(*ast.VarDecl)
+	if !ok {
+		return true
+	}
+	if varDecl.Else != nil {
+		return false
+	}
+	_, throws := varDecl.Init.(*ast.ThrowExpr)
+	return !throws
+}
+
+// nsMemberAssignment puts a namespace member on its namespace object, so the member `PI` of
+// namespace `constants` becomes `constants.PI = constants__PI;`. source is the declaration the
+// statement is attributed to in the source map. A root-level binding needs no such assignment,
+// so nothing is emitted for one.
+//
+// Every member reaches its namespace object, whether or not the source marked it `export`.
+// This module is the package's internal bundle, and a bin script imports it to reach members
+// the package keeps to itself. BuildPublicWrapper projects each namespace object down to its
+// exported members for external consumers.
+func (b *Builder) nsMemberAssignment(key dep_graph.BindingKey, source ast.Decl) []Stmt {
+	bindingName := key.Name()
+	if !strings.Contains(bindingName, ".") || !bindsUnderExpectedName(source) {
+		return nil
+	}
+
+	dunderName := strings.ReplaceAll(bindingName, ".", "__")
+	assignExpr := NewBinaryExpr(
+		NewIdentExpr(bindingName, "", nil),
+		Assign,
+		NewIdentExpr(dunderName, "", nil),
+		nil,
+	)
+
+	return []Stmt{&ExprStmt{
+		Expr:   assignExpr,
+		span:   nil,
+		source: source,
+	}}
 }
 
 // buildNamespaceStatements generates statements to create namespace objects

--- a/internal/codegen/builder_test.go
+++ b/internal/codegen/builder_test.go
@@ -507,7 +507,8 @@ func TestBuildDecls(t *testing.T) {
 				},
 			},
 			expected: `export const foo = {};
-const foo__x = 42;`,
+const foo__x = 42;
+foo.x = foo__x;`,
 		},
 		"Multiple_Decls_Same_Namespace": {
 			sources: []*ast.Source{
@@ -527,7 +528,9 @@ function math__double(temp1) {
   const n = temp1;
   return n * 2;
 }
-const math__x = 42;`,
+math.double = math__double;
+const math__x = 42;
+math.x = math__x;`,
 		},
 		"Multiple_Decls_Different_Namespaces": {
 			sources: []*ast.Source{
@@ -545,7 +548,9 @@ const math__x = 42;`,
 			expected: `export const math = {};
 export const strings = {};
 const math__PI = 3.14159;
-const strings__message = "hello";`,
+math.PI = math__PI;
+const strings__message = "hello";
+strings.message = strings__message;`,
 		},
 		"Nested_Namespaces": {
 			sources: []*ast.Source{
@@ -565,7 +570,9 @@ constants.math = {};
 export const utils = {};
 utils.math = {};
 const constants__math__PI = 3.14;
-const utils__math__add = 42;`,
+constants.math.PI = constants__math__PI;
+const utils__math__add = 42;
+utils.math.add = utils__math__add;`,
 		},
 		"Mixed_Namespace_Levels": {
 			sources: []*ast.Source{
@@ -590,10 +597,12 @@ constants.app = {};
 export const utils = {};
 export const config = {debug: true};
 const constants__app__VERSION = "1.0.0";
+constants.app.VERSION = constants__app__VERSION;
 function utils__log(temp1) {
   const msg = temp1;
   console.log(msg);
-}`,
+}
+utils.log = utils__log;`,
 		},
 		"Function_With_Complex_Namespace": {
 			sources: []*ast.Source{
@@ -609,7 +618,8 @@ services.data.processing = {};
 function services__data__processing__processData(temp1) {
   const input = temp1;
   return input;
-}`,
+}
+services.data.processing.processData = services__data__processing__processData;`,
 		},
 		"Variable_Destructuring_With_Namespace": {
 			sources: []*ast.Source{
@@ -620,7 +630,9 @@ function services__data__processing__processData(temp1) {
 				},
 			},
 			expected: `export const coords = {};
-const {coords__x, coords__y} = getPoint();`,
+const {coords__x, coords__y} = getPoint();
+coords.x = coords__x;
+coords.y = coords__y;`,
 		},
 		"Multiple_Declarations_Overlapping_Namespaces": {
 			sources: []*ast.Source{
@@ -647,8 +659,80 @@ function models__user__createUser(temp1) {
   const name = temp1;
   return {name};
 }
+models.user.createUser = models__user__createUser;
 const models__user__defaults__defaultUser = null;
-const models__user__user = {name: "Alice"};`,
+models.user.defaults.defaultUser = models__user__defaults__defaultUser;
+const models__user__user = {name: "Alice"};
+models.user.user = models__user__user;`,
+		},
+		"Overloaded_Function_With_Namespace": {
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "math/double.esc",
+					Contents: `fn double(n: number) -> number { return n * 2 }
+fn double(s: string) -> string { return s ++ s }`,
+				},
+			},
+			expected: `export const math = {};
+function math__double(param0) {
+  if (typeof param0 === "number") {
+    const n = param0;
+    return n * 2;
+  } else if (typeof param0 === "string") {
+    const s = param0;
+    return s + s;
+  } else throw new TypeError("No overload matches the provided arguments for function 'double'");
+}
+math.double = math__double;`,
+		},
+		// An overload set with no implemented overload emits no dispatch function, so
+		// there is no mangled name to put on the namespace object.
+		"Ambient_Overloaded_Function_With_Namespace": {
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "math/double.esc",
+					Contents: `declare fn double(n: number) -> number
+declare fn double(s: string) -> string`,
+				},
+			},
+			expected: `export const math = {};`,
+		},
+		// A declaration whose initializer throws binds nothing, so there is no mangled
+		// name to put on the namespace object.
+		"Throw_Initializer_With_Namespace": {
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "math/boom.esc",
+					Contents: `val boom = throw "nope"`,
+				},
+			},
+			expected: `export const math = {};
+throw "nope";`,
+		},
+		// `val pat = init else { … }` binds the names the source spells rather than the
+		// mangled ones, so the namespace object has nothing to read.
+		"Else_Initializer_With_Namespace": {
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "math/fallback.esc",
+					Contents: `val src = {a: 1}
+val a = src.a else { 0 }`,
+				},
+			},
+			expected: `export const math = {};
+const math__src = {a: 1};
+math.src = math__src;
+let temp1;
+temp1 = math__src.a;
+if (true) {
+} else {
+  temp1 = 0;
+}
+const a = temp1;`,
 		},
 		"Type_Declaration_Skip": {
 			sources: []*ast.Source{
@@ -665,7 +749,8 @@ const models__user__user = {name: "Alice"};`,
 			},
 			expected: `export const data = {};
 export const types = {};
-const data__admin = {name: "admin", age: 30};`,
+const data__admin = {name: "admin", age: 30};
+data.admin = data__admin;`,
 		},
 		"Var_Declaration_With_Namespace": {
 			sources: []*ast.Source{
@@ -684,7 +769,9 @@ const data__admin = {name: "admin", age: 30};`,
 state.app = {};
 state.ui = {};
 let state__app__counter = 0;
-let state__ui__isEnabled = true;`,
+state.app.counter = state__app__counter;
+let state__ui__isEnabled = true;
+state.ui.isEnabled = state__ui__isEnabled;`,
 		},
 	}
 
@@ -1307,7 +1394,9 @@ func TestBuildDecls_WithDependencies(t *testing.T) {
 			},
 			expected: `export const math = {};
 const math__base = 10;
-const math__derived = math__base * 2;`,
+math.base = math__base;
+const math__derived = math__base * 2;
+math.derived = math__derived;`,
 		},
 		"Cross_Namespace_Dependencies": {
 			sources: []*ast.Source{
@@ -1325,10 +1414,12 @@ const math__derived = math__base * 2;`,
 			expected: `export const constants = {};
 export const geometry = {};
 const constants__PI = 3.14159;
+constants.PI = constants__PI;
 function geometry__circleArea(temp1) {
   const r = temp1;
   return constants__PI * r * r;
-}`,
+}
+geometry.circleArea = geometry__circleArea;`,
 		},
 		"Complex_Dependency_Chain": {
 			sources: []*ast.Source{
@@ -1351,11 +1442,14 @@ function geometry__circleArea(temp1) {
 			expected: `export const app = {};
 app.utils = {};
 const app__config = {multiplier: 2};
+app.config = app__config;
 const app__utils__factor = app__config.multiplier;
+app.utils.factor = app__utils__factor;
 function app__utils__calculate(temp1) {
   const x = temp1;
   return x * app__utils__factor;
-}`,
+}
+app.utils.calculate = app__utils__calculate;`,
 		},
 	}
 
@@ -1429,7 +1523,8 @@ company.project = {};
 company.project.module = {};
 company.project.module.submodule = {};
 company.project.module.submodule.utils = {};
-const company__project__module__submodule__utils__constant = "deep";`,
+const company__project__module__submodule__utils__constant = "deep";
+company.project.module.submodule.utils.constant = company__project__module__submodule__utils__constant;`,
 		},
 	}
 

--- a/internal/codegen/printer.go
+++ b/internal/codegen/printer.go
@@ -1012,7 +1012,24 @@ func (p *Printer) PrintDecl(decl Decl) {
 		p.NewLine()
 		p.print("}")
 	case *ImportDecl:
-		p.print("import { ")
+		if d.NamespaceAlias != "" {
+			p.print("import * as ")
+			p.print(d.NamespaceAlias)
+		} else {
+			p.print("import { ")
+			for i, spec := range d.Specifiers {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.print(spec)
+			}
+			p.print(" }")
+		}
+		p.print(" from \"")
+		p.print(d.Path)
+		p.print("\";")
+	case *ReExportDecl:
+		p.print("export { ")
 		for i, spec := range d.Specifiers {
 			if i > 0 {
 				p.print(", ")

--- a/internal/codegen/wrapper.go
+++ b/internal/codegen/wrapper.go
@@ -1,0 +1,233 @@
+package codegen
+
+import (
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// nsProjection is one namespace of the module, holding the parts of it that belong in the
+// public wrapper. Members are the names the source marked `export`, and children are the
+// namespaces nested inside this one. A namespace with neither is left out of the wrapper.
+type nsProjection struct {
+	members  set.Set[string]
+	children map[string]*nsProjection
+}
+
+func newNsProjection() *nsProjection {
+	return &nsProjection{
+		members:  set.NewSet[string](),
+		children: map[string]*nsProjection{},
+	}
+}
+
+// child returns the projection for the namespace at path, creating a projection for it and
+// for every namespace along the way. path is dotted and relative to p, so "utils.text" walks
+// two levels down.
+func (p *nsProjection) child(path string) *nsProjection {
+	node := p
+	for _, segment := range strings.Split(path, ".") {
+		next, ok := node.children[segment]
+		if !ok {
+			next = newNsProjection()
+			node.children[segment] = next
+		}
+		node = next
+	}
+	return node
+}
+
+// empty reports whether the namespace contributes nothing to the public wrapper. Emptiness is
+// transitive, so a namespace holding only empty namespaces is itself empty.
+func (p *nsProjection) empty() bool {
+	if p.members.Len() > 0 {
+		return false
+	}
+	for _, child := range p.children {
+		if !child.empty() {
+			return false
+		}
+	}
+	return true
+}
+
+// keys returns the names the namespace contributes to the wrapper, sorted so the generated
+// file is stable across builds. Members and non-empty child namespaces share one name space,
+// matching how the internal bundle puts both on the same namespace object. A name that is
+// both appears once.
+func (p *nsProjection) keys() []string {
+	keys := p.members.Clone()
+	for name, child := range p.children {
+		if !child.empty() {
+			keys.Add(name)
+		}
+	}
+	sorted := keys.ToSlice()
+	sort.Strings(sorted)
+	return sorted
+}
+
+// entry renders one name the namespace contributes. path locates the namespace itself, so the
+// `pub` member of namespace `geo` is reached by path ["geo"] and name "pub". A member reads
+// straight out of the internal bundle, which the wrapper binds to alias. A nested namespace
+// becomes an object literal.
+//
+// A member wins over a child namespace spelled the same way, matching the internal bundle,
+// where the member assignment runs after the namespace object is created and overwrites it.
+func (p *nsProjection) entry(alias string, path []string, name string) Expr {
+	memberPath := slices.Concat(path, []string{name})
+	if p.members.Contains(name) {
+		return internalRef(alias, memberPath)
+	}
+	return buildProjectionObject(p.children[name], alias, memberPath)
+}
+
+// BuildPublicWrapper builds the package's public entry point, a module that re-exports the
+// part of the internal bundle at internalPath that the source marked `export`.
+//
+// The internal bundle exports every declaration and puts every namespace member on its
+// namespace object, so a bin script in the same package can reach members the package keeps
+// to itself. An external consumer imports this wrapper instead, which forwards the exported
+// root declarations and rebuilds each namespace object from its exported members.
+//
+//	import * as internal from "./internal.js";
+//	export { rootPub } from "./internal.js";
+//	export const geo = {pub: internal.geo.pub};
+//
+// Each class is defined once, in the internal bundle, and both entry points name that one
+// definition. An instance created through either entry point satisfies `instanceof` against
+// the other, which pattern matching relies on.
+func BuildPublicWrapper(depGraph *dep_graph.DepGraph, internalPath string) *Module {
+	root := newNsProjection()
+
+	for _, key := range depGraph.AllBindings() {
+		if key.Kind() != dep_graph.DepKindValue || !exportedBinding(depGraph, key) {
+			continue
+		}
+
+		nsName := depGraph.GetNamespace(key)
+		memberName := key.Name()
+		node := root
+		if nsName != "" {
+			node = root.child(nsName)
+			memberName = strings.TrimPrefix(memberName, nsName+".")
+		}
+		node.members.Add(memberName)
+	}
+
+	var rootNames, nsNames []string
+	for _, name := range root.keys() {
+		if root.members.Contains(name) {
+			rootNames = append(rootNames, name)
+		} else {
+			nsNames = append(nsNames, name)
+		}
+	}
+
+	var stmts []Stmt
+
+	// A root declaration is forwarded rather than copied, which keeps it a live binding. A
+	// consumer reading `counter` after an exported function reassigned it sees the new
+	// value, where `export const counter = internal.counter` would freeze the value this
+	// module read as it loaded.
+	if len(rootNames) > 0 {
+		stmts = append(stmts, &DeclStmt{
+			Decl:   NewReExportDecl(rootNames, internalPath, nil),
+			span:   nil,
+			source: nil,
+		})
+	}
+
+	if len(nsNames) == 0 {
+		return &Module{Stmts: stmts}
+	}
+
+	// A namespace object has to be rebuilt property by property, so the wrapper needs the
+	// internal bundle under a local name to read those properties from.
+	alias := wrapperAlias(nsNames)
+	importStmt := &DeclStmt{
+		Decl:   NewNamespaceImportDecl(alias, internalPath, nil),
+		span:   nil,
+		source: nil,
+	}
+
+	for _, name := range nsNames {
+		decl := &VarDecl{
+			Kind: ValKind,
+			Decls: []*Declarator{{
+				Pattern: NewIdentPat(name, nil, nil),
+				TypeAnn: nil,
+				Init:    root.entry(alias, nil, name),
+			}},
+			export:  true,
+			declare: false,
+			span:    nil,
+			source:  nil,
+		}
+		stmts = append(stmts, &DeclStmt{Decl: decl, span: nil, source: nil})
+	}
+
+	return &Module{Stmts: slices.Concat([]Stmt{importStmt}, stmts)}
+}
+
+// wrapperAlias picks the local name the wrapper binds the internal bundle to. It is `internal`
+// unless the wrapper declares a namespace object spelled that way, in which case underscores
+// are appended until the name is free. Reusing the name would redeclare the binding and the
+// entry point would fail to load.
+//
+// declared holds the names the wrapper introduces as bindings. A forwarded root declaration is
+// not among them, because `export {x} from "./internal.js"` binds nothing locally.
+func wrapperAlias(declared []string) string {
+	taken := set.FromSlice(declared)
+	alias := "internal"
+	for taken.Contains(alias) {
+		alias += "_"
+	}
+	return alias
+}
+
+// exportedBinding reports whether the binding belongs in the public wrapper. A binding is
+// exported when at least one of the declarations behind it carries the `export` keyword.
+// Overloaded functions and merged interfaces put several declarations under one key.
+//
+// An ambient declaration names something the runtime already provides, and the internal
+// bundle emits no definition for it, so there is nothing for the wrapper to forward. A
+// declaration the bundle binds under some other name is skipped for the same reason.
+// Forwarding a name the bundle does not export is a link error that keeps the whole entry
+// point from loading, not just that one binding.
+func exportedBinding(depGraph *dep_graph.DepGraph, key dep_graph.BindingKey) bool {
+	for _, decl := range depGraph.GetDecls(key) {
+		if decl.Export() && !decl.Declare() && bindsUnderExpectedName(decl) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildProjectionObject renders one namespace as an object literal. path locates the namespace
+// in the internal bundle, so the `pub` member of namespace `geo` becomes the property
+// `pub: internal.geo.pub`. Nested namespaces become nested object literals.
+func buildProjectionObject(node *nsProjection, alias string, path []string) Expr {
+	var elems []ObjExprElem
+	for _, name := range node.keys() {
+		elems = append(elems, NewPropertyExpr(
+			NewIdentExpr(name, "", nil),
+			node.entry(alias, path, name),
+			nil,
+		))
+	}
+	return NewObjectExpr(elems, nil)
+}
+
+// internalRef builds the member chain that reads a name out of the internal bundle, so alias
+// "internal" and path ["geo", "pub"] become `internal.geo.pub`.
+func internalRef(alias string, path []string) Expr {
+	var expr Expr = NewIdentExpr(alias, "", nil)
+	for _, segment := range path {
+		expr = NewMemberExpr(expr, NewIdentifier(segment, nil), false, nil)
+	}
+	return expr
+}

--- a/internal/codegen/wrapper_test.go
+++ b/internal/codegen/wrapper_test.go
@@ -1,0 +1,173 @@
+package codegen
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPublicWrapper(t *testing.T) {
+	tests := map[string]struct {
+		sources  []*ast.Source
+		expected string
+	}{
+		"RootDeclarations": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: "export val pub = 1\nval priv = 2"},
+			},
+			expected: `export { pub } from "./internal.js";`,
+		},
+		"NothingExported": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: "val priv = 2"},
+			},
+			expected: "",
+		},
+		// A mutable root binding is forwarded rather than copied, so a consumer sees
+		// whatever the internal bundle last assigned to it.
+		"MutableRootDeclaration": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: "export var counter = 0"},
+			},
+			expected: `export { counter } from "./internal.js";`,
+		},
+		"NamespaceMembers": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "geo/shapes.esc", Contents: "export val pub = 1\nval priv = 2"},
+			},
+			expected: `import * as internal from "./internal.js";
+export const geo = {pub: internal.geo.pub};`,
+		},
+		"NamespaceWithNoExportedMembers": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "geo/shapes.esc", Contents: "val priv = 2"},
+				{ID: 1, Path: "main.esc", Contents: "export val pub = 1"},
+			},
+			expected: `export { pub } from "./internal.js";`,
+		},
+		"NestedNamespaces": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "app/config.esc", Contents: "export val config = 1"},
+				{ID: 1, Path: "app/utils/text.esc", Contents: "export val trim = 2\nval pad = 3"},
+			},
+			expected: `import * as internal from "./internal.js";
+export const app = {config: internal.app.config, utils: {trim: internal.app.utils.trim}};`,
+		},
+		// The `app` namespace has no exported members of its own, so it reaches the
+		// wrapper only because `app.utils.trim` does.
+		"NestedNamespaceCarriesItsParent": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "app/config.esc", Contents: "val config = 1"},
+				{ID: 1, Path: "app/utils/text.esc", Contents: "export val trim = 2"},
+			},
+			expected: `import * as internal from "./internal.js";
+export const app = {utils: {trim: internal.app.utils.trim}};`,
+		},
+		// Emptiness is transitive: `app` holds only `app.utils`, and every member of
+		// `app.utils` is unexported.
+		"EmptinessIsTransitive": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "app/utils/text.esc", Contents: "val trim = 2"},
+				{ID: 1, Path: "main.esc", Contents: "export val pub = 1"},
+			},
+			expected: `export { pub } from "./internal.js";`,
+		},
+		// The internal bundle emits no definition for an ambient declaration, so there
+		// is nothing for the wrapper to forward.
+		"AmbientDeclaration": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: "export declare val ambient: number\nexport val pub = 1"},
+			},
+			expected: `export { pub } from "./internal.js";`,
+		},
+		// A type alias has no runtime value, so it never reaches the wrapper.
+		"TypeAlias": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: "export type Pub = number\nexport val pub = 1"},
+			},
+			expected: `export { pub } from "./internal.js";`,
+		},
+		// `app.utils` names both a member of `app` and a namespace nested in it. The
+		// member wins, matching the internal bundle, where `app.utils = app__utils`
+		// runs after `app.utils = {}` and overwrites it.
+		"MemberAndNamespaceShareAName": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "app/utils.esc", Contents: "export val utils = 1"},
+				{ID: 1, Path: "app/utils/text.esc", Contents: "export val trim = 2"},
+			},
+			expected: `import * as internal from "./internal.js";
+export const app = {utils: internal.app.utils};`,
+		},
+		// A namespace named `internal` would shadow the binding the wrapper reads the
+		// internal bundle through, so the alias moves out of its way.
+		"NamespaceNamedInternal": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "internal/thing.esc", Contents: "export val thing = 1"},
+			},
+			expected: `import * as internal_ from "./internal.js";
+export const internal = {thing: internal_.internal.thing};`,
+		},
+		// A forwarded root declaration binds nothing locally, so it cannot collide with
+		// the alias and the alias stays `internal`.
+		"RootDeclarationNamedInternal": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: "export val internal = 1"},
+				{ID: 1, Path: "geo/shapes.esc", Contents: "export val pub = 2"},
+			},
+			expected: `import * as internal from "./internal.js";
+export { internal } from "./internal.js";
+export const geo = {pub: internal.geo.pub};`,
+		},
+		// The internal bundle emits `throw "nope";` and binds nothing, so forwarding
+		// `boom` would be a link error that keeps the whole entry point from loading.
+		"ThrowInitializer": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: "export val boom = throw \"nope\"\nexport val pub = 1"},
+			},
+			expected: `export { pub } from "./internal.js";`,
+		},
+		// `val pat = init else { … }` binds through buildPatternCondition, which marks
+		// none of its bindings `export`, so there is nothing to forward.
+		"ElseInitializer": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "main.esc", Contents: "declare val obj: {a?: number}\nexport val a = obj.a else { 0 }\nexport val pub = 1"},
+			},
+			expected: `export { pub } from "./internal.js";`,
+		},
+		"Class": {
+			sources: []*ast.Source{
+				{ID: 0, Path: "geo/shapes.esc", Contents: "export class Point {\n    x: number,\n    constructor(mut self, x: number) {\n        self.x = x\n    },\n}"},
+			},
+			expected: `import * as internal from "./internal.js";
+export const geo = {Point: internal.geo.Point};`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			module, parseErrors := parser.ParseLibFiles(ctx, test.sources)
+			require.Empty(t, parseErrors)
+
+			depGraph := dep_graph.BuildDepGraph(module)
+			outModule := BuildPublicWrapper(depGraph, "./internal.js")
+
+			printer := NewPrinter()
+			for i, stmt := range outModule.Stmts {
+				if i > 0 {
+					printer.NewLine()
+				}
+				printer.PrintStmt(stmt)
+			}
+
+			require.Equal(t, test.expected, printer.Output)
+		})
+	}
+}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -17,6 +17,13 @@ import (
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
+// internalBundleName is the base name of the module holding every declaration in lib/. It is
+// not the package entry point. `main` in package.json points at the public wrapper emitted as
+// index.js, which re-exports the part of this bundle the source marked `export`. Scripts under
+// bin/ are part of the package and import the bundle directly, so they reach members the
+// package keeps to itself.
+const internalBundleName = "internal"
+
 type CompUnitOutput struct {
 	JS        string
 	SourceMap string
@@ -260,26 +267,46 @@ func CompilePackage(sources []*ast.Source) CompilerOutput {
 		libNS = inferCtx.Scope.Namespace
 
 		builder := &codegen.Builder{}
-		jsMod := builder.BuildTopLevelDecls(depGraph)
+		internalMod := builder.BuildTopLevelDecls(depGraph)
 		dtsMod := builder.BuildDefinitions(depGraph, libNS)
 
 		printer := codegen.NewPrinter()
-		jsOutput := printer.PrintModule(jsMod)
+		internalJS := printer.PrintModule(internalMod)
 
-		jsFile := "./index.js"
-		sourceMap := codegen.GenerateSourceMap(sources, jsMod, jsFile)
+		internalFile := "./" + internalBundleName + ".js"
+		internalSourceMap := codegen.GenerateSourceMap(sources, internalMod, internalFile)
+		internalJS += "//# sourceMappingURL=" + internalFile + ".map\n"
 
-		outmap := "./index.js.map"
-		jsOutput += "//# sourceMappingURL=" + outmap + "\n"
+		// The public wrapper re-exports the internal bundle rather than holding a second copy
+		// of the code, so a class has one definition and `instanceof` agrees across both entry
+		// points.
+		//
+		// Every statement in it is generated, so it carries no source map. A package that
+		// exports nothing needs no public entry point either, and the empty JS keeps the
+		// file off disk.
+		wrapperMod := codegen.BuildPublicWrapper(depGraph, internalFile)
+		wrapperJS := ""
+		if len(wrapperMod.Stmts) > 0 {
+			printer = codegen.NewPrinter()
+			wrapperJS = printer.PrintModule(wrapperMod)
+		}
 
 		printer = codegen.NewPrinter()
 		dtsOutput := printer.PrintModule(dtsMod)
 
 		output.ParseErrors = append(output.ParseErrors, parseErrors...)
 		output.TypeErrors = append(output.TypeErrors, typeErrors...)
+		output.CompUnits["lib/"+internalBundleName] = CompUnitOutput{
+			JS:        internalJS,
+			SourceMap: internalSourceMap,
+			DTS:       "",
+		}
+		// The .d.ts sits beside the public entry point, which is what `main` in
+		// package.json points at. It marks a declaration as exported when the source
+		// marked it `export`, matching what the wrapper forwards.
 		output.CompUnits["lib/index"] = CompUnitOutput{
-			JS:        jsOutput,
-			SourceMap: sourceMap,
+			JS:        wrapperJS,
+			SourceMap: "",
 			DTS:       dtsOutput,
 		}
 	}
@@ -378,8 +405,9 @@ func CompileScript(libNS *type_system.Namespace, source *ast.Source) CompilerOut
 	// Collect used library symbols and add import statement if needed
 	usedSymbols := collectUsedLibSymbols(inMod, libNS)
 	if len(usedSymbols) > 0 {
-		// Create an import declaration for the used symbols
-		importDecl := codegen.NewImportDecl(usedSymbols, "../lib/index.js", nil)
+		// A script is part of the package, so it imports the internal bundle and reaches
+		// declarations the source did not mark `export`.
+		importDecl := codegen.NewImportDecl(usedSymbols, "../lib/"+internalBundleName+".js", nil)
 		importStmt := &codegen.DeclStmt{
 			Decl: importDecl,
 			// span and source are nil, which is fine


### PR DESCRIPTION
Refs #297. Fixes #1112.

This is the compiler half of the change. The regenerated fixtures land in a follow-up PR, so `TestBuildFixtureTests` fails here. Every other package passes, including the new `internal/codegen` unit tests. Splitting it this way keeps the diff at 9 files so CodeRabbit will review it.

## Motivation

Scripts under `bin/` are part of the package, so `geo.Point(3, 4)` in a script reaches every symbol in `lib/`, exported or not. An external consumer must not get that access. One `index.js` cannot serve both, because the namespace object it exports carries one set of properties for everyone who reads it.

## What changes

Two entry points instead of one:

- `internal.js` holds every declaration, exports all of them, and puts every namespace member on its namespace object. A bin script imports this one.
- `index.js` is the package entry point named by `main` in `package.json`. It forwards the declarations marked `export` and rebuilds each namespace object from its exported members.

```js
// internal.js — every member on the object
export const geo = {};
geo.priv = geo__priv;
geo.pub = geo__pub;

// index.js — only the exported ones
import * as internal from "./internal.js";
export { rootPub } from "./internal.js";
export const geo = {pub: internal.geo.pub};
```

The wrapper forwards rather than holding a second copy of the code, so each class is defined once and an instance created through either entry point satisfies `instanceof` against the other. Pattern matching compiles to `instanceof` and `Symbol.customMatcher`, where a mismatch shows up as a match arm that silently does not fire.

A root declaration is forwarded with `export {x} from "./internal.js"` rather than copied into `export const x = internal.x`, which keeps it a live binding. With `export var counter = 0` and an exported function that reassigns it, a consumer reading `counter` sees the new value; the copy would freeze the value the wrapper read as it loaded. `ReExportDecl` and a namespace form of `ImportDecl` are new codegen nodes for the two statements the wrapper needs.

A namespace whose members are all unexported contributes nothing to the wrapper and is left out rather than exported as an empty object. Emptiness is transitive, so a namespace holding only empty namespaces is left out too. A package that exports nothing gets no `index.js` at all, and the wrapper never carries a source map, since every statement in it is generated.

The local name the wrapper reads the bundle through moves out of the way of a namespace object spelled the same way, so a package with a `lib/internal/` directory does not emit `import * as internal` alongside `export const internal = {...}`.

## Pre-existing bugs fixed along the way

Both put a name on a namespace object that nothing declares, and both reproduce on `main` today:

- An overloaded function inside a namespace skipped the assignment entirely, so `geo.f` was undefined even though the `.d.ts` named it.
- A member that binds nothing — `export val boom = throw "x"`, and `val a = obj.a else { 0 }` — emitted `geo.boom = geo__boom` and the module died with a `ReferenceError` as it loaded.

`writeOutputFile` now removes a file rather than writing empty content. That keeps a module with no definitions from getting a `.d.ts` describing it as exporting nothing, and clears a file left by an earlier build, which `escalier build` does not otherwise clean.

## Verification

Beyond the unit tests, I ran the emitted JS under node against the built fixtures: the public entry hides `rootPriv`, `geo.priv`, and `geo.privVal`; `pub.geo.pub === internal.geo.pub`, so `instanceof` agrees across entry points; a bin script still calls into an unexported namespace member; and `bump(); bump()` leaves a consumer reading `2` through the wrapper.

## Not included

The issue also asks that a namespace omitted from the wrapper lose its `declare namespace` block in the public `.d.ts`. Two fixtures reference such a namespace from a surviving declaration — `type_ann_typeof` has `declare type CX = typeof shapes.unitCircle.center.x` and `extractor_inside_namespaces` has `type MyEnum = MyEnum.Color | MyEnum.MyEvent` — so dropping the block yields a `.d.ts` with dangling references. Unexported members of a `declare namespace` are already invisible to importers, so the block leaks nothing; the real gap is that namespaces are emitted without `export` at all. That deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFN6v2hq1Z6u3j7dj8EQ4t

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFN6v2hq1Z6u3j7dj8EQ4t)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Library builds now provide a public entry point that cleanly exposes exported declarations, including nested namespaces and re-exports.
  - Added support for namespace imports and improved handling of exported symbols across bundled modules.
  - Generated namespace members are assigned more consistently, including variables, functions, destructured values, and nested namespaces.

- **Bug Fixes**
  - Empty outputs no longer leave stale generated files behind.
  - JavaScript and source map files are emitted only when corresponding content exists.
  - Prevented invalid namespace assignments for declarations without runtime output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->