### PR TITLE
Record a store into a method's own receiver

### DIFF
--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -511,6 +511,14 @@ func (c *checker) recordCallStoreEdges(
 // An argument that builds its carrier inline, such as `&{held: &mut b}`, names no place and
 // so has no edges. It holds the borrows written into the carrier, which referents already
 // carries — storedReferents falls back to the same scan for a non-place argument.
+//
+// A carrier the graph cannot see through holds nothing as far as this can tell, so nothing is
+// reported. `val s = wrap(&mut b)` is the case: a borrow passed to a call is not recorded as
+// an edge to the call's result, so s reaches b through no edge. That is the same gap
+// `return s` has, and every other reader of the graph shares it — escapingLocalsOf answers
+// the same way. Reporting the argument's own root instead would close it at the cost of a
+// false positive on `val s = {held: &mut q}` for a parameter q, which carries nothing that
+// can dangle.
 func (c *checker) collectStoredLocals(arg ast.Expr, referents []liveness.VarID, out set.Set[liveness.VarID]) {
 	if p, isPlace := exprPlace(borrowOperand(arg)); isPlace && p.root > 0 {
 		c.collectBorrowedFrom(p.root, p.path, out, set.NewSet[liveness.VarID](), c.fn.eagerBorrowGraph)

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -25,27 +25,36 @@ import (
 // since the two are spelled alike. That can record an alias the call never forms, reporting an
 // escape the program does not have. The opposite reading would miss a real dangling borrow.
 //
-// A method call reaches this recorder through its explicit parameters. freezeClassBody
-// coalesces each member's signature into the class body, and a lifetime written at two
-// borrows survives that pass, so the two sides still share a variable at the call site.
+// A method call reaches this recorder through its explicit parameters and through its `self`
+// receiver. freezeClassBody coalesces each member's signature into the class body, and a
+// lifetime written at two borrows survives that pass, so the two sides still share a variable
+// at the call site. memberValue strips the receiver off the signature it hands the call, so
+// the receiver's own type comes from the side table memberValue fills. An overloaded method
+// call reaches no store, since inferMethodOverloadCall resolves its arm and returns before the
+// recorder runs.
 //
-// Two method shapes miss it. A store into the `self` receiver does not reach the recorder,
-// since memberValue strips the receiver off the signature it hands the call. An overloaded
-// method call does not either, since inferMethodOverloadCall resolves its arm and returns
-// before the recorder runs.
-//
-// So `a.peers.push(&mut b)`, the container case this exists for, is not covered. It needs an
-// `Array` type with a method surface and the receiver's type at the call site.
+// `a.peers.push(&mut b)`, the container case this exists for, needs one more piece: an `Array`
+// type with a method surface, which the stdlib ingestion milestone brings. The same call
+// against a hand-written class records the edge today. Only a class works, since only a class
+// body puts its own lifetime parameters in scope for the member signatures that declare the
+// store.
 type storeEdge struct {
-	// arg is the index of the argument whose borrow the call stores.
+	// arg is the position of the argument whose borrow the call stores.
 	arg int
-	// target is the index of the parameter the borrow is stored into.
+	// target is the position the borrow is stored into.
 	target int
 	// path is the field path within the target's referent where the borrow lands, so
 	// `&'b mut {peer: &'a mut B}` gives [peer]. A store position the walk reaches but
 	// cannot name, such as a tuple element or a class type argument, keeps the path of
 	// its container.
 	path []placeSeg
+	// direct records that the shared lifetime is the argument's OWN borrow lifetime, so what
+	// lands in the target is the argument's referent. `item: &'a mut B` is direct: passing
+	// `&mut b` stores b itself. A lifetime nested inside the argument is not: a receiver
+	// typed `mut Holder<'a>` shares 'a from inside, so what lands in the target is whatever
+	// the receiver holds rather than the receiver. The two are reported differently when the
+	// target is a parameter — see recordCallStoreEdges.
+	direct bool
 }
 
 // callStoreEdges returns the store effects fn declares, one per (argument, target, path).
@@ -55,15 +64,31 @@ type storeEdge struct {
 // longer read what the callee writes there. A source must be a borrow too, since an owned
 // argument is moved and its escape belongs to the consuming-argument rule.
 //
+// self is the receiver of the method being called, or nil for a plain call. It sits on both
+// sides. As a target it is what a `mut self` method writes an argument into. As a source it is
+// what a method drains, since a signature sharing the receiver's lifetime with a `&mut`
+// parameter's referent says the callee may write the receiver's data out there. Either way a
+// receiver is borrowed for the call rather than moved into it, which is why the tests read it
+// differently from a parameter of the same shape.
+//
 // Each side is classified by type kind before any type is walked, so a call over owned
-// arguments costs one pass over the parameter list and walks no type at all. Every parameter
+// arguments costs one pass over the parameter list and walks no type at all. Every position
 // that is walked is walked once.
 //
 // A walk that exhausts either allowance saw only part of its type, so a shared lifetime may
 // sit past where it stopped. Such a pair takes a store at the whole target rather than
 // none, since dropping the edge would drop the escape a borrow written there raises.
-func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
+func callStoreEdges(ctx *Context, fn *soltype.FuncType, self *soltype.FuncParam) []storeEdge {
 	var sources, targets []int
+	if self != nil {
+		sources = append(sources, selfIndex)
+		// A `mut self` receiver is a mutable RefType carrying no lifetime, the same shape an
+		// owned-mutable parameter takes. The lifetime test that rules a parameter out does
+		// not apply here, since the receiver is borrowed for the call rather than moved.
+		if ref, isRef := self.Type.(*soltype.RefType); isRef && ref.Mut {
+			targets = append(targets, selfIndex)
+		}
+	}
 	for i, p := range fn.Params {
 		ref, isRef := p.Type.(*soltype.RefType)
 		if !isRef || ref.Lt == nil {
@@ -74,20 +99,18 @@ func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 			targets = append(targets, i)
 		}
 	}
-	// One borrow parameter alone declares no store: a store needs a source and a target that
-	// are different parameters.
-	if len(targets) == 0 || len(sources) < 2 {
+	if !storeIsPossible(sources, targets) {
 		return nil
 	}
 	sourceLts := map[int][]*soltype.LifetimeVar{}
 	sourceTruncated := map[int]bool{}
 	for _, i := range sources {
-		sourceLts[i], sourceTruncated[i] = lifetimeVarsIn(ctx, fn.Params[i].Type)
+		sourceLts[i], sourceTruncated[i] = lifetimeVarsIn(ctx, storeSourceType(fn, self, i))
 	}
 
 	var out []storeEdge
 	for _, j := range targets {
-		dst := fn.Params[j].Type.(*soltype.RefType)
+		dst := storeTargetType(fn, self, j)
 		sites, targetTruncated := lifetimeSites(ctx, dst.Inner)
 		if len(sites) == 0 && !targetTruncated {
 			continue
@@ -98,19 +121,61 @@ func callStoreEdges(ctx *Context, fn *soltype.FuncType) []storeEdge {
 			}
 			// An unnamed path is the widest position the recorder can name, and every field
 			// read through the target follows it. This function's doc comment says why a
-			// truncated walk takes a store rather than none.
+			// truncated walk takes a store rather than none. It is recorded direct, which
+			// reports the argument's own locals rather than only what its edges reach, the
+			// wider of the two readings.
 			if targetTruncated || sourceTruncated[i] {
-				out = append(out, storeEdge{arg: i, target: j})
+				out = append(out, storeEdge{arg: i, target: j, direct: true})
 				continue
 			}
+			src, isRef := storeSourceType(fn, self, i).(*soltype.RefType)
 			for _, lv := range sourceLts[i] {
+				direct := isRef && src.Lt == soltype.Lifetime(lv)
 				for _, path := range sites[lv] {
-					out = append(out, storeEdge{arg: i, target: j, path: path})
+					out = append(out, storeEdge{arg: i, target: j, path: path, direct: direct})
 				}
 			}
 		}
 	}
 	return out
+}
+
+// selfIndex is the store position of a method call's receiver, which sits outside the
+// argument list. Every other position indexes the arguments directly.
+const selfIndex = -1
+
+// storeSourceType returns the type at source position i, whose lifetimes name the data the
+// call may write into a target.
+func storeSourceType(fn *soltype.FuncType, self *soltype.FuncParam, i int) soltype.Type {
+	if i == selfIndex {
+		return self.Type
+	}
+	return fn.Params[i].Type
+}
+
+// storeTargetType returns the referent-carrying type at target position j.
+func storeTargetType(fn *soltype.FuncType, self *soltype.FuncParam, j int) *soltype.RefType {
+	if j == selfIndex {
+		return self.Type.(*soltype.RefType)
+	}
+	return fn.Params[j].Type.(*soltype.RefType)
+}
+
+// storeIsPossible reports whether some source could store into some target. It rules out the
+// two shapes that declare no store before any type is walked: no target or no source at all,
+// and a lone borrow parameter that is both, since a position never stores into itself.
+func storeIsPossible(sources, targets []int) bool {
+	if len(sources) == 0 || len(targets) == 0 {
+		return false
+	}
+	for _, i := range sources {
+		for _, j := range targets {
+			if i != j {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // lifetimeSites maps each lifetime variable occurring in t to the field paths within t it
@@ -339,7 +404,16 @@ func (w *lifetimeWalk) walkObjElem(elem soltype.ObjTypeElem, base []placeSeg) {
 // parameter escapes instead, since the parameter's referent belongs to the caller. It is the
 // call-site twin of the split recordFieldStoreEdges and checkParamFieldStoreEscape make for a
 // field store.
-func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, ref liveness.StmtRef) {
+//
+// recv is the receiver expression of a method call and nil for a plain call, so
+// `a.peers.push(&mut b)` roots an edge at a.peers the way `push(&mut a.peers, &mut b)` does.
+func (c *checker) recordCallStoreEdges(
+	e *ast.CallExpr,
+	fn *soltype.FuncType,
+	recv ast.Expr,
+	self *soltype.FuncParam,
+	ref liveness.StmtRef,
+) {
 	if c.fn == nil || c.fn.eagerBorrowGraph == nil {
 		return
 	}
@@ -348,21 +422,26 @@ func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, re
 	// argument reaches the loop once per position. Collecting per argument and reporting after
 	// the loop keeps that to one diagnostic, blamed on the argument carrying the local.
 	escaping := map[int]set.Set[liveness.VarID]{}
-	for _, edge := range callStoreEdges(c.ctx, fn) {
-		// A call whose argument count does not match the signature is reported elsewhere and
-		// still reaches here, so the positions are bounds-checked before use.
-		if edge.arg >= len(e.Args) || edge.target >= len(e.Args) {
+	// The expression each escaping position blames. A position is not always an argument index,
+	// so the blame node is captured alongside rather than looked up afterward.
+	escapeBlame := map[int]ast.Expr{}
+	for _, edge := range callStoreEdges(c.ctx, fn, self) {
+		// A position is the receiver or an argument. It resolves to neither when the call passes
+		// fewer arguments than the signature declares, which is reported elsewhere.
+		argExpr, hasArg := storeExprAt(e, recv, edge.arg)
+		targetExpr, hasTarget := storeExprAt(e, recv, edge.target)
+		if !hasArg || !hasTarget {
 			continue
 		}
 		// Only a borrow of a function-local can dangle. An argument carrying none of those
 		// stores nothing the graph needs to know about.
-		referents := c.storedReferents(e.Args[edge.arg])
+		referents := c.storedReferents(argExpr)
 		if len(referents) == 0 {
 			continue
 		}
 		// An edge hangs off a binding, so the target has to name one. An argument built inline
 		// names no place and leaves nothing to root the edge at.
-		target, isPlace := exprPlace(borrowOperand(e.Args[edge.target]))
+		target, isPlace := exprPlace(borrowOperand(targetExpr))
 		if !isPlace || target.root <= 0 {
 			continue
 		}
@@ -377,9 +456,19 @@ func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, re
 				carried = set.NewSet[liveness.VarID]()
 				escaping[edge.arg] = carried
 			}
-			for _, referent := range referents {
-				carried.Add(referent)
+			// Which local dangles depends on the store. A direct store puts the argument's own
+			// referent into the target, so the argument's locals dangle. An indirect store puts
+			// what the argument HOLDS there, so the locals its borrow edges reach dangle and its
+			// own root does not. A receiver holding only a parameter borrow writes nothing that
+			// can dangle.
+			if edge.direct {
+				for _, referent := range referents {
+					carried.Add(referent)
+				}
+			} else {
+				c.collectStoredLocals(argExpr, referents, carried)
 			}
+			escapeBlame[edge.arg] = argExpr
 			continue
 		}
 		for _, referent := range referents {
@@ -395,9 +484,11 @@ func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, re
 			recorded = true
 		}
 	}
-	for arg := range len(e.Args) {
-		if carried, ok := escaping[arg]; ok {
-			c.reportEscapingLocals(carried, e.Args[arg])
+	// Report in position order so a call with two escaping arguments reads left to right.
+	// selfIndex leads, since a receiver precedes the arguments in the source.
+	for arg := selfIndex; arg < len(e.Args); arg++ {
+		if carried, ok := escaping[arg]; ok && carried.Len() > 0 {
+			c.reportEscapingLocals(carried, escapeBlame[arg])
 		}
 	}
 	// The escape check reads the per-program-point graph rather than the eager one, so the
@@ -405,6 +496,28 @@ func (c *checker) recordCallStoreEdges(e *ast.CallExpr, fn *soltype.FuncType, re
 	// makes the same handoff.
 	if recorded {
 		c.flushBorrowDirty(ref)
+	}
+}
+
+// collectStoredLocals adds to out the function-locals an indirectly stored argument exposes,
+// which is what the argument holds rather than its own root. `h.drain(out)` on a receiver
+// holding a borrow of a local writes that local into the caller's object, while a receiver
+// holding only a parameter borrow writes nothing that can dangle.
+//
+// An argument that names a place holds what its borrow edges reach. It reads the eager graph,
+// which is current for everything recorded ahead of this call in source order, so a borrow
+// the argument took earlier in the body is already there.
+//
+// An argument that builds its carrier inline, such as `&{held: &mut b}`, names no place and
+// so has no edges. It holds the borrows written into the carrier, which referents already
+// carries — storedReferents falls back to the same scan for a non-place argument.
+func (c *checker) collectStoredLocals(arg ast.Expr, referents []liveness.VarID, out set.Set[liveness.VarID]) {
+	if p, isPlace := exprPlace(borrowOperand(arg)); isPlace && p.root > 0 {
+		c.collectBorrowedFrom(p.root, p.path, out, set.NewSet[liveness.VarID](), c.fn.eagerBorrowGraph)
+		return
+	}
+	for _, referent := range referents {
+		out.Add(referent)
 	}
 }
 
@@ -427,6 +540,20 @@ func (c *checker) storedReferents(arg ast.Expr) []liveness.VarID {
 		out = append(out, referent)
 	}
 	return out
+}
+
+// storeExprAt returns the expression at store position i: the receiver at selfIndex, and the
+// argument at that index otherwise. ok is false when the position names nothing, which covers
+// a plain call reaching selfIndex and an argument beyond the ones the call wrote — the
+// surplus a too-few-arguments call pads the demand with.
+func storeExprAt(e *ast.CallExpr, recv ast.Expr, i int) (ast.Expr, bool) {
+	if i == selfIndex {
+		return recv, recv != nil
+	}
+	if i < 0 || i >= len(e.Args) {
+		return nil, false
+	}
+	return e.Args[i], true
 }
 
 // borrowOperand returns the place a borrow argument names: the operand of an explicit

--- a/internal/solver/borrow_store_self_test.go
+++ b/internal/solver/borrow_store_self_test.go
@@ -6,24 +6,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// selfStoreDecls is the container the receiver-store cases call into. `put` spells the store
-// by sharing the class's 'a between the receiver's type and the argument, which is how a
-// container ties an element borrow to the container it lands in. `look` is the same shape
-// with a shared receiver, the control for a method that takes no write.
-const selfStoreDecls = `
-	class Holder<'a> {
-		peer: &'a mut {value: number},
-		put(mut self, p: &'a mut {value: number}) -> undefined { self.peer = p },
-		look(self, p: &'a mut {value: number}) -> undefined { },
-	}
-`
-
-const selfStoreHolderType = "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}"
-
 // TestSelfReceiverStoreEdge covers the store a method declares into its own receiver, the
 // `a.peers.push(&mut b)` shape. memberValue strips the receiver off the signature it hands
 // the call site, so the recorder reads the declared receiver from the side table memberValue
 // fills and roots the edge at the receiver expression.
+//
+// Each case declares its own Holder. `put` spells the store by sharing the class's 'a between
+// the receiver's type and the argument, which is how a container ties an element borrow to the
+// container it lands in.
 func TestSelfReceiverStoreEdge(t *testing.T) {
 	tests := map[string]struct {
 		src   string
@@ -33,7 +23,12 @@ func TestSelfReceiverStoreEdge(t *testing.T) {
 		// The method call is the only thing that aliases h to b, and reading the field back
 		// carries that borrow out of the frame.
 		"StoreIntoALocalReceiverEscapes": {
-			src: selfStoreDecls + `
+			src: `
+				class Holder<'a> {
+					peer: &'a mut {value: number},
+					put(mut self, p: &'a mut {value: number}) -> undefined { self.peer = p },
+				}
+
 				fn build(p: mut {value: number}) -> &mut {value: number} {
 					val mut b = {value: 2}
 					val mut h = Holder(&mut p)
@@ -41,39 +36,42 @@ func TestSelfReceiverStoreEdge(t *testing.T) {
 					return h.peer
 				}
 			`,
-			want:  []string{"12:13-12:19: borrowed value 'b' does not live long enough to escape the function"},
-			types: map[string]string{"build": "fn (p: mut {value: number}) -> &mut {value: number}"},
-		},
-		// Dropping the call isolates its effect: with no edge from h to b, the same read
-		// reports nothing.
-		"NoCallLeavesTheReceiverAlone": {
-			src: selfStoreDecls + `
-				fn build(p: mut {value: number}) -> &mut {value: number} {
-					val mut b = {value: 2}
-					val mut h = Holder(&mut p)
-					return h.peer
-				}
-			`,
-			want:  nil,
-			types: map[string]string{"build": "fn (p: mut {value: number}) -> &mut {value: number}"},
+			want: []string{"11:13-11:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+				"build":  "fn (p: mut {value: number}) -> &mut {value: number}",
+			},
 		},
 		// A receiver the caller owns outlives the frame, so a borrow of a local written into
 		// it escapes at once rather than recording an edge, the same split a field store
 		// makes between a local and a parameter receiver.
 		"StoreIntoAParameterReceiverEscapes": {
-			src: selfStoreDecls + `
+			src: `
+				class Holder<'a> {
+					peer: &'a mut {value: number},
+					put(mut self, p: &'a mut {value: number}) -> undefined { self.peer = p },
+				}
+
 				fn build<'x>(h: mut Holder<'x>) -> undefined {
 					val mut b = {value: 2}
 					h.put(&mut b)
 				}
 			`,
-			want:  []string{"10:12-10:18: borrowed value 'b' does not live long enough to escape the function"},
-			types: map[string]string{"build": "fn <'a>(h: mut Holder<'a>) -> undefined"},
+			want: []string{"9:12-9:18: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+				"build":  "fn <'a>(h: mut Holder<'a>) -> undefined",
+			},
 		},
 		// A shared receiver takes no write, so a lifetime it shares with the argument
 		// declares no store and the call records nothing.
 		"SharedReceiverRecordsNoEdge": {
-			src: selfStoreDecls + `
+			src: `
+				class Holder<'a> {
+					peer: &'a mut {value: number},
+					look(self, p: &'a mut {value: number}) -> undefined { },
+				}
+
 				fn build(p: mut {value: number}) -> &mut {value: number} {
 					val mut b = {value: 2}
 					val mut h = Holder(&mut p)
@@ -81,14 +79,22 @@ func TestSelfReceiverStoreEdge(t *testing.T) {
 					return h.peer
 				}
 			`,
-			want:  nil,
-			types: map[string]string{"build": "fn (p: mut {value: number}) -> &mut {value: number}"},
+			want: nil,
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+				"build":  "fn (p: mut {value: number}) -> &mut {value: number}",
+			},
 		},
 		// The bracket form of a member access reaches the same method, so it records the same
 		// edge. resolveIndexPath routes a constant string key through the member lookup that
 		// records the receiver.
 		"BracketFormRecordsTheSameEdge": {
-			src: selfStoreDecls + `
+			src: `
+				class Holder<'a> {
+					peer: &'a mut {value: number},
+					put(mut self, p: &'a mut {value: number}) -> undefined { self.peer = p },
+				}
+
 				fn build(p: mut {value: number}) -> &mut {value: number} {
 					val mut b = {value: 2}
 					val mut h = Holder(&mut p)
@@ -96,8 +102,11 @@ func TestSelfReceiverStoreEdge(t *testing.T) {
 					return h.peer
 				}
 			`,
-			want:  []string{"12:13-12:19: borrowed value 'b' does not live long enough to escape the function"},
-			types: map[string]string{"build": "fn (p: mut {value: number}) -> &mut {value: number}"},
+			want: []string{"11:13-11:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"Holder": "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}",
+				"build":  "fn (p: mut {value: number}) -> &mut {value: number}",
+			},
 		},
 	}
 
@@ -105,10 +114,7 @@ func TestSelfReceiverStoreEdge(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tc.src)
 			require.Equal(t, tc.want, messagesWithSpan(errs))
-			require.Equal(t, selfStoreHolderType, values["Holder"])
-			for name, want := range tc.types {
-				require.Equal(t, want, values[name], "value binding %s", name)
-			}
+			require.Equal(t, tc.types, values)
 		})
 	}
 }
@@ -119,57 +125,27 @@ func TestSelfReceiverStoreEdge(t *testing.T) {
 // argument being stored and the parameter is the target.
 //
 // The shared lifetime sits inside the receiver's type rather than being the receiver's own
-// borrow lifetime, so what lands in the target is whatever the receiver holds. Against a
-// local target that is an edge from the target to the receiver, which a later flow-out
-// follows. Against a PARAMETER target it becomes an escape site for the post-pass, whose
-// answer is what the receiver's borrow edges reach — nothing at all for a class instance
-// today, since a borrow passed to a constructor is not recorded as an edge to its result.
+// borrow lifetime, so what lands in the target is whatever the receiver holds. Against the
+// local target here that is an edge from the target to the receiver, which the return then
+// follows.
 func TestSelfReceiverIsAStoreSource(t *testing.T) {
-	const decls = `
+	_, _, errs := inferSource(t, `
 		class Holder<'a> {
 			peer: &'a mut {value: number},
 			drain(self, out: &mut {slot: &'a mut {value: number}}) -> undefined { out.slot = self.peer },
 		}
-	`
-	tests := map[string]struct {
-		src  string
-		want []string
-	}{
-		// The call is the only thing that aliases o to h, so returning o.slot follows that
-		// edge and reports the receiver, whose data the field now exposes.
-		"DrainIntoALocalRecordsAnEdge": {
-			src: decls + `
-				fn build(p: mut {value: number}) -> &mut {value: number} {
-					val mut b = {value: 2}
-					val mut h = Holder(&mut b)
-					val mut o = {slot: &mut p}
-					h.drain(&mut o)
-					return o.slot
-				}
-			`,
-			want: []string{"12:13-12:19: borrowed value 'h' does not live long enough to escape the function"},
-		},
-		// Dropping the call isolates its effect: with no edge from o to h, the same return
-		// reports nothing.
-		"NoCallLeavesTheTargetAlone": {
-			src: decls + `
-				fn build(p: mut {value: number}) -> &mut {value: number} {
-					val mut b = {value: 2}
-					val mut h = Holder(&mut b)
-					val mut o = {slot: &mut p}
-					return o.slot
-				}
-			`,
-			want: nil,
-		},
-	}
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			_, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, messagesWithSpan(errs))
-		})
-	}
+		fn build(p: mut {value: number}) -> &mut {value: number} {
+			val mut b = {value: 2}
+			val mut h = Holder(&mut b)
+			val mut o = {slot: &mut p}
+			h.drain(&mut o)
+			return o.slot
+		}
+	`)
+	require.Equal(t, []string{
+		"12:11-12:17: borrowed value 'h' does not live long enough to escape the function",
+	}, messagesWithSpan(errs))
 }
 
 // TestIndirectStoreIntoParameterEscapes covers what escapes when the shared lifetime sits

--- a/internal/solver/borrow_store_self_test.go
+++ b/internal/solver/borrow_store_self_test.go
@@ -1,0 +1,243 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// selfStoreDecls is the container the receiver-store cases call into. `put` spells the store
+// by sharing the class's 'a between the receiver's type and the argument, which is how a
+// container ties an element borrow to the container it lands in. `look` is the same shape
+// with a shared receiver, the control for a method that takes no write.
+const selfStoreDecls = `
+	class Holder<'a> {
+		peer: &'a mut {value: number},
+		put(mut self, p: &'a mut {value: number}) -> undefined { self.peer = p },
+		look(self, p: &'a mut {value: number}) -> undefined { },
+	}
+`
+
+const selfStoreHolderType = "<'a> {new (peer: &'a mut {value: number}) -> Holder<'a>}"
+
+// TestSelfReceiverStoreEdge covers the store a method declares into its own receiver, the
+// `a.peers.push(&mut b)` shape. memberValue strips the receiver off the signature it hands
+// the call site, so the recorder reads the declared receiver from the side table memberValue
+// fills and roots the edge at the receiver expression.
+func TestSelfReceiverStoreEdge(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// The method call is the only thing that aliases h to b, and reading the field back
+		// carries that borrow out of the frame.
+		"StoreIntoALocalReceiverEscapes": {
+			src: selfStoreDecls + `
+				fn build(p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut h = Holder(&mut p)
+					h.put(&mut b)
+					return h.peer
+				}
+			`,
+			want:  []string{"12:13-12:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn (p: mut {value: number}) -> &mut {value: number}"},
+		},
+		// Dropping the call isolates its effect: with no edge from h to b, the same read
+		// reports nothing.
+		"NoCallLeavesTheReceiverAlone": {
+			src: selfStoreDecls + `
+				fn build(p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut h = Holder(&mut p)
+					return h.peer
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn (p: mut {value: number}) -> &mut {value: number}"},
+		},
+		// A receiver the caller owns outlives the frame, so a borrow of a local written into
+		// it escapes at once rather than recording an edge, the same split a field store
+		// makes between a local and a parameter receiver.
+		"StoreIntoAParameterReceiverEscapes": {
+			src: selfStoreDecls + `
+				fn build<'x>(h: mut Holder<'x>) -> undefined {
+					val mut b = {value: 2}
+					h.put(&mut b)
+				}
+			`,
+			want:  []string{"10:12-10:18: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn <'a>(h: mut Holder<'a>) -> undefined"},
+		},
+		// A shared receiver takes no write, so a lifetime it shares with the argument
+		// declares no store and the call records nothing.
+		"SharedReceiverRecordsNoEdge": {
+			src: selfStoreDecls + `
+				fn build(p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut h = Holder(&mut p)
+					h.look(&mut b)
+					return h.peer
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn (p: mut {value: number}) -> &mut {value: number}"},
+		},
+		// The bracket form of a member access reaches the same method, so it records the same
+		// edge. resolveIndexPath routes a constant string key through the member lookup that
+		// records the receiver.
+		"BracketFormRecordsTheSameEdge": {
+			src: selfStoreDecls + `
+				fn build(p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut h = Holder(&mut p)
+					h["put"](&mut b)
+					return h.peer
+				}
+			`,
+			want:  []string{"12:13-12:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn (p: mut {value: number}) -> &mut {value: number}"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, selfStoreHolderType, values["Holder"])
+			for name, want := range tc.types {
+				require.Equal(t, want, values[name], "value binding %s", name)
+			}
+		})
+	}
+}
+
+// TestSelfReceiverIsAStoreSource covers the receiver on the other side of a store. A
+// signature sharing the receiver's lifetime with a `&mut` parameter's referent says the
+// callee may write the receiver's data out into that parameter, so the receiver is the
+// argument being stored and the parameter is the target.
+//
+// The shared lifetime sits inside the receiver's type rather than being the receiver's own
+// borrow lifetime, so what lands in the target is whatever the receiver holds. Against a
+// local target that is an edge from the target to the receiver, which a later flow-out
+// follows. Against a PARAMETER target it becomes an escape site for the post-pass, whose
+// answer is what the receiver's borrow edges reach — nothing at all for a class instance
+// today, since a borrow passed to a constructor is not recorded as an edge to its result.
+func TestSelfReceiverIsAStoreSource(t *testing.T) {
+	const decls = `
+		class Holder<'a> {
+			peer: &'a mut {value: number},
+			drain(self, out: &mut {slot: &'a mut {value: number}}) -> undefined { out.slot = self.peer },
+		}
+	`
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// The call is the only thing that aliases o to h, so returning o.slot follows that
+		// edge and reports the receiver, whose data the field now exposes.
+		"DrainIntoALocalRecordsAnEdge": {
+			src: decls + `
+				fn build(p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut h = Holder(&mut b)
+					val mut o = {slot: &mut p}
+					h.drain(&mut o)
+					return o.slot
+				}
+			`,
+			want: []string{"12:13-12:19: borrowed value 'h' does not live long enough to escape the function"},
+		},
+		// Dropping the call isolates its effect: with no edge from o to h, the same return
+		// reports nothing.
+		"NoCallLeavesTheTargetAlone": {
+			src: decls + `
+				fn build(p: mut {value: number}) -> &mut {value: number} {
+					val mut b = {value: 2}
+					val mut h = Holder(&mut b)
+					val mut o = {slot: &mut p}
+					return o.slot
+				}
+			`,
+			want: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// TestIndirectStoreIntoParameterEscapes covers what escapes when the shared lifetime sits
+// inside the stored argument rather than being the argument's own borrow lifetime. What
+// lands in the caller's object is what the argument HOLDS, so the locals its borrow edges
+// reach dangle and its own root does not.
+//
+// The signature here is a plain function rather than a method, since a class instance carries
+// no borrow edges: a borrow passed to a constructor is not recorded as an edge to its result.
+// The rule is the same either way, and TestSelfReceiverIsAStoreSource covers the method form
+// against a local target, where the edge is what a later flow-out follows.
+func TestIndirectStoreIntoParameterEscapes(t *testing.T) {
+	const decl = `
+		declare fn drain<'a>(
+			src: &mut {held: &'a mut {value: number}},
+			out: &mut {slot: &'a mut {value: number}},
+		) -> undefined
+	`
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// s holds a borrow of the local b, so draining s into the caller's out leaves b
+		// dangling there.
+		"HoldingALocalEscapesIt": {
+			src: decl + `
+				fn build(o: &mut {slot: &mut {value: number}}) -> undefined {
+					val mut b = {value: 2}
+					val mut s = {held: &mut b}
+					drain(&mut s, o)
+				}
+			`,
+			want: []string{"10:12-10:18: borrowed value 'b' does not live long enough to escape the function"},
+		},
+		// An argument that builds its carrier inline names no place and so has no borrow
+		// edges. What it holds is the borrows written into the carrier, found by the same
+		// scan the escape check runs over a returned value.
+		"HoldingALocalThroughAnInlineCarrierEscapesIt": {
+			src: `
+				declare fn drain<'a>(
+					src: &{held: &'a mut {value: number}},
+					out: &mut {slot: &'a mut {value: number}},
+				) -> undefined
+				fn build(o: &mut {slot: &mut {value: number}}) -> undefined {
+					val mut b = {value: 2}
+					drain(&{held: &mut b}, o)
+				}
+			`,
+			want: []string{"8:12-8:27: borrowed value 'b' does not live long enough to escape the function"},
+		},
+		// s holds a borrow of a parameter, whose lifetime the caller supplied, so draining it
+		// writes nothing that can dangle. Reporting s here — the argument's own root, which a
+		// direct store would report — would be a false positive on sound code.
+		"HoldingAParameterBorrowIsExempt": {
+			src: decl + `
+				fn build(o: &mut {slot: &mut {value: number}}, q: mut {value: number}) -> undefined {
+					val mut s = {held: &mut q}
+					drain(&mut s, o)
+				}
+			`,
+			want: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+		})
+	}
+}

--- a/internal/solver/borrow_store_self_test.go
+++ b/internal/solver/borrow_store_self_test.go
@@ -113,7 +113,7 @@ func TestSelfReceiverStoreEdge(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.want, messagesWithSpan(t, errs))
 			require.Equal(t, tc.types, values)
 		})
 	}
@@ -145,7 +145,7 @@ func TestSelfReceiverIsAStoreSource(t *testing.T) {
 	`)
 	require.Equal(t, []string{
 		"12:11-12:17: borrowed value 'h' does not live long enough to escape the function",
-	}, messagesWithSpan(errs))
+	}, messagesWithSpan(t, errs))
 }
 
 // TestIndirectStoreIntoParameterEscapes covers what escapes when the shared lifetime sits
@@ -213,7 +213,7 @@ func TestIndirectStoreIntoParameterEscapes(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.want, messagesWithSpan(t, errs))
 		})
 	}
 }

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -504,10 +504,12 @@ func (c *Context) constrainNominalWalk(sub, super *soltype.ClassType, seen *seen
 		def, _ := c.classDef(sub.Name)
 		var errs []SolverError
 		// Relate the lifetime arguments as equal regions. A class records no per-parameter
-		// variance for the lifetime sort, so each argument is invariant: `Holder<'x>` reaches
+		// variance for the lifetime sort, and a parameter may sit in a position of either
+		// variance inside the body, so each argument is invariant: `Holder<'x>` reaches
 		// `Holder<'static>` only when the two lifetimes outlive each other. Constraining one
 		// direction alone would let a caller launder a short region into a long one through
-		// the nominal name, which the structural twin `{peer: &'x mut B}` rejects.
+		// the nominal name wherever the parameter is used mutably. Measuring per-parameter
+		// lifetime variance the way def.Variance measures the type sort would relax this.
 		for i := range min(len(sub.LifetimeArgs), len(super.LifetimeArgs)) {
 			c.constrainLt(sub.LifetimeArgs[i], super.LifetimeArgs[i])
 			c.constrainLt(super.LifetimeArgs[i], sub.LifetimeArgs[i])
@@ -985,6 +987,7 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 		case 0:
 			out = &soltype.ErrorType{}
 		case 1:
+			c.recordMethodSelfParam(blame, m.Signatures[0].SelfParam)
 			out = strippedMethodSig(m.Signatures[0])
 		default:
 			arms := make([]soltype.Type, len(m.Signatures))
@@ -1080,6 +1083,20 @@ func (c *checker) raiseUnionAccessorThrows(lvl int, blame ast.Node, name string,
 	for _, t := range throws {
 		c.raiseAccessorThrows(lvl, blame, t)
 	}
+}
+
+// recordMethodSelfParam notes the receiver of the method a member access reads, so a rule at
+// the call site can reach the type strippedMethodSig drops. An overloaded method records
+// nothing: its arms may declare different receivers, and which arm a call resolves is decided
+// later, in resolveOverload.
+func (c *checker) recordMethodSelfParam(blame ast.Node, self *soltype.FuncParam) {
+	if self == nil {
+		return
+	}
+	if c.methodSelfParams == nil {
+		c.methodSelfParams = map[ast.Node]*soltype.FuncParam{}
+	}
+	c.methodSelfParams[blame] = self
 }
 
 // strippedMethodSig returns a method signature as a plain callable, its SelfParam

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -78,6 +78,15 @@ type checker struct {
 	// same reason. The map is allocated lazily by namedLifetime on first use.
 	namedLifetimes map[string]*soltype.LifetimeVar
 
+	// methodSelfParams maps a member-access node to the `self` receiver of the method it
+	// reads. memberValue hands the call site a signature with its receiver stripped, since
+	// `p.m` binds the receiver and returns a function of the remaining parameters, so a rule
+	// that needs the receiver's type reads it from here instead. The borrow-store recorder is
+	// the one reader: a signature that stores an argument into the receiver spells it by
+	// sharing a lifetime with the receiver's type. It holds an entry only for a method with a
+	// receiver and a single signature.
+	methodSelfParams map[ast.Node]*soltype.FuncParam
+
 	// declLifetimes maps each lifetime name the enclosing declaration binds to the variable
 	// its parameter carries. A class and a type alias both quantify lifetimes, and a
 	// signature nested in either may write `&'a` with no clause of its own, so inferFunc and

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1512,14 +1512,40 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 		// extra arguments that have no corresponding parameter.
 		if hasConsumeRef {
 			c.consumeCallArgs(e, fn, consumeRef)
-			// A borrow argument the signature stores into another argument aliases the two
-			// for as long as the target lives, so record that edge here rather than leaving
-			// the alias invisible to the escape check and the component move.
-			c.recordCallStoreEdges(e, fn, consumeRef)
+			// A borrow argument the signature stores into another argument, or into a
+			// method's receiver, aliases the two for as long as the target lives. Record that
+			// edge here rather than leaving the alias invisible to the escape check and the
+			// component move.
+			recv, self := c.calleeReceiver(e.Callee)
+			c.recordCallStoreEdges(e, fn, recv, self, consumeRef)
 		}
 	}
 	c.recordType(e, res)
 	return res
+}
+
+// calleeReceiver returns the receiver a method call is made through and the `self` parameter
+// the method declares, or nil for a plain call. memberValue strips the receiver off the
+// signature it hands the call site and records it against the member-access node, so the
+// declared receiver is read back from there rather than from the callee's type.
+//
+// Both spellings of a member access reach a method: `h.put` and the bracket form `h["put"]`,
+// which resolveIndexPath routes through the same member lookup for a constant string key.
+func (c *checker) calleeReceiver(callee ast.Expr) (ast.Expr, *soltype.FuncParam) {
+	var object ast.Expr
+	switch callee := callee.(type) {
+	case *ast.MemberExpr:
+		object = callee.Object
+	case *ast.IndexExpr:
+		object = callee.Object
+	default:
+		return nil, nil
+	}
+	self, ok := c.methodSelfParams[callee]
+	if !ok {
+		return nil, nil
+	}
+	return object, self
 }
 
 // consumeCallArgs consumes each owned argument passed to a bare owned parameter of

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -150,10 +150,10 @@ func (c *checker) resolveComponentEscapes(
 // The external-reference scan reads the same borrow-edge graph the escape check is built on,
 // so it sees every alias the recording sites listed at the top of this file record. An alias
 // formed by a path none of them covers is invisible here exactly as it is to the escape check.
-// `a.peers.push(&mut b)` is such a path. The store recorder reads a callee's explicit
-// parameters, and `.push` stores into the receiver, which memberValue strips off the
-// signature the call site sees. It is tracked under "Deferred and out of scope" in
-// planning/affine_semantics/implementation_plan.md.
+// The store recorder covers a call that writes an argument-borrow into another argument or
+// into a method's receiver, so `a.peers.push(&mut b)` records its edge once `Array` has a
+// method surface to declare the store on. Until then the same call against a hand-written
+// container records it; see borrow_store.go.
 func (c *checker) componentMoveCovers(
 	e ast.Expr, escaping set.Set[liveness.VarID],
 	stmtRef liveness.StmtRef,

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -1088,16 +1088,18 @@ places), PR 14 (the C2 mut-context flag the borrow-leaf upgrade's invariance rid
   &'a mut B)` records the edge at the whole Holder, since a class lifetime argument names no
   field.
 
-  `a.peers.push(&mut b)`, the canonical container case, is still not covered, because it
-  stores into the `self` receiver. Two pieces are missing. First, `Array<T>` and its method
-  surface: `internal/solver` has no `Array` type and no array/tuple method calls, and both
-  arrive with the M7.5 library-type ingestion
-  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7.5). Second, the
-  receiver type at the call site: `memberValue` hands the call a signature with its
-  `SelfParam` stripped, so the recorder has no receiver to search for the shared lifetime.
-  This is what keeps the requirements' canonical cyclic `build()` from being expressible as
-  written: the `.push` edges that wire the graph are never recorded, so the escape check sees
-  no borrows to co-move.
+  A method's `self` receiver is a store target too. `memberValue` hands the call site a
+  signature with its `SelfParam` stripped, so the declared receiver is read from the side
+  table `memberValue` fills and the edge is rooted at the receiver expression. `h.put(&mut b)`
+  on a `Holder<'a>` therefore records h → b the way `store(&mut h, &mut b)` does.
+
+  `a.peers.push(&mut b)`, the canonical container case, needs one remaining piece: `Array<T>`
+  and its method surface. `internal/solver` has no `Array` type and no array/tuple method
+  calls, and both arrive with the M7.5 library-type ingestion
+  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7.5). The same call
+  against a hand-written container records its edge today, which is what the requirements'
+  canonical cyclic `build()` needs; it stays unexpressible only for as long as the container
+  it wires the graph with is `Array`.
 
 ## Testing approach
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -226,7 +226,7 @@ that would introduce new PRs:
   lists as deferred and out of scope. It is blocked on the stdlib `Array`
   type and method surface, delivered by
   [M7.5 PR5](../simple_sub/m7.5-implementation-plan.md#pr5--a-real-arrayt-and-the-well-known-handle-mechanism),
-  and the receiver's own type at the call site.
+  which is now the only piece missing.
   That is **not this workstream's work** — until it lands, curation
   applies only the `move` spelling, and the `escape` facts for
   borrow-holding containers wait on it. Tracked here as an external

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1364,16 +1364,16 @@ a desugaring rule — rather than opaque placeholders.
   parameters, driven by a lifetime the argument-borrow shares with a position inside another
   parameter's referent
   ([internal/solver/borrow_store.go](../../internal/solver/borrow_store.go)). A borrow stored
-  into a container by a method call — `a.peers.push(&mut b)` — is still invisible, since it
-  stores into the `self` receiver rather than a parameter. That is why the affine
-  requirements' canonical cyclic `build()`, which wires the graph with `.push`, is not yet
-  expressible. This milestone is the prerequisite: it resolves `Array<T>` and its method
-  surface (`push`, …), which `internal/solver` has no representation for today — there is no
-  `Array` type and no array/tuple method call. What remains after it — the receiver's own type
-  at the call site, which `memberValue` strips — is affine work tracked under "Deferred and
-  out of scope" in
-  [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md).
-  Recorded here so the dependency is visible from the milestone that unblocks it.
+  into a container by a method call — `a.peers.push(&mut b)` — is invisible only because
+  `Array` is not a type the solver has. The recorder covers a store into a method's `self`
+  receiver, and the same call against a hand-written container records its edge today. That is
+  why the affine requirements' canonical cyclic `build()`, which wires the graph with `.push`,
+  is not yet expressible. This milestone is the whole remaining prerequisite: it resolves
+  `Array<T>` and its method surface (`push`, …), which `internal/solver` has no representation
+  for — there is no `Array` type and no array/tuple method call. Nothing in
+  [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md) is
+  waiting behind it. Recorded here so the dependency is visible from the milestone that
+  unblocks it.
 
 **Accept:** real source that **imports** core lib types (`import { Array } from
 "std:array"`, `Promise`, `Map<K, V>`, `Iterable<T>`/`Iterator<T>`/


### PR DESCRIPTION
Refs #1210. Stacked on #1216 → #1215 → #1212 — review those first.

This is item 3, the last of the four pieces #1210 needs that does not depend on M7.5. After this, `a.peers.push(&mut b)` is blocked only on `Array` having a method surface; the same call against a hand-written class records its edge today.

## The gap

The store recorder read a callee's explicit parameters only, so a method that wrote an argument-borrow into its own receiver recorded nothing. That is the `.push` shape: what the borrow lands in is `self`, not a parameter.

`memberValue` strips the receiver off the signature it hands the call site, since `p.m` binds the receiver and returns a function of the remaining parameters. It now records the receiver against the member-access node, and the call site reads it back from there. Both spellings reach a method, so `h.put(x)` and `h["put"](x)` record the same edge.

## The receiver sits on both sides

- **As a target** it is what a `mut self` method writes an argument into, rooted at the receiver expression, so `a.peers.push(&mut b)` records `a.peers → b`.
- **As a source** it is what a method drains out into a `&mut` parameter.

Either way a receiver is borrowed for the call rather than moved into it, which is why the target test reads it differently from a parameter of the same shape: `mut self` carries no lifetime, and an owned-mutable *parameter* with no lifetime is moved.

## Direct versus indirect stores

Which local escapes a store into a caller-owned parameter depends on where the shared lifetime sits.

- **Direct** — the lifetime is the argument's own borrow lifetime, as in `item: &'a mut B`. The argument's referent lands in the target, so its own locals escape.
- **Indirect** — the lifetime is nested, as in a receiver typed `mut Holder<'a>`. What the argument *holds* lands in the target, so the locals its borrow edges reach escape and its own root does not. A receiver holding only a parameter borrow writes nothing that can dangle, and reporting its root would be a false positive on sound code.

Both are reported inline rather than deferred to the escape post-pass, which would weigh an owned-looking argument as a connected-component move and consume locals the call never took.

## Tests

`internal/solver/borrow_store_self_test.go` covers the store into a local receiver and into a parameter receiver, the bracket form, a shared receiver recording nothing, the receiver as a store source, and the direct/indirect split including an inline carrier and the parameter-borrow exemption. Full `go test ./...` passes.

## Known gaps, not addressed

- A method bound to a value first loses its receiver: `val f = h.put; f(&mut b)` records nothing, since the call site sees an `Ident` callee. Tracking a receiver through a binding is the deferred closure-capture work.
- A class instance carries no borrow edges, because a borrow passed to a constructor is not recorded as an edge to its result. That predates this branch and equally affects `return id(&mut b)`. It is why the receiver-as-source path is exercised here against a plain function for the parameter-target case.
- `self.put(&mut b)` inside a method falls in neither the local nor the parameter bucket, so it records an edge instead of reporting an escape. The direct `self.peer = &mut b` form has the same gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8Ud86QkLyDRhGUdrXwA7d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved borrow and lifetime tracking for method calls, including operations involving the receiver.
  * Correctly detects direct and indirect escaping borrows passed through method receivers and arguments.
  * Supports receiver-aware analysis for dot notation and bracket-based method access.
  * Improves diagnostic accuracy for escaping local borrows and preserves relevant source locations.

* **Tests**
  * Added comprehensive coverage for receiver-based stores, indirect propagation, inline carriers, and non-escaping cases.

* **Documentation**
  * Updated implementation plans to reflect receiver participation in borrow tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->