### PR TITLE
Record each converted declaration's runtime path

### DIFF
--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -36,6 +36,12 @@ import (
 type StandaloneModule struct {
 	Module *ast.Module
 	Docs   map[ast.Decl]string
+	// Paths maps each emitted declaration to its dotted runtime path — the
+	// same string the `@js("...")` decorator carries, kept as a side map so
+	// the declarations that erase at codegen have one too. `InterfaceDecl`
+	// and `TypeDecl` carry no Decorators field by design (§3.3), yet the
+	// ECMA-262 join still has to address the members an interface declares.
+	Paths map[ast.Decl]string
 }
 
 // ConvertToStandaloneModule converts a dts_parser.Module to a form
@@ -58,11 +64,14 @@ type StandaloneModule struct {
 //   - Preserves the source's leading JSDoc on each top-level decl (see
 //     StandaloneModule.Docs); trio fusion takes the doc from the
 //     instance interface (the constructor interface's doc is dropped).
+//   - Records each emitted decl's dotted runtime path (see
+//     StandaloneModule.Paths).
 func ConvertToStandaloneModule(dtsModule *dts_parser.Module) (*StandaloneModule, error) {
 	cctx := &convertCtx{}
 	trios := detectTrios(dtsModule.Statements)
 	singletons := detectSingletons(dtsModule.Statements, trios)
 	docs := make(map[ast.Decl]string)
+	paths := make(map[ast.Decl]string)
 
 	var decls []ast.Decl
 	for _, stmt := range dtsModule.Statements {
@@ -75,6 +84,9 @@ func ConvertToStandaloneModule(dtsModule *dts_parser.Module) (*StandaloneModule,
 			if dd.doc != "" {
 				docs[dd.decl] = dd.doc
 			}
+			if dd.path != "" {
+				paths[dd.decl] = dd.path
+			}
 		}
 	}
 
@@ -83,13 +95,16 @@ func ConvertToStandaloneModule(dtsModule *dts_parser.Module) (*StandaloneModule,
 	return &StandaloneModule{
 		Module: ast.NewModule(namespaces),
 		Docs:   docs,
+		Paths:  paths,
 	}, nil
 }
 
-// docDecl pairs a converted top-level declaration with the JSDoc string
-// taken from its dts source statement (empty when there was none).
+// docDecl pairs a converted top-level declaration with the dotted runtime
+// path it is reached by and the JSDoc string taken from its dts source
+// statement. The JSDoc is empty when the source carried none.
 type docDecl struct {
 	doc  string
+	path string
 	decl ast.Decl
 }
 
@@ -353,16 +368,18 @@ func flattenSingleton(info *singletonInfo, jsBase string) ([]docDecl, error) {
 				return nil, fmt.Errorf("flattening singleton method %s.%s: %w",
 					info.iface.Name.Name, propertyKeyName(sig.Name), err)
 			}
-			attachJSDecorator(decl, jsBase+"."+propertyKeyName(sig.Name))
-			out = append(out, docDecl{doc: sig.Doc(), decl: decl})
+			path := jsBase + "." + propertyKeyName(sig.Name)
+			attachJSDecorator(decl, path)
+			out = append(out, docDecl{doc: sig.Doc(), path: path, decl: decl})
 		case *dts_parser.PropertySignature:
 			decl, err := singletonPropertyToVarDecl(sig)
 			if err != nil {
 				return nil, fmt.Errorf("flattening singleton property %s.%s: %w",
 					info.iface.Name.Name, propertyKeyName(sig.Name), err)
 			}
-			attachJSDecorator(decl, jsBase+"."+propertyKeyName(sig.Name))
-			out = append(out, docDecl{doc: sig.Doc(), decl: decl})
+			path := jsBase + "." + propertyKeyName(sig.Name)
+			attachJSDecorator(decl, path)
+			out = append(out, docDecl{doc: sig.Doc(), path: path, decl: decl})
 		}
 	}
 	return out, nil
@@ -732,11 +749,12 @@ func convertStandaloneStmt(
 			if err != nil {
 				return nil, fmt.Errorf("fusing trio for %s: %w", s.Name.Name, err)
 			}
-			attachJSDecorator(classDecl, jsName(nsPath, s.Name.Name))
+			path := jsName(nsPath, s.Name.Name)
+			attachJSDecorator(classDecl, path)
 			// Trio class doc comes from the instance interface; the
 			// constructor interface's doc (if any) is dropped — the
 			// instance side is the one users see and document.
-			return []docDecl{{doc: info.instance.Doc(), decl: classDecl}}, nil
+			return []docDecl{{doc: info.instance.Doc(), path: path, decl: classDecl}}, nil
 		}
 		if singletons != nil {
 			if info, ok := singletons.byName[s.Name.Name]; ok {
@@ -750,9 +768,10 @@ func convertStandaloneStmt(
 		if decl == nil {
 			return nil, nil
 		}
-		attachJSDecorator(decl, jsName(nsPath, s.Name.Name))
+		path := jsName(nsPath, s.Name.Name)
+		attachJSDecorator(decl, path)
 		decl.SetExport(true)
-		return []docDecl{{doc: s.Doc(), decl: decl}}, nil
+		return []docDecl{{doc: s.Doc(), path: path, decl: decl}}, nil
 
 	case *dts_parser.VarDecl:
 		if trios.consumedVar.Contains(s.Name.Name) {
@@ -765,18 +784,20 @@ func convertStandaloneStmt(
 		if err != nil {
 			return nil, err
 		}
-		attachJSDecorator(decl, jsName(nsPath, s.Name.Name))
+		path := jsName(nsPath, s.Name.Name)
+		attachJSDecorator(decl, path)
 		decl.SetExport(true)
-		return []docDecl{{doc: s.Doc(), decl: decl}}, nil
+		return []docDecl{{doc: s.Doc(), path: path, decl: decl}}, nil
 
 	case *dts_parser.FuncDecl:
 		decl, err := convertFuncDecl(s)
 		if err != nil {
 			return nil, err
 		}
-		attachJSDecorator(decl, jsName(nsPath, s.Name.Name))
+		path := jsName(nsPath, s.Name.Name)
+		attachJSDecorator(decl, path)
 		decl.SetExport(true)
-		return []docDecl{{doc: s.Doc(), decl: decl}}, nil
+		return []docDecl{{doc: s.Doc(), path: path, decl: decl}}, nil
 
 	case *dts_parser.TypeDecl:
 		decl, err := convertTypeDecl(s)
@@ -786,18 +807,20 @@ func convertStandaloneStmt(
 		if decl == nil {
 			return nil, nil
 		}
-		attachJSDecorator(decl, jsName(nsPath, s.Name.Name))
+		path := jsName(nsPath, s.Name.Name)
+		attachJSDecorator(decl, path)
 		decl.SetExport(true)
-		return []docDecl{{doc: s.Doc(), decl: decl}}, nil
+		return []docDecl{{doc: s.Doc(), path: path, decl: decl}}, nil
 
 	case *dts_parser.ClassDecl:
 		decl, err := convertClassDecl(cctx, s)
 		if err != nil {
 			return nil, err
 		}
-		attachJSDecorator(decl, jsName(nsPath, s.Name.Name))
+		path := jsName(nsPath, s.Name.Name)
+		attachJSDecorator(decl, path)
 		decl.SetExport(true)
-		return []docDecl{{doc: s.Doc(), decl: decl}}, nil
+		return []docDecl{{doc: s.Doc(), path: path, decl: decl}}, nil
 
 	case *dts_parser.EnumDecl, *dts_parser.ImportDecl,
 		*dts_parser.NamedExportStmt, *dts_parser.ExportAllStmt,

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -482,3 +482,47 @@ declare function f(x: void, p: Promise<void>, cb: (v: number) => void): void;
 	require.Contains(t, printed,
 		"fn f(x: never, p: Promise<undefined>, cb: fn (v: number) -> unknown) -> unknown")
 }
+
+// The converter records a runtime path for every declaration it emits,
+// including the ones that carry no `@js` decorator because they erase at
+// codegen. `InterfaceDecl` and `TypeDecl` have no Decorators field, so the
+// side map is the only place their path survives.
+func TestStandaloneModuleRecordsPaths(t *testing.T) {
+	t.Parallel()
+
+	mod, err := ConvertToStandaloneModule(parseLib(t, "lib.test.d.ts", `
+declare namespace Intl {
+    interface Collator { compare(x: string): number; }
+    function getCanonicalLocales(locales?: string): string[];
+}
+interface ConcatArray<T> { join(separator?: string): string; }
+declare function parseInt(s: string): number;
+`).Module)
+	require.NoError(t, err)
+
+	paths := map[string]string{}
+	mod.Module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		for _, decl := range ns.Decls {
+			paths[declName(decl)] = mod.Paths[decl]
+		}
+		return true
+	})
+	require.Equal(t, map[string]string{
+		"Collator":            "Intl.Collator",
+		"getCanonicalLocales": "Intl.getCanonicalLocales",
+		"ConcatArray":         "ConcatArray",
+		"parseInt":            "parseInt",
+	}, paths)
+}
+
+func declName(decl ast.Decl) string {
+	switch d := decl.(type) {
+	case *ast.InterfaceDecl:
+		return d.Name.Name
+	case *ast.FuncDecl:
+		return d.Name.Name
+	case *ast.ClassDecl:
+		return d.Name.Name
+	}
+	return ""
+}

--- a/internal/dts_to_esc/partition_writer.go
+++ b/internal/dts_to_esc/partition_writer.go
@@ -581,8 +581,35 @@ func appendReadonlyAliases(mod *StandaloneModule, twins []readonlyTwin) {
 //
 // Returns a sorted list of the URIs written, for caller-side reporting.
 func WritePartitionedTree(result *PartitionResult, outDir string) ([]string, error) {
-	uris := make([]string, 0, len(result.Buckets))
-	for uri := range result.Buckets {
+	mods, err := ConvertBuckets(result)
+	if err != nil {
+		return nil, err
+	}
+	return WriteConvertedTree(mods, outDir)
+}
+
+// ConvertBuckets converts every bucket in result, keyed by package URI.
+// Callers that need the converted modules for something other than writing
+// them — the ECMA-262 join reads them for the members each package declares —
+// go through this instead of converting a second time.
+func ConvertBuckets(result *PartitionResult) (map[string]*StandaloneModule, error) {
+	mods := make(map[string]*StandaloneModule, len(result.Buckets))
+	for uri, stmts := range result.Buckets {
+		mod, err := ConvertBucket(stmts)
+		if err != nil {
+			return nil, fmt.Errorf("converting bucket %s: %w", uri, err)
+		}
+		mods[uri] = mod
+	}
+	return mods, nil
+}
+
+// WriteConvertedTree writes each converted module to its package file under
+// outDir, creating parent directories as needed. Returns the package URIs
+// written, sorted.
+func WriteConvertedTree(mods map[string]*StandaloneModule, outDir string) ([]string, error) {
+	uris := make([]string, 0, len(mods))
+	for uri := range mods {
 		uris = append(uris, uri)
 	}
 	sort.Strings(uris)
@@ -591,14 +618,11 @@ func WritePartitionedTree(result *PartitionResult, outDir string) ([]string, err
 	for _, uri := range uris {
 		pkg, ok := PackageForURI(uri)
 		if !ok {
-			return nil, fmt.Errorf("WritePartitionedTree: unknown package URI %q "+
+			return nil, fmt.Errorf("WriteConvertedTree: unknown package URI %q "+
 				"(every bucket should come from Route, which only returns "+
 				"URIs in PackageList)", uri)
 		}
-		mod, err := ConvertBucket(result.Buckets[uri])
-		if err != nil {
-			return nil, fmt.Errorf("converting bucket %s: %w", uri, err)
-		}
+		mod := mods[uri]
 		dest := filepath.Join(outDir, filepath.FromSlash(pkg.File))
 		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 			return nil, fmt.Errorf("creating package dir for %s: %w", uri, err)

--- a/internal/dts_to_esc/partition_writer_test.go
+++ b/internal/dts_to_esc/partition_writer_test.go
@@ -555,3 +555,59 @@ func TestReportPartition_FormatsSortedSummary(t *testing.T) {
 	// Sorted: std comes before web.
 	require.Less(t, strings.Index(out, "std:array"), strings.Index(out, "web:dom"))
 }
+
+// WritePartitionedTree is ConvertBuckets followed by WriteConvertedTree. A
+// caller that needs the converted modules for something other than writing
+// them runs the two halves itself, which must land the same files.
+func TestConvertBucketsAndWriteConvertedTree(t *testing.T) {
+	t.Parallel()
+	es5 := parseLib(t, "lib.es5.d.ts", `
+interface Array<T> { length: number; }
+interface ArrayConstructor { new <T>(): Array<T>; readonly prototype: Array<any>; }
+declare var Array: ArrayConstructor;
+declare namespace Math {
+    function abs(x: number): number;
+}
+`)
+	res, err := PartitionLib([]LibInput{es5})
+	require.NoError(t, err)
+
+	mods, err := ConvertBuckets(res)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"std:array", "std:math"}, keysOf(mods))
+
+	split := t.TempDir()
+	written, err := WriteConvertedTree(mods, split)
+	require.NoError(t, err)
+	require.Equal(t, []string{"std:array", "std:math"}, written)
+
+	whole := t.TempDir()
+	_, err = WritePartitionedTree(res, whole)
+	require.NoError(t, err)
+
+	for _, rel := range []string{"std/array.esc", "std/math.esc"} {
+		fromSplit, err := os.ReadFile(filepath.Join(split, filepath.FromSlash(rel)))
+		require.NoError(t, err)
+		fromWhole, err := os.ReadFile(filepath.Join(whole, filepath.FromSlash(rel)))
+		require.NoError(t, err)
+		require.Equal(t, string(fromWhole), string(fromSplit), "%s", rel)
+	}
+}
+
+// WriteConvertedTree only knows the package URIs Route produces, so a URI
+// from anywhere else is a caller bug rather than a package it should invent
+// a path for.
+func TestWriteConvertedTreeRejectsUnknownURI(t *testing.T) {
+	t.Parallel()
+	_, err := WriteConvertedTree(map[string]*StandaloneModule{"std:nope": nil}, t.TempDir())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unknown package URI "std:nope"`)
+}
+
+func keysOf(mods map[string]*StandaloneModule) []string {
+	out := make([]string, 0, len(mods))
+	for uri := range mods {
+		out = append(out, uri)
+	}
+	return out
+}


### PR DESCRIPTION
Refs #1198. First of four stacked PRs implementing §5 of [planning/ecma-262/implementation_plan.md](https://github.com/escalier-lang/escalier/blob/main/planning/ecma-262/implementation_plan.md).

Two pieces of converter plumbing the ECMA-262 join needs. Neither changes what the converter emits.

## `StandaloneModule.Paths`

A side map from each emitted declaration to the dotted runtime path it is reached by, the same string the `@js("...")` decorator carries.

The decorator is not enough on its own. `InterfaceDecl` and `TypeDecl` carry no `Decorators` field by design, since they erase at codegen, so `attachJSDecorator` is an intentional no-op for both. A caller that has to address the members an interface declares therefore has nowhere to read the path from. Most of the `std:*` surface arrives as an interface rather than a fused trio class — `Array` among them, because `ArrayConstructor`'s `new` returns `T[]` rather than `Array<T>` — so this is the common case, not the edge.

The side map mirrors the existing `Docs` one, which exists for the same reason: the Escalier AST carries no field for it and adding one would touch the printer and every snapshot.

## `ConvertBuckets` / `WriteConvertedTree`

`WritePartitionedTree` splits into the two halves and keeps its behavior as their composition. A caller that needs the converted modules for something other than writing them can now get them without converting the tree a second time.

## Review notes

- The `Paths` entries are set at the same call sites that already call `attachJSDecorator`, so the two cannot disagree about a declaration's path.
- The split adds a test asserting the two halves land byte-identical files to the whole, since the existing `WritePartitionedTree` tests only cover the composition.

## Stack

1. **this PR** — runtime paths and the converter split
2. `claude/issue-1198-utgo5n-2-normalizer` — spec-key normalizer
3. `claude/issue-1198-utgo5n-3-join` — fact index and join report
4. `claude/issue-1198-utgo5n-4-collect` — declaration collection and CLI wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149DmSiUpQBxw7XVPh7LXrW)_