### PR TITLE
Document §1 feasibility spike findings and mark gate complete

### DIFF
--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -257,14 +257,28 @@ the plan" below.
 **Outcome.** The gate is met — [spike_findings.md](spike_findings.md)
 records the per-method evidence. The CFG carries every signal, so no
 shallow-parser fallback is needed and §8/§9 keep their scope. The spike
-resolves onto the happy-path side of the §1 branches below, and hands §3
-three lowering rules the serializer must apply: reconstruct the `?`/`!`
-completion guard from the post-call branch shape rather than a call
-attribute, seed the FR1 property-write mutators as direct because the `Set`
-family dispatches through a dynamic `[[Set]]` the fixpoint cannot resolve by
-name, and key internal slots by their bare name since the CFG drops the
-`[[ ]]` brackets. It also confirms `yet` incompleteness is per-step, so the
-FR5 fallback applies per signal rather than per method.
+resolves onto the happy-path side of the §1 branches below. It sharpens one
+§3 detail and confirms two §4 ones, and it leaves the §3/§4 boundary intact —
+§3 stays a structural dumper that makes no mutability or alias decision.
+
+- **§3 (serializer).** The compiled IR carries no `?`/`!` flag; the guard is
+  lowered into a stereotyped post-call branch — an abrupt-check that returns
+  the completion for `?`, a normal assertion for `!`. §3 populates the
+  completion-guard field the Appendix A schema already defines, and that §9
+  reads as `node.Guard`, by matching that branch shape. This recovers spec
+  control flow structurally, not by any Escalier-level decision, so it stays
+  within §3's remit. §3 also copies each internal-slot name verbatim from the
+  CFG, which is the bare `MapData`, not the bracketed `[[MapData]]` the
+  Appendix A example shows.
+- **§4.1 (Go).** The FR1 property-write seed is load-bearing, not an
+  optimization: `Set` and its kin dispatch through a dynamic `[[Set]]`
+  internal method the mutation fixpoint cannot resolve by callee name, so
+  without the seed those writes are invisible to it. §4.1's
+  `BackingStoreSlots` set must match the bare slot names §3 emits, since the
+  CFG drops the `[[ ]]` brackets.
+- **§4 / §9 (Go).** `yet` incompleteness is per-step, not per-method, so the
+  FR5 conservative fallback applies per signal — a determination is left
+  unclassified only when a `yet` sits on a step it reads.
 
 ## §2. Toolchain scoping
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -262,7 +262,7 @@ resolves onto the happy-path side of the §1 branches below. It sharpens one
 §3 stays a structural dumper that makes no mutability or alias decision.
 
 - **§3 (serializer).** The compiled IR carries no `?`/`!` flag; the guard is
-  lowered into a stereotyped post-call branch — an abrupt-check that returns
+  lowered into a fixed post-call branch — an abrupt-check that returns
   the completion for `?`, a normal assertion for `!`. §3 populates the
   completion-guard field the Appendix A schema already defines, and that §9
   reads as `node.Guard`, by matching that branch shape. This recovers spec

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -224,7 +224,9 @@ analysis needs before committing to the toolchain.
     `Array.prototype.map`;
   - internal-slot mutation, `Map.prototype.set`,
     `Set.prototype.add`;
-  - transitive mutation through a helper abstract operation;
+  - transitive mutation through a helper abstract operation, a named
+    subroutine the specification defines to factor out shared behavior and
+    abbreviated AO in the schema comments below;
   - immutable-primitive method, `String.prototype.replace`,
     `String.prototype.charAt`;
   - symbol-keyed method, `Array.prototype[Symbol.iterator]`;

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -33,7 +33,7 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 
 | PR   | Work                                       | FRs        | Status | Depends on | Gate |
 | ---- | ------------------------------------------ | ---------- | ------ | ---------- | ---- |
-| §1   | Feasibility spike                          | FR1–FR4    | ⬜      | —          | ESMeta CFG for ~10 representative methods (incl. escape, reject, callback) exposes the call nodes, args, stored-value operands, guards, `Throw`s, reject sites, and returns the analysis needs |
+| §1   | Feasibility spike                          | FR1–FR4    | ✅      | —          | ESMeta CFG for ~10 representative methods (incl. escape, reject, callback) exposes the call nodes, args, stored-value operands, guards, `Throw`s, reject sites, and returns the analysis needs — met, see [spike_findings.md](spike_findings.md) |
 | §2   | Toolchain scoping                          | NFR        | ⬜      | §1         | `tools/spec-extract/mise.toml` builds and runs ESMeta with no JVM in the root environment |
 | §3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ⬜      | §2         | `cfg.json` for the full `std:*` surface, pinned spec, round-trips a schema check |
 | §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ⬜      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` |
@@ -253,6 +253,18 @@ noted in §3 alternatives.
 **This spike can grow the plan.** §1 and §2 are discovery phases; their
 findings feed back into the later phases. See "Discovery phases may grow
 the plan" below.
+
+**Outcome.** The gate is met — [spike_findings.md](spike_findings.md)
+records the per-method evidence. The CFG carries every signal, so no
+shallow-parser fallback is needed and §8/§9 keep their scope. The spike
+resolves onto the happy-path side of the §1 branches below, and hands §3
+three lowering rules the serializer must apply: reconstruct the `?`/`!`
+completion guard from the post-call branch shape rather than a call
+attribute, seed the FR1 property-write mutators as direct because the `Set`
+family dispatches through a dynamic `[[Set]]` the fixpoint cannot resolve by
+name, and key internal slots by their bare name since the CFG drops the
+`[[ ]]` brackets. It also confirms `yet` incompleteness is per-step, so the
+FR5 fallback applies per signal rather than per method.
 
 ## §2. Toolchain scoping
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -452,6 +452,49 @@ or a mutation phrasing outside the FR1 vocabulary. Both force
 `classified: false` (§4.3), so FR5's heuristic fall-through handles the
 method rather than the analysis emitting a claim it cannot stand behind.
 
+**How the seed works, and why it is not inlining.** The seed entries are the
+fixpoint's base cases. The analysis never invents a mutation; it only carries
+existing ones up the call graph, so every position in a `MutArgs` set traces
+back either to a seed entry or to an FR3 `SlotWrite`. An entry's value is the
+*argument position that call site mutates*: `"Set":0` says a call to `Set`
+mutates whatever was passed as its argument 0. At each call the fixpoint looks
+up the callee's mutated positions, reads the argument expression sitting at
+each one, and asks the §4.2 origin map what that expression is **in the
+caller's terms**. `Array.prototype.push` calls `Set(O, %6, E, true)`, so
+position 0 selects `O`, whose origin is `ToObject(this)` — receiver — giving
+`MutatesReceiver`. The same entry yields a different answer elsewhere:
+`Array.prototype.slice` calls `Set(A, "length", …)` on its freshly allocated
+`A`, and a `Fresh` origin is ignored. Multi-parameter results need no special
+case, since `MutArgs` is a set of positions that unions as facts propagate: a
+helper writing both of its parameters accumulates `{0, 1}` from two separate
+`Set` calls, and its callers inherit both positions through the same lookup.
+
+The seed exists because these operations cannot be analyzed by descending into
+their bodies. `Set`'s body is a single dispatch, `O.Set(O, P, V, O)`, to the
+object's `[[Set]]` internal method — a callee chosen at runtime by the
+receiver's type, and in the CFG a field reference rather than a resolvable
+name. Inlining cannot follow it. Nor would inlining help further down: the
+ordinary path continues through `OrdinarySetWithOwnDescriptor`, which dispatches
+again on the prototype chain and can end in `Call(setter, …)`, arbitrary user
+code. The concrete writes it eventually performs land on property-descriptor
+records several dispatch layers below, phrased in ESMeta's internal object
+representation rather than as a mutation of `O`. Recognizing those would mean
+curating a larger and subtler artifact than the seed while still failing to
+cross the dispatch boundary.
+
+Treating `Set` as opaque with a known positional effect removes the problem
+instead of solving it: nothing above `Set` descends into it, so the dynamic
+dispatch is never reached. The claim "`Set(O, …)` mutates `O`" is also a
+deliberate over-approximation. A Proxy's `[[Set]]` trap may write elsewhere,
+but assuming the argument is mutated is the FR5-conservative direction — a
+wrong `&mut` fails loudly at a call site, a missed one is silent unsoundness.
+Composite mutators above the dispatch boundary stay derived rather than
+asserted: `Object.freeze` gets `MutArgs = {0}` from calling `SetIntegrityLevel`,
+which the fixpoint reads off that helper's own summary. `SetIntegrityLevel` is
+seeded for robustness, not necessity. Inlining reasoning belongs in review, not
+in the analysis: walking the ordinary-object path by hand is how the seed's
+argument positions are validated against the spec on a bump.
+
 `BackingStoreSlots` is the curated FR3 list: `[[MapData]]`,
 `[[SetData]]`, `[[ArrayBufferData]]`, `[[ArrayBufferByteLength]]`,
 `[[TypedArrayName]]`, `[[ViewedArrayBuffer]]`, `[[WeakRefTarget]]`, and

--- a/planning/ecma-262/reproduce_spike.sh
+++ b/planning/ecma-262/reproduce_spike.sh
@@ -47,6 +47,8 @@ REPRESENTATIVE=(
   "INTRINSICS.Array.prototype.forEach"              # callback propagation
   "INTRINSICS.Map.prototype.set"                    # internal-slot mutation + escape
   "INTRINSICS.Set.prototype.add"                    # internal-slot mutation + escape
+  "INTRINSICS.Object.freeze"                        # transitive mutation through a helper AO
+  "SetIntegrityLevel"                               # the helper freeze delegates its write to
   "INTRINSICS.Reflect.set"                          # namespace fn, param mutation + escape
   "INTRINSICS.String.prototype.charAt"              # immutable primitive
   "INTRINSICS.String.prototype.replace"             # immutable primitive + callback

--- a/planning/ecma-262/reproduce_spike.sh
+++ b/planning/ecma-262/reproduce_spike.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Reproduce the §1 feasibility spike: build ESMeta, run its CFG pipeline
+# against the pinned ECMA-262 revision, and collect the representative-method
+# control-flow-graph dumps the findings read from.
+#
+# Findings:  planning/ecma-262/spike_findings.md
+# Evidence:  planning/ecma-262/spike_evidence/  (the dumps this script regenerates)
+#
+# This is a one-time reproduction runbook, not part of the Go build or CI. §2
+# formalizes the JVM toolchain as a maintainer-only dependency under
+# tools/spec-extract/; until then this script documents the exact steps.
+#
+# Toolchain the spike used (install these first; JDK and sbt are not otherwise
+# needed to build the compiler):
+#   - JDK 17+            (spike used Temurin 21)
+#   - sbt 1.10.x         (spike used the launcher from github.com/sbt/sbt v1.10.7)
+#   - git, curl
+#
+# Pinned revisions:
+#   - ESMeta      7d237fd1680f473e674320cc97932702d950fa98  (v0.7.3)
+#   - ECMA-262    84b38ad852ff426795fa29cebc06949027336c64  (tag es2025)
+#                 pinned transitively as ESMeta's `ecma262` submodule at the
+#                 ESMeta revision above, so `git submodule update --init` checks
+#                 out the right spec with no extra pinning.
+#
+# Usage:  planning/ecma-262/reproduce_spike.sh [workdir]
+#   workdir defaults to a fresh ./esmeta-spike under the current directory.
+
+set -euo pipefail
+
+ESMETA_REV="7d237fd1680f473e674320cc97932702d950fa98"
+WORKDIR="${1:-$PWD/esmeta-spike}"
+REPO_DIR="$WORKDIR/esmeta"
+
+# The representative method set spanning every shape the analysis must handle.
+# Each name is an ESMeta CFG function; the dump lands at
+# logs/cfg/func/<name>.cfg. `Set` is the property-write abstract operation,
+# included because it shows the dynamic [[Set]] dispatch that the FR1 seed
+# short-circuits.
+REPRESENTATIVE=(
+  "INTRINSICS.Array.prototype.push"                 # direct receiver mutation + escape
+  "INTRINSICS.Array.prototype.fill"                 # receiver mutation returning receiver
+  "INTRINSICS.Array.prototype.sort"                 # receiver mutation returning receiver
+  "INTRINSICS.Array.prototype.slice"                # fresh allocation, no receiver mutation
+  "INTRINSICS.Array.prototype.map"                  # fresh allocation + callback
+  "INTRINSICS.Array.prototype.forEach"              # callback propagation
+  "INTRINSICS.Map.prototype.set"                    # internal-slot mutation + escape
+  "INTRINSICS.Set.prototype.add"                    # internal-slot mutation + escape
+  "INTRINSICS.Reflect.set"                          # namespace fn, param mutation + escape
+  "INTRINSICS.String.prototype.charAt"              # immutable primitive
+  "INTRINSICS.String.prototype.replace"             # immutable primitive + callback
+  "INTRINSICS.String.prototype[%Symbol.iterator%]"  # symbol-keyed method
+  "INTRINSICS.Number.prototype.toFixed"             # domain throw + partial `yet`
+  "INTRINSICS.Promise.reject"                       # async reject, param origin
+  "INTRINSICS.Promise.all"                          # async reject, combinator
+  "Set"                                             # dynamic [[Set]] dispatch (seed rationale)
+)
+
+echo "==> workdir: $WORKDIR"
+mkdir -p "$WORKDIR"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  echo "==> cloning ESMeta with submodules"
+  git clone --recurse-submodules https://github.com/es-meta/esmeta.git "$REPO_DIR"
+fi
+
+echo "==> checking out pinned ESMeta revision $ESMETA_REV"
+git -C "$REPO_DIR" checkout --quiet "$ESMETA_REV"
+git -C "$REPO_DIR" submodule update --init
+
+echo "==> spec revision (ESMeta ecma262 submodule):"
+git -C "$REPO_DIR/ecma262" rev-parse HEAD
+
+echo "==> building ESMeta (sbt assembly)"
+( cd "$REPO_DIR" && ESMETA_HOME="$REPO_DIR" sbt assembly )
+
+echo "==> running extract -> compile -> build-cfg with CFG logging"
+( cd "$REPO_DIR" && ESMETA_HOME="$REPO_DIR" ./bin/esmeta build-cfg -build-cfg:log )
+
+DUMP_DIR="$REPO_DIR/logs/cfg/func"
+echo "==> per-function CFG dumps in: $DUMP_DIR"
+echo "    total functions: $(ls "$DUMP_DIR" | wc -l)"
+
+echo "==> representative-method dumps (the committed spike_evidence/ set):"
+for name in "${REPRESENTATIVE[@]}"; do
+  if [ -f "$DUMP_DIR/$name.cfg" ]; then
+    echo "    OK   $name.cfg"
+  else
+    echo "    MISS $name.cfg"
+  fi
+done
+
+echo
+echo "Done. Compare $DUMP_DIR/<name>.cfg against planning/ecma-262/spike_evidence/"
+echo "to confirm the findings still hold on a spec bump."

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.fill.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.fill.cfg
@@ -1,0 +1,74 @@
+2527: def <BUILTIN>:INTRINSICS.Array.prototype.fill(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  26578: let __args__ = (record)[#1136] -> 26579
+  26579: if (< 0 (sizeof ArgumentsList)) then 26580 else 26581
+  26580: {
+    pop value < ArgumentsList
+    expand __args__.value
+  } -> 26582
+  26581: let value = undefined -> 26582
+  26582: if (< 0 (sizeof ArgumentsList)) then 26583 else 26584
+  26583: {
+    pop start < ArgumentsList
+    expand __args__.start
+  } -> 26585
+  26584: let start = undefined -> 26585
+  26585: if (< 0 (sizeof ArgumentsList)) then 26586 else 26587
+  26586: {
+    pop end < ArgumentsList
+    expand __args__.end
+  } -> 26588
+  26587: let end = undefined -> 26588
+  26588: call %0 = clo<"ToObject">(this) -> 26589
+  26589: assert (? %0: Completion) -> 26590
+  26590: if (? %0: Abrupt) then 26591 else 26592
+  26591: return %0
+  26592: %0 = %0.Value -> 26593
+  26593: let O = %0 -> 26594
+  26594: call %1 = clo<"LengthOfArrayLike">(O) -> 26595
+  26595: assert (? %1: Completion) -> 26596
+  26596: if (? %1: Abrupt) then 26597 else 26598
+  26597: return %1
+  26598: %1 = %1.Value -> 26599
+  26599: let len = %1 -> 26600
+  26600: call %2 = clo<"ToIntegerOrInfinity">(start) -> 26601
+  26601: assert (? %2: Completion) -> 26602
+  26602: if (? %2: Abrupt) then 26603 else 26604
+  26603: return %2
+  26604: %2 = %2.Value -> 26605
+  26605: let relativeStart = %2 -> 26606
+  26606: if (== relativeStart -INF) then 26607 else 26608
+  26607: let k = 0 -> 26611
+  26608: if (< relativeStart 0) then 26609 else 26610
+  26609: let k = (max (+ len relativeStart) 0) -> 26611
+  26610: let k = (min relativeStart len) -> 26611
+  26611: if (= end undefined) then 26612 else 26613
+  26612: let relativeEnd = len -> 26619
+  26613: call %3 = clo<"ToIntegerOrInfinity">(end) -> 26614
+  26614: assert (? %3: Completion) -> 26615
+  26615: if (? %3: Abrupt) then 26616 else 26617
+  26616: return %3
+  26617: %3 = %3.Value -> 26618
+  26618: let relativeEnd = %3 -> 26619
+  26619: if (== relativeEnd -INF) then 26620 else 26621
+  26620: let final = 0 -> 26624
+  26621: if (< relativeEnd 0) then 26622 else 26623
+  26622: let final = (max (+ len relativeEnd) 0) -> 26624
+  26623: let final = (min relativeEnd len) -> 26624
+  26624: while (< k final) then 26625 else 26633
+  26625: call %4 = clo<"ToString">(([number] k)) -> 26626
+  26626: {
+    assert (? %4: Normal)
+    %4 = %4.Value
+    let Pk = %4
+  } -> 26627
+  26627: call %5 = clo<"Set">(O, Pk, value, true) -> 26628
+  26628: assert (? %5: Completion) -> 26629
+  26629: if (? %5: Abrupt) then 26630 else 26631
+  26630: return %5
+  26631: %5 = %5.Value -> 26632
+  26632: k = (+ k 1) -> 26624
+  26633: if (? O: Completion) then 26634 else 26635
+  26634: return O
+  26635: call %6 = clo<"NormalCompletion">(O) -> 26636
+  26636: return %6
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.forEach.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.forEach.cfg
@@ -1,0 +1,61 @@
+2537: def <BUILTIN>:INTRINSICS.Array.prototype.forEach(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  27009: let __args__ = (record)[#1151] -> 27010
+  27010: if (< 0 (sizeof ArgumentsList)) then 27011 else 27012
+  27011: {
+    pop callback < ArgumentsList
+    expand __args__.callback
+  } -> 27013
+  27012: let callback = undefined -> 27013
+  27013: if (< 0 (sizeof ArgumentsList)) then 27014 else 27015
+  27014: {
+    pop thisArg < ArgumentsList
+    expand __args__.thisArg
+  } -> 27016
+  27015: let thisArg = undefined -> 27016
+  27016: call %0 = clo<"ToObject">(this) -> 27017
+  27017: assert (? %0: Completion) -> 27018
+  27018: if (? %0: Abrupt) then 27019 else 27020
+  27019: return %0
+  27020: %0 = %0.Value -> 27021
+  27021: let O = %0 -> 27022
+  27022: call %1 = clo<"LengthOfArrayLike">(O) -> 27023
+  27023: assert (? %1: Completion) -> 27024
+  27024: if (? %1: Abrupt) then 27025 else 27026
+  27025: return %1
+  27026: %1 = %1.Value -> 27027
+  27027: let len = %1 -> 27028
+  27028: call %2 = clo<"IsCallable">(callback) -> 27029
+  27029: if (= %2 false) then 27030 else 27033
+  27030: call %3 = clo<"__NEW_ERROR_OBJ__">("%TypeError.prototype%") -> 27031
+  27031: call %4 = clo<"ThrowCompletion">(%3) -> 27032
+  27032: return %4
+  27033: let k = 0 -> 27034
+  27034: while (< k len) then 27035 else 27056
+  27035: call %5 = clo<"ToString">(([number] k)) -> 27036
+  27036: {
+    assert (? %5: Normal)
+    %5 = %5.Value
+    let Pk = %5
+  } -> 27037
+  27037: call %6 = clo<"HasProperty">(O, Pk) -> 27038
+  27038: assert (? %6: Completion) -> 27039
+  27039: if (? %6: Abrupt) then 27040 else 27041
+  27040: return %6
+  27041: %6 = %6.Value -> 27042
+  27042: let kPresent = %6 -> 27043
+  27043: if (= kPresent true) then 27044 else 27055
+  27044: call %7 = clo<"Get">(O, Pk) -> 27045
+  27045: assert (? %7: Completion) -> 27046
+  27046: if (? %7: Abrupt) then 27047 else 27048
+  27047: return %7
+  27048: %7 = %7.Value -> 27049
+  27049: let kValue = %7 -> 27050
+  27050: call %8 = clo<"Call">(callback, thisArg, (list [kValue, ([number] k), O])[#1152]) -> 27051
+  27051: assert (? %8: Completion) -> 27052
+  27052: if (? %8: Abrupt) then 27053 else 27054
+  27053: return %8
+  27054: %8 = %8.Value -> 27055
+  27055: k = (+ k 1) -> 27034
+  27056: call %9 = clo<"NormalCompletion">(undefined) -> 27057
+  27057: return %9
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.map.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.map.cfg
@@ -1,0 +1,77 @@
+2543: def <BUILTIN>:INTRINSICS.Array.prototype.map(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  27298: let __args__ = (record)[#1158] -> 27299
+  27299: if (< 0 (sizeof ArgumentsList)) then 27300 else 27301
+  27300: {
+    pop callback < ArgumentsList
+    expand __args__.callback
+  } -> 27302
+  27301: let callback = undefined -> 27302
+  27302: if (< 0 (sizeof ArgumentsList)) then 27303 else 27304
+  27303: {
+    pop thisArg < ArgumentsList
+    expand __args__.thisArg
+  } -> 27305
+  27304: let thisArg = undefined -> 27305
+  27305: call %0 = clo<"ToObject">(this) -> 27306
+  27306: assert (? %0: Completion) -> 27307
+  27307: if (? %0: Abrupt) then 27308 else 27309
+  27308: return %0
+  27309: %0 = %0.Value -> 27310
+  27310: let O = %0 -> 27311
+  27311: call %1 = clo<"LengthOfArrayLike">(O) -> 27312
+  27312: assert (? %1: Completion) -> 27313
+  27313: if (? %1: Abrupt) then 27314 else 27315
+  27314: return %1
+  27315: %1 = %1.Value -> 27316
+  27316: let len = %1 -> 27317
+  27317: call %2 = clo<"IsCallable">(callback) -> 27318
+  27318: if (= %2 false) then 27319 else 27322
+  27319: call %3 = clo<"__NEW_ERROR_OBJ__">("%TypeError.prototype%") -> 27320
+  27320: call %4 = clo<"ThrowCompletion">(%3) -> 27321
+  27321: return %4
+  27322: call %5 = clo<"ArraySpeciesCreate">(O, len) -> 27323
+  27323: assert (? %5: Completion) -> 27324
+  27324: if (? %5: Abrupt) then 27325 else 27326
+  27325: return %5
+  27326: %5 = %5.Value -> 27327
+  27327: {
+    let A = %5
+    let k = 0
+  } -> 27328
+  27328: while (< k len) then 27329 else 27356
+  27329: call %6 = clo<"ToString">(([number] k)) -> 27330
+  27330: {
+    assert (? %6: Normal)
+    %6 = %6.Value
+    let Pk = %6
+  } -> 27331
+  27331: call %7 = clo<"HasProperty">(O, Pk) -> 27332
+  27332: assert (? %7: Completion) -> 27333
+  27333: if (? %7: Abrupt) then 27334 else 27335
+  27334: return %7
+  27335: %7 = %7.Value -> 27336
+  27336: let kPresent = %7 -> 27337
+  27337: if (= kPresent true) then 27338 else 27355
+  27338: call %8 = clo<"Get">(O, Pk) -> 27339
+  27339: assert (? %8: Completion) -> 27340
+  27340: if (? %8: Abrupt) then 27341 else 27342
+  27341: return %8
+  27342: %8 = %8.Value -> 27343
+  27343: let kValue = %8 -> 27344
+  27344: call %9 = clo<"Call">(callback, thisArg, (list [kValue, ([number] k), O])[#1159]) -> 27345
+  27345: assert (? %9: Completion) -> 27346
+  27346: if (? %9: Abrupt) then 27347 else 27348
+  27347: return %9
+  27348: %9 = %9.Value -> 27349
+  27349: let mappedValue = %9 -> 27350
+  27350: call %10 = clo<"CreateDataPropertyOrThrow">(A, Pk, mappedValue) -> 27351
+  27351: assert (? %10: Completion) -> 27352
+  27352: if (? %10: Abrupt) then 27353 else 27354
+  27353: return %10
+  27354: %10 = %10.Value -> 27355
+  27355: k = (+ k 1) -> 27328
+  27356: if (? A: Completion) then 27357 else 27358
+  27357: return A
+  27358: call %11 = clo<"NormalCompletion">(A) -> 27359
+  27359: return %11
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.push.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.push.cfg
@@ -1,0 +1,55 @@
+2545: def <BUILTIN>:INTRINSICS.Array.prototype.push(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  27404: {
+    let __args__ = (record)[#1161]
+    let items = ArgumentsList
+  } -> 27405
+  27405: call %0 = clo<"ToObject">(this) -> 27406
+  27406: assert (? %0: Completion) -> 27407
+  27407: if (? %0: Abrupt) then 27408 else 27409
+  27408: return %0
+  27409: %0 = %0.Value -> 27410
+  27410: let O = %0 -> 27411
+  27411: call %1 = clo<"LengthOfArrayLike">(O) -> 27412
+  27412: assert (? %1: Completion) -> 27413
+  27413: if (? %1: Abrupt) then 27414 else 27415
+  27414: return %1
+  27415: %1 = %1.Value -> 27416
+  27416: {
+    let len = %1
+    let argCount = (sizeof items)
+  } -> 27417
+  27417: if (< (- (** 2 53) 1) (+ len argCount)) then 27418 else 27421
+  27418: call %2 = clo<"__NEW_ERROR_OBJ__">("%TypeError.prototype%") -> 27419
+  27419: call %3 = clo<"ThrowCompletion">(%2) -> 27420
+  27420: return %3
+  27421: {
+    %5 = items
+    %4 = 0
+  } -> 27422
+  27422: while (< %4 (sizeof %5)) then 27423 else 27432
+  27423: let E = %5[%4] -> 27424
+  27424: call %6 = clo<"ToString">(([number] len)) -> 27425
+  27425: {
+    assert (? %6: Normal)
+    %6 = %6.Value
+  } -> 27426
+  27426: call %7 = clo<"Set">(O, %6, E, true) -> 27427
+  27427: assert (? %7: Completion) -> 27428
+  27428: if (? %7: Abrupt) then 27429 else 27430
+  27429: return %7
+  27430: %7 = %7.Value -> 27431
+  27431: {
+    len = (+ len 1)
+    %4 = (+ %4 1)
+  } -> 27422
+  27432: call %8 = clo<"Set">(O, "length", ([number] len), true) -> 27433
+  27433: assert (? %8: Completion) -> 27434
+  27434: if (? %8: Abrupt) then 27435 else 27436
+  27435: return %8
+  27436: %8 = %8.Value -> 27437
+  27437: %9 = ([number] len) -> 27438
+  27438: if (? %9: Completion) then 27439 else 27440
+  27439: return %9
+  27440: call %10 = clo<"NormalCompletion">(%9) -> 27441
+  27441: return %10
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.slice.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.slice.cfg
@@ -1,0 +1,104 @@
+2550: def <BUILTIN>:INTRINSICS.Array.prototype.slice(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  27759: let __args__ = (record)[#1168] -> 27760
+  27760: if (< 0 (sizeof ArgumentsList)) then 27761 else 27762
+  27761: {
+    pop start < ArgumentsList
+    expand __args__.start
+  } -> 27763
+  27762: let start = undefined -> 27763
+  27763: if (< 0 (sizeof ArgumentsList)) then 27764 else 27765
+  27764: {
+    pop end < ArgumentsList
+    expand __args__.end
+  } -> 27766
+  27765: let end = undefined -> 27766
+  27766: call %0 = clo<"ToObject">(this) -> 27767
+  27767: assert (? %0: Completion) -> 27768
+  27768: if (? %0: Abrupt) then 27769 else 27770
+  27769: return %0
+  27770: %0 = %0.Value -> 27771
+  27771: let O = %0 -> 27772
+  27772: call %1 = clo<"LengthOfArrayLike">(O) -> 27773
+  27773: assert (? %1: Completion) -> 27774
+  27774: if (? %1: Abrupt) then 27775 else 27776
+  27775: return %1
+  27776: %1 = %1.Value -> 27777
+  27777: let len = %1 -> 27778
+  27778: call %2 = clo<"ToIntegerOrInfinity">(start) -> 27779
+  27779: assert (? %2: Completion) -> 27780
+  27780: if (? %2: Abrupt) then 27781 else 27782
+  27781: return %2
+  27782: %2 = %2.Value -> 27783
+  27783: let relativeStart = %2 -> 27784
+  27784: if (== relativeStart -INF) then 27785 else 27786
+  27785: let k = 0 -> 27789
+  27786: if (< relativeStart 0) then 27787 else 27788
+  27787: let k = (max (+ len relativeStart) 0) -> 27789
+  27788: let k = (min relativeStart len) -> 27789
+  27789: if (= end undefined) then 27790 else 27791
+  27790: let relativeEnd = len -> 27797
+  27791: call %3 = clo<"ToIntegerOrInfinity">(end) -> 27792
+  27792: assert (? %3: Completion) -> 27793
+  27793: if (? %3: Abrupt) then 27794 else 27795
+  27794: return %3
+  27795: %3 = %3.Value -> 27796
+  27796: let relativeEnd = %3 -> 27797
+  27797: if (== relativeEnd -INF) then 27798 else 27799
+  27798: let final = 0 -> 27802
+  27799: if (< relativeEnd 0) then 27800 else 27801
+  27800: let final = (max (+ len relativeEnd) 0) -> 27802
+  27801: let final = (min relativeEnd len) -> 27802
+  27802: let count = (max (- final k) 0) -> 27803
+  27803: call %4 = clo<"ArraySpeciesCreate">(O, count) -> 27804
+  27804: assert (? %4: Completion) -> 27805
+  27805: if (? %4: Abrupt) then 27806 else 27807
+  27806: return %4
+  27807: %4 = %4.Value -> 27808
+  27808: {
+    let A = %4
+    let n = 0
+  } -> 27809
+  27809: while (< k final) then 27810 else 27833
+  27810: call %5 = clo<"ToString">(([number] k)) -> 27811
+  27811: {
+    assert (? %5: Normal)
+    %5 = %5.Value
+    let Pk = %5
+  } -> 27812
+  27812: call %6 = clo<"HasProperty">(O, Pk) -> 27813
+  27813: assert (? %6: Completion) -> 27814
+  27814: if (? %6: Abrupt) then 27815 else 27816
+  27815: return %6
+  27816: %6 = %6.Value -> 27817
+  27817: let kPresent = %6 -> 27818
+  27818: if (= kPresent true) then 27819 else 27832
+  27819: call %7 = clo<"Get">(O, Pk) -> 27820
+  27820: assert (? %7: Completion) -> 27821
+  27821: if (? %7: Abrupt) then 27822 else 27823
+  27822: return %7
+  27823: %7 = %7.Value -> 27824
+  27824: let kValue = %7 -> 27825
+  27825: call %8 = clo<"ToString">(([number] n)) -> 27826
+  27826: {
+    assert (? %8: Normal)
+    %8 = %8.Value
+  } -> 27827
+  27827: call %9 = clo<"CreateDataPropertyOrThrow">(A, %8, kValue) -> 27828
+  27828: assert (? %9: Completion) -> 27829
+  27829: if (? %9: Abrupt) then 27830 else 27831
+  27830: return %9
+  27831: %9 = %9.Value -> 27832
+  27832: {
+    k = (+ k 1)
+    n = (+ n 1)
+  } -> 27809
+  27833: call %10 = clo<"Set">(A, "length", ([number] n), true) -> 27834
+  27834: assert (? %10: Completion) -> 27835
+  27835: if (? %10: Abrupt) then 27836 else 27837
+  27836: return %10
+  27837: %10 = %10.Value -> 27838
+  27838: if (? A: Completion) then 27839 else 27840
+  27839: return A
+  27840: call %11 = clo<"NormalCompletion">(A) -> 27841
+  27841: return %11
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.sort.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Array.prototype.sort.cfg
@@ -1,0 +1,71 @@
+2553: def <BUILTIN>:INTRINSICS.Array.prototype.sort(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  27901: let __args__ = (record)[#1171] -> 27902
+  27902: if (< 0 (sizeof ArgumentsList)) then 27903 else 27904
+  27903: {
+    pop comparator < ArgumentsList
+    expand __args__.comparator
+  } -> 27905
+  27904: let comparator = undefined -> 27905
+  27905: %0 = (! (= comparator undefined)) -> 27906
+  27906: if %0 then 27907 else 27913
+  27907: call %1 = clo<"IsCallable">(comparator) -> 27908
+  27908: %0 = (= %1 false) -> 27909
+  27909: if %0 then 27910 else 27913
+  27910: call %2 = clo<"__NEW_ERROR_OBJ__">("%TypeError.prototype%") -> 27911
+  27911: call %3 = clo<"ThrowCompletion">(%2) -> 27912
+  27912: return %3
+  27913: call %4 = clo<"ToObject">(this) -> 27914
+  27914: assert (? %4: Completion) -> 27915
+  27915: if (? %4: Abrupt) then 27916 else 27917
+  27916: return %4
+  27917: %4 = %4.Value -> 27918
+  27918: let obj = %4 -> 27919
+  27919: call %5 = clo<"LengthOfArrayLike">(obj) -> 27920
+  27920: assert (? %5: Completion) -> 27921
+  27921: if (? %5: Abrupt) then 27922 else 27923
+  27922: return %5
+  27923: %5 = %5.Value -> 27924
+  27924: {
+    let len = %5
+    let SortCompare = clo<"INTRINSICS.Array.prototype.sort:clo0", [comparator]>
+  } -> 27925
+  27925: call %6 = clo<"SortIndexedProperties">(obj, len, SortCompare, ~skip-holes~) -> 27926
+  27926: assert (? %6: Completion) -> 27927
+  27927: if (? %6: Abrupt) then 27928 else 27929
+  27928: return %6
+  27929: %6 = %6.Value -> 27930
+  27930: {
+    let sortedList = %6
+    let itemCount = (sizeof sortedList)
+    let j = 0
+  } -> 27931
+  27931: while (< j itemCount) then 27932 else 27940
+  27932: call %7 = clo<"ToString">(([number] j)) -> 27933
+  27933: {
+    assert (? %7: Normal)
+    %7 = %7.Value
+  } -> 27934
+  27934: call %8 = clo<"Set">(obj, %7, sortedList[j], true) -> 27935
+  27935: assert (? %8: Completion) -> 27936
+  27936: if (? %8: Abrupt) then 27937 else 27938
+  27937: return %8
+  27938: %8 = %8.Value -> 27939
+  27939: j = (+ j 1) -> 27931
+  27940: nop -> 27941
+  27941: while (< j len) then 27942 else 27950
+  27942: call %9 = clo<"ToString">(([number] j)) -> 27943
+  27943: {
+    assert (? %9: Normal)
+    %9 = %9.Value
+  } -> 27944
+  27944: call %10 = clo<"DeletePropertyOrThrow">(obj, %9) -> 27945
+  27945: assert (? %10: Completion) -> 27946
+  27946: if (? %10: Abrupt) then 27947 else 27948
+  27947: return %10
+  27948: %10 = %10.Value -> 27949
+  27949: j = (+ j 1) -> 27941
+  27950: if (? obj: Completion) then 27951 else 27952
+  27951: return obj
+  27952: call %11 = clo<"NormalCompletion">(obj) -> 27953
+  27953: return %11
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Map.prototype.set.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Map.prototype.set.cfg
@@ -1,0 +1,52 @@
+2647: def <BUILTIN>:INTRINSICS.Map.prototype.set(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  31800: let __args__ = (record)[#1274] -> 31801
+  31801: if (< 0 (sizeof ArgumentsList)) then 31802 else 31803
+  31802: {
+    pop key < ArgumentsList
+    expand __args__.key
+  } -> 31804
+  31803: let key = undefined -> 31804
+  31804: if (< 0 (sizeof ArgumentsList)) then 31805 else 31806
+  31805: {
+    pop value < ArgumentsList
+    expand __args__.value
+  } -> 31807
+  31806: let value = undefined -> 31807
+  31807: let M = this -> 31808
+  31808: call %0 = clo<"RequireInternalSlot">(M, "MapData") -> 31809
+  31809: assert (? %0: Completion) -> 31810
+  31810: if (? %0: Abrupt) then 31811 else 31812
+  31811: return %0
+  31812: %0 = %0.Value -> 31813
+  31813: call %1 = clo<"CanonicalizeKeyedCollectionKey">(key) -> 31814
+  31814: {
+    key = %1
+    %3 = M.MapData
+    %2 = 0
+  } -> 31815
+  31815: while (< %2 (sizeof %3)) then 31816 else 31829
+  31816: let p = %3[%2] -> 31817
+  31817: if (? p: Record[{ Key, Value }]) then 31818 else 31828
+  31818: %4 = (! (= p.Key ~empty~)) -> 31819
+  31819: if %4 then 31820 else 31828
+  31820: call %5 = clo<"SameValue">(p.Key, key) -> 31821
+  31821: %4 = (= %5 true) -> 31822
+  31822: if %4 then 31823 else 31828
+  31823: p.Value = value -> 31824
+  31824: if (? M: Completion) then 31825 else 31826
+  31825: return M
+  31826: call %6 = clo<"NormalCompletion">(M) -> 31827
+  31827: return %6
+  31828: %2 = (+ %2 1) -> 31815
+  31829: {
+    let p = (record {
+      "Key" : key,
+      "Value" : value,
+    })[#1275]
+    push M.MapData < p
+  } -> 31830
+  31830: if (? M: Completion) then 31831 else 31832
+  31831: return M
+  31832: call %7 = clo<"NormalCompletion">(M) -> 31833
+  31833: return %7
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Number.prototype.toFixed.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Number.prototype.toFixed.cfg
@@ -1,0 +1,76 @@
+2147: def <BUILTIN>:INTRINSICS.Number.prototype.toFixed(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  20015: let __args__ = (record)[#907] -> 20016
+  20016: if (< 0 (sizeof ArgumentsList)) then 20017 else 20018
+  20017: {
+    pop fractionDigits < ArgumentsList
+    expand __args__.fractionDigits
+  } -> 20019
+  20018: let fractionDigits = undefined -> 20019
+  20019: call %0 = clo<"ThisNumberValue">(this) -> 20020
+  20020: assert (? %0: Completion) -> 20021
+  20021: if (? %0: Abrupt) then 20022 else 20023
+  20022: return %0
+  20023: %0 = %0.Value -> 20024
+  20024: let x = %0 -> 20025
+  20025: call %1 = clo<"ToIntegerOrInfinity">(fractionDigits) -> 20026
+  20026: assert (? %1: Completion) -> 20027
+  20027: if (? %1: Abrupt) then 20028 else 20029
+  20028: return %1
+  20029: %1 = %1.Value -> 20030
+  20030: {
+    let f = %1
+    assert (|| (! (= fractionDigits undefined)) (= f 0))
+  } -> 20031
+  20031: if (|| (= f NaN) (|| (= f +NUM_INF) (= f -NUM_INF))) then 20032 else 20035
+  20032: call %2 = clo<"__NEW_ERROR_OBJ__">("%RangeError.prototype%") -> 20033
+  20033: call %3 = clo<"ThrowCompletion">(%2) -> 20034
+  20034: return %3
+  20035: if (|| (< f 0) (< 100 f)) then 20036 else 20039
+  20036: call %4 = clo<"__NEW_ERROR_OBJ__">("%RangeError.prototype%") -> 20037
+  20037: call %5 = clo<"ThrowCompletion">(%4) -> 20038
+  20038: return %5
+  20039: if (|| (= x NaN) (|| (= x +NUM_INF) (= x -NUM_INF))) then 20040 else 20045
+  20040: call %6 = clo<"Number::toString">(x, 10) -> 20041
+  20041: if (? %6: Completion) then 20042 else 20043
+  20042: return %6
+  20043: call %7 = clo<"NormalCompletion">(%6) -> 20044
+  20044: return %7
+  20045: {
+    x = ([math] x)
+    let s = ""
+  } -> 20046
+  20046: if (< x 0) then 20047 else 20048
+  20047: {
+    s = "-"
+    x = (- x)
+  } -> 20048
+  20048: if (! (< x (** 10 21))) then 20049 else 20051
+  20049: call %8 = clo<"ToString">(([number] x)) -> 20050
+  20050: {
+    assert (? %8: Normal)
+    %8 = %8.Value
+    let m = %8
+  } -> 20060
+  20051: (yet "Let _n_ be an integer for which _n_ / 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.") -> 20052
+  20052: if (== n 0) then 20053 else 20054
+  20053: let m = "0" -> 20055
+  20054: (yet "let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).") -> 20055
+  20055: if (! (== f 0)) then 20056 else 20060
+  20056: let k = (sizeof m) -> 20057
+  20057: if (! (< f k)) then 20058 else 20059
+  20058: {
+    (yet "Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).")
+    m = (concat z m)
+    k = (+ f 1)
+  } -> 20059
+  20059: {
+    (yet "Let _a_ be the first _k_ - _f_ code units of _m_.")
+    (yet "Let _b_ be the other _f_ code units of _m_.")
+    m = (concat a "." b)
+  } -> 20060
+  20060: %9 = (concat s m) -> 20061
+  20061: if (? %9: Completion) then 20062 else 20063
+  20062: return %9
+  20063: call %10 = clo<"NormalCompletion">(%9) -> 20064
+  20064: return %10
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Object.freeze.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Object.freeze.cfg
@@ -1,0 +1,28 @@
+2079: def <BUILTIN>:INTRINSICS.Object.freeze(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  18447: let __args__ = (record)[#825] -> 18448
+  18448: if (< 0 (sizeof ArgumentsList)) then 18449 else 18450
+  18449: {
+    pop O < ArgumentsList
+    expand __args__.O
+  } -> 18451
+  18450: let O = undefined -> 18451
+  18451: if (! (? O: Record[Object])) then 18452 else 18456
+  18452: if (? O: Completion) then 18453 else 18454
+  18453: return O
+  18454: call %0 = clo<"NormalCompletion">(O) -> 18455
+  18455: return %0
+  18456: call %1 = clo<"SetIntegrityLevel">(O, ~frozen~) -> 18457
+  18457: assert (? %1: Completion) -> 18458
+  18458: if (? %1: Abrupt) then 18459 else 18460
+  18459: return %1
+  18460: %1 = %1.Value -> 18461
+  18461: let status = %1 -> 18462
+  18462: if (= status false) then 18463 else 18466
+  18463: call %2 = clo<"__NEW_ERROR_OBJ__">("%TypeError.prototype%") -> 18464
+  18464: call %3 = clo<"ThrowCompletion">(%2) -> 18465
+  18465: return %3
+  18466: if (? O: Completion) then 18467 else 18468
+  18467: return O
+  18468: call %4 = clo<"NormalCompletion">(O) -> 18469
+  18469: return %4
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Promise.all.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Promise.all.cfg
@@ -1,0 +1,89 @@
+2854: def <BUILTIN>:INTRINSICS.Promise.all(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  36745: let __args__ = (record)[#1521] -> 36746
+  36746: if (< 0 (sizeof ArgumentsList)) then 36747 else 36748
+  36747: {
+    pop iterable < ArgumentsList
+    expand __args__.iterable
+  } -> 36749
+  36748: let iterable = undefined -> 36749
+  36749: let C = this -> 36750
+  36750: call %0 = clo<"NewPromiseCapability">(C) -> 36751
+  36751: assert (? %0: Completion) -> 36752
+  36752: if (? %0: Abrupt) then 36753 else 36754
+  36753: return %0
+  36754: %0 = %0.Value -> 36755
+  36755: let promiseCapability = %0 -> 36756
+  36756: call %1 = clo<"GetPromiseResolve">(C) -> 36757
+  36757: call %2 = clo<"Completion">(%1) -> 36758
+  36758: {
+    let promiseResolve = %2
+    assert (? promiseResolve: Completion)
+  } -> 36759
+  36759: if (&& (? promiseResolve: Completion) (! (= promiseResolve.Type ~normal~))) then 36760 else 36770
+  36760: call %3 = clo<"Call">(promiseCapability.Reject, undefined, (list [promiseResolve.Value])[#1522]) -> 36761
+  36761: assert (? %3: Completion) -> 36762
+  36762: if (? %3: Abrupt) then 36763 else 36764
+  36763: return %3
+  36764: %3 = %3.Value -> 36765
+  36765: %4 = promiseCapability.Promise -> 36766
+  36766: if (? %4: Completion) then 36767 else 36768
+  36767: return %4
+  36768: call %5 = clo<"NormalCompletion">(%4) -> 36769
+  36769: return %5
+  36770: {
+    assert (? promiseResolve: Normal)
+    promiseResolve = promiseResolve.Value
+    promiseResolve = promiseResolve
+  } -> 36771
+  36771: call %6 = clo<"GetIterator">(iterable, ~sync~) -> 36772
+  36772: call %7 = clo<"Completion">(%6) -> 36773
+  36773: {
+    let iteratorRecord = %7
+    assert (? iteratorRecord: Completion)
+  } -> 36774
+  36774: if (&& (? iteratorRecord: Completion) (! (= iteratorRecord.Type ~normal~))) then 36775 else 36785
+  36775: call %8 = clo<"Call">(promiseCapability.Reject, undefined, (list [iteratorRecord.Value])[#1523]) -> 36776
+  36776: assert (? %8: Completion) -> 36777
+  36777: if (? %8: Abrupt) then 36778 else 36779
+  36778: return %8
+  36779: %8 = %8.Value -> 36780
+  36780: %9 = promiseCapability.Promise -> 36781
+  36781: if (? %9: Completion) then 36782 else 36783
+  36782: return %9
+  36783: call %10 = clo<"NormalCompletion">(%9) -> 36784
+  36784: return %10
+  36785: {
+    assert (? iteratorRecord: Normal)
+    iteratorRecord = iteratorRecord.Value
+    iteratorRecord = iteratorRecord
+  } -> 36786
+  36786: call %11 = clo<"PerformPromiseAll">(iteratorRecord, C, promiseCapability, promiseResolve) -> 36787
+  36787: call %12 = clo<"Completion">(%11) -> 36788
+  36788: let result = %12 -> 36789
+  36789: if (&& (? result: Completion) (! (= result.Type ~normal~))) then 36790 else 36807
+  36790: if (= iteratorRecord.Done false) then 36791 else 36794
+  36791: call %13 = clo<"IteratorClose">(iteratorRecord, result) -> 36792
+  36792: call %14 = clo<"Completion">(%13) -> 36793
+  36793: result = %14 -> 36794
+  36794: assert (? result: Completion) -> 36795
+  36795: if (&& (? result: Completion) (! (= result.Type ~normal~))) then 36796 else 36806
+  36796: call %15 = clo<"Call">(promiseCapability.Reject, undefined, (list [result.Value])[#1524]) -> 36797
+  36797: assert (? %15: Completion) -> 36798
+  36798: if (? %15: Abrupt) then 36799 else 36800
+  36799: return %15
+  36800: %15 = %15.Value -> 36801
+  36801: %16 = promiseCapability.Promise -> 36802
+  36802: if (? %16: Completion) then 36803 else 36804
+  36803: return %16
+  36804: call %17 = clo<"NormalCompletion">(%16) -> 36805
+  36805: return %17
+  36806: {
+    assert (? result: Normal)
+    result = result.Value
+    result = result
+  } -> 36807
+  36807: assert (? result: Completion) -> 36808
+  36808: if (? result: Abrupt) then 36809 else 36810
+  36809: return result
+  36810: return result
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Promise.reject.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Promise.reject.cfg
@@ -1,0 +1,26 @@
+2867: def <BUILTIN>:INTRINSICS.Promise.reject(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  37258: let __args__ = (record)[#1568] -> 37259
+  37259: if (< 0 (sizeof ArgumentsList)) then 37260 else 37261
+  37260: {
+    pop r < ArgumentsList
+    expand __args__.r
+  } -> 37262
+  37261: let r = undefined -> 37262
+  37262: let C = this -> 37263
+  37263: call %0 = clo<"NewPromiseCapability">(C) -> 37264
+  37264: assert (? %0: Completion) -> 37265
+  37265: if (? %0: Abrupt) then 37266 else 37267
+  37266: return %0
+  37267: %0 = %0.Value -> 37268
+  37268: let promiseCapability = %0 -> 37269
+  37269: call %1 = clo<"Call">(promiseCapability.Reject, undefined, (list [r])[#1569]) -> 37270
+  37270: assert (? %1: Completion) -> 37271
+  37271: if (? %1: Abrupt) then 37272 else 37273
+  37272: return %1
+  37273: %1 = %1.Value -> 37274
+  37274: %2 = promiseCapability.Promise -> 37275
+  37275: if (? %2: Completion) then 37276 else 37277
+  37276: return %2
+  37277: call %3 = clo<"NormalCompletion">(%2) -> 37278
+  37278: return %3
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Reflect.set.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Reflect.set.cfg
@@ -1,0 +1,44 @@
+2941: def <BUILTIN>:INTRINSICS.Reflect.set(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  38374: let __args__ = (record)[#1650] -> 38375
+  38375: if (< 0 (sizeof ArgumentsList)) then 38376 else 38377
+  38376: {
+    pop target < ArgumentsList
+    expand __args__.target
+  } -> 38378
+  38377: let target = undefined -> 38378
+  38378: if (< 0 (sizeof ArgumentsList)) then 38379 else 38380
+  38379: {
+    pop propertyKey < ArgumentsList
+    expand __args__.propertyKey
+  } -> 38381
+  38380: let propertyKey = undefined -> 38381
+  38381: if (< 0 (sizeof ArgumentsList)) then 38382 else 38383
+  38382: {
+    pop V < ArgumentsList
+    expand __args__.V
+  } -> 38384
+  38383: let V = undefined -> 38384
+  38384: if (< 0 (sizeof ArgumentsList)) then 38385 else 38386
+  38385: {
+    pop receiver < ArgumentsList
+    expand __args__.receiver
+  } -> 38387
+  38386: let receiver = undefined -> 38387
+  38387: if (! (? target: Record[Object])) then 38388 else 38391
+  38388: call %0 = clo<"__NEW_ERROR_OBJ__">("%TypeError.prototype%") -> 38389
+  38389: call %1 = clo<"ThrowCompletion">(%0) -> 38390
+  38390: return %1
+  38391: call %2 = clo<"ToPropertyKey">(propertyKey) -> 38392
+  38392: assert (? %2: Completion) -> 38393
+  38393: if (? %2: Abrupt) then 38394 else 38395
+  38394: return %2
+  38395: %2 = %2.Value -> 38396
+  38396: let key = %2 -> 38397
+  38397: if (! (exists __args__.receiver)) then 38398 else 38399
+  38398: receiver = target -> 38399
+  38399: call %3 = target.Set(target, key, V, receiver) -> 38400
+  38400: assert (? %3: Completion) -> 38401
+  38401: if (? %3: Abrupt) then 38402 else 38403
+  38402: return %3
+  38403: return %3
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.Set.prototype.add.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.Set.prototype.add.cfg
@@ -1,0 +1,40 @@
+2659: def <BUILTIN>:INTRINSICS.Set.prototype.add(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  32030: let __args__ = (record)[#1286] -> 32031
+  32031: if (< 0 (sizeof ArgumentsList)) then 32032 else 32033
+  32032: {
+    pop value < ArgumentsList
+    expand __args__.value
+  } -> 32034
+  32033: let value = undefined -> 32034
+  32034: let S = this -> 32035
+  32035: call %0 = clo<"RequireInternalSlot">(S, "SetData") -> 32036
+  32036: assert (? %0: Completion) -> 32037
+  32037: if (? %0: Abrupt) then 32038 else 32039
+  32038: return %0
+  32039: %0 = %0.Value -> 32040
+  32040: call %1 = clo<"CanonicalizeKeyedCollectionKey">(value) -> 32041
+  32041: {
+    value = %1
+    %3 = S.SetData
+    %2 = 0
+  } -> 32042
+  32042: while (< %2 (sizeof %3)) then 32043 else 32053
+  32043: {
+    let e = %3[%2]
+    %4 = (! (= e ~empty~))
+  } -> 32044
+  32044: if %4 then 32045 else 32052
+  32045: call %5 = clo<"SameValue">(e, value) -> 32046
+  32046: %4 = (= %5 true) -> 32047
+  32047: if %4 then 32048 else 32052
+  32048: if (? S: Completion) then 32049 else 32050
+  32049: return S
+  32050: call %6 = clo<"NormalCompletion">(S) -> 32051
+  32051: return %6
+  32052: %2 = (+ %2 1) -> 32042
+  32053: push S.SetData < value -> 32054
+  32054: if (? S: Completion) then 32055 else 32056
+  32055: return S
+  32056: call %7 = clo<"NormalCompletion">(S) -> 32057
+  32057: return %7
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.String.prototype.charAt.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.String.prototype.charAt.cfg
@@ -1,0 +1,38 @@
+2275: def <BUILTIN>:INTRINSICS.String.prototype.charAt(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  22985: let __args__ = (record)[#1008] -> 22986
+  22986: if (< 0 (sizeof ArgumentsList)) then 22987 else 22988
+  22987: {
+    pop pos < ArgumentsList
+    expand __args__.pos
+  } -> 22989
+  22988: let pos = undefined -> 22989
+  22989: call %0 = clo<"RequireObjectCoercible">(this) -> 22990
+  22990: assert (? %0: Completion) -> 22991
+  22991: if (? %0: Abrupt) then 22992 else 22993
+  22992: return %0
+  22993: %0 = %0.Value -> 22994
+  22994: let O = %0 -> 22995
+  22995: call %1 = clo<"ToString">(O) -> 22996
+  22996: assert (? %1: Completion) -> 22997
+  22997: if (? %1: Abrupt) then 22998 else 22999
+  22998: return %1
+  22999: %1 = %1.Value -> 23000
+  23000: let S = %1 -> 23001
+  23001: call %2 = clo<"ToIntegerOrInfinity">(pos) -> 23002
+  23002: assert (? %2: Completion) -> 23003
+  23003: if (? %2: Abrupt) then 23004 else 23005
+  23004: return %2
+  23005: %2 = %2.Value -> 23006
+  23006: {
+    let position = %2
+    let size = (sizeof S)
+  } -> 23007
+  23007: if (|| (< position 0) (! (< position size))) then 23008 else 23010
+  23008: call %3 = clo<"NormalCompletion">("") -> 23009
+  23009: return %3
+  23010: %4 = (substring S position (+ position 1)) -> 23011
+  23011: if (? %4: Completion) then 23012 else 23013
+  23012: return %4
+  23013: call %5 = clo<"NormalCompletion">(%4) -> 23014
+  23014: return %5
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.String.prototype.replace.cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.String.prototype.replace.cfg
@@ -1,0 +1,94 @@
+2294: def <BUILTIN>:INTRINSICS.String.prototype.replace(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  23597: let __args__ = (record)[#1028] -> 23598
+  23598: if (< 0 (sizeof ArgumentsList)) then 23599 else 23600
+  23599: {
+    pop searchValue < ArgumentsList
+    expand __args__.searchValue
+  } -> 23601
+  23600: let searchValue = undefined -> 23601
+  23601: if (< 0 (sizeof ArgumentsList)) then 23602 else 23603
+  23602: {
+    pop replaceValue < ArgumentsList
+    expand __args__.replaceValue
+  } -> 23604
+  23603: let replaceValue = undefined -> 23604
+  23604: call %0 = clo<"RequireObjectCoercible">(this) -> 23605
+  23605: assert (? %0: Completion) -> 23606
+  23606: if (? %0: Abrupt) then 23607 else 23608
+  23607: return %0
+  23608: %0 = %0.Value -> 23609
+  23609: let O = %0 -> 23610
+  23610: if (! (|| (= searchValue undefined) (= searchValue null))) then 23611 else 23623
+  23611: call %1 = clo<"GetMethod">(searchValue, @SYMBOL.replace) -> 23612
+  23612: assert (? %1: Completion) -> 23613
+  23613: if (? %1: Abrupt) then 23614 else 23615
+  23614: return %1
+  23615: %1 = %1.Value -> 23616
+  23616: let replacer = %1 -> 23617
+  23617: if (! (= replacer undefined)) then 23618 else 23623
+  23618: call %2 = clo<"Call">(replacer, searchValue, (list [O, replaceValue])[#1029]) -> 23619
+  23619: assert (? %2: Completion) -> 23620
+  23620: if (? %2: Abrupt) then 23621 else 23622
+  23621: return %2
+  23622: return %2
+  23623: call %3 = clo<"ToString">(O) -> 23624
+  23624: assert (? %3: Completion) -> 23625
+  23625: if (? %3: Abrupt) then 23626 else 23627
+  23626: return %3
+  23627: %3 = %3.Value -> 23628
+  23628: let string = %3 -> 23629
+  23629: call %4 = clo<"ToString">(searchValue) -> 23630
+  23630: assert (? %4: Completion) -> 23631
+  23631: if (? %4: Abrupt) then 23632 else 23633
+  23632: return %4
+  23633: %4 = %4.Value -> 23634
+  23634: let searchString = %4 -> 23635
+  23635: call %5 = clo<"IsCallable">(replaceValue) -> 23636
+  23636: let functionalReplace = %5 -> 23637
+  23637: if (= functionalReplace false) then 23638 else 23644
+  23638: call %6 = clo<"ToString">(replaceValue) -> 23639
+  23639: assert (? %6: Completion) -> 23640
+  23640: if (? %6: Abrupt) then 23641 else 23642
+  23641: return %6
+  23642: %6 = %6.Value -> 23643
+  23643: replaceValue = %6 -> 23644
+  23644: let searchLength = (sizeof searchString) -> 23645
+  23645: call %7 = clo<"StringIndexOf">(string, searchString, 0) -> 23646
+  23646: let position = %7 -> 23647
+  23647: if (= position ~not-found~) then 23648 else 23652
+  23648: if (? string: Completion) then 23649 else 23650
+  23649: return string
+  23650: call %8 = clo<"NormalCompletion">(string) -> 23651
+  23651: return %8
+  23652: {
+    let preceding = (substring string 0 position)
+    let following = (substring string (+ position searchLength))
+  } -> 23653
+  23653: if (= functionalReplace true) then 23654 else 23665
+  23654: call %9 = clo<"Call">(replaceValue, undefined, (list [searchString, ([number] position), string])[#1030]) -> 23655
+  23655: assert (? %9: Completion) -> 23656
+  23656: if (? %9: Abrupt) then 23657 else 23658
+  23657: return %9
+  23658: %9 = %9.Value -> 23659
+  23659: call %10 = clo<"ToString">(%9) -> 23660
+  23660: assert (? %10: Completion) -> 23661
+  23661: if (? %10: Abrupt) then 23662 else 23663
+  23662: return %10
+  23663: %10 = %10.Value -> 23664
+  23664: let replacement = %10 -> 23668
+  23665: {
+    assert (? replaceValue: String)
+    let captures = (list [])[#1031]
+  } -> 23666
+  23666: call %11 = clo<"GetSubstitution">(searchString, string, position, captures, undefined, replaceValue) -> 23667
+  23667: {
+    assert (? %11: Normal)
+    %11 = %11.Value
+    let replacement = %11
+  } -> 23668
+  23668: %12 = (concat preceding replacement following) -> 23669
+  23669: if (? %12: Completion) then 23670 else 23671
+  23670: return %12
+  23671: call %13 = clo<"NormalCompletion">(%12) -> 23672
+  23672: return %13
+}

--- a/planning/ecma-262/spike_evidence/INTRINSICS.String.prototype[%Symbol.iterator%].cfg
+++ b/planning/ecma-262/spike_evidence/INTRINSICS.String.prototype[%Symbol.iterator%].cfg
@@ -1,0 +1,23 @@
+2312: def <BUILTIN>:INTRINSICS.String.prototype[%Symbol.iterator%](this: ESValue, ArgumentsList: List[ESValue], NewTarget: Record[Constructor] | Undefined): Unknown {
+  24238: let __args__ = (record)[#1056] -> 24239
+  24239: call %0 = clo<"RequireObjectCoercible">(this) -> 24240
+  24240: assert (? %0: Completion) -> 24241
+  24241: if (? %0: Abrupt) then 24242 else 24243
+  24242: return %0
+  24243: %0 = %0.Value -> 24244
+  24244: let O = %0 -> 24245
+  24245: call %1 = clo<"ToString">(O) -> 24246
+  24246: assert (? %1: Completion) -> 24247
+  24247: if (? %1: Abrupt) then 24248 else 24249
+  24248: return %1
+  24249: %1 = %1.Value -> 24250
+  24250: {
+    let s = %1
+    let closure = clo<"INTRINSICS.String.prototype[%Symbol.iterator%]:clo0", [s]>
+  } -> 24251
+  24251: call %2 = clo<"CreateIteratorFromClosure">(closure, "%StringIteratorPrototype%", @EXECUTION_STACK[0].Realm.Intrinsics["%StringIteratorPrototype%"]) -> 24252
+  24252: if (? %2: Completion) then 24253 else 24254
+  24253: return %2
+  24254: call %3 = clo<"NormalCompletion">(%2) -> 24255
+  24255: return %3
+}

--- a/planning/ecma-262/spike_evidence/README.md
+++ b/planning/ecma-262/spike_evidence/README.md
@@ -1,0 +1,31 @@
+# §1 spike evidence: representative-method CFG dumps
+
+These are the ESMeta control-flow-graph dumps the §1 findings are read from,
+one text file per representative method. They let a reviewer check
+[../spike_findings.md](../spike_findings.md) line by line without building
+ESMeta.
+
+Each file is the `logs/cfg/func/<name>.cfg` output of
+`esmeta build-cfg -build-cfg:log`, copied verbatim. Regenerate them with
+[../reproduce_spike.sh](../reproduce_spike.sh), which pins ESMeta
+`7d237fd1` (v0.7.3) and the ECMA-262 `es2025` revision `84b38ad`. On a spec
+bump, diff the fresh dumps against these to confirm the findings still hold.
+
+| File | Shape it demonstrates |
+| ---- | --------------------- |
+| `INTRINSICS.Array.prototype.push.cfg` | direct receiver mutation + escape operand |
+| `INTRINSICS.Array.prototype.fill.cfg` | receiver mutation returning receiver |
+| `INTRINSICS.Array.prototype.sort.cfg` | receiver mutation returning receiver, via helper |
+| `INTRINSICS.Array.prototype.slice.cfg` | fresh allocation, no receiver mutation |
+| `INTRINSICS.Array.prototype.map.cfg` | fresh allocation + callback |
+| `INTRINSICS.Array.prototype.forEach.cfg` | callback propagation (`Call` on a param) |
+| `INTRINSICS.Map.prototype.set.cfg` | internal-slot mutation + escape into `[[MapData]]` |
+| `INTRINSICS.Set.prototype.add.cfg` | internal-slot mutation + escape into `[[SetData]]` |
+| `INTRINSICS.Reflect.set.cfg` | namespace function, param mutation + escape |
+| `INTRINSICS.String.prototype.charAt.cfg` | immutable primitive, read-only receiver |
+| `INTRINSICS.String.prototype.replace.cfg` | immutable primitive + callback |
+| `INTRINSICS.String.prototype[%Symbol.iterator%].cfg` | symbol-keyed method name |
+| `INTRINSICS.Number.prototype.toFixed.cfg` | domain `RangeError` throw + partial `yet` |
+| `INTRINSICS.Promise.reject.cfg` | async reject via capability `[[Reject]]`, param origin |
+| `INTRINSICS.Promise.all.cfg` | async reject, `IfAbruptRejectPromise`, combinator |
+| `Set.cfg` | the `Set` abstract operation dispatching through dynamic `[[Set]]` |

--- a/planning/ecma-262/spike_evidence/README.md
+++ b/planning/ecma-262/spike_evidence/README.md
@@ -21,6 +21,8 @@ bump, diff the fresh dumps against these to confirm the findings still hold.
 | `INTRINSICS.Array.prototype.forEach.cfg` | callback propagation (`Call` on a param) |
 | `INTRINSICS.Map.prototype.set.cfg` | internal-slot mutation + escape into `[[MapData]]` |
 | `INTRINSICS.Set.prototype.add.cfg` | internal-slot mutation + escape into `[[SetData]]` |
+| `INTRINSICS.Object.freeze.cfg` | transitive mutation: delegates its whole write to `SetIntegrityLevel` |
+| `SetIntegrityLevel.cfg` | the helper `Object.freeze` calls; writes the argument via seeded `DefinePropertyOrThrow` |
 | `INTRINSICS.Reflect.set.cfg` | namespace function, param mutation + escape |
 | `INTRINSICS.String.prototype.charAt.cfg` | immutable primitive, read-only receiver |
 | `INTRINSICS.String.prototype.replace.cfg` | immutable primitive + callback |

--- a/planning/ecma-262/spike_evidence/Set.cfg
+++ b/planning/ecma-262/spike_evidence/Set.cfg
@@ -1,0 +1,14 @@
+156: def Set(O: Record[Object], P: Record[Symbol] | String, V: ESValue, Throw: Boolean): Normal[Enum[~unused~]] | Throw {
+  1802: call %0 = O.Set(O, P, V, O) -> 1803
+  1803: assert (? %0: Completion) -> 1804
+  1804: if (? %0: Abrupt) then 1805 else 1806
+  1805: return %0
+  1806: %0 = %0.Value -> 1807
+  1807: let success = %0 -> 1808
+  1808: if (&& (= success false) (= Throw true)) then 1809 else 1812
+  1809: call %1 = clo<"__NEW_ERROR_OBJ__">("%TypeError.prototype%") -> 1810
+  1810: call %2 = clo<"ThrowCompletion">(%1) -> 1811
+  1811: return %2
+  1812: call %3 = clo<"NormalCompletion">(~unused~) -> 1813
+  1813: return %3
+}

--- a/planning/ecma-262/spike_evidence/SetIntegrityLevel.cfg
+++ b/planning/ecma-262/spike_evidence/SetIntegrityLevel.cfg
@@ -1,0 +1,63 @@
+167: def SetIntegrityLevel(O: Record[Object], level: Enum[~frozen~, ~sealed~]): Normal[Boolean] | Throw {
+  1914: call %0 = O.PreventExtensions(O) -> 1915
+  1915: assert (? %0: Completion) -> 1916
+  1916: if (? %0: Abrupt) then 1917 else 1918
+  1917: return %0
+  1918: %0 = %0.Value -> 1919
+  1919: let status = %0 -> 1920
+  1920: if (= status false) then 1921 else 1923
+  1921: call %1 = clo<"NormalCompletion">(false) -> 1922
+  1922: return %1
+  1923: call %2 = O.OwnPropertyKeys(O) -> 1924
+  1924: assert (? %2: Completion) -> 1925
+  1925: if (? %2: Abrupt) then 1926 else 1927
+  1926: return %2
+  1927: %2 = %2.Value -> 1928
+  1928: let keys = %2 -> 1929
+  1929: if (= level ~sealed~) then 1930 else 1939
+  1930: {
+    %4 = keys
+    %3 = 0
+  } -> 1931
+  1931: while (< %3 (sizeof %4)) then 1932 else 1959
+  1932: let k = %4[%3] -> 1933
+  1933: call %5 = clo<"DefinePropertyOrThrow">(O, k, (record [PropertyDescriptor] {
+    "Configurable" : false,
+  })[#35]) -> 1934
+  1934: assert (? %5: Completion) -> 1935
+  1935: if (? %5: Abrupt) then 1936 else 1937
+  1936: return %5
+  1937: %5 = %5.Value -> 1938
+  1938: %3 = (+ %3 1) -> 1931
+  1939: {
+    assert (= level ~frozen~)
+    %7 = keys
+    %6 = 0
+  } -> 1940
+  1940: while (< %6 (sizeof %7)) then 1941 else 1959
+  1941: let k = %7[%6] -> 1942
+  1942: call %8 = O.GetOwnProperty(O, k) -> 1943
+  1943: assert (? %8: Completion) -> 1944
+  1944: if (? %8: Abrupt) then 1945 else 1946
+  1945: return %8
+  1946: %8 = %8.Value -> 1947
+  1947: let currentDesc = %8 -> 1948
+  1948: if (! (= currentDesc undefined)) then 1949 else 1958
+  1949: call %9 = clo<"IsAccessorDescriptor">(currentDesc) -> 1950
+  1950: if (= %9 true) then 1951 else 1952
+  1951: let desc = (record [PropertyDescriptor] {
+    "Configurable" : false,
+  })[#36] -> 1953
+  1952: let desc = (record [PropertyDescriptor] {
+    "Configurable" : false,
+    "Writable" : false,
+  })[#37] -> 1953
+  1953: call %10 = clo<"DefinePropertyOrThrow">(O, k, desc) -> 1954
+  1954: assert (? %10: Completion) -> 1955
+  1955: if (? %10: Abrupt) then 1956 else 1957
+  1956: return %10
+  1957: %10 = %10.Value -> 1958
+  1958: %6 = (+ %6 1) -> 1940
+  1959: call %11 = clo<"NormalCompletion">(true) -> 1960
+  1960: return %11
+}

--- a/planning/ecma-262/spike_findings.md
+++ b/planning/ecma-262/spike_findings.md
@@ -77,7 +77,8 @@ that stores a parameter into the receiver, the signal §8.1 needs.
 | ------ | ----- | ---------------- |
 | `Array.prototype.push` | direct receiver mutation + escape | `Set(O, %6, E, true)` where `O = ToObject(this)`, `E` from `ArgumentsList`; receiver mutation and escape operand `E` (arg 2) both exposed; `RangeError` domain throw explicit; returns `fresh` |
 | `Array.prototype.fill` | receiver mutation returning receiver | `Set(O, Pk, value, true)`; returns `O` (receiver) |
-| `Array.prototype.sort` | receiver mutation returning receiver | writes back via `Set(obj, %7, sortedList[j], true)`; returns `obj`; comparator reached through `SortIndexedProperties` helper |
+| `Array.prototype.sort` | receiver mutation returning receiver | writes back **directly** via `Set(obj, %7, sortedList[j], true)`; returns `obj`; `SortIndexedProperties` only reads `obj` via `Get` and returns a fresh sorted list, so it supplies the ordering, not the write — this is not the helper-mediated case |
+| `Object.freeze` (and `Object.seal`) | transitive mutation through a helper AO | no write in its own body; mutates only by `SetIntegrityLevel(O, ~frozen~)` on param 0; the mutation is discovered by the FR2 fixpoint, not read off `freeze` directly; `receiver: none`, param 0 `mutBorrow`, returns `param:0` |
 | `Array.prototype.slice` | fresh allocation, no receiver mutation | `ArraySpeciesCreate(O, count) → A`; writes target `A` via `CreateDataPropertyOrThrow(A, …)`; receiver only read via `Get`/`HasProperty`; returns `A` (fresh) |
 | `Array.prototype.map` | fresh allocation + callback | `ArraySpeciesCreate(O, len) → A`; `Call(callback, …)`; `CreateDataPropertyOrThrow(A, Pk, mappedValue)`; returns `A` (fresh) |
 | `Map.prototype.set` | internal-slot mutation + escape | `push M.MapData < p` with `p = record{Key: key, Value: value}`; also `p.Value = value`; both params escape into `[[MapData]]`; returns `M` (receiver) |
@@ -111,6 +112,49 @@ through the chain. In `push`, `let O = %0` follows `%0 = %0.Value` following
 `call %0 = clo<"ToObject">(this)`, so `O` is receiver-origin; `let E = %5[%4]`
 with `%5 = items = ArgumentsList` is parameter-origin. Fresh origins are the
 allocation expressions: `slice` and `map` bind `let A = <ArraySpeciesCreate…>`.
+
+### Transitive mutation through a helper abstract operation
+
+The FR2 mutation summary is an inter-procedural fixpoint, so the gate needs
+the CFG to carry two things beyond a single method's own writes: every helper
+abstract operation as a first-class function with its body, and each call
+node's argument operands, so an origin at a caller's argument can be matched
+to the helper's mutated parameter. Both hold. Every abstract operation the
+representative methods call is dumped as its own `.cfg` function — `Set`,
+`CreateDataPropertyOrThrow`, `DefinePropertyOrThrow`, `SetIntegrityLevel`,
+`SortIndexedProperties`, `PerformPromiseAll`, and the rest — so the call graph
+is complete and `MutArgs` can propagate along it.
+
+`Object.freeze` is the representative that exercises the propagation rather
+than a direct write. Its body performs no write of its own; its only effect on
+the argument is one call:
+
+```
+INTRINSICS.Object.freeze:
+  pop O < ArgumentsList                        // O is param 0
+  call %1 = clo<"SetIntegrityLevel">(O, ~frozen~)
+  … return O                                   // returns param 0
+
+SetIntegrityLevel(O, level):
+  … call %5  = clo<"DefinePropertyOrThrow">(O, k, «Configurable: false»)   // sealed branch
+  … call %10 = clo<"DefinePropertyOrThrow">(O, k, desc)                    // frozen branch
+```
+
+`DefinePropertyOrThrow` is an FR1 seed mutator of argument 0. The fixpoint
+then resolves two hops with no direct write at either caller:
+
+- `MutArgs[DefinePropertyOrThrow] = {0}` — the seed.
+- `SetIntegrityLevel` passes its own parameter `O` as argument 0 of
+  `DefinePropertyOrThrow`, so `MutArgs[SetIntegrityLevel] = {0}`.
+- `Object.freeze` passes its own parameter `O` as argument 0 of
+  `SetIntegrityLevel`, so `MutArgs[Object.freeze] = {0}`.
+
+`Object.freeze` is a static, so it has `receiver: none`; the mutated argument
+0 is `mutBorrow`, and the return is `param:0`. `Object.seal` has the identical
+shape with `~sealed~`. This is the helper-mediated case sort does not cover:
+`Array.prototype.sort` performs its receiver write-back directly with
+`Set(obj, …)` in its own body, and `SortIndexedProperties` only reads the
+receiver, so sort exercises a direct write, not the fixpoint.
 
 ### Internal-slot writes
 

--- a/planning/ecma-262/spike_findings.md
+++ b/planning/ecma-262/spike_findings.md
@@ -31,8 +31,37 @@ Reproduced with the following, which §2 will pin exactly:
 `sbt assembly` produced `bin/esmeta` in ~2 minutes on 4 cores.
 `esmeta build-cfg -build-cfg:log` ran the full pipeline and dumped one
 `.cfg` text file per function to `logs/cfg/func/`. The run produced 2951
-functions total, of which 517 are builtin methods and statics named
-`INTRINSICS.<path>`.
+functions, covering the whole mechanized spec rather than the builtin library
+alone:
+
+| Category | Count | Example |
+| -------- | ----- | ------- |
+| Syntax-directed operations | 1746 | `AdditiveExpression[1,0].Evaluation` |
+| Abstract operations | 548 | `ToString`, `Call`, `SetIntegrityLevel` |
+| Builtin methods and statics | 501 | `INTRINSICS.Array.prototype.push` |
+| Internal methods | 107 | `Record[OrdinaryObject].Set` |
+| Abstract closures | 49 | `INTRINSICS.Promise.prototype.finally:clo0` |
+
+The categories partition the 2951. Closures are counted on their own row rather
+than under the algorithm that encloses them, so counting by the `INTRINSICS.`
+name prefix alone gives 517 — the 501 above plus the 16 closures defined inside
+a builtin algorithm. 517 is the builtin-surface figure used elsewhere in this
+document.
+
+The builtins are the target surface, but two other categories carry weight.
+The abstract operations are what the §4.1 fixpoint walks to resolve transitive
+mutation — `Object.freeze` reaches its write through `SetIntegrityLevel`, an
+abstract operation, not a builtin — so §3 must serialize the operations
+reachable from the builtin surface, not the 517 alone. The internal methods are
+the dispatch targets §4.1 deliberately does not enter: `[[Set]]` alone has five
+implementations, `Record[OrdinaryObject].Set`,
+`Record[ProxyExoticObject].Set`, `Record[TypedArray].Set`,
+`Record[ArgumentsExoticObject].Set`, and
+`Record[ModuleNamespaceExoticObject].Set`. Nothing in the CFG says which one a
+given `O.Set(…)` call selects, which is why the FR1 seed stops the fixpoint
+above them. The 1751 syntax-directed operations are the runtime semantics of
+the language itself, one function per grammar production and operation; they
+are out of scope for annotating a library surface, so §3 can skip them.
 
 [reproduce_spike.sh](reproduce_spike.sh) automates these steps end to end.
 The representative-method dumps this document reads from are committed under

--- a/planning/ecma-262/spike_findings.md
+++ b/planning/ecma-262/spike_findings.md
@@ -49,10 +49,14 @@ a builtin algorithm. 517 is the builtin-surface figure used elsewhere in this
 document.
 
 The builtins are the target surface, but two other categories carry weight.
-The abstract operations are what the §4.1 fixpoint walks to resolve transitive
-mutation — `Object.freeze` reaches its write through `SetIntegrityLevel`, an
-abstract operation, not a builtin — so §3 must serialize the operations
-reachable from the builtin surface, not the 517 alone. The internal methods are
+
+An abstract operation is a named subroutine ECMA-262 defines to factor out
+behavior shared across algorithms, such as `ToString` or `SetIntegrityLevel`.
+It is internal to the specification and not reachable from JavaScript. These
+are what the §4.1 fixpoint walks to resolve transitive mutation —
+`Object.freeze` reaches its write through `SetIntegrityLevel`, an abstract
+operation, not a builtin — so §3 must serialize the operations reachable from
+the builtin surface, not the 517 alone. The internal methods are
 the dispatch targets §4.1 deliberately does not enter: `[[Set]]` alone has five
 implementations, `Record[OrdinaryObject].Set`,
 `Record[ProxyExoticObject].Set`, `Record[TypedArray].Set`,
@@ -107,7 +111,7 @@ that stores a parameter into the receiver, the signal §8.1 needs.
 | `Array.prototype.push` | direct receiver mutation + escape | `Set(O, %6, E, true)` where `O = ToObject(this)`, `E` from `ArgumentsList`; receiver mutation and escape operand `E` (arg 2) both exposed; `RangeError` domain throw explicit; returns `fresh` |
 | `Array.prototype.fill` | receiver mutation returning receiver | `Set(O, Pk, value, true)`; returns `O` (receiver) |
 | `Array.prototype.sort` | receiver mutation returning receiver | writes back **directly** via `Set(obj, %7, sortedList[j], true)`; returns `obj`; `SortIndexedProperties` only reads `obj` via `Get` and returns a fresh sorted list, so it supplies the ordering, not the write — this is not the helper-mediated case |
-| `Object.freeze` (and `Object.seal`) | transitive mutation through a helper AO | no write in its own body; mutates only by `SetIntegrityLevel(O, ~frozen~)` on param 0; the mutation is discovered by the FR2 fixpoint, not read off `freeze` directly; `receiver: none`, param 0 `mutBorrow`, returns `param:0` |
+| `Object.freeze` (and `Object.seal`) | transitive mutation through a helper abstract operation | no write in its own body; mutates only by `SetIntegrityLevel(O, ~frozen~)` on param 0; the mutation is discovered by the FR2 fixpoint, not read off `freeze` directly; `receiver: none`, param 0 `mutBorrow`, returns `param:0` |
 | `Array.prototype.slice` | fresh allocation, no receiver mutation | `ArraySpeciesCreate(O, count) → A`; writes target `A` via `CreateDataPropertyOrThrow(A, …)`; receiver only read via `Get`/`HasProperty`; returns `A` (fresh) |
 | `Array.prototype.map` | fresh allocation + callback | `ArraySpeciesCreate(O, len) → A`; `Call(callback, …)`; `CreateDataPropertyOrThrow(A, Pk, mappedValue)`; returns `A` (fresh) |
 | `Map.prototype.set` | internal-slot mutation + escape | `push M.MapData < p` with `p = record{Key: key, Value: value}`; also `p.Value = value`; both params escape into `[[MapData]]`; returns `M` (receiver) |
@@ -146,7 +150,7 @@ The stored-value operand is the signal §8.1 needs to decide `escape`: a
 parameter appearing in that position outlives the call inside the written
 object.
 
-*Seen in:* `Array.prototype.push` stores its element through the AO form;
+*Seen in:* `Array.prototype.push` stores its element through the abstract-operation form;
 `Map.prototype.set` builds an entry record and appends it to the slot;
 `Reflect.set` writes through the dynamic form.
 
@@ -281,7 +285,7 @@ Both are `Call` nodes; the callee expression tells them apart:
 | Resolvable abstract operation | `call %r = clo<"AOName">(…)` | the callee's own throw set, by name |
 | Callback parameter | `call %r = clo<"Call">(cb, thisArg, «…»)` where `cb` is a popped formal | `throwsOf:param:k` |
 
-In the callback case the AO being invoked is `Call` itself, which *is*
+In the callback case the abstract operation being invoked is `Call` itself, which *is*
 statically known — the callback is its **first argument**. So §9.1 identifies
 the case by the origin of that argument, not by the callee name. The call is
 `?`-guarded, so the propagation edge is present.

--- a/planning/ecma-262/spike_findings.md
+++ b/planning/ecma-262/spike_findings.md
@@ -167,7 +167,7 @@ serializer keys `BackingStoreSlots` by the bare name.
 ### Completion guards `?` / `!` / plain
 
 The guards are **lowered into control flow, not kept as a flag on the call**.
-This is the first fact that shapes §3. The compiled forms are stereotyped and
+This is the first fact that shapes §3. The compiled forms are fixed and
 deterministic, so the serializer reconstructs the guard from the shape that
 follows a `Call`:
 
@@ -229,7 +229,7 @@ return-alias classifier reads `receiver` (`return O` / `NormalCompletion(O)`),
 1. **Guards are lowered, not flagged (§3).** The `?`/`!`/plain distinction
    lives in the post-call branch shape, not a call attribute. §3's Appendix A
    `Node.Call` still records one guard field, but the serializer must compute
-   it by matching the stereotyped abrupt-check / assert-normal patterns above.
+   it by matching the fixed abrupt-check / assert-normal patterns above.
    This is a lowering rule in the serializer, not a scope cut.
 
 2. **Property writes dispatch through dynamic `[[Set]]` (§4.1 seed).** The

--- a/planning/ecma-262/spike_findings.md
+++ b/planning/ecma-262/spike_findings.md
@@ -34,6 +34,11 @@ Reproduced with the following, which §2 will pin exactly:
 functions total, of which 517 are builtin methods and statics named
 `INTRINSICS.<path>`.
 
+[reproduce_spike.sh](reproduce_spike.sh) automates these steps end to end.
+The representative-method dumps this document reads from are committed under
+[spike_evidence/](spike_evidence/), so the per-method claims below are
+checkable without building ESMeta.
+
 ## What the CFG carries
 
 `build-cfg` lowers each algorithm to `esmeta.cfg.CFG`, a graph of three node

--- a/planning/ecma-262/spike_findings.md
+++ b/planning/ecma-262/spike_findings.md
@@ -1,0 +1,238 @@
+# §1 Feasibility spike: findings
+
+Records the outcome of [implementation_plan.md](implementation_plan.md) §1.
+The spike built ESMeta from source, ran `extract → compile → build-cfg`
+against a pinned ECMA-262 revision, and inspected the control-flow graph for
+the representative method set the analysis must handle.
+
+**Verdict: the happy path holds.** The CFG exposes every signal §4/§8/§9
+read: abstract-operation call nodes with their argument operands including
+the stored value of a write, `Let` bindings with traceable origins,
+internal-slot writes, the `?`/`!`/plain completion guards, explicit `Throw`
+steps with their error class, promise-rejection sites distinct from
+synchronous throws, callback-parameter calls distinct from resolvable
+abstract operations, and return values. No signal is missing wholesale, so
+the pure-Go `spec.html` shallow-parser fallback (§3 alternatives) is not
+needed. Two structural facts change how §3 lowers the CFG and are detailed
+below; neither narrows §8/§9 scope.
+
+## Toolchain and pinned revisions
+
+Reproduced with the following, which §2 will pin exactly:
+
+| Component      | Revision |
+| -------------- | -------- |
+| ESMeta         | `7d237fd1680f473e674320cc97932702d950fa98` (v0.7.3) |
+| ECMA-262 spec  | `84b38ad852ff426795fa29cebc06949027336c64` (tag `es2025`, ESMeta's `ecma262` submodule) |
+| Scala          | 3.3.6 |
+| sbt            | 1.10.11 |
+| JDK            | Temurin 21 (ESMeta requires 17+) |
+
+`sbt assembly` produced `bin/esmeta` in ~2 minutes on 4 cores.
+`esmeta build-cfg -build-cfg:log` ran the full pipeline and dumped one
+`.cfg` text file per function to `logs/cfg/func/`. The run produced 2951
+functions total, of which 517 are builtin methods and statics named
+`INTRINSICS.<path>`.
+
+## What the CFG carries
+
+`build-cfg` lowers each algorithm to `esmeta.cfg.CFG`, a graph of three node
+kinds — `Block` (a list of straight-line IR instructions), `Call`, and
+`Branch` — over the IR instruction set in
+`src/main/scala/esmeta/ir/Inst.scala`. This is the compiled IR, so the
+spec's `?`/`!` completion sugar is already lowered into explicit control
+flow. The IR instruction and expression vocabulary the analysis reads:
+
+- `ILet(name, expr)` — a `Let` binding, rendered `let x = <expr>`.
+- `IAssign(ref, expr)` — a write to a reference. A property or internal-slot
+  write is `IAssign(Field(base, slot), value)`, rendered `base.slot = value`.
+- `IPush(elem, list, front)` — a list append, rendered `push list < elem`.
+  This is how "Append … to a `[[List]]` slot" is spelled.
+- `ICall(lhs, callee, args)` — an abstract-operation call, rendered
+  `call %r = clo<"AOName">(args)`. A dynamic internal-method dispatch is
+  `base.Method(args)`, e.g. `target.Set(target, key, V, receiver)`.
+- `IReturn(expr)` — a return, rendered `return <expr>`.
+- `IAssert(expr)`, `IIf(cond, then, else)`, `IWhile(cond, body)`.
+- Allocation expressions `ERecord` / `EList` / `EMap` / `ECopy`, each
+  carrying an allocation-site id — these are the `fresh` origins.
+
+The receiver arrives as the explicit first parameter `this`, and arguments
+arrive in a `List` parameter `ArgumentsList` from which each named formal is
+`pop`ped in order. Origins are therefore recoverable: `this` and its
+coercions are receiver-origin, a popped formal is parameter-origin at its pop
+index, and an allocation expression is fresh.
+
+## Gate results per representative method
+
+Each method was read from its `logs/cfg/func/INTRINSICS.<name>.cfg` dump.
+"Escape operand" means the CFG exposes the stored-value argument of the write
+that stores a parameter into the receiver, the signal §8.1 needs.
+
+| Method | Shape | Confirmed in CFG |
+| ------ | ----- | ---------------- |
+| `Array.prototype.push` | direct receiver mutation + escape | `Set(O, %6, E, true)` where `O = ToObject(this)`, `E` from `ArgumentsList`; receiver mutation and escape operand `E` (arg 2) both exposed; `RangeError` domain throw explicit; returns `fresh` |
+| `Array.prototype.fill` | receiver mutation returning receiver | `Set(O, Pk, value, true)`; returns `O` (receiver) |
+| `Array.prototype.sort` | receiver mutation returning receiver | writes back via `Set(obj, %7, sortedList[j], true)`; returns `obj`; comparator reached through `SortIndexedProperties` helper |
+| `Array.prototype.slice` | fresh allocation, no receiver mutation | `ArraySpeciesCreate(O, count) → A`; writes target `A` via `CreateDataPropertyOrThrow(A, …)`; receiver only read via `Get`/`HasProperty`; returns `A` (fresh) |
+| `Array.prototype.map` | fresh allocation + callback | `ArraySpeciesCreate(O, len) → A`; `Call(callback, …)`; `CreateDataPropertyOrThrow(A, Pk, mappedValue)`; returns `A` (fresh) |
+| `Map.prototype.set` | internal-slot mutation + escape | `push M.MapData < p` with `p = record{Key: key, Value: value}`; also `p.Value = value`; both params escape into `[[MapData]]`; returns `M` (receiver) |
+| `Set.prototype.add` | internal-slot mutation + escape | `push S.SetData < value`; `value` escapes into `[[SetData]]`; returns `S` (receiver) |
+| `Reflect.set` | namespace fn, param mutation + escape | write dispatched through `target.Set(target, key, V, receiver)`; `target` mutated (arg 0), stored value `V` (arg 2) exposed; `TypeError` on non-object `target` explicit; `receiver: none` |
+| `String.prototype.charAt` | immutable primitive | `RequireObjectCoercible(this)` + `ToString`; zero mutation ops; returns `fresh` strings |
+| `String.prototype.replace` | immutable primitive + callback | zero mutation ops on receiver; `Call(replacer, …)` when replacer is a function; returns `fresh` |
+| `String.prototype[%Symbol.iterator%]` | symbol-keyed | own algorithm present under the `[%Symbol.iterator%]` name |
+| `Array.prototype.forEach` | callback propagation | `Call(callback, thisArg, «kValue, k, O»)` where `callback` is popped param 0; `?`-guarded; `IsCallable` `TypeError` explicit; returns `undefined` |
+| `Number.prototype.toFixed` | domain throw + partial `yet` | two `RangeError` domain guards fully visible; `yet` steps confined to the trailing decimal-string arithmetic |
+| `Promise.reject` | async reject, param origin | rejects via `Call(promiseCapability.Reject, undefined, «r»)`, `r` = param 0 |
+| `Promise.all` | async reject, combinator | `IfAbruptRejectPromise` lowered to a capability `[[Reject]]` call; element-`E` forwarding runs inside `PerformPromiseAll` |
+
+## How each required signal is exposed
+
+### Abstract-operation calls, arguments, and the stored-value operand
+
+A `Call` node carries the callee name and every argument expression, so a
+write's stored value is a plain argument operand. `Array.prototype.push`
+stores its element with `call %7 = clo<"Set">(O, %6, E, true)`: `E` traces
+to `ArgumentsList`, `O` traces to `ToObject(this)`, and `E` sits at argument
+index 2. `Map.prototype.set` stores both key and value by building
+`record{Key: key, Value: value}` and appending it, `push M.MapData < p`.
+`Reflect.set` stores `V` through `target.Set(target, key, V, receiver)`. The
+escape analysis reads the stored operand directly in every case.
+
+### Let bindings and origins
+
+`ILet` gives the bound name and its source expression, and origins propagate
+through the chain. In `push`, `let O = %0` follows `%0 = %0.Value` following
+`call %0 = clo<"ToObject">(this)`, so `O` is receiver-origin; `let E = %5[%4]`
+with `%5 = items = ArgumentsList` is parameter-origin. Fresh origins are the
+allocation expressions: `slice` and `map` bind `let A = <ArraySpeciesCreate…>`.
+
+### Internal-slot writes
+
+Two spellings appear. A list-backed slot append is `push M.MapData < p`
+(`IPush`). A direct slot store is `p.Value = value` (`IAssign(Field(…))`).
+Both name the object expression and the slot. **The slot name is rendered
+without its `[[ ]]` brackets** — `MapData`, not `[[MapData]]` — so the §3
+serializer keys `BackingStoreSlots` by the bare name.
+
+### Completion guards `?` / `!` / plain
+
+The guards are **lowered into control flow, not kept as a flag on the call**.
+This is the first fact that shapes §3. The compiled forms are stereotyped and
+deterministic, so the serializer reconstructs the guard from the shape that
+follows a `Call`:
+
+- `?` (`ReturnIfAbrupt`): `assert (? x: Completion)` then
+  `if (? x: Abrupt) then return x else x = x.Value`. An abrupt-check branch
+  whose then-edge returns the callee result unwrapped on the else-edge.
+- `!` (assert-normal): `assert (? x: Normal)` then `x = x.Value`. No
+  abrupt-return branch — the normal assertion and unwrap, nothing else.
+- plain: the result is used directly with no completion assertion.
+
+`(? e: T)` here is the IR's type-check expression `ETypeCheck`, distinct from
+the spec's `?` sugar; `(? x: Abrupt)` reads "is `x` an abrupt completion." §3
+must recognize the `?`/`!` patterns structurally rather than reading a guard
+attribute, because the compiler discards the surface annotation. The `?`/`!`
+distinction that FR10 depends on survives intact.
+
+### Explicit `Throw` steps
+
+`Throw a *T* exception` lowers to two calls and a return:
+`call %e = clo<"__NEW_ERROR_OBJ__">("%T.prototype%")` then
+`call %c = clo<"ThrowCompletion">(%e)` then `return %c`. **The error class is
+the string literal argument to `__NEW_ERROR_OBJ__`** — `"%TypeError.prototype%"`,
+`"%RangeError.prototype%"` — so the throw-set fixpoint reads the class name off
+that operand. `toFixed`'s two `RangeError` guards and `push`'s `TypeError`
+guard both appear in this form, each gated by an explicit `if` domain check
+that distinguishes them from the coercion `TypeError`s the FR11 filter drops.
+
+### Promise rejection versus synchronous throw
+
+The two channels are distinguishable. A synchronous throw is the
+`ThrowCompletion` form above. An asynchronous rejection is a call to the
+capability's reject slot, `Call(promiseCapability.Reject, undefined, «value»)`.
+`Promise.reject` rejects with `r` at param index 0, giving the `param:0`
+origin FR13 records. `IfAbruptRejectPromise` lowers to an abrupt-check branch
+whose then-edge calls `promiseCapability.Reject` and returns
+`promiseCapability.Promise`, again the capability-reject shape, never a
+`ThrowCompletion`. §9.3 tells them apart by the callee: `ThrowCompletion` is a
+sync throw, a `.Reject` capability call is a rejection.
+
+### Callback propagation versus a resolvable abstract operation
+
+A resolvable call names a fixed abstract operation, `clo<"AOName">(…)`. A
+callback call is the `Call` abstract operation applied to a parameter-origin
+callee: `forEach` emits `clo<"Call">(callback, thisArg, «…»)` with `callback`
+the popped param 0. §9.1 recognizes the callback case as a `Call`/`Construct`
+whose callee argument is parameter-origin, yielding `throwsOf:param:k`; every
+other guarded call resolves to a named abstract operation with its own throw
+set. The call is `?`-guarded, so the propagation edge is present.
+
+### Return values
+
+`IReturn` carries the returned expression. Normal returns are wrapped
+`NormalCompletion(v)` and abrupt returns forward the completion, so the
+return-alias classifier reads `receiver` (`return O` / `NormalCompletion(O)`),
+`fresh` (`NormalCompletion(A)` off an allocator), or `param` off the operand.
+
+## Facts that shape §3 / §8 / §9
+
+1. **Guards are lowered, not flagged (§3).** The `?`/`!`/plain distinction
+   lives in the post-call branch shape, not a call attribute. §3's Appendix A
+   `Node.Call` still records one guard field, but the serializer must compute
+   it by matching the stereotyped abrupt-check / assert-normal patterns above.
+   This is a lowering rule in the serializer, not a scope cut.
+
+2. **Property writes dispatch through dynamic `[[Set]]` (§4.1 seed).** The
+   `Set` abstract operation's body is `O.Set(O, P, V, O)`, a dynamic dispatch
+   to the object's `[[Set]]` internal method, unresolvable by callee name. The
+   FR1 seed that treats `Set`, `CreateDataProperty`, `DefinePropertyOrThrow`,
+   and the rest as direct mutators of argument 0 is therefore required, not an
+   optimization — the fixpoint cannot recover these writes by descending
+   through the method-table dispatch. `Reflect.set` reaches the same dispatch
+   as `target.Set(…)`, so its `target` mutation is caught by the same seed.
+
+3. **Internal-slot writes drop the bracket syntax (§3).** Slots render as
+   `MapData` / `SetData`, not `[[MapData]]`. The serializer and the
+   `BackingStoreSlots` list key on the bare name.
+
+4. **Promise combinators need hand-modeling, as planned (§9.3).**
+   `Promise.all` forwards its element promises' reject type through
+   `PerformPromiseAll` and the resolve/reject closures, not a traceable value
+   operand, so origin tagging alone cannot see the element `E`. This confirms
+   the plan's expectation that `Promise.all` / `race` / `any` / `allSettled`
+   are hand-modeled rules rather than derived facts. The synchronous reject
+   sites inside the combinator — the `IfAbruptRejectPromise` guards — are
+   visible and attributable; only the element-`E` union is hand-modeled.
+
+5. **`yet` is per-step, not per-method (§4/§9 fallback granularity).** 71 of
+   517 builtins carry at least one `yet` marker for an un-formalized step, but
+   the marker is local to that step. `Number.prototype.toFixed` is `yet` only
+   in its trailing decimal-string arithmetic, while its `RangeError` throw
+   guards and its read-only receiver are fully analyzable. The affected set is
+   concentrated in `Math.*`, `Atomics.*`, the `TypedArray` constructors,
+   `Date.*` formatting, `JSON.stringify`, and the numeric `toFixed` /
+   `toExponential` / `toPrecision` / `toLocaleString` family. The FR5
+   conservative fallback should be applied **per signal** — mark a
+   determination unclassified only when a `yet` sits on a step that
+   determination reads — rather than dropping a whole method because it
+   carries a `yet` anywhere.
+
+6. **Symbol-keyed names are exposed; some are spec aliases (§5).** A
+   symbol-keyed method with its own algorithm appears under the
+   `X.prototype[%Symbol.name%]` name, e.g.
+   `String.prototype[%Symbol.iterator%]`. `Array.prototype[Symbol.iterator]`
+   has no own algorithm — the spec defines it as the same function object as
+   `Array.prototype.values` — so it surfaces only as that alias. Resolving
+   such aliases is a keying concern for §5, not a CFG gap.
+
+## Scope impact
+
+No new fallback PR is triggered: the CFG carries the stored-value operand and
+the reject-versus-throw distinction, the two signals §1 was gated on, so §8
+and §9 keep their planned scope. The serializer gains the three lowering
+rules in facts 1–3 above, all mechanical pattern-matching over the CFG shape
+already dumped here, and §9.3 keeps the hand-modeled combinator layer the
+plan already scoped. The §1 → §3 and §1 → fallback branches in the plan's
+"Discovery phases may grow the plan" resolve to the happy-path side. The plan
+table's §1 gate is met.

--- a/planning/ecma-262/spike_findings.md
+++ b/planning/ecma-262/spike_findings.md
@@ -59,7 +59,7 @@ implementations, `Record[OrdinaryObject].Set`,
 `Record[ArgumentsExoticObject].Set`, and
 `Record[ModuleNamespaceExoticObject].Set`. Nothing in the CFG says which one a
 given `O.Set(…)` call selects, which is why the FR1 seed stops the fixpoint
-above them. The 1751 syntax-directed operations are the runtime semantics of
+above them. The syntax-directed operations are the runtime semantics of
 the language itself, one function per grammar production and operation; they
 are out of scope for annotating a library surface, so §3 can skip them.
 
@@ -123,135 +123,185 @@ that stores a parameter into the receiver, the signal §8.1 needs.
 
 ## How each required signal is exposed
 
+The snippets below are **illustrative**, written with readable names to show
+the shape the analysis matches on. Real dumps use compiler temporaries — `%0`,
+`%7` — and the surrounding coercion and bounds-check steps are elided here.
+Each subsection names the representative method it was read from, so the shape
+can be checked against that method's dump in [spike_evidence/](spike_evidence/).
+
 ### Abstract-operation calls, arguments, and the stored-value operand
 
-A `Call` node carries the callee name and every argument expression, so a
-write's stored value is a plain argument operand. `Array.prototype.push`
-stores its element with `call %7 = clo<"Set">(O, %6, E, true)`: `E` traces
-to `ArgumentsList`, `O` traces to `ToObject(this)`, and `E` sits at argument
-index 2. `Map.prototype.set` stores both key and value by building
-`record{Key: key, Value: value}` and appending it, `push M.MapData < p`.
-`Reflect.set` stores `V` through `target.Set(target, key, V, receiver)`. The
-escape analysis reads the stored operand directly in every case.
+A `Call` node carries the callee and every argument expression as operands, so
+the value being stored by a write is always a plain argument the analysis can
+read. Three write forms appear, and all three expose both the written object
+and the stored value:
+
+| Form | Illustrative shape | Written object | Stored value |
+| ---- | ------------------ | -------------- | ------------ |
+| Abstract-operation write | `call %r = clo<"Set">(obj, key, val, true)` | `obj` (arg 0) | `val` (arg 2) |
+| Backing-slot append | `push obj.MapData < entry` | `obj` | `entry` |
+| Dynamic internal-method write | `call %r = obj.Set(obj, key, val, receiver)` | `obj` (arg 0) | `val` (arg 2) |
+
+The stored-value operand is the signal §8.1 needs to decide `escape`: a
+parameter appearing in that position outlives the call inside the written
+object.
+
+*Seen in:* `Array.prototype.push` stores its element through the AO form;
+`Map.prototype.set` builds an entry record and appends it to the slot;
+`Reflect.set` writes through the dynamic form.
 
 ### Let bindings and origins
 
 `ILet` gives the bound name and its source expression, and origins propagate
-through the chain. In `push`, `let O = %0` follows `%0 = %0.Value` following
-`call %0 = clo<"ToObject">(this)`, so `O` is receiver-origin; `let E = %5[%4]`
-with `%5 = items = ArgumentsList` is parameter-origin. Fresh origins are the
-allocation expressions: `slice` and `map` bind `let A = <ArraySpeciesCreate…>`.
+along the binding chain. The three origins the analysis assigns:
+
+| Origin | Illustrative shape | Why |
+| ------ | ------------------ | --- |
+| Receiver | `call %r = clo<"ToObject">(this)` … `let obj = %r` | traces to `this` through an identity-preserving coercion |
+| Parameter | `pop item < ArgumentsList` … `let elem = item` | traces to a popped formal, at its pop index |
+| Fresh | `call %r = clo<"ArraySpeciesCreate">(obj, len)` … `let out = %r` | an allocator result, not observable to callers |
+
+A property or slot *read* breaks the chain, since the value read out of a
+container is a different object from the container.
+
+*Seen in:* `Array.prototype.push` for the receiver and parameter chains;
+`Array.prototype.slice` and `map` bind their `ArraySpeciesCreate` result as
+fresh.
 
 ### Transitive mutation through a helper abstract operation
 
-The FR2 mutation summary is an inter-procedural fixpoint, so the gate needs
-the CFG to carry two things beyond a single method's own writes: every helper
-abstract operation as a first-class function with its body, and each call
-node's argument operands, so an origin at a caller's argument can be matched
-to the helper's mutated parameter. Both hold. Every abstract operation the
-representative methods call is dumped as its own `.cfg` function — `Set`,
-`CreateDataPropertyOrThrow`, `DefinePropertyOrThrow`, `SetIntegrityLevel`,
-`SortIndexedProperties`, `PerformPromiseAll`, and the rest — so the call graph
-is complete and `MutArgs` can propagate along it.
+FR2's mutation summary is an inter-procedural fixpoint, so it needs two things
+the CFG must carry: every helper abstract operation present as a first-class
+function with its body, and each call's argument operands, so an argument at a
+caller can be matched to the helper's mutated parameter. Both hold — every
+abstract operation the representative methods call is dumped as its own
+function, so the call graph is complete.
 
-`Object.freeze` is the representative that exercises the propagation rather
-than a direct write. Its body performs no write of its own; its only effect on
-the argument is one call:
+The shape that matters is a caller with **no write of its own**, whose only
+effect on a parameter is passing it to a helper:
 
 ```
-INTRINSICS.Object.freeze:
-  pop O < ArgumentsList                        // O is param 0
-  call %1 = clo<"SetIntegrityLevel">(O, ~frozen~)
-  … return O                                   // returns param 0
+Caller(p):                                  // p is param 0
+  call %0 = clo<"Helper">(p, …)             // no write in this body
+  return p
 
-SetIntegrityLevel(O, level):
-  … call %5  = clo<"DefinePropertyOrThrow">(O, k, «Configurable: false»)   // sealed branch
-  … call %10 = clo<"DefinePropertyOrThrow">(O, k, desc)                    // frozen branch
+Helper(o, …):
+  call %1 = clo<"DefinePropertyOrThrow">(o, key, desc)   // seeded mutator
 ```
 
-`DefinePropertyOrThrow` is an FR1 seed mutator of argument 0. The fixpoint
-then resolves two hops with no direct write at either caller:
+The fixpoint resolves this in two hops, with no direct write at either caller:
 
-- `MutArgs[DefinePropertyOrThrow] = {0}` — the seed.
-- `SetIntegrityLevel` passes its own parameter `O` as argument 0 of
-  `DefinePropertyOrThrow`, so `MutArgs[SetIntegrityLevel] = {0}`.
-- `Object.freeze` passes its own parameter `O` as argument 0 of
-  `SetIntegrityLevel`, so `MutArgs[Object.freeze] = {0}`.
+- `MutArgs[DefinePropertyOrThrow] = {0}` — from the FR1 seed.
+- `Helper` passes its own parameter `o` as argument 0 of a function that
+  mutates argument 0, so `MutArgs[Helper] = {0}`.
+- `Caller` passes its own parameter `p` as argument 0 of `Helper`, so
+  `MutArgs[Caller] = {0}`.
 
-`Object.freeze` is a static, so it has `receiver: none`; the mutated argument
-0 is `mutBorrow`, and the return is `param:0`. `Object.seal` has the identical
-shape with `~sealed~`. This is the helper-mediated case sort does not cover:
-`Array.prototype.sort` performs its receiver write-back directly with
-`Set(obj, …)` in its own body, and `SortIndexedProperties` only reads the
-receiver, so sort exercises a direct write, not the fixpoint.
+*Seen in:* `Object.freeze` is this shape exactly — it delegates to
+`SetIntegrityLevel`, which writes through `DefinePropertyOrThrow`. As a static
+it has `receiver: none`, param 0 `mutBorrow`, and returns `param:0`;
+`Object.seal` is identical but for the integrity level. Note that
+`Array.prototype.sort` is *not* this case: it writes the receiver back
+directly in its own body, and its `SortIndexedProperties` helper only reads
+the receiver and returns a fresh sorted list.
 
 ### Internal-slot writes
 
-Two spellings appear. A list-backed slot append is `push M.MapData < p`
-(`IPush`). A direct slot store is `p.Value = value` (`IAssign(Field(…))`).
-Both name the object expression and the slot. **The slot name is rendered
-without its `[[ ]]` brackets** — `MapData`, not `[[MapData]]` — so the §3
-serializer keys `BackingStoreSlots` by the bare name.
+Two spellings appear, both naming the object expression and the slot:
+
+- **List append** (`IPush`) — `push obj.MapData < entry`, how "Append … to
+  *obj*.[[List]]" is lowered.
+- **Direct store** (`IAssign` over a `Field`) — `entry.Value = val`.
+
+**The slot name is rendered without its `[[ ]]` brackets** — `MapData`, not
+`[[MapData]]` — so §4.1's `BackingStoreSlots` must be keyed by the bare name.
+
+*Seen in:* `Map.prototype.set` uses both spellings; `Set.prototype.add` uses
+the append form.
 
 ### Completion guards `?` / `!` / plain
 
 The guards are **lowered into control flow, not kept as a flag on the call**.
 This is the first fact that shapes §3. The compiled forms are fixed and
-deterministic, so the serializer reconstructs the guard from the shape that
-follows a `Call`:
+deterministic, so the serializer reconstructs the guard from the shape
+following a `Call`:
 
-- `?` (`ReturnIfAbrupt`): `assert (? x: Completion)` then
-  `if (? x: Abrupt) then return x else x = x.Value`. An abrupt-check branch
-  whose then-edge returns the callee result unwrapped on the else-edge.
-- `!` (assert-normal): `assert (? x: Normal)` then `x = x.Value`. No
-  abrupt-return branch — the normal assertion and unwrap, nothing else.
-- plain: the result is used directly with no completion assertion.
+| Guard | Illustrative shape after the call | Distinguishing feature |
+| ----- | --------------------------------- | ---------------------- |
+| `?` | `assert (? %r: Completion)` → `if (? %r: Abrupt) then return %r else %r = %r.Value` | an abrupt-check branch that returns the completion |
+| `!` | `assert (? %r: Normal)` → `%r = %r.Value` | normal assertion and unwrap, no abrupt branch |
+| plain | the result is used directly | no completion assertion at all |
 
-`(? e: T)` here is the IR's type-check expression `ETypeCheck`, distinct from
-the spec's `?` sugar; `(? x: Abrupt)` reads "is `x` an abrupt completion." §3
-must recognize the `?`/`!` patterns structurally rather than reading a guard
-attribute, because the compiler discards the surface annotation. The `?`/`!`
-distinction that FR10 depends on survives intact.
+`(? e: T)` is the IR's type-check expression `ETypeCheck`, not the spec's `?`
+sugar; `(? %r: Abrupt)` reads "is `%r` an abrupt completion." §3 must match
+these structurally, because the compiler discards the surface annotation. The
+`?`/`!` distinction FR10 depends on survives intact.
 
 ### Explicit `Throw` steps
 
 `Throw a *T* exception` lowers to two calls and a return:
-`call %e = clo<"__NEW_ERROR_OBJ__">("%T.prototype%")` then
-`call %c = clo<"ThrowCompletion">(%e)` then `return %c`. **The error class is
-the string literal argument to `__NEW_ERROR_OBJ__`** — `"%TypeError.prototype%"`,
-`"%RangeError.prototype%"` — so the throw-set fixpoint reads the class name off
-that operand. `toFixed`'s two `RangeError` guards and `push`'s `TypeError`
-guard both appear in this form, each gated by an explicit `if` domain check
-that distinguishes them from the coercion `TypeError`s the FR11 filter drops.
+
+```
+call %e = clo<"__NEW_ERROR_OBJ__">("%RangeError.prototype%")
+call %c = clo<"ThrowCompletion">(%e)
+return %c
+```
+
+**The error class is the string literal argument to `__NEW_ERROR_OBJ__`**, so
+the throw-set fixpoint reads the class name off that operand.
+
+*Seen in:* `Number.prototype.toFixed` raises `RangeError` this way and
+`Array.prototype.push` raises `TypeError`. Each sits behind an explicit `if`
+domain check, which is what separates them from the receiver- and
+parameter-coercion `TypeError`s the FR11 filter drops.
 
 ### Promise rejection versus synchronous throw
 
-The two channels are distinguishable. A synchronous throw is the
-`ThrowCompletion` form above. An asynchronous rejection is a call to the
-capability's reject slot, `Call(promiseCapability.Reject, undefined, «value»)`.
-`Promise.reject` rejects with `r` at param index 0, giving the `param:0`
-origin FR13 records. `IfAbruptRejectPromise` lowers to an abrupt-check branch
-whose then-edge calls `promiseCapability.Reject` and returns
-`promiseCapability.Promise`, again the capability-reject shape, never a
-`ThrowCompletion`. §9.3 tells them apart by the callee: `ThrowCompletion` is a
-sync throw, a `.Reject` capability call is a rejection.
+The two channels are distinguishable by the callee at the raise site:
+
+| Channel | Illustrative shape | Recorded as |
+| ------- | ------------------ | ----------- |
+| Synchronous throw | `call %c = clo<"ThrowCompletion">(%e)` | `throws` (FR10) |
+| Asynchronous rejection | `call %r = clo<"Call">(capability.Reject, undefined, «val»)` | `rejects` (FR13) |
+
+`IfAbruptRejectPromise` lowers to an abrupt-check branch whose then-edge takes
+the capability-reject shape and returns `capability.Promise` — a rejection,
+never a `ThrowCompletion`. A rejected value that is a parameter gives the
+`param:k` origin FR13 records.
+
+*Seen in:* `Promise.reject` rejects with its param 0; `Promise.all` shows the
+`IfAbruptRejectPromise` form.
 
 ### Callback propagation versus a resolvable abstract operation
 
-A resolvable call names a fixed abstract operation, `clo<"AOName">(…)`. A
-callback call is the `Call` abstract operation applied to a parameter-origin
-callee: `forEach` emits `clo<"Call">(callback, thisArg, «…»)` with `callback`
-the popped param 0. §9.1 recognizes the callback case as a `Call`/`Construct`
-whose callee argument is parameter-origin, yielding `throwsOf:param:k`; every
-other guarded call resolves to a named abstract operation with its own throw
-set. The call is `?`-guarded, so the propagation edge is present.
+Both are `Call` nodes; the callee expression tells them apart:
+
+| Case | Illustrative shape | Throw contribution |
+| ---- | ------------------ | ------------------ |
+| Resolvable abstract operation | `call %r = clo<"AOName">(…)` | the callee's own throw set, by name |
+| Callback parameter | `call %r = clo<"Call">(cb, thisArg, «…»)` where `cb` is a popped formal | `throwsOf:param:k` |
+
+In the callback case the AO being invoked is `Call` itself, which *is*
+statically known — the callback is its **first argument**. So §9.1 identifies
+the case by the origin of that argument, not by the callee name. The call is
+`?`-guarded, so the propagation edge is present.
+
+*Seen in:* `Array.prototype.forEach`, whose `cb` is popped param 0.
 
 ### Return values
 
-`IReturn` carries the returned expression. Normal returns are wrapped
-`NormalCompletion(v)` and abrupt returns forward the completion, so the
-return-alias classifier reads `receiver` (`return O` / `NormalCompletion(O)`),
-`fresh` (`NormalCompletion(A)` off an allocator), or `param` off the operand.
+`IReturn` carries the returned expression. Normal returns are wrapped in
+`NormalCompletion` and abrupt returns forward the completion, so the
+return-alias classifier reads the operand:
+
+| Alias | Illustrative shape |
+| ----- | ------------------ |
+| `receiver` | `return obj` / `NormalCompletion(obj)` where `obj` is receiver-origin |
+| `fresh` | `NormalCompletion(out)` where `out` came from an allocator |
+| `param:k` | `NormalCompletion(p)` where `p` is the k-th formal |
+
+*Seen in:* `Array.prototype.fill` returns the receiver, `slice` returns fresh,
+`Object.freeze` returns `param:0`.
 
 ## Facts that shape §3 / §8 / §9
 

--- a/planning/ecma-262/spike_findings.md
+++ b/planning/ecma-262/spike_findings.md
@@ -267,6 +267,18 @@ return-alias classifier reads `receiver` (`return O` / `NormalCompletion(O)`),
    determination reads — rather than dropping a whole method because it
    carries a `yet` anywhere.
 
+   Most of that set is low-stakes for this workstream: `Math.*`, the `Date.*`
+   and numeric formatters, and `JSON.stringify` compute a fresh return value
+   without mutating the receiver or any parameter, so the facts worth
+   extracting there are `receiver: borrow` and `returns: fresh`, which the
+   visible part of each algorithm already establishes. `Atomics.*` is the
+   exception and the one to watch: `Atomics.add` carries a `yet` *and* mutates
+   its `typedArray` parameter, through `AtomicReadModifyWrite` and
+   `GetModifySetValueInBuffer` writing the underlying buffer. There a `yet`
+   coincides with a real effect, so the per-signal rule has to be applied
+   rather than assumed — the mutation is only safely extractable because the
+   `yet` sits off the path that establishes it.
+
 6. **Symbol-keyed names are exposed; some are spec aliases (§5).** A
    symbol-keyed method with its own algorithm appears under the
    `X.prototype[%Symbol.name%]` name, e.g.


### PR DESCRIPTION
Fixes #1192

Records the outcome of the §1 feasibility spike, which validated whether the ESMeta control-flow graph exposes every signal the mutation and promise-rejection analysis needs. The spike built ESMeta, ran the full `extract → compile → build-cfg` pipeline against a pinned ECMA-262 revision, and inspected the CFG for 16 representative methods covering direct receiver mutation, transitive mutation through a helper abstract operation, escape operands, internal-slot writes, completion guards, explicit throws, promise rejections, and callbacks.

**Verdict: the happy path holds.** The CFG exposes every required signal — abstract-operation call nodes with their argument operands including the stored value of a write, `Let` bindings with traceable origins, internal-slot writes, the `?`/`!`/plain completion guards, explicit `Throw` steps with their error class, promise-rejection sites distinct from synchronous throws, callback-parameter calls distinct from resolvable abstract operations, and return values. No signal is missing wholesale, so the pure-Go `spec.html` shallow-parser fallback is not needed and §8/§9 keep their planned scope.

The spike sharpens one §3 detail and confirms two §4 ones, leaving the §3/§4 boundary intact — §3 stays a structural dumper that makes no mutability or alias decision:

1. **§3 (serializer).** Completion guards are lowered into control flow rather than kept as a call attribute, so §3 populates the guard field the Appendix A schema already defines by matching the post-call branch shape. §3 also copies each internal-slot name verbatim, which is the bare `MapData`, not the bracketed `[[MapData]]`.
2. **§4.1 (Go).** The FR1 property-write seed is load-bearing, not an optimization: `Set` and its kin dispatch through a dynamic `[[Set]]` internal method the fixpoint cannot resolve by callee name, so without the seed those writes are invisible to it. `BackingStoreSlots` must match the bare slot names §3 emits.
3. **§4 / §9 (Go).** `yet` incompleteness is per-step rather than per-method, so the FR5 conservative fallback applies per signal. Most of the `yet`-carrying surface is low-stakes, but `Atomics.*` is the exception — `Atomics.add` carries a `yet` and also mutates its `typedArray` parameter.

**Changes:**
- Add `planning/ecma-262/spike_findings.md` documenting the pinned toolchain revisions, the CFG function breakdown by category, per-method gate results, how each required signal is exposed, and the scope impact
- Add `planning/ecma-262/spike_evidence/` with the 18 CFG dumps the findings are read from, so every per-method claim is checkable without building ESMeta
- Add `planning/ecma-262/reproduce_spike.sh`, a runbook that pins ESMeta and the spec revision and regenerates those dumps
- Update `planning/ecma-262/implementation_plan.md` to mark §1 complete, record the outcome against the correct phase boundaries, and explain in §4.1 how the seed drives the fixpoint and why the analysis asserts these mutators rather than inlining them

https://claude.ai/code/session_01BVUT1Dgj8Sn7nDjuaZKTSR

## Summary by CodeRabbit

* **Documentation**
  * Completed the feasibility assessment for ECMA-262 control-flow analysis.
  * Added findings covering calls, writes, guards, exceptions, promise rejection, callbacks, and returns.
  * Documented requirements for serialization, mutation, aliasing, fallback handling, and promise combinators.
  * Confirmed the planned happy-path approach is viable and the planning milestone is satisfied.
