### PR TITLE
Name a lifetime written at two or more borrows

### DIFF
--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -25,11 +25,18 @@ import (
 // since the two are spelled alike. That can record an alias the call never forms, reporting an
 // escape the program does not have. The opposite reading would miss a real dangling borrow.
 //
-// `a.peers.push(&mut b)`, the container case this exists for, is not covered. It needs an
+// A method call reaches this recorder through its explicit parameters. freezeClassBody
+// coalesces each member's signature into the class body, and a lifetime written at two
+// borrows survives that pass, so the two sides still share a variable at the call site.
+//
+// Two method shapes miss it. A store into the `self` receiver does not reach the recorder,
+// since memberValue strips the receiver off the signature it hands the call. An overloaded
+// method call does not either, since inferMethodOverloadCall resolves its arm and returns
+// before the recorder runs.
+//
+// So `a.peers.push(&mut b)`, the container case this exists for, is not covered. It needs an
 // `Array` type with a method surface, a lifetime parameter on the container tying the element
-// borrow to the receiver, the receiver's type at the call site, and named lifetimes on a
-// method signature. The last is why no method call records a store today: a method's
-// lifetimes reach the call site anonymized, so the two sides share nothing to match.
+// borrow to the receiver, and the receiver's type at the call site.
 type storeEdge struct {
 	// arg is the index of the argument whose borrow the call stores.
 	arg int

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -52,8 +52,8 @@ func TestCallStoreEdge(t *testing.T) {
 			`,
 			want: []string{"11:13-11:19: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-					"item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
 			},
 		},
@@ -76,8 +76,8 @@ func TestCallStoreEdge(t *testing.T) {
 			`,
 			want: nil,
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-					"item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
 			},
 		},
@@ -100,8 +100,8 @@ func TestCallStoreEdge(t *testing.T) {
 			`,
 			want: []string{"11:13-11:25: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-					"item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
 			},
 		},
@@ -126,8 +126,8 @@ func TestCallStoreEdge(t *testing.T) {
 			`,
 			want: []string{"13:14-13:15: use of moved value 'b'"},
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-					"item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &'a mut {value: number}) -> undefined",
 				"take":  "fn (x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
 				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> undefined",
 			},
@@ -151,8 +151,8 @@ func TestCallStoreEdge(t *testing.T) {
 			`,
 			want: nil,
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-					"item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &'a mut {value: number}) -> undefined",
 				"take":  "fn (x: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
 				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> undefined",
 			},
@@ -177,8 +177,8 @@ func TestCallStoreEdge(t *testing.T) {
 				`,
 				want: nil,
 				types: map[string]string{
-					"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-						"item: &mut {value: number}) -> undefined",
+					"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}, spare: &mut {value: number}}, " +
+						"item: &'a mut {value: number}) -> undefined",
 					"build": "fn (p: mut {peer: &mut {value: number}, spare: &mut {value: number}}) -> undefined",
 				},
 			},
@@ -200,7 +200,7 @@ func TestCallStoreEdge(t *testing.T) {
 				`,
 				want: nil,
 				types: map[string]string{
-					"store": "fn (target: &mut {peer: &{value: number}}, item: &{value: number}) -> undefined",
+					"store": "fn <'a>(target: &mut {peer: &'a {value: number}}, item: &'a {value: number}) -> undefined",
 					"build": "fn (p: mut {peer: &{value: number}}) -> undefined",
 				},
 			},
@@ -226,8 +226,8 @@ func TestCallStoreEdge(t *testing.T) {
 				`,
 				want: []string{"11:22-11:28: cannot borrow 'b' as mutable more than once at a time"},
 				types: map[string]string{
-					"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-						"item: &mut {value: number}) -> undefined",
+					"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}, spare: &mut {value: number}}, " +
+						"item: &'a mut {value: number}) -> undefined",
 					"build": "fn (p: mut {value: number}, q: mut {value: number}) " +
 						"-> [&mut {value: number}, &mut {value: number}]",
 				},
@@ -250,8 +250,8 @@ func TestCallStoreEdge(t *testing.T) {
 			`,
 			want: nil,
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {value: number}, spare: &mut {value: number}}, " +
-					"item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}, spare: &mut {value: number}}, " +
+					"item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}, q: mut {value: number}, r: mut {value: number}) " +
 					"-> &mut {value: number}",
 			},
@@ -293,7 +293,7 @@ func TestCallStoreEdgePositions(t *testing.T) {
 			`,
 			want: []string{"10:13-10:14: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{
-				"store": "fn (target: &mut [&mut {value: number}], item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut [&'a mut {value: number}], item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}) -> [&mut {value: number}]",
 			},
 		},
@@ -317,7 +317,7 @@ func TestCallStoreEdgePositions(t *testing.T) {
 			want: []string{"11:13-11:18: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{
 				"Box":   "<T> {new (value: T) -> Box<T>}",
-				"store": "fn (target: &mut {box: &mut Box<&mut {value: number}>}, item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {box: &mut Box<&'a mut {value: number}>}, item: &'a mut {value: number}) -> undefined",
 				"build": "fn <'a>(seeded: mut Box<&'a mut {value: number}>) -> &mut Box<&'a mut {value: number}>",
 			},
 		},
@@ -336,7 +336,7 @@ func TestCallStoreEdgePositions(t *testing.T) {
 			`,
 			want: []string{"8:13-8:19: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{
-				"store": "fn <'a>(target: &mut Holder<'a>, item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut Holder<'a>, item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}) -> &mut {value: number}",
 			},
 		},
@@ -358,7 +358,7 @@ func TestCallStoreEdgePositions(t *testing.T) {
 			`,
 			want: []string{"10:13-10:19: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {value: number}}, item: &{inner: &mut {value: number}}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}}, item: &{inner: &'a mut {value: number}}) -> undefined",
 				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
 			},
 		},
@@ -390,8 +390,8 @@ func TestCallStoreEdgePositions(t *testing.T) {
 				"10:13-10:19: borrowed value 'b' does not live long enough to escape the function",
 			},
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {other: number} | &mut {value: number}}, " +
-					"item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a mut {other: number} | &'a mut {value: number}}, " +
+					"item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}) -> &mut {value: number} | &mut {other: number}",
 			},
 		},
@@ -412,7 +412,7 @@ func TestCallStoreEdgePositions(t *testing.T) {
 			`,
 			want: []string{"10:13-10:19: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &mut {value: number}}, item: &{inner: &mut {value: number}}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a mut {value: number}}, item: &{inner: &'a mut {value: number}}) -> undefined",
 				"build": "fn (p: mut {value: number}) -> &mut {value: number}",
 			},
 		},
@@ -433,8 +433,8 @@ func TestCallStoreEdgePositions(t *testing.T) {
 			`,
 			want: []string{"10:13-10:20: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{
-				"store": "fn (target: &mut {peers: &mut {[key: string]?: &mut {value: number}}}, " +
-					"item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {peers: &mut {[key: string]?: &'a mut {value: number}}}, " +
+					"item: &'a mut {value: number}) -> undefined",
 				"build": "fn <'a>(seeded: mut {[key: string]?: &'a mut {value: number}}) " +
 					"-> &mut {[key: string]?: &'a mut {value: number}}",
 			},
@@ -457,7 +457,7 @@ func TestCallStoreEdgePositions(t *testing.T) {
 			`,
 			want: []string{"10:13-10:19: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{
-				"store": "fn (target: &mut {peer: &{value: number}}, item: &{value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {peer: &'a {value: number}}, item: &'a {value: number}) -> undefined",
 				"build": "fn (p: {value: number}) -> &{value: number}",
 			},
 		},
@@ -515,6 +515,81 @@ func TestCallStoreEdgePayloadPositions(t *testing.T) {
 	}
 }
 
+// TestMethodCallStoreEdge covers a store declared by a METHOD's signature. freezeClassBody
+// coalesces each member's signature into the class body, so the store is recorded only
+// because a lifetime written at two borrows survives that pass. A method whose signature
+// elided its lifetimes would leave the two sides of the store sharing nothing the recorder
+// can match.
+//
+// The receiver is not a store target here. memberValue strips the `self` param off the
+// signature it hands the call, so only a method's explicit parameters reach the recorder.
+func TestMethodCallStoreEdge(t *testing.T) {
+	const decls = `
+		class Store {
+			tag: number,
+			put<'a, 'b>(
+				self,
+				target: &'b mut {peer: &'a mut {value: number}},
+				item: &'a mut {value: number},
+			) -> undefined {
+				target.peer = item
+			},
+		}
+	`
+	storeTypes := map[string]string{
+		"Store": "{new (tag: number) -> Store}",
+	}
+	withTypes := func(build string) map[string]string {
+		out := map[string]string{"build": build}
+		for name, ty := range storeTypes {
+			out[name] = ty
+		}
+		return out
+	}
+
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// The method call is the only thing that aliases a to b, so returning a.peer reports
+		// the escape it would report for the equivalent free function.
+		"MethodStoreEscapes": {
+			src: decls + `
+				fn build(s: Store, p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p}
+					s.put(&mut a, &mut b)
+					return a.peer
+				}
+			`,
+			want:  []string{"17:13-17:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: withTypes("fn (s: Store, p: mut {value: number}) -> &mut {value: number}"),
+		},
+		// Dropping the call isolates its effect: with no edge from a to b, the same return
+		// reports nothing.
+		"NoMethodCallNoEdge": {
+			src: decls + `
+				fn build(s: Store, p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut a = {peer: &mut p}
+					return a.peer
+				}
+			`,
+			want:  nil,
+			types: withTypes("fn (s: Store, p: mut {value: number}) -> &mut {value: number}"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
+		})
+	}
+}
+
 // TestCallStoreEdgeNonStores covers the signatures that share a lifetime without declaring a
 // store, so the call records nothing and the locals it borrows stay free. Each pairs with a
 // case in TestCallStoreEdge that does record an edge on the same source shape.
@@ -541,7 +616,7 @@ func TestCallStoreEdgeNonStores(t *testing.T) {
 			`,
 			want: nil,
 			types: map[string]string{
-				"pair":  "fn (x: &mut {value: number}, y: &mut {value: number}) -> undefined",
+				"pair":  "fn <'a>(x: &'a mut {value: number}, y: &'a mut {value: number}) -> undefined",
 				"take":  "fn (x: mut {peer: &mut {value: number}}) -> undefined",
 				"build": "fn (p: mut {value: number}) -> undefined",
 			},
@@ -563,7 +638,7 @@ func TestCallStoreEdgeNonStores(t *testing.T) {
 			`,
 			want: nil,
 			types: map[string]string{
-				"read":  "fn (target: &{peer: &mut {value: number}}, item: &mut {value: number}) -> undefined",
+				"read":  "fn <'a>(target: &{peer: &'a mut {value: number}}, item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}) -> &mut {value: number}",
 			},
 		},
@@ -588,7 +663,7 @@ func TestCallStoreEdgeNonStores(t *testing.T) {
 			`,
 			want: nil,
 			types: map[string]string{
-				"store": "fn <'a, 'b>(target: &mut Holder<'a, 'b>, item: &mut {value: number}) -> undefined",
+				"store": "fn <'a, 'b>(target: &mut Holder<'a, 'b>, item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}, q: mut {value: number}) -> &mut {value: number}",
 			},
 		},
@@ -613,7 +688,7 @@ func TestCallStoreEdgeNonStores(t *testing.T) {
 			`,
 			want: nil,
 			types: map[string]string{
-				"store": "fn (target: &mut {deep: W<W<&mut {value: number}>>}, item: &mut {value: number}) -> undefined",
+				"store": "fn <'a>(target: &mut {deep: W<W<&'a mut {value: number}>>}, item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}) -> number",
 			},
 		},
@@ -634,7 +709,7 @@ func TestCallStoreEdgeNonStores(t *testing.T) {
 			`,
 			want: nil,
 			types: map[string]string{
-				"keep":  "fn (target: mut {peer: &mut {value: number}}, item: &mut {value: number}) -> undefined",
+				"keep":  "fn <'a>(target: mut {peer: &'a mut {value: number}}, item: &'a mut {value: number}) -> undefined",
 				"build": "fn (p: mut {value: number}) -> undefined",
 			},
 		},

--- a/internal/solver/borrow_store_test.go
+++ b/internal/solver/borrow_store_test.go
@@ -584,7 +584,7 @@ func TestMethodCallStoreEdge(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.want, messagesWithSpan(t, errs))
 			require.Equal(t, tc.types, values)
 		})
 	}

--- a/internal/solver/infer_alias_lifetime_test.go
+++ b/internal/solver/infer_alias_lifetime_test.go
@@ -117,6 +117,11 @@ func TestInferLifetimeGenericAliasKeepsLifetimesDistinct(t *testing.T) {
 // expanded borrow are interchangeable under subtyping. A `Ref<'a, {x: number}>` value flows
 // into a plain `&'a {x: number}` target, and a plain borrow flows back into the alias, so the
 // alias expands to exactly the borrow its body writes.
+//
+// Both signatures write `'a` twice, once at a borrow and once as the alias's lifetime
+// argument, so the name survives on both sides. Counting only the borrow would leave `'a`
+// quantified while eliding it from the half that wrote it as an alias argument, rendering an
+// `f` whose return names no lifetime its parameter supplies.
 func TestInferLifetimeGenericAliasIsTransparent(t *testing.T) {
 	src := `
 		type Ref<'a, T> = &'a T
@@ -125,8 +130,8 @@ func TestInferLifetimeGenericAliasIsTransparent(t *testing.T) {
 	`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: Ref<'a, {x: number}>) -> &{x: number}", values["f"])
-	require.Equal(t, "fn <'a>(p: &{x: number}) -> Ref<'a, {x: number}>", values["g"])
+	require.Equal(t, "fn <'a>(p: Ref<'a, {x: number}>) -> &'a {x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> Ref<'a, {x: number}>", values["g"])
 }
 
 // TestInferLifetimeGenericAliasArityErrors covers the lifetime-argument arity checks. A

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -41,6 +41,47 @@ func TestInferDistinctParamLifetimes(t *testing.T) {
 	require.Equal(t, "fn <'a>(p: &'a mut {x: number}, q: &mut {y: number}) -> &'a mut {x: number}", values["f"])
 }
 
+// TestInferSharedParamLifetimeIsNamed covers the naming rule for a lifetime written at
+// two or more borrows. One name repeated across borrows is a constraint the caller has to
+// satisfy — the regions must be the same — so it is named even when it reaches no output.
+// A lifetime written once and reaching no output still elides, since it constrains nothing.
+func TestInferSharedParamLifetimeIsNamed(t *testing.T) {
+	tests := map[string]struct {
+		src     string
+		binding string
+		want    string
+	}{
+		// Two params sharing `'a` must be borrows of the same region, so the name survives
+		// even though neither reaches the return.
+		"TwoParamsShareOneLifetime": {
+			src:     `declare fn pair<'a>(x: &'a mut {x: number}, y: &'a mut {x: number}) -> undefined`,
+			binding: "pair",
+			want:    "fn <'a>(x: &'a mut {x: number}, y: &'a mut {x: number}) -> undefined",
+		},
+		// One param whose outer borrow and inner field borrow share `'a` ties the two
+		// regions together, so the name survives on a single parameter as well.
+		"OneParamRepeatsItsLifetime": {
+			src:     `declare fn nest<'a>(x: &'a mut {peer: &'a mut {x: number}}) -> undefined`,
+			binding: "nest",
+			want:    "fn <'a>(x: &'a mut {peer: &'a mut {x: number}}) -> undefined",
+		},
+		// A lifetime written at one borrow and reaching no output constrains nothing, so it
+		// still elides to a bare `&mut`. This is the case the rule above must not swallow.
+		"SingleBorrowStillElides": {
+			src:     `declare fn drop<'a>(x: &'a mut {x: number}) -> undefined`,
+			binding: "drop",
+			want:    "fn (x: &mut {x: number}) -> undefined",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Empty(t, errs)
+			require.Equal(t, tc.want, values[tc.binding])
+		})
+	}
+}
+
 // Writing a field through an owned-mutable param checks. The write requirement's
 // fresh lifetime imposes no obligation, so an owned receiver satisfies it.
 func TestInferFieldWriteThroughBorrowParam(t *testing.T) {

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -66,7 +66,8 @@ func TestInferSharedParamLifetimeIsNamed(t *testing.T) {
 			want:    "fn <'a>(x: &'a mut {peer: &'a mut {x: number}}) -> undefined",
 		},
 		// A lifetime written at one borrow and reaching no output constrains nothing, so it
-		// still elides to a bare `&mut`. This is the case the rule above must not swallow.
+		// still elides to a bare `&mut`. Counting a single write as shared would name every
+		// borrow in every signature.
 		"SingleBorrowStillElides": {
 			src:     `declare fn drop<'a>(x: &'a mut {x: number}) -> undefined`,
 			binding: "drop",

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -81,13 +81,11 @@ func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 //   - noElide holds the lifetimes that must keep their name whatever their position.
 //     Two writes put a lifetime there, described below.
 //
-// A complement does not move a borrow between a parameter and an output. But
-// NegationType.Accept flips the polarity its operand is visited at, which is right for
-// variance and wrong for reading position. Undoing that flip recovers the position.
-// Each enclosing complement inverts it once, so the parity of negDepth says whether to
-// flip back. The recovered position decides which connected component counts as
-// output-reaching. That in turn governs which lifetimes survive elision, and which
-// outlives bounds ltOutlivesRelation asserts.
+// A complement does not move a borrow between a parameter and an output, so the flip
+// NegationType.Accept applies has to be undone before the polarity can be read as a
+// position. negTypeDepth below carries what that costs. The recovered position decides which
+// connected component counts as output-reaching, which in turn governs which lifetimes
+// survive elision and which outlives bounds ltOutlivesRelation asserts.
 //
 // noElide exists because position alone is not enough. Two kinds of lifetime reach no
 // output and still have to keep their name.
@@ -115,16 +113,21 @@ type ltOccVisitor struct {
 	// position a borrow the caller supplies sits in. The second write is what puts the
 	// lifetime in noElide. A nested function type flips polarity, so a borrow written at a
 	// CALLBACK's parameter is positive and does not count here.
-	//
-	// negDepth below counts enclosing NegationType nodes. The two share a prefix and nothing
-	// else: negPolSeen is about polarity, negDepth is about complements.
 	negPolSeen map[*soltype.LifetimeVar]int
-	negDepth   int
+	// negTypeDepth counts the NegationType nodes enclosing the node being visited.
+	// NegationType.Accept flips the polarity its operand is visited at, which is right for
+	// variance and wrong for reading position, so record converts polarity back into position
+	// by flipping once per enclosing complement. Two complements cancel, so only the parity
+	// matters. A non-zero depth also marks every lifetime written under it as never-elidable.
+	//
+	// It shares a prefix with negPolSeen and nothing else. This one is about NegationType,
+	// that one is about polarity.
+	negTypeDepth int
 }
 
 func (v *ltOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	if _, isNeg := t.(*soltype.NegationType); isNeg {
-		v.negDepth++
+		v.negTypeDepth++
 	}
 	// A lifetime is written at three kinds of node: the lifetime slot of a borrow, and the
 	// lifetime-argument list of an alias or class reference. `&'b mut Holder<'a>` writes 'a
@@ -155,10 +158,9 @@ func (v *ltOccVisitor) record(lt soltype.Lifetime, pol soltype.Polarity) {
 	if !ok {
 		return
 	}
-	// Undo one polarity flip per enclosing complement to recover the position the write
-	// structurally sits in. Two complements cancel, so only the parity counts.
+	// Recover the position this write structurally sits in. See negTypeDepth.
 	position := pol
-	if v.negDepth%2 == 1 {
+	if v.negTypeDepth%2 == 1 {
 		position = position.Flip()
 	}
 	if position == soltype.Positive {
@@ -170,7 +172,7 @@ func (v *ltOccVisitor) record(lt soltype.Lifetime, pol soltype.Polarity) {
 			v.noElide.Add(lv)
 		}
 	}
-	if v.negDepth > 0 {
+	if v.negTypeDepth > 0 {
 		v.noElide.Add(lv)
 	}
 }
@@ -179,7 +181,7 @@ func (v *ltOccVisitor) record(lt soltype.Lifetime, pol soltype.Polarity) {
 // visitor never sets SkipChildren, so Accept runs both halves for every node it enters.
 func (v *ltOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
 	if _, isNeg := t.(*soltype.NegationType); isNeg {
-		v.negDepth--
+		v.negTypeDepth--
 	}
 	return t
 }

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -94,11 +94,13 @@ func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 // under a complement changes the type rather than merely dropping a name, since `~(&'a T)`
 // rendered as `~(&T)` is the complement of any borrow of T rather than of the `'a` one.
 //
-// shared holds the param lifetimes written at two or more borrows. One name repeated
-// across borrows is a constraint the caller has to satisfy — the two regions must be the
-// same — so it is named even when it reaches no output. `fn f<'a>(x: &'a mut B, y: &'a
-// mut B)` renders its `'a` for that reason, while the single-borrow `fn f(x: &mut B)`
-// elides. negSeen is the running count the set is derived from.
+// shared holds the param lifetimes written twice or more. One name repeated is a constraint
+// the caller has to satisfy — the two regions must be the same — so it is named even when it
+// reaches no output. `fn f<'a>(x: &'a mut B, y: &'a mut B)` renders its `'a` for that reason,
+// while the single-write `fn f(x: &mut B)` elides. A write is any of the three positions
+// EnterType records: a borrow's lifetime slot and an alias or class reference's lifetime
+// argument, so `fn f<'a>(a: mut Holder<'a>, b: mut Holder<'a>)` counts too. negSeen is the
+// running count the set is derived from.
 type ltOccVisitor struct {
 	occ      map[*soltype.LifetimeVar]occPolarity
 	noElide  set.Set[*soltype.LifetimeVar]

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -78,8 +78,8 @@ func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 //     polarity carries, so EnterType converts one into the other. `Negative` means the
 //     borrow originates at a parameter, so its lifetime is nameable. `Positive` means
 //     the borrow reaches an output, so its lifetime is not elided.
-//   - noElide holds the lifetimes a complement encloses. A lifetime in it is never
-//     elided, whatever its position.
+//   - noElide holds the lifetimes that must keep their name whatever their position.
+//     Two writes put a lifetime there, described below.
 //
 // A complement does not move a borrow between a parameter and an output. But
 // NegationType.Accept flips the polarity its operand is visited at, which is right for
@@ -89,22 +89,28 @@ func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 // output-reaching. That in turn governs which lifetimes survive elision, and which
 // outlives bounds ltOutlivesRelation asserts.
 //
-// noElide exists because position alone is not enough. A complemented borrow reaching no
-// output is genuinely connect-nothing, and the elision rule above drops those. Eliding
-// under a complement changes the type rather than merely dropping a name, since `~(&'a T)`
-// rendered as `~(&T)` is the complement of any borrow of T rather than of the `'a` one.
+// noElide exists because position alone is not enough. Two kinds of lifetime reach no
+// output and still have to keep their name.
 //
-// shared holds the param lifetimes written twice or more. One name repeated is a constraint
+// A complement encloses the first kind. A complemented borrow reaching no output is
+// genuinely connect-nothing, and the elision rule above drops those. Eliding under a
+// complement changes the type rather than merely dropping a name, since `~(&'a T)` rendered
+// as `~(&T)` is the complement of any borrow of T rather than of the `'a` one.
+//
+// A repeated name is the second. One name written at two parameter positions is a constraint
 // the caller has to satisfy — the two regions must be the same — so it is named even when it
 // reaches no output. `fn f<'a>(x: &'a mut B, y: &'a mut B)` renders its `'a` for that reason,
 // while the single-write `fn f(x: &mut B)` elides. A write is any of the three positions
 // EnterType records: a borrow's lifetime slot and an alias or class reference's lifetime
 // argument, so `fn f<'a>(a: mut Holder<'a>, b: mut Holder<'a>)` counts too. negSeen is the
-// running count the set is derived from.
+// running count that second entry is derived from.
+//
+// Only a parameter lifetime enters by the second route, since the count runs in the negative
+// arm alone. resolveLt relies on that: its non-param branch reads noElide to mean the
+// complement case, which is the only one that can reach it.
 type ltOccVisitor struct {
 	occ      map[*soltype.LifetimeVar]occPolarity
 	noElide  set.Set[*soltype.LifetimeVar]
-	shared   set.Set[*soltype.LifetimeVar]
 	negSeen  map[*soltype.LifetimeVar]int
 	negDepth int
 }
@@ -134,9 +140,9 @@ func (v *ltOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.E
 
 // record notes one written occurrence of lt at the walk polarity pol, ignoring 'static and
 // an already-resolved display lifetime, neither of which is a variable to name. It converts
-// the walk's variance into the structural position the write sits in, tallies the negative
-// writes so a name repeated across borrows lands in shared, and marks a write a complement
-// encloses as never-elidable.
+// the walk's variance into the structural position the write sits in, then marks the write
+// never-elidable when a complement encloses it or when it is the second parameter-position
+// write of the same name.
 func (v *ltOccVisitor) record(lt soltype.Lifetime, pol soltype.Polarity) {
 	lv, ok := lt.(*soltype.LifetimeVar)
 	if !ok {
@@ -154,7 +160,7 @@ func (v *ltOccVisitor) record(lt soltype.Lifetime, pol soltype.Polarity) {
 		v.occ[lv] |= occNeg
 		v.negSeen[lv]++
 		if v.negSeen[lv] > 1 {
-			v.shared.Add(lv)
+			v.noElide.Add(lv)
 		}
 	}
 	if v.negDepth > 0 {
@@ -172,21 +178,18 @@ func (v *ltOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type
 }
 
 // walkLtOcc runs the occurrence walk over t from the root polarity pol, returning the
-// structural positions, the set of lifetimes a complement encloses, and the set written
-// at two or more borrows.
+// structural positions and the set of lifetimes that must keep their name.
 func walkLtOcc(t soltype.Type, pol soltype.Polarity) (
 	map[*soltype.LifetimeVar]occPolarity,
-	set.Set[*soltype.LifetimeVar],
 	set.Set[*soltype.LifetimeVar],
 ) {
 	v := &ltOccVisitor{
 		occ:     map[*soltype.LifetimeVar]occPolarity{},
 		noElide: set.NewSet[*soltype.LifetimeVar](),
-		shared:  set.NewSet[*soltype.LifetimeVar](),
 		negSeen: map[*soltype.LifetimeVar]int{},
 	}
 	t.Accept(v, pol)
-	return v.occ, v.noElide, v.shared
+	return v.occ, v.noElide
 }
 
 // ltAnalysis is the precomputed input the rewriter reads: per-variable structural
@@ -195,8 +198,7 @@ func walkLtOcc(t soltype.Type, pol soltype.Polarity) (
 // that hold a positive output lifetime.
 type ltAnalysis struct {
 	occ      map[*soltype.LifetimeVar]occPolarity
-	noElide  set.Set[*soltype.LifetimeVar] // lifetimes a complement encloses; never elided
-	shared   set.Set[*soltype.LifetimeVar] // lifetimes written at two or more borrows; never elided
+	noElide  set.Set[*soltype.LifetimeVar] // lifetimes that must keep their name; never elided
 	bs       *ltBoundSet                   // condensed outlives graph; rep IDs collapse mutual-outlives cycles
 	comp     map[int]int                   // representative ID -> connected-component leader ID in bs
 	posComps set.Set[int]                  // component leaders reaching a positive occurrence
@@ -219,7 +221,7 @@ type ltAnalysis struct {
 // rendering that layers on top.
 func newLtAnalysis(
 	occ map[*soltype.LifetimeVar]occPolarity,
-	noElide, shared set.Set[*soltype.LifetimeVar],
+	noElide set.Set[*soltype.LifetimeVar],
 ) *ltAnalysis {
 	bs := buildLtBoundSet(occ)
 	comp := bs.weakComponents()
@@ -234,7 +236,7 @@ func newLtAnalysis(
 			posComps.Add(comp[bs.repOf(v.ID)])
 		}
 	}
-	return &ltAnalysis{occ: occ, noElide: noElide, shared: shared, bs: bs, comp: comp, posComps: posComps}
+	return &ltAnalysis{occ: occ, noElide: noElide, bs: bs, comp: comp, posComps: posComps}
 }
 
 // isParam reports whether v is a param lifetime: one that originates at a borrow
@@ -293,16 +295,19 @@ func (a *ltAnalysis) componentParams(v *soltype.LifetimeVar) []*soltype.Lifetime
 // resolveLt maps a lifetime variable to its display form, or reports elide=true when
 // the borrow connects nothing and the wrapper should drop.
 //
-// A lifetime a complement encloses is never elided. It renders under its own name even
-// when it connects nothing, because dropping it would change the type rather than drop a
-// name. So `declare fn f<'a>() -> ~(&'a T)` keeps `'a` in the quantifier prefix, while
-// the same signature over a plain borrow elides it.
+// A lifetime noElide holds is never elided, even when it connects nothing. Two writes put
+// one there. A complement enclosing it means dropping the name would change the type, so
+// `declare fn f<'a>() -> ~(&'a T)` keeps `'a` in the quantifier prefix while the same
+// signature over a plain borrow elides it. A second parameter-position write of the same
+// name means the caller has a constraint to satisfy, so `fn f<'a>(x: &'a mut B, y: &'a mut B)`
+// keeps `'a` too. The non-param branch below reads noElide as the complement case alone,
+// which holds because only a parameter lifetime enters by the second route.
 func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, elide bool) {
 	if forcedToStatic(v) {
 		return soltype.Static, false
 	}
 	if a.isParam(v) {
-		if a.kept(v) || a.noElide.Contains(v) || a.shared.Contains(v) {
+		if a.kept(v) || a.noElide.Contains(v) {
 			return v, false // a named param renders under its own quantified name
 		}
 		return nil, true // connect-nothing param: elide
@@ -347,11 +352,11 @@ func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, eli
 // relation between them. pol is the polarity t was built at, threaded so the occurrence
 // walk starts from the same root.
 func ltOutlivesRelation(t soltype.Type, pol soltype.Polarity) (*ltAnalysis, []*soltype.LifetimeVar, func(u, w *soltype.LifetimeVar) bool) {
-	occ, noElide, shared := walkLtOcc(t, pol)
+	occ, noElide := walkLtOcc(t, pol)
 	if len(occ) == 0 {
 		return nil, nil, nil
 	}
-	a := newLtAnalysis(occ, noElide, shared)
+	a := newLtAnalysis(occ, noElide)
 	bs := a.bs
 
 	survivors := slices.Collect(maps.Keys(occ))

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -29,11 +29,14 @@ import (
 //     output. The printer assigns it 'a, 'b, … from the variables this pass leaves
 //     in the type.
 //
-//  2. Elision. A param lifetime whose borrow never reaches an output connects
-//     nothing. It occurs in no positive position, and its connected component in the
-//     condensed graph holds no output lifetime, so it is dropped. This is the
-//     lifetime-sort analogue of single-polarity type-variable elimination. The drop
-//     branches on the borrow's Mut flag:
+//  2. Elision. A param lifetime connects nothing when it is written at one borrow and
+//     never reaches an output. It occurs in no positive position, its connected
+//     component in the condensed graph holds no output lifetime, and no second borrow
+//     shares its name, so it is dropped. This is the lifetime-sort analogue of
+//     single-polarity type-variable elimination. A lifetime written at two or more
+//     borrows survives, since repeating one name across borrows says the regions are
+//     the same, which is a constraint on the caller whether or not it reaches an
+//     output. The drop branches on the borrow's Mut flag:
 //     - A mutable borrow becomes owned-mutable, RefType{Mut: true, Lt: nil}.
 //     - An immutable borrow drops the RefType wrapper entirely and returns its
 //     bare inner, because RefType{Mut: false, Lt: nil} is the forbidden
@@ -90,9 +93,17 @@ func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 // output is genuinely connect-nothing, and the elision rule above drops those. Eliding
 // under a complement changes the type rather than merely dropping a name, since `~(&'a T)`
 // rendered as `~(&T)` is the complement of any borrow of T rather than of the `'a` one.
+//
+// shared holds the param lifetimes written at two or more borrows. One name repeated
+// across borrows is a constraint the caller has to satisfy — the two regions must be the
+// same — so it is named even when it reaches no output. `fn f<'a>(x: &'a mut B, y: &'a
+// mut B)` renders its `'a` for that reason, while the single-borrow `fn f(x: &mut B)`
+// elides. negSeen is the running count the set is derived from.
 type ltOccVisitor struct {
 	occ      map[*soltype.LifetimeVar]occPolarity
 	noElide  set.Set[*soltype.LifetimeVar]
+	shared   set.Set[*soltype.LifetimeVar]
+	negSeen  map[*soltype.LifetimeVar]int
 	negDepth int
 }
 
@@ -100,25 +111,53 @@ func (v *ltOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.E
 	if _, isNeg := t.(*soltype.NegationType); isNeg {
 		v.negDepth++
 	}
-	if r, ok := t.(*soltype.RefType); ok {
-		if lv, ok := r.Lt.(*soltype.LifetimeVar); ok {
-			// Undo one polarity flip per enclosing complement to recover the position the
-			// borrow structurally sits in. Two complements cancel, so only the parity counts.
-			position := pol
-			if v.negDepth%2 == 1 {
-				position = position.Flip()
-			}
-			if position == soltype.Positive {
-				v.occ[lv] |= occPos
-			} else {
-				v.occ[lv] |= occNeg
-			}
-			if v.negDepth > 0 {
-				v.noElide.Add(lv)
-			}
+	// A lifetime is written at three kinds of node: the lifetime slot of a borrow, and the
+	// lifetime-argument list of an alias or class reference. `&'b mut Holder<'a>` writes 'a
+	// as an alias argument, and a signature that also writes it at a borrow ties the two
+	// together, so all three positions have to be recorded for the relation to be visible.
+	switch t := t.(type) {
+	case *soltype.RefType:
+		v.record(t.Lt, pol)
+	case *soltype.AliasType:
+		for _, arg := range t.LifetimeArgs {
+			v.record(arg, pol)
+		}
+	case *soltype.ClassType:
+		for _, arg := range t.LifetimeArgs {
+			v.record(arg, pol)
 		}
 	}
 	return soltype.EnterResult{}
+}
+
+// record notes one written occurrence of lt at the walk polarity pol, ignoring 'static and
+// an already-resolved display lifetime, neither of which is a variable to name. It converts
+// the walk's variance into the structural position the write sits in, tallies the negative
+// writes so a name repeated across borrows lands in shared, and marks a write a complement
+// encloses as never-elidable.
+func (v *ltOccVisitor) record(lt soltype.Lifetime, pol soltype.Polarity) {
+	lv, ok := lt.(*soltype.LifetimeVar)
+	if !ok {
+		return
+	}
+	// Undo one polarity flip per enclosing complement to recover the position the write
+	// structurally sits in. Two complements cancel, so only the parity counts.
+	position := pol
+	if v.negDepth%2 == 1 {
+		position = position.Flip()
+	}
+	if position == soltype.Positive {
+		v.occ[lv] |= occPos
+	} else {
+		v.occ[lv] |= occNeg
+		v.negSeen[lv]++
+		if v.negSeen[lv] > 1 {
+			v.shared.Add(lv)
+		}
+	}
+	if v.negDepth > 0 {
+		v.noElide.Add(lv)
+	}
 }
 
 // ExitType pops the complement EnterType pushed. The two stay balanced because this
@@ -131,14 +170,21 @@ func (v *ltOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type
 }
 
 // walkLtOcc runs the occurrence walk over t from the root polarity pol, returning the
-// structural positions and the set of lifetimes a complement encloses.
-func walkLtOcc(t soltype.Type, pol soltype.Polarity) (map[*soltype.LifetimeVar]occPolarity, set.Set[*soltype.LifetimeVar]) {
+// structural positions, the set of lifetimes a complement encloses, and the set written
+// at two or more borrows.
+func walkLtOcc(t soltype.Type, pol soltype.Polarity) (
+	map[*soltype.LifetimeVar]occPolarity,
+	set.Set[*soltype.LifetimeVar],
+	set.Set[*soltype.LifetimeVar],
+) {
 	v := &ltOccVisitor{
 		occ:     map[*soltype.LifetimeVar]occPolarity{},
 		noElide: set.NewSet[*soltype.LifetimeVar](),
+		shared:  set.NewSet[*soltype.LifetimeVar](),
+		negSeen: map[*soltype.LifetimeVar]int{},
 	}
 	t.Accept(v, pol)
-	return v.occ, v.noElide
+	return v.occ, v.noElide, v.shared
 }
 
 // ltAnalysis is the precomputed input the rewriter reads: per-variable structural
@@ -148,6 +194,7 @@ func walkLtOcc(t soltype.Type, pol soltype.Polarity) (map[*soltype.LifetimeVar]o
 type ltAnalysis struct {
 	occ      map[*soltype.LifetimeVar]occPolarity
 	noElide  set.Set[*soltype.LifetimeVar] // lifetimes a complement encloses; never elided
+	shared   set.Set[*soltype.LifetimeVar] // lifetimes written at two or more borrows; never elided
 	bs       *ltBoundSet                   // condensed outlives graph; rep IDs collapse mutual-outlives cycles
 	comp     map[int]int                   // representative ID -> connected-component leader ID in bs
 	posComps set.Set[int]                  // component leaders reaching a positive occurrence
@@ -168,7 +215,10 @@ type ltAnalysis struct {
 // the other along outlives edges. Condensing mutual-outlives cycles to one
 // representative first is what leaves a DAG for reduce and for the directional bound
 // rendering that layers on top.
-func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity, noElide set.Set[*soltype.LifetimeVar]) *ltAnalysis {
+func newLtAnalysis(
+	occ map[*soltype.LifetimeVar]occPolarity,
+	noElide, shared set.Set[*soltype.LifetimeVar],
+) *ltAnalysis {
 	bs := buildLtBoundSet(occ)
 	comp := bs.weakComponents()
 
@@ -182,7 +232,7 @@ func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity, noElide set.Set[*so
 			posComps.Add(comp[bs.repOf(v.ID)])
 		}
 	}
-	return &ltAnalysis{occ: occ, noElide: noElide, bs: bs, comp: comp, posComps: posComps}
+	return &ltAnalysis{occ: occ, noElide: noElide, shared: shared, bs: bs, comp: comp, posComps: posComps}
 }
 
 // isParam reports whether v is a param lifetime: one that originates at a borrow
@@ -250,7 +300,7 @@ func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, eli
 		return soltype.Static, false
 	}
 	if a.isParam(v) {
-		if a.kept(v) || a.noElide.Contains(v) {
+		if a.kept(v) || a.noElide.Contains(v) || a.shared.Contains(v) {
 			return v, false // a named param renders under its own quantified name
 		}
 		return nil, true // connect-nothing param: elide
@@ -295,11 +345,11 @@ func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, eli
 // relation between them. pol is the polarity t was built at, threaded so the occurrence
 // walk starts from the same root.
 func ltOutlivesRelation(t soltype.Type, pol soltype.Polarity) (*ltAnalysis, []*soltype.LifetimeVar, func(u, w *soltype.LifetimeVar) bool) {
-	occ, noElide := walkLtOcc(t, pol)
+	occ, noElide, shared := walkLtOcc(t, pol)
 	if len(occ) == 0 {
 		return nil, nil, nil
 	}
-	a := newLtAnalysis(occ, noElide)
+	a := newLtAnalysis(occ, noElide, shared)
 	bs := a.bs
 
 	survivors := slices.Collect(maps.Keys(occ))

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -102,17 +102,24 @@ func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 // reaches no output. `fn f<'a>(x: &'a mut B, y: &'a mut B)` renders its `'a` for that reason,
 // while the single-write `fn f(x: &mut B)` elides. A write is any of the three positions
 // EnterType records: a borrow's lifetime slot and an alias or class reference's lifetime
-// argument, so `fn f<'a>(a: mut Holder<'a>, b: mut Holder<'a>)` counts too. negSeen is the
-// running count that second entry is derived from.
+// argument, so `fn f<'a>(a: mut Holder<'a>, b: mut Holder<'a>)` counts too. negPolSeen is the
+// running per-lifetime tally that second entry is derived from.
 //
 // Only a parameter lifetime enters by the second route, since the count runs in the negative
 // arm alone. resolveLt relies on that: its non-param branch reads noElide to mean the
 // complement case, which is the only one that can reach it.
 type ltOccVisitor struct {
-	occ      map[*soltype.LifetimeVar]occPolarity
-	noElide  set.Set[*soltype.LifetimeVar]
-	negSeen  map[*soltype.LifetimeVar]int
-	negDepth int
+	occ     map[*soltype.LifetimeVar]occPolarity
+	noElide set.Set[*soltype.LifetimeVar]
+	// negPolSeen counts how many times each lifetime is written at NEGATIVE POLARITY, the
+	// position a borrow the caller supplies sits in. The second write is what puts the
+	// lifetime in noElide. A nested function type flips polarity, so a borrow written at a
+	// CALLBACK's parameter is positive and does not count here.
+	//
+	// negDepth below counts enclosing NegationType nodes. The two share a prefix and nothing
+	// else: negPolSeen is about polarity, negDepth is about complements.
+	negPolSeen map[*soltype.LifetimeVar]int
+	negDepth   int
 }
 
 func (v *ltOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
@@ -158,8 +165,8 @@ func (v *ltOccVisitor) record(lt soltype.Lifetime, pol soltype.Polarity) {
 		v.occ[lv] |= occPos
 	} else {
 		v.occ[lv] |= occNeg
-		v.negSeen[lv]++
-		if v.negSeen[lv] > 1 {
+		v.negPolSeen[lv]++
+		if v.negPolSeen[lv] > 1 {
 			v.noElide.Add(lv)
 		}
 	}
@@ -184,9 +191,9 @@ func walkLtOcc(t soltype.Type, pol soltype.Polarity) (
 	set.Set[*soltype.LifetimeVar],
 ) {
 	v := &ltOccVisitor{
-		occ:     map[*soltype.LifetimeVar]occPolarity{},
-		noElide: set.NewSet[*soltype.LifetimeVar](),
-		negSeen: map[*soltype.LifetimeVar]int{},
+		occ:        map[*soltype.LifetimeVar]occPolarity{},
+		noElide:    set.NewSet[*soltype.LifetimeVar](),
+		negPolSeen: map[*soltype.LifetimeVar]int{},
 	}
 	t.Accept(v, pol)
 	return v.occ, v.noElide

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -91,7 +91,7 @@ func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 // output and still have to keep their name.
 //
 // A complement encloses the first kind. A complemented borrow reaching no output is
-// genuinely connect-nothing, and the elision rule above drops those. Eliding under a
+// genuinely connect-nothing, and a lifetime reaching no output is dropped. Eliding under a
 // complement changes the type rather than merely dropping a name, since `~(&'a T)` rendered
 // as `~(&T)` is the complement of any borrow of T rather than of the `'a` one.
 //

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -151,10 +151,9 @@ func (c *checker) resolveComponentEscapes(
 // so it sees every alias the recording sites listed at the top of this file record. An alias
 // formed by a path none of them covers is invisible here exactly as it is to the escape check.
 // `a.peers.push(&mut b)` is such a path. The store recorder reads a callee's explicit
-// parameters and matches the two sides of a store by a shared lifetime variable, and a method
-// call supplies neither: its receiver is stripped off the signature the call site sees, and
-// its lifetimes reach that signature anonymized. It is tracked under "Deferred and out of
-// scope" in planning/affine_semantics/implementation_plan.md.
+// parameters, and `.push` stores into the receiver, which memberValue strips off the
+// signature the call site sees. It is tracked under "Deferred and out of scope" in
+// planning/affine_semantics/implementation_plan.md.
 func (c *checker) componentMoveCovers(
 	e ast.Expr, escaping set.Set[liveness.VarID],
 	stmtRef liveness.StmtRef,

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -1081,21 +1081,19 @@ places), PR 14 (the C2 mut-context flag the borrow-leaf upgrade's invariance rid
 
   records a → b at [peer], so the escape check and the connected-component move see the alias.
 
-  `a.peers.push(&mut b)`, the canonical container case, is not covered. No method call records
-  a store today, and four pieces are missing. First, `Array<T>` and its method surface:
-  `internal/solver` has no `Array` type and no array/tuple method calls, and both arrive with
-  the M7.5 library-type ingestion
+  A method call records a store through its explicit parameters, since a lifetime written at
+  two borrows survives the coalescing `freezeClassBody` applies to each member's signature.
+  `a.peers.push(&mut b)`, the canonical container case, is still not covered, because it
+  stores into the `self` receiver. Three pieces are missing. First, `Array<T>` and its method
+  surface: `internal/solver` has no `Array` type and no array/tuple method calls, and both
+  arrive with the M7.5 library-type ingestion
   ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7.5). Second, a
-  lifetime parameter on the container type, so `Array<'a, T>` can tie the element borrow to the
-  receiver; a class declares no lifetime parameters today, and neither can an object type's
-  method signature name a lifetime its enclosing signature binds. Third, the receiver type at
-  the call site: `memberValue` hands the call a signature with its `SelfParam` stripped, so
-  the recorder has no receiver to search for the shared lifetime. Fourth, named lifetimes on a
-  method signature at all: a method reaches the call site with its lifetimes coalesced to the
-  anonymous display lifetime, so the two sides of a store share nothing the search can match,
-  which is why even a store through a method's explicit parameter goes unrecorded. This is what
-  keeps the requirements' canonical cyclic `build()` from being expressible as written: the
-  `.push` edges that wire the graph are never recorded, so the escape check sees no borrows to
+  lifetime parameter on the container type, so `Array<'a, T>` can tie the element borrow to
+  the receiver; a class declares no lifetime parameters today. Third, the receiver type at the
+  call site: `memberValue` hands the call a signature with its `SelfParam` stripped, so the
+  recorder has no receiver to search for the shared lifetime. This is what keeps the
+  requirements' canonical cyclic `build()` from being expressible as written: the `.push`
+  edges that wire the graph are never recorded, so the escape check sees no borrows to
   co-move.
 
 ## Testing approach

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -226,8 +226,8 @@ that would introduce new PRs:
   lists as deferred and out of scope. It is blocked on the stdlib `Array`
   type and method surface, delivered by
   [M7.5 PR5](../simple_sub/m7.5-implementation-plan.md#pr5--a-real-arrayt-and-the-well-known-handle-mechanism),
-  a lifetime parameter on the container type, the receiver's own type at
-  the call site, and named lifetimes on a method signature.
+  a lifetime parameter on the container type, and the receiver's own type
+  at the call site.
   That is **not this workstream's work** — until it lands, curation
   applies only the `move` spelling, and the `escape` facts for
   borrow-holding containers wait on it. Tracked here as an external

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1364,16 +1364,15 @@ a desugaring rule — rather than opaque placeholders.
   parameters, driven by a lifetime the argument-borrow shares with a position inside another
   parameter's referent
   ([internal/solver/borrow_store.go](../../internal/solver/borrow_store.go)). A borrow stored
-  into a container by a method call — `a.peers.push(&mut b)` — is still invisible: it stores
-  into the `self` receiver rather than a parameter, and a method signature reaches the call
-  site with its lifetimes anonymized either way. That is why the affine
+  into a container by a method call — `a.peers.push(&mut b)` — is still invisible, since it
+  stores into the `self` receiver rather than a parameter. That is why the affine
   requirements' canonical cyclic `build()`, which wires the graph with `.push`, is not yet
   expressible. This milestone is the prerequisite: it resolves `Array<T>` and its method
   surface (`push`, …), which `internal/solver` has no representation for today — there is no
   `Array` type and no array/tuple method call. What remains after it — a lifetime parameter on
-  the container type to tie the element borrow to the receiver, the receiver's own type at the
-  call site, which `memberValue` strips, and named lifetimes on a method signature — is affine
-  work tracked under "Deferred and out of scope" in
+  the container type to tie the element borrow to the receiver, and the receiver's own type at
+  the call site, which `memberValue` strips — is affine work tracked under "Deferred and out
+  of scope" in
   [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md).
   Recorded here so the dependency is visible from the milestone that unblocks it.
 


### PR DESCRIPTION
Refs #1210. Stacked on #1212 — review that one first.

This is item 4 of the four pieces #1210 needs. It makes a method's store visible to the borrow-edge recorder #1212 adds.

## The rule

The display-time lifetime pass elided a param lifetime whose connected component reached no output, on the reading that such a borrow connects nothing. A lifetime written at two borrows does connect something. Repeating one name says the regions are the same, which the caller has to satisfy whether or not the borrow reaches a return. Rust keeps such a lifetime for the same reason.

```
declare fn pair<'a>(x: &'a mut B, y: &'a mut B) -> undefined
```

renders `fn <'a>(x: &'a mut B, y: &'a mut B) -> undefined` instead of dropping both names to bare `&mut`.

## Why it matters here

`freezeClassBody` coalesces each member's signature into the class body. A method that stored an argument-borrow into another argument therefore reached the call site with both lifetimes already anonymized, so the store recorder found nothing to match and no method call recorded an edge. With the rule in place a method call records the same edge the equivalent free function does, which `TestMethodCallStoreEdge` pins.

## A second gap the same change closes

The occurrence walk counted a lifetime only where a borrow wrote it, never where an alias or class reference wrote it as a lifetime argument. `Holder<'a>` writes `'a`, so a signature naming it there and at a borrow ties the two together. Counting only borrows produced incoherent renderings:

```
fn f<'a>(p: Ref<'a, {x: number}>) -> &'a {x: number} { return p }
```

rendered as `fn <'a>(p: Ref<'a, {x: number}>) -> &{x: number}` — a return that named no lifetime its parameter supplied, with `'a` still quantified. Both halves now render under one name.

## What is left for `a.peers.push(&mut b)`

Three pieces, tracked in `planning/affine_semantics/implementation_plan.md`: an `Array` type with a method surface, a lifetime parameter on the container type, and the receiver's own type at the call site, which `memberValue` strips.

## Tests

- `TestInferSharedParamLifetimeIsNamed` — two params sharing a lifetime keep it, one param repeating its own lifetime keeps it, a single borrow reaching no output still elides.
- `TestMethodCallStoreEdge` — a method call records the store edge, and dropping the call isolates its effect.
- `TestInferLifetimeGenericAliasIsTransparent` and the store-edge expectations updated to the coherent renderings.

Full `go test ./...` passes.

## Not addressed

`escapingLocalsOf` follows borrow-graph edges only when the whole outgoing expression is a place, so `return {v: a.peer}` misses a dangling borrow that `return a.peer` reports. That is pre-existing and affects all five recording sites, not just stores, so it wants its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8Ud86QkLyDRhGUdrXwA7d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved lifetime inference so shared lifetimes remain visible and correctly preserved across aliases, nested borrows, and complex type signatures.
  - Enhanced borrow tracking for method calls that store values passed through explicit parameters.
  - Refined lifetime elision behavior to avoid removing lifetimes needed to describe relationships between parameters.

- **Documentation**
  - Clarified current method-call borrow-tracking behavior and remaining limitations.
  - Updated implementation guidance to reflect the latest lifetime support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->