### PR TITLE
Index ECMA-262 facts by member address and report both sides

### DIFF
--- a/internal/ecma262/join.go
+++ b/internal/ecma262/join.go
@@ -205,9 +205,9 @@ func (j *Join) Match(decls Declarations) JoinReport {
 	return report
 }
 
-// WriteJoinReport prints the join's counts and the names present on one side
-// only. The converter's operator reads it the way ReportPartition's summary
-// is read, as a list of gaps rather than a failure.
+// WriteJoinReport prints the join's counts and every name it could not match.
+// The converter's operator reads it the way ReportPartition's summary is read,
+// as a list of gaps rather than a failure.
 func WriteJoinReport(report JoinReport, w io.Writer) error {
 	classified := 0
 	for _, m := range report.Matched {
@@ -233,6 +233,11 @@ func WriteJoinReport(report JoinReport, w io.Writer) error {
 	}
 	for _, path := range report.UnkeyedDecls {
 		if _, err := fmt.Fprintf(w, "    unkeyed declaration: %s\n", path); err != nil {
+			return err
+		}
+	}
+	for _, name := range report.UnjoinableFacts {
+		if _, err := fmt.Fprintf(w, "    unjoinable fact: %s\n", name); err != nil {
 			return err
 		}
 	}

--- a/internal/ecma262/join.go
+++ b/internal/ecma262/join.go
@@ -1,0 +1,240 @@
+package ecma262
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Signature is the declared parameter shape of one overload, which is all the
+// join needs from the type source. Params counts the declared parameters,
+// excluding a receiver. Rest is true when the last declared parameter takes
+// the remaining arguments, so every position from Params-1 onward exists.
+type Signature struct {
+	Params int
+	Rest   bool
+}
+
+// Holds reports whether the signature declares a parameter at the 0-based
+// position pos.
+func (s Signature) Holds(pos int) bool {
+	if pos < 0 {
+		return false
+	}
+	if s.Rest && s.Params > 0 {
+		// The last declared parameter takes every remaining argument, so no
+		// position past it is missing.
+		return true
+	}
+	return pos < s.Params
+}
+
+// ForSignature resolves the position-keyed parts of a fact against one
+// overload. A spec algorithm maps to a single member even where the type
+// source declares an overload set, so the algorithm-level claims apply to
+// every signature unchanged. A claim that names a parameter position applies
+// only to a signature that declares that position; where it does not, the
+// return alias drops to AliasUnknown, since the value handed back is one the
+// signature cannot name.
+func (f MethodFact) ForSignature(s Signature) MethodFact {
+	if f.Returns != AliasParam {
+		return f
+	}
+	if f.ParamIndex != nil && s.Holds(*f.ParamIndex) {
+		return f
+	}
+	f.Returns = AliasUnknown
+	f.ParamIndex = nil
+	return f
+}
+
+// Declaration is one member the type source declares. Signatures holds one
+// entry per overload, in declaration order, so a fact's position-keyed parts
+// resolve per overload while its algorithm-level parts apply to all of them.
+type Declaration struct {
+	Ref        MemberRef
+	Signatures []Signature
+}
+
+// Declarations is the member surface one type source declares, split by
+// whether a canonical spec key can name it.
+type Declarations struct {
+	// Keyed holds the members a MemberRef addresses.
+	Keyed []Declaration
+	// Unkeyed holds the dotted runtime paths that name no member of an
+	// owner, so no fact can address them. The functions the global object
+	// holds sit here, `parseInt` and `isNaN` among them. Their spec names
+	// sit in the report's UnjoinableFacts for the same reason.
+	Unkeyed []string
+}
+
+// Match is one declaration joined to the fact for its spec algorithm.
+type Match struct {
+	Decl     Declaration
+	SpecName string
+	Fact     MethodFact
+	// PerSignature is Fact resolved against each of Decl.Signatures, in the
+	// same order.
+	PerSignature []MethodFact
+}
+
+// ReceiverApplies reports whether the join may write the fact's receiver
+// claim onto the declaration. A spec getter or setter carries a fixed
+// mutability the converter already sets, so the join leaves it alone.
+func (m Match) ReceiverApplies() bool {
+	return m.Decl.Ref.Accessor == NotAccessor
+}
+
+// JoinReport is one run of the join. Every list but Matched is
+// informational. The spec and the TypeScript lib drift independently, so a
+// name on one side only is a gap to close rather than an error.
+type JoinReport struct {
+	// Matched holds every declaration a fact addresses.
+	Matched []Match
+	// DeclsWithoutFact holds the declarations no fact addresses, sorted.
+	DeclsWithoutFact []MemberRef
+	// FactsWithoutDecl holds the canonical spec names no declaration
+	// addresses, sorted.
+	FactsWithoutDecl []string
+	// UnjoinableFacts holds the spec names no declaration can ever reach,
+	// sorted. Two things land a name here. Normalize refuses it, which
+	// covers the bare globals and the closures an algorithm defines. Or the
+	// MemberRef it normalizes to is already claimed by another name. Either
+	// way the name is counted apart from FactsWithoutDecl, which holds names
+	// a declaration merely failed to claim.
+	UnjoinableFacts []string
+	// UnkeyedDecls holds the declared runtime paths no canonical spec key
+	// names, sorted. They are the declaration-side counterpart of the
+	// Normalize refusals in UnjoinableFacts.
+	UnkeyedDecls []string
+}
+
+// Join indexes classified facts by the MemberRef that addresses them, so a
+// converted member can resolve its fact by name alone. The index carries no
+// types, which is what keeps it valid whether the declarations come from a
+// `.d.ts` today or from committed `.esc` later.
+type Join struct {
+	byRef map[MemberRef]keyedFact
+	// unjoinable holds the spec names no declaration can reach, sorted.
+	unjoinable []string
+}
+
+// keyedFact is one indexed fact together with the canonical spec name it was
+// keyed from, which the report prints.
+type keyedFact struct {
+	name string
+	fact MethodFact
+}
+
+// NewJoin indexes facts by MemberRef. Spec names are indexed in sorted order,
+// so when two of them normalize to the same MemberRef the first one wins, the
+// second joins the unjoinable list, and the index stays the same across runs.
+func NewJoin(facts *Facts) *Join {
+	names := make([]string, 0, len(facts.Methods))
+	for name := range facts.Methods {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	j := &Join{byRef: make(map[MemberRef]keyedFact, len(names))}
+	for _, name := range names {
+		ref, ok := Normalize(name)
+		if !ok {
+			j.unjoinable = append(j.unjoinable, name)
+			continue
+		}
+		if _, taken := j.byRef[ref]; taken {
+			j.unjoinable = append(j.unjoinable, name)
+			continue
+		}
+		j.byRef[ref] = keyedFact{name: name, fact: facts.Methods[name]}
+	}
+	sort.Strings(j.unjoinable)
+	return j
+}
+
+// Lookup returns the canonical spec name and the fact that address ref.
+func (j *Join) Lookup(ref MemberRef) (string, MethodFact, bool) {
+	keyed, ok := j.byRef[ref]
+	if !ok {
+		return "", MethodFact{}, false
+	}
+	return keyed.name, keyed.fact, true
+}
+
+// Match joins decls against the index and reports both sides. Each
+// declaration is looked up by its MemberRef, and the accessor tag it carries
+// reaches the caller through Match.ReceiverApplies.
+//
+// A declaration that names an accessor still resolves, because the spec keys
+// `get Map.prototype.size` as its own algorithm. Refusing it here would
+// report it as a gap rather than as the deliberate carve-out it is.
+func (j *Join) Match(decls Declarations) JoinReport {
+	var report JoinReport
+	claimed := make(map[string]bool, len(decls.Keyed))
+
+	for _, decl := range decls.Keyed {
+		name, fact, ok := j.Lookup(decl.Ref)
+		if !ok {
+			report.DeclsWithoutFact = append(report.DeclsWithoutFact, decl.Ref)
+			continue
+		}
+		claimed[name] = true
+		match := Match{Decl: decl, SpecName: name, Fact: fact}
+		for _, sig := range decl.Signatures {
+			match.PerSignature = append(match.PerSignature, fact.ForSignature(sig))
+		}
+		report.Matched = append(report.Matched, match)
+	}
+
+	// Each name is indexed under at most one MemberRef, so iterating the
+	// index's values visits every keyed fact exactly once.
+	for _, keyed := range j.byRef {
+		if !claimed[keyed.name] {
+			report.FactsWithoutDecl = append(report.FactsWithoutDecl, keyed.name)
+		}
+	}
+	report.UnjoinableFacts = append(report.UnjoinableFacts, j.unjoinable...)
+	report.UnkeyedDecls = append(report.UnkeyedDecls, decls.Unkeyed...)
+
+	sort.Slice(report.DeclsWithoutFact, func(a, b int) bool {
+		return report.DeclsWithoutFact[a].String() < report.DeclsWithoutFact[b].String()
+	})
+	sort.Strings(report.FactsWithoutDecl)
+	sort.Strings(report.UnkeyedDecls)
+	return report
+}
+
+// WriteJoinReport prints the join's counts and the names present on one side
+// only. The converter's operator reads it the way ReportPartition's summary
+// is read, as a list of gaps rather than a failure.
+func WriteJoinReport(report JoinReport, w io.Writer) error {
+	classified := 0
+	for _, m := range report.Matched {
+		if m.Fact.Classified {
+			classified++
+		}
+	}
+	_, err := fmt.Fprintf(w, "  join: %d matched (%d classified), %d declarations without a fact, %d facts without a declaration, %d unkeyed declarations, %d unjoinable facts\n",
+		len(report.Matched), classified, len(report.DeclsWithoutFact),
+		len(report.FactsWithoutDecl), len(report.UnkeyedDecls), len(report.UnjoinableFacts))
+	if err != nil {
+		return err
+	}
+	for _, ref := range report.DeclsWithoutFact {
+		if _, err := fmt.Fprintf(w, "    no fact: %s\n", ref); err != nil {
+			return err
+		}
+	}
+	for _, name := range report.FactsWithoutDecl {
+		if _, err := fmt.Fprintf(w, "    no declaration: %s\n", name); err != nil {
+			return err
+		}
+	}
+	for _, path := range report.UnkeyedDecls {
+		if _, err := fmt.Fprintf(w, "    unkeyed declaration: %s\n", path); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/ecma262/join.go
+++ b/internal/ecma262/join.go
@@ -209,14 +209,18 @@ func (j *Join) Match(decls Declarations) JoinReport {
 // The converter's operator reads it the way ReportPartition's summary is read,
 // as a list of gaps rather than a failure.
 func WriteJoinReport(report JoinReport, w io.Writer) error {
-	classified := 0
+	// A matched fact does not always carry a receiver claim. The mutation
+	// fixpoint withholds one it could not read whole, which is the
+	// determination §7 auto-applies, so the count is worth reporting apart
+	// from the match count.
+	withReceiver := 0
 	for _, m := range report.Matched {
-		if m.Fact.Classified {
-			classified++
+		if m.Fact.Classified.Receiver {
+			withReceiver++
 		}
 	}
-	_, err := fmt.Fprintf(w, "  join: %d matched (%d classified), %d declarations without a fact, %d facts without a declaration, %d unkeyed declarations, %d unjoinable facts\n",
-		len(report.Matched), classified, len(report.DeclsWithoutFact),
+	_, err := fmt.Fprintf(w, "  join: %d matched (%d with a receiver claim), %d declarations without a fact, %d facts without a declaration, %d unkeyed declarations, %d unjoinable facts\n",
+		len(report.Matched), withReceiver, len(report.DeclsWithoutFact),
 		len(report.FactsWithoutDecl), len(report.UnkeyedDecls), len(report.UnjoinableFacts))
 	if err != nil {
 		return err

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -148,9 +148,9 @@ func TestJoinLookup(t *testing.T) {
 	}
 }
 
-// The accessor tag is not part of the address, so a plain method never
-// resolves to the getter of the same name and the getter never resolves to a
-// method's fact.
+// The accessor tag is part of the address, so a lookup resolves only against a
+// fact whose accessor matches. A plain method never picks up the fact for the
+// getter of the same name, and a getter never picks up a method's.
 func TestJoinLookupSeparatesAccessorsFromMethods(t *testing.T) {
 	t.Parallel()
 	join := NewJoin(joinFixture())
@@ -291,5 +291,6 @@ func TestWriteJoinReport(t *testing.T) {
     no declaration: String.prototype.at
     no declaration: get Map.prototype.size
     unkeyed declaration: parseInt
+    unjoinable fact: parseInt
 `))
 }

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -1,0 +1,295 @@
+package ecma262
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignatureHolds(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		sig  Signature
+		pos  int
+		want bool
+	}{
+		"FirstOfTwo":       {Signature{Params: 2}, 0, true},
+		"LastOfTwo":        {Signature{Params: 2}, 1, true},
+		"PastEnd":          {Signature{Params: 2}, 2, false},
+		"NoParams":         {Signature{}, 0, false},
+		"Negative":         {Signature{Params: 2}, -1, false},
+		"InsideRest":       {Signature{Params: 1, Rest: true}, 4, true},
+		"BeforeRest":       {Signature{Params: 2, Rest: true}, 0, true},
+		"RestWithNoParams": {Signature{Rest: true}, 0, false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.sig.Holds(tc.pos))
+		})
+	}
+}
+
+// A spec algorithm sits behind every overload of a member, so its
+// algorithm-level claims carry over unchanged and only the claim that names a
+// parameter position resolves per overload.
+func TestMethodFactForSignature(t *testing.T) {
+	t.Parallel()
+
+	returnsParam1 := MethodFact{
+		Classified: true,
+		Receiver:   RecvBorrow,
+		Returns:    AliasParam,
+		ParamIndex: position(1),
+	}
+
+	tests := map[string]struct {
+		fact MethodFact
+		sig  Signature
+		want string
+	}{
+		"PositionDeclared": {
+			fact: returnsParam1,
+			sig:  Signature{Params: 2},
+			want: "receiver:borrow returns:param(1)",
+		},
+		// The overload declares one parameter, so the value the algorithm
+		// hands back is one this signature cannot name.
+		"PositionMissing": {
+			fact: returnsParam1,
+			sig:  Signature{Params: 1},
+			want: "receiver:borrow returns:unknown",
+		},
+		"PositionInsideRest": {
+			fact: returnsParam1,
+			sig:  Signature{Params: 1, Rest: true},
+			want: "receiver:borrow returns:param(1)",
+		},
+		// A claim that names no position applies to every overload as it is.
+		"NoPositionClaimed": {
+			fact: MethodFact{Classified: true, Receiver: RecvMutBorrow, Returns: AliasReceiver},
+			sig:  Signature{},
+			want: "receiver:mutBorrow returns:receiver",
+		},
+		"Unclassified": {
+			fact: MethodFact{},
+			sig:  Signature{},
+			want: "unclassified",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.fact.ForSignature(tc.sig).String())
+		})
+	}
+}
+
+// ForSignature must not write through to the fact the index holds, or the
+// first overload it resolves would rewrite the claim for every later one.
+func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
+	t.Parallel()
+
+	fact := MethodFact{Classified: true, Returns: AliasParam, ParamIndex: position(3)}
+	require.Equal(t, "returns:unknown", strings.TrimPrefix(
+		fact.ForSignature(Signature{Params: 1}).String(), "receiver: "))
+	require.Equal(t, "receiver: returns:param(3)", fact.String())
+}
+
+// joinFixture is a hand-built fact set covering each keying shape the join
+// has to resolve.
+func joinFixture() *Facts {
+	return &Facts{
+		SpecTarget: "test",
+		Methods: map[string]MethodFact{
+			"Array.prototype.push":           {Classified: true, Receiver: RecvMutBorrow, Returns: AliasFresh},
+			"Array.prototype [ @@iterator ]": {Classified: true, Receiver: RecvBorrow, Returns: AliasFresh},
+			"Array.from":                     {Classified: true, Receiver: RecvNone, Returns: AliasFresh},
+			"get Map.prototype.size":         {Classified: true, Receiver: RecvBorrow, Returns: AliasFresh},
+			"Math.max":                       {Classified: true, Receiver: RecvNone, Returns: AliasFresh},
+			"String.prototype.at":            {Classified: true, Receiver: RecvBorrow, Returns: AliasParam, ParamIndex: position(1)},
+			"Set.prototype.add":              {Classified: false},
+			"parseInt":                       {Classified: true, Receiver: RecvNone, Returns: AliasFresh},
+		},
+	}
+}
+
+func TestJoinLookup(t *testing.T) {
+	t.Parallel()
+	join := NewJoin(joinFixture())
+
+	tests := map[string]struct {
+		ref  MemberRef
+		want string
+	}{
+		"Instance":  {MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance}, "Array.prototype.push"},
+		"Symbol":    {MemberRef{Owner: "Array", Member: SymMember("iterator"), Sort: SortInstance}, "Array.prototype [ @@iterator ]"},
+		"Static":    {MemberRef{Owner: "Array", Member: StrMember("from"), Sort: SortStatic}, "Array.from"},
+		"Namespace": {MemberRef{Owner: "Math", Member: StrMember("max"), Sort: SortNamespaceFunc}, "Math.max"},
+		"Getter": {
+			MemberRef{Owner: "Map", Member: StrMember("size"), Sort: SortInstance, Accessor: GetAccessor},
+			"get Map.prototype.size",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			specName, fact, ok := join.Lookup(tc.ref)
+			require.True(t, ok, "%s should resolve", tc.ref)
+			require.Equal(t, tc.want, specName)
+			require.True(t, fact.Classified)
+		})
+	}
+}
+
+// The accessor tag is not part of the address, so a plain method never
+// resolves to the getter of the same name and the getter never resolves to a
+// method's fact.
+func TestJoinLookupSeparatesAccessorsFromMethods(t *testing.T) {
+	t.Parallel()
+	join := NewJoin(joinFixture())
+
+	_, _, ok := join.Lookup(MemberRef{Owner: "Map", Member: StrMember("size"), Sort: SortInstance})
+	require.False(t, ok)
+
+	_, _, ok = join.Lookup(MemberRef{
+		Owner: "Array", Member: StrMember("push"),
+		Sort: SortInstance, Accessor: GetAccessor,
+	})
+	require.False(t, ok)
+}
+
+// The sort is part of the address, so a static never picks up the fact for
+// the instance member of the same name.
+func TestJoinLookupSeparatesSortsApart(t *testing.T) {
+	t.Parallel()
+	join := NewJoin(joinFixture())
+
+	_, _, ok := join.Lookup(MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortStatic})
+	require.False(t, ok)
+}
+
+// Two spec names that key to the same triple would make the join's answer
+// depend on map iteration order. The sorted-first name takes the slot and the
+// other is reported as unjoinable rather than dropped.
+func TestJoinIndexesOneNamePerTriple(t *testing.T) {
+	t.Parallel()
+
+	join := NewJoin(&Facts{
+		SpecTarget: "test",
+		Methods: map[string]MethodFact{
+			"Array.prototype [ @@iterator ]":    {Classified: true, Receiver: RecvBorrow},
+			"Array.prototype  [  @@iterator  ]": {Classified: true, Receiver: RecvMutBorrow},
+		},
+	})
+
+	name, fact, ok := join.Lookup(MemberRef{
+		Owner: "Array", Member: SymMember("iterator"), Sort: SortInstance,
+	})
+	require.True(t, ok)
+	require.Equal(t, "Array.prototype  [  @@iterator  ]", name)
+	require.Equal(t, RecvMutBorrow, fact.Receiver)
+	require.Equal(t, []string{"Array.prototype [ @@iterator ]"}, join.unjoinable)
+}
+
+func TestJoinMatch(t *testing.T) {
+	t.Parallel()
+
+	decls := []Declaration{
+		{
+			Ref:        MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance},
+			Signatures: []Signature{{Params: 1, Rest: true}},
+		},
+		{
+			// Two overloads of one algorithm: the shorter one cannot name
+			// the parameter the fact returns.
+			Ref:        MemberRef{Owner: "String", Member: StrMember("at"), Sort: SortInstance},
+			Signatures: []Signature{{Params: 1}, {Params: 2}},
+		},
+		{
+			Ref:        MemberRef{Owner: "Map", Member: StrMember("size"), Sort: SortInstance, Accessor: GetAccessor},
+			Signatures: []Signature{{}},
+		},
+		{
+			Ref:        MemberRef{Owner: "Array", Member: StrMember("toSorted"), Sort: SortInstance},
+			Signatures: []Signature{{Params: 1}},
+		},
+	}
+
+	report := NewJoin(joinFixture()).Match(Declarations{
+		Keyed:   decls,
+		Unkeyed: []string{"parseInt"},
+	})
+
+	var lines []string
+	for _, match := range report.Matched {
+		perSig := make([]string, 0, len(match.PerSignature))
+		for _, fact := range match.PerSignature {
+			perSig = append(perSig, fact.String())
+		}
+		lines = append(lines, match.SpecName+" -> "+match.Decl.Ref.String()+
+			" receiverApplies:"+boolWord(match.ReceiverApplies())+
+			" [ "+strings.Join(perSig, " | ")+" ]")
+	}
+	for _, ref := range report.DeclsWithoutFact {
+		lines = append(lines, "no fact: "+ref.String())
+	}
+	for _, name := range report.FactsWithoutDecl {
+		lines = append(lines, "no declaration: "+name)
+	}
+	for _, name := range report.UnjoinableFacts {
+		lines = append(lines, "unjoinable fact: "+name)
+	}
+	for _, path := range report.UnkeyedDecls {
+		lines = append(lines, "unkeyed declaration: "+path)
+	}
+
+	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`Array.prototype.push -> instance Array.push receiverApplies:yes [ receiver:mutBorrow returns:fresh ]
+String.prototype.at -> instance String.at receiverApplies:yes [ receiver:borrow returns:unknown | receiver:borrow returns:param(1) ]
+get Map.prototype.size -> get instance Map.size receiverApplies:no [ receiver:borrow returns:fresh ]
+no fact: instance Array.toSorted
+no declaration: Array.from
+no declaration: Array.prototype [ @@iterator ]
+no declaration: Math.max
+no declaration: Set.prototype.add
+unjoinable fact: parseInt
+unkeyed declaration: parseInt`))
+}
+
+func boolWord(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+func TestWriteJoinReport(t *testing.T) {
+	t.Parallel()
+
+	report := NewJoin(joinFixture()).Match(Declarations{
+		Keyed: []Declaration{
+			{Ref: MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance}, Signatures: []Signature{{Params: 1, Rest: true}}},
+			{Ref: MemberRef{Owner: "Set", Member: StrMember("add"), Sort: SortInstance}, Signatures: []Signature{{Params: 1}}},
+			{Ref: MemberRef{Owner: "Array", Member: StrMember("toSorted"), Sort: SortInstance}, Signatures: []Signature{{Params: 1}}},
+		},
+		Unkeyed: []string{"parseInt"},
+	})
+
+	var out strings.Builder
+	require.NoError(t, WriteJoinReport(report, &out))
+	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  join: 2 matched (1 classified), 1 declarations without a fact, 5 facts without a declaration, 1 unkeyed declarations, 1 unjoinable facts
+    no fact: instance Array.toSorted
+    no declaration: Array.from
+    no declaration: Array.prototype [ @@iterator ]
+    no declaration: Math.max
+    no declaration: String.prototype.at
+    no declaration: get Map.prototype.size
+    unkeyed declaration: parseInt
+`))
+}

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -101,21 +101,58 @@ func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 	require.Equal(t, "receiver: returns:param(3)", fact.String())
 }
 
-// joinFixture is a hand-built fact set covering each keying shape the join
-// has to resolve.
+// joinFixture is a hand-built fact set covering each keying shape the join has
+// to resolve. Every entry but one carries the fact the committed control-flow
+// graph really holds for that name, so the fixture doubles as a description of
+// the fact set rather than reading as a claim the graph does not make.
+//
+// The exception is the Fixture owner, which names no builtin. No real fact
+// returns a parameter above position 0 — all six that return a parameter are
+// `Object.*` statics at position 0 — so the case where a signature declares no
+// parameter at the position a fact names has no ECMA-262 instance yet. The
+// shape is real even though the fact is not: the spec's
+// `Array.prototype.splice(start, deleteCount, ...items)` meets a TypeScript
+// overload set whose shortest member is `splice(start: number): T[]`. The
+// position-keyed facts of §8.1 are what will populate it.
 func joinFixture() *Facts {
 	return &Facts{
 		SpecTarget: "test",
 		Methods: map[string]MethodFact{
-			"Array.prototype.push":           {Classified: true, Receiver: RecvMutBorrow, Returns: AliasFresh},
-			"Array.prototype [ @@iterator ]": {Classified: true, Receiver: RecvBorrow, Returns: AliasFresh},
-			"Array.from":                     {Classified: true, Receiver: RecvNone, Returns: AliasFresh},
-			"get Map.prototype.size":         {Classified: true, Receiver: RecvBorrow, Returns: AliasFresh},
-			"Math.max":                       {Classified: true, Receiver: RecvNone, Returns: AliasFresh},
-			"String.prototype.at":            {Classified: true, Receiver: RecvBorrow, Returns: AliasParam, ParamIndex: position(1)},
-			"Set.prototype.add":              {Classified: false},
-			"parseInt":                       {Classified: true, Receiver: RecvNone, Returns: AliasFresh},
+			// An instance member, string-keyed and symbol-keyed.
+			"Array.prototype.push":            {Classified: true, Receiver: RecvMutBorrow, Returns: AliasFresh},
+			"String.prototype [ @@iterator ]": {Classified: true, Receiver: RecvBorrow, Returns: AliasFresh},
+			// An accessor, whose fixed mutability the join must not overwrite.
+			"get Map.prototype.size": {Classified: true, Receiver: RecvBorrow, Returns: AliasFresh},
+			// A static that hands back one of its own parameters.
+			"Object.assign": {Classified: true, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(0)},
+			// A namespace function, which has no receiver.
+			"Math.max": {Classified: true, Receiver: RecvNone, Returns: AliasUnknown},
+			// A method the analysis left unclassified, carrying no claim.
+			"Array.from": {Classified: false},
+			// A function the global object holds, which addresses no owner and
+			// so is refused by Normalize.
+			"parseInt": {Classified: false},
+			// Not a builtin. See the note above.
+			"Fixture.prototype.returnsSecond": {Classified: true, Receiver: RecvBorrow, Returns: AliasParam, ParamIndex: position(1)},
 		},
+	}
+}
+
+// The fixture describes the committed fact set rather than inventing one, so
+// every entry that names a builtin has to keep matching what the graph holds.
+// Without this, an entry edited to drive a test reads afterwards as a claim
+// about ECMA-262 that nothing checks. The Fixture owner is the one documented
+// exception, since no builtin exercises the case it stands in for.
+func TestJoinFixtureMatchesCommittedFacts(t *testing.T) {
+	committed := testFacts(t)
+	for name, fact := range joinFixture().Methods {
+		if strings.HasPrefix(name, "Fixture.") {
+			continue
+		}
+		real, ok := committed.Of(name)
+		require.Truef(t, ok, "%s is not a builtin the committed graph holds", name)
+		require.Equalf(t, real.String(), fact.String(),
+			"the fixture's %s disagrees with the committed graph", name)
 	}
 }
 
@@ -128,8 +165,8 @@ func TestJoinLookup(t *testing.T) {
 		want string
 	}{
 		"Instance":  {MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance}, "Array.prototype.push"},
-		"Symbol":    {MemberRef{Owner: "Array", Member: SymMember("iterator"), Sort: SortInstance}, "Array.prototype [ @@iterator ]"},
-		"Static":    {MemberRef{Owner: "Array", Member: StrMember("from"), Sort: SortStatic}, "Array.from"},
+		"Symbol":    {MemberRef{Owner: "String", Member: SymMember("iterator"), Sort: SortInstance}, "String.prototype [ @@iterator ]"},
+		"Static":    {MemberRef{Owner: "Object", Member: StrMember("assign"), Sort: SortStatic}, "Object.assign"},
 		"Namespace": {MemberRef{Owner: "Math", Member: StrMember("max"), Sort: SortNamespaceFunc}, "Math.max"},
 		"Getter": {
 			MemberRef{Owner: "Map", Member: StrMember("size"), Sort: SortInstance, Accessor: GetAccessor},
@@ -207,9 +244,9 @@ func TestJoinMatch(t *testing.T) {
 			Signatures: []Signature{{Params: 1, Rest: true}},
 		},
 		{
-			// Two overloads of one algorithm: the shorter one cannot name
-			// the parameter the fact returns.
-			Ref:        MemberRef{Owner: "String", Member: StrMember("at"), Sort: SortInstance},
+			// Two overloads of one algorithm: the shorter one declares no
+			// parameter at the position the fact returns.
+			Ref:        MemberRef{Owner: "Fixture", Member: StrMember("returnsSecond"), Sort: SortInstance},
 			Signatures: []Signature{{Params: 1}, {Params: 2}},
 		},
 		{
@@ -251,13 +288,13 @@ func TestJoinMatch(t *testing.T) {
 	}
 
 	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`Array.prototype.push -> instance Array.push receiverApplies:yes [ receiver:mutBorrow returns:fresh ]
-String.prototype.at -> instance String.at receiverApplies:yes [ receiver:borrow returns:unknown | receiver:borrow returns:param(1) ]
+Fixture.prototype.returnsSecond -> instance Fixture.returnsSecond receiverApplies:yes [ receiver:borrow returns:unknown | receiver:borrow returns:param(1) ]
 get Map.prototype.size -> get instance Map.size receiverApplies:no [ receiver:borrow returns:fresh ]
 no fact: instance Array.toSorted
 no declaration: Array.from
-no declaration: Array.prototype [ @@iterator ]
 no declaration: Math.max
-no declaration: Set.prototype.add
+no declaration: Object.assign
+no declaration: String.prototype [ @@iterator ]
 unjoinable fact: parseInt
 unkeyed declaration: parseInt`))
 }
@@ -275,7 +312,7 @@ func TestWriteJoinReport(t *testing.T) {
 	report := NewJoin(joinFixture()).Match(Declarations{
 		Keyed: []Declaration{
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance}, Signatures: []Signature{{Params: 1, Rest: true}}},
-			{Ref: MemberRef{Owner: "Set", Member: StrMember("add"), Sort: SortInstance}, Signatures: []Signature{{Params: 1}}},
+			{Ref: MemberRef{Owner: "Array", Member: StrMember("from"), Sort: SortStatic}, Signatures: []Signature{{Params: 1}}},
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("toSorted"), Sort: SortInstance}, Signatures: []Signature{{Params: 1}}},
 		},
 		Unkeyed: []string{"parseInt"},
@@ -285,10 +322,10 @@ func TestWriteJoinReport(t *testing.T) {
 	require.NoError(t, WriteJoinReport(report, &out))
 	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  join: 2 matched (1 classified), 1 declarations without a fact, 5 facts without a declaration, 1 unkeyed declarations, 1 unjoinable facts
     no fact: instance Array.toSorted
-    no declaration: Array.from
-    no declaration: Array.prototype [ @@iterator ]
+    no declaration: Fixture.prototype.returnsSecond
     no declaration: Math.max
-    no declaration: String.prototype.at
+    no declaration: Object.assign
+    no declaration: String.prototype [ @@iterator ]
     no declaration: get Map.prototype.size
     unkeyed declaration: parseInt
     unjoinable fact: parseInt

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -41,7 +41,7 @@ func TestMethodFactForSignature(t *testing.T) {
 	t.Parallel()
 
 	returnsParam1 := MethodFact{
-		Classified: true,
+		Classified: Coverage{Receiver: true, Returns: true},
 		Receiver:   RecvBorrow,
 		Returns:    AliasParam,
 		ParamIndex: position(1),
@@ -71,7 +71,7 @@ func TestMethodFactForSignature(t *testing.T) {
 		},
 		// A claim that names no position applies to every overload as it is.
 		"NoPositionClaimed": {
-			fact: MethodFact{Classified: true, Receiver: RecvMutBorrow, Returns: AliasReceiver},
+			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvMutBorrow, Returns: AliasReceiver},
 			sig:  Signature{},
 			want: "receiver:mutBorrow returns:receiver",
 		},
@@ -95,7 +95,7 @@ func TestMethodFactForSignature(t *testing.T) {
 func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 	t.Parallel()
 
-	fact := MethodFact{Classified: true, Returns: AliasParam, ParamIndex: position(3)}
+	fact := MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Returns: AliasParam, ParamIndex: position(3)}
 	require.Equal(t, "returns:unknown", strings.TrimPrefix(
 		fact.ForSignature(Signature{Params: 1}).String(), "receiver: "))
 	require.Equal(t, "receiver: returns:param(3)", fact.String())
@@ -107,33 +107,35 @@ func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 // the fact set rather than reading as a claim the graph does not make.
 //
 // The exception is the Fixture owner, which names no builtin. No real fact
-// returns a parameter above position 0 — all six that return a parameter are
-// `Object.*` statics at position 0 — so the case where a signature declares no
-// parameter at the position a fact names has no ECMA-262 instance yet. The
+// returns a parameter above position 0 — every one that returns a parameter is
+// an `Object.*` static at position 0 — so the case where a signature declares
+// no parameter at the position a fact names has no ECMA-262 instance yet. The
 // shape is real even though the fact is not: the spec's
 // `Array.prototype.splice(start, deleteCount, ...items)` meets a TypeScript
 // overload set whose shortest member is `splice(start: number): T[]`. The
 // position-keyed facts of §8.1 are what will populate it.
 func joinFixture() *Facts {
+	covered := Coverage{Receiver: true, Returns: true}
 	return &Facts{
 		SpecTarget: "test",
 		Methods: map[string]MethodFact{
 			// An instance member, string-keyed and symbol-keyed.
-			"Array.prototype.push":            {Classified: true, Receiver: RecvMutBorrow, Returns: AliasFresh},
-			"String.prototype [ @@iterator ]": {Classified: true, Receiver: RecvBorrow, Returns: AliasFresh},
+			"Array.prototype.push":            {Classified: covered, Receiver: RecvMutBorrow, Returns: AliasFresh},
+			"String.prototype [ @@iterator ]": {Classified: covered, Receiver: RecvBorrow, Returns: AliasFresh},
 			// An accessor, whose fixed mutability the join must not overwrite.
-			"get Map.prototype.size": {Classified: true, Receiver: RecvBorrow, Returns: AliasFresh},
+			"get Map.prototype.size": {Classified: covered, Receiver: RecvBorrow, Returns: AliasFresh},
 			// A static that hands back one of its own parameters.
-			"Object.assign": {Classified: true, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(0)},
+			"Object.assign": {Classified: covered, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(0)},
 			// A namespace function, which has no receiver.
-			"Math.max": {Classified: true, Receiver: RecvNone, Returns: AliasUnknown},
-			// A method the analysis left unclassified, carrying no claim.
-			"Array.from": {Classified: false},
+			"Math.max": {Classified: covered, Receiver: RecvNone, Returns: AliasUnknown},
+			// A method the mutation fixpoint could not read whole, so its
+			// receiver claim is withheld while its return alias stands.
+			"Array.prototype.concat": {Classified: Coverage{Returns: true}, Returns: AliasFresh},
 			// A function the global object holds, which addresses no owner and
 			// so is refused by Normalize.
-			"parseInt": {Classified: false},
+			"parseInt": {Classified: covered, Receiver: RecvNone, Returns: AliasFresh},
 			// Not a builtin. See the note above.
-			"Fixture.prototype.returnsSecond": {Classified: true, Receiver: RecvBorrow, Returns: AliasParam, ParamIndex: position(1)},
+			"Fixture.prototype.returnsSecond": {Classified: covered, Receiver: RecvBorrow, Returns: AliasParam, ParamIndex: position(1)},
 		},
 	}
 }
@@ -180,7 +182,7 @@ func TestJoinLookup(t *testing.T) {
 			specName, fact, ok := join.Lookup(tc.ref)
 			require.True(t, ok, "%s should resolve", tc.ref)
 			require.Equal(t, tc.want, specName)
-			require.True(t, fact.Classified)
+			require.True(t, fact.Classified.Receiver)
 		})
 	}
 }
@@ -221,8 +223,8 @@ func TestJoinIndexesOneNamePerTriple(t *testing.T) {
 	join := NewJoin(&Facts{
 		SpecTarget: "test",
 		Methods: map[string]MethodFact{
-			"Array.prototype [ @@iterator ]":    {Classified: true, Receiver: RecvBorrow},
-			"Array.prototype  [  @@iterator  ]": {Classified: true, Receiver: RecvMutBorrow},
+			"Array.prototype [ @@iterator ]":    {Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvBorrow},
+			"Array.prototype  [  @@iterator  ]": {Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvMutBorrow},
 		},
 	})
 
@@ -291,7 +293,7 @@ func TestJoinMatch(t *testing.T) {
 Fixture.prototype.returnsSecond -> instance Fixture.returnsSecond receiverApplies:yes [ receiver:borrow returns:unknown | receiver:borrow returns:param(1) ]
 get Map.prototype.size -> get instance Map.size receiverApplies:no [ receiver:borrow returns:fresh ]
 no fact: instance Array.toSorted
-no declaration: Array.from
+no declaration: Array.prototype.concat
 no declaration: Math.max
 no declaration: Object.assign
 no declaration: String.prototype [ @@iterator ]
@@ -312,7 +314,7 @@ func TestWriteJoinReport(t *testing.T) {
 	report := NewJoin(joinFixture()).Match(Declarations{
 		Keyed: []Declaration{
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance}, Signatures: []Signature{{Params: 1, Rest: true}}},
-			{Ref: MemberRef{Owner: "Array", Member: StrMember("from"), Sort: SortStatic}, Signatures: []Signature{{Params: 1}}},
+			{Ref: MemberRef{Owner: "Array", Member: StrMember("concat"), Sort: SortInstance}, Signatures: []Signature{{Params: 1, Rest: true}}},
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("toSorted"), Sort: SortInstance}, Signatures: []Signature{{Params: 1}}},
 		},
 		Unkeyed: []string{"parseInt"},
@@ -320,7 +322,7 @@ func TestWriteJoinReport(t *testing.T) {
 
 	var out strings.Builder
 	require.NoError(t, WriteJoinReport(report, &out))
-	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  join: 2 matched (1 classified), 1 declarations without a fact, 5 facts without a declaration, 1 unkeyed declarations, 1 unjoinable facts
+	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  join: 2 matched (1 with a receiver claim), 1 declarations without a fact, 5 facts without a declaration, 1 unkeyed declarations, 1 unjoinable facts
     no fact: instance Array.toSorted
     no declaration: Fixture.prototype.returnsSecond
     no declaration: Math.max


### PR DESCRIPTION
Refs #1198. Third of four stacked PRs implementing §5 of [planning/ecma-262/implementation_plan.md](https://github.com/escalier-lang/escalier/blob/main/planning/ecma-262/implementation_plan.md). Based on #1295.

`Join` indexes the classified facts by the `MemberRef` that addresses them, so a declaration can resolve its fact by name alone. The index carries no types, which is what keeps it valid whether the declarations come from a `.d.ts` today or from committed `.esc` later (FR7). The converter side that feeds it is the next PR in the stack; everything here is tested against hand-built `Facts`.

## Overloads (FR15)

A spec algorithm resolves to a single declaration even where TypeScript spells an overload set, so the algorithm-level claims — receiver mutability, the raw return alias — apply to every signature unchanged.

A claim that names a parameter position resolves per overload through `MethodFact.ForSignature`. Where the signature declares no parameter at that position, the return alias drops to `unknown`, since the value handed back is one the signature cannot name. A rest parameter covers every position from its own onward, so `push(...items)` holds any position.

`ForSignature` takes its receiver by value, so resolving the first overload cannot rewrite the claim the index holds for the rest. There is a test pinning that.

## Accessors

An accessor resolves like any other member, because the spec keys `get Map.prototype.size` as its own algorithm. Refusing it here would report it as a gap rather than as the carve-out it is. `Match.ReceiverApplies` reports instead that the fixed mutability the converter sets on an accessor must not be overwritten, matching the `GetterElem`/`SetterElem` carve-out in `applyMethodMutability`.

## The report

`JoinReport` names what matched and what is present on one side only. Everything but `Matched` is informational — the spec and the TypeScript lib drift independently, so a name on one side only is a gap to close rather than an error, mirroring the converter's unmapped-symbol fail-safe.

`UnjoinableFacts` holds the names no declaration can ever reach: the ones `Normalize` refuses, plus any whose address another name already claimed. Two spec names keying to one address would make the answer depend on map iteration order, so the sorted-first name takes the slot and the other is reported rather than dropped. #1295 asserts no committed fact actually collides; this handles it deterministically regardless.

## Review notes

- `Signature.Holds` is the one piece of arithmetic here. The rest-parameter branch returns true for every non-negative position, which is the behavior the `InsideRest` and `RestWithNoParams` cases pin.
- `TestJoinIndexesOneNamePerTriple` uses two whitespace variants of the same key to exercise the collision path, since no genuine collision exists in the committed graph.

## Stack

1. #1294 — runtime paths and the converter split
2. #1295 — spec-key normalizer
3. **this PR** — fact index and join report
4. `claude/issue-1198-utgo5n-4-collect` — declaration collection and CLI wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149DmSiUpQBxw7XVPh7LXrW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consistency when correlating API declarations with specification data.
  * Added clearer handling for overloaded methods, accessors, static members, aliases, and unmatched entries.
  * Added deterministic summary reporting with reliable error handling.

* **Tests**
  * Expanded automated coverage for declaration matching, signature behavior, duplicate entries, accessor handling, and report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->