### PR TITLE
Split coverage per determination in MethodFact

### DIFF
--- a/internal/ecma262/__snapshots__/classify_test.snap
+++ b/internal/ecma262/__snapshots__/classify_test.snap
@@ -1,52 +1,15 @@
 
 [TestFactsUnclassifiedMethodsAreListed - 1]
-Array
-Array.from
-Array.of
 Array.prototype.concat
 Array.prototype.toLocaleString
-AsyncFunction
-AsyncGeneratorFunction
-Atomics.add
-Atomics.and
-Atomics.compareExchange
-Atomics.exchange
-Atomics.or
-Atomics.sub
-Atomics.xor
-BigInt64Array
-BigUint64Array
-Date
 Date.prototype.getTimezoneOffset
 Date.prototype.toISOString
 Date.prototype.toUTCString
-Float16Array
-Float32Array
-Float64Array
 ForInIteratorPrototype.next
-Function
-GeneratorFunction
-Int16Array
-Int32Array
-Int8Array
-JSON.parse
-JSON.stringify
-Map.groupBy
-Math.atan2
-Math.ceil
-Math.clz32
-Math.f16round
-Math.floor
-Math.fround
-Math.hypot
-Math.round
-Math.trunc
 Number.prototype.toExponential
 Number.prototype.toFixed
 Number.prototype.toLocaleString
 Number.prototype.toPrecision
-Object.fromEntries
-RegExp.escape
 RegExp.prototype [ @@matchAll ]
 RegExp.prototype [ @@replace ]
 RegExp.prototype [ @@split ]
@@ -64,21 +27,8 @@ String.prototype.toLocaleLowerCase
 String.prototype.toLocaleUpperCase
 String.prototype.toLowerCase
 String.prototype.toUpperCase
-Symbol.for
-TypedArray.from
 TypedArray.prototype.slice
 TypedArray.prototype.toLocaleString
-Uint16Array
-Uint32Array
-Uint8Array
-Uint8ClampedArray
 WeakSet.prototype.delete
-`Promise.allSettled`RejectElementFunction
-`Promise.allSettled`ResolveElementFunction
-`Promise.all`ResolveElementFunction
-`Promise.any`RejectElementFunction
-eval
 get RegExp.prototype.flags
-parseFloat
-parseInt
 ---

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -136,6 +136,18 @@ func receiverKind(fn *Func, mutations Mutations) ReceiverKind {
 	return RecvBorrow
 }
 
+// receiverCovered reports whether the analysis can answer the receiver axis for
+// fn. A static and a namespace function have no receiver, which fn.Kind settles
+// without reading a single step, so no warning can withhold it. A method has to
+// have been read whole, since a step the analysis missed could have written the
+// receiver.
+func receiverCovered(fn *Func, mutations Mutations) bool {
+	if fn.Kind != BuiltinMethod {
+		return true
+	}
+	return !mutations.Unattributable && !mutations.Incomplete
+}
+
 // Coverage records which of MethodFact's determinations the analysis resolved.
 // A determination is an independent axis of the fact, and requirements.md FR5's
 // conservative fallback applies to each one on its own. A step the analysis
@@ -145,10 +157,12 @@ func receiverKind(fn *Func, mutations Mutations) ReceiverKind {
 // Params, Throws, and Rejects join MethodFact in §8 and §9, and each adds its
 // own field here.
 type Coverage struct {
-	// Receiver is set when the mutation fixpoint read the whole algorithm and
-	// placed every write it saw. An opaque node carries no operands, so a
-	// missed step could have written anything, and the receiver claim is
-	// withheld rather than guessed.
+	// Receiver is always set for a static and a namespace function, which
+	// have no receiver to claim at all. For a method it is set when the
+	// mutation fixpoint read the whole algorithm and placed every write it
+	// saw. An opaque node carries no operands, so a missed step could have
+	// written a method's receiver, and the mutability claim is withheld
+	// rather than guessed.
 	Receiver bool `json:"receiver"`
 	// Returns is set whenever returnAlias ran, which is for every builtin.
 	// The alias lattice has a top, so an algorithm the walk could not tie to
@@ -230,7 +244,7 @@ type Facts struct {
 
 // NewFacts classifies every builtin in cfg. It runs the mutation fixpoint
 // itself, which supplies the receiver axis and the two warnings that withhold
-// it.
+// a method's mutability claim.
 //
 // The two axes carry different risk, which is why a warning takes only one of
 // them. Receiver mutability is a soundness claim §7 auto-applies, and a wrong
@@ -257,7 +271,7 @@ func NewFacts(cfg *CFG) *Facts {
 		returns := returnAlias(summary.originsOf(fn))
 		fact := MethodFact{
 			Classified: Coverage{
-				Receiver: !mutations.Unattributable && !mutations.Incomplete,
+				Receiver: receiverCovered(fn, mutations),
 				Returns:  true,
 			},
 			Returns: returns.Kind,
@@ -283,8 +297,10 @@ func (f *Facts) Of(name string) (MethodFact, bool) {
 
 // Unclassified returns the names whose receiver claim FR5 hands to the
 // converter's name-based heuristics, sorted. Shrinking this list is what §4 is
-// measured by. A method listed here still publishes its return alias, so the
-// list names a withheld determination rather than an empty fact.
+// measured by. Only a builtin method can appear, since a static and a namespace
+// function have no receiver for a warning to cost them. A name listed here
+// still publishes its return alias, so the list marks a withheld determination
+// rather than an empty fact.
 func (f *Facts) Unclassified() []string {
 	names := make([]string, 0, len(f.Methods))
 	for name, fact := range f.Methods {

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -136,11 +136,8 @@ func receiverKind(fn *Func, mutations Mutations) ReceiverKind {
 	return RecvBorrow
 }
 
-// receiverCovered reports whether the analysis can answer the receiver axis for
-// fn. A static and a namespace function have no receiver, which fn.Kind settles
-// without reading a single step, so no warning can withhold it. A method has to
-// have been read whole, since a step the analysis missed could have written the
-// receiver.
+// receiverCovered reports whether a warning leaves fn's receiver claim
+// standing. Only a method has a receiver a missed step could have written.
 func receiverCovered(fn *Func, mutations Mutations) bool {
 	if fn.Kind != BuiltinMethod {
 		return true
@@ -149,30 +146,26 @@ func receiverCovered(fn *Func, mutations Mutations) bool {
 }
 
 // Coverage records which of MethodFact's determinations the analysis resolved.
-// A determination is an independent axis of the fact, and requirements.md FR5's
-// conservative fallback applies to each one on its own. A step the analysis
-// could not read withholds only the determinations that read that step, so a
-// missed write costs the receiver claim and leaves the return alias standing.
-//
-// Params, Throws, and Rejects join MethodFact in §8 and §9, and each adds its
-// own field here.
+// Each is an independent axis, so requirements.md FR5's conservative fallback
+// applies to each on its own. A step the analysis could not read withholds only
+// the determinations that read it. §8 and §9 add a field per determination they
+// bring.
 type Coverage struct {
-	// Receiver is always set for a static and a namespace function, which
-	// have no receiver to claim at all. For a method it is set when the
-	// mutation fixpoint read the whole algorithm and placed every write it
-	// saw. An opaque node carries no operands, so a missed step could have
-	// written a method's receiver, and the mutability claim is withheld
-	// rather than guessed.
+	// Receiver is always set for a static and a namespace function, which have
+	// no receiver to claim. For a method it is set when the mutation fixpoint
+	// read the whole algorithm and placed every write. An opaque node carries
+	// no operands, so a missed step could have written the receiver, and the
+	// mutability claim is withheld rather than guessed.
 	Receiver bool `json:"receiver"`
-	// Returns is set whenever returnAlias ran, which is for every builtin.
-	// The alias lattice has a top, so an algorithm the walk could not tie to
-	// any origin resolves to AliasUnknown instead of leaving the axis open.
+	// Returns is set for every builtin, since returnAlias is total. The alias
+	// lattice has a top, so an algorithm the walk could not tie to any origin
+	// resolves to AliasUnknown rather than leaving the axis open.
 	//
-	// A step the analysis could not read can itself be a return, and the join
-	// then misses that path. `String.prototype.repeat` ends in a prose step
-	// that returns n copies of the string appended together, so the `fresh`
-	// it publishes comes from its empty-string path alone. FR4 accepts that,
-	// because §7 records the alias for curation rather than applying it.
+	// A missed step can itself be a return, which drops out of the join.
+	// `String.prototype.repeat` ends in a prose step returning n copies of the
+	// string, so the `fresh` it publishes comes from its empty-string path
+	// alone. FR4 accepts that, since §7 curates the alias rather than applying
+	// it.
 	Returns bool `json:"returns"`
 }
 
@@ -180,10 +173,10 @@ type Coverage struct {
 // as one entry of facts.json, described in Appendix B of
 // planning/ecma-262/implementation_plan.md.
 //
-// A determination Coverage leaves unset carries no claim. Its field is absent
-// from the JSON, so a consumer never reads "unanalyzed" as "proven none". The
-// converter applies requirements.md FR5's default for that axis instead, which
-// for an absent receiver is `&mut self`.
+// A determination Coverage leaves unset carries no claim, and its field is
+// absent from the JSON, so a consumer never reads "unanalyzed" as "proven
+// none". The converter applies requirements.md FR5's default instead, `&mut
+// self` for an absent receiver.
 //
 // Appendix B draws that absence with pointers. Receiver and Returns are plain
 // kinds, which have no empty member, so omitempty encodes their absence the
@@ -207,8 +200,8 @@ type MethodFact struct {
 }
 
 // String renders the covered determinations in one line, so a test can assert
-// a fact whole. An uncovered determination is left out rather than spelled with
-// a placeholder value, and a fact covering nothing reads "unclassified".
+// a fact whole. An uncovered one is left out, and a fact covering nothing reads
+// "unclassified".
 func (f MethodFact) String() string {
 	var parts []string
 	if f.Classified.Receiver {
@@ -245,12 +238,6 @@ type Facts struct {
 // NewFacts classifies every builtin in cfg. It runs the mutation fixpoint
 // itself, which supplies the receiver axis and the two warnings that withhold
 // a method's mutability claim.
-//
-// The two axes carry different risk, which is why a warning takes only one of
-// them. Receiver mutability is a soundness claim §7 auto-applies, and a wrong
-// `borrow` lets an immutable value call a mutating method. The return alias is
-// FR4's lifetime seed, which §7 records for curation rather than applies, so
-// withholding it costs precision and buys no safety.
 //
 // A published receiver claim is only as strong as §4.1. A mutation the analysis
 // does not see leaves no warning, so the borrow is published rather than
@@ -297,10 +284,8 @@ func (f *Facts) Of(name string) (MethodFact, bool) {
 
 // Unclassified returns the names whose receiver claim FR5 hands to the
 // converter's name-based heuristics, sorted. Shrinking this list is what §4 is
-// measured by. Only a builtin method can appear, since a static and a namespace
-// function have no receiver for a warning to cost them. A name listed here
-// still publishes its return alias, so the list marks a withheld determination
-// rather than an empty fact.
+// measured by. Only a method appears, and it still publishes its return alias,
+// so the list marks a withheld determination rather than an empty fact.
 func (f *Facts) Unclassified() []string {
 	names := make([]string, 0, len(f.Methods))
 	for name, fact := range f.Methods {

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -146,26 +146,14 @@ func receiverCovered(fn *Func, mutations Mutations) bool {
 }
 
 // Coverage records which of MethodFact's determinations the analysis resolved.
-// Each is an independent axis, so requirements.md FR5's conservative fallback
-// applies to each on its own. A step the analysis could not read withholds only
-// the determinations that read it. §8 and §9 add a field per determination they
-// bring.
+// A step it could not read withholds only the ones that read it (FR5).
 type Coverage struct {
-	// Receiver is always set for a static and a namespace function, which have
-	// no receiver to claim. For a method it is set when the mutation fixpoint
-	// read the whole algorithm and placed every write. An opaque node carries
-	// no operands, so a missed step could have written the receiver, and the
-	// mutability claim is withheld rather than guessed.
+	// Receiver is set for a static or namespace function, which has no receiver
+	// to claim, and for a method the mutation fixpoint read whole.
 	Receiver bool `json:"receiver"`
-	// Returns is set for every builtin, since returnAlias is total. The alias
-	// lattice has a top, so an algorithm the walk could not tie to any origin
-	// resolves to AliasUnknown rather than leaving the axis open.
-	//
-	// A missed step can itself be a return, which drops out of the join.
-	// `String.prototype.repeat` ends in a prose step returning n copies of the
-	// string, so the `fresh` it publishes comes from its empty-string path
-	// alone. FR4 accepts that, since §7 curates the alias rather than applying
-	// it.
+	// Returns is set for every builtin, since returnAlias is total. A return
+	// hidden in a step the analysis could not read drops out of the join, a
+	// loss FR4 accepts because §7 curates the alias rather than applying it.
 	Returns bool `json:"returns"`
 }
 

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -3,6 +3,7 @@ package ecma262
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // ReceiverKind is how a builtin takes the value it is called on. See
@@ -135,14 +136,40 @@ func receiverKind(fn *Func, mutations Mutations) ReceiverKind {
 	return RecvBorrow
 }
 
+// Coverage records which of MethodFact's determinations the analysis resolved.
+// A determination is an independent axis of the fact, and requirements.md FR5's
+// conservative fallback applies to each one on its own. A step the analysis
+// could not read withholds only the determinations that read that step, so a
+// missed write costs the receiver claim and leaves the return alias standing.
+//
+// Params, Throws, and Rejects join MethodFact in §8 and §9, and each adds its
+// own field here.
+type Coverage struct {
+	// Receiver is set when the mutation fixpoint read the whole algorithm and
+	// placed every write it saw. An opaque node carries no operands, so a
+	// missed step could have written anything, and the receiver claim is
+	// withheld rather than guessed.
+	Receiver bool `json:"receiver"`
+	// Returns is set whenever returnAlias ran, which is for every builtin.
+	// The alias lattice has a top, so an algorithm the walk could not tie to
+	// any origin resolves to AliasUnknown instead of leaving the axis open.
+	//
+	// A step the analysis could not read can itself be a return, and the join
+	// then misses that path. `String.prototype.repeat` ends in a prose step
+	// that returns n copies of the string appended together, so the `fresh`
+	// it publishes comes from its empty-string path alone. FR4 accepts that,
+	// because §7 records the alias for curation rather than applying it.
+	Returns bool `json:"returns"`
+}
+
 // MethodFact is what the analysis concluded about one builtin. It serializes
 // as one entry of facts.json, described in Appendix B of
 // planning/ecma-262/implementation_plan.md.
 //
-// An unclassified fact carries no claim at all. Every other field is absent
+// A determination Coverage leaves unset carries no claim. Its field is absent
 // from the JSON, so a consumer never reads "unanalyzed" as "proven none". The
-// converter falls such a method through to its name heuristics, which is
-// requirements.md FR5's soundness bias.
+// converter applies requirements.md FR5's default for that axis instead, which
+// for an absent receiver is `&mut self`.
 //
 // Appendix B draws that absence with pointers. Receiver and Returns are plain
 // kinds, which have no empty member, so omitempty encodes their absence the
@@ -153,7 +180,7 @@ func receiverKind(fn *Func, mutations Mutations) ReceiverKind {
 // Params, no fact makes a parameter claim, so an absent Params is not yet
 // Appendix B's proven-read-only one.
 type MethodFact struct {
-	Classified bool         `json:"classified"`
+	Classified Coverage     `json:"classified"`
 	Receiver   ReceiverKind `json:"receiver,omitempty"`
 	Returns    AliasKind    `json:"returns,omitempty"`
 	// ParamIndex is the 0-based position Returns aliases. It indexes the
@@ -165,23 +192,31 @@ type MethodFact struct {
 	ParamIndex *int `json:"paramIndex,omitempty"`
 }
 
-// String renders the fact in one line, so a test can assert it whole. An
-// unclassified fact reads "unclassified", since it holds nothing else.
+// String renders the covered determinations in one line, so a test can assert
+// a fact whole. An uncovered determination is left out rather than spelled with
+// a placeholder value, and a fact covering nothing reads "unclassified".
 func (f MethodFact) String() string {
-	if !f.Classified {
+	var parts []string
+	if f.Classified.Receiver {
+		parts = append(parts, "receiver:"+string(f.Receiver))
+	}
+	if f.Classified.Returns {
+		returns := string(f.Returns)
+		if f.Returns == AliasParam {
+			// A parameter return with no position is a fact nothing in this
+			// package builds. It reads as the missing position rather than as
+			// position 0, which is the confusion the pointer exists to prevent.
+			returns = "param(?)"
+			if f.ParamIndex != nil {
+				returns = fmt.Sprintf("param(%d)", *f.ParamIndex)
+			}
+		}
+		parts = append(parts, "returns:"+returns)
+	}
+	if len(parts) == 0 {
 		return "unclassified"
 	}
-	returns := string(f.Returns)
-	if f.Returns == AliasParam {
-		// A parameter return with no position is a fact nothing in this
-		// package builds. It reads as the missing position rather than as
-		// position 0, which is the confusion the pointer exists to prevent.
-		returns = "param(?)"
-		if f.ParamIndex != nil {
-			returns = fmt.Sprintf("param(%d)", *f.ParamIndex)
-		}
-	}
-	return fmt.Sprintf("receiver:%s returns:%s", f.Receiver, returns)
+	return strings.Join(parts, " ")
 }
 
 // Facts is the classification of every builtin in one graph, keyed by the
@@ -194,17 +229,19 @@ type Facts struct {
 }
 
 // NewFacts classifies every builtin in cfg. It runs the mutation fixpoint
-// itself, which supplies the receiver axis and the two warnings that decide
-// whether a method is classified at all.
+// itself, which supplies the receiver axis and the two warnings that withhold
+// it.
 //
-// An unresolved return alias does not unclassify a method. It is FR4's lifetime
-// seed, which §7 records rather than applies, not a soundness claim the way
-// receiver mutability is.
+// The two axes carry different risk, which is why a warning takes only one of
+// them. Receiver mutability is a soundness claim §7 auto-applies, and a wrong
+// `borrow` lets an immutable value call a mutating method. The return alias is
+// FR4's lifetime seed, which §7 records for curation rather than applies, so
+// withholding it costs precision and buys no safety.
 //
-// A classified receiver claim is only as strong as §4.1. A mutation that
-// analysis does not see leaves no warning, so the borrow is published rather
-// than withheld. §6's diff against the hand-written overrides is what
-// authorizes §7 to trust this source.
+// A published receiver claim is only as strong as §4.1. A mutation the analysis
+// does not see leaves no warning, so the borrow is published rather than
+// withheld. §6's diff against the hand-written overrides is what authorizes §7
+// to trust this source.
 func NewFacts(cfg *CFG) *Facts {
 	summary := NewMutationSummary(cfg)
 
@@ -217,15 +254,16 @@ func NewFacts(cfg *CFG) *Facts {
 			continue
 		}
 		mutations := summary.Of(fn)
-		if mutations.Unattributable || mutations.Incomplete {
-			facts.Methods[fn.Name] = MethodFact{Classified: false}
-			continue
-		}
 		returns := returnAlias(summary.originsOf(fn))
 		fact := MethodFact{
-			Classified: true,
-			Receiver:   receiverKind(fn, mutations),
-			Returns:    returns.Kind,
+			Classified: Coverage{
+				Receiver: !mutations.Unattributable && !mutations.Incomplete,
+				Returns:  true,
+			},
+			Returns: returns.Kind,
+		}
+		if fact.Classified.Receiver {
+			fact.Receiver = receiverKind(fn, mutations)
 		}
 		if returns.Kind == AliasParam {
 			fact.ParamIndex = new(returns.Index)
@@ -243,12 +281,14 @@ func (f *Facts) Of(name string) (MethodFact, bool) {
 	return fact, ok
 }
 
-// Unclassified returns the names FR5 hands to the converter's name-based
-// heuristics, sorted. Shrinking this list is what §4 is measured by.
+// Unclassified returns the names whose receiver claim FR5 hands to the
+// converter's name-based heuristics, sorted. Shrinking this list is what §4 is
+// measured by. A method listed here still publishes its return alias, so the
+// list names a withheld determination rather than an empty fact.
 func (f *Facts) Unclassified() []string {
 	names := make([]string, 0, len(f.Methods))
 	for name, fact := range f.Methods {
-		if !fact.Classified {
+		if !fact.Classified.Receiver {
 			names = append(names, name)
 		}
 	}

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -27,8 +27,7 @@ func testFacts(t *testing.T) *Facts {
 	return allFacts
 }
 
-// fullCoverage is what NewFacts builds for a builtin it read whole, with no
-// determination withheld.
+// fullCoverage is what NewFacts builds for a builtin it read whole.
 var fullCoverage = Coverage{Receiver: true, Returns: true}
 
 // position is the 0-based parameter position a fact returns, as MethodFact
@@ -170,19 +169,18 @@ func TestFactsSampleMethods(t *testing.T) {
 		"CallerOfAnIncompleteAlgorithm": {"GeneratorPrototype.next", "receiver:borrow returns:unknown"},
 		// A method carrying either warning keeps its return alias and loses only
 		// its receiver claim. union reaches the prose step `Let resultSetData be
-		// a copy of O.[[SetData]]`, which the analysis cannot read, so it cannot
-		// rule out a write to the receiver there. The Set it hands back is one it
-		// allocated either way.
+		// a copy of O.[[SetData]]`, which could have written the receiver for all
+		// the analysis can tell. The Set it hands back is one it allocated.
 		"IncompleteMethodReturningAFreshValue": {"Set.prototype.union", "returns:fresh"},
 		// The same withheld receiver over a return the walk could not resolve.
-		// toLowerCase reaches the Unicode case-mapping table through a prose step
-		// and returns what that step produced.
+		// toLowerCase returns what a prose step reaching the Unicode case-mapping
+		// table produced.
 		"IncompleteMethodReturningAnUnresolvedValue": {"String.prototype.toLowerCase", "returns:unknown"},
-		// A static keeps its receiver claim through either warning. Having no
-		// receiver follows from `Func.Kind`, not from a step the analysis had to
-		// read. Array.of builds its array through `Construct(C, ...)`, whose
-		// result the origin map cannot place, so the write to it is
-		// unattributable and the return it hands back is unresolved too.
+		// A static keeps its receiver claim through either warning, since having
+		// none follows from `Func.Kind` rather than from a step. Array.of builds
+		// its array through `Construct(C, ...)`, whose result the origin map
+		// cannot place, so the write to it is unattributable and the return
+		// unresolved.
 		"UnattributableStatic": {"Array.of", "receiver:none returns:unknown"},
 	}
 
@@ -197,7 +195,7 @@ func TestFactsSampleMethods(t *testing.T) {
 // with `ToString` before reading it, and §4.2 makes that coercion's result a
 // fresh primitive, so no write can reach the receiver. The seven left out are
 // the ones the analysis could not read whole, so they withhold the receiver
-// claim this checks. Each still publishes a return alias.
+// claim this checks.
 func TestFactsEveryStringMethodBorrowsItsReceiver(t *testing.T) {
 	var borrowed int
 	var unread []string
@@ -244,14 +242,12 @@ func TestFactsCoverEveryBuiltin(t *testing.T) {
 		builtins++
 		fact, ok := f.Of(fn.Name)
 		require.True(t, ok, "%s has no fact", fn.Name)
-		// Every builtin resolves a return alias, so the axis is covered even
-		// where a warning withheld the receiver.
+		// Every builtin resolves a return alias, warning or not.
 		require.True(t, fact.Classified.Returns, "%s has no return alias", fn.Name)
 		require.NotEmpty(t, fact.Returns, "%s covers a return alias it does not carry", fn.Name)
 		switch {
 		case fn.Kind != BuiltinMethod:
-			// A static's `none` follows from the function kind, so no warning
-			// withholds it.
+			// `none` follows from the function kind, so no warning withholds it.
 			require.True(t, fact.Classified.Receiver, "%s has no receiver claim", fn.Name)
 			require.Equal(t, RecvNone, fact.Receiver, "%s has no receiver", fn.Name)
 		case !fact.Classified.Receiver:
@@ -292,8 +288,8 @@ func TestFactsJSON(t *testing.T) {
 		want string
 	}{
 		"Method": {factOf(t, "Array.prototype.fill"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":"receiver"}`},
-		// A method the analysis could not read whole publishes its return alias
-		// and no receiver, so the receiver falls through to FR5's `&mut self`.
+		// A withheld receiver falls through to FR5's `&mut self`, so the entry
+		// carries the return alias alone.
 		"WithheldReceiver": {factOf(t, "Set.prototype.union"), `{"classified":{"receiver":false,"returns":true},"returns":"fresh"}`},
 		// The first parameter is written out like any other position. Every
 		// parameter the committed graph returns sits at 0, so omitting it would
@@ -319,14 +315,12 @@ func TestFactsJSON(t *testing.T) {
 
 // The methods whose receiver claim FR5 hands to the converter's name
 // heuristics. Each carries a mutation the analysis could not place or a step it
-// could not read, so its receiver mutability is withheld rather than guessed.
-// Each still publishes the return alias, which §7 records for curation rather
-// than applies. A static carrying the same warning is absent, since it has no
-// receiver for the warning to cost it.
+// could not read, so its mutability is withheld rather than guessed, and each
+// still publishes its return alias. A static is absent, having no receiver for
+// a warning to cost it.
 //
 // This list is the §4 objective made visible. Shrinking it is what a change to
-// the analysis is measured by, and the tallies below record the same number as
-// the withheld receivers.
+// the analysis is measured by, and the tallies below record the same count.
 func TestFactsUnclassifiedMethodsAreListed(t *testing.T) {
 	snaps.MatchSnapshot(t, strings.Join(testFacts(t).Unclassified(), "\n"))
 }
@@ -334,7 +328,7 @@ func TestFactsUnclassifiedMethodsAreListed(t *testing.T) {
 // The tallies over every builtin, which move when the mutation analysis, the
 // origin map, or the classification changes. Each determination is counted on
 // its own, so the return-alias distribution spans every builtin while the
-// receiver one leaves out the methods that withhold the claim.
+// receiver one leaves out the methods that withhold it.
 func TestFactsTallies(t *testing.T) {
 	counts := map[string]int{}
 	for _, fact := range testFacts(t).Methods {

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -27,6 +27,10 @@ func testFacts(t *testing.T) *Facts {
 	return allFacts
 }
 
+// fullCoverage is what NewFacts builds for a builtin it read whole, with no
+// determination withheld.
+var fullCoverage = Coverage{Receiver: true, Returns: true}
+
 // position is the 0-based parameter position a fact returns, as MethodFact
 // holds it.
 func position(i int) *int {
@@ -47,20 +51,19 @@ func TestMethodFactString(t *testing.T) {
 		fact MethodFact
 		want string
 	}{
-		// Every case in TestFactsSampleMethods renders a classified fact
-		// through String, so only what those cases cannot show is stated here:
-		// a fact with nothing to render, and a returned position past 0, which
-		// no builtin has.
-		"Unclassified": {MethodFact{}, "unclassified"},
+		// TestFactsSampleMethods renders every shape NewFacts builds, so only
+		// what those cases cannot show is stated here: a fact with nothing to
+		// render, and a returned position past 0, which no builtin has.
+		"NoDetermination": {MethodFact{}, "unclassified"},
 		"ParamReturn": {
-			MethodFact{Classified: true, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(2)},
+			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(2)},
 			"receiver:none returns:param(2)",
 		},
 		// A parameter return with no position reads as the missing position
 		// rather than as position 0. Nothing in the package builds such a fact;
 		// a hand-edited facts.json is where one would come from.
 		"ParamReturnWithNoPosition": {
-			MethodFact{Classified: true, Receiver: RecvNone, Returns: AliasParam},
+			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: AliasParam},
 			"receiver:none returns:param(?)",
 		},
 	}
@@ -165,13 +168,20 @@ func TestFactsSampleMethods(t *testing.T) {
 		// call graph and `Incomplete` not at all. next resumes the generator
 		// through `GeneratorResume`, which carries the warning.
 		"CallerOfAnIncompleteAlgorithm": {"GeneratorPrototype.next", "receiver:borrow returns:unknown"},
-		// A method carrying either warning is handed to the name heuristics
-		// whole. toLowerCase reaches the Unicode case-mapping table through a
-		// prose step, which leaves the analysis unable to read the algorithm.
-		"IncompleteMethod": {"String.prototype.toLowerCase", "unclassified"},
+		// A method carrying either warning keeps its return alias and loses only
+		// its receiver claim. union reaches the prose step `Let resultSetData be
+		// a copy of O.[[SetData]]`, which the analysis cannot read, so it cannot
+		// rule out a write to the receiver there. The Set it hands back is one it
+		// allocated either way.
+		"IncompleteMethodReturningAFreshValue": {"Set.prototype.union", "returns:fresh"},
+		// The same withheld receiver over a return the walk could not resolve.
+		// toLowerCase reaches the Unicode case-mapping table through a prose step
+		// and returns what that step produced.
+		"IncompleteMethodReturningAnUnresolvedValue": {"String.prototype.toLowerCase", "returns:unknown"},
 		// Array.of builds its array through `Construct(C, ...)`, whose result
-		// the origin map cannot place, so the write to it is unattributable.
-		"UnattributableStatic": {"Array.of", "unclassified"},
+		// the origin map cannot place, so the write to it is unattributable and
+		// the return it hands back is unresolved too.
+		"UnattributableStatic": {"Array.of", "returns:unknown"},
 	}
 
 	for name, test := range tests {
@@ -184,8 +194,8 @@ func TestFactsSampleMethods(t *testing.T) {
 // The §4.3 gate's last spot-check. Every String method coerces its receiver
 // with `ToString` before reading it, and §4.2 makes that coercion's result a
 // fresh primitive, so no write can reach the receiver. The seven left out are
-// the ones the analysis could not read at all, which carry no receiver claim
-// to check.
+// the ones the analysis could not read whole, so they withhold the receiver
+// claim this checks. Each still publishes a return alias.
 func TestFactsEveryStringMethodBorrowsItsReceiver(t *testing.T) {
 	var borrowed int
 	var unread []string
@@ -193,7 +203,7 @@ func TestFactsEveryStringMethodBorrowsItsReceiver(t *testing.T) {
 		if !strings.HasPrefix(name, "String.prototype") {
 			continue
 		}
-		if !fact.Classified {
+		if !fact.Classified.Receiver {
 			unread = append(unread, name)
 			continue
 		}
@@ -232,13 +242,16 @@ func TestFactsCoverEveryBuiltin(t *testing.T) {
 		builtins++
 		fact, ok := f.Of(fn.Name)
 		require.True(t, ok, "%s has no fact", fn.Name)
-		if !fact.Classified {
-			require.Equal(t, MethodFact{}, fact, "%s carries a claim it is not classified for", fn.Name)
-			continue
-		}
-		if fn.Kind == BuiltinMethod {
+		// Every builtin resolves a return alias, so the axis is covered even
+		// where a warning withheld the receiver.
+		require.True(t, fact.Classified.Returns, "%s has no return alias", fn.Name)
+		require.NotEmpty(t, fact.Returns, "%s covers a return alias it does not carry", fn.Name)
+		switch {
+		case !fact.Classified.Receiver:
+			require.Empty(t, fact.Receiver, "%s carries a receiver claim it is not classified for", fn.Name)
+		case fn.Kind == BuiltinMethod:
 			require.Contains(t, []ReceiverKind{RecvBorrow, RecvMutBorrow}, fact.Receiver, fn.Name)
-		} else {
+		default:
 			require.Equal(t, RecvNone, fact.Receiver, "%s has no receiver", fn.Name)
 		}
 		if fact.Returns == AliasParam {
@@ -265,27 +278,29 @@ func TestFactsOfAnAbsentName(t *testing.T) {
 	require.Equal(t, MethodFact{}, fact)
 }
 
-// A classified fact serializes as Appendix B describes, and an unclassified one
-// carries nothing beside the flag, so the converter cannot read an absent claim
+// A fact serializes as Appendix B describes. A determination its coverage
+// leaves unset omits its field, so the converter cannot read an absent claim
 // as a proven-empty one.
 func TestFactsJSON(t *testing.T) {
 	tests := map[string]struct {
 		fact MethodFact
 		want string
 	}{
-		"Method":       {factOf(t, "Array.prototype.fill"), `{"classified":true,"receiver":"mutBorrow","returns":"receiver"}`},
-		"Unclassified": {factOf(t, "String.prototype.toLowerCase"), `{"classified":false}`},
+		"Method": {factOf(t, "Array.prototype.fill"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":"receiver"}`},
+		// A method the analysis could not read whole publishes its return alias
+		// and no receiver, so the receiver falls through to FR5's `&mut self`.
+		"WithheldReceiver": {factOf(t, "Set.prototype.union"), `{"classified":{"receiver":false,"returns":true},"returns":"fresh"}`},
 		// The first parameter is written out like any other position. Every
 		// parameter the committed graph returns sits at 0, so omitting it would
 		// leave paramIndex absent from the whole file and spell the common case
 		// as missing data.
-		"ReturnedPositionZero": {factOf(t, "Object.freeze"), `{"classified":true,"receiver":"none","returns":"param","paramIndex":0}`},
+		"ReturnedPositionZero": {factOf(t, "Object.freeze"), `{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":"param","paramIndex":0}`},
 		"ReturnedPositionPastZero": {
-			MethodFact{Classified: true, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(2)},
-			`{"classified":true,"receiver":"none","returns":"param","paramIndex":2}`,
+			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(2)},
+			`{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":"param","paramIndex":2}`,
 		},
 		// A fact that returns no parameter carries no position at all.
-		"NoReturnedPosition": {factOf(t, "Array.prototype.push"), `{"classified":true,"receiver":"mutBorrow","returns":"fresh"}`},
+		"NoReturnedPosition": {factOf(t, "Array.prototype.push"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":"fresh"}`},
 	}
 
 	for name, test := range tests {
@@ -297,29 +312,37 @@ func TestFactsJSON(t *testing.T) {
 	}
 }
 
-// The methods FR5 hands to the converter's name heuristics. Each carries a
-// mutation the analysis could not place or a step it could not read, so it is
-// emitted with no claim at all rather than with a guess.
+// The methods whose receiver claim FR5 hands to the converter's name
+// heuristics. Each carries a mutation the analysis could not place or a step it
+// could not read, so its receiver is withheld rather than guessed. Each still
+// publishes the return alias, which §7 records for curation rather than
+// applies.
 //
-// This list is the §4 objective made visible: shrinking it is what a change to
-// the analysis is measured by, and the tallies below record the same number
-// against the classified ones.
+// This list is the §4 objective made visible. Shrinking it is what a change to
+// the analysis is measured by, and the tallies below record the same number as
+// the withheld receivers.
 func TestFactsUnclassifiedMethodsAreListed(t *testing.T) {
 	snaps.MatchSnapshot(t, strings.Join(testFacts(t).Unclassified(), "\n"))
 }
 
 // The tallies over every builtin, which move when the mutation analysis, the
-// origin map, or the classification changes.
+// origin map, or the classification changes. Each determination is counted on
+// its own, so the return-alias distribution spans every builtin while the
+// receiver one leaves out the methods that withhold the claim.
 func TestFactsTallies(t *testing.T) {
 	counts := map[string]int{}
 	for _, fact := range testFacts(t).Methods {
 		counts["total"]++
-		if !fact.Classified {
-			counts["unclassified"]++
-			continue
+		if fact.Classified.Receiver {
+			counts["receiver "+string(fact.Receiver)]++
+		} else {
+			counts["receiver unclassified"]++
 		}
-		counts["receiver "+string(fact.Receiver)]++
-		counts["returns "+string(fact.Returns)]++
+		if fact.Classified.Returns {
+			counts["returns "+string(fact.Returns)]++
+		} else {
+			counts["returns unclassified"]++
+		}
 	}
 
 	lines := make([]string, 0, len(counts))
@@ -330,11 +353,11 @@ func TestFactsTallies(t *testing.T) {
 	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`receiver borrow: 222
 receiver mutBorrow: 60
 receiver none: 138
-returns fresh: 177
+receiver unclassified: 81
+returns fresh: 229
 returns param: 6
 returns receiver: 15
 returns union: 1
-returns unknown: 221
-total: 501
-unclassified: 81`))
+returns unknown: 250
+total: 501`))
 }

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -178,10 +178,12 @@ func TestFactsSampleMethods(t *testing.T) {
 		// toLowerCase reaches the Unicode case-mapping table through a prose step
 		// and returns what that step produced.
 		"IncompleteMethodReturningAnUnresolvedValue": {"String.prototype.toLowerCase", "returns:unknown"},
-		// Array.of builds its array through `Construct(C, ...)`, whose result
-		// the origin map cannot place, so the write to it is unattributable and
-		// the return it hands back is unresolved too.
-		"UnattributableStatic": {"Array.of", "returns:unknown"},
+		// A static keeps its receiver claim through either warning. Having no
+		// receiver follows from `Func.Kind`, not from a step the analysis had to
+		// read. Array.of builds its array through `Construct(C, ...)`, whose
+		// result the origin map cannot place, so the write to it is
+		// unattributable and the return it hands back is unresolved too.
+		"UnattributableStatic": {"Array.of", "receiver:none returns:unknown"},
 	}
 
 	for name, test := range tests {
@@ -247,12 +249,15 @@ func TestFactsCoverEveryBuiltin(t *testing.T) {
 		require.True(t, fact.Classified.Returns, "%s has no return alias", fn.Name)
 		require.NotEmpty(t, fact.Returns, "%s covers a return alias it does not carry", fn.Name)
 		switch {
+		case fn.Kind != BuiltinMethod:
+			// A static's `none` follows from the function kind, so no warning
+			// withholds it.
+			require.True(t, fact.Classified.Receiver, "%s has no receiver claim", fn.Name)
+			require.Equal(t, RecvNone, fact.Receiver, "%s has no receiver", fn.Name)
 		case !fact.Classified.Receiver:
 			require.Empty(t, fact.Receiver, "%s carries a receiver claim it is not classified for", fn.Name)
-		case fn.Kind == BuiltinMethod:
-			require.Contains(t, []ReceiverKind{RecvBorrow, RecvMutBorrow}, fact.Receiver, fn.Name)
 		default:
-			require.Equal(t, RecvNone, fact.Receiver, "%s has no receiver", fn.Name)
+			require.Contains(t, []ReceiverKind{RecvBorrow, RecvMutBorrow}, fact.Receiver, fn.Name)
 		}
 		if fact.Returns == AliasParam {
 			require.NotNil(t, fact.ParamIndex, "%s returns a parameter but no position", fn.Name)
@@ -314,9 +319,10 @@ func TestFactsJSON(t *testing.T) {
 
 // The methods whose receiver claim FR5 hands to the converter's name
 // heuristics. Each carries a mutation the analysis could not place or a step it
-// could not read, so its receiver is withheld rather than guessed. Each still
-// publishes the return alias, which §7 records for curation rather than
-// applies.
+// could not read, so its receiver mutability is withheld rather than guessed.
+// Each still publishes the return alias, which §7 records for curation rather
+// than applies. A static carrying the same warning is absent, since it has no
+// receiver for the warning to cost it.
 //
 // This list is the §4 objective made visible. Shrinking it is what a change to
 // the analysis is measured by, and the tallies below record the same number as
@@ -352,8 +358,8 @@ func TestFactsTallies(t *testing.T) {
 	sort.Strings(lines)
 	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`receiver borrow: 222
 receiver mutBorrow: 60
-receiver none: 138
-receiver unclassified: 81
+receiver none: 188
+receiver unclassified: 31
 returns fresh: 229
 returns param: 6
 returns receiver: 15

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -38,7 +38,7 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ✅      | §2         | `cfg.json` covers all 501 builtin algorithms plus the 701 functions reachable from them, at the pinned spec revision, and round-trips the schema check the run ends with — met |
 | §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ✅      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.2 | Origin map                                 | FR2, FR4   | ✅      | §3         | origins asserted for sample functions — `ToObject(this)`→Receiver, allocators→Fresh, reads→Unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
-| §4.3 | Method classification                      | FR4, FR5   | ✅      | §4.1, §4.2 | facts.json core — receiver / returns / classified for the representative methods — met, see [internal/ecma262/](../../internal/ecma262/) |
+| §4.3 | Method classification                      | FR4, FR5   | ✅      | §4.1, §4.2 | facts.json core — receiver / returns / per-determination coverage for the representative methods — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §5   | Keying and join                            | FR7, FR15  | ⬜      | §4.3       | normalizer joins facts to `.d.ts` declarations; overloads share algorithm-level facts, type-dependent parts per signature; unmatched reported |
 | §6   | Validation diff                            | FR9        | ⬜      | §5         | receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
 | §7   | Integration as classification source       | FR8        | ⬜      | §6         | converter ranks facts above name tiers; the two application paths wired; redundant overrides removed |
@@ -479,9 +479,9 @@ maintainer runbook. Four findings shape the sections downstream.
   `String.prototype.toUpperCase`, `Math.random`, the `toLocaleString`
   family, `Function.prototype`, and its own `print` from manual sources
   rather than from `spec.html`. Six of the eight have a body that is a
-  single `yet`, so the analysis reads them as unclassified, which is the
-  right answer. They are keyed from the compiled function's name so the
-  surface stays complete.
+  single `yet`, so the analysis withholds their receiver claim, which is
+  the right answer. They are keyed from the compiled function's name so
+  the surface stays complete.
 
 Two limits are worth naming for §9.3. `Promise` is set from the shape
 Appendix A describes, an algorithm that builds a promise capability and
@@ -515,9 +515,10 @@ space is what makes static and namespace functions — whose parameter 0 is
 a real argument, not a receiver — fall out correctly.
 
 **The standing objective is to shrink the unclassified set.** A builtin
-carrying `Unattributable` or `Incomplete` is one §4.3 hands to FR5's
-name-based heuristics instead of deciding from the spec. Every change to
-this analysis is measured by what it does to that count, and the tallies
+carrying `Unattributable` or `Incomplete` is one whose receiver claim §4.3
+hands to FR5's name-based heuristics instead of deciding from the spec.
+Every change to this analysis is measured by what it does to that count,
+and the tallies
 snapshot in `internal/ecma262/mutation_test.go` is where the number is
 recorded. A change that leaves it flat needs a reason, and one that raises
 it needs a stronger one.
@@ -607,9 +608,10 @@ it knows something escaped but not what. `Incomplete` means the analysis
 could not see the whole algorithm: an `Opaque` node the serializer could
 not lower, which is a prose step from §3, a `Call` to a callee that is
 absent from the CFG and named by neither internal-method table, or a
-mutation phrasing outside the FR1 vocabulary. Both force
-`classified: false` (§4.3), so FR5's heuristic fall-through handles the
-method rather than the analysis emitting a claim it cannot stand behind.
+mutation phrasing outside the FR1 vocabulary. Either withholds the
+receiver claim (§4.3), so FR5's heuristic fall-through decides receiver
+mutability rather than the analysis emitting a claim it cannot stand
+behind. Neither withholds the return alias.
 
 **How the seed works, and why it is not inlining.** The seed entries are the
 fixpoint's base cases. The analysis never invents a mutation; it only carries
@@ -865,9 +867,9 @@ collapse to `Unknown` — and `returnAlias` (§4.3) considers *every*
 `Return` node, not only the reachable ones. This over-approximates
 (a throw or return on a dead branch still counts), which is safe here:
 the mutation and throw sets only grow, over-approximating rather than
-missing an effect, and a method the analysis cannot fully resolve is left
-unclassified rather than guessed (FR5). ESMeta's CFG does carry
-block successors and branch conditions; if a later precision pass wants
+missing an effect, and a determination the analysis cannot resolve is
+withheld rather than guessed (FR5). ESMeta's CFG does carry block
+successors and branch conditions; if a later precision pass wants
 reachability or per-path joins, the serializer (§3) can emit that
 structure and this section becomes flow-sensitive. Until then the schema
 omits it (Appendix A) and the guarantees here are path-insensitive by
@@ -997,9 +999,11 @@ func classify(M) MethodFact:
     fact.Returns    = returnAlias(M)               // below
     fact.Throws     = filterThrows(M)              // §9.2
     fact.Rejects    = rejectSet(M)                 // §9.3
-    // Soundness bias (FR5): a method the analysis could not fully cover
-    // OR could not fully attribute is unclassified.
-    fact.Classified = M not in Unattributable and M not in Incomplete
+    // Soundness bias (FR5), applied per determination. A method the
+    // analysis could not fully cover OR could not fully attribute
+    // withholds the determinations that read the steps it missed.
+    fact.Classified.Receiver = M not in Unattributable and M not in Incomplete
+    fact.Classified.Returns  = true   // returnAlias is total: its top is Unknown
     return fact
 
 func receiverKind(M):
@@ -1018,12 +1022,30 @@ func returnAlias(M) AliasKind:
 
 An `Unattributable` method has a mutation the analysis could not pin to
 a formal — a write through an `Unknown`-origin value, including deep
-mutation reached through a property read. It is emitted with
-`classified: false` and listed, so the converter falls it through to the
-name heuristics and the receiver defaults to `&mut self` (FR5). The
-return-alias axis tolerates `Unknown` without making the whole method
-unclassified, because it is the low-stakes lifetime seed, not a
-soundness-bearing claim.
+mutation reached through a property read. Its receiver claim is withheld
+and its name listed, so the converter falls the method through to the
+name heuristics and the receiver defaults to `&mut self` (FR5).
+
+**Coverage is per determination, not per method.** The two axes carry
+different risk. Receiver mutability is a soundness claim §7 auto-applies,
+and a wrong `borrow` lets an immutable value call a mutating method. The
+return alias is FR4's lifetime seed, which §7 records for curation rather
+than applies, so withholding it costs precision and buys no safety. A
+method whose only problem is a possible hidden mutation therefore keeps
+its `returns` and loses only its `receiver`. That is §2's per-signal
+finding — a determination is unclassified only when a `yet` sits on a step
+it reads.
+
+The receiver axis cannot be recovered the same way. An opaque node carries
+no operands, so there is no way to tell what a missed step would have
+written, and the claim has to keep paying for incompleteness.
+
+The return-alias axis also tolerates `Unknown` on its own, since the alias
+lattice has a top. A missed step can itself be a return, and the join then
+misses that path. `String.prototype.repeat` ends in a prose step that
+returns n copies of the string appended together, so the `fresh` it
+publishes comes from its empty-string path alone. FR4 accepts that,
+because the alias is curated rather than applied.
 
 **Gate.** Spot-check the representative methods from §1:
 - `Array.prototype.push` — `Set(O,…)` on `Param(0)` ⇒ `receiver:
@@ -1036,8 +1058,12 @@ soundness-bearing claim.
   `Param(0)`), `Return M` ⇒ `receiver: mutBorrow`, `returns: receiver`.
 - every `String.prototype` method — `this` coerced to a fresh string,
   never written ⇒ all `receiver: borrow`.
+- `Set.prototype.union` — the prose step `Let resultSetData be a copy of
+  O.[[SetData]]` leaves a possible receiver write unread, so no
+  `receiver`; the Set it allocates and hands back ⇒ `returns: fresh`.
 
-Unclassified methods are listed.
+Methods with a withheld receiver are listed. The `returns` tally spans
+every builtin, not only the ones that publish a receiver.
 
 ## §5. Keying and join (FR7, FR15)
 
@@ -1147,10 +1173,10 @@ entry. This is the gate that authorizes removing override entries in §7.
 - Insert the facts lookup into `dts_to_esc.Classify` at rung 2 (FR8):
   after explicit author signals, before the `get*` prefix and name
   heuristics.
-- Set receiver mutability from a classified fact; leave unclassified
-  methods to the existing tiers.
-- Apply the FR5 defaults for what a `classified: false` record omits (its
-  effect fields are absent). Receiver mutability falls through to the name
+- Set receiver mutability from a fact whose `classified.receiver` is set;
+  leave the rest to the existing tiers.
+- Apply the FR5 defaults for every determination a record leaves uncovered,
+  whose field is absent. Receiver mutability falls through to the name
   tiers, defaulting to `&mut self`. For the curation-grade determinations
   the converter writes a baseline and flags it for review rather than
   trusting it — parameter mutation defaults to **`&mut`** (FR5's flipped
@@ -1211,20 +1237,20 @@ Once §9.4's FR14 gate measures a zero false-negative rate, `throws` /
 `rejects` graduate from the reviewed path to the auto-applied one for the
 covered subset.
 
-**A method absent from `facts.json` falls back to types plus defaults.**
-When a `std:*` method has no fact — unclassified (§4.3) or unmatched by
-the join (§5) — its declaration is `.d.ts` types plus the FR5 defaults
-(`&mut self`, `&mut` parameters, empty `throws`/`rejects`), carrying no
-spec-derived effects. This is the degraded path, not a preferred one: FR5
-lists every unclassified method and §5 reports every unmatched
-declaration, precisely so these are visible gaps to close, not a silent
-route. (`web:*` / `node:*` methods have no `facts.json` entry by
-construction — out of ECMA-262 scope — and take the same
-types-plus-curation route until the WebIDL extractor lands.)
+**A determination `facts.json` does not carry falls back to a default.**
+When a `std:*` method is unmatched by the join (§5), or its fact leaves a
+determination uncovered (§4.3), that part of the declaration is `.d.ts`
+types plus the FR5 defaults — `&mut self`, `&mut` parameters, empty
+`throws`/`rejects` — carrying no spec-derived effect. This is the degraded
+path, not a preferred one. FR5 lists every method with a withheld receiver
+and §5 reports every unmatched declaration, precisely so these are visible
+gaps to close, not a silent route. (`web:*` / `node:*` methods have no
+`facts.json` entry by construction — out of ECMA-262 scope — and take the
+same types-plus-curation route until the WebIDL extractor lands.)
 
 **Gate.** Converter output for `std:*` matches the facts for every
-classified method; the removed override entries cause no regression in
-the converter and checker test suites.
+published determination; the removed override entries cause no regression
+in the converter and checker test suites.
 
 ## §8. Parameter disposition and return-borrow outputs (FR12, FR4)
 
@@ -1831,7 +1857,8 @@ const (
                                             // move or a lifetime-bounded borrow at curation (FR12)
     // A parameter the analysis PROVED read-only (&) is omitted from Params.
     // That omission is distinct from the FR5 uncertain default (&mut): it
-    // means "shown read-only", and applies only to a classified method.
+    // means "shown read-only", and reads that way only where
+    // Coverage.Params is set.
 )
 
 type ParamFact struct {
@@ -1848,11 +1875,22 @@ const (
     AliasUnknown  AliasKind = "unknown"  // a return origin could not be resolved
 )
 
-// The effect fields are pointers/slices so they are ABSENT (JSON null or
-// omitted) when Classified is false — an unanalyzed method, distinct from
-// a proven-empty result which is Classified:true with empty effect fields.
+// Coverage says which determinations the analysis resolved. Each axis is
+// withheld on its own, so a method that hides a mutation still publishes
+// its return alias (§4.3).
+type Coverage struct {
+    Receiver bool `json:"receiver"` // whole algorithm read and every write placed
+    Returns  bool `json:"returns"`  // returnAlias ran; true for every builtin
+    Params   bool `json:"params"`   // §8.1
+    Throws   bool `json:"throws"`   // §9.2
+    Rejects  bool `json:"rejects"`  // §9.3
+}
+
+// The effect fields are pointers/slices so an uncovered determination is
+// ABSENT (JSON null or omitted) — an unanalyzed axis, distinct from a
+// proven-empty result, which is covered with an empty effect field.
 type MethodFact struct {
-    Classified bool          `json:"classified"`           // false ⇒ effect fields absent (FR5)
+    Classified Coverage      `json:"classified"`           // per-determination coverage (FR5)
     Receiver   *ReceiverKind `json:"receiver,omitempty"`   // borrow | mutBorrow | none (FR2)
     Params     []ParamFact   `json:"params,omitempty"`     // only non-borrow parameters (FR12)
     Returns    *AliasKind    `json:"returns,omitempty"`    // return-borrow lifetime seed (FR4)
@@ -1872,15 +1910,16 @@ the **effect ref** `"throwsOf:param:k"` for a method that propagates a
 callback parameter's throws (`Array.prototype.forEach`/`map`/…), resolved
 at the FR7 join to throws polymorphism; or the sentinel `"unknown"` for a
 propagated value the analysis can neither name nor trace. All origin and
-effect refs resolve to types at the FR7 join. A `classified: false` entry carries no receiver,
-disposition, throw, or reject claim — those fields are absent, not empty —
-so the converter cannot mistake "unanalyzed" for "proven none"; it applies
-the FR5 defaults itself and falls the method through to the name
-heuristics. Such methods are also collected into a separate
-`unclassified` report alongside `facts.json` for auditing
-(FR5). In a *classified* method's entry, a parameter absent from `Params`
-was proven read-only (`&`) — not to be confused with the FR5 `&mut`
-default the converter applies to an *unclassified* method's parameters.
+effect refs resolve to types at the FR7 join. An entry carries no receiver,
+disposition, throw, or reject claim its `classified` coverage does not
+cover — those fields are absent, not empty — so the converter cannot
+mistake "unanalyzed" for "proven none"; it applies the FR5 default for
+that axis itself. A method whose `receiver` is uncovered falls through to
+the name heuristics and is collected into a separate `unclassified` report
+alongside `facts.json` for auditing (FR5). Where `classified.params` is
+set, a parameter absent from `Params` was proven read-only (`&`) — not to
+be confused with the FR5 `&mut` default the converter applies where it is
+not.
 The receiver-returning and fresh-returning alias kinds carry the return's
 borrow lifetime per FR4.
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -479,9 +479,9 @@ maintainer runbook. Four findings shape the sections downstream.
   `String.prototype.toUpperCase`, `Math.random`, the `toLocaleString`
   family, `Function.prototype`, and its own `print` from manual sources
   rather than from `spec.html`. Six of the eight have a body that is a
-  single `yet`, so the analysis withholds their receiver claim, which is
-  the right answer. They are keyed from the compiled function's name so
-  the surface stays complete.
+  single `yet`, so the analysis withholds the mutability of whichever of
+  them is a method, which is the right answer. They are keyed from the
+  compiled function's name so the surface stays complete.
 
 Two limits are worth naming for §9.3. `Promise` is set from the shape
 Appendix A describes, an algorithm that builds a promise capability and
@@ -515,10 +515,10 @@ space is what makes static and namespace functions — whose parameter 0 is
 a real argument, not a receiver — fall out correctly.
 
 **The standing objective is to shrink the unclassified set.** A builtin
-carrying `Unattributable` or `Incomplete` is one whose receiver claim §4.3
-hands to FR5's name-based heuristics instead of deciding from the spec.
-Every change to this analysis is measured by what it does to that count,
-and the tallies
+method carrying `Unattributable` or `Incomplete` is one whose receiver
+claim §4.3 hands to FR5's name-based heuristics instead of deciding from
+the spec. Every change to this analysis is measured by what it does to
+that count, and the tallies
 snapshot in `internal/ecma262/mutation_test.go` is where the number is
 recorded. A change that leaves it flat needs a reason, and one that raises
 it needs a stronger one.
@@ -608,10 +608,11 @@ it knows something escaped but not what. `Incomplete` means the analysis
 could not see the whole algorithm: an `Opaque` node the serializer could
 not lower, which is a prose step from §3, a `Call` to a callee that is
 absent from the CFG and named by neither internal-method table, or a
-mutation phrasing outside the FR1 vocabulary. Either withholds the
+mutation phrasing outside the FR1 vocabulary. Either withholds a method's
 receiver claim (§4.3), so FR5's heuristic fall-through decides receiver
 mutability rather than the analysis emitting a claim it cannot stand
-behind. Neither withholds the return alias.
+behind. Neither withholds the return alias, and neither reaches a static
+or a namespace function, which has no receiver to claim.
 
 **How the seed works, and why it is not inlining.** The seed entries are the
 fixpoint's base cases. The analysis never invents a mutation; it only carries
@@ -686,8 +687,8 @@ positions, the receiver flag, and the two warnings. All 1202 functions settle in
 about 10 ms. Eight of the nine seed entries name an operation the graph holds,
 and those eight grow into 47 abstract operations with a mutated position. Of the
 501 builtins, 61 mutate their receiver and 13 mutate a parameter, and 420 carry
-neither warning, so §4.3 decides them from the analysis rather than from FR5's
-name-based heuristics. The gate is
+neither warning, so §4.3 reads their receiver mutability from the analysis
+rather than from FR5's name-based heuristics. The gate is
 [internal/ecma262/mutation_test.go](../../internal/ecma262/mutation_test.go).
 `Array.prototype.push` and `Array.prototype.fill` mutate the receiver,
 `Array.prototype.slice` mutates nothing, and `Map.prototype.set` mutates the
@@ -1001,9 +1002,11 @@ func classify(M) MethodFact:
     fact.Rejects    = rejectSet(M)                 // §9.3
     // Soundness bias (FR5), applied per determination. A method the
     // analysis could not fully cover OR could not fully attribute
-    // withholds the determinations that read the steps it missed.
-    fact.Classified.Receiver = M not in Unattributable and M not in Incomplete
-    fact.Classified.Returns  = true   // returnAlias is total: its top is Unknown
+    // withholds the determinations that read the steps it missed. A
+    // static's RecvNone reads no step, so no warning withholds it.
+    fact.Classified.Receiver = M.Kind != BuiltinMethod
+        or (M not in Unattributable and M not in Incomplete)
+    fact.Classified.Returns  = true   // returnAlias is total, top Unknown
     return fact
 
 func receiverKind(M):
@@ -1036,9 +1039,15 @@ its `returns` and loses only its `receiver`. That is §2's per-signal
 finding — a determination is unclassified only when a `yet` sits on a step
 it reads.
 
-The receiver axis cannot be recovered the same way. An opaque node carries
-no operands, so there is no way to tell what a missed step would have
-written, and the claim has to keep paying for incompleteness.
+A method's receiver mutability cannot be recovered the same way. An opaque
+node carries no operands, so there is no way to tell what a missed step
+would have written, and that claim has to keep paying for incompleteness.
+
+The carve-out is a static or a namespace function, whose `receiver: none`
+comes from `Func.Kind` and reads no algorithm step at all. No `yet` can
+sit on a step it reads, so a warning never withholds it. That takes 50
+builtins out of the unclassified set, leaving 31 methods whose mutability
+the analysis has to leave to the heuristics.
 
 The return-alias axis also tolerates `Unknown` on its own, since the alias
 lattice has a top. A missed step can itself be a return, and the join then
@@ -1061,9 +1070,13 @@ because the alias is curated rather than applied.
 - `Set.prototype.union` — the prose step `Let resultSetData be a copy of
   O.[[SetData]]` leaves a possible receiver write unread, so no
   `receiver`; the Set it allocates and hands back ⇒ `returns: fresh`.
+- `Array.of` — `Construct(C, …)` leaves a write unattributable, but a
+  static has no receiver either way ⇒ `receiver: none`, `returns:
+  unknown`.
 
 Methods with a withheld receiver are listed. The `returns` tally spans
-every builtin, not only the ones that publish a receiver.
+every builtin, and the `receiver` tally leaves out only the 31 methods
+whose mutability is withheld.
 
 ## §5. Keying and join (FR7, FR15)
 
@@ -1877,9 +1890,11 @@ const (
 
 // Coverage says which determinations the analysis resolved. Each axis is
 // withheld on its own, so a method that hides a mutation still publishes
-// its return alias (§4.3).
+// its return alias (§4.3). An axis a warning cannot bear on is always
+// covered: a static's "receiver": "none" comes from the function kind,
+// not from a step (§4.3).
 type Coverage struct {
-    Receiver bool `json:"receiver"` // whole algorithm read and every write placed
+    Receiver bool `json:"receiver"` // §4.3; always set for a static
     Returns  bool `json:"returns"`  // returnAlias ran; true for every builtin
     Params   bool `json:"params"`   // §8.1
     Throws   bool `json:"throws"`   // §9.2

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1892,9 +1892,8 @@ const (
 
 // Coverage says which determinations the analysis resolved. Each axis is
 // withheld on its own, so a method that hides a mutation still publishes
-// its return alias (§4.3). An axis a warning cannot bear on is always
-// covered: a static's "receiver": "none" comes from the function kind,
-// not from a step (§4.3).
+// its return alias. An axis no step decides is always covered, such as a
+// static's "receiver": "none" (§4.3).
 type Coverage struct {
     Receiver bool `json:"receiver"` // §4.3; always set for a static
     Returns  bool `json:"returns"`  // returnAlias ran; true for every builtin
@@ -1906,10 +1905,8 @@ type Coverage struct {
 // The effect fields are pointers/slices so an uncovered determination is
 // ABSENT (JSON null or omitted) — an unanalyzed axis, distinct from a
 // proven-empty result, which is covered with an empty effect field. The
-// three slices carry no omitempty for that reason. omitempty drops an
-// empty slice, which would spell a covered determination with nothing to
-// report as an unanalyzed one. An uncovered slice encodes as null, and a
-// covered empty one as [].
+// three slices carry no omitempty, which would drop the [] that spells
+// that second case. Uncovered they encode as null.
 type MethodFact struct {
     Classified Coverage      `json:"classified"`           // per-determination coverage (FR5)
     Receiver   *ReceiverKind `json:"receiver,omitempty"`   // borrow | mutBorrow | none (FR2)

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -608,11 +608,13 @@ it knows something escaped but not what. `Incomplete` means the analysis
 could not see the whole algorithm: an `Opaque` node the serializer could
 not lower, which is a prose step from §3, a `Call` to a callee that is
 absent from the CFG and named by neither internal-method table, or a
-mutation phrasing outside the FR1 vocabulary. Either withholds a method's
-receiver claim (§4.3), so FR5's heuristic fall-through decides receiver
-mutability rather than the analysis emitting a claim it cannot stand
-behind. Neither withholds the return alias, and neither reaches a static
-or a namespace function, which has no receiver to claim.
+mutation phrasing outside the FR1 vocabulary. Either can land on any
+function the analysis reads. A warning withholds a receiver claim only for
+a `BuiltinMethod` (§4.3), where FR5's heuristic fall-through then decides
+the mutability rather than the analysis emitting a claim it cannot stand
+behind. A static or a namespace function has no receiver to claim, so a
+warning leaves its `receiver: none` standing. `Array.of` is unattributable
+and publishes it. Neither warning withholds the return alias.
 
 **How the seed works, and why it is not inlining.** The seed entries are the
 fixpoint's base cases. The analysis never invents a mutation; it only carries
@@ -1903,15 +1905,19 @@ type Coverage struct {
 
 // The effect fields are pointers/slices so an uncovered determination is
 // ABSENT (JSON null or omitted) — an unanalyzed axis, distinct from a
-// proven-empty result, which is covered with an empty effect field.
+// proven-empty result, which is covered with an empty effect field. The
+// three slices carry no omitempty for that reason. omitempty drops an
+// empty slice, which would spell a covered determination with nothing to
+// report as an unanalyzed one. An uncovered slice encodes as null, and a
+// covered empty one as [].
 type MethodFact struct {
     Classified Coverage      `json:"classified"`           // per-determination coverage (FR5)
     Receiver   *ReceiverKind `json:"receiver,omitempty"`   // borrow | mutBorrow | none (FR2)
-    Params     []ParamFact   `json:"params,omitempty"`     // only non-borrow parameters (FR12)
+    Params     []ParamFact   `json:"params"`               // only non-borrow parameters (FR12)
     Returns    *AliasKind    `json:"returns,omitempty"`    // return-borrow lifetime seed (FR4)
     ParamIndex *int          `json:"paramIndex,omitempty"` // set exactly when Returns == "param"
-    Throws     []string      `json:"throws,omitempty"`     // sync throws post-filter (FR10, FR11)
-    Rejects    []string      `json:"rejects,omitempty"`    // async rejects → Promise<T,E>.Err (FR13)
+    Throws     []string      `json:"throws"`               // sync throws post-filter (FR10, FR11)
+    Rejects    []string      `json:"rejects"`              // async rejects → Promise<T,E>.Err (FR13)
 }
 ```
 
@@ -1927,9 +1933,9 @@ at the FR7 join to throws polymorphism; or the sentinel `"unknown"` for a
 propagated value the analysis can neither name nor trace. All origin and
 effect refs resolve to types at the FR7 join. An entry carries no receiver,
 disposition, throw, or reject claim its `classified` coverage does not
-cover — those fields are absent, not empty — so the converter cannot
-mistake "unanalyzed" for "proven none"; it applies the FR5 default for
-that axis itself. A method whose `receiver` is uncovered falls through to
+cover — those fields are absent or null, never empty — so the converter
+cannot mistake "unanalyzed" for "proven none"; it applies the FR5 default
+for that axis itself. A method whose `receiver` is uncovered falls through to
 the name heuristics and is collected into a separate `unclassified` report
 alongside `facts.json` for auditing (FR5). Where `classified.params` is
 set, a parameter absent from `Params` was proven read-only (`&`) — not to

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -72,11 +72,11 @@ name heuristics.
 - **Throws as a finished, unreviewed annotation.** Emitting the throw
   set is an in-scope deliverable (FR10, FR11), but it ships as a reviewed
   candidate set, not a trusted final annotation. The review need is not
-  that the extraction is inaccurate — for a classified method FR10's
-  *raw* throw set is a sound, complete enumeration of what ECMA-262 models
-  the algorithm as throwing, and could ship unreviewed at the cost of
-  noise. Review guards the two things downstream of that, both properties
-  of the coercion filter (FR11):
+  that the extraction is inaccurate — where `classified.throws` is set,
+  FR10's *raw* throw set is a sound, complete enumeration of what
+  ECMA-262 models the algorithm as throwing, and could ship unreviewed at
+  the cost of noise. Review guards the two things downstream of that,
+  both properties of the coercion filter (FR11):
   - **The filter can under-report.** Making the raw set usable means
     *narrowing* it — dropping coercion `TypeError`s — and narrowing is the
     unsound direction: a dropped real throw yields a `throws` clause too
@@ -458,10 +458,12 @@ merely stricter.
 
 **Conservative defaults — assume the effect when uncertain:**
 
-- A method the analysis cannot classify — prose-only algorithm, host-
+- A determination the analysis cannot make — a prose-only algorithm, host-
   defined behavior, an unrecognized mutation phrasing — is emitted as
-  **unclassified**, not as a guess. Unclassified methods fall through to
-  the existing name heuristics and hand-curation in the converter.
+  **unclassified**, not as a guess. Coverage is per determination, so a
+  method withholds only the axes that read the step it could not resolve.
+  An unclassified determination falls through to the existing name
+  heuristics and hand-curation in the converter.
 - Receiver mutability defaults to **mutating** (`&mut self`) when
   unclassified, consistent with the interop core principle "default to
   mutating"
@@ -499,17 +501,24 @@ impractical:**
   accepting that this is the unsound direction, and both are curation-grade
   and gated by the FR14 validation before they could ever auto-apply.
 
-These defaults are applied by the **converter**, not serialized as
-facts. A `classified: false` record omits its effect fields — `receiver`,
-`params`, `throws`, `rejects` are absent (or null) on the wire — so the
-format never conflates "the analysis proved this method borrows and
-throws nothing" with "the analysis could not tell." A proven-empty result
-is `classified: true` with empty effect fields; an unanalyzed method is
-`classified: false` with the effect fields absent. FR6 and Appendix B use
-this one contract.
+These defaults are applied by the **converter**, not serialized as facts.
+A record's `classified` object marks each determination covered or not,
+and an uncovered one omits its field — `receiver`, `params`, `throws`,
+`rejects` are absent, or null, on the wire. So the format never conflates
+"the analysis proved this method borrows and throws nothing" with "the
+analysis could not tell." A proven-empty result is a covered determination
+with an empty effect field; an unanalyzed one is an uncovered
+determination with its field absent. FR6 and Appendix B use this one
+contract.
 
-Every unclassified method is reported by name so the gap is visible and
-auditable rather than silent.
+Splitting coverage this way keeps the conservative bias where it buys
+safety and drops it where it does not. `receiver` is auto-applied, so a
+missed mutation must cost the claim. `returns` is FR4's lifetime seed,
+recorded for curation rather than applied, so a method whose only problem
+is a possible hidden mutation still publishes it.
+
+Every method with an unclassified receiver is reported by name so the gap
+is visible and auditable rather than silent.
 
 ### FR6. Output contract
 
@@ -518,26 +527,34 @@ name. Each entry records the five determinations and the tier-relevant
 provenance. `receiver` is `borrow` (`&self`), `mutBorrow` (`&mut self`),
 or `none` (a static or namespace function with no receiver). `params`
 lists only the parameters the analysis found `mutBorrow` (`&mut`) or
-`escape` (stored into the receiver, spelled at curation — see FR12); a
-parameter omitted from a *classified* method's entry was proven read-only
-(`borrow`). That proven-read-only omission is distinct from the FR5
+`escape` (stored into the receiver, spelled at curation — see FR12).
+Where `classified.params` is set, a parameter omitted from the entry was
+proven read-only (`borrow`). That proven-read-only omission is distinct
+from the FR5
 uncertain default, which is `&mut`: the omission means "the analysis
-showed this parameter is only read," whereas the FR5 default applies to an
-*unclassified* method whose parameters are absent entirely.
+showed this parameter is only read," whereas the FR5 default applies where
+`classified.params` is unset and the parameters are absent entirely.
 
 ```json
 {
-  "Array.prototype.push":  { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"}], "returns": "fresh",    "throws": [], "rejects": [], "classified": true },
-  "Array.prototype.fill":  { "receiver": "mutBorrow", "params": [],                                    "returns": "receiver", "throws": [], "rejects": [], "classified": true },
-  "Array.prototype.slice": { "receiver": "borrow",    "params": [],                                    "returns": "fresh",    "throws": [], "rejects": [], "classified": true },
-  "Map.prototype.set":     { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"},{"index":1,"disposition":"escape"}], "returns": "receiver", "throws": [], "rejects": [], "classified": true },
-  "Number.prototype.toFixed": { "receiver": "borrow", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": true },
+  "Array.prototype.push":  { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"}], "returns": "fresh",    "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+  "Array.prototype.fill":  { "receiver": "mutBorrow", "params": [],                                    "returns": "receiver", "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+  "Array.prototype.slice": { "receiver": "borrow",    "params": [],                                    "returns": "fresh",    "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+  "Map.prototype.set":     { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"},{"index":1,"disposition":"escape"}], "returns": "receiver", "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+  "Number.prototype.toFixed": { "receiver": "borrow", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
 
-  "Reflect.set":              { "receiver": "none", "params": [{"index":0,"disposition":"mutBorrow"},{"index":2,"disposition":"escape"}], "returns": "fresh", "throws": [], "rejects": [], "classified": true },
-  "Intl.getCanonicalLocales": { "receiver": "none", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": true }
+  "Reflect.set":              { "receiver": "none", "params": [{"index":0,"disposition":"mutBorrow"},{"index":2,"disposition":"escape"}], "returns": "fresh", "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+  "Intl.getCanonicalLocales": { "receiver": "none", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+
+  "String.prototype.toLowerCase": { "returns": "unknown", "classified": {"receiver":false,"params":false,"returns":true,"throws":false,"rejects":false} }
 }
 ```
 
+- `classified` marks each determination covered or not, and an uncovered
+  one leaves its field out. `String.prototype.toLowerCase` reaches the
+  Unicode case-mapping table through a prose step, so the analysis cannot
+  say what that step wrote and the entry carries no `receiver`. The return
+  alias survives, because FR4 curates it rather than applying it.
 - `receiver` maps a non-mutating method to `&self` and a mutating one to
   `&mut self` (FR2). A method that stores an argument into the receiver
   marks that parameter `escape`, because the argument outlives the call
@@ -588,9 +605,10 @@ The key space therefore covers prototype methods
 (`X.prototype.method`), static methods (`X.method`), symbol-keyed
 methods, and namespace-qualified forms where `X` is a dotted path naming
 a namespace and optionally a nested constructor — all joined by FR7.
-`classified: false` marks the FR5 fall-through entries; their effect
-fields (`receiver`, `params`, `throws`, `rejects`) are absent, distinct
-from a proven-empty result (§FR5).
+The `classified` object marks each determination covered or not. An
+uncovered one is an FR5 fall-through, and its field — `receiver`,
+`params`, `throws`, or `rejects` — is absent, distinct from a proven-empty
+result (§FR5).
 
 ### FR7. Keying and join to typed declarations
 
@@ -1013,8 +1031,9 @@ types and arity.
   requires the JVM toolchain, scoped to `tools/spec-extract/` via a
   per-directory `mise.toml`.
 - **Auditability.** Every classification carries its provenance, and
-  every unclassified method is listed, so a reviewer can see exactly
-  which methods the spec proved and which fell through to heuristics.
+  every method with an unclassified receiver is listed, so a reviewer can
+  see exactly which methods the spec proved and which fell through to
+  heuristics.
 
 ## Coverage and limitations
 
@@ -1028,8 +1047,9 @@ types and arity.
   out of range, `Array(-1)`) is a tracked domain throw. The exclusion is
   what keeps the throw sets ergonomic and removes a would-be permanent
   blocker to the FR14 auto-apply gate.
-- A handful of algorithms are prose-only or host-defined and fall
-  through to the name heuristic per FR5.
+- A handful of algorithms are prose-only or host-defined, so their
+  receiver falls through to the name heuristic per FR5. The return alias
+  is published regardless, since FR4 curates it rather than applying it.
 - Generic and array-like receivers operate on `O ← ? ToObject(this
   value)`; the analysis treats `ToObject(this value)` as
   receiver-origin so that a write to `O` is a write to the receiver.

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -462,8 +462,10 @@ merely stricter.
   defined behavior, an unrecognized mutation phrasing — is emitted as
   **unclassified**, not as a guess. Coverage is per determination, so a
   method withholds only the axes that read the step it could not resolve.
-  An unclassified determination falls through to the existing name
-  heuristics and hand-curation in the converter.
+  An axis that reads no step is never withheld: a static and a namespace
+  function have `receiver: none` whatever the analysis missed. An
+  unclassified determination falls through to the existing name heuristics
+  and hand-curation in the converter.
 - Receiver mutability defaults to **mutating** (`&mut self`) when
   unclassified, consistent with the interop core principle "default to
   mutating"
@@ -512,13 +514,15 @@ determination with its field absent. FR6 and Appendix B use this one
 contract.
 
 Splitting coverage this way keeps the conservative bias where it buys
-safety and drops it where it does not. `receiver` is auto-applied, so a
-missed mutation must cost the claim. `returns` is FR4's lifetime seed,
-recorded for curation rather than applied, so a method whose only problem
-is a possible hidden mutation still publishes it.
+safety and drops it where it does not. A method's receiver mutability is
+auto-applied, so a missed mutation must cost that claim. `returns` is
+FR4's lifetime seed, recorded for curation rather than applied, so a
+method whose only problem is a possible hidden mutation still publishes
+it. A static's `receiver: none` reads no step at all, so nothing the
+analysis missed can put it in doubt.
 
-Every method with an unclassified receiver is reported by name so the gap
-is visible and auditable rather than silent.
+Every method whose receiver mutability is unclassified is reported by name
+so the gap is visible and auditable rather than silent.
 
 ### FR6. Output contract
 
@@ -554,7 +558,9 @@ showed this parameter is only read," whereas the FR5 default applies where
   one leaves its field out. `String.prototype.toLowerCase` reaches the
   Unicode case-mapping table through a prose step, so the analysis cannot
   say what that step wrote and the entry carries no `receiver`. The return
-  alias survives, because FR4 curates it rather than applying it.
+  alias survives, because FR4 curates it rather than applying it. A static
+  keeps `receiver: none` through the same warning, since its having no
+  receiver is a fact about the declaration rather than about a step.
 - `receiver` maps a non-mutating method to `&self` and a mutating one to
   `&mut self` (FR2). A method that stores an argument into the receiver
   marks that parameter `escape`, because the argument outlives the call
@@ -1031,9 +1037,9 @@ types and arity.
   requires the JVM toolchain, scoped to `tools/spec-extract/` via a
   per-directory `mise.toml`.
 - **Auditability.** Every classification carries its provenance, and
-  every method with an unclassified receiver is listed, so a reviewer can
-  see exactly which methods the spec proved and which fell through to
-  heuristics.
+  every method whose receiver mutability is unclassified is listed, so a
+  reviewer can see exactly which methods the spec proved and which fell
+  through to heuristics.
 
 ## Coverage and limitations
 
@@ -1047,9 +1053,10 @@ types and arity.
   out of range, `Array(-1)`) is a tracked domain throw. The exclusion is
   what keeps the throw sets ergonomic and removes a would-be permanent
   blocker to the FR14 auto-apply gate.
-- A handful of algorithms are prose-only or host-defined, so their
-  receiver falls through to the name heuristic per FR5. The return alias
-  is published regardless, since FR4 curates it rather than applying it.
+- A handful of algorithms are prose-only or host-defined, so a method
+  among them has its receiver mutability fall through to the name
+  heuristic per FR5. The return alias is published regardless, since FR4
+  curates it rather than applying it.
 - Generic and array-like receivers operate on `O ← ? ToObject(this
   value)`; the analysis treats `ToObject(this value)` as
   receiver-origin so that a write to `O` is a write to the receiver.


### PR DESCRIPTION
Fixes #1281.

This change refactors how the analysis reports coverage of builtin method facts. Instead of a single `Classified` boolean flag, facts now carry a `Coverage` struct that tracks which determinations (receiver mutability, return alias, etc.) the analysis resolved.

**Motivation:** The analysis withholds claims it cannot stand behind, but different determinations have different risk profiles. Receiver mutability is a soundness claim auto-applied by the converter, so a missed mutation must cost that claim. Return alias is FR4's lifetime seed, recorded for curation rather than applied, so a method whose only problem is a possible hidden mutation still publishes it. A static's `receiver: none` reads no algorithm step at all, so nothing the analysis missed can put it in doubt.

**Key changes:**

- Replace `Classified: bool` with `Classified: Coverage{Receiver, Returns}` in `MethodFact`. Each field tracks whether that determination was resolved.
- Add `receiverCovered()` to check whether a function's receiver claim can be decided from the analysis. Statics and namespace functions always have coverage (their `receiver: none` follows from `Func.Kind`, not from steps read). Methods need the mutation fixpoint to have read the whole algorithm.
- Update `NewFacts()` to set coverage per determination. Methods with `Unattributable` or `Incomplete` warnings now withhold only the receiver claim, keeping their return alias.
- Update `Unclassified()` to report only methods whose receiver claim is withheld, not empty facts. These methods still publish their return alias.
- Update `MethodFact.String()` to render only covered determinations, omitting uncovered ones from the output.
- Update test expectations: methods like `Set.prototype.union` and `String.prototype.toLowerCase` now render as `returns:fresh` and `returns:unknown` respectively, instead of `unclassified`. `Array.of` renders as `receiver:none returns:unknown` since statics always have receiver coverage.

The plan's §4.3 and Appendix B and the FR5 and FR6 text in `requirements.md` describe the same split.

**Tallies.** The `returns` distribution now spans all 501 builtins rather than the 420 that publish a receiver, and 52 of the 81 methods that previously carried no claim have a resolvable `fresh` alias:

```
receiver borrow: 225 / mutBorrow: 57 / none: 188 / unclassified: 31
returns fresh: 229 / param: 6 / receiver: 15 / union: 1 / unknown: 250
total: 501
```

The snapshot of unclassified methods shrinks from 81 to 31, removing the 50 statics and namespace functions, which keep `receiver: none` through any warning. The 31 that remain are all methods whose mutability the analysis genuinely cannot decide.

https://claude.ai/code/session_01YUvu3qrofazuzoRpT17VTv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Classification now reports receiver and return coverage independently.
  * Return aliases remain available even when receiver analysis is incomplete.
  * Static and namespace functions explicitly report no receiver effects.
  * Classification output now includes covered parameter alias indices and marks facts without coverage as unclassified.

* **Documentation**
  * Updated schemas, requirements, examples, and implementation guidance to describe per-determination coverage and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->