### PR TITLE
Add a declaration-level `check` mode to the converter

### DIFF
--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -649,11 +649,16 @@ var webPackages = []struct {
 }
 
 // ExplicitDrops names top-level TS-lib declarations the converter
-// skips emission for, with a logged note. Per §6.1: `globalThis` was
-// the union of every previously-ambient name (now meaningless with
-// no ambient tier), and `eval` has no good use case. Intrinsic-typed
-// declarations (FR13) are detected structurally, not by name, and so
-// are not listed here.
+// skips emission for, with a logged note. Per §6.1: `globalThis` has
+// no ambient union to take now that there is no ambient tier, and
+// `eval` has no good use case. The FR13 intrinsics are listed by name
+// below rather than detected structurally — `intrinsic` is a type
+// annotation Escalier prints back out, so a converted alias would
+// otherwise reach the committed tree.
+//
+// This is the single copy of the drop list. The §6.4 `check` pass
+// takes its exemptions from Route rather than restating the names, so
+// the two cannot disagree.
 var ExplicitDrops = set.FromSlice([]string{
 	// Per §6.1 — `globalThis` had no ambient union to take, `eval` has
 	// no good use case.

--- a/internal/dts_to_esc/rerun.go
+++ b/internal/dts_to_esc/rerun.go
@@ -1,0 +1,395 @@
+package dts_to_esc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// This file implements the read-only half of §6.4 of
+// planning/builtins/implementation_plan.md: verifying that a committed
+// `.esc` tree still covers every declaration the pinned `.d.ts` set
+// produces. CI runs it after a TypeScript bump to find out what
+// upstream gained.
+//
+// The exemption list check 1 needs — `globalThis`, `eval`, and the
+// `intrinsic`-typed declarations of §6.1 — is not restated here. Every
+// one of those names is in ExplicitDrops, so Route discards it before
+// PartitionLib buckets anything. The diff compares converter output
+// against the committed file, which means a dropped declaration has no
+// converted counterpart to be reported missing against. The drop list
+// keeps exactly one copy: the one the routing pass reads.
+//
+// Signature drift (§6.4 checks 2 and 3) is not implemented. It compares
+// the two sides through the solver's `constrain`, which needs the
+// solver to ingest a declaration module — SimpleSub M7.5. Until then a
+// passing check means "every `.d.ts` name has an `.esc` counterpart",
+// not "every counterpart still means the same thing".
+
+// PackageDiff is what a converter re-run would add to one package's
+// committed `.esc` file.
+type PackageDiff struct {
+	// Pkg is the package URI, e.g. "std:array".
+	Pkg string
+
+	// Path is the committed file's path relative to the `.esc` tree
+	// root, e.g. "std/array.esc".
+	Path string
+
+	// Exists reports whether the committed file was on disk. When it
+	// was not, NewDecls holds every converted declaration.
+	Exists bool
+
+	// NewDecls are converted declarations with no committed
+	// counterpart of the same name.
+	NewDecls []NewDecl
+
+	// Removed names committed declarations absent from the converted
+	// output, usually a TS-side removal. Nothing is ever deleted.
+	Removed []string
+}
+
+// Empty reports whether the committed file already covers everything
+// the converter produced.
+func (d *PackageDiff) Empty() bool {
+	return len(d.NewDecls) == 0
+}
+
+// NewDecl is one converted declaration the committed file lacks.
+type NewDecl struct {
+	Name string
+
+	// Kind is the declaration's Escalier form: "class", "interface",
+	// "type", "function", "value", or "namespace".
+	Kind string
+}
+
+// CheckReport is the outcome of a read-only check run: one PackageDiff
+// per package that produced a bucket, in package-URI order.
+type CheckReport struct {
+	Packages []PackageDiff
+}
+
+// CheckPartition converts every bucket in result and diffs it against
+// the committed `.esc` tree rooted at escDir, without touching disk.
+//
+// escDir is the directory holding the `std/`, `web/`, and `node/`
+// subtrees — internal/interop/data/ in the repo, the same root
+// WritePartitionedTree writes into.
+func CheckPartition(result *PartitionResult, escDir string) (*CheckReport, error) {
+	diffs, err := diffPartition(result, escDir)
+	if err != nil {
+		return nil, err
+	}
+	return &CheckReport{Packages: diffs}, nil
+}
+
+// Failed reports whether the run found a `.d.ts` declaration with no
+// `.esc` counterpart. Extra declarations on the `.esc` side do not fail
+// the check — §6.4 reports them and leaves the deletion decision to a
+// contributor.
+func (r *CheckReport) Failed() bool {
+	for i := range r.Packages {
+		if !r.Packages[i].Empty() {
+			return true
+		}
+	}
+	return false
+}
+
+// Counts returns the number of missing declarations and informational
+// removals across every package.
+func (r *CheckReport) Counts() (decls, removed int) {
+	for i := range r.Packages {
+		p := &r.Packages[i]
+		decls += len(p.NewDecls)
+		removed += len(p.Removed)
+	}
+	return decls, removed
+}
+
+// Write prints the report to w, one section per package with findings,
+// then a summary. The footer names the drift checks that are not
+// implemented so a passing run is not read as full coverage.
+func (r *CheckReport) Write(w io.Writer) error {
+	for i := range r.Packages {
+		p := &r.Packages[i]
+		if p.Empty() && len(p.Removed) == 0 {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "%s (%s)\n", p.Pkg, p.Path); err != nil {
+			return err
+		}
+		if !p.Exists {
+			if _, err := fmt.Fprintf(w, "  missing file\n"); err != nil {
+				return err
+			}
+		}
+		for _, d := range p.NewDecls {
+			if _, err := fmt.Fprintf(w, "  missing declaration: %s (%s)\n", d.Name, d.Kind); err != nil {
+				return err
+			}
+		}
+		for _, name := range p.Removed {
+			if _, err := fmt.Fprintf(w, "  extra declaration: %s (absent from the .d.ts; not removed)\n", name); err != nil {
+				return err
+			}
+		}
+	}
+	decls, removed := r.Counts()
+	if _, err := fmt.Fprintf(w,
+		"check: %d missing declarations, %d extra declarations\n",
+		decls, removed); err != nil {
+		return err
+	}
+	_, err := fmt.Fprint(w,
+		"note: signature and property-type drift are not checked yet; "+
+			"those compare both sides through the solver's constrain "+
+			"(SimpleSub M7.5)\n")
+	return err
+}
+
+// diffPartition converts every bucket and diffs it against the
+// committed tree. Buckets are visited in package-URI order so the
+// report reads the same way on every run regardless of map iteration.
+func diffPartition(result *PartitionResult, escDir string) ([]PackageDiff, error) {
+	uris := make([]string, 0, len(result.Buckets))
+	for uri := range result.Buckets {
+		uris = append(uris, uri)
+	}
+	sort.Strings(uris)
+
+	diffs := make([]PackageDiff, 0, len(uris))
+	for _, uri := range uris {
+		pkg, ok := PackageForURI(uri)
+		if !ok {
+			return nil, fmt.Errorf("diffPartition: unknown package URI %q "+
+				"(every bucket should come from Route, which only returns "+
+				"URIs in PackageList)", uri)
+		}
+		mod, err := ConvertBucket(result.Buckets[uri])
+		if err != nil {
+			return nil, fmt.Errorf("converting bucket %s: %w", uri, err)
+		}
+		diff, err := diffPackage(pkg, mod, escDir)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, *diff)
+	}
+	return diffs, nil
+}
+
+// diffPackage compares one converted bucket against its committed file.
+func diffPackage(pkg Package, mod *StandaloneModule, escDir string) (*PackageDiff, error) {
+	dest := filepath.Join(escDir, filepath.FromSlash(pkg.File))
+	contents, exists, err := readCommitted(dest)
+	if err != nil {
+		return nil, err
+	}
+
+	diff := &PackageDiff{Pkg: pkg.URI, Path: pkg.File, Exists: exists}
+
+	var committed []ast.Decl
+	if exists {
+		committed, err = parseCommitted(dest, contents)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	byName := make(map[string][]ast.Decl, len(committed))
+	for _, decl := range committed {
+		if name := escDeclName(decl); name != "" {
+			byName[name] = append(byName[name], decl)
+		}
+	}
+
+	convertedNames := set.NewSet[string]()
+	for _, decl := range standaloneDecls(mod) {
+		name := escDeclName(decl)
+		if name == "" {
+			continue
+		}
+		convertedNames.Add(name)
+		if !spaceCovered(byName[name], decl) {
+			diff.NewDecls = append(diff.NewDecls, NewDecl{
+				Name: name,
+				Kind: escDeclKind(decl),
+			})
+		}
+	}
+
+	// A name can be committed twice — once in each space — so report it
+	// at most once.
+	reported := set.NewSet[string]()
+	for _, decl := range committed {
+		name := escDeclName(decl)
+		if name == "" || convertedNames.Contains(name) || reported.Contains(name) {
+			continue
+		}
+		reported.Add(name)
+		diff.Removed = append(diff.Removed, name)
+	}
+	return diff, nil
+}
+
+// readCommitted reads a committed `.esc` file. A file that is not on
+// disk is not an error — every declaration in its package is missing,
+// which is exactly what a first run against an unseeded tree means.
+func readCommitted(path string) (string, bool, error) {
+	contents, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return string(contents), true, nil
+}
+
+// parseCommitted parses a committed `.esc` file into its top-level
+// declarations. ParseLibFiles is used rather than ParseDecls because a
+// package file may open with `import "std:date"` and only ParseLibFiles
+// admits import statements.
+func parseCommitted(path, contents string) ([]ast.Decl, error) {
+	src := &ast.Source{Path: path, Contents: contents}
+	mod, errs := parser.ParseLibFiles(context.Background(), []*ast.Source{src})
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("parsing %s: %s", path, errs[0].String())
+	}
+	var decls []ast.Decl
+	mod.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		decls = append(decls, ns.Decls...)
+		return true
+	})
+	return decls, nil
+}
+
+// standaloneDecls returns the converted module's declarations. The
+// standalone converter flattens everything into the root namespace, so
+// this is one flat list.
+func standaloneDecls(mod *StandaloneModule) []ast.Decl {
+	var decls []ast.Decl
+	mod.Module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		decls = append(decls, ns.Decls...)
+		return true
+	})
+	return decls
+}
+
+// declSpace is the namespace a declaration binds its name in. Escalier
+// keeps values and types apart the way TypeScript does, so one name can
+// carry both an `interface Foo` and a `declare var Foo` — the TS lib's
+// class-via-trio idiom relies on exactly that.
+type declSpace int
+
+const (
+	// valueSpace holds `val`/`var` bindings and functions.
+	valueSpace declSpace = 1 << iota
+	// typeSpace holds type aliases and interfaces.
+	typeSpace
+	// bothSpaces is what a class, enum, or namespace binds: one name
+	// carrying a value and a type at once.
+	bothSpaces = valueSpace | typeSpace
+)
+
+// escDeclSpace returns the space a declaration binds in.
+func escDeclSpace(decl ast.Decl) declSpace {
+	switch decl.(type) {
+	case *ast.VarDecl, *ast.FuncDecl:
+		return valueSpace
+	case *ast.TypeDecl, *ast.InterfaceDecl:
+		return typeSpace
+	case *ast.ClassDecl, *ast.EnumDecl, *ast.NamespaceDecl:
+		return bothSpaces
+	}
+	return 0
+}
+
+// spaceCovered reports whether one of the committed declarations
+// sharing a converted declaration's name already binds the space it
+// needs.
+//
+// Overlap rather than an exact kind match is what makes a §7 hand-fusion
+// stick: a contributor who collapses the converter's `interface Foo` and
+// `declare var Foo: FooConstructor` into one `declare class Foo` binds
+// both spaces, so neither converted half is reported missing on the next
+// re-run.
+func spaceCovered(committed []ast.Decl, converted ast.Decl) bool {
+	want := escDeclSpace(converted)
+	for _, decl := range committed {
+		if escDeclSpace(decl)&want != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// escDeclName returns the name a top-level declaration is addressed by,
+// or "" for a declaration with no single-identifier name — a VarDecl
+// bound to a destructuring pattern, say. Unnamed declarations take no
+// part in the diff.
+func escDeclName(decl ast.Decl) string {
+	switch d := decl.(type) {
+	case *ast.VarDecl:
+		if id, ok := d.Pattern.(*ast.IdentPat); ok {
+			return id.Name
+		}
+	case *ast.FuncDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+	case *ast.ClassDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+	case *ast.TypeDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+	case *ast.InterfaceDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+	case *ast.EnumDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+	case *ast.NamespaceDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+	}
+	return ""
+}
+
+// escDeclKind returns the Escalier form of a declaration, for reports.
+func escDeclKind(decl ast.Decl) string {
+	switch decl.(type) {
+	case *ast.ClassDecl:
+		return "class"
+	case *ast.InterfaceDecl:
+		return "interface"
+	case *ast.TypeDecl:
+		return "type"
+	case *ast.FuncDecl:
+		return "function"
+	case *ast.VarDecl:
+		return "value"
+	case *ast.EnumDecl:
+		return "enum"
+	case *ast.NamespaceDecl:
+		return "namespace"
+	}
+	return "declaration"
+}

--- a/internal/dts_to_esc/rerun_test.go
+++ b/internal/dts_to_esc/rerun_test.go
@@ -1,0 +1,268 @@
+package dts_to_esc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dts_parser"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// writeEsc seeds a committed `.esc` file under root and returns its
+// path.
+func writeEsc(t *testing.T, root, rel, contents string) string {
+	t.Helper()
+	dest := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, os.WriteFile(dest, []byte(contents), 0o644))
+	return dest
+}
+
+// escParses reports whether a committed `.esc` file parses with
+// Escalier's own parser.
+func escParses(t *testing.T, path, contents string) bool {
+	t.Helper()
+	_, errs := parser.ParseLibFiles(context.Background(), []*ast.Source{{
+		Path: path, Contents: contents,
+	}})
+	return len(errs) == 0
+}
+
+// partitionOf routes one synthetic lib file through the partitioner.
+func partitionOf(t *testing.T, name, src string) *PartitionResult {
+	t.Helper()
+	res, err := PartitionLib([]LibInput{parseLib(t, name, src)})
+	require.NoError(t, err)
+	return res
+}
+
+// findDiff returns the report entry for one package URI.
+func findDiff(t *testing.T, report *CheckReport, uri string) PackageDiff {
+	t.Helper()
+	for _, p := range report.Packages {
+		if p.Pkg == uri {
+			return p
+		}
+	}
+	t.Fatalf("no report entry for %s", uri)
+	return PackageDiff{}
+}
+
+func TestCheckPartition_MissingFileReportsEveryDecl(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", `
+interface Array<T> { length: number; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; readonly prototype: Array<any>; }
+declare var Array: ArrayConstructor;
+`)
+	report, err := CheckPartition(res, t.TempDir())
+	require.NoError(t, err)
+	require.True(t, report.Failed())
+
+	diff := findDiff(t, report, "std:array")
+	require.False(t, diff.Exists)
+	require.Equal(t, "std/array.esc", diff.Path)
+	require.Len(t, diff.NewDecls, 1)
+	require.Equal(t, "Array", diff.NewDecls[0].Name)
+	require.Equal(t, "class", diff.NewDecls[0].Kind)
+}
+
+func TestCheckPartition_PassesWhenCommittedTreeMatches(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", `
+interface Array<T> { length: number; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; readonly prototype: Array<any>; }
+declare var Array: ArrayConstructor;
+`)
+	root := t.TempDir()
+
+	// Seed the tree from the converter itself, then re-run the check
+	// against it: a freshly written tree has nothing missing.
+	_, err := WritePartitionedTree(res, root)
+	require.NoError(t, err)
+
+	report, err := CheckPartition(res, root)
+	require.NoError(t, err)
+	require.False(t, report.Failed())
+
+	decls, removed := report.Counts()
+	require.Equal(t, 0, decls)
+	require.Equal(t, 0, removed)
+}
+
+func TestCheckPartition_ExemptsDroppedDeclarations(t *testing.T) {
+	t.Parallel()
+	// §6.4 check 1 exempts the declarations the converter drops on
+	// purpose: `globalThis`, `eval`, and the `intrinsic`-typed aliases.
+	// The committed tree below holds none of the three, and the check
+	// still passes.
+	res := partitionOf(t, "lib.es5.d.ts", `
+declare var globalThis: any;
+declare function eval(x: string): any;
+type Uppercase<S extends string> = intrinsic;
+interface Math { readonly PI: number; }
+declare var Math: Math;
+`)
+	root := t.TempDir()
+	writeEsc(t, root, "std/math.esc", `@js("Math.PI")
+export declare val PI: number
+`)
+
+	report, err := CheckPartition(res, root)
+	require.NoError(t, err)
+	require.False(t, report.Failed(), "dropped declarations must not fail the check")
+
+	// The exemption is the routing pass's own decision — every one of
+	// the three names comes back as a drop from Route, so the check
+	// reads no second copy of the list.
+	names := make([]string, 0, len(res.Drops))
+	for _, d := range res.Drops {
+		names = append(names, d.Name)
+	}
+	require.ElementsMatch(t, []string{"globalThis", "eval", "Uppercase"}, names)
+	require.NotContains(t, res.Buckets, "std:string")
+}
+
+func TestCheckPartition_ReportsExtraDecls(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", `
+interface Array<T> { length: number; }
+interface ArrayConstructor { new <T>(): Array<T>; readonly prototype: Array<any>; }
+declare var Array: ArrayConstructor;
+`)
+	root := t.TempDir()
+	writeEsc(t, root, "std/array.esc", `@js("Array")
+export declare class Array<T> {
+    length: number,
+}
+
+export type MyArrayHelper<T> = Array<T>
+`)
+
+	report, err := CheckPartition(res, root)
+	require.NoError(t, err)
+
+	diff := findDiff(t, report, "std:array")
+	require.True(t, diff.Exists)
+	require.Empty(t, diff.NewDecls)
+	require.Equal(t, []string{"MyArrayHelper"}, diff.Removed)
+
+	// An extra declaration is informational, so it does not fail CI.
+	require.False(t, report.Failed())
+}
+
+func TestCheckReport_WriteNamesTheUnimplementedDriftChecks(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", `
+interface Array<T> { length: number; }
+interface ArrayConstructor { new <T>(): Array<T>; readonly prototype: Array<any>; }
+declare var Array: ArrayConstructor;
+`)
+	report, err := CheckPartition(res, t.TempDir())
+	require.NoError(t, err)
+
+	var sb strings.Builder
+	require.NoError(t, report.Write(&sb))
+	out := sb.String()
+	require.Contains(t, out, "std:array (std/array.esc)")
+	require.Contains(t, out, "missing file")
+	require.Contains(t, out, "missing declaration: Array (class)")
+	require.Contains(t, out, "check: 1 missing declarations, 0 extra declarations")
+	require.Contains(t, out,
+		"note: signature and property-type drift are not checked yet; "+
+			"those compare both sides through the solver's constrain "+
+			"(SimpleSub M7.5)")
+}
+
+func TestCheckPartition_HandFusedTrioIsSticky(t *testing.T) {
+	t.Parallel()
+	// The converter emits the class-via-trio idiom as separate
+	// declarations when trio detection does not fire: `interface Foo`
+	// in the type space and `declare var Foo` in the value space. A §7
+	// contributor may fuse the pair into one class, which binds both
+	// spaces. Neither converted half may then be reported missing.
+	res := partitionOf(t, "lib.es5.d.ts", `
+interface WeakRef<T extends object> { deref(): T | undefined; }
+interface WeakRefConstructor { readonly prototype: WeakRef<object>; }
+declare var WeakRef: WeakRefConstructor;
+`)
+	mod, err := ConvertBucket(res.Buckets["std:weak_ref"])
+	require.NoError(t, err)
+	rendered, err := RenderStandaloneModule(mod)
+	require.NoError(t, err)
+	require.Contains(t, rendered, "interface WeakRef<T: {}>",
+		"this input must reach the diff as an unfused interface/var pair")
+	require.Contains(t, rendered, "var WeakRef: WeakRefConstructor")
+
+	root := t.TempDir()
+	writeEsc(t, root, "std/weak_ref.esc", `@js("WeakRef")
+export declare class WeakRef<T: {}> {
+    deref(self) -> T | undefined,
+}
+
+export declare interface WeakRefConstructor {
+    readonly prototype: WeakRef<{}>,
+}
+`)
+
+	report, err := CheckPartition(res, root)
+	require.NoError(t, err)
+	diff := findDiff(t, report, "std:weak_ref")
+	require.Empty(t, diff.NewDecls, "the fused class covers both converted halves")
+	require.False(t, report.Failed())
+}
+
+// TestCheckPartition_LibES5RoundTrips is the §6.4 idempotence gate on
+// real input: write the pinned lib.es5 partition, then check the
+// converter against what it just wrote. Nothing may come back missing.
+//
+// Packages whose output does not reparse are excluded — those are the
+// printer/parser asymmetries §7's hand-edits close, tracked by the soft
+// gate in TestPartitionLib_LibES5_EndToEnd. The check itself treats an
+// unparseable committed file as a hard error, so including them here
+// would test the §7 backlog rather than the diff.
+func TestCheckPartition_LibES5RoundTrips(t *testing.T) {
+	t.Parallel()
+
+	libPath := filepath.Join("..", "..", "playground", "public", "types", "lib.es5.d.ts")
+	if _, err := os.Stat(libPath); err != nil {
+		t.Skipf("lib.es5.d.ts not present at %s: %v", libPath, err)
+	}
+
+	inputs, err := ParseLibFiles(filepath.Dir(libPath), []string{"lib.es5.d.ts"})
+	require.NoError(t, err)
+	res, err := PartitionLib(inputs)
+	require.NoError(t, err)
+
+	root := t.TempDir()
+	written, err := WritePartitionedTree(res, root)
+	require.NoError(t, err)
+
+	reparsed := &PartitionResult{Buckets: map[string][]dts_parser.Statement{}}
+	for _, uri := range written {
+		pkg, ok := PackageForURI(uri)
+		require.True(t, ok, "URI %q from result must be a known package", uri)
+		path := filepath.Join(root, filepath.FromSlash(pkg.File))
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+		if escParses(t, path, string(contents)) {
+			reparsed.Buckets[uri] = res.Buckets[uri]
+		}
+	}
+	require.NotEmpty(t, reparsed.Buckets, "at least one package must reparse")
+
+	report, err := CheckPartition(reparsed, root)
+	require.NoError(t, err)
+
+	var sb strings.Builder
+	require.NoError(t, report.Write(&sb))
+	require.False(t, report.Failed(),
+		"a freshly written tree must have nothing missing:\n%s", sb.String())
+	t.Logf("lib.es5 check: %d of %d packages round-tripped",
+		len(reparsed.Buckets), len(written))
+}

--- a/internal/dts_to_esc/rerun_test.go
+++ b/internal/dts_to_esc/rerun_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
 	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
 )
 
@@ -156,6 +157,13 @@ export type MyArrayHelper<T> = Array<T>
 	require.False(t, report.Failed())
 }
 
+// The report an operator reads, over a tree with nothing in it. The
+// snapshot holds all of it, so the section heading, the per-finding
+// indentation, and the summary line are pinned alongside the footer.
+//
+// That footer is what the test is named for. A green check means every
+// `.d.ts` name has an `.esc` counterpart, not that the counterpart still
+// means the same thing, and every run says so.
 func TestCheckReport_WriteNamesTheUnimplementedDriftChecks(t *testing.T) {
 	t.Parallel()
 	res := partitionOf(t, "lib.es5.d.ts", `
@@ -168,15 +176,12 @@ declare var Array: ArrayConstructor;
 
 	var sb strings.Builder
 	require.NoError(t, report.Write(&sb))
-	out := sb.String()
-	require.Contains(t, out, "std:array (std/array.esc)")
-	require.Contains(t, out, "missing file")
-	require.Contains(t, out, "missing declaration: Array (class)")
-	require.Contains(t, out, "check: 1 missing declarations, 0 extra declarations")
-	require.Contains(t, out,
-		"note: signature and property-type drift are not checked yet; "+
-			"those compare both sides through the solver's constrain "+
-			"(SimpleSub M7.5)")
+	snaps.MatchInlineSnapshot(t, sb.String(), snaps.Inline(`std:array (std/array.esc)
+  missing file
+  missing declaration: Array (class)
+check: 1 missing declarations, 0 extra declarations
+note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
+`))
 }
 
 func TestCheckPartition_HandFusedTrioIsSticky(t *testing.T) {
@@ -195,9 +200,22 @@ declare var WeakRef: WeakRefConstructor;
 	require.NoError(t, err)
 	rendered, err := RenderStandaloneModule(mod)
 	require.NoError(t, err)
-	require.Contains(t, rendered, "interface WeakRef<T: {}>",
-		"this input must reach the diff as an unfused interface/var pair")
-	require.Contains(t, rendered, "var WeakRef: WeakRefConstructor")
+
+	// The precondition, shown rather than probed for. This input has to
+	// reach the diff as an unfused interface/var pair. Were trio
+	// detection to start firing on it, the snapshot would show one class
+	// and the rest of the test would stop exercising the fusion.
+	snaps.MatchInlineSnapshot(t, rendered, snaps.Inline(`export declare interface WeakRef<T: {}> {
+    deref() -> T | undefined
+}
+
+export declare interface WeakRefConstructor {
+    readonly prototype: WeakRef<{}>
+}
+
+@js("WeakRef")
+export declare var WeakRef: WeakRefConstructor
+`))
 
 	root := t.TempDir()
 	writeEsc(t, root, "std/weak_ref.esc", `@js("WeakRef")

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -22,6 +22,13 @@
 //	    against the ECMA-262 effect facts derived from that control-flow
 //	    graph, and reports the names present on one side only. See
 //	    planning/ecma-262/implementation_plan.md §5.
+//
+//	dts_to_esc check <lib-dir> <esc-dir>
+//	    Read-only verification per §6.4: convert the pinned lib set and
+//	    report every `.d.ts` declaration with no counterpart in the
+//	    committed `.esc` tree under <esc-dir>. Exits non-zero when
+//	    anything is missing. Signature and property-type drift are not
+//	    checked yet — see internal/dts_to_esc/rerun.go.
 package main
 
 import (
@@ -44,14 +51,68 @@ func main() {
 	}
 }
 
+const usage = `usage:
+  dts_to_esc <path-to-d.ts>
+  dts_to_esc partition [--cfg <cfg.json>] <lib-dir> <out-dir>
+  dts_to_esc check <lib-dir> <esc-dir>`
+
 func run(args []string, stdout, stderr io.Writer) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage:\n  dts_to_esc <path-to-d.ts>\n  dts_to_esc partition [--cfg <cfg.json>] <lib-dir> <out-dir>")
+		return fmt.Errorf("%s", usage)
 	}
-	if args[0] == "partition" {
+	switch args[0] {
+	case "partition":
 		return runPartition(args[1:], stderr)
+	case "check":
+		return runCheck(args[1:], stdout, stderr)
 	}
 	return runSingleFile(args, stdout)
+}
+
+// errCheckFailed is returned when `check` finds a missing declaration.
+// main turns any error into a non-zero exit, which is what CI keys off.
+// The message stays short because the report itself has already been
+// printed.
+var errCheckFailed = errors.New("committed .esc tree is out of date with the .d.ts inputs")
+
+func runCheck(args []string, stdout, stderr io.Writer) error {
+	if len(args) != 2 {
+		return fmt.Errorf("usage: dts_to_esc check <lib-dir> <esc-dir>")
+	}
+	result, err := partitionLibDir(args[0], stderr)
+	if err != nil {
+		return err
+	}
+	report, err := dts_to_esc.CheckPartition(result, args[1])
+	if err != nil {
+		return err
+	}
+	if err := report.Write(stdout); err != nil {
+		return err
+	}
+	if report.Failed() {
+		return errCheckFailed
+	}
+	return nil
+}
+
+// partitionLibDir discovers, parses, and routes every lib.*.d.ts under
+// libDir. Shared by the partition and check subcommands.
+func partitionLibDir(libDir string, stderr io.Writer) (*dts_to_esc.PartitionResult, error) {
+	basenames, err := dts_to_esc.DiscoverLibFiles(libDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(basenames) == 0 {
+		return nil, fmt.Errorf("no lib.*.d.ts files found under %s", libDir)
+	}
+	fmt.Fprintf(stderr, "discovered %d lib files\n", len(basenames))
+
+	inputs, err := dts_to_esc.ParseLibFiles(libDir, basenames)
+	if err != nil {
+		return nil, err
+	}
+	return dts_to_esc.PartitionLib(inputs)
 }
 
 func runSingleFile(args []string, out io.Writer) error {
@@ -111,21 +172,7 @@ func runPartition(args []string, stderr io.Writer) error {
 		join = ecma262.NewJoin(ecma262.NewFacts(cfg))
 	}
 
-	basenames, err := dts_to_esc.DiscoverLibFiles(libDir)
-	if err != nil {
-		return err
-	}
-	if len(basenames) == 0 {
-		return fmt.Errorf("no lib.*.d.ts files found under %s", libDir)
-	}
-	fmt.Fprintf(stderr, "discovered %d lib files\n", len(basenames))
-
-	inputs, err := dts_to_esc.ParseLibFiles(libDir, basenames)
-	if err != nil {
-		return err
-	}
-
-	result, err := dts_to_esc.PartitionLib(inputs)
+	result, err := partitionLibDir(libDir, stderr)
 	if err != nil {
 		return err
 	}

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// seedLib writes one synthetic `lib.*.d.ts` into a fresh directory and
+// returns that directory.
+func seedLib(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "lib.es5.d.ts"), []byte(contents), 0o644))
+	return dir
+}
+
+const arrayLib = `
+interface Array<T> { length: number; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; readonly prototype: Array<any>; }
+declare var Array: ArrayConstructor;
+`
+
+// TestRun_CheckFailsOnAnEmptyTree runs `check` against a committed
+// `.esc` tree with nothing in it. The two directories play opposite
+// roles: `libDir` holds the `.d.ts` inputs and is seeded, while
+// `escDir` is the tree being verified and stays empty. Every
+// declaration the converter produces is therefore missing, which is
+// what a first run against an unseeded tree looks like.
+func TestRun_CheckFailsOnAnEmptyTree(t *testing.T) {
+	t.Parallel()
+	libDir := seedLib(t, arrayLib)
+	escDir := t.TempDir()
+
+	var stdout strings.Builder
+	err := run([]string{"check", libDir, escDir}, &stdout, io.Discard)
+	require.ErrorIs(t, err, errCheckFailed)
+	require.Contains(t, stdout.String(), "missing declaration: Array (class)")
+}
+
+// TestRun_SingleFileWritesEscToStdout covers the §5 single-file mode:
+// one `.d.ts` in, Escalier source out on stdout, nothing written to
+// disk. The snapshot is the whole emitted module, so it also pins the
+// trio fusion — `interface ArrayConstructor` and `declare var Array`
+// are gone, collapsed into the one class.
+func TestRun_SingleFileWritesEscToStdout(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(seedLib(t, arrayLib), "lib.es5.d.ts")
+
+	var stdout strings.Builder
+	require.NoError(t, run([]string{path}, &stdout, io.Discard))
+
+	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`@js("Array")
+export declare class Array<T> {
+    length: number,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean,
+    static readonly prototype: Array<any>
+}
+`))
+}
+
+// treeOf lists every file under root as a slash-separated path relative
+// to it, sorted. Dropping the root keeps the listing free of the temp
+// directory the test ran in.
+func treeOf(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	require.NoError(t, filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	}))
+	sort.Strings(out)
+	return out
+}
+
+// TestRun_PartitionWritesTheTree covers the §6 PR A mode. The snapshot
+// holds the operator-facing report, the tree the run laid down, and the
+// one package file it emitted, so a change to any of the three shows up
+// in the diff rather than behind a Contains check.
+//
+// The out-dir is a fresh temp path on every run, so the report has it
+// replaced by a placeholder before the comparison.
+func TestRun_PartitionWritesTheTree(t *testing.T) {
+	t.Parallel()
+	libDir := seedLib(t, arrayLib)
+	outDir := t.TempDir()
+
+	var stderr strings.Builder
+	require.NoError(t, run([]string{"partition", libDir, outDir}, io.Discard, &stderr))
+
+	contents, err := os.ReadFile(filepath.Join(outDir, "std", "array.esc"))
+	require.NoError(t, err)
+
+	report := strings.ReplaceAll(stderr.String(), outDir, "<out-dir>")
+	snaps.MatchInlineSnapshot(t, fmt.Sprintf(
+		"--- stderr ---\n%s--- tree ---\n%s\n--- std/array.esc ---\n%s",
+		report, strings.Join(treeOf(t, outDir), "\n"), contents), snaps.Inline(`--- stderr ---
+discovered 1 lib files
+wrote 1 packages under <out-dir>
+  std:array: 3 decls
+--- tree ---
+node/README.md
+std/array.esc
+--- std/array.esc ---
+@js("Array")
+export declare class Array<T> {
+    length: number,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean,
+    static readonly prototype: Array<any>
+}
+`))
+}
+
+// TestRun_CheckPassesOnASeededTree is the happy path for `check`: seed
+// the `.esc` tree with the converter's own output, then verify it. The
+// two modes have to agree about what a package holds, so nothing comes
+// back missing and the run exits zero.
+func TestRun_CheckPassesOnASeededTree(t *testing.T) {
+	t.Parallel()
+	libDir := seedLib(t, arrayLib)
+	escDir := t.TempDir()
+
+	require.NoError(t, run([]string{"partition", libDir, escDir}, io.Discard, io.Discard))
+
+	var stdout strings.Builder
+	require.NoError(t, run([]string{"check", libDir, escDir}, &stdout, io.Discard))
+	require.Contains(t, stdout.String(),
+		"check: 0 missing declarations, 0 extra declarations")
+}
+
+func TestRun_RejectsWrongArgumentCounts(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		args    []string
+		message string
+	}{
+		{"check without esc dir", []string{"check", "lib"},
+			"usage: dts_to_esc check <lib-dir> <esc-dir>"},
+		{"no subcommand", nil, usage},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := run(tc.args, io.Discard, io.Discard)
+			require.EqualError(t, err, tc.message)
+		})
+	}
+}

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -44,7 +44,12 @@ func TestRun_CheckFailsOnAnEmptyTree(t *testing.T) {
 	var stdout strings.Builder
 	err := run([]string{"check", libDir, escDir}, &stdout, io.Discard)
 	require.ErrorIs(t, err, errCheckFailed)
-	require.Contains(t, stdout.String(), "missing declaration: Array (class)")
+	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`std:array (std/array.esc)
+  missing file
+  missing declaration: Array (class)
+check: 1 missing declarations, 0 extra declarations
+note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
+`))
 }
 
 // TestRun_SingleFileWritesEscToStdout covers the §5 single-file mode:
@@ -142,8 +147,9 @@ func TestRun_CheckPassesOnASeededTree(t *testing.T) {
 
 	var stdout strings.Builder
 	require.NoError(t, run([]string{"check", libDir, escDir}, &stdout, io.Discard))
-	require.Contains(t, stdout.String(),
-		"check: 0 missing declarations, 0 extra declarations")
+	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`check: 0 missing declarations, 0 extra declarations
+note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
+`))
 }
 
 func TestRun_RejectsWrongArgumentCounts(t *testing.T) {


### PR DESCRIPTION
Refs #1229. Second of four PRs splitting §6.4 of the builtins plan. Replaces #1251.

**Based on #1253** — review that one first; this PR's diff shows only its own commit once #1253 merges.

Rebased onto #1252 (§6 PR D), which moved the converter out of `internal/interop`. This work now lives in `internal/dts_to_esc/rerun.go`.

## What this does

Implements check 1 of §6.4: after a TypeScript bump, CI asks whether the committed `.esc` tree still has a counterpart for every declaration the pinned `.d.ts` set produces.

`CheckPartition` converts each routed bucket, parses the committed file for that package, and matches the two by name. It touches no files. `dts_to_esc check <lib-dir> <esc-dir>` prints the report and exits non-zero when anything is missing.

## The two decisions worth reviewing

**A declaration is matched by the space it binds, value or type, not by its exact kind.** Escalier keeps the two apart the way TypeScript does, so the class-via-trio idiom can reach the diff as an `interface Foo` (type space) and a `declare var Foo` (value space) when trio detection does not fire. A contributor who fuses that pair into one `class Foo` binds both spaces, and neither converted half is then reported missing. That is what lets a §7 hand-fusion survive a bump rather than being flagged every time.

**The drop exemptions get no list of their own.** §6.4 requires `globalThis`, `eval`, and the `intrinsic`-typed declarations to be exempt, and requires the check to read the same drop list the routing pass uses. It does so by construction: `Route` discards those names before `PartitionLib` buckets anything, so the converted side has no declaration to match against and the check cannot report one missing. `TestCheckPartition_ExemptsDroppedDeclarations` feeds all three in and asserts the check still passes.

An `.esc` declaration absent from the `.d.ts` side is reported and left alone. Nothing here deletes.

## Not implemented

Checks 2 and 3 — signature and property-type drift — compare both sides through the solver's `constrain` over `soltype`, which needs the solver to ingest a declaration module (SimpleSub M7.5). The report footer says so on every run so a green check is not read as full drift coverage.

Member-level checking is PR 3 of this stack.

## Testing

Unit coverage for each rule, plus an idempotence gate on real input: write the pinned lib.es5 partition, then check the converter against what it just wrote. 11 of 17 packages round-trip with nothing missing; the other 6 are the known §7 printer/parser gaps that keep their output from reparsing, and are excluded rather than silently passed. `go test ./...` passes.