### PR TITLE
Refactor return alias analysis to track union members

### DIFF
--- a/internal/dts_to_esc/join_test.go
+++ b/internal/dts_to_esc/join_test.go
@@ -266,8 +266,7 @@ interface Fixture {
 			"Fixture.prototype.withTail": {
 				Classified: ecma262.Coverage{Receiver: true, Returns: true},
 				Receiver:   ecma262.RecvBorrow,
-				Returns:    ecma262.AliasParam,
-				ParamIndex: &tail,
+				Returns:    ecma262.ReturnFact{Kind: ecma262.AliasParam, Index: &tail},
 			},
 		},
 	}
@@ -335,14 +334,14 @@ declare function parseInt(string: string, radix?: number): number;
 	facts := &ecma262.Facts{
 		SpecTarget: "test",
 		Methods: map[string]ecma262.MethodFact{
-			"Array.prototype.push":           {Classified: covered, Receiver: ecma262.RecvMutBorrow, Returns: ecma262.AliasFresh},
-			"Array.prototype [ @@iterator ]": {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: ecma262.AliasFresh},
-			"Array.isArray":                  {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.AliasFresh},
-			"Math.max":                       {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.AliasFresh},
-			"Math.min":                       {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.AliasFresh},
+			"Array.prototype.push":           {Classified: covered, Receiver: ecma262.RecvMutBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Array.prototype [ @@iterator ]": {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Array.isArray":                  {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Math.max":                       {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Math.min":                       {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
 			// A function the global object holds names no owner, so neither
 			// side of the join can key it.
-			"parseInt": {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.AliasFresh},
+			"parseInt": {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
 		},
 	}
 	report := ecma262.NewJoin(facts).Match(StdDeclarations(mods))

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/escalier-lang/escalier/internal/set"
 )
 
 // ReceiverKind is how a builtin takes the value it is called on. See
@@ -26,9 +28,6 @@ const (
 type AliasKind string
 
 const (
-	// aliasUnset is the lattice bottom, the accumulator before any return has
-	// been read. returnAlias resolves it to AliasUnknown.
-	aliasUnset AliasKind = ""
 	// AliasReceiver is a return that hands back the receiver.
 	AliasReceiver AliasKind = "receiver"
 	// AliasParam is a return that hands back a declared parameter, identified
@@ -38,14 +37,16 @@ const (
 	// it computed. Nothing the caller holds is borrowed.
 	AliasFresh AliasKind = "fresh"
 	// AliasUnion is a return that aliases different values on different paths.
+	// The values it joined are the union's members, which §8.2 reads as the
+	// lifetimes the return borrows from.
 	AliasUnion AliasKind = "union"
 	// AliasUnknown is a return the analysis could not tie to any of the above.
 	// It is the top of the lattice, so joining it with anything yields it.
 	AliasUnknown AliasKind = "unknown"
 )
 
-// alias is what one return, or the join of every return in an algorithm,
-// aliases. Index is meaningful only when Kind is AliasParam.
+// alias is one value a return hands back. Index is meaningful only when Kind
+// is AliasParam.
 type alias struct {
 	Kind  AliasKind
 	Index int
@@ -58,24 +59,70 @@ func (a alias) String() string {
 	return string(a.Kind)
 }
 
-// join is the least upper bound of two aliases. Two returns that agree keep
-// their alias, and two that disagree collapse to a union, including two
-// parameters at different positions. Anything joined with `unknown` is unknown.
-// Every return contributes whichever branch reaches it, which is what makes the
-// walk path-insensitive.
-func (a alias) join(other alias) alias {
-	switch {
-	case a.Kind == aliasUnset:
-		return other
-	case other.Kind == aliasUnset:
-		return a
-	case a == other:
-		return a
-	case a.Kind == AliasUnknown || other.Kind == AliasUnknown:
-		return alias{Kind: AliasUnknown}
-	default:
-		return alias{Kind: AliasUnion}
+// aliasSet is what every return in one algorithm aliases, joined. It is the
+// lattice returnAlias accumulates over.
+//
+// members holds the distinct values the returns handed back. The empty set is
+// the bottom, the accumulator before any return has been read. A set of one
+// member is that member's kind, and a set of more is FR4's union, whose
+// members are what §8.2 spells a lifetime union from.
+//
+// unknown is the top, and joining it with anything yields it. A return the
+// walk could not resolve leaves the lifetime unbounded, so no member is worth
+// reading beside it. `RegExp` hands back parameter 0 on one path and an
+// unresolved value on another, and comes out `unknown` rather than a union
+// naming that position.
+type aliasSet struct {
+	unknown bool
+	members set.Set[alias]
+}
+
+// aliasOne is the set one return contributes. An unresolved return raises the
+// top rather than adding a member, since `unknown` names no value to borrow.
+func aliasOne(a alias) aliasSet {
+	if a.Kind == AliasUnknown {
+		return aliasSet{unknown: true}
 	}
+	return aliasSet{members: set.FromSlice([]alias{a})}
+}
+
+// join is the least upper bound of two sets, which is their union below the
+// top. Two returns that agree contribute one member, and two that disagree
+// contribute two, including two parameters at different positions. Every
+// return contributes whichever branch reaches it, which is what makes the walk
+// path-insensitive.
+func (s aliasSet) join(other aliasSet) aliasSet {
+	if s.unknown || other.unknown {
+		return aliasSet{unknown: true}
+	}
+	return aliasSet{members: s.members.Union(other.members)}
+}
+
+// kind names the lattice point the set sits at. The bottom resolves to
+// AliasUnknown the same way the top does, since an algorithm whose returns the
+// walk never read says nothing about what it hands back.
+func (s aliasSet) kind() AliasKind {
+	switch {
+	case s.unknown || s.members.Len() == 0:
+		return AliasUnknown
+	case s.members.Len() > 1:
+		return AliasUnion
+	default:
+		return s.sorted()[0].Kind
+	}
+}
+
+// sorted returns the members by kind and then by position. Map iteration order
+// would otherwise leak into a fact's members and its rendering.
+func (s aliasSet) sorted() []alias {
+	members := s.members.ToSlice()
+	sort.Slice(members, func(i, j int) bool {
+		if members[i].Kind != members[j].Kind {
+			return members[i].Kind < members[j].Kind
+		}
+		return members[i].Index < members[j].Index
+	})
+	return members
 }
 
 // aliasOf reads a returned value's origin as what the return aliases.
@@ -104,21 +151,19 @@ func aliasOf(o Origin) alias {
 }
 
 // returnAlias joins what every return in one algorithm aliases. An algorithm
-// with no return the serializer lowered is `unknown`, since the walk learned
-// nothing about what it hands back. `String.prototype.localeCompare` is one.
-// ESMeta lowers its argument coercions and stops there, because the comparison
-// itself is implementation-defined.
-func returnAlias(m *OriginMap) alias {
-	var acc alias
+// with no return the serializer lowered leaves the set empty, which kind reads
+// as `unknown`, since the walk learned nothing about what it hands back.
+// `String.prototype.localeCompare` is one. ESMeta lowers its argument
+// coercions and stops there, because the comparison itself is
+// implementation-defined.
+func returnAlias(m *OriginMap) aliasSet {
+	var acc aliasSet
 	for _, node := range m.Func().Nodes {
 		ret, ok := node.(*ReturnNode)
 		if !ok {
 			continue
 		}
-		acc = acc.join(aliasOf(m.Eval(ret.Value)))
-	}
-	if acc.Kind == aliasUnset {
-		return alias{Kind: AliasUnknown}
+		acc = acc.join(aliasOne(aliasOf(m.Eval(ret.Value))))
 	}
 	return acc
 }
@@ -157,6 +202,100 @@ type Coverage struct {
 	Returns bool `json:"returns"`
 }
 
+// AliasRef names one value a return hands back, as Appendix B of
+// planning/ecma-262/implementation_plan.md serializes it. Index is the 0-based
+// position among the declared parameters, which do not include a method's
+// receiver, so position 0 on an instance method is its first argument. It is
+// set exactly when Kind is AliasParam.
+//
+// Index is a pointer because position 0 is one a fact really carries, so
+// omitting it would spell the first parameter as an absence.
+type AliasRef struct {
+	Kind  AliasKind `json:"kind"`
+	Index *int      `json:"index,omitempty"`
+}
+
+func (r AliasRef) String() string {
+	if r.Kind != AliasParam {
+		return string(r.Kind)
+	}
+	// A parameter return with no position is a fact nothing in this package
+	// builds. It reads as the missing position rather than as position 0,
+	// which is the confusion the pointer exists to prevent.
+	if r.Index == nil {
+		return "param(?)"
+	}
+	return fmt.Sprintf("param(%d)", *r.Index)
+}
+
+// ReturnFact is FR4's return-borrow seed for one builtin, what its return
+// value aliases. Kind is the alias lattice's answer over every return in the
+// algorithm.
+//
+// Index and Members carry what the kind alone cannot spell, and at most one of
+// them is ever set. A union names its members so §8.2 can spell the lifetime
+// union they seed.
+type ReturnFact struct {
+	Kind AliasKind `json:"kind"`
+	// Index is the returned parameter's position, set exactly when Kind is
+	// AliasParam. See AliasRef.
+	Index *int `json:"index,omitempty"`
+	// Members holds the distinct values the returns joined, sorted, set
+	// exactly when Kind is AliasUnion. Every member comes from one return's
+	// own alias, which aliasOf reads as the receiver, a parameter, or a fresh
+	// value. No member is a union, and none is `unknown`, which raises the
+	// lattice top over the whole set instead.
+	Members []AliasRef `json:"members,omitempty"`
+}
+
+// refs returns every value the return hands back. A union names them, and any
+// other kind is its own single ref.
+func (r ReturnFact) refs() []AliasRef {
+	if r.Kind == AliasUnion {
+		return r.Members
+	}
+	return []AliasRef{{Kind: r.Kind, Index: r.Index}}
+}
+
+func (r ReturnFact) String() string {
+	if r.Kind != AliasUnion {
+		return AliasRef{Kind: r.Kind, Index: r.Index}.String()
+	}
+	// A union with no members is the counterpart of a positionless parameter
+	// return, a fact nothing in this package builds.
+	if len(r.Members) == 0 {
+		return "union(?)"
+	}
+	names := make([]string, 0, len(r.Members))
+	for _, ref := range r.Members {
+		names = append(names, ref.String())
+	}
+	return "union(" + strings.Join(names, ", ") + ")"
+}
+
+// newReturnFact publishes a joined alias set. A set of one member spells that
+// member's kind and position, and a set of more spells a union that names them
+// all.
+func newReturnFact(s aliasSet) ReturnFact {
+	members := s.sorted()
+	switch s.kind() {
+	case AliasParam:
+		return ReturnFact{Kind: AliasParam, Index: new(members[0].Index)}
+	case AliasUnion:
+		refs := make([]AliasRef, 0, len(members))
+		for _, member := range members {
+			ref := AliasRef{Kind: member.Kind}
+			if member.Kind == AliasParam {
+				ref.Index = new(member.Index)
+			}
+			refs = append(refs, ref)
+		}
+		return ReturnFact{Kind: AliasUnion, Members: refs}
+	default:
+		return ReturnFact{Kind: s.kind()}
+	}
+}
+
 // MethodFact is what the analysis concluded about one builtin. It serializes
 // as one entry of facts.json, described in Appendix B of
 // planning/ecma-262/implementation_plan.md.
@@ -166,10 +305,8 @@ type Coverage struct {
 // none". The converter applies requirements.md FR5's default instead, `&mut
 // self` for an absent receiver.
 //
-// Appendix B draws that absence with pointers. Receiver and Returns are plain
-// kinds, which have no empty member, so omitempty encodes their absence the
-// same way. ParamIndex needs the pointer, because its zero value is a position
-// a fact can really carry.
+// Receiver is a plain kind with no empty member, so omitempty encodes its
+// absence. Returns is a struct, and omitzero encodes the same absence for it.
 //
 // Params, Throws, and Rejects join this shape in §8 and §9. Until §8.1 fills
 // Params, no fact makes a parameter claim, so an absent Params is not yet
@@ -177,14 +314,7 @@ type Coverage struct {
 type MethodFact struct {
 	Classified Coverage     `json:"classified"`
 	Receiver   ReceiverKind `json:"receiver,omitempty"`
-	Returns    AliasKind    `json:"returns,omitempty"`
-	// ParamIndex is the 0-based position Returns aliases. It indexes the
-	// declared parameters, which do not include a method's receiver, so
-	// position 0 on an instance method is its first argument. It is set
-	// exactly when Returns is AliasParam, and position 0 is written out like
-	// any other, since omitting it would spell the first parameter as an
-	// absence.
-	ParamIndex *int `json:"paramIndex,omitempty"`
+	Returns    ReturnFact   `json:"returns,omitzero"`
 }
 
 // String renders the covered determinations in one line, so a test can assert
@@ -196,17 +326,7 @@ func (f MethodFact) String() string {
 		parts = append(parts, "receiver:"+string(f.Receiver))
 	}
 	if f.Classified.Returns {
-		returns := string(f.Returns)
-		if f.Returns == AliasParam {
-			// A parameter return with no position is a fact nothing in this
-			// package builds. It reads as the missing position rather than as
-			// position 0, which is the confusion the pointer exists to prevent.
-			returns = "param(?)"
-			if f.ParamIndex != nil {
-				returns = fmt.Sprintf("param(%d)", *f.ParamIndex)
-			}
-		}
-		parts = append(parts, "returns:"+returns)
+		parts = append(parts, "returns:"+f.Returns.String())
 	}
 	if len(parts) == 0 {
 		return "unclassified"
@@ -243,19 +363,15 @@ func NewFacts(cfg *CFG) *Facts {
 			continue
 		}
 		mutations := summary.Of(fn)
-		returns := returnAlias(summary.originsOf(fn))
 		fact := MethodFact{
 			Classified: Coverage{
 				Receiver: receiverCovered(fn, mutations),
 				Returns:  true,
 			},
-			Returns: returns.Kind,
+			Returns: newReturnFact(returnAlias(summary.originsOf(fn))),
 		}
 		if fact.Classified.Receiver {
 			fact.Receiver = receiverKind(fn, mutations)
-		}
-		if returns.Kind == AliasParam {
-			fact.ParamIndex = new(returns.Index)
 		}
 		facts.Methods[fn.Name] = fact
 	}

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -102,13 +102,13 @@ func (s aliasSet) join(other aliasSet) aliasSet {
 // AliasUnknown the same way the top does, since an algorithm whose returns the
 // walk never read says nothing about what it hands back.
 func (s aliasSet) kind() AliasKind {
-	switch {
-	case s.unknown || s.members.Len() == 0:
+	switch members := s.sorted(); {
+	case s.unknown || len(members) == 0:
 		return AliasUnknown
-	case s.members.Len() > 1:
-		return AliasUnion
+	case len(members) == 1:
+		return members[0].Kind
 	default:
-		return s.sorted()[0].Kind
+		return AliasUnion
 	}
 }
 

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -30,10 +30,16 @@ func testFacts(t *testing.T) *Facts {
 // fullCoverage is what NewFacts builds for a builtin it read whole.
 var fullCoverage = Coverage{Receiver: true, Returns: true}
 
-// position is the 0-based parameter position a fact returns, as MethodFact
+// position is the 0-based parameter position a fact returns, as AliasRef
 // holds it.
 func position(i int) *int {
 	return &i
+}
+
+// returnsParam is the return fact for a builtin that hands back the declared
+// parameter at position i.
+func returnsParam(i int) ReturnFact {
+	return ReturnFact{Kind: AliasParam, Index: position(i)}
 }
 
 // factOf returns the fact for one builtin, failing when the graph does not
@@ -55,15 +61,31 @@ func TestMethodFactString(t *testing.T) {
 		// render, and a returned position past 0, which no builtin has.
 		"NoDetermination": {MethodFact{}, "unclassified"},
 		"ParamReturn": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(2)},
+			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: returnsParam(2)},
 			"receiver:none returns:param(2)",
 		},
 		// A parameter return with no position reads as the missing position
 		// rather than as position 0. Nothing in the package builds such a fact;
 		// a hand-edited facts.json is where one would come from.
 		"ParamReturnWithNoPosition": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: AliasParam},
+			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasParam}},
 			"receiver:none returns:param(?)",
+		},
+		// A union names every value it joined, which is what §8.2 spells the
+		// lifetime union from.
+		"UnionOverThreeValues": {
+			MethodFact{Classified: fullCoverage, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion, Members: []AliasRef{
+				{Kind: AliasFresh},
+				{Kind: AliasParam, Index: position(1)},
+				{Kind: AliasReceiver},
+			}}},
+			"receiver:borrow returns:union(fresh, param(1), receiver)",
+		},
+		// A union with no members is the counterpart of the positionless
+		// parameter return above, and comes from the same place.
+		"UnionWithNoMembers": {
+			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnion}},
+			"receiver:none returns:union(?)",
 		},
 	}
 
@@ -75,42 +97,70 @@ func TestMethodFactString(t *testing.T) {
 }
 
 func TestAliasJoin(t *testing.T) {
-	receiver := alias{Kind: AliasReceiver}
-	fresh := alias{Kind: AliasFresh}
-	union := alias{Kind: AliasUnion}
-	unknown := alias{Kind: AliasUnknown}
+	receiver := aliasOne(alias{Kind: AliasReceiver})
+	fresh := aliasOne(alias{Kind: AliasFresh})
+	param0 := aliasOne(aliasOf(Param(0)))
+	param1 := aliasOne(aliasOf(Param(1)))
+	unknown := aliasOne(alias{Kind: AliasUnknown})
 
 	tests := map[string]struct {
-		a, b alias
-		want alias
+		a, b aliasSet
+		// want is the joined members in the order sorted puts them, and kind
+		// is the lattice point they add up to.
+		want []alias
+		kind AliasKind
 	}{
-		// The bottom of the lattice is the accumulator before any return has
-		// been read, so it never contributes. The loop below joins each pair
-		// both ways, which covers the bottom arriving on either side.
-		"UnsetTakesTheOther": {alias{}, receiver, receiver},
-		// Two returns that agree keep their alias, and a position is part of
-		// what they have to agree on.
-		"AgreeingReturns":        {fresh, fresh, fresh},
-		"AgreeingParamPositions": {aliasOf(Param(1)), aliasOf(Param(1)), aliasOf(Param(1))},
-		// Two returns that disagree collapse to a union. A fresh return counts
-		// as a distinct value the same way an input origin does, which §4.3
-		// states for two input origins only.
-		"ReceiverAndFresh": {receiver, fresh, union},
-		// Two positions disagree the way two kinds do. No builtin in the
-		// committed graph returns two different parameters, so this is the only
-		// place the case is stated.
-		"DifferingParamPosition": {aliasOf(Param(0)), aliasOf(Param(1)), union},
-		// A third return that agrees with neither leaves the union standing.
-		"UnionAbsorbsAnAgreeingReturn": {union, receiver, union},
-		// Unknown is the top, so it wins over a union too.
-		"UnknownWinsOverAKnownReturn": {receiver, unknown, unknown},
-		"UnknownWinsOverAUnion":       {union, unknown, unknown},
+		// The empty set is the accumulator before any return has been read, so
+		// it never contributes. The loop below joins each pair both ways, which
+		// covers it arriving on either side.
+		"EmptyTakesTheOther": {aliasSet{}, receiver, []alias{{Kind: AliasReceiver}}, AliasReceiver},
+		// An algorithm whose returns the walk never read says nothing about
+		// what it hands back, which reads the same way an unresolved return
+		// does.
+		"EmptyIsUnknown": {aliasSet{}, aliasSet{}, []alias{}, AliasUnknown},
+		// Two returns that agree contribute one member, and a position is part
+		// of what they have to agree on.
+		"AgreeingReturns":        {fresh, fresh, []alias{{Kind: AliasFresh}}, AliasFresh},
+		"AgreeingParamPositions": {param1, param1, []alias{{Kind: AliasParam, Index: 1}}, AliasParam},
+		// Two returns that disagree contribute two members, and the set is a
+		// union. A fresh return counts as a distinct value the same way an
+		// input origin does, which §4.3 states for two input origins only.
+		"ReceiverAndFresh": {receiver, fresh, []alias{{Kind: AliasFresh}, {Kind: AliasReceiver}}, AliasUnion},
+		// Two positions disagree the way two kinds do, and the union names
+		// both. No builtin in the committed graph returns two different
+		// parameters, so TestFactsUnionOverTwoReturnedParameters writes the
+		// graph that does.
+		"DifferingParamPosition": {
+			param0, param1,
+			[]alias{{Kind: AliasParam, Index: 0}, {Kind: AliasParam, Index: 1}},
+			AliasUnion,
+		},
+		// A third return that agrees with neither joins the union as its own
+		// member.
+		"UnionKeepsEveryMember": {
+			receiver.join(fresh), param0,
+			[]alias{{Kind: AliasFresh}, {Kind: AliasParam, Index: 0}, {Kind: AliasReceiver}},
+			AliasUnion,
+		},
+		// A return that agrees with a member the union already holds leaves the
+		// set as it was.
+		"UnionAbsorbsAnAgreeingReturn": {
+			receiver.join(fresh), receiver,
+			[]alias{{Kind: AliasFresh}, {Kind: AliasReceiver}},
+			AliasUnion,
+		},
+		// Unknown is the top, so it drops every member rather than joining
+		// them. `RegExp` loses the position it returns on one path this way.
+		"UnknownWinsOverAKnownReturn": {receiver, unknown, []alias{}, AliasUnknown},
+		"UnknownWinsOverAUnion":       {receiver.join(fresh), unknown, []alias{}, AliasUnknown},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.want, test.a.join(test.b))
-			require.Equal(t, test.want, test.b.join(test.a), "join is not commutative")
+			for _, joined := range []aliasSet{test.a.join(test.b), test.b.join(test.a)} {
+				require.Equal(t, test.want, joined.sorted(), "join is not commutative")
+				require.Equal(t, test.kind, joined.kind(), "join is not commutative")
+			}
 		})
 	}
 }
@@ -141,7 +191,7 @@ func TestFactsSampleMethods(t *testing.T) {
 		"NamespaceFunction": {"Math.max", "receiver:none returns:unknown"},
 		// The `Object` constructor returns `OrdinaryObjectCreate(...)` on one
 		// path and `ToObject(value)`, which is its parameter, on another.
-		"ReturnsDifferingOrigins": {"Object", "receiver:none returns:union"},
+		"ReturnsDifferingOrigins": {"Object", "receiver:none returns:union(fresh, param(0))"},
 		// The buffer a view was built over is the view's payload rather than
 		// the view, so returning it borrows neither.
 		"ReturnsAnInteriorValue": {"get DataView.prototype.buffer", "receiver:borrow returns:unknown"},
@@ -260,7 +310,7 @@ func TestFactsCoverEveryBuiltin(t *testing.T) {
 		require.True(t, ok, "%s has no fact", fn.Name)
 		// Every builtin resolves a return alias, warning or not.
 		require.True(t, fact.Classified.Returns, "%s has no return alias", fn.Name)
-		require.NotEmpty(t, fact.Returns, "%s covers a return alias it does not carry", fn.Name)
+		require.NotEmpty(t, fact.Returns.Kind, "%s covers a return alias it does not carry", fn.Name)
 		switch {
 		case fn.Kind != BuiltinMethod:
 			// `none` follows from the function kind, so no warning withholds it.
@@ -271,12 +321,21 @@ func TestFactsCoverEveryBuiltin(t *testing.T) {
 		default:
 			require.Contains(t, []ReceiverKind{RecvBorrow, RecvMutBorrow}, fact.Receiver, fn.Name)
 		}
-		if fact.Returns == AliasParam {
-			require.NotNil(t, fact.ParamIndex, "%s returns a parameter but no position", fn.Name)
-			require.Less(t, *fact.ParamIndex, len(fn.Params), "%s: returned position", fn.Name)
-			require.GreaterOrEqual(t, *fact.ParamIndex, 0, "%s: returned position", fn.Name)
-		} else {
-			require.Nil(t, fact.ParamIndex, "%s carries a position it does not return", fn.Name)
+		if fact.Returns.Kind != AliasParam {
+			require.Nil(t, fact.Returns.Index, "%s carries a position it does not return", fn.Name)
+		}
+		if fact.Returns.Kind != AliasUnion {
+			require.Empty(t, fact.Returns.Members, "%s carries members it did not join", fn.Name)
+		}
+		// Every position a fact names, whether alone or as one member of a
+		// union, indexes a parameter the algorithm declares.
+		for _, ref := range fact.Returns.refs() {
+			if ref.Kind != AliasParam {
+				continue
+			}
+			require.NotNil(t, ref.Index, "%s returns a parameter but no position", fn.Name)
+			require.Less(t, *ref.Index, len(fn.Params), "%s: returned position", fn.Name)
+			require.GreaterOrEqual(t, *ref.Index, 0, "%s: returned position", fn.Name)
 		}
 	}
 	// Each builtin resolved above, so an equal count leaves no room for
@@ -284,6 +343,33 @@ func TestFactsCoverEveryBuiltin(t *testing.T) {
 	// name is what keeps `Set` from failing it, since that name belongs to
 	// both the operations and the constructors.
 	require.Equal(t, builtins, len(f.Methods))
+}
+
+// A builtin that hands back a different parameter on each path carries both
+// positions. Three algorithms in the committed graph return two parameters,
+// and all three are abstract operations rather than a library surface, so no
+// fact is built for them. They are `Number::add`, `Number::multiply`, and
+// `__CLAMP__`. A spec bump that gives a builtin this shape would otherwise
+// publish a bare `union` with nothing for §8.2 to name.
+func TestFactsUnionOverTwoReturnedParameters(t *testing.T) {
+	cfg, err := ParseCFG([]byte(
+		`{"specTarget":"abc","funcs":[` +
+			`{"name":"Demo.pick","kind":"builtin-static","params":["a","b"],"nodes":[` +
+			`{"kind":"branch"},` +
+			`{"kind":"return","value":{"kind":"var","var":"a"}},` +
+			`{"kind":"return","value":{"kind":"var","var":"b"}}]}]}`))
+	require.NoError(t, err)
+
+	fact, ok := NewFacts(cfg).Of("Demo.pick")
+	require.True(t, ok)
+	require.Equal(t, "receiver:none returns:union(param(0), param(1))", fact.String())
+
+	encoded, err := json.Marshal(fact)
+	require.NoError(t, err)
+	require.Equal(t,
+		`{"classified":{"receiver":true,"returns":true},"receiver":"none",`+
+			`"returns":{"kind":"union","members":[{"kind":"param","index":0},{"kind":"param","index":1}]}}`,
+		string(encoded))
 }
 
 // A name the graph does not hold is missing rather than unclassified. The §5
@@ -303,21 +389,29 @@ func TestFactsJSON(t *testing.T) {
 		fact MethodFact
 		want string
 	}{
-		"Method": {factOf(t, "Array.prototype.fill"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":"receiver"}`},
+		"Method": {factOf(t, "Array.prototype.fill"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":{"kind":"receiver"}}`},
 		// A withheld receiver falls through to FR5's `&mut self`, so the entry
 		// carries the return alias alone.
-		"WithheldReceiver": {factOf(t, "Array.prototype.toLocaleString"), `{"classified":{"receiver":false,"returns":true},"returns":"fresh"}`},
+		"WithheldReceiver": {factOf(t, "Array.prototype.toLocaleString"), `{"classified":{"receiver":false,"returns":true},"returns":{"kind":"fresh"}}`},
 		// The first parameter is written out like any other position. Every
 		// parameter the committed graph returns sits at 0, so omitting it would
-		// leave paramIndex absent from the whole file and spell the common case
+		// leave the index absent from the whole file and spell the common case
 		// as missing data.
-		"ReturnedPositionZero": {factOf(t, "Object.freeze"), `{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":"param","paramIndex":0}`},
+		"ReturnedPositionZero": {factOf(t, "Object.freeze"), `{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":{"kind":"param","index":0}}`},
 		"ReturnedPositionPastZero": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(2)},
-			`{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":"param","paramIndex":2}`,
+			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: returnsParam(2)},
+			`{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":{"kind":"param","index":2}}`,
 		},
 		// A fact that returns no parameter carries no position at all.
-		"NoReturnedPosition": {factOf(t, "Array.prototype.push"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":"fresh"}`},
+		"NoReturnedPosition": {factOf(t, "Array.prototype.push"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":{"kind":"fresh"}}`},
+		// The §4.3 union gate. The `Object` constructor hands back an
+		// `OrdinaryObjectCreate` result on one path and `ToObject(value)` on
+		// another, and the entry names both so §8.2 can spell the lifetime
+		// union they seed.
+		"Union": {factOf(t, "Object"), `{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"param","index":0}]}}`},
+		// A fact covering no determination carries neither field. `returns` is
+		// a struct rather than a kind, so its absence is spelled by omitzero.
+		"NoDetermination": {MethodFact{}, `{"classified":{"receiver":false,"returns":false}}`},
 	}
 
 	for name, test := range tests {
@@ -355,7 +449,7 @@ func TestFactsTallies(t *testing.T) {
 			counts["receiver unclassified"]++
 		}
 		if fact.Classified.Returns {
-			counts["returns "+string(fact.Returns)]++
+			counts["returns "+string(fact.Returns.Kind)]++
 		} else {
 			counts["returns unclassified"]++
 		}

--- a/internal/ecma262/join.go
+++ b/internal/ecma262/join.go
@@ -33,18 +33,32 @@ func (s Signature) Holds(pos int) bool {
 // overload. A spec algorithm maps to a single member even where the type
 // source declares an overload set, so the algorithm-level claims apply to
 // every signature unchanged. A claim that names a parameter position applies
-// only to a signature that declares that position; where it does not, the
+// only to a signature that declares that position. Where it does not, the
 // return alias drops to AliasUnknown, since the value handed back is one the
 // signature cannot name.
+//
+// A union goes the same way as soon as one of its members names a position the
+// signature lacks. Keeping the other members would publish a narrower set of
+// lifetimes than the algorithm can return, which claims more than the analysis
+// showed.
 func (f MethodFact) ForSignature(s Signature) MethodFact {
-	if f.Returns != AliasParam {
+	refs := f.Returns.refs()
+	// A union names its members, so one naming none claims values the fact
+	// does not carry and no signature can resolve it. A parameter return with
+	// no position is the same shape, and the loop below drops it.
+	if f.Returns.Kind == AliasUnion && len(refs) == 0 {
+		f.Returns = ReturnFact{Kind: AliasUnknown}
 		return f
 	}
-	if f.ParamIndex != nil && s.Holds(*f.ParamIndex) {
-		return f
+	for _, ref := range refs {
+		if ref.Kind != AliasParam {
+			continue
+		}
+		if ref.Index == nil || !s.Holds(*ref.Index) {
+			f.Returns = ReturnFact{Kind: AliasUnknown}
+			return f
+		}
 	}
-	f.Returns = AliasUnknown
-	f.ParamIndex = nil
 	return f
 }
 

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -43,8 +43,17 @@ func TestMethodFactForSignature(t *testing.T) {
 	returnsParam1 := MethodFact{
 		Classified: Coverage{Receiver: true, Returns: true},
 		Receiver:   RecvBorrow,
-		Returns:    AliasParam,
-		ParamIndex: position(1),
+		Returns:    returnsParam(1),
+	}
+	// A union of two positions, which resolves only against a signature that
+	// declares both. No builtin in the committed graph has this shape.
+	returnsEitherParam := MethodFact{
+		Classified: Coverage{Receiver: true, Returns: true},
+		Receiver:   RecvBorrow,
+		Returns: ReturnFact{Kind: AliasUnion, Members: []AliasRef{
+			{Kind: AliasParam, Index: position(0)},
+			{Kind: AliasParam, Index: position(2)},
+		}},
 	}
 
 	tests := map[string]struct {
@@ -71,9 +80,38 @@ func TestMethodFactForSignature(t *testing.T) {
 		},
 		// A claim that names no position applies to every overload as it is.
 		"NoPositionClaimed": {
-			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvMutBorrow, Returns: AliasReceiver},
+			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasReceiver}},
 			sig:  Signature{},
 			want: "receiver:mutBorrow returns:receiver",
+		},
+		// Every member of the union names a position the overload declares, so
+		// the whole set carries over.
+		"UnionPositionsDeclared": {
+			fact: returnsEitherParam,
+			sig:  Signature{Params: 3},
+			want: "receiver:borrow returns:union(param(0), param(2))",
+		},
+		// One member names a position the overload lacks. Dropping that member
+		// alone would publish a narrower set of lifetimes than the algorithm
+		// can return, so the whole return drops to unknown.
+		"UnionPositionMissing": {
+			fact: returnsEitherParam,
+			sig:  Signature{Params: 2},
+			want: "receiver:borrow returns:unknown",
+		},
+		// A union with no members and a parameter return with no position are
+		// the two shapes a hand-edited facts.json can hold and this package
+		// cannot build. Neither states the value it claims to return, so both
+		// resolve to unknown.
+		"UnionWithNoMembers": {
+			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion}},
+			sig:  Signature{Params: 2},
+			want: "receiver:borrow returns:unknown",
+		},
+		"ParamReturnWithNoPosition": {
+			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasParam}},
+			sig:  Signature{Params: 2},
+			want: "receiver:borrow returns:unknown",
 		},
 		"Unclassified": {
 			fact: MethodFact{},
@@ -95,7 +133,7 @@ func TestMethodFactForSignature(t *testing.T) {
 func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 	t.Parallel()
 
-	fact := MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Returns: AliasParam, ParamIndex: position(3)}
+	fact := MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Returns: returnsParam(3)}
 	require.Equal(t, "returns:unknown", strings.TrimPrefix(
 		fact.ForSignature(Signature{Params: 1}).String(), "receiver: "))
 	require.Equal(t, "receiver: returns:param(3)", fact.String())
@@ -120,22 +158,22 @@ func joinFixture() *Facts {
 		SpecTarget: "test",
 		Methods: map[string]MethodFact{
 			// An instance member, string-keyed and symbol-keyed.
-			"Array.prototype.push":            {Classified: covered, Receiver: RecvMutBorrow, Returns: AliasFresh},
-			"String.prototype [ @@iterator ]": {Classified: covered, Receiver: RecvBorrow, Returns: AliasFresh},
+			"Array.prototype.push":            {Classified: covered, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasFresh}},
+			"String.prototype [ @@iterator ]": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
 			// An accessor, whose fixed mutability the join must not overwrite.
-			"get Map.prototype.size": {Classified: covered, Receiver: RecvBorrow, Returns: AliasFresh},
+			"get Map.prototype.size": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
 			// A static that hands back one of its own parameters.
-			"Object.assign": {Classified: covered, Receiver: RecvNone, Returns: AliasParam, ParamIndex: position(0)},
+			"Object.assign": {Classified: covered, Receiver: RecvNone, Returns: returnsParam(0)},
 			// A namespace function, which has no receiver.
-			"Math.max": {Classified: covered, Receiver: RecvNone, Returns: AliasUnknown},
+			"Math.max": {Classified: covered, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnknown}},
 			// A method the mutation fixpoint could not read whole, so its
 			// receiver claim is withheld while its return alias stands.
-			"Array.prototype.toLocaleString": {Classified: Coverage{Returns: true}, Returns: AliasFresh},
+			"Array.prototype.toLocaleString": {Classified: Coverage{Returns: true}, Returns: ReturnFact{Kind: AliasFresh}},
 			// A function the global object holds, which addresses no owner and
 			// so is refused by Normalize.
-			"parseInt": {Classified: covered, Receiver: RecvNone, Returns: AliasFresh},
+			"parseInt": {Classified: covered, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasFresh}},
 			// Not a builtin. See the note above.
-			"Fixture.prototype.returnsSecond": {Classified: covered, Receiver: RecvBorrow, Returns: AliasParam, ParamIndex: position(1)},
+			"Fixture.prototype.returnsSecond": {Classified: covered, Receiver: RecvBorrow, Returns: returnsParam(1)},
 		},
 	}
 }

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1121,15 +1121,26 @@ func receiverKind(M):
     if M.Kind != BuiltinMethod: return RecvNone    // static / namespace function: no receiver
     return RecvMutBorrow if M in MutatesReceiver else RecvBorrow
 
-func returnAlias(M) AliasKind:
-    acc = Bottom
+func returnAlias(M) AliasSet:
+    acc = {}                                  // the distinct values the returns handed back
     for node in M.Nodes where node.Kind == Return:
         acc = join(acc, aliasOf(eval(M, node.Value)))
     return acc
-// aliasOf: Receiver→Receiver; Param(j)→ParamJ; Fresh→FreshReturn; Unknown→UnknownReturn
-// join:    equal→same; FreshReturn⊔FreshReturn→FreshReturn;
-//          two distinct input origins→Union; anything⊔UnknownReturn→UnknownReturn
+// aliasOf: Receiver→{Receiver}; Param(j)→{Param(j)}; Fresh→{Fresh}; Unknown→⊤
+// join:    set union below ⊤; anything ⊔ ⊤ → ⊤
+// kind:    ⊤ or {} → Unknown; one member → that member's kind; more → Union
 ```
+
+The accumulator is a set rather than a single kind, so a union names the
+values it joined. `Object` returns an `OrdinaryObjectCreate` result on one
+path and `ToObject(value)` on another, and publishes `{Fresh, Param(0)}`
+rather than a bare `union`. Those members are what §8.2 spells a lifetime
+union from, and Appendix B's `ReturnFact` is where they are written.
+
+A position joined into `⊤` is gone, and that is the right answer rather
+than a loss. `RegExp` returns parameter 0 on one path and an unresolved
+value on another. A return that is unresolved on some path cannot have its
+lifetime bounded, so §8.2 has nothing to emit for it.
 
 An `Unattributable` method has a mutation the analysis could not pin to
 a formal — a write through an `Unknown`-origin value, including deep
@@ -1185,6 +1196,10 @@ because the alias is curated rather than applied.
   the call built out of the arguments, so the write is discarded ⇒
   `receiver: borrow`; the array `ArraySpeciesCreate` allocated and it
   hands back ⇒ `returns: fresh`.
+- `Object` — `OrdinaryObjectCreate(…)` on one path and `ToObject(value)`
+  on another ⇒ `receiver: none`, `returns: union` naming `fresh` and
+  `param(0)`. A hand-written graph returning two different parameters
+  names both positions, a shape no builtin in the pinned graph has.
 
 Methods with a withheld receiver are listed. The `returns` tally spans
 every builtin, and the `receiver` tally leaves out only the 24 methods
@@ -1461,7 +1476,21 @@ remain the mechanism; the facts only inform the curation. Document the
 mapping: `returns: receiver` ⇒ the return borrows the receiver
 (`-> &self` / `-> &mut self`); `returns: param` ⇒ the return borrows that
 parameter; `returns: fresh` ⇒ an owned return; `returns: union` ⇒ a
-lifetime union.
+lifetime union over the members the fact names.
+
+**What a union's members mean.** A union's members are the values the
+algorithm hands back on its several paths, and the annotation has to cover
+every one of them, so the return borrows all of them at once. The lifetime
+is the union of the members' lifetimes. `fresh` is the identity of that
+union rather than a member of it. An owned value has no lifetime to bound,
+so a caller holding it constrains nothing, and dropping `fresh` from the
+set leaves the same annotation the remaining members already require.
+
+`Object` is that shape. It publishes `{fresh, param(0)}`, and the
+annotation is the borrow of `value` alone, because a caller that keeps the
+returned object alive keeps the argument alive on the path that hands it
+back. A union of two input origins instead names both, and neither drops
+out.
 
 **Gate.** Disposition present in `facts.json` — `Array.prototype.push`
 and `Map.prototype.set` mark their stored parameters `escape`,
@@ -2002,11 +2031,26 @@ type ParamFact struct {
 type AliasKind string
 const (
     AliasReceiver AliasKind = "receiver" // return borrows the receiver (&self / &mut self)
-    AliasParam    AliasKind = "param"    // return borrows ParamIndex
+    AliasParam    AliasKind = "param"    // return borrows the parameter at Index
     AliasFresh    AliasKind = "fresh"    // owned return: fresh / primitive values
     AliasUnion    AliasKind = "union"    // returns borrow differing inputs (lifetime union)
     AliasUnknown  AliasKind = "unknown"  // a return origin could not be resolved
 )
+
+// AliasRef names one value a return hands back.
+type AliasRef struct {
+    Kind  AliasKind `json:"kind"`            // receiver | param | fresh
+    Index *int      `json:"index,omitempty"` // set exactly when Kind == "param"
+}
+
+// ReturnFact is FR4's return-borrow seed. At most one of Index and Members
+// is set. A union names the values it joined, so §8.2 can spell the
+// lifetime union rather than read only that there was more than one.
+type ReturnFact struct {
+    Kind    AliasKind  `json:"kind"`
+    Index   *int       `json:"index,omitempty"`   // set exactly when Kind == "param"
+    Members []AliasRef `json:"members,omitempty"` // set exactly when Kind == "union"
+}
 
 // Coverage says which determinations the analysis resolved. Each axis is
 // withheld on its own, so a method that hides a mutation still publishes
@@ -2020,19 +2064,19 @@ type Coverage struct {
     Rejects  bool `json:"rejects"`  // §9.3
 }
 
-// The effect fields are pointers/slices so an uncovered determination is
-// ABSENT (JSON null or omitted) — an unanalyzed axis, distinct from a
-// proven-empty result, which is covered with an empty effect field. The
-// three slices carry no omitempty, which would drop the [] that spells
-// that second case. Uncovered they encode as null.
+// An uncovered determination is ABSENT from the JSON — an unanalyzed axis,
+// distinct from a proven-empty result, which is covered with an empty
+// effect field. Receiver is a kind with no empty member and Returns is a
+// struct, so omitempty and omitzero spell their absence. The three slices
+// carry neither, which would drop the [] that spells that second case.
+// Uncovered they encode as null.
 type MethodFact struct {
-    Classified Coverage      `json:"classified"`           // per-determination coverage (FR5)
-    Receiver   *ReceiverKind `json:"receiver,omitempty"`   // borrow | mutBorrow | none (FR2)
-    Params     []ParamFact   `json:"params"`               // only non-borrow parameters (FR12)
-    Returns    *AliasKind    `json:"returns,omitempty"`    // return-borrow lifetime seed (FR4)
-    ParamIndex *int          `json:"paramIndex,omitempty"` // set exactly when Returns == "param"
-    Throws     []string      `json:"throws"`               // sync throws post-filter (FR10, FR11)
-    Rejects    []string      `json:"rejects"`              // async rejects → Promise<T,E>.Err (FR13)
+    Classified Coverage     `json:"classified"`         // per-determination coverage (FR5)
+    Receiver   ReceiverKind `json:"receiver,omitempty"` // borrow | mutBorrow | none (FR2)
+    Params     []ParamFact  `json:"params"`             // only non-borrow parameters (FR12)
+    Returns    ReturnFact   `json:"returns,omitzero"`   // return-borrow lifetime seed (FR4)
+    Throws     []string     `json:"throws"`             // sync throws post-filter (FR10, FR11)
+    Rejects    []string     `json:"rejects"`            // async rejects → Promise<T,E>.Err (FR13)
 }
 ```
 
@@ -2059,15 +2103,31 @@ not.
 The receiver-returning and fresh-returning alias kinds carry the return's
 borrow lifetime per FR4.
 
-`ParamIndex` is a pointer for a different reason than the fields above it.
-`Receiver` and `Returns` are kinds with no empty member, so an omitted
-field is unambiguous either way. A position of 0 is one a fact really
-carries — it is the first declared parameter, and the receiver is not in
-that index space — so writing it as an absence would spell the common case
-as missing data. Every parameter the pinned graph returns sits at position
-0, so `omitempty` on a plain `int` would keep `paramIndex` out of
+`Receiver` is a kind with no empty member, so `omitempty` spells its
+absence. `Returns` is a struct, and `omitzero` spells the same absence for
+it.
+
+An `Index` is a pointer for a different reason. A position of 0 is one a
+fact really carries — it is the first declared parameter, and the receiver
+is not in that index space — so writing it as an absence would spell the
+common case as missing data. Every parameter the pinned graph returns sits
+at position 0, so `omitempty` on a plain `int` would keep `index` out of
 `facts.json` entirely and leave a consumer no example to read the
 convention from.
+
+A `union` entry carries its members and no `index`, since a union can join
+two positions and a single field could name only one of them:
+
+```json
+"Object": {
+  "classified": { "receiver": true, "returns": true },
+  "receiver": "none",
+  "returns": {
+    "kind": "union",
+    "members": [{ "kind": "fresh" }, { "kind": "param", "index": 0 }]
+  }
+}
+```
 
 ## Appendix C. Canonical spec keys
 


### PR DESCRIPTION
This change refactors the return alias analysis in `internal/ecma262/classify.go` to track the distinct values that returns hand back, rather than collapsing them into a single kind. This enables the analysis to publish union members so §8.2 can spell the lifetime union they seed.

**Key changes:**

- Replace the `alias` join operation with an `aliasSet` type that accumulates distinct return values in a set. The empty set is the lattice bottom (before any return is read), and `unknown` is the top (when an unresolved return is encountered).

- Add `aliasOne()` to wrap individual return aliases into sets, and update `returnAlias()` to accumulate sets rather than single aliases.

- Introduce `ReturnFact` and `AliasRef` types to serialize return information. A union now names its members (the distinct values the returns joined) so consumers can see what lifetimes are involved. A parameter return carries its position in an `Index` pointer to distinguish position 0 from an absent position.

- Update `MethodFact` to use `ReturnFact` instead of separate `Returns` and `ParamIndex` fields, using `omitzero` to encode absence.

- Add `newReturnFact()` to convert an `aliasSet` to a `ReturnFact`, handling the three cases: a single member (publish its kind and position), multiple members (publish as a union), or unknown/empty (publish as unknown).

- Update `ForSignature()` in `join.go` to validate that all positions named by a union member are declared in the signature. If any member names a missing position, the entire return drops to unknown rather than narrowing the set.

- Add the `set` import and use `set.Set[alias]` to track distinct members.

**Notable details:**

The refactoring preserves the path-insensitive semantics: every return contributes whichever branch reaches it. A return that is unresolved on some path raises the lattice top, dropping all members, which is correct — `RegExp` returns parameter 0 on one path and an unresolved value on another, and comes out unknown rather than a union naming that position.

The sorted members ensure deterministic JSON serialization and rendering, preventing map iteration order from leaking into facts.

https://claude.ai/code/session_01JQqxoAtvdDPRtyMA9qtu1v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Return analysis now preserves detailed alias information, including parameter references and unions of possible return values.
  - Joined results resolve multiple return aliases more accurately and deterministically.

- **Bug Fixes**
  - Unresolvable or malformed return references now safely resolve to `unknown`.
  - Improved handling of mixed returns and aliases without valid parameter positions.

- **Documentation**
  - Updated the implementation plan and serialized fact examples to reflect the enhanced return information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->