### PR TITLE
Implement mutation-summary fixpoint analysis for ECMA-262

### DIFF
--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -1,9 +1,10 @@
 // Package ecma262 reads the ECMA-262 control-flow graph that
 // tools/spec-extract serializes to cfg.json and derives the mutation and alias
-// facts the builtin converter consumes. cfg.go models the graph, and origin.go
-// maps each value an algorithm names to where that value came from. See
-// planning/ecma-262/implementation_plan.md §4 for the analysis and Appendix A
-// for the serialized schema.
+// facts the builtin converter consumes. cfg.go models the graph, origin.go maps
+// each value an algorithm names to where that value came from, and mutation.go
+// charges every mutation the graph holds to the receiver or the parameter it
+// lands on. See planning/ecma-262/implementation_plan.md §4 for the analysis
+// and Appendix A for the serialized schema.
 package ecma262
 
 import (

--- a/internal/ecma262/mutation.go
+++ b/internal/ecma262/mutation.go
@@ -1,0 +1,358 @@
+package ecma262
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// directMutators are the abstract operations that mutate an argument outright,
+// mapped to the argument position they mutate. They are the fixpoint's base
+// cases, the only mutations the analysis asserts rather than derives. See
+// planning/ecma-262/implementation_plan.md §4.1 and requirements.md FR1.
+//
+// An entry reads as "a call to this operation mutates whatever was passed at
+// this position". `Array.prototype.push` calls `Set(O, %6, E, true)`, so the
+// `Set` entry selects `O`, whose origin is the receiver, and push comes out
+// mutating its receiver. The same entry answers differently in
+// `Array.prototype.slice`, which calls `Set(A, "length", ...)` on the array
+// `ArraySpeciesCreate` handed it. That origin is fresh, so the write is
+// invisible to slice's caller and is discarded.
+//
+// These operations are seeded rather than analyzed because their bodies cannot
+// be descended into. `Set`'s body is a single dispatch to the object's
+// `[[Set]]` internal method, a callee chosen at runtime by the receiver's type.
+// The ordinary path below it dispatches again on the prototype chain and can
+// end in a call to a user-supplied setter. The concrete writes land on
+// property-descriptor records several layers down, phrased in ESMeta's internal
+// object representation rather than as a write to the argument.
+//
+// Claiming that `Set(O, ...)` mutates `O` over-approximates, since a Proxy's
+// `[[Set]]` trap may write elsewhere. That is the FR5-conservative direction. A
+// mutation claimed where there is none fails loudly at a call site, while a
+// missed one is silent unsoundness.
+//
+// Composite mutators stay derived. `Object.freeze` gets position 0 from its
+// call to `SetIntegrityLevel`, which the fixpoint reads off that operation's
+// own summary. `SetIntegrityLevel` is seeded for robustness rather than
+// necessity, since its own body writes through `DefinePropertyOrThrow`.
+//
+// The map is a reviewed constant. A mutating operation the spec adds without an
+// entry here produces a false non-mutating result, so validating it against the
+// spec text is part of the spec-bump runbook.
+var directMutators = map[string]int{
+	// Property writes.
+	"CreateDataProperty":        0,
+	"CreateDataPropertyOrThrow": 0,
+	"CreateMethodProperty":      0,
+	"DefinePropertyOrThrow":     0,
+	"DeletePropertyOrThrow":     0,
+	"OrdinaryDefineOwnProperty": 0,
+	"Set":                       0,
+	// Integrity changes.
+	"SetIntegrityLevel": 0,
+}
+
+// backingStoreSlots are the internal slots that hold an object's mutable
+// payload, so that writing one mutates the object itself. See requirements.md
+// FR3.
+//
+// A collection does not keep its contents as properties. `Map.prototype.set`
+// appends to `M.[[MapData]]` and `Set.prototype.add` appends to
+// `S.[[SetData]]`, and neither goes through a property write, so neither is
+// reachable from the seed above. Without this list both would come out
+// non-mutating.
+//
+// The list is deliberately narrow. A slot belongs here when it holds the value
+// the object's own methods read back, not when it holds a field that merely
+// describes the object. `[[DateValue]]` is a backing store by that reading,
+// since `Date.prototype.setTime` writes it and `Date.prototype.getTime` reads
+// it back. `[[Prototype]]` and `[[Extensible]]` are not, because the property
+// operations that change them already go through the seed.
+//
+// Like the seed, this is a reviewed constant. A collection type entering the
+// spec with a new payload slot needs an entry here or its methods come out
+// non-mutating.
+var backingStoreSlots = set.FromSlice([]string{
+	// Keyed collections.
+	"MapData",
+	"SetData",
+	"WeakMapData",
+	"WeakSetData",
+	"WeakRefTarget",
+	// Array buffers and the views over them.
+	"ArrayBufferByteLength",
+	"ArrayBufferData",
+	"ArrayLength",
+	"ByteLength",
+	"ByteOffset",
+	"TypedArrayName",
+	"ViewedArrayBuffer",
+	// Dates.
+	"DateValue",
+})
+
+// Mutations is what the fixpoint concluded about one function. Args holds the
+// 0-based positions of the declared parameters the function may mutate,
+// sorted. A method's receiver is not a parameter, so it is reported separately
+// by Receiver.
+//
+// Unattributable and Incomplete are two different failures, and §4.3 turns
+// either one into `classified: false` so that FR5's heuristic fall-through
+// handles the method. Unattributable means the analysis saw a mutation and
+// could not tie it to the receiver or to a parameter. It knows something was
+// written but not what. Incomplete means the analysis could not see the whole
+// algorithm, so a mutation may be hiding in the part it could not read.
+type Mutations struct {
+	Args           []int
+	Receiver       bool
+	Unattributable bool
+	Incomplete     bool
+}
+
+// String renders a summary as a space-separated list of the facts that hold, so
+// a test can assert one in a single line. A function with no facts reads
+// "none".
+func (m Mutations) String() string {
+	var parts []string
+	if m.Receiver {
+		parts = append(parts, "receiver")
+	}
+	if len(m.Args) > 0 {
+		positions := make([]string, 0, len(m.Args))
+		for _, arg := range m.Args {
+			positions = append(positions, fmt.Sprint(arg))
+		}
+		parts = append(parts, "args{"+strings.Join(positions, ",")+"}")
+	}
+	if m.Unattributable {
+		parts = append(parts, "unattributable")
+	}
+	if m.Incomplete {
+		parts = append(parts, "incomplete")
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, " ")
+}
+
+// facts is one function's summary while the fixpoint is still running. It holds
+// the mutated positions as a set, which Mutations reports as a sorted slice.
+type facts struct {
+	args           set.Set[int]
+	receiver       bool
+	unattributable bool
+	incomplete     bool
+}
+
+// MutationSummary holds the mutation facts of every function in a graph. It
+// answers, for one function, which of its declared parameters it may mutate and
+// whether it mutates its receiver, counting both the writes the function
+// performs itself and those the functions it calls perform on its behalf.
+type MutationSummary struct {
+	facts map[*Func]*facts
+}
+
+// NewMutationSummary runs the mutation fixpoint over cfg.
+//
+// The seed above gives the base cases, and the summary of every other function
+// is derived from them. A function's own writes are charged to its receiver or
+// to one of its parameters through the origin map of §4.2, and a call charges
+// each position the callee mutates to whatever the call passed there. Since a
+// callee's summary can grow after its callers have been read, a function whose
+// summary grows re-enqueues its callers.
+//
+// The analysis never invents a mutation. Every position in an Args set traces
+// back either to a seed entry or to a backing-store slot write.
+func NewMutationSummary(cfg *CFG) *MutationSummary {
+	a := &analysis{
+		summary: &MutationSummary{facts: make(map[*Func]*facts, len(cfg.Funcs))},
+		origins: make(map[*Func]*OriginMap, len(cfg.Funcs)),
+		callers: make(map[*Func][]*Func, len(cfg.Funcs)),
+	}
+	for _, fn := range cfg.Funcs {
+		a.summary.facts[fn] = &facts{args: set.NewSet[int]()}
+		a.origins[fn] = NewOriginMap(fn)
+	}
+	for _, fn := range cfg.Funcs {
+		for _, callee := range a.callees(cfg, fn) {
+			a.callers[callee] = append(a.callers[callee], fn)
+		}
+	}
+	for name, position := range directMutators {
+		if fn := cfg.AbstractOp(name); fn != nil {
+			a.summary.facts[fn].args.Add(position)
+		}
+	}
+
+	a.run(cfg)
+	return a.summary
+}
+
+// Of returns fn's summary. A function the summary was not computed for reads
+// back empty, which is the answer for a function that mutates nothing.
+func (s *MutationSummary) Of(fn *Func) Mutations {
+	f := s.facts[fn]
+	if f == nil {
+		return Mutations{}
+	}
+	args := f.args.ToSlice()
+	sort.Ints(args)
+	return Mutations{
+		Args:           args,
+		Receiver:       f.receiver,
+		Unattributable: f.unattributable,
+		Incomplete:     f.incomplete,
+	}
+}
+
+// analysis is the state the fixpoint runs over. origins and callers are built
+// once and read throughout; only summary changes.
+type analysis struct {
+	summary *MutationSummary
+	origins map[*Func]*OriginMap
+	callers map[*Func][]*Func
+}
+
+// callees returns the functions fn calls, in call order and without repeats. A
+// callee that names no function in the graph is left out, and the transfer
+// function records it as incomplete when it reaches the call.
+func (a *analysis) callees(cfg *CFG, fn *Func) []*Func {
+	var called []*Func
+	seen := set.NewSet[*Func]()
+	for _, node := range fn.Nodes {
+		call, ok := node.(*CallNode)
+		if !ok {
+			continue
+		}
+		callee := cfg.AbstractOp(call.Callee)
+		if callee == nil || seen.Contains(callee) {
+			continue
+		}
+		seen.Add(callee)
+		called = append(called, callee)
+	}
+	return called
+}
+
+// run iterates the transfer function until no summary moves. It terminates
+// because a summary only ever grows: a position enters an Args set and never
+// leaves, and each flag goes from false to true at most once.
+func (a *analysis) run(cfg *CFG) {
+	queue := make([]*Func, len(cfg.Funcs))
+	copy(queue, cfg.Funcs)
+	queued := set.FromSlice(queue)
+
+	for len(queue) > 0 {
+		fn := queue[0]
+		queue = queue[1:]
+		queued.Remove(fn)
+
+		if !a.transfer(cfg, fn) {
+			continue
+		}
+		for _, caller := range a.callers[fn] {
+			if queued.Contains(caller) {
+				continue
+			}
+			queued.Add(caller)
+			queue = append(queue, caller)
+		}
+	}
+}
+
+// transfer walks fn once, charging every mutation it can see to fn's receiver
+// or to one of fn's parameters, and reports whether fn's summary grew.
+func (a *analysis) transfer(cfg *CFG, fn *Func) bool {
+	f := a.summary.facts[fn]
+	origin := a.origins[fn]
+	changed := false
+
+	for _, node := range fn.Nodes {
+		switch node := node.(type) {
+		case *SlotWriteNode:
+			if node.Slot == "" {
+				// The algorithm computes the slot it writes, so the curated
+				// list cannot say whether this write reaches the object's
+				// backing store. A write onto a value the function allocated
+				// itself stays invisible to the caller whichever slot it
+				// lands on. At any other origin the analysis has seen a write
+				// it cannot read, which is what Incomplete records.
+				if origin.Eval(node.Object).Kind != OriginFresh {
+					changed = f.markIncomplete() || changed
+				}
+			} else if backingStoreSlots.Contains(node.Slot) {
+				changed = a.attribute(f, origin, node.Object) || changed
+			}
+		case *CallNode:
+			callee := cfg.AbstractOp(node.Callee)
+			if callee == nil {
+				// A callee absent from the graph, which is either an internal
+				// method chosen by the receiver's type or a callback the caller
+				// supplied. Either way the analysis cannot see what it writes.
+				changed = f.markIncomplete() || changed
+				continue
+			}
+			for position := range a.summary.facts[callee].args {
+				if position >= len(node.Args) {
+					// No call in the pinned graph omits an argument its callee
+					// mutates. The bound keeps a spec bump that introduces one
+					// from indexing off the end of the argument list.
+					continue
+				}
+				changed = a.attribute(f, origin, node.Args[position]) || changed
+			}
+		case *OpaqueNode:
+			// A step §3 could not lower, such as a prose step.
+			changed = f.markIncomplete() || changed
+		default:
+			// No other node shape writes a value.
+		}
+	}
+	return changed
+}
+
+// attribute charges one mutated value expression to fn's receiver or to one of
+// its parameters, and reports whether that grew the summary.
+func (a *analysis) attribute(f *facts, origin *OriginMap, e Expr) bool {
+	switch o := origin.Eval(e); o.Kind {
+	case OriginReceiver:
+		if f.receiver {
+			return false
+		}
+		f.receiver = true
+		return true
+	case OriginParam:
+		if f.args.Contains(o.Index) {
+			return false
+		}
+		f.args.Add(o.Index)
+		return true
+	case OriginFresh:
+		// A write to a value the function allocated itself, which its caller
+		// never sees.
+		return false
+	default:
+		// OriginUnknown. A mutation the analysis cannot place.
+		return f.markUnattributable()
+	}
+}
+
+func (f *facts) markIncomplete() bool {
+	if f.incomplete {
+		return false
+	}
+	f.incomplete = true
+	return true
+}
+
+func (f *facts) markUnattributable() bool {
+	if f.unattributable {
+		return false
+	}
+	f.unattributable = true
+	return true
+}

--- a/internal/ecma262/mutation.go
+++ b/internal/ecma262/mutation.go
@@ -9,39 +9,26 @@ import (
 )
 
 // directMutators are the abstract operations that mutate an argument outright,
-// mapped to the argument position they mutate. They are the fixpoint's base
-// cases, the only mutations the analysis asserts rather than derives. See
+// mapped to the position they mutate. They are the fixpoint's base cases, the
+// only mutations the analysis asserts rather than derives. See
 // planning/ecma-262/implementation_plan.md §4.1 and requirements.md FR1.
 //
 // An entry reads as "a call to this operation mutates whatever was passed at
-// this position". `Array.prototype.push` calls `Set(O, %6, E, true)`, so the
-// `Set` entry selects `O`, whose origin is the receiver, and push comes out
-// mutating its receiver. The same entry answers differently in
-// `Array.prototype.slice`, which calls `Set(A, "length", ...)` on the array
-// `ArraySpeciesCreate` handed it. That origin is fresh, so the write is
-// invisible to slice's caller and is discarded.
+// this position", and the argument's origin decides what that means for the
+// caller. `Array.prototype.push` calls `Set(O, ...)` where `O` is the receiver,
+// so push mutates its receiver. `Array.prototype.slice` calls `Set(A, ...)` on
+// the array `ArraySpeciesCreate` handed it, and a fresh origin is discarded.
 //
-// These operations are seeded rather than analyzed because their bodies cannot
-// be descended into. `Set`'s body is a single dispatch to the object's
-// `[[Set]]` internal method, a callee chosen at runtime by the receiver's type.
-// The ordinary path below it dispatches again on the prototype chain and can
-// end in a call to a user-supplied setter. The concrete writes land on
-// property-descriptor records several layers down, phrased in ESMeta's internal
-// object representation rather than as a write to the argument.
-//
-// Claiming that `Set(O, ...)` mutates `O` over-approximates, since a Proxy's
-// `[[Set]]` trap may write elsewhere. That is the FR5-conservative direction. A
-// mutation claimed where there is none fails loudly at a call site, while a
-// missed one is silent unsoundness.
-//
-// Composite mutators stay derived. `Object.freeze` gets position 0 from its
-// call to `SetIntegrityLevel`, which the fixpoint reads off that operation's
-// own summary. `SetIntegrityLevel` is seeded for robustness rather than
-// necessity, since its own body writes through `DefinePropertyOrThrow`.
+// These operations are seeded because their bodies cannot be descended into.
+// `Set` dispatches to the object's `[[Set]]` internal method, a callee the
+// receiver's type chooses at runtime, and the writes below it land on
+// property-descriptor records rather than on the argument. Claiming that
+// `Set(O, ...)` mutates `O` therefore over-approximates. That is the
+// FR5-conservative direction, since a mutation claimed where there is none
+// fails loudly at a call site while a missed one is silent unsoundness.
 //
 // The map is a reviewed constant. A mutating operation the spec adds without an
-// entry here produces a false non-mutating result, so validating it against the
-// spec text is part of the spec-bump runbook.
+// entry here produces a false non-mutating result.
 var directMutators = map[string]int{
 	// Property writes.
 	"CreateDataProperty":        0,
@@ -53,37 +40,27 @@ var directMutators = map[string]int{
 	"Set":                       0,
 	// Integrity changes.
 	"SetIntegrityLevel": 0,
-	// Data-block writes. SetValueInBuffer writes bytes into the Data Block an
-	// ArrayBuffer holds in its `[[ArrayBufferData]]` slot. Its argument 0 is
-	// that buffer, and every write a DataView setter, `Atomics.store`, or
-	// `TypedArray.prototype.set` performs goes through it. The write itself is
-	// a byte-range store the graph does not lower, so nothing below this entry
-	// reports it.
+	// Data-block writes. SetValueInBuffer stores bytes into the Data Block its
+	// argument 0 holds, and the graph does not lower that store. Every write a
+	// DataView setter, `Atomics.store`, or `TypedArray.prototype.set` performs
+	// goes through it.
 	"SetValueInBuffer": 0,
 }
 
 // backingStoreSlots are the internal slots that hold an object's mutable
-// payload, so that writing one mutates the object itself. See requirements.md
-// FR3.
+// payload, so writing one mutates the object itself. See requirements.md FR3.
 //
 // A collection does not keep its contents as properties. `Map.prototype.set`
-// appends to `M.[[MapData]]` and `Set.prototype.add` appends to
-// `S.[[SetData]]`, and neither goes through a property write, so neither is
-// reachable from the seed above. Without this list both would come out
-// non-mutating.
+// appends to `M.[[MapData]]` and `Set.prototype.add` appends to `S.[[SetData]]`,
+// neither through a property write, so the seed above never reaches them.
 //
-// The list is deliberately narrow. A slot belongs here when it holds the value
-// the object's own methods read back. `[[DateValue]]` qualifies, since
-// `Date.prototype.setTime` writes it and `Date.prototype.getTime` reads it
-// back. `[[Prototype]]` and `[[Extensible]]` do not, because they describe how
-// the object behaves rather than what it holds. Leaving them out costs nothing,
-// since `Object.setPrototypeOf` and `Object.preventExtensions` reach their
-// writes through an internal method the graph does not resolve and come out
-// incomplete either way.
+// A slot belongs here when it holds the value the object's own methods read
+// back. `[[DateValue]]` qualifies, since `Date.prototype.setTime` writes it and
+// `Date.prototype.getTime` reads it. `[[Prototype]]` and `[[Extensible]]` do
+// not, because they describe how the object behaves rather than what it holds.
 //
-// Like the seed, this is a reviewed constant. A collection type entering the
-// spec with a new payload slot needs an entry here or its methods come out
-// non-mutating.
+// Like the seed, a reviewed constant. A collection type entering the spec with
+// a new payload slot needs an entry or its methods come out non-mutating.
 var backingStoreSlots = set.FromSlice([]string{
 	// Keyed collections.
 	"MapData",
@@ -106,16 +83,14 @@ var backingStoreSlots = set.FromSlice([]string{
 })
 
 // Mutations is what the fixpoint concluded about one function. Args holds the
-// 0-based positions of the declared parameters the function may mutate,
-// sorted. A method's receiver is not a parameter, so it is reported separately
-// by Receiver.
+// sorted 0-based positions of the declared parameters it may mutate. A method's
+// receiver is not a parameter, so Receiver reports it separately.
 //
-// Unattributable and Incomplete are two different failures, and §4.3 turns
-// either one into `classified: false` so that FR5's name-based heuristics
-// decide the method instead. Unattributable means the analysis saw a mutation
-// and could not tie it to the receiver or to a parameter. It knows something
-// was written but not what. Incomplete means the analysis could not see the
-// whole algorithm, so a mutation may be hiding in the part it could not read.
+// The two warnings name different failures, and §4.3 turns either into
+// `classified: false` so FR5's name-based heuristics decide the method instead.
+// Unattributable means the analysis saw a mutation it could not tie to the
+// receiver or to a parameter. Incomplete means it could not read the whole
+// algorithm, so a mutation may be hiding in the part it missed.
 type Mutations struct {
 	Args           []int
 	Receiver       bool
@@ -123,9 +98,8 @@ type Mutations struct {
 	Incomplete     bool
 }
 
-// String renders a summary as a space-separated list of the facts that hold, so
-// a test can assert one in a single line. A function with no facts reads
-// "none".
+// String renders the facts that hold as a space-separated list, so a test can
+// assert a summary in one line. A function with no facts reads "none".
 func (m Mutations) String() string {
 	var parts []string
 	if m.Receiver {
@@ -160,27 +134,24 @@ type facts struct {
 }
 
 // MutationSummary holds the mutation facts of every function in a graph. It
-// answers, for one function, which of its declared parameters it may mutate and
-// whether it mutates its receiver, counting both the writes the function
-// performs itself and those the functions it calls perform on its behalf.
+// answers, for one function, which declared parameters it may mutate and
+// whether it mutates its receiver, counting the writes it performs itself and
+// those its callees perform on its behalf.
 type MutationSummary struct {
 	facts map[*Func]*facts
 }
 
 // NewMutationSummary runs the mutation fixpoint over cfg.
 //
-// The seed above gives the base cases, and the summary of every other function
-// is derived from them. A function's own writes are charged to its receiver or
-// to one of its parameters through the origin map of §4.2, and a call charges
-// each position the callee mutates to whatever the call passed there. Since a
-// callee's summary can grow after its callers have been read, a function whose
-// summary grows re-enqueues its callers.
-//
-// A call also carries the callee's Unattributable flag up, since the value the
-// callee could not place may have arrived as one of the arguments.
+// The seed above gives the base cases and every other summary derives from
+// them. A function's own writes are charged to its receiver or to a parameter
+// through the origin map of §4.2. A call charges each position the callee
+// mutates to whatever the call passed there, and carries the callee's
+// Unattributable flag up, since the value it could not place may have arrived
+// as one of the arguments. A summary that grows re-enqueues its callers.
 //
 // The analysis never invents a mutation. Every position in an Args set traces
-// back either to a seed entry or to a backing-store slot write.
+// back to a seed entry or to a backing-store slot write.
 func NewMutationSummary(cfg *CFG) *MutationSummary {
 	a := &analysis{
 		summary: &MutationSummary{facts: make(map[*Func]*facts, len(cfg.Funcs))},
@@ -207,7 +178,7 @@ func NewMutationSummary(cfg *CFG) *MutationSummary {
 }
 
 // Of returns fn's summary. A function the summary was not computed for reads
-// back empty, which is the answer for a function that mutates nothing.
+// back empty, the same as one that mutates nothing.
 func (s *MutationSummary) Of(fn *Func) Mutations {
 	f := s.facts[fn]
 	if f == nil {
@@ -232,8 +203,8 @@ type analysis struct {
 }
 
 // callees returns the functions fn calls, in call order and without repeats. A
-// callee the analysis cannot resolve is left out, and the transfer function
-// records it as incomplete when it reaches the call.
+// callee the analysis cannot resolve is left out, and transfer records it as
+// incomplete when it reaches the call.
 func (a *analysis) callees(cfg *CFG, fn *Func) []*Func {
 	var called []*Func
 	seen := set.NewSet[*Func]()
@@ -256,12 +227,11 @@ func (a *analysis) callees(cfg *CFG, fn *Func) []*Func {
 // callee is not a body the analysis can read.
 //
 // A callee is either an abstract-operation name or a value the function holds,
-// such as the `callbackfn` a caller passed in. The origin map tells the two
-// apart, since a name bound to one of the function's own parameters is a
-// callback rather than the operation of that name. No callee in the pinned
-// graph shadows an operation this way. The check is there for a spec bump that
-// names a parameter after a seeded operation, where resolving by name alone
-// would charge the callback with that operation's mutations.
+// such as the `callbackfn` a caller passed in. A name bound to one of the
+// function's own parameters is the second kind. No callee in the pinned graph
+// shadows an operation this way; the check guards a spec bump that names a
+// parameter after a seeded operation, where resolving by name alone would
+// charge the callback with that operation's mutations.
 func (a *analysis) resolve(cfg *CFG, origin *OriginMap, callee string) *Func {
 	if origin.Of(callee).Kind == OriginParam {
 		return nil

--- a/internal/ecma262/mutation.go
+++ b/internal/ecma262/mutation.go
@@ -53,6 +53,13 @@ var directMutators = map[string]int{
 	"Set":                       0,
 	// Integrity changes.
 	"SetIntegrityLevel": 0,
+	// Data-block writes. SetValueInBuffer writes bytes into the Data Block an
+	// ArrayBuffer holds in its `[[ArrayBufferData]]` slot. Its argument 0 is
+	// that buffer, and every write a DataView setter, `Atomics.store`, or
+	// `TypedArray.prototype.set` performs goes through it. The write itself is
+	// a byte-range store the graph does not lower, so nothing below this entry
+	// reports it.
+	"SetValueInBuffer": 0,
 }
 
 // backingStoreSlots are the internal slots that hold an object's mutable
@@ -66,11 +73,13 @@ var directMutators = map[string]int{
 // non-mutating.
 //
 // The list is deliberately narrow. A slot belongs here when it holds the value
-// the object's own methods read back, not when it holds a field that merely
-// describes the object. `[[DateValue]]` is a backing store by that reading,
-// since `Date.prototype.setTime` writes it and `Date.prototype.getTime` reads
-// it back. `[[Prototype]]` and `[[Extensible]]` are not, because the property
-// operations that change them already go through the seed.
+// the object's own methods read back. `[[DateValue]]` qualifies, since
+// `Date.prototype.setTime` writes it and `Date.prototype.getTime` reads it
+// back. `[[Prototype]]` and `[[Extensible]]` do not, because they describe how
+// the object behaves rather than what it holds. Leaving them out costs nothing,
+// since `Object.setPrototypeOf` and `Object.preventExtensions` reach their
+// writes through an internal method the graph does not resolve and come out
+// incomplete either way.
 //
 // Like the seed, this is a reviewed constant. A collection type entering the
 // spec with a new payload slot needs an entry here or its methods come out
@@ -92,6 +101,8 @@ var backingStoreSlots = set.FromSlice([]string{
 	"ViewedArrayBuffer",
 	// Dates.
 	"DateValue",
+	// Finalization registries.
+	"Cells",
 })
 
 // Mutations is what the fixpoint concluded about one function. Args holds the
@@ -100,11 +111,11 @@ var backingStoreSlots = set.FromSlice([]string{
 // by Receiver.
 //
 // Unattributable and Incomplete are two different failures, and §4.3 turns
-// either one into `classified: false` so that FR5's heuristic fall-through
-// handles the method. Unattributable means the analysis saw a mutation and
-// could not tie it to the receiver or to a parameter. It knows something was
-// written but not what. Incomplete means the analysis could not see the whole
-// algorithm, so a mutation may be hiding in the part it could not read.
+// either one into `classified: false` so that FR5's name-based heuristics
+// decide the method instead. Unattributable means the analysis saw a mutation
+// and could not tie it to the receiver or to a parameter. It knows something
+// was written but not what. Incomplete means the analysis could not see the
+// whole algorithm, so a mutation may be hiding in the part it could not read.
 type Mutations struct {
 	Args           []int
 	Receiver       bool
@@ -165,6 +176,9 @@ type MutationSummary struct {
 // callee's summary can grow after its callers have been read, a function whose
 // summary grows re-enqueues its callers.
 //
+// A call also carries the callee's Unattributable flag up, since the value the
+// callee could not place may have arrived as one of the arguments.
+//
 // The analysis never invents a mutation. Every position in an Args set traces
 // back either to a seed entry or to a backing-store slot write.
 func NewMutationSummary(cfg *CFG) *MutationSummary {
@@ -210,7 +224,7 @@ func (s *MutationSummary) Of(fn *Func) Mutations {
 }
 
 // analysis is the state the fixpoint runs over. origins and callers are built
-// once and read throughout; only summary changes.
+// once and read from then on. Only summary changes as the fixpoint iterates.
 type analysis struct {
 	summary *MutationSummary
 	origins map[*Func]*OriginMap
@@ -218,8 +232,8 @@ type analysis struct {
 }
 
 // callees returns the functions fn calls, in call order and without repeats. A
-// callee that names no function in the graph is left out, and the transfer
-// function records it as incomplete when it reaches the call.
+// callee the analysis cannot resolve is left out, and the transfer function
+// records it as incomplete when it reaches the call.
 func (a *analysis) callees(cfg *CFG, fn *Func) []*Func {
 	var called []*Func
 	seen := set.NewSet[*Func]()
@@ -228,7 +242,7 @@ func (a *analysis) callees(cfg *CFG, fn *Func) []*Func {
 		if !ok {
 			continue
 		}
-		callee := cfg.AbstractOp(call.Callee)
+		callee := a.resolve(cfg, a.origins[fn], call.Callee)
 		if callee == nil || seen.Contains(callee) {
 			continue
 		}
@@ -236,6 +250,23 @@ func (a *analysis) callees(cfg *CFG, fn *Func) []*Func {
 		called = append(called, callee)
 	}
 	return called
+}
+
+// resolve returns the function a call node's callee names, or nil when the
+// callee is not a body the analysis can read.
+//
+// A callee is either an abstract-operation name or a value the function holds,
+// such as the `callbackfn` a caller passed in. The origin map tells the two
+// apart, since a name bound to one of the function's own parameters is a
+// callback rather than the operation of that name. No callee in the pinned
+// graph shadows an operation this way. The check is there for a spec bump that
+// names a parameter after a seeded operation, where resolving by name alone
+// would charge the callback with that operation's mutations.
+func (a *analysis) resolve(cfg *CFG, origin *OriginMap, callee string) *Func {
+	if origin.Of(callee).Kind == OriginParam {
+		return nil
+	}
+	return cfg.AbstractOp(callee)
 }
 
 // run iterates the transfer function until no summary moves. It terminates
@@ -279,8 +310,8 @@ func (a *analysis) transfer(cfg *CFG, fn *Func) bool {
 				// list cannot say whether this write reaches the object's
 				// backing store. A write onto a value the function allocated
 				// itself stays invisible to the caller whichever slot it
-				// lands on. At any other origin the analysis has seen a write
-				// it cannot read, which is what Incomplete records.
+				// lands on. At any other origin this is a write the analysis
+				// cannot read, which is what Incomplete records.
 				if origin.Eval(node.Object).Kind != OriginFresh {
 					changed = f.markIncomplete() || changed
 				}
@@ -288,19 +319,26 @@ func (a *analysis) transfer(cfg *CFG, fn *Func) bool {
 				changed = a.attribute(f, origin, node.Object) || changed
 			}
 		case *CallNode:
-			callee := cfg.AbstractOp(node.Callee)
+			callee := a.resolve(cfg, origin, node.Callee)
 			if callee == nil {
-				// A callee absent from the graph, which is either an internal
-				// method chosen by the receiver's type or a callback the caller
-				// supplied. Either way the analysis cannot see what it writes.
+				// The callee is an internal method the receiver's type
+				// chooses, or a function the caller supplied. Neither is a
+				// body the analysis can read.
 				changed = f.markIncomplete() || changed
 				continue
 			}
-			for position := range a.summary.facts[callee].args {
+			summary := a.summary.facts[callee]
+			if summary.unattributable {
+				// The callee wrote a value it could not place, and that value
+				// may have arrived as one of these arguments.
+				changed = f.markUnattributable() || changed
+			}
+			for position := range summary.args {
 				if position >= len(node.Args) {
 					// No call in the pinned graph omits an argument its callee
-					// mutates. The bound keeps a spec bump that introduces one
-					// from indexing off the end of the argument list.
+					// mutates. A spec bump that introduces one leaves a write
+					// with no argument expression to charge it to.
+					changed = f.markIncomplete() || changed
 					continue
 				}
 				changed = a.attribute(f, origin, node.Args[position]) || changed

--- a/internal/ecma262/mutation.go
+++ b/internal/ecma262/mutation.go
@@ -19,13 +19,13 @@ import (
 // so push mutates its receiver. `Array.prototype.slice` calls `Set(A, ...)` on
 // the array `ArraySpeciesCreate` handed it, and a fresh origin is discarded.
 //
-// These operations are seeded because their bodies cannot be descended into.
-// `Set` dispatches to the object's `[[Set]]` internal method, a callee the
-// receiver's type chooses at runtime, and the writes below it land on
-// property-descriptor records rather than on the argument. Claiming that
-// `Set(O, ...)` mutates `O` therefore over-approximates. That is the
-// FR5-conservative direction, since a mutation claimed where there is none
-// fails loudly at a call site while a missed one is silent unsoundness.
+// These are seeded because their bodies cannot be descended into. `Set`
+// dispatches to the object's `[[Set]]` internal method, chosen at runtime by the
+// receiver's type, and the writes below it land on property-descriptor records
+// rather than on the argument. Claiming that `Set(O, ...)` mutates `O` therefore
+// over-approximates, which is the FR5-conservative direction. A mutation claimed
+// where there is none fails loudly at a call site, while a missed one is silent
+// unsoundness.
 //
 // The map is a reviewed constant. A mutating operation the spec adds without an
 // entry here produces a false non-mutating result.
@@ -52,15 +52,15 @@ var directMutators = map[string]int{
 //
 // A collection does not keep its contents as properties. `Map.prototype.set`
 // appends to `M.[[MapData]]` and `Set.prototype.add` appends to `S.[[SetData]]`,
-// neither through a property write, so the seed above never reaches them.
+// neither through a property write, so the seed never reaches them.
 //
 // A slot belongs here when it holds the value the object's own methods read
 // back. `[[DateValue]]` qualifies, since `Date.prototype.setTime` writes it and
 // `Date.prototype.getTime` reads it. `[[Prototype]]` and `[[Extensible]]` do
 // not, because they describe how the object behaves rather than what it holds.
 //
-// Like the seed, a reviewed constant. A collection type entering the spec with
-// a new payload slot needs an entry or its methods come out non-mutating.
+// A reviewed constant like the seed. A collection type entering the spec with a
+// new payload slot needs an entry or its methods come out non-mutating.
 var backingStoreSlots = set.FromSlice([]string{
 	// Keyed collections.
 	"MapData",
@@ -89,14 +89,12 @@ var backingStoreSlots = set.FromSlice([]string{
 // 0. See planning/ecma-262/implementation_plan.md §4.1 and requirements.md FR1.
 //
 // These are the seed's counterpart for the dispatch the graph cannot follow.
-// Each name resolves to no body, since the receiver's type chooses the
-// implementation at runtime, and without an entry here the call reads as a step
-// the analysis could not see. `Object.setPrototypeOf` and
-// `Reflect.preventExtensions` reach their write through nothing else.
-//
-// Claiming the write over-approximates the same way the seed does. A Proxy trap
-// may write elsewhere or nowhere, and assuming the object is mutated is the
-// FR5-conservative direction.
+// Each name resolves to no body, since the implementation is chosen at runtime,
+// and without an entry here the call reads as a step the analysis could not see.
+// `Object.setPrototypeOf` and `Reflect.preventExtensions` reach their write
+// through nothing else. Claiming the write over-approximates the way the seed
+// does, since a Proxy trap may write elsewhere or nowhere. directMutators
+// describes why that is the safe direction under FR5.
 var mutatingInternalMethods = map[string]int{
 	"DefineOwnProperty": 0,
 	"Delete":            0,
@@ -117,9 +115,9 @@ var mutatingInternalMethods = map[string]int{
 // an ordinary object's accessor property invokes a getter. `[[Call]]` and
 // `[[Construct]]` are left out because they run a function body.
 //
-// A Proxy is the remaining escape, since every trap is user code. The analysis
-// does not model that, and §6's validation diff against the hand-written
-// overrides is where a trap's write would surface.
+// A Proxy is the remaining escape, since every trap is user code. §6's
+// validation diff against the hand-written overrides is where a trap's write
+// would surface.
 var readOnlyInternalMethods = set.FromSlice([]string{
 	"GetOwnProperty",
 	"GetPrototypeOf",
@@ -196,9 +194,9 @@ type MutationSummary struct {
 // up, since the value it could not place may have arrived as one of the
 // arguments. A summary that grows re-enqueues its callers.
 //
-// A call whose callee resolves to no body is an object internal method or a
-// function the caller supplied. The two internal-method tables answer for the
-// first, and the second leaves the summary incomplete.
+// A callee that resolves to no body is an object internal method, which the two
+// tables answer for, or a function the caller supplied, which leaves the summary
+// incomplete.
 //
 // The analysis never invents a mutation. Every position in an Args set traces
 // back to a seed entry, an internal-method entry, or a backing-store slot
@@ -308,10 +306,9 @@ func (a *analysis) callees(cfg *CFG, fn *Func) []*Func {
 //
 // A callee is either an abstract-operation name or a value the function holds,
 // such as the `callbackfn` a caller passed in. A name bound to one of the
-// function's own parameters is the second kind. No callee in the pinned graph
-// shadows an operation this way; the check guards a spec bump that names a
-// parameter after a seeded operation, where resolving by name alone would
-// charge the callback with that operation's mutations.
+// function's own parameters is the second kind, whatever it is named. Resolving
+// by name alone would charge such a callback with a seeded operation's
+// mutations.
 func (a *analysis) resolve(cfg *CFG, origin *OriginMap, callee string) *Func {
 	if origin.Of(callee).Kind == OriginParam {
 		return nil
@@ -357,11 +354,11 @@ func (a *analysis) transfer(cfg *CFG, fn *Func) bool {
 		case *SlotWriteNode:
 			if node.Slot == "" {
 				// The algorithm computes the slot it writes, so the curated
-				// list cannot say whether this write reaches the object's
+				// list cannot say whether the write reaches the object's
 				// backing store. A write onto a value the function allocated
 				// itself stays invisible to the caller whichever slot it
-				// lands on. At any other origin this is a write the analysis
-				// cannot read, which is what Incomplete records.
+				// lands on. Any other origin is a write the analysis cannot
+				// read.
 				if origin.Eval(node.Object).Kind != OriginFresh {
 					changed = f.markIncomplete() || changed
 				}
@@ -376,9 +373,9 @@ func (a *analysis) transfer(cfg *CFG, fn *Func) bool {
 		default:
 			// No other node shape writes a value.
 		}
-		// A call can also sit inside an expression the node reads. Appendix A
-		// reserves that shape even though §3 emits none, so it is charged the
-		// same way rather than passing unseen.
+		// A call can also sit inside an expression the node reads. ParseCFG
+		// accepts that shape even though §3 emits none, so it is charged the
+		// same way rather than dropping a mutation silently.
 		for _, e := range readsOf(node) {
 			changed = a.chargeNested(cfg, f, origin, e) || changed
 		}
@@ -447,9 +444,7 @@ func (a *analysis) charge(cfg *CFG, f *facts, origin *OriginMap, callee string, 
 	}
 	for position := range summary.args {
 		if position >= len(args) {
-			// No call in the pinned graph omits an argument its callee mutates.
-			// A spec bump that introduces one leaves a write with no argument
-			// expression to charge it to.
+			// The write has no argument expression to charge it to.
 			changed = f.markIncomplete() || changed
 			continue
 		}
@@ -470,9 +465,7 @@ func (a *analysis) chargeUnresolved(f *facts, origin *OriginMap, callee string, 
 	}
 	if position, ok := mutatingInternalMethods[callee]; ok {
 		if position >= len(args) {
-			// Every internal method takes the dispatching object first, so a
-			// call with no argument there is one the serializer lowered
-			// differently than this table expects.
+			// The write has no argument expression to charge it to.
 			return f.markIncomplete()
 		}
 		return a.attribute(f, origin, args[position])

--- a/internal/ecma262/mutation.go
+++ b/internal/ecma262/mutation.go
@@ -82,6 +82,52 @@ var backingStoreSlots = set.FromSlice([]string{
 	"Cells",
 })
 
+// mutatingInternalMethods are the object internal methods that write the object
+// they dispatch on, mapped to the argument position that object arrives at. The
+// CFG flattens `O.[[SetPrototypeOf]](V)` to a call whose callee is the bare name
+// `SetPrototypeOf` and whose argument 0 is `O`, so every entry mutates position
+// 0. See planning/ecma-262/implementation_plan.md §4.1 and requirements.md FR1.
+//
+// These are the seed's counterpart for the dispatch the graph cannot follow.
+// Each name resolves to no body, since the receiver's type chooses the
+// implementation at runtime, and without an entry here the call reads as a step
+// the analysis could not see. `Object.setPrototypeOf` and
+// `Reflect.preventExtensions` reach their write through nothing else.
+//
+// Claiming the write over-approximates the same way the seed does. A Proxy trap
+// may write elsewhere or nowhere, and assuming the object is mutated is the
+// FR5-conservative direction.
+var mutatingInternalMethods = map[string]int{
+	"DefineOwnProperty": 0,
+	"Delete":            0,
+	"PreventExtensions": 0,
+	"Set":               0,
+	"SetPrototypeOf":    0,
+}
+
+// readOnlyInternalMethods are the object internal methods that read the object
+// they dispatch on and write nothing. A call to one contributes no mutation and
+// no warning.
+//
+// This is the one place the analysis asserts the absence of a mutation rather
+// than its presence, so the list is narrow. An entry belongs here only when the
+// ordinary implementation runs no user code. `[[GetOwnProperty]]` returns a
+// descriptor off the object's own property table, and `[[HasProperty]]` walks
+// the prototype chain through that same lookup. `[[Get]]` is left out because
+// an ordinary object's accessor property invokes a getter. `[[Call]]` and
+// `[[Construct]]` are left out because they run a function body.
+//
+// A Proxy is the remaining escape, since every trap is user code. The analysis
+// does not model that, and §6's validation diff against the hand-written
+// overrides is where a trap's write would surface.
+var readOnlyInternalMethods = set.FromSlice([]string{
+	"GetOwnProperty",
+	"GetPrototypeOf",
+	"HasProperty",
+	"IsExtensible",
+	"OwnPropertyKeys",
+})
+
 // Mutations is what the fixpoint concluded about one function. Args holds the
 // sorted 0-based positions of the declared parameters it may mutate. A method's
 // receiver is not a parameter, so Receiver reports it separately.
@@ -143,15 +189,20 @@ type MutationSummary struct {
 
 // NewMutationSummary runs the mutation fixpoint over cfg.
 //
-// The seed above gives the base cases and every other summary derives from
-// them. A function's own writes are charged to its receiver or to a parameter
-// through the origin map of §4.2. A call charges each position the callee
-// mutates to whatever the call passed there, and carries the callee's
-// Unattributable flag up, since the value it could not place may have arrived
-// as one of the arguments. A summary that grows re-enqueues its callers.
+// The seed gives the base cases and every other summary derives from them. A
+// function's own writes are charged to its receiver or to a parameter through
+// the origin map of §4.2. A call charges each position the callee mutates to
+// whatever the call passed there, and carries the callee's Unattributable flag
+// up, since the value it could not place may have arrived as one of the
+// arguments. A summary that grows re-enqueues its callers.
+//
+// A call whose callee resolves to no body is an object internal method or a
+// function the caller supplied. The two internal-method tables answer for the
+// first, and the second leaves the summary incomplete.
 //
 // The analysis never invents a mutation. Every position in an Args set traces
-// back to a seed entry or to a backing-store slot write.
+// back to a seed entry, an internal-method entry, or a backing-store slot
+// write.
 func NewMutationSummary(cfg *CFG) *MutationSummary {
 	a := &analysis{
 		summary: &MutationSummary{facts: make(map[*Func]*facts, len(cfg.Funcs))},
@@ -384,10 +435,7 @@ func (a *analysis) chargeNested(cfg *CFG, f *facts, origin *OriginMap, e Expr) b
 func (a *analysis) charge(cfg *CFG, f *facts, origin *OriginMap, callee string, args []Expr) bool {
 	target := a.resolve(cfg, origin, callee)
 	if target == nil {
-		// The callee is an internal method the receiver's type chooses, or a
-		// function the caller supplied. Neither is a body the analysis can
-		// read.
-		return f.markIncomplete()
+		return a.chargeUnresolved(f, origin, callee, args)
 	}
 
 	changed := false
@@ -408,6 +456,31 @@ func (a *analysis) charge(cfg *CFG, f *facts, origin *OriginMap, callee string, 
 		changed = a.attribute(f, origin, args[position]) || changed
 	}
 	return changed
+}
+
+// chargeUnresolved charges a call whose callee is not a body the analysis can
+// read, and reports whether that grew the summary. The two tables above answer
+// for an object internal method. Anything else is a step the analysis could not
+// see.
+func (a *analysis) chargeUnresolved(f *facts, origin *OriginMap, callee string, args []Expr) bool {
+	if origin.Of(callee).Kind == OriginParam {
+		// A function the caller supplied, which may name an internal method
+		// without being one.
+		return f.markIncomplete()
+	}
+	if position, ok := mutatingInternalMethods[callee]; ok {
+		if position >= len(args) {
+			// Every internal method takes the dispatching object first, so a
+			// call with no argument there is one the serializer lowered
+			// differently than this table expects.
+			return f.markIncomplete()
+		}
+		return a.attribute(f, origin, args[position])
+	}
+	if readOnlyInternalMethods.Contains(callee) {
+		return false
+	}
+	return f.markIncomplete()
 }
 
 // attribute charges one mutated value expression to fn's receiver or to one of

--- a/internal/ecma262/mutation.go
+++ b/internal/ecma262/mutation.go
@@ -184,8 +184,11 @@ func (s *MutationSummary) Of(fn *Func) Mutations {
 	if f == nil {
 		return Mutations{}
 	}
-	args := f.args.ToSlice()
-	sort.Ints(args)
+	var args []int
+	if f.args.Len() > 0 {
+		args = f.args.ToSlice()
+		sort.Ints(args)
+	}
 	return Mutations{
 		Args:           args,
 		Receiver:       f.receiver,
@@ -208,17 +211,43 @@ type analysis struct {
 func (a *analysis) callees(cfg *CFG, fn *Func) []*Func {
 	var called []*Func
 	seen := set.NewSet[*Func]()
+	add := func(callee string) {
+		target := a.resolve(cfg, a.origins[fn], callee)
+		if target == nil || seen.Contains(target) {
+			return
+		}
+		seen.Add(target)
+		called = append(called, target)
+	}
+
+	var nested func(Expr)
+	nested = func(e Expr) {
+		switch e := e.(type) {
+		case *CallExpr:
+			add(e.Callee)
+			for _, arg := range e.Args {
+				nested(arg)
+			}
+		case *AllocExpr:
+			for _, arg := range e.Args {
+				nested(arg)
+			}
+		case *SlotExpr:
+			nested(e.Object)
+		case *PropExpr:
+			nested(e.Object)
+		default:
+			// No other expression holds a call.
+		}
+	}
+
 	for _, node := range fn.Nodes {
-		call, ok := node.(*CallNode)
-		if !ok {
-			continue
+		if call, ok := node.(*CallNode); ok {
+			add(call.Callee)
 		}
-		callee := a.resolve(cfg, a.origins[fn], call.Callee)
-		if callee == nil || seen.Contains(callee) {
-			continue
+		for _, e := range readsOf(node) {
+			nested(e)
 		}
-		seen.Add(callee)
-		called = append(called, callee)
 	}
 	return called
 }
@@ -289,36 +318,94 @@ func (a *analysis) transfer(cfg *CFG, fn *Func) bool {
 				changed = a.attribute(f, origin, node.Object) || changed
 			}
 		case *CallNode:
-			callee := a.resolve(cfg, origin, node.Callee)
-			if callee == nil {
-				// The callee is an internal method the receiver's type
-				// chooses, or a function the caller supplied. Neither is a
-				// body the analysis can read.
-				changed = f.markIncomplete() || changed
-				continue
-			}
-			summary := a.summary.facts[callee]
-			if summary.unattributable {
-				// The callee wrote a value it could not place, and that value
-				// may have arrived as one of these arguments.
-				changed = f.markUnattributable() || changed
-			}
-			for position := range summary.args {
-				if position >= len(node.Args) {
-					// No call in the pinned graph omits an argument its callee
-					// mutates. A spec bump that introduces one leaves a write
-					// with no argument expression to charge it to.
-					changed = f.markIncomplete() || changed
-					continue
-				}
-				changed = a.attribute(f, origin, node.Args[position]) || changed
-			}
+			changed = a.charge(cfg, f, origin, node.Callee, node.Args) || changed
 		case *OpaqueNode:
 			// A step §3 could not lower, such as a prose step.
 			changed = f.markIncomplete() || changed
 		default:
 			// No other node shape writes a value.
 		}
+		// A call can also sit inside an expression the node reads. Appendix A
+		// reserves that shape even though §3 emits none, so it is charged the
+		// same way rather than passing unseen.
+		for _, e := range readsOf(node) {
+			changed = a.chargeNested(cfg, f, origin, e) || changed
+		}
+	}
+	return changed
+}
+
+// readsOf returns the expressions a node reads, so the walk can find a call
+// nested inside one.
+func readsOf(node Node) []Expr {
+	switch node := node.(type) {
+	case *LetNode:
+		return []Expr{node.Source}
+	case *CallNode:
+		return node.Args
+	case *SlotWriteNode:
+		return []Expr{node.Object, node.Value}
+	case *ReturnNode:
+		return []Expr{node.Value}
+	case *ThrowNode:
+		return []Expr{node.Value}
+	default:
+		// A branch and an opaque step read nothing.
+		return nil
+	}
+}
+
+// chargeNested charges every call nested inside e, and reports whether that
+// grew the summary.
+func (a *analysis) chargeNested(cfg *CFG, f *facts, origin *OriginMap, e Expr) bool {
+	changed := false
+	switch e := e.(type) {
+	case *CallExpr:
+		changed = a.charge(cfg, f, origin, e.Callee, e.Args) || changed
+		for _, arg := range e.Args {
+			changed = a.chargeNested(cfg, f, origin, arg) || changed
+		}
+	case *AllocExpr:
+		for _, arg := range e.Args {
+			changed = a.chargeNested(cfg, f, origin, arg) || changed
+		}
+	case *SlotExpr:
+		changed = a.chargeNested(cfg, f, origin, e.Object) || changed
+	case *PropExpr:
+		changed = a.chargeNested(cfg, f, origin, e.Object) || changed
+	default:
+		// A name, a this value, a literal, and an absent operand hold no call.
+	}
+	return changed
+}
+
+// charge attributes one call's mutations to the calling function, and reports
+// whether that grew its summary.
+func (a *analysis) charge(cfg *CFG, f *facts, origin *OriginMap, callee string, args []Expr) bool {
+	target := a.resolve(cfg, origin, callee)
+	if target == nil {
+		// The callee is an internal method the receiver's type chooses, or a
+		// function the caller supplied. Neither is a body the analysis can
+		// read.
+		return f.markIncomplete()
+	}
+
+	changed := false
+	summary := a.summary.facts[target]
+	if summary.unattributable {
+		// The callee wrote a value it could not place, and that value may have
+		// arrived as one of these arguments.
+		changed = f.markUnattributable() || changed
+	}
+	for position := range summary.args {
+		if position >= len(args) {
+			// No call in the pinned graph omits an argument its callee mutates.
+			// A spec bump that introduces one leaves a write with no argument
+			// expression to charge it to.
+			changed = f.markIncomplete() || changed
+			continue
+		}
+		changed = a.attribute(f, origin, args[position]) || changed
 	}
 	return changed
 }

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -326,6 +326,27 @@ read-only: HasProperty
 read-only: IsExtensible`))
 }
 
+// An internal method takes the object it dispatches on as its first argument, so
+// a call with no argument there is one the serializer lowered differently than
+// the table expects. The write has no argument expression to charge, which
+// leaves the caller incomplete rather than silently non-mutating.
+//
+// No call in the committed graph omits that argument, so the case is stated as a
+// graph of its own.
+func TestInternalMethodTableOnACallMissingItsObject(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget": "test", "funcs": [
+			{"name": "Demo", "kind": "abstract-op", "params": ["x"], "nodes": [
+				{"kind": "call", "callee": "SetPrototypeOf", "args": [], "guard": "plain"}
+			]}
+		]}`))
+	require.NoError(t, err)
+
+	fn := cfg.AbstractOp("Demo")
+	require.NotNil(t, fn)
+	require.Equal(t, "incomplete", NewMutationSummary(cfg).Of(fn).String())
+}
+
 // A callee that names an internal method but is bound to one of the calling
 // function's parameters is a function the caller was handed, not a dispatch. The
 // tables must not answer for it, or a callback named `Delete` would be charged

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -1,0 +1,240 @@
+package ecma262
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	summaryOnce sync.Once
+	summary     *MutationSummary
+)
+
+// testSummary runs the mutation fixpoint over the committed graph once for the
+// whole package.
+func testSummary(t *testing.T) *MutationSummary {
+	t.Helper()
+	cfg := testCFG(t)
+	summaryOnce.Do(func() {
+		summary = NewMutationSummary(cfg)
+	})
+	return summary
+}
+
+// mutationsOf returns the summary of one builtin or abstract operation.
+func mutationsOf(t *testing.T, name string) Mutations {
+	t.Helper()
+	cfg := testCFG(t)
+	fn := cfg.Builtin(name)
+	if fn == nil {
+		fn = cfg.AbstractOp(name)
+	}
+	require.NotNil(t, fn, "no function named %s", name)
+	return testSummary(t).Of(fn)
+}
+
+func TestMutationsString(t *testing.T) {
+	tests := map[string]struct {
+		mutations Mutations
+		want      string
+	}{
+		"Empty":          {Mutations{}, "none"},
+		"Receiver":       {Mutations{Receiver: true}, "receiver"},
+		"OneArg":         {Mutations{Args: []int{0}}, "args{0}"},
+		"SeveralArgs":    {Mutations{Args: []int{0, 2}}, "args{0,2}"},
+		"Unattributable": {Mutations{Unattributable: true}, "unattributable"},
+		"Incomplete":     {Mutations{Incomplete: true}, "incomplete"},
+		"Every": {
+			Mutations{Args: []int{1}, Receiver: true, Unattributable: true, Incomplete: true},
+			"receiver args{1} unattributable incomplete",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, test.mutations.String())
+		})
+	}
+}
+
+func TestMutationSummarySampleFunctions(t *testing.T) {
+	tests := map[string]struct {
+		fn   string
+		want string
+	}{
+		// push calls `Set(O, %6, E, true)`, and the seed says a call to `Set`
+		// mutates its argument 0. That argument is `O`, which §4.2 puts at the
+		// receiver through `Let O be ? ToObject(this value)`.
+		"ReceiverThroughASeededCall": {"Array.prototype.push", "receiver"},
+		// fill writes the receiver the same way, through `Set(O, Pk, value,
+		// true)` inside its loop.
+		"ReceiverInALoop": {"Array.prototype.fill", "receiver"},
+		// slice calls `Set` too, but on the array `? ArraySpeciesCreate(O,
+		// count)` handed it. That origin is fresh, so the write is invisible to
+		// slice's caller and is discarded.
+		"FreshWritesAreDiscarded": {"Array.prototype.slice", "none"},
+		// Map.prototype.set appends to `M.[[MapData]]`, which no property
+		// operation covers. It comes out mutating only because [[MapData]] is a
+		// backing-store slot.
+		"ReceiverThroughABackingStoreSlot": {"Map.prototype.set", "receiver"},
+		"BackingStoreSlotOnASet":           {"Set.prototype.add", "receiver"},
+		// Date.prototype.setTime writes `dateObject.[[DateValue]]`, the slot
+		// Date.prototype.getTime reads back.
+		"BackingStoreSlotOnADate": {"Date.prototype.setTime", "receiver"},
+		// indexOf only reads the receiver, and every String method coerces its
+		// receiver to a fresh string before touching it.
+		"ReadOnlyMethod": {"Array.prototype.indexOf", "none"},
+		// A static has no receiver, so the object it writes sits at a real
+		// parameter position. freeze reaches the write through
+		// `SetIntegrityLevel(O, ...)` rather than performing it itself.
+		"ParameterThroughAHelper": {"Object.freeze", "args{0}"},
+		"ParameterThroughASeed":   {"Reflect.set", "args{0}"},
+		// assign writes its target through `CreateDataPropertyOrThrow(to, ...)`
+		// and also carries a step §3 could not lower, so the mutation it found
+		// stands alongside the warning that it could not read the whole
+		// algorithm.
+		"MutatingAndIncomplete": {"Object.assign", "args{0} incomplete"},
+		// toLowerCase reaches the Unicode case-mapping table through a prose
+		// step, which §3 emits as an opaque node.
+		"OpaqueStep": {"String.prototype.toLowerCase", "incomplete"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, mutationsOf(t, test.fn).String())
+		})
+	}
+}
+
+// A mutation travels as far up the call graph as the origin map can follow it.
+// `Object.defineProperties` performs no write of its own. It calls
+// `ObjectDefineProperties(O, Properties)`, which calls `DefinePropertyOrThrow`
+// on the same object, and only that last operation is seeded.
+func TestMutationSummaryCarriesMutationsUpTheCallGraph(t *testing.T) {
+	require.Equal(t, "args{0}", mutationsOf(t, "Object.defineProperties").String())
+	require.Equal(t, "args{0} incomplete", mutationsOf(t, "ObjectDefineProperties").String())
+	require.Equal(t, "args{0} incomplete", mutationsOf(t, "DefinePropertyOrThrow").String())
+}
+
+// The mutated position is the one the call site passes the written object at,
+// not the position the seed names. `OrdinarySet(O, P, V, Receiver)` ends up
+// writing `Receiver` rather than `O`, so its summary is position 3.
+func TestMutationSummaryReadsThePositionTheCallPassesTheObjectAt(t *testing.T) {
+	cfg := testCFG(t)
+	fn := cfg.AbstractOp("OrdinarySet")
+	require.NotNil(t, fn)
+	require.Equal(t, []string{"O", "P", "V", "Receiver"}, fn.Params)
+	require.Equal(t, []int{3}, testSummary(t).Of(fn).Args)
+}
+
+// A write the analysis cannot place leaves the function unattributable rather
+// than silently non-mutating. `Array.of` builds its array through
+// `CreateDataPropertyOrThrow(A, ...)`, where `A` came out of `Construct(C, ...)`
+// and §4.2 refuses to call a constructor's result fresh.
+func TestMutationSummaryUnattributableWrite(t *testing.T) {
+	require.Equal(t, "unattributable", mutationsOf(t, "Array.of").String())
+}
+
+// Only a backing-store slot write counts as a mutation of the object written.
+// `Map.prototype.delete` empties the entry in place, `Set p.[[Key]] to EMPTY`,
+// and `[[Key]]` is a field of a Map Entry Record rather than a backing store.
+// The record itself came out of a read of `M.[[MapData]]`, which breaks the
+// origin chain, so the receiver is not in `p` either. delete therefore comes
+// out non-mutating, and §6's validation diff is where that disagreement with
+// the hand-written overrides surfaces.
+func TestMutationSummarySkipsNonBackingStoreSlots(t *testing.T) {
+	require.Equal(t, "none", mutationsOf(t, "Map.prototype.delete").String())
+}
+
+// A function the summary never saw reads back as mutating nothing.
+func TestMutationSummaryOfUnknownFunc(t *testing.T) {
+	require.Equal(t, Mutations{}, testSummary(t).Of(&Func{Name: "nosuchfunction"}))
+}
+
+// Every seed entry has to name an operation the graph holds, or it can never
+// fire and the mutations below it go unreported. CreateMethodProperty is the
+// one entry with no function at the pinned revision. Nothing reachable from a
+// builtin calls it, since the spec uses it from the syntax-directed operations
+// §3 drops. It stays in the seed because the seed is a review artifact of FR1's
+// vocabulary rather than a list of what this graph happens to contain. A spec
+// bump that renames a seeded operation fails here.
+func TestMutationSummarySeedResolves(t *testing.T) {
+	cfg := testCFG(t)
+
+	absent := make([]string, 0, len(directMutators))
+	for name := range directMutators {
+		if cfg.AbstractOp(name) == nil {
+			absent = append(absent, name)
+		}
+	}
+	sort.Strings(absent)
+	snaps.MatchInlineSnapshot(t, strings.Join(absent, "\n"), snaps.Inline(`CreateMethodProperty`))
+}
+
+// Every function in the committed graph gets a summary, and two invariants hold
+// across all of them. A mutated position is one of the function's own declared
+// parameters, so §4.3 can always name the parameter a fact refers to. Only a
+// builtin method mutates a receiver, because only a builtin method has one.
+func TestMutationSummaryCoversEveryFunction(t *testing.T) {
+	cfg := testCFG(t)
+	s := testSummary(t)
+
+	for _, fn := range cfg.Funcs {
+		m := s.Of(fn)
+		for _, position := range m.Args {
+			require.Less(t, position, len(fn.Params), "%s: mutated position %d", fn.Name, position)
+			require.GreaterOrEqual(t, position, 0, "%s: mutated position %d", fn.Name, position)
+		}
+		if m.Receiver {
+			require.Equal(t, BuiltinMethod, fn.Kind, "%s mutates a receiver it does not have", fn.Name)
+		}
+	}
+}
+
+// The tallies over the whole graph, which move when a seed entry, a
+// backing-store slot, or the transfer function changes. A method that mutates
+// nothing is the common case, and a builtin that carries neither a mutation nor
+// a warning is one §4.3 can classify as non-mutating.
+func TestMutationSummaryTallies(t *testing.T) {
+	cfg := testCFG(t)
+	s := testSummary(t)
+
+	tallies := map[FuncKind]map[string]int{}
+	for _, fn := range cfg.Funcs {
+		byKind, ok := tallies[fn.Kind]
+		if !ok {
+			byKind = map[string]int{}
+			tallies[fn.Kind] = byKind
+		}
+		m := s.Of(fn)
+		byKind["total"]++
+		if m.Receiver {
+			byKind["receiver"]++
+		}
+		if len(m.Args) > 0 {
+			byKind["args"]++
+		}
+		if m.Unattributable {
+			byKind["unattributable"]++
+		}
+		if m.Incomplete {
+			byKind["incomplete"]++
+		}
+	}
+
+	kinds := make([]string, 0, len(tallies))
+	for kind, byKind := range tallies {
+		kinds = append(kinds, fmt.Sprintf("%s: total %d, receiver %d, args %d, unattributable %d, incomplete %d",
+			kind, byKind["total"], byKind["receiver"], byKind["args"], byKind["unattributable"], byKind["incomplete"]))
+	}
+	sort.Strings(kinds)
+	snaps.MatchInlineSnapshot(t, strings.Join(kinds, "\n"), snaps.Inline(`abstract-op: total 701, receiver 0, args 42, unattributable 17, incomplete 268
+builtin-method: total 313, receiver 43, args 0, unattributable 3, incomplete 35
+builtin-static: total 188, receiver 0, args 6, unattributable 3, incomplete 58`))
+}

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -120,11 +120,30 @@ func TestMutationSummarySampleFunctions(t *testing.T) {
 		// `SetIntegrityLevel(O, ...)` rather than performing it itself.
 		"ParameterThroughAHelper": {"Object.freeze", "args{0}"},
 		"ParameterThroughASeed":   {"Reflect.set", "args{0}"},
-		// assign writes its target through `CreateDataPropertyOrThrow(to, ...)`
-		// and also carries a step §3 could not lower, so the mutation it found
-		// stands alongside the warning that it could not read the whole
-		// algorithm.
-		"MutatingAndIncomplete": {"Object.assign", "args{0} incomplete"},
+		// assign writes its target through `CreateDataPropertyOrThrow(to, ...)`.
+		// It reaches each source through `from.[[OwnPropertyKeys]]()` and
+		// `from.[[GetOwnProperty]](nextKey)`, two internal methods the
+		// read-only table answers for, so the write to `to` is the only fact
+		// left and no warning stands beside it.
+		"ParameterPastReadOnlyInternalMethods": {"Object.assign", "args{0}"},
+		// @@replace calls `Set(rx, "lastIndex", 0, true)` on its receiver, and
+		// separately appends to three lists through writes whose slot the
+		// algorithm computes. The appends land on values the analysis cannot
+		// place, so the mutation it found stands alongside the warning that it
+		// could not read the whole algorithm.
+		"MutatingAndIncomplete": {"RegExp.prototype [ @@replace ]", "receiver incomplete"},
+		// setPrototypeOf performs no write of its own. It ends in
+		// `O.[[SetPrototypeOf]](proto)`, a dispatch that resolves to no body,
+		// and the internal-method table is what reports the write at all.
+		"ParameterThroughAnInternalMethod":        {"Object.setPrototypeOf", "args{0}"},
+		"ParameterThroughADeletingInternalMethod": {"Reflect.deleteProperty", "args{0}"},
+		// The __proto__ setter reaches the same dispatch with its receiver.
+		"ReceiverThroughAnInternalMethod": {"set Object.prototype.__proto__", "receiver"},
+		// getOwnPropertyDescriptor bottoms out in `obj.[[GetOwnProperty]](key)`.
+		// Naming that dispatch read-only is what lets the method come out
+		// non-mutating rather than unreadable.
+		"ReadOnlyInternalMethod":           {"Object.getOwnPropertyDescriptor", "none"},
+		"ReadOnlyInternalMethodOnAKeyList": {"Reflect.ownKeys", "none"},
 		// toLowerCase reaches the Unicode case-mapping table through a prose
 		// step, which §3 emits as an opaque node.
 		"OpaqueStep": {"String.prototype.toLowerCase", "incomplete"},
@@ -142,7 +161,7 @@ func TestMutationSummarySampleFunctions(t *testing.T) {
 // nothing itself. It is unattributable because `InternalizeJSONProperty`, which
 // it calls, writes a value that operation cannot place.
 func TestMutationSummaryCarriesUnattributableWritesUpTheCallGraph(t *testing.T) {
-	require.Equal(t, "unattributable incomplete", mutationsOf(t, "InternalizeJSONProperty").String())
+	require.Equal(t, "unattributable", mutationsOf(t, "InternalizeJSONProperty").String())
 	require.Equal(t, "unattributable", mutationsOf(t, "JSON.parse").String())
 }
 
@@ -162,8 +181,8 @@ func TestMutationSummaryChargesAnInteriorWriteToItsHolder(t *testing.T) {
 // on the same object, and only that last operation is seeded.
 func TestMutationSummaryCarriesMutationsUpTheCallGraph(t *testing.T) {
 	require.Equal(t, "args{0}", mutationsOf(t, "Object.defineProperties").String())
-	require.Equal(t, "args{0} incomplete", mutationsOf(t, "ObjectDefineProperties").String())
-	require.Equal(t, "args{0} incomplete", mutationsOf(t, "DefinePropertyOrThrow").String())
+	require.Equal(t, "args{0}", mutationsOf(t, "ObjectDefineProperties").String())
+	require.Equal(t, "args{0}", mutationsOf(t, "DefinePropertyOrThrow").String())
 }
 
 // The mutated position is the one the call site passes the written object at,
@@ -280,6 +299,53 @@ func TestMutationSummarySeedResolves(t *testing.T) {
 	snaps.MatchInlineSnapshot(t, strings.Join(absent, "\n"), snaps.Inline(`CreateMethodProperty`))
 }
 
+// The internal-method tables answer for a call only when the callee resolves to
+// no abstract operation, so an entry whose name the graph also defines as an
+// operation is inert: the body answers instead. Three entries are inert at the
+// pinned revision. They stay listed because the tables are a review artifact of
+// FR1's vocabulary rather than a list of what this graph happens to leave
+// unresolved. A spec bump that adds or drops a body for one of these names fails
+// here rather than quietly changing which rule decides the call.
+func TestInternalMethodTablesResolve(t *testing.T) {
+	cfg := testCFG(t)
+
+	var inert []string
+	for name := range mutatingInternalMethods {
+		if cfg.AbstractOp(name) != nil {
+			inert = append(inert, "mutating: "+name)
+		}
+	}
+	for _, name := range readOnlyInternalMethods.ToSlice() {
+		if cfg.AbstractOp(name) != nil {
+			inert = append(inert, "read-only: "+name)
+		}
+	}
+	sort.Strings(inert)
+	snaps.MatchInlineSnapshot(t, strings.Join(inert, "\n"), snaps.Inline(`mutating: Set
+read-only: HasProperty
+read-only: IsExtensible`))
+}
+
+// A callee that names an internal method but is bound to one of the calling
+// function's parameters is a function the caller was handed, not a dispatch. The
+// tables must not answer for it, or a callback named `Delete` would be charged
+// with mutating its first argument.
+func TestInternalMethodTableSkipsACallback(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget": "test", "funcs": [
+			{"name": "Demo", "kind": "abstract-op", "params": ["Delete", "x"], "nodes": [
+				{"kind": "call", "callee": "Delete", "args": [
+					{"kind": "var", "var": "x"}
+				], "guard": "plain"}
+			]}
+		]}`))
+	require.NoError(t, err)
+
+	fn := cfg.AbstractOp("Demo")
+	require.NotNil(t, fn)
+	require.Equal(t, "incomplete", NewMutationSummary(cfg).Of(fn).String())
+}
+
 // Every function in the committed graph gets a summary, and two invariants hold
 // across all of them. A mutated position is one of the function's own declared
 // parameters, so §4.3 can always name the parameter a fact refers to. Only a
@@ -301,9 +367,12 @@ func TestMutationSummaryCoversEveryFunction(t *testing.T) {
 }
 
 // The tallies over the whole graph, which move when a seed entry, a
-// backing-store slot, or the transfer function changes. A method that mutates
-// nothing is the common case, and a builtin that carries neither a mutation nor
-// a warning is one §4.3 can classify as non-mutating.
+// backing-store slot, an internal-method entry, or the transfer function
+// changes. A method that mutates nothing is the common case.
+//
+// `classifiable` counts the functions carrying neither warning, the ones §4.3
+// decides from the analysis rather than handing to FR5's name-based heuristics.
+// It is the number a change to this analysis should push up.
 func TestMutationSummaryTallies(t *testing.T) {
 	cfg := testCFG(t)
 	s := testSummary(t)
@@ -329,15 +398,18 @@ func TestMutationSummaryTallies(t *testing.T) {
 		if m.Incomplete {
 			byKind["incomplete"]++
 		}
+		if !m.Unattributable && !m.Incomplete {
+			byKind["classifiable"]++
+		}
 	}
 
 	kinds := make([]string, 0, len(tallies))
 	for kind, byKind := range tallies {
-		kinds = append(kinds, fmt.Sprintf("%s: total %d, receiver %d, args %d, unattributable %d, incomplete %d",
-			kind, byKind["total"], byKind["receiver"], byKind["args"], byKind["unattributable"], byKind["incomplete"]))
+		kinds = append(kinds, fmt.Sprintf("%s: total %d, receiver %d, args %d, unattributable %d, incomplete %d, classifiable %d",
+			kind, byKind["total"], byKind["receiver"], byKind["args"], byKind["unattributable"], byKind["incomplete"], byKind["classifiable"]))
 	}
 	sort.Strings(kinds)
-	snaps.MatchInlineSnapshot(t, strings.Join(kinds, "\n"), snaps.Inline(`abstract-op: total 701, receiver 0, args 47, unattributable 31, incomplete 268
-builtin-method: total 313, receiver 57, args 0, unattributable 3, incomplete 35
-builtin-static: total 188, receiver 0, args 7, unattributable 21, incomplete 58`))
+	snaps.MatchInlineSnapshot(t, strings.Join(kinds, "\n"), snaps.Inline(`abstract-op: total 701, receiver 0, args 47, unattributable 37, incomplete 226, classifiable 449
+builtin-method: total 313, receiver 58, args 0, unattributable 3, incomplete 29, classifiable 282
+builtin-static: total 188, receiver 0, args 13, unattributable 21, incomplete 45, classifiable 138`))
 }

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -102,11 +102,16 @@ func TestMutationSummarySampleFunctions(t *testing.T) {
 		// Atomics.store writes the buffer behind the typed array it was handed
 		// rather than a receiver, so the store lands on a parameter.
 		"DataBlockWriteOnAParameter": {"Atomics.store", "args{0}"},
-		// TypedArray.prototype.slice writes the buffer behind the array it
-		// allocated itself. A fresh object's interior is Unknown rather than
-		// fresh, since an algorithm can store a caller's value into a record it
-		// allocated, so the write is flagged rather than discarded.
-		"InteriorOfAFreshObject": {"TypedArray.prototype.slice", "unattributable incomplete"},
+		// TypedArray.prototype.slice writes the buffer behind the array
+		// TypedArraySpeciesCreate handed it. That allocator captures none of
+		// its arguments, so the buffer is fresh and the write is discarded.
+		// Only the prose step §3 could not lower is left to report.
+		"InteriorOfAFreshAllocation": {"TypedArray.prototype.slice", "incomplete"},
+		// InitializeTypedArrayFromTypedArray writes the buffer behind an
+		// AllocateTypedArray result, and that allocator stores the name it was
+		// given into the array, so reading inside its result can reach a
+		// caller's value and the write cannot be placed.
+		"InteriorOfACapturingAllocation": {"InitializeTypedArrayFromTypedArray", "args{0} unattributable"},
 		// indexOf only reads the receiver, and every String method coerces its
 		// receiver to a fresh string before touching it.
 		"ReadOnlyMethod": {"Array.prototype.indexOf", "none"},
@@ -313,6 +318,6 @@ func TestMutationSummaryTallies(t *testing.T) {
 	}
 	sort.Strings(kinds)
 	snaps.MatchInlineSnapshot(t, strings.Join(kinds, "\n"), snaps.Inline(`abstract-op: total 701, receiver 0, args 47, unattributable 31, incomplete 268
-builtin-method: total 313, receiver 57, args 0, unattributable 4, incomplete 35
+builtin-method: total 313, receiver 57, args 0, unattributable 3, incomplete 35
 builtin-static: total 188, receiver 0, args 7, unattributable 21, incomplete 58`))
 }

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -193,6 +193,22 @@ func TestMutationSummaryCalleeNamingAParameterIsACallback(t *testing.T) {
 	require.Equal(t, "incomplete", s.Of(cfg.Builtin("Demo")).String())
 }
 
+// A call that omits the argument its callee mutates leaves the write with no
+// argument expression to charge it to, so the caller is incomplete rather than
+// quietly clean. Every call in the committed graph passes the argument, so the
+// case is stated as a graph of its own.
+func TestMutationSummaryCallOmittingTheMutatedArgument(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[` +
+			`{"name":"Set","kind":"abstract-op","params":["O","P","V","Throw"]},` +
+			`{"name":"Demo","kind":"builtin-static","params":["target"],` +
+			`"nodes":[{"kind":"call","callee":"Set","args":[],"guard":"?"}]}]}`))
+	require.NoError(t, err)
+
+	s := NewMutationSummary(cfg)
+	require.Equal(t, "incomplete", s.Of(cfg.Builtin("Demo")).String())
+}
+
 // A function the summary never saw reads back as mutating nothing.
 func TestMutationSummaryOfUnknownFunc(t *testing.T) {
 	require.Equal(t, Mutations{}, testSummary(t).Of(&Func{Name: "nosuchfunction"}))

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -92,10 +92,21 @@ func TestMutationSummarySampleFunctions(t *testing.T) {
 		"BackingStoreSlotOnARegistry": {"FinalizationRegistry.prototype.register", "receiver"},
 		// A DataView setter stores bytes into the Data Block behind its buffer
 		// through `SetValueInBuffer`. The buffer reaches that call as
-		// `view.[[ViewedArrayBuffer]]`, and reading a slot breaks the origin
-		// chain, so the write lands on a value neither the receiver nor a
-		// parameter accounts for.
-		"DataBlockWrite": {"DataView.prototype.setUint8", "unattributable"},
+		// `view.[[ViewedArrayBuffer]]`, an interior value of the view, so the
+		// store is charged to the view and then to the receiver the setter
+		// passed as it.
+		"DataBlockWrite": {"DataView.prototype.setUint8", "receiver"},
+		// TypedArray.prototype.set writes the same way, two calls further down
+		// through `SetTypedArrayFromTypedArray`.
+		"DataBlockWriteThroughAHelper": {"TypedArray.prototype.set", "receiver"},
+		// Atomics.store writes the buffer behind the typed array it was handed
+		// rather than a receiver, so the store lands on a parameter.
+		"DataBlockWriteOnAParameter": {"Atomics.store", "args{0}"},
+		// TypedArray.prototype.slice writes the buffer behind the array it
+		// allocated itself. A fresh object's interior is Unknown rather than
+		// fresh, since an algorithm can store a caller's value into a record it
+		// allocated, so the write is flagged rather than discarded.
+		"InteriorOfAFreshObject": {"TypedArray.prototype.slice", "unattributable incomplete"},
 		// indexOf only reads the receiver, and every String method coerces its
 		// receiver to a fresh string before touching it.
 		"ReadOnlyMethod": {"Array.prototype.indexOf", "none"},
@@ -122,12 +133,22 @@ func TestMutationSummarySampleFunctions(t *testing.T) {
 }
 
 // A write the callee could not place travels up to its callers, since the value
-// it wrote may have arrived as one of their arguments. `SetViewValue` stores
-// into the Data Block behind the view it was handed and cannot say whose block
-// that is, and every DataView setter calls it.
+// it wrote may have arrived as one of their arguments. `JSON.parse` writes
+// nothing itself. It is unattributable because `InternalizeJSONProperty`, which
+// it calls, writes a value that operation cannot place.
 func TestMutationSummaryCarriesUnattributableWritesUpTheCallGraph(t *testing.T) {
-	require.Equal(t, "unattributable", mutationsOf(t, "SetViewValue").String())
-	require.Equal(t, "unattributable", mutationsOf(t, "DataView.prototype.setFloat64").String())
+	require.Equal(t, "unattributable incomplete", mutationsOf(t, "InternalizeJSONProperty").String())
+	require.Equal(t, "unattributable", mutationsOf(t, "JSON.parse").String())
+}
+
+// A write to a value read out of a backing-store slot is charged to the object
+// that holds the slot. `SetViewValue` passes `view.[[ViewedArrayBuffer]]` to
+// `SetValueInBuffer`, which the seed says mutates its argument 0, so the store
+// lands on `view` itself. Every DataView setter then passes its receiver as
+// `view`.
+func TestMutationSummaryChargesAnInteriorWriteToItsHolder(t *testing.T) {
+	require.Equal(t, "args{0}", mutationsOf(t, "SetViewValue").String())
+	require.Equal(t, "receiver", mutationsOf(t, "DataView.prototype.setFloat64").String())
 }
 
 // A mutation travels as far up the call graph as the origin map can follow it.
@@ -291,7 +312,7 @@ func TestMutationSummaryTallies(t *testing.T) {
 			kind, byKind["total"], byKind["receiver"], byKind["args"], byKind["unattributable"], byKind["incomplete"]))
 	}
 	sort.Strings(kinds)
-	snaps.MatchInlineSnapshot(t, strings.Join(kinds, "\n"), snaps.Inline(`abstract-op: total 701, receiver 0, args 43, unattributable 36, incomplete 268
-builtin-method: total 313, receiver 44, args 0, unattributable 17, incomplete 35
-builtin-static: total 188, receiver 0, args 6, unattributable 22, incomplete 58`))
+	snaps.MatchInlineSnapshot(t, strings.Join(kinds, "\n"), snaps.Inline(`abstract-op: total 701, receiver 0, args 47, unattributable 31, incomplete 268
+builtin-method: total 313, receiver 57, args 0, unattributable 4, incomplete 35
+builtin-static: total 188, receiver 0, args 7, unattributable 21, incomplete 58`))
 }

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -87,6 +87,15 @@ func TestMutationSummarySampleFunctions(t *testing.T) {
 		// Date.prototype.setTime writes `dateObject.[[DateValue]]`, the slot
 		// Date.prototype.getTime reads back.
 		"BackingStoreSlotOnADate": {"Date.prototype.setTime", "receiver"},
+		// A finalization registry keeps its cells the way a Map keeps its
+		// entries, so `finalizationRegistry.[[Cells]]` is a backing store too.
+		"BackingStoreSlotOnARegistry": {"FinalizationRegistry.prototype.register", "receiver"},
+		// A DataView setter stores bytes into the Data Block behind its buffer
+		// through `SetValueInBuffer`. The buffer reaches that call as
+		// `view.[[ViewedArrayBuffer]]`, and reading a slot breaks the origin
+		// chain, so the write lands on a value neither the receiver nor a
+		// parameter accounts for.
+		"DataBlockWrite": {"DataView.prototype.setUint8", "unattributable"},
 		// indexOf only reads the receiver, and every String method coerces its
 		// receiver to a fresh string before touching it.
 		"ReadOnlyMethod": {"Array.prototype.indexOf", "none"},
@@ -112,6 +121,15 @@ func TestMutationSummarySampleFunctions(t *testing.T) {
 	}
 }
 
+// A write the callee could not place travels up to its callers, since the value
+// it wrote may have arrived as one of their arguments. `SetViewValue` stores
+// into the Data Block behind the view it was handed and cannot say whose block
+// that is, and every DataView setter calls it.
+func TestMutationSummaryCarriesUnattributableWritesUpTheCallGraph(t *testing.T) {
+	require.Equal(t, "unattributable", mutationsOf(t, "SetViewValue").String())
+	require.Equal(t, "unattributable", mutationsOf(t, "DataView.prototype.setFloat64").String())
+}
+
 // A mutation travels as far up the call graph as the origin map can follow it.
 // `Object.defineProperties` performs no write of its own. It calls
 // `ObjectDefineProperties(O, Properties)`, which calls `DefinePropertyOrThrow`
@@ -135,8 +153,10 @@ func TestMutationSummaryReadsThePositionTheCallPassesTheObjectAt(t *testing.T) {
 
 // A write the analysis cannot place leaves the function unattributable rather
 // than silently non-mutating. `Array.of` builds its array through
-// `CreateDataPropertyOrThrow(A, ...)`, where `A` came out of `Construct(C, ...)`
-// and §4.2 refuses to call a constructor's result fresh.
+// `CreateDataPropertyOrThrow(A, ...)`, where `A` came out of `Construct(C, ...)`.
+// §4.2 leaves a constructor's result Unknown rather than fresh, since the
+// constructor runs at runtime and may hand back a value the caller already
+// holds.
 func TestMutationSummaryUnattributableWrite(t *testing.T) {
 	require.Equal(t, "unattributable", mutationsOf(t, "Array.of").String())
 }
@@ -150,6 +170,27 @@ func TestMutationSummaryUnattributableWrite(t *testing.T) {
 // the hand-written overrides surfaces.
 func TestMutationSummarySkipsNonBackingStoreSlots(t *testing.T) {
 	require.Equal(t, "none", mutationsOf(t, "Map.prototype.delete").String())
+}
+
+// A callee that names one of the calling function's parameters is a function
+// the caller was handed, not the abstract operation of that name. Charging it
+// with the operation's mutations would claim a write the callback may never
+// perform, so the call is treated as a body the analysis cannot read.
+//
+// No callee in the committed graph shadows an operation this way, so the case
+// is stated as a graph of its own. `Set` is the seeded property write, and
+// `Demo` calls a parameter that happens to carry the same name.
+func TestMutationSummaryCalleeNamingAParameterIsACallback(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[` +
+			`{"name":"Set","kind":"abstract-op","params":["O","P","V","Throw"]},` +
+			`{"name":"Demo","kind":"builtin-static","params":["Set","target"],` +
+			`"nodes":[{"kind":"call","callee":"Set","args":[{"kind":"var","var":"target"}],"guard":"?"}]}]}`))
+	require.NoError(t, err)
+
+	s := NewMutationSummary(cfg)
+	require.Equal(t, "args{0}", s.Of(cfg.AbstractOp("Set")).String())
+	require.Equal(t, "incomplete", s.Of(cfg.Builtin("Demo")).String())
 }
 
 // A function the summary never saw reads back as mutating nothing.
@@ -234,7 +275,7 @@ func TestMutationSummaryTallies(t *testing.T) {
 			kind, byKind["total"], byKind["receiver"], byKind["args"], byKind["unattributable"], byKind["incomplete"]))
 	}
 	sort.Strings(kinds)
-	snaps.MatchInlineSnapshot(t, strings.Join(kinds, "\n"), snaps.Inline(`abstract-op: total 701, receiver 0, args 42, unattributable 17, incomplete 268
-builtin-method: total 313, receiver 43, args 0, unattributable 3, incomplete 35
-builtin-static: total 188, receiver 0, args 6, unattributable 3, incomplete 58`))
+	snaps.MatchInlineSnapshot(t, strings.Join(kinds, "\n"), snaps.Inline(`abstract-op: total 701, receiver 0, args 43, unattributable 36, incomplete 268
+builtin-method: total 313, receiver 44, args 0, unattributable 17, incomplete 35
+builtin-static: total 188, receiver 0, args 6, unattributable 22, incomplete 58`))
 }

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -217,14 +217,16 @@ func TestMutationSummarySkipsNonBackingStoreSlots(t *testing.T) {
 	require.Equal(t, "none", mutationsOf(t, "Map.prototype.delete").String())
 }
 
-// A callee that names one of the calling function's parameters is a function
-// the caller was handed, not the abstract operation of that name. Charging it
-// with the operation's mutations would claim a write the callback may never
-// perform, so the call is treated as a body the analysis cannot read.
+// The origin map decides what a callee is before the seed does. A callee bound
+// to one of the calling function's parameters is a function the caller was
+// handed, so charging it with the seeded operation's mutations would claim a
+// write the callback may never perform.
 //
-// No callee in the committed graph shadows an operation this way, so the case
-// is stated as a graph of its own. `Set` is the seeded property write, and
-// `Demo` calls a parameter that happens to carry the same name.
+// This pins the order of those two checks. The graph holds callbacks, and
+// `chargeUnresolved` treats them as unreadable bodies on every one, but none
+// carries a seeded name, so reversing the order would leave every real answer
+// and every tally unchanged. `TestGraphHoldsNoneOfTheHandWrittenShapes` is what
+// reports the day the graph grows a collision.
 func TestMutationSummaryCalleeNamingAParameterIsACallback(t *testing.T) {
 	cfg, err := ParseCFG([]byte(
 		`{"specTarget":"abc","funcs":[` +
@@ -240,8 +242,9 @@ func TestMutationSummaryCalleeNamingAParameterIsACallback(t *testing.T) {
 
 // A call that omits the argument its callee mutates leaves the write with no
 // argument expression to charge it to, so the caller is incomplete rather than
-// quietly clean. Every call in the committed graph passes the argument, so the
-// case is stated as a graph of its own.
+// quietly clean. The guard also keeps the index off the end of the argument
+// list. Every call in the committed graph passes the argument, so the case is
+// stated as a graph of its own.
 func TestMutationSummaryCallOmittingTheMutatedArgument(t *testing.T) {
 	cfg, err := ParseCFG([]byte(
 		`{"specTarget":"abc","funcs":[` +
@@ -255,9 +258,9 @@ func TestMutationSummaryCallOmittingTheMutatedArgument(t *testing.T) {
 }
 
 // A call can sit inside an expression rather than in a node of its own.
-// Appendix A reserves that shape and §3 emits none, so the case is stated as a
-// graph of its own. Charging it the same way keeps a mutation from passing
-// unseen, which is the direction the seed's own warning is about.
+// `ParseCFG` accepts that shape, so leaving it uncharged would drop a mutation
+// with no warning attached, which is the one outcome the two warnings exist to
+// prevent. §3 emits none today, so the case is stated as a graph of its own.
 func TestMutationSummaryCallNestedInAnExpression(t *testing.T) {
 	cfg, err := ParseCFG([]byte(
 		`{"specTarget":"abc","funcs":[` +
@@ -329,10 +332,9 @@ read-only: IsExtensible`))
 // An internal method takes the object it dispatches on as its first argument, so
 // a call with no argument there is one the serializer lowered differently than
 // the table expects. The write has no argument expression to charge, which
-// leaves the caller incomplete rather than silently non-mutating.
-//
-// No call in the committed graph omits that argument, so the case is stated as a
-// graph of its own.
+// leaves the caller incomplete rather than silently non-mutating, and keeps the
+// index off the end of the argument list. No call in the committed graph omits
+// that argument, so the case is stated as a graph of its own.
 func TestInternalMethodTableOnACallMissingItsObject(t *testing.T) {
 	cfg, err := ParseCFG([]byte(
 		`{"specTarget": "test", "funcs": [
@@ -347,10 +349,11 @@ func TestInternalMethodTableOnACallMissingItsObject(t *testing.T) {
 	require.Equal(t, "incomplete", NewMutationSummary(cfg).Of(fn).String())
 }
 
-// A callee that names an internal method but is bound to one of the calling
-// function's parameters is a function the caller was handed, not a dispatch. The
-// tables must not answer for it, or a callback named `Delete` would be charged
-// with mutating its first argument.
+// The same ordering holds for the internal-method tables, where getting it wrong
+// is worse than with the seed. A callback named `Delete` charged from the
+// mutating table claims a write that may not happen, which is merely imprecise.
+// One named `GetOwnProperty` answered from the read-only table asserts that
+// arbitrary user code mutates nothing, which is unsound.
 func TestInternalMethodTableSkipsACallback(t *testing.T) {
 	cfg, err := ParseCFG([]byte(
 		`{"specTarget": "test", "funcs": [
@@ -365,6 +368,133 @@ func TestInternalMethodTableSkipsACallback(t *testing.T) {
 	fn := cfg.AbstractOp("Demo")
 	require.NotNil(t, fn)
 	require.Equal(t, "incomplete", NewMutationSummary(cfg).Of(fn).String())
+}
+
+// handWrittenShapes are the four shapes the committed graph does not hold, each
+// of which a rule in the transfer function answers for.
+type handWrittenShapes struct {
+	shadowed      []string // a callee bound to a parameter that also names a seed or table entry
+	shortCall     []string // a call omitting a position its resolved callee mutates
+	shortDispatch []string // an internal-method call with no dispatching object
+	nested        []string // an expression holding a call
+}
+
+// findHandWrittenShapes reports where cfg holds each shape. The gate below runs
+// it over the committed graph and expects nothing; the test after that runs it
+// over a graph holding all four and expects each one found, so the gate cannot
+// rot into a check that passes because it looks at nothing.
+func findHandWrittenShapes(cfg *CFG, s *MutationSummary) handWrittenShapes {
+	var holdsCall func(Expr) bool
+	holdsCall = func(e Expr) bool {
+		switch e := e.(type) {
+		case *CallExpr:
+			return true
+		case *AllocExpr:
+			for _, arg := range e.Args {
+				if holdsCall(arg) {
+					return true
+				}
+			}
+		case *SlotExpr:
+			return holdsCall(e.Object)
+		case *PropExpr:
+			return holdsCall(e.Object)
+		}
+		return false
+	}
+
+	var found handWrittenShapes
+	for _, fn := range cfg.Funcs {
+		origin := NewOriginMap(fn)
+		for _, node := range fn.Nodes {
+			for _, e := range readsOf(node) {
+				if e != nil && holdsCall(e) {
+					found.nested = append(found.nested, fn.Name)
+				}
+			}
+
+			call, ok := node.(*CallNode)
+			if !ok {
+				continue
+			}
+			where := fmt.Sprintf("%s calls %s", fn.Name, call.Callee)
+
+			// resolve consults the origin map before the graph, so a callee
+			// bound to a parameter is a callback whatever it is named.
+			if origin.Of(call.Callee).Kind == OriginParam {
+				_, seeded := directMutators[call.Callee]
+				_, mutating := mutatingInternalMethods[call.Callee]
+				if seeded || mutating || readOnlyInternalMethods.Contains(call.Callee) {
+					found.shadowed = append(found.shadowed, where)
+				}
+				continue
+			}
+			if target := cfg.AbstractOp(call.Callee); target != nil {
+				for _, position := range s.Of(target).Args {
+					if position >= len(call.Args) {
+						found.shortCall = append(found.shortCall, where)
+					}
+				}
+				continue
+			}
+			if position, ok := mutatingInternalMethods[call.Callee]; ok {
+				if position >= len(call.Args) {
+					found.shortDispatch = append(found.shortDispatch, where)
+				}
+			}
+		}
+	}
+	return found
+}
+
+// Each shape above is tested with a hand-written graph of its own, because the
+// committed graph holds none of them. This checks they are still absent, which
+// is what those tests assume and cannot themselves show.
+//
+// A failure here is not a defect. It means the pinned spec grew the case, so the
+// hand-written test is no longer the only description of how the analysis treats
+// it and the real occurrence wants reading.
+func TestGraphHoldsNoneOfTheHandWrittenShapes(t *testing.T) {
+	found := findHandWrittenShapes(testCFG(t), testSummary(t))
+
+	require.Empty(t, found.shadowed,
+		"a callee bound to a parameter shares a name with a seed or internal-method entry; "+
+			"TestMutationSummaryCalleeNamingAParameterIsACallback and "+
+			"TestInternalMethodTableSkipsACallback describe how that call is treated")
+	require.Empty(t, found.shortCall,
+		"a call omits an argument position its callee mutates; "+
+			"TestMutationSummaryCallOmittingTheMutatedArgument describes how it is treated")
+	require.Empty(t, found.shortDispatch,
+		"an internal-method call omits its dispatching object; "+
+			"TestInternalMethodTableOnACallMissingItsObject describes how it is treated")
+	require.Empty(t, found.nested,
+		"an expression holds a nested call; "+
+			"TestMutationSummaryCallNestedInAnExpression describes how it is charged")
+}
+
+// The gate above passes over the committed graph. This shows it passes because
+// the graph holds none of the shapes rather than because the walk finds nothing,
+// by running the same walk over a graph that holds all four.
+func TestHandWrittenShapesAreFoundWhenPresent(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[` +
+			`{"name":"Set","kind":"abstract-op","params":["O","P","V","Throw"]},` +
+			`{"name":"Shadow","kind":"abstract-op","params":["Set","x"],"nodes":[` +
+			`{"kind":"call","callee":"Set","args":[{"kind":"var","var":"x"}],"guard":"plain"}]},` +
+			`{"name":"Short","kind":"abstract-op","params":["x"],"nodes":[` +
+			`{"kind":"call","callee":"Set","args":[],"guard":"plain"}]},` +
+			`{"name":"ShortDispatch","kind":"abstract-op","params":["x"],"nodes":[` +
+			`{"kind":"call","callee":"SetPrototypeOf","args":[],"guard":"plain"}]},` +
+			`{"name":"Nested","kind":"abstract-op","params":["x"],"nodes":[` +
+			`{"kind":"let","target":"y","source":{"kind":"call","callee":"Set",` +
+			`"args":[{"kind":"var","var":"x"}]}}]}]}`))
+	require.NoError(t, err)
+
+	found := findHandWrittenShapes(cfg, NewMutationSummary(cfg))
+	require.Equal(t, []string{"Shadow calls Set"}, found.shadowed)
+	require.Equal(t, []string{"Short calls Set"}, found.shortCall)
+	require.Equal(t, []string{"ShortDispatch calls SetPrototypeOf"}, found.shortDispatch)
+	require.Equal(t, []string{"Nested"}, found.nested)
 }
 
 // Every function in the committed graph gets a summary, and two invariants hold

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -235,9 +235,29 @@ func TestMutationSummaryCallOmittingTheMutatedArgument(t *testing.T) {
 	require.Equal(t, "incomplete", s.Of(cfg.Builtin("Demo")).String())
 }
 
-// A function the summary never saw reads back as mutating nothing.
+// A call can sit inside an expression rather than in a node of its own.
+// Appendix A reserves that shape and §3 emits none, so the case is stated as a
+// graph of its own. Charging it the same way keeps a mutation from passing
+// unseen, which is the direction the seed's own warning is about.
+func TestMutationSummaryCallNestedInAnExpression(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[` +
+			`{"name":"Set","kind":"abstract-op","params":["O","P","V","Throw"]},` +
+			`{"name":"Demo","kind":"builtin-static","params":["target"],"nodes":[` +
+			`{"kind":"let","target":"x","source":{"kind":"call","callee":"Set",` +
+			`"args":[{"kind":"var","var":"target"}]}}]}]}`))
+	require.NoError(t, err)
+
+	s := NewMutationSummary(cfg)
+	require.Equal(t, "args{0}", s.Of(cfg.Builtin("Demo")).String())
+}
+
+// A function the summary never saw reads back as mutating nothing, and so does
+// one the fixpoint analyzed and found clean.
 func TestMutationSummaryOfUnknownFunc(t *testing.T) {
-	require.Equal(t, Mutations{}, testSummary(t).Of(&Func{Name: "nosuchfunction"}))
+	s := testSummary(t)
+	require.Equal(t, Mutations{}, s.Of(&Func{Name: "nosuchfunction"}))
+	require.Equal(t, Mutations{}, s.Of(testCFG(t).Builtin("Array.prototype.indexOf")))
 }
 
 // Every seed entry has to name an operation the graph holds, or it can never

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -40,10 +40,16 @@ const (
 // holding it, which is what lets §4.1 charge a DataView setter's byte store to
 // its receiver. An interior value is not the object itself, so it never stands
 // in for it where identity is what matters, such as §4.3's return alias.
+//
+// Captures marks a fresh value the algorithm built around something it was
+// given, so reading inside it can hand back a value its caller already owns.
+// It changes nothing about the fresh value itself, only about its interior.
+// See capturingAllocators.
 type Origin struct {
 	Kind     OriginKind
 	Index    int
 	Interior bool
+	Captures bool
 }
 
 // Receiver, Fresh and Unknown are the origins that carry no index.
@@ -58,14 +64,14 @@ func Param(i int) Origin {
 	return Origin{Kind: OriginParam, Index: i}
 }
 
-// interiorOf returns the origin of a value read out of o's backing store. Only
-// a receiver or a parameter has an interior the analysis can place.
+// interiorOf returns the origin of a value read out of o's backing store.
 //
-// A fresh object's interior is `Unknown` rather than `Fresh`, because a value
-// the algorithm allocated can hold a value its caller already owns.
-// `MakeDataViewWithBufferWitnessRecord` builds a fresh record and stores the
-// view it was handed in it. Calling the record's contents fresh would discard a
-// write to that view, and `Fresh` is the one origin whose mutations §4.1 drops.
+// A fresh object's interior is fresh too, unless the allocator that built it
+// captured one of its arguments. `TypedArray.prototype.slice` writes the buffer
+// behind the array `TypedArraySpeciesCreate` handed it, and that write is
+// invisible to its caller. `MakeDataViewWithBufferWitnessRecord` instead
+// returns a record holding the view it was given, so reading inside its result
+// can reach a value the caller owns.
 func interiorOf(o Origin) Origin {
 	switch o.Kind {
 	case originUnset:
@@ -77,6 +83,13 @@ func interiorOf(o Origin) Origin {
 	case OriginReceiver, OriginParam:
 		o.Interior = true
 		return o
+	case OriginFresh:
+		// A value the algorithm allocated holds only values it also made,
+		// unless the allocator captured something it was given.
+		if o.Captures {
+			return Unknown
+		}
+		return Fresh
 	default:
 		return Unknown
 	}
@@ -97,6 +110,9 @@ func (o Origin) String() string {
 		name = "Unknown"
 	default:
 		name = fmt.Sprintf("Origin(%d)", o.Kind)
+	}
+	if o.Captures {
+		name += "(captures)"
 	}
 	if o.Interior {
 		return "Interior(" + name + ")"
@@ -283,6 +299,32 @@ var allocators = set.FromSlice([]string{
 	"NewGlobalEnvironment",
 	"NewModuleEnvironment",
 	"NewObjectEnvironment",
+})
+
+// capturingAllocators are the allocators that build their result around a value
+// they were given, so reading inside that result can reach a value the caller
+// already owns. Every other allocator hands back something whose contents it
+// also made, and interiorOf keeps those fresh.
+//
+// `MakeDataViewWithBufferWitnessRecord` is the shape: it ends in `return
+// « obj, byteLength »`, so the fresh record holds the very view it was passed.
+// `TypedArraySpeciesCreate` is the other shape. It builds a new typed array
+// over a new buffer, which is why `TypedArray.prototype.slice` writing that
+// buffer is invisible to its caller.
+//
+// The list is derived from the graph rather than judged by hand. An allocator
+// belongs here when one of its parameters reaches a place interiorOf would read
+// it back from: the operands of an allocation it returns, or a backing-store
+// slot it writes on the value it allocated.
+// TestCapturingAllocatorsMatchTheGraph recomputes it, so a spec bump that
+// changes an allocator's shape fails there.
+var capturingAllocators = set.FromSlice([]string{
+	"AllocateArrayBuffer",
+	"AllocateSharedArrayBuffer",
+	"AllocateTypedArray",
+	"HostMakeJobCallback",
+	"MakeDataViewWithBufferWitnessRecord",
+	"MakeTypedArrayWithBufferWitnessRecord",
 })
 
 // OriginMap holds the origin of every value name in one function.
@@ -494,7 +536,13 @@ func (m *OriginMap) eval(e Expr) Origin {
 // evalCall returns the origin of a call's result.
 func (m *OriginMap) evalCall(callee string, args []Expr) Origin {
 	switch {
-	case allocators.Contains(callee), freshPrimitives.Contains(callee):
+	case allocators.Contains(callee):
+		if capturingAllocators.Contains(callee) {
+			return Origin{Kind: OriginFresh, Captures: true}
+		}
+		return Fresh
+	case freshPrimitives.Contains(callee):
+		// A new primitive holds nothing, so it never captures.
 		return Fresh
 	case identityCoercions.Contains(callee) && len(args) > 0:
 		return m.eval(args[0])

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -13,10 +13,15 @@ import (
 type OriginKind uint8
 
 const (
-	// originUnset is a name the analysis has not bound to anything yet. It is
-	// the bottom of the lattice, so joining it with an origin yields that
-	// origin. A name still unset when the analysis finishes reads back as
+	// originUnset is a name NewOriginMap's walk has not bound yet. It is the
+	// bottom of the lattice, so joining it with an origin yields that origin,
+	// and a name still unset when the walk finishes reads back as
 	// OriginUnknown.
+	//
+	// A reader that reaches an unset name stays unset for this pass and takes
+	// its origin on the next one. A join never retracts, so answering
+	// `Unknown` early would pin the reader there and make the result depend on
+	// the order the walk visits nodes in.
 	originUnset OriginKind = iota
 	// OriginReceiver is a builtin method's `this` value.
 	OriginReceiver
@@ -38,13 +43,12 @@ const (
 // rather than that value itself. `view.[[ViewedArrayBuffer]]` in `SetViewValue`
 // is the interior of parameter 0. Writing an interior value writes the object
 // holding it, which is what lets §4.1 charge a DataView setter's byte store to
-// its receiver. An interior value is not the object itself, so it never stands
-// in for it where identity is what matters, such as §4.3's return alias.
+// its receiver. It is not the object itself, so it never stands in where
+// identity matters, such as §4.3's return alias.
 //
-// Captures marks a fresh value the algorithm built around something it was
-// given, so reading inside it can hand back a value its caller already owns.
-// It changes nothing about the fresh value itself, only about its interior.
-// See capturingAllocators.
+// Captures marks a fresh value built around something the algorithm was given.
+// It changes nothing about the fresh value, only about its interior. See
+// capturingAllocators.
 type Origin struct {
 	Kind     OriginKind
 	Index    int
@@ -69,16 +73,12 @@ func Param(i int) Origin {
 // A fresh object's interior is fresh too, unless the allocator that built it
 // captured one of its arguments. `TypedArray.prototype.slice` writes the buffer
 // behind the array `TypedArraySpeciesCreate` handed it, and that write is
-// invisible to its caller. `MakeDataViewWithBufferWitnessRecord` instead
-// returns a record holding the view it was given, so reading inside its result
-// can reach a value the caller owns.
+// invisible to its caller.
 func interiorOf(o Origin) Origin {
 	switch o.Kind {
 	case originUnset:
-		// The walk has not reached the definition of the object being read
-		// yet. Answering `Unknown` would pin the reader there for good, since
-		// a join never retracts. Staying at the bottom lets the next pass
-		// bind it, which is what keeps the walk independent of node order.
+		// The walk has not reached the definition of the object being read.
+		// See originUnset.
 		return o
 	case OriginReceiver, OriginParam:
 		o.Interior = true
@@ -121,10 +121,9 @@ func (o Origin) String() string {
 }
 
 // join is the least upper bound of two origins. Two definitions that agree keep
-// their origin. Two that disagree collapse to OriginUnknown. That collapse is
+// their origin and two that disagree collapse to `Unknown`. That collapse is
 // what makes the analysis path-insensitive. A name assigned on two branches
-// takes the join of both definitions rather than whichever one the walk
-// reached last.
+// takes the join of both rather than whichever the walk reached last.
 func (o Origin) join(other Origin) Origin {
 	switch {
 	case o.Kind == originUnset:
@@ -139,26 +138,24 @@ func (o Origin) join(other Origin) Origin {
 }
 
 // identityCoercions are the abstract operations that hand back the value they
-// were given, so an origin propagates through them. The list is short and
-// reviewed by hand. Calling an operation identity-preserving when it builds a
-// new value would charge a mutation to the wrong place.
+// were given, so an origin propagates through them. Calling one
+// identity-preserving when it builds a new value would charge a mutation to the
+// wrong place, so the list is short and reviewed by hand.
 //
 // ToObject is the entry that makes receiver tracking work. `Let O be ?
 // ToObject(this value)` keeps `O` at the receiver, which is how
 // `Array.prototype.push` comes out mutating. ToObject wraps a primitive
-// receiver rather than returning it, so the entry over-approximates. That is
-// the safe direction under FR5. A mutation claimed where there is none fails
-// loudly at a call site, while a missed one is silent unsoundness.
+// receiver rather than returning it, so the entry over-approximates in the
+// FR5-safe direction. A mutation claimed where there is none fails loudly at a
+// call site, while a missed one is silent unsoundness.
 //
 // CanonicalizeKeyedCollectionKey returns its key unchanged apart from
 // normalizing -0 to +0, which cannot apply to an object. Completion and
 // NormalCompletion wrap a value in a completion record, and the serializer
 // drops the matching unwrap, so a caller sees the value they were handed.
 //
-// Coercions that build a new value are absent by design. ToString and ToNumber
-// break the chain. That is why every `String.prototype` method comes out
-// non-mutating. The algorithm coerces `this` to a fresh string and never writes
-// back through the receiver.
+// A coercion that builds a new value is absent by design. ToString and ToNumber
+// break the chain instead. See freshPrimitives.
 var identityCoercions = set.FromSlice([]string{
 	"CanonicalizeKeyedCollectionKey",
 	"Completion",
@@ -169,19 +166,18 @@ var identityCoercions = set.FromSlice([]string{
 
 // freshPrimitives are the abstract operations that build a new primitive from
 // their argument. Their result is `Fresh` for the same reason an allocation is,
-// and with none of the risk: a primitive cannot be mutated, so an entry here
-// can never hide a write the caller would observe. The list exists so that
-// `ToString` resolving away from its argument reads as a decision rather than
-// an omission from allocators.
+// and with none of the risk, since a primitive cannot be mutated. The list
+// exists so that `ToString` resolving away from its argument reads as a
+// decision rather than an omission from allocators.
 //
 // `Let S be ? ToString(O)` is the case that matters. `O` is the receiver, `S`
-// is a new string, and nothing the algorithm does to `S` can reach `O`. That is
-// why every `String.prototype` method comes out non-mutating.
+// is a new string, and nothing done to `S` can reach `O`. That is why every
+// `String.prototype` method comes out non-mutating.
 //
-// Predicates such as IsArray and SameValue return primitives too and are
-// deliberately absent. Listing every operation that returns a boolean would add
-// review surface without changing an answer, since a predicate's result is only
-// ever branched on.
+// A predicate such as IsArray returns a primitive too and is deliberately
+// absent. Listing every operation that returns a boolean would add review
+// surface without changing an answer, since a predicate's result is only ever
+// branched on.
 var freshPrimitives = set.FromSlice([]string{
 	// Coercions to a primitive. ToObject is not among them, since it returns an
 	// object and is identity-preserving instead.
@@ -223,21 +219,20 @@ var freshPrimitives = set.FromSlice([]string{
 
 // allocators are the abstract operations that return a value they allocated.
 // Their result is `Fresh`, the one origin whose mutations the fixpoint
-// discards, because a write to a value the algorithm made itself is invisible
-// to its caller. Every entry must therefore genuinely allocate. Listing an
-// operation that can hand back a value the caller already holds would turn a
-// real mutation invisible.
+// discards, since a write to a value the algorithm made itself is invisible to
+// its caller. Listing an operation that can hand back a value the caller
+// already holds would turn a real mutation invisible.
 //
-// Two absences follow from that. Construct runs a constructor chosen at runtime
-// and may return any object, including one of its arguments. ProxyCreate
-// allocates a proxy, but a write to that proxy reaches its target, so its
-// result is not independent of its argument. Both resolve to `Unknown` instead.
+// Construct and ProxyCreate are absent for that reason. Construct runs a
+// constructor chosen at runtime and may return any object, including one of its
+// arguments. A write to a proxy reaches its target, so ProxyCreate's result is
+// not independent of its argument. Both resolve to `Unknown`.
 //
-// ArraySpeciesCreate, TypedArraySpeciesCreate, and the TypedArrayCreate family
-// run a constructor the caller can replace, so they carry the same risk. §4.2
-// lists ArraySpeciesCreate anyway, because `Array.prototype.slice` and its
-// neighbours build their result through it. Reading a value back out of that
-// result is a slot or property access, which breaks the chain regardless.
+// ArraySpeciesCreate and the TypedArray create family run a constructor the
+// caller can replace, so they carry the same risk. They are listed anyway,
+// because `Array.prototype.slice` and its neighbours build their result through
+// one. Reading a value back out of that result is a slot or property access,
+// which breaks the chain regardless.
 var allocators = set.FromSlice([]string{
 	// Ordinary objects and records.
 	"MakeBasicObject",
@@ -303,14 +298,10 @@ var allocators = set.FromSlice([]string{
 
 // capturingAllocators are the allocators that build their result around a value
 // they were given, so reading inside that result can reach a value the caller
-// already owns. Every other allocator hands back something whose contents it
-// also made, and interiorOf keeps those fresh.
+// already owns. interiorOf keeps every other allocator's result fresh.
 //
-// `MakeDataViewWithBufferWitnessRecord` is the shape: it ends in `return
+// `MakeDataViewWithBufferWitnessRecord` is the shape. It ends in `return
 // « obj, byteLength »`, so the fresh record holds the very view it was passed.
-// `TypedArraySpeciesCreate` is the other shape. It builds a new typed array
-// over a new buffer, which is why `TypedArray.prototype.slice` writing that
-// buffer is invisible to its caller.
 //
 // The list is derived from the graph rather than judged by hand. An allocator
 // belongs here when one of its parameters reaches a place interiorOf would read
@@ -337,14 +328,13 @@ type OriginMap struct {
 // freeNames returns fn's free names, the value names it reads but never binds.
 // A closure's captured value is the common case. `Iterator.prototype.drop`
 // builds a helper that opens with `Let remaining be integerLimit`, and
-// `integerLimit` belongs to the algorithm that built the helper, not to the
-// helper itself.
+// `integerLimit` belongs to the algorithm that built the helper.
 //
-// The walk has to answer Unknown for such a name from the start, because it
-// never learns anything more about it. Left at the lattice bottom it would
-// contribute nothing to a join, and `remaining`, which a later step assigns a
-// literal, would come out Fresh. A mutation of it would then read as
-// unobservable to the caller when on one path it is the captured value.
+// Such a name is `Unknown` from the first pass, since the walk never learns more
+// about it. Left at the lattice bottom it would contribute nothing to a join,
+// and `remaining`, which a later step assigns a literal, would come out `Fresh`.
+// A mutation of it would then read as unobservable to the caller when on one
+// path it is the captured value.
 func freeNames(fn *Func) set.Set[string] {
 	bound := set.FromSlice(fn.Params)
 	for _, node := range fn.Nodes {
@@ -411,11 +401,10 @@ func freeNames(fn *Func) set.Set[string] {
 // every definition of its name.
 //
 // The walk is path-insensitive. It never interprets a branch and reads the node
-// list as a flat sequence. Repeating the walk until nothing moves makes the
-// result independent of the order the serializer emitted the nodes in, so a
-// name a loop's back edge redefines still reaches its uses. The repetition
-// terminates because an origin only climbs the lattice, from unset to one
-// origin to `Unknown`.
+// list as a flat sequence. Repeating it until nothing moves makes the result
+// independent of the order the serializer emitted the nodes in, so a name a
+// loop's back edge redefines still reaches its uses. It terminates because an
+// origin only climbs the lattice, from unset to one origin to `Unknown`.
 func NewOriginMap(fn *Func) *OriginMap {
 	m := &OriginMap{
 		fn:      fn,
@@ -485,16 +474,10 @@ func resolved(o Origin) Origin {
 
 // eval returns an expression's origin. It keeps the lattice bottom rather than
 // resolving it, which separates the two reasons a name can be unbound when the
-// walk reads it.
-//
-// A name the walk has not reached the definition of yet is still bottom, and
-// bottom contributes nothing to a join. The reader is left alone for this pass
-// and takes its origin on the next one, once the definition is bound. Answering
-// `Unknown` there would pin the reader at `Unknown` for good, since a join
-// never retracts.
-//
-// A free name is never going to be bound, so waiting gains nothing and the
-// answer is `Unknown` from the first pass.
+// walk reads it. A name whose definition the walk has not reached yet is still
+// bottom and takes its origin on a later pass, as originUnset describes. A free
+// name is never going to be bound, so waiting gains nothing and the answer is
+// `Unknown` from the first pass.
 func (m *OriginMap) eval(e Expr) Origin {
 	switch e := e.(type) {
 	case *VarExpr:
@@ -547,11 +530,10 @@ func (m *OriginMap) evalCall(callee string, args []Expr) Origin {
 	case identityCoercions.Contains(callee) && len(args) > 0:
 		return m.eval(args[0])
 	default:
-		// Everything else breaks the chain. An operation such as Get reads a
-		// value out of a container, and the value read is a different object
-		// from the container. A predicate such as IsArray returns a boolean
-		// that stands for none of its arguments. Neither hands back the object
-		// it was given, and neither is a value the analysis can place.
+		// Everything else breaks the chain. Get reads a value out of a
+		// container, and that value is a different object from the container.
+		// A predicate such as IsArray returns a boolean standing for none of
+		// its arguments.
 		return Unknown
 	}
 }

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -33,9 +33,17 @@ const (
 
 // Origin is where a value came from. Index is the parameter position and is
 // meaningful only when Kind is OriginParam.
+//
+// Interior marks a value read out of the backing store of the value Kind names,
+// rather than that value itself. `view.[[ViewedArrayBuffer]]` in `SetViewValue`
+// is the interior of parameter 0. Writing an interior value writes the object
+// holding it, which is what lets §4.1 charge a DataView setter's byte store to
+// its receiver. An interior value is not the object itself, so it never stands
+// in for it where identity is what matters, such as §4.3's return alias.
 type Origin struct {
-	Kind  OriginKind
-	Index int
+	Kind     OriginKind
+	Index    int
+	Interior bool
 }
 
 // Receiver, Fresh and Unknown are the origins that carry no index.
@@ -50,21 +58,50 @@ func Param(i int) Origin {
 	return Origin{Kind: OriginParam, Index: i}
 }
 
-func (o Origin) String() string {
+// interiorOf returns the origin of a value read out of o's backing store. Only
+// a receiver or a parameter has an interior the analysis can place.
+//
+// A fresh object's interior is `Unknown` rather than `Fresh`, because a value
+// the algorithm allocated can hold a value its caller already owns.
+// `MakeDataViewWithBufferWitnessRecord` builds a fresh record and stores the
+// view it was handed in it. Calling the record's contents fresh would discard a
+// write to that view, and `Fresh` is the one origin whose mutations §4.1 drops.
+func interiorOf(o Origin) Origin {
 	switch o.Kind {
 	case originUnset:
-		return "unset"
-	case OriginReceiver:
-		return "Receiver"
-	case OriginParam:
-		return fmt.Sprintf("Param(%d)", o.Index)
-	case OriginFresh:
-		return "Fresh"
-	case OriginUnknown:
-		return "Unknown"
+		// The walk has not reached the definition of the object being read
+		// yet. Answering `Unknown` would pin the reader there for good, since
+		// a join never retracts. Staying at the bottom lets the next pass
+		// bind it, which is what keeps the walk independent of node order.
+		return o
+	case OriginReceiver, OriginParam:
+		o.Interior = true
+		return o
 	default:
-		return fmt.Sprintf("Origin(%d)", o.Kind)
+		return Unknown
 	}
+}
+
+func (o Origin) String() string {
+	var name string
+	switch o.Kind {
+	case originUnset:
+		name = "unset"
+	case OriginReceiver:
+		name = "Receiver"
+	case OriginParam:
+		name = fmt.Sprintf("Param(%d)", o.Index)
+	case OriginFresh:
+		name = "Fresh"
+	case OriginUnknown:
+		name = "Unknown"
+	default:
+		name = fmt.Sprintf("Origin(%d)", o.Kind)
+	}
+	if o.Interior {
+		return "Interior(" + name + ")"
+	}
+	return name
 }
 
 // join is the least upper bound of two origins. Two definitions that agree keep
@@ -435,9 +472,18 @@ func (m *OriginMap) eval(e Expr) Origin {
 		return m.evalCall(e.Callee, e.Args)
 	case *AllocExpr, *LitExpr:
 		return Fresh
-	case *SlotExpr, *PropExpr:
-		// A read, so the chain breaks here. The value read out of a container
-		// is a different object from the container itself.
+	case *SlotExpr:
+		// A backing-store slot holds the object's own payload, so the value
+		// read out of one is charged to the object that holds it. Reading such
+		// a slot off an interior value keeps the same base, which is how
+		// `targetBuffer` stays at parameter 0 in `SetTypedArrayFromTypedArray`.
+		if backingStoreSlots.Contains(e.Slot) {
+			return interiorOf(m.eval(e.Object))
+		}
+		// Any other read breaks the chain. The value read out of a container is
+		// a different object from the container itself.
+		return Unknown
+	case *PropExpr:
 		return Unknown
 	default:
 		// An operand the graph left out, which reaches Eval as a nil Expr.

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -145,9 +145,8 @@ func (o Origin) join(other Origin) Origin {
 // ToObject is the entry that makes receiver tracking work. `Let O be ?
 // ToObject(this value)` keeps `O` at the receiver, which is how
 // `Array.prototype.push` comes out mutating. ToObject wraps a primitive
-// receiver rather than returning it, so the entry over-approximates in the
-// FR5-safe direction. A mutation claimed where there is none fails loudly at a
-// call site, while a missed one is silent unsoundness.
+// receiver rather than returning it, so the entry over-approximates.
+// directMutators describes why that is the safe direction under FR5.
 //
 // CanonicalizeKeyedCollectionKey returns its key unchanged apart from
 // normalizing -0 to +0, which cannot apply to an object. Completion and

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -295,13 +295,18 @@ func TestCapturingAllocatorsMatchTheGraph(t *testing.T) {
 
 // capturesAnArgument reports whether one of fn's parameters can be read back
 // out of the value fn allocates.
+//
+// A name is at a parameter when fn's own origin map says so, which is how a
+// parameter reached through an intermediate binding still counts. Matching a
+// parameter's spelling alone would miss `Let b be obj` followed by an
+// allocation over `b`.
 func capturesAnArgument(fn *Func) bool {
-	params := set.FromSlice(fn.Params)
+	origins := NewOriginMap(fn)
 	var reaches func(Expr) bool
 	reaches = func(e Expr) bool {
 		switch e := e.(type) {
 		case *VarExpr:
-			return params.Contains(e.Var)
+			return origins.Of(e.Var).Kind == OriginParam
 		case *AllocExpr:
 			for _, arg := range e.Args {
 				if reaches(arg) {

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -53,6 +53,11 @@ func TestOriginString(t *testing.T) {
 	require.Equal(t, "unset", Origin{}.String())
 	require.Equal(t, "Interior(Receiver)", interiorOf(Receiver).String())
 	require.Equal(t, "Interior(Param(2))", interiorOf(Param(2)).String())
+
+	// A kind outside the lattice renders as its number rather than as one of
+	// the names above, so an origin the walk could not produce is still legible
+	// in a failing assertion.
+	require.Equal(t, "Origin(99)", Origin{Kind: 99}.String())
 }
 
 // Only a receiver or a parameter has an interior the analysis can place. A

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -1,8 +1,10 @@
 package ecma262
 
 import (
+	"sort"
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
 )
@@ -53,6 +55,7 @@ func TestOriginString(t *testing.T) {
 	require.Equal(t, "unset", Origin{}.String())
 	require.Equal(t, "Interior(Receiver)", interiorOf(Receiver).String())
 	require.Equal(t, "Interior(Param(2))", interiorOf(Param(2)).String())
+	require.Equal(t, "Fresh(captures)", Origin{Kind: OriginFresh, Captures: true}.String())
 
 	// A kind outside the lattice renders as its number rather than as one of
 	// the names above, so an origin the walk could not produce is still legible
@@ -60,14 +63,14 @@ func TestOriginString(t *testing.T) {
 	require.Equal(t, "Origin(99)", Origin{Kind: 99}.String())
 }
 
-// Only a receiver or a parameter has an interior the analysis can place. A
-// fresh object's interior is `Unknown`, since a value the algorithm allocated
-// can hold a value its caller already owns, and calling that fresh would let
-// §4.1 discard a write to it.
+// A receiver's or a parameter's interior is marked and stays placed. A fresh
+// object's interior is fresh too, since the algorithm made its contents as
+// well, unless the allocator captured one of its arguments.
 func TestInteriorOf(t *testing.T) {
 	require.Equal(t, Origin{Kind: OriginReceiver, Interior: true}, interiorOf(Receiver))
 	require.Equal(t, Origin{Kind: OriginParam, Index: 1, Interior: true}, interiorOf(Param(1)))
-	require.Equal(t, Unknown, interiorOf(Fresh))
+	require.Equal(t, Fresh, interiorOf(Fresh))
+	require.Equal(t, Unknown, interiorOf(Origin{Kind: OriginFresh, Captures: true}))
 	require.Equal(t, Unknown, interiorOf(Unknown))
 
 	// The lattice bottom stays at the bottom. A name whose definition the walk
@@ -269,6 +272,92 @@ func TestOriginMapFreeNames(t *testing.T) {
 
 	require.Equal(t, Unknown, m.Of("integerLimit"))
 	require.Equal(t, Unknown, m.Of("remaining"))
+}
+
+// capturingAllocators is derived from the graph, so this recomputes it. An
+// allocator captures when one of its parameters reaches a place interiorOf
+// would read it back from: the operands of an allocation it builds, or the
+// value it writes into a backing-store slot.
+func TestCapturingAllocatorsMatchTheGraph(t *testing.T) {
+	cfg := testCFG(t)
+
+	derived := set.NewSet[string]()
+	for _, name := range allocators.ToSlice() {
+		fn := cfg.AbstractOp(name)
+		require.NotNil(t, fn, "no abstract operation named %s", name)
+		if capturesAnArgument(fn) {
+			derived.Add(name)
+		}
+	}
+
+	require.Equal(t, sorted(capturingAllocators), sorted(derived))
+}
+
+// capturesAnArgument reports whether one of fn's parameters can be read back
+// out of the value fn allocates.
+func capturesAnArgument(fn *Func) bool {
+	params := set.FromSlice(fn.Params)
+	var reaches func(Expr) bool
+	reaches = func(e Expr) bool {
+		switch e := e.(type) {
+		case *VarExpr:
+			return params.Contains(e.Var)
+		case *AllocExpr:
+			for _, arg := range e.Args {
+				if reaches(arg) {
+					return true
+				}
+			}
+		case *CallExpr:
+			for _, arg := range e.Args {
+				if reaches(arg) {
+					return true
+				}
+			}
+		case *SlotExpr:
+			return reaches(e.Object)
+		case *PropExpr:
+			return reaches(e.Object)
+		}
+		return false
+	}
+
+	for _, node := range fn.Nodes {
+		switch node := node.(type) {
+		case *ReturnNode:
+			if alloc, ok := node.Value.(*AllocExpr); ok && reaches(alloc) {
+				return true
+			}
+		case *LetNode:
+			if alloc, ok := node.Source.(*AllocExpr); ok && reaches(alloc) {
+				return true
+			}
+		case *SlotWriteNode:
+			if backingStoreSlots.Contains(node.Slot) && reaches(node.Value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sorted(s set.Set[string]) []string {
+	names := s.ToSlice()
+	sort.Strings(names)
+	return names
+}
+
+// A write to the buffer behind a freshly allocated typed array is invisible to
+// the caller, which is what makes `TypedArray.prototype.slice` non-mutating.
+// `A` comes from `TypedArraySpeciesCreate`, which captures nothing, so
+// `A.[[ViewedArrayBuffer]]` stays fresh while `O.[[ViewedArrayBuffer]]` is the
+// receiver's interior.
+func TestOriginMapInteriorOfAFreshAllocation(t *testing.T) {
+	m := originsOf(t, "TypedArray.prototype.slice")
+
+	require.Equal(t, Fresh, m.Of("A"))
+	require.Equal(t, Fresh, m.Of("targetBuffer"))
+	require.Equal(t, interiorOf(Receiver), m.Of("srcBuffer"))
 }
 
 func TestOriginMapString(t *testing.T) {

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -51,6 +51,62 @@ func TestOriginString(t *testing.T) {
 	require.Equal(t, "Fresh", Fresh.String())
 	require.Equal(t, "Unknown", Unknown.String())
 	require.Equal(t, "unset", Origin{}.String())
+	require.Equal(t, "Interior(Receiver)", interiorOf(Receiver).String())
+	require.Equal(t, "Interior(Param(2))", interiorOf(Param(2)).String())
+}
+
+// Only a receiver or a parameter has an interior the analysis can place. A
+// fresh object's interior is `Unknown`, since a value the algorithm allocated
+// can hold a value its caller already owns, and calling that fresh would let
+// §4.1 discard a write to it.
+func TestInteriorOf(t *testing.T) {
+	require.Equal(t, Origin{Kind: OriginReceiver, Interior: true}, interiorOf(Receiver))
+	require.Equal(t, Origin{Kind: OriginParam, Index: 1, Interior: true}, interiorOf(Param(1)))
+	require.Equal(t, Unknown, interiorOf(Fresh))
+	require.Equal(t, Unknown, interiorOf(Unknown))
+
+	// The lattice bottom stays at the bottom. A name whose definition the walk
+	// has not reached yet takes its origin on the next pass, and answering
+	// `Unknown` here would pin it for good.
+	require.Equal(t, Origin{}, interiorOf(Origin{}))
+
+	// Reading a backing-store slot off an interior value keeps the same base.
+	require.Equal(t, interiorOf(Receiver), interiorOf(interiorOf(Receiver)))
+}
+
+// An interior value is not the object that holds it, so the two never join into
+// one origin. §4.3 reads a return alias off this map, and returning
+// `M.[[MapData]]` is not returning `M`.
+func TestInteriorIsNotItsHolder(t *testing.T) {
+	require.NotEqual(t, Receiver, interiorOf(Receiver))
+	require.Equal(t, Unknown, Receiver.join(interiorOf(Receiver)))
+}
+
+// Reading a backing-store slot off a name the walk has not bound yet resolves
+// on a later pass rather than sticking at `Unknown`, so the result does not
+// depend on the order the serializer emitted the nodes in. Here `buf` reads the
+// receiver's payload one node before `O` is bound to the receiver.
+func TestOriginMapInteriorIsOrderIndependent(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[{"name":"Demo","kind":"builtin-method","params":[],"nodes":[` +
+			`{"kind":"let","target":"buf","source":{"kind":"slot","object":{"kind":"var","var":"O"},"slot":"MapData"}},` +
+			`{"kind":"let","target":"O","source":{"kind":"this"}}]}]}`))
+	require.NoError(t, err)
+
+	m := NewOriginMap(cfg.Builtin("Demo"))
+	require.Equal(t, Receiver, m.Of("O"))
+	require.Equal(t, interiorOf(Receiver), m.Of("buf"))
+}
+
+// A value read out of a backing-store slot is charged to the object holding it,
+// even when a name binds it first. `SetTypedArrayFromTypedArray` opens with
+// `Let targetBuffer be target.[[ViewedArrayBuffer]]` and passes `targetBuffer`
+// to the byte store several steps later.
+func TestOriginMapInteriorThroughALetBinding(t *testing.T) {
+	m := originsOf(t, "SetTypedArrayFromTypedArray")
+
+	require.Equal(t, Param(0), m.Of("target"))
+	require.Equal(t, interiorOf(Param(0)), m.Of("targetBuffer"))
 }
 
 func TestOriginMapSampleFunctions(t *testing.T) {
@@ -167,9 +223,14 @@ func TestOriginMapEval(t *testing.T) {
 	require.Equal(t, Fresh, m.Eval(&AllocExpr{Args: nil}))
 	require.Equal(t, Unknown, m.Eval(nil))
 
-	// A read off the receiver is a different value from the receiver.
-	readO := &SlotExpr{Object: &VarExpr{Var: "O"}, Slot: "MapData"}
-	require.Equal(t, Unknown, m.Eval(readO))
+	// A backing-store slot holds the receiver's own payload, so the value read
+	// out of one is the receiver's interior rather than an unplaceable value.
+	readData := &SlotExpr{Object: &VarExpr{Var: "O"}, Slot: "MapData"}
+	require.Equal(t, Origin{Kind: OriginReceiver, Interior: true}, m.Eval(readData))
+
+	// Any other slot read is a different value from the receiver.
+	readOther := &SlotExpr{Object: &VarExpr{Var: "O"}, Slot: "Prototype"}
+	require.Equal(t, Unknown, m.Eval(readOther))
 
 	// A nested call resolves through the same lists a call node does.
 	toObject := &CallExpr{Callee: "ToObject", Args: []Expr{&ThisExpr{}}}
@@ -210,7 +271,7 @@ func TestOriginMapString(t *testing.T) {
 	snaps.MatchInlineSnapshot(t, m.String(), snaps.Inline(`%0: Unknown
 %1: Param(0)
 %2: Fresh
-%3: Unknown
+%3: Interior(Receiver)
 %4: Fresh
 %5: Unknown
 %6: Receiver

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -36,7 +36,7 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §1   | Feasibility spike                          | FR1–FR4    | ✅      | —          | ESMeta CFG for ~10 representative methods (incl. escape, reject, callback) exposes the call nodes, args, stored-value operands, guards, `Throw`s, reject sites, and returns the analysis needs — met, see [spike_findings.md](spike_findings.md) |
 | §2   | Toolchain scoping                          | NFR        | 🚧      | §1         | `tools/spec-extract/mise.toml` builds and runs ESMeta with no JVM in the root environment — see [tools/spec-extract/README.md](../../tools/spec-extract/README.md); `mise.lock` is still missing |
 | §3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ✅      | §2         | `cfg.json` covers all 501 builtin algorithms plus the 701 functions reachable from them, at the pinned spec revision, and round-trips the schema check the run ends with — met |
-| §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ⬜      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` |
+| §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ✅      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.2 | Origin map                                 | FR2, FR4   | ✅      | §3         | origins asserted for sample functions — `ToObject(this)`→Receiver, allocators→Fresh, reads→Unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.3 | Method classification                      | FR4, FR5   | ⬜      | §4.1, §4.2 | facts.json core — receiver / returns / classified for the representative methods |
 | §5   | Keying and join                            | FR7, FR15  | ⬜      | §4.3       | normalizer joins facts to `.d.ts` declarations; overloads share algorithm-level facts, type-dependent parts per signature; unmatched reported |
@@ -630,6 +630,68 @@ others added as collection types enter the spec. Both the seed map and
 this list are reviewed Go constants — adding a mutator to the spec
 without listing it here produces a false non-mutating result, so they
 are deliberately explicit (FR1).
+
+**Outcome.** Done. [internal/ecma262/mutation.go](../../internal/ecma262/mutation.go)
+holds the seed, the backing-store slot list, and the fixpoint.
+`NewMutationSummary(cfg)` runs the fixpoint over a whole graph and `Of(fn)`
+returns one function's `Mutations`, which carries the mutated parameter
+positions, the receiver flag, and the two warnings. All 1202 functions settle in
+about 10 ms. Seven seed entries grow into 42 abstract operations with a mutated
+position, and of the 501 builtins 43 mutate their receiver and 6 mutate a
+parameter. The gate is
+[internal/ecma262/mutation_test.go](../../internal/ecma262/mutation_test.go).
+`Array.prototype.push` and `Array.prototype.fill` mutate the receiver,
+`Array.prototype.slice` mutates nothing, and `Map.prototype.set` mutates the
+receiver through `[[MapData]]`. The Date setters, the in-place Array methods,
+`RegExp.prototype.exec`, and the collection adders come out receiver-mutating;
+`Object.freeze`, `Object.seal`, `Object.assign`, `Object.defineProperty`,
+`Object.defineProperties`, and `Reflect.set` come out mutating argument 0. Five
+findings.
+
+- **`Incomplete` stays on the function that carries the unreadable step and is
+  not charged to its callers.** A callee the analysis could not fully read may
+  under-report its mutated positions, so a caller that reads that summary
+  inherits the gap. Charging the caller as well is the sound reading and costs
+  too much to use: it takes the incomplete builtins from 93 of 501 to 340, which
+  would leave §4.3 able to classify under a third of the surface. The unreadable
+  steps sit in operations nearly every algorithm reaches, so the flag saturates.
+  The narrower rule is what §4.1 specifies and what the code does. §6's
+  validation diff against the hand-written overrides is where a mutation lost
+  inside an incomplete callee surfaces.
+- **A computed slot on a fresh value is not a warning.** The serializer leaves
+  the slot name empty on the 155 writes whose slot the algorithm computes, and
+  the curated list cannot answer for those. They mark the function incomplete,
+  except where the written value is fresh, since no slot name makes a write to a
+  value the function allocated itself visible to its caller. 94 of the 155 land
+  on a fresh value, which keeps 47 functions out of `Incomplete`, 10 of them
+  builtins.
+- **The mutated position is the one the call site passes the object at, not the
+  one the seed names.** `OrdinarySet(O, P, V, Receiver)` performs its write
+  through `OrdinarySetWithOwnDescriptor`, which calls
+  `CreateDataProperty(Receiver, …)`. Position 0 is where the seed charges
+  `CreateDataProperty`, and reading the argument sitting there gives `Receiver`,
+  which is `OrdinarySet`'s parameter 3. Its summary is `{3}`, and a caller of
+  `OrdinarySet` charges whatever it passed fourth.
+- **A record read out of a backing store loses the receiver, so
+  `Map.prototype.delete` comes out non-mutating.** delete empties the entry in
+  place with `Set p.[[Key]] to EMPTY`. `[[Key]]` is a field of a Map Entry
+  Record rather than a backing store, and `p` itself came out of a read of
+  `M.[[MapData]]`, which breaks the origin chain under §4.2. Both halves of the
+  attribution fail, so the method reads as writing nothing.
+  `Map.prototype.clear`, `WeakMap.prototype.delete`, and
+  `TypedArray.prototype.set` are the same shape. Flagging every slot write the
+  analysis cannot place as `Unattributable` catches them, at the cost of
+  `Map.prototype.set` and `WeakMap.prototype.set`, which write the same record
+  on their update path and would stop being classifiable. §6 triages these
+  against the hand-written overrides, so the false negative is recorded rather
+  than resolved here.
+- **`CreateMethodProperty` is seeded and absent from the graph.** Nothing
+  reachable from a builtin calls it; the spec uses it from the syntax-directed
+  operations §3 drops. The entry stays, because the seed is a review artifact of
+  FR1's vocabulary rather than a list of what the pinned graph happens to
+  contain. `TestMutationSummarySeedResolves` snapshots the absent entries, so a
+  spec bump that renames a seeded operation fails there rather than quietly
+  reporting one less mutation.
 
 ### §4.2. Origin map (FR2, FR4)
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -636,28 +636,41 @@ holds the seed, the backing-store slot list, and the fixpoint.
 `NewMutationSummary(cfg)` runs the fixpoint over a whole graph and `Of(fn)`
 returns one function's `Mutations`, which carries the mutated parameter
 positions, the receiver flag, and the two warnings. All 1202 functions settle in
-about 10 ms. Seven seed entries grow into 42 abstract operations with a mutated
-position, and of the 501 builtins 43 mutate their receiver and 6 mutate a
-parameter. The gate is
+about 10 ms. Eight of the nine seed entries name an operation the graph holds,
+and those eight grow into 43 abstract operations with a mutated position. Of the
+501 builtins, 44 mutate their receiver and 6 mutate a parameter. The gate is
 [internal/ecma262/mutation_test.go](../../internal/ecma262/mutation_test.go).
 `Array.prototype.push` and `Array.prototype.fill` mutate the receiver,
 `Array.prototype.slice` mutates nothing, and `Map.prototype.set` mutates the
 receiver through `[[MapData]]`. The Date setters, the in-place Array methods,
 `RegExp.prototype.exec`, and the collection adders come out receiver-mutating;
 `Object.freeze`, `Object.seal`, `Object.assign`, `Object.defineProperty`,
-`Object.defineProperties`, and `Reflect.set` come out mutating argument 0. Five
-findings.
+`Object.defineProperties`, and `Reflect.set` come out mutating argument 0.
+Seven findings.
 
-- **`Incomplete` stays on the function that carries the unreadable step and is
-  not charged to its callers.** A callee the analysis could not fully read may
-  under-report its mutated positions, so a caller that reads that summary
-  inherits the gap. Charging the caller as well is the sound reading and costs
-  too much to use: it takes the incomplete builtins from 93 of 501 to 340, which
-  would leave §4.3 able to classify under a third of the surface. The unreadable
-  steps sit in operations nearly every algorithm reaches, so the flag saturates.
-  The narrower rule is what §4.1 specifies and what the code does. §6's
-  validation diff against the hand-written overrides is where a mutation lost
-  inside an incomplete callee surfaces.
+- **`Unattributable` is charged to callers and `Incomplete` is not.** Both
+  warnings mean the caller's own summary may be missing something, so the sound
+  reading charges each of them up the call graph. Only one is affordable. A
+  callee that wrote a value it could not place may have written a value the
+  caller handed it, and carrying that up costs 30 builtins and is what makes the
+  DataView setters reportable at all. Carrying `Incomplete` up takes the
+  incomplete builtins from 93 of 501 to 340, which would leave §4.3 able to
+  classify under a third of the surface, because the steps §3 could not lower
+  sit in operations nearly every algorithm reaches. §6's validation diff against
+  the hand-written overrides is where a mutation lost inside an incomplete
+  callee surfaces.
+- **A byte written into a Data Block needs a seed of its own.** FR3 names
+  `TypedArray.prototype.set` writing through `[[ArrayBufferData]]`, but the
+  write is not a slot write. The method reads the buffer out of that slot and
+  passes it to `SetValueInBuffer`, which stores a byte range the graph does not
+  lower. Reading a slot breaks the origin chain under §4.2, so the seed entry
+  cannot recover which buffer was written and the mutation surfaces as
+  `Unattributable` rather than as a receiver fact. That still moves the 11
+  `DataView.prototype.set*` methods, `Atomics.store`,
+  `TypedArray.prototype.copyWithin`, and `TypedArray.prototype.set` off a silent
+  non-mutating answer, which is the FR5-conservative direction. Reaching a
+  receiver fact for them needs an origin that survives a read out of a
+  backing-store slot, which §4.2 does not model.
 - **A computed slot on a fresh value is not a warning.** The serializer leaves
   the slot name empty on the 155 writes whose slot the algorithm computes, and
   the curated list cannot answer for those. They mark the function incomplete,
@@ -678,13 +691,24 @@ findings.
   Record rather than a backing store, and `p` itself came out of a read of
   `M.[[MapData]]`, which breaks the origin chain under §4.2. Both halves of the
   attribution fail, so the method reads as writing nothing.
-  `Map.prototype.clear`, `WeakMap.prototype.delete`, and
-  `TypedArray.prototype.set` are the same shape. Flagging every slot write the
-  analysis cannot place as `Unattributable` catches them, at the cost of
-  `Map.prototype.set` and `WeakMap.prototype.set`, which write the same record
-  on their update path and would stop being classifiable. §6 triages these
-  against the hand-written overrides, so the false negative is recorded rather
-  than resolved here.
+  `Map.prototype.clear` and `WeakMap.prototype.delete` are the same shape.
+  Flagging every slot write the analysis cannot place as `Unattributable`
+  catches them, at the cost of `Map.prototype.set` and `WeakMap.prototype.set`,
+  which write the same record on their update path and would stop being
+  classifiable. §6 triages these against the hand-written overrides, so the
+  false negative is recorded rather than resolved here.
+- **An iterator's cursor is left out of the backing-store list.** Nine slots
+  take a receiver-origin write inside a builtin method that the curated list
+  does not count, and all nine are iterator or generator bookkeeping:
+  `[[ArrayLikeNextIndex]]` and `[[IteratedArrayLike]]` in
+  `ArrayIteratorPrototype.next`, `[[VisitedKeys]]`, `[[RemainingKeys]]`,
+  `[[ObjectWasVisited]]` and `[[Object]]` in `ForInIteratorPrototype.next`,
+  `[[Done]]`, `[[GeneratorState]]`, and `[[AsyncGeneratorState]]` elsewhere.
+  Listing them would make every `next` method mutate its receiver, which is the
+  right answer if Escalier's iterator protocol takes `&mut self` and the wrong
+  one otherwise. That is a decision about the emitted surface rather than about
+  the analysis, so §11's curation makes it. `[[Cells]]` is listed, because a
+  finalization registry keeps its cells the way a Map keeps its entries.
 - **`CreateMethodProperty` is seeded and absent from the graph.** Nothing
   reachable from a builtin calls it; the spec uses it from the syntax-directed
   operations §3 drops. The entry stays, because the seed is a review artifact of

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -637,40 +637,47 @@ holds the seed, the backing-store slot list, and the fixpoint.
 returns one function's `Mutations`, which carries the mutated parameter
 positions, the receiver flag, and the two warnings. All 1202 functions settle in
 about 10 ms. Eight of the nine seed entries name an operation the graph holds,
-and those eight grow into 43 abstract operations with a mutated position. Of the
-501 builtins, 44 mutate their receiver and 6 mutate a parameter. The gate is
+and those eight grow into 47 abstract operations with a mutated position. Of the
+501 builtins, 57 mutate their receiver and 7 mutate a parameter. The gate is
 [internal/ecma262/mutation_test.go](../../internal/ecma262/mutation_test.go).
 `Array.prototype.push` and `Array.prototype.fill` mutate the receiver,
 `Array.prototype.slice` mutates nothing, and `Map.prototype.set` mutates the
 receiver through `[[MapData]]`. The Date setters, the in-place Array methods,
-`RegExp.prototype.exec`, and the collection adders come out receiver-mutating;
-`Object.freeze`, `Object.seal`, `Object.assign`, `Object.defineProperty`,
-`Object.defineProperties`, and `Reflect.set` come out mutating argument 0.
-Seven findings.
+`RegExp.prototype.exec`, the collection adders, the 11 `DataView.prototype.set*`
+methods, `TypedArray.prototype.set`, and `TypedArray.prototype.copyWithin` come
+out receiver-mutating. `Object.freeze`, `Object.seal`, `Object.assign`,
+`Object.defineProperty`, `Object.defineProperties`, `Reflect.set`, and
+`Atomics.store` come out mutating argument 0. Seven findings.
 
 - **`Unattributable` is charged to callers and `Incomplete` is not.** Both
   warnings mean the caller's own summary may be missing something, so the sound
   reading charges each of them up the call graph. Only one is affordable. A
   callee that wrote a value it could not place may have written a value the
-  caller handed it, and carrying that up costs 30 builtins and is what makes the
-  DataView setters reportable at all. Carrying `Incomplete` up takes the
-  incomplete builtins from 93 of 501 to 340, which would leave §4.3 able to
-  classify under a third of the surface, because the steps §3 could not lower
-  sit in operations nearly every algorithm reaches. §6's validation diff against
-  the hand-written overrides is where a mutation lost inside an incomplete
-  callee surfaces.
-- **A byte written into a Data Block needs a seed of its own.** FR3 names
-  `TypedArray.prototype.set` writing through `[[ArrayBufferData]]`, but the
-  write is not a slot write. The method reads the buffer out of that slot and
-  passes it to `SetValueInBuffer`, which stores a byte range the graph does not
-  lower. Reading a slot breaks the origin chain under §4.2, so the seed entry
-  cannot recover which buffer was written and the mutation surfaces as
-  `Unattributable` rather than as a receiver fact. That still moves the 11
-  `DataView.prototype.set*` methods, `Atomics.store`,
-  `TypedArray.prototype.copyWithin`, and `TypedArray.prototype.set` off a silent
-  non-mutating answer, which is the FR5-conservative direction. Reaching a
-  receiver fact for them needs an origin that survives a read out of a
-  backing-store slot, which §4.2 does not model.
+  caller handed it, and carrying that up flags 18 more builtins, of which only 2
+  were otherwise classifiable. `JSON.parse` is the shape it catches: the method
+  writes nothing itself and is unattributable because `InternalizeJSONProperty`
+  is. Carrying `Incomplete` up takes the incomplete builtins from 93 of 501 to
+  340 and the classifiable ones from 401 to 161, because the steps §3 could not
+  lower sit in operations nearly every algorithm reaches. §6's validation diff
+  against the hand-written overrides is where a mutation lost inside an
+  incomplete callee surfaces.
+- **A byte written into a Data Block needs a seed and an interior origin.** FR3
+  names `TypedArray.prototype.set` writing through `[[ArrayBufferData]]`, but
+  the write is not a slot write. The method reads the buffer out of that slot
+  and passes it to `SetValueInBuffer`, which stores a byte range the graph does
+  not lower, so the seed entry above is what reports it at all. The seed alone
+  charges nothing, since the buffer arrives at that call as a slot read and a
+  plain read resolves to `Unknown`. Reading a backing-store slot instead yields
+  the interior of the object that holds it, so the store lands on the view or
+  typed array itself. Six call sites attribute through an interior origin:
+  `SetViewValue`, `TypedArraySetElement`, `Atomics.store`,
+  `TypedArray.prototype.copyWithin`, and `SetTypedArrayFromTypedArray` twice.
+  That gives the 11 `DataView.prototype.set*` methods,
+  `TypedArray.prototype.set`, and `TypedArray.prototype.copyWithin` a receiver
+  fact, and `Atomics.store` argument 0. `TypedArray.prototype.slice` and
+  `InitializeTypedArrayFromTypedArray` write a buffer they read out of an object
+  they allocated themselves, and a fresh object's interior is `Unknown`, so both
+  stay unattributable.
 - **A computed slot on a fresh value is not a warning.** The serializer leaves
   the slot name empty on the 155 writes whose slot the algorithm computes, and
   the curated list cannot answer for those. They mark the function incomplete,
@@ -692,11 +699,12 @@ Seven findings.
   `M.[[MapData]]`, which breaks the origin chain under §4.2. Both halves of the
   attribution fail, so the method reads as writing nothing.
   `Map.prototype.clear` and `WeakMap.prototype.delete` are the same shape.
-  Flagging every slot write the analysis cannot place as `Unattributable`
-  catches them, at the cost of `Map.prototype.set` and `WeakMap.prototype.set`,
-  which write the same record on their update path and would stop being
-  classifiable. §6 triages these against the hand-written overrides, so the
-  false negative is recorded rather than resolved here.
+  Carrying the interior origin through the indexed read that produces `p`, and
+  charging a write to any slot of an interior value to the object holding it,
+  resolves all three and costs nothing measurable: the receiver-mutating
+  builtins go from 57 to 60 with the unattributable and classifiable counts
+  unchanged. It widens the origin rules a second time, so it is left to §6,
+  which triages these against the hand-written overrides.
 - **An iterator's cursor is left out of the backing-store list.** Nine slots
   take a receiver-origin write inside a builtin method that the curated list
   does not count, and all nine are iterator or generator bookkeeping:
@@ -720,12 +728,15 @@ Seven findings.
 ### §4.2. Origin map (FR2, FR4)
 
 For each function, map every value name to its origin by a forward pass.
-Origins propagate only through **identity-preserving** operations; a
-property or slot *read* breaks the origin chain, because the value read
-out of a container is a different object from the container.
+Origins propagate only through **identity-preserving** operations. A
+property read breaks the origin chain, because the value read out of a
+container is a different object from the container. A read of a
+**backing-store slot** is the one exception. It yields the *interior* of
+the object read, a value that is not the object but lives inside it, so
+that §4.1 can charge a write to it back to the object holding it.
 
 ```
-type Origin struct { Kind OriginKind; Index int }
+type Origin struct { Kind OriginKind; Index int; Interior bool }
 // OriginKind ∈ { Receiver, Param, Fresh, Unknown }
 // Receiver is a BuiltinMethod's `this` value; Param(i) is the i-th
 // declared parameter, 0-based, matching the fact's param index. The
@@ -752,7 +763,9 @@ func eval(F, e Expr) Origin:
                 // or namespace object, never a parameter.
     case Call:  return evalCall(F, e)
     case Alloc, Lit: return Fresh                     // fresh object / primitive
-    case Slot, Prop: return Unknown                   // a READ: origin chain breaks
+    case Slot:  return Interior(eval(F, e.Object))    // if e.Slot is a backing store
+                return Unknown                        // otherwise the chain breaks
+    case Prop:  return Unknown                        // a READ: origin chain breaks
     default:    return Unknown
 
 func evalCall(F, c) Origin:
@@ -796,13 +809,14 @@ reader for `cfg.json`, mirroring Appendix A, and the origin map.
 `NewOriginMap(fn)` returns the origins of one function's value names.
 `Eval(expr)` answers the same question for an expression, which is the call
 §4.1 makes when it charges a mutation to a receiver or a parameter. All 1202
-functions analyze in about 4 ms, binding 11663 names. Of those, 373 are at the
-receiver, 2007 at a parameter, 2969 fresh, and 6314 unknown. The gate is
+functions analyze in about 8 ms, binding 11756 names. Of those, 373 are at the
+receiver, 2007 at a parameter, 4045 fresh, 100 interior, and 5231 unknown. The
+gate is
 [internal/ecma262/origin_test.go](../../internal/ecma262/origin_test.go).
 `Let O be ? ToObject(this value)` puts `O` at the receiver in
 `Array.prototype.push`, `? ArraySpeciesCreate(O, count)` puts `A` at `Fresh` in
 `Array.prototype.slice`, and `? ToString(O)` puts `S` at `Unknown` in
-`String.prototype.toLowerCase`. Four findings.
+`String.prototype.toLowerCase`. Five findings.
 
 - **One walk in node order is unsound, so the walk repeats until nothing
   moves.** A loop's back edge redefines a name after its uses, and a single
@@ -835,6 +849,18 @@ receiver, 2007 at a parameter, 2969 fresh, and 6314 unknown. The gate is
   operations carry the same risk and are listed anyway, as §4.2 specifies,
   because `Array.prototype.slice` and its neighbours build their result through
   them.
+
+- **A backing-store slot read yields an interior origin, not `Unknown`.** The
+  value a collection or buffer keeps in its payload slot is not the object, but
+  a write to it is a write to the object. `SetViewValue` passes
+  `view.[[ViewedArrayBuffer]]` straight to the byte store, and resolving that to
+  `Unknown` left every `DataView.prototype.set*` method unable to name what it
+  wrote. `Interior` marks the 100 names this reaches. It is deliberately not the
+  same value as its holder, so it never stands in where identity is what
+  matters, such as §4.3's return alias: returning `M.[[MapData]]` is not
+  returning `M`. A fresh object's interior stays `Unknown` rather than becoming
+  `Fresh`, since an algorithm can store a value its caller owns into a record it
+  allocated, and `MakeDataViewWithBufferWitnessRecord` does exactly that.
 
 `Node` and `Expr` are sealed interfaces with one type per kind rather than
 one struct tagged by kind, matching how [internal/ast/](../../internal/ast/)

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -542,6 +542,18 @@ seed = {
 }
 for ao, k in seed: MutArgs[ao].add(k)
 
+// Object internal methods. The CFG flattens `O.[[SetPrototypeOf]](V)` to a call
+// whose callee is the bare name and whose argument 0 is `O`, and no body in the
+// graph carries that name. These two tables answer for such a call instead.
+mutatingInternalMethods = {
+    "Set":0, "DefineOwnProperty":0, "Delete":0,
+    "PreventExtensions":0, "SetPrototypeOf":0,
+}
+readOnlyInternalMethods = {
+    "GetOwnProperty", "GetPrototypeOf", "HasProperty",
+    "IsExtensible", "OwnPropertyKeys",
+}
+
 worklist = all funcs
 while worklist nonempty:
     F = worklist.pop()
@@ -553,7 +565,8 @@ while worklist nonempty:
         case SlotWrite where node.Slot in BackingStoreSlots:   // FR3
             attribute(F, origin, node.Object)
         case Call:
-            if node.Callee not in AllFuncs: Incomplete.add(F)  // unresolved callee
+            if node.Callee not in AllFuncs:                    // unresolved callee
+                chargeUnresolved(F, origin, node)
             else for k in MutArgs[node.Callee]:
                 attribute(F, origin, node.Args[k])
         case Opaque: Incomplete.add(F)  // a step the serializer could not lower (§3)
@@ -561,6 +574,15 @@ while worklist nonempty:
     //  value F allocated itself is not observable to F's callers.)
 
     if changed(before, F): worklist.push(callers(F))
+
+// chargeUnresolved: a callee with no body is an object internal method or a
+// function F's caller supplied. The tables answer for the first kind.
+func chargeUnresolved(F, origin, node):
+    if originOf(origin, node.Callee) is Param: Incomplete.add(F)   // a callback
+    elif node.Callee in mutatingInternalMethods:
+        attribute(F, origin, node.Args[0])                         // the dispatching object
+    elif node.Callee in readOnlyInternalMethods: pass              // writes nothing
+    else: Incomplete.add(F)
 
 // attribute: charge a mutated value expression to F's receiver or a formal.
 func attribute(F, origin, expr):
@@ -575,8 +597,9 @@ func attribute(F, origin, expr):
 the analysis saw a mutation it could not tie to a receiver or formal —
 it knows something escaped but not what. `Incomplete` means the analysis
 could not see the whole algorithm: an `Opaque` node the serializer could
-not lower (a prose step, §3), a `Call` to a callee absent from the CFG,
-or a mutation phrasing outside the FR1 vocabulary. Both force
+not lower, which is a prose step from §3, a `Call` to a callee that is
+absent from the CFG and named by neither internal-method table, or a
+mutation phrasing outside the FR1 vocabulary. Both force
 `classified: false` (§4.3), so FR5's heuristic fall-through handles the
 method rather than the analysis emitting a claim it cannot stand behind.
 
@@ -631,14 +654,30 @@ this list are reviewed Go constants — adding a mutator to the spec
 without listing it here produces a false non-mutating result, so they
 are deliberately explicit (FR1).
 
+`MutatingInternalMethods` and `ReadOnlyInternalMethods` are the seed's
+counterpart for the object internal methods. The CFG flattens
+`O.[[SetPrototypeOf]](V)` to a call whose callee is the bare name
+`SetPrototypeOf` and whose argument 0 is `O`, and no body in the graph carries
+that name, because the receiver's type chooses the implementation at runtime.
+Without an entry the call reads as a step the analysis could not see. The
+mutating table charges argument 0 the way the seed does, an
+over-approximation in the FR5-conservative direction. The read-only table is
+the one place the analysis asserts that a call writes nothing, so it lists only
+the methods whose ordinary implementation runs no user code. `[[Get]]`,
+`[[Call]]`, and `[[Construct]]` are left out, since an accessor property and a
+function object both reach user code. A Proxy trap is the remaining escape and
+§6's validation diff is where one would surface.
+
 **Outcome.** Done. [internal/ecma262/mutation.go](../../internal/ecma262/mutation.go)
-holds the seed, the backing-store slot list, and the fixpoint.
-`NewMutationSummary(cfg)` runs the fixpoint over a whole graph and `Of(fn)`
-returns one function's `Mutations`, which carries the mutated parameter
+holds the seed, the backing-store slot list, the internal-method tables, and the
+fixpoint. `NewMutationSummary(cfg)` runs the fixpoint over a whole graph and
+`Of(fn)` returns one function's `Mutations`, which carries the mutated parameter
 positions, the receiver flag, and the two warnings. All 1202 functions settle in
 about 10 ms. Eight of the nine seed entries name an operation the graph holds,
 and those eight grow into 47 abstract operations with a mutated position. Of the
-501 builtins, 57 mutate their receiver and 7 mutate a parameter. The gate is
+501 builtins, 58 mutate their receiver and 13 mutate a parameter, and 420 carry
+neither warning, so §4.3 decides them from the analysis rather than from FR5's
+name-based heuristics. The gate is
 [internal/ecma262/mutation_test.go](../../internal/ecma262/mutation_test.go).
 `Array.prototype.push` and `Array.prototype.fill` mutate the receiver,
 `Array.prototype.slice` mutates nothing, and `Map.prototype.set` mutates the
@@ -647,7 +686,7 @@ receiver through `[[MapData]]`. The Date setters, the in-place Array methods,
 methods, `TypedArray.prototype.set`, and `TypedArray.prototype.copyWithin` come
 out receiver-mutating. `Object.freeze`, `Object.seal`, `Object.assign`,
 `Object.defineProperty`, `Object.defineProperties`, `Reflect.set`, and
-`Atomics.store` come out mutating argument 0. Seven findings.
+`Atomics.store` come out mutating argument 0. Eight findings.
 
 - **`Unattributable` is charged to callers and `Incomplete` is not.** Both
   warnings mean the caller's own summary may be missing something, so the sound
@@ -656,11 +695,27 @@ out receiver-mutating. `Object.freeze`, `Object.seal`, `Object.assign`,
   caller handed it, and carrying that up flags 18 more builtins, of which only 2
   were otherwise classifiable. `JSON.parse` is the shape it catches: the method
   writes nothing itself and is unattributable because `InternalizeJSONProperty`
-  is. Carrying `Incomplete` up takes the incomplete builtins from 93 of 501 to
-  340 and the classifiable ones from 401 to 161, because the steps §3 could not
+  is. Carrying `Incomplete` up takes the incomplete builtins from 74 of 501 to
+  307 and the classifiable ones from 420 to 194, because the steps §3 could not
   lower sit in operations nearly every algorithm reaches. §6's validation diff
   against the hand-written overrides is where a mutation lost inside an
   incomplete callee surfaces.
+- **An unresolved callee is an internal-method dispatch more often than
+  anything else, and naming those is the largest single reduction available.**
+  Every call the graph cannot resolve to a body left the caller incomplete. 19
+  builtins carried that warning and nothing else, and all 19 died on the same
+  seven names: `[[GetOwnProperty]]`, `[[GetPrototypeOf]]`, `[[OwnPropertyKeys]]`,
+  `[[SetPrototypeOf]]`, `[[PreventExtensions]]`, `[[DefineOwnProperty]]`, and
+  `[[Delete]]`. The two tables take the incomplete builtins from 93 to 74 and the
+  classifiable ones from 401 to 420. They also recover seven mutations the
+  analysis had been losing: `Object.setPrototypeOf`, `Object.preventExtensions`,
+  `Reflect.setPrototypeOf`, `Reflect.preventExtensions`, `Reflect.defineProperty`,
+  and `Reflect.deleteProperty` go from `incomplete` to `args{0}`, and
+  `set Object.prototype.__proto__` to `receiver`. The abstract-op layer trades 42
+  incomplete for 6 unattributable, since a position the mutating table charges
+  can land on a value that layer cannot place. `[[Set]]`, `[[HasProperty]]`, and
+  `[[IsExtensible]]` are inert entries: the graph defines an abstract operation
+  of each name, so the body answers and the table is never consulted.
 - **A byte written into a Data Block needs a seed and an interior origin.** FR3
   names `TypedArray.prototype.set` writing through `[[ArrayBufferData]]`, but
   the write is not a slot write. The method reads the buffer out of that slot

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -674,10 +674,12 @@ out receiver-mutating. `Object.freeze`, `Object.seal`, `Object.assign`,
   `TypedArray.prototype.copyWithin`, and `SetTypedArrayFromTypedArray` twice.
   That gives the 11 `DataView.prototype.set*` methods,
   `TypedArray.prototype.set`, and `TypedArray.prototype.copyWithin` a receiver
-  fact, and `Atomics.store` argument 0. `TypedArray.prototype.slice` and
-  `InitializeTypedArrayFromTypedArray` write a buffer they read out of an object
-  they allocated themselves, and a fresh object's interior is `Unknown`, so both
-  stay unattributable.
+  fact, and `Atomics.store` argument 0. `InitializeTypedArrayFromTypedArray`
+  stays unattributable, because it writes the buffer behind an
+  `AllocateTypedArray` result and that allocator captures an argument.
+  `TypedArray.prototype.slice` writes the buffer behind a
+  `TypedArraySpeciesCreate` result, which captures nothing, so its write is
+  discarded and only the prose step §3 could not lower is left to report.
 - **A computed slot on a fresh value is not a warning.** The serializer leaves
   the slot name empty on the 155 writes whose slot the algorithm computes, and
   the curated list cannot answer for those. They mark the function incomplete,
@@ -736,7 +738,7 @@ the object read, a value that is not the object but lives inside it, so
 that §4.1 can charge a write to it back to the object holding it.
 
 ```
-type Origin struct { Kind OriginKind; Index int; Interior bool }
+type Origin struct { Kind OriginKind; Index int; Interior, Captures bool }
 // OriginKind ∈ { Receiver, Param, Fresh, Unknown }
 // Receiver is a BuiltinMethod's `this` value; Param(i) is the i-th
 // declared parameter, 0-based, matching the fact's param index. The
@@ -810,13 +812,13 @@ reader for `cfg.json`, mirroring Appendix A, and the origin map.
 `Eval(expr)` answers the same question for an expression, which is the call
 §4.1 makes when it charges a mutation to a receiver or a parameter. All 1202
 functions analyze in about 8 ms, binding 11756 names. Of those, 373 are at the
-receiver, 2007 at a parameter, 4045 fresh, 100 interior, and 5231 unknown. The
-gate is
+receiver, 2007 at a parameter, 3927 fresh, 118 fresh from an allocator that
+captured an argument, 100 interior, and 5231 unknown. The gate is
 [internal/ecma262/origin_test.go](../../internal/ecma262/origin_test.go).
 `Let O be ? ToObject(this value)` puts `O` at the receiver in
 `Array.prototype.push`, `? ArraySpeciesCreate(O, count)` puts `A` at `Fresh` in
 `Array.prototype.slice`, and `? ToString(O)` puts `S` at `Unknown` in
-`String.prototype.toLowerCase`. Five findings.
+`String.prototype.toLowerCase`. Six findings.
 
 - **One walk in node order is unsound, so the walk repeats until nothing
   moves.** A loop's back edge redefines a name after its uses, and a single
@@ -858,9 +860,23 @@ gate is
   wrote. `Interior` marks the 100 names this reaches. It is deliberately not the
   same value as its holder, so it never stands in where identity is what
   matters, such as §4.3's return alias: returning `M.[[MapData]]` is not
-  returning `M`. A fresh object's interior stays `Unknown` rather than becoming
-  `Fresh`, since an algorithm can store a value its caller owns into a record it
-  allocated, and `MakeDataViewWithBufferWitnessRecord` does exactly that.
+  returning `M`.
+- **A fresh object's interior is fresh unless its allocator captured an
+  argument.** `MakeDataViewWithBufferWitnessRecord` ends in `return « obj,
+  byteLength »`, so the record it builds holds the very view it was passed, and
+  reading inside that result reaches a value the caller owns.
+  `TypedArraySpeciesCreate` instead builds a new array over a new buffer.
+  Collapsing both to `Unknown` cost `TypedArray.prototype.slice` a clean answer,
+  since it writes the buffer behind the array it allocated and MDN documents
+  that it modifies nothing. The split is derived from the graph rather than
+  judged by hand: an allocator captures when one of its parameters reaches the
+  operands of an allocation it builds or the value it writes into a
+  backing-store slot. Six of the 52 allocators qualify — `AllocateArrayBuffer`,
+  `AllocateSharedArrayBuffer`, `AllocateTypedArray`, `HostMakeJobCallback`, and
+  the two witness-record operations — and a transitive closure over calls
+  between allocators adds none. `TestCapturingAllocatorsMatchTheGraph`
+  recomputes the list, so a spec bump that reshapes an allocator fails there
+  rather than silently widening or narrowing what counts as fresh.
 
 `Node` and `Expr` are sealed interfaces with one type per kind rather than
 one struct tagged by kind, matching how [internal/ast/](../../internal/ast/)

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -514,6 +514,14 @@ parameter `j` is `&mut`. Keeping the receiver out of the parameter index
 space is what makes static and namespace functions — whose parameter 0 is
 a real argument, not a receiver — fall out correctly.
 
+**The standing objective is to shrink the unclassified set.** A builtin
+carrying `Unattributable` or `Incomplete` is one §4.3 hands to FR5's
+name-based heuristics instead of deciding from the spec. Every change to
+this analysis is measured by what it does to that count, and the tallies
+snapshot in `internal/ecma262/mutation_test.go` is where the number is
+recorded. A change that leaves it flat needs a reason, and one that raises
+it needs a stronger one.
+
 ### §4.1. Mutation summary fixpoint (FR1, FR2, FR3)
 
 Compute `MutArgs(F) ⊆ {0..arity-1}`, the formal positions function `F`


### PR DESCRIPTION
Fixes #1196.

Implements §4.1 of the implementation plan: a fixpoint analysis that determines which parameters and receivers each function may mutate, tracking mutations through the call graph.

## Summary

The mutation analysis computes, for every function in the ECMA-262 CFG, which of its declared parameters it may mutate and whether it mutates its receiver. It seeds the fixpoint with a curated list of abstract operations that perform direct mutations (`Set`, `DefinePropertyOrThrow`, etc.), a list of backing-store slots that hold mutable payloads (`[[MapData]]`, `[[SetData]]`, `[[DateValue]]`, etc.), and two tables naming the object internal methods the graph cannot resolve to a body. The fixpoint then propagates mutations up the call graph, charging each mutated value to the receiver or to a parameter through the origin map from §4.2.

Of the 501 builtins, 58 mutate their receiver and 13 mutate a parameter. 420 carry neither warning, so §4.3 decides them from the analysis rather than handing them to FR5's name-based heuristics.

## Key changes

- **mutation.go**: Core fixpoint implementation with four reviewed constants and the transfer function:
  - `directMutators`: Seed entries mapping 9 abstract operations to the argument position they mutate (property writes, integrity changes, data-block writes)
  - `backingStoreSlots`: Set of 14 internal slots that hold mutable payloads (collections, buffers, dates, registries)
  - `mutatingInternalMethods` and `readOnlyInternalMethods`: The object internal methods the CFG flattens to a bare callee name that resolves to no body
  - `NewMutationSummary(cfg)`: Runs the fixpoint over all functions, propagating mutations through the call graph until convergence
  - `Mutations` type: Reports mutated parameter positions, receiver flag, and two warnings (`Unattributable` for mutations the analysis cannot place, `Incomplete` for steps the lowering could not read)

- **origin.go**: Adds the interior origin. Reading a backing-store slot yields the interior of the object that holds it rather than `Unknown`, so a write to a collection's or buffer's payload is charged back to the object. Interior is never equal to its holder, so it does not leak into §4.3's return alias.

- **mutation_test.go**, **origin_test.go**: Test suite covering:
  - Sample functions: `Array.prototype.push` (receiver), `Array.prototype.slice` (none), `Map.prototype.set` (receiver via backing store), `Object.freeze` (arg 0), `DataView.prototype.setUint8` (receiver, through an interior origin), `Object.setPrototypeOf` (arg 0, through an internal method)
  - Invariants: mutated positions are valid parameter indices, only builtin methods mutate receivers, an internal-method entry that the graph also defines as an abstract operation is inert
  - Call-graph propagation: mutations and unattributable writes travel up to callers
  - Edge cases: callbacks shadowing operation names, computed slots on fresh values, non-backing-store slot writes, an interior read reached before its object is bound
  - Tallies: per-kind counts including the classifiable total, which is the number a change to this analysis should push up

- **cfg.go**: Updated package documentation to mention mutation analysis alongside origin mapping

- **implementation_plan.md**: Marked §4.1 complete with outcome details and eight findings about the analysis design; §4.2 gains the interior origin and a fifth finding; §4 records shrinking the unclassified set as its standing objective

## Notable implementation details

- **An unresolved callee is usually an internal-method dispatch**: The CFG flattens `O.[[SetPrototypeOf]](V)` to a call whose callee is the bare name `SetPrototypeOf` and whose argument 0 is `O`, and no body carries that name, because the receiver's type chooses the implementation at runtime. 19 builtins were incomplete on that alone, all on the same seven names. The mutating table charges argument 0 the way the seed does. The read-only table is the one place the analysis asserts that a call writes nothing, so it lists only the methods whose ordinary implementation runs no user code; `[[Get]]`, `[[Call]]`, and `[[Construct]]` are left out. This takes the incomplete builtins from 93 to 74 and the classifiable ones from 401 to 420, and recovers seven mutations that were being lost.

- **Unattributable is carried up, Incomplete is not**: A callee's unattributable write may have arrived as an argument, so it propagates to callers. Incomplete does not propagate because the steps §3 could not lower sit in operations nearly every algorithm reaches, which would take the incomplete builtins from 74 of 501 to 307 and the classifiable ones from 420 to 194.

- **A backing-store slot read is charged to its holder**: `SetViewValue` passes `view.[[ViewedArrayBuffer]]` to the seeded `SetValueInBuffer`, and resolving that read to `Unknown` left every DataView setter unable to name what it wrote. The interior origin fixes six such call sites, giving the 11 `DataView.prototype.set*` methods, `TypedArray.prototype.set`, and `TypedArray.prototype.copyWithin` a receiver fact and `Atomics.store` argument 0. `Map.prototype.delete` and `Map.prototype.clear` still report no mutation, because they write a record reached through an indexed read; §6's validation diff is where that surfaces.

- **Fresh values are invisible**: Writes to values the function allocated itself, origin `Fresh`, are discarded, since the caller never sees them. `Array.prototype.slice` calls `Set` on a fresh array and comes out non-mutating. A fresh object's *interior* is `Unknown` rather than `Fresh`, since an algorithm can store a caller's value into a record it allocated, as `MakeDataViewWithBufferWitnessRecord` does.

- **Callback detection**: A callee that names one of the calling function's parameters is treated as a callback, not the abstract operation or internal method of that name, to avoid false mutation claims.

All 1,202 functions settle in ~10 ms. Eight of nine seed entries resolve in the graph; `CreateMethodProperty` is absent, used only in syntax-directed operations §3 drops.

https://claude.ai/code/session_01M4RWbUrdhp8BnQqqZxrGeo