### PR TITLE
printer: print a single class or interface member

### DIFF
--- a/internal/printer/print_member_test.go
+++ b/internal/printer/print_member_test.go
@@ -1,0 +1,111 @@
+package printer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// parseOneDecl parses a single declaration out of an `.esc` source
+// string.
+func parseOneDecl(t *testing.T, src string) ast.Decl {
+	t.Helper()
+	decls, errs := parser.ParseDecls(context.Background(),
+		&ast.Source{Path: "member_test.esc", Contents: src})
+	require.Empty(t, errs, "parsing %q", src)
+	require.Len(t, decls, 1)
+	return decls[0]
+}
+
+// TestPrintClassElem prints each member of a class one at a time. The
+// printed member carries no leading indent and no trailing separator,
+// so a caller splicing it into an existing body places both itself.
+func TestPrintClassElem(t *testing.T) {
+	t.Parallel()
+	decl := parseOneDecl(t, `declare class Foo<T> {
+    constructor(mut self, length: number),
+    readonly length: number,
+    static isFoo(value: unknown) -> boolean,
+    indexOf(self, item: T) -> number,
+    get first(self) -> T,
+    set first(mut self, value: T),
+}`)
+	class, ok := decl.(*ast.ClassDecl)
+	require.True(t, ok)
+
+	expected := []string{
+		"constructor(mut self, length: number)",
+		"readonly length: number",
+		"static isFoo(value: unknown) -> boolean",
+		"indexOf(self, item: T) -> number",
+		"get first(self) -> T",
+		"set first(mut self, value: T)",
+	}
+	require.Len(t, class.Body, len(expected))
+	for i, want := range expected {
+		got, err := PrintClassElem(class.Body[i], DefaultOptions())
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+}
+
+// TestPrintObjTypeAnnElem is TestPrintClassElem for interface members.
+func TestPrintObjTypeAnnElem(t *testing.T) {
+	t.Parallel()
+	decl := parseOneDecl(t, `interface Foo<T> {
+    readonly length: number,
+    name?: string,
+    indexOf(item: T) -> number,
+    get first() -> T,
+    set first(value: T),
+}`)
+	iface, ok := decl.(*ast.InterfaceDecl)
+	require.True(t, ok)
+	require.NotNil(t, iface.TypeAnn)
+
+	expected := []string{
+		"readonly length: number",
+		"name?: string",
+		"indexOf(item: T) -> number",
+		"get first(self) -> T",
+		"set first(mut self, value: T)",
+	}
+	require.Len(t, iface.TypeAnn.Elems, len(expected))
+	for i, want := range expected {
+		got, err := PrintObjTypeAnnElem(iface.TypeAnn.Elems[i], DefaultOptions())
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+}
+
+// TestPrintMemberKeepsDoc checks that a member's retained JSDoc prints
+// ahead of it, so splicing a documented member does not drop the doc.
+func TestPrintMemberKeepsDoc(t *testing.T) {
+	t.Parallel()
+	decl := parseOneDecl(t, `declare class Foo {
+    /** Counts the items. */
+    length: number,
+}`)
+	class, ok := decl.(*ast.ClassDecl)
+	require.True(t, ok)
+	require.Len(t, class.Body, 1)
+
+	got, err := PrintClassElem(class.Body[0], DefaultOptions())
+	require.NoError(t, err)
+	require.Equal(t, "/** Counts the items. */\nlength: number", got)
+}
+
+// TestPrintMemberRejectsNil covers the nil guards: both entry points
+// take an interface, so a nil member is a caller bug rather than an
+// empty print.
+func TestPrintMemberRejectsNil(t *testing.T) {
+	t.Parallel()
+	_, err := PrintClassElem(nil, DefaultOptions())
+	require.EqualError(t, err, "cannot print a nil class member")
+
+	_, err = PrintObjTypeAnnElem(nil, DefaultOptions())
+	require.EqualError(t, err, "cannot print a nil object type member")
+}

--- a/internal/printer/print_member_test.go
+++ b/internal/printer/print_member_test.go
@@ -101,11 +101,43 @@ func TestPrintMemberKeepsDoc(t *testing.T) {
 // TestPrintMemberRejectsNil covers the nil guards: both entry points
 // take an interface, so a nil member is a caller bug rather than an
 // empty print.
+//
+// A typed nil is the case worth pinning. Every member variant is a
+// pointer type, so an interface can hold a nil `*ast.FieldElem`, which
+// a plain `== nil` test reports as non-nil. Without the reflect-based
+// guard the printer reaches the member's Doc method and panics.
 func TestPrintMemberRejectsNil(t *testing.T) {
 	t.Parallel()
-	_, err := PrintClassElem(nil, DefaultOptions())
-	require.EqualError(t, err, "cannot print a nil class member")
+	classCases := []struct {
+		name string
+		elem ast.ClassElem
+	}{
+		{"untyped nil", nil},
+		{"typed nil field", (*ast.FieldElem)(nil)},
+		{"typed nil method", (*ast.MethodElem)(nil)},
+		{"typed nil constructor", (*ast.ConstructorElem)(nil)},
+	}
+	for _, tc := range classCases {
+		t.Run("class/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := PrintClassElem(tc.elem, DefaultOptions())
+			require.EqualError(t, err, "cannot print a nil class member")
+		})
+	}
 
-	_, err = PrintObjTypeAnnElem(nil, DefaultOptions())
-	require.EqualError(t, err, "cannot print a nil object type member")
+	annCases := []struct {
+		name string
+		elem ast.ObjTypeAnnElem
+	}{
+		{"untyped nil", nil},
+		{"typed nil property", (*ast.PropertyTypeAnn)(nil)},
+		{"typed nil method", (*ast.MethodTypeAnn)(nil)},
+	}
+	for _, tc := range annCases {
+		t.Run("objTypeAnn/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := PrintObjTypeAnnElem(tc.elem, DefaultOptions())
+			require.EqualError(t, err, "cannot print a nil object type member")
+		})
+	}
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2091,6 +2091,35 @@ func PrintBlock(block *ast.Block, opts Options) (string, error) {
 	return builder.String(), nil
 }
 
+// PrintClassElem prints one class member — a field, method, getter,
+// setter, or constructor — without the enclosing class body. Print
+// dispatches over the six node families a whole declaration is built
+// from and a member is not one of them, so it cannot reach a ClassElem.
+// The output carries no leading indent and no trailing separator. The
+// caller places both.
+func PrintClassElem(elem ast.ClassElem, opts Options) (string, error) {
+	if elem == nil {
+		return "", fmt.Errorf("cannot print a nil class member")
+	}
+	var builder strings.Builder
+	NewPrinter(&builder, opts).printClassElem(elem)
+	return builder.String(), nil
+}
+
+// PrintObjTypeAnnElem prints one member of an object type annotation or
+// interface body, without the enclosing braces. An ObjTypeAnnElem is
+// not an ast.Node at all — it declares no Span — so this is the only
+// way to print one on its own. Same no-indent, no-separator contract as
+// PrintClassElem.
+func PrintObjTypeAnnElem(elem ast.ObjTypeAnnElem, opts Options) (string, error) {
+	if elem == nil {
+		return "", fmt.Errorf("cannot print a nil object type member")
+	}
+	var builder strings.Builder
+	NewPrinter(&builder, opts).printObjTypeAnnElem(elem)
+	return builder.String(), nil
+}
+
 // PrintToWriter prints an AST node to an io.Writer
 func PrintToWriter(node ast.Node, writer io.Writer, opts Options) error {
 	printer := NewPrinter(writer, opts)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"fmt"
 	"io"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -2098,7 +2099,7 @@ func PrintBlock(block *ast.Block, opts Options) (string, error) {
 // The output carries no leading indent and no trailing separator. The
 // caller places both.
 func PrintClassElem(elem ast.ClassElem, opts Options) (string, error) {
-	if elem == nil {
+	if isNilMember(elem) {
 		return "", fmt.Errorf("cannot print a nil class member")
 	}
 	var builder strings.Builder
@@ -2112,12 +2113,25 @@ func PrintClassElem(elem ast.ClassElem, opts Options) (string, error) {
 // way to print one on its own. Same no-indent, no-separator contract as
 // PrintClassElem.
 func PrintObjTypeAnnElem(elem ast.ObjTypeAnnElem, opts Options) (string, error) {
-	if elem == nil {
+	if isNilMember(elem) {
 		return "", fmt.Errorf("cannot print a nil object type member")
 	}
 	var builder strings.Builder
 	NewPrinter(&builder, opts).printObjTypeAnnElem(elem)
 	return builder.String(), nil
+}
+
+// isNilMember reports whether a member interface holds nothing to
+// print. Every ClassElem and ObjTypeAnnElem variant is a pointer type,
+// so an interface can carry a typed nil: `elem == nil` reports false
+// for it and the first method call then panics. A caller handing over
+// an absent member gets the same error either way.
+func isNilMember(elem any) bool {
+	if elem == nil {
+		return true
+	}
+	value := reflect.ValueOf(elem)
+	return value.Kind() == reflect.Ptr && value.IsNil()
 }
 
 // PrintToWriter prints an AST node to an io.Writer


### PR DESCRIPTION
Refs #1229. First of four PRs splitting §6.4 of the builtins plan (`check` mode and additive re-run semantics). Replaces #1251.

## What this does

Adds `PrintClassElem` and `PrintObjTypeAnnElem`, which render one class or interface member without the body that encloses it.

Neither form could be printed on its own before. `Print` dispatches over the six node families a whole declaration is built from — `Script`, `Expr`, `Stmt`, `Decl`, `Pat`, `TypeAnn` — and a member is not one of them. An `ObjTypeAnnElem` is not an `ast.Node` at all, since it declares no `Span`.

Both follow `PrintBlock`'s existing shape: take the printer options, return the rendered string, reject a nil member. The output carries no leading indent and no trailing separator, so a caller splicing a member into an existing body places both itself.

## Why

The §6.4 converter re-run (#1256) needs to add a method the `.d.ts` gained to a committed `.esc` class without reprinting the rest of the class. Nothing else in the tree calls these yet.

## Stack

1. **This PR** — print one member
2. #1254 — declaration-level `check` mode
3. #1255 — member-level checking
4. #1256 — additive write mode

## Testing

New `internal/printer/print_member_test.go` covers every class-member form (constructor, field, static method, method, getter, setter), the interface-member forms, JSDoc retention, and the nil guards. `go test ./...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering individual class members and object-type members.
  * Preserved JSDoc output when printing individual members.
  * Added clear validation for unsupported or empty member inputs.

* **Tests**
  * Added coverage for class members, interface members, JSDoc preservation, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->