### PR TITLE
Implement throw/reject split for promise-returning functions

### DIFF
--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -174,6 +174,10 @@ type Coverage struct {
 // Params, Throws, and Rejects join this shape in §8 and §9. Until §8.1 fills
 // Params, no fact makes a parameter claim, so an absent Params is not yet
 // Appendix B's proven-read-only one.
+//
+// Both throw fields land together, in §9.2. ThrowSummary already computes each
+// channel, but publishing the reject set on its own would spell a method whose
+// synchronous throws are simply not published yet as one that throws nothing.
 type MethodFact struct {
 	Classified Coverage     `json:"classified"`
 	Receiver   ReceiverKind `json:"receiver,omitempty"`

--- a/internal/ecma262/rejects.go
+++ b/internal/ecma262/rejects.go
@@ -16,8 +16,8 @@ type Sink uint8
 const (
 	// SinkSync is a value that leaves as a synchronous abrupt completion.
 	SinkSync Sink = iota
-	// SinkReject is a value handed to the reject function of the promise
-	// capability the algorithm returns.
+	// SinkReject is a value handed to the reject function of the
+	// PromiseCapability Record the algorithm returns. See newPromiseCapability.
 	SinkReject
 )
 
@@ -28,7 +28,7 @@ func (s Sink) String() string {
 	return "throws"
 }
 
-// A promise capability record holds the promise and the two functions that
+// A PromiseCapability Record holds the promise and the two functions that
 // settle it. These are the field names the graph reads off one.
 const (
 	// rejectSlot holds the function that rejects the promise. A step calling it
@@ -38,9 +38,13 @@ const (
 	resolveSlot = "Resolve"
 )
 
-// newCapability is the abstract operation that builds a promise capability: the
-// promise, the function that resolves it, and the function that rejects it.
-const newCapability = "NewPromiseCapability"
+// newPromiseCapability is the abstract operation that builds a
+// PromiseCapability Record. The record holds a promise, the function that
+// resolves it, and the function that rejects it, which is what `new
+// Promise((resolve, reject) => ...)` hands its executor. An algorithm builds
+// one, returns its `[[Promise]]`, and settles that promise later by calling
+// one of the two functions.
+const newPromiseCapability = "NewPromiseCapability"
 
 // completionValue is the field of a completion record holding the value it
 // carries. The inlined `IfAbruptRejectPromise` reads it off a captured
@@ -56,11 +60,12 @@ var argLists = map[string]int{
 	"Construct": 1,
 }
 
-// capabilityInvoke reports whether a call invokes one of the two functions a
-// promise capability holds, and which. `? Call(promiseCapability.[[Reject]],
-// undefined, « reason »)` is the shape, and the graph writes the invoked
-// function as the argument an invoker reads rather than as the callee.
-func capabilityInvoke(node *CallNode) (string, bool) {
+// promiseCapabilityInvoke reports whether a call settles a promise by invoking
+// one of the two functions its capability holds, and which of them.
+// `? Call(promiseCapability.[[Reject]], undefined, « reason »)` is the shape,
+// and the graph writes the invoked function as the argument an invoker reads
+// rather than as the callee.
+func promiseCapabilityInvoke(node *CallNode) (string, bool) {
 	position, invoking := invokers[node.Callee]
 	if !invoking || position >= len(node.Args) {
 		return "", false
@@ -75,7 +80,7 @@ func capabilityInvoke(node *CallNode) (string, bool) {
 // rejectReason returns the value a step hands to a promise capability's reject
 // function, and whether the step is such a call at all.
 func rejectReason(node *CallNode) (Expr, bool) {
-	slot, settling := capabilityInvoke(node)
+	slot, settling := promiseCapabilityInvoke(node)
 	if !settling || slot != rejectSlot {
 		return nil, false
 	}
@@ -145,7 +150,7 @@ func newRejectPlan(fn *Func, rejecters set.Set[string]) *rejectPlan {
 		return plan
 	}
 	plan.modeled = combinatorRejects(fn)
-	plan.delegated = delegatesCapability(fn, rejecters)
+	plan.delegated = delegatesPromiseCapability(fn, rejecters)
 
 	scan := &rejectScan{fn: fn, defs: definitions(fn), plan: plan}
 	routed := set.NewSet[int]()
@@ -197,7 +202,7 @@ func rejecters(cfg *CFG) set.Set[string] {
 			if !ok {
 				continue
 			}
-			if slot, settling := capabilityInvoke(call); settling && slot == rejectSlot {
+			if slot, settling := promiseCapabilityInvoke(call); settling && slot == rejectSlot {
 				names.Add(fn.Name)
 				break
 			}
@@ -206,7 +211,7 @@ func rejecters(cfg *CFG) set.Set[string] {
 	return names
 }
 
-// delegatesCapability reports whether fn passes a promise capability it built to
+// delegatesPromiseCapability reports whether fn passes a capability it built to
 // a function that rejects one. `AsyncFromSyncIteratorPrototype.next` is the
 // shape: it hands its capability to `AsyncFromSyncIteratorContinuation`, where
 // three of the four rejections of the promise it returns happen. Following the
@@ -214,8 +219,8 @@ func rejecters(cfg *CFG) set.Set[string] {
 // §9.3 does not build, so the caller is flagged instead. The check is on the
 // immediate callee, which leaves the combinators alone; each passes its
 // capability to a `PerformPromise*` operation that only resolves it.
-func delegatesCapability(fn *Func, rejecters set.Set[string]) bool {
-	held := capabilityNames(fn)
+func delegatesPromiseCapability(fn *Func, rejecters set.Set[string]) bool {
+	held := promiseCapabilityNames(fn)
 	if held.Len() == 0 {
 		return false
 	}
@@ -233,17 +238,17 @@ func delegatesCapability(fn *Func, rejecters set.Set[string]) bool {
 	return false
 }
 
-// capabilityNames returns the value names a function binds to a promise
-// capability it built. A binding that renames one carries it along, which is how
-// `let promiseCapability be %0` reaches the name the steps below it use.
-func capabilityNames(fn *Func) set.Set[string] {
+// promiseCapabilityNames returns the value names a function binds to a
+// capability it built. A binding that renames one carries it along, which is
+// how `let promiseCapability be %0` reaches the name the steps below it use.
+func promiseCapabilityNames(fn *Func) set.Set[string] {
 	held := set.NewSet[string]()
 	for {
 		grew := false
 		for _, node := range fn.Nodes {
 			switch node := node.(type) {
 			case *CallNode:
-				if node.Callee == newCapability && node.Target != "" && !held.Contains(node.Target) {
+				if node.Callee == newPromiseCapability && node.Target != "" && !held.Contains(node.Target) {
 					held.Add(node.Target)
 					grew = true
 				}

--- a/internal/ecma262/rejects.go
+++ b/internal/ecma262/rejects.go
@@ -125,7 +125,7 @@ type rejectPlan struct {
 	read set.Set[int]
 	// modeled holds what the hand-written combinator model contributes, which
 	// has no step in the graph at all.
-	modeled []Raised
+	modeled []Exception
 	// delegated marks a function that hands the capability it built to another
 	// function which rejects one. Those rejections settle the promise this
 	// function returns and neither source above sees them, so the function is
@@ -368,7 +368,7 @@ func (s *rejectScan) capturedSteps(e Expr) []int {
 // as. A nil form is a combinator that never rejects from its elements.
 type promiseCombinator struct {
 	iterable string
-	form     func(Origin) Raised
+	form     func(Origin) Exception
 }
 
 // promiseCombinators models the four `Promise` combinators by name. Each
@@ -389,14 +389,14 @@ var promiseCombinators = map[string]promiseCombinator{
 // combinatorRejects returns what the hand-written model contributes to fn's
 // reject set, which is nothing for any function that is not one of the four
 // combinators.
-func combinatorRejects(fn *Func) []Raised {
+func combinatorRejects(fn *Func) []Exception {
 	model, modeled := promiseCombinators[fn.Name]
 	if !modeled || model.form == nil {
 		return nil
 	}
 	for i, param := range fn.Params {
 		if param == model.iterable {
-			return []Raised{model.form(Param(i))}
+			return []Exception{model.form(Param(i))}
 		}
 	}
 	return nil

--- a/internal/ecma262/rejects.go
+++ b/internal/ecma262/rejects.go
@@ -1,0 +1,434 @@
+package ecma262
+
+import (
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// Sink is the exit a raised value leaves a function through. Every throw site
+// belongs to exactly one, which is what splits a method's raised set into the
+// synchronous `throws` and the asynchronous `rejects` of the promise it
+// returns. See planning/ecma-262/implementation_plan.md §9.3 and
+// requirements.md FR13.
+//
+// The split needs no case for generators. A generator's `next` raises
+// synchronously and an async generator's `next` rejects the promise it hands
+// back, and the partition below reads each off the same node list.
+type Sink uint8
+
+const (
+	// SinkSync is a value that leaves as a synchronous abrupt completion.
+	SinkSync Sink = iota
+	// SinkReject is a value handed to the reject function of the promise
+	// capability the algorithm returns.
+	SinkReject
+)
+
+func (s Sink) String() string {
+	if s == SinkReject {
+		return "rejects"
+	}
+	return "throws"
+}
+
+// A promise capability record holds the promise and the two functions that
+// settle it. These are the field names the graph reads off one.
+const (
+	// rejectSlot holds the function that rejects the promise. A step calling it
+	// routes its argument to the reject sink.
+	rejectSlot = "Reject"
+	// resolveSlot holds the function that resolves the promise.
+	resolveSlot = "Resolve"
+)
+
+// newCapability is the abstract operation that builds a promise capability: the
+// promise, the function that resolves it, and the function that rejects it.
+const newCapability = "NewPromiseCapability"
+
+// completionValue is the field of a completion record holding the value it
+// carries. The inlined `IfAbruptRejectPromise` reads it off a captured
+// completion to hand the raised value to the capability's reject function.
+const completionValue = "Value"
+
+// argLists is where each invoker's argument list sits. `Call(F, V,
+// argumentsList)` holds it third and `Construct(F, argumentsList, newTarget)`
+// second. The graph writes the list as an allocation whose operands are the
+// arguments, so a rejection's reason is the first operand of that allocation.
+var argLists = map[string]int{
+	"Call":      2,
+	"Construct": 1,
+}
+
+// capabilityInvoke reports whether a call invokes one of the two functions a
+// promise capability holds, and which. `? Call(promiseCapability.[[Reject]],
+// undefined, « reason »)` is the shape, and the graph writes the invoked
+// function as the argument an invoker reads rather than as the callee.
+func capabilityInvoke(node *CallNode) (string, bool) {
+	position, invoking := invokers[node.Callee]
+	if !invoking || position >= len(node.Args) {
+		return "", false
+	}
+	slot, ok := node.Args[position].(*SlotExpr)
+	if !ok || (slot.Slot != rejectSlot && slot.Slot != resolveSlot) {
+		return "", false
+	}
+	return slot.Slot, true
+}
+
+// rejectReason returns the value a step hands to a promise capability's reject
+// function, and whether the step is such a call at all.
+func rejectReason(node *CallNode) (Expr, bool) {
+	slot, settling := capabilityInvoke(node)
+	if !settling || slot != rejectSlot {
+		return nil, false
+	}
+	position, known := argLists[node.Callee]
+	if !known || position >= len(node.Args) {
+		return nil, false
+	}
+	list, ok := node.Args[position].(*AllocExpr)
+	if !ok || len(list.Args) == 0 {
+		return nil, false
+	}
+	return list.Args[0], true
+}
+
+// rejectRoute is one step whose exceptions reach the reject sink, and where in
+// the function that step sits.
+type rejectRoute struct {
+	node  *CallNode
+	index int
+}
+
+// directReject is a step that rejects with a plain value rather than with an
+// abrupt completion. `Promise.reject` is the shape: it hands its own argument
+// to the reject function, so the reason is a value whose origin the map can
+// read.
+type directReject struct {
+	rejectRoute
+	reason Expr
+}
+
+// rejectPlan is where one function's rejections come from. It is worked out
+// from the node list alone, so the fixpoint builds it once and reads it on
+// every pass.
+//
+// routed and direct are the two sources §9.3 names. routed holds the steps
+// whose abrupt completion an `IfAbruptRejectPromise` sends to the reject
+// function, and what each raises is whatever the fixpoint concluded about the
+// operation that step calls. direct holds the steps handed a plain value.
+//
+// read holds the positions of the `Completion` captures the walk traced back
+// through. Such a capture is the point where an abrupt completion stops being
+// control flow and becomes a value, and §9.1 flags a function that has one
+// because it can no longer name the step that raised it. A capture this walk
+// read through is named after all, so it leaves the flag alone.
+//
+// modeled holds what the hand-written combinator model contributes, which has
+// no step in the graph at all.
+//
+// delegated marks a function that hands the capability it built to another
+// function which rejects one. Those rejections settle the promise this function
+// returns and neither source above sees them, so the function is flagged rather
+// than published as if its reject set were whole.
+type rejectPlan struct {
+	routed    []rejectRoute
+	direct    []directReject
+	read      set.Set[int]
+	modeled   []Raised
+	delegated bool
+}
+
+// newRejectPlan works out where fn's rejections come from.
+//
+// A function that does not return a promise has none. It may still call some
+// capability's reject function, as `NewPromiseReactionJob`'s closure does, but
+// that capability belongs to whoever handed it over, so the value settles a
+// promise this function does not return.
+func newRejectPlan(fn *Func, rejecters set.Set[string]) *rejectPlan {
+	plan := &rejectPlan{read: set.NewSet[int]()}
+	if !fn.Promise {
+		return plan
+	}
+	plan.modeled = combinatorRejects(fn)
+	plan.delegated = delegatesCapability(fn, rejecters)
+
+	scan := &rejectScan{fn: fn, defs: definitions(fn), plan: plan}
+	routed := set.NewSet[int]()
+	for i, node := range fn.Nodes {
+		call, ok := node.(*CallNode)
+		if !ok {
+			continue
+		}
+		reason, rejecting := rejectReason(call)
+		if !rejecting {
+			continue
+		}
+		steps := scan.raisingSteps(reason, set.NewSet[string]())
+		if len(steps) == 0 {
+			// A reason the walk could not trace to a raising step is a plain
+			// value. So is one it could trace to a step that raises nothing,
+			// such as the freshly built error object
+			// `AsyncFromSyncIteratorPrototype.return` rejects with, and there
+			// the origin map answers `Unknown` rather than naming a class. The
+			// graph carries the class only on a `Throw` step, so a rejection
+			// built that way cannot be named until the serializer records it.
+			plan.direct = append(plan.direct, directReject{rejectRoute{node: call, index: i}, reason})
+			continue
+		}
+		for _, step := range steps {
+			if routed.Contains(step) {
+				continue
+			}
+			routed.Add(step)
+			call, ok := fn.Nodes[step].(*CallNode)
+			if !ok {
+				continue
+			}
+			plan.routed = append(plan.routed, rejectRoute{node: call, index: step})
+		}
+	}
+	sort.Slice(plan.routed, func(i, j int) bool { return plan.routed[i].index < plan.routed[j].index })
+	return plan
+}
+
+// rejecters returns the names of the functions with a step that rejects a
+// promise capability, whether that capability is one they built or one they
+// were handed.
+func rejecters(cfg *CFG) set.Set[string] {
+	names := set.NewSet[string]()
+	for _, fn := range cfg.Funcs {
+		for _, node := range fn.Nodes {
+			call, ok := node.(*CallNode)
+			if !ok {
+				continue
+			}
+			if slot, settling := capabilityInvoke(call); settling && slot == rejectSlot {
+				names.Add(fn.Name)
+				break
+			}
+		}
+	}
+	return names
+}
+
+// delegatesCapability reports whether fn passes a promise capability it built
+// to a function that rejects one.
+//
+// `AsyncFromSyncIteratorPrototype.next` is the shape. It builds a capability,
+// hands it to `AsyncFromSyncIteratorContinuation`, and returns the capability's
+// promise, and the continuation is where three of the four rejections of that
+// promise happen. Following the value into the callee would take a summary of
+// which parameter each function rejects and how a caller fills it, which §9.3
+// does not build, so the caller is flagged instead.
+//
+// The four `Promise` combinators pass their capability to a `PerformPromise*`
+// operation that resolves rather than rejects it. What those forward is each
+// element promise's rejection, which reaches the capability through a reaction
+// handler rather than a reject step, and the combinator model is what covers
+// it.
+func delegatesCapability(fn *Func, rejecters set.Set[string]) bool {
+	held := capabilityNames(fn)
+	if held.Len() == 0 {
+		return false
+	}
+	for _, node := range fn.Nodes {
+		call, ok := node.(*CallNode)
+		if !ok || !rejecters.Contains(call.Callee) {
+			continue
+		}
+		for _, arg := range call.Args {
+			if name, ok := arg.(*VarExpr); ok && held.Contains(name.Var) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// capabilityNames returns the value names a function binds to a promise
+// capability it built. A binding that renames one carries it along, which is how
+// `let promiseCapability be %0` reaches the name the steps below it use.
+func capabilityNames(fn *Func) set.Set[string] {
+	held := set.NewSet[string]()
+	for {
+		grew := false
+		for _, node := range fn.Nodes {
+			switch node := node.(type) {
+			case *CallNode:
+				if node.Callee == newCapability && node.Target != "" && !held.Contains(node.Target) {
+					held.Add(node.Target)
+					grew = true
+				}
+			case *LetNode:
+				source, ok := node.Source.(*VarExpr)
+				if ok && held.Contains(source.Var) && !held.Contains(node.Target) {
+					held.Add(node.Target)
+					grew = true
+				}
+			default:
+				// No other node shape binds a name.
+			}
+		}
+		if !grew {
+			return held
+		}
+	}
+}
+
+// definitions indexes each value name a function binds by the positions of the
+// steps that bind it. A name bound on two paths has both, which is what lets
+// the walk below read an abrupt completion back to either step it came from.
+func definitions(fn *Func) map[string][]int {
+	defs := make(map[string][]int, len(fn.Nodes))
+	for i, node := range fn.Nodes {
+		switch node := node.(type) {
+		case *LetNode:
+			defs[node.Target] = append(defs[node.Target], i)
+		case *CallNode:
+			if node.Target != "" {
+				defs[node.Target] = append(defs[node.Target], i)
+			}
+		default:
+			// No other node shape binds a name.
+		}
+	}
+	return defs
+}
+
+// rejectScan walks one function's value names back to the steps that raised
+// what its rejections carry.
+type rejectScan struct {
+	fn   *Func
+	defs map[string][]int
+	plan *rejectPlan
+}
+
+// raisingSteps walks the value handed to a reject function back to the steps
+// whose abrupt completion it carries, and returns their positions.
+//
+// ESMeta inlines `IfAbruptRejectPromise(v, capability)` rather than leaving it
+// an opaque helper, so the shape reaching the graph is four steps:
+//
+//	%1 = plain GetPromiseResolve(C)
+//	%2 = plain Completion(%1)
+//	let promiseResolve = %2
+//	%3 = ? Call(promiseCapability.[[Reject]], lit, alloc(promiseResolve.[[Value]]))
+//
+// The call the exception came from is `GetPromiseResolve`, three hops back
+// through a completion capture and a binding, and reading it is what makes the
+// rejection a fact about that operation rather than an untraced value. The walk
+// unwraps `.[[Value]]`, follows a binding to its source, and stops at the
+// capture.
+//
+// seen holds the names already walked, since a name is bound from itself on the
+// path where the completion turns out to be a normal one, as in `let
+// promiseResolve be promiseResolve.[[Value]]`.
+func (s *rejectScan) raisingSteps(e Expr, seen set.Set[string]) []int {
+	switch e := e.(type) {
+	case *SlotExpr:
+		if e.Slot == completionValue {
+			return s.raisingSteps(e.Object, seen)
+		}
+	case *VarExpr:
+		if seen.Contains(e.Var) {
+			return nil
+		}
+		seen.Add(e.Var)
+		var steps []int
+		for _, i := range s.defs[e.Var] {
+			switch def := s.fn.Nodes[i].(type) {
+			case *LetNode:
+				steps = append(steps, s.raisingSteps(def.Source, seen)...)
+			case *CallNode:
+				if def.Callee != completionCapture || len(def.Args) == 0 {
+					continue
+				}
+				captured := s.capturedSteps(def.Args[0])
+				if len(captured) == 0 {
+					continue
+				}
+				s.plan.read.Add(i)
+				steps = append(steps, captured...)
+			default:
+				// No other node shape binds a name.
+			}
+		}
+		return steps
+	default:
+		// A `this` value, a literal, an allocation, and a property read name no
+		// step the walk can follow.
+	}
+	return nil
+}
+
+// capturedSteps returns the positions of the steps whose result a `Completion`
+// capture wrapped. The operand names a call's result, so a name bound to
+// anything else contributes nothing.
+func (s *rejectScan) capturedSteps(e Expr) []int {
+	name, ok := e.(*VarExpr)
+	if !ok {
+		return nil
+	}
+	var steps []int
+	for _, i := range s.defs[name.Var] {
+		call, ok := s.fn.Nodes[i].(*CallNode)
+		if !ok || call.Callee == completionCapture {
+			continue
+		}
+		steps = append(steps, i)
+	}
+	return steps
+}
+
+// promiseCombinator is the hand-written model of one `Promise` combinator's
+// element rejections. iterable names the parameter holding the promises whose
+// reject type the combinator forwards, and form is what it forwards that type
+// as. A nil form is a combinator that never rejects from its elements.
+type promiseCombinator struct {
+	iterable string
+	form     func(Origin) Raised
+}
+
+// promiseCombinators models the four `Promise` combinators by name.
+//
+// Each forwards the reject type of the promises its iterable yields, and that
+// value arrives through the promise-resolution machinery rather than along an
+// edge the graph holds: `Promise.all` hands each element to
+// `PerformPromiseAll`, which registers a reaction whose rejection settles the
+// returned promise. No origin the analysis computes reaches that, so FR13 asks
+// for the four to be modeled by hand instead.
+//
+// The model is the element channel alone. What a combinator rejects on its own
+// account — the `TypeError` from `? GetIterator(iterable)` on a non-iterable
+// argument, say — is a routed rejection the walk above already finds, and the
+// two are unioned. `Promise.allSettled` is the case that shows why: it captures
+// each element rejection as a `{status, reason}` record, so its element channel
+// is empty while its own iterator rejection stands.
+//
+// TestPromiseCombinatorsMatchTheGraph checks each entry against the graph, so a
+// spec bump that renames the parameter fails there rather than silently
+// modeling nothing.
+var promiseCombinators = map[string]promiseCombinator{
+	"Promise.all":        {iterable: "iterable", form: ElementErr},
+	"Promise.race":       {iterable: "iterable", form: ElementErr},
+	"Promise.any":        {iterable: "iterable", form: AggregateErr},
+	"Promise.allSettled": {iterable: "iterable"},
+}
+
+// combinatorRejects returns what the hand-written model contributes to fn's
+// reject set, which is nothing for any function that is not one of the four
+// combinators.
+func combinatorRejects(fn *Func) []Raised {
+	model, modeled := promiseCombinators[fn.Name]
+	if !modeled || model.form == nil {
+		return nil
+	}
+	for i, param := range fn.Params {
+		if param == model.iterable {
+			return []Raised{model.form(Param(i))}
+		}
+	}
+	return nil
+}

--- a/internal/ecma262/rejects.go
+++ b/internal/ecma262/rejects.go
@@ -7,14 +7,10 @@ import (
 )
 
 // Sink is the exit a raised value leaves a function through. Every throw site
-// belongs to exactly one, which is what splits a method's raised set into the
-// synchronous `throws` and the asynchronous `rejects` of the promise it
-// returns. See planning/ecma-262/implementation_plan.md §9.3 and
-// requirements.md FR13.
-//
-// The split needs no case for generators. A generator's `next` raises
-// synchronously and an async generator's `next` rejects the promise it hands
-// back, and the partition below reads each off the same node list.
+// belongs to exactly one, which splits a method's raised set into the
+// synchronous `throws` and the `rejects` of the promise it returns. A generator
+// needs no case of its own, since its `next` reaches the first sink and an async
+// generator's the second. See implementation_plan.md §9.3 and FR13.
 type Sink uint8
 
 const (
@@ -113,30 +109,27 @@ type directReject struct {
 // rejectPlan is where one function's rejections come from. It is worked out
 // from the node list alone, so the fixpoint builds it once and reads it on
 // every pass.
-//
-// routed and direct are the two sources §9.3 names. routed holds the steps
-// whose abrupt completion an `IfAbruptRejectPromise` sends to the reject
-// function, and what each raises is whatever the fixpoint concluded about the
-// operation that step calls. direct holds the steps handed a plain value.
-//
-// read holds the positions of the `Completion` captures the walk traced back
-// through. Such a capture is the point where an abrupt completion stops being
-// control flow and becomes a value, and §9.1 flags a function that has one
-// because it can no longer name the step that raised it. A capture this walk
-// read through is named after all, so it leaves the flag alone.
-//
-// modeled holds what the hand-written combinator model contributes, which has
-// no step in the graph at all.
-//
-// delegated marks a function that hands the capability it built to another
-// function which rejects one. Those rejections settle the promise this function
-// returns and neither source above sees them, so the function is flagged rather
-// than published as if its reject set were whole.
 type rejectPlan struct {
-	routed    []rejectRoute
-	direct    []directReject
-	read      set.Set[int]
-	modeled   []Raised
+	// routed holds the steps whose abrupt completion an `IfAbruptRejectPromise`
+	// sends to the reject function. What each raises is whatever the fixpoint
+	// concluded about the operation that step calls. routed and direct are the
+	// two sources §9.3 names.
+	routed []rejectRoute
+	// direct holds the steps handed a plain value rather than a completion.
+	direct []directReject
+	// read holds the positions of the `Completion` captures the walk traced
+	// back through. Such a capture is where an abrupt completion stops being
+	// control flow and becomes a value, and §9.1 flags a function that has one
+	// because it can no longer name the step that raised it. A capture this
+	// walk read through is named after all, so it leaves the flag alone.
+	read set.Set[int]
+	// modeled holds what the hand-written combinator model contributes, which
+	// has no step in the graph at all.
+	modeled []Raised
+	// delegated marks a function that hands the capability it built to another
+	// function which rejects one. Those rejections settle the promise this
+	// function returns and neither source above sees them, so the function is
+	// flagged rather than published as if its reject set were whole.
 	delegated bool
 }
 
@@ -213,21 +206,14 @@ func rejecters(cfg *CFG) set.Set[string] {
 	return names
 }
 
-// delegatesCapability reports whether fn passes a promise capability it built
-// to a function that rejects one.
-//
-// `AsyncFromSyncIteratorPrototype.next` is the shape. It builds a capability,
-// hands it to `AsyncFromSyncIteratorContinuation`, and returns the capability's
-// promise, and the continuation is where three of the four rejections of that
-// promise happen. Following the value into the callee would take a summary of
-// which parameter each function rejects and how a caller fills it, which §9.3
-// does not build, so the caller is flagged instead.
-//
-// The four `Promise` combinators pass their capability to a `PerformPromise*`
-// operation that resolves rather than rejects it. What those forward is each
-// element promise's rejection, which reaches the capability through a reaction
-// handler rather than a reject step, and the combinator model is what covers
-// it.
+// delegatesCapability reports whether fn passes a promise capability it built to
+// a function that rejects one. `AsyncFromSyncIteratorPrototype.next` is the
+// shape: it hands its capability to `AsyncFromSyncIteratorContinuation`, where
+// three of the four rejections of the promise it returns happen. Following the
+// value in would take a summary of which parameter each function rejects, which
+// §9.3 does not build, so the caller is flagged instead. The check is on the
+// immediate callee, which leaves the combinators alone; each passes its
+// capability to a `PerformPromise*` operation that only resolves it.
 func delegatesCapability(fn *Func, rejecters set.Set[string]) bool {
 	held := capabilityNames(fn)
 	if held.Len() == 0 {
@@ -306,25 +292,19 @@ type rejectScan struct {
 }
 
 // raisingSteps walks the value handed to a reject function back to the steps
-// whose abrupt completion it carries, and returns their positions.
-//
-// ESMeta inlines `IfAbruptRejectPromise(v, capability)` rather than leaving it
-// an opaque helper, so the shape reaching the graph is four steps:
+// whose abrupt completion it carries, and returns their positions. ESMeta
+// inlines `IfAbruptRejectPromise`, so the shape is four steps:
 //
 //	%1 = plain GetPromiseResolve(C)
 //	%2 = plain Completion(%1)
 //	let promiseResolve = %2
 //	%3 = ? Call(promiseCapability.[[Reject]], lit, alloc(promiseResolve.[[Value]]))
 //
-// The call the exception came from is `GetPromiseResolve`, three hops back
-// through a completion capture and a binding, and reading it is what makes the
-// rejection a fact about that operation rather than an untraced value. The walk
-// unwraps `.[[Value]]`, follows a binding to its source, and stops at the
-// capture.
-//
-// seen holds the names already walked, since a name is bound from itself on the
-// path where the completion turns out to be a normal one, as in `let
-// promiseResolve be promiseResolve.[[Value]]`.
+// Reading back to `GetPromiseResolve` is what makes the rejection a fact about
+// that operation rather than an untraced value, so the walk unwraps
+// `.[[Value]]`, follows a binding to its source, and stops at the capture. seen
+// holds the names already walked, since a name is bound from itself on the path
+// where the completion turns out to be a normal one.
 func (s *rejectScan) raisingSteps(e Expr, seen set.Set[string]) []int {
 	switch e := e.(type) {
 	case *SlotExpr:
@@ -391,25 +371,14 @@ type promiseCombinator struct {
 	form     func(Origin) Raised
 }
 
-// promiseCombinators models the four `Promise` combinators by name.
-//
-// Each forwards the reject type of the promises its iterable yields, and that
-// value arrives through the promise-resolution machinery rather than along an
-// edge the graph holds: `Promise.all` hands each element to
-// `PerformPromiseAll`, which registers a reaction whose rejection settles the
-// returned promise. No origin the analysis computes reaches that, so FR13 asks
-// for the four to be modeled by hand instead.
-//
-// The model is the element channel alone. What a combinator rejects on its own
-// account — the `TypeError` from `? GetIterator(iterable)` on a non-iterable
-// argument, say — is a routed rejection the walk above already finds, and the
-// two are unioned. `Promise.allSettled` is the case that shows why: it captures
-// each element rejection as a `{status, reason}` record, so its element channel
-// is empty while its own iterator rejection stands.
-//
-// TestPromiseCombinatorsMatchTheGraph checks each entry against the graph, so a
-// spec bump that renames the parameter fails there rather than silently
-// modeling nothing.
+// promiseCombinators models the four `Promise` combinators by name. Each
+// forwards the reject type of the promises its iterable yields, which arrives
+// through the promise-resolution machinery rather than along an edge the graph
+// holds, so FR13 asks for the four to be modeled by hand. The model is the
+// element channel alone, unioned with the routed rejections the walk above
+// finds, which is why `Promise.allSettled` keeps its own iterator `TypeError`
+// while forwarding nothing from its elements.
+// TestPromiseCombinatorsMatchTheGraph checks each entry against the graph.
 var promiseCombinators = map[string]promiseCombinator{
 	"Promise.all":        {iterable: "iterable", form: ElementErr},
 	"Promise.race":       {iterable: "iterable", form: ElementErr},

--- a/internal/ecma262/rejects_test.go
+++ b/internal/ecma262/rejects_test.go
@@ -143,7 +143,9 @@ func TestRejectSetSplitsACombinatorBySite(t *testing.T) {
 // `C.resolve`. Each is a function the combinator rejects with the throws of,
 // and each was read off a property rather than handed in as a parameter, so
 // there is no origin to thread it back to. FR6 spells that `unknown`, and the
-// FR7 join fills it from the typed signature.
+// FR7 join fills it from the typed signature. Whether an origin naming the
+// property path is worth recording instead is
+// https://github.com/escalier-lang/escalier/issues/1304.
 func TestCombinatorRejects(t *testing.T) {
 	tests := map[string]struct {
 		fn   string

--- a/internal/ecma262/rejects_test.go
+++ b/internal/ecma262/rejects_test.go
@@ -335,9 +335,9 @@ func TestRejectSetFlagsADelegatedCapability(t *testing.T) {
 	}
 }
 
-// The reason a rejection carries is read from the invoker's own argument list,
-// which sits third in `Call(F, V, argumentsList)` and second in `Construct(F,
-// argumentsList, newTarget)`.
+// The reason a rejection carries is read from the argument list of the invoker
+// that carries it. `Call(F, V, argumentsList)` holds that list third and
+// `Construct(F, argumentsList, newTarget)` holds it second.
 func TestRejectReasonReadsEachInvokersArgumentList(t *testing.T) {
 	const reject = `{"kind":"slot","object":{"kind":"var","var":"cap"},"slot":"Reject"}`
 	const list = `{"kind":"alloc","args":[{"kind":"var","var":"r"}]}`
@@ -360,10 +360,20 @@ func TestRejectReasonReadsEachInvokersArgumentList(t *testing.T) {
 	}
 }
 
-// A callee's rejections settle the promise the callee returns, so they reach
-// neither channel of a caller that `?`-guards it. Only what the callee raises
-// synchronously travels out. Without the split the caller would report the
-// callee's rejected value as one of its own synchronous throws.
+// A callee's rejections settle the promise the callee returns, so a caller that
+// `?`-guards it inherits only what the callee raises synchronously. Without the
+// split the caller would report the callee's rejected value as one of its own
+// synchronous throws.
+//
+// A caller that returned the callee's promise rather than guarding it would
+// hand those rejections on, and §9.3 would not see them. It reads a function's
+// own `[[Reject]]` steps and never a callee's reject set. That case does not
+// arise in the pinned graph: `Promise.resolve` is the one builtin returning a
+// callee's promise, and `PromiseResolve` rejects nowhere. The serializer also
+// leaves `Func.Promise` unset on a function returning a promise built
+// elsewhere, so such a function reports no rejections rather than the wrong
+// ones. See the §3 findings on `Promise.prototype.catch` in
+// planning/ecma-262/implementation_plan.md.
 func TestCalleeRejectionsDoNotPropagate(t *testing.T) {
 	cfg, err := ParseCFG([]byte(
 		`{"specTarget":"abc","funcs":[` +

--- a/internal/ecma262/rejects_test.go
+++ b/internal/ecma262/rejects_test.go
@@ -14,9 +14,9 @@ func rejectsOf(t *testing.T, name string) string {
 	return throwsOf(t, name).RejectsString()
 }
 
-func TestRaisedStringOfACombinatorForm(t *testing.T) {
+func TestExceptionStringOfACombinatorForm(t *testing.T) {
 	tests := map[string]struct {
-		raised Raised
+		raised Exception
 		want   string
 	}{
 		"ElementErr": {ElementErr(Param(0)), "ElementErr(Param(0))"},
@@ -32,10 +32,10 @@ func TestRaisedStringOfACombinatorForm(t *testing.T) {
 
 func TestThrowsRejectsString(t *testing.T) {
 	require.Equal(t, "none", Throws{}.RejectsString())
-	require.Equal(t, "none", Throws{Raised: []Raised{Class("TypeError")}}.RejectsString())
+	require.Equal(t, "none", Throws{Raised: []Exception{Class("TypeError")}}.RejectsString())
 	require.Equal(t,
 		"TypeError ElementErr(Param(0))",
-		Throws{Rejects: []Raised{Class("TypeError"), ElementErr(Param(0))}}.RejectsString(),
+		Throws{Rejects: []Exception{Class("TypeError"), ElementErr(Param(0))}}.RejectsString(),
 	)
 }
 
@@ -76,7 +76,7 @@ func TestRejectSetIsEmptyWithoutAReturnedPromise(t *testing.T) {
 // set names the parameter rather than an error class. FR6 spells the fact
 // `param:0` on the wire.
 func TestRejectSetRecordsADirectRejectionsOrigin(t *testing.T) {
-	require.Equal(t, []Raised{Propagated(Param(0))}, throwsOf(t, "Promise.reject").Rejects)
+	require.Equal(t, []Exception{Propagated(Param(0))}, throwsOf(t, "Promise.reject").Rejects)
 }
 
 // The same error class reaches both channels when a method raises it on both

--- a/internal/ecma262/rejects_test.go
+++ b/internal/ecma262/rejects_test.go
@@ -194,11 +194,11 @@ func TestChannelsHoldWhatTheirSitesRaise(t *testing.T) {
 	for _, fn := range testCFG(t).Funcs {
 		throws := summary.Of(fn)
 		for _, site := range throws.SyncSites() {
-			require.Contains(t, throws.Raised, site.Raised, fn.Name)
-			require.NotContains(t, combinatorRejects(fn), site.Raised, fn.Name)
+			require.Contains(t, throws.Raised, site.Exception, fn.Name)
+			require.NotContains(t, combinatorRejects(fn), site.Exception, fn.Name)
 		}
 		for _, site := range throws.RejectSites() {
-			require.Contains(t, throws.Rejects, site.Raised, fn.Name)
+			require.Contains(t, throws.Rejects, site.Exception, fn.Name)
 		}
 		for _, modeled := range combinatorRejects(fn) {
 			require.Contains(t, throws.Rejects, modeled, fn.Name)

--- a/internal/ecma262/rejects_test.go
+++ b/internal/ecma262/rejects_test.go
@@ -1,0 +1,350 @@
+package ecma262
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// rejectsOf returns the reject channel of one builtin or abstract operation,
+// rendered the way String renders the synchronous one.
+func rejectsOf(t *testing.T, name string) string {
+	t.Helper()
+	return throwsOf(t, name).RejectsString()
+}
+
+func TestRaisedStringOfACombinatorForm(t *testing.T) {
+	tests := map[string]struct {
+		raised Raised
+		want   string
+	}{
+		"ElementErr": {ElementErr(Param(0)), "ElementErr(Param(0))"},
+		"Aggregate":  {AggregateErr(Param(0)), "AggregateError<ElementErr(Param(0))>"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, test.raised.String())
+		})
+	}
+}
+
+func TestThrowsRejectsString(t *testing.T) {
+	require.Equal(t, "none", Throws{}.RejectsString())
+	require.Equal(t, "none", Throws{Raised: []Raised{Class("TypeError")}}.RejectsString())
+	require.Equal(t,
+		"TypeError ElementErr(Param(0))",
+		Throws{Rejects: []Raised{Class("TypeError"), ElementErr(Param(0))}}.RejectsString(),
+	)
+}
+
+// A promise-returning method carries a reject set of its own, and the two
+// channels say different things about the same method. `Promise.prototype.then`
+// is the case that shows the reject channel is computed rather than mirrored:
+// it validates its receiver synchronously and rejects nothing itself.
+func TestRejectSetIsDistinctFromTheThrowSet(t *testing.T) {
+	tests := map[string]struct {
+		fn      string
+		throws  string
+		rejects string
+	}{
+		"DirectReject":  {"Promise.reject", "TypeError Unknown", "Origin(Param(0))"},
+		"NoRejectSite":  {"Promise.prototype.then", "TypeError Unknown", "none"},
+		"AsyncIterator": {"AsyncGeneratorPrototype.next", "none", "TypeError"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			throws := throwsOf(t, test.fn)
+			require.Equal(t, test.throws, Throws{Raised: throws.Raised}.String())
+			require.Equal(t, test.rejects, throws.RejectsString())
+		})
+	}
+}
+
+// A function that does not return a promise has no reject channel, whatever it
+// does with a capability it was handed. `NewPromiseReactionJob`'s closure calls
+// `? Call(promiseCapability.[[Reject]], ...)` on the capability its caller
+// built, so the value settles a promise the closure does not return.
+func TestRejectSetIsEmptyWithoutAReturnedPromise(t *testing.T) {
+	require.False(t, testCFG(t).AbstractOp("NewPromiseReactionJob:clo0").Promise)
+	require.Equal(t, "none", rejectsOf(t, "NewPromiseReactionJob:clo0"))
+}
+
+// `Promise.reject` hands its own argument to the reject function, so the reject
+// set names the parameter rather than an error class. FR6 spells the fact
+// `param:0` on the wire.
+func TestRejectSetRecordsADirectRejectionsOrigin(t *testing.T) {
+	require.Equal(t, []Raised{Propagated(Param(0))}, throwsOf(t, "Promise.reject").Rejects)
+}
+
+// The same error class reaches both channels when a method raises it on both
+// paths, which is what makes the split per site rather than per error type.
+// `Promise.try` raises a TypeError synchronously when its `this` value is not a
+// constructor, and rejects with one when the callback it was handed is not
+// callable. It also rejects with whatever that callback itself raises, since
+// `Completion(Call(callback, ...))` routes the callback's throws to the reject
+// sink rather than out through the method.
+func TestRejectSetAndThrowSetShareAnErrorClass(t *testing.T) {
+	throws := throwsOf(t, "Promise.try")
+	require.Contains(t, throws.Raised, Class("TypeError"))
+	require.Contains(t, throws.Rejects, Class("TypeError"))
+	require.Contains(t, throws.Rejects, CallbackThrows(Param(0)))
+	require.NotContains(t, throws.Raised, CallbackThrows(Param(0)))
+}
+
+// A generator surfaces its body's failures synchronously and an async generator
+// surfaces them as rejections of the promise each `next` hands back. Both route
+// through the one partition with no case of their own: the pair below raises
+// the same value, its own first argument, and the channel differs.
+func TestRejectSetSubsumesAsyncGenerators(t *testing.T) {
+	sync := throwsOf(t, "GeneratorPrototype.throw")
+	require.Contains(t, sync.Raised, Propagated(Param(0)))
+	require.Equal(t, "none", sync.RejectsString())
+
+	async := throwsOf(t, "AsyncGeneratorPrototype.throw")
+	require.Contains(t, async.Rejects, Propagated(Param(0)))
+}
+
+// A combinator's synchronous validation and its `IfAbruptRejectPromise` steps
+// land in different channels. `Promise.all` raises a TypeError synchronously
+// through `? NewPromiseCapability(C)` when `this` is not a constructor, and
+// rejects with one when `? GetIterator(iterable)` finds the argument is not
+// iterable.
+func TestRejectSetSplitsACombinatorBySite(t *testing.T) {
+	sites := func(sites []ThrowSite) []string {
+		var chains []string
+		for _, site := range sites {
+			chains = append(chains, site.String())
+		}
+		return chains
+	}
+	all := throwsOf(t, "Promise.all")
+
+	require.Contains(t, sites(all.SyncSites()), "#2 TypeError <- NewPromiseCapability#3")
+	require.Contains(t, sites(all.RejectSites()), "#19 rejects TypeError <- GetIterator#20")
+	// A validation `Throw` the algorithm writes for itself reads the same way.
+	// `Promise.try` raises one before it ever builds a capability.
+	require.Contains(t, sites(throwsOf(t, "Promise.try").SyncSites()), "#4 TypeError")
+}
+
+// The four combinators forward the reject type of the promises their iterable
+// yields. That value arrives through the promise-resolution machinery, so the
+// model supplies it by name, and it is added to what the walk found rather than
+// replacing it. `Promise.allSettled` shows the difference: its element channel
+// is empty, and the TypeError it rejects with on a non-iterable argument still
+// stands.
+func TestCombinatorRejects(t *testing.T) {
+	tests := map[string]struct {
+		fn   string
+		want string
+	}{
+		"All":        {"Promise.all", "TypeError ElementErr(Param(0)) Unknown"},
+		"Race":       {"Promise.race", "TypeError ElementErr(Param(0)) Unknown"},
+		"Any":        {"Promise.any", "TypeError AggregateError<ElementErr(Param(0))> Unknown"},
+		"AllSettled": {"Promise.allSettled", "TypeError Unknown"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, rejectsOf(t, test.fn))
+		})
+	}
+}
+
+// Every combinator the model names is a promise-returning builtin with the
+// parameter the entry keys on, so a spec bump that renames one fails here
+// rather than quietly modeling nothing.
+func TestPromiseCombinatorsMatchTheGraph(t *testing.T) {
+	cfg := testCFG(t)
+	for name, model := range promiseCombinators {
+		t.Run(name, func(t *testing.T) {
+			fn := cfg.Builtin(name)
+			require.NotNil(t, fn, "no builtin named %s", name)
+			require.True(t, fn.Promise, "%s does not return a promise", name)
+			require.Contains(t, fn.Params, model.iterable)
+		})
+	}
+}
+
+// The two partitions are disjoint and together they are every site, so no site
+// is counted in both channels or dropped from both.
+func TestSitePartitionCoversEverySite(t *testing.T) {
+	summary := testThrows(t)
+	for _, fn := range testCFG(t).Funcs {
+		throws := summary.Of(fn)
+		require.Len(t, throws.Sites, len(throws.SyncSites())+len(throws.RejectSites()), fn.Name)
+	}
+}
+
+// Each channel holds exactly the values its own sites raise, apart from the
+// combinator model, which has no site at all.
+func TestChannelsHoldWhatTheirSitesRaise(t *testing.T) {
+	summary := testThrows(t)
+	for _, fn := range testCFG(t).Funcs {
+		throws := summary.Of(fn)
+		for _, site := range throws.SyncSites() {
+			require.Contains(t, throws.Raised, site.Raised, fn.Name)
+			require.NotContains(t, combinatorRejects(fn), site.Raised, fn.Name)
+		}
+		for _, site := range throws.RejectSites() {
+			require.Contains(t, throws.Rejects, site.Raised, fn.Name)
+		}
+		for _, modeled := range combinatorRejects(fn) {
+			require.Contains(t, throws.Rejects, modeled, fn.Name)
+		}
+	}
+}
+
+// The whole route back to the operation that raised a rejected value is kept,
+// the same as on the synchronous channel, so §9.2's coercion filter reads a
+// reject site the way it reads a throw site.
+//
+// The synchronous site at #30 is a §3 lowering artifact. The step is `Let
+// completion be ThrowCompletion(exception)`, which builds a completion the
+// algorithm then enqueues, and the serializer writes it as a `Throw`. The
+// method returns a promise on every path and cannot throw synchronously.
+func TestRejectSiteProvenanceChains(t *testing.T) {
+	snaps.MatchInlineSnapshot(t, throwsOf(t, "AsyncGeneratorPrototype.throw").SitesString(), snaps.Inline(`#4 rejects TypeError <- AsyncGeneratorValidate#0 <- RequireInternalSlot#2
+#4 rejects TypeError <- AsyncGeneratorValidate#0 <- RequireInternalSlot#5
+#4 rejects TypeError <- AsyncGeneratorValidate#5
+#24 rejects Origin(Param(0))
+#30 Origin(Param(0))
+`),
+	)
+}
+
+// rejectGraph is the inlined `IfAbruptRejectPromise` shape: a plain call whose
+// completion is captured as a value, bound to a name, and handed to the
+// capability's reject function. reason is what the reject call is passed.
+func rejectGraph(t *testing.T, promise bool, reason string) *CFG {
+	t.Helper()
+	returns := "false"
+	if promise {
+		returns = "true"
+	}
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[` +
+			`{"name":"Raiser","kind":"abstract-op","params":[],` +
+			`"nodes":[{"kind":"throw","errorType":"RangeError"}]},` +
+			`{"name":"Demo","kind":"builtin-static","params":["r"],"promise":` + returns + `,"nodes":[` +
+			`{"kind":"call","target":"%0","callee":"Raiser","args":[],"guard":"plain"},` +
+			`{"kind":"call","target":"%1","callee":"Completion",` +
+			`"args":[{"kind":"var","var":"%0"}],"guard":"plain"},` +
+			`{"kind":"let","target":"status","source":{"kind":"var","var":"%1"}},` +
+			`{"kind":"call","target":"%2","callee":"Call","guard":"?","args":[` +
+			`{"kind":"slot","object":{"kind":"var","var":"cap"},"slot":"Reject"},` +
+			`{"kind":"lit"},` +
+			`{"kind":"alloc","args":[` + reason + `]}]}]}]}`))
+	require.NoError(t, err)
+	return cfg
+}
+
+// A completion the reject walk read through is a step the analysis can name
+// after all, so it no longer leaves the function incomplete. The same shape in
+// a function that returns no promise stays incomplete, since nothing there says
+// where the captured completion goes.
+func TestRejectWalkReadsThroughACapturedCompletion(t *testing.T) {
+	const completionValue = `{"kind":"slot","object":{"kind":"var","var":"status"},"slot":"Value"}`
+
+	cfg := rejectGraph(t, true, completionValue)
+	throws := NewThrowSummary(cfg).Of(cfg.Builtin("Demo"))
+	require.Equal(t, "none", throws.String())
+	require.Equal(t, "RangeError", throws.RejectsString())
+	require.Equal(t, "#0 rejects RangeError <- Raiser#0", throws.Sites[0].String())
+
+	cfg = rejectGraph(t, false, completionValue)
+	throws = NewThrowSummary(cfg).Of(cfg.Builtin("Demo"))
+	require.Equal(t, "incomplete", throws.String())
+	require.Equal(t, "none", throws.RejectsString())
+}
+
+// directRejectGraph is `Promise.reject`'s shape: one step handing a plain value
+// to the capability's reject function, with no completion capture in between.
+func directRejectGraph(t *testing.T, reason string) *CFG {
+	t.Helper()
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[` +
+			`{"name":"Demo","kind":"builtin-static","params":["r"],"promise":true,"nodes":[` +
+			`{"kind":"call","target":"%0","callee":"Call","guard":"?","args":[` +
+			`{"kind":"slot","object":{"kind":"var","var":"cap"},"slot":"Reject"},` +
+			`{"kind":"lit"},` +
+			`{"kind":"alloc","args":[` + reason + `]}]}]}]}`))
+	require.NoError(t, err)
+	return cfg
+}
+
+// A reason that is a plain value rather than a captured completion is the
+// direct-rejection source, and the origin map reads where it came from.
+func TestRejectWalkRecordsAPlainReason(t *testing.T) {
+	cfg := directRejectGraph(t, `{"kind":"var","var":"r"}`)
+	throws := NewThrowSummary(cfg).Of(cfg.Builtin("Demo"))
+	require.Equal(t, "Origin(Param(0))", throws.RejectsString())
+	require.Equal(t, "#0 rejects Origin(Param(0))", throws.Sites[0].String())
+}
+
+// A reason the walk can place nowhere is untraced rather than dropped, which
+// FR6 spells `unknown` on the wire.
+func TestRejectWalkRecordsAnUnplaceableReason(t *testing.T) {
+	cfg := directRejectGraph(t, `{"kind":"alloc","args":[]}`)
+	require.Equal(t, "Unknown", NewThrowSummary(cfg).Of(cfg.Builtin("Demo")).RejectsString())
+}
+
+// Calling one of the two functions a promise capability holds contributes to
+// neither channel. `NewPromiseCapability` built them, they settle a promise
+// rather than run code the caller supplied, and reading the step as an invoke
+// of an untraceable function value would leave every promise-returning method
+// incomplete and raising an unknown value.
+func TestCapabilityInvokeContributesToNeitherChannel(t *testing.T) {
+	cfg := directRejectGraph(t, `{"kind":"var","var":"r"}`)
+	demo := cfg.Builtin("Demo")
+	throws := NewThrowSummary(cfg).Of(demo)
+	require.False(t, throws.Incomplete)
+	require.Equal(t, "none", throws.String())
+
+	settle, ok := capabilityInvoke(demo.Nodes[0].(*CallNode))
+	require.True(t, ok)
+	require.Equal(t, rejectSlot, settle)
+}
+
+// A function that hands the capability it built to another function which
+// rejects one is flagged, since those rejections settle the promise it returns
+// and no source above sees them.
+// `AsyncFromSyncIteratorPrototype.next` passes its capability to
+// `AsyncFromSyncIteratorContinuation`, which rejects it three times over.
+func TestRejectSetFlagsADelegatedCapability(t *testing.T) {
+	require.True(t, throwsOf(t, "AsyncFromSyncIteratorPrototype.next").Incomplete)
+
+	// The combinators pass their capability to a `PerformPromise*` operation
+	// that resolves rather than rejects it, so the flag stays off and the
+	// modeled element rejections stand as a whole answer.
+	for name := range promiseCombinators {
+		require.False(t, throwsOf(t, name).Incomplete, name)
+	}
+}
+
+// The reason a rejection carries is read from the invoker's own argument list,
+// which sits third in `Call(F, V, argumentsList)` and second in `Construct(F,
+// argumentsList, newTarget)`.
+func TestRejectReasonReadsEachInvokersArgumentList(t *testing.T) {
+	const reject = `{"kind":"slot","object":{"kind":"var","var":"cap"},"slot":"Reject"}`
+	const list = `{"kind":"alloc","args":[{"kind":"var","var":"r"}]}`
+
+	tests := map[string]string{
+		"Call":      `"callee":"Call","args":[` + reject + `,{"kind":"lit"},` + list + `]`,
+		"Construct": `"callee":"Construct","args":[` + reject + `,` + list + `,{"kind":"lit"}]`,
+	}
+
+	for name, call := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := ParseCFG([]byte(
+				`{"specTarget":"abc","funcs":[` +
+					`{"name":"Demo","kind":"builtin-static","params":["r"],"promise":true,` +
+					`"nodes":[{"kind":"call","target":"%0","guard":"?",` + call + `}]}]}`))
+			require.NoError(t, err)
+
+			require.Equal(t, "Origin(Param(0))", NewThrowSummary(cfg).Of(cfg.Builtin("Demo")).RejectsString())
+		})
+	}
+}

--- a/internal/ecma262/rejects_test.go
+++ b/internal/ecma262/rejects_test.go
@@ -135,6 +135,15 @@ func TestRejectSetSplitsACombinatorBySite(t *testing.T) {
 // replacing it. `Promise.allSettled` shows the difference: its element channel
 // is empty, and the TypeError it rejects with on a non-iterable argument still
 // stands.
+//
+// The `Unknown` every row carries is two callback effects the analysis could
+// not name. `? GetIterator(iterable)` ends at `? Call(method, obj)` on the
+// method it read off `iterable[@@iterator]`, and `PerformPromise*` ends at `?
+// Call(promiseResolve, ...)` on the function `GetPromiseResolve(C)` read off
+// `C.resolve`. Each is a function the combinator rejects with the throws of,
+// and each was read off a property rather than handed in as a parameter, so
+// there is no origin to thread it back to. FR6 spells that `unknown`, and the
+// FR7 join fills it from the typed signature.
 func TestCombinatorRejects(t *testing.T) {
 	tests := map[string]struct {
 		fn   string

--- a/internal/ecma262/rejects_test.go
+++ b/internal/ecma262/rejects_test.go
@@ -307,14 +307,14 @@ func TestRejectWalkRecordsAnUnplaceableReason(t *testing.T) {
 // rather than run code the caller supplied, and reading the step as an invoke
 // of an untraceable function value would leave every promise-returning method
 // incomplete and raising an unknown value.
-func TestCapabilityInvokeContributesToNeitherChannel(t *testing.T) {
+func TestSettlingAPromiseContributesToNeitherChannel(t *testing.T) {
 	cfg := directRejectGraph(t, `{"kind":"var","var":"r"}`)
 	demo := cfg.Builtin("Demo")
 	throws := NewThrowSummary(cfg).Of(demo)
 	require.False(t, throws.Incomplete)
 	require.Equal(t, "none", throws.String())
 
-	settle, ok := capabilityInvoke(demo.Nodes[0].(*CallNode))
+	settle, ok := promiseCapabilityInvoke(demo.Nodes[0].(*CallNode))
 	require.True(t, ok)
 	require.Equal(t, rejectSlot, settle)
 }
@@ -324,7 +324,7 @@ func TestCapabilityInvokeContributesToNeitherChannel(t *testing.T) {
 // and no source above sees them.
 // `AsyncFromSyncIteratorPrototype.next` passes its capability to
 // `AsyncFromSyncIteratorContinuation`, which rejects it three times over.
-func TestRejectSetFlagsADelegatedCapability(t *testing.T) {
+func TestRejectSetFlagsADelegatedPromiseCapability(t *testing.T) {
 	require.True(t, throwsOf(t, "AsyncFromSyncIteratorPrototype.next").Incomplete)
 
 	// The combinators pass their capability to a `PerformPromise*` operation

--- a/internal/ecma262/rejects_test.go
+++ b/internal/ecma262/rejects_test.go
@@ -246,15 +246,15 @@ func rejectGraph(t *testing.T, promise bool, reason string) *CFG {
 // a function that returns no promise stays incomplete, since nothing there says
 // where the captured completion goes.
 func TestRejectWalkReadsThroughACapturedCompletion(t *testing.T) {
-	const completionValue = `{"kind":"slot","object":{"kind":"var","var":"status"},"slot":"Value"}`
+	const capturedReason = `{"kind":"slot","object":{"kind":"var","var":"status"},"slot":"Value"}`
 
-	cfg := rejectGraph(t, true, completionValue)
+	cfg := rejectGraph(t, true, capturedReason)
 	throws := NewThrowSummary(cfg).Of(cfg.Builtin("Demo"))
 	require.Equal(t, "none", throws.String())
 	require.Equal(t, "RangeError", throws.RejectsString())
 	require.Equal(t, "#0 rejects RangeError <- Raiser#0", throws.Sites[0].String())
 
-	cfg = rejectGraph(t, false, completionValue)
+	cfg = rejectGraph(t, false, capturedReason)
 	throws = NewThrowSummary(cfg).Of(cfg.Builtin("Demo"))
 	require.Equal(t, "incomplete", throws.String())
 	require.Equal(t, "none", throws.RejectsString())
@@ -347,4 +347,31 @@ func TestRejectReasonReadsEachInvokersArgumentList(t *testing.T) {
 			require.Equal(t, "Origin(Param(0))", NewThrowSummary(cfg).Of(cfg.Builtin("Demo")).RejectsString())
 		})
 	}
+}
+
+// A callee's rejections settle the promise the callee returns, so they reach
+// neither channel of a caller that `?`-guards it. Only what the callee raises
+// synchronously travels out. Without the split the caller would report the
+// callee's rejected value as one of its own synchronous throws.
+func TestCalleeRejectionsDoNotPropagate(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[` +
+			`{"name":"Rejecter","kind":"abstract-op","params":["r"],"promise":true,"nodes":[` +
+			`{"kind":"throw","errorType":"RangeError"},` +
+			`{"kind":"call","target":"%0","callee":"Call","guard":"?","args":[` +
+			`{"kind":"slot","object":{"kind":"var","var":"cap"},"slot":"Reject"},` +
+			`{"kind":"lit"},` +
+			`{"kind":"alloc","args":[{"kind":"var","var":"r"}]}]}]},` +
+			`{"name":"Demo","kind":"builtin-static","params":["x"],"nodes":[` +
+			`{"kind":"call","callee":"Rejecter","args":[{"kind":"var","var":"x"}],"guard":"?"}]}]}`))
+	require.NoError(t, err)
+
+	summary := NewThrowSummary(cfg)
+	rejecter := summary.Of(cfg.AbstractOp("Rejecter"))
+	require.Equal(t, "RangeError", rejecter.String())
+	require.Equal(t, "Origin(Param(0))", rejecter.RejectsString())
+
+	demo := summary.Of(cfg.Builtin("Demo"))
+	require.Equal(t, "RangeError", demo.String())
+	require.Equal(t, "none", demo.RejectsString())
 }

--- a/internal/ecma262/throws.go
+++ b/internal/ecma262/throws.go
@@ -35,9 +35,11 @@ var invokers = map[string]int{
 // the guards say nothing about, so the analysis cannot name the step that
 // raised it.
 //
-// A function that captures a completion is incomplete for that reason. Naming
-// the raising step needs the definitions of each value name, which §9.3 has to
-// build anyway to tell a rejection site from a synchronous one.
+// A function that captures a completion is incomplete for that reason, unless
+// the reject walk names the raising step for it. §9.3 walks each value name
+// back to where it was bound, so the capture an inlined `IfAbruptRejectPromise`
+// makes reads back to the operation whose completion it holds. The captures
+// that walk read through are rejectPlan.read, and they leave the flag alone.
 const completionCapture = "Completion"
 
 // objectInternalMethods are the internal methods of ECMA-262 Tables 4 and 5,
@@ -84,16 +86,25 @@ const (
 	// raises. FR10 spells it `throwsOf:param:k`, and FR13 turns it into throws
 	// polymorphism at the join.
 	RaisedCallback
+	// RaisedElementErr is the reject type of the promises an iterable yields,
+	// forwarded by a `Promise` combinator. Origin names the parameter holding
+	// that iterable. `Promise.all` rejects with it. See promiseCombinators.
+	RaisedElementErr
+	// RaisedAggregate is an `AggregateError` whose errors list holds the reject
+	// types RaisedElementErr names. `Promise.any` rejects with it once every
+	// element promise has rejected.
+	RaisedAggregate
 	// RaisedUnknown is a raised value the analysis could neither name nor
 	// trace. See Untraced.
 	RaisedUnknown
 )
 
 // Raised is one exception a function can raise. Class holds the error class
-// name when Kind is RaisedClass. Origin holds the receiver or the parameter
-// when Kind is RaisedOrigin or RaisedCallback. The two kinds differ in what
-// that origin names. A RaisedOrigin origin names the raised value itself. A
-// RaisedCallback origin names a function whose own throws travel outward.
+// name when Kind is RaisedClass. Every other kind but RaisedUnknown holds an
+// origin, and each names something different by it. A RaisedOrigin origin names
+// the raised value itself. A RaisedCallback origin names a function whose own
+// throws travel outward. A RaisedElementErr or RaisedAggregate origin names the
+// iterable parameter whose element promises carry the reject type.
 type Raised struct {
 	Kind   RaisedKind
 	Class  string
@@ -122,6 +133,17 @@ func CallbackThrows(o Origin) Raised {
 	return Raised{Kind: RaisedCallback, Origin: o}
 }
 
+// ElementErr returns the reject type of the promises the iterable at o yields.
+func ElementErr(o Origin) Raised {
+	return Raised{Kind: RaisedElementErr, Origin: o}
+}
+
+// AggregateErr returns the `AggregateError` that aggregates the reject types of
+// the promises the iterable at o yields.
+func AggregateErr(o Origin) Raised {
+	return Raised{Kind: RaisedAggregate, Origin: o}
+}
+
 func (r Raised) String() string {
 	switch r.Kind {
 	case RaisedClass:
@@ -130,11 +152,33 @@ func (r Raised) String() string {
 		return fmt.Sprintf("Origin(%s)", r.Origin)
 	case RaisedCallback:
 		return fmt.Sprintf("CallbackThrows(%s)", r.Origin)
+	case RaisedElementErr:
+		return fmt.Sprintf("ElementErr(%s)", r.Origin)
+	case RaisedAggregate:
+		return fmt.Sprintf("AggregateError<ElementErr(%s)>", r.Origin)
 	case RaisedUnknown:
 		return "Unknown"
 	default:
 		return fmt.Sprintf("Raised(%d)", r.Kind)
 	}
+}
+
+// carriesOrigin reports whether the raised value names an origin. Every kind
+// but an error class and an untraced value does, and remap threads each of them
+// back through a call's arguments the same way.
+func (r Raised) carriesOrigin() bool {
+	switch r.Kind {
+	case RaisedOrigin, RaisedCallback, RaisedElementErr, RaisedAggregate:
+		return true
+	default:
+		return false
+	}
+}
+
+// at returns the same kind of raised value read against another origin.
+func (r Raised) at(o Origin) Raised {
+	r.Origin = o
+	return r
 }
 
 // less orders two raised values so a rendered set always reads the same way.
@@ -171,13 +215,14 @@ func (r Root) Direct() bool {
 
 // ThrowSite is one place a function raises an exception. Node is the step that
 // raises or propagates it and Index is that step's position in the function's
-// node list, which §9.3 reads to decide whether the site reaches the
-// synchronous exit or the reject sink of a returned promise.
+// node list. Sink is the exit the value leaves through, which is what splits
+// the raised set into `throws` and `rejects`.
 type ThrowSite struct {
 	Raised Raised
 	Root   Root
 	Node   Node
 	Index  int
+	Sink   Sink
 }
 
 // Base returns the site that raised the value, walking Root back through every
@@ -201,9 +246,15 @@ func (s *ThrowSite) base() *ThrowSite {
 
 // String renders the site as its position, its raised value, and the chain of
 // operations it propagated out of, innermost last: `#4 TypeError <- ToObject#5`.
+// A site on the reject channel says so before its raised value, as in `#7
+// rejects TypeError`.
 func (s ThrowSite) String() string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "#%d %s", s.Index, s.Raised)
+	fmt.Fprintf(&sb, "#%d ", s.Index)
+	if s.Sink == SinkReject {
+		sb.WriteString("rejects ")
+	}
+	fmt.Fprintf(&sb, "%s", s.Raised)
 	for root := s.Root; root.Inner != nil; root = root.Inner.Root {
 		fmt.Fprintf(&sb, " <- %s#%d", root.Callee, root.Inner.Index)
 	}
@@ -211,15 +262,23 @@ func (s ThrowSite) String() string {
 }
 
 // Throws is what the fixpoint concluded about one function. Raised holds the
-// exceptions it can raise, sorted, and Sites holds one entry per place it
-// raises one, sorted by position.
+// exceptions it raises synchronously, sorted, Rejects holds the ones it hands
+// to the reject function of the promise it returns, and Sites holds one entry
+// per place it raises one, sorted by position and tagged with the channel.
+//
+// The two sets are computed from one fixpoint and differ only in which exit a
+// site reaches, so an error class raised on both a synchronous and an
+// asynchronous path appears in both. `Promise.try` is the shape: it raises a
+// TypeError synchronously when its `this` value is not a constructor, and
+// rejects with one when the callback it was handed is not callable.
 //
 // Incomplete marks a function with a step whose throws the analysis could not
 // read. Four shapes leave it set: a prose step §3 could not lower, an object
 // internal method whose implementation is chosen at runtime, a call into a
-// function value the graph holds no body for, and a captured abrupt completion.
-// FR10 asks for such a method to be flagged rather than guessed at, and §4.3
-// turns the flag into `classified: false`.
+// function value the graph holds no body for, and an abrupt completion the
+// algorithm captured as a value without the reject walk naming where it came
+// from. FR10 asks for such a method to be flagged rather than guessed at, and
+// §4.3 turns the flag into `classified: false`.
 //
 // The flag is about this function's own steps and does not travel up the call
 // graph, the same way §4.1's is. A consumer that wants the transitive answer
@@ -228,13 +287,14 @@ func (s ThrowSite) String() string {
 // internal method through some callee.
 type Throws struct {
 	Raised     []Raised
+	Rejects    []Raised
 	Sites      []ThrowSite
 	Incomplete bool
 }
 
-// String renders the raised set as a space-separated list, so a test can assert
-// a summary in one line. A function that raises nothing and hides nothing reads
-// "none".
+// String renders the synchronous channel as a space-separated list, so a test
+// can assert a summary in one line. A function that raises nothing and hides
+// nothing reads "none". RejectsString renders the other channel.
 func (t Throws) String() string {
 	parts := make([]string, 0, len(t.Raised)+1)
 	for _, r := range t.Raised {
@@ -247,6 +307,43 @@ func (t Throws) String() string {
 		return "none"
 	}
 	return strings.Join(parts, " ")
+}
+
+// RejectsString renders the reject channel the way String renders the
+// synchronous one. The incomplete flag belongs to the function rather than to
+// either channel, so String is where it reads.
+func (t Throws) RejectsString() string {
+	if len(t.Rejects) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(t.Rejects))
+	for _, r := range t.Rejects {
+		parts = append(parts, r.String())
+	}
+	return strings.Join(parts, " ")
+}
+
+// SyncSites returns the sites whose value leaves as a synchronous abrupt
+// completion. §9.2 filters these to reach the `throws` fact.
+func (t Throws) SyncSites() []ThrowSite {
+	return t.sitesTo(SinkSync)
+}
+
+// RejectSites returns the sites whose value reaches the reject function of the
+// promise the algorithm returns. The two partitions are disjoint and together
+// they are Sites.
+func (t Throws) RejectSites() []ThrowSite {
+	return t.sitesTo(SinkReject)
+}
+
+func (t Throws) sitesTo(sink Sink) []ThrowSite {
+	var sites []ThrowSite
+	for _, site := range t.Sites {
+		if site.Sink == sink {
+			sites = append(sites, site)
+		}
+	}
+	return sites
 }
 
 // SitesString renders one site per line, so a test can assert a whole
@@ -282,6 +379,7 @@ type siteKey struct {
 	index  int
 	raised Raised
 	base   *ThrowSite
+	sink   Sink
 }
 
 // throwFacts is one function's throw set while the fixpoint is still running.
@@ -291,6 +389,7 @@ type throwFacts struct {
 	sites      map[siteKey]*ThrowSite
 	order      []*ThrowSite
 	raised     set.Set[Raised]
+	rejected   set.Set[Raised]
 	incomplete bool
 }
 
@@ -314,18 +413,27 @@ type ThrowSummary struct {
 // Every other `?`-guarded call carries the callee's sites, with a parametric
 // raised value threaded back through the arguments to the calling function's
 // own formals. A summary that grows re-enqueues its callers.
+//
+// A site's channel is decided alongside it. A value a step hands to the reject
+// function of the promise the algorithm returns lands in the reject set, and
+// every other one in the synchronous set. rejectPlan is where each function's
+// rejections are worked out.
 func NewThrowSummary(cfg *CFG) *ThrowSummary {
+	rejecting := rejecters(cfg)
 	a := &throwAnalysis{
 		summary: &ThrowSummary{facts: make(map[*Func]*throwFacts, len(cfg.Funcs))},
 		origins: make(map[*Func]*OriginMap, len(cfg.Funcs)),
+		plans:   make(map[*Func]*rejectPlan, len(cfg.Funcs)),
 		callers: make(map[*Func][]*Func, len(cfg.Funcs)),
 	}
 	for _, fn := range cfg.Funcs {
 		a.summary.facts[fn] = &throwFacts{
-			sites:  make(map[siteKey]*ThrowSite),
-			raised: set.NewSet[Raised](),
+			sites:    make(map[siteKey]*ThrowSite),
+			raised:   set.NewSet[Raised](),
+			rejected: set.NewSet[Raised](),
 		}
 		a.origins[fn] = NewOriginMap(fn)
+		a.plans[fn] = newRejectPlan(fn, rejecting)
 	}
 	for _, fn := range cfg.Funcs {
 		for _, callee := range a.callees(cfg, fn) {
@@ -345,11 +453,8 @@ func (s *ThrowSummary) Of(fn *Func) Throws {
 		return Throws{}
 	}
 
-	var raised []Raised
-	if f.raised.Len() > 0 {
-		raised = f.raised.ToSlice()
-		sort.Slice(raised, func(i, j int) bool { return raised[i].less(raised[j]) })
-	}
+	raised := sortedRaised(f.raised)
+	rejects := sortedRaised(f.rejected)
 
 	var sites []ThrowSite
 	if len(f.order) > 0 {
@@ -371,35 +476,63 @@ func (s *ThrowSummary) Of(fn *Func) Throws {
 		})
 	}
 
-	return Throws{Raised: raised, Sites: sites, Incomplete: f.incomplete}
+	return Throws{Raised: raised, Rejects: rejects, Sites: sites, Incomplete: f.incomplete}
 }
 
-// throwAnalysis is the state the fixpoint runs over. origins and callers are
-// built once and read from then on. Only summary changes as the fixpoint
-// iterates.
+// sortedRaised reads a raised set back in a fixed order, so a rendered set
+// always looks the same. An empty set reads back nil rather than an empty
+// slice, which keeps a channel that carries nothing distinguishable in a
+// struct comparison.
+func sortedRaised(s set.Set[Raised]) []Raised {
+	if s.Len() == 0 {
+		return nil
+	}
+	raised := s.ToSlice()
+	sort.Slice(raised, func(i, j int) bool { return raised[i].less(raised[j]) })
+	return raised
+}
+
+// throwAnalysis is the state the fixpoint runs over. origins, plans, and
+// callers are built once and read from then on. Only summary changes as the
+// fixpoint iterates.
 type throwAnalysis struct {
 	summary *ThrowSummary
 	origins map[*Func]*OriginMap
+	plans   map[*Func]*rejectPlan
 	callers map[*Func][]*Func
 }
 
 // callees returns the functions whose throws reach fn, in call order and
-// without repeats. Only a `?`-guarded call propagates. An unguarded one is left
-// out, so fn is not walked again when that callee's summary moves.
+// without repeats.
+//
+// Two kinds of call carry them. A `?`-guarded call propagates an abrupt
+// completion to fn's own caller, and a step the reject plan routed hands its
+// abrupt completion to the promise fn returns. Every other call is left out, so
+// fn is not walked again when that callee's summary moves.
 func (a *throwAnalysis) callees(cfg *CFG, fn *Func) []*Func {
 	var called []*Func
 	seen := set.NewSet[*Func]()
+	add := func(call *CallNode) {
+		if _, settling := capabilityInvoke(call); settling {
+			return
+		}
+		target := resolveCallee(cfg, a.origins[fn], call.Callee)
+		if target == nil || seen.Contains(target) {
+			return
+		}
+		seen.Add(target)
+		called = append(called, target)
+	}
+
 	for _, node := range fn.Nodes {
 		call, ok := node.(*CallNode)
 		if !ok || call.Guard != GuardQuestion {
 			continue
 		}
-		target := resolveCallee(cfg, a.origins[fn], call.Callee)
-		if target == nil || seen.Contains(target) {
-			continue
-		}
-		seen.Add(target)
-		called = append(called, target)
+		add(call)
+	}
+	for _, route := range a.plans[fn].routed {
+		add(route.node)
 	}
 	return called
 }
@@ -436,18 +569,19 @@ func (a *throwAnalysis) run(cfg *CFG) {
 func (a *throwAnalysis) transfer(cfg *CFG, fn *Func) bool {
 	f := a.summary.facts[fn]
 	origin := a.origins[fn]
+	plan := a.plans[fn]
 	changed := false
 
 	for i, node := range fn.Nodes {
 		switch node := node.(type) {
 		case *ThrowNode:
-			changed = f.add(raisedAt(origin, node), Root{}, node, i) || changed
+			changed = f.add(raisedAt(origin, node), Root{}, node, i, SinkSync) || changed
 		case *CallNode:
-			if node.Callee == completionCapture {
+			if node.Callee == completionCapture && !plan.read.Contains(i) {
 				changed = f.markIncomplete() || changed
 			}
 			if node.Guard == GuardQuestion {
-				changed = a.propagate(cfg, fn, f, origin, node, i) || changed
+				changed = a.propagate(cfg, fn, f, origin, node, i, SinkSync) || changed
 			}
 		case *OpaqueNode:
 			// A step §3 could not lower, such as a prose step. It may raise an
@@ -456,6 +590,22 @@ func (a *throwAnalysis) transfer(cfg *CFG, fn *Func) bool {
 		default:
 			// No other node shape raises or propagates an exception.
 		}
+	}
+
+	// The reject channel. A routed step raises into the promise fn returns
+	// whatever it raises on its own account, whatever its guard, since the
+	// completion the step produced was captured rather than propagated.
+	for _, route := range plan.routed {
+		changed = a.propagate(cfg, fn, f, origin, route.node, route.index, SinkReject) || changed
+	}
+	for _, reject := range plan.direct {
+		changed = f.add(raisedOf(origin, reject.reason), Root{}, reject.node, reject.index, SinkReject) || changed
+	}
+	for _, raised := range plan.modeled {
+		changed = f.model(raised) || changed
+	}
+	if plan.delegated {
+		changed = f.markIncomplete() || changed
 	}
 	return changed
 }
@@ -489,13 +639,22 @@ func raisedOf(origin *OriginMap, e Expr) Raised {
 	}
 }
 
-// propagate records what one `?`-guarded call hands on to fn, and reports
+// propagate records what one call hands on to fn through sink, and reports
 // whether that grew fn's throws.
-func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *OriginMap, node *CallNode, index int) bool {
+func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *OriginMap, node *CallNode, index int, sink Sink) bool {
+	if _, settling := capabilityInvoke(node); settling {
+		// `? Call(promiseCapability.[[Reject]], undefined, « reason »)` and its
+		// resolve counterpart. The function invoked is one
+		// NewPromiseCapability built, which settles a promise and raises
+		// nothing, so the step contributes to neither channel. The reason it
+		// carries is the reject plan's business.
+		return false
+	}
+
 	changed := false
 	position, invoking := invokers[node.Callee]
 	if invoking {
-		changed = a.propagateInvoked(f, origin, node, position, index)
+		changed = a.propagateInvoked(f, origin, node, position, index, sink)
 	}
 
 	target := resolveCallee(cfg, origin, node.Callee)
@@ -526,7 +685,7 @@ func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *Ori
 			continue
 		}
 		raised := remap(origin, node.Args, site.Raised)
-		changed = f.add(raised, Root{Callee: node.Callee, Inner: site}, node, index) || changed
+		changed = f.add(raised, Root{Callee: node.Callee, Inner: site}, node, index, sink) || changed
 	}
 	return changed
 }
@@ -540,7 +699,7 @@ func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *Ori
 // RaisedCallback effect. Any other function value was read off a property or
 // out of a slot, so the graph holds no body for it and its throws cannot be
 // read.
-func (a *throwAnalysis) propagateInvoked(f *throwFacts, origin *OriginMap, node *CallNode, position, index int) bool {
+func (a *throwAnalysis) propagateInvoked(f *throwFacts, origin *OriginMap, node *CallNode, position, index int, sink Sink) bool {
 	if position >= len(node.Args) {
 		return f.markIncomplete()
 	}
@@ -549,7 +708,7 @@ func (a *throwAnalysis) propagateInvoked(f *throwFacts, origin *OriginMap, node 
 		if o.Interior {
 			return f.markIncomplete()
 		}
-		return f.add(CallbackThrows(o), Root{}, node, index)
+		return f.add(CallbackThrows(o), Root{}, node, index, sink)
 	default:
 		return f.markIncomplete()
 	}
@@ -565,7 +724,7 @@ func (a *throwAnalysis) propagateInvoked(f *throwFacts, origin *OriginMap, node 
 // call passes at a position it does not fill, or one it fills with something
 // that is neither the receiver nor a parameter of the caller.
 func remap(origin *OriginMap, args []Expr, r Raised) Raised {
-	if r.Kind != RaisedOrigin && r.Kind != RaisedCallback {
+	if !r.carriesOrigin() {
 		return r
 	}
 	if r.Origin.Kind != OriginParam || r.Origin.Index >= len(args) {
@@ -576,29 +735,44 @@ func remap(origin *OriginMap, args []Expr, r Raised) Raised {
 		if caller.Interior {
 			return Untraced
 		}
-		if r.Kind == RaisedCallback {
-			return CallbackThrows(caller)
-		}
-		return Propagated(caller)
+		return r.at(caller)
 	default:
 		return Untraced
 	}
 }
 
-// add records one site and reports whether it was new.
-func (f *throwFacts) add(raised Raised, root Root, node Node, index int) bool {
-	key := siteKey{index: index, raised: raised}
+// add records one site on sink's channel and reports whether it was new.
+func (f *throwFacts) add(raised Raised, root Root, node Node, index int, sink Sink) bool {
+	key := siteKey{index: index, raised: raised, sink: sink}
 	if root.Inner != nil {
 		key.base = root.Inner.base()
 	}
 	if _, seen := f.sites[key]; seen {
 		return false
 	}
-	site := &ThrowSite{Raised: raised, Root: root, Node: node, Index: index}
+	site := &ThrowSite{Raised: raised, Root: root, Node: node, Index: index, Sink: sink}
 	f.sites[key] = site
 	f.order = append(f.order, site)
-	f.raised.Add(raised)
+	f.channel(sink).Add(raised)
 	return true
+}
+
+// model records a rejection the hand-written combinator model supplies. It has
+// no site, because the value reaches the returned promise through the
+// resolution machinery rather than through a step the graph holds.
+func (f *throwFacts) model(raised Raised) bool {
+	if f.rejected.Contains(raised) {
+		return false
+	}
+	f.rejected.Add(raised)
+	return true
+}
+
+func (f *throwFacts) channel(sink Sink) set.Set[Raised] {
+	if sink == SinkReject {
+		return f.rejected
+	}
+	return f.raised
 }
 
 func (f *throwFacts) markIncomplete() bool {

--- a/internal/ecma262/throws.go
+++ b/internal/ecma262/throws.go
@@ -675,6 +675,13 @@ func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *Ori
 	}
 
 	for _, site := range a.summary.facts[target].order {
+		if site.Sink == SinkReject {
+			// The callee settles its own returned promise with this value. It
+			// never leaves the callee as an abrupt completion, so neither the
+			// `?` guard nor a capture of the callee's completion carries it
+			// out, and it belongs to no channel of the caller's.
+			continue
+		}
 		if invoking && site.Raised.Kind == RaisedCallback {
 			// The invoking operation's own callback effect is the effect of the
 			// function this very call invokes, which propagateInvoked already

--- a/internal/ecma262/throws.go
+++ b/internal/ecma262/throws.go
@@ -520,7 +520,7 @@ func (a *throwAnalysis) callees(cfg *CFG, fn *Func) []*Func {
 	var called []*Func
 	seen := set.NewSet[*Func]()
 	add := func(call *CallNode) {
-		if _, settling := capabilityInvoke(call); settling {
+		if _, settling := promiseCapabilityInvoke(call); settling {
 			return
 		}
 		target := resolveCallee(cfg, a.origins[fn], call.Callee)
@@ -649,10 +649,10 @@ func raisedOf(origin *OriginMap, e Expr) Exception {
 // propagate records what one call hands on to fn through sink, and reports
 // whether that grew fn's throws.
 func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *OriginMap, node *CallNode, index int, sink Sink) bool {
-	if _, settling := capabilityInvoke(node); settling {
-		// `? Call(promiseCapability.[[Reject]], undefined, « reason »)` and its
-		// resolve counterpart. The function invoked is one
-		// NewPromiseCapability built, which settles a promise and raises
+	if _, settling := promiseCapabilityInvoke(node); settling {
+		// `? Call(promiseCapability.[[Reject]], undefined, « reason »)` and
+		// its resolve counterpart. The function invoked is one
+		// `NewPromiseCapability` built, which settles a promise and raises
 		// nothing, so the step contributes to neither channel. The reason it
 		// carries is the reject plan's business.
 		return false

--- a/internal/ecma262/throws.go
+++ b/internal/ecma262/throws.go
@@ -219,16 +219,17 @@ func (r Root) Direct() bool {
 	return r.Inner == nil
 }
 
-// ThrowSite is one place a function raises an exception. Node is the step that
-// raises or propagates it and Index is that step's position in the function's
-// node list. Sink is the exit the value leaves through, which is what splits
-// the raised set into `throws` and `rejects`.
+// ThrowSite is one place a function raises an exception. Exception is what it
+// raises there, Node is the step that raises or propagates it, and Index is
+// that step's position in the function's node list. Sink is the exit the value
+// leaves through, which is what splits the raised set into `throws` and
+// `rejects`, so a site on either channel fills the same Exception field.
 type ThrowSite struct {
-	Raised Exception
-	Root   Root
-	Node   Node
-	Index  int
-	Sink   Sink
+	Exception Exception
+	Root      Root
+	Node      Node
+	Index     int
+	Sink      Sink
 }
 
 // Base returns the site that raised the value, walking Root back through every
@@ -260,7 +261,7 @@ func (s ThrowSite) String() string {
 	if s.Sink == SinkReject {
 		sb.WriteString("rejects ")
 	}
-	fmt.Fprintf(&sb, "%s", s.Raised)
+	fmt.Fprintf(&sb, "%s", s.Exception)
 	for root := s.Root; root.Inner != nil; root = root.Inner.Root {
 		fmt.Fprintf(&sb, " <- %s#%d", root.Callee, root.Inner.Index)
 	}
@@ -475,8 +476,8 @@ func (s *ThrowSummary) Of(fn *Func) Throws {
 			if sites[i].Index != sites[j].Index {
 				return sites[i].Index < sites[j].Index
 			}
-			if sites[i].Raised != sites[j].Raised {
-				return sites[i].Raised.less(sites[j].Raised)
+			if sites[i].Exception != sites[j].Exception {
+				return sites[i].Exception.less(sites[j].Exception)
 			}
 			return sites[i].String() < sites[j].String()
 		})
@@ -688,7 +689,7 @@ func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *Ori
 			// out, and it belongs to no channel of the caller's.
 			continue
 		}
-		if invoking && site.Raised.Kind == ExceptionCallback {
+		if invoking && site.Exception.Kind == ExceptionCallback {
 			// The invoking operation's own callback effect is the effect of the
 			// function this very call invokes, which propagateInvoked already
 			// recorded against the origin the caller passed. Threading it back
@@ -697,7 +698,7 @@ func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *Ori
 			// `incomplete` with an `Unknown` where it cannot.
 			continue
 		}
-		raised := remap(origin, node.Args, site.Raised)
+		raised := remap(origin, node.Args, site.Exception)
 		changed = f.add(raised, Root{Callee: node.Callee, Inner: site}, node, index, sink) || changed
 	}
 	return changed
@@ -763,7 +764,7 @@ func (f *throwFacts) add(raised Exception, root Root, node Node, index int, sink
 	if _, seen := f.sites[key]; seen {
 		return false
 	}
-	site := &ThrowSite{Raised: raised, Root: root, Node: node, Index: index, Sink: sink}
+	site := &ThrowSite{Exception: raised, Root: root, Node: node, Index: index, Sink: sink}
 	f.sites[key] = site
 	f.order = append(f.order, site)
 	f.channel(sink).Add(raised)

--- a/internal/ecma262/throws.go
+++ b/internal/ecma262/throws.go
@@ -68,45 +68,51 @@ var objectInternalMethods = set.FromSlice([]string{
 	"SetPrototypeOf",
 })
 
-// RaisedKind classifies an exception an algorithm can raise. See
+// ExceptionKind classifies an exception an algorithm can raise. See
 // planning/ecma-262/implementation_plan.md §9.1.
-type RaisedKind uint8
+type ExceptionKind uint8
 
 const (
-	// RaisedClass is an error class the algorithm constructs, as in `Throw a
+	// ExceptionClass is an error class the algorithm constructs, as in `Throw a
 	// *TypeError* exception`. It is the dominant form in the synchronous
 	// channel, since every such step in ECMA-262 names a constructor.
-	RaisedClass RaisedKind = iota
-	// RaisedOrigin is a value the algorithm raises without constructing it,
+	ExceptionClass ExceptionKind = iota
+	// ExceptionOrigin is a value the algorithm raises without constructing it,
 	// resolved to the receiver or the parameter it arrived at.
 	// `Generator.prototype.throw` raises its own first argument.
-	RaisedOrigin
-	// RaisedCallback is the effect of a function the caller supplied, rather
+	ExceptionOrigin
+	// ExceptionCallback is the effect of a function the caller supplied, rather
 	// than a value. `Array.prototype.forEach` raises whatever its callback
 	// raises. FR10 spells it `throwsOf:param:k`, and FR13 turns it into throws
 	// polymorphism at the join.
-	RaisedCallback
-	// RaisedElementErr is the reject type of the promises an iterable yields,
+	ExceptionCallback
+	// ExceptionElementErr is the reject type of the promises an iterable yields,
 	// forwarded by a `Promise` combinator. Origin names the parameter holding
 	// that iterable. `Promise.all` rejects with it. See promiseCombinators.
-	RaisedElementErr
-	// RaisedAggregate is an `AggregateError` whose errors list holds the reject
-	// types RaisedElementErr names. `Promise.any` rejects with it once every
+	ExceptionElementErr
+	// ExceptionAggregate is an `AggregateError` whose errors list holds the reject
+	// types ExceptionElementErr names. `Promise.any` rejects with it once every
 	// element promise has rejected.
-	RaisedAggregate
-	// RaisedUnknown is a raised value the analysis could neither name nor
+	ExceptionAggregate
+	// ExceptionUnknown is a raised value the analysis could neither name nor
 	// trace. See Untraced.
-	RaisedUnknown
+	ExceptionUnknown
 )
 
-// Raised is one exception a function can raise. Class holds the error class
-// name when Kind is RaisedClass. Every other kind but RaisedUnknown holds an
-// origin, and each names something different by it. A RaisedOrigin origin names
-// the raised value itself. A RaisedCallback origin names a function whose own
-// throws travel outward. A RaisedElementErr or RaisedAggregate origin names the
-// iterable parameter whose element promises carry the reject type.
-type Raised struct {
-	Kind   RaisedKind
+// Exception is one exception a function can raise. Class holds the error class
+// name when Kind is ExceptionClass. Every other kind but ExceptionUnknown holds
+// an origin, and each names something different by it. An ExceptionOrigin origin
+// names the raised value itself. An ExceptionCallback origin names a function
+// whose own throws travel outward. An ExceptionElementErr or ExceptionAggregate
+// origin names the iterable parameter whose element promises carry the reject
+// type.
+//
+// The last three name where an exception comes from rather than an exception
+// value, because the value itself is not in the graph. It is whatever the
+// caller's callback raises, or whatever the promises the caller passed reject
+// with.
+type Exception struct {
+	Kind   ExceptionKind
 	Class  string
 	Origin Origin
 }
@@ -114,61 +120,61 @@ type Raised struct {
 // Untraced is the raised value the analysis could not place. It renders as
 // `Unknown`, which is the vocabulary §9.1 uses, and FR6 spells it `unknown` on
 // the wire.
-var Untraced = Raised{Kind: RaisedUnknown}
+var Untraced = Exception{Kind: ExceptionUnknown}
 
 // Class returns the exception a `Throw a *T* exception` step raises.
-func Class(name string) Raised {
-	return Raised{Kind: RaisedClass, Class: name}
+func Class(name string) Exception {
+	return Exception{Kind: ExceptionClass, Class: name}
 }
 
 // Propagated returns the exception a step raises by handing on a value that
 // came from o.
-func Propagated(o Origin) Raised {
-	return Raised{Kind: RaisedOrigin, Origin: o}
+func Propagated(o Origin) Exception {
+	return Exception{Kind: ExceptionOrigin, Origin: o}
 }
 
 // CallbackThrows returns the exception a step raises by invoking the function
 // that came from o, which is whatever that function itself raises.
-func CallbackThrows(o Origin) Raised {
-	return Raised{Kind: RaisedCallback, Origin: o}
+func CallbackThrows(o Origin) Exception {
+	return Exception{Kind: ExceptionCallback, Origin: o}
 }
 
 // ElementErr returns the reject type of the promises the iterable at o yields.
-func ElementErr(o Origin) Raised {
-	return Raised{Kind: RaisedElementErr, Origin: o}
+func ElementErr(o Origin) Exception {
+	return Exception{Kind: ExceptionElementErr, Origin: o}
 }
 
 // AggregateErr returns the `AggregateError` that aggregates the reject types of
 // the promises the iterable at o yields.
-func AggregateErr(o Origin) Raised {
-	return Raised{Kind: RaisedAggregate, Origin: o}
+func AggregateErr(o Origin) Exception {
+	return Exception{Kind: ExceptionAggregate, Origin: o}
 }
 
-func (r Raised) String() string {
+func (r Exception) String() string {
 	switch r.Kind {
-	case RaisedClass:
+	case ExceptionClass:
 		return r.Class
-	case RaisedOrigin:
+	case ExceptionOrigin:
 		return fmt.Sprintf("Origin(%s)", r.Origin)
-	case RaisedCallback:
+	case ExceptionCallback:
 		return fmt.Sprintf("CallbackThrows(%s)", r.Origin)
-	case RaisedElementErr:
+	case ExceptionElementErr:
 		return fmt.Sprintf("ElementErr(%s)", r.Origin)
-	case RaisedAggregate:
+	case ExceptionAggregate:
 		return fmt.Sprintf("AggregateError<ElementErr(%s)>", r.Origin)
-	case RaisedUnknown:
+	case ExceptionUnknown:
 		return "Unknown"
 	default:
-		return fmt.Sprintf("Raised(%d)", r.Kind)
+		return fmt.Sprintf("Exception(%d)", r.Kind)
 	}
 }
 
 // carriesOrigin reports whether the raised value names an origin. Every kind
 // but an error class and an untraced value does, and remap threads each of them
 // back through a call's arguments the same way.
-func (r Raised) carriesOrigin() bool {
+func (r Exception) carriesOrigin() bool {
 	switch r.Kind {
-	case RaisedOrigin, RaisedCallback, RaisedElementErr, RaisedAggregate:
+	case ExceptionOrigin, ExceptionCallback, ExceptionElementErr, ExceptionAggregate:
 		return true
 	default:
 		return false
@@ -176,7 +182,7 @@ func (r Raised) carriesOrigin() bool {
 }
 
 // at returns the same kind of raised value read against another origin.
-func (r Raised) at(o Origin) Raised {
+func (r Exception) at(o Origin) Exception {
 	r.Origin = o
 	return r
 }
@@ -184,7 +190,7 @@ func (r Raised) at(o Origin) Raised {
 // less orders two raised values so a rendered set always reads the same way.
 // The kinds sort in declaration order, which puts the error classes first, and
 // two values of one kind sort by how they render.
-func (r Raised) less(other Raised) bool {
+func (r Exception) less(other Exception) bool {
 	if r.Kind != other.Kind {
 		return r.Kind < other.Kind
 	}
@@ -218,7 +224,7 @@ func (r Root) Direct() bool {
 // node list. Sink is the exit the value leaves through, which is what splits
 // the raised set into `throws` and `rejects`.
 type ThrowSite struct {
-	Raised Raised
+	Raised Exception
 	Root   Root
 	Node   Node
 	Index  int
@@ -278,7 +284,7 @@ func (s ThrowSite) String() string {
 // function value the graph holds no body for, and an abrupt completion the
 // algorithm captured as a value without the reject walk naming where it came
 // from. FR10 asks for such a method to be flagged rather than guessed at, and
-// §4.3 turns the flag into `classified: false`.
+// §4.3 withholds the receiver determination from a method carrying it.
 //
 // The flag is about this function's own steps and does not travel up the call
 // graph, the same way §4.1's is. A consumer that wants the transitive answer
@@ -286,8 +292,8 @@ func (s ThrowSite) String() string {
 // flag on most of the builtins, since nearly every algorithm reaches an object
 // internal method through some callee.
 type Throws struct {
-	Raised     []Raised
-	Rejects    []Raised
+	Raised     []Exception
+	Rejects    []Exception
 	Sites      []ThrowSite
 	Incomplete bool
 }
@@ -377,7 +383,7 @@ func (t Throws) SitesString() string {
 // particular route walks the call graph from Base itself.
 type siteKey struct {
 	index  int
-	raised Raised
+	raised Exception
 	base   *ThrowSite
 	sink   Sink
 }
@@ -388,8 +394,8 @@ type siteKey struct {
 type throwFacts struct {
 	sites      map[siteKey]*ThrowSite
 	order      []*ThrowSite
-	raised     set.Set[Raised]
-	rejected   set.Set[Raised]
+	raised     set.Set[Exception]
+	rejected   set.Set[Exception]
 	incomplete bool
 }
 
@@ -408,7 +414,7 @@ type ThrowSummary struct {
 // leaves the result unchecked, so neither contributes.
 //
 // A call that invokes a function the caller supplied contributes that
-// function's own throws as a RaisedCallback effect rather than a value, which
+// function's own throws as a ExceptionCallback effect rather than a value, which
 // is what makes `Array.prototype.forEach` raise whatever its callback raises.
 // Every other `?`-guarded call carries the callee's sites, with a parametric
 // raised value threaded back through the arguments to the calling function's
@@ -429,8 +435,8 @@ func NewThrowSummary(cfg *CFG) *ThrowSummary {
 	for _, fn := range cfg.Funcs {
 		a.summary.facts[fn] = &throwFacts{
 			sites:    make(map[siteKey]*ThrowSite),
-			raised:   set.NewSet[Raised](),
-			rejected: set.NewSet[Raised](),
+			raised:   set.NewSet[Exception](),
+			rejected: set.NewSet[Exception](),
 		}
 		a.origins[fn] = NewOriginMap(fn)
 		a.plans[fn] = newRejectPlan(fn, rejecting)
@@ -453,8 +459,8 @@ func (s *ThrowSummary) Of(fn *Func) Throws {
 		return Throws{}
 	}
 
-	raised := sortedRaised(f.raised)
-	rejects := sortedRaised(f.rejected)
+	raised := sortedExceptions(f.raised)
+	rejects := sortedExceptions(f.rejected)
 
 	var sites []ThrowSite
 	if len(f.order) > 0 {
@@ -479,11 +485,11 @@ func (s *ThrowSummary) Of(fn *Func) Throws {
 	return Throws{Raised: raised, Rejects: rejects, Sites: sites, Incomplete: f.incomplete}
 }
 
-// sortedRaised reads a raised set back in a fixed order, so a rendered set
+// sortedExceptions reads a channel's set back in a fixed order, so a rendered set
 // always looks the same. An empty set reads back nil rather than an empty
 // slice, which keeps a channel that carries nothing distinguishable in a
 // struct comparison.
-func sortedRaised(s set.Set[Raised]) []Raised {
+func sortedExceptions(s set.Set[Exception]) []Exception {
 	if s.Len() == 0 {
 		return nil
 	}
@@ -613,7 +619,7 @@ func (a *throwAnalysis) transfer(cfg *CFG, fn *Func) bool {
 // raisedAt returns what a Throw step raises. An algorithm that constructs its
 // error names the class, and one that hands on a value it was given resolves to
 // where that value came from.
-func raisedAt(origin *OriginMap, node *ThrowNode) Raised {
+func raisedAt(origin *OriginMap, node *ThrowNode) Exception {
 	if node.ErrorType != "" {
 		return Class(node.ErrorType)
 	}
@@ -627,7 +633,7 @@ func raisedAt(origin *OriginMap, node *ThrowNode) Raised {
 // An interior value is left untraced. It was read out of the backing store of
 // the receiver or a parameter and is a different value from the one that names
 // it, so reporting it as that parameter would name the wrong type at the join.
-func raisedOf(origin *OriginMap, e Expr) Raised {
+func raisedOf(origin *OriginMap, e Expr) Exception {
 	switch o := origin.Eval(e); o.Kind {
 	case OriginReceiver, OriginParam:
 		if o.Interior {
@@ -682,7 +688,7 @@ func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *Ori
 			// out, and it belongs to no channel of the caller's.
 			continue
 		}
-		if invoking && site.Raised.Kind == RaisedCallback {
+		if invoking && site.Raised.Kind == ExceptionCallback {
 			// The invoking operation's own callback effect is the effect of the
 			// function this very call invokes, which propagateInvoked already
 			// recorded against the origin the caller passed. Threading it back
@@ -703,7 +709,7 @@ func (a *throwAnalysis) propagate(cfg *CFG, fn *Func, f *throwFacts, origin *Ori
 //
 // A function that reached the algorithm as its receiver or one of its
 // parameters raises whatever the algorithm's own caller passed in, which is the
-// RaisedCallback effect. Any other function value was read off a property or
+// ExceptionCallback effect. Any other function value was read off a property or
 // out of a slot, so the graph holds no body for it and its throws cannot be
 // read.
 func (a *throwAnalysis) propagateInvoked(f *throwFacts, origin *OriginMap, node *CallNode, position, index int, sink Sink) bool {
@@ -730,7 +736,7 @@ func (a *throwAnalysis) propagateInvoked(f *throwFacts, origin *OriginMap, node 
 // standing for one cannot be threaded and is left untraced. So is a value the
 // call passes at a position it does not fill, or one it fills with something
 // that is neither the receiver nor a parameter of the caller.
-func remap(origin *OriginMap, args []Expr, r Raised) Raised {
+func remap(origin *OriginMap, args []Expr, r Exception) Exception {
 	if !r.carriesOrigin() {
 		return r
 	}
@@ -749,7 +755,7 @@ func remap(origin *OriginMap, args []Expr, r Raised) Raised {
 }
 
 // add records one site on sink's channel and reports whether it was new.
-func (f *throwFacts) add(raised Raised, root Root, node Node, index int, sink Sink) bool {
+func (f *throwFacts) add(raised Exception, root Root, node Node, index int, sink Sink) bool {
 	key := siteKey{index: index, raised: raised, sink: sink}
 	if root.Inner != nil {
 		key.base = root.Inner.base()
@@ -767,7 +773,7 @@ func (f *throwFacts) add(raised Raised, root Root, node Node, index int, sink Si
 // model records a rejection the hand-written combinator model supplies. It has
 // no site, because the value reaches the returned promise through the
 // resolution machinery rather than through a step the graph holds.
-func (f *throwFacts) model(raised Raised) bool {
+func (f *throwFacts) model(raised Exception) bool {
 	if f.rejected.Contains(raised) {
 		return false
 	}
@@ -775,7 +781,7 @@ func (f *throwFacts) model(raised Raised) bool {
 	return true
 }
 
-func (f *throwFacts) channel(sink Sink) set.Set[Raised] {
+func (f *throwFacts) channel(sink Sink) set.Set[Exception] {
 	if sink == SinkReject {
 		return f.rejected
 	}

--- a/internal/ecma262/throws_test.go
+++ b/internal/ecma262/throws_test.go
@@ -208,7 +208,7 @@ func TestThrowSiteBase(t *testing.T) {
 
 	base := propagated.Base()
 	require.True(t, base.Root.Direct())
-	require.Equal(t, Class("RangeError"), base.Raised)
+	require.Equal(t, Class("RangeError"), base.Exception)
 	require.Equal(t, 1, base.Index)
 }
 
@@ -377,7 +377,7 @@ func TestThrowSummaryIsIndependentOfFuncOrder(t *testing.T) {
 		lines := make([]string, 0, len(throws.Sites))
 		for _, site := range throws.Sites {
 			base := site.Base()
-			lines = append(lines, fmt.Sprintf("#%d %s %s from #%d %s", site.Index, site.Sink, site.Raised, base.Index, base.Raised))
+			lines = append(lines, fmt.Sprintf("#%d %s %s from #%d %s", site.Index, site.Sink, site.Exception, base.Index, base.Exception))
 		}
 		sort.Strings(lines)
 		return throws.String() + " / " + throws.RejectsString() + "\n" + strings.Join(lines, "\n")

--- a/internal/ecma262/throws_test.go
+++ b/internal/ecma262/throws_test.go
@@ -377,10 +377,10 @@ func TestThrowSummaryIsIndependentOfFuncOrder(t *testing.T) {
 		lines := make([]string, 0, len(throws.Sites))
 		for _, site := range throws.Sites {
 			base := site.Base()
-			lines = append(lines, fmt.Sprintf("#%d %s from #%d %s", site.Index, site.Raised, base.Index, base.Raised))
+			lines = append(lines, fmt.Sprintf("#%d %s %s from #%d %s", site.Index, site.Sink, site.Raised, base.Index, base.Raised))
 		}
 		sort.Strings(lines)
-		return throws.String() + "\n" + strings.Join(lines, "\n")
+		return throws.String() + " / " + throws.RejectsString() + "\n" + strings.Join(lines, "\n")
 	}
 
 	forward := testThrows(t)

--- a/internal/ecma262/throws_test.go
+++ b/internal/ecma262/throws_test.go
@@ -39,9 +39,9 @@ func throwsOf(t *testing.T, name string) Throws {
 	return testThrows(t).Of(fn)
 }
 
-func TestRaisedString(t *testing.T) {
+func TestExceptionString(t *testing.T) {
 	tests := map[string]struct {
-		raised Raised
+		raised Exception
 		want   string
 	}{
 		"Class":    {Class("TypeError"), "TypeError"},
@@ -66,7 +66,7 @@ func TestThrowsString(t *testing.T) {
 		"Incomplete": {Throws{Incomplete: true}, "incomplete"},
 		"Every": {
 			Throws{
-				Raised:     []Raised{Class("TypeError"), Propagated(Param(0)), CallbackThrows(Param(1)), Untraced},
+				Raised:     []Exception{Class("TypeError"), Propagated(Param(0)), CallbackThrows(Param(1)), Untraced},
 				Incomplete: true,
 			},
 			"TypeError Origin(Param(0)) CallbackThrows(Param(1)) Unknown incomplete",
@@ -113,7 +113,7 @@ func TestThrowSummarySampleFunctions(t *testing.T) {
 func TestThrowSummaryCallbackEffect(t *testing.T) {
 	tests := map[string]struct {
 		fn   string
-		want Raised
+		want Exception
 	}{
 		// `? Call(callback, thisArg, « kValue, 𝔽(k), O »)` invokes the method's
 		// first declared parameter.

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1382,7 +1382,7 @@ ThrowSites : map[FuncName] []ThrowSite  // provenance chains for §9.2 / §9.3
 // A site preserves where the value ULTIMATELY came from, so a coercion
 // throw stays recognizable however many `?`-hops it propagates through.
 type ThrowSite:
-    Raised : Class(name)                 // a constructed error class (Throw a T exception)
+    Exception : Class(name)                 // a constructed error class (Throw a T exception)
            | Origin(Param(k) | Receiver) // a propagated value, resolved to a type at the join (FR13)
            | CallbackThrows(Param(k))    // throwsOf:param:k — the method throws whatever the
                                          // function-typed parameter k throws (FR13); throws polymorphism
@@ -1401,15 +1401,15 @@ while worklist nonempty:
             raised = node.ErrorType ? Class(node.ErrorType)   // "Throw a T exception" → class
                                     : raisedOf(F, node.Value)  // "throw <value>" → origin (rare in std:*)
             Throws[F].add(raised)
-            ThrowSites[F].append(ThrowSite{ Raised: raised, Root: Direct(node), Node: node })
+            ThrowSites[F].append(ThrowSite{ Exception: raised, Root: Direct(node), Node: node })
         case Call where node.Guard == GuardQuestion:   // ? propagates the callee's throws
             if node.Callee is a function-typed Param(k):   // ? Call(callbackfn, …) → the callback's throws
                 raised = CallbackThrows(Param(k))          // throwsOf:param:k (FR13)
                 Throws[F].add(raised)
-                ThrowSites[F].append(ThrowSite{ Raised: raised, Root: Direct(node), Node: node })
+                ThrowSites[F].append(ThrowSite{ Exception: raised, Root: Direct(node), Node: node })
             else for s in ThrowSites[node.Callee]:         // resolvable AO: carry its OWN sites, by name
-                Throws[F].add(s.Raised)
-                ThrowSites[F].append(ThrowSite{ Raised: s.Raised,
+                Throws[F].add(s.Exception)
+                ThrowSites[F].append(ThrowSite{ Exception: s.Exception,
                                                 Root: Propagated(node.Callee, s), Node: node })
         // GuardBang (! asserts no abrupt completion) and GuardPlain
         // (result not completion-checked) contribute nothing.
@@ -1459,9 +1459,9 @@ CoercionAOs = { ToObject, RequireObjectCoercible,
 func filterThrows(M) []Exception:
     kept = {}
     for site in syncSites(M):                        // §9.3: sites reaching the synchronous exit
-        if site.Raised == Class(TypeError) and precludedCoercion(M, site):
+        if site.Exception == Class(TypeError) and precludedCoercion(M, site):
             continue                                  // statically unreachable
-        kept.add(site.Raised)                         // a class name, an Origin, or Unknown
+        kept.add(site.Exception)                         // a class name, an Origin, or Unknown
     return sorted(kept)
 
 // precludedCoercion: the throw's Root bottoms out at a coercion AO whose
@@ -1512,8 +1512,8 @@ func rejectSet(M) []Exception:
     // (a) abrupt completions routed to the reject sink — IfAbruptRejectPromise,
     //     or a throw value reaching [[Reject]]. These ARE ThrowSites.
     for site in rejectSites(M):
-        if not (site.Raised == Class(TypeError) and precludedCoercion(M, site)):
-            kept.add(site.Raised)                // a class name, an Origin, or Unknown
+        if not (site.Exception == Class(TypeError) and precludedCoercion(M, site)):
+            kept.add(site.Exception)                // a class name, an Origin, or Unknown
     // (b) direct rejections — Call(cap.[[Reject]], reason) whose reason is a
     //     plain value, not an abrupt completion, as in Promise.reject(r).
     //     These are NOT ThrowSites; scan them and record the reason's origin.

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -46,7 +46,7 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §8.2 | Return-borrow seed                         | FR4        | ⬜      | §4.3       | documented `returns` → `&`/lifetime annotation mapping (small) |
 | §9.1 | Throw-set fixpoint                          | FR10       | ✅      | §4.2       | raw throw sets, `Raised` = class / origin / callback-effect / unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §9.2 | Coercion filter                            | FR11       | ⬜      | §9.1, §5   | filtered throws — toFixed keeps RangeError, drops the receiver-coercion TypeError; param branch runs post-join |
-| §9.3 | Throw/reject split, parametric origins, combinators | FR10, FR13 | ⬜ | §9.1  | `rejects` distinct from `throws`; Promise.reject `param:0`, forEach `throwsOf:param:k`; combinators hand-modeled |
+| §9.3 | Throw/reject split, parametric origins, combinators | FR10, FR13 | ✅ | §9.1  | `rejects` distinct from `throws`; Promise.reject `param:0`, forEach `throwsOf:param:k`; combinators hand-modeled — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §9.4 | Throws validation + auto-apply gate        | FR14       | ⬜      | §9.1–§9.3, §7 | spec-independent (dynamically-observed) ground truth; false-negative rate report gates auto-apply |
 | §10  | Maintenance workflow                       | NFR        | ⬜      | §7         | spec-bump runbook; `--check`-style drift report in CI |
 | §11  | Curation of the override layer             | FR12, FR4, FR13, FR14 | ⬜ | §7, §8, §9 | override layer populated per pseudo-package by review; fans out into per-package PRs |
@@ -1001,7 +1001,7 @@ func classify(M) MethodFact:
     fact.Params     = paramDispositions(M)         // §8: escape / mutBorrow (borrow omitted)
     fact.Returns    = returnAlias(M)               // below
     fact.Throws     = filterThrows(M)              // §9.2
-    fact.Rejects    = rejectSet(M)                 // §9.3
+    fact.Rejects    = rejectSet(M)                 // §9.3, published alongside Throws in §9.2
     // Soundness bias (FR5), applied per determination. A method the
     // analysis could not fully cover OR could not fully attribute
     // withholds the determinations that read the steps it missed. A
@@ -1508,8 +1508,7 @@ fixpoint; they differ only in classifying the site:
 ```
 func rejectSet(M) []Raised:
     if not returnsPromise(M): return []          // no async channel (source below)
-    if M in PromiseCombinators: return combinatorRejects(M)   // hand-modeled (below)
-    kept = {}
+    kept = combinatorRejects(M)                  // hand-modeled (below); empty for anything else
     // (a) abrupt completions routed to the reject sink — IfAbruptRejectPromise,
     //     or a throw value reaching [[Reject]]. These ARE ThrowSites.
     for site in rejectSites(M):
@@ -1557,10 +1556,65 @@ func rejectSet(M) []Raised:
 Recognizing a rejection site needs the CFG to represent the promise
 capability and its `[[Reject]]` field access, and — for the direct-reject
 source (b) — the argument passed to `[[Reject]]`, so `raisedOf` can read
-its origin. Whether ESMeta's CFG surfaces `IfAbruptRejectPromise` as an
-inlined reject or an opaque helper is a **§1 spike question**; if opaque,
-hand-model `IfAbruptRejectPromise(x, cap)` as a reject of `cap` with `x`'s
-raised value. The four combinators are hand-modeled unconditionally
+its origin. Both are there. The graph writes every rejection the same way,
+as `Call(capability.[[Reject]], undefined, « reason »)`. The capability's
+field access is the argument the invoke reads, and the reason is the first
+operand of the argument list.
+
+Six findings shape what landed in
+[internal/ecma262/rejects.go](../../internal/ecma262/rejects.go).
+
+- **ESMeta inlines `IfAbruptRejectPromise`**, which settles the §1 spike
+  question the paragraph above raised, so no hand model is needed for it.
+  What arrives instead is four steps: a plain call, a `Completion(...)`
+  capture of its result, a binding of that capture to a name, and the
+  reject call reading `.[[Value]]` off the name. So a routed site is not a
+  `ThrowSite` the §9.1 fixpoint already found — the call is unguarded and
+  §9.1 records nothing for it. `rejectPlan` walks each rejection's reason
+  back through those steps to the call, and the fixpoint then records what
+  that call raises on the reject channel.
+- **A capture the walk read through stops being a source of
+  incompleteness.** §9.1 flags a function that captures an abrupt
+  completion, because it can no longer name the step that raised it. The
+  walk names it, so the four `Promise` combinators come out complete rather
+  than unclassifiable.
+- **The combinator model is unioned with the walk, not substituted for
+  it.** `rejectSet`'s early return above would drop the `TypeError` a
+  combinator rejects with on a non-iterable argument, which is a real fact
+  the walk finds. `Promise.allSettled` is where the difference shows: its
+  element channel is empty and its iterator rejection stands.
+- **A rejection built from a fresh error object cannot be named.**
+  `AsyncFromSyncIteratorPrototype.return` rejects with a newly created
+  `TypeError` that never passes through a `Throw` step, and the graph
+  carries an error class only on that step, so the reject set records
+  `unknown` there. Naming it needs the serializer to record the class on
+  the allocation, which is a §10 spec-bump change.
+- **A capability handed to a helper leaves the caller flagged.**
+  `AsyncFromSyncIteratorPrototype.next` builds a capability, passes it to
+  `AsyncFromSyncIteratorContinuation`, and returns its promise, and three
+  of that promise's four rejections happen inside the continuation.
+  Following the value in would take a per-function summary of which
+  parameter each function rejects, which §9.3 does not build, so a caller
+  that passes a capability it built to a function with a reject step is
+  incomplete. The check is on the immediate callee. It leaves the four
+  combinators alone, since each passes its capability to a `PerformPromise*`
+  operation that only resolves it, and it misses
+  `AsyncGeneratorPrototype.next`, whose capability is stored in the
+  generator's request queue and rejected by a job much later. That queue is
+  the resolution machinery FR13 already says origin tagging cannot see, so
+  an async generator's body rejections are a §11 curation entry rather than
+  an extraction gap.
+- **`ThrowCompletion(v)` reaches the graph as a `Throw` step.** The lowering
+  is right in 19 of the 20 places it occurs, because `Let error be
+  ThrowCompletion(...)` is followed by `Return ? IteratorClose(iterated,
+  error)` and the value does leave synchronously.
+  `AsyncGeneratorPrototype.throw` is the exception: it builds a throw
+  completion, enqueues it, and returns a promise, so its own first argument
+  is reported on both channels where only the reject one is real. Telling
+  the two apart needs the serializer to distinguish a `Throw` step from a
+  completion the algorithm builds as a value, which is a §3 change.
+
+The four combinators are hand-modeled unconditionally
 (`combinatorRejects`), and that model needs the CFG only to identify the
 iterable parameter whose element-promise `E` is forwarded, not to trace
 the value through the resolution machinery.

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -44,7 +44,7 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §7   | Integration as classification source       | FR8        | ⬜      | §6         | converter ranks facts above name tiers; the two application paths wired; redundant overrides removed |
 | §8.1 | Parameter disposition                      | FR12       | ⬜      | §4.1, §7   | push/Map.set `escape`, Reflect.set `mutBorrow`+`escape`, indexOf `borrow` in facts.json |
 | §8.2 | Return-borrow seed                         | FR4        | ⬜      | §4.3       | documented `returns` → `&`/lifetime annotation mapping (small) |
-| §9.1 | Throw-set fixpoint                          | FR10       | ✅      | §4.2       | raw throw sets, `Raised` = class / origin / callback-effect / unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
+| §9.1 | Throw-set fixpoint                          | FR10       | ✅      | §4.2       | raw throw sets, `Exception` = class / origin / callback-effect / unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §9.2 | Coercion filter                            | FR11       | ⬜      | §9.1, §5   | filtered throws — toFixed keeps RangeError, drops the receiver-coercion TypeError; param branch runs post-join |
 | §9.3 | Throw/reject split, parametric origins, combinators | FR10, FR13 | ✅ | §9.1  | `rejects` distinct from `throws`; Promise.reject `param:0`, forEach `throwsOf:param:k`; combinators hand-modeled — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §9.4 | Throws validation + auto-apply gate        | FR14       | ⬜      | §9.1–§9.3, §7 | spec-independent (dynamically-observed) ground truth; false-negative rate report gates auto-apply |
@@ -1368,7 +1368,7 @@ type-guard noise.
 
 ### §9.1. Throw-set fixpoint (FR10)
 
-Compute `Throws(F) ⊆ Raised`, the exceptions `F` can raise (a constructed
+Compute `Throws(F) ⊆ Exception`, the exceptions `F` can raise (a constructed
 error class, or a `Param(k)`/`Receiver` origin for a propagated value),
 directly or transitively. The structure is identical to the §4.1
 mutation-summary fixpoint: a worklist over the call graph, a per-call
@@ -1376,7 +1376,7 @@ transfer, re-enqueue callers on change. The transfer differs and depends
 on each call's completion guard, which §3 now records on the `Node`.
 
 ```
-Throws : map[FuncName] Set[Raised]      // Class(TypeError), Origin(Param(k)), Unknown, ...
+Throws : map[FuncName] Set[Exception]      // Class(TypeError), Origin(Param(k)), Unknown, ...
 ThrowSites : map[FuncName] []ThrowSite  // provenance chains for §9.2 / §9.3
 
 // A site preserves where the value ULTIMATELY came from, so a coercion
@@ -1456,7 +1456,7 @@ unreachable.
 CoercionAOs = { ToObject, RequireObjectCoercible,
                 ToString, ToNumber, ToNumeric, ToPrimitive }
 
-func filterThrows(M) []Raised:
+func filterThrows(M) []Exception:
     kept = {}
     for site in syncSites(M):                        // §9.3: sites reaching the synchronous exit
         if site.Raised == Class(TypeError) and precludedCoercion(M, site):
@@ -1506,7 +1506,7 @@ feeds `rejects` (the `Promise<T, E>` reject type). The two use the same
 fixpoint; they differ only in classifying the site:
 
 ```
-func rejectSet(M) []Raised:
+func rejectSet(M) []Exception:
     if not returnsPromise(M): return []          // no async channel (source below)
     kept = combinatorRejects(M)                  // hand-modeled (below); empty for anything else
     // (a) abrupt completions routed to the reject sink — IfAbruptRejectPromise,


### PR DESCRIPTION
Fixes #1205.

Implements §9.3 of the implementation plan: partitioning a promise-returning function&#39;s exceptions into synchronous `throws` and asynchronous `rejects` channels, with support for parametric origins and hand-modeled Promise combinators.

## Changes

- **New file `internal/ecma262/rejects.go`**: Core logic for computing rejection sites
  - `rejectPlan` struct tracks where a function&#39;s rejections come from: routed (abrupt completions via `IfAbruptRejectPromise`), direct (plain values handed to reject), modeled (Promise combinator element promises), and delegated (capability passed to another function)
  - `newRejectPlan()` analyzes a function&#39;s node list to identify rejection sources
  - `rejectScan` walks value names back through completions and bindings to find the raising steps
  - `capabilityNames()` and `delegatesCapability()` detect when a function passes its capability to another rejecter
  - `combinatorRejects()` applies hand-written models for the four Promise combinators (all, race, any, allSettled)
  - `Sink` enum distinguishes `SinkSync` (synchronous exit) from `SinkReject` (promise rejection)

- **New file `internal/ecma262/rejects_test.go`**: Comprehensive test suite covering
  - Direct rejections (Promise.reject shape)
  - Routed rejections (IfAbruptRejectPromise with completion captures)
  - Combinator models and element error forwarding
  - Site partitioning and provenance chains
  - Edge cases (untraced reasons, delegated capabilities, non-promise-returning functions)

- **Modified `internal/ecma262/throws.go`**:
  - Added `RaisedElementErr` and `RaisedAggregate` kinds to represent Promise combinator element rejections
  - `Raised` now supports `ElementErr()` and `AggregateErr()` constructors
  - `ThrowSite` now carries a `Sink` field to tag whether a site reaches the synchronous or reject channel
  - `Throws` struct split into `Raised` (synchronous) and `Rejects` (asynchronous) channels
  - Added `RejectsString()`, `SyncSites()`, and `RejectSites()` methods to `Throws`
  - `NewThrowSummary()` now builds rejection plans for all functions and routes sites to the appropriate channel
  - Updated comments to reflect that captured completions no longer mark a function incomplete if the reject walk can name the raising step

- **Modified `internal/ecma262/classify.go`**: Updated comment to note that `Rejects` is published alongside `Throws` in §9.2

- **Modified `planning/ecma-262/implementation_plan.md`**: Marked §9.3 as complete (✅) with reference to the implementation

## Implementation details

The reject walk unwraps `.[[Value]]` slots on completion captures, follows bindings through `LetNode` and `CallNode` definitions, and stops at `Completion()` captures to identify the raising step. This allows `IfAbruptRejectPromise` inlining (four-step shape with completion capture and binding) to be traced back to the operation that raised the value, making the rejection a named fact rather than leaving the function incomplete.

Promise combinators are hand-modeled because their element rejections arrive through promise-resolution machinery with no graph edge. The model supplies `ElementErr(Param(k))` for the iterable parameter, and `AggregateErr()` wraps it for `Promise.any`. These are unioned with routed rejections found by the walk.

A function that delegates its capability to another rejecter is flagged as incomplete, since those rejections settle the returned promise but no source above sees them (e.g., `AsyncFromSyncIteratorPrototype.next`).

## Follow-up

`MethodFact` gains neither throw field here. `NewFacts` does not run the throw fixpoint yet, and publishing `rejects` without `throws` would spell a method whose synchronous throws are simply not published as one that throws nothing — the unanalyzed-versus-proven-none confusion Appendix B exists to prevent. Both fields land together in §9.2. Refs #1289, which owns that wiring.

https://claude.ai/code/session_01XMSxohCyj6UinZ7CCQrRjL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved ECMAScript behavior analysis by separately identifying synchronous exceptions and promise rejections.
  - Added clearer tracking of rejection origins across promise capabilities, combinators, async generators, and delegated flows.
  - Expanded error classification to include iterable-element and aggregate errors.

- **Bug Fixes**
  - Improved handling of captured completion values and rejection paths.
  - Prevented missing rejection information from being misinterpreted as proof that no synchronous exception exists.

- **Documentation**
  - Updated implementation documentation to reflect the completed rejection analysis work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->