### PR TITLE
Implement origin analysis for ECMA-262 algorithms

### DIFF
--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -1,9 +1,9 @@
 // Package ecma262 reads the ECMA-262 control-flow graph that
 // tools/spec-extract serializes to cfg.json and derives the mutation and alias
-// facts the builtin converter consumes. cfg.go mirrors the serialized schema,
-// and origin.go maps each value an algorithm names to where that value came
-// from. See planning/ecma-262/implementation_plan.md §4 for the analysis and
-// Appendix A for the schema.
+// facts the builtin converter consumes. cfg.go models the graph, and origin.go
+// maps each value an algorithm names to where that value came from. See
+// planning/ecma-262/implementation_plan.md §4 for the analysis and Appendix A
+// for the serialized schema.
 package ecma262
 
 import (
@@ -12,11 +12,12 @@ import (
 	"os"
 )
 
-// CFG is a serialized control-flow graph. It holds every builtin algorithm at a
-// pinned spec revision, plus the abstract operations reachable from them.
+// CFG is a control-flow graph read back from cfg.json. It holds every builtin
+// algorithm at a pinned spec revision, plus the abstract operations reachable
+// from them.
 type CFG struct {
-	SpecTarget string  `json:"specTarget"` // pinned ecma262 git ref
-	Funcs      []*Func `json:"funcs"`
+	SpecTarget string // pinned ecma262 git ref
+	Funcs      []*Func
 
 	abstractOps map[string]*Func
 	builtins    map[string]*Func
@@ -37,26 +38,96 @@ const (
 
 // Func is one algorithm. Params holds the declared parameters in order. A
 // method's receiver is not among them; it is the `this` value, reached through
-// an ExprThis.
+// a ThisExpr.
 type Func struct {
-	Name    string   `json:"name"` // canonical spec key or abstract-operation name
-	Kind    FuncKind `json:"kind"`
-	Params  []string `json:"params"`  // declared parameters, in order, 0-based
-	Promise bool     `json:"promise"` // the algorithm returns a promise
-	Nodes   []*Node  `json:"nodes"`   // CFG nodes in flat order
+	Name    string   // canonical spec key or abstract-operation name
+	Kind    FuncKind //
+	Params  []string // declared parameters, in order, 0-based
+	Promise bool     // the algorithm returns a promise
+	Nodes   []Node   // CFG nodes in flat order
 }
 
-// NodeKind names the statement shapes the serializer lowers a spec step to.
+// Node is one step of an algorithm.
+//
+//sumtype:decl
+type Node interface {
+	isNode()
+}
+
+func (*LetNode) isNode()       {}
+func (*CallNode) isNode()      {}
+func (*SlotWriteNode) isNode() {}
+func (*ThrowNode) isNode()     {}
+func (*ReturnNode) isNode()    {}
+func (*BranchNode) isNode()    {}
+func (*OpaqueNode) isNode()    {}
+
+// LetNode binds Target to Source. Serialized as kind "let".
+type LetNode struct {
+	Target string
+	Source Expr
+}
+
+// CallNode calls Callee, binding its result to Target when the algorithm names
+// the result. Serialized as kind "call".
+//
+// Callee is either an abstract-operation name, which resolves in the graph, or
+// a formal parameter holding a function, which is a callback such as the
+// `callbackfn` in `? Call(callbackfn, ...)`. The origin map tells the two
+// apart: a callee whose origin is a parameter is a callback.
+type CallNode struct {
+	Target string // empty when the result is discarded
+	Callee string
+	Args   []Expr
+	Guard  Guard
+}
+
+// SlotWriteNode writes Value into Object's Slot. Slot is the name without its
+// brackets, so [[MapData]] is "MapData". Serialized as kind "slotwrite".
+//
+// Value is the operand §8.1 reads to see a parameter escape into a container.
+// The serializer cannot always name it, so it can be nil: a closure's argument
+// prologue writes an incoming argument the algorithm never named, as in
+// `NewPromiseCapability:clo0` storing into `__args__.[[resolve]]`. Slot is
+// empty on the few writes whose slot the algorithm computes.
+type SlotWriteNode struct {
+	Object Expr
+	Slot   string
+	Value  Expr // nil when the graph does not name the stored value
+}
+
+// ThrowNode throws. ErrorType names the error the algorithm constructs, such as
+// "TypeError". Value is set instead for the rare algorithm that throws a value
+// it did not construct. Serialized as kind "throw".
+type ThrowNode struct {
+	ErrorType string
+	Value     Expr // nil when the algorithm constructs the error
+}
+
+// ReturnNode returns Value. Serialized as kind "return".
+type ReturnNode struct {
+	Value Expr
+}
+
+// BranchNode is control flow. The analysis never interprets one, so it carries
+// no data. Serialized as kind "branch".
+type BranchNode struct{}
+
+// OpaqueNode is a step the serializer could not lower, which leaves the
+// analysis unable to see the whole algorithm. Serialized as kind "opaque".
+type OpaqueNode struct{}
+
+// NodeKind is the tag each Node variant serializes under.
 type NodeKind string
 
 const (
-	NodeLet       NodeKind = "let"       // bind Target = Source
-	NodeCall      NodeKind = "call"      // optional Target = Callee(Args...)
-	NodeSlotWrite NodeKind = "slotwrite" // write Value into Object.Slot
-	NodeThrow     NodeKind = "throw"     // Throw a <ErrorType> exception
-	NodeReturn    NodeKind = "return"    // return Value
-	NodeBranch    NodeKind = "branch"    // control flow; carries no analyzed data
-	NodeOpaque    NodeKind = "opaque"    // a step the serializer could not lower
+	NodeLet       NodeKind = "let"
+	NodeCall      NodeKind = "call"
+	NodeSlotWrite NodeKind = "slotwrite"
+	NodeThrow     NodeKind = "throw"
+	NodeReturn    NodeKind = "return"
+	NodeBranch    NodeKind = "branch"
+	NodeOpaque    NodeKind = "opaque"
 )
 
 // Guard is the completion-record guard on a call. `?` propagates an abrupt
@@ -69,54 +140,73 @@ const (
 	GuardPlain    Guard = "plain" // result not completion-checked
 )
 
-// Node is one step of an algorithm. Which fields carry a value depends on Kind.
-type Node struct {
-	Kind   NodeKind `json:"kind"`
-	Target string   `json:"target,omitempty"` // Let target, or Call result binding
-	Source *Expr    `json:"source,omitempty"` // Let
-	// Callee is a Call's callee. It is either an abstract-operation name, which
-	// resolves in the graph, or a formal parameter holding a function, which is
-	// a callback such as the `callbackfn` in `? Call(callbackfn, ...)`. The
-	// origin map tells the two apart: a callee whose origin is Param(k) is a
-	// callback.
-	Callee string  `json:"callee,omitempty"`
-	Args   []*Expr `json:"args,omitempty"`   // Call
-	Guard  Guard   `json:"guard,omitempty"`  // Call: ? / ! / plain
-	Object *Expr   `json:"object,omitempty"` // SlotWrite: the written object
-	// Slot is the written slot name without its brackets, so [[MapData]] is
-	// "MapData".
-	Slot      string `json:"slot,omitempty"`
-	ErrorType string `json:"errorType,omitempty"` // Throw of a constructed error: "TypeError", ...
-	// Value is the returned expression on a Return, the stored value on a
-	// SlotWrite, and on a Throw the thrown expression, for the rare algorithm
-	// that throws a value it did not construct.
-	Value *Expr `json:"value,omitempty"`
+// Expr is a value an algorithm step reads or builds.
+//
+//sumtype:decl
+type Expr interface {
+	isExpr()
 }
 
-// ExprKind names the value shapes an algorithm step reads or builds.
+func (*VarExpr) isExpr()   {}
+func (*ThisExpr) isExpr()  {}
+func (*LitExpr) isExpr()   {}
+func (*CallExpr) isExpr()  {}
+func (*SlotExpr) isExpr()  {}
+func (*PropExpr) isExpr()  {}
+func (*AllocExpr) isExpr() {}
+
+// VarExpr names a value. The name also reaches a closure passed as a value,
+// which resolves against the abstract operations the way a callee does.
+// Serialized as kind "var".
+type VarExpr struct {
+	Var string
+}
+
+// ThisExpr is the `this` value. Serialized as kind "this".
+type ThisExpr struct{}
+
+// LitExpr is a literal or primitive. Serialized as kind "lit".
+type LitExpr struct{}
+
+// CallExpr is a call nested inside an expression. The compiled IR states every
+// call as its own node, so the serializer emits none of these, but Appendix A
+// reserves the shape. Serialized as kind "call".
+type CallExpr struct {
+	Callee string
+	Args   []Expr
+}
+
+// SlotExpr reads Object's Slot. Serialized as kind "slot".
+type SlotExpr struct {
+	Object Expr
+	Slot   string
+}
+
+// PropExpr reads a property off Object, through Get(Object, Key) or a similar
+// step. Serialized as kind "prop".
+type PropExpr struct {
+	Object Expr
+}
+
+// AllocExpr is a record, list, or map the algorithm allocates, or a copy of
+// one. The value is fresh, and Args holds the operands stored into it.
+// Serialized as kind "alloc".
+type AllocExpr struct {
+	Args []Expr
+}
+
+// ExprKind is the tag each Expr variant serializes under.
 type ExprKind string
 
 const (
-	ExprVar  ExprKind = "var"  // a named value
-	ExprThis ExprKind = "this" // the this value
-	ExprLit  ExprKind = "lit"  // literal / primitive
-	ExprCall ExprKind = "call" // nested abstract-operation call
-	ExprSlot ExprKind = "slot" // READ of Object.Slot
-	ExprProp ExprKind = "prop" // READ via Get(Object, Key) etc.
-	// ExprAlloc is a record, list, or map the algorithm allocates, or a copy of
-	// one. The value is fresh, and Args holds the operands stored into it.
+	ExprVar   ExprKind = "var"
+	ExprThis  ExprKind = "this"
+	ExprLit   ExprKind = "lit"
+	ExprCall  ExprKind = "call"
+	ExprSlot  ExprKind = "slot"
+	ExprProp  ExprKind = "prop"
 	ExprAlloc ExprKind = "alloc"
 )
-
-// Expr is a value expression. Which fields carry a value depends on Kind.
-type Expr struct {
-	Kind   ExprKind `json:"kind"`
-	Var    string   `json:"var,omitempty"`    // ExprVar; also names a closure passed as a value
-	Callee string   `json:"callee,omitempty"` // ExprCall
-	Args   []*Expr  `json:"args,omitempty"`   // ExprCall / ExprAlloc
-	Object *Expr    `json:"object,omitempty"` // ExprSlot / ExprProp
-	Slot   string   `json:"slot,omitempty"`   // ExprSlot
-}
 
 // LoadCFG reads and decodes a serialized control-flow graph.
 func LoadCFG(path string) (*CFG, error) {
@@ -129,27 +219,25 @@ func LoadCFG(path string) (*CFG, error) {
 
 // ParseCFG decodes a serialized control-flow graph and indexes its functions by
 // name. Anything the analysis cannot walk or address is an error here rather
-// than a silently dropped entry or a panic further in: a missing function or
-// node, an unnamed function, a kind with no index, and a name repeated within
-// one index.
+// than a silently dropped entry or a panic further in: a missing function,
+// node, or operand, an unnamed function, a tag that names no variant, and a
+// name repeated within one index.
 func ParseCFG(data []byte) (*CFG, error) {
-	cfg := &CFG{}
-	if err := json.Unmarshal(data, cfg); err != nil {
+	var wire wireCFG
+	if err := json.Unmarshal(data, &wire); err != nil {
 		return nil, fmt.Errorf("decoding cfg: %w", err)
 	}
-	cfg.abstractOps = make(map[string]*Func)
-	cfg.builtins = make(map[string]*Func)
-	for i, fn := range cfg.Funcs {
-		if fn == nil {
-			return nil, fmt.Errorf("decoding cfg: funcs[%d] is missing", i)
-		}
-		if fn.Name == "" {
-			return nil, fmt.Errorf("decoding cfg: funcs[%d] has no name", i)
-		}
-		for j, node := range fn.Nodes {
-			if node == nil {
-				return nil, fmt.Errorf("decoding cfg: node %d of %s is missing", j, fn.Name)
-			}
+
+	cfg := &CFG{
+		SpecTarget:  wire.SpecTarget,
+		Funcs:       make([]*Func, 0, len(wire.Funcs)),
+		abstractOps: make(map[string]*Func),
+		builtins:    make(map[string]*Func),
+	}
+	for i, wf := range wire.Funcs {
+		fn, err := wf.toFunc(i)
+		if err != nil {
+			return nil, fmt.Errorf("decoding cfg: %w", err)
 		}
 		var index map[string]*Func
 		switch fn.Kind {
@@ -157,6 +245,8 @@ func ParseCFG(data []byte) (*CFG, error) {
 			index = cfg.abstractOps
 		case BuiltinMethod, BuiltinStatic:
 			index = cfg.builtins
+		case SyntaxDirected:
+			fallthrough
 		default:
 			return nil, fmt.Errorf("decoding cfg: %s has kind %q, which the analysis cannot index", fn.Name, fn.Kind)
 		}
@@ -164,12 +254,13 @@ func ParseCFG(data []byte) (*CFG, error) {
 			return nil, fmt.Errorf("decoding cfg: two %s functions named %s", fn.Kind, fn.Name)
 		}
 		index[fn.Name] = fn
+		cfg.Funcs = append(cfg.Funcs, fn)
 	}
 	return cfg, nil
 }
 
 // AbstractOp returns the abstract operation of that name, or nil. A call's
-// callee and a closure named by an ExprVar both resolve here. Names live in two
+// callee and a closure named by a VarExpr both resolve here. Names live in two
 // spaces that a lookup has to keep apart. `Set` is both the property-write
 // abstract operation and the `Set` constructor.
 func (c *CFG) AbstractOp(name string) *Func {
@@ -180,4 +271,189 @@ func (c *CFG) AbstractOp(name string) *Func {
 // as "Array.prototype.push", or nil.
 func (c *CFG) Builtin(name string) *Func {
 	return c.builtins[name]
+}
+
+// The wire types mirror the serialized schema in Appendix A, where a node and
+// an expression are each one object tagged by kind. encoding/json cannot pick a
+// variant of a sealed interface on its own, so decoding lands here first and
+// the conversions below rebuild the graph as the sum types above.
+
+type wireCFG struct {
+	SpecTarget string      `json:"specTarget"`
+	Funcs      []*wireFunc `json:"funcs"`
+}
+
+type wireFunc struct {
+	Name    string      `json:"name"`
+	Kind    FuncKind    `json:"kind"`
+	Params  []string    `json:"params"`
+	Promise bool        `json:"promise"`
+	Nodes   []*wireNode `json:"nodes"`
+}
+
+type wireNode struct {
+	Kind      NodeKind    `json:"kind"`
+	Target    string      `json:"target"`
+	Source    *wireExpr   `json:"source"`
+	Callee    string      `json:"callee"`
+	Args      []*wireExpr `json:"args"`
+	Guard     Guard       `json:"guard"`
+	Object    *wireExpr   `json:"object"`
+	Slot      string      `json:"slot"`
+	ErrorType string      `json:"errorType"`
+	Value     *wireExpr   `json:"value"`
+}
+
+type wireExpr struct {
+	Kind   ExprKind    `json:"kind"`
+	Var    string      `json:"var"`
+	Callee string      `json:"callee"`
+	Args   []*wireExpr `json:"args"`
+	Object *wireExpr   `json:"object"`
+	Slot   string      `json:"slot"`
+}
+
+func (w *wireFunc) toFunc(index int) (*Func, error) {
+	if w == nil {
+		return nil, fmt.Errorf("funcs[%d] is missing", index)
+	}
+	if w.Name == "" {
+		return nil, fmt.Errorf("funcs[%d] has no name", index)
+	}
+
+	fn := &Func{
+		Name:    w.Name,
+		Kind:    w.Kind,
+		Params:  w.Params,
+		Promise: w.Promise,
+		Nodes:   make([]Node, 0, len(w.Nodes)),
+	}
+	for i, wn := range w.Nodes {
+		if wn == nil {
+			return nil, fmt.Errorf("node %d of %s is missing", i, w.Name)
+		}
+		node, err := wn.toNode()
+		if err != nil {
+			return nil, fmt.Errorf("node %d of %s: %w", i, w.Name, err)
+		}
+		fn.Nodes = append(fn.Nodes, node)
+	}
+	return fn, nil
+}
+
+func (w *wireNode) toNode() (Node, error) {
+	switch w.Kind {
+	case NodeLet:
+		source, err := requireExpr(w.Source, "source")
+		if err != nil {
+			return nil, err
+		}
+		return &LetNode{Target: w.Target, Source: source}, nil
+	case NodeCall:
+		args, err := toExprs(w.Args)
+		if err != nil {
+			return nil, err
+		}
+		return &CallNode{Target: w.Target, Callee: w.Callee, Args: args, Guard: w.Guard}, nil
+	case NodeSlotWrite:
+		object, err := requireExpr(w.Object, "written object")
+		if err != nil {
+			return nil, err
+		}
+		value, err := w.Value.toExpr()
+		if err != nil {
+			return nil, err
+		}
+		return &SlotWriteNode{Object: object, Slot: w.Slot, Value: value}, nil
+	case NodeThrow:
+		value, err := w.Value.toExpr()
+		if err != nil {
+			return nil, err
+		}
+		return &ThrowNode{ErrorType: w.ErrorType, Value: value}, nil
+	case NodeReturn:
+		value, err := requireExpr(w.Value, "returned value")
+		if err != nil {
+			return nil, err
+		}
+		return &ReturnNode{Value: value}, nil
+	case NodeBranch:
+		return &BranchNode{}, nil
+	case NodeOpaque:
+		return &OpaqueNode{}, nil
+	default:
+		return nil, fmt.Errorf("kind %q names no node", w.Kind)
+	}
+}
+
+// toExpr converts a decoded expression. A nil receiver is an operand the graph
+// left out, which requireExpr rejects wherever the shape needs one.
+func (w *wireExpr) toExpr() (Expr, error) {
+	if w == nil {
+		return nil, nil
+	}
+	switch w.Kind {
+	case ExprVar:
+		return &VarExpr{Var: w.Var}, nil
+	case ExprThis:
+		return &ThisExpr{}, nil
+	case ExprLit:
+		return &LitExpr{}, nil
+	case ExprCall:
+		args, err := toExprs(w.Args)
+		if err != nil {
+			return nil, err
+		}
+		return &CallExpr{Callee: w.Callee, Args: args}, nil
+	case ExprSlot:
+		object, err := requireExpr(w.Object, "read object")
+		if err != nil {
+			return nil, err
+		}
+		return &SlotExpr{Object: object, Slot: w.Slot}, nil
+	case ExprProp:
+		object, err := requireExpr(w.Object, "read object")
+		if err != nil {
+			return nil, err
+		}
+		return &PropExpr{Object: object}, nil
+	case ExprAlloc:
+		args, err := toExprs(w.Args)
+		if err != nil {
+			return nil, err
+		}
+		return &AllocExpr{Args: args}, nil
+	default:
+		return nil, fmt.Errorf("kind %q names no expression", w.Kind)
+	}
+}
+
+// requireExpr converts an operand the shape cannot do without. what names the
+// operand's role in the error.
+func requireExpr(w *wireExpr, what string) (Expr, error) {
+	e, err := w.toExpr()
+	if err != nil {
+		return nil, err
+	}
+	if e == nil {
+		return nil, fmt.Errorf("the %s is missing", what)
+	}
+	return e, nil
+}
+
+// toExprs converts an argument list, where a missing entry is an error because
+// an argument's position is what the analysis reads it by.
+func toExprs(ws []*wireExpr) ([]Expr, error) {
+	if len(ws) == 0 {
+		return nil, nil
+	}
+	exprs := make([]Expr, 0, len(ws))
+	for i, w := range ws {
+		e, err := requireExpr(w, fmt.Sprintf("argument %d", i))
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, e)
+	}
+	return exprs, nil
 }

--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -1,0 +1,158 @@
+// Package ecma262 analyzes the ECMA-262 control-flow graph that
+// tools/spec-extract serializes to cfg.json and derives the mutation and
+// alias facts the builtin converter consumes. See
+// planning/ecma-262/implementation_plan.md §4 for the analysis and
+// Appendix A for the schema this file mirrors.
+package ecma262
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// CFG is a serialized control-flow graph: every builtin algorithm at a pinned
+// spec revision, plus the abstract operations reachable from them.
+type CFG struct {
+	SpecTarget string  `json:"specTarget"` // pinned ecma262 git ref
+	Funcs      []*Func `json:"funcs"`
+
+	abstractOps map[string]*Func
+	builtins    map[string]*Func
+}
+
+// FuncKind distinguishes the four algorithm shapes the spec defines. Only a
+// BuiltinMethod has a receiver.
+type FuncKind string
+
+const (
+	BuiltinMethod  FuncKind = "builtin-method"  // X.prototype.method; has a `this` value
+	BuiltinStatic  FuncKind = "builtin-static"  // X.method; no receiver
+	AbstractOp     FuncKind = "abstract-op"     // Set, ToObject, ArrayCreate, ...
+	SyntaxDirected FuncKind = "syntax-directed" // evaluation semantics; not serialized
+)
+
+// Func is one algorithm. Params holds the declared parameters in order. A
+// method's receiver is not among them; it is the `this` value, reached through
+// an ExprThis.
+type Func struct {
+	Name    string   `json:"name"` // canonical spec key or abstract-operation name
+	Kind    FuncKind `json:"kind"`
+	Params  []string `json:"params"`  // declared parameters, in order, 0-based
+	Promise bool     `json:"promise"` // the algorithm returns a promise
+	Nodes   []*Node  `json:"nodes"`   // CFG nodes in flat order
+}
+
+// NodeKind names the statement shapes the serializer lowers a spec step to.
+type NodeKind string
+
+const (
+	NodeLet       NodeKind = "let"       // bind Target = Source
+	NodeCall      NodeKind = "call"      // optional Target = Callee(Args...)
+	NodeSlotWrite NodeKind = "slotwrite" // write Value into Object.Slot
+	NodeThrow     NodeKind = "throw"     // Throw a <ErrorType> exception
+	NodeReturn    NodeKind = "return"    // return Value
+	NodeBranch    NodeKind = "branch"    // control flow; carries no analyzed data
+	NodeOpaque    NodeKind = "opaque"    // a step the serializer could not lower
+)
+
+// Guard is the completion-record guard on a call. `?` propagates an abrupt
+// completion to the caller and `!` asserts that none arises.
+type Guard string
+
+const (
+	GuardQuestion Guard = "?"     // Let x be ? Foo(...)
+	GuardBang     Guard = "!"     // Let x be ! Foo(...)
+	GuardPlain    Guard = "plain" // result not completion-checked
+)
+
+// Node is one step of an algorithm. Which fields carry a value depends on Kind.
+type Node struct {
+	Kind   NodeKind `json:"kind"`
+	Target string   `json:"target,omitempty"` // Let target, or Call result binding
+	Source *Expr    `json:"source,omitempty"` // Let
+	// Callee is a Call's callee. It is either an abstract-operation name, which
+	// resolves in the graph, or a formal parameter holding a function, which is
+	// a callback such as the `callbackfn` in `? Call(callbackfn, ...)`. The
+	// origin map tells the two apart: a callee whose origin is Param(k) is a
+	// callback.
+	Callee string  `json:"callee,omitempty"`
+	Args   []*Expr `json:"args,omitempty"`   // Call
+	Guard  Guard   `json:"guard,omitempty"`  // Call: ? / ! / plain
+	Object *Expr   `json:"object,omitempty"` // SlotWrite: the written object
+	// Slot is the written slot name without its brackets, so [[MapData]] is
+	// "MapData".
+	Slot      string `json:"slot,omitempty"`
+	ErrorType string `json:"errorType,omitempty"` // Throw of a constructed error: "TypeError", ...
+	// Value is the returned expression on a Return, the stored value on a
+	// SlotWrite, and on a Throw the thrown expression, for the rare algorithm
+	// that throws a value it did not construct.
+	Value *Expr `json:"value,omitempty"`
+}
+
+// ExprKind names the value shapes an algorithm step reads or builds.
+type ExprKind string
+
+const (
+	ExprVar  ExprKind = "var"  // a named value
+	ExprThis ExprKind = "this" // the this value
+	ExprLit  ExprKind = "lit"  // literal / primitive
+	ExprCall ExprKind = "call" // nested abstract-operation call
+	ExprSlot ExprKind = "slot" // READ of Object.Slot
+	ExprProp ExprKind = "prop" // READ via Get(Object, Key) etc.
+	// ExprAlloc is a record, list, or map the algorithm allocates, or a copy of
+	// one. The value is fresh, and Args holds the operands stored into it.
+	ExprAlloc ExprKind = "alloc"
+)
+
+// Expr is a value expression. Which fields carry a value depends on Kind.
+type Expr struct {
+	Kind   ExprKind `json:"kind"`
+	Var    string   `json:"var,omitempty"`    // ExprVar; also names a closure passed as a value
+	Callee string   `json:"callee,omitempty"` // ExprCall
+	Args   []*Expr  `json:"args,omitempty"`   // ExprCall / ExprAlloc
+	Object *Expr    `json:"object,omitempty"` // ExprSlot / ExprProp
+	Slot   string   `json:"slot,omitempty"`   // ExprSlot
+}
+
+// LoadCFG reads and decodes a serialized control-flow graph.
+func LoadCFG(path string) (*CFG, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return ParseCFG(data)
+}
+
+// ParseCFG decodes a serialized control-flow graph and indexes its functions
+// by name.
+func ParseCFG(data []byte) (*CFG, error) {
+	cfg := &CFG{}
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("decoding cfg: %w", err)
+	}
+	cfg.abstractOps = make(map[string]*Func)
+	cfg.builtins = make(map[string]*Func)
+	for _, fn := range cfg.Funcs {
+		if fn.Kind == AbstractOp {
+			cfg.abstractOps[fn.Name] = fn
+		} else {
+			cfg.builtins[fn.Name] = fn
+		}
+	}
+	return cfg, nil
+}
+
+// AbstractOp returns the abstract operation named name, or nil. A call's callee
+// and a closure named by an ExprVar both resolve here. Names live in two spaces
+// that a lookup must keep apart: `Set` is both the property-write abstract
+// operation and the `Set` constructor.
+func (c *CFG) AbstractOp(name string) *Func {
+	return c.abstractOps[name]
+}
+
+// Builtin returns the builtin method or static named by its canonical spec key,
+// such as "Array.prototype.push", or nil.
+func (c *CFG) Builtin(name string) *Func {
+	return c.builtins[name]
+}

--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -128,8 +128,10 @@ func LoadCFG(path string) (*CFG, error) {
 }
 
 // ParseCFG decodes a serialized control-flow graph and indexes its functions by
-// name. A function whose kind the analysis cannot index, and a name repeated
-// within one index, are both errors rather than a silently dropped entry.
+// name. Anything the analysis cannot walk or address is an error here rather
+// than a silently dropped entry or a panic further in: a missing function or
+// node, an unnamed function, a kind with no index, and a name repeated within
+// one index.
 func ParseCFG(data []byte) (*CFG, error) {
 	cfg := &CFG{}
 	if err := json.Unmarshal(data, cfg); err != nil {
@@ -137,7 +139,18 @@ func ParseCFG(data []byte) (*CFG, error) {
 	}
 	cfg.abstractOps = make(map[string]*Func)
 	cfg.builtins = make(map[string]*Func)
-	for _, fn := range cfg.Funcs {
+	for i, fn := range cfg.Funcs {
+		if fn == nil {
+			return nil, fmt.Errorf("decoding cfg: funcs[%d] is missing", i)
+		}
+		if fn.Name == "" {
+			return nil, fmt.Errorf("decoding cfg: funcs[%d] has no name", i)
+		}
+		for j, node := range fn.Nodes {
+			if node == nil {
+				return nil, fmt.Errorf("decoding cfg: node %d of %s is missing", j, fn.Name)
+			}
+		}
 		var index map[string]*Func
 		switch fn.Kind {
 		case AbstractOp:

--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -1,8 +1,9 @@
-// Package ecma262 analyzes the ECMA-262 control-flow graph that
-// tools/spec-extract serializes to cfg.json and derives the mutation and
-// alias facts the builtin converter consumes. See
-// planning/ecma-262/implementation_plan.md §4 for the analysis and
-// Appendix A for the schema this file mirrors.
+// Package ecma262 reads the ECMA-262 control-flow graph that
+// tools/spec-extract serializes to cfg.json and derives the mutation and alias
+// facts the builtin converter consumes. cfg.go mirrors the serialized schema,
+// and origin.go maps each value an algorithm names to where that value came
+// from. See planning/ecma-262/implementation_plan.md §4 for the analysis and
+// Appendix A for the schema.
 package ecma262
 
 import (
@@ -11,8 +12,8 @@ import (
 	"os"
 )
 
-// CFG is a serialized control-flow graph: every builtin algorithm at a pinned
-// spec revision, plus the abstract operations reachable from them.
+// CFG is a serialized control-flow graph. It holds every builtin algorithm at a
+// pinned spec revision, plus the abstract operations reachable from them.
 type CFG struct {
 	SpecTarget string  `json:"specTarget"` // pinned ecma262 git ref
 	Funcs      []*Func `json:"funcs"`
@@ -22,7 +23,9 @@ type CFG struct {
 }
 
 // FuncKind distinguishes the four algorithm shapes the spec defines. Only a
-// BuiltinMethod has a receiver.
+// BuiltinMethod has a receiver. A SyntaxDirected operation is the runtime
+// semantics of the language rather than a library surface, so the serializer
+// drops it and ParseCFG rejects one that reaches it.
 type FuncKind string
 
 const (
@@ -124,8 +127,9 @@ func LoadCFG(path string) (*CFG, error) {
 	return ParseCFG(data)
 }
 
-// ParseCFG decodes a serialized control-flow graph and indexes its functions
-// by name.
+// ParseCFG decodes a serialized control-flow graph and indexes its functions by
+// name. A function whose kind the analysis cannot index, and a name repeated
+// within one index, are both errors rather than a silently dropped entry.
 func ParseCFG(data []byte) (*CFG, error) {
 	cfg := &CFG{}
 	if err := json.Unmarshal(data, cfg); err != nil {
@@ -134,25 +138,33 @@ func ParseCFG(data []byte) (*CFG, error) {
 	cfg.abstractOps = make(map[string]*Func)
 	cfg.builtins = make(map[string]*Func)
 	for _, fn := range cfg.Funcs {
-		if fn.Kind == AbstractOp {
-			cfg.abstractOps[fn.Name] = fn
-		} else {
-			cfg.builtins[fn.Name] = fn
+		var index map[string]*Func
+		switch fn.Kind {
+		case AbstractOp:
+			index = cfg.abstractOps
+		case BuiltinMethod, BuiltinStatic:
+			index = cfg.builtins
+		default:
+			return nil, fmt.Errorf("decoding cfg: %s has kind %q, which the analysis cannot index", fn.Name, fn.Kind)
 		}
+		if _, dup := index[fn.Name]; dup {
+			return nil, fmt.Errorf("decoding cfg: two %s functions named %s", fn.Kind, fn.Name)
+		}
+		index[fn.Name] = fn
 	}
 	return cfg, nil
 }
 
-// AbstractOp returns the abstract operation named name, or nil. A call's callee
-// and a closure named by an ExprVar both resolve here. Names live in two spaces
-// that a lookup must keep apart: `Set` is both the property-write abstract
-// operation and the `Set` constructor.
+// AbstractOp returns the abstract operation of that name, or nil. A call's
+// callee and a closure named by an ExprVar both resolve here. Names live in two
+// spaces that a lookup has to keep apart. `Set` is both the property-write
+// abstract operation and the `Set` constructor.
 func (c *CFG) AbstractOp(name string) *Func {
 	return c.abstractOps[name]
 }
 
-// Builtin returns the builtin method or static named by its canonical spec key,
-// such as "Array.prototype.push", or nil.
+// Builtin returns the builtin method or static of that canonical spec key, such
+// as "Array.prototype.push", or nil.
 func (c *CFG) Builtin(name string) *Func {
 	return c.builtins[name]
 }

--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/escalier-lang/escalier/internal/set"
 )
 
 // CFG is a control-flow graph read back from cfg.json. It holds every builtin
@@ -220,22 +222,22 @@ func LoadCFG(path string) (*CFG, error) {
 // ParseCFG decodes a serialized control-flow graph and indexes its functions by
 // name. Anything the analysis cannot walk or address is an error here rather
 // than a silently dropped entry or a panic further in: a missing function,
-// node, or operand, an unnamed function, a tag that names no variant, and a
-// name repeated within one index.
+// node, or operand, an unnamed function, a tag that names no variant, a field
+// the tagged kind does not use, and a name repeated within one index.
 func ParseCFG(data []byte) (*CFG, error) {
-	var wire wireCFG
-	if err := json.Unmarshal(data, &wire); err != nil {
+	var decoded decodeCFG
+	if err := json.Unmarshal(data, &decoded); err != nil {
 		return nil, fmt.Errorf("decoding cfg: %w", err)
 	}
 
 	cfg := &CFG{
-		SpecTarget:  wire.SpecTarget,
-		Funcs:       make([]*Func, 0, len(wire.Funcs)),
+		SpecTarget:  decoded.SpecTarget,
+		Funcs:       make([]*Func, 0, len(decoded.Funcs)),
 		abstractOps: make(map[string]*Func),
 		builtins:    make(map[string]*Func),
 	}
-	for i, wf := range wire.Funcs {
-		fn, err := wf.toFunc(i)
+	for i, df := range decoded.Funcs {
+		fn, err := df.toFunc(i)
 		if err != nil {
 			return nil, fmt.Errorf("decoding cfg: %w", err)
 		}
@@ -273,165 +275,261 @@ func (c *CFG) Builtin(name string) *Func {
 	return c.builtins[name]
 }
 
-// The wire types mirror the serialized schema in Appendix A, where a node and
+// The decode types mirror the serialized schema in Appendix A, where a node and
 // an expression are each one object tagged by kind. encoding/json cannot pick a
-// variant of a sealed interface on its own, so decoding lands here first and
-// the conversions below rebuild the graph as the sum types above.
+// variant of a sealed interface on its own, so decoding lands here first and the
+// conversions below rebuild the graph as the sum types above. Nothing marshals
+// back, so these types are read only when a graph is parsed.
 
-type wireCFG struct {
-	SpecTarget string      `json:"specTarget"`
-	Funcs      []*wireFunc `json:"funcs"`
+type decodeCFG struct {
+	SpecTarget string        `json:"specTarget"`
+	Funcs      []*decodeFunc `json:"funcs"`
 }
 
-type wireFunc struct {
-	Name    string      `json:"name"`
-	Kind    FuncKind    `json:"kind"`
-	Params  []string    `json:"params"`
-	Promise bool        `json:"promise"`
-	Nodes   []*wireNode `json:"nodes"`
+type decodeFunc struct {
+	Name    string        `json:"name"`
+	Kind    FuncKind      `json:"kind"`
+	Params  []string      `json:"params"`
+	Promise bool          `json:"promise"`
+	Nodes   []*decodeNode `json:"nodes"`
 }
 
-type wireNode struct {
-	Kind      NodeKind    `json:"kind"`
-	Target    string      `json:"target"`
-	Source    *wireExpr   `json:"source"`
-	Callee    string      `json:"callee"`
-	Args      []*wireExpr `json:"args"`
-	Guard     Guard       `json:"guard"`
-	Object    *wireExpr   `json:"object"`
-	Slot      string      `json:"slot"`
-	ErrorType string      `json:"errorType"`
-	Value     *wireExpr   `json:"value"`
+type decodeNode struct {
+	Kind      NodeKind      `json:"kind"`
+	Target    string        `json:"target"`
+	Source    *decodeExpr   `json:"source"`
+	Callee    string        `json:"callee"`
+	Args      []*decodeExpr `json:"args"`
+	Guard     Guard         `json:"guard"`
+	Object    *decodeExpr   `json:"object"`
+	Slot      string        `json:"slot"`
+	ErrorType string        `json:"errorType"`
+	Value     *decodeExpr   `json:"value"`
 }
 
-type wireExpr struct {
-	Kind   ExprKind    `json:"kind"`
-	Var    string      `json:"var"`
-	Callee string      `json:"callee"`
-	Args   []*wireExpr `json:"args"`
-	Object *wireExpr   `json:"object"`
-	Slot   string      `json:"slot"`
+type decodeExpr struct {
+	Kind   ExprKind      `json:"kind"`
+	Var    string        `json:"var"`
+	Callee string        `json:"callee"`
+	Args   []*decodeExpr `json:"args"`
+	Object *decodeExpr   `json:"object"`
+	Slot   string        `json:"slot"`
 }
 
-func (w *wireFunc) toFunc(index int) (*Func, error) {
-	if w == nil {
+// field pairs a schema field name with whether the decoded object carries it.
+type field struct {
+	name string
+	set  bool
+}
+
+// checkFields rejects a field the kind does not use. One decode struct covers
+// every kind, so a field the schema moved to another kind would otherwise be
+// read as absent and the change would pass unnoticed. used names the fields the
+// kind does carry, and fields returns them in schema order so a given graph
+// always fails on the same one.
+func checkFields(shape string, fields []field, used ...string) error {
+	carried := set.FromSlice(used)
+	for _, f := range fields {
+		if f.set && !carried.Contains(f.name) {
+			return fmt.Errorf("%s carries %q", shape, f.name)
+		}
+	}
+	return nil
+}
+
+func (d *decodeNode) fields() []field {
+	return []field{
+		{"target", d.Target != ""},
+		{"source", d.Source != nil},
+		{"callee", d.Callee != ""},
+		{"args", d.Args != nil},
+		{"guard", d.Guard != ""},
+		{"object", d.Object != nil},
+		{"slot", d.Slot != ""},
+		{"errorType", d.ErrorType != ""},
+		{"value", d.Value != nil},
+	}
+}
+
+func (d *decodeNode) check(used ...string) error {
+	return checkFields(fmt.Sprintf("a %s node", d.Kind), d.fields(), used...)
+}
+
+func (d *decodeExpr) fields() []field {
+	return []field{
+		{"var", d.Var != ""},
+		{"callee", d.Callee != ""},
+		{"args", d.Args != nil},
+		{"object", d.Object != nil},
+		{"slot", d.Slot != ""},
+	}
+}
+
+func (d *decodeExpr) check(used ...string) error {
+	return checkFields(fmt.Sprintf("a %s expression", d.Kind), d.fields(), used...)
+}
+
+func (d *decodeFunc) toFunc(index int) (*Func, error) {
+	if d == nil {
 		return nil, fmt.Errorf("funcs[%d] is missing", index)
 	}
-	if w.Name == "" {
+	if d.Name == "" {
 		return nil, fmt.Errorf("funcs[%d] has no name", index)
 	}
 
 	fn := &Func{
-		Name:    w.Name,
-		Kind:    w.Kind,
-		Params:  w.Params,
-		Promise: w.Promise,
-		Nodes:   make([]Node, 0, len(w.Nodes)),
+		Name:    d.Name,
+		Kind:    d.Kind,
+		Params:  d.Params,
+		Promise: d.Promise,
+		Nodes:   make([]Node, 0, len(d.Nodes)),
 	}
-	for i, wn := range w.Nodes {
-		if wn == nil {
-			return nil, fmt.Errorf("node %d of %s is missing", i, w.Name)
+	for i, dn := range d.Nodes {
+		if dn == nil {
+			return nil, fmt.Errorf("node %d of %s is missing", i, d.Name)
 		}
-		node, err := wn.toNode()
+		node, err := dn.toNode()
 		if err != nil {
-			return nil, fmt.Errorf("node %d of %s: %w", i, w.Name, err)
+			return nil, fmt.Errorf("node %d of %s: %w", i, d.Name, err)
 		}
 		fn.Nodes = append(fn.Nodes, node)
 	}
 	return fn, nil
 }
 
-func (w *wireNode) toNode() (Node, error) {
-	switch w.Kind {
+func (d *decodeNode) toNode() (Node, error) {
+	switch d.Kind {
 	case NodeLet:
-		source, err := requireExpr(w.Source, "source")
+		if err := d.check("target", "source"); err != nil {
+			return nil, err
+		}
+		source, err := requireExpr(d.Source, "source")
 		if err != nil {
 			return nil, err
 		}
-		return &LetNode{Target: w.Target, Source: source}, nil
+		return &LetNode{Target: d.Target, Source: source}, nil
 	case NodeCall:
-		args, err := toExprs(w.Args)
+		if err := d.check("target", "callee", "args", "guard"); err != nil {
+			return nil, err
+		}
+		args, err := toExprs(d.Args)
 		if err != nil {
 			return nil, err
 		}
-		return &CallNode{Target: w.Target, Callee: w.Callee, Args: args, Guard: w.Guard}, nil
+		return &CallNode{Target: d.Target, Callee: d.Callee, Args: args, Guard: d.Guard}, nil
 	case NodeSlotWrite:
-		object, err := requireExpr(w.Object, "written object")
+		if err := d.check("object", "slot", "value"); err != nil {
+			return nil, err
+		}
+		object, err := requireExpr(d.Object, "written object")
 		if err != nil {
 			return nil, err
 		}
-		value, err := w.Value.toExpr()
+		value, err := d.Value.toExpr()
 		if err != nil {
 			return nil, err
 		}
-		return &SlotWriteNode{Object: object, Slot: w.Slot, Value: value}, nil
+		return &SlotWriteNode{Object: object, Slot: d.Slot, Value: value}, nil
 	case NodeThrow:
-		value, err := w.Value.toExpr()
+		if err := d.check("errorType", "value"); err != nil {
+			return nil, err
+		}
+		value, err := d.Value.toExpr()
 		if err != nil {
 			return nil, err
 		}
-		return &ThrowNode{ErrorType: w.ErrorType, Value: value}, nil
+		return &ThrowNode{ErrorType: d.ErrorType, Value: value}, nil
 	case NodeReturn:
-		value, err := requireExpr(w.Value, "returned value")
+		if err := d.check("value"); err != nil {
+			return nil, err
+		}
+		value, err := requireExpr(d.Value, "returned value")
 		if err != nil {
 			return nil, err
 		}
 		return &ReturnNode{Value: value}, nil
 	case NodeBranch:
+		if err := d.check(); err != nil {
+			return nil, err
+		}
 		return &BranchNode{}, nil
 	case NodeOpaque:
+		if err := d.check(); err != nil {
+			return nil, err
+		}
 		return &OpaqueNode{}, nil
 	default:
-		return nil, fmt.Errorf("kind %q names no node", w.Kind)
+		return nil, fmt.Errorf("kind %q names no node", d.Kind)
 	}
 }
 
 // toExpr converts a decoded expression. A nil receiver is an operand the graph
 // left out, which requireExpr rejects wherever the shape needs one.
-func (w *wireExpr) toExpr() (Expr, error) {
-	if w == nil {
+func (d *decodeExpr) toExpr() (Expr, error) {
+	if d == nil {
 		return nil, nil
 	}
-	switch w.Kind {
+	switch d.Kind {
 	case ExprVar:
-		return &VarExpr{Var: w.Var}, nil
+		if err := d.check("var"); err != nil {
+			return nil, err
+		}
+		return &VarExpr{Var: d.Var}, nil
 	case ExprThis:
+		if err := d.check(); err != nil {
+			return nil, err
+		}
 		return &ThisExpr{}, nil
 	case ExprLit:
+		if err := d.check(); err != nil {
+			return nil, err
+		}
 		return &LitExpr{}, nil
 	case ExprCall:
-		args, err := toExprs(w.Args)
+		if err := d.check("callee", "args"); err != nil {
+			return nil, err
+		}
+		args, err := toExprs(d.Args)
 		if err != nil {
 			return nil, err
 		}
-		return &CallExpr{Callee: w.Callee, Args: args}, nil
+		return &CallExpr{Callee: d.Callee, Args: args}, nil
 	case ExprSlot:
-		object, err := requireExpr(w.Object, "read object")
+		if err := d.check("object", "slot"); err != nil {
+			return nil, err
+		}
+		object, err := requireExpr(d.Object, "read object")
 		if err != nil {
 			return nil, err
 		}
-		return &SlotExpr{Object: object, Slot: w.Slot}, nil
+		return &SlotExpr{Object: object, Slot: d.Slot}, nil
 	case ExprProp:
-		object, err := requireExpr(w.Object, "read object")
+		if err := d.check("object"); err != nil {
+			return nil, err
+		}
+		object, err := requireExpr(d.Object, "read object")
 		if err != nil {
 			return nil, err
 		}
 		return &PropExpr{Object: object}, nil
 	case ExprAlloc:
-		args, err := toExprs(w.Args)
+		if err := d.check("args"); err != nil {
+			return nil, err
+		}
+		args, err := toExprs(d.Args)
 		if err != nil {
 			return nil, err
 		}
 		return &AllocExpr{Args: args}, nil
 	default:
-		return nil, fmt.Errorf("kind %q names no expression", w.Kind)
+		return nil, fmt.Errorf("kind %q names no expression", d.Kind)
 	}
 }
 
 // requireExpr converts an operand the shape cannot do without. what names the
 // operand's role in the error.
-func requireExpr(w *wireExpr, what string) (Expr, error) {
-	e, err := w.toExpr()
+func requireExpr(d *decodeExpr, what string) (Expr, error) {
+	e, err := d.toExpr()
 	if err != nil {
 		return nil, err
 	}
@@ -443,13 +541,13 @@ func requireExpr(w *wireExpr, what string) (Expr, error) {
 
 // toExprs converts an argument list, where a missing entry is an error because
 // an argument's position is what the analysis reads it by.
-func toExprs(ws []*wireExpr) ([]Expr, error) {
-	if len(ws) == 0 {
+func toExprs(ds []*decodeExpr) ([]Expr, error) {
+	if len(ds) == 0 {
 		return nil, nil
 	}
-	exprs := make([]Expr, 0, len(ws))
-	for i, w := range ws {
-		e, err := requireExpr(w, fmt.Sprintf("argument %d", i))
+	exprs := make([]Expr, 0, len(ds))
+	for i, d := range ds {
+		e, err := requireExpr(d, fmt.Sprintf("argument %d", i))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/ecma262/cfg_test.go
+++ b/internal/ecma262/cfg_test.go
@@ -70,6 +70,23 @@ func TestParseCFGRejects(t *testing.T) {
 		// has nowhere to put anything else. Syntax-directed operations are the
 		// runtime semantics of the language rather than a library surface, so
 		// the serializer drops them.
+		// A missing entry would otherwise be a nil dereference here or in the
+		// walk that follows.
+		"MissingFunc": {
+			json: `{"specTarget":"abc","funcs":[null]}`,
+			err:  "decoding cfg: funcs[0] is missing",
+		},
+		"MissingNode": {
+			json: `{"specTarget":"abc","funcs":[{"name":"ToObject","kind":"abstract-op",` +
+				`"nodes":[{"kind":"branch"},null]}]}`,
+			err: "decoding cfg: node 1 of ToObject is missing",
+		},
+		// The analysis addresses a function only by name, so an unnamed one is
+		// unreachable.
+		"UnnamedFunc": {
+			json: `{"specTarget":"abc","funcs":[{"kind":"abstract-op"}]}`,
+			err:  "decoding cfg: funcs[0] has no name",
+		},
 		"UnindexableKind": {
 			json: `{"specTarget":"abc","funcs":[{"name":"Evaluation","kind":"` +
 				string(SyntaxDirected) + `"}]}`,

--- a/internal/ecma262/cfg_test.go
+++ b/internal/ecma262/cfg_test.go
@@ -87,6 +87,28 @@ func TestParseCFGRejects(t *testing.T) {
 			json: `{"specTarget":"abc","funcs":[{"kind":"abstract-op"}]}`,
 			err:  "decoding cfg: funcs[0] has no name",
 		},
+		// A required operand the graph leaves out would otherwise reach the
+		// origin walk as a nil Expr and resolve to Unknown, hiding the gap.
+		"MissingOperand": {
+			json: `{"specTarget":"abc","funcs":[{"name":"ToObject","kind":"abstract-op",` +
+				`"nodes":[{"kind":"let","target":"O"}]}]}`,
+			err: "decoding cfg: node 0 of ToObject: the source is missing",
+		},
+		"MissingArgument": {
+			json: `{"specTarget":"abc","funcs":[{"name":"ToObject","kind":"abstract-op",` +
+				`"nodes":[{"kind":"call","callee":"Get","args":[{"kind":"this"},null]}]}]}`,
+			err: "decoding cfg: node 0 of ToObject: the argument 1 is missing",
+		},
+		"UnknownNodeTag": {
+			json: `{"specTarget":"abc","funcs":[{"name":"ToObject","kind":"abstract-op",` +
+				`"nodes":[{"kind":"assign"}]}]}`,
+			err: `decoding cfg: node 0 of ToObject: kind "assign" names no node`,
+		},
+		"UnknownExprTag": {
+			json: `{"specTarget":"abc","funcs":[{"name":"ToObject","kind":"abstract-op",` +
+				`"nodes":[{"kind":"return","value":{"kind":"regexp"}}]}]}`,
+			err: `decoding cfg: node 0 of ToObject: kind "regexp" names no expression`,
+		},
 		"UnindexableKind": {
 			json: `{"specTarget":"abc","funcs":[{"name":"Evaluation","kind":"` +
 				string(SyntaxDirected) + `"}]}`,
@@ -105,6 +127,25 @@ func TestParseCFGRejects(t *testing.T) {
 			require.Equal(t, test.err, err.Error())
 		})
 	}
+}
+
+// The graph does not always name the value a slot write stores. A closure's
+// argument prologue writes an incoming argument the algorithm never named, so
+// the node decodes with a nil Value rather than being rejected.
+func TestParseCFGAllowsSlotWriteWithoutValue(t *testing.T) {
+	cfg := testCFG(t)
+
+	fn := cfg.AbstractOp("NewPromiseCapability:clo0")
+	require.NotNil(t, fn)
+
+	var slots []string
+	for _, node := range fn.Nodes {
+		if write, ok := node.(*SlotWriteNode); ok && write.Value == nil {
+			require.Equal(t, &VarExpr{Var: "__args__"}, write.Object)
+			slots = append(slots, write.Slot)
+		}
+	}
+	require.Equal(t, []string{"resolve", "reject"}, slots)
 }
 
 // One name can name both an abstract operation and a builtin. `Set` is the

--- a/internal/ecma262/cfg_test.go
+++ b/internal/ecma262/cfg_test.go
@@ -99,6 +99,19 @@ func TestParseCFGRejects(t *testing.T) {
 				`"nodes":[{"kind":"call","callee":"Get","args":[{"kind":"this"},null]}]}]}`,
 			err: "decoding cfg: node 0 of ToObject: the argument 1 is missing",
 		},
+		// The serializer omits every field the kind does not carry, so a field
+		// on the wrong kind means the schema moved and the reader has to be
+		// taught the new shape.
+		"StrayNodeField": {
+			json: `{"specTarget":"abc","funcs":[{"name":"ToObject","kind":"abstract-op",` +
+				`"nodes":[{"kind":"let","target":"O","source":{"kind":"this"},"slot":"MapData"}]}]}`,
+			err: `decoding cfg: node 0 of ToObject: a let node carries "slot"`,
+		},
+		"StrayExprField": {
+			json: `{"specTarget":"abc","funcs":[{"name":"ToObject","kind":"abstract-op",` +
+				`"nodes":[{"kind":"return","value":{"kind":"var","var":"O","args":[]}}]}]}`,
+			err: `decoding cfg: node 0 of ToObject: a var expression carries "args"`,
+		},
 		"UnknownNodeTag": {
 			json: `{"specTarget":"abc","funcs":[{"name":"ToObject","kind":"abstract-op",` +
 				`"nodes":[{"kind":"assign"}]}]}`,

--- a/internal/ecma262/cfg_test.go
+++ b/internal/ecma262/cfg_test.go
@@ -1,0 +1,64 @@
+package ecma262
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// cfgPath is the control-flow graph tools/spec-extract commits.
+const cfgPath = "../../tools/spec-extract/cfg.json"
+
+var (
+	loadOnce sync.Once
+	loaded   *CFG
+	loadErr  error
+)
+
+// testCFG loads the committed control-flow graph once for the whole package.
+func testCFG(t *testing.T) *CFG {
+	t.Helper()
+	loadOnce.Do(func() {
+		loaded, loadErr = LoadCFG(cfgPath)
+	})
+	require.NoError(t, loadErr)
+	return loaded
+}
+
+func TestLoadCFG(t *testing.T) {
+	cfg := testCFG(t)
+
+	require.NotEmpty(t, cfg.SpecTarget)
+	require.NotEmpty(t, cfg.Funcs)
+	for _, fn := range cfg.Funcs {
+		require.Contains(t, []FuncKind{BuiltinMethod, BuiltinStatic, AbstractOp}, fn.Kind,
+			"unexpected kind on %s", fn.Name)
+		require.NotEmpty(t, fn.Name)
+	}
+}
+
+func TestLookupKeepsNameSpacesApart(t *testing.T) {
+	cfg := testCFG(t)
+
+	// `Set` names both the property-write abstract operation and the `Set`
+	// constructor, so a lookup has to say which space it means.
+	setOp := cfg.AbstractOp("Set")
+	require.NotNil(t, setOp)
+	require.Equal(t, AbstractOp, setOp.Kind)
+	require.Equal(t, []string{"O", "P", "V", "Throw"}, setOp.Params)
+
+	require.Nil(t, cfg.Builtin("ToObject"))
+	require.Nil(t, cfg.AbstractOp("Array.prototype.push"))
+
+	push := cfg.Builtin("Array.prototype.push")
+	require.NotNil(t, push)
+	require.Equal(t, BuiltinMethod, push.Kind)
+	require.Equal(t, []string{"items"}, push.Params)
+}
+
+func TestParseCFGRejectsMalformedJSON(t *testing.T) {
+	_, err := ParseCFG([]byte("{"))
+	require.Error(t, err)
+	require.Equal(t, "decoding cfg: unexpected end of JSON input", err.Error())
+}

--- a/internal/ecma262/cfg_test.go
+++ b/internal/ecma262/cfg_test.go
@@ -57,8 +57,49 @@ func TestLookupKeepsNameSpacesApart(t *testing.T) {
 	require.Equal(t, []string{"items"}, push.Params)
 }
 
-func TestParseCFGRejectsMalformedJSON(t *testing.T) {
-	_, err := ParseCFG([]byte("{"))
-	require.Error(t, err)
-	require.Equal(t, "decoding cfg: unexpected end of JSON input", err.Error())
+func TestParseCFGRejects(t *testing.T) {
+	tests := map[string]struct {
+		json string
+		err  string
+	}{
+		"MalformedJSON": {
+			json: `{`,
+			err:  "decoding cfg: unexpected end of JSON input",
+		},
+		// The analysis indexes an abstract operation apart from a builtin and
+		// has nowhere to put anything else. Syntax-directed operations are the
+		// runtime semantics of the language rather than a library surface, so
+		// the serializer drops them.
+		"UnindexableKind": {
+			json: `{"specTarget":"abc","funcs":[{"name":"Evaluation","kind":"` +
+				string(SyntaxDirected) + `"}]}`,
+			err: `decoding cfg: Evaluation has kind "syntax-directed", which the analysis cannot index`,
+		},
+		"RepeatedName": {
+			json: `{"specTarget":"abc","funcs":[{"name":"Set","kind":"abstract-op"},{"name":"Set","kind":"abstract-op"}]}`,
+			err:  "decoding cfg: two abstract-op functions named Set",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseCFG([]byte(test.json))
+			require.Error(t, err)
+			require.Equal(t, test.err, err.Error())
+		})
+	}
+}
+
+// One name can name both an abstract operation and a builtin. `Set` is the
+// property-write operation and the `Set` constructor, and the two indexes keep
+// them apart.
+func TestParseCFGIndexesBothNameSpaces(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[` +
+			`{"name":"Set","kind":"abstract-op"},` +
+			`{"name":"Set","kind":"builtin-static"}]}`))
+	require.NoError(t, err)
+
+	require.Equal(t, AbstractOp, cfg.AbstractOp("Set").Kind)
+	require.Equal(t, BuiltinStatic, cfg.Builtin("Set").Kind)
 }

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -27,7 +27,7 @@ const (
 	// observable to the caller.
 	OriginFresh
 	// OriginUnknown is a value the analysis could not tie to any of the above.
-	// It is the top of the lattice: joining it with anything yields it.
+	// It is the top of the lattice, so joining it with anything yields it.
 	OriginUnknown
 )
 
@@ -67,10 +67,11 @@ func (o Origin) String() string {
 	}
 }
 
-// join is the least upper bound of two origins. Two definitions that agree
-// keep their origin and two that disagree collapse to OriginUnknown, which is
-// what makes the analysis path-insensitive: a name assigned on two branches
-// takes the join of both rather than the one the analysis walked last.
+// join is the least upper bound of two origins. Two definitions that agree keep
+// their origin. Two that disagree collapse to OriginUnknown. That collapse is
+// what makes the analysis path-insensitive. A name assigned on two branches
+// takes the join of both definitions rather than whichever one the walk
+// reached last.
 func (o Origin) join(other Origin) Origin {
 	switch {
 	case o.Kind == originUnset:
@@ -85,26 +86,25 @@ func (o Origin) join(other Origin) Origin {
 }
 
 // identityCoercions are the abstract operations that hand back the value they
-// were given, so an origin propagates through them. The list is deliberately
-// short and reviewed by hand, because calling an operation identity-preserving
-// when it builds a new value would attribute a mutation to the wrong place.
+// were given, so an origin propagates through them. The list is short and
+// reviewed by hand. Calling an operation identity-preserving when it builds a
+// new value would charge a mutation to the wrong place.
 //
-// ToObject is the entry that makes receiver tracking work: `Let O be ?
-// ToObject(this value)` keeps O at the receiver, which is how
-// Array.prototype.push comes out mutating. For a primitive receiver ToObject
-// wraps rather than returns, so this over-approximates. That is the safe
-// direction under FR5 — a mutation claimed where there is none fails loudly at
-// a call site, while a missed one is silent unsoundness.
+// ToObject is the entry that makes receiver tracking work. `Let O be ?
+// ToObject(this value)` keeps `O` at the receiver, which is how
+// `Array.prototype.push` comes out mutating. ToObject wraps a primitive
+// receiver rather than returning it, so the entry over-approximates. That is
+// the safe direction under FR5. A mutation claimed where there is none fails
+// loudly at a call site, while a missed one is silent unsoundness.
 //
-// CanonicalizeKeyedCollectionKey returns its key unchanged except that it
-// normalizes -0 to +0, which cannot apply to an object. Completion and
+// CanonicalizeKeyedCollectionKey returns its key unchanged apart from
+// normalizing -0 to +0, which cannot apply to an object. Completion and
 // NormalCompletion wrap a value in a completion record, and the serializer
-// drops the matching unwrap, so from a caller's side they pass the value
-// through.
+// drops the matching unwrap, so a caller sees the value they were handed.
 //
 // Coercions that build a new value are absent by design. ToString and ToNumber
-// break the chain, which is why every String.prototype method comes out
-// non-mutating: the algorithm coerces `this` to a fresh string and never writes
+// break the chain. That is why every `String.prototype` method comes out
+// non-mutating. The algorithm coerces `this` to a fresh string and never writes
 // back through the receiver.
 var identityCoercions = set.FromSlice([]string{
 	"CanonicalizeKeyedCollectionKey",
@@ -115,22 +115,22 @@ var identityCoercions = set.FromSlice([]string{
 })
 
 // allocators are the abstract operations that return a value they allocated.
-// Their result is Fresh, so a mutation of it is invisible to the caller and the
-// mutation fixpoint ignores it. Every entry must genuinely allocate: claiming
-// Fresh for an operation that can hand back a caller-visible object would hide
-// a real mutation.
+// Their result is `Fresh`, the one origin whose mutations the fixpoint
+// discards, because a write to a value the algorithm made itself is invisible
+// to its caller. Every entry must therefore genuinely allocate. Listing an
+// operation that can hand back a value the caller already holds would turn a
+// real mutation invisible.
 //
-// Two absences are deliberate. Construct runs a constructor chosen at runtime
-// and can return any object, including one of its arguments. ProxyCreate
-// allocates a proxy, but a write to that proxy reaches its target, so the
-// result is not independent of the argument.
+// Two absences follow from that. Construct runs a constructor chosen at runtime
+// and may return any object, including one of its arguments. ProxyCreate
+// allocates a proxy, but a write to that proxy reaches its target, so its
+// result is not independent of its argument. Both resolve to `Unknown` instead.
 //
-// The species entries — ArraySpeciesCreate, TypedArraySpeciesCreate and the
-// TypedArrayCreate* family — run a constructor the caller can replace and so
-// carry the same risk as Construct. §4.2 names ArraySpeciesCreate as an
-// allocator because Array.prototype.slice and its neighbours build their result
-// through it, and a value read back out of that result is a slot or property
-// read, which breaks the chain anyway.
+// ArraySpeciesCreate, TypedArraySpeciesCreate, and the TypedArrayCreate family
+// run a constructor the caller can replace, so they carry the same risk. §4.2
+// lists ArraySpeciesCreate anyway, because `Array.prototype.slice` and its
+// neighbours build their result through it. Reading a value back out of that
+// result is a slot or property access, which breaks the chain regardless.
 var allocators = set.FromSlice([]string{
 	// Ordinary objects and records.
 	"MakeBasicObject",
@@ -204,12 +204,12 @@ type OriginMap struct {
 // seed the map, and each Let and each Call result binding takes the join of
 // every definition of its name.
 //
-// The pass is path-insensitive: a branch is never interpreted, and the node
-// list is walked as a flat sequence. Walking it repeatedly until nothing moves
-// makes the result independent of the order the serializer emitted the nodes
-// in, so a name defined by a loop's back edge still reaches its uses. The
-// walk terminates because an origin only ever climbs the lattice, from unset to
-// an origin to Unknown.
+// The walk is path-insensitive. It never interprets a branch and reads the node
+// list as a flat sequence. Repeating the walk until nothing moves makes the
+// result independent of the order the serializer emitted the nodes in, so a
+// name a loop's back edge redefines still reaches its uses. The repetition
+// terminates because an origin only climbs the lattice, from unset to one
+// origin to `Unknown`.
 func NewOriginMap(fn *Func) *OriginMap {
 	m := &OriginMap{fn: fn, origins: make(map[string]Origin, len(fn.Params)+len(fn.Nodes))}
 	for {
@@ -249,8 +249,8 @@ func (m *OriginMap) Func() *Func {
 	return m.fn
 }
 
-// Of returns the origin of a value name. A name the analysis never bound is
-// Unknown.
+// Of returns the origin of a value name. A name the walk never bound is
+// `Unknown`.
 func (m *OriginMap) Of(name string) Origin {
 	return resolved(m.origins[name])
 }
@@ -261,9 +261,9 @@ func (m *OriginMap) Eval(e *Expr) Origin {
 	return resolved(m.eval(e))
 }
 
-// resolved turns the lattice bottom into Unknown. A name is still unset when
-// every definition of it evaluated to unset, which means the analysis learned
-// nothing about it.
+// resolved turns the lattice bottom into `Unknown`. A name reaches the end of
+// the walk unset when every definition of it evaluated to unset, which means
+// the walk learned nothing about it.
 func resolved(o Origin) Origin {
 	if o.Kind == originUnset {
 		return Unknown
@@ -271,9 +271,9 @@ func resolved(o Origin) Origin {
 	return o
 }
 
-// eval returns an expression's origin, keeping the lattice bottom so that a
-// name read before the walk reaches its definition contributes nothing rather
-// than pinning the reader at Unknown.
+// eval returns an expression's origin, keeping the lattice bottom rather than
+// resolving it. A name read before the walk reaches its definition then
+// contributes nothing to the reader instead of pinning it at `Unknown`.
 func (m *OriginMap) eval(e *Expr) Origin {
 	if e == nil {
 		return Unknown
@@ -295,7 +295,7 @@ func (m *OriginMap) eval(e *Expr) Origin {
 		return Fresh
 	case ExprSlot, ExprProp:
 		// A read, so the chain breaks here. The value read out of a container
-		// is a different object from the container.
+		// is a different object from the container itself.
 		return Unknown
 	default:
 		return Unknown
@@ -329,7 +329,8 @@ func (m *OriginMap) Names() []string {
 }
 
 // String renders the map as one `name: origin` line per name, sorted by name,
-// so a test can assert the whole map at once.
+// so a test can assert the whole map at once. Origin.String spells each origin,
+// so a parameter reads as `Param(0)`.
 func (m *OriginMap) String() string {
 	names := m.Names()
 

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -114,6 +114,60 @@ var identityCoercions = set.FromSlice([]string{
 	"ToObject",
 })
 
+// freshPrimitives are the abstract operations that build a new primitive from
+// their argument. Their result is `Fresh` for the same reason an allocation is,
+// and with none of the risk: a primitive cannot be mutated, so an entry here
+// can never hide a write the caller would observe. The list exists so that
+// `ToString` resolving away from its argument reads as a decision rather than
+// an omission from allocators.
+//
+// `Let S be ? ToString(O)` is the case that matters. `O` is the receiver, `S`
+// is a new string, and nothing the algorithm does to `S` can reach `O`. That is
+// why every `String.prototype` method comes out non-mutating.
+//
+// Predicates such as IsArray and SameValue return primitives too and are
+// deliberately absent. Listing every operation that returns a boolean would add
+// review surface without changing an answer, since a predicate's result is only
+// ever branched on.
+var freshPrimitives = set.FromSlice([]string{
+	// Coercions to a primitive. ToObject is not among them, since it returns an
+	// object and is identity-preserving instead.
+	"ToBigInt",
+	"ToBigInt64",
+	"ToBoolean",
+	"ToDateString",
+	"ToIndex",
+	"ToInt32",
+	"ToIntegerOrInfinity",
+	"ToLength",
+	"ToNumber",
+	"ToNumeric",
+	"ToPrimitive",
+	"ToPropertyKey",
+	"ToString",
+	"ToUint16",
+	"ToUint32",
+	"ToZeroPaddedDecimalString",
+	// The numeric type operations of ECMA-262 §6.1.6, which return a Number, a
+	// BigInt, or a Boolean.
+	"BigInt::divide",
+	"BigInt::equal",
+	"BigInt::exponentiate",
+	"BigInt::leftShift",
+	"BigInt::lessThan",
+	"BigInt::remainder",
+	"BigInt::toString",
+	"BigInt::unsignedRightShift",
+	"Number::add",
+	"Number::equal",
+	"Number::exponentiate",
+	"Number::lessThan",
+	"Number::sameValue",
+	"Number::sameValueZero",
+	"Number::toString",
+	"Number::unaryMinus",
+})
+
 // allocators are the abstract operations that return a value they allocated.
 // Their result is `Fresh`, the one origin whose mutations the fixpoint
 // discards, because a write to a value the algorithm made itself is invisible
@@ -394,13 +448,16 @@ func (m *OriginMap) eval(e Expr) Origin {
 // evalCall returns the origin of a call's result.
 func (m *OriginMap) evalCall(callee string, args []Expr) Origin {
 	switch {
-	case allocators.Contains(callee):
+	case allocators.Contains(callee), freshPrimitives.Contains(callee):
 		return Fresh
 	case identityCoercions.Contains(callee) && len(args) > 0:
 		return m.eval(args[0])
 	default:
-		// Get, ToString, ToNumber, and everything else either read a value out
-		// of a container or build a new one.
+		// Everything else breaks the chain. An operation such as Get reads a
+		// value out of a container, and the value read is a different object
+		// from the container. A predicate such as IsArray returns a boolean
+		// that stands for none of its arguments. Neither hands back the object
+		// it was given, and neither is a value the analysis can place.
 		return Unknown
 	}
 }

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -1,0 +1,341 @@
+package ecma262
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// OriginKind classifies where a value in an algorithm came from. See
+// planning/ecma-262/implementation_plan.md §4.2.
+type OriginKind uint8
+
+const (
+	// originUnset is a name the analysis has not bound to anything yet. It is
+	// the bottom of the lattice, so joining it with an origin yields that
+	// origin. A name still unset when the analysis finishes reads back as
+	// OriginUnknown.
+	originUnset OriginKind = iota
+	// OriginReceiver is a builtin method's `this` value.
+	OriginReceiver
+	// OriginParam is a declared parameter, identified by its 0-based position.
+	// The receiver is never a parameter, so there is no receiver offset.
+	OriginParam
+	// OriginFresh is a value the algorithm itself allocated. Mutating it is not
+	// observable to the caller.
+	OriginFresh
+	// OriginUnknown is a value the analysis could not tie to any of the above.
+	// It is the top of the lattice: joining it with anything yields it.
+	OriginUnknown
+)
+
+// Origin is where a value came from. Index is the parameter position and is
+// meaningful only when Kind is OriginParam.
+type Origin struct {
+	Kind  OriginKind
+	Index int
+}
+
+// Receiver, Fresh and Unknown are the origins that carry no index.
+var (
+	Receiver = Origin{Kind: OriginReceiver}
+	Fresh    = Origin{Kind: OriginFresh}
+	Unknown  = Origin{Kind: OriginUnknown}
+)
+
+// Param returns the origin of the i-th declared parameter, 0-based.
+func Param(i int) Origin {
+	return Origin{Kind: OriginParam, Index: i}
+}
+
+func (o Origin) String() string {
+	switch o.Kind {
+	case originUnset:
+		return "unset"
+	case OriginReceiver:
+		return "Receiver"
+	case OriginParam:
+		return fmt.Sprintf("Param(%d)", o.Index)
+	case OriginFresh:
+		return "Fresh"
+	case OriginUnknown:
+		return "Unknown"
+	default:
+		return fmt.Sprintf("Origin(%d)", o.Kind)
+	}
+}
+
+// join is the least upper bound of two origins. Two definitions that agree
+// keep their origin and two that disagree collapse to OriginUnknown, which is
+// what makes the analysis path-insensitive: a name assigned on two branches
+// takes the join of both rather than the one the analysis walked last.
+func (o Origin) join(other Origin) Origin {
+	switch {
+	case o.Kind == originUnset:
+		return other
+	case other.Kind == originUnset:
+		return o
+	case o == other:
+		return o
+	default:
+		return Unknown
+	}
+}
+
+// identityCoercions are the abstract operations that hand back the value they
+// were given, so an origin propagates through them. The list is deliberately
+// short and reviewed by hand, because calling an operation identity-preserving
+// when it builds a new value would attribute a mutation to the wrong place.
+//
+// ToObject is the entry that makes receiver tracking work: `Let O be ?
+// ToObject(this value)` keeps O at the receiver, which is how
+// Array.prototype.push comes out mutating. For a primitive receiver ToObject
+// wraps rather than returns, so this over-approximates. That is the safe
+// direction under FR5 — a mutation claimed where there is none fails loudly at
+// a call site, while a missed one is silent unsoundness.
+//
+// CanonicalizeKeyedCollectionKey returns its key unchanged except that it
+// normalizes -0 to +0, which cannot apply to an object. Completion and
+// NormalCompletion wrap a value in a completion record, and the serializer
+// drops the matching unwrap, so from a caller's side they pass the value
+// through.
+//
+// Coercions that build a new value are absent by design. ToString and ToNumber
+// break the chain, which is why every String.prototype method comes out
+// non-mutating: the algorithm coerces `this` to a fresh string and never writes
+// back through the receiver.
+var identityCoercions = set.FromSlice([]string{
+	"CanonicalizeKeyedCollectionKey",
+	"Completion",
+	"NormalCompletion",
+	"RequireObjectCoercible",
+	"ToObject",
+})
+
+// allocators are the abstract operations that return a value they allocated.
+// Their result is Fresh, so a mutation of it is invisible to the caller and the
+// mutation fixpoint ignores it. Every entry must genuinely allocate: claiming
+// Fresh for an operation that can hand back a caller-visible object would hide
+// a real mutation.
+//
+// Two absences are deliberate. Construct runs a constructor chosen at runtime
+// and can return any object, including one of its arguments. ProxyCreate
+// allocates a proxy, but a write to that proxy reaches its target, so the
+// result is not independent of the argument.
+//
+// The species entries — ArraySpeciesCreate, TypedArraySpeciesCreate and the
+// TypedArrayCreate* family — run a constructor the caller can replace and so
+// carry the same risk as Construct. §4.2 names ArraySpeciesCreate as an
+// allocator because Array.prototype.slice and its neighbours build their result
+// through it, and a value read back out of that result is a slot or property
+// read, which breaks the chain anyway.
+var allocators = set.FromSlice([]string{
+	// Ordinary objects and records.
+	"MakeBasicObject",
+	"OrdinaryCreateFromConstructor",
+	"OrdinaryObjectCreate",
+	"__NEW_ERROR_OBJ__",
+	"__NEW_OBJ__",
+	// Arrays and lists.
+	"ArrayCreate",
+	"ArraySpeciesCreate",
+	"CreateArrayFromList",
+	"CreateListFromArrayLike",
+	"MakeMatchIndicesIndexPairArray",
+	// Typed arrays, array buffers, and data blocks.
+	"AllocateArrayBuffer",
+	"AllocateSharedArrayBuffer",
+	"AllocateTypedArray",
+	"CreateByteDataBlock",
+	"CreateSharedByteDataBlock",
+	"MakeDataViewWithBufferWitnessRecord",
+	"MakeTypedArrayWithBufferWitnessRecord",
+	"TypedArrayCreateFromConstructor",
+	"TypedArrayCreateSameType",
+	"TypedArraySpeciesCreate",
+	// Iterators and iterator results.
+	"CreateArrayIterator",
+	"CreateAsyncFromSyncIterator",
+	"CreateForInIterator",
+	"CreateIteratorFromClosure",
+	"CreateIteratorResultObject",
+	"CreateListIteratorRecord",
+	"CreateMapIterator",
+	"CreateRegExpStringIterator",
+	"CreateSetIterator",
+	// Functions and arguments objects.
+	"BoundFunctionCreate",
+	"CreateBuiltinFunction",
+	"CreateDynamicFunction",
+	"CreateMappedArgumentsObject",
+	"CreateUnmappedArgumentsObject",
+	"MakeArgGetter",
+	"MakeArgSetter",
+	"OrdinaryFunctionCreate",
+	// Promises and jobs.
+	"CreateResolvingFunctions",
+	"HostMakeJobCallback",
+	"NewPromiseCapability",
+	"NewPromiseReactionJob",
+	"NewPromiseResolveThenableJob",
+	// Other exotic objects.
+	"RegExpAlloc",
+	"RegExpCreate",
+	"StringCreate",
+	// Environments and modules.
+	"CreateDefaultExportSyntheticModule",
+	"ModuleNamespaceCreate",
+	"NewDeclarativeEnvironment",
+	"NewFunctionEnvironment",
+	"NewGlobalEnvironment",
+	"NewModuleEnvironment",
+	"NewObjectEnvironment",
+})
+
+// OriginMap holds the origin of every value name in one function.
+type OriginMap struct {
+	fn      *Func
+	origins map[string]Origin
+}
+
+// NewOriginMap computes the origins of fn's value names. Declared parameters
+// seed the map, and each Let and each Call result binding takes the join of
+// every definition of its name.
+//
+// The pass is path-insensitive: a branch is never interpreted, and the node
+// list is walked as a flat sequence. Walking it repeatedly until nothing moves
+// makes the result independent of the order the serializer emitted the nodes
+// in, so a name defined by a loop's back edge still reaches its uses. The
+// walk terminates because an origin only ever climbs the lattice, from unset to
+// an origin to Unknown.
+func NewOriginMap(fn *Func) *OriginMap {
+	m := &OriginMap{fn: fn, origins: make(map[string]Origin, len(fn.Params)+len(fn.Nodes))}
+	for {
+		changed := false
+		for i, p := range fn.Params {
+			changed = m.bind(p, Param(i)) || changed
+		}
+		for _, node := range fn.Nodes {
+			switch node.Kind {
+			case NodeLet:
+				changed = m.bind(node.Target, m.eval(node.Source)) || changed
+			case NodeCall:
+				if node.Target != "" {
+					changed = m.bind(node.Target, m.evalCall(node.Callee, node.Args)) || changed
+				}
+			}
+		}
+		if !changed {
+			return m
+		}
+	}
+}
+
+// bind joins origin into name's current origin and reports whether that moved
+// name up the lattice.
+func (m *OriginMap) bind(name string, origin Origin) bool {
+	joined := m.origins[name].join(origin)
+	if joined == m.origins[name] {
+		return false
+	}
+	m.origins[name] = joined
+	return true
+}
+
+// Func returns the function the map was computed for.
+func (m *OriginMap) Func() *Func {
+	return m.fn
+}
+
+// Of returns the origin of a value name. A name the analysis never bound is
+// Unknown.
+func (m *OriginMap) Of(name string) Origin {
+	return resolved(m.origins[name])
+}
+
+// Eval returns the origin of an expression read in this function. The mutation
+// fixpoint calls it to charge a mutated value to the receiver or a parameter.
+func (m *OriginMap) Eval(e *Expr) Origin {
+	return resolved(m.eval(e))
+}
+
+// resolved turns the lattice bottom into Unknown. A name is still unset when
+// every definition of it evaluated to unset, which means the analysis learned
+// nothing about it.
+func resolved(o Origin) Origin {
+	if o.Kind == originUnset {
+		return Unknown
+	}
+	return o
+}
+
+// eval returns an expression's origin, keeping the lattice bottom so that a
+// name read before the walk reaches its definition contributes nothing rather
+// than pinning the reader at Unknown.
+func (m *OriginMap) eval(e *Expr) Origin {
+	if e == nil {
+		return Unknown
+	}
+	switch e.Kind {
+	case ExprVar:
+		return m.origins[e.Var]
+	case ExprThis:
+		// Only a prototype method has a `this` value to track. A static or
+		// namespace function's `this` is the constructor or the namespace
+		// object, never a parameter.
+		if m.fn.Kind == BuiltinMethod {
+			return Receiver
+		}
+		return Unknown
+	case ExprCall:
+		return m.evalCall(e.Callee, e.Args)
+	case ExprAlloc, ExprLit:
+		return Fresh
+	case ExprSlot, ExprProp:
+		// A read, so the chain breaks here. The value read out of a container
+		// is a different object from the container.
+		return Unknown
+	default:
+		return Unknown
+	}
+}
+
+// evalCall returns the origin of a call's result.
+func (m *OriginMap) evalCall(callee string, args []*Expr) Origin {
+	switch {
+	case allocators.Contains(callee):
+		return Fresh
+	case identityCoercions.Contains(callee) && len(args) > 0:
+		return m.eval(args[0])
+	default:
+		// Get, ToString, ToNumber, and everything else either read a value out
+		// of a container or build a new one.
+		return Unknown
+	}
+}
+
+// Names returns every value name the map binds, sorted. A name beginning with
+// `%` is a temporary ESMeta's compiler introduced, not a name the spec text
+// uses.
+func (m *OriginMap) Names() []string {
+	names := make([]string, 0, len(m.origins))
+	for name := range m.origins {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// String renders the map as one `name: origin` line per name, sorted by name,
+// so a test can assert the whole map at once.
+func (m *OriginMap) String() string {
+	names := m.Names()
+
+	var sb strings.Builder
+	for _, name := range names {
+		fmt.Fprintf(&sb, "%s: %s\n", name, m.Of(name))
+	}
+	return sb.String()
+}

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -198,6 +198,79 @@ var allocators = set.FromSlice([]string{
 type OriginMap struct {
 	fn      *Func
 	origins map[string]Origin
+	free    set.Set[string]
+}
+
+// freeNames returns fn's free names, the value names it reads but never binds.
+// A closure's captured value is the common case. `Iterator.prototype.drop`
+// builds a helper that opens with `Let remaining be integerLimit`, and
+// `integerLimit` belongs to the algorithm that built the helper, not to the
+// helper itself.
+//
+// The walk has to answer Unknown for such a name from the start, because it
+// never learns anything more about it. Left at the lattice bottom it would
+// contribute nothing to a join, and `remaining`, which a later step assigns a
+// literal, would come out Fresh. A mutation of it would then read as
+// unobservable to the caller when on one path it is the captured value.
+func freeNames(fn *Func) set.Set[string] {
+	bound := set.FromSlice(fn.Params)
+	for _, node := range fn.Nodes {
+		switch node := node.(type) {
+		case *LetNode:
+			bound.Add(node.Target)
+		case *CallNode:
+			if node.Target != "" {
+				bound.Add(node.Target)
+			}
+		default:
+			// No other node shape binds a name.
+		}
+	}
+
+	free := set.NewSet[string]()
+	var read func(Expr)
+	read = func(e Expr) {
+		switch e := e.(type) {
+		case *VarExpr:
+			if !bound.Contains(e.Var) {
+				free.Add(e.Var)
+			}
+		case *CallExpr:
+			for _, arg := range e.Args {
+				read(arg)
+			}
+		case *AllocExpr:
+			for _, arg := range e.Args {
+				read(arg)
+			}
+		case *SlotExpr:
+			read(e.Object)
+		case *PropExpr:
+			read(e.Object)
+		default:
+			// A this value, a literal, and an absent operand name nothing.
+		}
+	}
+	for _, node := range fn.Nodes {
+		switch node := node.(type) {
+		case *LetNode:
+			read(node.Source)
+		case *CallNode:
+			for _, arg := range node.Args {
+				read(arg)
+			}
+		case *SlotWriteNode:
+			read(node.Object)
+			read(node.Value)
+		case *ReturnNode:
+			read(node.Value)
+		case *ThrowNode:
+			read(node.Value)
+		default:
+			// No other node shape reads an operand.
+		}
+	}
+	return free
 }
 
 // NewOriginMap computes the origins of fn's value names. Declared parameters
@@ -211,7 +284,11 @@ type OriginMap struct {
 // terminates because an origin only climbs the lattice, from unset to one
 // origin to `Unknown`.
 func NewOriginMap(fn *Func) *OriginMap {
-	m := &OriginMap{fn: fn, origins: make(map[string]Origin, len(fn.Params)+len(fn.Nodes))}
+	m := &OriginMap{
+		fn:      fn,
+		origins: make(map[string]Origin, len(fn.Params)+len(fn.Nodes)),
+		free:    freeNames(fn),
+	}
 	for {
 		changed := false
 		for i, p := range fn.Params {
@@ -273,12 +350,24 @@ func resolved(o Origin) Origin {
 	return o
 }
 
-// eval returns an expression's origin, keeping the lattice bottom rather than
-// resolving it. A name read before the walk reaches its definition then
-// contributes nothing to the reader instead of pinning it at `Unknown`.
+// eval returns an expression's origin. It keeps the lattice bottom rather than
+// resolving it, which separates the two reasons a name can be unbound when the
+// walk reads it.
+//
+// A name the walk has not reached the definition of yet is still bottom, and
+// bottom contributes nothing to a join. The reader is left alone for this pass
+// and takes its origin on the next one, once the definition is bound. Answering
+// `Unknown` there would pin the reader at `Unknown` for good, since a join
+// never retracts.
+//
+// A free name is never going to be bound, so waiting gains nothing and the
+// answer is `Unknown` from the first pass.
 func (m *OriginMap) eval(e Expr) Origin {
 	switch e := e.(type) {
 	case *VarExpr:
+		if m.free.Contains(e.Var) {
+			return Unknown
+		}
 		return m.origins[e.Var]
 	case *ThisExpr:
 		// Only a prototype method has a `this` value to track. A static or

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -218,13 +218,15 @@ func NewOriginMap(fn *Func) *OriginMap {
 			changed = m.bind(p, Param(i)) || changed
 		}
 		for _, node := range fn.Nodes {
-			switch node.Kind {
-			case NodeLet:
+			switch node := node.(type) {
+			case *LetNode:
 				changed = m.bind(node.Target, m.eval(node.Source)) || changed
-			case NodeCall:
+			case *CallNode:
 				if node.Target != "" {
 					changed = m.bind(node.Target, m.evalCall(node.Callee, node.Args)) || changed
 				}
+			default:
+				// No other node shape binds a name.
 			}
 		}
 		if !changed {
@@ -257,7 +259,7 @@ func (m *OriginMap) Of(name string) Origin {
 
 // Eval returns the origin of an expression read in this function. The mutation
 // fixpoint calls it to charge a mutated value to the receiver or a parameter.
-func (m *OriginMap) Eval(e *Expr) Origin {
+func (m *OriginMap) Eval(e Expr) Origin {
 	return resolved(m.eval(e))
 }
 
@@ -274,14 +276,11 @@ func resolved(o Origin) Origin {
 // eval returns an expression's origin, keeping the lattice bottom rather than
 // resolving it. A name read before the walk reaches its definition then
 // contributes nothing to the reader instead of pinning it at `Unknown`.
-func (m *OriginMap) eval(e *Expr) Origin {
-	if e == nil {
-		return Unknown
-	}
-	switch e.Kind {
-	case ExprVar:
+func (m *OriginMap) eval(e Expr) Origin {
+	switch e := e.(type) {
+	case *VarExpr:
 		return m.origins[e.Var]
-	case ExprThis:
+	case *ThisExpr:
 		// Only a prototype method has a `this` value to track. A static or
 		// namespace function's `this` is the constructor or the namespace
 		// object, never a parameter.
@@ -289,21 +288,22 @@ func (m *OriginMap) eval(e *Expr) Origin {
 			return Receiver
 		}
 		return Unknown
-	case ExprCall:
+	case *CallExpr:
 		return m.evalCall(e.Callee, e.Args)
-	case ExprAlloc, ExprLit:
+	case *AllocExpr, *LitExpr:
 		return Fresh
-	case ExprSlot, ExprProp:
+	case *SlotExpr, *PropExpr:
 		// A read, so the chain breaks here. The value read out of a container
 		// is a different object from the container itself.
 		return Unknown
 	default:
+		// An operand the graph left out, which reaches Eval as a nil Expr.
 		return Unknown
 	}
 }
 
 // evalCall returns the origin of a call's result.
-func (m *OriginMap) evalCall(callee string, args []*Expr) Origin {
+func (m *OriginMap) evalCall(callee string, args []Expr) Origin {
 	switch {
 	case allocators.Contains(callee):
 		return Fresh

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -189,6 +189,20 @@ func TestOriginMapReachesFixpointAcrossBackEdges(t *testing.T) {
 	require.Equal(t, Unknown, m.Of("%4"))
 }
 
+// A name the function reads but never binds is Unknown from the first pass, not
+// a value that drops silently out of a join. The closure behind
+// `Iterator.prototype.drop` opens with `Let remaining be integerLimit`, where
+// `integerLimit` belongs to the algorithm that built the closure, and a later
+// step assigns `remaining` a literal. Treating the captured name as nothing to
+// join would leave `remaining` at Fresh and make a mutation of it read as
+// unobservable.
+func TestOriginMapFreeNames(t *testing.T) {
+	m := originsOf(t, "INTRINSICS.Iterator.prototype.drop:clo0")
+
+	require.Equal(t, Unknown, m.Of("integerLimit"))
+	require.Equal(t, Unknown, m.Of("remaining"))
+}
+
 func TestOriginMapString(t *testing.T) {
 	m := originsOf(t, "Map.prototype.set")
 	snaps.MatchInlineSnapshot(t, m.String(), snaps.Inline(`%0: Unknown

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -20,6 +20,12 @@ func originsOf(t *testing.T, name string) *OriginMap {
 }
 
 func TestOriginJoin(t *testing.T) {
+	// Origin{} is the zero value, whose kind is originUnset. That is the bottom
+	// of the lattice, a name no definition has bound yet. Joining it with an
+	// origin yields that origin, which is what lets a definition the walk has
+	// not evaluated yet contribute nothing to the name it defines instead of
+	// pinning it at Unknown. The three origins above the bottom have
+	// package-level names, so only this one is written as a literal.
 	tests := map[string]struct {
 		left, right, want Origin
 	}{

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -153,22 +153,22 @@ func TestOriginMapUnboundName(t *testing.T) {
 func TestOriginMapEval(t *testing.T) {
 	m := originsOf(t, "Array.prototype.push")
 
-	require.Equal(t, Receiver, m.Eval(&Expr{Kind: ExprThis}))
-	require.Equal(t, Receiver, m.Eval(&Expr{Kind: ExprVar, Var: "O"}))
-	require.Equal(t, Fresh, m.Eval(&Expr{Kind: ExprLit}))
-	require.Equal(t, Fresh, m.Eval(&Expr{Kind: ExprAlloc}))
+	require.Equal(t, Receiver, m.Eval(&ThisExpr{}))
+	require.Equal(t, Receiver, m.Eval(&VarExpr{Var: "O"}))
+	require.Equal(t, Fresh, m.Eval(&LitExpr{}))
+	require.Equal(t, Fresh, m.Eval(&AllocExpr{Args: nil}))
 	require.Equal(t, Unknown, m.Eval(nil))
 
 	// A read off the receiver is a different value from the receiver.
-	readO := &Expr{Kind: ExprSlot, Object: &Expr{Kind: ExprVar, Var: "O"}, Slot: "MapData"}
+	readO := &SlotExpr{Object: &VarExpr{Var: "O"}, Slot: "MapData"}
 	require.Equal(t, Unknown, m.Eval(readO))
 
 	// A nested call resolves through the same lists a call node does.
-	toObject := &Expr{Kind: ExprCall, Callee: "ToObject", Args: []*Expr{{Kind: ExprThis}}}
+	toObject := &CallExpr{Callee: "ToObject", Args: []Expr{&ThisExpr{}}}
 	require.Equal(t, Receiver, m.Eval(toObject))
-	arrayCreate := &Expr{Kind: ExprCall, Callee: "ArrayCreate", Args: []*Expr{{Kind: ExprLit}}}
+	arrayCreate := &CallExpr{Callee: "ArrayCreate", Args: []Expr{&LitExpr{}}}
 	require.Equal(t, Fresh, m.Eval(arrayCreate))
-	get := &Expr{Kind: ExprCall, Callee: "Get", Args: []*Expr{{Kind: ExprVar, Var: "O"}}}
+	get := &CallExpr{Callee: "Get", Args: []Expr{&VarExpr{Var: "O"}}}
 	require.Equal(t, Unknown, m.Eval(get))
 }
 

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -84,16 +84,14 @@ func TestOriginMapSampleFunctions(t *testing.T) {
 		},
 		// A String method reaches its receiver through RequireObjectCoercible,
 		// which preserves identity, and then coerces it with ToString, which
-		// does not. The string ToString builds really is a new value, but
-		// `Fresh` is a claim only the curated allocator list makes, and
-		// ToString is not on it, so `S` falls through to `Unknown`. Either
-		// answer keeps the receiver out of `S`, which is what makes every
+		// does not. `S` is the new string ToString built, so it is `Fresh` and
+		// the receiver is not in it. That is what makes every
 		// `String.prototype` method come out non-mutating.
 		"ValueCoercionsBreakTheChain": {
 			fn: "String.prototype.toLowerCase",
 			origins: map[string]string{
 				"O": "Receiver",
-				"S": "Unknown",
+				"S": "Fresh",
 			},
 		},
 		// A static has no receiver. Its `this` is the constructor object, so

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -55,7 +55,9 @@ func TestOriginString(t *testing.T) {
 
 func TestOriginMapSampleFunctions(t *testing.T) {
 	tests := map[string]struct {
-		fn      string
+		fn string
+		// origins names the values each case is about, not every value the
+		// function binds. TestOriginMapString below prints a whole map.
 		origins map[string]string
 	}{
 		// `Let O be ? ToObject(this value)` carries the receiver into `O`. That

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -52,9 +52,9 @@ func TestOriginMapSampleFunctions(t *testing.T) {
 		fn      string
 		origins map[string]string
 	}{
-		// `Let O be ? ToObject(this value)` carries the receiver into O, which
-		// is what makes push come out as a receiver mutation once the fixpoint
-		// reads `Set(O, ...)`.
+		// `Let O be ? ToObject(this value)` carries the receiver into `O`. That
+		// is what makes push come out as a receiver mutation once §4.1 reads
+		// its `Set(O, ...)` call.
 		"ReceiverThroughToObject": {
 			fn: "Array.prototype.push",
 			origins: map[string]string{
@@ -65,7 +65,8 @@ func TestOriginMapSampleFunctions(t *testing.T) {
 			},
 		},
 		// slice writes only into the array ArraySpeciesCreate handed it, so
-		// every write it performs lands on a Fresh value.
+		// every write it makes lands on a `Fresh` value and none of them
+		// reaches the receiver.
 		"AllocatorsAreFresh": {
 			fn: "Array.prototype.slice",
 			origins: map[string]string{
@@ -77,8 +78,9 @@ func TestOriginMapSampleFunctions(t *testing.T) {
 		},
 		// A String method reaches its receiver through RequireObjectCoercible,
 		// which preserves identity, and then coerces it with ToString, which
-		// does not. S is a fresh primitive the algorithm never writes back
-		// through, so String.prototype methods come out non-mutating.
+		// does not. `S` is a fresh string the algorithm never writes back
+		// through, which is why `String.prototype` methods come out
+		// non-mutating.
 		"ValueCoercionsBreakTheChain": {
 			fn: "String.prototype.toLowerCase",
 			origins: map[string]string{
@@ -86,9 +88,9 @@ func TestOriginMapSampleFunctions(t *testing.T) {
 				"S": "Unknown",
 			},
 		},
-		// A static has no receiver. `this` is the constructor object, so
-		// nothing here is Receiver and the mutated object is a real parameter
-		// position.
+		// A static has no receiver. Its `this` is the constructor object, so
+		// nothing here is `Receiver`, and the object assign writes into sits
+		// at a real parameter position.
 		"StaticHasNoReceiver": {
 			fn: "Object.assign",
 			origins: map[string]string{
@@ -109,8 +111,8 @@ func TestOriginMapSampleFunctions(t *testing.T) {
 				"value": "Param(1)",
 			},
 		},
-		// An abstract operation has no receiver either, so an ExprThis inside
-		// one resolves to Unknown rather than to a value the caller owns.
+		// An abstract operation has no receiver either. An ExprThis inside one
+		// resolves to `Unknown` rather than to a value its caller owns.
 		"AbstractOperationHasNoReceiver": {
 			fn: "OrdinaryToPrimitive",
 			origins: map[string]string{
@@ -131,16 +133,18 @@ func TestOriginMapSampleFunctions(t *testing.T) {
 }
 
 // A name bound on two branches takes the join of both definitions. In
-// Map.prototype.set, `p` is the entry for the key: on one branch it is read out
-// of the receiver's [[MapData]] list, and on the other it is a record the
-// algorithm allocates. The two disagree, so `p` collapses to Unknown and a
-// write to it is charged to nothing.
+// `Map.prototype.set`, `p` is the entry holding the key. One branch reads it
+// out of the receiver's [[MapData]] list and the other allocates it as a fresh
+// record. The two disagree, so `p` collapses to `Unknown`. §4.1 then reads a
+// write to `p` as a mutation it cannot attribute, which leaves the method
+// unclassified rather than claiming an effect it cannot place.
 func TestOriginMapJoinsBranches(t *testing.T) {
 	m := originsOf(t, "Map.prototype.set")
 	require.Equal(t, Unknown, m.Of("p"))
 }
 
-// A name the function never binds is Unknown, not the lattice bottom.
+// A name the function never binds reads back as `Unknown`, not as the lattice
+// bottom.
 func TestOriginMapUnboundName(t *testing.T) {
 	m := originsOf(t, "Array.prototype.push")
 	require.Equal(t, Unknown, m.Of("nosuchvalue"))
@@ -170,9 +174,10 @@ func TestOriginMapEval(t *testing.T) {
 
 // The walk repeats until nothing moves, so a name a loop's back edge redefines
 // takes the join of both definitions rather than whichever the serializer
-// emitted first. ForBodyEvaluation binds %4 from a literal ahead of the loop
-// and from a value read inside it. One walk in node order would leave %4 at
-// Fresh and hide any mutation of it.
+// emitted first. ForBodyEvaluation binds `%4` from a literal ahead of its loop
+// and from a value read inside it. A single walk in node order would leave `%4`
+// at `Fresh`, which tells §4.1 that a mutation of it is invisible to the
+// caller.
 func TestOriginMapReachesFixpointAcrossBackEdges(t *testing.T) {
 	m := originsOf(t, "ForBodyEvaluation")
 	require.Equal(t, Unknown, m.Of("%4"))
@@ -195,8 +200,13 @@ value: Param(1)
 `))
 }
 
-// Every function in the committed graph analyzes, and a declared parameter is
-// never shadowed into an origin the analysis invented.
+// Every function in the committed graph analyzes, and two invariants hold
+// across all of them. No name is left at the lattice bottom, so every name the
+// walk bound reached a definition it could evaluate. A declared parameter's own
+// name reads back as its own position or as `Unknown`. It can never read back
+// as an origin the walk invented, because the only other definitions of that
+// name are assignments the algorithm makes to it, and those join to
+// `Unknown`.
 func TestOriginMapCoversEveryFunction(t *testing.T) {
 	cfg := testCFG(t)
 
@@ -204,10 +214,10 @@ func TestOriginMapCoversEveryFunction(t *testing.T) {
 		m := NewOriginMap(fn)
 		require.Same(t, fn, m.Func())
 		for _, name := range m.Names() {
-			require.NotEqual(t, originUnset, m.Of(name).Kind, "%s: %s left unset", fn.Name, name)
-			if origin := m.Of(name); origin.Kind == OriginParam {
-				require.Less(t, origin.Index, len(fn.Params), "%s: %s", fn.Name, name)
-			}
+			require.NotEqual(t, originUnset, m.origins[name].Kind, "%s: %s left unset", fn.Name, name)
+		}
+		for i, param := range fn.Params {
+			require.Contains(t, []Origin{Param(i), Unknown}, m.Of(param), "%s: %s", fn.Name, param)
 		}
 	}
 }

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -84,9 +84,11 @@ func TestOriginMapSampleFunctions(t *testing.T) {
 		},
 		// A String method reaches its receiver through RequireObjectCoercible,
 		// which preserves identity, and then coerces it with ToString, which
-		// does not. `S` is a fresh string the algorithm never writes back
-		// through, which is why `String.prototype` methods come out
-		// non-mutating.
+		// does not. The string ToString builds really is a new value, but
+		// `Fresh` is a claim only the curated allocator list makes, and
+		// ToString is not on it, so `S` falls through to `Unknown`. Either
+		// answer keeps the receiver out of `S`, which is what makes every
+		// `String.prototype` method come out non-mutating.
 		"ValueCoercionsBreakTheChain": {
 			fn: "String.prototype.toLowerCase",
 			origins: map[string]string{

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -1,0 +1,213 @@
+package ecma262
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// originsOf computes the origin map of one builtin or abstract operation.
+func originsOf(t *testing.T, name string) *OriginMap {
+	t.Helper()
+	cfg := testCFG(t)
+	fn := cfg.Builtin(name)
+	if fn == nil {
+		fn = cfg.AbstractOp(name)
+	}
+	require.NotNil(t, fn, "no function named %s", name)
+	return NewOriginMap(fn)
+}
+
+func TestOriginJoin(t *testing.T) {
+	tests := map[string]struct {
+		left, right, want Origin
+	}{
+		"UnsetTakesTheOther":       {Origin{}, Receiver, Receiver},
+		"OtherTakesUnset":          {Fresh, Origin{}, Fresh},
+		"EqualOriginsSurvive":      {Param(1), Param(1), Param(1)},
+		"DifferentIndicesCollapse": {Param(0), Param(1), Unknown},
+		"DifferentKindsCollapse":   {Receiver, Fresh, Unknown},
+		"UnknownAbsorbs":           {Unknown, Receiver, Unknown},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, test.left.join(test.right))
+			require.Equal(t, test.want, test.right.join(test.left))
+		})
+	}
+}
+
+func TestOriginString(t *testing.T) {
+	require.Equal(t, "Receiver", Receiver.String())
+	require.Equal(t, "Param(2)", Param(2).String())
+	require.Equal(t, "Fresh", Fresh.String())
+	require.Equal(t, "Unknown", Unknown.String())
+	require.Equal(t, "unset", Origin{}.String())
+}
+
+func TestOriginMapSampleFunctions(t *testing.T) {
+	tests := map[string]struct {
+		fn      string
+		origins map[string]string
+	}{
+		// `Let O be ? ToObject(this value)` carries the receiver into O, which
+		// is what makes push come out as a receiver mutation once the fixpoint
+		// reads `Set(O, ...)`.
+		"ReceiverThroughToObject": {
+			fn: "Array.prototype.push",
+			origins: map[string]string{
+				"O":     "Receiver",
+				"items": "Param(0)",
+				"E":     "Unknown", // read out of the argument list
+				"len":   "Unknown", // ? LengthOfArrayLike(O)
+			},
+		},
+		// slice writes only into the array ArraySpeciesCreate handed it, so
+		// every write it performs lands on a Fresh value.
+		"AllocatorsAreFresh": {
+			fn: "Array.prototype.slice",
+			origins: map[string]string{
+				"O":     "Receiver",
+				"A":     "Fresh", // ? ArraySpeciesCreate(O, count)
+				"start": "Param(0)",
+				"end":   "Param(1)",
+			},
+		},
+		// A String method reaches its receiver through RequireObjectCoercible,
+		// which preserves identity, and then coerces it with ToString, which
+		// does not. S is a fresh primitive the algorithm never writes back
+		// through, so String.prototype methods come out non-mutating.
+		"ValueCoercionsBreakTheChain": {
+			fn: "String.prototype.toLowerCase",
+			origins: map[string]string{
+				"O": "Receiver",
+				"S": "Unknown",
+			},
+		},
+		// A static has no receiver. `this` is the constructor object, so
+		// nothing here is Receiver and the mutated object is a real parameter
+		// position.
+		"StaticHasNoReceiver": {
+			fn: "Object.assign",
+			origins: map[string]string{
+				"target":  "Param(0)",
+				"to":      "Param(0)", // ? ToObject(target)
+				"sources": "Param(1)",
+				"from":    "Unknown", // ? ToObject(nextSource), off a list read
+			},
+		},
+		// Map.prototype.set reaches its receiver straight off `this` rather
+		// than through a coercion, and CanonicalizeKeyedCollectionKey passes
+		// the key through untouched.
+		"ReceiverStraightFromThis": {
+			fn: "Map.prototype.set",
+			origins: map[string]string{
+				"M":     "Receiver",
+				"key":   "Param(0)",
+				"value": "Param(1)",
+			},
+		},
+		// An abstract operation has no receiver either, so an ExprThis inside
+		// one resolves to Unknown rather than to a value the caller owns.
+		"AbstractOperationHasNoReceiver": {
+			fn: "OrdinaryToPrimitive",
+			origins: map[string]string{
+				"O":    "Param(0)",
+				"hint": "Param(1)",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := originsOf(t, test.fn)
+			for value, want := range test.origins {
+				require.Equal(t, want, m.Of(value).String(), "origin of %s", value)
+			}
+		})
+	}
+}
+
+// A name bound on two branches takes the join of both definitions. In
+// Map.prototype.set, `p` is the entry for the key: on one branch it is read out
+// of the receiver's [[MapData]] list, and on the other it is a record the
+// algorithm allocates. The two disagree, so `p` collapses to Unknown and a
+// write to it is charged to nothing.
+func TestOriginMapJoinsBranches(t *testing.T) {
+	m := originsOf(t, "Map.prototype.set")
+	require.Equal(t, Unknown, m.Of("p"))
+}
+
+// A name the function never binds is Unknown, not the lattice bottom.
+func TestOriginMapUnboundName(t *testing.T) {
+	m := originsOf(t, "Array.prototype.push")
+	require.Equal(t, Unknown, m.Of("nosuchvalue"))
+}
+
+func TestOriginMapEval(t *testing.T) {
+	m := originsOf(t, "Array.prototype.push")
+
+	require.Equal(t, Receiver, m.Eval(&Expr{Kind: ExprThis}))
+	require.Equal(t, Receiver, m.Eval(&Expr{Kind: ExprVar, Var: "O"}))
+	require.Equal(t, Fresh, m.Eval(&Expr{Kind: ExprLit}))
+	require.Equal(t, Fresh, m.Eval(&Expr{Kind: ExprAlloc}))
+	require.Equal(t, Unknown, m.Eval(nil))
+
+	// A read off the receiver is a different value from the receiver.
+	readO := &Expr{Kind: ExprSlot, Object: &Expr{Kind: ExprVar, Var: "O"}, Slot: "MapData"}
+	require.Equal(t, Unknown, m.Eval(readO))
+
+	// A nested call resolves through the same lists a call node does.
+	toObject := &Expr{Kind: ExprCall, Callee: "ToObject", Args: []*Expr{{Kind: ExprThis}}}
+	require.Equal(t, Receiver, m.Eval(toObject))
+	arrayCreate := &Expr{Kind: ExprCall, Callee: "ArrayCreate", Args: []*Expr{{Kind: ExprLit}}}
+	require.Equal(t, Fresh, m.Eval(arrayCreate))
+	get := &Expr{Kind: ExprCall, Callee: "Get", Args: []*Expr{{Kind: ExprVar, Var: "O"}}}
+	require.Equal(t, Unknown, m.Eval(get))
+}
+
+// The walk repeats until nothing moves, so a name a loop's back edge redefines
+// takes the join of both definitions rather than whichever the serializer
+// emitted first. ForBodyEvaluation binds %4 from a literal ahead of the loop
+// and from a value read inside it. One walk in node order would leave %4 at
+// Fresh and hide any mutation of it.
+func TestOriginMapReachesFixpointAcrossBackEdges(t *testing.T) {
+	m := originsOf(t, "ForBodyEvaluation")
+	require.Equal(t, Unknown, m.Of("%4"))
+}
+
+func TestOriginMapString(t *testing.T) {
+	m := originsOf(t, "Map.prototype.set")
+	snaps.MatchInlineSnapshot(t, m.String(), snaps.Inline(`%0: Unknown
+%1: Param(0)
+%2: Fresh
+%3: Unknown
+%4: Fresh
+%5: Unknown
+%6: Receiver
+%7: Receiver
+M: Receiver
+key: Param(0)
+p: Unknown
+value: Param(1)
+`))
+}
+
+// Every function in the committed graph analyzes, and a declared parameter is
+// never shadowed into an origin the analysis invented.
+func TestOriginMapCoversEveryFunction(t *testing.T) {
+	cfg := testCFG(t)
+
+	for _, fn := range cfg.Funcs {
+		m := NewOriginMap(fn)
+		require.Same(t, fn, m.Func())
+		for _, name := range m.Names() {
+			require.NotEqual(t, originUnset, m.Of(name).Kind, "%s: %s left unset", fn.Name, name)
+			if origin := m.Of(name); origin.Kind == OriginParam {
+				require.Less(t, origin.Index, len(fn.Params), "%s: %s", fn.Name, name)
+			}
+		}
+	}
+}

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -37,7 +37,7 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §2   | Toolchain scoping                          | NFR        | 🚧      | §1         | `tools/spec-extract/mise.toml` builds and runs ESMeta with no JVM in the root environment — see [tools/spec-extract/README.md](../../tools/spec-extract/README.md); `mise.lock` is still missing |
 | §3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ✅      | §2         | `cfg.json` covers all 501 builtin algorithms plus the 701 functions reachable from them, at the pinned spec revision, and round-trips the schema check the run ends with — met |
 | §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ⬜      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` |
-| §4.2 | Origin map                                 | FR2, FR4   | ⬜      | §3         | origins asserted for sample functions — `ToObject(this)`→Receiver, allocators→Fresh, reads→Unknown |
+| §4.2 | Origin map                                 | FR2, FR4   | ✅      | §3         | origins asserted for sample functions — `ToObject(this)`→Receiver, allocators→Fresh, reads→Unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.3 | Method classification                      | FR4, FR5   | ⬜      | §4.1, §4.2 | facts.json core — receiver / returns / classified for the representative methods |
 | §5   | Keying and join                            | FR7, FR15  | ⬜      | §4.3       | normalizer joins facts to `.d.ts` declarations; overloads share algorithm-level facts, type-dependent parts per signature; unmatched reported |
 | §6   | Validation diff                            | FR9        | ⬜      | §5         | receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
@@ -633,13 +633,16 @@ type Origin struct { Kind OriginKind; Index int }
 // receiver is never a Param, so there is no receiver offset.
 
 func OriginMap(F) map[string]Origin:
-    origin = {}
-    for i, p in F.Params: origin[p] = Param(i)       // declared params only; no receiver
-    for node in F.Nodes:
-        if node.Kind == Let:   origin[node.Target] = eval(F, node.Source)
-        if node.Kind == Call && node.Target != "":
-                               origin[node.Target] = evalCall(F, node)
-    return origin
+    origin = {}                                      // unset = lattice bottom
+    repeat until nothing moves:                      // a name defined by a loop's
+        for i, p in F.Params:                        // back edge reaches its uses
+            origin[p] = origin[p] ⊔ Param(i)         // declared params only; no receiver
+        for node in F.Nodes:
+            if node.Kind == Let:
+                origin[node.Target] ⊔= eval(F, node.Source)
+            if node.Kind == Call && node.Target != "":
+                origin[node.Target] ⊔= evalCall(F, node)
+    return origin                                    // a still-unset name reads back Unknown
 
 func eval(F, e Expr) Origin:
     switch e.Kind:
@@ -661,9 +664,9 @@ func evalCall(F, c) Origin:
     return Unknown                                    // Get, ToString, ToNumber, ... → read/fresh
 ```
 
-`IdentityCoercions` is the key list for receiver tracking: `ToObject`
+`IdentityCoercions` is the key list for receiver tracking. `ToObject`
 and `RequireObjectCoercible` return the same object, so `O ← ?
-ToObject(this value)` keeps `O` at `Param(0)`. Coercions that build a
+ToObject(this value)` keeps `O` at the receiver. Coercions that build a
 new value — `ToString`, `ToNumber` — are *not* identity-preserving,
 which is exactly why every `String.prototype` method comes out
 non-mutating: the algorithm coerces `this` to a fresh string primitive
@@ -684,6 +687,58 @@ reachability or per-path joins, the serializer (§3) can emit that
 structure and this section becomes flow-sensitive. Until then the schema
 omits it (Appendix A) and the guarantees here are path-insensitive by
 construction, not by accident.
+
+**Outcome.** Done. [internal/ecma262/](../../internal/ecma262/) holds the Go
+reader for `cfg.json`, mirroring Appendix A, and the origin map.
+`NewOriginMap(fn)` returns the origins of one function's value names;
+`Eval(expr)` answers the same question for an expression, which is the call
+§4.1 makes to charge a mutation. All 1202 functions analyze in about 4 ms,
+binding 11663 names: 373 at the receiver, 2007 at a parameter, 2969 fresh, and
+6314 unknown. The gate is
+[internal/ecma262/origin_test.go](../../internal/ecma262/origin_test.go).
+`Let O be ? ToObject(this value)` puts `O` at the receiver in
+`Array.prototype.push`, `? ArraySpeciesCreate(O, count)` puts `A` at `Fresh` in
+`Array.prototype.slice`, and `? ToString(O)` puts `S` at `Unknown` in
+`String.prototype.toLowerCase`. Four findings.
+
+- **One walk in node order is unsound, so the walk repeats until nothing
+  moves.** A loop's back edge redefines a name after its uses, and a single
+  walk records only the definition it reached first. `ForBodyEvaluation` binds
+  `%4` from a literal ahead of its loop and from a value read inside it: one
+  walk leaves `%4` at `Fresh`, which would tell §4.1 that a mutation of it is
+  invisible to the caller. Repeating the walk joins both definitions and gives
+  `Unknown`. It changes 7 names across 4 functions, all of them loops, and
+  costs at most three passes over any function in the graph.
+- **Completion wrapping preserves the value, so `NormalCompletion` joins the
+  identity list.** ESMeta compiles a normal return as
+  `NormalCompletion(v)`, which is 1204 of the graph's call nodes and stands on
+  nearly every algorithm's return. The record it builds is fresh, but §3 drops
+  the caller-side unwrap, so the value the caller receives is `v`. Reading the
+  wrap as an allocation would resolve every method's return to `Fresh` and cost
+  §4.3 its `returnAlias`: `Map.prototype.set` ends in `return
+  NormalCompletion(M)`, and the receiver has to survive that.
+- **`CanonicalizeKeyedCollectionKey` is identity-preserving and had to be
+  listed.** It returns its key unchanged apart from normalizing `-0` to `+0`,
+  which cannot apply to an object. `Map.prototype.set` rebinds `key` to its
+  result, so without the entry `key` joins `Param(0)` with `Unknown` and
+  collapses, which is exactly the parameter §8.1 needs to follow into the
+  `[[MapData]]` record.
+- **`Construct` and `ProxyCreate` are deliberately not allocators.**
+  `Fresh` is the one origin whose mutations the fixpoint discards, so an entry
+  that can hand back a value the caller already holds turns a real mutation
+  invisible. `Construct` runs a constructor chosen at runtime and may return
+  one of its arguments, and a write to a proxy reaches its target. Both resolve
+  to `Unknown` instead. `ArraySpeciesCreate` and the typed-array species
+  operations carry the same risk and are listed anyway, as §4.2 specifies,
+  because `Array.prototype.slice` and its neighbours build their result through
+  them.
+
+283 of the 313 builtin methods bind a name at the receiver. The other 30 pass
+`this` straight into an operation that reads a value out of it, such as
+`ThisNumberValue` or `GeneratorResume`, or are among the eight §3 builtins with
+no algorithm head. Binding no name is not a loss, because §4.1 asks the map
+about expressions rather than names, and an `ExprThis` argument resolves to the
+receiver at the call site.
 
 ### §4.3. Method classification (FR4, FR5)
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1542,7 +1542,7 @@ named by an `ExprVar`, resolve against the `abstract-op` functions only.
 `ExprCall` is reserved: the compiled IR states every call as its own node,
 so a call never appears nested inside an expression.
 
-**The schema above is the wire shape, not the Go model.** A node and an
+**The schema above is the serialized shape, not the Go model.** A node and an
 expression each serialize as one object tagged by `kind`, which is what the
 Scala serializer writes and what a reader has to decode. Tagging one struct
 with a kind is not how this repository models a tree with several node
@@ -1551,8 +1551,13 @@ such as `Slot` on a `let`. So
 [internal/ecma262/cfg.go](../../internal/ecma262/cfg.go) declares `Node` and
 `Expr` as sealed interfaces with one type per kind, the pattern
 [internal/ast/expr.go](../../internal/ast/expr.go) uses, and decodes the
-JSON through unexported wire structs that mirror the schema above. The wire
-format does not change, so §3 is untouched. Two operands are genuinely
+JSON through unexported structs that mirror the schema above and are read
+only while parsing. The serialized format does not change, so §3 is
+untouched. The serializer omits every field a kind does not carry, so a
+`branch` node is `{"kind":"branch"}` and nothing more. The reader holds it
+to that: a field appearing on a kind that does not use it is an error,
+which is what catches the schema moving a field rather than letting the
+reader take it for absent. Two operands are genuinely
 optional and the rest are required at decode time: a `Throw` carries no
 `Value` when it constructs its error, and 22 `SlotWrite` nodes carry none
 because the serializer could not name what they store. Those 22 are all

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -742,6 +742,16 @@ one struct tagged by kind, matching how [internal/ast/](../../internal/ast/)
 models the compiler's own trees. Appendix A describes what that means for the
 schema, which is unchanged.
 
+A name the function reads but never binds resolves to `Unknown` before the
+walk starts rather than sitting at the lattice bottom. 325 of the 1202
+functions read such a name, 607 in total, and a closure's captured value is
+the usual case. The distinction matters where the name shares a target with
+another definition. `Iterator.prototype.drop`'s closure opens with `Let
+remaining be integerLimit`, which the enclosing algorithm owns, and a later
+step assigns `remaining` a literal. Left at the bottom the capture would
+contribute nothing to the join, `remaining` would come out `Fresh`, and §4.1
+would read a mutation of it as invisible to the caller.
+
 283 of the 313 builtin methods bind a name at the receiver. The other 30 pass
 `this` straight into an operation that reads a value out of it, such as
 `ThisNumberValue` or `GeneratorResume`, or are among the eight §3 builtins with

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -665,12 +665,16 @@ func evalCall(F, c) Origin:
 ```
 
 `IdentityCoercions` is the key list for receiver tracking. `ToObject`
-and `RequireObjectCoercible` return the same object, so `O ← ?
-ToObject(this value)` keeps `O` at the receiver. Coercions that build a
-new value — `ToString`, `ToNumber` — are *not* identity-preserving,
-which is exactly why every `String.prototype` method comes out
-non-mutating: the algorithm coerces `this` to a fresh string primitive
-and never writes back to `Param(0)`.
+and `RequireObjectCoercible` return the object they were given, so `O ← ?
+ToObject(this value)` keeps `O` at the receiver. `ToObject` preserves
+identity only for an object argument. Given a primitive it allocates a
+wrapper, and the analysis propagates the receiver through it anyway. That
+approximation runs in the FR5-conservative direction, since a mutation
+claimed where there is none fails loudly at a call site while a missed one
+is silent unsoundness. Coercions that build a new value — `ToString`,
+`ToNumber` — are *not* identity-preserving, which is exactly why every
+`String.prototype` method comes out non-mutating: the algorithm coerces
+`this` to a fresh string primitive and never writes back to the receiver.
 
 **The analysis is deliberately path-insensitive.** It does not model
 control flow: `NodeBranch` is not interpreted, and the node list is

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -690,11 +690,11 @@ construction, not by accident.
 
 **Outcome.** Done. [internal/ecma262/](../../internal/ecma262/) holds the Go
 reader for `cfg.json`, mirroring Appendix A, and the origin map.
-`NewOriginMap(fn)` returns the origins of one function's value names;
+`NewOriginMap(fn)` returns the origins of one function's value names.
 `Eval(expr)` answers the same question for an expression, which is the call
-§4.1 makes to charge a mutation. All 1202 functions analyze in about 4 ms,
-binding 11663 names: 373 at the receiver, 2007 at a parameter, 2969 fresh, and
-6314 unknown. The gate is
+§4.1 makes when it charges a mutation to a receiver or a parameter. All 1202
+functions analyze in about 4 ms, binding 11663 names. Of those, 373 are at the
+receiver, 2007 at a parameter, 2969 fresh, and 6314 unknown. The gate is
 [internal/ecma262/origin_test.go](../../internal/ecma262/origin_test.go).
 `Let O be ? ToObject(this value)` puts `O` at the receiver in
 `Array.prototype.push`, `? ArraySpeciesCreate(O, count)` puts `A` at `Fresh` in
@@ -704,7 +704,7 @@ binding 11663 names: 373 at the receiver, 2007 at a parameter, 2969 fresh, and
 - **One walk in node order is unsound, so the walk repeats until nothing
   moves.** A loop's back edge redefines a name after its uses, and a single
   walk records only the definition it reached first. `ForBodyEvaluation` binds
-  `%4` from a literal ahead of its loop and from a value read inside it: one
+  `%4` from a literal ahead of its loop and from a value read inside it. One
   walk leaves `%4` at `Fresh`, which would tell §4.1 that a mutation of it is
   invisible to the caller. Repeating the walk joins both definitions and gives
   `Unknown`. It changes 7 names across 4 functions, all of them loops, and
@@ -715,14 +715,14 @@ binding 11663 names: 373 at the receiver, 2007 at a parameter, 2969 fresh, and
   nearly every algorithm's return. The record it builds is fresh, but §3 drops
   the caller-side unwrap, so the value the caller receives is `v`. Reading the
   wrap as an allocation would resolve every method's return to `Fresh` and cost
-  §4.3 its `returnAlias`: `Map.prototype.set` ends in `return
-  NormalCompletion(M)`, and the receiver has to survive that.
+  §4.3 its `returnAlias`. `Map.prototype.set` ends in `return
+  NormalCompletion(M)`, and the receiver has to survive that wrap.
 - **`CanonicalizeKeyedCollectionKey` is identity-preserving and had to be
   listed.** It returns its key unchanged apart from normalizing `-0` to `+0`,
   which cannot apply to an object. `Map.prototype.set` rebinds `key` to its
-  result, so without the entry `key` joins `Param(0)` with `Unknown` and
-  collapses, which is exactly the parameter §8.1 needs to follow into the
-  `[[MapData]]` record.
+  result. Without the entry, `key` joins `Param(0)` with `Unknown` and
+  collapses, losing the parameter §8.1 has to follow into the `[[MapData]]`
+  record.
 - **`Construct` and `ProxyCreate` are deliberately not allocators.**
   `Fresh` is the one origin whose mutations the fixpoint discards, so an entry
   that can hand back a value the caller already holds turns a real mutation

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -737,6 +737,11 @@ receiver, 2007 at a parameter, 2969 fresh, and 6314 unknown. The gate is
   because `Array.prototype.slice` and its neighbours build their result through
   them.
 
+`Node` and `Expr` are sealed interfaces with one type per kind rather than
+one struct tagged by kind, matching how [internal/ast/](../../internal/ast/)
+models the compiler's own trees. Appendix A describes what that means for the
+schema, which is unchanged.
+
 283 of the 313 builtin methods bind a name at the receiver. The other 30 pass
 `this` straight into an operation that reads a value out of it, such as
 `ThisNumberValue` or `GeneratorResume`, or are among the eight §3 builtins with
@@ -1536,6 +1541,24 @@ abstract operation and the `Set` constructor. A `Callee`, and a closure
 named by an `ExprVar`, resolve against the `abstract-op` functions only.
 `ExprCall` is reserved: the compiled IR states every call as its own node,
 so a call never appears nested inside an expression.
+
+**The schema above is the wire shape, not the Go model.** A node and an
+expression each serialize as one object tagged by `kind`, which is what the
+Scala serializer writes and what a reader has to decode. Tagging one struct
+with a kind is not how this repository models a tree with several node
+shapes, though, and it lets a reader consult a field the tag does not carry,
+such as `Slot` on a `let`. So
+[internal/ecma262/cfg.go](../../internal/ecma262/cfg.go) declares `Node` and
+`Expr` as sealed interfaces with one type per kind, the pattern
+[internal/ast/expr.go](../../internal/ast/expr.go) uses, and decodes the
+JSON through unexported wire structs that mirror the schema above. The wire
+format does not change, so §3 is untouched. Two operands are genuinely
+optional and the rest are required at decode time: a `Throw` carries no
+`Value` when it constructs its error, and 22 `SlotWrite` nodes carry none
+because the serializer could not name what they store. Those 22 are all
+closure argument prologues writing into `__args__`, as in
+`NewPromiseCapability:clo0`, and none is a builtin method, so §8.1 sees a
+`SlotWrite` with no stored value only inside an abstract operation.
 
 ## Appendix B. `facts.json` schema
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -742,6 +742,19 @@ one struct tagged by kind, matching how [internal/ast/](../../internal/ast/)
 models the compiler's own trees. Appendix A describes what that means for the
 schema, which is unchanged.
 
+`freshPrimitives` names the coercions that build a new primitive from their
+argument, `ToString` and `ToNumber` among them, plus the numeric type
+operations of §6.1.6. Their result is `Fresh` for the same reason an
+allocation is, and with none of the risk, since a primitive cannot be
+mutated and so an entry there can never hide a write. The list exists mostly
+to be read: `Let S be ? ToString(O)` resolving away from the receiver is a
+decision, not an omission from `allocators`. It moves no mutation site at
+all, receiver attribution included, because a coerced primitive never
+reaches a mutating position. It turns four returns from `Unknown` into
+`Fresh` — `BigInt.prototype.toString`, `Date.prototype.toString`,
+`Number.prototype.toString`, and `String.prototype.concat` — and §5's join
+would settle those from the declared return type anyway.
+
 A name the function reads but never binds resolves to `Unknown` before the
 walk starts rather than sitting at the lattice bottom. 325 of the 1202
 functions read such a name, 607 in total, and a closure's captured value is


### PR DESCRIPTION
Fixes #1195.

Implements §4.2 of the implementation plan: origin tracking for values in ECMA-262 builtin algorithms. This analysis determines where each named value in an algorithm came from — the receiver, a parameter, a fresh allocation, or unknown — which feeds into the mutation-summary fixpoint (§4.1).

**Key changes:**

- `cfg.go`: Schema definitions for the serialized control-flow graph from `tools/spec-extract`, including `CFG`, `Func`, `Node`, and `Expr` types. Provides `LoadCFG` and `ParseCFG` to deserialize and index functions by name, keeping abstract operations and builtins in separate namespaces.

- `origin.go`: Origin analysis that computes where each value name in a function came from. `OriginMap` walks the CFG nodes in a path-insensitive fixpoint loop, binding parameters and tracking how values flow through Let bindings and Call results. Identity-preserving coercions like `ToObject` propagate origins, while allocators like `ArrayCreate` produce `Fresh` values, and reads break the chain to `Unknown`. The analysis handles loops correctly by repeating until convergence.

- `cfg_test.go` and `origin_test.go`: Tests covering CFG parsing, origin lattice operations, and origin inference on representative builtin methods (`Array.prototype.push`, `Array.prototype.slice`, `String.prototype.toLowerCase`, `Object.assign`, `Map.prototype.set`, etc.). Tests verify that receiver tracking works through `ToObject`, allocators produce fresh values, and value coercions break the chain.

- `planning/ecma-262/implementation_plan.md`: Updated §4.2 status to ✅, refined the pseudocode to show the fixpoint loop and lattice join operations explicitly, and recorded the outcome.

The implementation is path-insensitive by design: a name assigned on two branches takes the join of both definitions, collapsing to `Unknown` when they disagree. `Fresh` is the one origin whose mutations §4.1 discards, since a write to a value the algorithm allocated itself is invisible to its caller. A write to an `Unknown` origin is the opposite case — the analysis saw a mutation it cannot attribute, so the method is left unclassified rather than claimed as non-mutating (FR5).

Three findings shaped the implementation:

- **The walk repeats until nothing moves.** A loop's back edge redefines a name after its uses, so a single walk in node order records only the definition it reached first. `ForBodyEvaluation` binds `%4` from a literal ahead of its loop and from a value read inside it; one walk leaves `%4` at `Fresh`, which would tell §4.1 that a mutation of it is unobservable. Repeating joins both definitions and gives `Unknown`. It changes 7 names across 4 functions and costs at most three passes over any function in the graph.
- **`NormalCompletion` is identity-preserving.** It stands on 1204 of the graph's call nodes and on nearly every algorithm's return. The record it builds is fresh, but §3 drops the caller-side unwrap, so the caller receives the wrapped value. Reading the wrap as an allocation would resolve every method's return to `Fresh` and cost §4.3 its `returnAlias`.
- **`Construct` and `ProxyCreate` are deliberately not allocators.** `Construct` runs a constructor chosen at runtime and may return one of its arguments, and a write to a proxy reaches its target. Both resolve to `Unknown` instead.

All 1202 functions in the committed graph analyze in about 4 ms.

https://claude.ai/code/session_01EaX8SuLc84bCw5fRzm96tw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added control-flow graph loading, validation, and lookup capabilities for ECMAScript builtins and abstract operations.
  * Added origin analysis to track values across parameters, receivers, allocations, calls, branches, and loops.
  * Preserved origin information through identity-preserving conversions.

* **Documentation**
  * Marked origin-map implementation as complete and documented outcomes, examples, measurements, and findings.

* **Tests**
  * Added comprehensive validation for graph parsing, namespace lookups, origin analysis, branching, loops, and expression evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->