### PR TITLE
Add M7.5 implementation plan for library type resolution

### DIFF
--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -103,7 +103,7 @@ flowchart TD
 
     subgraph external["External — other planning docs"]
         EXT_CONV["builtins converter<br/>(planning/builtins FR10)"]
-        EXT_M75["M7.5 Library type resolution<br/>(planning/simple_sub)"]
+        EXT_M75["M7.5 Library type resolution<br/>(planning/simple_sub, PR5 + PR6)"]
         EXT_AFFINE["container-method borrow tracking<br/>(planning/affine_semantics)"]
     end
     subgraph followons["Follow-ons — not numbered PRs"]
@@ -122,9 +122,14 @@ flowchart TD
 
 The **external** group is work in other workstreams that this plan
 depends on: the builtins converter (planning/builtins FR10) that §5 and
-§7 wire into; M7.5 library-type resolution (planning/simple_sub); and the
-affine container-method borrow tracking (planning/affine_semantics),
-which is itself blocked on M7.5's `Array` ingestion. The **follow-ons**
+§7 wire into; M7.5 library-type resolution, broken into PRs in
+[../simple_sub/m7.5-implementation-plan.md](../simple_sub/m7.5-implementation-plan.md);
+and the affine container-method borrow tracking (planning/affine_semantics),
+which is itself blocked on M7.5's `Array` ingestion. The two M7.5 PRs
+this plan turns on are **PR5**, which makes `Array` and its method
+surface real, and **PR6**, which deletes the solver's stdlib
+placeholders. That plan records both edges from its own side under "What
+M7.5 unblocks." The **follow-ons**
 are ecma-262 work this plan names but does not number as PRs, because each
 waits on an external dependency: the solver-side application needs §7 and
 M7.5, and the `escape` lifetime-borrow spelling needs §11 and the affine
@@ -173,7 +178,14 @@ that would introduce new PRs:
   blocker is M7.5's ingestion, not the alias representation.) Wiring the
   facts into that ingestion is a **dependent PR that cannot be written
   until M7.5 lands**, tracked here as a known follow-on rather than a
-  scheduled phase.
+  scheduled phase. The specific PR that clears it is
+  [M7.5 PR6](../simple_sub/m7.5-implementation-plan.md#pr6--the-well-known-protocol-set),
+  which deletes `addStdlibTypePlaceholders` and resolves `Promise` /
+  `Iterable` / `Generator` from the committed `.esc` files. That PR also
+  retires the hardcoded `soltype.PromiseType` in favor of the ingested
+  declaration, keeping the two-argument `Promise<T, E>` form this plan's
+  `rejects` sets are spelled against — see "Two checkers; the active one is
+  the target" in [requirements.md](requirements.md).
 - **Applying the non-receiver facts.** §7 auto-applies only receiver
   mutability, the high-confidence determination. Parameter disposition
   (§8), the return-borrow seed (§8.2), `throws` (§9), and `rejects` (§9.3)
@@ -196,8 +208,9 @@ that would introduce new PRs:
   `a.peers.push(&mut b)`), which the affine plan
   ([../affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md))
   lists as deferred and out of scope. It is blocked on two things: the
-  stdlib `Array` type and method surface (M7.5 ingestion, the same blocker
-  as the solver-side application above) and a container-method lifetime
+  stdlib `Array` type and method surface, delivered by
+  [M7.5 PR5](../simple_sub/m7.5-implementation-plan.md#pr5--a-real-arrayt-and-the-well-known-handle-mechanism),
+  and a container-method lifetime
   annotation expressing "the argument-borrow is stored into the receiver."
   That is **not this workstream's work** — until it lands, curation
   applies only the `move` spelling, and the `escape` facts for

--- a/planning/simple_sub/m7.5-implementation-plan.md
+++ b/planning/simple_sub/m7.5-implementation-plan.md
@@ -1,0 +1,888 @@
+# M7.5 implementation plan — Library type resolution (`std:*` / `web:*` / `node:*`)
+
+This plan covers **M7.5 — Library type resolution** as listed in
+[01-milestones.md](01-milestones.md). It follows the shape of the
+[M4](m4-implementation-plan.md), [M5](m5-implementation-plan.md),
+[M6](m6-implementation-plan.md), and [M7](m7-implementation-plan.md) plans: what
+the tree already ships, where the milestone text no longer matches the code, the
+delta M7.5 adds, a PR-by-PR design with file references, and a dependency graph.
+
+M7.5 is the milestone that gives `internal/solver` a way to see code it did not
+parse itself. Everything before it types a single `*ast.Module` against a
+hand-seeded prelude. M7.5 adds the second module, the import statement that names
+it, the registry that caches it, and the standard-library types that flow through
+it — and then spends the rest of its budget on the type-system surface that only
+becomes expressible once `Array<T>` is real.
+
+## What the tree already ships (ground truth)
+
+### The solver has no import path at all
+
+`InferModule` ([module.go:37](../../internal/solver/module.go)) takes one
+`*ast.Module`, hangs a module `Scope` off `sharedPrelude()`, and walks the dep
+graph. There is no `*ast.ImportStmt` handling anywhere in the package, no
+per-file scope, and no package registry. The old checker's `InferModule`
+([infer_module.go:1954](../../internal/checker/infer_module.go)) does all of that
+in a Phase 1 that runs before the dep graph: it mints a file `Scope` per
+`*ast.File` and calls `inferImport` for each of that file's `Imports`, so import
+bindings are file-scoped while declarations are module-scoped. The solver has no
+counterpart to that phase.
+
+### The scheme-URI resolver exists, and lives entirely in the old checker
+
+`internal/checker/infer_stdlib_import.go` already implements the whole
+`<scheme>:<pkg>` surface: scheme split and validation over `std` / `web` / `node`,
+the `?local` binding-shape flag, package-name validation, the map from
+`std:array` to `<stdlib-dir>/std/array.esc`, the `@js` loader rules, and the FR5
+single-class shortcut that binds `std:array` directly to the `Array` class when
+the package declares one class whose name matches the package name.
+`internal/checker/infer_stdlib_scc.go` adds cycle handling: it scans each package
+file for its own pseudo-package imports, runs Tarjan over the resulting graph, and
+loads a strongly connected component as one merged module. Both produce
+`type_system.Namespace` and are unreachable from `soltype`.
+
+The directory discovery itself — the `--stdlib-dir` flag, the
+`ESCALIER_STDLIB_DIR` variable, the sibling-to-executable and repo-relative
+fallbacks — is `interop.StdlibDir`
+([stdlib_dir.go](../../internal/interop/stdlib_dir.go)), which is
+`type_system`-free and reusable as-is.
+
+### The standard library's content is two stub files
+
+`internal/interop/data/` holds `std/array.esc` and `std/math.esc`, both stubs
+written to satisfy a resolver gate. `web/`, `node/`, `builtins/`, and `libs/` hold
+only a README. Filling them is §7 of
+[planning/builtins/implementation_plan.md](../builtins/implementation_plan.md),
+which is not started and depends on §6, the converter productionization, which is
+partial. This is the single largest external dependency on M7.5's acceptance
+criteria; see [§Cross-workstream dependencies](#cross-workstream-dependencies).
+
+### `Array`, `Promise`, and `Generator` are dedicated `soltype` concretes
+
+`ArrayType{Elem}` ([type.go:847](../../internal/soltype/type.go)) exists so a rest
+parameter has an element type. Its own comment states the limit: "The minimal form
+carries no members, so `xs.length` and `xs[0]` do not resolve." `PromiseType`
+([type.go:774](../../internal/soltype/type.go)) and `GeneratorType` are the same
+shape of decision — one stdlib generic hardcoded ahead of ingestion. All three are
+reached by a hardcoded name test in `resolveTypeAnn`
+([type_ann.go:145](../../internal/solver/type_ann.go)), which fires only after
+`resolveScopedTypeRef` finds nothing, so a user declaration already shadows them.
+
+`Iterable` and `AsyncIterable` have no representation at all: they are two of the
+five names in `stdlibTypePlaceholders`
+([prelude.go:102](../../internal/solver/prelude.go)), each bound to a bare
+`UnknownType`. `IteratorResult`, `IteratorYieldResult`, and `IteratorReturnResult`
+are the exception — they are real built-in aliases registered on every `Context`
+by `registerIteratorResultAliases`.
+
+Iteration is therefore structural rather than protocol-driven. `syncElemType`
+([infer_for_in.go](../../internal/solver/infer_for_in.go)) reads an element type
+off a tuple, a union of tuples, or a generator, and rejects everything else. There
+is no `[Symbol.iterator]` lookup.
+
+### M7 aliases landed; the type operators landed further than the milestone assumed
+
+`AliasType`, `AliasDef`, `expandAlias`, the canonical-identity interning in
+`Context.aliasInterns`, and the alias arms of the module SCC path are all in
+([aliases.go](../../internal/solver/aliases.go),
+[context.go:22](../../internal/solver/context.go),
+[module.go:252](../../internal/solver/module.go)).
+
+M9's operator machinery is substantially in as well, which retires several of the
+milestone's "wait for M9" deferrals. `KeyofType`, `IndexType`, `CondType`,
+`MappedElem`, `TemplateLitType`, `RestSpreadType`, and the string intrinsics all
+exist in `soltype`, and `typeEvaluator`
+([typeops.go](../../internal/solver/typeops.go)) reduces them.
+`ObjectType.IndexSignatures` reads index signatures off a settled `MappedElem`, so
+the `IndexSignatureElem` representation the milestone asks M7.5 to introduce is
+already there under a different name.
+
+### Usage-based inference seals objects, and only objects
+
+`valueProp` ([infer_expr.go:2476](../../internal/solver/infer_expr.go)) lowers
+`recv.prop` — and, through `resolveIndexPath`, a constant *string* index
+`recv["prop"]` — to an inexact one-property `ObjectType` upper bound on the
+receiver var. `foldUsageBounds` and `mergeObjectGroup`
+([coalesce.go:915](../../internal/solver/coalesce.go)) merge those requirements by
+property NAME, and `sealUsageObjects`
+([poly.go:509](../../internal/solver/poly.go)) writes the merged, exact object
+back into the var's stored upper bounds at generalization, gated on the var being
+non-`open`, negative-only, and lower-bound-free.
+
+There is no positional twin. A constant *numeric* index `recv[0]` is not a
+constant key as far as `constStringKey`
+([infer_expr.go:2720](../../internal/solver/infer_expr.go)) is concerned, so it
+falls to `dynamicIndexRead`, which types it as `Recv[Kt]` and reduces it. On a
+concrete tuple `indexTuple` ([typeops.go:1609](../../internal/solver/typeops.go))
+answers correctly. On an inference variable the reduction does not ground, so the
+access reports unsupported and no tuple is ever inferred from usage.
+
+### The move engine's place segments carry a kind tag with one kind
+
+`placeSeg{kind, name}` ([moves.go:170](../../internal/solver/moves.go)) has the
+tag the milestone asks for, and `namedSeg` is its only value. `exprPlace`
+([moves.go:202](../../internal/solver/moves.go)) builds a segment from a static
+member or a `constStringKey` index and falls back to the container place for
+everything else, so `arr[i]` and `t[0]` both resolve to the whole binding.
+`soltype` has `SymbolPrim` but no unique-symbol type carrying a stable id, so
+there is nothing for a symbol-keyed segment to key on.
+
+### Three lib-shaped decl kinds are unsupported, and `export` is ignored
+
+`inferDeclDef` ([infer_decl.go:31](../../internal/solver/infer_decl.go)) handles
+`VarDecl`, `FuncDecl`, and `ClassDecl`; the type-key path adds `TypeDecl` and
+`EnumDecl`. `InterfaceDecl` and `NamespaceDecl` reach `reportUnsupported`. The
+solver reads no decl's `Export()` flag, and only `inferEnum` ever calls
+`defineNamespace`, so there is no module-namespace tree and no notion of a
+package's exported surface.
+
+### Registries are per-run and keyed by dep-graph-qualified name
+
+`Context.classes` and `Context.aliases`
+([context.go:49](../../internal/solver/context.go)) key on the name stored in the
+`ClassType` / `AliasType` node, which `dep_graph` qualifies within one module.
+`newChecker` mints one `Context` per `InferModule` call. Two modules inferred into
+one run would collide on any shared qualified name.
+
+### The parallel-package gate is a comment, not a test
+
+[doc.go:17](../../internal/solver/doc.go) and
+[prelude.go:38](../../internal/solver/prelude.go) both assert that nothing in
+`solver` imports `internal/checker` or `internal/type_system`. Nothing enforces
+it. M7.5 is the first milestone with a real temptation to break it, because
+`internal/interop` imports `type_system` at package scope even though its
+AST-producing entry points do not.
+
+## Where this plan diverges from the milestone text
+
+The milestone was written before several of the things it defers. Five corrections
+carry through the PR list.
+
+- **Rest-param element checking (#677) is already done.** The milestone defers it
+  to M7.5 on the grounds that it needs `Array<T>`. The `Array<T>` stub was enough:
+  `constrain`'s function rule ([constrain.go:864](../../internal/solver/constrain.go))
+  already checks each absorbed argument against an `Array<E>` rest slot's element
+  type, in both the absorb and the scatter direction, and the scatter path is what
+  a direct call goes through. M7.5 inherits this rather than building it.
+- **Dynamic-key reads and index signatures are already done.** The milestone
+  splits index-signature *representation* into M7.5 and index-signature
+  *inference* into M9. Both landed: `MappedElem` is the representation, and
+  `dynamicIndexRead` ([infer_expr.go:2678](../../internal/solver/infer_expr.go))
+  routes `recv[k]` through `IndexType` reduction. What M7.5 still owes is the
+  constant-numeric tuple arm and the `Array` element read.
+- **`.esc` is the ingestion channel, not `.d.ts`.** The milestone describes
+  ingestion as `dts_parser` → `interop.ConvertModule` → `*ast.Module`. That is the
+  npm `@types` channel. The standard library goes through committed `.esc` files
+  that the ordinary parser reads, with the `.d.ts` conversion happening offline in
+  `tools/dts_to_esc`. Both channels end at `*ast.Module`, so the solver-side work
+  is shared, but the stdlib path needs no `interop` dependency at all.
+- **Named imports from a pseudo-package are rejected today.** The milestone's
+  acceptance criteria say `import { Array } from "std:array"` resolves. The
+  shipped resolver rejects a named import from a scheme URI and requires a bare
+  `import "std:array"` plus member access through the bound namespace, with the
+  single-class shortcut binding `Array` directly. This plan follows the shipped
+  design, and PR2 records the wording fix to the milestone. Adding named imports
+  is a separable change to both checkers and is not scheduled here.
+- **Unions no longer carry exactness.** The exactness item cites
+  [exact-types/requirements.md](../exact-types/requirements.md) §8, which lists
+  unions among the four inexact-on-import categories. The union exactness fields
+  were removed. PR12 stamps objects, tuples, and functions only.
+
+## What M7.5 adds (the delta)
+
+1. **Cross-module inference.** A package registry with an in-progress sentinel, a
+   per-file `Scope`, an exported-surface `Namespace` per package, and registry
+   keys qualified by package URI so two modules share one `Context` without
+   colliding.
+2. **Scheme-URI resolution on the solver.** `std:` / `web:` / `node:` split,
+   validation, `.esc` path mapping, `@js` loader rules, and the two binding
+   shapes, ported off `type_system`.
+3. **Pseudo-package import cycles.** The package-import graph, Tarjan
+   condensation, and the merged-module load for a component larger than one.
+4. **The lib-shaped decl kinds.** `InterfaceDecl` with declaration merging,
+   `NamespaceDecl`, and `export` visibility.
+5. **Well-known type handles.** A `Context`-held handle per checker-known protocol
+   type, resolved from its stdlib module rather than from lexical scope, so
+   `await` / `for-in` / `yield` type-check in a file that imports nothing.
+6. **A real `Array<T>`.** The `ArrayType` concrete gives way to the ingested
+   declaration, so `xs.length`, `xs.push(v)`, `xs[i]`, and `for (x in xs)` all
+   resolve.
+7. **Positional usage inference.** A constant numeric index lowers to an inexact
+   tuple requirement, `mergeTupleGroup` folds those by index, and
+   `sealUsageObjects` grows a tuple arm under the existing gating.
+8. **Index writes.** `recv[0] = v` and `recv[k] = v` extend the member-assign path
+   with the same tuple-versus-array classification the read path uses.
+9. **Variadic tuple types.** `[number, ...Array<number>]` as a typed unbounded
+   tail, with its subtyping rules.
+10. **`unique symbol` and symbol-keyed access.** A `soltype` kind carrying a
+    stable id, plumbed through the visitor, printer, `constrain`, and `coalesce`.
+11. **Precise place segments.** A type-aware `constKey` for the move engine, an
+    `indexSeg` kind keyed by integer, and a `symbolSeg` kind keyed by symbol id.
+12. **Visibility of the gaps.** Exactness stamping on ingested formers, an
+    inventory of every lib name that resolves as a stub, and an executable
+    parallel-package gate.
+13. **The npm `.d.ts` channel.** `dts_parser` → `interop.ConvertModule` →
+    `*ast.Module` → the solver, without pulling `type_system` into the output path.
+
+## Cross-workstream dependencies
+
+M7.5's acceptance criteria name `Map<K, V>`, `console`, and `web:dom`. None of
+those exist on disk. The dependency is on
+[planning/builtins/implementation_plan.md](../builtins/implementation_plan.md) §7,
+"Stdlib bootstrap", which runs the converter, reviews the output, hand-edits
+`throws` / lifetimes / mutability, and commits the `.esc` files. §7 depends on §6,
+whose PR B and PR C are outstanding.
+
+This plan does not wait on §7. Every PR below is testable against a **test stdlib
+tree** — a fixture directory of hand-written `.esc` files pointed at through
+`ESCALIER_STDLIB_DIR`, holding exactly the declarations that PR needs. PR2
+establishes that harness. The consequence is a split acceptance boundary worth
+stating plainly:
+
+- **What M7.5 owns and can finish alone:** the resolver, the registry, the cycle
+  handling, the decl kinds, the well-known handles, the whole `Array`-unlocked
+  type-system surface, and the tests for all of it against the test tree.
+- **What M7.5 cannot finish alone:** "real source that imports core lib types
+  type-checks" against the *shipped* tree. That criterion is met when builtins §7
+  lands, not when the last PR here merges.
+
+The same split applies downstream. M8's real-package differential needs both this
+plan and §7. Recording it here keeps a green M7.5 from reading as a populated
+standard library.
+
+Two smaller ones: the affine borrow-through-container-methods work
+([affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md))
+is unblocked by PR5's real `Array` and its `push` method, and is not owned here;
+and the "Tuple-index place segments" item in the same document is discharged by
+PR11.
+
+---
+
+## PR-by-PR breakdown
+
+Thirteen PRs in three lanes. **Lane A** (PR1–PR4, PR13) is ingestion plumbing.
+**Lane B** (PR5–PR9) is the type-system surface `Array` unlocks. **Lane C**
+(PR10–PR11) is symbol and index precision. PR12 is hygiene and can land any time
+after PR5.
+
+### PR1 — Cross-module inference core
+
+The foundation: make the solver able to infer a second module and keep the result.
+
+**Data structures.**
+- `PackageRegistry` on the `checker`: `map[string]*packageEntry` keyed by the full
+  URI, where `packageEntry` holds the package's exported `Namespace`, its resolved
+  file path, and a `loading bool` in-progress sentinel. Modeled on
+  [package_registry.go](../../internal/checker/package_registry.go), over
+  `solver.Namespace` instead of `type_system.Namespace`.
+- **A file scope per `*ast.File`.** `InferModule` grows a phase that mints a
+  `Scope` child per file before the dep-graph walk, holding that file's import
+  bindings. Declarations stay module-scoped; imports do not leak across files.
+  This is the solver's counterpart to
+  [infer_module.go:1960-1990](../../internal/checker/infer_module.go).
+- **URI-qualified registry keys.** `Context.classes` and `Context.aliases` gain a
+  package-URI prefix on every key minted while a package is being inferred, so
+  `std:array`'s `Array` and a user's `Array` are distinct entries. The prefix is
+  applied at registration and carried in the `ClassType.Name` / `AliasType.Name`
+  the node stores, so nothing downstream needs to learn about packages.
+
+**Algorithms.**
+- **`loadModule(uri, path)` with a cycle sentinel.** Look the URI up; return the
+  cached `Namespace` on a hit. On a miss, mark in-progress, parse, infer into a
+  fresh `Namespace` under the SAME `Context`, then publish. A re-entrant lookup
+  during the in-progress window returns the sentinel, and the caller skips binding
+  rather than recursing. Sharing the `Context` is what makes a cross-package
+  `ClassType` reference resolve through the one nominal registry; the URI prefix
+  above is what makes that safe.
+- **Exported-surface assembly.** After a package's dep graph is inferred, walk its
+  top-level decls and copy the ones whose `Export()` is true into the package
+  `Namespace`. This is the solver's first reader of the flag. A package with a
+  non-exported top-level decl keeps it out of the namespace, so a consumer cannot
+  name it.
+
+**Accept.** A hand-built two-module fixture infers both: module B's `import`
+resolves a class declared in module A, `B` sees only A's exported decls, and a
+mutually-importing A/B pair terminates through the sentinel instead of recursing.
+Two modules each declaring a class named `Point` produce two distinct
+`ClassDef`s.
+
+**Size.** Medium — one new file plus a phase in `module.go`.
+
+### PR2 — Scheme-URI imports and `.esc` stdlib binding
+
+Port the `std:` / `web:` / `node:` surface onto the solver.
+
+**Data structures.**
+- `stdlibSchemes` / `stdlibSchemesSet` / `stdlibKnownFlags`, ported verbatim from
+  [infer_stdlib_import.go:21-33](../../internal/checker/infer_stdlib_import.go).
+  These are plain string sets with no `type_system` content.
+- The **test stdlib tree** the rest of the plan tests against: a fixture directory
+  of hand-written `.esc` files selected through `ESCALIER_STDLIB_DIR`, with a
+  helper that points a test run at it.
+
+**Algorithms.**
+- **`splitScheme` / `isRecognizedScheme` / `isSchemePrefixedImport` /
+  `resolveStdlibFlags` / `isValidPackagePath`** — direct ports. Each is a pure
+  string function with no checker coupling.
+- **`resolveStdlibPath`** maps `scheme:pkg` to `<dir>/<scheme>/<pkg>.esc`, reusing
+  `interop.StdlibDir` for discovery. `interop` imports `type_system` at package
+  scope, so PR12's gate test must allow this one edge deliberately, or the
+  discovery function moves to a leaf package. **Decide in this PR**; moving it is
+  the cleaner answer and is a small mechanical change.
+- **`bindStdlibLocal`** binds the package under the lowercased last URI segment,
+  with the FR5 single-class shortcut: when the package declares exactly one class
+  whose name matches the package name case-insensitively, bind that class directly
+  under its own capitalization instead. Reads `Namespace.Types` / `Namespace.Values`
+  from PR1's exported surface.
+- **The `@js` loader rules** (§3.4(1-3) of the builtins plan): every exported
+  value-level decl in a stdlib file must carry `@js`, and an unexported
+  value-level decl is rejected. Rule 4, validating the `@js` argument against a
+  real runtime path, stays out — the builtins plan §9 moves it to a CI-only test.
+- **Diagnostics** re-anchor to the importing `import` statement's span, so a parse
+  or inference error inside a stdlib file underlines the user's import rather than
+  a file they cannot navigate to. The original location stays in the message body.
+
+**Milestone correction.** Update
+[01-milestones.md](01-milestones.md) M7.5's acceptance wording from
+`import { Array } from "std:array"` to the bare-import form the resolver
+implements, in this PR, so the two documents stop disagreeing.
+
+**Accept.** `import "std:array"` against the test tree binds `Array` through the
+single-class shortcut and `val xs: Array<number>` resolves to the ingested class;
+`import "std:bogus"` reports an unknown-package diagnostic naming the searched
+directory; `import "bogus:array"` reports an unknown-scheme diagnostic listing the
+three recognized schemes; a named import from a scheme URI reports the
+named-import rejection; a file that names `Array` with no import is an
+unbound-name error, proving there is no ambient surface.
+
+**Depends on** PR1.
+
+**Size.** Medium-large — roughly the 420 lines of `infer_stdlib_import.go`, minus
+the parts PR1 already carries.
+
+### PR3 — Pseudo-package import cycles
+
+`web:dom`'s siblings mutually reference it, so a cycle is the normal case, not an
+edge case.
+
+**Data structures.**
+- The **pseudo-package import graph**: `map[string][]string` from a package URI to
+  the URIs it imports, built by scanning each `.esc` file under the stdlib
+  directory for its own scheme-prefixed imports.
+- A **process-level SCC cache** keyed by stdlib directory, so the graph is built
+  once per directory rather than once per import.
+
+**Algorithms.**
+- **`extractPseudoPackageImports`** parses one stdlib file and collects the
+  scheme-prefixed specifiers in its `Imports`. Ported from
+  [infer_stdlib_scc.go:124](../../internal/checker/infer_stdlib_scc.go).
+- **`tarjanSCCs`** condenses the graph into strongly connected components. A
+  direct port; it is a pure graph algorithm over strings.
+- **Merged-module load.** When a URI's component has more than one member, parse
+  every member into one `*ast.Module` and infer it as a single unit, so the
+  existing dep-graph SCC ordering resolves the cross-package references. Publish
+  each member's namespace into the registry afterwards. A member importing a
+  sibling short-circuits its own bind, since the merged module already exposes the
+  sibling.
+
+**Accept.** A test tree with a `std:a` ↔ `std:b` cycle loads once, both packages
+resolve each other's types, and each is registered under its own URI; a
+three-package cycle behaves the same; an acyclic package still takes the
+single-module path.
+
+**Depends on** PR2.
+
+**Size.** Medium — roughly the 330 lines of `infer_stdlib_scc.go`.
+
+### PR4 — Lib-shaped declaration kinds
+
+The converter emits declarations the solver cannot read yet.
+
+**Data structures.**
+- No new `soltype` node. An `InterfaceDecl` produces an `ObjectType`, reusing the
+  `MethodElem` / `GetterElem` / `SetterElem` arms M5 landed.
+- A `NamespaceDecl` produces a `solver.Namespace`, the container PR1 already
+  assembles for a package's exported surface.
+
+**Algorithms.**
+- **Interface inference.** Slot an `*ast.InterfaceDecl` arm into the module
+  type-key path beside the alias and enum arms, resolving the body through
+  `resolveObjectTypeAnn` and binding the name. An interface is structural and
+  transparent, so it binds to an `AliasType` over the object body rather than to a
+  nominal identity — the same shape PR5 of the M7 plan gave an enum. Type
+  parameters route through the existing `resolveTypeParams`.
+- **Declaration merging.** Two `interface Foo` declarations in one module
+  contribute to one type. Merge the element lists at bind time, last-wins per
+  member name, matching the old checker's behavior. An interface merging with a
+  same-named class is out of scope and reports a diagnostic.
+- **`extends`.** An interface's `extends` clause resolves to the referenced object
+  types and prepends their elements, so the merged element list is the flattened
+  surface. This is member inheritance, not nominal subtyping.
+- **Namespace inference.** A `*ast.NamespaceDecl` recurses into its own decls
+  under a nested `Namespace`, wired into `Scope.defineNamespace`. The existing
+  `resolveNamespaceMember` ([infer_expr.go:2704](../../internal/solver/infer_expr.go))
+  then reads members off it with no change.
+
+**Accept.** `declare interface Point { x: number }` binds and `val p: Point = {x: 1}`
+type-checks; two `interface Point` blocks merge into one type carrying both member
+sets; `interface Sq extends Rect {}` carries `Rect`'s members; a namespace decl
+binds and `NS.member` resolves; a non-exported member of a stdlib package is
+invisible to an importer.
+
+**Depends on** PR1. Independent of PR2 and PR3.
+
+**Size.** Medium.
+
+### PR5 — A real `Array<T>` and the well-known-handle mechanism
+
+The hinge PR. Everything in Lane B after it needs a real `Array`.
+
+**Data structures.**
+- **`Context.wellKnown map[wellKnownName]soltype.Type`**, a handle per
+  checker-known type, populated on first use by loading that type's stdlib module
+  through PR1's registry. The handle is independent of lexical scope, so a rule
+  that needs `Array` fires in a file that never imports it. The set is fixed and
+  closed — it is not a general ambient surface.
+- **`ArrayType` retires.** The `soltype` concrete
+  ([type.go:847](../../internal/soltype/type.go)) is replaced by the `ClassType`
+  the ingested `Array` declaration produces, so an array carries its full member
+  surface. Every arm that switches on `ArrayType` —
+  [constrain.go:1213](../../internal/solver/constrain.go),
+  [coalesce.go:1474](../../internal/solver/coalesce.go),
+  [lattice.go:497](../../internal/solver/lattice.go),
+  [inhabited.go:164](../../internal/solver/inhabited.go),
+  [productivity.go:213](../../internal/solver/productivity.go) — either deletes or
+  redirects to the nominal path. The rest-param absorb and scatter rules
+  ([constrain.go:864](../../internal/solver/constrain.go)) switch from a type
+  assertion on `*ArrayType` to a well-known-handle identity test, keeping #677's
+  behavior intact.
+
+**Algorithms.**
+- **Handle resolution.** `wellKnownType(name)` loads the owning module, reads the
+  name off its exported `Namespace`, and caches the result on `Context`. A missing
+  name is a structured diagnostic naming the module and the name, reported once,
+  not a panic — a partial stdlib tree must degrade legibly.
+- **`Array` element reads.** `reduceIndex`
+  ([typeops.go:1409](../../internal/solver/typeops.go)) grows an arm for the array
+  instance: a numeric index or a `number`-typed key yields the element type. This
+  is the "dynamic key → `Array`, not tuple" half of the milestone's index-read
+  item.
+- **Array iteration.** `syncElemType`
+  ([infer_for_in.go](../../internal/solver/infer_for_in.go)) grows an array arm
+  yielding the element type. The full `[Symbol.iterator]` protocol waits for PR10;
+  this arm is the direct structural answer for the one container the milestone
+  requires.
+- **Annotation resolution.** Delete the hardcoded `Array` branch in `resolveTypeAnn`
+  ([type_ann.go:145](../../internal/solver/type_ann.go)) and the `Array` arm of the
+  arity-mismatch fallback below it, so a written `Array<number>` resolves through
+  the ordinary scope path against the imported declaration.
+
+**Accept.** With `Array` in the test tree, `val xs: Array<number>` resolves to the
+ingested class; `xs.length` is `number`; `xs.push(1)` type-checks and `xs.push("a")`
+is rejected with the full message; `xs[0]` is `number`; `for (x in xs) { … }` binds
+`x` at `number`; a rest param `...args: Array<string>` still rejects a numeric
+trailing argument, showing #677's behavior survived the concrete's retirement.
+
+**Depends on** PR2. Independent of PR3 and PR4.
+
+**Size.** Large. This is the PR to split further if review drags — the handle
+mechanism and the `ArrayType` retirement are separable, in that order.
+
+### PR6 — The well-known protocol set
+
+Extend PR5's mechanism to the rest of the checker-known types and delete the
+placeholders.
+
+**Algorithms.**
+- **`Promise`.** `PromiseType` retires the way `ArrayType` did in PR5, so
+  `p.then(…)` resolves. `await e` constrains `e` against the handle-resolved
+  `Promise<U>` rather than minting the concrete. The no-auto-flatten contract is
+  unchanged: awaiting `Promise<Promise<T>>` yields `Promise<T>`, and flattening
+  stays `Awaited<T>`.
+- **`Iterable` / `AsyncIterable` / `Iterator`.** These have no concrete to retire
+  — they are `UnknownType` stubs today. `for (x in xs)` and `for await` constrain
+  the operand against the handle-resolved protocol type and read the element type
+  off the result, replacing `syncElemType` / `asyncElemType`'s structural walk.
+  Keep the tuple arm: a tuple is iterable by a rule the protocol lookup does not
+  cover.
+- **`Generator` / `AsyncGenerator`.** `GeneratorType` retires last, since it
+  carries four slots and a `Raises` predicate that `iterationRaise`
+  ([infer_for_in.go:107](../../internal/solver/infer_for_in.go)) reads. The
+  ingested declaration must expose the same four type parameters for the raise
+  path to survive; if it does not, this half splits out and the concrete stays,
+  recorded in PR12's stub inventory.
+- **Delete `stdlibTypePlaceholders` and `addStdlibTypePlaceholders`**
+  ([prelude.go:98-117](../../internal/solver/prelude.go)). The prelude keeps the
+  operator bindings and the built-in iterator-result aliases and loses its ambient
+  type surface entirely.
+
+**Accept.** `await` in a file that imports nothing type-checks against the real
+`Promise`; `for (x in xs)` in a file that imports nothing type-checks against the
+real `Iterable`; writing `Promise` in an annotation without importing it is an
+unbound-name error, so the handle is reachable to the rule and not to the source;
+a `yield` in a generator resolves its `IteratorResult` through the handle.
+
+**Depends on** PR5.
+
+**Size.** Large, and naturally splits per protocol if needed.
+
+### PR7 — Constant-numeric index reads: tuple usage inference and the seal
+
+The positional twin of M4's object close.
+
+**Data structures.**
+- **An inexact tuple requirement.** `recv[0]` lowers to
+  `TupleType{Elems: […, β], Inexact: true}` — "has at least a slot at this index" —
+  the positional analogue of the `{prop: β, ...}` object requirement. Holes below
+  the accessed index are fresh vars.
+- **`mergeTupleGroup`**, beside `mergeObjectGroup`
+  ([coalesce.go:978](../../internal/solver/coalesce.go)).
+
+**Algorithms.**
+- **`inferIndex` tuple arm.** `resolveIndexPath`
+  ([infer_expr.go:2648](../../internal/solver/infer_expr.go)) gains a branch for a
+  constant numeric key, beside the existing `constStringKey` → `valueProp` call and
+  before the `dynamicIndexRead` fallback. It mints the requirement above,
+  constrains it as an upper bound on the receiver, and returns the element var. A
+  receiver that is already a concrete tuple or array keeps today's reduction path;
+  the new arm fires for an inference variable.
+- **Merge by position.** Where `mergeObjectGroup` unions properties by name,
+  `mergeTupleGroup` unions slots by index: `recv[0]; recv[2]` requires length ≥ 3
+  with index 1 a fresh-var hole, and a slot required at several indices intersects
+  its element types, exactly as the object fold intersects a shared property. The
+  result is exact unless `open`.
+- **Seal arm.** `foldUsageBounds` ([coalesce.go:915](../../internal/solver/coalesce.go))
+  classifies an inexact tuple as a usage requirement alongside the inexact object,
+  and `sealUsageObjects` ([poly.go:509](../../internal/solver/poly.go)) folds tuple
+  bounds through the SAME gating — non-`open`, negative-only, no lower bounds. No
+  new gating condition. An escaping receiver keeps its open row and an `open` param
+  keeps the inexact `[T0, ...]` form, both falling straight out of the existing
+  checks.
+- **Number keys versus string keys.** `constStringKey` stays syntactic and
+  string-only for the name-resolution call sites; the numeric arm is a separate
+  reader. `recv[0]` and `recv["0"]` therefore take different paths and produce
+  different requirements. PR11 applies the same split to the move engine.
+
+**Accept.** `fn f(t) { t[0]; t[1] }` infers and SEALS the parameter to exact
+`[T0, T1]`, and a caller passing a three-element tuple is rejected with the full
+message; `fn f(open t) { t[0]; t[1] }` stays inexact `[T0, ...]` and accepts the
+longer tuple; `fn f(t) { t[0]; return t }` is not sealed and the returned value
+keeps the caller's extra elements; `fn f(t) { t[0]; t[2] }` requires length ≥ 3
+with a fresh var at index 1; `fn f(t) { t[0].x; t[0].y }` seals both the tuple and
+the nested object, showing the two folds compose.
+
+**Depends on** PR5, for the dynamic-key-to-`Array` half of the classification.
+
+**Size.** Medium-large.
+
+### PR8 — Index writes
+
+`recv[0] = v` and `recv[k] = v`, the write twin of PR7.
+
+**Algorithms.**
+- **Extend `inferMemberAssign`** (M4 C3) with the `*ast.IndexExpr` sub-case it
+  currently reports unsupported. The write reuses PR7's classification — constant
+  numeric to a tuple slot, dynamic to an array element, constant string to the
+  existing object property path — plus C3's `mut` receiver requirement and
+  `widen` on the written value.
+- **A tuple write requirement is `mut`-wrapped**, so `foldUsageBounds`'s existing
+  whole-container `mut` merge applies: any write among a receiver's selections
+  folds every selection, reads included, into one `mut` tuple. This is the rule
+  already in place for objects, reused verbatim rather than re-derived.
+- **Read-after-write** through the `written` map keyed on `{recvID, field}` needs
+  an index-shaped key. Generalize the key's field component to carry either a name
+  or an integer index, so `t[0] = 5; t[0]` reads `number`.
+
+**Accept.** `fn f(mut t) { t[0] = 5 }` requires a mutable tuple receiver and
+rejects an immutable one with the full message; `t[0] = 5; t[0]` is `number`;
+`xs[i] = 5` on an `Array<number>` type-checks and `xs[i] = "a"` is rejected;
+writing through a non-`mut` receiver is rejected.
+
+**Depends on** PR7.
+
+**Size.** Medium.
+
+### PR9 — Variadic tuple types
+
+`[number, ...Array<number>]` — a fixed prefix with a typed, unbounded,
+homogeneous tail. Distinct from M4's `Inexact` flag, which means "at least these,
+then `unknown`."
+
+**Data structures.**
+- **Reuse `RestSpreadType` over an array**, rather than adding a tail field to
+  `TupleType`. `resolveTupleTypeAnn`
+  ([type_ann.go:539](../../internal/solver/type_ann.go)) already builds
+  `TupleType{Elems: [number, RestSpreadType{Array<number>}]}` for this annotation;
+  what is missing is every rule that reads it. Reusing the existing element keeps
+  the printer, the visitor, and `coalesce` unchanged, and it is the same shape the
+  `infer`-matching form will need. **Confirm this in the PR against the
+  alternative**, a dedicated `Tail` field, before writing the rules.
+
+**Algorithms.**
+- **Grounding.** `groundTuple` / `reduceTuple`
+  ([typeops.go:476](../../internal/solver/typeops.go)) splice a spread operand's
+  elements in at its position. An array operand has no element list to splice, so
+  add an arm that recognizes it as a settled variadic tail rather than an unground
+  spread, so the tuple stops being treated as symbolic.
+- **Subtyping.** Two rules, both in the tuple arm of `constrain`:
+  `[number, number] <: [number, ...Array<number>]` — a fixed tuple satisfies a
+  variadic one when its prefix matches and every surplus element is a subtype of
+  the tail element — and `[number, ...Array<number>] <: Array<number>` — a
+  variadic tuple is an array of the join of its prefix and tail elements.
+- **`keyof` and indexed access.** `keyofTuple`
+  ([typeops.go:1265](../../internal/solver/typeops.go)) and `indexTuple`
+  ([typeops.go:1609](../../internal/solver/typeops.go)) grow tail arms: a numeric
+  index at or beyond the prefix yields the tail element rather than an
+  out-of-range error.
+
+**Out of scope.** The `infer`-matching form
+`T extends [any, ...infer R] ? R : never` stays with the conditional and `infer`
+work, not here.
+
+**Accept.** `val t: [number, ...Array<number>] = [1, 2, 3]` type-checks and
+`[1, "a"]` is rejected with the full message; `[number, ...Array<number>]` is a
+subtype of `Array<number>`; `t[5]` is `number` rather than out of range; a
+variadic tuple renders with its tail spelled `...Array<number>`.
+
+**Depends on** PR5.
+
+**Size.** Medium.
+
+### PR10 — `unique symbol` and symbol-keyed access
+
+**Data structures.**
+- **`soltype.UniqueSymbolType{ID int}`**, carrying a stable id so
+  `val it = Symbol.iterator` and the original `Symbol.iterator` are one type. The
+  old checker's `type_system.UniqueSymbolType{Value int}` is the model. Needs an
+  `isType()` arm, a visitor arm, a printer arm rendering the symbol's name, a
+  `constrain` arm — two unique symbols are subtypes only when their ids match, and
+  every unique symbol is a subtype of the `symbol` primitive — a `coalesce` arm,
+  and a `compareType` entry for canonical ordering.
+- **A symbol-keyed object member.** `objKeyName`
+  ([infer_expr.go:2735](../../internal/solver/infer_expr.go)) returns false for a
+  `ComputedKey`; give it an arm that reads a unique-symbol-typed key so a
+  symbol-keyed field is a member rather than a structured error.
+
+**Algorithms.**
+- **Symbol-keyed member access.** `resolveIndexPath` gains an arm for a key whose
+  inferred type is a `UniqueSymbolType`, resolving against the receiver's
+  symbol-keyed members. This is what makes `xs[Symbol.iterator]` reachable, and
+  therefore what makes the full iteration protocol expressible.
+- **Iteration through the protocol.** With symbol-keyed access working, PR6's
+  `Iterable` constraint can resolve its element type through
+  `[Symbol.iterator]()` rather than through a structural arm per container. Wire
+  it here, keeping the tuple arm.
+
+**Accept.** `Symbol.iterator` from the test tree has a unique-symbol type; two
+references to it are the same type and two distinct symbols are not subtypes;
+`{[Symbol.iterator]: … }` declares a symbol-keyed member; a user class declaring
+`[Symbol.iterator]` is iterable by `for (x in …)` with no structural arm for its
+shape.
+
+**Depends on** PR6, for the `Iterable` protocol half. The `soltype` kind alone
+depends on nothing in this plan.
+
+**Size.** Medium-large.
+
+### PR11 — Precise place segments in the move engine
+
+Discharges the milestone's field-level-move item and the affine plan's
+"Tuple-index place segments".
+
+**Data structures.**
+- **Two new `placeSeg` kinds** beside `namedSeg`
+  ([moves.go:177](../../internal/solver/moves.go)): `indexSeg`, keyed by an
+  integer, and `symbolSeg`, keyed by a symbol id. `placeSeg` grows the fields those
+  kinds need. **The number-key decision is settled here in favor of the distinct
+  `indexSeg`**, not a `namedSeg` carrying the literal text: a `namedSeg` is keyed
+  by string, so mapping `a[0]` onto one conflates it with `a["0"]`. Both are
+  sound; the distinct kind is more precise and is what tuple-element tracking
+  needs. Apply the choice uniformly to `constKey`, `renderPlace`, and the
+  tuple-literal walk.
+- `placeKey` ([moves.go:249](../../internal/solver/moves.go)) already
+  length-prefixes each segment's name under its kind, so it admits both kinds
+  unchanged.
+
+**Algorithms.**
+- **A type-aware `constKey` for the move engine**, beside the syntactic
+  `constStringKey` the name-resolution call sites keep. Priority order: an index
+  whose inferred type is a singleton string `LitType` yields a `namedSeg`, so
+  `obj[k]` with `k: "foo"` keys the same place as `obj.foo`; a singleton number
+  `LitType` yields an `indexSeg`; a `UniqueSymbolType` yields a `symbolSeg` keyed
+  on its id. Anything else falls back to the container place, exactly as a dynamic
+  index does today — over-conservative at worst, never a missed use-after-move.
+- **Thread the index type through.** `exprPlace`
+  ([moves.go:202](../../internal/solver/moves.go)) is a free, purely syntactic
+  function today. It, `recordMemberUse`, and `consumeOwned` take the checker's
+  type side table so `constKey` can read an index expression's inferred type.
+- **`renderPlace`** ([moves.go:299](../../internal/solver/moves.go)) prints an
+  `indexSeg` as `[0]` and a `symbolSeg` as `[Symbol.iterator]`.
+- **The tuple-literal walk** extends its path by element index, so a borrow stored
+  at `a[1]` is recorded there rather than at `a`.
+
+**Accept.** Moving `t[0]` leaves `t[1]` usable and a later read of `t[0]` is a
+use-after-move naming `t[0]`; `obj[k]` with `k: "foo"` conflicts with a move of
+`obj.foo`; `a[0]` and `a["0"]` are distinct places; `val a = [&mut b, {x: 1}];
+return a[1]` no longer flags `b`; a dynamic `t[i]` still falls back to the
+container.
+
+**Depends on** PR7 for the numeric index path and PR10 for the symbol kind.
+
+**Size.** Medium.
+
+### PR12 — Exactness, the stub inventory, and the parallel-package gate
+
+Three small pieces of hygiene that keep the milestone's gaps visible.
+
+**Algorithms.**
+- **Exactness stamping.** Every object, tuple, and function former minted while
+  ingesting a library declaration is stamped `Inexact`
+  ([exact-types/requirements.md](../exact-types/requirements.md) §8). The flag's
+  zero value is exact, so this is an explicit set at each ingestion mint, not a
+  default. Unions are excluded — their exactness fields were removed. A user
+  wanting the closed reading opts in at the use site with `Exact<T>`, which the
+  exactness intrinsic already implements.
+- **The stub inventory.** A `Context`-held record of every lib name that resolved
+  to a placeholder rather than a real structure, with the module it came from and
+  why. Surfaced through a reporting hook so a run against a partial stdlib tree
+  says what it could not represent instead of reading as full coverage. This is
+  what keeps the builtins-§7 gap legible from inside the compiler.
+- **The parallel-package gate.** A test that asserts `internal/solver` and
+  `internal/soltype` do not transitively import `internal/checker` or
+  `internal/type_system`, walking the package's own import graph rather than
+  trusting the comment at [doc.go:17](../../internal/solver/doc.go). PR2's
+  `interop.StdlibDir` decision is what this test would otherwise catch.
+
+**Accept.** An ingested object type renders inexact and accepts an argument with
+extra fields; a written Escalier object stays exact; the gate test fails when a
+`type_system` import is added to `solver` and passes on the tree as shipped; a run
+against a partial stdlib tree reports the names it stubbed.
+
+**Depends on** PR5. Independent of PR6–PR11.
+
+**Size.** Small.
+
+### PR13 — The npm `.d.ts` channel
+
+The second ingestion channel, and the one M8's real-package differential needs
+beyond the standard library.
+
+**Algorithms.**
+- **Reuse the AST-producing front half.** `dts_parser` parse →
+  `interop.ConvertModule` → `*ast.Module`
+  ([module.go:176](../../internal/interop/module.go)), then hand that module to
+  PR1's `loadModule`. The back half — the old checker's walk to `type_system` — is
+  what this replaces.
+- **Package resolution.** `resolveImport`
+  ([infer_import.go:62](../../internal/checker/infer_import.go)) and
+  `resolver.ResolveTypesPackage` locate a package's entry `.d.ts` from a
+  `package.json`. Both are `type_system`-free and portable.
+- **Export statement processing.** `export *`, `export * as ns`, and named
+  re-exports across `.d.ts` files
+  ([infer_import.go:430-690](../../internal/checker/infer_import.go)) are the bulk
+  of the work, and they operate on PR1's `Namespace` rather than on types.
+- **Keep the gate.** `interop` imports `type_system` at package scope, so this PR
+  consumes only its AST-producing entry points and PR12's gate test constrains the
+  result. If the gate cannot hold, the AST-producing surface splits into a leaf
+  package.
+
+**Accept.** A fixture npm package with a `.d.ts` entry point resolves through
+`import { … } from "pkg"` and its exported types check; `export *` re-exports
+resolve; a package with no types reports a structured diagnostic.
+
+**Depends on** PR1, PR4, and PR12's gate.
+
+**Size.** Large. This is the most deferrable PR in the plan — the milestone's
+acceptance criteria and M8's fixture tree both rest on `std:*` / `web:*`, not on
+npm.
+
+---
+
+## Dependency graph
+
+```
+PR1 (cross-module core: registry, file scopes, URI-qualified keys, exported surface)
+ ├─► PR2 (scheme-URI imports + .esc stdlib binding + test stdlib tree)
+ │    ├─► PR3 (pseudo-package import cycles: graph, Tarjan, merged load)
+ │    └─► PR5 (real Array<T> + the well-known-handle mechanism)
+ │         ├─► PR6 (well-known protocol set: Promise, Iterable, Generator)
+ │         │    └─► PR10 (unique symbol + symbol-keyed access + the iteration protocol)
+ │         │         └─► PR11 (place segments: constKey, indexSeg, symbolSeg)  ── also needs PR7
+ │         ├─► PR7 (constant-numeric index reads: tuple requirement, mergeTupleGroup, seal arm)
+ │         │    └─► PR8 (index writes)
+ │         ├─► PR9 (variadic tuple types)
+ │         └─► PR12 (exactness stamping + stub inventory + parallel-package gate)
+ ├─► PR4 (lib decl kinds: interface, namespace, export visibility)
+ └─► PR13 (npm .d.ts channel)                          ── also needs PR4, PR12
+
+needs ─► builtins §7 (committed .esc files) for the shipped-tree acceptance criteria
+feeds ─► M8 (the real-package differential needs real lib types)
+feeds ─► affine borrow tracking through container methods (Array.push)
+```
+
+The same graph in mermaid, with the ingestion critical path PR1 → PR2 → PR5
+highlighted, the external workstream and downstream consumers dashed:
+
+```mermaid
+graph TD
+    PR1["PR1 (cross-module core: registry, file scopes, qualified keys)"]
+    PR2["PR2 (scheme-URI imports + .esc stdlib binding)"]
+    PR3["PR3 (pseudo-package import cycles)"]
+    PR4["PR4 (lib decl kinds: interface, namespace, export)"]
+    PR5["PR5 (real Array&lt;T&gt; + well-known-handle mechanism)"]
+    PR6["PR6 (protocol set: Promise, Iterable, Generator)"]
+    PR7["PR7 (numeric index reads: tuple requirement + seal)"]
+    PR8["PR8 (index writes)"]
+    PR9["PR9 (variadic tuple types)"]
+    PR10["PR10 (unique symbol + symbol-keyed access)"]
+    PR11["PR11 (place segments: indexSeg, symbolSeg)"]
+    PR12["PR12 (exactness + stub inventory + package gate)"]
+    PR13["PR13 (npm .d.ts channel)"]
+    B7["builtins §7 (committed .esc files)"]
+    M8["M8 (differential triage)"]
+    AFF["affine borrow through container methods"]
+
+    PR1 --> PR2
+    PR1 --> PR4
+    PR1 --> PR13
+    PR2 --> PR3
+    PR2 --> PR5
+    PR5 --> PR6
+    PR5 --> PR7
+    PR5 --> PR9
+    PR5 --> PR12
+    PR6 --> PR10
+    PR7 --> PR8
+    PR7 --> PR11
+    PR10 --> PR11
+    PR4 --> PR13
+    PR12 --> PR13
+
+    B7 -.-> M8
+    PR6 -.-> M8
+    PR13 -.-> M8
+    PR5 -.-> AFF
+
+    linkStyle default stroke:#888
+    style PR1 fill:#e06666,stroke:#333,color:#fff
+    style PR2 fill:#e06666,stroke:#333,color:#fff
+    style PR5 fill:#e06666,stroke:#333,color:#fff
+    style B7 fill:#6fa8dc,stroke:#333,color:#fff
+```
+
+### Parallelism
+
+- **Critical path** — PR1 → PR2 → PR5. Nothing in Lane B starts before PR5, and
+  PR5 is the PR to split if its review stalls.
+- **PR3 and PR4** hang off different parents and never block Lane B. PR4 needs
+  only PR1, so it can run alongside PR2 from the start.
+- **PR7, PR9, and PR12** are mutually independent once PR5 lands, and PR6 joins
+  them — four reviewable branches off one parent.
+- **PR11** is the only PR with two parents in different sub-lanes, PR7 and PR10.
+  It is last for that reason, not because it is large.
+- **PR13** is independent of Lane B entirely and can land at any point after PR4
+  and PR12, or slip past the milestone without blocking M8's `std:*` coverage.
+
+The milestone is functionally complete for its own test tree once PR11 lands, and
+complete against the shipped standard library once builtins §7 commits the `.esc`
+files.

--- a/planning/simple_sub/m7.5-implementation-plan.md
+++ b/planning/simple_sub/m7.5-implementation-plan.md
@@ -978,9 +978,9 @@ feeds ─► ecma-262 solver-side application (PR6 deletes the placeholders it w
 feeds ─► ecma-262 §11 escape lifetime-borrow spelling, through the affine work
 ```
 
-The same graph in mermaid. The core is solid and the critical path PR1 → PR2 → PR5
-is highlighted; the deferred tail is grouped and dashed, as are the external
-workstream and the downstream consumers:
+The core in mermaid, with the critical path PR1 → PR2 → PR5 highlighted and the
+work outside this milestone dashed. PR4 is a leaf here, because its only consumer,
+PR13, is deferred.
 
 ```mermaid
 graph TD
@@ -993,19 +993,13 @@ graph TD
     PR8["PR8 (index writes)"]
     PR12["PR12 (exactness + stub inventory + package gate)"]
 
-    subgraph deferred["Deferred tail — nothing in the core depends on these"]
-        PR3["PR3 (pseudo-package import cycles)"]
-        PR9["PR9 (variadic tuple types)"]
-        PR10["PR10 (unique symbol + symbol-keyed access)"]
-        PR11["PR11 (place segments: indexSeg, symbolSeg)"]
-        PR13["PR13 (npm .d.ts channel)"]
+    subgraph outside["Outside this milestone"]
+        B7["builtins §7 (committed .esc files)"]
+        M8["M8 (differential triage)"]
+        AFF["affine borrow through container methods"]
+        E262["ecma-262 solver-side application"]
+        E262C["ecma-262 §11 escape borrow spelling"]
     end
-
-    B7["builtins §7 (committed .esc files)"]
-    M8["M8 (differential triage)"]
-    AFF["affine borrow through container methods"]
-    E262["ecma-262 solver-side application"]
-    E262C["ecma-262 §11 escape borrow spelling"]
 
     PR1 --> PR2
     PR1 --> PR4
@@ -1014,15 +1008,6 @@ graph TD
     PR5 --> PR7
     PR5 --> PR12
     PR7 --> PR8
-
-    PR2 -.-> PR3
-    PR5 -.-> PR9
-    PR6 -.-> PR10
-    PR7 -.-> PR11
-    PR10 -.-> PR11
-    PR1 -.-> PR13
-    PR4 -.-> PR13
-    PR12 -.-> PR13
 
     B7 -.-> M8
     PR6 -.-> M8
@@ -1035,6 +1020,49 @@ graph TD
     style PR2 fill:#e06666,stroke:#333,color:#fff
     style PR5 fill:#e06666,stroke:#333,color:#fff
     style B7 fill:#6fa8dc,stroke:#333,color:#fff
+```
+
+The [deferred tail](#deferred-tail) in mermaid. Each core PR it attaches to is
+shown grey, as the prerequisite already in place; the dashed edges are the ones
+crossing out of the core. Every arrow points out of the core and none back in,
+which is the property that lets the core ship without any of this.
+
+```mermaid
+graph TD
+    subgraph core["Core — the prerequisite each one attaches to"]
+        PR1["PR1 (cross-module core)"]
+        PR2["PR2 (scheme-URI imports)"]
+        PR4["PR4 (lib decl kinds)"]
+        PR5["PR5 (real Array&lt;T&gt;)"]
+        PR6["PR6 (protocol set)"]
+        PR7["PR7 (numeric index reads)"]
+        PR12["PR12 (exactness + package gate)"]
+    end
+
+    PR3["PR3 (pseudo-package import cycles)"]
+    PR9["PR9 (variadic tuple types)"]
+    PR10["PR10 (unique symbol + symbol-keyed access)"]
+    PR11["PR11 (place segments: indexSeg, symbolSeg)"]
+    PR13["PR13 (npm .d.ts channel)"]
+
+    PR2 -.-> PR3
+    PR5 -.-> PR9
+    PR6 -.-> PR10
+    PR7 -.-> PR11
+    PR1 -.-> PR13
+    PR4 -.-> PR13
+    PR12 -.-> PR13
+
+    PR10 --> PR11
+
+    linkStyle default stroke:#888
+    style PR1 fill:#d9d9d9,stroke:#666,color:#333
+    style PR2 fill:#d9d9d9,stroke:#666,color:#333
+    style PR4 fill:#d9d9d9,stroke:#666,color:#333
+    style PR5 fill:#d9d9d9,stroke:#666,color:#333
+    style PR6 fill:#d9d9d9,stroke:#666,color:#333
+    style PR7 fill:#d9d9d9,stroke:#666,color:#333
+    style PR12 fill:#d9d9d9,stroke:#666,color:#333
 ```
 
 ### Parallelism

--- a/planning/simple_sub/m7.5-implementation-plan.md
+++ b/planning/simple_sub/m7.5-implementation-plan.md
@@ -41,6 +41,22 @@ file for its own pseudo-package imports, runs Tarjan over the resulting graph, a
 loads a strongly connected component as one merged module. Both produce
 `type_system.Namespace` and are unreachable from `soltype`.
 
+**One `.esc` file is one pseudo-package is one module.** `std/array.esc` is
+`std:array` and nothing else; the registry keys on the full URI, so each file gets
+its own entry and its own namespace. The layout is flat — `isValidPackagePath`
+admits only lowercase letters, digits, and underscores, so there are no
+subdirectories and a multi-word package spells out as `std:typed_arrays` →
+`std/typed_arrays.esc`. Sibling files do not see each other, by construction rather
+than by accident: `loadStdlibPackage` passes `filepath.Base(filePath)` as the source
+path precisely so `deriveNamespaceFromPath` returns `""`, its comment noting that
+stdlib files "live in a flat namespace, not the directory hierarchy of their on-disk
+location." That is the opposite of an ordinary Escalier lib module, where
+`parser.ParseLibFiles` unions several sources into one `*ast.Module` with
+path-derived namespaces; the stdlib loader hands it exactly one source. A reference
+from one pseudo-package to another therefore needs an explicit import, the same rule
+user code follows — which is what makes a cycle between two of them a real problem
+and PR3 a real PR.
+
 The directory discovery itself — the `--stdlib-dir` flag, the
 `ESCALIER_STDLIB_DIR` variable, the sibling-to-executable and repo-relative
 fallbacks — is `interop.StdlibDir`
@@ -787,22 +803,39 @@ that needs.
   [infer_stdlib_scc.go:124](../../internal/checker/infer_stdlib_scc.go).
 - **`tarjanSCCs`** condenses the graph into strongly connected components. A
   direct port; it is a pure graph algorithm over strings.
-- **Merged-module load.** When a URI's component has more than one member, parse
-  every member into one `*ast.Module` and infer it as a single unit, so the
-  existing dep-graph SCC ordering resolves the cross-package references. Publish
-  each member's namespace into the registry afterward. A member importing a sibling
-  short-circuits its own bind, since the merged module already exposes the sibling.
-- **The merge must not dissolve the export boundary between members.** Merging into
-  one `*ast.Module` makes every declaration module-scoped, so without care a
-  non-exported declaration in `std:a` becomes resolvable from `std:b` — a
-  visibility hole that only appears inside a cycle, which is exactly where it is
-  least likely to be noticed. PR1's rule is that a consumer sees only exported
-  declarations, and merging is an implementation detail of loading that must not
-  weaken it. Track each declaration's originating member through the merge and
-  filter a cross-member lookup by it, so the merged module resolves a sibling's
-  EXPORTED names and nothing else. Keeping one scope per member is the alternative;
-  it needs the SCC ordering to span the scopes, so filtering is the smaller change.
-  Either way the acceptance test below pins the behavior.
+- **Merged-module load — one module, one namespace per member.** When a URI's
+  component has more than one member, parse every member into one `*ast.Module` so
+  the existing dep-graph SCC ordering resolves the cross-package references. The
+  members do NOT flatten into one namespace. Each member's source is handed to
+  `ParseLibFiles` under the synthetic path `<pkg>/index.esc`, so
+  `deriveNamespaceFromPath` yields `<pkg>` and that member's declarations land in
+  their own `mod.Namespaces` entry, which is also the dep-graph binding-key prefix.
+  A member references a sibling as `<pkg>.<name>`, the qualified form the dep graph
+  already resolves. The on-disk file stays flat at `<scheme>/<pkg>.esc`; the
+  synthetic path only steers namespace inference. Publish each member's namespace
+  into the registry afterward, using the same pointer the merged namespace holds, so
+  a later import of that URI sees what the merged load built. A member importing a
+  sibling short-circuits its own bind, since the merged module already exposes the
+  sibling. Ported from
+  [infer_stdlib_scc.go:191](../../internal/checker/infer_stdlib_scc.go).
+- **The export boundary between members still needs enforcing.** The per-member
+  namespaces separate ADDRESSING — a sibling is reached at `<pkg>.<name>` rather
+  than bare — but they do not by themselves hide a non-exported declaration, since
+  the member's namespace holds whatever its inference put there. A non-exported
+  declaration in `std:a` reachable as `a.secret` from `std:b` is a visibility hole
+  that appears only inside a cycle, which is where it is least likely to be noticed.
+  Filter each member's published namespace to its exported declarations, the same
+  rule PR1 applies to a singleton package, and apply it before the merged inference
+  rather than at bind time so a sibling reference cannot see through it.
+  - **M7.5 cannot inherit the old checker's argument here.** `bindStdlibLocal`
+    shares its namespace pointer unfiltered, reasoning that loader rule §3.4 already
+    rejects an unexported value-level declaration, so a stdlib namespace is filtered
+    by construction. That argument does not carry: PR2 does not implement the §3.4
+    rules — they arrive with builtins §9
+    ([#1234](https://github.com/escalier-lang/escalier/issues/1234)) — and §3.4
+    covers value-level declarations only, so an unexported `type` leaks past it even
+    in the old checker. Enforce the boundary in the loader here rather than relying
+    on a rule this milestone does not land.
 
 **Accept.** A test tree with a `std:a` ↔ `std:b` cycle loads once, both packages
 resolve each other's types, and each is registered under its own URI; a
@@ -813,7 +846,8 @@ beside it still resolves.
 
 **Depends on** PR2.
 
-**Size.** Medium — roughly the 330 lines of `infer_stdlib_scc.go`.
+**Size.** Medium — roughly the 330 lines of `infer_stdlib_scc.go`, plus the export
+filter, which the old checker has no counterpart for.
 
 ### PR9 — Variadic tuple types
 

--- a/planning/simple_sub/m7.5-implementation-plan.md
+++ b/planning/simple_sub/m7.5-implementation-plan.md
@@ -53,9 +53,10 @@ fallbacks — is `interop.StdlibDir`
 written to satisfy a resolver gate. `web/`, `node/`, `builtins/`, and `libs/` hold
 only a README. Filling them is §7 of
 [planning/builtins/implementation_plan.md](../builtins/implementation_plan.md),
-which is not started and depends on §6, the converter productionization, which is
-partial. This is the single largest external dependency on M7.5's acceptance
-criteria; see [§Cross-workstream dependencies](#cross-workstream-dependencies).
+tracked as [#1232](https://github.com/escalier-lang/escalier/issues/1232) and
+sequenced to land before this milestone. It is the largest external dependency on
+M7.5's acceptance criteria; see
+[§Cross-workstream dependencies](#cross-workstream-dependencies).
 
 ### `Array`, `Promise`, and `Generator` are dedicated `soltype` concretes
 
@@ -232,26 +233,38 @@ handling, is deferred with them.
 
 ## Cross-workstream dependencies
 
-M7.5's acceptance criteria name `Map<K, V>`, `console`, and `web:dom`. None of
-those exist on disk. The dependency is on
-[planning/builtins/implementation_plan.md](../builtins/implementation_plan.md) §7,
-"Stdlib bootstrap", which runs the converter, reviews the output, hand-edits
-`throws` / lifetimes / mutability, and commits the `.esc` files. §7 depends on §6,
-whose PR B and PR C are outstanding.
+M7.5's acceptance criteria name `Map<K, V>`, `console`, and `web:dom`. Today the
+committed tree holds two stub files. Filling it is builtins §7, "Stdlib bootstrap"
+([#1232](https://github.com/escalier-lang/escalier/issues/1232)), which runs the
+converter, reviews every file by hand, hand-edits `throws` / lifetimes /
+mutability, and commits the result as the source of truth.
 
-This plan does not wait on §7. Every PR below is testable against a **test stdlib
-tree** — a fixture directory of hand-written `.esc` files pointed at through
+**§7 is sequenced before this milestone, not after it.** #1232 states the reason:
+it changes no checker behavior, so it can land well ahead of M7.5, "which is what
+first type-checks them." So the plan does not own filling the tree and does not
+schedule a PR for it. Two edges cross the other way and are recorded where they
+land: #1232 item 4 defers FR5 finalization into PR2, and builtins §9
+([#1234](https://github.com/escalier-lang/escalier/issues/1234)) re-homes the `@js`
+loader rules onto PR2's load path once this milestone has built it.
+
+This plan still does not *block* on §7. Every PR below is testable against a **test
+stdlib tree** — a fixture directory of hand-written `.esc` files pointed at through
 `ESCALIER_STDLIB_DIR`, holding exactly the declarations that PR needs. PR2
-establishes that harness. The consequence is a split acceptance boundary worth
-stating plainly:
+establishes that harness, and it stays useful after §7 lands because it is
+hermetic: a per-PR test against three hand-written declarations does not churn
+every time the converter regenerates the shipped tree. The consequence is a split
+acceptance boundary worth stating plainly:
 
 - **What M7.5 owns and can finish alone:** the resolver, the registry, the decl
   kinds, the well-known handles, real `Array` and `Promise`, positional usage
   inference and index writes, and the tests for all of it against the test tree.
   See [§Scope](#scope-the-core-and-the-deferred-tail) for what the core leaves out.
 - **What M7.5 cannot finish alone:** "real source that imports core lib types
-  type-checks" against the *shipped* tree. That criterion is met when builtins §7
-  lands, not when the last PR here merges.
+  type-checks" against the *shipped* tree. That criterion needs §7's files. With
+  §7 sequenced first it is expected to be met when the last PR here merges, so add
+  one acceptance test against the shipped tree rather than the fixture tree — and
+  if §7 has slipped, that test is what records the gap instead of a green run
+  implying coverage.
 
 The same split applies downstream. M8's real-package differential needs both this
 plan and §7. Recording it here keeps a green M7.5 from reading as a populated
@@ -259,8 +272,9 @@ standard library.
 
 ### What M7.5 unblocks
 
-Two workstreams wait on this milestone. Neither is owned here, and neither gates
-any PR below — the edges run outward only.
+Three workstreams wait on this milestone. None is owned here. Only builtins §7
+sends anything back, and the two edges it does are named in
+[§Cross-workstream dependencies](#cross-workstream-dependencies); both land in PR2.
 
 - **Affine borrow tracking through container methods**
   ([affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md)).
@@ -280,9 +294,19 @@ any PR below — the edges run outward only.
   lifetime-borrow spelling** (§11 curation) waits on the affine container-method
   work above, so it reaches M7.5 through PR5 at one remove. Both edges land on core
   PRs, so scoping the milestone down does not push either follow-on further out.
+- **Builtins §9, per-file shape loading**
+  ([#1234](https://github.com/escalier-lang/escalier/issues/1234)). It gives a file
+  the method surface of the literals and features it uses — `"abc".toUpperCase()`,
+  `xs.map(f)`, `await p` — with no import naming the owning package, through a
+  trigger map from syntax to pseudo-package. It states the division directly:
+  "Explicit import ingestion is SimpleSub M7.5's job; this adds the trigger-driven
+  load on top." It builds on PR1's registry, which it needs memoized by URI and
+  "shared with the import path", and on PR2's resolution. It also carries the `@js`
+  loader rules onto PR2's path, so that half of PR2's scope arrives with §9 rather
+  than never.
 
-The reverse edge does not exist: no PR here waits on ecma-262. That plan's §11
-curation is explicitly independent of the solver-side application, and the
+The reverse edge from ecma-262 does not exist — no PR here waits on it. That
+plan's §11 curation is explicitly independent of the solver-side application, and the
 override layer it populates is applied by the builtins converter before the solver
 sees the result. ECMA-262 raises the *fidelity* of the receiver mutability,
 disposition, `throws`, and `rejects` annotations in the committed `.esc` files;
@@ -399,21 +423,33 @@ Port the `std:` / `web:` / `node:` surface onto the solver.
   string function with no checker coupling.
 - **`resolveStdlibPath`** maps `scheme:pkg` to `<dir>/<scheme>/<pkg>.esc`, reusing
   `interop.StdlibDir` for discovery. `interop` imports `type_system` at package
-  scope, so PR12's gate test must allow this one edge deliberately, or the
-  discovery function moves to a leaf package. **Decide in this PR**; moving it is
-  the cleaner answer and is a small mechanical change.
+  scope, so importing it here would drag that package into the solver. Builtins
+  §6 PR D ([#1231](https://github.com/escalier-lang/escalier/issues/1231)) splits
+  `interop` into its AST-producing half and its runtime-override-store half for
+  the same reason on the converter's side, and names the same file list. Land this
+  PR after it and depend on the AST-producing half; if it has not landed, lift
+  `StdlibDir` into a leaf package here and let §6 PR D absorb that move.
 - **`bindStdlibLocal`** binds the package under the lowercased last URI segment,
   with the FR5 single-class shortcut: when the package declares exactly one class
   whose name matches the package name case-insensitively, bind that class directly
   under its own capitalization instead. Reads `Namespace.Types` / `Namespace.Values`
   from PR1's exported surface.
-- **No `@js` loader rules.** The builtins plan's §3.4 rules require every exported
-  value-level decl in a stdlib file to carry `@js` naming its runtime path. That is
-  a codegen contract, and this checker emits nothing, so the solver-side loader
-  does not enforce it. The old checker still does for its own path, and the
-  builtins plan §9 moves the argument-validation half to a CI-only test over the
-  committed tree — the right home for all of it. A stdlib decl missing `@js`
-  type-checks fine here and fails there.
+  - **FR5 finalization is owed here.** Builtins §7
+    ([#1232](https://github.com/escalier-lang/escalier/issues/1232) item 4) defers
+    it into this PR by name: the first package pairing a class with non-class
+    exports appears in the committed tree, so a shortcut binding must merge the
+    package's other members onto the bound class rather than hiding them. Implement
+    the merge and pin the static-method-wins tiebreaker with a unit test. This is
+    the one edge that runs from §7 back into M7.5.
+- **No `@js` loader rules yet.** The builtins plan's §3.4 rules require every
+  exported value-level decl in a stdlib file to carry `@js` naming its runtime
+  path. This PR does not implement them, and it is not the last word on them:
+  builtins §9 ([#1234](https://github.com/escalier-lang/escalier/issues/1234))
+  re-homes rules 1 to 3 onto **this** load path, because they are AST-only, turns
+  rule 4 into a CI-only test over the pinned TS lib, and adds a rule 5 checking
+  that a decl's shape matches its lib target. So the rules arrive here later,
+  landed by that phase. Leaving them out now keeps this PR to resolution and
+  binding, and a stdlib decl missing `@js` type-checks until §9 lands.
 - **Diagnostics** re-anchor to the importing `import` statement's span, so a parse
   or inference error inside a stdlib file underlines the user's import rather than
   a file they cannot navigate to. The original location stays in the message body.
@@ -429,12 +465,16 @@ single-class shortcut and `val xs: Array<number>` resolves to the ingested class
 directory; `import "bogus:array"` reports an unknown-scheme diagnostic listing the
 three recognized schemes; a named import from a scheme URI reports the
 named-import rejection; a file that names `Array` with no import is an
-unbound-name error, proving there is no ambient surface.
+unbound-name error, proving there is no ambient surface. For FR5: a package
+pairing one shortcut class with non-class exports binds the class AND reaches its
+sibling members through the same binding, and a package whose class carries a
+static method of the same name as a sibling export resolves to the static method.
 
 **Depends on** PR1.
 
 **Size.** Medium-large — roughly the 420 lines of `infer_stdlib_import.go`, minus
-the parts PR1 already carries.
+the parts PR1 already carries, plus the FR5 member merge. Split the FR5 half out if
+that lands it past a comfortable review size.
 
 ### PR4 — Lib-shaped declaration kinds
 
@@ -680,7 +720,11 @@ Three small pieces of hygiene that keep the milestone's gaps visible.
   `internal/soltype` do not transitively import `internal/checker` or
   `internal/type_system`, walking the package's own import graph rather than
   trusting the comment at [doc.go:17](../../internal/solver/doc.go). PR2's
-  `interop.StdlibDir` decision is what this test would otherwise catch.
+  `interop.StdlibDir` import is what this test would otherwise catch. Builtins §6
+  PR D ([#1231](https://github.com/escalier-lang/escalier/issues/1231)) splits
+  `interop` so the AST-producing half stands alone, which is what makes that import
+  safe; this gate is the solver-side twin of that issue's own
+  `go list -deps ./tools/dts_to_esc` gate.
 
 **Accept.** An ingested object type renders inexact and accepts an argument with
 extra fields; a written Escalier object stays exact; the gate test fails when a
@@ -971,7 +1015,8 @@ DEFERRED TAIL — hangs off the core, nothing in the core hangs off it
              ┄► PR11 (place segments: constKey, indexSeg, symbolSeg) ── also needs PR7
  PR4  ┄► PR13 (npm .d.ts channel)                                    ── also needs PR12
 
-needs ─► builtins §7 (committed .esc files) for the shipped-tree acceptance criteria
+needs ─► builtins §7 / #1232 (committed .esc files), sequenced to land before this milestone
+feeds ─► builtins §9 / #1234 (per-file shape loading reuses PR1's registry, PR2's resolution)
 feeds ─► M8 (the real-package differential needs real lib types)
 feeds ─► affine borrow tracking through container methods (PR5's Array.push)
 feeds ─► ecma-262 solver-side application (PR6 deletes the placeholders it waits on)
@@ -994,7 +1039,8 @@ graph TD
     PR12["PR12 (exactness + stub inventory + package gate)"]
 
     subgraph outside["Outside this milestone"]
-        B7["builtins §7 (committed .esc files)"]
+        B7["builtins §7 / #1232 (committed .esc files)"]
+        B9["builtins §9 / #1234 (per-file shape loading)"]
         M8["M8 (differential triage)"]
         AFF["affine borrow through container methods"]
         E262["ecma-262 solver-side application"]
@@ -1010,6 +1056,8 @@ graph TD
     PR7 --> PR8
 
     B7 -.-> M8
+    PR1 -.-> B9
+    PR2 -.-> B9
     PR6 -.-> M8
     PR5 -.-> AFF
     PR6 -.-> E262
@@ -1020,6 +1068,7 @@ graph TD
     style PR2 fill:#e06666,stroke:#333,color:#fff
     style PR5 fill:#e06666,stroke:#333,color:#fff
     style B7 fill:#6fa8dc,stroke:#333,color:#fff
+    style B9 fill:#6fa8dc,stroke:#333,color:#fff
 ```
 
 The [deferred tail](#deferred-tail) in mermaid. Each core PR it attaches to is

--- a/planning/simple_sub/m7.5-implementation-plan.md
+++ b/planning/simple_sub/m7.5-implementation-plan.md
@@ -716,20 +716,35 @@ Three small pieces of hygiene that keep the milestone's gaps visible.
   why. Surfaced through a reporting hook so a run against a partial stdlib tree
   says what it could not represent instead of reading as full coverage. This is
   what keeps the builtins-§7 gap legible from inside the compiler.
-- **The parallel-package gate.** A test that asserts `internal/solver` and
-  `internal/soltype` do not transitively import `internal/checker` or
-  `internal/type_system`, walking the package's own import graph rather than
-  trusting the comment at [doc.go:17](../../internal/solver/doc.go). PR2's
-  `interop.StdlibDir` import is what this test would otherwise catch. Builtins §6
-  PR D ([#1231](https://github.com/escalier-lang/escalier/issues/1231)) splits
-  `interop` so the AST-producing half stands alone, which is what makes that import
-  safe; this gate is the solver-side twin of that issue's own
-  `go list -deps ./tools/dts_to_esc` gate.
+- **The parallel-package gate — over DIRECT imports, not the transitive closure.**
+  A test that asserts no `.go` file under `internal/solver` or `internal/soltype`
+  imports `internal/checker` or `internal/type_system`, replacing the comment at
+  [doc.go:17](../../internal/solver/doc.go) with something executable. It must read
+  each package's own import declarations, because **a transitive gate fails on the
+  tree as shipped**: `internal/ast` imports `internal/type_system` for the
+  `type Type = type_system.Type` alias and the generated `inferredType` field
+  ([ast.go:4](../../internal/ast/ast.go), [expr.go:9](../../internal/ast/expr.go)),
+  so `solver → ast → type_system` is a real edge that `go list -deps` reports
+  today. That edge is deliberate and is not this milestone's to remove — the
+  migration plan deletes the field and the alias at the M12 flip
+  ([00-overview.md](00-overview.md) step 5). The invariant the gate protects is
+  that the solver writes no `type_system` types and calls no `type_system` code,
+  which a direct-import check captures exactly and a transitive one does not.
+- **Two consequences for PR2 and PR13.** A direct-import gate does not by itself
+  make `interop.StdlibDir` safe: importing `interop` puts `type_system` in the
+  binary through a package the solver names directly. Builtins §6 PR D
+  ([#1231](https://github.com/escalier-lang/escalier/issues/1231)) splits `interop`
+  so its AST-producing half stands alone, and PR2 and PR13 depend on that half. If
+  §6 PR D has not landed, lift the entry point the solver needs into a leaf package
+  here rather than importing `interop` whole. This gate is the solver-side twin of
+  that issue's `go list -deps ./tools/dts_to_esc` gate.
 
 **Accept.** An ingested object type renders inexact and accepts an argument with
-extra fields; a written Escalier object stays exact; the gate test fails when a
-`type_system` import is added to `solver` and passes on the tree as shipped; a run
-against a partial stdlib tree reports the names it stubbed.
+extra fields; a written Escalier object stays exact; the gate test passes on the
+tree as shipped, fails when a direct `type_system` import is added to `solver`,
+and still passes with the `solver → ast → type_system` edge in place, which is
+what pins it to direct imports; a run against a partial stdlib tree reports the
+names it stubbed.
 
 **Depends on** PR5. Independent of PR6, PR7, and PR8.
 
@@ -775,14 +790,26 @@ that needs.
 - **Merged-module load.** When a URI's component has more than one member, parse
   every member into one `*ast.Module` and infer it as a single unit, so the
   existing dep-graph SCC ordering resolves the cross-package references. Publish
-  each member's namespace into the registry afterwards. A member importing a
-  sibling short-circuits its own bind, since the merged module already exposes the
-  sibling.
+  each member's namespace into the registry afterward. A member importing a sibling
+  short-circuits its own bind, since the merged module already exposes the sibling.
+- **The merge must not dissolve the export boundary between members.** Merging into
+  one `*ast.Module` makes every declaration module-scoped, so without care a
+  non-exported declaration in `std:a` becomes resolvable from `std:b` — a
+  visibility hole that only appears inside a cycle, which is exactly where it is
+  least likely to be noticed. PR1's rule is that a consumer sees only exported
+  declarations, and merging is an implementation detail of loading that must not
+  weaken it. Track each declaration's originating member through the merge and
+  filter a cross-member lookup by it, so the merged module resolves a sibling's
+  EXPORTED names and nothing else. Keeping one scope per member is the alternative;
+  it needs the SCC ordering to span the scopes, so filtering is the smaller change.
+  Either way the acceptance test below pins the behavior.
 
 **Accept.** A test tree with a `std:a` ↔ `std:b` cycle loads once, both packages
 resolve each other's types, and each is registered under its own URI; a
 three-package cycle behaves the same; an acyclic package still takes the
-single-module path.
+single-module path; and a NON-EXPORTED declaration in `std:a` is unresolvable from
+`std:b` even though the two loaded as one merged module, while an exported sibling
+beside it still resolves.
 
 **Depends on** PR2.
 
@@ -1126,6 +1153,11 @@ graph TD
   PR3 needs only PR2, PR9 needs only PR5, and PR13 needs PR4 plus PR12's gate.
   PR10 → PR11 is the only chain in it.
 
-The core is functionally complete for its own test tree once PR8 and PR12 land,
-and complete against the shipped standard library once builtins §7 commits the
-`.esc` files.
+The core is functionally complete for its own test tree once **PR4, PR6, PR8, and
+PR12** land. Naming all four matters because the graph has branches that no single
+leaf subsumes: PR8 pulls in PR7, PR5, PR2, and PR1, but PR4, PR6, and PR12 each
+hang off the chain separately, so "once PR8 lands" would leave the lib decl kinds,
+the protocol set, and the gate unfinished. The [deferred tail](#deferred-tail) is
+excluded by construction — PR3, PR9, PR10, PR11, and PR13 are not part of the
+completion condition. The core is complete against the shipped standard library
+once builtins §7 commits the `.esc` files.

--- a/planning/simple_sub/m7.5-implementation-plan.md
+++ b/planning/simple_sub/m7.5-implementation-plan.md
@@ -250,11 +250,41 @@ The same split applies downstream. M8's real-package differential needs both thi
 plan and §7. Recording it here keeps a green M7.5 from reading as a populated
 standard library.
 
-Two smaller ones: the affine borrow-through-container-methods work
-([affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md))
-is unblocked by PR5's real `Array` and its `push` method, and is not owned here;
-and the "Tuple-index place segments" item in the same document is discharged by
-PR11.
+### What M7.5 unblocks
+
+Two workstreams wait on this milestone. Neither is owned here, and neither gates
+any PR below — the edges run outward only.
+
+- **Affine borrow tracking through container methods**
+  ([affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md)).
+  The borrow-edge recorder sees a borrow stored into a container by a method call —
+  `a.peers.push(&mut b)` — only once `Array` and its method surface exist. PR5 is
+  that prerequisite. The fix itself is affine work. The same document's
+  "Tuple-index place segments" item is discharged by PR11.
+- **ECMA-262-derived builtin annotations**
+  ([ecma-262/implementation_plan.md](../ecma-262/implementation_plan.md)). That
+  plan names two follow-ons it cannot schedule until M7.5 lands, both listed under
+  its "Discovery phases may grow the plan" section rather than as numbered PRs.
+  Its **solver-side application** — wiring the extracted facts into the active
+  checker's builtin ingestion — cites `addStdlibTypePlaceholders` as its evidence
+  that the ingestion does not exist; PR6 deletes it. Its **`escape`
+  lifetime-borrow spelling** (§11 curation) waits on the affine container-method
+  work above, so it reaches M7.5 through PR5 at one remove.
+
+The reverse edge does not exist: no PR here waits on ecma-262. That plan's §11
+curation is explicitly independent of the solver-side application, and the
+override layer it populates is applied by the builtins converter before the solver
+sees the result. ECMA-262 raises the *fidelity* of the receiver mutability,
+disposition, `throws`, and `rejects` annotations in the committed `.esc` files;
+it does not gate their existence, which is builtins §7's job.
+
+One representational coupling is worth naming, because it runs from this plan into
+theirs. ECMA-262's requirements place the extracted effect facts in the MLstruct
+lattice: a `throws` set is a union such as `TypeError | RangeError`, and a
+`rejects` set lands on the two-argument `Promise<T, E>`. PR6 retires the
+`PromiseType` concrete in favor of the ingested declaration, so the shape PR6
+gives that type's error slot is the shape a `rejects` annotation is spelled
+against. Keep the two-argument form through the retirement.
 
 ---
 
@@ -498,7 +528,10 @@ placeholders.
   `p.then(…)` resolves. `await e` constrains `e` against the handle-resolved
   `Promise<U>` rather than minting the concrete. The no-auto-flatten contract is
   unchanged: awaiting `Promise<Promise<T>>` yields `Promise<T>`, and flattening
-  stays `Awaited<T>`.
+  stays `Awaited<T>`. **The two-argument `Promise<T, E>` form must survive the
+  retirement**: the ingested declaration keeps an error parameter, because that slot
+  is where the ECMA-262 workstream's extracted `rejects` sets are spelled. See
+  [§What M7.5 unblocks](#what-m75-unblocks).
 - **`Iterable` / `AsyncIterable` / `Iterator`.** These have no concrete to retire
   — they are `UnknownType` stubs today. `for (x in xs)` and `for await` constrain
   the operand against the handle-resolved protocol type and read the element type
@@ -817,7 +850,9 @@ PR1 (cross-module core: registry, file scopes, URI-qualified keys, exported surf
 
 needs ─► builtins §7 (committed .esc files) for the shipped-tree acceptance criteria
 feeds ─► M8 (the real-package differential needs real lib types)
-feeds ─► affine borrow tracking through container methods (Array.push)
+feeds ─► affine borrow tracking through container methods (PR5's Array.push)
+feeds ─► ecma-262 solver-side application (PR6 deletes the placeholders it waits on)
+feeds ─► ecma-262 §11 escape lifetime-borrow spelling, through the affine work
 ```
 
 The same graph in mermaid, with the ingestion critical path PR1 → PR2 → PR5
@@ -841,6 +876,8 @@ graph TD
     B7["builtins §7 (committed .esc files)"]
     M8["M8 (differential triage)"]
     AFF["affine borrow through container methods"]
+    E262["ecma-262 solver-side application"]
+    E262C["ecma-262 §11 escape borrow spelling"]
 
     PR1 --> PR2
     PR1 --> PR4
@@ -862,6 +899,8 @@ graph TD
     PR6 -.-> M8
     PR13 -.-> M8
     PR5 -.-> AFF
+    PR6 -.-> E262
+    AFF -.-> E262C
 
     linkStyle default stroke:#888
     style PR1 fill:#e06666,stroke:#333,color:#fff

--- a/planning/simple_sub/m7.5-implementation-plan.md
+++ b/planning/simple_sub/m7.5-implementation-plan.md
@@ -224,6 +224,12 @@ carry through the PR list.
 13. **The npm `.d.ts` channel.** `dts_parser` → `interop.ConvertModule` →
     `*ast.Module` → the solver, without pulling `type_system` into the output path.
 
+Items 1–8 and 12 are the core this plan schedules. Items 9, 10, 11, and 13 —
+variadic tuples, unique symbols, precise place segments, and the npm channel —
+are designed here but deferred, for the reasons in
+[§Scope](#scope-the-core-and-the-deferred-tail). Item 3, the pseudo-package cycle
+handling, is deferred with them.
+
 ## Cross-workstream dependencies
 
 M7.5's acceptance criteria name `Map<K, V>`, `console`, and `web:dom`. None of
@@ -239,9 +245,10 @@ tree** — a fixture directory of hand-written `.esc` files pointed at through
 establishes that harness. The consequence is a split acceptance boundary worth
 stating plainly:
 
-- **What M7.5 owns and can finish alone:** the resolver, the registry, the cycle
-  handling, the decl kinds, the well-known handles, the whole `Array`-unlocked
-  type-system surface, and the tests for all of it against the test tree.
+- **What M7.5 owns and can finish alone:** the resolver, the registry, the decl
+  kinds, the well-known handles, real `Array` and `Promise`, positional usage
+  inference and index writes, and the tests for all of it against the test tree.
+  See [§Scope](#scope-the-core-and-the-deferred-tail) for what the core leaves out.
 - **What M7.5 cannot finish alone:** "real source that imports core lib types
   type-checks" against the *shipped* tree. That criterion is met when builtins §7
   lands, not when the last PR here merges.
@@ -259,8 +266,10 @@ any PR below — the edges run outward only.
   ([affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md)).
   The borrow-edge recorder sees a borrow stored into a container by a method call —
   `a.peers.push(&mut b)` — only once `Array` and its method surface exist. PR5 is
-  that prerequisite. The fix itself is affine work. The same document's
-  "Tuple-index place segments" item is discharged by PR11.
+  that prerequisite, and it is in the core. The fix itself is affine work. The same
+  document's "Tuple-index place segments" item is [PR11](#pr11--precise-place-segments-in-the-move-engine),
+  which this plan defers back to that workstream rather than carrying — see
+  [§Deferred tail](#deferred-tail).
 - **ECMA-262-derived builtin annotations**
   ([ecma-262/implementation_plan.md](../ecma-262/implementation_plan.md)). That
   plan names two follow-ons it cannot schedule until M7.5 lands, both listed under
@@ -269,7 +278,8 @@ any PR below — the edges run outward only.
   checker's builtin ingestion — cites `addStdlibTypePlaceholders` as its evidence
   that the ingestion does not exist; PR6 deletes it. Its **`escape`
   lifetime-borrow spelling** (§11 curation) waits on the affine container-method
-  work above, so it reaches M7.5 through PR5 at one remove.
+  work above, so it reaches M7.5 through PR5 at one remove. Both edges land on core
+  PRs, so scoping the milestone down does not push either follow-on further out.
 
 The reverse edge does not exist: no PR here waits on ecma-262. That plan's §11
 curation is explicitly independent of the solver-side application, and the
@@ -288,12 +298,45 @@ against. Keep the two-argument form through the retirement.
 
 ---
 
-## PR-by-PR breakdown
+## Scope: the core and the deferred tail
 
-Thirteen PRs in three lanes. **Lane A** (PR1–PR4, PR13) is ingestion plumbing.
-**Lane B** (PR5–PR9) is the type-system surface `Array` unlocks. **Lane C**
-(PR10–PR11) is symbol and index precision. PR12 is hygiene and can land any time
-after PR5.
+The milestone as written in [01-milestones.md](01-milestones.md) reaches past
+`internal/solver`. It carries an npm `.d.ts` channel that is interop and resolver
+work, and move-engine precision that belongs to the affine workstream. It also
+carries two type-system features that a real `Array<T>` makes expressible but that
+nothing in the milestone reads. Scoped to the solver, the milestone is eight PRs,
+not thirteen.
+
+The five cut PRs keep their designs and their numbers in
+[§Deferred tail](#deferred-tail), each with the condition that brings it back.
+Nothing in the core depends on any of them, so the core is a complete, testable
+milestone on its own.
+
+| | PR | What it covers |
+| --- | --- | --- |
+| **Core** | PR1, PR2, PR4 | cross-module inference, scheme-URI imports, lib decl kinds |
+| | PR5, PR6 | real `Array<T>`, the well-known handle mechanism, the protocol set |
+| | PR7, PR8 | positional usage inference and index writes |
+| | PR12 | exactness, the stub inventory, the parallel-package gate |
+| **Deferred** | PR3 | pseudo-package import cycles — unreachable until the shipped tree has one |
+| | PR9 | variadic tuple types — nothing in the core reads one |
+| | PR10 | `unique symbol` — PR6 uses reserved keys over the closed well-known set instead |
+| | PR11 | move-engine place segments — affine work, tracked in the affine plan |
+| | PR13 | the npm `.d.ts` channel — interop and resolver work, its own milestone |
+
+Two things shrink inside the core rather than leaving it. PR2 drops the `@js`
+decorator loader rules, which check that a stdlib declaration names a real JS
+runtime path. That is a codegen contract, and this checker emits nothing. PR6
+covers `[Symbol.iterator]` with reserved member keys rather than the full
+unique-symbol representation, which is what lets PR10 leave.
+
+## PR-by-PR breakdown — the core
+
+Eight PRs, the set a working `internal/solver` library-type path actually needs.
+**Lane A** (PR1, PR2, PR4) is ingestion plumbing. **Lane B** (PR5–PR8) is the
+type-system surface `Array` unlocks. PR12 is hygiene and can land any time after
+PR5. The [deferred tail](#deferred-tail) keeps its numbering, so no core PR is
+renumbered when a deferred one is pulled back in.
 
 ### PR1 — Cross-module inference core
 
@@ -364,10 +407,13 @@ Port the `std:` / `web:` / `node:` surface onto the solver.
   whose name matches the package name case-insensitively, bind that class directly
   under its own capitalization instead. Reads `Namespace.Types` / `Namespace.Values`
   from PR1's exported surface.
-- **The `@js` loader rules** (§3.4(1-3) of the builtins plan): every exported
-  value-level decl in a stdlib file must carry `@js`, and an unexported
-  value-level decl is rejected. Rule 4, validating the `@js` argument against a
-  real runtime path, stays out — the builtins plan §9 moves it to a CI-only test.
+- **No `@js` loader rules.** The builtins plan's §3.4 rules require every exported
+  value-level decl in a stdlib file to carry `@js` naming its runtime path. That is
+  a codegen contract, and this checker emits nothing, so the solver-side loader
+  does not enforce it. The old checker still does for its own path, and the
+  builtins plan §9 moves the argument-validation half to a CI-only test over the
+  committed tree — the right home for all of it. A stdlib decl missing `@js`
+  type-checks fine here and fails there.
 - **Diagnostics** re-anchor to the importing `import` statement's span, so a parse
   or inference error inside a stdlib file underlines the user's import rather than
   a file they cannot navigate to. The original location stays in the message body.
@@ -389,40 +435,6 @@ unbound-name error, proving there is no ambient surface.
 
 **Size.** Medium-large — roughly the 420 lines of `infer_stdlib_import.go`, minus
 the parts PR1 already carries.
-
-### PR3 — Pseudo-package import cycles
-
-`web:dom`'s siblings mutually reference it, so a cycle is the normal case, not an
-edge case.
-
-**Data structures.**
-- The **pseudo-package import graph**: `map[string][]string` from a package URI to
-  the URIs it imports, built by scanning each `.esc` file under the stdlib
-  directory for its own scheme-prefixed imports.
-- A **process-level SCC cache** keyed by stdlib directory, so the graph is built
-  once per directory rather than once per import.
-
-**Algorithms.**
-- **`extractPseudoPackageImports`** parses one stdlib file and collects the
-  scheme-prefixed specifiers in its `Imports`. Ported from
-  [infer_stdlib_scc.go:124](../../internal/checker/infer_stdlib_scc.go).
-- **`tarjanSCCs`** condenses the graph into strongly connected components. A
-  direct port; it is a pure graph algorithm over strings.
-- **Merged-module load.** When a URI's component has more than one member, parse
-  every member into one `*ast.Module` and infer it as a single unit, so the
-  existing dep-graph SCC ordering resolves the cross-package references. Publish
-  each member's namespace into the registry afterwards. A member importing a
-  sibling short-circuits its own bind, since the merged module already exposes the
-  sibling.
-
-**Accept.** A test tree with a `std:a` ↔ `std:b` cycle loads once, both packages
-resolve each other's types, and each is registered under its own URI; a
-three-package cycle behaves the same; an acyclic package still takes the
-single-module path.
-
-**Depends on** PR2.
-
-**Size.** Medium — roughly the 330 lines of `infer_stdlib_scc.go`.
 
 ### PR4 — Lib-shaped declaration kinds
 
@@ -459,7 +471,7 @@ sets; `interface Sq extends Rect {}` carries `Rect`'s members; a namespace decl
 binds and `NS.member` resolves; a non-exported member of a stdlib package is
 invisible to an importer.
 
-**Depends on** PR1. Independent of PR2 and PR3.
+**Depends on** PR1. Independent of PR2, so it runs alongside it.
 
 **Size.** Medium.
 
@@ -499,9 +511,9 @@ The hinge PR. Everything in Lane B after it needs a real `Array`.
   item.
 - **Array iteration.** `syncElemType`
   ([infer_for_in.go](../../internal/solver/infer_for_in.go)) grows an array arm
-  yielding the element type. The full `[Symbol.iterator]` protocol waits for PR10;
-  this arm is the direct structural answer for the one container the milestone
-  requires.
+  yielding the element type. PR6 replaces this arm with the protocol lookup, over
+  the reserved symbol keys it introduces; this arm is the direct structural answer
+  for the one container the milestone requires, and the fallback if PR6 splits.
 - **Annotation resolution.** Delete the hardcoded `Array` branch in `resolveTypeAnn`
   ([type_ann.go:145](../../internal/solver/type_ann.go)) and the `Array` arm of the
   arity-mismatch fallback below it, so a written `Array<number>` resolves through
@@ -513,7 +525,7 @@ is rejected with the full message; `xs[0]` is `number`; `for (x in xs) { … }` 
 `x` at `number`; a rest param `...args: Array<string>` still rejects a numeric
 trailing argument, showing #677's behavior survived the concrete's retirement.
 
-**Depends on** PR2. Independent of PR3 and PR4.
+**Depends on** PR2. Independent of PR4.
 
 **Size.** Large. This is the PR to split further if review drags — the handle
 mechanism and the `ArrayType` retirement are separable, in that order.
@@ -538,6 +550,16 @@ placeholders.
   off the result, replacing `syncElemType` / `asyncElemType`'s structural walk.
   Keep the tuple arm: a tuple is iterable by a rule the protocol lookup does not
   cover.
+  - **`[Symbol.iterator]` is a reserved member key here, not a unique symbol.**
+    The ingested `Iterable<T>` declares its member under a symbol key, so the
+    solver must represent one to infer the declaration at all. This PR stores each
+    well-known symbol key under a reserved name that no source identifier can
+    collide with, rather than landing the full `soltype` unique-symbol kind. That
+    is sound because the well-known set is fixed and closed, and each member of it
+    has a distinct name. It stops being sound the moment a user can mint a symbol,
+    which is what [PR10](#pr10--unique-symbol-and-symbol-keyed-access) covers. Pick
+    the reserved spelling so the printer renders it back as `[Symbol.iterator]`,
+    and record the closed-set assumption at the definition.
 - **`Generator` / `AsyncGenerator`.** `GeneratorType` retires last, since it
   carries four slots and a `Raises` predicate that `iterationRaise`
   ([infer_for_in.go:107](../../internal/solver/infer_for_in.go)) reads. The
@@ -594,7 +616,9 @@ The positional twin of M4's object close.
 - **Number keys versus string keys.** `constStringKey` stays syntactic and
   string-only for the name-resolution call sites; the numeric arm is a separate
   reader. `recv[0]` and `recv["0"]` therefore take different paths and produce
-  different requirements. PR11 applies the same split to the move engine.
+  different requirements. [PR11](#pr11--precise-place-segments-in-the-move-engine)
+  applies the same split to the move engine, and is deferred — until it lands, both
+  forms fall back to the container place, which is conservative-sound.
 
 **Accept.** `fn f(t) { t[0]; t[1] }` infers and SEALS the parameter to exact
 `[T0, T1]`, and a caller passing a three-element tuple is rejected with the full
@@ -635,7 +659,101 @@ writing through a non-`mut` receiver is rejected.
 
 **Size.** Medium.
 
+### PR12 — Exactness, the stub inventory, and the parallel-package gate
+
+Three small pieces of hygiene that keep the milestone's gaps visible.
+
+**Algorithms.**
+- **Exactness stamping.** Every object, tuple, and function former minted while
+  ingesting a library declaration is stamped `Inexact`
+  ([exact-types/requirements.md](../exact-types/requirements.md) §8). The flag's
+  zero value is exact, so this is an explicit set at each ingestion mint, not a
+  default. Unions are excluded — their exactness fields were removed. A user
+  wanting the closed reading opts in at the use site with `Exact<T>`, which the
+  exactness intrinsic already implements.
+- **The stub inventory.** A `Context`-held record of every lib name that resolved
+  to a placeholder rather than a real structure, with the module it came from and
+  why. Surfaced through a reporting hook so a run against a partial stdlib tree
+  says what it could not represent instead of reading as full coverage. This is
+  what keeps the builtins-§7 gap legible from inside the compiler.
+- **The parallel-package gate.** A test that asserts `internal/solver` and
+  `internal/soltype` do not transitively import `internal/checker` or
+  `internal/type_system`, walking the package's own import graph rather than
+  trusting the comment at [doc.go:17](../../internal/solver/doc.go). PR2's
+  `interop.StdlibDir` decision is what this test would otherwise catch.
+
+**Accept.** An ingested object type renders inexact and accepts an argument with
+extra fields; a written Escalier object stays exact; the gate test fails when a
+`type_system` import is added to `solver` and passes on the tree as shipped; a run
+against a partial stdlib tree reports the names it stubbed.
+
+**Depends on** PR5. Independent of PR6, PR7, and PR8.
+
+**Size.** Small.
+
+---
+
+## Deferred tail
+
+Five PRs cut from the milestone, with their designs kept rather than deleted so
+pulling one back in is a scheduling decision and not a redesign. Each names what
+brings it back. Nothing in the core depends on anything here — the tail is a clean
+downward closure, so the core lands and passes with none of it.
+
+### PR3 — Pseudo-package import cycles
+
+**Why it is out.** Loader plumbing that only bites once one pseudo-package
+imports another. The test stdlib tree PR2 establishes is acyclic, and the shipped
+tree gains cycles only when builtins §7 lands `web:dom`'s siblings, which thread
+DOM types through qualified references in both directions.
+
+**What brings it back.** The first cyclic pair in the shipped tree. Until then a
+cycle is unreachable, and PR2's registry sentinel already terminates on one rather
+than recursing — it simply skips the bind instead of resolving the pair.
+
+Once the shipped tree is populated, `web:dom`'s siblings mutually reference it, so
+a cycle is the normal case there rather than an edge case. The design below is what
+that needs.
+
+**Data structures.**
+- The **pseudo-package import graph**: `map[string][]string` from a package URI to
+  the URIs it imports, built by scanning each `.esc` file under the stdlib
+  directory for its own scheme-prefixed imports.
+- A **process-level SCC cache** keyed by stdlib directory, so the graph is built
+  once per directory rather than once per import.
+
+**Algorithms.**
+- **`extractPseudoPackageImports`** parses one stdlib file and collects the
+  scheme-prefixed specifiers in its `Imports`. Ported from
+  [infer_stdlib_scc.go:124](../../internal/checker/infer_stdlib_scc.go).
+- **`tarjanSCCs`** condenses the graph into strongly connected components. A
+  direct port; it is a pure graph algorithm over strings.
+- **Merged-module load.** When a URI's component has more than one member, parse
+  every member into one `*ast.Module` and infer it as a single unit, so the
+  existing dep-graph SCC ordering resolves the cross-package references. Publish
+  each member's namespace into the registry afterwards. A member importing a
+  sibling short-circuits its own bind, since the merged module already exposes the
+  sibling.
+
+**Accept.** A test tree with a `std:a` ↔ `std:b` cycle loads once, both packages
+resolve each other's types, and each is registered under its own URI; a
+three-package cycle behaves the same; an acyclic package still takes the
+single-module path.
+
+**Depends on** PR2.
+
+**Size.** Medium — roughly the 330 lines of `infer_stdlib_scc.go`.
+
 ### PR9 — Variadic tuple types
+
+**Why it is out.** A type-system feature the milestone bundles here because
+`Array<T>` makes the form expressible, not because anything needs it. No
+acceptance criterion, no core PR, and no lib signature the core ingests reads a
+variadic tuple.
+
+**What brings it back.** A stdlib signature that needs the typed tail — the
+overload sets on `Promise.all` are the likely first — or the `infer`-matching
+form landing in the conditional-type work.
 
 `[number, ...Array<number>]` — a fixed prefix with a typed, unbounded,
 homogeneous tail. Distinct from M4's `Inexact` flag, which means "at least these,
@@ -683,6 +801,19 @@ variadic tuple renders with its tail spelled `...Array<number>`.
 
 ### PR10 — `unique symbol` and symbol-keyed access
 
+**Why it is out.** The milestone's stated reason for a unique-symbol
+`soltype` kind is PR11's `symbolSeg`, and PR11 is deferred below. PR6 covers its
+own need for `[Symbol.iterator]` with reserved member keys over the closed
+well-known set instead — see PR6's `Iterable` bullet for that decision and its
+limit.
+
+**What brings it back.** A user minting a symbol, through `Symbol()` or a
+`unique symbol` annotation. The reserved-key scheme is sound only for the fixed
+well-known set, so the first user-defined symbol key needs the real kind. PR11 also
+needs it. The parser, `dts_parser`, and interop halves are already done
+([well_known_symbols_as_keys/implementation_plan.md](../well_known_symbols_as_keys/implementation_plan.md)
+phases 1–4); only the `soltype` kind is missing.
+
 **Data structures.**
 - **`soltype.UniqueSymbolType{ID int}`**, carrying a stable id so
   `val it = Symbol.iterator` and the original `Symbol.iterator` are one type. The
@@ -718,6 +849,17 @@ depends on nothing in this plan.
 **Size.** Medium-large.
 
 ### PR11 — Precise place segments in the move engine
+
+**Why it is out.** It lives in `internal/solver/moves.go`, but it is affine
+work, not library-type resolution. The affine plan already carries it as its own
+deferred "Tuple-index place segments" item, and no M7.5 acceptance criterion
+touches moves. The milestone hosts it only because PR7's numeric index path is its
+prerequisite.
+
+**What brings it back.** The affine workstream scheduling it, once PR7 and PR10
+have both landed. The imprecision it fixes is conservative-sound in both
+directions — the escape check over-reports and a partial move over-consumes — so
+deferring it costs precision, never soundness.
 
 Discharges the milestone's field-level-move item and the affine plan's
 "Tuple-index place segments".
@@ -763,42 +905,20 @@ container.
 
 **Size.** Medium.
 
-### PR12 — Exactness, the stub inventory, and the parallel-package gate
-
-Three small pieces of hygiene that keep the milestone's gaps visible.
-
-**Algorithms.**
-- **Exactness stamping.** Every object, tuple, and function former minted while
-  ingesting a library declaration is stamped `Inexact`
-  ([exact-types/requirements.md](../exact-types/requirements.md) §8). The flag's
-  zero value is exact, so this is an explicit set at each ingestion mint, not a
-  default. Unions are excluded — their exactness fields were removed. A user
-  wanting the closed reading opts in at the use site with `Exact<T>`, which the
-  exactness intrinsic already implements.
-- **The stub inventory.** A `Context`-held record of every lib name that resolved
-  to a placeholder rather than a real structure, with the module it came from and
-  why. Surfaced through a reporting hook so a run against a partial stdlib tree
-  says what it could not represent instead of reading as full coverage. This is
-  what keeps the builtins-§7 gap legible from inside the compiler.
-- **The parallel-package gate.** A test that asserts `internal/solver` and
-  `internal/soltype` do not transitively import `internal/checker` or
-  `internal/type_system`, walking the package's own import graph rather than
-  trusting the comment at [doc.go:17](../../internal/solver/doc.go). PR2's
-  `interop.StdlibDir` decision is what this test would otherwise catch.
-
-**Accept.** An ingested object type renders inexact and accepts an argument with
-extra fields; a written Escalier object stays exact; the gate test fails when a
-`type_system` import is added to `solver` and passes on the tree as shipped; a run
-against a partial stdlib tree reports the names it stubbed.
-
-**Depends on** PR5. Independent of PR6–PR11.
-
-**Size.** Small.
-
 ### PR13 — The npm `.d.ts` channel
 
-The second ingestion channel, and the one M8's real-package differential needs
-beyond the standard library.
+**Why it is out.** It is `internal/interop`, `internal/resolver`, and
+`package.json` walking. The solver-side surface is one call into PR1's
+`loadModule`, which the core already provides. No fixture under `fixtures/`
+imports a non-scheme package, so M8's real-package regression does not need it
+either, and the milestone's acceptance criteria name only `std:*` and `web:*`.
+
+**What brings it back.** Its own milestone after M8, or the first real Escalier
+package that depends on an npm package with `@types`.
+
+The second ingestion channel, for real Escalier packages that depend on npm
+packages with `@types`. M8's differential runs over `fixtures/`, which imports no
+npm package, so it needs the standard-library channel and not this one.
 
 **Algorithms.**
 - **Reuse the AST-producing front half.** `dts_parser` parse →
@@ -834,19 +954,22 @@ npm.
 ## Dependency graph
 
 ```
+CORE
 PR1 (cross-module core: registry, file scopes, URI-qualified keys, exported surface)
  ├─► PR2 (scheme-URI imports + .esc stdlib binding + test stdlib tree)
- │    ├─► PR3 (pseudo-package import cycles: graph, Tarjan, merged load)
  │    └─► PR5 (real Array<T> + the well-known-handle mechanism)
  │         ├─► PR6 (well-known protocol set: Promise, Iterable, Generator)
- │         │    └─► PR10 (unique symbol + symbol-keyed access + the iteration protocol)
- │         │         └─► PR11 (place segments: constKey, indexSeg, symbolSeg)  ── also needs PR7
  │         ├─► PR7 (constant-numeric index reads: tuple requirement, mergeTupleGroup, seal arm)
  │         │    └─► PR8 (index writes)
- │         ├─► PR9 (variadic tuple types)
  │         └─► PR12 (exactness stamping + stub inventory + parallel-package gate)
- ├─► PR4 (lib decl kinds: interface, namespace, export visibility)
- └─► PR13 (npm .d.ts channel)                          ── also needs PR4, PR12
+ └─► PR4 (lib decl kinds: interface, namespace, export visibility)
+
+DEFERRED TAIL — hangs off the core, nothing in the core hangs off it
+ PR2  ┄► PR3  (pseudo-package import cycles)
+ PR5  ┄► PR9  (variadic tuple types)
+ PR6  ┄► PR10 (unique symbol + symbol-keyed access)
+             ┄► PR11 (place segments: constKey, indexSeg, symbolSeg) ── also needs PR7
+ PR4  ┄► PR13 (npm .d.ts channel)                                    ── also needs PR12
 
 needs ─► builtins §7 (committed .esc files) for the shipped-tree acceptance criteria
 feeds ─► M8 (the real-package differential needs real lib types)
@@ -855,24 +978,29 @@ feeds ─► ecma-262 solver-side application (PR6 deletes the placeholders it w
 feeds ─► ecma-262 §11 escape lifetime-borrow spelling, through the affine work
 ```
 
-The same graph in mermaid, with the ingestion critical path PR1 → PR2 → PR5
-highlighted, the external workstream and downstream consumers dashed:
+The same graph in mermaid. The core is solid and the critical path PR1 → PR2 → PR5
+is highlighted; the deferred tail is grouped and dashed, as are the external
+workstream and the downstream consumers:
 
 ```mermaid
 graph TD
     PR1["PR1 (cross-module core: registry, file scopes, qualified keys)"]
     PR2["PR2 (scheme-URI imports + .esc stdlib binding)"]
-    PR3["PR3 (pseudo-package import cycles)"]
     PR4["PR4 (lib decl kinds: interface, namespace, export)"]
     PR5["PR5 (real Array&lt;T&gt; + well-known-handle mechanism)"]
     PR6["PR6 (protocol set: Promise, Iterable, Generator)"]
     PR7["PR7 (numeric index reads: tuple requirement + seal)"]
     PR8["PR8 (index writes)"]
-    PR9["PR9 (variadic tuple types)"]
-    PR10["PR10 (unique symbol + symbol-keyed access)"]
-    PR11["PR11 (place segments: indexSeg, symbolSeg)"]
     PR12["PR12 (exactness + stub inventory + package gate)"]
-    PR13["PR13 (npm .d.ts channel)"]
+
+    subgraph deferred["Deferred tail — nothing in the core depends on these"]
+        PR3["PR3 (pseudo-package import cycles)"]
+        PR9["PR9 (variadic tuple types)"]
+        PR10["PR10 (unique symbol + symbol-keyed access)"]
+        PR11["PR11 (place segments: indexSeg, symbolSeg)"]
+        PR13["PR13 (npm .d.ts channel)"]
+    end
+
     B7["builtins §7 (committed .esc files)"]
     M8["M8 (differential triage)"]
     AFF["affine borrow through container methods"]
@@ -881,23 +1009,23 @@ graph TD
 
     PR1 --> PR2
     PR1 --> PR4
-    PR1 --> PR13
-    PR2 --> PR3
     PR2 --> PR5
     PR5 --> PR6
     PR5 --> PR7
-    PR5 --> PR9
     PR5 --> PR12
-    PR6 --> PR10
     PR7 --> PR8
-    PR7 --> PR11
-    PR10 --> PR11
-    PR4 --> PR13
-    PR12 --> PR13
+
+    PR2 -.-> PR3
+    PR5 -.-> PR9
+    PR6 -.-> PR10
+    PR7 -.-> PR11
+    PR10 -.-> PR11
+    PR1 -.-> PR13
+    PR4 -.-> PR13
+    PR12 -.-> PR13
 
     B7 -.-> M8
     PR6 -.-> M8
-    PR13 -.-> M8
     PR5 -.-> AFF
     PR6 -.-> E262
     AFF -.-> E262C
@@ -911,17 +1039,16 @@ graph TD
 
 ### Parallelism
 
-- **Critical path** — PR1 → PR2 → PR5. Nothing in Lane B starts before PR5, and
-  PR5 is the PR to split if its review stalls.
-- **PR3 and PR4** hang off different parents and never block Lane B. PR4 needs
-  only PR1, so it can run alongside PR2 from the start.
-- **PR7, PR9, and PR12** are mutually independent once PR5 lands, and PR6 joins
-  them — four reviewable branches off one parent.
-- **PR11** is the only PR with two parents in different sub-lanes, PR7 and PR10.
-  It is last for that reason, not because it is large.
-- **PR13** is independent of Lane B entirely and can land at any point after PR4
-  and PR12, or slip past the milestone without blocking M8's `std:*` coverage.
+- **Critical path** — PR1 → PR2 → PR5, three PRs deep. Nothing in Lane B starts
+  before PR5, and PR5 is the PR to split if its review stalls.
+- **PR4** needs only PR1, so it runs alongside PR2 from the start and never blocks
+  Lane B.
+- **PR6, PR7, and PR12** are mutually independent once PR5 lands — three
+  reviewable branches off one parent, with PR8 trailing PR7.
+- **The deferred tail parallelizes trivially** if any of it is pulled back in.
+  PR3 needs only PR2, PR9 needs only PR5, and PR13 needs PR4 plus PR12's gate.
+  PR10 → PR11 is the only chain in it.
 
-The milestone is functionally complete for its own test tree once PR11 lands, and
-complete against the shipped standard library once builtins §7 commits the `.esc`
-files.
+The core is functionally complete for its own test tree once PR8 and PR12 land,
+and complete against the shipped standard library once builtins §7 commits the
+`.esc` files.


### PR DESCRIPTION
This adds the detailed implementation plan for M7.5 — Library type resolution (`std:*` / `web:*` / `node:*`), covering the work to enable the solver to infer and type-check code that imports from the standard library and npm packages.

The plan document follows the established format of prior milestone plans (M4–M7), providing:

- **Ground truth inventory**: What the tree already ships, including the existing scheme-URI resolver in the old checker, the two stdlib stub files, the hardcoded `Array`/`Promise`/`Generator` concretes, and the current limitations of cross-module inference.

- **Divergences from milestone text**: Five corrections where the milestone text no longer matches the shipped code, including that rest-param element checking and dynamic-key reads are already done, that `.esc` is the ingestion channel (not `.d.ts`), that named imports from pseudo-packages are rejected, and that unions no longer carry exactness.

- **Delta specification**: Thirteen concrete additions, from cross-module inference and scheme-URI resolution through to variadic tuples, unique symbols, and precise place segments.

- **Cross-workstream dependencies**: Explicit acknowledgment that the builtins §7 work (committed `.esc` files) is a blocker for the shipped-tree acceptance criteria, with a clear split between what M7.5 can finish alone (the resolver, registry, type-system surface) and what requires builtins §7 (real source importing core lib types).

- **PR-by-PR breakdown**: Thirteen PRs organized into three lanes (ingestion plumbing, type-system surface, symbol and index precision), with data structures, algorithms, acceptance criteria, dependencies, and size estimates for each.

- **Dependency graph**: Both textual and mermaid-rendered, showing the critical path (PR1 → PR2 → PR5), parallelism opportunities, and downstream consumers (M8, affine borrow tracking).

This plan is the detailed roadmap for implementing library type resolution in the solver, unblocking real-package type-checking and the standard library's type surface.

https://claude.ai/code/session_01LJkkbZUxmQY7QJDwE8hx8f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive implementation plan for improved solver-side library type resolution.
  * Documented planned support for standard library and package resolution, cyclic loading, interfaces, namespaces, exports, tuples, arrays, symbols, move tracking, and type declaration ingestion.
  * Defined dependencies, acceptance criteria, pull request sizing, and execution milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->