### PR TITLE
Give a class its own lifetime parameters

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -285,7 +285,7 @@ func PrintAsSchemeWith(
 	//
 	// Name each 'a, 'b, … in first-appearance order and add it to the quantifier prefix
 	// after the type parameters.
-	ltVars := freeLifetimeVars(t)
+	ltVars := declaredLtsFirst(freeLifetimeVars(t), declaredLts)
 	ltNames := map[*LifetimeVar]string{}
 	ltIndex := map[*LifetimeVar]int{}
 	// A lifetime the declaration named keeps that name, the lifetime twin of the declared
@@ -364,6 +364,32 @@ func PrintAsSchemeWith(
 	// one prefix form cannot be split by a following operator, so it needs none: the
 	// class-constructor rendering stays `<T> {new (value: T) -> Node<T>}`.
 	return prefix + " " + p.printTypeMinPrec(t, precPrefix)
+}
+
+// declaredLtsFirst returns free with the lifetimes a declaration names moved to the front, in
+// the order the declaration wrote them, and the rest left in first-appearance order. The
+// quantifier prefix then reads in the same order as the argument list a reference writes, so
+// `class Pair<'x, 'y>` renders `<'x, 'y>` whichever field mentions 'y first. It is the
+// lifetime twin of the declared-first ordering the type-parameter labels take.
+func declaredLtsFirst(free []*LifetimeVar, declared []*LifetimeParam) []*LifetimeVar {
+	if len(declared) == 0 {
+		return free
+	}
+	present := set.FromSlice(free)
+	taken := set.NewSet[*LifetimeVar]()
+	out := make([]*LifetimeVar, 0, len(free))
+	for _, lp := range declared {
+		if present.Contains(lp.Var) && !taken.Contains(lp.Var) {
+			taken.Add(lp.Var)
+			out = append(out, lp.Var)
+		}
+	}
+	for _, lv := range free {
+		if !taken.Contains(lv) {
+			out = append(out, lv)
+		}
+	}
+	return out
 }
 
 // lifetimeBinder renders one lifetime binder in the quantifier prefix: the bare name

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -169,7 +169,7 @@ func PrintElided(t Type, maxDepth int) string {
 // PrintAsSchemeWith, which the solver's renderScheme does. Use renderScheme, not
 // PrintAsScheme, to display a solver scheme that may carry borrow lifetimes.
 func PrintAsScheme(t Type) string {
-	return PrintAsSchemeWith(t, func(*TypeVarType) bool { return true }, nil, nil)
+	return PrintAsSchemeWith(t, func(*TypeVarType) bool { return true }, nil, nil, nil)
 }
 
 // PrintWithParams renders a type like Print, naming each variable in declared under the
@@ -230,6 +230,7 @@ func PrintAsSchemeWith(
 	isParam func(*TypeVarType) bool,
 	ltBounds map[*LifetimeVar][]*LifetimeVar,
 	declared []*TypeParam,
+	declaredLts []*LifetimeParam,
 ) string {
 	p := &namedPrinter{}
 	// A function's own type parameters claim their source names before anything else, so a
@@ -287,14 +288,32 @@ func PrintAsSchemeWith(
 	ltVars := freeLifetimeVars(t)
 	ltNames := map[*LifetimeVar]string{}
 	ltIndex := map[*LifetimeVar]int{}
+	// A lifetime the declaration named keeps that name, the lifetime twin of the declared
+	// type parameters above, so `class Pair<'x, 'y>` renders under 'x and 'y rather than
+	// taking the generated 'a and 'b. A generated name skips one a declaration claims, the
+	// way it skips a name a function's own parameter claims.
+	declaredLtNames := map[*LifetimeVar]string{}
+	for _, lp := range declaredLts {
+		if lp.Name != "" {
+			declaredLtNames[lp.Var] = lp.Name
+		}
+	}
 	// A function's own lifetime parameters keep their source names in the prefix, and a
 	// free lifetime gets a generated name from the same 'a, 'b, … alphabet, so a generated
 	// name must skip any source name a parameter already claims. Without this a captured
 	// 'a and a declared 'a would both render as 'a. The type-parameter loop above skips a
 	// claimed name the same way.
 	reserved := ownLifetimeParamNames(t)
+	for _, name := range declaredLtNames {
+		reserved.Add(name)
+	}
 	nextLt := 0
 	for i, lv := range ltVars {
+		ltIndex[lv] = i
+		if declaredName, ok := declaredLtNames[lv]; ok {
+			ltNames[lv] = declaredName
+			continue
+		}
 		name := lifetimeParamName(nextLt)
 		for reserved.Contains(name) {
 			nextLt++
@@ -302,7 +321,6 @@ func PrintAsSchemeWith(
 		}
 		nextLt++
 		ltNames[lv] = name
-		ltIndex[lv] = i
 	}
 	if len(labels) == 0 && len(ltVars) == 0 {
 		// No quantified parameters: render as a plain (possibly raw-var) type, which

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -810,7 +810,7 @@ func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
 		Params: []*FuncParam{identP("x", param)},
 		Ret:    &TupleType{Elems: []Type{param, leaked}},
 	}
-	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 }, nil, nil)
+	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 }, nil, nil, nil)
 	require.Equal(t, "fn <T0>(x: T0) -> [T0, t99]", got)
 }
 
@@ -832,7 +832,7 @@ func TestPrintSchemeDeclaredNames(t *testing.T) {
 			Params: []*FuncParam{identP("value", tv), identP("tail", node)},
 			Ret:    node,
 		})
-		got := PrintAsSchemeWith(obj, quantified, nil, []*TypeParam{{Name: "T", Var: tv}})
+		got := PrintAsSchemeWith(obj, quantified, nil, []*TypeParam{{Name: "T", Var: tv}}, nil)
 		require.Equal(t, "<T> {new (value: T, tail: Node<T>) -> Node<T>}", got)
 	})
 
@@ -847,7 +847,7 @@ func TestPrintSchemeDeclaredNames(t *testing.T) {
 			Ret:    pair,
 		})
 		got := PrintAsSchemeWith(obj, quantified, nil,
-			[]*TypeParam{{Name: "K", Var: k}, {Name: "V", Var: v}})
+			[]*TypeParam{{Name: "K", Var: k}, {Name: "V", Var: v}}, nil)
 		require.Equal(t, "<K, V> {new (v: V, k: K) -> Pair<K, V>}", got)
 	})
 
@@ -860,7 +860,7 @@ func TestPrintSchemeDeclaredNames(t *testing.T) {
 			Params: []*FuncParam{identP("a", declared), identP("b", extra)},
 			Ret:    &ClassType{Name: "C", TypeArgs: []Type{declared}},
 		})
-		got := PrintAsSchemeWith(obj, quantified, nil, []*TypeParam{{Name: "T0", Var: declared}})
+		got := PrintAsSchemeWith(obj, quantified, nil, []*TypeParam{{Name: "T0", Var: declared}}, nil)
 		require.Equal(t, "<T0, T1> {new (a: T0, b: T1) -> C<T0>}", got)
 	})
 
@@ -874,7 +874,7 @@ func TestPrintSchemeDeclaredNames(t *testing.T) {
 			Ret:    &ClassType{Name: "C", TypeArgs: []Type{tv}},
 		})
 		got := PrintAsSchemeWith(obj, quantified, nil,
-			[]*TypeParam{{Name: "T", Var: tv}, {Name: "E", Var: leaked}})
+			[]*TypeParam{{Name: "T", Var: tv}, {Name: "E", Var: leaked}}, nil)
 		require.Equal(t, "<T> {new (a: T, b: t99) -> C<T>}", got)
 	})
 
@@ -891,7 +891,7 @@ func TestPrintSchemeDeclaredNames(t *testing.T) {
 				Ret:        outer,
 			}}},
 		}}
-		got := PrintAsSchemeWith(obj, quantified, nil, []*TypeParam{{Name: "T", Var: outer}})
+		got := PrintAsSchemeWith(obj, quantified, nil, []*TypeParam{{Name: "T", Var: outer}}, nil)
 		require.Equal(t, "<T> {v: T, m<T_2>(x: T_2) -> T}", got)
 	})
 }

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -219,6 +219,14 @@ func (c *checker) inferAliasBody(sh *aliasShell) {
 	c.namedLifetimes = sh.namedLts
 	defer func() { c.namedLifetimes = savedNamedLts }()
 
+	// A signature nested in the body binds its own lifetimes and would otherwise start from
+	// nothing, so `type Box<'a> = fn (x: &'a B) -> &'a B` would mint an `'a` of its own and
+	// leave the alias's parameter naming nothing. Hand the nested scope the alias's declared
+	// parameters, the same way a class body does for its members.
+	savedDeclLts := c.declLifetimes
+	c.declLifetimes = declaredLifetimeScope(sh.decl.LifetimeParams, sh.def.LifetimeParams)
+	defer func() { c.declLifetimes = savedDeclLts }()
+
 	// A nil TypeAnn is parser error recovery for `type Foo =`, already reported. Bind a
 	// fresh var and skip resolveTypeAnn, since a nil annotation has no span to report on.
 	quiet := c.errorWindow()

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -158,7 +158,7 @@ func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns str
 		declScope = scope.Child()
 		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
 	}
-	lifetimeParams := c.resolveAliasLifetimeParams(lvl, decl.LifetimeParams)
+	lifetimeParams := c.resolveLifetimeParams(lvl, decl.LifetimeParams)
 	aliasNamedLts := c.namedLifetimes
 	c.namedLifetimes = savedNamedLts
 
@@ -184,9 +184,10 @@ func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns str
 	}
 }
 
-// resolveAliasLifetimeParams mints one lifetime variable per `<'a, ...>` parameter through
+// resolveLifetimeParams mints one lifetime variable per `<'a, ...>` parameter through
 // namedLifetime, so a `&'a` in the body resolved under the same scope reaches that variable.
-func (c *checker) resolveAliasLifetimeParams(lvl int, ltParams []*ast.LifetimeParam) []*soltype.LifetimeParam {
+// An alias and a class both quantify lifetimes this way, so both bind their parameters here.
+func (c *checker) resolveLifetimeParams(lvl int, ltParams []*ast.LifetimeParam) []*soltype.LifetimeParam {
 	if len(ltParams) == 0 {
 		return nil
 	}
@@ -251,7 +252,7 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 			kind = EnumDeclKind
 		}
 	}
-	ltArgs := c.resolveAliasLifetimeArgs(ref, kind, ltParams, lvl)
+	ltArgs := c.resolveLifetimeArgs(ref, kind, ltParams, lvl)
 	args := c.resolveTypeArgs(scope, ref, kind, params, arityOfParams(params), lvl)
 	if len(args) == 0 {
 		// A non-generic alias carries no type arguments; any that were supplied are reported
@@ -266,10 +267,11 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 	return &soltype.AliasType{Name: at.Name, TypeArgs: args, LifetimeArgs: ltArgs}
 }
 
-// resolveAliasLifetimeArgs resolves a reference's `<'a, ...>` lifetime arguments and checks
-// their count against the alias's lifetime parameters, which have no default. A mismatch
-// reports a LifetimeArgArityMismatchError and recovers with fresh lifetimes.
-func (c *checker) resolveAliasLifetimeArgs(ref *ast.TypeRefTypeAnn, kind TypeDeclKind, ltParams []*soltype.LifetimeParam, lvl int) []soltype.Lifetime {
+// resolveLifetimeArgs resolves a reference's `<'a, ...>` lifetime arguments and checks their
+// count against the referenced declaration's lifetime parameters, which have no default. A
+// mismatch reports a LifetimeArgArityMismatchError and recovers with fresh lifetimes. An
+// alias reference and a class reference are checked the same way, so both resolve here.
+func (c *checker) resolveLifetimeArgs(ref *ast.TypeRefTypeAnn, kind TypeDeclKind, ltParams []*soltype.LifetimeParam, lvl int) []soltype.Lifetime {
 	total := len(ltParams)
 	got := len(ref.LifetimeArgs)
 	if got != total {

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -35,8 +35,7 @@ import (
 // before the recorder runs.
 //
 // So `a.peers.push(&mut b)`, the container case this exists for, is not covered. It needs an
-// `Array` type with a method surface, a lifetime parameter on the container tying the element
-// borrow to the receiver, and the receiver's type at the call site.
+// `Array` type with a method surface and the receiver's type at the call site.
 type storeEdge struct {
 	// arg is the index of the argument whose borrow the call stores.
 	arg int
@@ -211,11 +210,12 @@ type lifetimeWalk struct {
 //   - An object descends each named property at base plus that name. A member that names no
 //     field of its own descends at base, attributing what it holds to the enclosing object.
 //     walkObjElem says which members those are.
-//   - A tuple element, an array element, a class type argument, and a promise or generator
-//     payload descend at base unchanged. None of them contributes a name, since the place
-//     model has no index segment and neither a class type argument nor a payload is
+//   - A tuple element, an array element, a class type or lifetime argument, and a promise or
+//     generator payload descend at base unchanged. None of them contributes a name, since the
+//     place model has no index segment and neither a class argument nor a payload is
 //     addressable as a field. So `&'c mut Box<&'a mut B>` stores at the whole Box, which is
-//     where a class holding a borrowed element lands.
+//     where a class holding a borrowed element lands, and so does the `&'c mut Holder<'a>` a
+//     class lifetime parameter spells.
 //   - A union or intersection descends each member at base, since a borrow any member holds is
 //     reachable through the whole.
 //   - An alias descends its expansion at base. An alias is transparent, so `Holder<'a>` is
@@ -223,9 +223,7 @@ type lifetimeWalk struct {
 //
 // Any other kind stops the walk there, so the call reads as storing nothing through it. That
 // silence is deliberate, unlike the truncation an allowance causes: the kind holds no
-// field-addressable borrow. One case is worth naming. A class LIFETIME argument, the `'a` of `Box<'a, T>` rather
-// than the type argument this walk does descend, is unreachable because a class declares no
-// lifetime parameters. It wants an arm here once one can be written.
+// field-addressable borrow.
 func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 	if t == nil || w.onPath.Contains(t) {
 		return
@@ -269,6 +267,11 @@ func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 	case *soltype.ClassType:
 		for _, arg := range t.TypeArgs {
 			w.walk(arg, base)
+		}
+		for _, arg := range t.LifetimeArgs {
+			if lv, ok := arg.(*soltype.LifetimeVar); ok {
+				w.visit(lv, base)
+			}
 		}
 	case *soltype.UnionType:
 		for _, member := range t.Types {

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -503,6 +503,15 @@ func (c *Context) constrainNominalWalk(sub, super *soltype.ClassType, seen *seen
 	if sub.Name == super.Name {
 		def, _ := c.classDef(sub.Name)
 		var errs []SolverError
+		// Relate the lifetime arguments as equal regions. A class records no per-parameter
+		// variance for the lifetime sort, so each argument is invariant: `Holder<'x>` reaches
+		// `Holder<'static>` only when the two lifetimes outlive each other. Constraining one
+		// direction alone would let a caller launder a short region into a long one through
+		// the nominal name, which the structural twin `{peer: &'x mut B}` rejects.
+		for i := range min(len(sub.LifetimeArgs), len(super.LifetimeArgs)) {
+			c.constrainLt(sub.LifetimeArgs[i], super.LifetimeArgs[i])
+			c.constrainLt(super.LifetimeArgs[i], sub.LifetimeArgs[i])
+		}
 		n := min(len(sub.TypeArgs), len(super.TypeArgs))
 		for i := range n {
 			variance := def.varianceAt(i, mutCtx)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -38,7 +38,7 @@ func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	// symbolic keeps a rank-2 callback type such as `<T>(x: T) -> T` intact instead of
 	// inlining its `T` binder to never. acceptTypeParamVar panics on a non-variable binder.
 	// funcTypeParamVars is empty for a monomorphic type, so this is inert on the common path.
-	return coalesceKeeping(t, pol, funcTypeParamVars(t), nil)
+	return coalesceKeeping(t, pol, funcTypeParamVars(t), nil, nil)
 }
 
 // groundedCarrier reports the shape of t, looking through any borrow and resolving t if it is
@@ -78,10 +78,19 @@ func carrierIsVar(t soltype.Type) bool {
 // `read`'s return as `T` rather than collapsing the intermediate var to `never`.
 // projectClassMember then substitutes `T` for the instance's argument. A nil keep and nil
 // flow reduce it to the plain uniform-inlining coalesce.
-func coalesceKeeping(t soltype.Type, pol soltype.Polarity, keep set.Set[*soltype.TypeVarType], flow map[*soltype.TypeVarType][]*soltype.TypeVarType) soltype.Type {
+func coalesceKeeping(
+	t soltype.Type,
+	pol soltype.Polarity,
+	keep set.Set[*soltype.TypeVarType],
+	flow map[*soltype.TypeVarType][]*soltype.TypeVarType,
+	keepLts set.Set[*soltype.LifetimeVar],
+) soltype.Type {
 	c := t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType](), keep: keep, flow: flow}, pol)
-	c = bubbleOwnedMut(c)            // #779: lift an owned-mut cell out of an immutable container
-	return coalesceLifetimes(c, pol) // D4: resolve borrow lifetimes to their display form
+	c = bubbleOwnedMut(c) // #779: lift an owned-mut cell out of an immutable container
+	// D4: resolve borrow lifetimes to their display form, holding keepLts under their own
+	// names so a lifetime the enclosing declaration quantifies survives the member's own
+	// occurrence count.
+	return coalesceLifetimes(c, pol, keepLts)
 }
 
 // muBinders turns a cycle in the bound graph into a finite μ-knot. Both coalescers embed it, so
@@ -429,7 +438,7 @@ func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 	}, soltype.Positive)
 	c = bubbleOwnedMut(c) // #779: lift an owned-mut cell out of an immutable container
 	// A scheme display is always coalesced from the Positive root.
-	return coalesceLifetimes(c, soltype.Positive) // D4: resolve borrow lifetimes to their display form
+	return coalesceLifetimes(c, soltype.Positive, nil) // D4: resolve borrow lifetimes to their display form
 }
 
 // funcTypeParamVars collects every generic function's own TypeParams binder var
@@ -731,6 +740,57 @@ func (c *checker) declaredTypeParams(t soltype.Type) []*soltype.TypeParam {
 		}
 	}
 	return nil
+}
+
+// declaredLifetimeParams returns the lifetime parameters written by the declaration a display
+// type stands for, or nil when it stands for none. It is the lifetime-sort twin of
+// declaredTypeParams and reads the same three carriers: a class handle, an alias handle, and
+// the class-value object whose constructor returns the handle.
+func (c *checker) declaredLifetimeParams(t soltype.Type) []*soltype.LifetimeParam {
+	switch t := t.(type) {
+	case *soltype.ClassType:
+		if def, ok := c.ctx.classDef(t.Name); ok {
+			return ltParamsForArgs(def.LifetimeParams, t.LifetimeArgs)
+		}
+	case *soltype.AliasType:
+		if def, ok := c.ctx.aliasDef(t.Name); ok {
+			return ltParamsForArgs(def.LifetimeParams, t.LifetimeArgs)
+		}
+	case *soltype.ObjectType:
+		for _, elem := range t.Elems {
+			ctor, isCtor := elem.(*soltype.ConstructorElem)
+			if !isCtor {
+				continue
+			}
+			if cls, isClass := ctor.Fn.Ret.(*soltype.ClassType); isClass {
+				return c.declaredLifetimeParams(cls)
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+// ltParamsForArgs returns lps with each parameter's variable replaced by the variable a
+// reference passes in that argument position, the lifetime-sort twin of paramsForArgs and
+// for the reason it gives. A position holding 'static or an anonymous lifetime keeps the
+// parameter as declared, as does a reference whose argument count does not match.
+func ltParamsForArgs(lps []*soltype.LifetimeParam, args []soltype.Lifetime) []*soltype.LifetimeParam {
+	if len(args) != len(lps) {
+		return lps
+	}
+	out := make([]*soltype.LifetimeParam, len(lps))
+	for i, lp := range lps {
+		v, isVar := args[i].(*soltype.LifetimeVar)
+		if !isVar || v == lp.Var {
+			out[i] = lp
+			continue
+		}
+		cp := *lp
+		cp.Var = v
+		out[i] = &cp
+	}
+	return out
 }
 
 // paramsForArgs returns tps with each parameter's variable replaced by the variable a

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -668,7 +668,7 @@ func schemeType(s TypeScheme) soltype.Type {
 // It passes the printer no source names, so a class value binding's parameters render
 // positionally. renderSchemeWith renders them under the names the declaration wrote.
 func renderScheme(s TypeScheme) string {
-	return renderSchemeWith(s, nil)
+	return renderSchemeWith(s, nil, nil)
 }
 
 // renderSchemeWith renders a scheme like renderScheme, under the source names of the type
@@ -677,7 +677,11 @@ func renderScheme(s TypeScheme) string {
 // scheme's display type. It is called with that type once it is derived, since the lookup
 // reads the class or alias the type names. Pass nil to name nothing from the source, which
 // is right for every function: a FuncType carries its own parameters and names them itself.
-func renderSchemeWith(s TypeScheme, declaredFor func(soltype.Type) []*soltype.TypeParam) string {
+func renderSchemeWith(
+	s TypeScheme,
+	declaredFor func(soltype.Type) []*soltype.TypeParam,
+	declaredLtsFor func(soltype.Type) []*soltype.LifetimeParam,
+) string {
 	var t soltype.Type
 	// A MonoScheme coalesces to a var-free type, so every free variable left in it is a
 	// parameter. A PolyScheme names only the variables generalization quantified — those with
@@ -699,14 +703,19 @@ func renderSchemeWith(s TypeScheme, declaredFor func(soltype.Type) []*soltype.Ty
 	if declaredFor != nil {
 		declared = declaredFor(t)
 	}
-	return soltype.PrintAsSchemeWith(t, isParam, displayLtBounds(t, soltype.Positive), declared)
+	var declaredLts []*soltype.LifetimeParam
+	if declaredLtsFor != nil {
+		declaredLts = declaredLtsFor(t)
+	}
+	return soltype.PrintAsSchemeWith(t, isParam, displayLtBounds(t, soltype.Positive), declared, declaredLts)
 }
 
-// renderValueBinding renders a value binding's scheme under the source type-parameter names
-// of the declaration it came from, so `class Node<T> {value: T}` binds a value that renders
-// `<T> {new (value: T) -> Node<T>}`.
+// renderValueBinding renders a value binding's scheme under the source parameter names of the
+// declaration it came from, both sorts, so `class Node<T> {value: T}` binds a value that
+// renders `<T> {new (value: T) -> Node<T>}` and `class Pair<'x, 'y>` keeps 'x and 'y rather
+// than taking the generated 'a and 'b.
 func (c *checker) renderValueBinding(s TypeScheme) string {
-	return renderSchemeWith(s, c.declaredTypeParams)
+	return renderSchemeWith(s, c.declaredTypeParams, c.declaredLifetimeParams)
 }
 
 // declaredTypeParams returns the type parameters written by the declaration a display type

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2028,7 +2028,20 @@ type UndeclaredLifetimeError struct {
 	Name        string
 	Suggestions []string // nearest declared siblings by edit distance; empty when none is close
 	hasClause   bool     // whether the signature carries any `<…>` binder at all
-	span        ast.Span
+	// binder names what the missing `<…>` clause belongs to, so the hint points at the
+	// declaration the reader has to edit. Empty reads as "function signature", the case a
+	// signature's own scan reports; a class field's scan names the class instead.
+	binder string
+	span   ast.Span
+}
+
+// binderOrDefault resolves the binder label the hint names, defaulting to the function
+// signature a use inside one belongs to.
+func (e *UndeclaredLifetimeError) binderOrDefault() string {
+	if e.binder == "" {
+		return "function signature"
+	}
+	return e.binder
 }
 
 func (*UndeclaredLifetimeError) isSolverError()        {}
@@ -2039,7 +2052,7 @@ func (e *UndeclaredLifetimeError) Message() string {
 	msg := "lifetime '" + e.Name + " is used but not declared"
 	switch {
 	case !e.hasClause:
-		msg += "; add `<'" + e.Name + ">` to the enclosing function signature"
+		msg += "; add `<'" + e.Name + ">` to the enclosing " + e.binderOrDefault()
 	case len(e.Suggestions) > 0:
 		msg += "; did you mean '" + strings.Join(e.Suggestions, " or '") + "?"
 	default:

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -78,13 +78,14 @@ type checker struct {
 	// same reason. The map is allocated lazily by namedLifetime on first use.
 	namedLifetimes map[string]*soltype.LifetimeVar
 
-	// classLifetimes maps each lifetime name the enclosing class binds to the variable its
-	// parameter carries. A member signature may write `&'a` with no clause of its own, so
-	// inferFunc seeds the member's own named-lifetime scope from this and
-	// checkLifetimeDeclarations reads the names as declared. It is nil outside a class body,
-	// and a member never writes into it: inferFunc copies before minting, so a member's own
-	// `'z` stays out of the class's scope and out of a sibling member's.
-	classLifetimes map[string]*soltype.LifetimeVar
+	// declLifetimes maps each lifetime name the enclosing declaration binds to the variable
+	// its parameter carries. A class and a type alias both quantify lifetimes, and a
+	// signature nested in either may write `&'a` with no clause of its own, so inferFunc and
+	// resolveFuncTypeAnn seed the nested scope from this and checkLifetimeDeclarations reads
+	// the names as declared. It is nil outside such a body, and a nested signature never
+	// writes into it: both readers copy before minting, so a name one mints stays out of the
+	// declaration's scope and out of a sibling signature's.
+	declLifetimes map[string]*soltype.LifetimeVar
 
 	// classNamespace is the dep_graph namespace of the class declaration currently
 	// being inferred, empty at the root namespace and outside any class body.

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -78,6 +78,14 @@ type checker struct {
 	// same reason. The map is allocated lazily by namedLifetime on first use.
 	namedLifetimes map[string]*soltype.LifetimeVar
 
+	// classLifetimes maps each lifetime name the enclosing class binds to the variable its
+	// parameter carries. A member signature may write `&'a` with no clause of its own, so
+	// inferFunc seeds the member's own named-lifetime scope from this and
+	// checkLifetimeDeclarations reads the names as declared. It is nil outside a class body,
+	// and a member never writes into it: inferFunc copies before minting, so a member's own
+	// `'z` stays out of the class's scope and out of a sibling member's.
+	classLifetimes map[string]*soltype.LifetimeVar
+
 	// classNamespace is the dep_graph namespace of the class declaration currently
 	// being inferred, empty at the root namespace and outside any class body.
 	// inferClassDecl sets it on entry and restores it on exit. A class-body type
@@ -183,6 +191,12 @@ type checker struct {
 type classShell struct {
 	declScope  *Scope
 	typeParams []*soltype.TypeParam
+	// lifetimeParams are the class's quantified `<'a, ...>` parameters, and namedLts is the
+	// named-lifetime scope they were minted in. inferClassDecl installs namedLts around the
+	// body walk, so a `&'a` written in a field or a member signature resolves to the same
+	// variable the parameter carries rather than minting one of its own.
+	lifetimeParams []*soltype.LifetimeParam
+	namedLts       map[string]*soltype.LifetimeVar
 	// paramsClean records that the parameters resolved with no diagnostic. The module SCC
 	// pre-pass resolves them, so a bad bound or default is reported before inferClassDecl
 	// opens its own window and only this carries that news forward. A parameter whose

--- a/internal/solver/infer_alias_lifetime_test.go
+++ b/internal/solver/infer_alias_lifetime_test.go
@@ -180,3 +180,28 @@ func TestInferLifetimeGenericAliasArityErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestAliasFuncBodySeesTheAliasLifetime covers a function type written as an alias body. The
+// body binds its own lifetimes, so without the alias's parameters in scope its `&'a` would
+// mint a lifetime of its own and the alias's `<'a>` would name nothing — the same seeding a
+// class body gives its member signatures.
+func TestAliasFuncBodySeesTheAliasLifetime(t *testing.T) {
+	values, types, errs := inferSource(t,
+		`type Box<'a> = fn (x: &'a {v: number}) -> &'a {v: number}
+		 declare fn call<'q>(b: Box<'q>, p: &'q {v: number}) -> &'q {v: number}`,
+	)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t, "fn (x: &'a {v: number}) -> &'a {v: number}", types["Box"])
+	require.Equal(t, "fn <'a>(b: Box<'a>, p: &'a {v: number}) -> &'a {v: number}", values["call"])
+}
+
+// TestAliasFuncBodyBinderShadows covers a body that rebinds the alias's name. The nested
+// binder wins, so its `'a` is a lifetime of its own and the alias's parameter reaches nothing
+// in the body — the shadowing rule a class member follows.
+func TestAliasFuncBodyBinderShadows(t *testing.T) {
+	_, types, errs := inferSource(t,
+		`type Box<'a> = fn <'a>(x: &'a {v: number}) -> &'a {v: number}`,
+	)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t, "fn (x: &{v: number}) -> &{v: number}", types["Box"])
+}

--- a/internal/solver/infer_alias_lifetime_test.go
+++ b/internal/solver/infer_alias_lifetime_test.go
@@ -190,7 +190,7 @@ func TestAliasFuncBodySeesTheAliasLifetime(t *testing.T) {
 		`type Box<'a> = fn (x: &'a {v: number}) -> &'a {v: number}
 		 declare fn call<'q>(b: Box<'q>, p: &'q {v: number}) -> &'q {v: number}`,
 	)
-	require.Empty(t, messagesWithSpan(errs))
+	require.Empty(t, messagesWithSpan(t, errs))
 	require.Equal(t, "fn (x: &'a {v: number}) -> &'a {v: number}", types["Box"])
 	require.Equal(t, "fn <'a>(b: Box<'a>, p: &'a {v: number}) -> &'a {v: number}", values["call"])
 }
@@ -202,6 +202,6 @@ func TestAliasFuncBodyBinderShadows(t *testing.T) {
 	_, types, errs := inferSource(t,
 		`type Box<'a> = fn <'a>(x: &'a {v: number}) -> &'a {v: number}`,
 	)
-	require.Empty(t, messagesWithSpan(errs))
+	require.Empty(t, messagesWithSpan(t, errs))
 	require.Equal(t, "fn (x: &{v: number}) -> &{v: number}", types["Box"])
 }

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"fmt"
+	"maps"
 	"sort"
 
 	"github.com/escalier-lang/escalier/internal/ast"
@@ -53,7 +54,26 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// The class's type parameters and the scope its body resolves in, taken from the module
 	// SCC pre-pass when there was one and resolved here when there was not.
 	paramsClean := c.classParamsClean(decl)
-	declScope, typeParams := c.classDeclScope(scope, lvl, decl)
+	declScope, shell := c.classDeclScope(scope, lvl, decl)
+	typeParams := shell.typeParams
+
+	// A member signature may write the class's `'a` without binding it itself. inferFunc and
+	// resolveFuncTypeAnn seed each nested signature's own scope from this map, so the `&'a`
+	// they resolve reaches the variable the class parameter carries rather than minting one
+	// of its own. It holds the declared parameters and nothing else: the shell's map is
+	// written only by resolveClassLifetimeParams, and every reader below copies before
+	// minting, so an undeclared name a field writes cannot intern itself as a class binder.
+	savedClassLts := c.classLifetimes
+	c.classLifetimes = shell.namedLts
+	defer func() { c.classLifetimes = savedClassLts }()
+
+	// Resolve the body under a copy of that scope, so a `&'a` written in a field reaches the
+	// class parameter while a name the body mints stays out of the shell's map. A class is
+	// only ever inferred at top level, so saving and restoring is enough to keep the scope
+	// from leaking into a sibling declaration.
+	savedNamedLts := c.namedLifetimes
+	c.namedLifetimes = maps.Clone(shell.namedLts)
+	defer func() { c.namedLifetimes = savedNamedLts }()
 
 	// The instance's nominal identity and its heavy ClassDef. getOrCreateClass returns
 	// the pair the SCC pre-pass registered for this class — an empty shell it minted
@@ -70,8 +90,10 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// resolves — fills in the resolved type params. The handle carries the class's own
 	// type-parameter vars as its arguments.
 	self.TypeArgs = typeParamVars(typeParams)
+	self.LifetimeArgs = lifetimeParamVars(shell.lifetimeParams)
 	def.Level = lvl - 1
 	def.TypeParams = typeParams
+	def.LifetimeParams = shell.lifetimeParams
 	def.Variance = make([]Variance, len(typeParams))
 	def.MutVariance = make([]Variance, len(typeParams))
 	body := def.Body
@@ -113,14 +135,18 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// lookup can substitute an instance's argument for them (B8): a plain freeze would
 	// collapse a member typed through `T`, such as `read(self) { self.v }`, to `never`
 	// because the intermediate inference var's only bound is the still-unconstrained `T`.
+	// The class's own lifetime parameters are pinned through the freeze. A field such as
+	// `peer: &'a mut B` writes 'a once and in an output position, so the elision rule would
+	// drop it and leave an instance's lifetime argument with nothing to replace.
+	keepLts := classKeepLifetimes(shell.lifetimeParams)
 	if len(typeParams) == 0 {
-		c.freezeClassBody(body, nil, nil)
-		c.freezeClassBody(static, nil, nil)
+		c.freezeClassBody(body, nil, nil, keepLts)
+		c.freezeClassBody(static, nil, nil, keepLts)
 	} else {
 		keep := classKeepVars(typeParams, body, static)
 		flow := keptFlowMap(keep)
-		c.freezeClassBody(body, keep, flow)
-		c.freezeClassBody(static, keep, flow)
+		c.freezeClassBody(body, keep, flow, keepLts)
+		c.freezeClassBody(static, keep, flow, keepLts)
 	}
 
 	// Freeze both per-parameter variance vectors once every member body has refined its
@@ -285,15 +311,41 @@ func (c *checker) getOrCreateClass(scope *Scope, decl *ast.ClassDecl, ns string)
 // parameters, reusing what preBindClassTypeParams produced for this declaration. A generic
 // class gets a child scope holding its parameters, so the body reads each `T` as the one
 // shared var the ClassDef stores. A non-generic class reuses the enclosing scope.
-func (c *checker) classDeclScope(scope *Scope, lvl int, decl *ast.ClassDecl) (*Scope, []*soltype.TypeParam) {
+func (c *checker) classDeclScope(scope *Scope, lvl int, decl *ast.ClassDecl) (*Scope, *classShell) {
 	if sh, ok := c.classShells[decl]; ok {
-		return sh.declScope, sh.typeParams
+		return sh.declScope, sh
 	}
-	if len(decl.TypeParams) == 0 {
-		return scope, nil
+	sh := &classShell{declScope: scope, paramsClean: true}
+	if len(decl.TypeParams) > 0 {
+		sh.declScope = scope.Child()
+		sh.typeParams = c.resolveTypeParams(sh.declScope, lvl, decl.TypeParams)
 	}
-	declScope := scope.Child()
-	return declScope, c.resolveTypeParams(declScope, lvl, decl.TypeParams)
+	sh.lifetimeParams, sh.namedLts = c.resolveClassLifetimeParams(lvl, decl)
+	return sh.declScope, sh
+}
+
+// resolveClassLifetimeParams mints the class's `<'a, ...>` parameters in a named-lifetime
+// scope of their own and returns both, mirroring what preBindAlias does for an alias.
+// Isolating the scope keeps one class's `'a` independent of a sibling's, and handing it back
+// lets inferClassDecl install it around the body so every `&'a` there shares one variable.
+func (c *checker) resolveClassLifetimeParams(
+	lvl int, decl *ast.ClassDecl,
+) ([]*soltype.LifetimeParam, map[string]*soltype.LifetimeVar) {
+	saved := c.namedLifetimes
+	c.namedLifetimes = nil
+	defer func() { c.namedLifetimes = saved }()
+	params := c.resolveLifetimeParams(lvl, decl.LifetimeParams)
+	// Build the scope from the declared parameters rather than handing back the map
+	// resolveLifetimeParams minted into. A bound clause such as `<'a: 'b>` interns 'b there
+	// too, but 'b binds nothing a reference can supply, so a member writing it is undeclared
+	// and must not reach a variable through this scope.
+	scope := make(map[string]*soltype.LifetimeVar, len(params))
+	for i, p := range decl.LifetimeParams {
+		if i < len(params) {
+			scope[p.Name] = params[i].Var
+		}
+	}
+	return params, scope
 }
 
 // classParamsClean reports whether the module pre-pass resolved this class's type parameters
@@ -327,13 +379,21 @@ func (c *checker) preBindClassTypeParams(scope *Scope, lvl int, decl *ast.ClassD
 		declScope = scope.Child()
 		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
 	}
+	lifetimeParams, namedLts := c.resolveClassLifetimeParams(lvl, decl)
 	if c.classShells == nil {
 		c.classShells = map[*ast.ClassDecl]*classShell{}
 	}
-	c.classShells[decl] = &classShell{declScope: declScope, typeParams: typeParams, paramsClean: quiet()}
+	c.classShells[decl] = &classShell{
+		declScope:      declScope,
+		typeParams:     typeParams,
+		lifetimeParams: lifetimeParams,
+		namedLts:       namedLts,
+		paramsClean:    quiet(),
+	}
 
 	if def, ok := c.ctx.classDef(c.qualifyClassName(ns, decl)); ok {
 		def.TypeParams = typeParams
+		def.LifetimeParams = lifetimeParams
 	}
 }
 
@@ -368,6 +428,53 @@ func packageKeyPrefix(uri string) string {
 	}
 	escaped := strings.ReplaceAll(uri, "%", "%25")
 	return "import:" + strings.ReplaceAll(escaped, ".", "%2E")
+}
+
+// nestedLifetimeScope returns the named-lifetime scope a signature nested in a class body
+// starts from: the class's own parameters, minus every name the signature rebinds. A rebound
+// name shadows the class's, so the `'a` of `pick<'a>` inside `class Holder<'a>` is a lifetime
+// of its own rather than the class's. own is the signature's `<…>` clause.
+//
+// The result is a fresh map, so a name the signature mints stays out of the class's scope and
+// out of a sibling signature's. It is nil outside a class body, where a signature starts from
+// nothing.
+func (c *checker) nestedLifetimeScope(own []*ast.LifetimeParam) map[string]*soltype.LifetimeVar {
+	if len(c.classLifetimes) == 0 {
+		return nil
+	}
+	out := maps.Clone(c.classLifetimes)
+	for _, p := range own {
+		delete(out, p.Name)
+	}
+	return out
+}
+
+// classKeepLifetimes returns the lifetime variables a class's own parameters carry, the set
+// freezeClassBody pins so a member holding one keeps it under the parameter's name. It is nil
+// for a class that quantifies no lifetime, where the freeze has nothing to pin.
+func classKeepLifetimes(params []*soltype.LifetimeParam) set.Set[*soltype.LifetimeVar] {
+	if len(params) == 0 {
+		return nil
+	}
+	out := set.NewSet[*soltype.LifetimeVar]()
+	for _, p := range params {
+		out.Add(p.Var)
+	}
+	return out
+}
+
+// lifetimeParamVars returns each lifetime parameter's var, the lifetime arguments a class's
+// own instance carries. The Self reference `Holder<'a>` fills its LifetimeArgs with them, so
+// a member reading `self` sees the class at its own parameters rather than at fresh ones.
+func lifetimeParamVars(params []*soltype.LifetimeParam) []soltype.Lifetime {
+	if len(params) == 0 {
+		return nil
+	}
+	out := make([]soltype.Lifetime, len(params))
+	for i, p := range params {
+		out[i] = p.Var
+	}
+	return out
 }
 
 // typeParamVars returns each type parameter's var, the arguments a class's own
@@ -447,24 +554,32 @@ func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn, lvl int
 // TypeParams. Arity still counts it, and an omitted argument recovers to a fresh var.
 func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *ast.TypeRefTypeAnn, lvl int) *soltype.ClassType {
 	var params []*soltype.TypeParam
+	var ltParams []*soltype.LifetimeParam
 	// An unregistered name has no declared count to check against, so take the reference's own
 	// as the expected one and let it through unreported.
 	arity := typeParamArity{Required: len(ref.TypeArgs), Total: len(ref.TypeArgs)}
 	if def, ok := c.ctx.classDef(ct.Name); ok {
 		params = def.TypeParams
+		ltParams = def.LifetimeParams
 		arity = def.Arity
 	}
+	ltArgs := c.resolveLifetimeArgs(ref, ClassDeclKind, ltParams, lvl)
 	args := c.resolveTypeArgs(scope, ref, ClassDeclKind, params, arity, lvl)
-	if len(args) == 0 {
-		// The class declares no type parameters and the reference wrote no arguments, or it
-		// wrote some against a non-generic class and resolveTypeArgs already reported them.
-		// Either way the handle carries no arguments, so return the declaration's own.
+	if len(args) == 0 && len(ltArgs) == 0 {
+		// The class declares neither sort of parameter and the reference wrote no arguments,
+		// or it wrote some against a non-generic class and the two resolvers above already
+		// reported them. Either way the handle carries no arguments, so return the
+		// declaration's own.
 		return ct
 	}
-	// A class reference carries no lifetime arguments today, so the bound check substitutes
-	// the type sort only.
-	c.checkTypeArgBounds(params, args, nil, nil, ref)
-	return &soltype.ClassType{Name: ct.Name, TypeArgs: args, Final: ct.Final, Variant: ct.Variant}
+	c.checkTypeArgBounds(params, args, ltParams, ltArgs, ref)
+	return &soltype.ClassType{
+		Name:         ct.Name,
+		TypeArgs:     args,
+		LifetimeArgs: ltArgs,
+		Final:        ct.Final,
+		Variant:      ct.Variant,
+	}
 }
 
 // lookupClassBinding resolves a written type name to its scope TypeBinding, honoring
@@ -1108,11 +1223,16 @@ func keptFlowMap(keep set.Set[*soltype.TypeVarType]) map[*soltype.TypeVarType][]
 // coalesceThrows coalesces an accessor's throws position, keeping the nil shorthand that
 // stands for `never` rather than materializing a `never` the accessor was never written
 // with. The position is covariant, so it always coalesces positively.
-func coalesceThrows(t soltype.Type, keep set.Set[*soltype.TypeVarType], flow map[*soltype.TypeVarType][]*soltype.TypeVarType) soltype.Type {
+func coalesceThrows(
+	t soltype.Type,
+	keep set.Set[*soltype.TypeVarType],
+	flow map[*soltype.TypeVarType][]*soltype.TypeVarType,
+	keepLts set.Set[*soltype.LifetimeVar],
+) soltype.Type {
 	if t == nil {
 		return nil
 	}
-	return coalesceKeeping(t, soltype.Positive, keep, flow)
+	return coalesceKeeping(t, soltype.Positive, keep, flow, keepLts)
 }
 
 // freezeClassBody coalesces each member's type in place so member lookup and the
@@ -1126,31 +1246,36 @@ func coalesceThrows(t soltype.Type, keep set.Set[*soltype.TypeVarType], flow map
 // inlined to their bounds — and the kept-flow map so a member typed through a class parameter,
 // such as `read(self) { self.v }` on `class Box<T>`, reads `T` rather than collapsing to
 // `never`, leaving `T` in place for projectClassMember to substitute at an instance's argument.
-func (c *checker) freezeClassBody(obj *soltype.ObjectType, keep set.Set[*soltype.TypeVarType], flow map[*soltype.TypeVarType][]*soltype.TypeVarType) {
+func (c *checker) freezeClassBody(
+	obj *soltype.ObjectType,
+	keep set.Set[*soltype.TypeVarType],
+	flow map[*soltype.TypeVarType][]*soltype.TypeVarType,
+	keepLts set.Set[*soltype.LifetimeVar],
+) {
 	for i, e := range obj.Elems {
 		switch e := e.(type) {
 		case *soltype.PropertyElem:
-			obj.Elems[i] = &soltype.PropertyElem{Name: e.Name, Type: coalesceKeeping(e.Type, soltype.Positive, keep, flow), Optional: e.Optional, Readonly: e.Readonly}
+			obj.Elems[i] = &soltype.PropertyElem{Name: e.Name, Type: coalesceKeeping(e.Type, soltype.Positive, keep, flow, keepLts), Optional: e.Optional, Readonly: e.Readonly}
 		case *soltype.GetterElem:
 			obj.Elems[i] = &soltype.GetterElem{
 				Name:      e.Name,
 				SelfParam: e.SelfParam,
-				Type:      coalesceKeeping(e.Type, soltype.Positive, keep, flow),
-				Throws:    coalesceThrows(e.Throws, keep, flow),
+				Type:      coalesceKeeping(e.Type, soltype.Positive, keep, flow, keepLts),
+				Throws:    coalesceThrows(e.Throws, keep, flow, keepLts),
 			}
 		case *soltype.SetterElem:
 			obj.Elems[i] = &soltype.SetterElem{
 				Name:      e.Name,
 				SelfParam: e.SelfParam,
-				Param:     coalesceKeeping(e.Param, soltype.Negative, keep, flow),
+				Param:     coalesceKeeping(e.Param, soltype.Negative, keep, flow, keepLts),
 				// A setter's written value coalesces negatively, but what the write raises
 				// flows out to the writer, so its throws position still coalesces positively.
-				Throws: coalesceThrows(e.Throws, keep, flow),
+				Throws: coalesceThrows(e.Throws, keep, flow, keepLts),
 			}
 		case *soltype.MethodElem:
 			sigs := make([]*soltype.FuncType, len(e.Signatures))
 			for j, sig := range e.Signatures {
-				if cs, ok := coalesceKeeping(sig, soltype.Positive, keep, flow).(*soltype.FuncType); ok {
+				if cs, ok := coalesceKeeping(sig, soltype.Positive, keep, flow, keepLts).(*soltype.FuncType); ok {
 					sigs[j] = cs
 				} else {
 					sigs[j] = sig

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -115,7 +115,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// resolves through the pre-declared sibling signature — self-recursive, mutually
 	// recursive, or a forward call to a member declared later.
 	ctors := c.collectConstructors(decl)
-	c.checkFieldLifetimes(decl)
+	c.checkClassBodyLifetimes(decl)
 	c.buildFieldSigs(declScope, lvl, decl, body, static)
 	pending := c.buildMemberSigs(declScope, lvl, decl, self, body, static)
 	// A mutually recursive method group with no annotated return cannot ground its own
@@ -317,36 +317,56 @@ func (c *checker) classDeclScope(scope *Scope, lvl int, decl *ast.ClassDecl) (*S
 		return sh.declScope, sh
 	}
 	sh := &classShell{declScope: scope, paramsClean: true}
+	c.resolveClassParams(scope, lvl, decl, sh)
+	return sh.declScope, sh
+}
+
+// resolveClassParams fills sh with the class's parameters of both sorts, resolved under one
+// named-lifetime scope of the class's own. Isolating the scope keeps one class's `'a`
+// independent of a sibling's, and the scope is kept so inferClassDecl can install it around
+// the body and have every `&'a` there share one variable.
+//
+// The type parameters resolve first, inside that scope, so a bound written `<'a, T: &'a X>`
+// reaches the same variable the `'a` parameter carries rather than minting one of its own.
+// preBindAlias orders the two the same way.
+func (c *checker) resolveClassParams(scope *Scope, lvl int, decl *ast.ClassDecl, sh *classShell) {
+	saved := c.namedLifetimes
+	c.namedLifetimes = nil
+	defer func() { c.namedLifetimes = saved }()
+
+	sh.declScope = scope
 	if len(decl.TypeParams) > 0 {
 		sh.declScope = scope.Child()
 		sh.typeParams = c.resolveTypeParams(sh.declScope, lvl, decl.TypeParams)
 	}
-	sh.lifetimeParams, sh.namedLts = c.resolveClassLifetimeParams(lvl, decl)
-	return sh.declScope, sh
+	sh.lifetimeParams = c.resolveLifetimeParams(lvl, decl.LifetimeParams)
+	sh.namedLts = c.classLifetimeScope(decl, sh.lifetimeParams)
 }
 
-// resolveClassLifetimeParams mints the class's `<'a, ...>` parameters in a named-lifetime
-// scope of their own and returns both, mirroring what preBindAlias does for an alias.
-// Isolating the scope keeps one class's `'a` independent of a sibling's, and handing it back
-// lets inferClassDecl install it around the body so every `&'a` there shares one variable.
-func (c *checker) resolveClassLifetimeParams(
-	lvl int, decl *ast.ClassDecl,
-) ([]*soltype.LifetimeParam, map[string]*soltype.LifetimeVar) {
-	saved := c.namedLifetimes
-	c.namedLifetimes = nil
-	defer func() { c.namedLifetimes = saved }()
-	params := c.resolveLifetimeParams(lvl, decl.LifetimeParams)
-	// Build the scope from the declared parameters rather than handing back the map
-	// resolveLifetimeParams minted into. A bound clause such as `<'a: 'b>` interns 'b there
-	// too, but 'b binds nothing a reference can supply, so a member writing it is undeclared
-	// and must not reach a variable through this scope.
-	scope := make(map[string]*soltype.LifetimeVar, len(params))
+// classLifetimeScope maps each name the class's `<…>` clause binds to the variable its
+// parameter carries. It is built from the declared parameters rather than from the map
+// resolveLifetimeParams minted into, since a bound clause such as `<'a: 'b>` interns 'b there
+// too and 'b binds nothing a reference can supply.
+//
+// A name bound twice binds nothing new, so the repeat is reported and the first binder's
+// variable is kept, matching what checkLifetimeDeclarations does for a signature.
+func (c *checker) classLifetimeScope(
+	decl *ast.ClassDecl, params []*soltype.LifetimeParam,
+) map[string]*soltype.LifetimeVar {
+	out := make(map[string]*soltype.LifetimeVar, len(params))
+	first := map[string]*ast.LifetimeParam{}
 	for i, p := range decl.LifetimeParams {
-		if i < len(params) {
-			scope[p.Name] = params[i].Var
+		if i >= len(params) {
+			break
 		}
+		if kept, seen := first[p.Name]; seen {
+			c.report(&DuplicateLifetimeParamError{Name: p.Name, Param: p, First: kept})
+			continue
+		}
+		first[p.Name] = p
+		out[p.Name] = params[i].Var
 	}
-	return params, scope
+	return out
 }
 
 // classParamsClean reports whether the module pre-pass resolved this class's type parameters
@@ -374,27 +394,17 @@ func (c *checker) preBindClassTypeParams(scope *Scope, lvl int, decl *ast.ClassD
 	defer func() { c.classNamespace = prevNS }()
 
 	quiet := c.errorWindow()
-	declScope := scope
-	var typeParams []*soltype.TypeParam
-	if len(decl.TypeParams) > 0 {
-		declScope = scope.Child()
-		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
-	}
-	lifetimeParams, namedLts := c.resolveClassLifetimeParams(lvl, decl)
+	sh := &classShell{}
+	c.resolveClassParams(scope, lvl, decl, sh)
+	sh.paramsClean = quiet()
 	if c.classShells == nil {
 		c.classShells = map[*ast.ClassDecl]*classShell{}
 	}
-	c.classShells[decl] = &classShell{
-		declScope:      declScope,
-		typeParams:     typeParams,
-		lifetimeParams: lifetimeParams,
-		namedLts:       namedLts,
-		paramsClean:    quiet(),
-	}
+	c.classShells[decl] = sh
 
 	if def, ok := c.ctx.classDef(c.qualifyClassName(ns, decl)); ok {
-		def.TypeParams = typeParams
-		def.LifetimeParams = lifetimeParams
+		def.TypeParams = sh.typeParams
+		def.LifetimeParams = sh.lifetimeParams
 	}
 }
 
@@ -684,14 +694,20 @@ func (c *checker) collectConstructors(decl *ast.ClassDecl) []*ast.ConstructorEle
 	return ctors
 }
 
-// checkFieldLifetimes reports a named lifetime a field annotation writes that the class's
-// `<…>` clause does not bind. A member signature is checked by checkLifetimeDeclarations,
-// which scans a signature's parameters and return and so never reaches a field.
+// checkClassBodyLifetimes reports a named lifetime the class writes outside a member
+// signature that its `<…>` clause does not bind. Three places carry one: a field's
+// annotation, and the `extends` and `implements` references. A member signature is checked by
+// checkLifetimeDeclarations, which scans a signature's parameters and return and so reaches
+// none of the three.
 //
 // Without this a field's `&'z` interns 'z through namedLifetime, and two fields writing it
 // would share a lifetime the class quantifies but no reference can supply — the class value
 // would render a binder over an argument its instances do not carry.
-func (c *checker) checkFieldLifetimes(decl *ast.ClassDecl) {
+//
+// A lifetime argument on a type reference counts here, unlike in a signature's scan. There a
+// reference recovers an undeclared argument on its own and reporting it would double up; a
+// class body has no other check to double up with.
+func (c *checker) checkClassBodyLifetimes(decl *ast.ClassDecl) {
 	var col lifetimeUseCollector
 	for _, elem := range decl.Body {
 		field, isField := elem.(*ast.FieldElem)
@@ -700,12 +716,19 @@ func (c *checker) checkFieldLifetimes(decl *ast.ClassDecl) {
 		}
 		field.Type.Accept(&col)
 	}
+	if decl.Extends != nil {
+		decl.Extends.Accept(&col)
+	}
+	for _, impl := range decl.Implements {
+		impl.Accept(&col)
+	}
+
 	hasClause := len(decl.LifetimeParams) > 0
 	declaredOrder := make([]string, 0, len(decl.LifetimeParams))
 	for _, p := range decl.LifetimeParams {
 		declaredOrder = append(declaredOrder, p.Name)
 	}
-	for _, u := range col.uses {
+	for _, u := range append(col.uses, col.refArgs...) {
 		if _, ok := c.classLifetimes[u.Name]; ok {
 			continue
 		}

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -115,6 +115,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// resolves through the pre-declared sibling signature — self-recursive, mutually
 	// recursive, or a forward call to a member declared later.
 	ctors := c.collectConstructors(decl)
+	c.checkFieldLifetimes(decl)
 	c.buildFieldSigs(declScope, lvl, decl, body, static)
 	pending := c.buildMemberSigs(declScope, lvl, decl, self, body, static)
 	// A mutually recursive method group with no annotated return cannot ground its own
@@ -681,6 +682,41 @@ func (c *checker) collectConstructors(decl *ast.ClassDecl) []*ast.ConstructorEle
 		}
 	}
 	return ctors
+}
+
+// checkFieldLifetimes reports a named lifetime a field annotation writes that the class's
+// `<…>` clause does not bind. A member signature is checked by checkLifetimeDeclarations,
+// which scans a signature's parameters and return and so never reaches a field.
+//
+// Without this a field's `&'z` interns 'z through namedLifetime, and two fields writing it
+// would share a lifetime the class quantifies but no reference can supply — the class value
+// would render a binder over an argument its instances do not carry.
+func (c *checker) checkFieldLifetimes(decl *ast.ClassDecl) {
+	var col lifetimeUseCollector
+	for _, elem := range decl.Body {
+		field, isField := elem.(*ast.FieldElem)
+		if !isField || field.Type == nil {
+			continue
+		}
+		field.Type.Accept(&col)
+	}
+	hasClause := len(decl.LifetimeParams) > 0
+	declaredOrder := make([]string, 0, len(decl.LifetimeParams))
+	for _, p := range decl.LifetimeParams {
+		declaredOrder = append(declaredOrder, p.Name)
+	}
+	for _, u := range col.uses {
+		if _, ok := c.classLifetimes[u.Name]; ok {
+			continue
+		}
+		c.report(&UndeclaredLifetimeError{
+			Name:        u.Name,
+			Suggestions: nearestLifetimes(u.Name, declaredOrder),
+			hasClause:   hasClause,
+			binder:      "class declaration",
+			span:        u.Span(),
+		})
+	}
 }
 
 // buildFieldSigs adds one PropertyElem per field to the instance or static body,

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -63,9 +63,9 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// of its own. It holds the declared parameters and nothing else: the shell's map is
 	// written only by resolveClassLifetimeParams, and every reader below copies before
 	// minting, so an undeclared name a field writes cannot intern itself as a class binder.
-	savedClassLts := c.classLifetimes
-	c.classLifetimes = shell.namedLts
-	defer func() { c.classLifetimes = savedClassLts }()
+	savedClassLts := c.declLifetimes
+	c.declLifetimes = shell.namedLts
+	defer func() { c.declLifetimes = savedClassLts }()
 
 	// Resolve the body under a copy of that scope, so a `&'a` written in a field reaches the
 	// class parameter while a name the body mints stays out of the shell's map. A class is
@@ -353,18 +353,36 @@ func (c *checker) resolveClassParams(scope *Scope, lvl int, decl *ast.ClassDecl,
 func (c *checker) classLifetimeScope(
 	decl *ast.ClassDecl, params []*soltype.LifetimeParam,
 ) map[string]*soltype.LifetimeVar {
-	out := make(map[string]*soltype.LifetimeVar, len(params))
 	first := map[string]*ast.LifetimeParam{}
-	for i, p := range decl.LifetimeParams {
-		if i >= len(params) {
-			break
-		}
+	for _, p := range decl.LifetimeParams {
 		if kept, seen := first[p.Name]; seen {
 			c.report(&DuplicateLifetimeParamError{Name: p.Name, Param: p, First: kept})
 			continue
 		}
 		first[p.Name] = p
-		out[p.Name] = params[i].Var
+	}
+	return declaredLifetimeScope(decl.LifetimeParams, params)
+}
+
+// declaredLifetimeScope maps each name a declaration's `<…>` clause binds to the variable its
+// parameter carries, keeping the first binder when a name is bound twice. A class and a type
+// alias both build their nested-signature scope from it.
+//
+// It reads the declared parameters rather than the map resolveLifetimeParams minted into,
+// since a bound clause such as `<'a: 'b>` interns 'b there too and 'b binds nothing a
+// reference can supply.
+func declaredLifetimeScope(
+	written []*ast.LifetimeParam, resolved []*soltype.LifetimeParam,
+) map[string]*soltype.LifetimeVar {
+	out := make(map[string]*soltype.LifetimeVar, len(resolved))
+	for i, p := range written {
+		if i >= len(resolved) {
+			break
+		}
+		if _, seen := out[p.Name]; seen {
+			continue
+		}
+		out[p.Name] = resolved[i].Var
 	}
 	return out
 }
@@ -450,10 +468,10 @@ func packageKeyPrefix(uri string) string {
 // out of a sibling signature's. It is nil outside a class body, where a signature starts from
 // nothing.
 func (c *checker) nestedLifetimeScope(own []*ast.LifetimeParam) map[string]*soltype.LifetimeVar {
-	if len(c.classLifetimes) == 0 {
+	if len(c.declLifetimes) == 0 {
 		return nil
 	}
-	out := maps.Clone(c.classLifetimes)
+	out := maps.Clone(c.declLifetimes)
 	for _, p := range own {
 		delete(out, p.Name)
 	}
@@ -729,7 +747,7 @@ func (c *checker) checkClassBodyLifetimes(decl *ast.ClassDecl) {
 		declaredOrder = append(declaredOrder, p.Name)
 	}
 	for _, u := range append(col.uses, col.refArgs...) {
-		if _, ok := c.classLifetimes[u.Name]; ok {
+		if _, ok := c.declLifetimes[u.Name]; ok {
 			continue
 		}
 		c.report(&UndeclaredLifetimeError{

--- a/internal/solver/infer_class_lifetime_test.go
+++ b/internal/solver/infer_class_lifetime_test.go
@@ -132,6 +132,26 @@ func TestInferClassLifetimeParams(t *testing.T) {
 	}
 }
 
+// TestClassLifetimeParamsRenderUnderSourceNames covers the names a class's two bindings
+// render its lifetime parameters under. Both keep what the source wrote, so the value binding
+// and the type binding read the same, and neither takes the generated 'a, 'b the quantifier
+// would otherwise assign.
+func TestClassLifetimeParamsRenderUnderSourceNames(t *testing.T) {
+	src := `
+		class Pair<'x, 'y> {
+			a: &'x mut {value: number},
+			b: &'y mut {value: number},
+		}
+	`
+	values, types, errs := inferSource(t, src)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t,
+		"<'x, 'y> {new (a: &'x mut {value: number}, b: &'y mut {value: number}) -> Pair<'x, 'y>}",
+		values["Pair"],
+	)
+	require.Equal(t, "Pair<'x, 'y>", types["Pair"])
+}
+
 // TestClassLifetimeSubtyping covers what a class's lifetime arguments oblige at the nominal
 // subtype rule. A class records no per-parameter variance for the lifetime sort, so each
 // argument is invariant: reaching `Holder<'static>` forces the source's region to 'static

--- a/internal/solver/infer_class_lifetime_test.go
+++ b/internal/solver/infer_class_lifetime_test.go
@@ -1,0 +1,281 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInferClassLifetimeParams covers a class that quantifies lifetimes. `class Holder<'a>`
+// binds 'a for the whole declaration, so a field or a member signature writing `&'a` shares
+// the variable the parameter carries, a reference supplies one argument per parameter, and
+// the instance's own handle carries its parameters as its arguments.
+//
+// This is the class twin of what a lifetime-generic alias already does. The two resolve their
+// parameters and their reference arguments through the same helpers, so a class reference is
+// checked for arity the way an alias reference is.
+func TestInferClassLifetimeParams(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// The parameter reaches the field, so reading the field off an instance yields a
+		// borrow at the argument the reference supplied. Without the parameter binding, the
+		// field's `&'a` would mint a lifetime of its own that no argument could reach.
+		"FieldCarriesTheClassLifetime": {
+			src: `
+				class Holder<'a> { peer: &'a mut {value: number} }
+				fn read<'x>(h: Holder<'x>) -> &'x mut {value: number} { return h.peer }
+			`,
+			want: nil,
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+				"read":   "fn <'a>(h: Holder<'a>) -> &'a mut {value: number}",
+			},
+		},
+		// Returning the field at a DIFFERENT lifetime relates the two rather than passing
+		// silently, so the field's borrow is a real obligation on the caller. This is the
+		// case that fails vacuously when the class parameter is erased from the frozen body:
+		// with nothing there to relate, the function infers no bound at all. The structural
+		// twin `h: {peer: &'x mut B}` infers the identical signature.
+		"FieldAtAnotherLifetimeInfersABound": {
+			src: `
+				class Holder<'a> { peer: &'a mut {value: number} }
+				fn read<'x, 'y>(h: Holder<'x>, other: &'y mut {value: number}) -> &'y mut {value: number} {
+					return h.peer
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+				"read": "fn <'a, 'b: 'a>(h: Holder<'a>, other: &'b mut {value: number}) " +
+					"-> &'b mut {value: number}",
+			},
+		},
+		// A member's `&'a` is the class's 'a, not one of its own, so a call unifies the
+		// argument and the result at the instance's lifetime argument.
+		"MemberLifetimeIsTheClassLifetime": {
+			src: `
+				class Holder<'a> {
+					peer: &'a mut {value: number},
+					swap(mut self, p: &'a mut {value: number}) -> &'a mut {value: number} {
+						self.peer = p
+						return self.peer
+					},
+				}
+				fn call<'x>(h: mut Holder<'x>, p: &'x mut {value: number}) -> &'x mut {value: number} {
+					return h.swap(p)
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+				"call": "fn <'a>(h: mut Holder<'a>, p: &'a mut {value: number}) " +
+					"-> &'a mut {value: number}",
+			},
+		},
+		// A member signature writes the class's 'a without a clause of its own. The binder
+		// sits on the class, so the undeclared-lifetime check reads it as declared.
+		"MemberWritesTheClassLifetime": {
+			src: `
+				class Holder<'a> {
+					peer: &'a mut {value: number},
+					put(mut self, p: &'a mut {value: number}) -> undefined { self.peer = p },
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+			},
+		},
+		// A name neither the class nor the member binds is still undeclared, so the class
+		// binder widens the scope rather than disabling the check.
+		"MemberWritesAnUnboundLifetime": {
+			src: `
+				class Holder<'a> {
+					peer: &'a mut {value: number},
+					put(mut self, p: &'z mut {value: number}) -> undefined { },
+				}
+			`,
+			want: []string{
+				"4:24-4:26: lifetime 'z is used but not declared; add `<'z>` to the enclosing function signature",
+			},
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+			},
+		},
+		// A reference supplies one argument per parameter, and a count mismatch reports the
+		// same arity error an alias reference reports.
+		"ReferenceMustSupplyEveryLifetimeArgument": {
+			src: `
+				class Holder<'a> { peer: &'a mut {value: number} }
+				declare fn f(h: Holder) -> undefined
+			`,
+			want: []string{"3:21-3:27: class `Holder` expects 1 lifetime arguments but got 0"},
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+				"f":      "fn <'a>(h: Holder<'a>) -> undefined",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, types, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			for name, want := range tc.types {
+				require.Equal(t, want, values[name], "value binding %s", name)
+			}
+			require.Equal(t, "Holder<'a>", types["Holder"])
+		})
+	}
+}
+
+// TestClassLifetimeSubtyping covers what a class's lifetime arguments oblige at the nominal
+// subtype rule. A class records no per-parameter variance for the lifetime sort, so each
+// argument is invariant: reaching `Holder<'static>` forces the source's region to 'static
+// rather than laundering a short region into a long one through the nominal name.
+func TestClassLifetimeSubtyping(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		// Returning a Holder at a longer region forces the parameter's own argument, so the
+		// caller has to supply a 'static Holder rather than any Holder at all.
+		"ReturningAtALongerRegionForcesTheArgument": {
+			src: `
+				class Holder<'a> { peer: &'a mut {value: number} }
+				fn launder<'x>(h: Holder<'x>) -> Holder<'static> { return h }
+			`,
+			want: "fn (h: Holder<'static>) -> Holder<'static>",
+		},
+		// Constructing one from a borrow forces that borrow the same way, so the region
+		// reaches the constructor's argument through the class's parameter.
+		"ConstructingAtALongerRegionForcesTheBorrow": {
+			src: `
+				class Holder<'a> { peer: &'a mut {value: number} }
+				fn launder<'x>(p: &'x mut {value: number}) -> Holder<'static> { return Holder(p) }
+			`,
+			want: "fn (p: &'static mut {value: number}) -> Holder<'static>",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Empty(t, messagesWithSpan(errs))
+			require.Equal(t, tc.want, values["launder"])
+		})
+	}
+}
+
+// TestClassLifetimeScopeIsTheDeclaredParameters covers what a member may write without a
+// clause of its own: the names the class's `<…>` binds, and nothing a field happened to
+// write. A field writing an unbound `'z` must not intern it as a class binder, which would
+// suppress the undeclared report in every member and unify their borrows with the field's.
+func TestClassLifetimeScopeIsTheDeclaredParameters(t *testing.T) {
+	src := `
+		class Holder<'a> {
+			peer: &'a mut {value: number},
+			other: &'z mut {value: number},
+			put(mut self, p: &'z mut {value: number}) -> undefined { },
+		}
+	`
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"5:22-5:24: lifetime 'z is used but not declared; add `<'z>` to the enclosing function signature",
+	}, messagesWithSpan(errs))
+}
+
+// TestClassLifetimeBoundNameIsNotABinder covers the other name a class's clause mentions
+// without binding: the right-hand side of an outlives bound. `<'a: 'b>` constrains 'a but
+// binds only 'a, so a member writing `&'b` names a lifetime no reference can supply and is
+// reported undeclared.
+func TestClassLifetimeBoundNameIsNotABinder(t *testing.T) {
+	src := `
+		class Holder<'a: 'b> {
+			peer: &'a mut {value: number},
+			put(mut self, p: &'b mut {value: number}) -> undefined { },
+		}
+	`
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"4:22-4:24: lifetime 'b is used but not declared; add `<'b>` to the enclosing function signature",
+	}, messagesWithSpan(errs))
+}
+
+// TestClassLifetimeShadowing covers a nested signature that rebinds a name the class already
+// binds. The nested binder wins, so the two are alpha-equivalent: rewriting `pick<'a>` to
+// `pick<'b>` must not change what a call infers. Seeding the member's scope from the class
+// without dropping the rebound names would capture the member's `'a` as the class's, forcing
+// a caller's argument to the class's region.
+func TestClassLifetimeShadowing(t *testing.T) {
+	const call = `
+		fn g<'y>(h: Holder<'static>, o: &'y mut {value: number}) -> undefined { h.pick(o) }
+	`
+	tests := map[string]string{
+		"MemberRebindsTheClassName": `
+			class Holder<'a> {
+				peer: &'a mut {value: number},
+				pick<'a>(self, p: &'a mut {value: number}) -> &'a mut {value: number} { return p },
+			}
+		` + call,
+		"MemberBindsAFreshName": `
+			class Holder<'a> {
+				peer: &'a mut {value: number},
+				pick<'b>(self, p: &'b mut {value: number}) -> &'b mut {value: number} { return p },
+			}
+		` + call,
+	}
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, src)
+			require.Empty(t, messagesWithSpan(errs))
+			require.Equal(t,
+				"fn (h: Holder<'static>, o: &mut {value: number}) -> undefined",
+				values["g"],
+			)
+		})
+	}
+}
+
+// TestFuncAnnLifetimeShadowing is the annotation twin of TestClassLifetimeShadowing: a `fn`
+// type written in a class body binds its own lifetimes, so one named after the class's still
+// shadows it rather than being captured.
+func TestFuncAnnLifetimeShadowing(t *testing.T) {
+	src := `
+		class Holder<'a> {
+			peer: &'a mut {value: number},
+			cb: fn <'a>(x: &'a mut {value: number}) -> &'a mut {value: number},
+		}
+		fn g<'y>(h: Holder<'static>, o: &'y mut {value: number}) -> undefined { h.cb(o) }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t, "fn (h: Holder<'static>, o: &mut {value: number}) -> undefined", values["g"])
+}
+
+// TestClassLifetimeStoreEdge covers the payoff: a container whose element borrow is tied to
+// the receiver by a class lifetime parameter. The store lands at the whole `Holder`, since a
+// class lifetime argument names no field, so a borrow written into a Holder the caller owns
+// escapes the frame.
+func TestClassLifetimeStoreEdge(t *testing.T) {
+	const decls = `
+		class Holder<'a> { peer: &'a mut {value: number} }
+		declare fn store<'a, 'c>(target: &'c mut Holder<'a>, item: &'a mut {value: number}) -> undefined
+	`
+	src := decls + `
+		fn build(h: mut Holder<'static>) -> undefined {
+			val mut b = {value: 2}
+			store(&mut h, &mut b)
+		}
+	`
+	values, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"7:18-7:24: borrowed value 'b' does not live long enough to escape the function",
+	}, messagesWithSpan(errs))
+	require.Equal(t,
+		"fn <'a>(target: &mut Holder<'a>, item: &'a mut {value: number}) -> undefined",
+		values["store"],
+	)
+}

--- a/internal/solver/infer_class_lifetime_test.go
+++ b/internal/solver/infer_class_lifetime_test.go
@@ -320,37 +320,83 @@ func TestClassLifetimeBoundNameIsNotABinder(t *testing.T) {
 	}, messagesWithSpan(errs))
 }
 
-// TestClassLifetimeShadowing covers a nested signature that rebinds a name the class already
-// binds. The nested binder wins, so the two are alpha-equivalent: rewriting `pick<'a>` to
-// `pick<'b>` must not change what a call infers. Seeding the member's scope from the class
-// without dropping the rebound names would capture the member's `'a` as the class's, forcing
-// a caller's argument to the class's region.
+// TestClassLifetimeShadowing covers a member signature written against the class's lifetime
+// scope. The first two cases rebind a name the class already binds: the nested binder wins,
+// so `pick<'a>` and `pick<'b>` are alpha-equivalent and a call infers the same type from
+// either. Seeding the member's scope from the class without dropping the rebound names would
+// capture the member's `'a` as the class's, forcing a caller's argument to the class's
+// region.
+//
+// The last two cases run the other interaction, a member that names the class's `'a` and
+// binds its own `'b` in one signature. The two must stay separate, and must still admit one
+// caller lifetime at both positions.
 func TestClassLifetimeShadowing(t *testing.T) {
-	const call = `
+	const pickCall = `
 		fn g<'y>(h: Holder<'static>, o: &'y mut {value: number}) -> undefined { h.pick(o) }
 	`
-	tests := map[string]string{
-		"MemberRebindsTheClassName": `
-			class Holder<'a> {
-				peer: &'a mut {value: number},
-				pick<'a>(self, p: &'a mut {value: number}) -> &'a mut {value: number} { return p },
-			}
-		` + call,
-		"MemberBindsAFreshName": `
-			class Holder<'a> {
-				peer: &'a mut {value: number},
-				pick<'b>(self, p: &'b mut {value: number}) -> &'b mut {value: number} { return p },
-			}
-		` + call,
+	// `swap` names the class's 'a at its first parameter and binds its own 'b at the second, so
+	// a call fills the two from different places: 'a from the receiver's lifetime argument, 'b
+	// from the argument passed at the call.
+	const swapClass = `
+		class Holder<'a> {
+			peer: &'a mut {value: number},
+			swap<'b>(mut self, p: &'a mut {value: number}, q: &'b mut {value: number}) -> &'b mut {value: number} {
+				self.peer = p
+				return q
+			},
+		}
+	`
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		"MemberRebindsTheClassName": {
+			src: `
+				class Holder<'a> {
+					peer: &'a mut {value: number},
+					pick<'a>(self, p: &'a mut {value: number}) -> &'a mut {value: number} { return p },
+				}
+			` + pickCall,
+			want: "fn (h: Holder<'static>, o: &mut {value: number}) -> undefined",
+		},
+		"MemberBindsAFreshName": {
+			src: `
+				class Holder<'a> {
+					peer: &'a mut {value: number},
+					pick<'b>(self, p: &'b mut {value: number}) -> &'b mut {value: number} { return p },
+				}
+			` + pickCall,
+			want: "fn (h: Holder<'static>, o: &mut {value: number}) -> undefined",
+		},
+		// The receiver fills 'a and the last argument fills 'b, so the caller quantifies two
+		// lifetimes. Capturing 'b as the class's would collapse them into one and tie the
+		// returned borrow to the receiver's region, which the caller never asked for.
+		"MemberBindsItsOwnBesideTheClassLifetime": {
+			src: swapClass + `
+				fn g<'x, 'y>(h: mut Holder<'x>, p: &'x mut {value: number}, q: &'y mut {value: number}) -> &'y mut {value: number} {
+					return h.swap(p, q)
+				}
+			`,
+			want: "fn <'a, 'b>(h: mut Holder<'a>, p: &'a mut {value: number}, " +
+				"q: &'b mut {value: number}) -> &'b mut {value: number}",
+		},
+		// Separate binders do not force separate arguments. One caller lifetime passed at both
+		// positions fills 'a and 'b alike, so the caller quantifies a single lifetime.
+		"ClassLifetimeFillsTheMemberBinder": {
+			src: swapClass + `
+				fn g<'x>(h: mut Holder<'x>, p: &'x mut {value: number}, q: &'x mut {value: number}) -> &'x mut {value: number} {
+					return h.swap(p, q)
+				}
+			`,
+			want: "fn <'a>(h: mut Holder<'a>, p: &'a mut {value: number}, " +
+				"q: &'a mut {value: number}) -> &'a mut {value: number}",
+		},
 	}
-	for name, src := range tests {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			values, _, errs := inferSource(t, src)
+			values, _, errs := inferSource(t, tc.src)
 			require.Empty(t, messagesWithSpan(errs))
-			require.Equal(t,
-				"fn (h: Holder<'static>, o: &mut {value: number}) -> undefined",
-				values["g"],
-			)
+			require.Equal(t, tc.want, values["g"])
 		})
 	}
 }

--- a/internal/solver/infer_class_lifetime_test.go
+++ b/internal/solver/infer_class_lifetime_test.go
@@ -228,6 +228,63 @@ func TestClassFieldLifetimeIsChecked(t *testing.T) {
 	}, messagesWithSpan(errs))
 }
 
+// TestClassLifetimeClauseErrors covers what the class's own `<…>` clause and the body
+// outside a member signature can get wrong. Each name a class writes has to reach a binder
+// the clause declares, and each binder has to bind something new.
+func TestClassLifetimeClauseErrors(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// A lifetime argument on a type reference is a written use like a borrow's, so a
+		// field annotated `Cell<'z>` names 'z the way `&'z B` does.
+		"ReferenceArgumentOnAField": {
+			src: `
+				type Cell<'c> = {v: &'c mut {value: number}}
+				class Holder<'a> { peer: &'a mut {value: number}, x: Cell<'z> }
+			`,
+			want: []string{"3:63-3:65: lifetime 'z is used but not declared; did you mean 'a?"},
+		},
+		// An implements reference is a type reference too, so a lifetime argument on it is
+		// checked against the same binders. So is an extends reference, which the same scan
+		// walks.
+		"ReferenceArgumentOnImplements": {
+			src: `
+				class Shape<'b> { v: &'b mut {value: number} }
+				class Sub<'a> implements Shape<'z> { peer: &'a mut {value: number} }
+			`,
+			want: []string{"3:36-3:38: lifetime 'z is used but not declared; did you mean 'a?"},
+		},
+		// A name bound twice binds nothing new. Without the report the two would share one
+		// variable, silently equating a caller's two distinct arguments.
+		"DuplicateBinder": {
+			src:  `class Holder<'a, 'a> { peer: &'a mut {value: number} }`,
+			want: []string{"1:18-1:20: lifetime parameter 'a is declared more than once"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// TestClassTypeParamBoundSeesTheClassLifetime covers the order the two parameter sorts
+// resolve in. A type parameter's bound may write the class's `'a`, so the type parameters
+// resolve inside the class's named-lifetime scope and the bound reaches the variable the
+// lifetime parameter carries rather than minting one of its own, which would render a bare
+// `&` with no name.
+func TestClassTypeParamBoundSeesTheClassLifetime(t *testing.T) {
+	src := `class Holder<'a, T: &'a {value: number}> { peer: T }`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t,
+		"<T, 'a> {new (peer: T & &'a {value: number}) -> Holder<'a, T>}",
+		values["Holder"],
+	)
+}
+
 // TestClassLifetimeBinderOrderFollowsTheDeclaration covers the order the quantifier prefix
 // names a class's lifetime parameters in. It follows the `<…>` clause rather than the order
 // the fields happen to mention them, so the prefix and the instance's argument list agree.

--- a/internal/solver/infer_class_lifetime_test.go
+++ b/internal/solver/infer_class_lifetime_test.go
@@ -191,8 +191,11 @@ func TestClassLifetimeSubtyping(t *testing.T) {
 
 // TestClassLifetimeScopeIsTheDeclaredParameters covers what a member may write without a
 // clause of its own: the names the class's `<…>` binds, and nothing a field happened to
-// write. A field writing an unbound `'z` must not intern it as a class binder, which would
-// suppress the undeclared report in every member and unify their borrows with the field's.
+// write. Both writes of the unbound `'z` are reported, the field's against the class
+// declaration it would have to be added to and the member's against its own signature.
+//
+// Interning a field's `'z` as a class binder instead would suppress the member's report and
+// unify the two borrows, leaving the class quantified over a lifetime no reference supplies.
 func TestClassLifetimeScopeIsTheDeclaredParameters(t *testing.T) {
 	src := `
 		class Holder<'a> {
@@ -203,8 +206,44 @@ func TestClassLifetimeScopeIsTheDeclaredParameters(t *testing.T) {
 	`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
+		"4:12-4:14: lifetime 'z is used but not declared; did you mean 'a?",
 		"5:22-5:24: lifetime 'z is used but not declared; add `<'z>` to the enclosing function signature",
 	}, messagesWithSpan(errs))
+}
+
+// TestClassFieldLifetimeIsChecked covers the field scan on its own. A class with no `<…>`
+// clause has no lifetime a field may write, and the hint names the class rather than a
+// function signature, since the class declaration is where the binder would go.
+func TestClassFieldLifetimeIsChecked(t *testing.T) {
+	src := `
+		class Bad {
+			f: &'z mut {value: number},
+			g: &'z mut {value: number},
+		}
+	`
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"3:8-3:10: lifetime 'z is used but not declared; add `<'z>` to the enclosing class declaration",
+		"4:8-4:10: lifetime 'z is used but not declared; add `<'z>` to the enclosing class declaration",
+	}, messagesWithSpan(errs))
+}
+
+// TestClassLifetimeBinderOrderFollowsTheDeclaration covers the order the quantifier prefix
+// names a class's lifetime parameters in. It follows the `<…>` clause rather than the order
+// the fields happen to mention them, so the prefix and the instance's argument list agree.
+func TestClassLifetimeBinderOrderFollowsTheDeclaration(t *testing.T) {
+	src := `
+		class Pair<'x, 'y> {
+			b: &'y mut {value: number},
+			a: &'x mut {value: number},
+		}
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, messagesWithSpan(errs))
+	require.Equal(t,
+		"<'x, 'y> {new (b: &'y mut {value: number}, a: &'x mut {value: number}) -> Pair<'x, 'y>}",
+		values["Pair"],
+	)
 }
 
 // TestClassLifetimeBoundNameIsNotABinder covers the other name a class's clause mentions

--- a/internal/solver/infer_class_lifetime_test.go
+++ b/internal/solver/infer_class_lifetime_test.go
@@ -123,7 +123,7 @@ func TestInferClassLifetimeParams(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			values, types, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.want, messagesWithSpan(t, errs))
 			for name, want := range tc.types {
 				require.Equal(t, want, values[name], "value binding %s", name)
 			}
@@ -144,7 +144,7 @@ func TestClassLifetimeParamsRenderUnderSourceNames(t *testing.T) {
 		}
 	`
 	values, types, errs := inferSource(t, src)
-	require.Empty(t, messagesWithSpan(errs))
+	require.Empty(t, messagesWithSpan(t, errs))
 	require.Equal(t,
 		"<'x, 'y> {new (a: &'x mut {value: number}, b: &'y mut {value: number}) -> Pair<'x, 'y>}",
 		values["Pair"],
@@ -183,7 +183,7 @@ func TestClassLifetimeSubtyping(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tc.src)
-			require.Empty(t, messagesWithSpan(errs))
+			require.Empty(t, messagesWithSpan(t, errs))
 			require.Equal(t, tc.want, values["launder"])
 		})
 	}
@@ -208,7 +208,7 @@ func TestClassLifetimeScopeIsTheDeclaredParameters(t *testing.T) {
 	require.Equal(t, []string{
 		"4:12-4:14: lifetime 'z is used but not declared; did you mean 'a?",
 		"5:22-5:24: lifetime 'z is used but not declared; add `<'z>` to the enclosing function signature",
-	}, messagesWithSpan(errs))
+	}, messagesWithSpan(t, errs))
 }
 
 // TestClassFieldLifetimeIsChecked covers the field scan on its own. A class with no `<…>`
@@ -225,7 +225,7 @@ func TestClassFieldLifetimeIsChecked(t *testing.T) {
 	require.Equal(t, []string{
 		"3:8-3:10: lifetime 'z is used but not declared; add `<'z>` to the enclosing class declaration",
 		"4:8-4:10: lifetime 'z is used but not declared; add `<'z>` to the enclosing class declaration",
-	}, messagesWithSpan(errs))
+	}, messagesWithSpan(t, errs))
 }
 
 // TestClassLifetimeClauseErrors covers what the class's own `<…>` clause and the body
@@ -265,7 +265,7 @@ func TestClassLifetimeClauseErrors(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.want, messagesWithSpan(t, errs))
 		})
 	}
 }
@@ -278,7 +278,7 @@ func TestClassLifetimeClauseErrors(t *testing.T) {
 func TestClassTypeParamBoundSeesTheClassLifetime(t *testing.T) {
 	src := `class Holder<'a, T: &'a {value: number}> { peer: T }`
 	values, _, errs := inferSource(t, src)
-	require.Empty(t, messagesWithSpan(errs))
+	require.Empty(t, messagesWithSpan(t, errs))
 	require.Equal(t,
 		"<T, 'a> {new (peer: T & &'a {value: number}) -> Holder<'a, T>}",
 		values["Holder"],
@@ -296,7 +296,7 @@ func TestClassLifetimeBinderOrderFollowsTheDeclaration(t *testing.T) {
 		}
 	`
 	values, _, errs := inferSource(t, src)
-	require.Empty(t, messagesWithSpan(errs))
+	require.Empty(t, messagesWithSpan(t, errs))
 	require.Equal(t,
 		"<'x, 'y> {new (b: &'y mut {value: number}, a: &'x mut {value: number}) -> Pair<'x, 'y>}",
 		values["Pair"],
@@ -317,7 +317,7 @@ func TestClassLifetimeBoundNameIsNotABinder(t *testing.T) {
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
 		"4:22-4:24: lifetime 'b is used but not declared; add `<'b>` to the enclosing function signature",
-	}, messagesWithSpan(errs))
+	}, messagesWithSpan(t, errs))
 }
 
 // TestClassLifetimeShadowing covers a member signature written against the class's lifetime
@@ -395,7 +395,7 @@ func TestClassLifetimeShadowing(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tc.src)
-			require.Empty(t, messagesWithSpan(errs))
+			require.Empty(t, messagesWithSpan(t, errs))
 			require.Equal(t, tc.want, values["g"])
 		})
 	}
@@ -413,7 +413,7 @@ func TestFuncAnnLifetimeShadowing(t *testing.T) {
 		fn g<'y>(h: Holder<'static>, o: &'y mut {value: number}) -> undefined { h.cb(o) }
 	`
 	values, _, errs := inferSource(t, src)
-	require.Empty(t, messagesWithSpan(errs))
+	require.Empty(t, messagesWithSpan(t, errs))
 	require.Equal(t, "fn (h: Holder<'static>, o: &mut {value: number}) -> undefined", values["g"])
 }
 
@@ -435,7 +435,7 @@ func TestClassLifetimeStoreEdge(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
 		"7:18-7:24: borrowed value 'b' does not live long enough to escape the function",
-	}, messagesWithSpan(errs))
+	}, messagesWithSpan(t, errs))
 	require.Equal(t,
 		"fn <'a>(target: &mut Holder<'a>, item: &'a mut {value: number}) -> undefined",
 		values["store"],

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -195,10 +195,15 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// Give this function its own named-lifetime scope so a `&'a` in its signature
 	// resolves consistently across its params and return, without sharing the name
 	// with an enclosing or sibling function. Restored on exit so a nested function
-	// does not clobber the outer scope's names. namedLifetime allocates the map on
-	// first use, so a body with no `&'a` annotation pays no allocation.
+	// does not clobber the outer scope's names.
+	//
+	// A class member starts from the class's own parameters rather than from nothing, so a
+	// member writing the class's `&'a` reaches the variable that parameter carries. A name
+	// this signature rebinds shadows the class's, and nestedLifetimeScope drops those.
+	// namedLifetime allocates the map on first use, so a plain function with no `&'a`
+	// annotation pays no allocation.
 	savedNamedLts := c.namedLifetimes
-	c.namedLifetimes = nil
+	c.namedLifetimes = c.nestedLifetimeScope(sig.LifetimeParams)
 	defer func() { c.namedLifetimes = savedNamedLts }()
 	// Take the name inferMemberBodies left for this member, and clear it so a lambda nested in
 	// the body walked below is not blamed under the member's name. It is empty for every function

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -122,7 +122,8 @@ func inferModule(module *ast.Module) (values, types map[string]string, errs []So
 	//
 	// The alias's own type parameters are read off the handle before the body replaces it,
 	// since the body carries their variables but not their names: `type Alias<T> = {v: T}`
-	// shows `{v: T}`.
+	// shows `{v: T}`. Its lifetime parameters are read the same way, so `class Holder<'a>`
+	// renders `Holder<'a>` rather than the `'l{ID}` debug form a nameless lifetime falls to.
 	types = make(map[string]string, len(scope.types))
 	for name, b := range scope.types {
 		ty := b.Type
@@ -132,7 +133,7 @@ func inferModule(module *ast.Module) (values, types map[string]string, errs []So
 				ty = def.Body
 			}
 		}
-		types[name] = soltype.PrintWithParams(ty, params)
+		types[name] = soltype.PrintWithDeclaredParams(ty, params, c.declaredLifetimeParams(b.Type))
 	}
 	return values, types, c.errs
 }

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -61,8 +61,10 @@ import (
 // coalesced type was built from. Every caller coalesces a display type from the
 // Positive root today, so this is Positive in practice. Threading it keeps the
 // lifetime analysis consistent with the coalescing polarity rather than assuming it.
-func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
-	a := newLtAnalysis(walkLtOcc(t, pol))
+func coalesceLifetimes(t soltype.Type, pol soltype.Polarity, keepLts set.Set[*soltype.LifetimeVar]) soltype.Type {
+	occ, noElide := walkLtOcc(t, pol)
+	a := newLtAnalysis(occ, noElide)
+	a.keepLts = keepLts
 	return t.Accept(&ltRewriter{a: a}, pol)
 }
 
@@ -206,11 +208,17 @@ func walkLtOcc(t soltype.Type, pol soltype.Polarity) (
 // connected-component leader of each representative, and the set of component leaders
 // that hold a positive output lifetime.
 type ltAnalysis struct {
-	occ      map[*soltype.LifetimeVar]occPolarity
-	noElide  set.Set[*soltype.LifetimeVar] // lifetimes that must keep their name; never elided
-	bs       *ltBoundSet                   // condensed outlives graph; rep IDs collapse mutual-outlives cycles
-	comp     map[int]int                   // representative ID -> connected-component leader ID in bs
-	posComps set.Set[int]                  // component leaders reaching a positive occurrence
+	occ     map[*soltype.LifetimeVar]occPolarity
+	noElide set.Set[*soltype.LifetimeVar] // lifetimes that must keep their name; never elided
+	// keepLts holds the lifetimes a caller pins by identity, whatever their occurrences say.
+	// freezeClassBody passes a class's own lifetime parameters: a field such as
+	// `peer: &'a mut B` writes 'a once and in an output position, so the elision rule would
+	// drop it and leave the frozen body with nothing for an instance's argument to replace.
+	// Nil for every caller that pins nothing.
+	keepLts  set.Set[*soltype.LifetimeVar]
+	bs       *ltBoundSet  // condensed outlives graph; rep IDs collapse mutual-outlives cycles
+	comp     map[int]int  // representative ID -> connected-component leader ID in bs
+	posComps set.Set[int] // component leaders reaching a positive occurrence
 }
 
 // newLtAnalysis builds the grouping from the structurally-occurring lifetime
@@ -314,6 +322,12 @@ func (a *ltAnalysis) componentParams(v *soltype.LifetimeVar) []*soltype.Lifetime
 func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, elide bool) {
 	if forcedToStatic(v) {
 		return soltype.Static, false
+	}
+	// A pinned lifetime renders under its own name wherever it occurs. A class parameter is
+	// the pinned case: it is named by the declaration, not by the member the walk is
+	// coalescing, so the member's own occurrences do not decide whether it survives.
+	if a.keepLts.Contains(v) {
+		return v, false
 	}
 	if a.isParam(v) {
 		if a.kept(v) || a.noElide.Contains(v) {
@@ -480,6 +494,24 @@ func (r *ltRewriter) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ent
 }
 
 func (r *ltRewriter) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.ClassType:
+		args, changed := r.resolveArgs(t.LifetimeArgs)
+		if !changed {
+			return t
+		}
+		cp := *t
+		cp.LifetimeArgs = args
+		return &cp
+	case *soltype.AliasType:
+		args, changed := r.resolveArgs(t.LifetimeArgs)
+		if !changed {
+			return t
+		}
+		cp := *t
+		cp.LifetimeArgs = args
+		return &cp
+	}
 	rt, ok := t.(*soltype.RefType)
 	if !ok || rt.Lt == nil {
 		return t
@@ -498,6 +530,36 @@ func (r *ltRewriter) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
 		return &soltype.RefType{Mut: rt.Mut, Lt: soltype.Anon, Inner: rt.Inner}
 	}
 	return &soltype.RefType{Mut: rt.Mut, Lt: resolved, Inner: rt.Inner}
+}
+
+// resolveArgs rewrites a class or alias reference's lifetime arguments to their display
+// form, so `Holder<'x>` constrained to outlive 'static renders `Holder<'static>` the way the
+// borrow `&'x B` under the same constraint renders `&'static B`. changed is false when every
+// argument came back unchanged, which lets the caller keep the node it was handed.
+//
+// An argument the analysis would elide keeps its variable. Eliding drops the `'a` from a
+// borrow and leaves the `&`, but an argument position has no such reduced form to fall back
+// on, so dropping it would leave the reference short an argument.
+func (r *ltRewriter) resolveArgs(args []soltype.Lifetime) ([]soltype.Lifetime, bool) {
+	if len(args) == 0 {
+		return args, false
+	}
+	out := make([]soltype.Lifetime, len(args))
+	changed := false
+	for i, arg := range args {
+		out[i] = arg
+		lv, isVar := arg.(*soltype.LifetimeVar)
+		if !isVar {
+			continue
+		}
+		resolved, elide := r.a.resolveLt(lv)
+		if elide || resolved == arg {
+			continue
+		}
+		out[i] = resolved
+		changed = true
+	}
+	return out, changed
 }
 
 // forcedToStatic reports whether a lifetime variable has 'static among its bounds,

--- a/internal/solver/lifetime_undeclared.go
+++ b/internal/solver/lifetime_undeclared.go
@@ -24,7 +24,7 @@ import (
 // so a nested function is judged only by its own clause.
 //
 // A lifetime an enclosing class binds is in scope with no clause of this signature's own, and
-// c.classLifetimes holds those names. A class member writing the class's `'a` is the case
+// c.declLifetimes holds those names. A class member writing the class's `'a` is the case
 // that needs it.
 //
 // Recovery is left to namedLifetime, which mints a fresh lifetime for an undeclared name
@@ -88,7 +88,7 @@ func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam,
 		// is declared even though the member binds nothing. It marks no binder of this
 		// signature used, since a member that rebinds the name lands in the declared map
 		// above instead.
-		if _, ok := c.classLifetimes[u.Name]; ok {
+		if _, ok := c.declLifetimes[u.Name]; ok {
 			continue
 		}
 		c.report(&UndeclaredLifetimeError{

--- a/internal/solver/lifetime_undeclared.go
+++ b/internal/solver/lifetime_undeclared.go
@@ -23,6 +23,10 @@ import (
 // signature's binders. An enclosing function's lifetimes are not visible to a nested one,
 // so a nested function is judged only by its own clause.
 //
+// A lifetime an enclosing class binds is in scope with no clause of this signature's own, and
+// c.classLifetimes holds those names. A class member writing the class's `'a` is the case
+// that needs it.
+//
 // Recovery is left to namedLifetime, which mints a fresh lifetime for an undeclared name
 // so the signature stays well-formed. This scan only reports; it changes no resolution.
 func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam, params []*ast.Param, ret, throws ast.TypeAnn) {
@@ -77,6 +81,14 @@ func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam,
 	for _, u := range col.uses {
 		used.Add(u.Name)
 		if _, ok := declared[u.Name]; ok {
+			continue
+		}
+		// A name the enclosing class binds is in scope here without a clause of this
+		// signature's own. The binder sits on `class Holder<'a>`, so a member writing `&'a`
+		// is declared even though the member binds nothing. It marks no binder of this
+		// signature used, since a member that rebinds the name lands in the declared map
+		// above instead.
+		if _, ok := c.classLifetimes[u.Name]; ok {
 			continue
 		}
 		c.report(&UndeclaredLifetimeError{

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -979,7 +979,7 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 	// function's `'a` and its declared bound would force that outer lifetime, so an
 	// unrelated borrow parameter of the enclosing function would be pinned to 'static.
 	savedNamedLts := c.namedLifetimes
-	c.namedLifetimes = nil
+	c.namedLifetimes = c.nestedLifetimeScope(ta.LifetimeParams)
 	defer func() { c.namedLifetimes = savedNamedLts }()
 
 	// Resolve the annotation's type parameters into a child scope so a parameter, the

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -1083,18 +1083,21 @@ places), PR 14 (the C2 mut-context flag the borrow-leaf upgrade's invariance rid
 
   A method call records a store through its explicit parameters, since a lifetime written at
   two borrows survives the coalescing `freezeClassBody` applies to each member's signature.
+  A class quantifies lifetimes, so a container can tie its element borrow to the receiver:
+  `class Holder<'a> { peer: &'a mut B }` with `store<'a, 'c>(target: &'c mut Holder<'a>, item:
+  &'a mut B)` records the edge at the whole Holder, since a class lifetime argument names no
+  field.
+
   `a.peers.push(&mut b)`, the canonical container case, is still not covered, because it
-  stores into the `self` receiver. Three pieces are missing. First, `Array<T>` and its method
+  stores into the `self` receiver. Two pieces are missing. First, `Array<T>` and its method
   surface: `internal/solver` has no `Array` type and no array/tuple method calls, and both
   arrive with the M7.5 library-type ingestion
-  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7.5). Second, a
-  lifetime parameter on the container type, so `Array<'a, T>` can tie the element borrow to
-  the receiver; a class declares no lifetime parameters today. Third, the receiver type at the
-  call site: `memberValue` hands the call a signature with its `SelfParam` stripped, so the
-  recorder has no receiver to search for the shared lifetime. This is what keeps the
-  requirements' canonical cyclic `build()` from being expressible as written: the `.push`
-  edges that wire the graph are never recorded, so the escape check sees no borrows to
-  co-move.
+  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7.5). Second, the
+  receiver type at the call site: `memberValue` hands the call a signature with its
+  `SelfParam` stripped, so the recorder has no receiver to search for the shared lifetime.
+  This is what keeps the requirements' canonical cyclic `build()` from being expressible as
+  written: the `.push` edges that wire the graph are never recorded, so the escape check sees
+  no borrows to co-move.
 
 ## Testing approach
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -226,8 +226,7 @@ that would introduce new PRs:
   lists as deferred and out of scope. It is blocked on the stdlib `Array`
   type and method surface, delivered by
   [M7.5 PR5](../simple_sub/m7.5-implementation-plan.md#pr5--a-real-arrayt-and-the-well-known-handle-mechanism),
-  a lifetime parameter on the container type, and the receiver's own type
-  at the call site.
+  and the receiver's own type at the call site.
   That is **not this workstream's work** — until it lands, curation
   applies only the `move` spelling, and the `escape` facts for
   borrow-holding containers wait on it. Tracked here as an external

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1369,10 +1369,9 @@ a desugaring rule — rather than opaque placeholders.
   requirements' canonical cyclic `build()`, which wires the graph with `.push`, is not yet
   expressible. This milestone is the prerequisite: it resolves `Array<T>` and its method
   surface (`push`, …), which `internal/solver` has no representation for today — there is no
-  `Array` type and no array/tuple method call. What remains after it — a lifetime parameter on
-  the container type to tie the element borrow to the receiver, and the receiver's own type at
-  the call site, which `memberValue` strips — is affine work tracked under "Deferred and out
-  of scope" in
+  `Array` type and no array/tuple method call. What remains after it — the receiver's own type
+  at the call site, which `memberValue` strips — is affine work tracked under "Deferred and
+  out of scope" in
   [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md).
   Recorded here so the dependency is visible from the milestone that unblocks it.
 


### PR DESCRIPTION
Refs #1210. Stacked on #1215, which is stacked on #1212 — review those first.

This is item 2 of the four pieces #1210 needs. It lets a container tie its element borrow to its receiver.

## The gap

`class Holder<'a>` parsed and was then ignored. A field written `&'a` minted an unrelated lifetime, a reference `Holder<'x>` dropped its argument with no arity check, and a member writing the class's `'a` was reported undeclared.

The pieces downstream already existed — `ClassDef.LifetimeParams`, `ClassType.LifetimeArgs`, `newClassSubst`, the printer — so this connects the declaration to them, mirroring what a lifetime-generic alias already does. `infer_class.go` contained the string "lifetime" exactly once before this change, in a comment reading "A class reference carries no lifetime arguments today".

## What it does

- The class mints its parameters in a named-lifetime scope of its own, and every signature nested in the body starts from that scope, so a member's `&'a` reaches the variable the parameter carries. A nested binder of the same name shadows the class's, keeping `pick<'a>` and `pick<'b>` alpha-equivalent.
- A reference resolves one lifetime argument per parameter, and reports the arity mismatch a reference to a lifetime-generic alias already reports.
- The nominal subtype rule relates the arguments as equal regions. A class records no per-parameter variance for the lifetime sort, so `Holder<'x>` reaches `Holder<'static>` only by forcing `'x`, rather than laundering a short region into a long one through the nominal name.
- The class's own lifetimes are pinned through the class-body freeze. A field such as `peer: &'a mut B` writes `'a` once and in an output position, so the elision rule would otherwise drop it and leave an instance's argument with nothing to replace.
- The display pass resolves a class or alias reference's lifetime arguments the way it resolves a borrow's, so `Holder<'x>` under a `'static` constraint renders `Holder<'static>` instead of keeping a raw variable.

The scope holds the declared parameters and nothing else. A name a bound clause mentions (`<'a: 'b>`) and a name a field writes both intern through `namedLifetime`, and neither binds anything a reference can supply, so a member writing one is still reported undeclared.

## The payoff

```
class Holder<'a> { peer: &'a mut {value: number} }
declare fn store<'a, 'c>(target: &'c mut Holder<'a>, item: &'a mut {value: number}) -> undefined
```

records the store edge at the whole `Holder`, since a class lifetime argument names no field. `TestClassLifetimeStoreEdge` pins it.

## What is left for `a.peers.push(&mut b)`

Two pieces: an `Array` type with a method surface, and the receiver's own type at the call site, which `memberValue` strips.

## Tests

`internal/solver/infer_class_lifetime_test.go` covers the field carrying the parameter, a field read at another lifetime inferring the same bound its structural twin infers, a member call unifying at the instance's argument, the undeclared-name and arity reports, invariant subtyping in both the return and constructor directions, shadowing for both members and `fn` annotations, and the store edge. Full `go test ./...` passes.

## Two limitations found while writing this, not addressed here

Both trace to one root cause: `resolveFuncTypeAnn` never records `FuncType.LifetimeParams`, so the printer's binder exclusion has nothing to read.

1. A nested `fn <'a>(x: &'a mut B, y: &'a mut B)` in a return position has its `'a` quantified at the enclosing signature. Surfaced by #1215's shared-lifetime rule; the same shape in a parameter slot still elides, so the two positions disagree.
2. A class field annotated `fn <'b: 'a>(…)` renders as `fn (x: &'a mut B)`, collapsing the bound to an equality instead of keeping `'b` quantified with its bound.

Fixing either means recording the binders and teaching the printer to drop one whose variable does not survive coalescing, which is a printer-contract change rather than part of this item.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8Ud86QkLyDRhGUdrXwA7d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for lifetime parameters on classes and class members.
  * Preserved declared lifetime names and validated lifetime usage, bounds, scopes, and shadowing.
  * Improved lifetime propagation through fields, methods, constructors, inheritance, aliases, and type rendering.
* **Bug Fixes**
  * Improved subtype checks and borrow tracking for lifetime-parameterized classes.
  * Enhanced undeclared-lifetime diagnostics with more accurate binder context.
* **Tests**
  * Added comprehensive coverage for class lifetime inference, borrowing, validation, rendering, and error handling.
* **Documentation**
  * Updated implementation plans to reflect current lifetime and borrow-tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->