### PR TITLE
Settle an unnamed return from the joined type

### DIFF
--- a/internal/dts_to_esc/join.go
+++ b/internal/dts_to_esc/join.go
@@ -67,7 +67,7 @@ func CollectDeclarations(mod *StandaloneModule) ecma262.Declarations {
 			case *ast.FuncDecl:
 				// A namespace member is flattened to a top-level function
 				// whose path is already the spec key that names it.
-				add(path, signatureOf(d.Params))
+				add(path, signatureOf(d.Params, d.Return))
 			case *ast.ClassDecl:
 				for _, elem := range d.Body {
 					collectClassElem(path, elem, add)
@@ -184,20 +184,17 @@ func isFunctionObject(ifaces map[string]*ast.InterfaceDecl, name string, seen se
 func collectClassElem(path string, elem ast.ClassElem, add func(string, ecma262.Signature)) {
 	var (
 		name   ast.ObjKey
-		params []*ast.Param
+		fn     *ast.FuncExpr
 		static bool
 		prefix string
 	)
 	switch e := elem.(type) {
 	case *ast.MethodElem:
-		name, static = e.Name, e.Static
-		params = funcExprParams(e.Fn)
+		name, fn, static = e.Name, e.Fn, e.Static
 	case *ast.GetterElem:
-		name, static, prefix = e.Name, e.Static, "get "
-		params = funcExprParams(e.Fn)
+		name, fn, static, prefix = e.Name, e.Fn, e.Static, "get "
 	case *ast.SetterElem:
-		name, static, prefix = e.Name, e.Static, "set "
-		params = funcExprParams(e.Fn)
+		name, fn, static, prefix = e.Name, e.Fn, e.Static, "set "
 	default:
 		return
 	}
@@ -205,7 +202,14 @@ func collectClassElem(path string, elem ast.ClassElem, add func(string, ecma262.
 	if !static {
 		owner += ".prototype"
 	}
-	add(specKey(prefix, owner, name), signatureOf(params))
+	var (
+		params []*ast.Param
+		ret    ast.TypeAnn
+	)
+	if fn != nil {
+		params, ret = fn.Params, fn.Return
+	}
+	add(specKey(prefix, owner, name), signatureOf(params, ret))
 }
 
 // collectObjTypeElem addresses one member of an emitted interface. `owner` is
@@ -227,11 +231,14 @@ func collectObjTypeElem(owner string, elem ast.ObjTypeAnnElem, add func(string, 
 	default:
 		return
 	}
-	var params []*ast.Param
+	var (
+		params []*ast.Param
+		ret    ast.TypeAnn
+	)
 	if fn != nil {
-		params = fn.Params
+		params, ret = fn.Params, fn.Return
 	}
-	add(specKey(prefix, owner, name), signatureOf(params))
+	add(specKey(prefix, owner, name), signatureOf(params, ret))
 }
 
 // specKey spells the canonical spec key for one member of owner. A
@@ -259,30 +266,58 @@ func specKey(prefix, owner string, name ast.ObjKey) string {
 	return prefix + owner + ".[computed]"
 }
 
-// funcExprParams returns a function expression's declared parameters, or nil
-// when the member carries no function at all.
-func funcExprParams(fn *ast.FuncExpr) []*ast.Param {
-	if fn == nil {
-		return nil
-	}
-	return fn.Params
-}
-
-// signatureOf reads the declared parameter shape the join needs. A leading
-// `this` parameter is a TypeScript receiver annotation rather than an
+// signatureOf reads the declared shape the join needs from one overload. A
+// leading `this` parameter is a TypeScript receiver annotation rather than an
 // argument, so dropping it keeps the remaining positions aligned with the
 // spec algorithm's own parameter numbering.
-func signatureOf(params []*ast.Param) ecma262.Signature {
+func signatureOf(params []*ast.Param, ret ast.TypeAnn) ecma262.Signature {
 	if len(params) > 0 {
 		if ident, ok := params[0].Pattern.(*ast.IdentPat); ok && ident.Name == "this" {
 			params = params[1:]
 		}
 	}
-	sig := ecma262.Signature{Params: len(params)}
+	sig := ecma262.Signature{Params: len(params), PrimitiveReturn: primitiveTypeAnn(ret)}
 	if len(params) > 0 {
 		_, sig.Rest = params[len(params)-1].Pattern.(*ast.RestPat)
 	}
 	return sig
+}
+
+// primitiveTypeAnn reports whether every value ta can hold is a primitive. A
+// primitive keyword, a literal of one, and `never` count. A union counts when
+// all of its members do, and an empty union does not. Every other annotation
+// is refused, a type reference and `unknown` among them.
+func primitiveTypeAnn(ta ast.TypeAnn) bool {
+	switch t := ta.(type) {
+	case *ast.NumberTypeAnn, *ast.StringTypeAnn, *ast.BooleanTypeAnn,
+		*ast.BigintTypeAnn, *ast.SymbolTypeAnn, *ast.UniqueSymbolTypeAnn,
+		*ast.NeverTypeAnn:
+		return true
+	case *ast.LitTypeAnn:
+		// `null` and `undefined` reach here as literals. So would a regex
+		// literal, the one JS literal that is an object rather than a
+		// primitive, which is why this names the literals it accepts instead
+		// of accepting whatever a literal type turns out to hold.
+		switch t.Lit.(type) {
+		case *ast.BoolLit, *ast.NumLit, *ast.StrLit, *ast.BigIntLit,
+			*ast.NullLit, *ast.UndefinedLit:
+			return true
+		}
+		return false
+	case *ast.UnionTypeAnn:
+		// A union of nothing names no value to read, so it settles nothing.
+		if len(t.Types) == 0 {
+			return false
+		}
+		for _, member := range t.Types {
+			if !primitiveTypeAnn(member) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
 }
 
 // StdDeclarations collects the declarations of the `std:*` packages across a

--- a/internal/dts_to_esc/join_test.go
+++ b/internal/dts_to_esc/join_test.go
@@ -274,14 +274,19 @@ interface Fixture {
 
 	require.Len(t, report.Matched, 1)
 	match := report.Matched[0]
-	require.Equal(t, []ecma262.Signature{{Params: 1}, {Params: 2}}, match.Decl.Signatures)
+	require.Equal(t, []ecma262.Signature{
+		{Params: 1, PrimitiveReturn: true},
+		{Params: 2, PrimitiveReturn: true},
+	}, match.Decl.Signatures)
 
 	resolved := make([]string, 0, len(match.PerSignature))
 	for _, fact := range match.PerSignature {
 		resolved = append(resolved, fact.String())
 	}
+	// Both overloads return `string`, so the return the shorter one drops is
+	// settled as owned by the type that names it.
 	require.Equal(t, []string{
-		"receiver:borrow returns:unknown",
+		"receiver:borrow returns:unknown settled:owned",
 		"receiver:borrow returns:param(1)",
 	}, resolved)
 
@@ -301,6 +306,134 @@ interface CallableFunction extends Function {
 }
 `)
 	snaps.MatchInlineSnapshot(t, got, snaps.Inline(`instance CallableFunction.apply (1)`))
+}
+
+// returnsFrom converts one `.d.ts` source and renders, per overload, whether
+// the declared return type is one the join can settle a return's ownership
+// from.
+func returnsFrom(t *testing.T, src string) string {
+	t.Helper()
+	mod, err := ConvertToStandaloneModule(parseLib(t, "lib.test.d.ts", src).Module)
+	require.NoError(t, err)
+
+	var lines []string
+	for _, decl := range CollectDeclarations(mod).Keyed {
+		shapes := make([]string, 0, len(decl.Signatures))
+		for _, sig := range decl.Signatures {
+			if sig.PrimitiveReturn {
+				shapes = append(shapes, "primitive")
+			} else {
+				shapes = append(shapes, "-")
+			}
+		}
+		lines = append(lines, decl.Ref.String()+" ("+strings.Join(shapes, ", ")+")")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// A primitive return is owned, so the join reads whether each overload
+// declares one. A union counts only when every member is primitive.
+//
+// Two of the refusals are worth reading off the list. A type reference may
+// name an alias that expands to primitives, and resolving it needs the checker
+// the join does without. TypeScript's `void` arrives as `unknown`, since
+// convertReturnTypeAnn lowers it that way, and `unknown` also holds every
+// object.
+func TestCollectDeclarationsReadsPrimitiveReturns(t *testing.T) {
+	t.Parallel()
+
+	got := returnsFrom(t, `
+interface Sample {
+    num(): number;
+    str(): string;
+    bool(): boolean;
+    big(): bigint;
+    sym(): symbol;
+    lit(): "a";
+    nul(): null;
+    undef(): undefined;
+    nev(): never;
+    optional(): string | undefined;
+    mixed(): string | ArrayBuffer;
+    obj(): object;
+    ref(): Date;
+    list(): number[];
+    anything(): any;
+    unk(): unknown;
+    nothing(): void;
+}
+`)
+	snaps.MatchInlineSnapshot(t, got, snaps.Inline(`instance Sample.num (primitive)
+instance Sample.str (primitive)
+instance Sample.bool (primitive)
+instance Sample.big (primitive)
+instance Sample.sym (primitive)
+instance Sample.lit (primitive)
+instance Sample.nul (primitive)
+instance Sample.undef (primitive)
+instance Sample.nev (primitive)
+instance Sample.optional (primitive)
+instance Sample.mixed (-)
+instance Sample.obj (-)
+instance Sample.ref (-)
+instance Sample.list (-)
+instance Sample.anything (-)
+instance Sample.unk (-)
+instance Sample.nothing (-)`))
+}
+
+// The gate on settlement: a return the ECMA-262 walk could not read settles as
+// owned wherever the pinned lib declares a primitive return.
+//
+// The four members below carry the shapes `lib.es5.d.ts` really declares for
+// them, and the committed graph reads no return for any of the four. ESMeta
+// lowers `localeCompare`'s two argument coercions and stops, because the
+// comparison itself is implementation-defined. Each `DataView` accessor hands
+// back a value read out of a Data Block, which resolves to no origin the walk
+// can name. The setter is the one that stays unsettled, since its `void`
+// return reaches the join as `unknown`.
+func TestPrimitiveReturnsSettleUnnamedReturns(t *testing.T) {
+	t.Parallel()
+
+	mod, err := ConvertToStandaloneModule(parseLib(t, "lib.test.d.ts", `
+interface String {
+    localeCompare(that: string): number;
+}
+interface DataView {
+    getFloat64(byteOffset: number, littleEndian?: boolean): number;
+    getUint8(byteOffset: number): number;
+    setFloat64(byteOffset: number, value: number, littleEndian?: boolean): void;
+}
+`).Module)
+	require.NoError(t, err)
+
+	covered := ecma262.Coverage{Receiver: true, Returns: true}
+	unnamed := ecma262.ReturnFact{Kind: ecma262.AliasUnknown}
+	facts := &ecma262.Facts{
+		SpecTarget: "test",
+		Methods: map[string]ecma262.MethodFact{
+			"String.prototype.localeCompare": {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: unnamed},
+			"DataView.prototype.getFloat64":  {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: unnamed},
+			"DataView.prototype.getUint8":    {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: unnamed},
+			"DataView.prototype.setFloat64":  {Classified: covered, Receiver: ecma262.RecvMutBorrow, Returns: unnamed},
+		},
+	}
+	report := ecma262.NewJoin(facts).Match(CollectDeclarations(mod))
+
+	var lines []string
+	for _, match := range report.Matched {
+		for _, resolved := range match.PerSignature {
+			lines = append(lines, match.Decl.Ref.String()+": "+resolved.String())
+		}
+	}
+	lines = append(lines, fmt.Sprintf("settled %d, left %d",
+		report.SettledReturns, report.UnsettledReturns))
+
+	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`instance String.localeCompare: receiver:borrow returns:unknown settled:owned
+instance DataView.getFloat64: receiver:borrow returns:unknown settled:owned
+instance DataView.getUint8: receiver:borrow returns:unknown settled:owned
+instance DataView.setFloat64: receiver:mutBorrow returns:unknown
+settled 3, left 1`))
 }
 
 // The join is the §5 gate: every std:* method the converter emits either
@@ -349,6 +482,7 @@ declare function parseInt(string: string, radix?: number): number;
 	var out strings.Builder
 	require.NoError(t, ecma262.WriteJoinReport(report, &out))
 	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  join: 4 matched (4 with a receiver claim), 0 declarations without a fact, 1 facts without a declaration, 1 unkeyed declarations, 1 unjoinable facts
+  returns: 0 settled as owned by the declared type, 0 left unknown
     no declaration: Math.min
     unkeyed declaration: parseInt
     unjoinable fact: parseInt

--- a/internal/ecma262/join.go
+++ b/internal/ecma262/join.go
@@ -6,13 +6,17 @@ import (
 	"sort"
 )
 
-// Signature is the declared parameter shape of one overload, which is all the
-// join needs from the type source. Params counts the declared parameters,
-// excluding a receiver. Rest is true when the last declared parameter takes
-// the remaining arguments, so every position from Params-1 onward exists.
+// Signature is the declared shape of one overload, which is all the join needs
+// from the type source. Params counts the declared parameters, excluding a
+// receiver. Rest is true when the last declared parameter takes the remaining
+// arguments, so every position from Params-1 onward exists.
 type Signature struct {
 	Params int
 	Rest   bool
+	// PrimitiveReturn is true when every value the declared return type can
+	// hold is a primitive. A union counts only when all of its members do, so
+	// `string | undefined` counts and `string | ArrayBuffer` does not.
+	PrimitiveReturn bool
 }
 
 // Holds reports whether the signature declares a parameter at the 0-based
@@ -29,19 +33,48 @@ func (s Signature) Holds(pos int) bool {
 	return pos < s.Params
 }
 
-// ForSignature resolves the position-keyed parts of a fact against one
-// overload. A spec algorithm maps to a single member even where the type
-// source declares an overload set, so the algorithm-level claims apply to
-// every signature unchanged. A claim that names a parameter position applies
-// only to a signature that declares that position. Where it does not, the
-// return alias drops to AliasUnknown, since the value handed back is one the
-// signature cannot name.
-//
-// A union goes the same way as soon as one of its members names a position the
-// signature lacks. Keeping the other members would publish a narrower set of
-// lifetimes than the algorithm can return, which claims more than the analysis
-// showed.
-func (f MethodFact) ForSignature(s Signature) MethodFact {
+// SignatureFact is one algorithm's fact resolved against one overload. Fact is
+// what the analysis concluded. ReturnOwned is what the declared return type
+// settled on top of it.
+type SignatureFact struct {
+	// Fact is the algorithm's fact with its position-keyed claims resolved
+	// against this overload.
+	Fact MethodFact
+	// ReturnOwned is set when the resolved return is `unknown` and the
+	// overload declares a primitive return type. Fact.Returns is left as the
+	// analysis published it.
+	ReturnOwned bool
+}
+
+func (f SignatureFact) String() string {
+	if !f.ReturnOwned {
+		return f.Fact.String()
+	}
+	return f.Fact.String() + " settled:owned"
+}
+
+// unnamedReturn reports whether the resolved fact hands back a value the join
+// cannot name. Two things leave one. The walk read no return it could
+// resolve, or ForSignature dropped a return naming a position this overload
+// does not declare. A fact with no return coverage makes no claim either way.
+func (f SignatureFact) unnamedReturn() bool {
+	return f.Fact.Classified.Returns && f.Fact.Returns.Kind == AliasUnknown
+}
+
+// ForSignature resolves a fact against one overload. A return naming a
+// parameter position the signature does not declare drops to AliasUnknown, and
+// a union drops whole as soon as one member names such a position. A return
+// left `unknown` is then settled as owned where the signature declares a
+// primitive return type. Every other claim carries over unchanged.
+func (f MethodFact) ForSignature(s Signature) SignatureFact {
+	resolved := SignatureFact{Fact: f.resolvePositions(s)}
+	resolved.ReturnOwned = s.PrimitiveReturn && resolved.unnamedReturn()
+	return resolved
+}
+
+// resolvePositions drops a return claim naming a parameter position this
+// overload does not declare.
+func (f MethodFact) resolvePositions(s Signature) MethodFact {
 	refs := f.Returns.refs()
 	// A union names its members, so one naming none claims values the fact
 	// does not carry and no signature can resolve it. A parameter return with
@@ -89,7 +122,7 @@ type Match struct {
 	Fact     MethodFact
 	// PerSignature is Fact resolved against each of Decl.Signatures, in the
 	// same order.
-	PerSignature []MethodFact
+	PerSignature []SignatureFact
 }
 
 // ReceiverApplies reports whether the join may write the fact's receiver
@@ -121,6 +154,11 @@ type JoinReport struct {
 	// names, sorted. They are the declaration-side counterpart of the
 	// Normalize refusals in UnjoinableFacts.
 	UnkeyedDecls []string
+	// SettledReturns and UnsettledReturns split the resolved signatures whose
+	// return the join cannot name, by whether the declared return type settled
+	// it as owned. Both count per signature rather than per declaration.
+	SettledReturns   int
+	UnsettledReturns int
 }
 
 // Join indexes classified facts by the MemberRef that addresses them, so a
@@ -196,7 +234,14 @@ func (j *Join) Match(decls Declarations) JoinReport {
 		claimed[name] = true
 		match := Match{Decl: decl, SpecName: name, Fact: fact}
 		for _, sig := range decl.Signatures {
-			match.PerSignature = append(match.PerSignature, fact.ForSignature(sig))
+			resolved := fact.ForSignature(sig)
+			match.PerSignature = append(match.PerSignature, resolved)
+			switch {
+			case resolved.ReturnOwned:
+				report.SettledReturns++
+			case resolved.unnamedReturn():
+				report.UnsettledReturns++
+			}
 		}
 		report.Matched = append(report.Matched, match)
 	}
@@ -236,6 +281,11 @@ func WriteJoinReport(report JoinReport, w io.Writer) error {
 	_, err := fmt.Fprintf(w, "  join: %d matched (%d with a receiver claim), %d declarations without a fact, %d facts without a declaration, %d unkeyed declarations, %d unjoinable facts\n",
 		len(report.Matched), withReceiver, len(report.DeclsWithoutFact),
 		len(report.FactsWithoutDecl), len(report.UnkeyedDecls), len(report.UnjoinableFacts))
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "  returns: %d settled as owned by the declared type, %d left unknown\n",
+		report.SettledReturns, report.UnsettledReturns)
 	if err != nil {
 		return err
 	}

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -55,6 +55,13 @@ func TestMethodFactForSignature(t *testing.T) {
 			{Kind: AliasParam, Index: position(2)},
 		}},
 	}
+	// An algorithm whose returns the walk never read, which is the shape
+	// `String.prototype.localeCompare` has in the committed graph.
+	readsNoReturn := MethodFact{
+		Classified: Coverage{Receiver: true, Returns: true},
+		Receiver:   RecvBorrow,
+		Returns:    ReturnFact{Kind: AliasUnknown},
+	}
 
 	tests := map[string]struct {
 		fact MethodFact
@@ -118,6 +125,43 @@ func TestMethodFactForSignature(t *testing.T) {
 			sig:  Signature{},
 			want: "unclassified",
 		},
+		// The walk read no return, and the overload declares a primitive one.
+		// A primitive carries no identity to borrow, so the declared type
+		// settles the ownership the analysis could not read.
+		"UnnamedReturnSettledByPrimitive": {
+			fact: readsNoReturn,
+			sig:  Signature{Params: 1, PrimitiveReturn: true},
+			want: "receiver:borrow returns:unknown settled:owned",
+		},
+		// An object return the walk could not read has no ownership answer
+		// the type can give, so the `unknown` stands.
+		"UnnamedReturnLeftByNonPrimitive": {
+			fact: readsNoReturn,
+			sig:  Signature{Params: 1},
+			want: "receiver:borrow returns:unknown",
+		},
+		// A return dropped because this overload lacks the position it names
+		// is `unknown` for the same reason one the walk never read is, and a
+		// primitive return type settles it the same way.
+		"DroppedPositionSettledByPrimitive": {
+			fact: returnsParam1,
+			sig:  Signature{Params: 1, PrimitiveReturn: true},
+			want: "receiver:borrow returns:unknown settled:owned",
+		},
+		// The analysis named the value handed back, so there is nothing left
+		// for the type to settle.
+		"ResolvedReturnNotSettled": {
+			fact: returnsParam1,
+			sig:  Signature{Params: 2, PrimitiveReturn: true},
+			want: "receiver:borrow returns:param(1)",
+		},
+		// A fact whose return the analysis never covered makes no claim, so
+		// the type settles nothing onto it.
+		"UncoveredReturnNotSettled": {
+			fact: MethodFact{Classified: Coverage{Receiver: true}, Receiver: RecvBorrow},
+			sig:  Signature{PrimitiveReturn: true},
+			want: "receiver:borrow",
+		},
 	}
 
 	for name, tc := range tests {
@@ -166,6 +210,14 @@ func joinFixture() *Facts {
 			"Object.assign": {Classified: covered, Receiver: RecvNone, Returns: returnsParam(0)},
 			// A namespace function, which has no receiver.
 			"Math.max": {Classified: covered, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnknown}},
+			// Two methods whose returns the walk never read, which the type
+			// source settles apart. `lib.es5.d.ts` declares
+			// `localeCompare(that: string): number`, a primitive, so the
+			// return is owned. It declares `exec(string: string):
+			// RegExpExecArray | null`, a union with a member that is not, so
+			// the `unknown` stands.
+			"String.prototype.localeCompare": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
+			"RegExp.prototype.exec":          {Classified: covered, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
 			// A method the mutation fixpoint could not read whole, so its
 			// receiver claim is withheld while its return alias stands.
 			"Array.prototype.toLocaleString": {Classified: Coverage{Returns: true}, Returns: ReturnFact{Kind: AliasFresh}},
@@ -297,6 +349,18 @@ func TestJoinMatch(t *testing.T) {
 			Ref:        MemberRef{Owner: "Array", Member: StrMember("toSorted"), Sort: SortInstance},
 			Signatures: []Signature{{Params: 1}},
 		},
+		{
+			// A primitive return type settles the ownership of a return the
+			// walk never read.
+			Ref:        MemberRef{Owner: "String", Member: StrMember("localeCompare"), Sort: SortInstance},
+			Signatures: []Signature{{Params: 1, PrimitiveReturn: true}},
+		},
+		{
+			// The same return against a declaration that hands back an
+			// object, which the type cannot settle.
+			Ref:        MemberRef{Owner: "RegExp", Member: StrMember("exec"), Sort: SortInstance},
+			Signatures: []Signature{{Params: 1}},
+		},
 	}
 
 	report := NewJoin(joinFixture()).Match(Declarations{
@@ -330,6 +394,8 @@ func TestJoinMatch(t *testing.T) {
 	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`Array.prototype.push -> instance Array.push receiverApplies:yes [ receiver:mutBorrow returns:fresh ]
 Fixture.prototype.returnsSecond -> instance Fixture.returnsSecond receiverApplies:yes [ receiver:borrow returns:unknown | receiver:borrow returns:param(1) ]
 get Map.prototype.size -> get instance Map.size receiverApplies:no [ receiver:borrow returns:fresh ]
+String.prototype.localeCompare -> instance String.localeCompare receiverApplies:yes [ receiver:borrow returns:unknown settled:owned ]
+RegExp.prototype.exec -> instance RegExp.exec receiverApplies:yes [ receiver:mutBorrow returns:unknown ]
 no fact: instance Array.toSorted
 no declaration: Array.prototype.toLocaleString
 no declaration: Math.max
@@ -337,6 +403,36 @@ no declaration: Object.assign
 no declaration: String.prototype [ @@iterator ]
 unjoinable fact: parseInt
 unkeyed declaration: parseInt`))
+}
+
+// The §5 gate on settlement. The join counts the returns it could not name,
+// split by whether the declared return type settled one as owned, so an
+// operator reads the share off the report rather than inferring it from the
+// matches.
+func TestJoinMatchCountsSettledReturns(t *testing.T) {
+	t.Parallel()
+
+	report := NewJoin(joinFixture()).Match(Declarations{Keyed: []Declaration{
+		// Two overloads of one return the join cannot name, only one of which
+		// declares a primitive. The return type belongs to the overload, so the
+		// two settle apart and each is counted on its own.
+		{
+			Ref:        MemberRef{Owner: "String", Member: StrMember("localeCompare"), Sort: SortInstance},
+			Signatures: []Signature{{Params: 1, PrimitiveReturn: true}, {Params: 2}},
+		},
+		{
+			Ref:        MemberRef{Owner: "RegExp", Member: StrMember("exec"), Sort: SortInstance},
+			Signatures: []Signature{{Params: 1}},
+		},
+		// A return the walk read, which neither count covers.
+		{
+			Ref:        MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance},
+			Signatures: []Signature{{Params: 1, Rest: true, PrimitiveReturn: true}},
+		},
+	}})
+
+	require.Equal(t, 1, report.SettledReturns)
+	require.Equal(t, 2, report.UnsettledReturns)
 }
 
 func boolWord(b bool) string {
@@ -354,13 +450,18 @@ func TestWriteJoinReport(t *testing.T) {
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance}, Signatures: []Signature{{Params: 1, Rest: true}}},
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("toLocaleString"), Sort: SortInstance}, Signatures: []Signature{{Params: 0}}},
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("toSorted"), Sort: SortInstance}, Signatures: []Signature{{Params: 1}}},
+			// One return the declared type settles and one it leaves, so the
+			// report's return counts carry both.
+			{Ref: MemberRef{Owner: "String", Member: StrMember("localeCompare"), Sort: SortInstance}, Signatures: []Signature{{Params: 1, PrimitiveReturn: true}}},
+			{Ref: MemberRef{Owner: "RegExp", Member: StrMember("exec"), Sort: SortInstance}, Signatures: []Signature{{Params: 1}}},
 		},
 		Unkeyed: []string{"parseInt"},
 	})
 
 	var out strings.Builder
 	require.NoError(t, WriteJoinReport(report, &out))
-	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  join: 2 matched (1 with a receiver claim), 1 declarations without a fact, 5 facts without a declaration, 1 unkeyed declarations, 1 unjoinable facts
+	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  join: 4 matched (3 with a receiver claim), 1 declarations without a fact, 5 facts without a declaration, 1 unkeyed declarations, 1 unjoinable facts
+  returns: 1 settled as owned by the declared type, 1 left unknown
     no fact: instance Array.toSorted
     no declaration: Fixture.prototype.returnsSecond
     no declaration: Math.max

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -39,7 +39,7 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ✅      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.2 | Origin map                                 | FR2, FR4   | ✅      | §3         | origins asserted for sample functions — `ToObject(this)`→Receiver, allocators→Fresh, reads→Unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.3 | Method classification                      | FR4, FR5   | ✅      | §4.1, §4.2 | facts.json core — receiver / returns / per-determination coverage for the representative methods — met, see [internal/ecma262/](../../internal/ecma262/) |
-| §5   | Keying and join                            | FR7, FR15  | ✅      | §4.3       | normalizer joins facts to `.d.ts` declarations; overloads share algorithm-level facts, type-dependent parts per signature; unmatched reported — met, see [internal/ecma262/key.go](../../internal/ecma262/key.go) and [internal/ecma262/join.go](../../internal/ecma262/join.go) |
+| §5   | Keying and join                            | FR7, FR15  | ✅      | §4.3       | normalizer joins facts to `.d.ts` declarations; overloads share algorithm-level facts, type-dependent parts per signature; a primitive return type settles a return the analysis cannot name as owned; unmatched reported — met, see [internal/ecma262/key.go](../../internal/ecma262/key.go) and [internal/ecma262/join.go](../../internal/ecma262/join.go) |
 | §6   | Validation diff                            | FR9        | ⬜      | §5         | receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
 | §7   | Integration as classification source       | FR8        | ⬜      | §6         | converter ranks facts above name tiers; the two application paths wired; redundant overrides removed |
 | §8.1 | Parameter disposition                      | FR12       | ⬜      | §4.1, §7   | push/Map.set `escape`, Reflect.set `mutBorrow`+`escape`, indexOf `borrow` in facts.json |
@@ -1281,10 +1281,40 @@ func normalize(specKey string) (owner []string, member MemberKey, sort MemberSor
   ([../../internal/dts_to_esc/partition.go](../../internal/dts_to_esc/partition.go)).
   A fact with no declaration and a declaration with no fact are both
   informational, since the spec and the TS lib drift independently.
+- Settle a return the analysis could not read against the declared return
+  type. Half of the classified builtins carry `returns: unknown`, which
+  records that the walk read no usable return rather than that the return is
+  unknowable. A primitive return is owned, since a primitive carries no
+  identity a lifetime could be tied to, and Appendix B already spells that
+  `fresh`. The type is simply on the other side of FR7's split: `cfg.json` is
+  typeless by design, and §5 is the first point where the return type exists.
+  `String.prototype.localeCompare` is the case. ESMeta lowers its two argument
+  coercions and stops, because the comparison itself is implementation-defined,
+  and `lib.es5.d.ts` declares `localeCompare(that: string): number`. The rules:
+    - A union settles only when every member is primitive. `string | undefined`
+      is owned and `string | ArrayBuffer` is not.
+    - The settlement rides on the join's per-signature result and does not
+      rewrite `returns`, so a `fresh` the analysis proved stays apart from an
+      ownership the type answered. `facts.json` is unchanged, so §6's diff and
+      any audit of the facts source keep reading only what the analysis
+      concluded.
+    - It resolves per signature. FR15 gives one fact per algorithm while the
+      return type belongs to each overload, so two signatures of one method
+      can settle differently.
+    - A non-primitive `unknown` is left alone. An object return the walk could
+      not read has no ownership answer the type can give. TypeScript's `void`
+      is one: the converter lowers a `void` return to `unknown` to keep a
+      callback slot permissive, so `DataView.prototype.setFloat64` and the rest
+      of the setters keep a return the join cannot name.
+  The join reports how many of these returns it settled and how many it left,
+  so the number is read off the report rather than inferred.
 
 **Gate.** Every `std:*` method the converter emits either resolves to a
 fact or is reported as unmatched; symbol-keyed and accessor members
-resolve correctly.
+resolve correctly. A return the analysis could not read settles as owned
+where the joined signature declares a primitive return, which
+`String.prototype.localeCompare` and the `DataView.prototype.get*` family
+show, and the join's report carries the settled and unsettled counts.
 
 ## §6. Validation diff
 


### PR DESCRIPTION
Fixes #1285.

The join (§5) now settles returns the analysis could not name against the declared return type. When a fact's `returns` is `unknown` and the overload declares a primitive return type, the join marks it as owned, since primitives carry no identity that a lifetime could be tied to.

This addresses the case where ESMeta's analysis stops before reading a return. `String.prototype.localeCompare` is one, since the comparison itself is implementation-defined, and there the TypeScript library declares a primitive return type that answers the ownership question.

Key changes:

- Added `PrimitiveReturn` field to `Signature` to track whether the declared return type is primitive
- Added `SignatureFact` struct to hold both the resolved fact and whether the return was settled by the declared type. The fact's own `Returns` is untouched, so a `fresh` the analysis proved stays apart from an ownership the type answered, and `facts.json` is unchanged
- Implemented `primitiveTypeAnn()` to check whether a type annotation is primitive: the primitive keywords, a literal of one, `never`, and unions of those, but not type references or `void`/`unknown`
- Updated `ForSignature()` to settle a return the join cannot name when the signature declares a primitive return
- Added `SettledReturns` and `UnsettledReturns` counters to `JoinReport` to track settlement outcomes per signature
- Updated `CollectDeclarations()` in dts_to_esc to read each overload's return type annotation
- Updated test expectations and added new tests (`TestCollectDeclarationsReadsPrimitiveReturns`, `TestPrimitiveReturnsSettleUnnamedReturns`, `TestJoinMatchCountsSettledReturns`) to verify the settlement logic

A union of return types counts as primitive only when all members are primitive. `string | undefined` is owned and `string | ArrayBuffer` is not.

Running the converter over `lib.es5.d.ts` against the committed graph settles 74 returns and leaves 31. `String.prototype.localeCompare` and the `DataView.prototype.get*` family settle as owned, which is the gate the issue names. The `DataView.prototype.set*` family does not: the converter lowers a `void` return to `unknown` to keep callback slots permissive, and `unknown` also holds every object, so the annotation alone cannot separate the two.

https://claude.ai/code/session_018L47rstamCv4FnFHxFcvx4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved return-type analysis for joined declarations, including primitive types and primitive-only unions.
  - Added per-signature tracking for resolved and unresolved return information.
  - Join reports now show counts for settled and unsettled unknown returns.

- **Bug Fixes**
  - Primitive return types are now correctly recognized and attributed during matching.
  - Non-primitive, unsupported, and `void` returns remain accurately classified as unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->