### PR TITLE
Rewrite language documentation with new design

### DIFF
--- a/docs/00_types.md
+++ b/docs/00_types.md
@@ -122,8 +122,14 @@ val x = p.x           // x: number
 
 Nominality follows the compilation target. Escalier compiles to JavaScript,
 where `instanceof` distinguishes two classes with identical fields, so the type
-system distinguishes them too. TypeScript treats classes structurally and gets a
-different answer for the same program.
+system distinguishes them too.
+
+TypeScript answers differently, and conditionally. It compares two classes by
+their public members, so classes with matching public shapes are interchangeable.
+Private and protected members are the exception: they match only when both sides
+inherit them from the same declaration, which makes a class carrying one behave
+nominally. Escalier applies the nominal rule to every class instead of leaving it
+to whether the class happens to declare a private member.
 
 A class instance is exact when the class is `final`; a non-`final` class may have
 subclass instances, so its instance type stays inexact.

--- a/docs/00_types.md
+++ b/docs/00_types.md
@@ -128,6 +128,35 @@ different answer for the same program.
 A class instance is exact when the class is `final`; a non-`final` class may have
 subclass instances, so its instance type stays inexact.
 
+### `sealed` classes
+
+Not implemented; see [#842](https://github.com/escalier-lang/escalier/issues/842).
+
+A `sealed` class sits between `final` and the open default. It may be subclassed
+inside the module that declares it, and an `extends` from a module that imports
+it is an error.
+
+`final` and `sealed` close different things, and the two axes are orthogonal.
+
+- `final` closes the instance **width**. There are no subclasses, so an instance
+  has exactly the declared members and the instance type is exact.
+- `sealed` closes the **set of alternatives**. A sealed base still has
+  subclasses, so a base-typed value may carry members the base does not declare,
+  and its instance type stays inexact. What is closed is the set of classes such
+  a value can be at runtime.
+
+Closing the alternatives is what makes a `match` over the hierarchy exhaustive.
+The checker can enumerate every permitted subclass and discriminate with
+`instanceof`, the same strategy it uses for enums. That buys the one thing
+neither existing option does: a shared base carrying fields and methods, with a
+closed set of leaves.
+
+So reach for an enum when the cases are independent shapes, and for a sealed
+class when they share inherited behavior.
+
+Escalier's `sealed` is not C#'s. C# spells `final` as `sealed` and forbids
+subclassing outright, which is the opposite of the concept here.
+
 ## Enums
 
 Enums are variant types with their own namespace. An enum name binds both a type

--- a/docs/00_types.md
+++ b/docs/00_types.md
@@ -1,114 +1,274 @@
 # 00 Types
 
-Escalier supports the same types supported by TypeScript.  This results in very
-good interop.
+Escalier's type system is built on **algebraic subtyping**. Every expression has
+exactly one principal type, inference never needs annotations to succeed, and
+subtyping is a lattice rather than a set of unification rules. The checker lives
+in [internal/solver/](../internal/solver/).
 
-There are some additional types that Escalier provides.  These types will be
-converted to the closest TypeScript equivalent when the compiler generates .d.ts
-files.  TSDoc comments are included in the output so that an Escalier program
-importing the .d.ts files will be able to use the original original types.
+Two consequences shape everything below.
+
+- **Types form a Boolean algebra.** Union `|`, intersection `&`, and negation
+  `~` are all first-class, with `unknown` at the top and `never` at the bottom.
+- **Inference is usage-driven.** A type variable carries a list of lower bounds
+  and a list of upper bounds. Reading a field adds an upper bound, passing a
+  value adds a lower bound, and the final type is read off those bounds.
+
+## Primitives and literals
+
+`number`, `string`, and `boolean` are the primitive types, and `null` and
+`undefined` are two atoms with one inhabitant each. Every literal also names a
+type of its own.
+
+```esc
+val a = 5           // a: 5
+val c = "hi"        // c: "hi"
+val b: number = 5   // b: number
+var d = 5           // d: number
+```
+
+A `val` keeps the literal type, since the binding can never hold anything else. A
+`var` widens to the primitive, since it can be reassigned. An annotation fixes
+whichever type it names.
+
+## `unknown` and `never`
+
+`unknown` is the top of the lattice: every type is a subtype of it, and nothing
+can be read off a value typed `unknown` without narrowing first. `never` is the
+bottom: it has no values, and it is what `throw` and a diverging branch
+contribute to a union.
 
 ## `any`
 
-There are a few different situations where `any` can be considered "safe":
-- appearing in type constraints
-- appearing in conditionals
-- annotation function params in function types and in .d.ts files, function declarations
+`any` is not part of the type system. Where TypeScript's `.d.ts` files use `any`
+in a position Escalier can express, the importer lowers it to `unknown`; where it
+appears in a constraint or a conditional's pattern, the corresponding Escalier
+form uses `unknown` or the `_` marker described below. There is no escape hatch
+that silently disables checking.
 
-We can use `never` and `unknown`, but the user has to remember which one to use
-in order to get the right behaviour, e.g.
+## Objects and tuples
 
-```ts
-type IsFunc<T extends (...args: never[]) => unknown> = T extends (...args: never[]) => unknown ? true : false
+Object and tuple types are structural and **exact by default** — a value may not
+carry members the type does not declare. A trailing `...` opts into inexactness.
+
+```esc
+type ExactPoint = {x: number, y: number}
+type OpenPoint  = {x: number, y: number, ...}
+
+type Pair       = [string, number]
+type OpenPair   = [string, number, ...]
 ```
 
-It's easier to allow the use of `any` in this type instead.  It will have the
-exact same semantics:
+Members may be optional or read-only:
 
-```ts
-type IsFunc<T extends (...args: any[]) => any> = T extends (...args: any[]) => any ? true : false
+```esc
+type Config = {
+    host: string,
+    port?: number,
+    readonly id: string,
+}
 ```
 
-All other uses of `any` will be converted to `unknown`, e.g. `JSON`'s `parse`
-method will be update like so upon import.
+`?` marks a member that may be absent. `readonly` forbids reassigning the member
+but says nothing about the depth of the value it holds. See
+[Exact Types](07_exact_types.md) for the subtyping rules and
+[Mutability](08_mutability.md) for how `readonly` relates to `mut`.
 
-```ts
-// lib.es5.d.ts
-parse(text: string, reviver?: (this: any, key: string, value: any) => any): any;
+## Unions, intersections, and negation
 
-// imported
-parse(text: string, reviver?: (this: any, key: string, value: any) => any): unknown;
+```esc
+type Id     = string | number
+type Both   = {x: number} & {y: number}
+type NotNum = ~number
 ```
 
-NOTE: `any` can be used in type annotations for imported types.
+`~T` is the set-theoretic complement of `T`: every value `T` rejects. The solver
+normalizes unions, intersections, and negations to disjunctive and conjunctive
+normal form rather than guessing which alternative to commit to, so these
+compose in any position, including under a type variable.
 
-## Exact types
-
-TODO
+A union is exact by default like the other formers. `A | B | ...` is an inexact
+union that may hold members beyond the ones written, which is what makes an
+exhaustive `match` over it require a catch-all arm.
 
 ## Classes
 
-Classes are nominally typed.  Even though the class name isn't part of a class'
-structure, it does affect the result of `instanceof` of checks, e.g.
+Classes are **nominal**. A value of class `Point` is not assignable to an exact
+structural `{x: number, y: number}`, and a structural object is never assignable
+to `Point`, however well the fields line up. A class instance does satisfy an
+**inexact** object target structurally, so the target's exactness is what decides.
 
-```js
-// NOTE: This code block is written in JavaScript
-class Foo {}
-class Bar {}
+```esc
+class Point {
+    x: number,
+    y: number,
+    getX(self) -> number { return self.x },
+}
 
-const foo = new Foo();
-
-foo instanceof Foo; // true
-foo instanceof Bar; // false
+val p = Point(1, 2)   // p: Point — no `new` keyword
+val x = p.x           // x: number
 ```
 
-Because Escalier compiles to JavaScript so its type semantics should reflect the
-semantics of its target.  This differs from TypeScript which treats classes as
-strictly structural.
+Nominality follows the compilation target. Escalier compiles to JavaScript,
+where `instanceof` distinguishes two classes with identical fields, so the type
+system distinguishes them too. TypeScript treats classes structurally and gets a
+different answer for the same program.
+
+A class instance is exact when the class is `final`; a non-`final` class may have
+subclass instances, so its instance type stays inexact.
 
 ## Enums
 
-Escalier enums are implemented as classes with extractors.  This is significantly
-different from TypeScript's enums.  When importing enums from .d.ts they will be
-modelled in the following way:
+Enums are variant types with their own namespace. An enum name binds both a type
+and a namespace of variant constructors.
 
-```ts
-// TypeScript representation
-enum MyEnum {
-    Foo,
-    Bar,
-    Baz
-}
-enum StringEnum {
-    MouseUp = "mouseup",
-    MouseDown = "mousedown",
-    MouseClick = "mouseclick",
+```esc
+enum Color {
+    RGB(r: number, g: number, b: number),
+    Hex(code: string),
 }
 
-// Escalier representation
-type MyEnum = 0 | 1 | 2
-val MyEnum = {
-    Foo: 0,
-    Bar: 0,
-    Baz: 0,
-}
-
-type StringEnum = "mouseup" | "mousedown" | "mouseclick"
-val StringEnum = {
-    MouseUp: "mouseup",
-    MouseDown: "mousedown",
-    MouseClick: "mouseclick",
-}
+val red = Color.RGB(255, 0, 0)   // red: Color
 ```
 
-See [Enums](05_enums.md) for information on Escalier enums.
+See [Enums](05_enums.md).
 
-## `Compose` and `Pipe` utility types
+## Ownership and mutability in types
 
-These types can be used to compose a sequence of functions.  For interop we can
-replace the `Compose<F1, F2, ..., Fn>` type with it's result by expanding it 
-before exporting it.
+A type annotation also records whether a value is owned or borrowed, and whether
+it is mutable.
 
-## Regex checked string type
+| | owned | borrowed |
+|---|---|---|
+| immutable | `{x: number}` | `&{x: number}` |
+| mutable | `mut {x: number}` | `&mut {x: number}` |
 
-TODO: link to the RFC for this.
+A borrow may name its lifetime, as in `&'a mut {x: number}`. These two axes are
+covered in [Mutability](08_mutability.md) and [Ownership](09_ownership.md).
+
+## Type aliases and generics
+
+```esc
+type Pair<T> = [T, T]
+type Tree<T> = {value: T, children: Array<Tree<T>>}
+
+fn id<T>(x: T) -> T { return x }
+```
+
+Aliases may be recursive and mutually recursive across files. The dependency
+graph orders declarations, so an alias may reference one written later in the
+source.
+
+Functions may also carry lifetime parameters, written `<'a>` and optionally
+bounded with `'a: 'b`. See [Ownership](09_ownership.md).
+
+## Type-level operators
+
+Escalier has TypeScript's type-level operator surface with syntax adapted to the
+rest of the language.
+
+**`keyof`** yields the union of a type's keys.
+
+```esc
+type Keys = keyof {x: number, y: string}   // "x" | "y"
+```
+
+**Indexed access** reads a member type out.
+
+```esc
+type X = {x: number, y: string}["x"]   // number
+```
+
+**`typeof`** lifts a value's type into type position.
+
+```esc
+val origin = {x: 0, y: 0}
+type Origin = typeof origin
+```
+
+**Conditional types** are written as `if`/`else` rather than with `extends` and
+`?`. The pattern may capture with `infer`.
+
+```esc
+type Elem<T> = if T : Array<infer E> { E } else { never }
+```
+
+`_` in a pattern is an `infer` clause with no name. The match fills it and the
+capture is dropped, which is how a pattern names only the position it cares
+about.
+
+```esc
+type ReturnType<F: fn (...args: Array<_>) -> _> =
+    if F : fn (...args: Array<_>) -> infer R { R } else { never }
+```
+
+A type parameter's constraint is written with `:`, as `F` does above.
+
+**Mapped types** are written as a comprehension. Two forms exist and mean the
+same thing.
+
+```esc
+type Copy1<T> = {[K: keyof T]: T[K]}
+type Copy2<T> = {[K]: T[K] for K in keyof T}
+```
+
+Modifiers go where they would on an ordinary member. `?` adds optionality, `-?`
+removes it, and `readonly` adds read-only.
+
+```esc
+type Partial<T>  = {[K]?: T[K] for K in keyof T}
+type Required<T> = {[K]-?: T[K] for K in keyof T}
+type Readonly<T> = {readonly [K]: T[K] for K in keyof T}
+```
+
+A trailing `if` clause filters the key set. TypeScript has no filter clause and
+expresses the same thing by remapping a key to `never`; Escalier accepts that
+bracketed form too.
+
+```esc
+type Pick<T, Ks> = {[K]: T[K] for K in keyof T if K : Ks}
+type Omit<T, Ks> = {[if K : Ks { never } else { K }]: T[K] for K in keyof T}
+```
+
+**Template literal types** build string types from parts.
+
+```esc
+type Getters<T> = {[`get${Capitalize<K>}`]: T[K] for K in keyof T}
+```
+
+The utility types TypeScript ships in its standard library are ordinary Escalier
+aliases written with these operators, not compiler magic. The exceptions are
+`Uppercase`, `Lowercase`, `Capitalize`, `Uncapitalize`, and `NoInfer`, which are
+checker-resident handlers with no source definition. They come from `std:object`
+and `std:function`; see [Imports](03_imports.md).
+
+## The `_` marker
+
+`_` in a type annotation is a hole: it asks the checker to infer that position
+instead of fixing it.
+
+```esc
+async fn f() -> Promise<_, _> { ... }   // infer both the payload and the rejection
+fn g() throws _ { ... }                 // infer what the body throws
+```
+
+A displayed type never contains `_`. Everything the compiler infers, it can also
+print as a type the program could have written.
+
+## TypeScript interop
+
+Escalier reads TypeScript declarations and emits them, so most types have a
+direct counterpart. The places they differ:
+
+| Escalier | TypeScript |
+|---|---|
+| Objects and tuples exact by default | Always inexact |
+| Classes nominal | Structural |
+| Enums are variant types with extractors | `enum` is a numeric or string map |
+| `~T` negation | No equivalent |
+| `Promise<T, E>` carries a rejection type | `Promise<T>` only |
+| `mut` / `&` / lifetimes | No equivalent |
+
+Types imported from TypeScript are **inexact** in every category, since a `.d.ts`
+file cannot state that a shape is closed. Emitted declarations carry the original
+Escalier type in a JSDoc field so that an Escalier program importing them
+recovers the exact type.

--- a/docs/00_types.md
+++ b/docs/00_types.md
@@ -54,11 +54,11 @@ Object and tuple types are structural and **exact by default** — a value may n
 carry members the type does not declare. A trailing `...` opts into inexactness.
 
 ```esc
-type ExactPoint = {x: number, y: number}
-type OpenPoint  = {x: number, y: number, ...}
+type ExactPoint   = {x: number, y: number}
+type InexactPoint = {x: number, y: number, ...}
 
-type Pair       = [string, number]
-type OpenPair   = [string, number, ...]
+type ExactPair    = [string, number]
+type InexactPair  = [string, number, ...]
 ```
 
 Members may be optional or read-only:

--- a/docs/00_types.md
+++ b/docs/00_types.md
@@ -10,8 +10,11 @@ Two consequences shape everything below.
 - **Types form a Boolean algebra.** Union `|`, intersection `&`, and negation
   `~` are all first-class, with `unknown` at the top and `never` at the bottom.
 - **Inference is usage-driven.** A type variable carries a list of lower bounds
-  and a list of upper bounds. Reading a field adds an upper bound, passing a
-  value adds a lower bound, and the final type is read off those bounds.
+  and a list of upper bounds, and every constraint the program imposes lands on
+  one of the two. Reading `p.x` records an upper bound on `p`'s variable, saying
+  the value must have an `x`. Flowing a value into a position records a lower
+  bound on that position's variable, saying the position must accept that value.
+  The final type is read off the two lists.
 
 ## Primitives and literals
 
@@ -68,9 +71,8 @@ type Config = {
 }
 ```
 
-`?` marks a member that may be absent. `readonly` forbids reassigning the member
-but says nothing about the depth of the value it holds. See
-[Exact Types](07_exact_types.md) for the subtyping rules and
+`?` marks a member that may be absent. `readonly` forbids reassigning the member.
+See [Exact Types](07_exact_types.md) for the subtyping rules and
 [Mutability](08_mutability.md) for how `readonly` relates to `mut`.
 
 ## Unions, intersections, and negation
@@ -83,12 +85,12 @@ type NotNum = ~number
 
 `~T` is the set-theoretic complement of `T`: every value `T` rejects. The solver
 normalizes unions, intersections, and negations to disjunctive and conjunctive
-normal form rather than guessing which alternative to commit to, so these
-compose in any position, including under a type variable.
+normal forms rather than guessing which alternative to commit to, so the three
+compose in any position, including inside an inference variable's bounds.
 
-A union is exact by default like the other formers. `A | B | ...` is an inexact
-union that may hold members beyond the ones written, which is what makes an
-exhaustive `match` over it require a catch-all arm.
+Unions are always closed. There is no syntax for a union that may hold members
+beyond the ones listed, so `string`, `number`, or `unknown` is how you name an
+open set of values.
 
 ## Classes
 
@@ -96,6 +98,16 @@ Classes are **nominal**. A value of class `Point` is not assignable to an exact
 structural `{x: number, y: number}`, and a structural object is never assignable
 to `Point`, however well the fields line up. A class instance does satisfy an
 **inexact** object target structurally, so the target's exactness is what decides.
+
+Nominality governs assignability, not pattern matching. An object pattern
+destructures a class instance by field:
+
+```esc
+fn f(p: Point) {
+    val {x, y} = p    // x: number, y: number
+    return x
+}
+```
 
 ```esc
 class Point {
@@ -158,8 +170,15 @@ Aliases may be recursive and mutually recursive across files. The dependency
 graph orders declarations, so an alias may reference one written later in the
 source.
 
-Functions may also carry lifetime parameters, written `<'a>` and optionally
-bounded with `'a: 'b`. See [Ownership](09_ownership.md).
+Lifetime parameters are written in the same list, `<'a>`, and optionally bounded
+with `'a: 'b`. Functions, classes, interfaces, and type aliases may all take
+them; enums may not. See [Ownership](09_ownership.md).
+
+```esc
+type Ref<'a, T> = &'a T
+class Container<'a> { p: &'a {x: number} }
+declare fn id<'a>(p: &'a {x: number}) -> &'a {x: number}
+```
 
 ## Type-level operators
 
@@ -226,6 +245,13 @@ bracketed form too.
 
 ```esc
 type Pick<T, Ks> = {[K]: T[K] for K in keyof T if K : Ks}
+type Omit<T, Ks> = {[K]: T[K] for K in keyof T if K : ~Ks}
+```
+
+The same filtering can be written as a key remapping to `never`, which is how
+TypeScript spells it, and Escalier accepts that form too:
+
+```esc
 type Omit<T, Ks> = {[if K : Ks { never } else { K }]: T[K] for K in keyof T}
 ```
 

--- a/docs/01_destructuring.md
+++ b/docs/01_destructuring.md
@@ -1,41 +1,93 @@
 # 01 Destructuring
 
-Destructuring can be used to bind parts of an expression to different variables.
+Destructuring binds parts of a value to separate names.
 
-```ts
-val [a, b, c] = [1, 2, 3] // same as `val a = 1`, `val b = 2`, `val c = 3`
+```esc
+val [a, b, c] = [1, 2, 3]     // a = 1, b = 2, c = 3
+
 val point = {x: 5, y: 10}
-val {x, y} = point // same as `val x = point.x`, `val y = point.y`
+val {x, y} = point            // x = 5, y = 10
 ```
 
-Destructuring can also used with assignment statements.
+Patterns nest:
 
-```ts
+```esc
+val {p: {x}} = {p: {x: 5}}
+val [[a], b] = [[1], 2]
+```
+
+## Renaming
+
+```esc
+val {x: a, y: b} = {x: 5, y: 10}   // a = 5, b = 10
+```
+
+## Rest elements
+
+An ellipsis captures whatever the earlier elements did not.
+
+```esc
+val [a, ...rest] = [1, 2, 3]       // rest = [2, 3]
+val {x, ...rest} = {x: 5, y: 10}   // rest = {y: 10}
+```
+
+The rest binding carries the source's exactness: destructuring an exact object
+leaves an exact rest, and an inexact one leaves an inexact rest. See
+[Exact Types](07_exact_types.md).
+
+## `val`, `var`, and `mut`
+
+Two different kinds of mutability meet in a binding, and they are independent.
+
+- `val` binds a name once; `var` binds a name that can be reassigned. This is the
+  difference JavaScript spells `const` and `let`.
+- `mut` marks the *value* as writable through the binding.
+
+```esc
+val p = {x: 0}         // cannot reassign p; cannot write p.x
+val mut q = {x: 0}     // cannot reassign q; can write q.x
+var r = {x: 0}         // can reassign r; cannot write r.x
+var mut s = {x: 0}     // can reassign s; can write s.x
+```
+
+Inside a destructuring pattern, `mut` attaches to each binding leaf rather than
+to the surrounding pattern, because mutability belongs to the place:
+
+```esc
+val {mut x, y: mut a} = point
+```
+
+Writing `mut {x, y}` is rejected, and the diagnostic names the per-leaf form.
+
+## Type annotations
+
+A binding leaf may carry an annotation. In a refutable form it also narrows; see
+[Pattern Matching](04_pattern_matching.md).
+
+```esc
+val {x, y}: {x: number, y: number} = point
+val {a: n}: {a: number} = record
+```
+
+## Ownership
+
+Destructuring moves or borrows each extracted part following the ordinary
+ownership rules. Extracting a field of an owned object moves that field's slot
+and leaves the siblings usable, and annotating a leaf with `&` borrows instead.
+See [Ownership](09_ownership.md).
+
+## Assignment targets
+
+Destructuring works in `val` and `var` declarations and in function parameters.
+It does not work on the left of an assignment: the assignable targets are a `var`
+name and a member expression such as `obj.x`.
+
+```esc
 var x = 0
-var y = 0
-val point = {x: 5, y: 10}
-{x, y} = point
-```
+x = 5             // OK
 
-Destructuring of objects and arrays can include "rest" elements, specified using
-ellipsis, to capture the remaining values.
+var mut p = {x: 0}
+p.x = 5           // OK
 
-```ts
-val [a, ...rest] = [1, 2, 3] // `rest` will have the value `[2, 3]`
-val point = {x: 5, y: 10}
-val {x, ...rest} = point // `rest` will have the value `{y: 10}`
-```
-
-Variables can be renamed when destructuring objects
-
-```ts
-val {x: a, y: b} = {x: 5, y: 10} // `a` will be `5` and `b` will be `10`
-```
-
-Tuples can be used to swap variables, but only if they are the same type.
-
-```ts
-var x: number = 5
-var y: number = 10
-[y, x] = [x, y]
+// {x, y} = point // not supported
 ```

--- a/docs/02_functions.md
+++ b/docs/02_functions.md
@@ -1,10 +1,10 @@
 # 02 Functions
 
-## Type Annotations
+## Declarations and inference
 
-```ts
-// Function params must have type annotations, but the return type annotation
-// is optional since it can always be inferred.
+A function declaration names its parameters and, optionally, its return type.
+
+```esc
 fn add(a: number, b: number) {
     return a + b
 }
@@ -12,83 +12,211 @@ fn add(a: number, b: number) {
 fn sub(a: number, b: number) -> number {
     return a - b
 }
-
-fn sqrt(x: number) -> number throws RangeError {
-    if x < 0 {
-        throw RangeError("Can't take root of negative numbers")
-    }
-    return Math.sqrt(x)
-}
-
-// When passing a function expression as a callback, we can infer the param
-// types from the higher order function's callback param type.  Param types
-// can also be ommited when passing a function expression as a prop.  If you
-// assign the function to a variable function, the param types must be provided.
-const strings = ["1", "2", "3"]
-const numbers = strings.map(fn (elem, index) { return parseInt(elem) })
 ```
 
-The reason we don't allow function param types to be inferred from the usage
-of the params within the function is that it's difficult to infer object types
-from property access.
+The return type is always inferable from the body, so annotating it is optional.
+Parameter types are inferred too, from the body's usage of each parameter:
 
-## Destructuring Params
-
-TODO
-
-## Function Overloading
-
-TODO
-
-## Async/Await
-
+```esc
+fn dist(p) { p.x
+             p.y }
+// inferred: fn (p: {x: unknown, y: unknown}) -> undefined
 ```
-// Inferred as `fn(url: string) -> Promise<string>`
-async fn fetchJSON(url: string) {
-    val res = await fetch(url)
-    return res.json()
-}
 
-// Inferred as `fn(url: string) -> Promise<unknown, Error>`
-async fn fetchJSON(url: string) {
+The inferred parameter shape is **exact**, so a caller may not pass an object
+with extra fields. Mark the parameter `open` to keep it row-polymorphic:
+
+```esc
+fn dist(open p) { p.x
+                  p.y }
+// inferred: fn (p: {x: unknown, y: unknown, ...}) -> undefined
+```
+
+A function expression passed as a callback infers its parameter types from the
+higher-order function's signature:
+
+```esc
+val strings = ["1", "2", "3"]
+val numbers = strings.map(fn (elem, index) { return parseInt(elem) })
+```
+
+## Generics
+
+Type parameters are written in `<>` and may carry a constraint after `:`.
+
+```esc
+fn id<T>(x: T) -> T { return x }
+fn first<T>(x: T, y: T) -> T { return x }
+fn call<F: fn (x: number) -> number>(f: F) -> number { return f(1) }
+```
+
+Each call instantiates the parameters independently, so two calls to `id` keep
+their own argument types:
+
+```esc
+val a = id(5)      // a: 5
+val b = id("hi")   // b: "hi"
+```
+
+A function may also take **lifetime parameters**, written `<'a>` and optionally
+bounded with `'a: 'b`. They are inferred when possible and appear in the
+signature only when they connect an input to an output. See
+[Ownership](09_ownership.md).
+
+```esc
+declare fn id<'a>(p: &'a {x: number}) -> &'a {x: number}
+```
+
+## Parameters, ownership, and mutability
+
+A parameter's annotation says whether the function borrows its argument or takes
+ownership of it.
+
+```esc
+fn read(p: &{x: number}) -> number { return p.x }    // borrows; caller keeps p
+fn bump(p: &mut {x: number}) { p.x = p.x + 1 }       // mutable borrow
+fn store(p: {x: number}) { ... }                     // consumes; caller gives p up
+```
+
+The borrow is inserted at the call site, so a caller writes `read(p)` rather than
+`read(&p)`. An unannotated parameter is inferred: the checker picks a borrow when
+the body never lets the value escape and ownership when it does. See
+[Ownership](09_ownership.md) for what counts as escape.
+
+## `throws`
+
+A function's exceptional exits are part of its type. **Omitting the `throws`
+clause declares that the function raises nothing**, and a body that does raise is
+rejected at the site that raises.
+
+```esc
+fn f() { throw "boom" }
+// ERROR: cannot constrain "boom" <: never
+```
+
+Write `throws _` to infer the clause from the body:
+
+```esc
+fn f() throws _ { throw "boom" }
+// inferred: fn () -> never throws "boom"
+
+fn g(c: boolean) throws _ { if c { throw "a" } else { throw 5 } }
+// inferred: fn (c: boolean) -> never throws 5 | "a"
+```
+
+Write `throws T` to fix it, in which case each `throw` in the body is checked
+against `T` at its own site:
+
+```esc
+fn f() throws string { throw "boom" }    // OK — the literal widens to string
+fn g() throws number { throw "boom" }    // ERROR at the throw
+```
+
+A call raises whatever its callee declares, so the callee's `throws` reaches the
+caller's clause the way a `throw` in the caller's own body would. A body with no
+exceptional exit renders no clause, whether or not one was written. Nested
+functions own their own clause, so an inner function's `throws` does not leak
+into the enclosing one.
+
+See [Error Handling](06_error_handling.md) for `try`/`catch` and the rest.
+
+## Async and `await`
+
+An `async fn` returns `Promise<T, E>`, where `E` is the rejection type. Unlike a
+sync function, an `async fn` cannot raise: what its body throws is absorbed into
+the promise's rejection slot, so it never carries a `throws` clause.
+
+```esc
+async fn f() { throw "x" }
+// inferred: fn () -> Promise<never, "x">
+
+async fn g() { return 5 }
+// inferred: fn () -> Promise<5>
+```
+
+The rejection type may be written, in which case the body's throws are checked
+against it:
+
+```esc
+async fn fetchJSON(url: string) -> Promise<unknown, FetchError> {
     val res = await fetch(url)
     if !res.ok {
-        throw new Error(`couldn't fetch ${url}`)
+        throw FetchError(url)
     }
     return res.json()
 }
 ```
 
-`Promise<T, E = never>` differs from the `Promise` type provided by TypeScript.
-It has a second, optional type param that can be used to describe which errors
-an async function can throw.
+Either slot accepts `_` to infer just that slot:
 
-If an `await` expression is awaiting `Promise<T, E>` where `E` is not `never`,
-we will need to set the `ThrowsType` on this expression node.  This is used
-when determining what the caller throws.
-
-## Generators (post-MVP)
-
+```esc
+async fn f() -> Promise<_, _> { throw "x" }   // fn () -> Promise<never, "x">
 ```
-// Inferred as `fn(start: number, stop: number) -> Generator<number, "done", unknown>`
-gen fn range(start: number, stop: number) {
-    for i = start; i < stop; i++ {
-        yield i
-    }
-    return "done"
-}
 
+`Promise<T, E = never>` differs from TypeScript's `Promise<T>` by carrying the
+rejection type. Awaiting a `Promise<T, E>` where `E` is not `never` contributes
+`E` to the awaiting function's own rejection or `throws` clause.
+
+## Overloading
+
+Declaring the same name more than once at the top level makes it an overload
+set. A direct call resolves to the arm whose parameters accept the arguments.
+
+```esc
+fn f(x: number) -> number { return x }
+fn f(x: string) -> string { return x }
+
+val r = f(5)      // r: number
+val s = f("hi")   // s: string
+```
+
+Arms are tried most-specific-first when every argument has a known shape, and in
+declaration order otherwise. Overload resolution runs as a phase separate from
+subtyping, so "callable in several ways" never enters the type lattice. Each arm
+needs its own parameter annotations, since the runtime dispatcher generated for
+the set is built from them.
+
+## Generators
+
+```esc
+gen fn f() { yield 1 }
+// inferred: fn () -> Generator<1, undefined, unknown>
+
+gen fn g() { yield 1
+             return "done" }
+// inferred: fn () -> Generator<1, "done", unknown>
+```
+
+The three type arguments are the yield type, the return type, and the type sent
+back in through `next`. Multiple `yield`s union their types. `async gen fn`
+produces an `AsyncGenerator` with the same shape.
+
+A generator's values are consumed with `for`-`in`:
+
+```esc
 for i in range(0, 10) {
     console.log(`i = ${i}`)
 }
+```
 
-// Inferred as `fn(url: string, intervalMs: number) -> AsyncGenerator<unknown, "done", unknown>
-async gen fn pollData(url: string, intervalMs: number) {
-    while (true) {
-        const response = await fetch(url);
-        yield await response.json();
-        await new Promise(resolve => setTimeout(resolve, intervalMs));
-    }
-    return "done"
+## Function subtyping and exactness
+
+A written function value is **exact**: it accepts exactly the arities its
+parameter list declares, and a direct call with extra arguments is rejected.
+Exactness governs callback subtyping. A function type accepts a set of argument
+counts — `[required, declared]` when exact, `[required, ∞)` when inexact — and
+`G <: F` when `G` accepts every count `F`'s holders may call with, with
+parameters contravariant and the return covariant. This is what lets a
+one-parameter callback be passed where a three-parameter one is expected.
+
+## Destructuring parameters
+
+Parameters accept the same patterns as `val` bindings.
+
+```esc
+fn dist({x, y}: {x: number, y: number}) -> number {
+    return Math.sqrt(x ** 2 + y ** 2)
 }
 ```
+
+See [Destructuring](01_destructuring.md).

--- a/docs/02_functions.md
+++ b/docs/02_functions.md
@@ -18,37 +18,62 @@ The return type is always inferable from the body, so annotating it is optional.
 Parameter types are inferred too, from the body's usage of each parameter:
 
 ```esc
-fn dist(p) { p.x
-             p.y }
-// inferred: fn (p: {x: unknown, y: unknown}) -> undefined
+import "std:math"
+
+fn dist(p) {
+    return math.sqrt(p.x * p.x + p.y * p.y)
+}
+// inferred: fn (p: {x: number, y: number}) -> number
 ```
+
+`p` is never annotated. Reading `p.x` says the argument must have an `x`, and
+multiplying it says that field must be a `number`, so the two constraints
+together give the parameter its type.
 
 The inferred parameter shape is **exact**, so a caller may not pass an object
 with extra fields. Mark the parameter `open` to keep it row-polymorphic:
 
 ```esc
-fn dist(open p) { p.x
-                  p.y }
-// inferred: fn (p: {x: unknown, y: unknown, ...}) -> undefined
+fn dist(open p) {
+    return math.sqrt(p.x * p.x + p.y * p.y)
+}
+// inferred: fn (p: {x: number, y: number, ...}) -> number
 ```
 
 A function expression passed as a callback infers its parameter types from the
 higher-order function's signature:
 
 ```esc
-val strings = ["1", "2", "3"]
-val numbers = strings.map(fn (elem, index) { return parseInt(elem) })
+import "std:array"
+import "std:number"
+
+val strings: Array<string> = ["1", "2", "3"]
+val numbers = strings.map(fn (elem, index) { return Number.parseInt(elem) })
+// elem: string, index: number, numbers: Array<number>
 ```
+
+`Array<T>.map` declares its callback as `fn (elem: T, index: number) -> U`, so
+`elem` and `index` are fixed by the slot the function expression lands in and `U`
+comes back from its body.
+
+The annotation on `strings` is what makes it an `Array<string>`. Without one,
+`val strings = ["1", "2", "3"]` infers the tuple `["1", "2", "3"]`, since a `val`
+binding keeps each element's literal type.
 
 ## Generics
 
-Type parameters are written in `<>` and may carry a constraint after `:`.
+Type parameters are written in `<>`, may carry a constraint after `:`, and may
+have a default after `=`.
 
 ```esc
 fn id<T>(x: T) -> T { return x }
 fn first<T>(x: T, y: T) -> T { return x }
 fn call<F: fn (x: number) -> number>(f: F) -> number { return f(1) }
+fn parse<T = string>(x: T) -> T { return x }
 ```
+
+A default fills the parameter in where the reference names no argument for it,
+so `type Box<T = number> = {value: T}` makes a bare `Box` mean `Box<number>`.
 
 Each call instantiates the parameters independently, so two calls to `id` keep
 their own argument types:
@@ -78,10 +103,11 @@ fn bump(p: &mut {x: number}) { p.x = p.x + 1 }       // mutable borrow
 fn store(p: {x: number}) { ... }                     // consumes; caller gives p up
 ```
 
-The borrow is inserted at the call site, so a caller writes `read(p)` rather than
-`read(&p)`. An unannotated parameter is inferred: the checker picks a borrow when
-the body never lets the value escape and ownership when it does. See
-[Ownership](09_ownership.md) for what counts as escape.
+The borrow is inserted at the call site, so a caller may write `read(p)`; writing
+`read(&p)` explicitly is also accepted. An unannotated parameter is inferred, and
+the checker picks a borrow when the body never lets the value escape and
+ownership when it does. See [Ownership](09_ownership.md) for what counts as
+escape.
 
 ## `throws`
 
@@ -94,7 +120,7 @@ fn f() { throw "boom" }
 // ERROR: cannot constrain "boom" <: never
 ```
 
-Write `throws _` to infer the clause from the body:
+Write `throws _` to read the clause off the body:
 
 ```esc
 fn f() throws _ { throw "boom" }
@@ -104,13 +130,25 @@ fn g(c: boolean) throws _ { if c { throw "a" } else { throw 5 } }
 // inferred: fn (c: boolean) -> never throws 5 | "a"
 ```
 
-Write `throws T` to fix it, in which case each `throw` in the body is checked
-against `T` at its own site:
+This is the point of the design. Checked exceptions in other languages make you
+enumerate what a function raises, which means tracing every call it makes and
+redoing that work whenever a callee changes. `throws _` opts a function into
+checked exceptions and leaves the enumeration to the compiler, so callers get the
+obligation without the author doing the bookkeeping. It is the same deal the
+return type already offers.
+
+Write `throws T` when you want to name the clause yourself. The declared type is
+what callers see, and each `throw` in the body is checked against it at its own
+site:
 
 ```esc
-fn f() throws string { throw "boom" }    // OK — the literal widens to string
+fn f() throws string { throw "boom" }    // the literal widens to string
 fn g() throws number { throw "boom" }    // ERROR at the throw
 ```
+
+Naming it is how you widen past what the body happens to raise today, so adding a
+second `throw` later does not change the signature every caller was written
+against.
 
 A call raises whatever its callee declares, so the callee's `throws` reaches the
 caller's clause the way a `throw` in the caller's own body would. A body with no

--- a/docs/02_functions.md
+++ b/docs/02_functions.md
@@ -103,11 +103,12 @@ fn bump(p: &mut {x: number}) { p.x = p.x + 1 }       // mutable borrow
 fn store(p: {x: number}) { ... }                     // consumes; caller gives p up
 ```
 
-The borrow is inserted at the call site, so a caller may write `read(p)`; writing
-`read(&p)` explicitly is also accepted. An unannotated parameter is inferred, and
-the checker picks a borrow when the body never lets the value escape and
-ownership when it does. See [Ownership](09_ownership.md) for what counts as
-escape.
+Passing an owned value to a borrowing parameter takes the same marker the
+parameter carries, so a caller writes `read(&p)` and `bump(&mut p)`. A method
+receiver is the exception and needs none. An unannotated parameter is inferred,
+and the checker picks a borrow when the body never lets the value escape and
+ownership when it does. See [Ownership](09_ownership.md) for the call-site rule
+and for what counts as escape.
 
 ## `throws`
 

--- a/docs/02_functions.md
+++ b/docs/02_functions.md
@@ -210,9 +210,36 @@ val s = f("hi")   // s: string
 
 Arms are tried most-specific-first when every argument has a known shape, and in
 declaration order otherwise. Overload resolution runs as a phase separate from
-subtyping, so "callable in several ways" never enters the type lattice. Each arm
-needs its own parameter annotations, since the runtime dispatcher generated for
-the set is built from them.
+subtyping, so "callable in several ways" never enters the type lattice.
+
+### How overloads compile
+
+JavaScript has no overloading, so the compiler merges the whole set into **one**
+function whose body dispatches on the arguments at runtime. Arms are emitted
+most-specific-first, and a call matching none of them throws.
+
+```esc
+fn dup(value: number) -> number { return 2 * value }
+fn dup(value: string) -> string { return value ++ value }
+```
+
+```js
+export function dup(param0) {
+  if (typeof param0 === "number") {
+    const value = param0;
+    return 2 * value;
+  } else if (typeof param0 === "string") {
+    const value = param0;
+    return value + value;
+  } else throw new TypeError("No overload matches the provided arguments for function 'dup'");
+}
+```
+
+The test for each arm comes from that arm's parameter annotations, which is why
+every arm needs them. A primitive becomes a `typeof` check, a class becomes an
+`instanceof` check, and an object type becomes a check per required property.
+Arity participates too, so a three-parameter arm is tested before a
+two-parameter one.
 
 ## Generators
 
@@ -229,9 +256,20 @@ The three type arguments are the yield type, the return type, and the type sent
 back in through `next`. Multiple `yield`s union their types. `async gen fn`
 produces an `AsyncGenerator` with the same shape.
 
-A generator's values are consumed with `for`-`in`:
+`yield from` delegates to another generator, and a generator's values are
+consumed with `for`-`in`:
 
 ```esc
+import "std:console"
+
+gen fn range(start: number, stop: number) {
+    if start < stop {
+        yield start
+        yield from range(start + 1, stop)
+    }
+}
+// inferred: fn (start: number, stop: number) -> Generator<number, undefined, unknown>
+
 for i in range(0, 10) {
     console.log(`i = ${i}`)
 }

--- a/docs/02_functions.md
+++ b/docs/02_functions.md
@@ -241,11 +241,33 @@ for i in range(0, 10) {
 
 A written function value is **exact**: it accepts exactly the arities its
 parameter list declares, and a direct call with extra arguments is rejected.
-Exactness governs callback subtyping. A function type accepts a set of argument
+
+Exactness governs callback subtyping. A function type accepts a range of argument
 counts — `[required, declared]` when exact, `[required, ∞)` when inexact — and
 `G <: F` when `G` accepts every count `F`'s holders may call with, with
-parameters contravariant and the return covariant. This is what lets a
-one-parameter callback be passed where a three-parameter one is expected.
+parameters contravariant and the return covariant.
+
+An exact value therefore has to match the slot's arity. Passing a
+one-parameter function where three arguments will be supplied is rejected,
+because its range is `[1, 1]` and the slot's holders call with 3:
+
+```esc
+declare fn hof(cb: fn (a: number, b: number, c: number) -> number) -> number
+
+val r = hof(fn (a) { return a })
+// ERROR: cannot constrain function of arity 1 <: function of arity 3
+```
+
+A trailing `...` makes the value inexact, opening its range to `[1, ∞)`, which
+does cover 3:
+
+```esc
+val r = hof(fn (a, ...) { return a })   // OK
+```
+
+This is the one place Escalier asks for something JavaScript does not. In
+JavaScript a callback may simply ignore trailing arguments; here that has to be
+stated, and `...` is how you state it.
 
 ## Destructuring parameters
 

--- a/docs/03_imports.md
+++ b/docs/03_imports.md
@@ -76,7 +76,9 @@ val d: Date = Date()          // construct — no `new` keyword
 ```
 
 The shortcut is structural: it fires when the package declares a top-level class
-whose name matches the lowercased URI segment. `std:array`, `std:string`,
+whose name matches the URI segment, ignoring case and the underscores that
+separate words in a package name. That is what pairs `std:weak_ref` with
+`WeakRef`. `std:array`, `std:string`,
 `std:number`, `std:boolean`, `std:bigint`, `std:regexp`, `std:symbol`,
 `std:object`, `std:function`, `std:date`, `std:map`, `std:set`, and
 `std:weak_ref` all qualify. `std:math` declares no `Math` class, so its binding
@@ -97,10 +99,12 @@ an error.
 
 ### Imports are runtime-erased
 
-At runtime `Math.sin` and `console.log` are already available in every JavaScript
-environment. A pseudo-package import adds type information to the compile-time
-scope and codegen deletes the import line. The package is a type-checking
-grouping mechanism with zero runtime cost.
+The names behind these imports already exist at runtime. `Math.sin` is an
+ECMAScript builtin, present in every conforming engine; `console.log` is a host
+API, present wherever the target JavaScript host provides one. A pseudo-package
+import adds type information to the compile-time scope and codegen deletes the
+import line, so the package is a type-checking grouping mechanism with zero
+runtime cost.
 
 Binding names are not always the runtime names, so each exported declaration in a
 pseudo-package carries a `@js("...")` decorator naming the JavaScript expression
@@ -145,7 +149,8 @@ Web families with no DOM coupling get their own packages: `web:fetch`,
 imports `web:dom` plus one or two siblings.
 
 A sibling that needs a `web:dom` type refers to it through a qualified name, so
-`web:fetch`'s `Response.body` returns a `web.streams.ReadableStream`.
+`web:fetch`'s `Response.body` is a `web.streams.ReadableStream | null` and has to
+be narrowed before a stream method can be called on it.
 Pseudo-packages import each other exactly like ordinary code, and import cycles
 between them are permitted.
 

--- a/docs/03_imports.md
+++ b/docs/03_imports.md
@@ -13,9 +13,13 @@ ambient name, and there is nothing left to take its union over. Neither does
 ## The two kinds of import
 
 ```escalier
-import "std:math"                       // pseudo-package: the JS and Web platform
-import * as lodash from "lodash"        // npm package
+import "std:math"    // pseudo-package: the JS and Web platform
+import "lodash"      // npm package
 ```
+
+Both forms are the same statement. The specifier names what to import and the
+binding follows from it; there is nothing to spell out about the namespace,
+since a package always binds as one.
 
 Pseudo-packages hold the platform surface Escalier owns as first-class `.esc`
 source. npm packages come from `node_modules` and are typed by their `.d.ts`
@@ -54,7 +58,7 @@ Package names use underscores, matching the file naming, so `import
 
 ### Named imports are not accepted
 
-All pseudo-package imports go through the bare form above. Writing
+Every import goes through the bare form above. Writing
 `import { sin } from "std:math"` is a compile error that points at the
 alternative. Qualified-only access is the Go convention: reading `math.sin(x)`
 makes the origin of `sin` visible at every call site, and gives editor tooling an
@@ -89,6 +93,21 @@ iteration protocol and `AggregateError`, so the access is `async.Promise.all(…
 
 Other exports of a shortcut package are reachable as namespace members on the
 same binding. Where a name collides, class statics win.
+
+`std:number` is the case that has one. It exports the `Number` class, whose
+static side already carries `parseInt`, and it also owns the free `parseInt` that
+JavaScript exposes globally, since both belong to the numeric-parsing domain.
+Both would land on the same binding:
+
+```escalier
+import "std:number"
+
+Number.parseInt("42")   // the class static
+```
+
+The class static is what `Number.parseInt` resolves to. The rule exists so that
+the shortcut binding behaves the way the class does, rather than depending on
+what else the package happens to export.
 
 ### Binding-shape flags
 
@@ -149,39 +168,31 @@ Web families with no DOM coupling get their own packages: `web:fetch`,
 imports `web:dom` plus one or two siblings.
 
 A sibling that needs a `web:dom` type refers to it through a qualified name, so
-`web:fetch`'s `Response.body` is a `web.streams.ReadableStream | null` and has to
-be narrowed before a stream method can be called on it.
+`web:fetch`'s `Response.body` is a `streams.ReadableStream | null` and has to be
+narrowed before a stream method can be called on it. The scheme does not appear
+in the qualified name — the binding is the last URI segment, so `web:streams`
+binds as `streams`.
 Pseudo-packages import each other exactly like ordinary code, and import cycles
 between them are permitted.
 
 ## npm packages
 
-Third-party packages are imported by name, as a namespace or by member.
+Third-party packages use the same bare-string form, and the binding is the
+package's last path segment.
 
 ```escalier
-import * as lodash from "lodash"
-import * as fp from "lodash/fp"
+import "lodash"
+import "lodash/fp"
 
 val result = lodash.map([1, 2, 3], fn(x) { x * 2 })
 val piped = fp.pipe(fn1, fn2, fn3)
 ```
 
-```escalier
-import { map, filter } from "lodash"
-import { useState, useEffect } from "react"
+Access stays qualified, as it does for a pseudo-package, so where a name comes
+from is visible at the call site.
 
-val doubled = map([1, 2, 3], fn(x) { x * 2 })
-```
-
-Members may be renamed to avoid conflicts:
-
-```escalier
-import { map as lodashMap } from "lodash"
-import { map as ramdaMap } from "ramda"
-```
-
-Subpath exports are separate namespaces with their own contents, as `lodash` and
-`lodash/fp` are above.
+Subpath exports are separate packages with their own contents and their own
+binding, as `lodash` and `lodash/fp` are above.
 
 Types imported from a `.d.ts` file are **inexact** in every category, since
 TypeScript cannot state that a shape is closed. See
@@ -193,7 +204,7 @@ Imports are **file-scoped**, as in Go. Each file states what it depends on.
 
 ```escalier
 // lib/utils.esc
-import * as lodash from "lodash"
+import "lodash"
 
 fn helper() -> number {
     return lodash.sum([1, 2, 3])
@@ -252,11 +263,13 @@ packages are not.
 
 A local declaration shadows an imported one. Since there are no ambient globals,
 there is nothing to shadow implicitly, and no `globalThis` escape hatch for
-reaching a shadowed name. Where you need both, alias one at the import:
+reaching a shadowed name.
+
+Two imports whose last segments collide need one of them renamed. The syntax is
+not settled; the shape under consideration is a trailing `as`:
 
 ```escalier
-import "std:array"
-import { Array as VecArray } from "@repo/vec"
+import "lodash" as underscore
 ```
 
 ## Status

--- a/docs/03_imports.md
+++ b/docs/03_imports.md
@@ -1,307 +1,270 @@
-# 03 Imports and Package System
+# 03 Imports
 
-This document describes Escalier's import system, package namespaces, and how to work with external TypeScript packages.
+Escalier has **no ambient globals**. Every name a program uses is either declared
+in that program's own module or imported. `Array`, `Promise`, `Math`, `console`,
+and `document` are all behind an explicit import, unlike TypeScript, where the
+whole `lib.es*` surface and, in a browser program, the whole `lib.dom` surface
+are visible everywhere without asking.
 
-## Overview
+Two things follow. `globalThis` does not exist — it was the union of every
+ambient name, and there is nothing left to take its union over. Neither does
+`eval`.
 
-Escalier uses a namespace-based import system where:
+## The two kinds of import
 
-- **Global types** (from TypeScript's lib.es5.d.ts, lib.dom.d.ts) are available without imports
-- **Package symbols** require imports and qualified access (e.g., `lodash.map`)
-- **Local declarations** can shadow globals
-- **Imports are file-scoped** - each file must import the packages it uses
+```escalier
+import "std:math"                       // pseudo-package: the JS and Web platform
+import * as lodash from "lodash"        // npm package
+```
 
-## Import Syntax
+Pseudo-packages hold the platform surface Escalier owns as first-class `.esc`
+source. npm packages come from `node_modules` and are typed by their `.d.ts`
+files.
 
-### Namespace Imports
+## Pseudo-packages
 
-Import an entire package as a namespace:
+The URI scheme names the platform layer:
+
+| Scheme | Surface |
+|---|---|
+| `std:` | The JavaScript language surface, from ECMA-262 |
+| `web:` | The Web platform surface, from the browser specs |
+| `node:` | Reserved; content lands when Node support does |
+
+```escalier
+import "std:math"
+import "std:json"
+import "web:dom"
+import "web:fetch"
+```
+
+The import binds the package under a local identifier equal to the lowercased
+last URI segment:
+
+```escalier
+import "std:math"
+val area = math.PI * r * r
+
+import "web:webgl"
+fn draw(ctx: webgl.WebGLRenderingContext) { ... }
+```
+
+Package names use underscores, matching the file naming, so `import
+"std:typed_arrays"` binds as `typed_arrays`.
+
+### Named imports are not accepted
+
+All pseudo-package imports go through the bare form above. Writing
+`import { sin } from "std:math"` is a compile error that points at the
+alternative. Qualified-only access is the Go convention: reading `math.sin(x)`
+makes the origin of `sin` visible at every call site, and gives editor tooling an
+unambiguous target.
+
+### The single-class shortcut
+
+When a package's lowercased name matches a class declared in it, the binding
+**is** that class, named with its original capitalization.
+
+```escalier
+import "std:array"
+import "std:date"
+
+val nums = [1, 2, 3]
+Array.isArray(nums)           // class statics
+val xs: Array<number> = []    // type position
+val d: Date = Date()          // construct — no `new` keyword
+```
+
+The shortcut is structural: it fires when the package declares a top-level class
+whose name matches the lowercased URI segment. `std:array`, `std:string`,
+`std:number`, `std:boolean`, `std:bigint`, `std:regexp`, `std:symbol`,
+`std:object`, `std:function`, `std:date`, `std:map`, `std:set`, and
+`std:weak_ref` all qualify. `std:math` declares no `Math` class, so its binding
+stays the lowercase namespace `math`.
+
+`Promise` is not on the list. It lives in `std:async` alongside the async
+iteration protocol and `AggregateError`, so the access is `async.Promise.all(…)`.
+
+Other exports of a shortcut package are reachable as namespace members on the
+same binding. Where a name collides, class statics win.
+
+### Binding-shape flags
+
+A URI may carry `?flag` modifiers separated by `&`. The binding shape today is
+`?local`, which is the default and the behavior described above. The flag slot is
+reserved for future additions such as `?type-only`, and an unrecognized flag is
+an error.
+
+### Imports are runtime-erased
+
+At runtime `Math.sin` and `console.log` are already available in every JavaScript
+environment. A pseudo-package import adds type information to the compile-time
+scope and codegen deletes the import line. The package is a type-checking
+grouping mechanism with zero runtime cost.
+
+Binding names are not always the runtime names, so each exported declaration in a
+pseudo-package carries a `@js("...")` decorator naming the JavaScript expression
+it lowers to. `math.sin(x)` lowers to `Math.sin(x)`, and `parseInt` from
+`std:number` lowers to bare `parseInt(...)` rather than `Number.parseInt(...)`.
+Construction is not carried by the decorator: codegen inserts `new` at the call
+site from the callee's type, so `Date()` lowers to `new Date()`.
+
+### The checker still knows what the language guarantees
+
+Requiring an import for every name does not mean writing `import "std:string"`
+before calling `.toUpperCase()`. Each `std:*` package loads in one of two modes.
+
+- **Shape-loaded.** The checker loads a package's contents to satisfy needs that
+  arise from the language itself: method dispatch on a string or number literal,
+  the result type of `await`, the iterable protocol behind `for x in xs`, the
+  array shape behind an array literal, the regex shape behind a regex literal.
+  No identifier enters scope. This is the checker knowing what the language
+  guarantees about its own values.
+- **Named.** Naming a class, type, or value — `Array`, `Promise`, `Error`,
+  `parseInt`, `Partial`, `Symbol` — requires the explicit import. The bindings
+  exposed are exactly the package's top-level declarations.
+
+Shape-loading is per-file and additive, and it never satisfies an explicit
+reference. `for x in xs` works without an import; `Array.from(xs)` needs
+`import "std:array"`.
+
+### The Web surface
+
+The entire DOM tree lives in one package, `web:dom` — `Document`, `Element`,
+`Node`, `Window`, every HTML, SVG, and MathML element class, the tag-name and
+event-map registries, CSSOM, events, observers, animations, and custom elements.
+One import gets the whole DOM surface, and the registries are closed inside the
+package, so `createElement("canvas")` narrows to `HTMLCanvasElement` and
+`createElement("does-not-exist")` is an error.
+
+Web families with no DOM coupling get their own packages: `web:fetch`,
+`web:streams`, `web:crypto`, `web:workers`, `web:webgl`, `web:web_audio`,
+`web:web_rtc`, `web:web_codecs`, `web:indexeddb`, `web:service_worker`,
+`web:websocket`, `web:storage`, `web:url`, `web:encoding`, `web:file`,
+`web:performance`, `web:webauthn`, `web:payments`. A typical browser program
+imports `web:dom` plus one or two siblings.
+
+A sibling that needs a `web:dom` type refers to it through a qualified name, so
+`web:fetch`'s `Response.body` returns a `web.streams.ReadableStream`.
+Pseudo-packages import each other exactly like ordinary code, and import cycles
+between them are permitted.
+
+## npm packages
+
+Third-party packages are imported by name, as a namespace or by member.
 
 ```escalier
 import * as lodash from "lodash"
 import * as fp from "lodash/fp"
 
-// Use qualified access
 val result = lodash.map([1, 2, 3], fn(x) { x * 2 })
 val piped = fp.pipe(fn1, fn2, fn3)
 ```
-
-### Named Imports
-
-Import specific symbols from a package:
 
 ```escalier
 import { map, filter } from "lodash"
 import { useState, useEffect } from "react"
 
-// Use directly (but still file-scoped)
 val doubled = map([1, 2, 3], fn(x) { x * 2 })
 ```
 
-### Named Imports with Aliases
-
-Rename imports to avoid conflicts or for convenience:
+Members may be renamed to avoid conflicts:
 
 ```escalier
 import { map as lodashMap } from "lodash"
 import { map as ramdaMap } from "ramda"
-
-// Both are available with different names
-val arr1 = lodashMap([1, 2], fn(x) { x * 2 })
-val arr2 = ramdaMap(fn(x) { x + 1 }, [1, 2])
 ```
 
-## File-Scoped Imports
+Subpath exports are separate namespaces with their own contents, as `lodash` and
+`lodash/fp` are above.
 
-Imports in Escalier are **file-scoped**, similar to Go. Each file must contain its own import statements for the packages it uses.
+Types imported from a `.d.ts` file are **inexact** in every category, since
+TypeScript cannot state that a shape is closed. See
+[Exact Types](07_exact_types.md).
+
+## Import scope and declaration scope
+
+Imports are **file-scoped**, as in Go. Each file states what it depends on.
 
 ```escalier
 // lib/utils.esc
 import * as lodash from "lodash"
 
 fn helper() -> number {
-    lodash.sum([1, 2, 3])  // OK: lodash imported in this file
+    return lodash.sum([1, 2, 3])
 }
 ```
 
 ```escalier
-// lib/main.esc
-// No import statement for lodash
-
+// lib/main.esc — no import statement for lodash
 fn main() -> number {
-    lodash.sum([1, 2, 3])  // ERROR: 'lodash' is not defined
+    return lodash.sum([1, 2, 3])   // ERROR: 'lodash' is not defined
 }
 ```
 
-Even if both files are in the same module, imports do not leak across files. If `main.esc` needs lodash, it must import it explicitly:
-
-```escalier
-// lib/main.esc
-import * as lodash from "lodash"
-
-fn main() -> number {
-    lodash.sum([1, 2, 3])  // OK now
-}
-```
-
-### Why File-Scoped Imports?
-
-1. **Explicit dependencies**: Each file clearly shows what external packages it depends on
-2. **Easier refactoring**: Moving a file to a different location doesn't break imports
-3. **Better tooling**: IDEs can easily determine what's available in each file
-4. **Familiar pattern**: Developers from Go, Python, and JavaScript will find this natural
-
-## Module-Level Declarations
-
-While imports are file-scoped, **type and function declarations** are shared across files within a module:
+Type and value **declarations**, by contrast, are shared across the files of a
+module:
 
 ```escalier
 // lib/types.esc
 type UserId = string
-type User = { id: UserId, name: string }
+type User = {id: UserId, name: string}
 ```
 
 ```escalier
-// lib/users.esc
-// No need to import User - it's in the same module
-
+// lib/users.esc — no import needed; same module
 fn createUser(id: UserId, name: string) -> User {
-    { id, name }
+    return {id, name}
 }
 ```
 
-## Global Types and Shadowing
+File-scoped imports keep each file's external dependencies visible, let a file
+move without breaking its imports, and give tooling an exact answer for what is
+in scope where. See [Code Organization](10_code_organization.md) for how files
+map onto modules and namespaces.
 
-### Accessing Global Types
+## Cyclic dependencies
 
-Global types from TypeScript's standard library (Array, Promise, Map, Set, etc.) are available without imports:
-
-```escalier
-declare val arr: Array<number>
-declare val promise: Promise<string>
-declare val map: Map<string, number>
-```
-
-### Shadowing Globals
-
-Local type declarations can shadow global types:
-
-```escalier
-// Define a custom Array type that shadows the global
-type Array<T> = {
-    items: T,
-    length: number,
-    isEmpty: boolean,
-}
-
-// Uses our custom Array type
-declare val myArray: Array<string>
-```
-
-### Accessing Shadowed Globals with globalThis
-
-When you shadow a global type, you can still access the original via `globalThis`:
-
-```escalier
-// Shadow the global Array
-type Array<T> = { items: T, isCustom: boolean }
-
-// Use our custom Array
-declare val customArr: Array<number>
-
-// Access the global Array via globalThis
-declare val globalArr: globalThis.Array<number>
-```
-
-This works for both types and values:
-
-```escalier
-// Access global Symbol
-val iterator = globalThis.Symbol.iterator
-
-// Access global Array constructor
-val arr = globalThis.Array.from([1, 2, 3])
-```
-
-## Package Registry
-
-Escalier maintains a package registry that caches loaded packages. When you import a package:
-
-1. The registry checks if the package is already loaded
-2. If not, it loads and parses the `.d.ts` file
-3. The package namespace is stored in the registry
-4. Future imports reuse the cached namespace
-
-This ensures:
-- Consistent type identity across files
-- Efficient memory usage
-- Fast subsequent imports
-
-## Subpath Imports
-
-Packages can have subpath exports that provide different functionality:
-
-```escalier
-import * as lodash from "lodash"       // Main package
-import * as fp from "lodash/fp"        // Functional programming variant
-
-// These are separate namespaces with different exports
-val arr1 = lodash.map([1, 2], fn(x) { x * 2 })  // (array, iteratee)
-val arr2 = fp.map(fn(x) { x * 2 })              // curried: (iteratee) -> (array)
-```
-
-## Cross-File Cyclic Dependencies
-
-Escalier handles cyclic type dependencies across files correctly:
+Types may reference each other across files within a module:
 
 ```escalier
 // lib/node.esc
-type Node<T> = {
-    value: T,
-    children: Tree<T>,  // References Tree from tree.esc
-}
+type Node<T> = {value: T, children: Tree<T>}
 ```
 
 ```escalier
 // lib/tree.esc
-type Tree<T> = {
-    root: Node<T>,      // References Node from node.esc
-    size: number,
-}
+type Tree<T> = {root: Node<T>, size: number}
 ```
 
-Both types can reference each other because:
-1. All declarations in a module are collected before type checking
-2. A unified dependency graph handles cyclic references
-3. Placeholder types are created for forward references
+All declarations in a module are collected before checking, and a dependency
+graph orders them by strongly connected component, so mutual references resolve.
 
-Note: Circular **package** dependencies (Package A imports B, which imports A) are not supported.
+Cycles between pseudo-packages are permitted. Circular dependencies between npm
+packages are not.
 
-## Migration Guide
+## Shadowing
 
-If you're migrating from an older version of Escalier or from TypeScript:
-
-### Breaking Change: Qualified Package Access
-
-**Before** (hypothetical old behavior):
-```escalier
-import "lodash"
-val result = map([1, 2, 3], fn(x) { x * 2 })  // Direct access
-```
-
-**After**:
-```escalier
-import * as lodash from "lodash"
-val result = lodash.map([1, 2, 3], fn(x) { x * 2 })  // Qualified access
-```
-
-### Re-exporting Package Symbols
-
-If you want shorter access, create module-level re-exports:
+A local declaration shadows an imported one. Since there are no ambient globals,
+there is nothing to shadow implicitly, and no `globalThis` escape hatch for
+reaching a shadowed name. Where you need both, alias one at the import:
 
 ```escalier
-// lib/utils.esc
-import * as lodash from "lodash"
-
-// Re-export for convenience
-export val map = lodash.map
-export val filter = lodash.filter
+import "std:array"
+import { Array as VecArray } from "@repo/vec"
 ```
 
-```escalier
-// lib/main.esc
-// Now you can use the re-exported symbols
-val doubled = map([1, 2, 3], fn(x) { x * 2 })
-```
+## Status
 
-### Handling Shadowing Conflicts
+The parser, the resolver, the binding shape, the single-class shortcut, `@js`
+lowering, and the `web:dom` partition are implemented.
 
-If you have local types that conflict with globals:
-
-```escalier
-// Your local Promise type
-type Promise<T> = { value: T, status: string }
-
-// Use globalThis for the actual Promise
-fn fetchData() -> globalThis.Promise<Data> {
-    // ...
-}
-
-// Use your local Promise type
-fn createPromise<T>(value: T) -> Promise<T> {
-    { value, status: "pending" }
-}
-```
-
-## Best Practices
-
-1. **Use namespace imports** for packages with many exports you'll use:
-   ```escalier
-   import * as lodash from "lodash"
-   ```
-
-2. **Use named imports** for packages where you only need a few symbols:
-   ```escalier
-   import { useState, useEffect } from "react"
-   ```
-
-3. **Import in every file** that needs the package - don't rely on other files' imports
-
-4. **Avoid shadowing globals** unless you have a good reason - it can cause confusion
-
-5. **Use globalThis explicitly** when you need to access a shadowed global
-
-6. **Create re-exports** in a utility file if you want short access to package functions
-
-## Summary
-
-| Feature | Behavior |
-|---------|----------|
-| Import scope | File-scoped (each file imports what it needs) |
-| Declaration scope | Module-scoped (shared across files in same directory) |
-| Global types | Available without import (Array, Promise, etc.) |
-| Package symbols | Require import + qualified access |
-| Shadowing | Local declarations can shadow globals |
-| Shadowed global access | Use `globalThis.TypeName` |
-| Cyclic types | Supported across files |
-| Cyclic packages | Not supported |
+Three pieces are still in progress. The committed `.esc` source for the `std:*`
+and `web:*` packages is generated from the pinned TypeScript `.d.ts` set by a
+bootstrap converter and then hand-edited, and that generation is not finished.
+The per-file shape loader that makes the shape-loaded mode work is not built, so
+until it is, the compiler resolves the previously-ambient names through the older
+prelude. Two editor features are planned on top: **auto-import**, a quick fix that
+adds the namespace import for a name the file references but has not imported, and
+**adaptive diagnostic rendering**, which prints a type name in the shortest form
+that is unambiguous given the bindings in the file the diagnostic came from.

--- a/docs/04_pattern_matching.md
+++ b/docs/04_pattern_matching.md
@@ -118,9 +118,9 @@ fn f(c: Color) {
 // ERROR: match is not exhaustive; add a branch for `Color.Hex`
 ```
 
-The rules follow exactness. An **exact** union is covered once every member has a
-covering branch. An **inexact** scrutinee admits values no pattern can name, so it
-requires a catch-all:
+The rules follow exactness. A union is closed, so it is covered once every member
+has a covering branch. An **inexact** object or tuple scrutinee admits values no
+pattern can name, so it requires a catch-all:
 
 ```esc
 // ERROR: match is not exhaustive; `{x: number, ...}` admits values no pattern

--- a/docs/04_pattern_matching.md
+++ b/docs/04_pattern_matching.md
@@ -138,13 +138,11 @@ which admits values no pattern can name and so requires a catch-all:
 
 Two shapes of near-miss get their own message, since the edit differs:
 
-```
-match is not exhaustive; `number` is matched only by a guarded branch, whose
-guard can fail, so add an unguarded branch for it
+> match is not exhaustive; `number` is matched only by a guarded branch, whose
+> guard can fail, so add an unguarded branch for it
 
-match is not exhaustive; `Color.RGB` is matched only by a branch whose own
-pattern can fail, so add a branch that matches it irrefutably
-```
+> match is not exhaustive; `Color.RGB` is matched only by a branch whose own
+> pattern can fail, so add a branch that matches it irrefutably
 
 ## `if val` and `if var`
 

--- a/docs/04_pattern_matching.md
+++ b/docs/04_pattern_matching.md
@@ -1,72 +1,182 @@
 # 04 Pattern Matching
 
+Escalier has three conditional forms that bind: `match`, `if val`, and
+`val … else`. All three lower into one intermediate representation, so a pattern
+means the same thing wherever it is written. The lowering follows "The Ultimate
+Conditional Syntax" by Cheng and Parreaux and lives in
+[internal/solver/ucs/](../internal/solver/ucs/).
+
 ## `match`
 
-Basic syntax
-
-```rs
-val output = match <expr> {
-    <pattern_1> => "foo",
-    <pattern_2> => "bar",
-    ...
-    <pattern_n> => {
-        // block expression
-        "baz"
-    }
+```esc
+val output = match value {
+    <pattern> => <expr>,
+    <pattern> if <guard> => <expr>,
+    _ => {
+        // a block is an expression
+        "fallback"
+    },
 }
 ```
 
-```rs
-val bar = match foo {
-    // primitives and literals
-    5 => ...,
-    a is 5 => ...,
-    number => ...,
-    a is number => ...,
+Arms are tried in source order and the first match wins.
 
+## Patterns
+
+```esc
+match value {
+    // literals
+    5 => ...,
+    "hello" => ...,
+
+    // tuples and arrays
     [fst, snd] => ...,
     [fst, snd, ...rest] => ...,
 
-    // Objects
+    // objects
     {a, b} => ...,
     {a, b, ...rest} => ...,
-    {a is number, b is string} => ...,
     {a: x, b: y} => ...,
-    {a: x is number, b: y is string} => ...,
-    
-    // Class instances
+
+    // class instances
     Point {x, y} => ...,
 
-    // Enums
-    Maybe.Some(value) => ...,
-    Maybe.None => ...,
+    // enum variants
+    MyOption.Some(value) => ...,
+    MyOption.None => ...,
 
-    // defined and non-null
-    a! => ...,
-    {a!} => ...,
-    {a: x!} => ...,
+    // wildcard
+    _ => ...,
 }
 ```
 
-Pattern can also be followed with a conditional that has access to any bindings
-introduced by the pattern, e.g.
+A binding leaf may be marked `mut`. Mutability lives on the place, so it attaches
+to the identifier rather than to the surrounding pattern:
 
+```esc
+val {mut x, y: mut a} = point
 ```
-val bar = match foo {
+
+## Narrowing with `:`
+
+A binding may carry a type annotation. The pattern then matches only the part of
+the scrutinee that annotation admits, and the binding has the narrowed type.
+
+```esc
+fn f(u: number | string) {
+    return match u {
+        x: number => x,     // x: number
+        y: string => y,     // y: string
+    }
+}
+// inferred: fn (u: number | string) -> number | string
+```
+
+This is Escalier's only narrowing mechanism, and it is deliberately different
+from TypeScript's control-flow narrowing. **A narrow always introduces a new
+binding rather than re-typing an existing one.** A binding has exactly one type
+for its whole scope, so a narrow cannot change it; it can only bind a new name at
+the narrower type.
+
+That keeps narrowing compatible with the one-principal-type-per-expression model
+the checker is built on, and it means there is no flow-sensitive re-typing to
+reason about. The narrowed value lives on a different name, visible in the source.
+
+An annotation that no member of the scrutinee fits is rejected, since the arm
+could never run.
+
+## Guards
+
+An arm may be followed by a condition with access to the bindings the pattern
+introduced.
+
+```esc
+match value {
     [fst, snd] if fst == snd => ...,
 }
 ```
 
-## `if`-`val` and `if`-`var`
+A guard can fail, so a guarded arm covers nothing on its own for the purposes of
+exhaustiveness.
 
-All of the patterns that can be used with pattern matching, can also be used in
-`if`-`val` and `if`-`var` expressions.
+## Exhaustiveness
+
+A `match` must cover its scrutinee. The compiler reports what is missing and, as
+far as it can, what edit would cover it.
+
+```esc
+enum Color {
+    RGB(r: number, g: number, b: number),
+    Hex(code: string),
+}
+
+fn f(c: Color) {
+    return match c {
+        Color.RGB(r, g, b) => r,
+    }
+}
+// ERROR: match is not exhaustive; add a branch for `Color.Hex`
+```
+
+The rules follow exactness. An **exact** union is covered once every member has a
+covering branch. An **inexact** scrutinee admits values no pattern can name, so it
+requires a catch-all:
+
+```esc
+// ERROR: match is not exhaustive; `{x: number, ...}` admits values no pattern
+// names, so add a catch-all branch
+```
+
+Two shapes of near-miss get their own message, since the edit differs:
 
 ```
-if val <pattern> = expr { ... }
-if var <pattern> = expr { ... }
+match is not exhaustive; `number` is matched only by a guarded branch, whose
+guard can fail, so add an unguarded branch for it
+
+match is not exhaustive; `Color.RGB` is matched only by a branch whose own
+pattern can fail, so add a branch that matches it irrefutably
 ```
 
-## `val`-`else` and `var`-`else`
+## `if val` and `if var`
 
-TODO
+Every pattern usable in a `match` arm works in an `if val`. The binding is in
+scope in the consequent.
+
+```esc
+fn f(u: number | string) {
+    return if val x: number = u { x } else { 0 }
+}
+// inferred: fn (u: number | string) -> number
+```
+
+A bare identifier pattern carries no annotation, so it binds the whole scrutinee:
+
+```esc
+if val x = u { x } else { 0 }
+// x: number | string
+```
+
+`if var` binds mutably instead.
+
+## `val … else`
+
+The refutable form of a `val` binding. The `else` block runs when the pattern
+does not match, and it must not fall through — it returns, throws, or otherwise
+diverges, or it supplies a value.
+
+```esc
+val x = u else { return }
+val x: number = u else { return 0 }
+val [a, b] = u else { throw "no" }
+val x: number = u else { 0 }
+```
+
+This is the early-return shape: the binding is in scope for the rest of the
+enclosing block, at the narrowed type, with no nesting.
+
+## Moves and borrows in patterns
+
+Destructuring moves or borrows each extracted part following the ordinary
+ownership rules, and `match` arm bindings behave the same way. Binding a part of
+an owned scrutinee moves that part, and the sibling parts stay usable. See
+[Ownership](09_ownership.md).

--- a/docs/04_pattern_matching.md
+++ b/docs/04_pattern_matching.md
@@ -51,11 +51,20 @@ match value {
 ```
 
 A binding leaf may be marked `mut`. Mutability lives on the place, so it attaches
-to the identifier rather than to the surrounding pattern:
+to the identifier rather than to the surrounding pattern, and each leaf decides
+for itself:
 
 ```esc
-val {mut x, y: mut a} = point
+fn go(pair: mut {left: {x: number}, right: {x: number}}) {
+    val {mut left, right} = pair
+    left.x = 1      // OK — left is mutable
+    // right.x = 1  // ERROR: cannot constrain immutable object <: mutable object
+}
 ```
+
+`mut` only means something on a leaf holding a reference-shaped value. A
+`number`, `string`, or `boolean` has no interior to mutate, so marking one has
+nothing to say.
 
 ## Narrowing with `:`
 
@@ -118,9 +127,9 @@ fn f(c: Color) {
 // ERROR: match is not exhaustive; add a branch for `Color.Hex`
 ```
 
-The rules follow exactness. A union is closed, so it is covered once every member
-has a covering branch. An **inexact** object or tuple scrutinee admits values no
-pattern can name, so it requires a catch-all:
+A union is always closed, so it is covered once every member has a covering
+branch. What can still leave a gap is an **inexact** object or tuple scrutinee,
+which admits values no pattern can name and so requires a catch-all:
 
 ```esc
 // ERROR: match is not exhaustive; `{x: number, ...}` admits values no pattern
@@ -158,6 +167,12 @@ if val x = u { x } else { 0 }
 
 `if var` binds mutably instead.
 
+A nullable scrutinee is planned to get its own handling. Where the scrutinee is
+`T | null`, `T | undefined`, or `T | null | undefined`, a bare identifier pattern
+will bind `x` at `T`, since testing for the absent case is the whole reason to
+write the form. Today it binds the full union like any other, so the narrowing
+has to be written out as `if val x: T = u`.
+
 ## `val … else`
 
 The refutable form of a `val` binding. The `else` block runs when the pattern
@@ -173,6 +188,13 @@ val x: number = u else { 0 }
 
 This is the early-return shape: the binding is in scope for the rest of the
 enclosing block, at the narrowed type, with no nesting.
+
+Rust's `let … else` is the same idea with one restriction Escalier drops. There
+the `else` block must diverge — its type is `!`, so it has to `return`, `break`,
+`continue`, or panic, and it can never produce a value. Escalier's block may do
+either. It may diverge, as the first three examples above do, or it may evaluate
+to a value of the binding's type, as `val x: number = u else { 0 }` does, which
+binds `0` when `u` is not a `number`.
 
 ## Moves and borrows in patterns
 

--- a/docs/05_enums.md
+++ b/docs/05_enums.md
@@ -68,8 +68,8 @@ enum Expr {
 
 ## Exhaustiveness
 
-An enum type is an exact union of its variants, so a `match` over one is checked
-for exhaustiveness by variant:
+An enum type is the union of its variants, and a union is closed, so a `match`
+over one is checked for exhaustiveness by variant:
 
 ```esc
 match c {

--- a/docs/05_enums.md
+++ b/docs/05_enums.md
@@ -1,48 +1,131 @@
 # 05 Enums
 
-## Syntax
+An enum declares one or more variants. Each variant is an identifier followed by
+an optional parameter list.
 
-Enums contain one or more variants.  Each variant consists of an identifier 
-followed by an optional param list.
-
-```rs
-enum Maybe<T> {
+```esc
+enum MyOption<T> {
     Some(value: T),
     None,
 }
 
-val msg = Maybe.Some("hello") // inferred as Maybe<"hello">
-if val Maybe.Some(greeting) = msg {
-    // `greeting` has type `"hello"`
+val msg = MyOption.Some("hello")   // msg: MyOption<"hello">
+
+if val MyOption.Some(greeting) = msg {
+    // greeting: "hello"
 }
 
 match msg {
-    Maybe.Some(greeting) => console.log(`${greeting}, world!`),
-    Maybe.None => console.log("nothing here"),
+    MyOption.Some(greeting) => console.log(`${greeting}, world!`),
+    MyOption.None => console.log("nothing here"),
 }
 ```
 
-Enums can also contain object variants which consist of an identifier followed
-by an object type annotation.
+The enum's name binds two things: a **type**, which is a transparent alias for
+the union of its variants, and a **namespace** holding one constructor per
+variant. `MyOption.Some(5)` calls the constructor and yields `MyOption<5>`.
 
-```rs
-enum Shape {
-    Circle {center: Point, radius: number},
-    Rectangle {x: number, y: number, width: number, height: number},
-    Polygon {points: Array<Point>},
+## Variants are nominal
+
+A variant belongs to its enum, so two enums that share a variant name stay
+distinct. A variant renders qualified, as `Color.RGB`, wherever it surfaces —
+in a union member, in a diagnostic, or in a narrowed `match` arm.
+
+```esc
+enum Color { RGB(r: number, g: number, b: number), Hex(code: string) }
+enum Ink   { RGB(r: number, g: number, b: number) }
+
+val c: Color = Color.RGB(255, 0, 0)
+// val i: Ink = c   // ERROR: Color and Ink are distinct
+```
+
+## Parameter names
+
+Variant parameters may be named or written `_`, in which case the constructor
+gets positional names:
+
+```esc
+enum E {
+    Pair(_: number, _: string),
+}
+val ctor = E.Pair
+// ctor: fn (arg0: number, arg1: string) -> E
+```
+
+## Recursion
+
+Enums may be recursive, mutually recursive with each other, and mutually
+recursive with classes. Declarations in a module are ordered by dependency graph,
+so a variant may reference an enum declared later in the file or in another file
+of the same module.
+
+```esc
+enum Expr {
+    Lit(value: number),
+    Add(left: Expr, right: Expr),
 }
 ```
 
-Enums can be extended using spread notation.
+## Exhaustiveness
 
-```rs
+An enum type is an exact union of its variants, so a `match` over one is checked
+for exhaustiveness by variant:
+
+```esc
+match c {
+    Color.RGB(r, g, b) => r,
+}
+// ERROR: match is not exhaustive; add a branch for `Color.Hex`
+```
+
+See [Pattern Matching](04_pattern_matching.md).
+
+## Placement
+
+Enums are declared at module top level or script top level. A local enum inside a
+function body is rejected, the same as a local class.
+
+## TypeScript interop
+
+Escalier enums are variant types with extractors. TypeScript's `enum` is a
+numeric or string map, which is a different construct, so importing one models it
+as a union of literal types plus a value holding the members:
+
+```ts
+// TypeScript
+enum MyEnum { Foo, Bar, Baz }
+enum StringEnum {
+    MouseUp = "mouseup",
+    MouseDown = "mousedown",
+    MouseClick = "mouseclick",
+}
+```
+
+```esc
+// Escalier representation of the imported declarations
+type MyEnum = 0 | 1 | 2
+val MyEnum = {Foo: 0, Bar: 1, Baz: 2}
+
+type StringEnum = "mouseup" | "mousedown" | "mouseclick"
+val StringEnum = {
+    MouseUp: "mouseup",
+    MouseDown: "mousedown",
+    MouseClick: "mouseclick",
+}
+```
+
+## Extension with spread (not implemented)
+
+The planned syntax for extending an enum is a spread rather than `extends`:
+
+```esc
 enum Color {
     RGB(number, number, number),
     HSL(number, number, number),
 }
 
 enum FutureColor {
-    ...Color
+    ...Color,
     Oklab(number, number, number),
 }
 
@@ -50,8 +133,7 @@ val c = Color.RGB(255, 0, 0)
 val fc: FutureColor = c
 ```
 
-**DESIGN NOTE**
-The reason for choosing spread notation for extending enums instead of the
-`extends` keyword (e.g. `enum FutureColor extends Color`) is that the subtyping
-relation is in the opposite direction to `class`'s use of `extends`.
-
+Spread is chosen over `extends` because the subtyping relation runs the opposite
+way from a class's: a `Color` is a `FutureColor`, where a subclass instance is a
+superclass instance. The parser accepts the form; the checker reports it as
+unsupported.

--- a/docs/05_enums.md
+++ b/docs/05_enums.md
@@ -41,16 +41,19 @@ val c: Color = Color.RGB(255, 0, 0)
 
 ## Parameter names
 
-Variant parameters may be named or written `_`, in which case the constructor
-gets positional names:
+Variant parameters are named and annotated, the same as function parameters, and
+the names carry through to the constructor:
 
 ```esc
 enum E {
-    Pair(_: number, _: string),
+    Pair(a: number, b: string),
 }
 val ctor = E.Pair
-// ctor: fn (arg0: number, arg1: string) -> E
+// ctor: fn (a: number, b: string) -> E
 ```
+
+A name is not optional. `Pair(number, string)` is not two unannotated types —
+it declares two parameters *named* `number` and `string`, each typed `unknown`.
 
 ## Recursion
 
@@ -120,13 +123,13 @@ The planned syntax for extending an enum is a spread rather than `extends`:
 
 ```esc
 enum Color {
-    RGB(number, number, number),
-    HSL(number, number, number),
+    RGB(r: number, g: number, b: number),
+    HSL(h: number, s: number, l: number),
 }
 
 enum FutureColor {
     ...Color,
-    Oklab(number, number, number),
+    Oklab(l: number, a: number, b: number),
 }
 
 val c = Color.RGB(255, 0, 0)

--- a/docs/06_error_handling.md
+++ b/docs/06_error_handling.md
@@ -1,112 +1,165 @@
-# 04 Error Handling
+# 06 Error Handling
 
-## `try`-`catch`-`finally`
+A function's exceptional exits are part of its type. Omitting the `throws` clause
+declares that the function raises nothing.
 
-If an exception is thrown by a function call inside a `try` block program execution
-will jump to the associated `catch` block.  The "caught" exception will not be
-included in the inferred `throws` clause of the function.
+```esc
+fn f() { throw "boom" }
+// ERROR: cannot constrain "boom" <: never
+```
 
-```ts
-class FooError extends Error {
-    constructor() {
-        super("foo")
-    }
+Writing `throws never` is not how a non-throwing function is spelled. Omitting
+the clause is. See [Functions](02_functions.md) for `throws _`, declared clauses,
+and how a callee's throws reaches its caller.
+
+Any value may be thrown, not only an `Error` subclass, since that is what
+JavaScript permits.
+
+## `try` / `catch` / `finally`
+
+Catch arms are patterns, the same ones `match` uses.
+
+```esc
+try { riskyOperation() } catch { error => console.log(error) }
+
+try { operation() } catch {
+    NetworkError{msg} => `Network: ${msg}`,
+    TimeoutError => "Timeout",
+    _ => "Unknown error",
 }
 
-// inferred as `fn() -> undefined throws FooError | ...`
-fn foo() {
-    throw FooError()
-}
-
-fn bar() {
-    try {
-        foo()
-    } catch (e) {
-        FooError => console.log(`caught FooError`)
-        _ => console.log("some other Error occurred")
-    }
+try { getValue() } catch {
+    error if error.code == 404 => "Not found",
+    error => error.message,
 }
 ```
 
-The error `e` that's caught in the example of above will have type `FooError | ...`.
-Caught errors will always be an inexact/open union.  This means that even if we
-handle `FooError` there could be another error.  In the example above we have a
-catch-all at the bottom which handles this.  If there is no catch-all, the 
-compiler will automatically re-throw the unhandled error.
+A `try` block collects what it raises into a sink of its own, so an exception the
+arms cover never reaches the enclosing function's clause. `try` is an expression,
+so it produces a value, and a `finally` block may follow the arms.
 
-In `async`-`await` functions, the type of exceptions that can be throw 
+A `try` with no catch arms is rejected:
 
-```ts
-class FetchError extends Error {
-    constructor(url: string) {
-        super(`failed to fetch ${url}`)
+```
+a `try` with no catch arms catches nothing; drop the `try` and keep its block, or
+add at least one catch arm
+```
+
+### The caught value is `unknown`
+
+Whatever the block's signatures named, the runtime can throw anything, so the
+caught binding has type `unknown`. An arm narrows it by naming a type or a shape:
+
+```esc
+fn f() { try { throw "boom" } catch { e => { return e } } }
+// inferred: fn () -> unknown
+
+fn g() {
+    try { a() } catch {
+        FooError{msg} => { return msg },   // msg: string — narrowed to FooError
+        e => { return 0 },
     }
 }
+// inferred: fn () -> string | 0
+```
 
-// inferred as `fn(url: string) -> Promise<unknown, Error | SyntaxError | ...>
-async fn fetchJSON(url: string) {
+### Uncovered exceptions are rethrown
+
+Without a catch-all, the arms leave part of the block's known throws unhandled.
+Those are rethrown rather than reported as a non-exhaustive `match`, and they
+reach the enclosing function's clause.
+
+```esc
+fn f(c: boolean) throws _ {
+    try {
+        if c { throw "boom" } else { throw 5 }
+    } catch {
+        5 => 0
+    }
+}
+// inferred: fn (c: boolean) -> undefined throws "boom"
+```
+
+Covering every known member removes the obligation entirely, so a caller needs no
+clause of its own:
+
+```esc
+fn f() { try { throw "boom" } catch { "boom" => 0 } }
+// inferred: fn () -> undefined
+```
+
+A guarded arm can always fail its guard, so it covers nothing and its member is
+still rethrown.
+
+Only the **known** throws are weighed. A value outside them can still be thrown
+and rethrown at runtime, but no signature named its type, and recording it would
+widen every clause to `unknown`. This is the deliberate limit of the system:
+checked exceptions are not a proof that nothing else can happen. They let you
+handle, exhaustively, what a function is known to raise.
+
+### What escapes is a set difference
+
+The type that escapes a `try` is `caught & ~handled`, where `handled` is what the
+arms catch. Taking a difference rather than matching member names is what lets an
+arm subtract more than the one type it spells: an arm naming a base class catches
+every value of a subclass, so the subclass member is subtracted too.
+
+```esc
+class AppError { code: number, constructor(mut self) { self.code = 0 } }
+class ParseError extends AppError { constructor(mut self) { super() } }
+```
+
+An arm naming `AppError` also handles a raised `ParseError`. See
+[Types](00_types.md) for negation.
+
+## Async errors
+
+An `async fn` cannot raise. What its body throws is absorbed into the rejection
+slot of the promise it returns, so its type is always `Promise<T, E>` and never
+carries a `throws` clause.
+
+```esc
+class FetchError { url: string, constructor(mut self, url: string) { self.url = url } }
+
+async fn fetchJSON(url: string) -> Promise<unknown, FetchError | SyntaxError> {
     val res = await fetch(url)
     if !res.ok {
-        throw new FetchError(url)
+        throw FetchError(url)
     }
-    return res.json() // can throw `SyntaxError`
+    return res.json()
 }
+```
 
-// inferred as `fn(url: string) -> Promise<undefined>
-fn foo() {
+Awaiting a promise whose `E` is not `never` contributes `E` to the awaiting
+function's own rejection or `throws` clause, so the obligation propagates the way
+a synchronous one does. Handle it with the same `try`/`catch`:
+
+```esc
+async fn main() {
     try {
-        val json = fetchJSON("https://foo.com/bar")
-        // do stuff with `json`
-        return
-    } catch (e) {
-        SyntaxError{message} => ...
-        FetchError{message} => ...
-        // Since we don't have a catchall, the compiler automatically rethrows
-        // the error if none of the patterns match.
+        val json = await fetchJSON("https://example.com/data")
+        use(json)
+    } catch {
+        SyntaxError{message} => report(message),
+        FetchError{url} => report(url),
     }
 }
 ```
 
-Just because a function signature doesn't include a `throws` clause, doesn't
-mean that it can't throw.  Literally any function has the potential to throw.  The
-purpose of checked exceptions is not provide a fool-proof system for handling all
-exceptions.  Rather, the goal is to provide a system that allows you to safely
-handle exceptions that we know for sure can be thrown by a function.
-
-The return type of `foo()` in the example above is `Promise<undefined>`.  It
-doesn't specify an error type in the promise because we've handled all known
-errors.  It still could throw an error, but so could any function.
+Since both known members are covered, `main`'s promise has no rejection type.
 
 ## `Result<T, E>` (post-MVP)
 
-`try`-`catch` blocks can be a bit heavy handed.  `Result<T, E>` provide an 
-alternative way of handling errors.
+`try`/`catch` is heavy for a value-level failure. A `Result<T, E>` enum offers an
+alternative, together with a `?` operator that desugars to an early return:
 
-We can use a wrapper function and a decorator to convert functions that throw
-to functions that return a `Result<T, E>` value.
-
-In order to make working with `Result<T, E>` easier, we can add a `?` operator
-to the language which will behave similarly to Rust's `?` operator.  This can
-be implemented, by desugaring `value?` to the following:
-
-```
-match value {
-    Ok(value) => value,
-    Err(_) as e => return e,
+```esc
+val value = fallible()?
+// desugars to
+val value = match fallible() {
+    Result.Ok(v) => v,
+    Result.Err(_) as e => return e,
 }
 ```
 
-```
-
-val a: number = value
-if val a: number = value { ... }
-
-val {a} = value
-if val {a is number} = value { ... }
-
-val {a: b} = value
-if val {a: b is number} = value { ... }
-
-val p: Point = value
-if val p: Point = value { ... }
-```
+This is not implemented.

--- a/docs/06_error_handling.md
+++ b/docs/06_error_handling.md
@@ -15,6 +15,11 @@ and how a callee's throws reaches its caller.
 Any value may be thrown, not only an `Error` subclass, since that is what
 JavaScript permits.
 
+This is planned to change. Throwing will be restricted to `Error` and its
+subclasses so that every exception carries a stack trace. A thrown string or
+object literal has none, which is what makes a failure in production hard to
+trace back to where it came from.
+
 ## `try` / `catch` / `finally`
 
 Catch arms are patterns, the same ones `match` uses.
@@ -38,11 +43,12 @@ A `try` block collects what it raises into a sink of its own, so an exception th
 arms cover never reaches the enclosing function's clause. `try` is an expression,
 so it produces a value, and a `finally` block may follow the arms.
 
-A `try` with no catch arms is rejected:
+A `try` with no catch arms is rejected, whether or not its block can raise:
 
-```
-a `try` with no catch arms catches nothing; drop the `try` and keep its block, or
-add at least one catch arm
+```esc
+fn f() { try { 42 } }
+// ERROR: a `try` with no catch arms catches nothing; drop the `try` and keep
+// its block, or add at least one catch arm
 ```
 
 ### The caught value is `unknown`
@@ -62,6 +68,12 @@ fn g() {
 }
 // inferred: fn () -> string | 0
 ```
+
+When throwing is restricted to `Error` and its subclasses, the caught binding
+becomes `Error` instead, and an arm narrows from there. Calls into third-party
+npm packages keep the weaker guarantee, since nothing constrains what a
+JavaScript library throws, so which of the two applies will be a setting rather
+than a fixed rule.
 
 ### Uncovered exceptions are rethrown
 

--- a/docs/07_exact_types.md
+++ b/docs/07_exact_types.md
@@ -12,7 +12,8 @@ types that might, and it makes the former the default.
 
 ## Syntax
 
-A trailing `...` opts a former into inexactness.
+A **former** is a type constructor that builds a type out of parts — an object,
+a tuple, a function, a union. A trailing `...` opts one into inexactness.
 
 ```esc
 type ExactPoint = {x: number, y: number}

--- a/docs/07_exact_types.md
+++ b/docs/07_exact_types.md
@@ -22,15 +22,15 @@ type ExactTuple = [string, number]
 type OpenTuple  = [string, number, ...]
 ```
 
-Unions carry the same flag. `A | B` is closed and `A | B | ...` may hold members
-beyond the ones written. A union may not have a trailing `...` written directly
-after a `|`; the compiler suggests `string`, `number`, or `unknown` for an open
-set of members.
+Unions and intersections have no exactness of their own. A union is always
+closed, and writing a trailing `...` after a `|` is rejected with a diagnostic
+pointing at `string`, `number`, or `unknown` as the way to name an open set of
+values.
 
-Intersections have no exactness of their own. Exactness is about whether the set
-of inhabitants is *open*, and an intersection is a constraint combinator rather
-than a value shape — the dual reading would mean hidden extra constraints, which
-is the opposite of what inexact means everywhere else. The exactness of an
+Exactness is about whether the set of inhabitants of a *value shape* is open, and
+neither former describes one. An intersection is a constraint combinator, so the
+dual reading would mean hidden extra constraints — fewer inhabitants, the
+opposite of what inexact means everywhere else. The exactness of an
 intersection's *result* is derived from its operands during normalization and
 lands on the resulting object or tuple.
 
@@ -63,7 +63,6 @@ val cq = {color, ...q}  // cq is inexact
 - Object, tuple, and array **literals** infer as exact.
 - A shape **inferred from usage** is exact too. Once body inference finishes, the
   row is closed.
-- **Unions** are exact.
 - A **class instance** is exact when the class is `final`. A non-`final` class may
   have subclass instances carrying extra members, so its instance type is inexact.
 - A written **function value** is exact, meaning it accepts exactly the arities its
@@ -120,13 +119,10 @@ type OpenObj = {x: number, y: string, ...}
 OpenObj[keyof OpenObj]       // unknown
 ```
 
-An exact union distributes through a conditional over exactly its written
-members. An inexact one cannot, since a member it does not name might behave
-differently.
-
-Exactness is also what makes `match` exhaustiveness decidable. An exact union is
-covered once every member has a branch; an inexact scrutinee always needs a
-catch-all. See [Pattern Matching](04_pattern_matching.md).
+Exactness is also what makes `match` exhaustiveness decidable. A union is closed,
+so it is covered once every member has a branch. An inexact object or tuple
+scrutinee admits values no pattern can name, so it always needs a catch-all. See
+[Pattern Matching](04_pattern_matching.md).
 
 ## Ownership is orthogonal
 
@@ -143,8 +139,20 @@ JSDoc field holding the original Escalier type annotation. An Escalier program
 importing those declarations reads the annotation and recovers the exact type;
 a TypeScript consumer ignores it and sees ordinary structural types.
 
-## Not yet implemented
+## `Exact<T>` and `Inexact<T>`
 
-The `Exact<T>` and `Inexact<T>` type operators are not implemented. Neither is
-the value-level `exact<T>(v)` conversion, which belongs to codegen: it lowers to
-a runtime check rather than a checker rule.
+The two operators convert between the forms. `Inexact<T>` sets the trailing `...`
+marker on its operand and `Exact<T>` clears it.
+
+```esc
+type A = Inexact<{x: number}>       // {x: number, ...}
+type B = Exact<{x: number, ...}>    // {x: number}
+```
+
+An operand carrying no such marker, a primitive or a literal, reduces to itself.
+An operand that is still abstract, such as a type parameter, stays symbolic until
+it grounds.
+
+The value-level `exact<T>(v)` conversion is a separate thing and is not
+implemented. It belongs to codegen, since it lowers to a runtime check rather
+than a checker rule.

--- a/docs/07_exact_types.md
+++ b/docs/07_exact_types.md
@@ -1,55 +1,150 @@
 # 07 Exact Types
 
-TypeScript uses structural sub-typing which means that an object conforms to a
-particular type as long as it has all of the same properties.  It's fine if the
-object has extra properties.
+TypeScript uses structural subtyping, so an object conforms to a type as long as
+it has all the required properties. Extra properties are fine.
 
-This leads to some interesting consequences.  In particular it means that you
-can't be sure it doesn't have extra properties.  As a result, TypeScript defines
-the type of `Object.keys` to be `string[]`.
+That has a consequence worth naming: given a value of some object type, you can
+never be sure it has no extra properties. It is why TypeScript types
+`Object.keys` as `string[]` rather than as the union of the declared keys.
 
-We can do better than this, but it requires differentiating types which we know
-don't have extra properties (exact types) from those that might (inexact types).
+Escalier does better by distinguishing types known to have no extra members from
+types that might, and it makes the former the default.
 
 ## Syntax
 
-```
+A trailing `...` opts a former into inexactness.
+
+```esc
 type ExactPoint = {x: number, y: number}
-type InexactPoint = {x: number, y: number, ...}
+type OpenPoint  = {x: number, y: number, ...}
+
+type ExactTuple = [string, number]
+type OpenTuple  = [string, number, ...]
 ```
+
+Unions carry the same flag. `A | B` is closed and `A | B | ...` may hold members
+beyond the ones written. A union may not have a trailing `...` written directly
+after a `|`; the compiler suggests `string`, `number`, or `unknown` for an open
+set of members.
+
+Intersections have no exactness of their own. Exactness is about whether the set
+of inhabitants is *open*, and an intersection is a constraint combinator rather
+than a value shape — the dual reading would mean hidden extra constraints, which
+is the opposite of what inexact means everywhere else. The exactness of an
+intersection's *result* is derived from its operands during normalization and
+lands on the resulting object or tuple.
 
 ## Semantics
 
+The rule is one-way: exact is a subtype of inexact, not the reverse.
+
+```esc
+fn f(p: ExactPoint, q: OpenPoint) {
+    val a: OpenPoint = p    // OK
+    val b: ExactPoint = q   // ERROR: q may have members ExactPoint does not declare
+}
 ```
-declare var p: ExactPoint
-declare var q: InexactPoint
 
-val a: InexactPoint = p // Okay
-val b: ExactPoint = q // Error! Exact types can't have properties
+Exact against exact requires the *same* member set, with no width subtyping.
+Inexact against inexact is ordinary structural width subtyping.
 
-val {x, ...rest} = p // `rest` will be exact
-val {x, ...rest} = q // `rest` will be inexact
+Rest patterns and spreads carry exactness through:
 
-val cp = {color, ...p} // `cp` will be exact
-val cq = {color, ...q} // `cq` will be inexact
+```esc
+val {x, ...rest} = p    // rest is exact
+val {x, ...rest} = q    // rest is inexact
+
+val cp = {color, ...p}  // cp is exact
+val cq = {color, ...q}  // cq is inexact
 ```
+
+## What is exact by default
+
+- Object, tuple, and array **literals** infer as exact.
+- A shape **inferred from usage** is exact too. Once body inference finishes, the
+  row is closed.
+- **Unions** are exact.
+- A **class instance** is exact when the class is `final`. A non-`final` class may
+  have subclass instances carrying extra members, so its instance type is inexact.
+- A written **function value** is exact, meaning it accepts exactly the arities its
+  parameter list declares.
+- Everything imported from a TypeScript `.d.ts` file is **inexact**, in every
+  category. A `.d.ts` file has no way to say a shape is closed.
+
+## Opting out with `open`
+
+Usage-inferred exactness is right for application code and wrong for a
+row-polymorphic helper, which wants to accept anything carrying the fields the
+body touches. Mark such a parameter `open`:
+
+```esc
+fn dist(open p) { p.x
+                  p.y }
+// inferred: fn (p: {x: unknown, y: unknown, ...}) -> undefined
+```
+
+Without `open`, the same function infers `{x: unknown, y: unknown}` and a caller
+passing an object with a third field is rejected.
+
+The default is chosen for the typical audience. Most Escalier code is application
+code, where exact-by-default catches extra-field bugs at the call site. Library
+authors writing row-polymorphic helpers pay one keyword.
+
+## Function exactness
+
+Direct calls reject extra arguments whatever the exactness. Exactness governs
+**callback subtyping** instead.
+
+A function type accepts a range of argument counts: `[required, declared]` when
+exact, `[required, ∞)` when inexact. `G <: F` when `G` accepts every count `F`'s
+holders may invoke with, with parameters contravariant and the return covariant.
+The familiar "a one-parameter callback works where three are supplied" rule is
+the inexact case.
+
+## Exactness and type-level operators
+
+Exactness changes what the operators compute, which is the whole point of
+tracking it.
+
+```esc
+type Tup = [string, number]
+keyof Tup                    // 0 | 1
+
+type OpenTup = [string, number, ...]
+keyof OpenTup                // number
+
+type Obj = {x: number, y: string}
+Obj[keyof Obj]               // number | string
+
+type OpenObj = {x: number, y: string, ...}
+OpenObj[keyof OpenObj]       // unknown
+```
+
+An exact union distributes through a conditional over exactly its written
+members. An inexact one cannot, since a member it does not name might behave
+differently.
+
+Exactness is also what makes `match` exhaustiveness decidable. An exact union is
+covered once every member has a branch; an inexact scrutinee always needs a
+catch-all. See [Pattern Matching](04_pattern_matching.md).
+
+## Ownership is orthogonal
+
+A `&` or `mut` wrapper carries its inner type's exactness through unchanged. The
+mutability and lifetime axes neither tighten nor loosen exactness, and the two
+compose without interacting.
 
 ## Interop
 
-As mentioned at the start of this page, TypeScript doesn't support exact types.
-This means that all types imported from TypeScript packages will be inexact.
+TypeScript has no exact types, so everything imported from a package is inexact.
 
-In order to preserve Escalier types across package boundaries, all declarations
-will include JSDoc comments that include a field containing type annotations of
-the original Escalier types.
+To keep Escalier types across a package boundary, emitted declarations carry a
+JSDoc field holding the original Escalier type annotation. An Escalier program
+importing those declarations reads the annotation and recovers the exact type;
+a TypeScript consumer ignores it and sees ordinary structural types.
 
-## Tuples
+## Not yet implemented
 
-The same idea cna be extended to tuples, with the following syntax.
-
-```
-type ExactTuple = [string, number]
-type InexactTuple = [string, number, ...]
-```
-
-The semantics and TypeScript interop would be similar as well.
+The `Exact<T>` and `Inexact<T>` type operators are not implemented. Neither is
+the value-level `exact<T>(v)` conversion, which belongs to codegen: it lowers to
+a runtime check rather than a checker rule.

--- a/docs/07_exact_types.md
+++ b/docs/07_exact_types.md
@@ -5,7 +5,9 @@ it has all the required properties. Extra properties are fine.
 
 That has a consequence worth naming: given a value of some object type, you can
 never be sure it has no extra properties. It is why TypeScript types
-`Object.keys` as `string[]` rather than as the union of the declared keys.
+`Object.keys` as `string[]`. With exact types the same call is an array of the
+declared keys — `Array<"x" | "y">` for a `{x: number, y: string}` — because the
+key set is known to be closed.
 
 Escalier does better by distinguishing types known to have no extra members from
 types that might, and it makes the former the default.
@@ -13,14 +15,14 @@ types that might, and it makes the former the default.
 ## Syntax
 
 A **former** is a type constructor that builds a type out of parts — an object,
-a tuple, a function, a union. A trailing `...` opts one into inexactness.
+a tuple, a function. A trailing `...` opts one into inexactness.
 
 ```esc
-type ExactPoint = {x: number, y: number}
-type OpenPoint  = {x: number, y: number, ...}
+type ExactPoint   = {x: number, y: number}
+type InexactPoint = {x: number, y: number, ...}
 
-type ExactTuple = [string, number]
-type OpenTuple  = [string, number, ...]
+type ExactTuple   = [string, number]
+type InexactTuple = [string, number, ...]
 ```
 
 Unions and intersections have no exactness of their own. A union is always
@@ -40,9 +42,9 @@ lands on the resulting object or tuple.
 The rule is one-way: exact is a subtype of inexact, not the reverse.
 
 ```esc
-fn f(p: ExactPoint, q: OpenPoint) {
-    val a: OpenPoint = p    // OK
-    val b: ExactPoint = q   // ERROR: q may have members ExactPoint does not declare
+fn f(p: ExactPoint, q: InexactPoint) {
+    val a: InexactPoint = p   // OK
+    val b: ExactPoint = q     // ERROR: q may have members ExactPoint does not declare
 }
 ```
 
@@ -78,17 +80,22 @@ row-polymorphic helper, which wants to accept anything carrying the fields the
 body touches. Mark such a parameter `open`:
 
 ```esc
-fn dist(open p) { p.x
-                  p.y }
-// inferred: fn (p: {x: unknown, y: unknown, ...}) -> undefined
+import "std:math"
+
+fn dist(open p) {
+    return math.sqrt(p.x * p.x + p.y * p.y)
+}
+// inferred: fn (p: {x: number, y: number, ...}) -> number
 ```
 
-Without `open`, the same function infers `{x: unknown, y: unknown}` and a caller
+Without `open`, the same function infers `{x: number, y: number}` and a caller
 passing an object with a third field is rejected.
 
 The default is chosen for the typical audience. Most Escalier code is application
 code, where exact-by-default catches extra-field bugs at the call site. Library
-authors writing row-polymorphic helpers pay one keyword.
+authors writing row-polymorphic helpers pay one keyword — and they are the ones
+most likely to be writing explicit annotations anyway, where exactness is stated
+outright rather than inferred.
 
 ## Function exactness
 
@@ -98,8 +105,21 @@ Direct calls reject extra arguments whatever the exactness. Exactness governs
 A function type accepts a range of argument counts: `[required, declared]` when
 exact, `[required, ∞)` when inexact. `G <: F` when `G` accepts every count `F`'s
 holders may invoke with, with parameters contravariant and the return covariant.
-The familiar "a one-parameter callback works where three are supplied" rule is
-the inexact case.
+
+So the familiar "a one-parameter callback works where three are supplied" rule
+is the *inexact* case, and only that case. A written function value is exact, so
+it has to match the slot's arity:
+
+```esc
+declare fn hof(cb: fn (a: number, b: number, c: number) -> number) -> number
+
+val r = hof(fn (a) { return a })
+// ERROR: cannot constrain function of arity 1 <: function of arity 3
+
+val s = hof(fn (a, ...) { return a })   // OK — [1, ∞) covers 3
+```
+
+See [Functions](02_functions.md) for the same rule from the caller's side.
 
 ## Exactness and type-level operators
 
@@ -107,22 +127,37 @@ Exactness changes what the operators compute, which is the whole point of
 tracking it.
 
 ```esc
-type Tup = [string, number]
-keyof Tup                    // 0 | 1
+type ExactTup = [string, number]
+keyof ExactTup                   // 0 | 1
 
-type OpenTup = [string, number, ...]
-keyof OpenTup                // number
+type InexactTup = [string, number, ...]
+keyof InexactTup                 // number
 
-type Obj = {x: number, y: string}
-Obj[keyof Obj]               // number | string
+type ExactObj = {x: number, y: string}
+ExactObj[keyof ExactObj]         // number | string
 
-type OpenObj = {x: number, y: string, ...}
-OpenObj[keyof OpenObj]       // unknown
+type InexactObj = {x: number, y: string, ...}
+InexactObj[keyof InexactObj]     // unknown
+```
+
+A mapped type carries its operand's exactness onto its result, so a utility
+built from one preserves the distinction rather than flattening it:
+
+```esc
+type Partial<T> = {[K]?: T[K] for K in keyof T}
+
+Partial<ExactObj>     // {x?: number, y?: string}
+Partial<InexactObj>   // {x?: number, y?: string, ...}
 ```
 
 Exactness is also what makes `match` exhaustiveness decidable. A union is closed,
 so it is covered once every member has a branch. An inexact object or tuple
-scrutinee admits values no pattern can name, so it always needs a catch-all. See
+scrutinee admits values no pattern can name, so it always needs a catch-all.
+
+A rest pattern still *matches* an inexact scrutinee and binds whatever it did not
+name, so `{x, ...rest}` reads `x` and collects the undeclared members into
+`rest`. What it does not do yet is discharge the catch-all requirement — the
+coverage check asks for a catch-all whatever the arms look like. See
 [Pattern Matching](04_pattern_matching.md).
 
 ## Ownership is orthogonal
@@ -135,10 +170,24 @@ compose without interacting.
 
 TypeScript has no exact types, so everything imported from a package is inexact.
 
-To keep Escalier types across a package boundary, emitted declarations carry a
-JSDoc field holding the original Escalier type annotation. An Escalier program
-importing those declarations reads the annotation and recovers the exact type;
-a TypeScript consumer ignores it and sees ordinary structural types.
+To keep Escalier types across a package boundary, emitted declarations carry an
+`@escalier-type` JSDoc tag holding the original annotation in source form. The
+emitted TypeScript is a best-effort erasure for plain TypeScript consumers; the
+tag is the source of truth for an Escalier consumer re-importing the declaration.
+
+```esc
+export declare val p: {x: number, ...}
+```
+
+```ts
+/** @escalier-type {x: number, ...} */
+export declare const p: { x: number };
+```
+
+A TypeScript consumer ignores the tag and sees an ordinary structural type. An
+Escalier consumer reads it and recovers the inexactness the `.d.ts` form cannot
+express. The same mechanism carries tuples, functions, unions, and the
+`Exact<T>` / `Inexact<T>` wrappers.
 
 ## `Exact<T>` and `Inexact<T>`
 

--- a/docs/08_mutability.md
+++ b/docs/08_mutability.md
@@ -88,21 +88,34 @@ so the points live elsewhere and must outlive it.
 
 ## `readonly`
 
-`readonly` is a field-level modifier that forbids **reassigning** the field. It
-says nothing about the depth of the value the field holds.
+`readonly` is a field-level modifier that forbids **reassigning** the field.
 
 ```esc
-type Config = {readonly id: string, name: string}
+fn f(p: mut {readonly id: string, name: string}) {
+    p.name = "x"    // OK
+    p.id = "y"      // ERROR: cannot assign to readonly property: id
+}
 ```
 
-So `readonly` governs the slot and `mut` governs depth. The two compose without
-interacting.
+`readonly` governs one slot; `mut` governs everything the value owns. So the two
+answer different questions and compose without interacting. A field is never
+annotated `mut` on its own — the enclosing context decides mutability, and the
+compiler rejects a `mut` on a field with a diagnostic saying so.
 
 `readonly` also constrains structural compatibility. A `{readonly a: T}` value
-cannot satisfy a writable `{a: T}` target, because a holder of the target could
-reassign through `a` and break the source's guarantee. The reverse is allowed: a
-writable `{a: T}` value satisfies a `{readonly a: T}` target, since the target
-only ever reads.
+cannot satisfy a **writable** `{a: T}` target, since a holder of that target
+could reassign through `a` and break the source's guarantee:
+
+```esc
+fn f(p: mut {readonly a: number}) {
+    val q: mut {a: number} = p
+    // ERROR: readonly field a cannot satisfy a writable field requirement
+}
+```
+
+An immutable target is fine, because nobody can write through it. The reverse
+direction is always allowed: a writable `{a: T}` value satisfies a
+`{readonly a: T}` target, since the target only ever reads.
 
 `readonly` survives a freeze and a thaw unchanged, since it is part of the
 structural shape rather than the `mut` wrapper.

--- a/docs/08_mutability.md
+++ b/docs/08_mutability.md
@@ -1,17 +1,167 @@
 # 08 Mutability
 
-Escalier is immutable by default.  This differs from TypeScript which is mutable
-by default.
+Escalier is immutable by default. This differs from TypeScript and JavaScript,
+where every object is mutable and `readonly` is the opt-in.
 
+The guarantee the system provides:
 
+> No immutable reference ever observes a mutation. If a value is reachable
+> through an immutable reference that is live at some point, then between the
+> creation of that reference and its last use, the value is not mutated through
+> any other path.
+
+Everything below follows from holding that invariant. The ownership machinery
+that enforces it lives in [Ownership](09_ownership.md); this page covers what
+`mut` means and where it applies.
+
+## `mut`
+
+A freshly produced value is owned and immutable. Opt into mutability at the
+binding pattern or with a `mut` annotation.
+
+```esc
+val p = {x: 0, y: 0}                       // p: {x: number, y: number}
+// p.x = 1                                 // ERROR: p is immutable
+
+val mut q = {x: 0, y: 0}                   // q: mut {x: number, y: number}
+q.x = 1                                    // OK
+
+val r: mut {x: number, y: number} = {x: 0, y: 0}
+```
+
+This applies uniformly to object literals, tuple and array literals, and class
+instances. A class instance is immutable by default whether or not the class
+declares `mut self` methods:
+
+```esc
+class Counter {
+    count: number,
+    constructor(mut self, count: number) { self.count = count },
+    increment(mut self) -> number { return self.count },
+}
+
+val c = Counter(0)        // c: Counter — immutable
+val mut d = Counter(0)    // d: mut Counter
+```
+
+A method declares its receiver's mutability in its own parameter list. `fn m(self)`
+reads, and `fn m(mut self)` writes. A `mut self` method may only be called through
+a mutable binding.
+
+## `mut` is deep and uniform
+
+A `mut` applies to a type and propagates through everything the value owns.
+
+```esc
+val a: mut {a: {b: {c: number}}} = {a: {b: {c: 0}}}
+a.a.b.c = 1                     // OK — every layer is writable
+```
+
+The `mut` goes on the type, not on the outermost layer of it. Writing
+`val mut a: {a: {b: {c: number}}} = ...` is a conflict: the binding pattern asks
+for a mutable value and the annotation names an immutable one.
+
+It flows through type arguments as well, so it does not stop at a type parameter.
+`mut Foo<Point>` makes both `Foo`'s body and the `Point` it holds writable. The
+container case follows: `mut Array<Point>` is a mutable array of mutable points,
+where you may push, reorder, and reassign elements *and* mutate a point's fields.
+`Array<Point>` is immutable all the way down.
+
+Depth is therefore all-or-nothing. There is no "mutable container, immutable
+element" type built out of `mut` alone.
+
+## Mixing mutable and immutable data
+
+The one boundary that stops the propagation is a **borrow**. A `&` or `&mut`
+field is a window into another value and carries its own mutability, not the
+enclosing modifier's.
+
+```esc
+type A = mut Array<&Point>       // mutable array of immutable points
+type B = Array<&mut Point>       // immutable array of mutable points
+```
+
+In `A` you may push, reorder, and reassign elements, but each element is a
+read-only window. In `B` the array's shape is fixed, yet each element lets you
+write through to its point. The trade-off is ownership: the array holds borrows,
+so the points live elsewhere and must outlive it.
+
+## `readonly`
+
+`readonly` is a field-level modifier that forbids **reassigning** the field. It
+says nothing about the depth of the value the field holds.
+
+```esc
+type Config = {readonly id: string, name: string}
+```
+
+So `readonly` governs the slot and `mut` governs depth. The two compose without
+interacting.
+
+`readonly` also constrains structural compatibility. A `{readonly a: T}` value
+cannot satisfy a writable `{a: T}` target, because a holder of the target could
+reassign through `a` and break the source's guarantee. The reverse is allowed: a
+writable `{a: T}` value satisfies a `{readonly a: T}` target, since the target
+only ever reads.
+
+`readonly` survives a freeze and a thaw unchanged, since it is part of the
+structural shape rather than the `mut` wrapper.
+
+## Freezing and thawing
+
+There is no utility type that converts between mutable and immutable forms. The
+binding's mutability already governs the whole reachable owned structure, so
+moving a value into a differently-mutable binding *is* the conversion.
+
+```esc
+val mut g = build()
+val frozen = g            // freeze — consumes g
+val mut thawed = frozen   // thaw — consumes frozen
+```
+
+Both are free at runtime. Soundness comes from the move consuming the source. See
+[Ownership](09_ownership.md).
+
+## Exclusivity
+
+Two paths to one value may not disagree about whether it can change. An immutable
+borrow and a mutable path to the same value may never both be live. Within one
+kind, aliasing is free: several immutable borrows may be live at once, and so may
+several mutable ones.
+
+This is checked with liveness analysis over the control-flow graph, so a borrow
+that is never used again does not block a later transition.
 
 ## Interop
 
-TypeScript includes some official types that make the distinction between mutable
-and immutable versions of the same class, e.g. `Array`/`ReadonlyArray`, 
-`Set`/`ReadonlySet`, and `Map`/`ReadonlyMap`.  The majority of classes in the
-TypeScript ecosystem do not make this distinction.
+TypeScript's standard library ships paired mutable and immutable versions of a
+few classes — `Array`/`ReadonlyArray`, `Set`/`ReadonlySet`, `Map`/`ReadonlyMap`.
+Escalier uses those pairs to work out which methods on the class mutate their
+receiver. Most classes in the TypeScript ecosystem do not make the distinction,
+so for those the receiver's mutability has to come from somewhere else.
 
-Escalier uses these pairs to construct an Escalier type for class instances
-that marks methods as mutating or not
+For the JavaScript standard library, that source is **ECMA-262 itself**. Each
+builtin is specified as a numbered algorithm, and an algorithm states directly
+whether it performs a mutating abstract operation on a value and whether it
+returns an input rather than a freshly allocated object. Those facts are
+extracted mechanically and used to annotate the `std:*` packages, giving five
+things per method:
 
+1. whether it mutates its receiver, so `&self` or `&mut self`;
+2. each other parameter's disposition — read-only borrow, in-place mutable
+   borrow, or escape;
+3. whether the return value borrows the receiver or a parameter;
+4. which exceptions it can throw, as a candidate `throws` clause;
+5. which exceptions a promise-returning method rejects with, as a candidate `E`
+   in `Promise<T, E>`.
+
+This replaces name-based heuristics, which guess from a method's name and get
+cases like `String.prototype.replace` wrong — the name looks mutating, but the
+method returns a fresh string.
+
+The `web:*` packages have no equivalent machine-readable source in ECMA-262. The
+closest analogue is WebIDL's `[Throws]`, `[NewObject]`, and `[SameObject]`
+extended attributes. Node builtins have neither and stay hand-authored.
+
+Mutability, borrows, and lifetimes are all editable inline in the `.esc` source
+for each pseudo-package, with no separate override or merge layer.

--- a/docs/08_mutability.md
+++ b/docs/08_mutability.md
@@ -45,8 +45,26 @@ val mut d = Counter(0)    // d: mut Counter
 ```
 
 A method declares its receiver's mutability in its own parameter list. `fn m(self)`
-reads, and `fn m(mut self)` writes. A `mut self` method may only be called through
-a mutable binding.
+reads and `fn m(mut self)` writes.
+
+```esc
+class Counter {
+    count: number,
+    constructor(mut self, count: number) { self.count = count },
+    incr(mut self) { self.count = self.count + 1 },
+    read(self) -> number { return self.count },
+}
+
+fn go() {
+    val mut c = Counter(0)
+    c.incr()          // mut self — needs the mutable binding
+    return c.read()   // self — reads through either
+}
+```
+
+A `mut self` method is meant to require a mutable binding, so calling `incr` on a
+plain `val c = Counter(0)` should be an error. The receiver's mutability is not
+checked at the call yet, so that call is currently accepted.
 
 ## `mut` is deep and uniform
 
@@ -113,9 +131,31 @@ fn f(p: mut {readonly a: number}) {
 }
 ```
 
-An immutable target is fine, because nobody can write through it. The reverse
-direction is always allowed: a writable `{a: T}` value satisfies a
-`{readonly a: T}` target, since the target only ever reads.
+An immutable target is fine, because nobody can write through it.
+
+The reverse direction — a writable `{a: T}` value against a `{readonly a: T}`
+target — depends on whether the target *owns* the value and on how long the
+source stays in use. Moving into the target is fine, since the move consumes the
+source and leaves no writable path. Borrowing is fine only while no mutable path
+is still live:
+
+```esc
+fn go() {
+    val mut p = {a: 0}
+    val q: &{readonly a: number} = p
+    p.a = 1                  // ERROR: cannot assign 'p' to immutable 'q':
+    val n = q.a              //        'p' is still used mutably after this point
+}
+
+fn ok() {
+    val mut p = {a: 0}
+    p.a = 1                  // last mutable use of p
+    val q: &{readonly a: number} = p
+    val n = q.a              // OK
+}
+```
+
+This is the exclusivity rule below, not a `readonly` rule of its own.
 
 `readonly` survives a freeze and a thaw unchanged, since it is part of the
 structural shape rather than the `mut` wrapper.
@@ -124,7 +164,9 @@ structural shape rather than the `mut` wrapper.
 
 There is no utility type that converts between mutable and immutable forms. The
 binding's mutability already governs the whole reachable owned structure, so
-moving a value into a differently-mutable binding *is* the conversion.
+moving a value into a differently-mutable binding *is* the conversion. Naming
+the converted type is tracked in
+[#1266](https://github.com/escalier-lang/escalier/issues/1266).
 
 ```esc
 val mut g = build()
@@ -142,8 +184,33 @@ borrow and a mutable path to the same value may never both be live. Within one
 kind, aliasing is free: several immutable borrows may be live at once, and so may
 several mutable ones.
 
-This is checked with liveness analysis over the control-flow graph, so a borrow
-that is never used again does not block a later transition.
+Liveness is what makes this workable. The check runs over the control-flow graph,
+so a path that is never used again does not block a later transition — only an
+overlap does.
+
+```esc
+fn conflicting() {
+    val mut p = {x: 0}
+    val q: &{x: number} = p   // ERROR: cannot assign 'p' to immutable 'q':
+    p.x = 1                   //        'p' is still used mutably after this point
+    val n = q.x
+}
+
+fn fine() {
+    val mut p = {x: 0}
+    p.x = 1                   // the mutable path ends here
+    val q: &{x: number} = p   // OK — nothing mutable is live past this point
+    val n = q.x
+}
+```
+
+The two functions differ only in statement order. In `conflicting` the write to
+`p` comes after `q` is created and `q` is read afterwards, so the two paths
+overlap. In `fine` the write is `p`'s last use, so no mutable path survives.
+
+Exclusivity between two `&` borrows of one value is specified but not yet
+enforced. Taking `&p` and `&mut p` and using both is accepted today; see
+[#794](https://github.com/escalier-lang/escalier/issues/794).
 
 ## Interop
 

--- a/docs/09_ownership.md
+++ b/docs/09_ownership.md
@@ -94,8 +94,20 @@ Escape is the single trigger for a move. An owned value moves when it flows into
 - a closure that itself escapes, capturing the value.
 
 A value does **not** escape when it flows into a strictly shorter-lived
-destination: a non-escaping argument, an inner-scope binding that dies first, or
-a local reborrow. Those are borrows, and the source is retained.
+destination: a non-escaping argument or a local reborrow. Those are borrows, and
+the source is retained.
+
+Binding is the exception to that shape. A `val` or `var` binding of an owned
+value moves it whatever its scope, because the new binding takes ownership rather
+than borrowing for a while:
+
+```esc
+val p = {x: 0}
+if true { val q = p }       // moves p, even though q dies first
+p.x                         // ERROR: use of moved value 'p'
+```
+
+Annotate the destination `&` to borrow instead.
 
 The escape verdict is read off the lifetime constraints rather than recomputed. A
 value escapes exactly when its lifetime is forced to outlive its binding's scope.
@@ -132,7 +144,7 @@ collected, so drops need no generated code.
 | Field or element store | Move when the container outlives the source |
 | `return` | Move, unless the value is a value type or an already-outliving borrow |
 | Function argument | Borrow for a `&` parameter, move for a bare owned one |
-| Closure capture | Move into an escaping closure, borrow into a local one |
+| Closure capture | Move into an escaping closure, borrow into a local one; see below |
 | Destructuring | Per part, following the same rules |
 | `match` arm bindings | Per part, consistent with destructuring |
 
@@ -325,9 +337,21 @@ concrete value type or take a borrow.
 
 ## What ownership does not cover
 
+Out of scope by design:
+
 - **Concurrency and data races.** Excluding them would require Rust-style
   exclusive borrowing, which Escalier deliberately gives up.
-- **Heap escape analysis** beyond function return values.
+
+Specified above but not yet enforced:
+
+- **Escaping closure captures.** Capturing a value in a closure that escapes is
+  specified as a move, but the checker does not consume the captured binding
+  today, so the later use goes unreported.
+- **Element stores.** `t[i] = x` is rejected as unsupported rather than treated
+  as an escape.
 - **Reassignment clearing a move.** Reassigning a `var` after it was moved gives
   it a fresh value, but the analysis still reads the binding as moved, so a use
   after re-initialization is reported spuriously.
+
+The other escape sites — a longer-lived binding, a field store, a `return`, and a
+consuming argument — do consume their source.

--- a/docs/09_ownership.md
+++ b/docs/09_ownership.md
@@ -64,9 +64,31 @@ val q = &p       // q: &Point — immutable borrow
 val r = &mut p   // r: &mut Point — mutable borrow; requires p to be owned-mutable
 ```
 
-Call arguments still borrow implicitly. Write `foo(p)`, not `foo(&p)` — the
-parameter's own `&` already states the borrow, and owning a value subsumes
-lending it.
+Passing an **owned** value to a borrowing parameter takes the same `&` or `&mut`,
+following Rust. The borrow is written at the call rather than inferred from the
+signature, so a reader sees at the call site that the callee only borrows:
+
+```esc
+fn read(p: &{x: number}) -> number { return p.x }
+fn bump(p: &mut {x: number}) { p.x = 1 }
+
+fn go() {
+    val mut p = {x: 0}
+    bump(&mut p)
+    val n = read(&p)
+}
+```
+
+An argument that is *already* a borrow passes as-is; there is nothing to borrow
+again.
+
+**Method receivers are the exception.** Calling a method whose `self` is borrowed
+needs no marker — `c.read()`, never `(&c).read()` — because the receiver's
+mutability is already written on `self` in the method's own parameter list and
+there is only ever one receiver to mark.
+
+The call-site `&` is not required yet. Today the compiler inserts the borrow
+itself, so both `read(p)` and `read(&p)` are accepted.
 
 ## Copy, borrow, move
 
@@ -92,6 +114,25 @@ Escape is the single trigger for a move. An owned value moves when it flows into
 - a `return`, since the value outlives the call frame;
 - an argument whose parameter the callee lets escape;
 - a closure that itself escapes, capturing the value.
+
+The escaping-argument case is the one that depends on the callee's body rather
+than on its signature. `store` below writes its parameter into module-level
+state, so the value has to outlive the call, and passing to it moves:
+
+```esc
+var sink: {x: number} = {x: 0}
+
+fn store(p: {x: number}) { sink = p }
+
+fn go() {
+    val p = {x: 1}
+    store(p)
+    val n = p.x     // ERROR: use of moved value 'p'
+}
+```
+
+A callee that only reads its parameter lets nothing escape, so the same call
+shape borrows and leaves the source usable.
 
 A value does **not** escape when it flows into a strictly shorter-lived
 destination: a non-escaping argument or a local reborrow. Those are borrows, and
@@ -141,18 +182,43 @@ collected, so drops need no generated code.
 |---|---|
 | `val` / `var` binding | Copy a value type, duplicate a borrow, move an owned value |
 | Reassignment | Same decision as a binding; the old value is dropped |
-| Field or element store | Move when the container outlives the source |
+| Field or element store | Move when the container outlives the source, borrowed containers included |
 | `return` | Move, unless the value is a value type or an already-outliving borrow |
-| Function argument | Borrow for a `&` parameter, move for a bare owned one |
+| Function argument | Borrow for a `&` parameter, written `&`/`&mut` at the call; move for a bare owned one |
 | Closure capture | Move into an escaping closure, borrow into a local one; see below |
 | Destructuring | Per part, following the same rules |
 | `match` arm bindings | Per part, consistent with destructuring |
+
+Whether the container is owned or borrowed does not change the field-store row.
+What matters is how long the container's storage lives, and a `&mut` container
+borrows from something that already outlives the value being stored:
+
+```esc
+fn put(c: &mut {slot: {x: number}}, v: {x: number}) { c.slot = v }
+
+fn go() {
+    val mut c = {slot: {x: 0}}
+    val v = {x: 1}
+    put(&mut c, v)
+    val n = v.x     // ERROR: use of moved value 'v'
+}
+```
 
 An owned value's mutability belongs to the binding and defaults to immutable, so
 moving into a plain `val` freezes it and `val mut` keeps it mutable. A borrow's
 mutability belongs to its `&`/`&mut` type and is inherited on copy. It can be
 narrowed by annotation but never widened, since a view cannot grant itself access
-the owner withheld.
+the owner withheld:
+
+```esc
+val mut p = {x: 0}
+
+val q = &mut p
+val r: &{x: number} = q        // OK — narrowing a mutable view to a read-only one
+
+val s = &p
+val t: &mut {x: number} = s    // ERROR: cannot constrain immutable object <: mutable object
+```
 
 ## Partial moves
 
@@ -182,17 +248,60 @@ phases that never overlap:
 but an immutable borrow's lifetime and a mutable borrow's lifetime for the same
 value may never overlap. The owner's own write path counts as a mutable path.
 
+Aliasing within one kind is free:
+
 ```esc
 val mut a = {x: 1}
 val b = &mut a       // mutable borrow
 val c = &mut a       // a second one — allowed
 b.x = 2
-print(a.x)           // OK — prints 2
+c.x = 3
 ```
 
 Multiple simultaneous mutable borrows are safe because Escalier compiles to
 single-threaded JavaScript. There is no data race to exclude, and the invariant
 forbids only mixing the two kinds, not aliasing within one kind.
+
+Mixing them is decided by *overlap*, not by which borrows exist. Running the
+mutable phase to completion before the immutable one begins is fine:
+
+```esc
+fn sequential() {
+    val mut p = {x: 0}
+    val a = &mut p
+    a.x = 1          // the mutable phase ends here
+    val b = &p
+    val n = b.x      // OK — the immutable phase starts after it
+}
+```
+
+Interleaving them is not. Here `b` is read after a write through `a`, so an
+immutable view observes a mutation:
+
+```esc
+fn overlapping() {
+    val mut p = {x: 0}
+    val b = &p
+    val a = &mut p
+    a.x = 1
+    val n = b.x      // should be rejected — b is live across the write
+}
+```
+
+Escalier catches that today only when the immutable view is created by
+annotation rather than by an explicit `&`:
+
+```esc
+val mut p = {x: 0}
+val b: &{x: number} = p   // ERROR: cannot assign 'p' to immutable 'b':
+p.x = 1                   //        'p' is still used mutably after this point
+val n = b.x
+```
+
+`overlapping` above is accepted as written; exclusivity between two `&` borrows
+of one value is specified but not yet enforced. See
+[#794](https://github.com/escalier-lang/escalier/issues/794) and
+[Mutability](08_mutability.md).
 
 ## Freezing and thawing
 
@@ -303,6 +412,7 @@ memory-safety motivation removed.
 | Drops | None; the runtime is garbage collected | `Drop` runs at scope end |
 | `Copy` trait | No such bound; primitives, functions, and promises are value types | `Copy`/`Clone` bounds on type parameters |
 | Lifetimes as a kind | Ordinary types, so a type parameter can be instantiated at a borrow | A separate kind that must be threaded explicitly |
+| Call-site borrows | `&` / `&mut` on the argument, none on a method receiver | The same |
 | Mutability depth | Deep and uniform through owned structure | Per-reference, and interior mutability via `Cell`/`RefCell` |
 | Freeze and thaw | A move into a `val` or `val mut` binding | No equivalent |
 | Concurrency | Out of scope; the target is single-threaded | `Send`/`Sync` built on exclusive borrowing |

--- a/docs/09_ownership.md
+++ b/docs/09_ownership.md
@@ -454,14 +454,18 @@ Out of scope by design:
 
 Specified above but not yet enforced:
 
-- **Escaping closure captures.** Capturing a value in a closure that escapes is
-  specified as a move, but the checker does not consume the captured binding
-  today, so the later use goes unreported.
-- **Element stores.** `t[i] = x` is rejected as unsupported rather than treated
-  as an escape.
-- **Reassignment clearing a move.** Reassigning a `var` after it was moved gives
-  it a fresh value, but the analysis still reads the binding as moved, so a use
-  after re-initialization is reported spuriously.
+- **Escaping closure captures**
+  ([#1267](https://github.com/escalier-lang/escalier/issues/1267)). Capturing a
+  value in a closure that escapes is specified as a move, but the checker does
+  not consume the captured binding today, so the later use goes unreported.
+- **Element stores**
+  ([#1268](https://github.com/escalier-lang/escalier/issues/1268)). `t[i] = x`
+  is rejected as unsupported rather than treated as an escape.
+- **Reassignment clearing a move**
+  ([#1269](https://github.com/escalier-lang/escalier/issues/1269)). Reassigning
+  a `var` after it was moved gives it a fresh value, but the analysis still
+  reads the binding as moved, so a use after re-initialization is reported
+  spuriously.
 
 The other escape sites — a longer-lived binding, a field store, a `return`, and a
 consuming argument — do consume their source.

--- a/docs/09_ownership.md
+++ b/docs/09_ownership.md
@@ -1,0 +1,333 @@
+# 09 Ownership
+
+Escalier tracks, for every reference-shaped value, which binding **owns** it and
+which bindings **borrow** it. This is what lets the compiler guarantee the
+property [Mutability](08_mutability.md) states:
+
+> No immutable reference ever observes a mutation. If a value is reachable
+> through an immutable reference that is live at some point, then between the
+> creation of that reference and its last use, the value is not mutated through
+> any other path.
+
+Correctness comes first: the invariant holds on every accepted program. Precision
+is the secondary goal — among the programs that preserve it, reject as few as
+possible.
+
+## Owned and borrowed
+
+At each point in the program, an object, tuple, array, or class instance is
+either owned by a binding or borrowed from an owner. The distinction is written
+in the type.
+
+| | owned | borrowed |
+|---|---|---|
+| **immutable** | `{x: number}` | `&{x: number}` / `&'a {x: number}` |
+| **mutable** | `mut {x: number}` | `&mut {x: number}` / `&'a mut {x: number}` |
+
+- **Owned** — the binding is the value's owner and the value's lifetime is the
+  binding's own region.
+- **Borrowed** — the value is a reference into storage owned elsewhere, valid
+  only for the borrow's lifetime, written with a leading `&`.
+
+Ownership and mutability are orthogonal. Ownership decides who is responsible for
+the value and whether a transfer consumes the source. Mutability decides whether
+writes are allowed.
+
+Primitives, functions, and promises are **value types**. They are never wrapped
+in a borrow, ownership does not apply to them, and they are freely duplicated.
+
+## How ownership is decided
+
+1. **Freshly produced values are owned, and immutable by default.** An object,
+   tuple, or array literal and a class constructor call all yield a value the
+   binding owns. Opt into mutability at the binding pattern, `val mut p = ...`,
+   or with a `mut` annotation.
+2. **A parameter is owned or borrowed according to its annotation.** `p: &T` and
+   `p: &mut T` borrow, and the caller keeps the value. A bare `p: T` or
+   `p: mut T` is consuming: the signature declares an ownership transfer. An
+   unannotated parameter is inferred from whether the body lets the value escape.
+3. **A bare annotation is owned; a `&` annotation borrows.** This holds in every
+   annotation position — a binding, a return type, a field, a parameter. So
+   `val q: &{x: number} = p` borrows `p` and leaves it usable, while
+   `val q: {x: number} = p` moves `p` into `q` and consumes it.
+4. **Member reads borrow the receiver.** `obj.f` yields a borrow of the field for
+   a lifetime bounded by the receiver, not a fresh owned value.
+5. **Escape forces ownership and a lifetime.** A value that flows into storage
+   outliving its current binding has its lifetime constrained to outlive the
+   destination.
+
+A binding can also borrow with an explicit `&` on the initializer, which avoids
+repeating the pointee's shape:
+
+```esc
+val q = &p       // q: &Point — immutable borrow
+val r = &mut p   // r: &mut Point — mutable borrow; requires p to be owned-mutable
+```
+
+Call arguments still borrow implicitly. Write `foo(p)`, not `foo(&p)` — the
+parameter's own `&` already states the borrow, and owning a value subsumes
+lending it.
+
+## Copy, borrow, move
+
+At every site where a value flows from a source into a destination, the transfer
+has one of three outcomes.
+
+1. **Copy.** The source is a value type, so the transfer never consumes it. An
+   immutable borrow is copyable too: copying one yields another immutable borrow
+   of the same value.
+2. **Borrow.** The destination takes a reference whose lifetime is bounded within
+   the source's region. The source keeps ownership and stays usable.
+3. **Move.** Ownership transfers out of the source binding, which is **consumed**.
+   Any later use of it is a use-after-move error.
+
+Binding a borrow never consumes it. Only owned values move.
+
+### What counts as escape
+
+Escape is the single trigger for a move. An owned value moves when it flows into:
+
+- a longer-lived binding, such as a module-level or outer-scope one;
+- a field or element of an object that outlives the source;
+- a `return`, since the value outlives the call frame;
+- an argument whose parameter the callee lets escape;
+- a closure that itself escapes, capturing the value.
+
+A value does **not** escape when it flows into a strictly shorter-lived
+destination: a non-escaping argument, an inner-scope binding that dies first, or
+a local reborrow. Those are borrows, and the source is retained.
+
+The escape verdict is read off the lifetime constraints rather than recomputed. A
+value escapes exactly when its lifetime is forced to outlive its binding's scope.
+
+### Use-after-move
+
+```esc
+val p = {x: 0}              // p owns a fresh value
+storeGlobally(p)            // p escapes into global state — moved, p consumed
+print(p.x)                  // ERROR: use of moved value 'p'
+```
+
+"Use" means reading, mutating through, calling a method on, moving again, or
+borrowing. A move also requires the source to have no live borrow at the move
+point, since the move would consume storage the borrow still points into.
+
+The check runs as a post-pass over the control-flow graph, so a move on one
+branch consumes the binding only on paths where it happens, and a move on a back
+edge is still caught at a use above it.
+
+### Affine, not linear
+
+A value may be consumed **at most** once. A binding that is never moved is simply
+dropped at the end of its scope. There is no obligation to move or explicitly
+destroy anything, and no use-before-anything requirement. JavaScript is garbage
+collected, so drops need no generated code.
+
+## Flow sites
+
+| Site | Outcome |
+|---|---|
+| `val` / `var` binding | Copy a value type, duplicate a borrow, move an owned value |
+| Reassignment | Same decision as a binding; the old value is dropped |
+| Field or element store | Move when the container outlives the source |
+| `return` | Move, unless the value is a value type or an already-outliving borrow |
+| Function argument | Borrow for a `&` parameter, move for a bare owned one |
+| Closure capture | Move into an escaping closure, borrow into a local one |
+| Destructuring | Per part, following the same rules |
+| `match` arm bindings | Per part, consistent with destructuring |
+
+An owned value's mutability belongs to the binding and defaults to immutable, so
+moving into a plain `val` freezes it and `val mut` keeps it mutable. A borrow's
+mutability belongs to its `&`/`&mut` type and is inherited on copy. It can be
+narrowed by annotation but never widened, since a view cannot grant itself access
+the owner withheld.
+
+## Partial moves
+
+Moving one field out of an owned object consumes that field's slot, not the whole
+object.
+
+```esc
+val pair = {a: makeWidget(), b: makeWidget()}
+storeGlobally(pair.a)      // moves pair.a out
+print(pair.b.id)           // OK: pair.b is untouched
+print(pair.a.id)           // ERROR: use of moved value 'pair.a'
+```
+
+Moves and borrows are tracked at the same path granularity, so `&obj.f` locks
+only that path and a disjoint sibling `obj.g` stays independently usable. A path
+the checker cannot prove disjoint, such as `arr[i]` versus `arr[j]`, falls back to
+a container-level borrow.
+
+## Borrow phases
+
+A mutable owned value may be borrowed many times. Its borrows fall into two
+phases that never overlap:
+
+- multiple immutable borrows may be live at once, **or**
+- multiple mutable borrows may be live at once,
+
+but an immutable borrow's lifetime and a mutable borrow's lifetime for the same
+value may never overlap. The owner's own write path counts as a mutable path.
+
+```esc
+val mut a = {x: 1}
+val b = &mut a       // mutable borrow
+val c = &mut a       // a second one — allowed
+b.x = 2
+print(a.x)           // OK — prints 2
+```
+
+Multiple simultaneous mutable borrows are safe because Escalier compiles to
+single-threaded JavaScript. There is no data race to exclude, and the invariant
+forbids only mixing the two kinds, not aliasing within one kind.
+
+## Freezing and thawing
+
+Freezing means moving a value into an immutable binding; thawing means moving it
+into a `val mut` binding. Because `mut` is deep and uniform, both reach the whole
+structure the value owns.
+
+```esc
+val mut g = build()
+g.peers[0].value = 20     // OK — mutable to the leaves
+
+val frozen = g            // freeze: consumes g, deeply immutable
+// frozen.peers[0].value = 5   // ERROR
+
+val mut thawed = frozen   // thaw: consumes frozen, mutable again
+thawed.peers[0].value = 7
+```
+
+Neither transition costs anything at runtime. The value is unchanged and only the
+type is stricter or looser. Soundness comes from the move: the freeze requires
+every mutable path to be dead, and the thaw requires no live immutable observer.
+
+The "only binding" requirement is load-bearing, and the checker enforces it by
+tracking aliases across the freeze:
+
+```esc
+val mut g = build()
+val first = g.peers[0]    // first: &mut Node — a live mutable path into the component
+val frozen = g            // ERROR: a mutable path into the component is still live
+first.value = 5           // the later use that keeps `first` live across the freeze
+```
+
+Thawing is not a faithful inverse for a value that mixes mutable and immutable
+edges. The freeze makes every internal edge `&` and the thaw makes every internal
+edge `&mut`, so an edge originally authored `&` comes back `&mut`. That is sound,
+since the consuming move leaves the thawed binding the sole owner, but wider than
+the author wrote.
+
+## Lifetimes
+
+A borrow's lifetime is inferred. It appears in a rendered type only when it is
+**load-bearing** — when it connects an input to an output, or escapes to
+`'static`.
+
+```esc
+fn f(p: &mut {x: number}) -> &{x: number} {
+    val q: &{x: number} = p
+    return q
+}
+// inferred: fn <'a>(p: &'a mut {x: number}) -> &'a {x: number}
+```
+
+A lifetime that connects nothing is dropped, leaving the bare `&{x: number}`. The
+`&` marker itself is never hidden, so owned and borrowed are always
+distinguishable in a displayed type.
+
+Lifetimes may be named and bounded explicitly, which is what a body-less
+declaration needs:
+
+```esc
+declare fn id<'a>(p: &'a {x: number}) -> &'a {x: number}
+declare fn f<'a, 'b: 'a>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number}
+```
+
+`'a: 'b` reads "`'a` outlives `'b`". A declared lifetime that connects nothing is
+elided from the rendered signature, and `'a: 'static` renders as `'static`
+directly.
+
+`'static` is the lifetime of a value that escapes into permanent storage. A
+borrow forced to `'static` may never be the target of a mutability transition,
+since an outside reference to it survives indefinitely.
+
+### Displayed types are writable types
+
+The governing rule for how any of this is rendered:
+
+> A type annotation should match the inferred type. The displayed signature is
+> always a valid annotation, and writing it back produces the same type.
+
+The compiler fills in a type the program did not write only at an explicit hole,
+such as the `_` in `fn () -> _ throws _`.
+
+## How this compares to Rust
+
+Escalier's ownership model is Rust's, with the aliasing rule relaxed and the
+memory-safety motivation removed.
+
+**What is the same**
+
+- Values are owned by one binding, and ownership transfers on a move.
+- A move consumes the source, and use after move is a compile-time error.
+- Borrows are written `&` and `&mut`, with lifetimes inferred and elided where
+  they connect nothing.
+- Lifetimes are named `'a` and bounded `'a: 'b`, with `'static` for values that
+  escape permanently.
+- Ownership is affine: a value may be consumed at most once, with no obligation
+  to consume it.
+- Moves and borrows are tracked per path, so a field can be moved or borrowed
+  while a disjoint sibling stays usable.
+- An immutable borrow and a mutable one may never be live at the same time.
+
+**What is different**
+
+| | Escalier | Rust |
+|---|---|---|
+| Motivation | Preserving the immutability guarantee | Memory safety and data-race freedom |
+| Multiple `&mut` | Allowed simultaneously | Forbidden; `&mut` is exclusive |
+| Drops | None; the runtime is garbage collected | `Drop` runs at scope end |
+| `Copy` trait | No such bound; primitives, functions, and promises are value types | `Copy`/`Clone` bounds on type parameters |
+| Lifetimes as a kind | Ordinary types, so a type parameter can be instantiated at a borrow | A separate kind that must be threaded explicitly |
+| Mutability depth | Deep and uniform through owned structure | Per-reference, and interior mutability via `Cell`/`RefCell` |
+| Freeze and thaw | A move into a `val` or `val mut` binding | No equivalent |
+| Concurrency | Out of scope; the target is single-threaded | `Send`/`Sync` built on exclusive borrowing |
+
+The multiple-`&mut` relaxation is the substantive one. Rust needs `&mut` to be
+unique because two mutable references can race and because a live `&` must not
+see a write through an aliased `&mut` in a compiled, unmanaged setting. Escalier
+targets single-threaded JavaScript with a garbage collector, so neither concern
+applies. What remains is the immutability guarantee, and that only requires the
+two *kinds* of borrow never to overlap — not that mutable borrows be unique. So
+`&mut`-to-`&mut` aliasing is legal, and it never consumes the source.
+
+The lifetime-as-an-ordinary-type choice follows from the same simplification.
+`&'a T` is a type like any other, so instantiating `fn id<T>(x: T) -> T` at a
+borrow yields `fn (&'a U) -> &'a U` with no separate lifetime parameter to
+thread. Explicit lifetime variables are needed only to relate two borrows that
+elision cannot disambiguate.
+
+There is deliberately no `Copy` bound. Generic code treats a type parameter as
+non-duplicable, the conservative affine assumption, so a body may use a `T` value
+at most once. A function that needs to reuse its argument takes it by `&T` and
+reads through the borrow:
+
+```esc
+fn dup<T>(x: &T) -> [&T, &T] { return [x, x] }
+```
+
+Copying a reference is not a move, and the result is two immutable borrows of one
+value, which the borrow-phase rule permits. A function that genuinely duplicates
+an *owned* generic value is not expressible; it must be written against a
+concrete value type or take a borrow.
+
+## What ownership does not cover
+
+- **Concurrency and data races.** Excluding them would require Rust-style
+  exclusive borrowing, which Escalier deliberately gives up.
+- **Heap escape analysis** beyond function return values.
+- **Reassignment clearing a move.** Reassigning a `var` after it was moved gives
+  it a fresh value, but the analysis still reads the binding as moved, so a use
+  after re-initialization is reported spuriously.

--- a/docs/10_code_organization.md
+++ b/docs/10_code_organization.md
@@ -103,5 +103,9 @@ another package in the same monorepo through the `@repo/` scope, and may import
 only that package's exported symbols even though both live in one repository.
 
 ```escalier
-import * as vec from "@repo/vec"
+import "@repo/vec"
+
+val v = vec.zero()
 ```
+
+The binding is the specifier's last segment, so `@repo/vec` binds as `vec`.

--- a/docs/10_code_organization.md
+++ b/docs/10_code_organization.md
@@ -19,9 +19,10 @@ bin/
 build/            # generated
 ```
 
-- **`lib/`** holds the package's library source. Every `.esc` file under `lib/`
-  is a module, which means statements may not appear outside a function or
-  method. `.test.esc` files are the exception.
+- **`lib/`** holds the package's library source. Its `.esc` files are source
+  files rather than modules of their own — a module spans every file that shares
+  a namespace. Statements may not appear outside a function or method in them,
+  with `.test.esc` files the exception.
 - **`bin/`** holds executable scripts. These run top to bottom, so statements at
   top level are allowed.
 - **`build/`** holds the generated `.js`, `.d.ts`, and source maps.

--- a/docs/10_code_organization.md
+++ b/docs/10_code_organization.md
@@ -6,7 +6,7 @@ A package is the smallest unit of interop with TypeScript. A package is either a
 Escalier package or a TypeScript package, never both, and both use a standard
 `package.json` to say where the dist files and type definitions live.
 
-```
+```text
 package.json
 lib/
   index.esc

--- a/docs/10_code_organization.md
+++ b/docs/10_code_organization.md
@@ -6,6 +6,10 @@ A package is the smallest unit of interop with TypeScript. A package is either a
 Escalier package or a TypeScript package, never both, and both use a standard
 `package.json` to say where the dist files and type definitions live.
 
+An Escalier package has a fixed layout. A TypeScript package has whatever layout
+its authors chose — Escalier reads it through its `package.json` and its `.d.ts`
+files, so nothing below applies to it.
+
 ```text
 package.json
 lib/
@@ -20,11 +24,15 @@ build/            # generated
 ```
 
 - **`lib/`** holds the package's library source. Its `.esc` files are source
-  files rather than modules of their own — a module spans every file that shares
-  a namespace. Statements may not appear outside a function or method in them,
-  with `.test.esc` files the exception.
+  files rather than modules of their own: **one module spans all of `lib/`**,
+  subdirectories included. A subdirectory introduces a namespace within that
+  module rather than a module of its own. Statements may not appear outside a
+  function or method in these files, with `.test.esc` files the exception.
 - **`bin/`** holds executable scripts. These run top to bottom, so statements at
-  top level are allowed.
+  top level are allowed. A `bin/` script reaches the package's own `lib/`
+  exports by name, with no import — the lib namespace sits between the prelude
+  and the script's own scope. Each script is checked on its own, so one `bin/`
+  file never sees another's declarations.
 - **`build/`** holds the generated `.js`, `.d.ts`, and source maps.
 
 ## Namespaces
@@ -96,16 +104,27 @@ There are two bundling modes:
 - **`dev`** produces several bundles derived from the dependency graph, which is
   what hot-reloading tools such as Vite need.
 
+A third mode, **`test`**, is planned. It exists to make symbols in other packages
+mockable. It emits a bundle whose symbols are all read through a module-level
+object rather than bound directly, so a test can replace one entry on that object
+and every call site picks up the replacement. Jest and similar libraries already
+work this way against CommonJS; the `test` bundle gives them the same handle over
+an Escalier build.
+
 ## Monorepos
 
 A monorepo may hold many packages, and packages may not nest. A package imports
-another package in the same monorepo through the `@repo/` scope, and may import
-only that package's exported symbols even though both live in one repository.
+another package in the same monorepo through the repository's own scope, and may
+import only that package's exported symbols even though both live in one
+repository.
+
+The scope is the repository's own name, not a literal `@repo`. In a monorepo
+called `acme`, a package named `vec` is `@acme/vec`:
 
 ```escalier
-import "@repo/vec"
+import "@acme/vec"
 
 val v = vec.zero()
 ```
 
-The binding is the specifier's last segment, so `@repo/vec` binds as `vec`.
+The binding is the specifier's last segment, so `@acme/vec` binds as `vec`.

--- a/docs/10_code_organization.md
+++ b/docs/10_code_organization.md
@@ -2,30 +2,51 @@
 
 ## Packages
 
-This is the smallest unit of interop with TypeScript.  A package
-must either be an Escalier package or a TypeScript package.  Both
-will use a standard package.json for specifying where dist files
-and type definitions live.
+A package is the smallest unit of interop with TypeScript. A package is either an
+Escalier package or a TypeScript package, never both, and both use a standard
+`package.json` to say where the dist files and type definitions live.
 
-Within a package all symbols are visible.  There is no need to
-import something from one file to another.  The directory structure
-defines a series of nested namespaces.  The only imports necessary
-are for external packages or other packages within a monorepo.
+```
+package.json
+lib/
+  index.esc
+  foo/
+    foo.esc
+    bar/
+      bar.esc
+bin/
+  main.esc
+build/            # generated
+```
 
-Child namespaces have access to all symbols in parent namespaces 
-automatically.  Parents must qualify symbols in child namespaces.  
-This maches how namespaces work in TypeScript.
+- **`lib/`** holds the package's library source. Every `.esc` file under `lib/`
+  is a module, which means statements may not appear outside a function or
+  method. `.test.esc` files are the exception.
+- **`bin/`** holds executable scripts. These run top to bottom, so statements at
+  top level are allowed.
+- **`build/`** holds the generated `.js`, `.d.ts`, and source maps.
 
-Example file structure:
-- package.json
-- src
-  - foo
-    - bar
-      - bar.esc  
-    - foo.esc
-  - foo_bar.esc
+## Namespaces
 
-This would be equivalent to the following TypeScript file:
+The directory structure under `lib/` defines a nested namespace hierarchy. The
+path of a file, minus the `lib/` prefix and the filename, is the namespace its
+declarations land in.
+
+| File | Namespace |
+|---|---|
+| `lib/index.esc` | root |
+| `lib/foo/foo.esc` | `foo` |
+| `lib/foo/bar/bar.esc` | `foo.bar` |
+
+Files sharing a namespace merge their declarations into it, so splitting a
+namespace across several files needs no plumbing.
+
+A child namespace sees every symbol in its parent namespaces without qualifying.
+A parent must qualify to reach a child's symbols. This matches how namespaces
+work in TypeScript.
+
+The layout above corresponds to:
+
 ```ts
 namespace Foo {
     namespace Bar {
@@ -37,34 +58,49 @@ namespace Foo {
         return "foo"
     }
 }
-export function foo_bar() { 
+export function foo_bar() {
     return Foo.foo() + Foo.Bar.bar()
 }
 ```
 
-Any symbol marked with the `export` modifier will be exported from
-the bundle that is created when building the package.  If a
-namespace doesn't export anything then it won't be include in the
-exports.
+## Declarations, imports, and dependency order
 
-Any .esc file located inside src/ will be considered a module which
-prohibits the use of statements outside of functions/methods.  The exception to this is .test.esc files.
+Declarations are visible across the whole module regardless of source order.
+Before checking, every declaration is collected and a dependency graph orders
+them by strongly connected component, so a function may call one defined further
+down, and two types may reference each other across files.
+
+Imports do **not** work this way: they are file-scoped, and each file states its
+own. See [Imports](03_imports.md).
+
+## Exporting
+
+A declaration marked `export` is exported from the bundle built for the package.
+A namespace that exports nothing is left out of the exports entirely.
+
+```esc
+export fn greet(name: string) -> string {
+    return `hello, ${name}`
+}
+```
 
 ## Bundling
 
-Files outside of the src/ are not included in the dist file bundle
-or the published package.  Files inside the bin/ will be included in
-the published package but not in dist file bundle.
+Files outside `lib/` and `bin/` are neither bundled nor published. Files in
+`bin/` are published but stay out of the dist bundle.
 
 There are two bundling modes:
-- `prod`: bundles everything into a single bundle
-- `dev`: produces a number of bundles based on the dependency graph
 
-`dev` mode is to support hot-loading using tools such as `vitejs`.
+- **`prod`** bundles everything into a single file.
+- **`dev`** produces several bundles derived from the dependency graph, which is
+  what hot-reloading tools such as Vite need.
 
-## Monorepo
+## Monorepos
 
-Monorepos can have multiple packages.  Packages cannot be nested.
-Packages can import other packages within the monorepo using the
-`@repo/` scope.  A package can only import exported symbols even if
-both packages are in the same monorepo.
+A monorepo may hold many packages, and packages may not nest. A package imports
+another package in the same monorepo through the `@repo/` scope, and may import
+only that package's exported symbols even though both live in one repository.
+
+```escalier
+import * as vec from "@repo/vec"
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,17 @@
 # Escalier language reference
 
 Escalier is a programming language that compiles to JavaScript. It keeps
-TypeScript's structural type system and interop story, and changes three things
-about it: values are immutable by default, object types are exact by default, and
-ownership of reference-shaped values is tracked so the immutability guarantee
-actually holds.
+TypeScript's structural core and its interop story, and departs from it in a
+number of places. The largest ones:
+
+- Values are immutable by default, and ownership of reference-shaped values is
+  tracked so that guarantee holds.
+- Object, tuple, and function types are exact by default.
+- Classes are nominal and enums are variant types.
+- `any` is gone; negation `~T` is a real type; a `throws` clause is checked; and
+  a promise carries its rejection type as `Promise<T, E>`.
+
+The pages below cover the rest.
 
 | | |
 |---|---|

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# Escalier language reference
+
+Escalier is a programming language that compiles to JavaScript. It keeps
+TypeScript's structural type system and interop story, and changes three things
+about it: values are immutable by default, object types are exact by default, and
+ownership of reference-shaped values is tracked so the immutability guarantee
+actually holds.
+
+| | |
+|---|---|
+| [00 Types](00_types.md) | Primitives, objects, unions, negation, classes, generics, type-level operators |
+| [01 Destructuring](01_destructuring.md) | Patterns in bindings and parameters; `val`, `var`, and `mut` |
+| [02 Functions](02_functions.md) | Signatures, inference, generics, `throws`, async, overloading, generators |
+| [03 Imports](03_imports.md) | Pseudo-packages, npm packages, file-scoped imports; no ambient globals |
+| [04 Pattern Matching](04_pattern_matching.md) | `match`, `if val`, `val … else`, narrowing, exhaustiveness |
+| [05 Enums](05_enums.md) | Variant types and their namespaces |
+| [06 Error Handling](06_error_handling.md) | `throws`, `try`/`catch`, async rejection |
+| [07 Exact Types](07_exact_types.md) | Exact by default, the `open` marker, interop |
+| [08 Mutability](08_mutability.md) | `mut`, `readonly`, deep mutability, exclusivity |
+| [09 Ownership](09_ownership.md) | Owned and borrowed values, moves, lifetimes, and how this compares to Rust |
+| [10 Code Organization](10_code_organization.md) | Packages, namespaces, bundling |
+
+## Scope of these documents
+
+They describe the language as the checker in
+[internal/solver/](../internal/solver/) defines it. Where a feature is designed
+but not built, the page says so at the point it matters. The design documents the
+pages draw on live under [planning/](../planning/).


### PR DESCRIPTION
This PR rewrites the language documentation to reflect a redesigned type system and ownership model. The changes represent a significant shift in Escalier's core semantics and are intended to serve as the authoritative reference for the language going forward.

**Key changes:**

- **Types (00_types.md)**: Replaced TypeScript-centric overview with algebraic subtyping foundation. Introduced `unknown` and `never` as lattice bounds, exact-by-default objects and tuples, structural vs. nominal class semantics, and type-level operators (union, intersection, negation).

- **Imports (03_imports.md)**: Completely redesigned import system. Removed ambient globals; all names must be explicitly imported. Introduced pseudo-packages (`std:`, `web:`, `node:`) with URI-based naming, shape-loaded vs. named imports, and the single-class shortcut for packages like `std:array` and `std:date`. Removed file-scoped import semantics in favor of module-level visibility.

- **Functions (02_functions.md)**: Expanded to cover generics, lifetime parameters, ownership and mutability in parameters, and the `throws` clause as part of function type. Clarified that return types and parameter types are inferable.

- **Pattern matching (04_pattern_matching.md)**: Introduced narrowing with `:` annotations as the sole narrowing mechanism (replacing control-flow narrowing), guards, and exhaustiveness checking. Documented that patterns are used in `match`, `if val`, and `val … else`.

- **Enums (05_enums.md)**: Redesigned to show enums as nominal variants with optional parameters, recursive enum support, and exhaustiveness checking.

- **Error handling (06_error_handling.md)**: Moved from chapter 04 to 06. Rewrote to explain `throws` as part of function type, `try`/`catch`/`finally` with pattern-based arms, and that caught values have type `unknown`.

- **Exact types (07_exact_types.md)**: Expanded semantics section to clarify one-way subtyping (exact ⊆ inexact), rest patterns, and spread behavior. Documented what is exact by default.

- **Mutability (08_mutability.md)**: Expanded to explain immutability as the default, `mut` as deep and uniform, interaction with borrows, and the invariant the system guarantees.

- **Ownership (09_ownership.md)**: New chapter documenting owned vs. borrowed values, how ownership is decided, copy/borrow/move semantics, use-after-move checking, partial moves, and lifetime constraints.

- **Code organization (10_code_organization.md)**: Clarified package structure, namespace hierarchy, and how child namespaces see parent symbols.

- **Destructuring (01_destructuring.md)**: Expanded to cover nesting, renaming, rest elements, and the interaction of `val`/`var` with `mut`.

- **README.md**: New file providing a high-level overview and navigation guide to all chapters.

These changes establish the language reference for a type system built on algebraic subtyping, immutability by default, exact types by default, and ownership tracking for reference-shaped values.

https://claude.ai/code/session_018NKKYan88M18CzJ38ieWCp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Escalier language reference covering types, functions, imports, pattern matching, enums, error handling, exact types, mutability, ownership, and code organization.
  * Added practical examples and clarified inference, ownership, scoping, interoperability, and diagnostic behavior.
  * Documented supported features, limitations, and planned functionality.
  * Added a central reference README with links to all language topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->