### PR TITLE
Record borrow edges for call store effects

### DIFF
--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -195,21 +195,20 @@ type lifetimeWalk struct {
 //     field of its own descends at base, attributing what it holds to the enclosing object,
 //     the approximation recordBorrowSources makes for a computed key. walkObjElem says which
 //     members those are.
-//   - A tuple element and a class type argument descend at base unchanged. Neither
-//     contributes a name: the place model has no index segment, and a class type argument is
-//     not addressable as a field at all. `&'c mut Box<&'a mut B>` therefore stores at the
-//     whole Box, which is where a class holding a borrowed element lands.
+//   - A tuple element, an array element, a class type argument, and a promise or generator
+//     payload descend at base unchanged. None of them contributes a name: the place model
+//     has no index segment, and neither a class type argument nor a payload is addressable
+//     as a field at all. `&'c mut Box<&'a mut B>` therefore stores at the whole Box, which
+//     is where a class holding a borrowed element lands.
 //   - A union or intersection descends each member at base, since a borrow any member holds
 //     is reachable through the whole.
 //   - An alias descends its expansion at base. An alias is transparent, so a referent
 //     written as `Holder<'a>` is searched the way the object the alias names is.
 //
-// Any other kind stops the walk, so the call reads as storing nothing through it. Two kinds
-// are worth naming, since both are the container shapes the stdlib ingestion milestone
-// brings and each wants an arm here once it can be written. An `Array<T>` element is
-// unreachable because `&mut Array<T>` is not a borrowable type. A class lifetime argument —
-// the `'a` of `Box<'a, T>`, as opposed to the type argument this walk does descend — is
-// unreachable because a class declares no lifetime parameters.
+// Any other kind stops the walk, so the call reads as storing nothing through it. One is
+// worth naming. A class LIFETIME argument — the `'a` of `Box<'a, T>`, as opposed to the type
+// argument this walk does descend — is unreachable because a class declares no lifetime
+// parameters, and it wants an arm here once one can be written.
 func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 	if t == nil || w.budget <= 0 || w.onPath.Contains(t) {
 		return
@@ -237,6 +236,15 @@ func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 		for _, elem := range t.Elems {
 			w.walk(elem, base)
 		}
+	case *soltype.ArrayType:
+		w.walk(t.Elem, base)
+	case *soltype.PromiseType:
+		w.walk(t.Inner, base)
+		w.walk(t.Err, base)
+	case *soltype.GeneratorType:
+		w.walk(t.Yield, base)
+		w.walk(t.Ret, base)
+		w.walk(t.Next, base)
 	case *soltype.ClassType:
 		for _, arg := range t.TypeArgs {
 			w.walk(arg, base)

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -7,39 +7,29 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// A call stores one of its argument-borrows into another argument when the two share a
-// lifetime and the shared lifetime sits inside the second parameter's referent. In
+// A call stores one argument's borrow into another when the two share a lifetime and that
+// lifetime sits inside the second parameter's referent. In
 //
 //	declare fn store<'a, 'b>(target: &'b mut {peer: &'a mut B}, item: &'a mut B)
 //
-// item's borrow lifetime 'a reappears at target's peer field. Whatever item borrows must
-// therefore stay alive for as long as target.peer is readable, which is what "the call
-// writes item's borrow into target" means. At the call `store(&mut a, &mut b)` that is the
-// edge a → b at [peer], the same edge `val a = {peer: &mut b}` records at its initializer.
+// item's 'a reappears at target's peer field, so whatever item borrows must outlive
+// target.peer. At `store(&mut a, &mut b)` that is the edge a → b at [peer], the same edge
+// `val a = {peer: &mut b}` records at its initializer.
 //
-// A lifetime shared at the two parameters' outermost position is not a store. In
-// `fn f<'a>(x: &'a mut B, y: &'a mut B)` the two borrows only share one region; neither
-// referent is reachable through the other. The search below skips each candidate target's
-// own outer lifetime and looks inside its referent. The stored argument's side has no such
-// exemption: any lifetime its type mentions, outermost or nested, names data the callee
-// holds and may write into the target.
+// Sharing a lifetime at both parameters' outermost position is not a store. In
+// `fn f<'a>(x: &'a mut B, y: &'a mut B)` neither referent is reachable through the other. So
+// the search skips a target's own outer lifetime and looks inside its referent. The source
+// side has no such exemption. Any lifetime its type mentions names data the callee holds.
 //
-// A signature that only reads through the shared lifetime gets the same treatment as one
-// that writes, because the two are spelled alike: a mutable borrow whose referent mentions
-// the argument's lifetime may write it there, and the recorder takes the permission at face
-// value. That errs toward recording an alias the call might not form, which reports an
+// A signature that only reads through the shared lifetime is treated as one that writes,
+// since the two are spelled alike. That can record an alias the call never forms, reporting an
 // escape the program does not have. The opposite reading would miss a real dangling borrow.
 //
-// `a.peers.push(&mut b)`, the container case this machinery exists for, is not covered. Four
-// pieces are missing: an `Array` type with a method surface, a lifetime parameter on the
-// container type tying the element borrow to the receiver, the receiver's own type at the
-// call site, which memberValue strips off the signature it hands the call, and named
-// lifetimes on a method signature.
-//
-// That last one is why no method call records a store today, through `self` or through an
-// explicit parameter alike. A method signature reaches the call site with its lifetimes
-// coalesced to the anonymous display lifetime rather than lifetime variables, so the two
-// sides of a store share nothing the search can match.
+// `a.peers.push(&mut b)`, the container case this exists for, is not covered. It needs an
+// `Array` type with a method surface, a lifetime parameter on the container tying the element
+// borrow to the receiver, the receiver's type at the call site, and named lifetimes on a
+// method signature. The last is why no method call records a store today: a method's
+// lifetimes reach the call site anonymized, so the two sides share nothing to match.
 type storeEdge struct {
 	// arg is the index of the argument whose borrow the call stores.
 	arg int
@@ -52,27 +42,20 @@ type storeEdge struct {
 	path []placeSeg
 }
 
-// callStoreEdges returns the store effects the resolved signature fn declares, one per
-// (argument, target, field path) triple.
+// callStoreEdges returns the store effects fn declares, one per (argument, target, path).
 //
-// A target must be a mutable borrow: a shared borrow takes no write, and an owned-mutable
-// parameter — a `RefType` with a nil lifetime — is moved into the callee, so what the callee
-// writes into it the caller can no longer read. A source must be a borrow too, since an
-// owned argument is moved into the callee and its escape belongs to the consuming-argument
-// rule.
+// A target must be a mutable borrow. A shared borrow takes no write, and an owned-mutable
+// parameter — a `RefType` with a nil lifetime — is moved into the callee, so the caller can no
+// longer read what the callee writes there. A source must be a borrow too, since an owned
+// argument is moved and its escape belongs to the consuming-argument rule.
 //
-// A signature that declares no store returns none, the common case. Each side is classified
-// by type kind alone before any type is walked, so an ordinary call over owned arguments
-// costs one pass over the parameter list. Every parameter that is walked is walked once: a
-// source's lifetimes are collected before the target loop, and a target's referent is
-// searched into a map from lifetime to the paths it sits at rather than once per source
-// lifetime.
+// Each side is classified by type kind before any type is walked, so a call over owned
+// arguments costs one pass over the parameter list and walks no type at all. Every parameter
+// that is walked is walked once.
 //
-// A walk that runs out of budget or alias fuel saw only part of its type, so a lifetime the
-// two sides share may sit past where it stopped. Such a pair takes a store at the whole
-// target rather than none: dropping the edge would drop the escape a borrow written there
-// raises, and the widest position is the sound reading when the exact one is unknown. Only a
-// signature far past anything hand-written reaches either limit.
+// A walk that runs out of budget or alias fuel saw only part of its type, so a shared lifetime
+// may sit past where it stopped. Such a pair takes a store at the whole target rather than
+// none, since dropping the edge would drop the escape a borrow written there raises.
 func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 	var sources, targets []int
 	for i, p := range fn.Params {
@@ -107,11 +90,8 @@ func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 			if i == j {
 				continue
 			}
-			// A walk that stopped short saw a subset of the type's lifetimes, so a shared one
-			// may sit past where it stopped. Reading that as "no store" would drop the edge
-			// and with it the escape a dangling borrow written there would raise, so record
-			// the store at the whole target instead: an unnamed path is the widest position
-			// the recorder can name, and every field read through the target follows it.
+			// An unnamed path is the widest position the recorder can name, and every field
+			// read through the target follows it. See the cut rule above.
 			if targetCut || sourceCut[i] {
 				out = append(out, storeEdge{arg: i, target: j})
 				continue
@@ -138,8 +118,8 @@ func lifetimeSites(ctx *Context, t soltype.Type) (map[*soltype.LifetimeVar][][]p
 }
 
 // lifetimeVarsIn returns the lifetime variables occurring anywhere in t, deduped by identity
-// and ordered as the walk reaches them, which keeps the store edges a signature yields in a
-// stable order across runs.
+// and ordered as the walk reaches them. That order keeps a signature's store edges stable
+// across runs.
 func lifetimeVarsIn(ctx *Context, t soltype.Type) ([]*soltype.LifetimeVar, bool) {
 	var out []*soltype.LifetimeVar
 	seen := set.NewSet[*soltype.LifetimeVar]()
@@ -171,33 +151,34 @@ func walkLifetimes(
 }
 
 // maxLifetimeWalkNodes bounds how many type nodes one walk visits. Alias expansion is what
-// makes the bound necessary: a chain of aliases that each name the next one twice describes
+// makes the bound necessary. A chain of aliases that each name the next one twice describes
 // exponentially many field paths, and walking them all takes minutes at a depth a signature
-// could plausibly reach. A signature carrying this many type nodes is far past anything
-// hand-written. Running out reports the walk as cut, which callStoreEdges reads as a store at
-// the whole target rather than as no store.
+// could plausibly reach. Running out marks the walk cut, which callStoreEdges reads as a
+// store at the whole target.
 const maxLifetimeWalkNodes = 1024
 
 // maxAliasExpansionDepth bounds how many alias expansions one root-to-node chain may stack.
 // A recursive alias such as `type List<T> = {head: T, tail: List<T>}` expands forever
-// otherwise: each expansion substitutes into a fresh body, which the identity-keyed onPath
-// set cannot recognize as the one already being walked. Bounding the depth rather than
-// refusing a repeated alias NAME is what keeps a re-nesting like `W<W<&'a mut B>>` correct,
-// since its two levels are different types and the inner one holds the borrow.
+// otherwise. Each expansion substitutes into a fresh body, which the identity-keyed onPath set
+// cannot recognize as the one already being walked. Bounding the depth rather than refusing a
+// repeated alias NAME is what keeps a re-nesting like `W<W<&'a mut B>>` correct: its two
+// levels are different types and the inner one holds the borrow.
 //
-// Running out reports the walk as cut, the same as running out of node budget.
+// Running out marks the walk cut, the same as running out of node budget.
 const maxAliasExpansionDepth = 8
 
 // lifetimeWalk reports where each lifetime variable occurs in a type, as a field path from
-// the type's root. The soltype visitor cannot drive it: that visitor rewrites a type
-// bottom-up and hands each node no record of the fields traversed to reach it, and the path
-// is the whole point here. recordBorrowSources walks the AST by hand for the same reason.
+// the type's root. The soltype visitor cannot drive it. That visitor rewrites a type bottom-up
+// and hands each node no record of the fields traversed to reach it, and the path is the whole
+// point here. recordBorrowSources walks the AST by hand for the same reason.
 //
-// Three limits keep the walk finite and cheap. onPath holds the types on the current
-// root-to-node chain, so a type that refers to itself terminates while a type reached twice
-// at two different field paths still yields both. fuel is the alias expansions left on that
-// chain, which onPath cannot bound, for the reason maxAliasExpansionDepth gives. budget caps
-// the total nodes visited, for the reason maxLifetimeWalkNodes gives.
+// Three limits keep the walk finite and cheap:
+//
+//   - onPath holds the types on the current root-to-node chain, so a type that refers to
+//     itself terminates while a type reached at two different field paths still yields both.
+//   - fuel is the alias expansions left on that chain, which onPath cannot bound. See
+//     maxAliasExpansionDepth.
+//   - budget caps the total nodes visited. See maxLifetimeWalkNodes.
 type lifetimeWalk struct {
 	ctx    *Context
 	visit  func(*soltype.LifetimeVar, []placeSeg)
@@ -213,28 +194,26 @@ type lifetimeWalk struct {
 // walk descends t, extending base by a segment at each named field. Only the kinds that can
 // hold a borrow reachable by a field path are descended:
 //
-//   - A borrow reports its own lifetime at base, then descends its referent, so a borrow of
-//     a borrow is reached.
+//   - A borrow reports its own lifetime at base, then descends its referent, so a borrow of a
+//     borrow is reached.
 //   - An object descends each named property at base plus that name. A member that names no
-//     field of its own descends at base, attributing what it holds to the enclosing object,
-//     the approximation recordBorrowSources makes for a computed key. walkObjElem says which
-//     members those are.
+//     field of its own descends at base, attributing what it holds to the enclosing object.
+//     walkObjElem says which members those are.
 //   - A tuple element, an array element, a class type argument, and a promise or generator
-//     payload descend at base unchanged. None of them contributes a name: the place model
-//     has no index segment, and neither a class type argument nor a payload is addressable
-//     as a field at all. `&'c mut Box<&'a mut B>` therefore stores at the whole Box, which
-//     is where a class holding a borrowed element lands.
-//   - A union or intersection descends each member at base, since a borrow any member holds
-//     is reachable through the whole.
-//   - An alias descends its expansion at base. An alias is transparent, so a referent
-//     written as `Holder<'a>` is searched the way the object the alias names is.
+//     payload descend at base unchanged. None of them contributes a name, since the place
+//     model has no index segment and neither a class type argument nor a payload is
+//     addressable as a field. So `&'c mut Box<&'a mut B>` stores at the whole Box, which is
+//     where a class holding a borrowed element lands.
+//   - A union or intersection descends each member at base, since a borrow any member holds is
+//     reachable through the whole.
+//   - An alias descends its expansion at base. An alias is transparent, so `Holder<'a>` is
+//     searched the way the object it names is.
 //
 // Any other kind stops the walk there, so the call reads as storing nothing through it. That
-// is a deliberate silence about a kind that holds no field-addressable borrow, unlike the cut
-// a limit causes, which says the walk stopped before it finished looking. One is
-// worth naming. A class LIFETIME argument — the `'a` of `Box<'a, T>`, as opposed to the type
-// argument this walk does descend — is unreachable because a class declares no lifetime
-// parameters, and it wants an arm here once one can be written.
+// silence is deliberate, unlike the cut a limit causes: the kind holds no field-addressable
+// borrow. One case is worth naming. A class LIFETIME argument, the `'a` of `Box<'a, T>` rather
+// than the type argument this walk does descend, is unreachable because a class declares no
+// lifetime parameters. It wants an arm here once one can be written.
 func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 	if t == nil || w.onPath.Contains(t) {
 		return
@@ -293,11 +272,11 @@ func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 }
 
 // walkAlias descends an alias reference. A registered alias with a body is walked through its
-// expansion alone: expandAlias substitutes the reference's type and lifetime arguments into
+// expansion alone. expandAlias substitutes the reference's type and lifetime arguments into
 // the body, so the expansion already carries each argument at the field path it really sits
-// at, and walking the arguments here as well would report a second occurrence at the
-// container's path. An alias with no expansion — unregistered, bodyless, or reached with the
-// expansion fuel spent — has its arguments attributed to base instead of being dropped.
+// at. Walking the arguments here as well would report a second occurrence at the container's
+// path. An alias with no expansion — unregistered, bodyless, or reached with the expansion fuel
+// spent — has its arguments attributed to base instead of being dropped.
 func (w *lifetimeWalk) walkAlias(t *soltype.AliasType, base []placeSeg) {
 	if w.ctx != nil {
 		if def, ok := w.ctx.aliasDef(t.Name); ok && def.Body != nil {
@@ -326,9 +305,9 @@ func (w *lifetimeWalk) walkAlias(t *soltype.AliasType, base []placeSeg) {
 
 // walkObjElem descends an object member that names no field of its own. Three hold data the
 // enclosing object exposes, so each is attributed to base: a getter's value, a spread's
-// source, and an index signature's value, which covers every key it admits rather than one.
-// A method, a setter, and a constructor hold their borrows in a signature the enclosing
-// object does not expose as data, so they contribute nothing.
+// source, and an index signature's value, which covers every key it admits rather than one. A
+// method, a setter, and a constructor hold their borrows in a signature the object does not
+// expose as data, so they contribute nothing.
 func (w *lifetimeWalk) walkObjElem(elem soltype.ObjTypeElem, base []placeSeg) {
 	switch elem := elem.(type) {
 	case *soltype.GetterElem:
@@ -340,33 +319,30 @@ func (w *lifetimeWalk) walkObjElem(elem soltype.ObjTypeElem, base []placeSeg) {
 	}
 }
 
-// recordCallStoreEdges handles, for the call e against the resolved signature fn, each store
-// the signature declares. Where the borrow lands decides what happens, the same split a
-// field store makes between recordFieldStoreEdges and checkParamFieldStoreEscape:
+// recordCallStoreEdges handles each store fn declares at the call e. Where the borrow lands
+// decides what happens, the same split a field store makes between recordFieldStoreEdges and
+// checkParamFieldStoreEscape:
 //
 //   - Into a local, the call records a borrow edge. `store(&mut a, &mut b)` against the
-//     store-effect signature in this file's opening comment records a → b at [peer], so a
-//     later flow-out of a finds b the way it would had a's initializer written the borrow in
-//     directly. The target's own place is the prefix, so `store(&mut a.slot, &mut b)` records
+//     signature in this file's opening comment records a → b at [peer], so a later flow-out of
+//     a finds b. The target's own place is the prefix, so `store(&mut a.slot, &mut b)` records
 //     at [slot, peer].
 //   - Into a parameter, the locals the argument carries are reported at once. The parameter's
 //     referent belongs to the caller and outlives the frame, so a borrow of a local written
-//     into it dangles. The report is direct rather than deferred to the escape post-pass,
-//     because the callee borrows the argument instead of taking it, and the post-pass would
-//     weigh an owned-looking argument as a connected-component move and consume it.
+//     into it dangles. Reporting here rather than deferring to the escape post-pass is what
+//     keeps the callee's borrow from being weighed as a move, which would consume the locals.
 //
 // A store is skipped when the argument carries no function-local, when the target names no
-// binding, or when the two are the same binding, which would make a self-loop no reader of
-// the graph can use.
+// binding, or when the two are the same binding, which would make an unusable self-loop.
 //
-// An edge is added to whatever the target already holds rather than replacing it, since a
+// An edge is added to what the target already holds rather than replacing it, since a
 // signature says where a borrow lands and not whether the callee overwrites what was there.
-// A container that accumulates is the shape this models, and keeping the prior edge is the
-// sound reading for one that overwrites.
+// This models a container that accumulates, and keeps the sound reading for one that
+// overwrites.
 //
-// Recording alone does not reach the escape check, which reads the per-program-point graph
-// rather than the eager one, so a call that recorded an edge flushes the roots it dirtied
-// into this statement's borrowGens, the same handoff a `val` initializer makes.
+// The escape check reads the per-program-point graph rather than the eager one, so a call that
+// recorded an edge flushes the roots it dirtied into this statement's borrowGens, the same
+// handoff a `val` initializer makes.
 func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, ref liveness.StmtRef) {
 	if c.fn == nil || c.fn.eagerBorrowGraph == nil {
 		return
@@ -418,7 +394,7 @@ func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, re
 }
 
 // storedReferents returns the function-locals a stored argument carries. A borrow of a place
-// names one: `&mut b`, and a bare `b` passed to a shared-borrow parameter, both carry b. An
+// names one. Both `&mut b` and a bare `b` passed to a shared-borrow parameter carry b. An
 // argument that builds its carrier inline, such as `&{inner: &mut b}`, names one per borrow
 // the carrier holds, found by the same scan escapingLocalsOf runs over a returned value.
 func (c *checker) storedReferents(arg ast.Expr) []liveness.VarID {

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -53,8 +53,8 @@ type storeEdge struct {
 // arguments costs one pass over the parameter list and walks no type at all. Every parameter
 // that is walked is walked once.
 //
-// A walk that runs out of budget or alias fuel saw only part of its type, so a shared lifetime
-// may sit past where it stopped. Such a pair takes a store at the whole target rather than
+// A walk that exhausts either allowance saw only part of its type, so a shared lifetime may
+// sit past where it stopped. Such a pair takes a store at the whole target rather than
 // none, since dropping the edge would drop the escape a borrow written there raises.
 func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 	var sources, targets []int
@@ -74,16 +74,16 @@ func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 		return nil
 	}
 	sourceLts := map[int][]*soltype.LifetimeVar{}
-	sourceCut := map[int]bool{}
+	sourceTruncated := map[int]bool{}
 	for _, i := range sources {
-		sourceLts[i], sourceCut[i] = lifetimeVarsIn(ctx, fn.Params[i].Type)
+		sourceLts[i], sourceTruncated[i] = lifetimeVarsIn(ctx, fn.Params[i].Type)
 	}
 
 	var out []storeEdge
 	for _, j := range targets {
 		dst := fn.Params[j].Type.(*soltype.RefType)
-		sites, targetCut := lifetimeSites(ctx, dst.Inner)
-		if len(sites) == 0 && !targetCut {
+		sites, targetTruncated := lifetimeSites(ctx, dst.Inner)
+		if len(sites) == 0 && !targetTruncated {
 			continue
 		}
 		for _, i := range sources {
@@ -91,8 +91,8 @@ func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 				continue
 			}
 			// An unnamed path is the widest position the recorder can name, and every field
-			// read through the target follows it. See the cut rule above.
-			if targetCut || sourceCut[i] {
+			// read through the target follows it. See the truncation rule above.
+			if targetTruncated || sourceTruncated[i] {
 				out = append(out, storeEdge{arg: i, target: j})
 				continue
 			}
@@ -111,10 +111,10 @@ func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 // for every source lifetime.
 func lifetimeSites(ctx *Context, t soltype.Type) (map[*soltype.LifetimeVar][][]placeSeg, bool) {
 	sites := map[*soltype.LifetimeVar][][]placeSeg{}
-	cut := walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, path []placeSeg) {
+	truncated := walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, path []placeSeg) {
 		sites[lv] = append(sites[lv], path)
 	})
-	return sites, cut
+	return sites, truncated
 }
 
 // lifetimeVarsIn returns the lifetime variables occurring anywhere in t, deduped by identity
@@ -123,38 +123,38 @@ func lifetimeSites(ctx *Context, t soltype.Type) (map[*soltype.LifetimeVar][][]p
 func lifetimeVarsIn(ctx *Context, t soltype.Type) ([]*soltype.LifetimeVar, bool) {
 	var out []*soltype.LifetimeVar
 	seen := set.NewSet[*soltype.LifetimeVar]()
-	cut := walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, _ []placeSeg) {
+	truncated := walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, _ []placeSeg) {
 		if seen.Contains(lv) {
 			return
 		}
 		seen.Add(lv)
 		out = append(out, lv)
 	})
-	return out, cut
+	return out, truncated
 }
 
 // walkLifetimes calls visit once per lifetime-variable occurrence in t, passing the field
-// path within t at which it occurs. cut reports that a limit stopped the walk before it
-// reached every node, so the occurrences visit saw are a subset of what t holds.
+// path within t at which it occurs. truncated reports that an allowance ran out before the
+// walk reached every node, so the occurrences visit saw are a subset of what t holds.
 func walkLifetimes(
 	ctx *Context, t soltype.Type, visit func(*soltype.LifetimeVar, []placeSeg),
-) (cut bool) {
+) (truncated bool) {
 	w := &lifetimeWalk{
-		ctx:    ctx,
-		visit:  visit,
-		onPath: set.NewSet[soltype.Type](),
-		budget: maxLifetimeWalkNodes,
-		fuel:   maxAliasExpansionDepth,
+		ctx:            ctx,
+		visit:          visit,
+		onPath:         set.NewSet[soltype.Type](),
+		nodesLeft:      maxLifetimeWalkNodes,
+		aliasDepthLeft: maxAliasExpansionDepth,
 	}
 	w.walk(t, nil)
-	return w.cut
+	return w.truncated
 }
 
 // maxLifetimeWalkNodes bounds how many type nodes one walk visits. Alias expansion is what
 // makes the bound necessary. A chain of aliases that each name the next one twice describes
 // exponentially many field paths, and walking them all takes minutes at a depth a signature
-// could plausibly reach. Running out marks the walk cut, which callStoreEdges reads as a
-// store at the whole target.
+// could plausibly reach. Running out marks the walk truncated, which callStoreEdges reads as
+// a store at the whole target.
 const maxLifetimeWalkNodes = 1024
 
 // maxAliasExpansionDepth bounds how many alias expansions one root-to-node chain may stack.
@@ -164,7 +164,7 @@ const maxLifetimeWalkNodes = 1024
 // repeated alias NAME is what keeps a re-nesting like `W<W<&'a mut B>>` correct: its two
 // levels are different types and the inner one holds the borrow.
 //
-// Running out marks the walk cut, the same as running out of node budget.
+// Running out marks the walk truncated, the same as running out of the node allowance.
 const maxAliasExpansionDepth = 8
 
 // lifetimeWalk reports where each lifetime variable occurs in a type, as a field path from
@@ -176,19 +176,23 @@ const maxAliasExpansionDepth = 8
 //
 //   - onPath holds the types on the current root-to-node chain, so a type that refers to
 //     itself terminates while a type reached at two different field paths still yields both.
-//   - fuel is the alias expansions left on that chain, which onPath cannot bound. See
+//   - aliasDepthLeft bounds the alias expansions on that chain, which onPath cannot. See
 //     maxAliasExpansionDepth.
-//   - budget caps the total nodes visited. See maxLifetimeWalkNodes.
+//   - nodesLeft caps the total nodes visited. See maxLifetimeWalkNodes.
 type lifetimeWalk struct {
 	ctx    *Context
 	visit  func(*soltype.LifetimeVar, []placeSeg)
 	onPath set.Set[soltype.Type]
-	budget int
-	fuel   int
-	// cut records that budget or fuel ran out, so the walk stopped before reaching every
-	// node. Its caller reads this to tell "t holds no more occurrences" apart from "the walk
-	// stopped looking", which decide a store differently.
-	cut bool
+	// nodesLeft is the node allowance remaining for the WHOLE walk, counted down from
+	// maxLifetimeWalkNodes. It is never restored, so every branch spends one shared pool.
+	nodesLeft int
+	// aliasDepthLeft is the alias expansions remaining on the CURRENT root-to-node chain,
+	// counted down from maxAliasExpansionDepth and restored on the way back up.
+	aliasDepthLeft int
+	// truncated records that one of the two allowances ran out, so the walk stopped before
+	// reaching every node. Its caller reads this to tell "t holds no more occurrences" apart
+	// from "the walk stopped looking", which decide a store differently.
+	truncated bool
 }
 
 // walk descends t, extending base by a segment at each named field. Only the kinds that can
@@ -210,19 +214,19 @@ type lifetimeWalk struct {
 //     searched the way the object it names is.
 //
 // Any other kind stops the walk there, so the call reads as storing nothing through it. That
-// silence is deliberate, unlike the cut a limit causes: the kind holds no field-addressable
-// borrow. One case is worth naming. A class LIFETIME argument, the `'a` of `Box<'a, T>` rather
+// silence is deliberate, unlike the truncation an allowance causes: the kind holds no
+// field-addressable borrow. One case is worth naming. A class LIFETIME argument, the `'a` of `Box<'a, T>` rather
 // than the type argument this walk does descend, is unreachable because a class declares no
 // lifetime parameters. It wants an arm here once one can be written.
 func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 	if t == nil || w.onPath.Contains(t) {
 		return
 	}
-	if w.budget <= 0 {
-		w.cut = true
+	if w.nodesLeft <= 0 {
+		w.truncated = true
 		return
 	}
-	w.budget--
+	w.nodesLeft--
 	w.onPath.Add(t)
 	defer w.onPath.Remove(t)
 
@@ -275,20 +279,20 @@ func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 // expansion alone. expandAlias substitutes the reference's type and lifetime arguments into
 // the body, so the expansion already carries each argument at the field path it really sits
 // at. Walking the arguments here as well would report a second occurrence at the container's
-// path. An alias with no expansion — unregistered, bodyless, or reached with the expansion fuel
-// spent — has its arguments attributed to base instead of being dropped.
+// path. An alias with no expansion — unregistered, bodyless, or reached with the chain's alias
+// depth spent — has its arguments attributed to base instead of being dropped.
 func (w *lifetimeWalk) walkAlias(t *soltype.AliasType, base []placeSeg) {
 	if w.ctx != nil {
 		if def, ok := w.ctx.aliasDef(t.Name); ok && def.Body != nil {
-			if w.fuel <= 0 {
+			if w.aliasDepthLeft <= 0 {
 				// The expansion this would have walked holds occurrences the caller does not
 				// get to see, so say the walk stopped short rather than reading the
 				// reference's own arguments as all the alias contributes.
-				w.cut = true
+				w.truncated = true
 				return
 			}
-			w.fuel--
-			defer func() { w.fuel++ }()
+			w.aliasDepthLeft--
+			defer func() { w.aliasDepthLeft++ }()
 			w.walk(w.ctx.expandAlias(t), base)
 			return
 		}

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -67,6 +67,12 @@ type storeEdge struct {
 // source's lifetimes are collected before the target loop, and a target's referent is
 // searched into a map from lifetime to the paths it sits at rather than once per source
 // lifetime.
+//
+// A walk that runs out of budget or alias fuel saw only part of its type, so a lifetime the
+// two sides share may sit past where it stopped. Such a pair takes a store at the whole
+// target rather than none: dropping the edge would drop the escape a borrow written there
+// raises, and the widest position is the sound reading when the exact one is unknown. Only a
+// signature far past anything hand-written reaches either limit.
 func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 	var sources, targets []int
 	for i, p := range fn.Params {
@@ -85,19 +91,29 @@ func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 		return nil
 	}
 	sourceLts := map[int][]*soltype.LifetimeVar{}
+	sourceCut := map[int]bool{}
 	for _, i := range sources {
-		sourceLts[i] = lifetimeVarsIn(ctx, fn.Params[i].Type)
+		sourceLts[i], sourceCut[i] = lifetimeVarsIn(ctx, fn.Params[i].Type)
 	}
 
 	var out []storeEdge
 	for _, j := range targets {
 		dst := fn.Params[j].Type.(*soltype.RefType)
-		sites := lifetimeSites(ctx, dst.Inner)
-		if len(sites) == 0 {
+		sites, targetCut := lifetimeSites(ctx, dst.Inner)
+		if len(sites) == 0 && !targetCut {
 			continue
 		}
 		for _, i := range sources {
 			if i == j {
+				continue
+			}
+			// A walk that stopped short saw a subset of the type's lifetimes, so a shared one
+			// may sit past where it stopped. Reading that as "no store" would drop the edge
+			// and with it the escape a dangling borrow written there would raise, so record
+			// the store at the whole target instead: an unnamed path is the widest position
+			// the recorder can name, and every field read through the target follows it.
+			if targetCut || sourceCut[i] {
+				out = append(out, storeEdge{arg: i, target: j})
 				continue
 			}
 			for _, lv := range sourceLts[i] {
@@ -113,33 +129,36 @@ func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 // lifetimeSites maps each lifetime variable occurring in t to the field paths within t it
 // occurs at. Reading the map by lifetime is what lets one walk of a target's referent answer
 // for every source lifetime.
-func lifetimeSites(ctx *Context, t soltype.Type) map[*soltype.LifetimeVar][][]placeSeg {
+func lifetimeSites(ctx *Context, t soltype.Type) (map[*soltype.LifetimeVar][][]placeSeg, bool) {
 	sites := map[*soltype.LifetimeVar][][]placeSeg{}
-	walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, path []placeSeg) {
+	cut := walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, path []placeSeg) {
 		sites[lv] = append(sites[lv], path)
 	})
-	return sites
+	return sites, cut
 }
 
 // lifetimeVarsIn returns the lifetime variables occurring anywhere in t, deduped by identity
 // and ordered as the walk reaches them, which keeps the store edges a signature yields in a
 // stable order across runs.
-func lifetimeVarsIn(ctx *Context, t soltype.Type) []*soltype.LifetimeVar {
+func lifetimeVarsIn(ctx *Context, t soltype.Type) ([]*soltype.LifetimeVar, bool) {
 	var out []*soltype.LifetimeVar
 	seen := set.NewSet[*soltype.LifetimeVar]()
-	walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, _ []placeSeg) {
+	cut := walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, _ []placeSeg) {
 		if seen.Contains(lv) {
 			return
 		}
 		seen.Add(lv)
 		out = append(out, lv)
 	})
-	return out
+	return out, cut
 }
 
 // walkLifetimes calls visit once per lifetime-variable occurrence in t, passing the field
-// path within t at which it occurs.
-func walkLifetimes(ctx *Context, t soltype.Type, visit func(*soltype.LifetimeVar, []placeSeg)) {
+// path within t at which it occurs. cut reports that a limit stopped the walk before it
+// reached every node, so the occurrences visit saw are a subset of what t holds.
+func walkLifetimes(
+	ctx *Context, t soltype.Type, visit func(*soltype.LifetimeVar, []placeSeg),
+) (cut bool) {
 	w := &lifetimeWalk{
 		ctx:    ctx,
 		visit:  visit,
@@ -148,13 +167,15 @@ func walkLifetimes(ctx *Context, t soltype.Type, visit func(*soltype.LifetimeVar
 		fuel:   maxAliasExpansionDepth,
 	}
 	w.walk(t, nil)
+	return w.cut
 }
 
 // maxLifetimeWalkNodes bounds how many type nodes one walk visits. Alias expansion is what
 // makes the bound necessary: a chain of aliases that each name the next one twice describes
 // exponentially many field paths, and walking them all takes minutes at a depth a signature
 // could plausibly reach. A signature carrying this many type nodes is far past anything
-// hand-written.
+// hand-written. Running out reports the walk as cut, which callStoreEdges reads as a store at
+// the whole target rather than as no store.
 const maxLifetimeWalkNodes = 1024
 
 // maxAliasExpansionDepth bounds how many alias expansions one root-to-node chain may stack.
@@ -164,8 +185,7 @@ const maxLifetimeWalkNodes = 1024
 // refusing a repeated alias NAME is what keeps a re-nesting like `W<W<&'a mut B>>` correct,
 // since its two levels are different types and the inner one holds the borrow.
 //
-// Running out of either limit records fewer store edges, the same silence a kind the walk
-// does not descend produces.
+// Running out reports the walk as cut, the same as running out of node budget.
 const maxAliasExpansionDepth = 8
 
 // lifetimeWalk reports where each lifetime variable occurs in a type, as a field path from
@@ -184,6 +204,10 @@ type lifetimeWalk struct {
 	onPath set.Set[soltype.Type]
 	budget int
 	fuel   int
+	// cut records that budget or fuel ran out, so the walk stopped before reaching every
+	// node. Its caller reads this to tell "t holds no more occurrences" apart from "the walk
+	// stopped looking", which decide a store differently.
+	cut bool
 }
 
 // walk descends t, extending base by a segment at each named field. Only the kinds that can
@@ -205,12 +229,18 @@ type lifetimeWalk struct {
 //   - An alias descends its expansion at base. An alias is transparent, so a referent
 //     written as `Holder<'a>` is searched the way the object the alias names is.
 //
-// Any other kind stops the walk, so the call reads as storing nothing through it. One is
+// Any other kind stops the walk there, so the call reads as storing nothing through it. That
+// is a deliberate silence about a kind that holds no field-addressable borrow, unlike the cut
+// a limit causes, which says the walk stopped before it finished looking. One is
 // worth naming. A class LIFETIME argument — the `'a` of `Box<'a, T>`, as opposed to the type
 // argument this walk does descend — is unreachable because a class declares no lifetime
 // parameters, and it wants an arm here once one can be written.
 func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
-	if t == nil || w.budget <= 0 || w.onPath.Contains(t) {
+	if t == nil || w.onPath.Contains(t) {
+		return
+	}
+	if w.budget <= 0 {
+		w.cut = true
 		return
 	}
 	w.budget--
@@ -269,8 +299,15 @@ func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 // container's path. An alias with no expansion — unregistered, bodyless, or reached with the
 // expansion fuel spent — has its arguments attributed to base instead of being dropped.
 func (w *lifetimeWalk) walkAlias(t *soltype.AliasType, base []placeSeg) {
-	if w.ctx != nil && w.fuel > 0 {
+	if w.ctx != nil {
 		if def, ok := w.ctx.aliasDef(t.Name); ok && def.Body != nil {
+			if w.fuel <= 0 {
+				// The expansion this would have walked holds occurrences the caller does not
+				// get to see, so say the walk stopped short rather than reading the
+				// reference's own arguments as all the alias contributes.
+				w.cut = true
+				return
+			}
 			w.fuel--
 			defer func() { w.fuel++ }()
 			w.walk(w.ctx.expandAlias(t), base)

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -1,0 +1,403 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// A call stores one of its argument-borrows into another argument when the two share a
+// lifetime and the shared lifetime sits inside the second parameter's referent. In
+//
+//	declare fn store<'a, 'b>(target: &'b mut {peer: &'a mut B}, item: &'a mut B)
+//
+// item's borrow lifetime 'a reappears at target's peer field. Whatever item borrows must
+// therefore stay alive for as long as target.peer is readable, which is what "the call
+// writes item's borrow into target" means. At the call `store(&mut a, &mut b)` that is the
+// edge a → b at [peer], the same edge `val a = {peer: &mut b}` records at its initializer.
+//
+// A lifetime shared at the two parameters' outermost position is not a store. In
+// `fn f<'a>(x: &'a mut B, y: &'a mut B)` the two borrows only share one region; neither
+// referent is reachable through the other. The search below skips each candidate target's
+// own outer lifetime and looks inside its referent. The stored argument's side has no such
+// exemption: any lifetime its type mentions, outermost or nested, names data the callee
+// holds and may write into the target.
+//
+// A signature that only reads through the shared lifetime gets the same treatment as one
+// that writes, because the two are spelled alike: a mutable borrow whose referent mentions
+// the argument's lifetime may write it there, and the recorder takes the permission at face
+// value. That errs toward recording an alias the call might not form, which reports an
+// escape the program does not have. The opposite reading would miss a real dangling borrow.
+//
+// `a.peers.push(&mut b)`, the container case this machinery exists for, is not covered. Four
+// pieces are missing: an `Array` type with a method surface, a lifetime parameter on the
+// container type tying the element borrow to the receiver, the receiver's own type at the
+// call site, which memberValue strips off the signature it hands the call, and named
+// lifetimes on a method signature.
+//
+// That last one is why no method call records a store today, through `self` or through an
+// explicit parameter alike. A method signature reaches the call site with its lifetimes
+// coalesced to the anonymous display lifetime rather than lifetime variables, so the two
+// sides of a store share nothing the search can match.
+type storeEdge struct {
+	// arg is the index of the argument whose borrow the call stores.
+	arg int
+	// target is the index of the parameter the borrow is stored into.
+	target int
+	// path is the field path within the target's referent where the borrow lands, so
+	// `&'b mut {peer: &'a mut B}` gives [peer]. A store position the walk reaches but
+	// cannot name, such as a tuple element or a class type argument, keeps the path of
+	// its container.
+	path []placeSeg
+}
+
+// callStoreEdges returns the store effects the resolved signature fn declares, one per
+// (argument, target, field path) triple.
+//
+// A target must be a mutable borrow: a shared borrow takes no write, and an owned-mutable
+// parameter — a `RefType` with a nil lifetime — is moved into the callee, so what the callee
+// writes into it the caller can no longer read. A source must be a borrow too, since an
+// owned argument is moved into the callee and its escape belongs to the consuming-argument
+// rule.
+//
+// A signature that declares no store returns none, the common case. Each side is classified
+// by type kind alone before any type is walked, so an ordinary call over owned arguments
+// costs one pass over the parameter list. Every parameter that is walked is walked once: a
+// source's lifetimes are collected before the target loop, and a target's referent is
+// searched into a map from lifetime to the paths it sits at rather than once per source
+// lifetime.
+func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
+	var sources, targets []int
+	for i, p := range fn.Params {
+		ref, isRef := p.Type.(*soltype.RefType)
+		if !isRef || ref.Lt == nil {
+			continue
+		}
+		sources = append(sources, i)
+		if ref.Mut {
+			targets = append(targets, i)
+		}
+	}
+	// One borrow parameter alone declares no store: a store needs a source and a target that
+	// are different parameters.
+	if len(targets) == 0 || len(sources) < 2 {
+		return nil
+	}
+	sourceLts := map[int][]*soltype.LifetimeVar{}
+	for _, i := range sources {
+		sourceLts[i] = lifetimeVarsIn(ctx, fn.Params[i].Type)
+	}
+
+	var out []storeEdge
+	for _, j := range targets {
+		dst := fn.Params[j].Type.(*soltype.RefType)
+		sites := lifetimeSites(ctx, dst.Inner)
+		if len(sites) == 0 {
+			continue
+		}
+		for _, i := range sources {
+			if i == j {
+				continue
+			}
+			for _, lv := range sourceLts[i] {
+				for _, path := range sites[lv] {
+					out = append(out, storeEdge{arg: i, target: j, path: path})
+				}
+			}
+		}
+	}
+	return out
+}
+
+// lifetimeSites maps each lifetime variable occurring in t to the field paths within t it
+// occurs at. Reading the map by lifetime is what lets one walk of a target's referent answer
+// for every source lifetime.
+func lifetimeSites(ctx *Context, t soltype.Type) map[*soltype.LifetimeVar][][]placeSeg {
+	sites := map[*soltype.LifetimeVar][][]placeSeg{}
+	walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, path []placeSeg) {
+		sites[lv] = append(sites[lv], path)
+	})
+	return sites
+}
+
+// lifetimeVarsIn returns the lifetime variables occurring anywhere in t, deduped by identity
+// and ordered as the walk reaches them, which keeps the store edges a signature yields in a
+// stable order across runs.
+func lifetimeVarsIn(ctx *Context, t soltype.Type) []*soltype.LifetimeVar {
+	var out []*soltype.LifetimeVar
+	seen := set.NewSet[*soltype.LifetimeVar]()
+	walkLifetimes(ctx, t, func(lv *soltype.LifetimeVar, _ []placeSeg) {
+		if seen.Contains(lv) {
+			return
+		}
+		seen.Add(lv)
+		out = append(out, lv)
+	})
+	return out
+}
+
+// walkLifetimes calls visit once per lifetime-variable occurrence in t, passing the field
+// path within t at which it occurs.
+func walkLifetimes(ctx *Context, t soltype.Type, visit func(*soltype.LifetimeVar, []placeSeg)) {
+	w := &lifetimeWalk{
+		ctx:    ctx,
+		visit:  visit,
+		onPath: set.NewSet[soltype.Type](),
+		budget: maxLifetimeWalkNodes,
+		fuel:   maxAliasExpansionDepth,
+	}
+	w.walk(t, nil)
+}
+
+// maxLifetimeWalkNodes bounds how many type nodes one walk visits. Alias expansion is what
+// makes the bound necessary: a chain of aliases that each name the next one twice describes
+// exponentially many field paths, and walking them all takes minutes at a depth a signature
+// could plausibly reach. A signature carrying this many type nodes is far past anything
+// hand-written.
+const maxLifetimeWalkNodes = 1024
+
+// maxAliasExpansionDepth bounds how many alias expansions one root-to-node chain may stack.
+// A recursive alias such as `type List<T> = {head: T, tail: List<T>}` expands forever
+// otherwise: each expansion substitutes into a fresh body, which the identity-keyed onPath
+// set cannot recognize as the one already being walked. Bounding the depth rather than
+// refusing a repeated alias NAME is what keeps a re-nesting like `W<W<&'a mut B>>` correct,
+// since its two levels are different types and the inner one holds the borrow.
+//
+// Running out of either limit records fewer store edges, the same silence a kind the walk
+// does not descend produces.
+const maxAliasExpansionDepth = 8
+
+// lifetimeWalk reports where each lifetime variable occurs in a type, as a field path from
+// the type's root. The soltype visitor cannot drive it: that visitor rewrites a type
+// bottom-up and hands each node no record of the fields traversed to reach it, and the path
+// is the whole point here. recordBorrowSources walks the AST by hand for the same reason.
+//
+// Three limits keep the walk finite and cheap. onPath holds the types on the current
+// root-to-node chain, so a type that refers to itself terminates while a type reached twice
+// at two different field paths still yields both. fuel is the alias expansions left on that
+// chain, which onPath cannot bound, for the reason maxAliasExpansionDepth gives. budget caps
+// the total nodes visited, for the reason maxLifetimeWalkNodes gives.
+type lifetimeWalk struct {
+	ctx    *Context
+	visit  func(*soltype.LifetimeVar, []placeSeg)
+	onPath set.Set[soltype.Type]
+	budget int
+	fuel   int
+}
+
+// walk descends t, extending base by a segment at each named field. Only the kinds that can
+// hold a borrow reachable by a field path are descended:
+//
+//   - A borrow reports its own lifetime at base, then descends its referent, so a borrow of
+//     a borrow is reached.
+//   - An object descends each named property at base plus that name. A member that names no
+//     field of its own descends at base, attributing what it holds to the enclosing object,
+//     the approximation recordBorrowSources makes for a computed key. walkObjElem says which
+//     members those are.
+//   - A tuple element and a class type argument descend at base unchanged. Neither
+//     contributes a name: the place model has no index segment, and a class type argument is
+//     not addressable as a field at all. `&'c mut Box<&'a mut B>` therefore stores at the
+//     whole Box, which is where a class holding a borrowed element lands.
+//   - A union or intersection descends each member at base, since a borrow any member holds
+//     is reachable through the whole.
+//   - An alias descends its expansion at base. An alias is transparent, so a referent
+//     written as `Holder<'a>` is searched the way the object the alias names is.
+//
+// Any other kind stops the walk, so the call reads as storing nothing through it. Two kinds
+// are worth naming, since both are the container shapes the stdlib ingestion milestone
+// brings and each wants an arm here once it can be written. An `Array<T>` element is
+// unreachable because `&mut Array<T>` is not a borrowable type. A class lifetime argument —
+// the `'a` of `Box<'a, T>`, as opposed to the type argument this walk does descend — is
+// unreachable because a class declares no lifetime parameters.
+func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
+	if t == nil || w.budget <= 0 || w.onPath.Contains(t) {
+		return
+	}
+	w.budget--
+	w.onPath.Add(t)
+	defer w.onPath.Remove(t)
+
+	switch t := t.(type) {
+	case *soltype.RefType:
+		if lv, ok := t.Lt.(*soltype.LifetimeVar); ok {
+			w.visit(lv, base)
+		}
+		w.walk(t.Inner, base)
+	case *soltype.ObjectType:
+		for _, elem := range t.Elems {
+			prop, isProp := elem.(*soltype.PropertyElem)
+			if !isProp {
+				w.walkObjElem(elem, base)
+				continue
+			}
+			w.walk(prop.Type, appendSeg(base, prop.Name))
+		}
+	case *soltype.TupleType:
+		for _, elem := range t.Elems {
+			w.walk(elem, base)
+		}
+	case *soltype.ClassType:
+		for _, arg := range t.TypeArgs {
+			w.walk(arg, base)
+		}
+	case *soltype.UnionType:
+		for _, member := range t.Types {
+			w.walk(member, base)
+		}
+	case *soltype.IntersectionType:
+		for _, member := range t.Types {
+			w.walk(member, base)
+		}
+	case *soltype.AliasType:
+		w.walkAlias(t, base)
+	}
+}
+
+// walkAlias descends an alias reference. A registered alias with a body is walked through its
+// expansion alone: expandAlias substitutes the reference's type and lifetime arguments into
+// the body, so the expansion already carries each argument at the field path it really sits
+// at, and walking the arguments here as well would report a second occurrence at the
+// container's path. An alias with no expansion — unregistered, bodyless, or reached with the
+// expansion fuel spent — has its arguments attributed to base instead of being dropped.
+func (w *lifetimeWalk) walkAlias(t *soltype.AliasType, base []placeSeg) {
+	if w.ctx != nil && w.fuel > 0 {
+		if def, ok := w.ctx.aliasDef(t.Name); ok && def.Body != nil {
+			w.fuel--
+			defer func() { w.fuel++ }()
+			w.walk(w.ctx.expandAlias(t), base)
+			return
+		}
+	}
+	for _, arg := range t.TypeArgs {
+		w.walk(arg, base)
+	}
+	for _, arg := range t.LifetimeArgs {
+		if lv, ok := arg.(*soltype.LifetimeVar); ok {
+			w.visit(lv, base)
+		}
+	}
+}
+
+// walkObjElem descends an object member that names no field of its own. Three hold data the
+// enclosing object exposes, so each is attributed to base: a getter's value, a spread's
+// source, and an index signature's value, which covers every key it admits rather than one.
+// A method, a setter, and a constructor hold their borrows in a signature the enclosing
+// object does not expose as data, so they contribute nothing.
+func (w *lifetimeWalk) walkObjElem(elem soltype.ObjTypeElem, base []placeSeg) {
+	switch elem := elem.(type) {
+	case *soltype.GetterElem:
+		w.walk(elem.Type, base)
+	case *soltype.SpreadElem:
+		w.walk(elem.Type, base)
+	case *soltype.MappedElem:
+		w.walk(elem.Value, base)
+	}
+}
+
+// recordCallStoreEdges handles, for the call e against the resolved signature fn, each store
+// the signature declares. Where the borrow lands decides what happens, the same split a
+// field store makes between recordFieldStoreEdges and checkParamFieldStoreEscape:
+//
+//   - Into a local, the call records a borrow edge. `store(&mut a, &mut b)` against the
+//     store-effect signature in this file's opening comment records a → b at [peer], so a
+//     later flow-out of a finds b the way it would had a's initializer written the borrow in
+//     directly. The target's own place is the prefix, so `store(&mut a.slot, &mut b)` records
+//     at [slot, peer].
+//   - Into a parameter, the locals the argument carries are reported at once. The parameter's
+//     referent belongs to the caller and outlives the frame, so a borrow of a local written
+//     into it dangles. The report is direct rather than deferred to the escape post-pass,
+//     because the callee borrows the argument instead of taking it, and the post-pass would
+//     weigh an owned-looking argument as a connected-component move and consume it.
+//
+// A store is skipped when the argument carries no function-local, when the target names no
+// binding, or when the two are the same binding, which would make a self-loop no reader of
+// the graph can use.
+//
+// An edge is added to whatever the target already holds rather than replacing it, since a
+// signature says where a borrow lands and not whether the callee overwrites what was there.
+// A container that accumulates is the shape this models, and keeping the prior edge is the
+// sound reading for one that overwrites.
+//
+// Recording alone does not reach the escape check, which reads the per-program-point graph
+// rather than the eager one, so a call that recorded an edge flushes the roots it dirtied
+// into this statement's borrowGens, the same handoff a `val` initializer makes.
+func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, ref liveness.StmtRef) {
+	if c.fn == nil || c.fn.eagerBorrowGraph == nil {
+		return
+	}
+	recorded := false
+	// A signature can write one argument to several positions in the target, so its escape
+	// reaches this loop once per position. Collecting per argument and emitting after the loop
+	// keeps one diagnostic per escaping local, blamed on the argument that carries it.
+	escaping := map[int]set.Set[liveness.VarID]{}
+	for _, edge := range callStoreEdges(c.ctx, fn) {
+		if edge.arg >= len(e.Args) || edge.target >= len(e.Args) {
+			continue
+		}
+		referents := c.storedReferents(e.Args[edge.arg])
+		if len(referents) == 0 {
+			continue
+		}
+		target, isPlace := exprPlace(borrowOperand(e.Args[edge.target]))
+		if !isPlace || target.root <= 0 {
+			continue
+		}
+		if c.fn.paramVarIDs.Contains(target.root) {
+			carried, seen := escaping[edge.arg]
+			if !seen {
+				carried = set.NewSet[liveness.VarID]()
+				escaping[edge.arg] = carried
+			}
+			for _, referent := range referents {
+				carried.Add(referent)
+			}
+			continue
+		}
+		for _, referent := range referents {
+			if target.root == referent {
+				continue
+			}
+			c.addBorrowEdge(target.root, appendPath(target.path, edge.path), referent)
+			recorded = true
+		}
+	}
+	for arg := range len(e.Args) {
+		if carried, ok := escaping[arg]; ok {
+			c.reportEscapingLocals(carried, e.Args[arg])
+		}
+	}
+	if recorded {
+		c.flushBorrowDirty(ref)
+	}
+}
+
+// storedReferents returns the function-locals a stored argument carries. A borrow of a place
+// names one: `&mut b`, and a bare `b` passed to a shared-borrow parameter, both carry b. An
+// argument that builds its carrier inline, such as `&{inner: &mut b}`, names one per borrow
+// the carrier holds, found by the same scan escapingLocalsOf runs over a returned value.
+func (c *checker) storedReferents(arg ast.Expr) []liveness.VarID {
+	if referent, ok := c.isLocalReferent(borrowOperand(arg)); ok {
+		return []liveness.VarID{referent}
+	}
+	var out []liveness.VarID
+	seen := set.NewSet[liveness.VarID]()
+	for _, b := range borrowsIn(arg) {
+		referent, ok := c.isLocalReferent(b.Arg)
+		if !ok || seen.Contains(referent) {
+			continue
+		}
+		seen.Add(referent)
+		out = append(out, referent)
+	}
+	return out
+}
+
+// borrowOperand returns the place a borrow argument names: the operand of an explicit
+// `&`/`&mut`, or the argument itself when the call auto-borrows a place passed by name.
+func borrowOperand(arg ast.Expr) ast.Expr {
+	if b, ok := arg.(*ast.BorrowExpr); ok {
+		return b.Arg
+	}
+	return arg
+}

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -324,66 +324,43 @@ func (w *lifetimeWalk) walkObjElem(elem soltype.ObjTypeElem, base []placeSeg) {
 	}
 }
 
-// recordCallStoreEdges handles each store fn declares at the call e. Where the borrow lands
-// decides what happens, the same split a field store makes between recordFieldStoreEdges and
-// checkParamFieldStoreEscape:
-//
-//   - Into a local, the call records a borrow edge, so a later flow-out of that local finds
-//     the borrow. The target's own place is the prefix, so `store(&mut a.slot, &mut b)`
-//     records at [slot, peer] rather than at [peer].
-//   - Into a parameter, the locals the argument carries are reported at once, since the
-//     parameter's referent belongs to the caller and outlives the frame. Reporting here
-//     rather than deferring to the escape post-pass is what keeps the callee's borrow from
-//     being weighed as a move, which would consume the locals.
-//
-// Both read against the signature in this file's opening comment. A local target:
-//
-//	fn build(p: mut {value: number}) -> &mut {value: number} {
-//		val mut b = {value: 2}
-//		val mut a = {peer: &mut p}
-//		store(&mut a, &mut b)   // records a → b at [peer]
-//		return a.peer           // follows that edge and reports b
-//	}
-//
-// A parameter target, where nothing is recorded and b is reported at the call:
-//
-//	fn build(p: &mut {peer: &mut {value: number}}) -> undefined {
-//		val mut b = {value: 2}
-//		store(p, &mut b)
-//	}
-//
-// A store is skipped when the argument carries no function-local, when the target names no
-// binding, or when the two are the same binding, which would make an unusable self-loop.
-//
-// An edge is added to what the target already holds rather than replacing it, since a
-// signature says where a borrow lands and not whether the callee overwrites what was there.
-// This models a container that accumulates, and keeps the sound reading for one that
-// overwrites.
-//
-// The escape check reads the per-program-point graph rather than the eager one, so a call that
-// recorded an edge flushes the roots it dirtied into this statement's borrowGens, the same
-// handoff a `val` initializer makes.
+// recordCallStoreEdges records the stores fn declares at the call e. A store into a local
+// records a borrow edge, so a later flow-out of that local finds the borrow. A store into a
+// parameter escapes instead, since the parameter's referent belongs to the caller. It is the
+// call-site twin of the split recordFieldStoreEdges and checkParamFieldStoreEscape make for a
+// field store.
 func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, ref liveness.StmtRef) {
 	if c.fn == nil || c.fn.eagerBorrowGraph == nil {
 		return
 	}
 	recorded := false
-	// A signature can write one argument to several positions in the target, so its escape
-	// reaches this loop once per position. Collecting per argument and emitting after the loop
-	// keeps one diagnostic per escaping local, blamed on the argument that carries it.
+	// A signature can write one argument into several positions of the target, so an escaping
+	// argument reaches the loop once per position. Collecting per argument and reporting after
+	// the loop keeps that to one diagnostic, blamed on the argument carrying the local.
 	escaping := map[int]set.Set[liveness.VarID]{}
 	for _, edge := range callStoreEdges(c.ctx, fn) {
+		// A call whose argument count does not match the signature is reported elsewhere and
+		// still reaches here, so the positions are bounds-checked before use.
 		if edge.arg >= len(e.Args) || edge.target >= len(e.Args) {
 			continue
 		}
+		// Only a borrow of a function-local can dangle. An argument carrying none of those
+		// stores nothing the graph needs to know about.
 		referents := c.storedReferents(e.Args[edge.arg])
 		if len(referents) == 0 {
 			continue
 		}
+		// An edge hangs off a binding, so the target has to name one. An argument built inline
+		// names no place and leaves nothing to root the edge at.
 		target, isPlace := exprPlace(borrowOperand(e.Args[edge.target]))
 		if !isPlace || target.root <= 0 {
 			continue
 		}
+		// A parameter's referent belongs to the caller and outlives the frame, so a borrow of
+		// a local written into it dangles. Reporting it here rather than recording an edge is
+		// what keeps the escape post-pass out of it. The callee borrows this argument instead
+		// of taking it, and the post-pass would weigh an owned-looking argument as a
+		// connected-component move and consume the locals it borrows.
 		if c.fn.paramVarIDs.Contains(target.root) {
 			carried, seen := escaping[edge.arg]
 			if !seen {
@@ -396,9 +373,14 @@ func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, re
 			continue
 		}
 		for _, referent := range referents {
+			// An edge from a binding to itself tells no reader of the graph anything.
 			if target.root == referent {
 				continue
 			}
+			// The target's own place prefixes the store's path, so `store(&mut a.slot, &mut b)`
+			// against a signature storing at [peer] records at [slot, peer]. The edge is added
+			// to what the target already holds rather than replacing it, since a signature says
+			// where a borrow lands and not whether the callee overwrites what was there.
 			c.addBorrowEdge(target.root, appendPath(target.path, edge.path), referent)
 			recorded = true
 		}
@@ -408,6 +390,9 @@ func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, re
 			c.reportEscapingLocals(carried, e.Args[arg])
 		}
 	}
+	// The escape check reads the per-program-point graph rather than the eager one, so the
+	// roots this call dirtied have to reach the statement's borrowGens. A `val` initializer
+	// makes the same handoff.
 	if recorded {
 		c.flushBorrowDirty(ref)
 	}

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -91,7 +91,8 @@ func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 				continue
 			}
 			// An unnamed path is the widest position the recorder can name, and every field
-			// read through the target follows it. See the truncation rule above.
+			// read through the target follows it. This function's doc comment says why a
+			// truncated walk takes a store rather than none.
 			if targetTruncated || sourceTruncated[i] {
 				out = append(out, storeEdge{arg: i, target: j})
 				continue

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -328,14 +328,29 @@ func (w *lifetimeWalk) walkObjElem(elem soltype.ObjTypeElem, base []placeSeg) {
 // decides what happens, the same split a field store makes between recordFieldStoreEdges and
 // checkParamFieldStoreEscape:
 //
-//   - Into a local, the call records a borrow edge. `store(&mut a, &mut b)` against the
-//     signature in this file's opening comment records a → b at [peer], so a later flow-out of
-//     a finds b. The target's own place is the prefix, so `store(&mut a.slot, &mut b)` records
-//     at [slot, peer].
-//   - Into a parameter, the locals the argument carries are reported at once. The parameter's
-//     referent belongs to the caller and outlives the frame, so a borrow of a local written
-//     into it dangles. Reporting here rather than deferring to the escape post-pass is what
-//     keeps the callee's borrow from being weighed as a move, which would consume the locals.
+//   - Into a local, the call records a borrow edge, so a later flow-out of that local finds
+//     the borrow. The target's own place is the prefix, so `store(&mut a.slot, &mut b)`
+//     records at [slot, peer] rather than at [peer].
+//   - Into a parameter, the locals the argument carries are reported at once, since the
+//     parameter's referent belongs to the caller and outlives the frame. Reporting here
+//     rather than deferring to the escape post-pass is what keeps the callee's borrow from
+//     being weighed as a move, which would consume the locals.
+//
+// Both read against the signature in this file's opening comment. A local target:
+//
+//	fn build(p: mut {value: number}) -> &mut {value: number} {
+//		val mut b = {value: 2}
+//		val mut a = {peer: &mut p}
+//		store(&mut a, &mut b)   // records a → b at [peer]
+//		return a.peer           // follows that edge and reports b
+//	}
+//
+// A parameter target, where nothing is recorded and b is reported at the call:
+//
+//	fn build(p: &mut {peer: &mut {value: number}}) -> undefined {
+//		val mut b = {value: 2}
+//		store(p, &mut b)
+//	}
 //
 // A store is skipped when the argument carries no function-local, when the target names no
 // binding, or when the two are the same binding, which would make an unusable self-loop.

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -9,37 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// storeEffectDecls are the declarations the store-edge cases share. `store` is the
-// store-effect signature: 'a ties item to target's peer field, 'b is the spare field's own
-// lifetime, and 'c is target's own borrow lifetime, so only peer takes the stored borrow.
-// `take` consumes an owned carrier of that shape, giving the cases a flow-out site other
-// than a return.
-const storeEffectDecls = `
-	declare fn store<'a, 'b, 'c>(
-		target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
-		item: &'a mut {value: number},
-	) -> undefined
-	declare fn take(x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined
-`
-
-// storeEffectTypes are the inferred types of the two shared declarations, repeated in every
-// case's expectation since inferSource renders every binding in the module.
-var storeEffectTypes = map[string]string{
-	"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-		"item: &mut {value: number}) -> undefined",
-	"take": "fn (x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
-}
-
-// withStoreEffectTypes returns storeEffectTypes extended with the type of the function a
-// case declares, so each expectation names only what that case adds.
-func withStoreEffectTypes(build string) map[string]string {
-	out := map[string]string{"build": build}
-	for name, ty := range storeEffectTypes {
-		out[name] = ty
-	}
-	return out
-}
-
 // TestCallStoreEdge covers the borrow edge a call records when its signature stores an
 // argument-borrow into another argument. The signature spells the store by sharing one
 // lifetime between the stored argument and a position inside the target's referent, so
@@ -48,6 +17,10 @@ func withStoreEffectTypes(build string) map[string]string {
 //
 // says item lands at target.peer. `store(&mut a, &mut b)` then aliases a to b at [peer],
 // the same edge `val a = {peer: &mut b}` records at its initializer.
+//
+// Each case declares its own `store`. 'a ties item to target's peer field, 'b is the spare
+// field's own lifetime, and 'c is target's own borrow lifetime, so only peer takes the
+// stored borrow and spare is a sibling position the store must miss.
 //
 // The edge is observed through the two rules that read the borrow-edge graph: the
 // return-escape check, which reports a local a returned value still borrows, and the
@@ -64,7 +37,12 @@ func TestCallStoreEdge(t *testing.T) {
 		// borrow out of the frame. Without the store edge the escape check finds no borrow
 		// under [peer] and reports nothing.
 		"StoredBorrowEscapes": {
-			src: storeEffectDecls + `
+			src: `
+				declare fn store<'a, 'b, 'c>(
+					target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+
 				fn build(p: mut {value: number}, q: mut {value: number}) -> &mut {value: number} {
 					val mut b = {value: 2}
 					val mut a = {peer: &mut p, spare: &mut q}
@@ -72,14 +50,23 @@ func TestCallStoreEdge(t *testing.T) {
 					return a.peer
 				}
 			`,
-			want:  []string{"12:13-12:19: borrowed value 'b' does not live long enough to escape the function"},
-			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}"),
+			want: []string{"11:13-11:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
+			},
 		},
 		// The edge lands at [peer], so returning the disjoint [spare] field follows no edge
 		// and reports nothing. This is what the store's field path buys over attributing the
 		// borrow to the whole target.
 		"StoredBorrowDoesNotEscapeThroughDisjointField": {
-			src: storeEffectDecls + `
+			src: `
+				declare fn store<'a, 'b, 'c>(
+					target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+
 				fn build(p: mut {value: number}, q: mut {value: number}) -> &mut {value: number} {
 					val mut b = {value: 2}
 					val mut a = {peer: &mut p, spare: &mut q}
@@ -87,14 +74,23 @@ func TestCallStoreEdge(t *testing.T) {
 					return a.spare
 				}
 			`,
-			want:  nil,
-			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}"),
+			want: nil,
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
+			},
 		},
 		// The target's own place prefixes the store's field path, so storing into a field of
 		// the target records the edge at [inner, peer] and returning that nested field
 		// follows it.
 		"StoreThroughTargetFieldPlace": {
-			src: storeEffectDecls + `
+			src: `
+				declare fn store<'a, 'b, 'c>(
+					target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+
 				fn build(p: mut {value: number}, q: mut {value: number}) -> &mut {value: number} {
 					val mut b = {value: 2}
 					val mut a = {inner: {peer: &mut p, spare: &mut q}}
@@ -102,14 +98,24 @@ func TestCallStoreEdge(t *testing.T) {
 					return a.inner.peer
 				}
 			`,
-			want:  []string{"12:13-12:25: borrowed value 'b' does not live long enough to escape the function"},
-			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}"),
+			want: []string{"11:13-11:25: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
+			},
 		},
 		// The edge reaches the connected-component move as well as the escape check: passing
 		// a to a consuming parameter carries the stored borrow into the callee, so the move
 		// co-moves b and the read after it is a use-after-move.
 		"StoredBorrowIsCoMovedWithItsCarrier": {
-			src: storeEffectDecls + `
+			src: `
+				declare fn store<'a, 'b, 'c>(
+					target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+				declare fn take(x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined
+
 				fn build(p: mut {value: number}, q: mut {value: number}) -> undefined {
 					val mut b = {value: 2}
 					val mut a = {peer: &mut p, spare: &mut q}
@@ -118,13 +124,24 @@ func TestCallStoreEdge(t *testing.T) {
 					val y = b
 				}
 			`,
-			want:  []string{"13:14-13:15: use of moved value 'b'"},
-			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> undefined"),
+			want: []string{"13:14-13:15: use of moved value 'b'"},
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &mut {value: number}) -> undefined",
+				"take":  "fn (x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
+				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> undefined",
+			},
 		},
 		// Dropping the store call from the case above isolates its effect: with no edge from
 		// a to b, consuming a co-moves nothing and the read of b is fine.
 		"NoStoreLeavesTheCarrierAlone": {
-			src: storeEffectDecls + `
+			src: `
+				declare fn store<'a, 'b, 'c>(
+					target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+				declare fn take(x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined
+
 				fn build(p: mut {value: number}, q: mut {value: number}) -> undefined {
 					val mut b = {value: 2}
 					val mut a = {peer: &mut p, spare: &mut q}
@@ -132,22 +149,36 @@ func TestCallStoreEdge(t *testing.T) {
 					val y = b
 				}
 			`,
-			want:  nil,
-			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> undefined"),
+			want: nil,
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &mut {value: number}) -> undefined",
+				"take":  "fn (x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
+				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> undefined",
+			},
 		},
 		// A store whose target is a parameter escapes at once rather than recording an edge:
 		// the parameter's referent belongs to the caller and outlives the frame, so a borrow
 		// of a local written into it dangles. This is the call-site twin of the field store
 		// `p.peer = &mut b`, which checkParamFieldStoreEscape reports the same way.
 		"StoreIntoParameterTargetEscapes": {
-			src: storeEffectDecls + `
+			src: `
+				declare fn store<'a, 'b, 'c>(
+					target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+
 				fn build(p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined {
 					val mut b = {value: 2}
 					store(&mut p, &mut b)
 				}
 			`,
-			want:  []string{"10:20-10:26: borrowed value 'b' does not live long enough to escape the function"},
-			types: withStoreEffectTypes("fn (p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined"),
+			want: []string{"9:20-9:26: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
+			},
 		},
 		// An auto-borrowed place stored into a parameter escapes too. The argument names no
 		// borrow expression, so the local it carries is the place's own root rather than
@@ -172,7 +203,12 @@ func TestCallStoreEdge(t *testing.T) {
 		// Storing a borrow of a parameter records no edge: a parameter's lifetime is the
 		// caller's and already outlives the frame, so it is not a local that can dangle.
 		"StoredParamBorrowIsExempt": {
-			src: storeEffectDecls + `
+			src: `
+				declare fn store<'a, 'b, 'c>(
+					target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+
 				fn build(p: mut {value: number}, q: mut {value: number}, r: mut {value: number}) -> &mut {value: number} {
 					val mut a = {peer: &mut p, spare: &mut q}
 					store(&mut a, &mut r)
@@ -180,9 +216,12 @@ func TestCallStoreEdge(t *testing.T) {
 				}
 			`,
 			want: nil,
-			types: withStoreEffectTypes(
-				"fn (p: mut {value: number}, q: mut {value: number}, r: mut {value: number}) -> &mut {value: number}",
-			),
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}, q: mut {value: number}, r: mut {value: number}) " +
+					"-> &mut {value: number}",
+			},
 		},
 	}
 

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -686,7 +686,7 @@ func TestCallStoreEdgeAliasChainTerminates(t *testing.T) {
 	}
 }
 
-// TestCallStoreEdgeCutWalkStaysSound covers what a walk that runs out of alias fuel records.
+// TestCallStoreEdgeTruncatedWalkStaysSound covers what a walk that spends its alias depth records.
 // The borrow sits deeper in the chain than the fuel reaches, so the exact field path is
 // unknown; recording no store would drop the escape that borrow raises. The store lands at
 // the whole target instead, which every field read through it follows.
@@ -694,7 +694,7 @@ func TestCallStoreEdgeAliasChainTerminates(t *testing.T) {
 // The observable is the escape the store reports into an owned parameter target. #1262 will
 // stop reporting that, correctly, so this test needs a different observable when it lands.
 // A borrow parameter target keeps reporting and is the likely replacement.
-func TestCallStoreEdgeCutWalkStaysSound(t *testing.T) {
+func TestCallStoreEdgeTruncatedWalkStaysSound(t *testing.T) {
 	// One alias per level, each naming the next, with the borrow past maxAliasExpansionDepth.
 	depth := maxAliasExpansionDepth * 2
 	var b strings.Builder

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -474,10 +474,11 @@ func TestCallStoreEdgePositions(t *testing.T) {
 // payload sits in and returning that tuple follows the edge.
 //
 // Every case also reports one constrain error unrelated to the store. `&mut a` over a tuple
-// literal whose element is a bare name does not read as a mutable tuple, which is a
-// pre-existing limitation of the deep-mut rule rather than anything the store recorder does.
-// The same shape with a borrow element, TestCallStoreEdgePositions/StoreIntoTupleElement,
-// reports only the escape.
+// literal whose element is a bare name does not read as a mutable tuple, a pre-existing
+// limitation of the deep-mut rule rather than anything the store recorder does. The same shape
+// with a borrow element, TestCallStoreEdgePositions/StoreIntoTupleElement, reports only the
+// escape. #1270 tracks it, and the constrain error drops out of these expectations once the
+// unannotated `val mut` arm accepts a moved place inside a literal.
 func TestCallStoreEdgePayloadPositions(t *testing.T) {
 	tests := map[string]struct {
 		payload  string

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -157,49 +157,82 @@ func TestCallStoreEdge(t *testing.T) {
 				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> undefined",
 			},
 		},
-		// A store whose target is a parameter escapes at once rather than recording an edge:
-		// the parameter's referent belongs to the caller and outlives the frame, so a borrow
-		// of a local written into it dangles. This is the call-site twin of the field store
-		// `p.peer = &mut b`, which checkParamFieldStoreEscape reports the same way.
-		"StoreIntoParameterTargetEscapes": {
-			src: `
-				declare fn store<'a, 'b, 'c>(
-					target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
-					item: &'a mut {value: number},
-				) -> undefined
+		// DISABLED until #1262. `p` is an owned parameter, so it was moved into build and the
+		// caller holds no path to it. Nothing escapes, and the store should record an edge the
+		// way it does into a local. The check reports an escape because it asks only whether
+		// the root is a parameter, without separating a borrow parameter from an owned one.
+		// #1262 explains why narrowing that test has to land with the exclusivity pass in #794.
+		/*
+			"StoreIntoOwnedParameterTargetRecordsAnEdge": {
+				src: `
+					declare fn store<'a, 'b, 'c>(
+						target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+						item: &'a mut {value: number},
+					) -> undefined
 
-				fn build(p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined {
-					val mut b = {value: 2}
-					store(&mut p, &mut b)
-				}
-			`,
-			want: []string{"9:20-9:26: borrowed value 'b' does not live long enough to escape the function"},
-			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-					"item: &mut {value: number}) -> undefined",
-				"build": "fn (p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
+					fn build(p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined {
+						val mut b = {value: 2}
+						store(&mut p, &mut b)
+					}
+				`,
+				want: nil,
+				types: map[string]string{
+					"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+						"item: &mut {value: number}) -> undefined",
+					"build": "fn (p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
+				},
 			},
-		},
-		// An auto-borrowed place stored into a parameter escapes too. The argument names no
-		// borrow expression, so the local it carries is the place's own root rather than
-		// anything the escape post-pass would find by scanning the argument.
-		"AutoBorrowedArgumentIntoParameterEscapes": {
-			src: `
-				declare fn store<'a, 'c>(
-					target: &'c mut {peer: &'a {value: number}},
-					item: &'a {value: number},
-				) -> undefined
-				fn build(p: mut {peer: &{value: number}}) -> undefined {
-					val b = {value: 2}
-					store(&mut p, b)
-				}
-			`,
-			want: []string{"8:20-8:21: borrowed value 'b' does not live long enough to escape the function"},
-			types: map[string]string{
-				"store": "fn (target: &mut {peer: &{value: number}}, item: &{value: number}) -> undefined",
-				"build": "fn (p: mut {peer: &{value: number}}) -> undefined",
+		*/
+		// DISABLED until #1262. The auto-borrowed form of the case above. The argument names no
+		// borrow expression, so the local it carries is the place's own root, but the target is
+		// still an owned parameter and still nothing the caller can reach.
+		/*
+			"AutoBorrowedArgumentIntoOwnedParameterRecordsAnEdge": {
+				src: `
+					declare fn store<'a, 'c>(
+						target: &'c mut {peer: &'a {value: number}},
+						item: &'a {value: number},
+					) -> undefined
+					fn build(p: mut {peer: &{value: number}}) -> undefined {
+						val b = {value: 2}
+						store(&mut p, b)
+					}
+				`,
+				want: nil,
+				types: map[string]string{
+					"store": "fn (target: &mut {peer: &{value: number}}, item: &{value: number}) -> undefined",
+					"build": "fn (p: mut {peer: &{value: number}}) -> undefined",
+				},
 			},
-		},
+		*/
+		// DISABLED until #1263. The store aliases a.peer to b, so the returned tuple hands the
+		// caller two mutable paths to one object. That is the shape a GC'd target makes unsafe,
+		// and nothing reports it. The wording and span below are a guess at what the
+		// exclusivity pass in #794 will produce; confirm both when re-enabling.
+		/*
+			"TwoMutablePathsEscape": {
+				src: `
+					declare fn store<'a, 'b, 'c>(
+						target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+						item: &'a mut {value: number},
+					) -> undefined
+
+					fn build(p: mut {value: number}, q: mut {value: number}) -> [&mut {value: number}, &mut {value: number}] {
+						val mut b = {value: 2}
+						val mut a = {peer: &mut p, spare: &mut q}
+						store(&mut a, &mut b)
+						return [a.peer, &mut b]
+					}
+				`,
+				want: []string{"11:22-11:28: cannot borrow 'b' as mutable more than once at a time"},
+				types: map[string]string{
+					"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+						"item: &mut {value: number}) -> undefined",
+					"build": "fn (p: mut {value: number}, q: mut {value: number}) " +
+						"-> [&mut {value: number}, &mut {value: number}]",
+				},
+			},
+		*/
 		// Storing a borrow of a parameter records no edge: a parameter's lifetime is the
 		// caller's and already outlives the frame, so it is not a local that can dangle.
 		"StoredParamBorrowIsExempt": {
@@ -616,6 +649,10 @@ func TestCallStoreEdgeNonStores(t *testing.T) {
 // its field paths number 2^depth. Without the budget the walk enumerates all of them and the
 // call takes minutes; with it the walk stops early, and the store at the chain's leaf is
 // still found because the first path to reach it does so within budget.
+//
+// The observable is the escape the store reports into an owned parameter target. #1262 will
+// stop reporting that, correctly, so this test needs a different observable when it lands.
+// A borrow parameter target keeps reporting and is the likely replacement.
 func TestCallStoreEdgeAliasChainTerminates(t *testing.T) {
 	const depth = 16
 	var b strings.Builder
@@ -652,6 +689,10 @@ func TestCallStoreEdgeAliasChainTerminates(t *testing.T) {
 // The borrow sits deeper in the chain than the fuel reaches, so the exact field path is
 // unknown; recording no store would drop the escape that borrow raises. The store lands at
 // the whole target instead, which every field read through it follows.
+//
+// The observable is the escape the store reports into an owned parameter target. #1262 will
+// stop reporting that, correctly, so this test needs a different observable when it lands.
+// A borrow parameter target keeps reporting and is the likely replacement.
 func TestCallStoreEdgeCutWalkStaysSound(t *testing.T) {
 	// One alias per level, each naming the next, with the borrow past maxAliasExpansionDepth.
 	depth := maxAliasExpansionDepth * 2

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -608,3 +608,27 @@ func TestCallStoreEdgeAliasChainTerminates(t *testing.T) {
 		t.Fatal("inference did not finish: the lifetime walk did not stay within its node budget")
 	}
 }
+
+// TestCallStoreEdgeCutWalkStaysSound covers what a walk that runs out of alias fuel records.
+// The borrow sits deeper in the chain than the fuel reaches, so the exact field path is
+// unknown; recording no store would drop the escape that borrow raises. The store lands at
+// the whole target instead, which every field read through it follows.
+func TestCallStoreEdgeCutWalkStaysSound(t *testing.T) {
+	// One alias per level, each naming the next, with the borrow past maxAliasExpansionDepth.
+	depth := maxAliasExpansionDepth * 2
+	var b strings.Builder
+	for i := 1; i < depth; i++ {
+		fmt.Fprintf(&b, "type A%d<'a> = {x: A%d<'a>}\n", i, i+1)
+	}
+	fmt.Fprintf(&b, "type A%d<'a> = {peer: &'a mut {value: number}}\n", depth)
+	b.WriteString("declare fn store<'a, 'c>(target: &'c mut A1<'a>, item: &'a mut {value: number}) -> undefined\n")
+	b.WriteString("fn build(t: mut A1<'static>) -> undefined {\n")
+	b.WriteString("\tval mut b = {value: 2}\n")
+	b.WriteString("\tstore(&mut t, &mut b)\n")
+	b.WriteString("}\n")
+
+	_, _, errs := inferSource(t, b.String())
+	require.Equal(t, []string{
+		"20:16-20:22: borrowed value 'b' does not live long enough to escape the function",
+	}, messagesWithSpan(errs))
+}

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -396,6 +396,48 @@ func TestCallStoreEdgePositions(t *testing.T) {
 	}
 }
 
+// TestCallStoreEdgePayloadPositions covers the three payload positions that hold a borrow
+// without naming a field: an array element, a promise's resolved value, and a generator's
+// yield. Each stores at the container holding it, so the store lands at the tuple slot the
+// payload sits in and returning that tuple follows the edge.
+//
+// Every case also reports one constrain error unrelated to the store. `&mut a` over a tuple
+// literal whose element is a bare name does not read as a mutable tuple, which is a
+// pre-existing limitation of the deep-mut rule rather than anything the store recorder does.
+// The same shape with a borrow element, TestCallStoreEdgePositions/StoreIntoTupleElement,
+// reports only the escape.
+func TestCallStoreEdgePayloadPositions(t *testing.T) {
+	tests := map[string]struct {
+		payload  string
+		declared string
+	}{
+		"ArrayElement":   {payload: "Array<&'a mut {value: number}>", declared: "Array<&mut {value: number}>"},
+		"PromiseValue":   {payload: "Promise<&'a mut {value: number}>", declared: "Promise<&mut {value: number}>"},
+		"GeneratorYield": {payload: "Generator<&'a mut {value: number}, undefined, undefined>", declared: "Generator<&mut {value: number}, undefined, undefined>"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			src := fmt.Sprintf(`
+				declare fn store<'a, 'c>(
+					target: &'c mut [%s],
+					item: &'a mut {value: number},
+				) -> undefined
+				fn build(seeded: %s) -> [%s] {
+					val mut b = {value: 2}
+					val mut a = [seeded]
+					store(&mut a, &mut b)
+					return a
+				}
+			`, tc.payload, tc.declared, tc.declared)
+			_, _, errs := inferSource(t, src)
+			require.Equal(t, []string{
+				"9:12-9:18: cannot constrain immutable tuple <: mutable tuple",
+				"10:13-10:14: borrowed value 'b' does not live long enough to escape the function",
+			}, messagesWithSpan(errs))
+		})
+	}
+}
+
 // TestCallStoreEdgeNonStores covers the signatures that share a lifetime without declaring a
 // store, so the call records nothing and the locals it borrows stay free. Each pairs with a
 // case in TestCallStoreEdge that does record an edge on the same source shape.

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -1,0 +1,568 @@
+package solver
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// storeEffectDecls are the declarations the store-edge cases share. `store` is the
+// store-effect signature: 'a ties item to target's peer field, 'b is the spare field's own
+// lifetime, and 'c is target's own borrow lifetime, so only peer takes the stored borrow.
+// `take` consumes an owned carrier of that shape, giving the cases a flow-out site other
+// than a return.
+const storeEffectDecls = `
+	declare fn store<'a, 'b, 'c>(
+		target: &'c mut {peer: &'a mut {value: number}, spare: &'b mut {value: number}},
+		item: &'a mut {value: number},
+	) -> undefined
+	declare fn take(x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined
+`
+
+// storeEffectTypes are the inferred types of the two shared declarations, repeated in every
+// case's expectation since inferSource renders every binding in the module.
+var storeEffectTypes = map[string]string{
+	"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
+		"item: &mut {value: number}) -> undefined",
+	"take": "fn (x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
+}
+
+// withStoreEffectTypes returns storeEffectTypes extended with the type of the function a
+// case declares, so each expectation names only what that case adds.
+func withStoreEffectTypes(build string) map[string]string {
+	out := map[string]string{"build": build}
+	for name, ty := range storeEffectTypes {
+		out[name] = ty
+	}
+	return out
+}
+
+// TestCallStoreEdge covers the borrow edge a call records when its signature stores an
+// argument-borrow into another argument. The signature spells the store by sharing one
+// lifetime between the stored argument and a position inside the target's referent, so
+//
+//	declare fn store<'a, 'b>(target: &'b mut {peer: &'a mut B}, item: &'a mut B)
+//
+// says item lands at target.peer. `store(&mut a, &mut b)` then aliases a to b at [peer],
+// the same edge `val a = {peer: &mut b}` records at its initializer.
+//
+// The edge is observed through the two rules that read the borrow-edge graph: the
+// return-escape check, which reports a local a returned value still borrows, and the
+// connected-component move, which co-moves the locals an escaping owned carrier owns. Each
+// case builds its target's fields from parameter borrows, which the graph exempts, so the
+// store call is the sole source of any edge to a local.
+func TestCallStoreEdge(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// The call is the only thing that aliases a to b, and returning a.peer carries that
+		// borrow out of the frame. Without the store edge the escape check finds no borrow
+		// under [peer] and reports nothing.
+		"StoredBorrowEscapes": {
+			src: storeEffectDecls + `
+				fn build(p: mut {value: number}, q: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p, spare: &mut q}
+					store(&mut a, &mut b)
+					return a.peer
+				}
+			`,
+			want:  []string{"12:13-12:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}"),
+		},
+		// The edge lands at [peer], so returning the disjoint [spare] field follows no edge
+		// and reports nothing. This is what the store's field path buys over attributing the
+		// borrow to the whole target.
+		"StoredBorrowDoesNotEscapeThroughDisjointField": {
+			src: storeEffectDecls + `
+				fn build(p: mut {value: number}, q: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p, spare: &mut q}
+					store(&mut a, &mut b)
+					return a.spare
+				}
+			`,
+			want:  nil,
+			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}"),
+		},
+		// The target's own place prefixes the store's field path, so storing into a field of
+		// the target records the edge at [inner, peer] and returning that nested field
+		// follows it.
+		"StoreThroughTargetFieldPlace": {
+			src: storeEffectDecls + `
+				fn build(p: mut {value: number}, q: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut a = {inner: {peer: &mut p, spare: &mut q}}
+					store(&mut a.inner, &mut b)
+					return a.inner.peer
+				}
+			`,
+			want:  []string{"12:13-12:25: borrowed value 'b' does not live long enough to escape the function"},
+			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}"),
+		},
+		// The edge reaches the connected-component move as well as the escape check: passing
+		// a to a consuming parameter carries the stored borrow into the callee, so the move
+		// co-moves b and the read after it is a use-after-move.
+		"StoredBorrowIsCoMovedWithItsCarrier": {
+			src: storeEffectDecls + `
+				fn build(p: mut {value: number}, q: mut {value: number}) -> undefined {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p, spare: &mut q}
+					store(&mut a, &mut b)
+					take(a)
+					val y = b
+				}
+			`,
+			want:  []string{"13:14-13:15: use of moved value 'b'"},
+			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> undefined"),
+		},
+		// Dropping the store call from the case above isolates its effect: with no edge from
+		// a to b, consuming a co-moves nothing and the read of b is fine.
+		"NoStoreLeavesTheCarrierAlone": {
+			src: storeEffectDecls + `
+				fn build(p: mut {value: number}, q: mut {value: number}) -> undefined {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p, spare: &mut q}
+					take(a)
+					val y = b
+				}
+			`,
+			want:  nil,
+			types: withStoreEffectTypes("fn (p: mut {value: number}, q: mut {value: number}) -> undefined"),
+		},
+		// A store whose target is a parameter escapes at once rather than recording an edge:
+		// the parameter's referent belongs to the caller and outlives the frame, so a borrow
+		// of a local written into it dangles. This is the call-site twin of the field store
+		// `p.peer = &mut b`, which checkParamFieldStoreEscape reports the same way.
+		"StoreIntoParameterTargetEscapes": {
+			src: storeEffectDecls + `
+				fn build(p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined {
+					val mut b = {value: 2}
+					store(&mut p, &mut b)
+				}
+			`,
+			want:  []string{"10:20-10:26: borrowed value 'b' does not live long enough to escape the function"},
+			types: withStoreEffectTypes("fn (p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined"),
+		},
+		// An auto-borrowed place stored into a parameter escapes too. The argument names no
+		// borrow expression, so the local it carries is the place's own root rather than
+		// anything the escape post-pass would find by scanning the argument.
+		"AutoBorrowedArgumentIntoParameterEscapes": {
+			src: `
+				declare fn store<'a, 'c>(
+					target: &'c mut {peer: &'a {value: number}},
+					item: &'a {value: number},
+				) -> undefined
+				fn build(p: mut {peer: &{value: number}}) -> undefined {
+					val b = {value: 2}
+					store(&mut p, b)
+				}
+			`,
+			want: []string{"8:20-8:21: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &{value: number}}, item: &{value: number}) -> undefined",
+				"build": "fn (p: mut {peer: &{value: number}}) -> undefined",
+			},
+		},
+		// Storing a borrow of a parameter records no edge: a parameter's lifetime is the
+		// caller's and already outlives the frame, so it is not a local that can dangle.
+		"StoredParamBorrowIsExempt": {
+			src: storeEffectDecls + `
+				fn build(p: mut {value: number}, q: mut {value: number}, r: mut {value: number}) -> &mut {value: number} {
+					val mut a = {peer: &mut p, spare: &mut q}
+					store(&mut a, &mut r)
+					return a.peer
+				}
+			`,
+			want: nil,
+			types: withStoreEffectTypes(
+				"fn (p: mut {value: number}, q: mut {value: number}, r: mut {value: number}) -> &mut {value: number}",
+			),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
+		})
+	}
+}
+
+// TestCallStoreEdgePositions covers the store positions inside a target's referent that are
+// not a named object field, and the argument forms the recorder reads a place off. Each
+// records an edge the return-escape check then reports.
+func TestCallStoreEdgePositions(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// A tuple element contributes no field segment, so a store into one lands at the
+		// tuple itself and returning the whole tuple follows the edge.
+		"StoreIntoTupleElement": {
+			src: `
+				declare fn store<'a, 'c>(
+					target: &'c mut [&'a mut {value: number}],
+					item: &'a mut {value: number},
+				) -> undefined
+				fn build(p: mut {value: number}) -> [&mut {value: number}] {
+					val mut b = {value: 2}
+					val mut a = [&mut p]
+					store(&mut a, &mut b)
+					return a
+				}
+			`,
+			want: []string{"10:13-10:14: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (target: &mut [&mut {value: number}], item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}) -> [&mut {value: number}]",
+			},
+		},
+		// A class type argument is not addressable as a field either, so a store into a
+		// borrowed `Box<&'a mut B>` field lands at that field and returning it follows the
+		// edge. This is the shape a borrow-holding container takes.
+		"StoreIntoClassTypeArgument": {
+			src: `
+				class Box<T> { value: T }
+				declare fn store<'a, 'c, 'd>(
+					target: &'c mut {box: &'d mut Box<&'a mut {value: number}>},
+					item: &'a mut {value: number},
+				) -> undefined
+				fn build(seeded: mut Box<&mut {value: number}>) -> &mut Box<&mut {value: number}> {
+					val mut b = {value: 2}
+					val mut a = {box: &mut seeded}
+					store(&mut a, &mut b)
+					return a.box
+				}
+			`,
+			want: []string{"11:13-11:18: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"Box":   "<T> {new (value: T) -> Box<T>}",
+				"store": "fn (target: &mut {box: &mut Box<&mut {value: number}>}, item: &mut {value: number}) -> undefined",
+				"build": "fn <'a>(seeded: mut Box<&'a mut {value: number}>) -> &mut Box<&'a mut {value: number}>",
+			},
+		},
+		// An alias is transparent, so a target's referent written under an alias name is
+		// searched the way the object the alias names is.
+		"StoreThroughAliasedReferent": {
+			src: `
+				type Holder<'a> = {peer: &'a mut {value: number}}
+				declare fn store<'a, 'c>(target: &'c mut Holder<'a>, item: &'a mut {value: number}) -> undefined
+				fn build(p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p}
+					store(&mut a, &mut b)
+					return a.peer
+				}
+			`,
+			want: []string{"8:13-8:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn <'a>(target: &mut Holder<'a>, item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}) -> &mut {value: number}",
+			},
+		},
+		// The stored argument's own outer lifetime is not the only one that counts: a lifetime
+		// nested inside its referent names data the callee holds just as much, so sharing that
+		// one with the target is a store too.
+		"StoreOfNestedArgumentLifetime": {
+			src: `
+				declare fn store<'a, 'c, 'd>(
+					target: &'c mut {peer: &'a mut {value: number}},
+					item: &'d {inner: &'a mut {value: number}},
+				) -> undefined
+				fn build(p: mut {value: number}, q: mut {value: number}) -> &mut {value: number} {
+					val mut b = {inner: &mut q}
+					val mut a = {peer: &mut p}
+					store(&mut a, &b)
+					return a.peer
+				}
+			`,
+			want: []string{"10:13-10:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {value: number}}, item: &{inner: &mut {value: number}}) -> undefined",
+				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
+			},
+		},
+		// A union member holds a borrow the whole union exposes, so a store into one is found
+		// at the union's own path. The two constrain errors are unrelated to the store: a
+		// `&mut` field is invariant, so the argument's `&mut {value: number}` does not satisfy
+		// a field declared as a union of borrows. They pin that limitation alongside the edge
+		// the walk still records through the union.
+		"StoreIntoUnionMember": {
+			src: `
+				declare fn store<'a, 'c>(
+					target: &'c mut {peer: &'a mut {value: number} | &'a mut {other: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+				fn build(p: mut {value: number}) -> &mut {value: number} | &mut {other: number} {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p}
+					store(&mut a, &mut b)
+					return a.peer
+				}
+			`,
+			want: []string{
+				"6:29-6:35: object is missing property: value",
+				"3:71-3:77: object has extra property: other",
+				"10:13-10:19: borrowed value 'b' does not live long enough to escape the function",
+			},
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {other: number} | &mut {value: number}}, " +
+					"item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}) -> &mut {value: number} | &mut {other: number}",
+			},
+		},
+		// An argument that builds its carrier inline names no place, so the referents come
+		// from the borrows the carrier holds rather than from the argument's own place.
+		"StoreOfInlineCarrierArgument": {
+			src: `
+				declare fn store<'a, 'c, 'd>(
+					target: &'c mut {peer: &'a mut {value: number}},
+					item: &'d {inner: &'a mut {value: number}},
+				) -> undefined
+				fn build(p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p}
+					store(&mut a, &{inner: &mut b})
+					return a.peer
+				}
+			`,
+			want: []string{"10:13-10:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &mut {value: number}}, item: &{inner: &mut {value: number}}) -> undefined",
+				"build": "fn (p: mut {value: number}) -> &mut {value: number}",
+			},
+		},
+		// An index signature names no single field, so a store into one lands at the object
+		// holding it, covering every key it admits rather than one.
+		"StoreIntoIndexSignature": {
+			src: `
+				declare fn store<'a, 'c, 'd>(
+					target: &'c mut {peers: &'d mut {[key: string]?: &'a mut {value: number}}},
+					item: &'a mut {value: number},
+				) -> undefined
+				fn build(seeded: mut {[key: string]?: &mut {value: number}}) -> &mut {[key: string]?: &mut {value: number}} {
+					val mut b = {value: 2}
+					val mut a = {peers: &mut seeded}
+					store(&mut a, &mut b)
+					return a.peers
+				}
+			`,
+			want: []string{"10:13-10:20: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (target: &mut {peers: &mut {[key: string]?: &mut {value: number}}}, " +
+					"item: &mut {value: number}) -> undefined",
+				"build": "fn <'a>(seeded: mut {[key: string]?: &'a mut {value: number}}) " +
+					"-> &mut {[key: string]?: &'a mut {value: number}}",
+			},
+		},
+		// A shared-borrow parameter auto-borrows the place passed to it, so the stored
+		// argument is a bare name rather than an `&` expression and the recorder reads the
+		// place off the argument itself.
+		"AutoBorrowedArgumentIsStored": {
+			src: `
+				declare fn store<'a, 'c>(
+					target: &'c mut {peer: &'a {value: number}},
+					item: &'a {value: number},
+				) -> undefined
+				fn build(p: {value: number}) -> &{value: number} {
+					val b = {value: 2}
+					val mut a = {peer: &p}
+					store(&mut a, b)
+					return a.peer
+				}
+			`,
+			want: []string{"10:13-10:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (target: &mut {peer: &{value: number}}, item: &{value: number}) -> undefined",
+				"build": "fn (p: {value: number}) -> &{value: number}",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
+		})
+	}
+}
+
+// TestCallStoreEdgeNonStores covers the signatures that share a lifetime without declaring a
+// store, so the call records nothing and the locals it borrows stay free. Each pairs with a
+// case in TestCallStoreEdge that does record an edge on the same source shape.
+func TestCallStoreEdgeNonStores(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// Two parameters sharing one lifetime at their outermost position declare no store:
+		// the borrows share a region, and neither referent is reachable through the other.
+		"SiblingBorrowsRecordNoEdge": {
+			src: `
+				declare fn pair<'a>(x: &'a mut {value: number}, y: &'a mut {value: number}) -> undefined
+				declare fn take(x: mut {peer: &mut {value: number}}) -> undefined
+				fn build(p: mut {value: number}) -> undefined {
+					val mut b = {value: 2}
+					val mut c = {value: 3}
+					val mut a = {peer: &mut p}
+					pair(&mut b, &mut c)
+					take(a)
+					val y = b
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"pair":  "fn (x: &mut {value: number}, y: &mut {value: number}) -> undefined",
+				"take":  "fn (x: mut {peer: &mut {value: number}}) -> undefined",
+				"build": "fn (p: mut {value: number}) -> undefined",
+			},
+		},
+		// A shared-borrow target takes no write, so a lifetime occurring inside it declares
+		// no store and the call records nothing.
+		"SharedBorrowTargetRecordsNoEdge": {
+			src: `
+				declare fn read<'a, 'b>(
+					target: &'b {peer: &'a mut {value: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+				fn build(p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p}
+					read(&a, &mut b)
+					return a.peer
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"read":  "fn (target: &{peer: &mut {value: number}}, item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}) -> &mut {value: number}",
+			},
+		},
+		// An alias reference carries its lifetime arguments and its expansion carries them
+		// again, at the field paths they really sit at. Only the expansion counts, so the
+		// store lands at [peer] alone and returning the disjoint [spare] field is clean.
+		// Counting the reference's arguments too would put a second edge at the alias's own
+		// path, which every field of the target sits under.
+		"AliasArgumentsDoNotWidenTheStorePath": {
+			src: `
+				type Holder<'a, 'b> = {peer: &'a mut {value: number}, spare: &'b mut {value: number}}
+				declare fn store<'a, 'b, 'c>(
+					target: &'c mut Holder<'a, 'b>,
+					item: &'a mut {value: number},
+				) -> undefined
+				fn build(p: mut {value: number}, q: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p, spare: &mut q}
+					store(&mut a, &mut b)
+					return a.spare
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"store": "fn <'a, 'b>(target: &mut Holder<'a, 'b>, item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
+			},
+		},
+		// An alias re-nested inside itself is two different types, so both levels expand and
+		// the store lands at the borrow's real path, [deep, inner, inner]. Returning the
+		// sibling [deep, inner, tag] follows no edge. Stopping at the first repeat of the
+		// alias NAME would put the store one level short, at [deep, inner], which sits above
+		// the returned field and would report a borrow that is not there.
+		"RenestedAliasKeepsTheFullStorePath": {
+			src: `
+				type W<T> = {inner: T, tag: number}
+				declare fn store<'a, 'c>(
+					target: &'c mut {deep: W<W<&'a mut {value: number}>>},
+					item: &'a mut {value: number},
+				) -> undefined
+				fn build(p: mut {value: number}) -> number {
+					val mut b = {value: 2}
+					val mut a = {deep: {inner: {inner: &mut p, tag: 1}, tag: 0}}
+					store(&mut a, &mut b)
+					return a.deep.inner.tag
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"store": "fn (target: &mut {deep: W<W<&mut {value: number}>>}, item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}) -> number",
+			},
+		},
+		// An owned target is moved into the callee rather than written through, so a lifetime
+		// occurring inside it declares no store either.
+		"OwnedTargetRecordsNoEdge": {
+			src: `
+				declare fn keep<'a>(
+					target: mut {peer: &'a mut {value: number}},
+					item: &'a mut {value: number},
+				) -> undefined
+				fn build(p: mut {value: number}) -> undefined {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p}
+					keep(a, &mut b)
+					val y = b
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"keep":  "fn (target: mut {peer: &mut {value: number}}, item: &mut {value: number}) -> undefined",
+				"build": "fn (p: mut {value: number}) -> undefined",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
+		})
+	}
+}
+
+// TestCallStoreEdgeAliasChainTerminates pins the node budget the lifetime walk runs under.
+// The signature below names a chain of aliases where each body names the next one twice, so
+// its field paths number 2^depth. Without the budget the walk enumerates all of them and the
+// call takes minutes; with it the walk stops early, and the store at the chain's leaf is
+// still found because the first path to reach it does so within budget.
+func TestCallStoreEdgeAliasChainTerminates(t *testing.T) {
+	const depth = 16
+	var b strings.Builder
+	for i := 1; i < depth; i++ {
+		fmt.Fprintf(&b, "type A%d<'a> = {x: A%d<'a>, y: A%d<'a>}\n", i, i+1, i+1)
+	}
+	fmt.Fprintf(&b, "type A%d<'a> = {peer: &'a mut {value: number}}\n", depth)
+	b.WriteString("declare fn store<'a, 'c>(target: &'c mut A1<'a>, item: &'a mut {value: number}) -> undefined\n")
+	b.WriteString("fn build(t: mut A1<'static>) -> undefined {\n")
+	b.WriteString("\tval mut b = {value: 2}\n")
+	b.WriteString("\tstore(&mut t, &mut b)\n")
+	b.WriteString("}\n")
+
+	// Parsing stays on the test goroutine, since parseModule asserts through require and a
+	// failed assertion off the test goroutine would surface as this test's timeout instead of
+	// as the parse error it is. Only inference, the step the budget bounds, runs detached.
+	module := parseModule(t, b.String())
+	done := make(chan []SolverError, 1)
+	go func() {
+		_, _, errs := inferModule(module)
+		done <- errs
+	}()
+	select {
+	case errs := <-done:
+		require.Equal(t, []string{
+			"20:16-20:22: borrowed value 'b' does not live long enough to escape the function",
+		}, messagesWithSpan(errs))
+	case <-time.After(30 * time.Second):
+		t.Fatal("inference did not finish: the lifetime walk did not stay within its node budget")
+	}
+}

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -261,7 +261,7 @@ func TestCallStoreEdge(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.want, messagesWithSpan(t, errs))
 			require.Equal(t, tc.types, values)
 		})
 	}
@@ -462,7 +462,7 @@ func TestCallStoreEdgePositions(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.want, messagesWithSpan(t, errs))
 			require.Equal(t, tc.types, values)
 		})
 	}
@@ -506,7 +506,7 @@ func TestCallStoreEdgePayloadPositions(t *testing.T) {
 			require.Equal(t, []string{
 				"9:12-9:18: cannot constrain immutable tuple <: mutable tuple",
 				"10:13-10:14: borrowed value 'b' does not live long enough to escape the function",
-			}, messagesWithSpan(errs))
+			}, messagesWithSpan(t, errs))
 		})
 	}
 }
@@ -639,7 +639,7 @@ func TestCallStoreEdgeNonStores(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.want, messagesWithSpan(t, errs))
 			require.Equal(t, tc.types, values)
 		})
 	}
@@ -680,7 +680,7 @@ func TestCallStoreEdgeAliasChainTerminates(t *testing.T) {
 	case errs := <-done:
 		require.Equal(t, []string{
 			"20:16-20:22: borrowed value 'b' does not live long enough to escape the function",
-		}, messagesWithSpan(errs))
+		}, messagesWithSpan(t, errs))
 	case <-time.After(30 * time.Second):
 		t.Fatal("inference did not finish: the lifetime walk did not stay within its node budget")
 	}
@@ -711,5 +711,5 @@ func TestCallStoreEdgeTruncatedWalkStaysSound(t *testing.T) {
 	_, _, errs := inferSource(t, b.String())
 	require.Equal(t, []string{
 		"20:16-20:22: borrowed value 'b' does not live long enough to escape the function",
-	}, messagesWithSpan(errs))
+	}, messagesWithSpan(t, errs))
 }

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -690,10 +690,10 @@ func TestCallStoreEdgeAliasChainTerminates(t *testing.T) {
 	}
 }
 
-// TestCallStoreEdgeTruncatedWalkStaysSound covers what a walk that spends its alias depth records.
-// The borrow sits deeper in the chain than the fuel reaches, so the exact field path is
-// unknown; recording no store would drop the escape that borrow raises. The store lands at
-// the whole target instead, which every field read through it follows.
+// TestCallStoreEdgeTruncatedWalkStaysSound covers what a walk records once it spends its
+// alias depth. The borrow sits deeper in the chain than maxAliasExpansionDepth reaches, so
+// the exact field path is unknown. Recording no store would drop the escape that borrow
+// raises, so the store lands at the whole target, which every field read through it follows.
 //
 // The observable is the escape the store reports into an owned parameter target. #1262 will
 // stop reporting that, correctly, so this test needs a different observable when it lands.

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -363,10 +363,14 @@ func TestCallStoreEdgePositions(t *testing.T) {
 			},
 		},
 		// A union member holds a borrow the whole union exposes, so a store into one is found
-		// at the union's own path. The two constrain errors are unrelated to the store: a
-		// `&mut` field is invariant, so the argument's `&mut {value: number}` does not satisfy
-		// a field declared as a union of borrows. They pin that limitation alongside the edge
-		// the walk still records through the union.
+		// at the union's own path. The two constrain errors are unrelated to the store. The
+		// target is a `&mut` to the container, which makes its `peer` field read-write and so
+		// invariant. Invariance runs the comparison in both directions, and the reverse one has
+		// to hold against every arm rather than picking the one that fits. The same signature
+		// without the outer `&mut` selects the matching arm and reports nothing.
+		//
+		// Their spans point at a `number` on the declaration line and a `number` on the `build`
+		// line, neither of which is the `store` call between them. #1481 covers that.
 		"StoreIntoUnionMember": {
 			src: `
 				declare fn store<'a, 'c>(

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1507,6 +1507,10 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 		// extra arguments that have no corresponding parameter.
 		if hasConsumeRef {
 			c.consumeCallArgs(e, fn, consumeRef)
+			// A borrow argument the signature stores into another argument aliases the two
+			// for as long as the target lives, so record that edge here rather than leaving
+			// the alias invisible to the escape check and the component move.
+			c.recordCallStoreEdges(e, fn, consumeRef)
 		}
 	}
 	c.recordType(e, res)

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -44,12 +44,14 @@ import (
 //   - A disjoint field return `return a.data` follows the edges on the [data] path, finds
 //     none, and is sound with no false positive.
 //
-// Edges are recorded at four sites:
+// Edges are recorded at five sites:
 //
 //   - a `val`/`var` initializer,
 //   - a `var` reassignment,
 //   - a field store into a local receiver,
-//   - a destructuring leaf.
+//   - a destructuring leaf,
+//   - a call whose signature stores an argument-borrow into another argument. See
+//     borrow_store.go for how a signature spells that store.
 //
 // The graph is flow-sensitive. Each recording strong-updates the binding, clearing the replaced
 // subtree before adding the new edges. analyzeBorrows folds the per-statement edge sets
@@ -146,12 +148,13 @@ func (c *checker) resolveComponentEscapes(
 //     return does not block the move. The loop below explains what "dead" covers.
 //
 // The external-reference scan reads the same borrow-edge graph the escape check is built on,
-// so it sees the aliases recorded at a `val`/`var` initializer, a `var` reassignment, and a
-// destructuring leaf. An alias formed by a path the graph does not record, such as a `.push`
-// of a borrow into a container, is invisible here exactly as it is to the escape check, the
-// shared limitation the graph's three recording sites impose. Recording a container-method
-// borrow needs `Array` and method-call support the solver lacks today; it is tracked as a
-// post-M7 item under "Deferred and out of scope" in planning/affine_semantics/implementation_plan.md.
+// so it sees every alias the recording sites listed at the top of this file record. An alias
+// formed by a path none of them covers is invisible here exactly as it is to the escape check.
+// `a.peers.push(&mut b)` is such a path. The store recorder reads a callee's explicit
+// parameters and matches the two sides of a store by a shared lifetime variable, and a method
+// call supplies neither: its receiver is stripped off the signature the call site sees, and
+// its lifetimes reach that signature anonymized. It is tracked under "Deferred and out of
+// scope" in planning/affine_semantics/implementation_plan.md.
 func (c *checker) componentMoveCovers(
 	e ast.Expr, escaping set.Set[liveness.VarID],
 	stmtRef liveness.StmtRef,

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -1075,7 +1075,7 @@ places), PR 14 (the C2 mut-context flag the borrow-leaf upgrade's invariance rid
   referent declares that the call writes the borrow there, and the recorder turns that into a
   `receiver → referent` edge at the call site. `store(&mut a, &mut b)` against
 
-  ```
+  ```text
   declare fn store<'a, 'b>(target: &'b mut {peer: &'a mut B}, item: &'a mut B)
   ```
 
@@ -1084,8 +1084,8 @@ places), PR 14 (the C2 mut-context flag the borrow-leaf upgrade's invariance rid
   `a.peers.push(&mut b)`, the canonical container case, is not covered. No method call records
   a store today, and four pieces are missing. First, `Array<T>` and its method surface:
   `internal/solver` has no `Array` type and no array/tuple method calls, and both arrive with
-  the M7 stdlib ingestion
-  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7). Second, a
+  the M7.5 library-type ingestion
+  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7.5). Second, a
   lifetime parameter on the container type, so `Array<'a, T>` can tie the element borrow to the
   receiver; a class declares no lifetime parameters today, and neither can an object type's
   method signature name a lifetime its enclosing signature binds. Third, the receiver type at

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -1068,23 +1068,35 @@ places), PR 14 (the C2 mut-context flag the borrow-leaf upgrade's invariance rid
   rides the M7 computed-key/index-segment work
   ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7);
   pull it forward if tuple-heavy code makes the imprecision bite.
-- **Borrow tracking through container methods.** The borrow-edge graph records an alias only
-  at a `val`/`var` initializer, a `var` reassignment, and a destructuring leaf, so a borrow
-  stored into a container through a method call — `a.peers.push(&mut b)` — is invisible to the
-  escape check and the connected-component move
-  ([internal/solver/return_escape.go](../../internal/solver/return_escape.go)). This is what
+- **Borrow tracking through a `self` receiver.** The borrow-edge graph records the store a
+  call performs through the callee's explicit parameters
+  ([internal/solver/borrow_store.go](../../internal/solver/borrow_store.go)): a signature that
+  shares one lifetime between an argument-borrow and a position inside another parameter's
+  referent declares that the call writes the borrow there, and the recorder turns that into a
+  `receiver → referent` edge at the call site. `store(&mut a, &mut b)` against
+
+  ```
+  declare fn store<'a, 'b>(target: &'b mut {peer: &'a mut B}, item: &'a mut B)
+  ```
+
+  records a → b at [peer], so the escape check and the connected-component move see the alias.
+
+  `a.peers.push(&mut b)`, the canonical container case, is not covered. No method call records
+  a store today, and four pieces are missing. First, `Array<T>` and its method surface:
+  `internal/solver` has no `Array` type and no array/tuple method calls, and both arrive with
+  the M7 stdlib ingestion
+  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7). Second, a
+  lifetime parameter on the container type, so `Array<'a, T>` can tie the element borrow to the
+  receiver; a class declares no lifetime parameters today, and neither can an object type's
+  method signature name a lifetime its enclosing signature binds. Third, the receiver type at
+  the call site: `memberValue` hands the call a signature with its `SelfParam` stripped, so
+  the recorder has no receiver to search for the shared lifetime. Fourth, named lifetimes on a
+  method signature at all: a method reaches the call site with its lifetimes coalesced to the
+  anonymous display lifetime, so the two sides of a store share nothing the search can match,
+  which is why even a store through a method's explicit parameter goes unrecorded. This is what
   keeps the requirements' canonical cyclic `build()` from being expressible as written: the
   `.push` edges that wire the graph are never recorded, so the escape check sees no borrows to
-  co-move. This is NOT part of PR 16, whose scope is the flow-sensitivity of the existing three
-  recording sites. It needs two things the affine PRs do not provide. First, `Array<T>` and its
-  method surface: `internal/solver` has no `Array` type and no array/tuple method calls today,
-  and both arrive with the M7 stdlib ingestion
-  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7). Second, a
-  lifetime annotation on a container method that expresses "the argument-borrow is stored into
-  the receiver," which the edge recorder reads at the call site to record a `receiver →
-  referent` edge — the same call-effect modeling a `&mut Holder` write needs. So it lands after
-  M7 as an extension of the borrow-edge recorder to model a call that stores a borrow into its
-  receiver, gated on the container-method lifetime annotations that supply the effect.
+  co-move.
 
 ## Testing approach
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -214,15 +214,20 @@ that would introduce new PRs:
   `escape` disposition; curation spells it a `move` (owning container) or
   a lifetime-bounded borrow (borrow-holding container), per requirements
   FR12. The affine *core* — moves, use-after-move, borrows, escape forcing
-  — has landed, but the lifetime-borrow spelling needs one piece that has
-  not: **borrow tracking through container methods** (`.push` of a borrow,
-  `a.peers.push(&mut b)`), which the affine plan
+  — has landed, and so has the store-effect spelling for a callee's explicit
+  parameters: a signature that shares one lifetime between an argument-borrow
+  and a position inside another parameter's referent records a `receiver →
+  referent` edge at the call site
+  ([../../internal/solver/borrow_store.go](../../internal/solver/borrow_store.go)).
+  What the lifetime-borrow spelling still needs is the *container-method*
+  form, a `.push` of a borrow into the `self` receiver
+  (`a.peers.push(&mut b)`), which the affine plan
   ([../affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md))
-  lists as deferred and out of scope. It is blocked on two things: the
-  stdlib `Array` type and method surface, delivered by
+  lists as deferred and out of scope. It is blocked on the stdlib `Array`
+  type and method surface, delivered by
   [M7.5 PR5](../simple_sub/m7.5-implementation-plan.md#pr5--a-real-arrayt-and-the-well-known-handle-mechanism),
-  and a container-method lifetime
-  annotation expressing "the argument-borrow is stored into the receiver."
+  a lifetime parameter on the container type, the receiver's own type at
+  the call site, and named lifetimes on a method signature.
   That is **not this workstream's work** — until it lands, curation
   applies only the `move` spelling, and the `escape` facts for
   borrow-holding containers wait on it. Tracked here as an external

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -203,15 +203,20 @@ that would introduce new PRs:
   `escape` disposition; curation spells it a `move` (owning container) or
   a lifetime-bounded borrow (borrow-holding container), per requirements
   FR12. The affine *core* — moves, use-after-move, borrows, escape forcing
-  — has landed, but the lifetime-borrow spelling needs one piece that has
-  not: **borrow tracking through container methods** (`.push` of a borrow,
-  `a.peers.push(&mut b)`), which the affine plan
+  — has landed, and so has the store-effect spelling for a callee's explicit
+  parameters: a signature that shares one lifetime between an argument-borrow
+  and a position inside another parameter's referent records a `receiver →
+  referent` edge at the call site
+  ([../../internal/solver/borrow_store.go](../../internal/solver/borrow_store.go)).
+  What the lifetime-borrow spelling still needs is the *container-method*
+  form, a `.push` of a borrow into the `self` receiver
+  (`a.peers.push(&mut b)`), which the affine plan
   ([../affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md))
-  lists as deferred and out of scope. It is blocked on two things: the
-  stdlib `Array` type and method surface, delivered by
+  lists as deferred and out of scope. It is blocked on the stdlib `Array`
+  type and method surface, delivered by
   [M7.5 PR5](../simple_sub/m7.5-implementation-plan.md#pr5--a-real-arrayt-and-the-well-known-handle-mechanism),
-  and a container-method lifetime
-  annotation expressing "the argument-borrow is stored into the receiver."
+  a lifetime parameter on the container type, the receiver's own type at
+  the call site, and named lifetimes on a method signature.
   That is **not this workstream's work** — until it lands, curation
   applies only the `move` spelling, and the `escape` facts for
   borrow-holding containers wait on it. Tracked here as an external

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1360,17 +1360,20 @@ a desugaring rule — rather than opaque placeholders.
       name, so it admits a new kind without change.
 
 - **Unblocks (not owned here): affine borrow tracking through container methods.** The affine
-  connected-component move records a borrow alias only at a binding initializer, a `var`
-  reassignment, and a destructuring leaf, so a borrow stored into a container by a method
-  call — `a.peers.push(&mut b)` — is invisible to its escape check
-  ([internal/solver/return_escape.go](../../internal/solver/return_escape.go)). That is why the
-  affine requirements' canonical cyclic `build()`, which wires the graph with `.push`, is not
-  yet expressible. This milestone is the prerequisite: it resolves `Array<T>` and its method
+  borrow-edge graph records the store a call performs through the callee's explicit
+  parameters, driven by a lifetime the argument-borrow shares with a position inside another
+  parameter's referent
+  ([internal/solver/borrow_store.go](../../internal/solver/borrow_store.go)). A borrow stored
+  into a container by a method call — `a.peers.push(&mut b)` — is still invisible: it stores
+  into the `self` receiver rather than a parameter, and a method signature reaches the call
+  site with its lifetimes anonymized either way. That is why the affine
+  requirements' canonical cyclic `build()`, which wires the graph with `.push`, is not yet
+  expressible. This milestone is the prerequisite: it resolves `Array<T>` and its method
   surface (`push`, …), which `internal/solver` has no representation for today — there is no
-  `Array` type and no array/tuple method call. The fix itself — teaching the borrow-edge
-  recorder to model a call that stores an argument-borrow into its receiver, gated on a
-  container-method lifetime annotation that expresses that effect — is affine work that lands
-  after this milestone, tracked under "Deferred and out of scope" in
+  `Array` type and no array/tuple method call. What remains after it — a lifetime parameter on
+  the container type to tie the element borrow to the receiver, the receiver's own type at the
+  call site, which `memberValue` strips, and named lifetimes on a method signature — is affine
+  work tracked under "Deferred and out of scope" in
   [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md).
   Recorded here so the dependency is visible from the milestone that unblocks it.
 


### PR DESCRIPTION
Adds support for tracking borrow aliases created when a function call stores an argument-borrow into another argument's referent. This enables the escape check and connected-component move to see borrows written into containers through function calls.

A signature declares a store when it shares a lifetime between an argument-borrow and a position inside another parameter's referent. For example:

```
declare fn store<'a, 'b>(target: &'b mut {peer: &'a mut B}, item: &'a mut B)
```

says `item` lands at `target.peer`. At the call `store(&mut a, &mut b)`, this creates the edge `a → b` at `[peer]`, the same edge that `val a = {peer: &mut b}` records at its initializer.

**Key changes:**

- Added `internal/solver/borrow_store.go` with the store-effect detection and recording logic:
  - `callStoreEdges()` identifies which (argument, target, field path) triples a signature declares as stores
  - `lifetimeSites()` maps each lifetime variable in a type to the field paths it occurs at
  - `lifetimeWalk` traverses types to find lifetime occurrences, with budgets to prevent exponential blowup from alias chains
  - `recordCallStoreEdges()` records edges for local targets and reports escapes for parameter targets

- Added comprehensive test coverage in `internal/solver/borrow_store_test.go` with 20 test cases covering:
  - Basic store effects and escape detection
  - Field paths (nested fields, tuple elements, class type arguments, index signatures)
  - Alias handling (transparent expansion, re-nesting, argument widening)
  - Non-store cases (sibling borrows, shared-borrow targets, owned targets)
  - Alias chain termination under node budget

- Updated `internal/solver/infer_expr.go` to call `recordCallStoreEdges()` after consuming-argument handling

- Updated documentation in `internal/solver/return_escape.go` and planning files to reflect the new store-effect recording

The implementation does not yet cover method calls (which lack lifetime variables in their signatures) or container methods like `.push()` (which require `Array<T>` and method surface support arriving in a later milestone).

https://claude.ai/code/session_01Y8Ud86QkLyDRhGUdrXwA7d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved borrow and escape analysis for function calls that store borrowed values.
  - Tracks borrow relationships through nested fields, tuples, arrays, classes, aliases, unions, payloads, and other supported type structures.
  - Detects escaping borrows and propagates move information more accurately, including automatically borrowed arguments and explicit parameter references.

- **Documentation**
  - Clarified supported call-site borrow tracking and documented current limitations for container method calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->