### PR TITLE
Charge record writes in backing stores to their holder

### DIFF
--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -155,14 +155,11 @@ func TestFactsSampleMethods(t *testing.T) {
 		// it stored, which reaches the return through `TimeClip`, an operation
 		// §4.2 does not resolve.
 		"MutatingMethodWithAnUnresolvedReturn": {"Date.prototype.setTime", "receiver:mutBorrow returns:unknown"},
-		// A borrow claim is only as good as the mutation analysis behind it.
 		// delete empties its entry with `Set p.[[Key]] to EMPTY`, a write to a
-		// Map Entry Record read out of `M.[[MapData]]`, and §4.1 places
-		// neither half. The method is classified because no warning stands, so
-		// the wrong answer is published rather than handed to the heuristics.
-		// §6's validation diff against the hand-written overrides is where the
-		// three methods of this shape are triaged.
-		"MutationTheAnalysisDoesNotSee": {"Map.prototype.delete", "receiver:borrow returns:fresh"},
+		// Map Entry Record read out of `M.[[MapData]]`. §4.1 charges it to the
+		// Map, so the receiver claim is mutBorrow. The return is the boolean
+		// the algorithm built, which is fresh and not the receiver.
+		"MutationThroughARecordInABackingStore": {"Map.prototype.delete", "receiver:mutBorrow returns:fresh"},
 		// A caller of an algorithm the analysis could not read whole is
 		// classified all the same, since §4.1 charges `Unattributable` up the
 		// call graph and `Incomplete` not at all. next resumes the generator
@@ -330,8 +327,8 @@ func TestFactsTallies(t *testing.T) {
 		lines = append(lines, fmt.Sprintf("%s: %d", key, count))
 	}
 	sort.Strings(lines)
-	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`receiver borrow: 225
-receiver mutBorrow: 57
+	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`receiver borrow: 222
+receiver mutBorrow: 60
 receiver none: 138
 returns fresh: 177
 returns param: 6

--- a/internal/ecma262/mutation.go
+++ b/internal/ecma262/mutation.go
@@ -374,7 +374,15 @@ func (a *analysis) transfer(cfg *CFG, fn *Func) bool {
 				if origin.Eval(node.Object).Kind != OriginFresh {
 					changed = f.markIncomplete() || changed
 				}
-			} else if backingStoreSlots.Contains(node.Slot) {
+			} else if backingStoreSlots.Contains(node.Slot) || origin.Eval(node.Object).Interior {
+				// A write to a backing-store slot mutates the object that
+				// holds it. So does a write to any slot of an interior value,
+				// since that value lives inside the object holding it and the
+				// object's own methods read it back. `Map.prototype.delete`
+				// empties one entry of `M.[[MapData]]` with `Set p.[[Key]] to
+				// EMPTY`. `[[Key]]` is a field of a Map Entry Record rather
+				// than a backing-store slot, so only the interior origin of
+				// `p` places that write.
 				changed = a.attribute(f, origin, node.Object) || changed
 			}
 		case *CallNode:

--- a/internal/ecma262/mutation_test.go
+++ b/internal/ecma262/mutation_test.go
@@ -84,6 +84,17 @@ func TestMutationSummarySampleFunctions(t *testing.T) {
 		// backing-store slot.
 		"ReceiverThroughABackingStoreSlot": {"Map.prototype.set", "receiver"},
 		"BackingStoreSlotOnASet":           {"Set.prototype.add", "receiver"},
+		// Map.prototype.delete empties one entry of `M.[[MapData]]` in place
+		// with `Set p.[[Key]] to EMPTY`. `[[Key]]` is a field of a Map Entry
+		// Record rather than a backing-store slot, so the write counts only
+		// because `p` came out of a read of `M.[[MapData]]` and carries the
+		// receiver's interior origin.
+		"SlotOnARecordReadOutOfABackingStore": {"Map.prototype.delete", "receiver"},
+		// clear empties every entry of `M.[[MapData]]` the same way, and
+		// WeakMap.prototype.delete empties the entry it matched in
+		// `M.[[WeakMapData]]`.
+		"ClearingEveryRecordInABackingStore": {"Map.prototype.clear", "receiver"},
+		"SlotOnARecordInAWeakBackingStore":   {"WeakMap.prototype.delete", "receiver"},
 		// Date.prototype.setTime writes `dateObject.[[DateValue]]`, the slot
 		// Date.prototype.getTime reads back.
 		"BackingStoreSlotOnADate": {"Date.prototype.setTime", "receiver"},
@@ -206,15 +217,35 @@ func TestMutationSummaryUnattributableWrite(t *testing.T) {
 	require.Equal(t, "unattributable", mutationsOf(t, "Array.of").String())
 }
 
-// Only a backing-store slot write counts as a mutation of the object written.
-// `Map.prototype.delete` empties the entry in place, `Set p.[[Key]] to EMPTY`,
-// and `[[Key]]` is a field of a Map Entry Record rather than a backing store.
-// The record itself came out of a read of `M.[[MapData]]`, which breaks the
-// origin chain, so the receiver is not in `p` either. delete therefore comes
-// out non-mutating, and §6's validation diff is where that disagreement with
-// the hand-written overrides surfaces.
+// A write to any slot of a record read out of a backing store is charged to the
+// object holding that store. `Map.prototype.delete` empties its entry in place
+// with `Set p.[[Key]] to EMPTY`. `[[Key]]` is a field of a Map Entry Record
+// rather than a backing-store slot, so the slot list alone reports nothing.
+// `p` came out of a read of `M.[[MapData]]`, which puts it at the receiver's
+// interior, and the write lands on `M`.
+//
+// The three methods of this shape are `Map.prototype.delete`,
+// `Map.prototype.clear`, and `WeakMap.prototype.delete`. Their Set counterparts
+// reach the same replacement through a prose step §3 could not lower, so they
+// come out incomplete and FR5's name heuristics decide them.
+func TestMutationSummaryChargesARecordWriteToItsCollection(t *testing.T) {
+	require.Equal(t, "receiver", mutationsOf(t, "Map.prototype.delete").String())
+	require.Equal(t, "receiver", mutationsOf(t, "Map.prototype.clear").String())
+	require.Equal(t, "receiver", mutationsOf(t, "WeakMap.prototype.delete").String())
+
+	require.Equal(t, "incomplete", mutationsOf(t, "Set.prototype.delete").String())
+	require.Equal(t, "incomplete", mutationsOf(t, "Set.prototype.clear").String())
+	require.Equal(t, "incomplete", mutationsOf(t, "WeakSet.prototype.delete").String())
+}
+
+// A write to a slot outside the backing-store list is skipped when the object
+// written is the receiver itself rather than a value read out of its backing
+// store. `ArrayIteratorPrototype.next` writes `[[IteratedArrayLike]]` and
+// `[[ArrayLikeNextIndex]]` on the iterator, and both are cursor bookkeeping
+// rather than payload. Whether an iterator's `next` mutates its receiver is a
+// decision about the emitted surface, which §11's curation makes.
 func TestMutationSummarySkipsNonBackingStoreSlots(t *testing.T) {
-	require.Equal(t, "none", mutationsOf(t, "Map.prototype.delete").String())
+	require.Equal(t, "none", mutationsOf(t, "ArrayIteratorPrototype.next").String())
 }
 
 // The origin map decides what a callee is before the seed does. A callee bound
@@ -561,6 +592,6 @@ func TestMutationSummaryTallies(t *testing.T) {
 	}
 	sort.Strings(kinds)
 	snaps.MatchInlineSnapshot(t, strings.Join(kinds, "\n"), snaps.Inline(`abstract-op: total 701, receiver 0, args 47, unattributable 37, incomplete 226, classifiable 449
-builtin-method: total 313, receiver 58, args 0, unattributable 3, incomplete 29, classifiable 282
+builtin-method: total 313, receiver 61, args 0, unattributable 3, incomplete 29, classifiable 282
 builtin-static: total 188, receiver 0, args 13, unattributable 21, incomplete 45, classifiable 138`))
 }

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -95,6 +95,28 @@ func interiorOf(o Origin) Origin {
 	}
 }
 
+// insideOf returns the origin of a value read out of o by a property read, such
+// as one entry of a List an object keeps in a backing-store slot.
+//
+// An interior value's contents are still inside the object holding it, so
+// writing one of them writes that object. `Map.prototype.delete` reaches the
+// entry it empties through `M.[[MapData]]`, and the write to that entry is
+// charged to `M`. Reading a property off anything else breaks the chain,
+// because the value read out of a container is a different object from the
+// container.
+func insideOf(o Origin) Origin {
+	switch {
+	case o.Kind == originUnset:
+		// The walk has not reached the definition of the object being read.
+		// See originUnset.
+		return o
+	case o.Interior:
+		return o
+	default:
+		return Unknown
+	}
+}
+
 func (o Origin) String() string {
 	var name string
 	switch o.Kind {
@@ -508,7 +530,12 @@ func (m *OriginMap) eval(e Expr) Origin {
 		// a different object from the container itself.
 		return Unknown
 	case *PropExpr:
-		return Unknown
+		// A property read off an interior value stays interior. `p` in
+		// `Map.prototype.delete` is one entry of the List in the receiver's
+		// `[[MapData]]`, so a write to `p` writes the Map. Reading a property
+		// off anything else breaks the chain the way a slot read outside the
+		// backing-store list does.
+		return insideOf(m.eval(e.Object))
 	default:
 		// An operand the graph left out, which reaches Eval as a nil Expr.
 		return Unknown

--- a/internal/ecma262/origin.go
+++ b/internal/ecma262/origin.go
@@ -46,6 +46,16 @@ const (
 // its receiver. It is not the object itself, so it never stands in where
 // identity matters, such as §4.3's return alias.
 //
+// An interior value is part of its holder's own state, which is what separates
+// a backing-store slot from an ordinary property. The List in `M.[[MapData]]`
+// is reachable only through the Map's own methods, so emptying one of its
+// entries changes what `Map.prototype.get` returns. A property instead holds a
+// separate object that the owner only references. Writing that object leaves
+// every method of the owner returning what it did before, and the read itself
+// may run a getter that returns anything. Interior therefore means "inside this
+// object's state" rather than "one read below it", which is why a further read
+// off an interior value keeps the marker.
+//
 // Captures marks a fresh value built around something the algorithm was given.
 // It changes nothing about the fresh value, only about its interior. See
 // capturingAllocators.

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -258,8 +258,9 @@ func TestOriginMapEval(t *testing.T) {
 	readOther := &SlotExpr{Object: &VarExpr{Var: "O"}, Slot: "Prototype"}
 	require.Equal(t, Unknown, m.Eval(readOther))
 
-	// A property read off that payload stays inside the receiver, while one off
-	// the receiver itself yields a different object.
+	// A property read off that payload is still the receiver's own state, while
+	// one off the receiver reaches a separate object it only references. The
+	// Origin doc comment spells out the difference.
 	readEntry := &PropExpr{Object: readData}
 	require.Equal(t, Origin{Kind: OriginReceiver, Interior: true}, m.Eval(readEntry))
 	readProp := &PropExpr{Object: &VarExpr{Var: "O"}}

--- a/internal/ecma262/origin_test.go
+++ b/internal/ecma262/origin_test.go
@@ -90,6 +90,24 @@ func TestInteriorIsNotItsHolder(t *testing.T) {
 	require.Equal(t, Unknown, Receiver.join(interiorOf(Receiver)))
 }
 
+// A property read keeps an interior origin and breaks every other chain. The
+// entries of a List a collection keeps in a backing-store slot are inside that
+// collection, so a write to one is a write to the collection.
+func TestInsideOf(t *testing.T) {
+	require.Equal(t, interiorOf(Receiver), insideOf(interiorOf(Receiver)))
+	require.Equal(t, interiorOf(Param(1)), insideOf(interiorOf(Param(1))))
+
+	// Reading a property off the object itself yields a different object.
+	require.Equal(t, Unknown, insideOf(Receiver))
+	require.Equal(t, Unknown, insideOf(Param(1)))
+	require.Equal(t, Unknown, insideOf(Fresh))
+	require.Equal(t, Unknown, insideOf(Unknown))
+
+	// The lattice bottom stays at the bottom, for the reason TestInteriorOf
+	// gives.
+	require.Equal(t, Origin{}, insideOf(Origin{}))
+}
+
 // Reading a backing-store slot off a name the walk has not bound yet resolves
 // on a later pass rather than sticking at `Unknown`, so the result does not
 // depend on the order the serializer emitted the nodes in. Here `buf` reads the
@@ -240,6 +258,13 @@ func TestOriginMapEval(t *testing.T) {
 	readOther := &SlotExpr{Object: &VarExpr{Var: "O"}, Slot: "Prototype"}
 	require.Equal(t, Unknown, m.Eval(readOther))
 
+	// A property read off that payload stays inside the receiver, while one off
+	// the receiver itself yields a different object.
+	readEntry := &PropExpr{Object: readData}
+	require.Equal(t, Origin{Kind: OriginReceiver, Interior: true}, m.Eval(readEntry))
+	readProp := &PropExpr{Object: &VarExpr{Var: "O"}}
+	require.Equal(t, Unknown, m.Eval(readProp))
+
 	// A nested call resolves through the same lists a call node does.
 	toObject := &CallExpr{Callee: "ToObject", Args: []Expr{&ThisExpr{}}}
 	require.Equal(t, Receiver, m.Eval(toObject))
@@ -363,6 +388,17 @@ func TestOriginMapInteriorOfAFreshAllocation(t *testing.T) {
 	require.Equal(t, Fresh, m.Of("A"))
 	require.Equal(t, Fresh, m.Of("targetBuffer"))
 	require.Equal(t, interiorOf(Receiver), m.Of("srcBuffer"))
+}
+
+// A record read out of a backing store keeps the holder's interior origin, so
+// §4.1 can charge a write to that record to the holder. `Map.prototype.delete`
+// binds `p` from a read of `M.[[MapData]]` and then empties it with `Set
+// p.[[Key]] to EMPTY`.
+func TestOriginMapRecordReadOutOfABackingStore(t *testing.T) {
+	m := originsOf(t, "Map.prototype.delete")
+
+	require.Equal(t, Receiver, m.Of("M"))
+	require.Equal(t, interiorOf(Receiver), m.Of("p"))
 }
 
 func TestOriginMapString(t *testing.T) {

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -683,16 +683,16 @@ fixpoint. `NewMutationSummary(cfg)` runs the fixpoint over a whole graph and
 positions, the receiver flag, and the two warnings. All 1202 functions settle in
 about 10 ms. Eight of the nine seed entries name an operation the graph holds,
 and those eight grow into 47 abstract operations with a mutated position. Of the
-501 builtins, 58 mutate their receiver and 13 mutate a parameter, and 420 carry
+501 builtins, 61 mutate their receiver and 13 mutate a parameter, and 420 carry
 neither warning, so §4.3 decides them from the analysis rather than from FR5's
 name-based heuristics. The gate is
 [internal/ecma262/mutation_test.go](../../internal/ecma262/mutation_test.go).
 `Array.prototype.push` and `Array.prototype.fill` mutate the receiver,
 `Array.prototype.slice` mutates nothing, and `Map.prototype.set` mutates the
 receiver through `[[MapData]]`. The Date setters, the in-place Array methods,
-`RegExp.prototype.exec`, the collection adders, the 11 `DataView.prototype.set*`
-methods, `TypedArray.prototype.set`, and `TypedArray.prototype.copyWithin` come
-out receiver-mutating. `Object.freeze`, `Object.seal`, `Object.assign`,
+`RegExp.prototype.exec`, the collection adders, the Map and WeakMap removals,
+the 11 `DataView.prototype.set*` methods, `TypedArray.prototype.set`, and
+`TypedArray.prototype.copyWithin` come out receiver-mutating. `Object.freeze`, `Object.seal`, `Object.assign`,
 `Object.defineProperty`, `Object.defineProperties`, `Reflect.set`, and
 `Atomics.store` come out mutating argument 0. Eight findings.
 
@@ -757,19 +757,22 @@ out receiver-mutating. `Object.freeze`, `Object.seal`, `Object.assign`,
   `CreateDataProperty`, and reading the argument sitting there gives `Receiver`,
   which is `OrdinarySet`'s parameter 3. Its summary is `{3}`, and a caller of
   `OrdinarySet` charges whatever it passed fourth.
-- **A record read out of a backing store loses the receiver, so
-  `Map.prototype.delete` comes out non-mutating.** delete empties the entry in
-  place with `Set p.[[Key]] to EMPTY`. `[[Key]]` is a field of a Map Entry
-  Record rather than a backing store, and `p` itself came out of a read of
-  `M.[[MapData]]`, which breaks the origin chain under §4.2. Both halves of the
-  attribution fail, so the method reads as writing nothing.
-  `Map.prototype.clear` and `WeakMap.prototype.delete` are the same shape.
-  Carrying the interior origin through the indexed read that produces `p`, and
-  charging a write to any slot of an interior value to the object holding it,
-  resolves all three and costs nothing measurable: the receiver-mutating
-  builtins go from 57 to 60 with the unattributable and classifiable counts
-  unchanged. It widens the origin rules a second time, so it is left to §6,
-  which triages these against the hand-written overrides.
+- **A record read out of a backing store is charged to the object holding
+  that store.** `Map.prototype.delete` empties its entry in place with `Set
+  p.[[Key]] to EMPTY`. `[[Key]]` is a field of a Map Entry Record rather than a
+  backing store, so the slot list alone reports nothing, and `p` itself came out
+  of a read of `M.[[MapData]]`. Two rules together place the write. A property
+  read off an interior value stays interior, which puts `p` at the receiver's
+  interior, and a slot write on an interior value is charged to its holder
+  whatever the slot is named. `Map.prototype.clear` and `WeakMap.prototype.delete`
+  are the same shape, and the three take the receiver-mutating builtins from 58
+  to 61 with the unattributable, incomplete, and classifiable counts unchanged.
+  §4.3 publishes 60 of the 61 as `mutBorrow`. `RegExp.prototype [ @@replace ]`
+  is the one left out, because it also carries a warning.
+  The Set counterparts are the same operation failing the other way.
+  `Set.prototype.delete`, `Set.prototype.clear`, and `WeakSet.prototype.delete`
+  reach the replacement through a prose step §3 could not lower, so they come out
+  incomplete and FR5's name heuristics decide them.
 - **An iterator's cursor is left out of the backing-store list.** Nine slots
   take a receiver-origin write inside a builtin method that the curated list
   does not count, and all nine are iterator or generator bookkeeping:
@@ -830,7 +833,8 @@ func eval(F, e Expr) Origin:
     case Alloc, Lit: return Fresh                     // fresh object / primitive
     case Slot:  return Interior(eval(F, e.Object))    // if e.Slot is a backing store
                 return Unknown                        // otherwise the chain breaks
-    case Prop:  return Unknown                        // a READ: origin chain breaks
+    case Prop:  return Inside(eval(F, e.Object))      // interior stays interior;
+                                                      // any other read breaks the chain
     default:    return Unknown
 
 func evalCall(F, c) Origin:
@@ -876,7 +880,7 @@ reader for `cfg.json`, mirroring Appendix A, and the origin map.
 §4.1 makes when it charges a mutation to a receiver or a parameter. All 1202
 functions analyze in about 8 ms, binding 11756 names. Of those, 373 are at the
 receiver, 2007 at a parameter, 3927 fresh, 118 fresh from an allocator that
-captured an argument, 100 interior, and 5231 unknown. The gate is
+captured an argument, 121 interior, and 5210 unknown. The gate is
 [internal/ecma262/origin_test.go](../../internal/ecma262/origin_test.go).
 `Let O be ? ToObject(this value)` puts `O` at the receiver in
 `Array.prototype.push`, `? ArraySpeciesCreate(O, count)` puts `A` at `Fresh` in
@@ -920,10 +924,14 @@ captured an argument, 100 interior, and 5231 unknown. The gate is
   a write to it is a write to the object. `SetViewValue` passes
   `view.[[ViewedArrayBuffer]]` straight to the byte store, and resolving that to
   `Unknown` left every `DataView.prototype.set*` method unable to name what it
-  wrote. `Interior` marks the 100 names this reaches. It is deliberately not the
+  wrote. `Interior` marks the 121 names this reaches. It is deliberately not the
   same value as its holder, so it never stands in where identity is what
   matters, such as §4.3's return alias: returning `M.[[MapData]]` is not
-  returning `M`.
+  returning `M`. A property read off an interior value keeps that origin, which
+  is how one entry of a collection's payload List stays placed. `p` in
+  `Map.prototype.delete` comes out of a read of `M.[[MapData]]` and stays at the
+  receiver's interior, so §4.1 charges `Set p.[[Key]] to EMPTY` to `M`. Reading
+  a property off anything else still breaks the chain.
 - **A fresh object's interior is fresh unless its allocator captured an
   argument.** `MakeDataViewWithBufferWitnessRecord` ends in `return « obj,
   byteLength »`, so the record it builds holds the very view it was passed, and


### PR DESCRIPTION
Fixes #1280

`Map.prototype.delete` empties its entry in place with `Set p.[[Key]] to EMPTY`, and both halves of the attribution failed. `[[Key]]` is a field of a Map Entry Record rather than a backing-store slot, so `backingStoreSlots` does not cover it. `p` came out of a property read of `M.[[MapData]]`, which §4.2 resolves to `Unknown`, so the receiver is not in `p` either. The write was dropped with neither `Unattributable` nor `Incomplete` set, so §4.3 classified the method and published `receiver: borrow` for a method that mutates. That is a false claim rather than a warning, and once §7 auto-applies receiver mutability an immutable value could call it.

## Changes

Two rules together place the write.

- `internal/ecma262/origin.go` — a property read off an interior value keeps that origin instead of resolving to `Unknown`, so `p` sits at the receiver's interior. The new `insideOf` helper preserves the lattice bottom the way `interiorOf` does, which keeps the answer independent of the order the serializer emitted the nodes in.
- `internal/ecma262/mutation.go` — in `transfer`, a slot write whose object carries an interior origin is charged to the holder whatever the slot is named, alongside the existing `backingStoreSlots` rule.

## Measured

- `Map.prototype.delete`, `Map.prototype.clear`, and `WeakMap.prototype.delete` go from `none` to `receiver`. Receiver-mutating builtins rise 58 to 61, and published `mutBorrow` facts 57 to 60.
- `unattributable`, `incomplete`, and `unclassified` are unchanged at 81, and every §4.3 gate method keeps its fact.

The Set counterparts are the same operation failing the other way. `Set.prototype.delete`, `Set.prototype.clear`, and `WeakSet.prototype.delete` reach the replacement through a prose step §3 could not lower, so they stay `incomplete` and belong to #1272.

## Tests

- Three entries added to `TestMutationSummarySampleFunctions`.
- `TestMutationSummarySkipsNonBackingStoreSlots` split in two. `TestMutationSummaryChargesARecordWriteToItsCollection` asserts the new answer for the three Map and WeakMap methods and pins the three Set methods as incomplete. The skip test repoints at `ArrayIteratorPrototype.next`, whose cursor slots stay uncounted pending §11's curation.
- New `TestInsideOf` and `TestOriginMapRecordReadOutOfABackingStore`.
- Both tallies snapshots and the `Map.prototype.delete` case in `TestFactsSampleMethods` updated.

The §4.1 findings and the §4.2 outcome in `planning/ecma-262/implementation_plan.md` record the new rule and the recomputed counts.

https://claude.ai/code/session_017b8KsgxT6nACfvuiN5CGCa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mutation analysis for collection operations, including map and weak map deletion and clearing.
  * More accurately associates changes made through collection records and nested values with their originating objects.
  * Corrected classification of iterator operations and related mutation totals.

* **Documentation**
  * Updated implementation analysis results and origin-handling documentation to reflect improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->