### PR TITLE
Check class and interface members, not just declarations

### DIFF
--- a/internal/dts_to_esc/rerun.go
+++ b/internal/dts_to_esc/rerun.go
@@ -17,9 +17,14 @@ import (
 
 // This file implements the read-only half of §6.4 of
 // planning/builtins/implementation_plan.md: verifying that a committed
-// `.esc` tree still covers every declaration the pinned `.d.ts` set
-// produces. CI runs it after a TypeScript bump to find out what
-// upstream gained.
+// `.esc` tree still covers every declaration and member the pinned
+// `.d.ts` set produces. CI runs it after a TypeScript bump to find out
+// what upstream gained.
+//
+// §6.4 states check 1 over declarations. Members are checked on the
+// same footing here. The §6.4 write mode adds them, so a check that
+// stayed silent about them would tell CI a bump was clean while the
+// write mode still had methods to add.
 //
 // The exemption list check 1 needs — `globalThis`, `eval`, and the
 // `intrinsic`-typed declarations of §6.1 — is not restated here. Every
@@ -53,6 +58,10 @@ type PackageDiff struct {
 	// counterpart of the same name.
 	NewDecls []NewDecl
 
+	// NewMembers are converted class or interface members missing from
+	// the committed declaration that shares their owner's name.
+	NewMembers []NewMember
+
 	// Removed names committed declarations absent from the converted
 	// output, usually a TS-side removal. Nothing is ever deleted.
 	Removed []string
@@ -61,7 +70,7 @@ type PackageDiff struct {
 // Empty reports whether the committed file already covers everything
 // the converter produced.
 func (d *PackageDiff) Empty() bool {
-	return len(d.NewDecls) == 0
+	return len(d.NewDecls) == 0 && len(d.NewMembers) == 0
 }
 
 // NewDecl is one converted declaration the committed file lacks.
@@ -71,6 +80,30 @@ type NewDecl struct {
 	// Kind is the declaration's Escalier form: "class", "interface",
 	// "type", "function", "value", or "namespace".
 	Kind string
+}
+
+// NewMember is one converted member the committed declaration lacks.
+type NewMember struct {
+	// Owner is the name of the committed declaration the member would
+	// be added to.
+	Owner string
+
+	// Name is the member's key: an identifier, a string-literal key, or
+	// a dotted computed key such as "Symbol.iterator". A constructor is
+	// named "constructor".
+	Name string
+
+	// Static reports whether the member lives on the static side.
+	Static bool
+}
+
+// Label renders a member as it appears in a report, e.g.
+// "Array.isArray (static)".
+func (m *NewMember) Label() string {
+	if m.Static {
+		return fmt.Sprintf("%s.%s (static)", m.Owner, m.Name)
+	}
+	return fmt.Sprintf("%s.%s", m.Owner, m.Name)
 }
 
 // CheckReport is the outcome of a read-only check run: one PackageDiff
@@ -93,10 +126,10 @@ func CheckPartition(result *PartitionResult, escDir string) (*CheckReport, error
 	return &CheckReport{Packages: diffs}, nil
 }
 
-// Failed reports whether the run found a `.d.ts` declaration with no
-// `.esc` counterpart. Extra declarations on the `.esc` side do not fail
-// the check — §6.4 reports them and leaves the deletion decision to a
-// contributor.
+// Failed reports whether the run found a `.d.ts` declaration or member
+// with no `.esc` counterpart. Extra declarations on the `.esc` side do
+// not fail the check — §6.4 reports them and leaves the deletion
+// decision to a contributor.
 func (r *CheckReport) Failed() bool {
 	for i := range r.Packages {
 		if !r.Packages[i].Empty() {
@@ -106,15 +139,16 @@ func (r *CheckReport) Failed() bool {
 	return false
 }
 
-// Counts returns the number of missing declarations and informational
-// removals across every package.
-func (r *CheckReport) Counts() (decls, removed int) {
+// Counts returns the number of missing declarations, missing members,
+// and informational removals across every package.
+func (r *CheckReport) Counts() (decls, members, removed int) {
 	for i := range r.Packages {
 		p := &r.Packages[i]
 		decls += len(p.NewDecls)
+		members += len(p.NewMembers)
 		removed += len(p.Removed)
 	}
-	return decls, removed
+	return decls, members, removed
 }
 
 // Write prints the report to w, one section per package with findings,
@@ -139,16 +173,21 @@ func (r *CheckReport) Write(w io.Writer) error {
 				return err
 			}
 		}
+		for j := range p.NewMembers {
+			if _, err := fmt.Fprintf(w, "  missing member: %s\n", p.NewMembers[j].Label()); err != nil {
+				return err
+			}
+		}
 		for _, name := range p.Removed {
 			if _, err := fmt.Fprintf(w, "  extra declaration: %s (absent from the .d.ts; not removed)\n", name); err != nil {
 				return err
 			}
 		}
 	}
-	decls, removed := r.Counts()
+	decls, members, removed := r.Counts()
 	if _, err := fmt.Fprintf(w,
-		"check: %d missing declarations, %d extra declarations\n",
-		decls, removed); err != nil {
+		"check: %d missing declarations, %d missing members, %d extra declarations\n",
+		decls, members, removed); err != nil {
 		return err
 	}
 	_, err := fmt.Fprint(w,
@@ -226,7 +265,13 @@ func diffPackage(pkg Package, mod *StandaloneModule, escDir string) (*PackageDif
 				Name: name,
 				Kind: escDeclKind(decl),
 			})
+			continue
 		}
+		host := memberHost(byName[name], decl)
+		if host == nil {
+			continue
+		}
+		diff.NewMembers = append(diff.NewMembers, missingMembers(name, host, decl)...)
 	}
 
 	// A name can be committed twice — once in each space — so report it
@@ -333,6 +378,156 @@ func spaceCovered(committed []ast.Decl, converted ast.Decl) bool {
 		}
 	}
 	return false
+}
+
+// memberHost returns the committed declaration whose members the
+// converted declaration's members are compared against, or nil when the
+// converted declaration has no member list or nothing of its shape was
+// committed under that name.
+//
+// Only a same-shape pair is member-comparable. A class and an interface
+// hold their members in different slots, and turning one into the other
+// is a signature change, which §6.4 leaves to a contributor.
+func memberHost(committed []ast.Decl, converted ast.Decl) ast.Decl {
+	switch converted.(type) {
+	case *ast.ClassDecl:
+		for _, decl := range committed {
+			if _, ok := decl.(*ast.ClassDecl); ok {
+				return decl
+			}
+		}
+	case *ast.InterfaceDecl:
+		for _, decl := range committed {
+			if _, ok := decl.(*ast.InterfaceDecl); ok {
+				return decl
+			}
+		}
+	}
+	return nil
+}
+
+// missingMembers returns the members of the converted declaration that
+// the committed declaration of the same name does not already fill.
+// `name` is the shared name, used to label each result.
+//
+// Only classes and interfaces have members, and memberHost has already
+// paired the two sides by shape, so anything else yields nothing.
+func missingMembers(name string, committed, converted ast.Decl) []NewMember {
+	switch conv := converted.(type) {
+	case *ast.ClassDecl:
+		host, ok := committed.(*ast.ClassDecl)
+		if !ok {
+			return nil
+		}
+		filled := set.NewSet[memberSlot]()
+		for _, elem := range host.Body {
+			if slot, ok := classElemSlot(elem); ok {
+				filled.Add(slot)
+			}
+		}
+		var out []NewMember
+		for _, elem := range conv.Body {
+			slot, ok := classElemSlot(elem)
+			if !ok || filled.Contains(slot) {
+				continue
+			}
+			filled.Add(slot)
+			out = append(out, NewMember{Owner: name, Name: slot.Name, Static: slot.Static})
+		}
+		return out
+
+	case *ast.InterfaceDecl:
+		host, ok := committed.(*ast.InterfaceDecl)
+		if !ok || host.TypeAnn == nil || conv.TypeAnn == nil {
+			return nil
+		}
+		filled := set.NewSet[memberSlot]()
+		for _, elem := range host.TypeAnn.Elems {
+			if slot, ok := objElemSlot(elem); ok {
+				filled.Add(slot)
+			}
+		}
+		var out []NewMember
+		for _, elem := range conv.TypeAnn.Elems {
+			slot, ok := objElemSlot(elem)
+			if !ok || filled.Contains(slot) {
+				continue
+			}
+			filled.Add(slot)
+			out = append(out, NewMember{Owner: name, Name: slot.Name, Static: slot.Static})
+		}
+		return out
+	}
+	return nil
+}
+
+// memberSlot identifies a member by the name it is addressed with plus
+// which side of the class it lives on. Members share a slot when a
+// hand-edit could have turned one into the other: a converted
+// `readonly x: T` field and a committed `get x() -> T` occupy the same
+// slot, so the check leaves the hand-written getter alone instead of
+// reporting the field missing beside it.
+//
+// Overload sets collapse to one slot too. Whether the committed
+// overloads still cover the `.d.ts` ones is a signature question, which
+// §6.4 checks 2 and 3 answer once the solver can compare them.
+type memberSlot struct {
+	Name   string
+	Static bool
+}
+
+// classElemSlot returns the slot a class member fills. The bool is
+// false for a member whose key is neither an identifier, a string
+// literal, nor a dotted computed key such as `[Symbol.iterator]`. Both
+// sides run through this function, so an unnameable member is invisible
+// to the member diff and is never reported.
+func classElemSlot(elem ast.ClassElem) (memberSlot, bool) {
+	switch e := elem.(type) {
+	case *ast.FieldElem:
+		return slotFor(e.Name, e.Static)
+	case *ast.MethodElem:
+		return slotFor(e.Name, e.Static)
+	case *ast.GetterElem:
+		return slotFor(e.Name, e.Static)
+	case *ast.SetterElem:
+		return slotFor(e.Name, e.Static)
+	case *ast.ConstructorElem:
+		return memberSlot{Name: "constructor"}, true
+	}
+	return memberSlot{}, false
+}
+
+// objElemSlot is classElemSlot for an interface or object-type member.
+// Call and construct signatures carry no name, so the diff passes over
+// them the same way it passes over an unnameable key.
+func objElemSlot(elem ast.ObjTypeAnnElem) (memberSlot, bool) {
+	switch e := elem.(type) {
+	case *ast.PropertyTypeAnn:
+		return slotFor(e.Name, false)
+	case *ast.MethodTypeAnn:
+		return slotFor(e.Name, false)
+	case *ast.GetterTypeAnn:
+		return slotFor(e.Name, false)
+	case *ast.SetterTypeAnn:
+		return slotFor(e.Name, false)
+	}
+	return memberSlot{}, false
+}
+
+// slotFor builds a memberSlot from a member key, reporting false for a
+// key with no stable textual name.
+func slotFor(key ast.ObjKey, static bool) (memberSlot, bool) {
+	switch k := key.(type) {
+	case *ast.IdentExpr:
+		return memberSlot{Name: k.Name, Static: static}, true
+	case *ast.StrLit:
+		return memberSlot{Name: k.Value, Static: static}, true
+	case *ast.ComputedKey:
+		if dotted := astExprDottedName(k.Expr); dotted != "" {
+			return memberSlot{Name: dotted, Static: static}, true
+		}
+	}
+	return memberSlot{}, false
 }
 
 // escDeclName returns the name a top-level declaration is addressed by,

--- a/internal/dts_to_esc/rerun_test.go
+++ b/internal/dts_to_esc/rerun_test.go
@@ -91,8 +91,9 @@ declare var Array: ArrayConstructor;
 	require.NoError(t, err)
 	require.False(t, report.Failed())
 
-	decls, removed := report.Counts()
+	decls, members, removed := report.Counts()
 	require.Equal(t, 0, decls)
+	require.Equal(t, 0, members)
 	require.Equal(t, 0, removed)
 }
 
@@ -140,6 +141,8 @@ declare var Array: ArrayConstructor;
 	writeEsc(t, root, "std/array.esc", `@js("Array")
 export declare class Array<T> {
     length: number,
+    constructor(mut self),
+    static readonly prototype: Array<any>,
 }
 
 export type MyArrayHelper<T> = Array<T>
@@ -148,12 +151,78 @@ export type MyArrayHelper<T> = Array<T>
 	report, err := CheckPartition(res, root)
 	require.NoError(t, err)
 
-	diff := findDiff(t, report, "std:array")
-	require.True(t, diff.Exists)
-	require.Empty(t, diff.NewDecls)
-	require.Equal(t, []string{"MyArrayHelper"}, diff.Removed)
+	// Nothing is missing on either side; the one finding is the `.esc`
+	// declaration the `.d.ts` has no counterpart for, which the report
+	// names and leaves in place.
+	var sb strings.Builder
+	require.NoError(t, report.Write(&sb))
+	snaps.MatchInlineSnapshot(t, sb.String(), snaps.Inline(`std:array (std/array.esc)
+  extra declaration: MyArrayHelper (absent from the .d.ts; not removed)
+check: 0 missing declarations, 0 missing members, 1 extra declarations
+note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
+`))
 
 	// An extra declaration is informational, so it does not fail CI.
+	// That verdict is the one fact the rendered report does not carry.
+	require.False(t, report.Failed())
+}
+
+func TestCheckPartition_ReportsMissingMembers(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", `
+interface Array<T> { length: number; indexOf(searchElement: T): number; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; readonly prototype: Array<any>; }
+declare var Array: ArrayConstructor;
+`)
+	root := t.TempDir()
+	writeEsc(t, root, "std/array.esc", `@js("Array")
+export declare class Array<T> {
+    length: number,
+}
+`)
+
+	report, err := CheckPartition(res, root)
+	require.NoError(t, err)
+	require.True(t, report.Failed())
+
+	// The rendered report carries every fact this test is about: no
+	// declaration is missing because the class itself is committed, and
+	// each of the four members the `.d.ts` adds is named, static ones
+	// marked as such. Members are listed in the order the converted
+	// class declares them.
+	var sb strings.Builder
+	require.NoError(t, report.Write(&sb))
+	snaps.MatchInlineSnapshot(t, sb.String(), snaps.Inline(`std:array (std/array.esc)
+  missing member: Array.indexOf
+  missing member: Array.constructor
+  missing member: Array.isArray (static)
+  missing member: Array.prototype (static)
+check: 0 missing declarations, 4 missing members, 0 extra declarations
+note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
+`))
+}
+
+func TestCheckPartition_AHandWrittenGetterFillsTheFieldSlot(t *testing.T) {
+	t.Parallel()
+	// A §7 hand-edit that turns a converted `readonly` field into a
+	// getter is a refinement, not a gap: the check must leave it alone
+	// rather than reporting the field missing beside it.
+	res := partitionOf(t, "lib.es5.d.ts", `
+interface Array<T> { readonly length: number; }
+interface ArrayConstructor { new <T>(): Array<T>; readonly prototype: Array<any>; }
+declare var Array: ArrayConstructor;
+`)
+	root := t.TempDir()
+	writeEsc(t, root, "std/array.esc", `@js("Array")
+export declare class Array<T> {
+    get length(self) -> number,
+    constructor(mut self),
+    static readonly prototype: Array<any>,
+}
+`)
+
+	report, err := CheckPartition(res, root)
+	require.NoError(t, err)
 	require.False(t, report.Failed())
 }
 
@@ -179,7 +248,7 @@ declare var Array: ArrayConstructor;
 	snaps.MatchInlineSnapshot(t, sb.String(), snaps.Inline(`std:array (std/array.esc)
   missing file
   missing declaration: Array (class)
-check: 1 missing declarations, 0 extra declarations
+check: 1 missing declarations, 0 missing members, 0 extra declarations
 note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
 `))
 }
@@ -232,6 +301,7 @@ export declare interface WeakRefConstructor {
 	require.NoError(t, err)
 	diff := findDiff(t, report, "std:weak_ref")
 	require.Empty(t, diff.NewDecls, "the fused class covers both converted halves")
+	require.Empty(t, diff.NewMembers)
 	require.False(t, report.Failed())
 }
 

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -47,7 +47,7 @@ func TestRun_CheckFailsOnAnEmptyTree(t *testing.T) {
 	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`std:array (std/array.esc)
   missing file
   missing declaration: Array (class)
-check: 1 missing declarations, 0 extra declarations
+check: 1 missing declarations, 0 missing members, 0 extra declarations
 note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
 `))
 }
@@ -147,7 +147,7 @@ func TestRun_CheckPassesOnASeededTree(t *testing.T) {
 
 	var stdout strings.Builder
 	require.NoError(t, run([]string{"check", libDir, escDir}, &stdout, io.Discard))
-	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`check: 0 missing declarations, 0 extra declarations
+	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`check: 0 missing declarations, 0 missing members, 0 extra declarations
 note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
 `))
 }


### PR DESCRIPTION
Refs #1229. Third of four PRs splitting §6.4 of the builtins plan. Replaces #1251.

**Based on #1254** — review #1253 and #1254 first.

## What this does

Extends the check from "does the committed `.esc` file declare this name" to "does the committed declaration carry this member". A TypeScript bump that adds a method to `Array` changes no declaration name, so the declaration-level check alone reports a clean tree while the class is a method short.

## Scope note

§6.4 states check 1 over declarations, not members. This PR is that extension, isolated so it can be accepted or rejected on its own. The argument for it: the §6.4 write mode adds members, so a check that stayed silent about them would tell CI a bump was clean while the write mode still had methods to add.

## The matching rule

A member is identified by its name plus which side of the class it lives on, and nothing else. Two consequences, both deliberate:

- A converted `readonly x: T` field and a committed `get x() -> T` fill the same slot. A contributor who refined the field into a getter does not get the field reported missing beside it.
- An overload set collapses to one slot. Whether the committed overloads still cover the `.d.ts` ones is a signature question, which §6.4 checks 2 and 3 answer once the solver can compare the two sides.

Members whose key is neither an identifier, a string literal, nor a dotted computed key such as `[Symbol.iterator]` are invisible to the diff. Both sides run through the same slot function, so an unnameable key on one side cannot mask a nameable one on the other — the failure mode is silence, not a false report.

Only a class-to-class or interface-to-interface pair is compared. The two forms hold their members in different slots, and rewriting one into the other is a signature change §6.4 leaves to a contributor.

## Testing

`TestCheckPartition_ReportsMissingMembers` covers the instance/static/constructor cases; `TestCheckPartition_AHandWrittenGetterFillsTheFieldSlot` pins the refinement rule. The lib.es5 round-trip gate from #1254 still passes with member checking on, which is the real evidence the slot keys agree across a full conversion. `go test ./...` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AggxQCRLhHRt6QdY6BDfTV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interoperability checks now detect missing class and interface members, including constructors, static members, getters, and computed properties.
  * Reports now include missing-member counts alongside missing declarations and removed declarations.
  * Improved matching handles equivalent class or interface shapes and avoids false positives for unsupported or unnamed signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->