### PR TITLE
Add curated fact layer for ECMA-262 builtin analysis

### DIFF
--- a/internal/dts_to_esc/join_test.go
+++ b/internal/dts_to_esc/join_test.go
@@ -264,9 +264,8 @@ interface Fixture {
 		SpecTarget: "test",
 		Methods: map[string]ecma262.MethodFact{
 			"Fixture.prototype.withTail": {
-				Classified: ecma262.Coverage{Receiver: true, Returns: true},
-				Receiver:   ecma262.RecvBorrow,
-				Returns:    ecma262.ReturnFact{Kind: ecma262.AliasParam, Index: &tail},
+				Receiver: ecma262.RecvBorrow,
+				Returns:  ecma262.ReturnFact{Kind: ecma262.AliasParam, Index: &tail},
 			},
 		},
 	}
@@ -407,15 +406,14 @@ interface DataView {
 `).Module)
 	require.NoError(t, err)
 
-	covered := ecma262.Coverage{Receiver: true, Returns: true}
 	unnamed := ecma262.ReturnFact{Kind: ecma262.AliasUnknown}
 	facts := &ecma262.Facts{
 		SpecTarget: "test",
 		Methods: map[string]ecma262.MethodFact{
-			"String.prototype.localeCompare": {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: unnamed},
-			"DataView.prototype.getFloat64":  {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: unnamed},
-			"DataView.prototype.getUint8":    {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: unnamed},
-			"DataView.prototype.setFloat64":  {Classified: covered, Receiver: ecma262.RecvMutBorrow, Returns: unnamed},
+			"String.prototype.localeCompare": {Receiver: ecma262.RecvBorrow, Returns: unnamed},
+			"DataView.prototype.getFloat64":  {Receiver: ecma262.RecvBorrow, Returns: unnamed},
+			"DataView.prototype.getUint8":    {Receiver: ecma262.RecvBorrow, Returns: unnamed},
+			"DataView.prototype.setFloat64":  {Receiver: ecma262.RecvMutBorrow, Returns: unnamed},
 		},
 	}
 	report := ecma262.NewJoin(facts).Match(CollectDeclarations(mod))
@@ -463,18 +461,17 @@ declare function parseInt(string: string, radix?: number): number;
 	mods, err := ConvertBuckets(result)
 	require.NoError(t, err)
 
-	covered := ecma262.Coverage{Receiver: true, Returns: true}
 	facts := &ecma262.Facts{
 		SpecTarget: "test",
 		Methods: map[string]ecma262.MethodFact{
-			"Array.prototype.push":           {Classified: covered, Receiver: ecma262.RecvMutBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
-			"Array.prototype [ @@iterator ]": {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
-			"Array.isArray":                  {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
-			"Math.max":                       {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
-			"Math.min":                       {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Array.prototype.push":           {Receiver: ecma262.RecvMutBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Array.prototype [ @@iterator ]": {Receiver: ecma262.RecvBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Array.isArray":                  {Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Math.max":                       {Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Math.min":                       {Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
 			// A function the global object holds names no owner, so neither
 			// side of the join can key it.
-			"parseInt": {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"parseInt": {Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
 		},
 	}
 	report := ecma262.NewJoin(facts).Match(StdDeclarations(mods))

--- a/internal/dts_to_esc/mutability.go
+++ b/internal/dts_to_esc/mutability.go
@@ -467,4 +467,3 @@ func isReadonlyWrapperType(t dts_parser.TypeAnn) bool {
 	}
 	return false
 }
-

--- a/internal/ecma262/__snapshots__/curated_test.snap
+++ b/internal/ecma262/__snapshots__/curated_test.snap
@@ -1,11 +1,11 @@
 
 [TestCurationReportOverTheCommittedGraph - 1]
 Array.prototype.toLocaleString receiver: fill-in borrow
-Date.prototype.getTime returns: correction fresh over unknown
+Date.prototype.getTime returns: fill-in fresh
 Date.prototype.getTimezoneOffset receiver: fill-in borrow
 Date.prototype.toISOString receiver: fill-in borrow
 Date.prototype.toUTCString receiver: fill-in borrow
-Date.prototype.valueOf returns: correction fresh over unknown
+Date.prototype.valueOf returns: fill-in fresh
 ForInIteratorPrototype.next receiver: fill-in mutBorrow
 Number.prototype.toExponential receiver: fill-in borrow
 Number.prototype.toFixed receiver: fill-in borrow
@@ -26,5 +26,5 @@ String.prototype.toUpperCase receiver: fill-in borrow
 TypedArray.prototype.slice receiver: fill-in borrow
 TypedArray.prototype.toLocaleString receiver: fill-in borrow
 get RegExp.prototype.flags receiver: fill-in borrow
-get TypedArray.prototype [ @@toStringTag ] returns: correction fresh over unknown
+get TypedArray.prototype [ @@toStringTag ] returns: fill-in fresh
 ---

--- a/internal/ecma262/__snapshots__/curated_test.snap
+++ b/internal/ecma262/__snapshots__/curated_test.snap
@@ -1,0 +1,30 @@
+
+[TestCurationReportOverTheCommittedGraph - 1]
+Array.prototype.toLocaleString receiver: fill-in borrow
+Date.prototype.getTime returns: correction fresh over unknown
+Date.prototype.getTimezoneOffset receiver: fill-in borrow
+Date.prototype.toISOString receiver: fill-in borrow
+Date.prototype.toUTCString receiver: fill-in borrow
+Date.prototype.valueOf returns: correction fresh over unknown
+ForInIteratorPrototype.next receiver: fill-in mutBorrow
+Number.prototype.toExponential receiver: fill-in borrow
+Number.prototype.toFixed receiver: fill-in borrow
+Number.prototype.toLocaleString receiver: fill-in borrow
+Number.prototype.toPrecision receiver: fill-in borrow
+RegExp.prototype [ @@matchAll ] receiver: fill-in borrow
+RegExp.prototype [ @@replace ] receiver: fill-in mutBorrow
+RegExp.prototype [ @@split ] receiver: fill-in borrow
+RegExpStringIteratorPrototype.next receiver: fill-in mutBorrow
+SharedArrayBuffer.prototype.grow receiver: fill-in mutBorrow
+String.prototype.normalize receiver: fill-in borrow
+String.prototype.repeat receiver: fill-in borrow
+String.prototype.split receiver: fill-in borrow
+String.prototype.toLocaleLowerCase receiver: fill-in borrow
+String.prototype.toLocaleUpperCase receiver: fill-in borrow
+String.prototype.toLowerCase receiver: fill-in borrow
+String.prototype.toUpperCase receiver: fill-in borrow
+TypedArray.prototype.slice receiver: fill-in borrow
+TypedArray.prototype.toLocaleString receiver: fill-in borrow
+get RegExp.prototype.flags receiver: fill-in borrow
+get TypedArray.prototype [ @@toStringTag ] returns: correction fresh over unknown
+---

--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -624,6 +624,10 @@ const digestLen = 12
 // The fingerprint is taken over the decode type rather than over Func because
 // Node is a sealed interface. encoding/json writes no tag for the variant an
 // interface holds, so two different steps could fingerprint alike.
+//
+// The decode types hold only strings, ints, bools, and slices and pointers to
+// those, so the marshal cannot fail. The error is returned rather than dropped
+// in case a later field can, which leaves that path untestable as it stands.
 func (d *decodeFunc) digest() (string, error) {
 	encoded, err := json.Marshal(d)
 	if err != nil {

--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -63,9 +63,9 @@ type Func struct {
 	Nodes    []Node   // CFG nodes in flat order
 
 	// Digest fingerprints this algorithm as cfg.json serializes it. A curated
-	// entry records the digest of the algorithm its author reviewed, so a spec
-	// bump that rewrites the algorithm can flag the entry for re-review while
-	// leaving every untouched entry alone. See curated.go.
+	// entry records the digest of the algorithm its author reviewed. A spec
+	// bump then flags the entries whose algorithm it rewrote and leaves the
+	// rest alone. See curated.go.
 	Digest string
 }
 
@@ -617,9 +617,9 @@ func toExprs(ds []*decodeExpr) ([]Expr, error) {
 const digestLen = 12
 
 // digest fingerprints one serialized algorithm. It changes when any step,
-// parameter, or kind does, and not when cfg.json's key order or whitespace
-// does, so a curated entry that names a digest is flagged for re-review by a
-// spec bump that rewrote the algorithm and by nothing else.
+// parameter, or kind does. It does not change when cfg.json's key order or
+// whitespace does. So a curated entry naming a digest is flagged for re-review
+// by a spec bump that rewrote its algorithm, and by nothing else.
 //
 // The fingerprint is taken over the decode type rather than over Func because
 // Node is a sealed interface. encoding/json writes no tag for the variant an

--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -11,6 +11,8 @@
 package ecma262
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -59,6 +61,12 @@ type Func struct {
 	Variadic *int     // rest-parameter position; nil when the head declares none
 	Promise  bool     // the algorithm returns a promise
 	Nodes    []Node   // CFG nodes in flat order
+
+	// Digest fingerprints this algorithm as cfg.json serializes it. A curated
+	// entry records the digest of the algorithm its author reviewed, so a spec
+	// bump that rewrites the algorithm can flag the entry for re-review while
+	// leaving every untouched entry alone. See curated.go.
+	Digest string
 }
 
 // Node is one step of an algorithm.
@@ -302,8 +310,9 @@ func (c *CFG) Builtin(name string) *Func {
 // The decode types mirror the serialized schema in Appendix A, where a node and
 // an expression are each one object tagged by kind. encoding/json cannot pick a
 // variant of a sealed interface on its own, so decoding lands here first and the
-// conversions below rebuild the graph as the sum types above. Nothing marshals
-// back, so these types are read only when a graph is parsed.
+// conversions below rebuild the graph as the sum types above. A decoded
+// function marshals back once, to fingerprint it for Func.Digest; nothing else
+// writes this schema.
 
 type decodeCFG struct {
 	SpecTarget string        `json:"specTarget"`
@@ -408,6 +417,11 @@ func (d *decodeFunc) toFunc(index int) (*Func, error) {
 		return nil, fmt.Errorf("%s declares a rest parameter at position %d, outside its %d parameters", d.Name, *d.Variadic, len(d.Params))
 	}
 
+	digest, err := d.digest()
+	if err != nil {
+		return nil, fmt.Errorf("fingerprinting %s: %w", d.Name, err)
+	}
+
 	fn := &Func{
 		Name:     d.Name,
 		Kind:     d.Kind,
@@ -415,6 +429,7 @@ func (d *decodeFunc) toFunc(index int) (*Func, error) {
 		Variadic: d.Variadic,
 		Promise:  d.Promise,
 		Nodes:    make([]Node, 0, len(d.Nodes)),
+		Digest:   digest,
 	}
 	for i, dn := range d.Nodes {
 		if dn == nil {
@@ -594,4 +609,26 @@ func toExprs(ds []*decodeExpr) ([]Expr, error) {
 		exprs = append(exprs, e)
 	}
 	return exprs, nil
+}
+
+// digestLen is how much of the fingerprint Func.Digest keeps. Twelve hex digits
+// distinguish the roughly twelve hundred algorithms in one graph with room to
+// spare, and stay short enough to read in curated.json.
+const digestLen = 12
+
+// digest fingerprints one serialized algorithm. It changes when any step,
+// parameter, or kind does, and not when cfg.json's key order or whitespace
+// does, so a curated entry that names a digest is flagged for re-review by a
+// spec bump that rewrote the algorithm and by nothing else.
+//
+// The fingerprint is taken over the decode type rather than over Func because
+// Node is a sealed interface. encoding/json writes no tag for the variant an
+// interface holds, so two different steps could fingerprint alike.
+func (d *decodeFunc) digest() (string, error) {
+	encoded, err := json.Marshal(d)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])[:digestLen], nil
 }

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -363,7 +363,7 @@ type Facts struct {
 // reads Curation to tell a curated claim from an analyzed one.
 func NewFacts(cfg *CFG) *Facts {
 	facts := analyze(cfg)
-	facts.curation = curate(cfg, curated, facts.Methods)
+	facts.curation = mergeCuration(cfg, curated, facts.Methods)
 	return facts
 }
 

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -190,11 +190,14 @@ func receiverCovered(fn *Func, mutations Mutations) bool {
 	return !mutations.Unattributable && !mutations.Incomplete
 }
 
-// Coverage marks a subset of the determinations a builtin carries. On a
-// MethodFact it marks the ones the analysis resolved, and a step the analysis
-// could not read withholds only the ones that read it (FR5). On a CuratedEntry
-// it marks the ones that entry answers by review. The two share the type
-// because the merge reads them the same way, one axis at a time.
+// Coverage records which of MethodFact's determinations the analysis resolved.
+// A step it could not read withholds only the ones that read it (FR5).
+//
+// A curated entry carries no Coverage. Which axes it answers follows from which
+// fields it sets, since neither determination has a valid zero value. The
+// published fact keeps the flags because §8 and §9 add three slice-valued axes,
+// where a proven-empty result and an unanalyzed one would otherwise differ only
+// by nil versus empty.
 type Coverage struct {
 	// Receiver is set for a static or namespace function, which has no receiver
 	// to claim, and for a method the mutation fixpoint read whole.

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -383,8 +383,8 @@ func (f *Facts) Curation() CurationReport {
 // mutation fixpoint itself, which supplies the receiver axis and the two
 // warnings that withhold a method's mutability claim.
 //
-// This is what §4 is measured by, and Facts.Unclassified over its result is
-// the objective made visible. NewFacts is what a consumer reads, since a
+// This is what §4 is measured by, and Facts.Unclassified over its result is the
+// objective made visible, per axis. NewFacts is what a consumer reads, since a
 // determination §4 cannot reach is answered by review rather than left open.
 func analyze(cfg *CFG) *Facts {
 	summary := NewMutationSummary(cfg)
@@ -421,21 +421,43 @@ func (f *Facts) Of(name string) (MethodFact, bool) {
 	return fact, ok
 }
 
-// Unclassified returns the names whose receiver claim FR5 hands to the
-// converter's name-based heuristics, sorted. Only a method appears, and it
-// still publishes its return alias, so the list marks a withheld determination
-// rather than an empty fact.
+// Unclassified returns the names carrying no answer on axis, sorted.
 //
 // Over an analyze result the list is what §4 is measured by. Over a NewFacts
 // result it is what neither the analysis nor the curated layer answers, which
-// is the list §7 actually falls back to heuristics for.
-func (f *Facts) Unclassified() []string {
+// is the surface still waiting on review.
+//
+// The two axes are worth reading apart rather than summed. §7 auto-applies the
+// receiver, so a name on that list is a method whose mutability falls to the
+// converter's name heuristics — a soundness gap. A name on the returns list
+// costs only the lifetime precision §8.2 would have seeded from it.
+func (f *Facts) Unclassified(axis Axis) []string {
 	names := make([]string, 0, len(f.Methods))
 	for name, fact := range f.Methods {
-		if !fact.Classified.Receiver {
+		if !fact.answers(axis) {
 			names = append(names, name)
 		}
 	}
 	sort.Strings(names)
 	return names
+}
+
+// answers reports whether the fact carries a real answer on axis.
+//
+// The two axes spell the absence of one differently. ReceiverKind has no member
+// meaning "could not tell", so an unanswered receiver is one whose coverage is
+// unset. The alias lattice does have a top and returnAlias is total, so an
+// unanswered return is a covered `unknown` rather than a missing field.
+//
+// An axis this does not name reads as unanswered, so an axis §8 or §9 adds
+// shows up as wholly open until it is wired in here.
+func (f MethodFact) answers(axis Axis) bool {
+	switch axis {
+	case AxisReceiver:
+		return f.Classified.Receiver
+	case AxisReturns:
+		return f.Classified.Returns && f.Returns.Kind != AliasUnknown
+	default:
+		return false
+	}
 }

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -345,17 +345,42 @@ func (f MethodFact) String() string {
 type Facts struct {
 	SpecTarget string                `json:"specTarget"`
 	Methods    map[string]MethodFact `json:"methods"`
+
+	// curation is what the curated layer did to the analyzed determinations.
+	// It is unexported because facts.json records the merged answer and not
+	// where each half of it came from. See CurationReport.
+	curation CurationReport
 }
 
-// NewFacts classifies every builtin in cfg. It runs the mutation fixpoint
-// itself, which supplies the receiver axis and the two warnings that withhold
-// a method's mutability claim.
+// NewFacts is the published fact set for cfg, what §7's converter consumes. It
+// classifies every builtin from the graph and then merges the curated layer of
+// curated.go over the result, one determination at a time.
 //
-// A published receiver claim is only as strong as §4.1. A mutation the analysis
-// does not see leaves no warning, so the borrow is published rather than
-// withheld. §6's diff against the hand-written overrides is what authorizes §7
-// to trust this source.
+// A published receiver claim is only as strong as §4.1 or as the review behind
+// a curated entry. A mutation the analysis does not see leaves no warning, so
+// the borrow is published rather than withheld. §6's diff against the
+// hand-written overrides is what authorizes §7 to trust this source, and it
+// reads Curation to tell a curated claim from an analyzed one.
 func NewFacts(cfg *CFG) *Facts {
+	facts := analyze(cfg)
+	facts.curation = curate(cfg, curated, facts.Methods)
+	return facts
+}
+
+// Curation reports what the curated layer did to this run's analyzed
+// determinations.
+func (f *Facts) Curation() CurationReport {
+	return f.curation
+}
+
+// analyze classifies every builtin in cfg from the graph alone. It runs the
+// mutation fixpoint itself, which supplies the receiver axis and the two
+// warnings that withhold a method's mutability claim.
+//
+// This is what §4 is measured by, and Facts.Unclassified over its result is
+// the objective made visible. NewFacts is what a consumer reads, since a
+// determination §4 cannot reach is answered by review rather than left open.
+func analyze(cfg *CFG) *Facts {
 	summary := NewMutationSummary(cfg)
 
 	facts := &Facts{
@@ -391,9 +416,13 @@ func (f *Facts) Of(name string) (MethodFact, bool) {
 }
 
 // Unclassified returns the names whose receiver claim FR5 hands to the
-// converter's name-based heuristics, sorted. Shrinking this list is what §4 is
-// measured by. Only a method appears, and it still publishes its return alias,
-// so the list marks a withheld determination rather than an empty fact.
+// converter's name-based heuristics, sorted. Only a method appears, and it
+// still publishes its return alias, so the list marks a withheld determination
+// rather than an empty fact.
+//
+// Over an analyze result the list is what §4 is measured by. Over a NewFacts
+// result it is what neither the analysis nor the curated layer answers, which
+// is the list §7 actually falls back to heuristics for.
 func (f *Facts) Unclassified() []string {
 	names := make([]string, 0, len(f.Methods))
 	for name, fact := range f.Methods {

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -190,8 +190,11 @@ func receiverCovered(fn *Func, mutations Mutations) bool {
 	return !mutations.Unattributable && !mutations.Incomplete
 }
 
-// Coverage records which of MethodFact's determinations the analysis resolved.
-// A step it could not read withholds only the ones that read it (FR5).
+// Coverage marks a subset of the determinations a builtin carries. On a
+// MethodFact it marks the ones the analysis resolved, and a step the analysis
+// could not read withholds only the ones that read it (FR5). On a CuratedEntry
+// it marks the ones that entry answers by review. The two share the type
+// because the merge reads them the same way, one axis at a time.
 type Coverage struct {
 	// Receiver is set for a static or namespace function, which has no receiver
 	// to claim, and for a method the mutation fixpoint read whole.

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -190,24 +190,6 @@ func receiverCovered(fn *Func, mutations Mutations) bool {
 	return !mutations.Unattributable && !mutations.Incomplete
 }
 
-// Coverage records which of MethodFact's determinations the analysis resolved.
-// A step it could not read withholds only the ones that read it (FR5).
-//
-// A curated entry carries no Coverage. Which axes it answers follows from which
-// fields it sets, since neither determination has a valid zero value. The
-// published fact keeps the flags because §8 and §9 add three slice-valued axes,
-// where a proven-empty result and an unanalyzed one would otherwise differ only
-// by nil versus empty.
-type Coverage struct {
-	// Receiver is set for a static or namespace function, which has no receiver
-	// to claim, and for a method the mutation fixpoint read whole.
-	Receiver bool `json:"receiver"`
-	// Returns is set for every builtin, since returnAlias is total. A return
-	// hidden in a step the analysis could not read drops out of the join, a
-	// loss FR4 accepts because §7 curates the alias rather than applying it.
-	Returns bool `json:"returns"`
-}
-
 // AliasRef names one value a return hands back, as Appendix B of
 // planning/ecma-262/implementation_plan.md serializes it. Index is the 0-based
 // position among the declared parameters, which do not include a method's
@@ -306,36 +288,34 @@ func newReturnFact(s aliasSet) ReturnFact {
 // as one entry of facts.json, described in Appendix B of
 // planning/ecma-262/implementation_plan.md.
 //
-// A determination Coverage leaves unset carries no claim, and its field is
-// absent from the JSON, so a consumer never reads "unanalyzed" as "proven
-// none". The converter applies requirements.md FR5's default instead, `&mut
-// self` for an absent receiver.
+// A published fact carries every determination. Neither field has a valid zero
+// value — "" is not a ReceiverKind and not an AliasKind — so a field a fact
+// does not carry is a hole rather than a claim, and Facts.Incomplete names the
+// methods that have one. Generation refuses to write those, which is why the
+// entries hold no coverage flags: an axis is present or the run failed.
 //
-// Receiver is a plain kind with no empty member, so omitempty encodes its
-// absence. Returns is a struct, and omitzero encodes the same absence for it.
+// `unknown` is a value, not a hole. The alias lattice's top says the walk read
+// the returns and could tie none of them to a value the caller holds, which is
+// something §8.2 can act on. The methods still waiting on an answer there are
+// Facts.Unclassified(AxisReturns), a review report rather than a wire concern.
 //
-// Params, Throws, and Rejects join this shape in §8 and §9. Until §8.1 fills
-// Params, no fact makes a parameter claim, so an absent Params is not yet
-// Appendix B's proven-read-only one.
-//
-// Both throw fields land together, in §9.2. ThrowSummary already computes each
-// channel, but publishing the reject set on its own would spell a method whose
-// synchronous throws are simply not published yet as one that throws nothing.
+// Params, Throws, and Rejects join this shape in §8 and §9, and the same rule
+// covers them: an axis a fact cannot answer fails the run rather than encoding
+// a hole a consumer might read as a proven-empty result.
 type MethodFact struct {
-	Classified Coverage     `json:"classified"`
-	Receiver   ReceiverKind `json:"receiver,omitempty"`
-	Returns    ReturnFact   `json:"returns,omitzero"`
+	Receiver ReceiverKind `json:"receiver,omitempty"`
+	Returns  ReturnFact   `json:"returns,omitzero"`
 }
 
-// String renders the covered determinations in one line, so a test can assert
-// a fact whole. An uncovered one is left out, and a fact covering nothing reads
+// String renders the determinations the fact carries in one line, so a test can
+// assert a fact whole. A hole is left out, and a fact with nothing in it reads
 // "unclassified".
 func (f MethodFact) String() string {
 	var parts []string
-	if f.Classified.Receiver {
+	if f.Receiver != "" {
 		parts = append(parts, "receiver:"+string(f.Receiver))
 	}
-	if f.Classified.Returns {
+	if f.Returns.Kind != "" {
 		parts = append(parts, "returns:"+f.Returns.String())
 	}
 	if len(parts) == 0 {
@@ -399,13 +379,9 @@ func analyze(cfg *CFG) *Facts {
 		}
 		mutations := summary.Of(fn)
 		fact := MethodFact{
-			Classified: Coverage{
-				Receiver: receiverCovered(fn, mutations),
-				Returns:  true,
-			},
 			Returns: newReturnFact(returnAlias(summary.originsOf(fn))),
 		}
-		if fact.Classified.Receiver {
+		if receiverCovered(fn, mutations) {
 			fact.Receiver = receiverKind(fn, mutations)
 		}
 		facts.Methods[fn.Name] = fact
@@ -442,22 +418,59 @@ func (f *Facts) Unclassified(axis Axis) []string {
 	return names
 }
 
-// answers reports whether the fact carries a real answer on axis.
+// answers reports whether the fact settles axis, which is a stronger question
+// than whether it carries a value there. A return of `unknown` is a value the
+// converter can act on and an open question for a reviewer, so it is carried
+// but not settled.
 //
-// The two axes spell the absence of one differently. ReceiverKind has no member
-// meaning "could not tell", so an unanswered receiver is one whose coverage is
-// unset. The alias lattice does have a top and returnAlias is total, so an
-// unanswered return is a covered `unknown` rather than a missing field.
-//
-// An axis this does not name reads as unanswered, so an axis §8 or §9 adds
-// shows up as wholly open until it is wired in here.
+// An axis this does not name reads as unsettled, so an axis §8 or §9 adds shows
+// up as wholly open until it is wired in here.
 func (f MethodFact) answers(axis Axis) bool {
 	switch axis {
 	case AxisReceiver:
-		return f.Classified.Receiver
+		return f.Receiver != ""
 	case AxisReturns:
-		return f.Classified.Returns && f.Returns.Kind != AliasUnknown
+		return f.Returns.Kind != "" && f.Returns.Kind != AliasUnknown
 	default:
 		return false
 	}
+}
+
+// carries reports whether the fact holds a value on axis at all. This is what
+// generation requires, and Unclassified's `answers` is the reviewer's stricter
+// reading of the same fact.
+//
+// An axis this does not name reads as carried, because a fact cannot be faulted
+// for a determination §8 or §9 has not added yet.
+func (f MethodFact) carries(axis Axis) bool {
+	switch axis {
+	case AxisReceiver:
+		return f.Receiver != ""
+	case AxisReturns:
+		return f.Returns.Kind != ""
+	default:
+		return true
+	}
+}
+
+// Incomplete returns the names whose fact holds a hole, one rendered line each,
+// sorted. A hole is a determination neither the analysis nor the curated layer
+// answered, and writing one to facts.json would leave a consumer to guess.
+//
+// The receiver axis is where this bites. §7 auto-applies it, so a hole there
+// would silently become the FR5 `&mut self` default, and a spec bump that
+// withholds a receiver nobody has curated is exactly the case that must be loud.
+// The list is empty for the committed graph, and TestFactsCarryEveryAxis holds
+// it that way.
+func (f *Facts) Incomplete() []string {
+	var holes []string
+	for name, fact := range f.Methods {
+		for _, axis := range []Axis{AxisReceiver, AxisReturns} {
+			if !fact.carries(axis) {
+				holes = append(holes, fmt.Sprintf("%s: no %s determination", name, axis))
+			}
+		}
+	}
+	sort.Strings(holes)
+	return holes
 }

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -441,7 +441,9 @@ func (f MethodFact) answers(axis Axis) bool {
 // reading of the same fact.
 //
 // An axis this does not name reads as carried, because a fact cannot be faulted
-// for a determination §8 or §9 has not added yet.
+// for a determination §8 or §9 has not added yet. That permissive default is
+// also how the switch could fall out of step with publishedAxes and let a hole
+// through, which TestCarriesCoversEveryPublishedAxis is there to catch.
 func (f MethodFact) carries(axis Axis) bool {
 	switch axis {
 	case AxisReceiver:
@@ -452,6 +454,10 @@ func (f MethodFact) carries(axis Axis) bool {
 		return true
 	}
 }
+
+// publishedAxes are the determinations every published fact must carry. §8 and
+// §9 add to it, and each axis added here needs a case in MethodFact.carries.
+var publishedAxes = []Axis{AxisReceiver, AxisReturns}
 
 // Incomplete returns the names whose fact holds a hole, one rendered line each,
 // sorted. A hole is a determination neither the analysis nor the curated layer
@@ -465,7 +471,7 @@ func (f MethodFact) carries(axis Axis) bool {
 func (f *Facts) Incomplete() []string {
 	var holes []string
 	for name, fact := range f.Methods {
-		for _, axis := range []Axis{AxisReceiver, AxisReturns} {
+		for _, axis := range publishedAxes {
 			if !fact.carries(axis) {
 				holes = append(holes, fmt.Sprintf("%s: no %s determination", name, axis))
 			}

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -43,9 +43,6 @@ func testAnalyzedFacts(t *testing.T) *Facts {
 	return analyzedFacts
 }
 
-// fullCoverage is what NewFacts builds for a builtin it read whole.
-var fullCoverage = Coverage{Receiver: true, Returns: true}
-
 // position is the 0-based parameter position a fact returns, as AliasRef
 // holds it.
 func position(i int) *int {
@@ -85,20 +82,20 @@ func TestMethodFactString(t *testing.T) {
 		// render, and a returned position past 0, which no builtin has.
 		"NoDetermination": {MethodFact{}, "unclassified"},
 		"ParamReturn": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: returnsParam(2)},
+			MethodFact{Receiver: RecvNone, Returns: returnsParam(2)},
 			"receiver:none returns:param(2)",
 		},
 		// A parameter return with no position reads as the missing position
 		// rather than as position 0. Nothing in the package builds such a fact;
 		// a hand-edited facts.json is where one would come from.
 		"ParamReturnWithNoPosition": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasParam}},
+			MethodFact{Receiver: RecvNone, Returns: ReturnFact{Kind: AliasParam}},
 			"receiver:none returns:param(?)",
 		},
 		// A union names every value it joined, which is what §8.2 spells the
 		// lifetime union from.
 		"UnionOverThreeValues": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion, Members: []AliasRef{
+			MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion, Members: []AliasRef{
 				{Kind: AliasFresh},
 				{Kind: AliasParam, Index: position(1)},
 				{Kind: AliasReceiver},
@@ -108,7 +105,7 @@ func TestMethodFactString(t *testing.T) {
 		// A union with no members is the counterpart of the positionless
 		// parameter return above, and comes from the same place.
 		"UnionWithNoMembers": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnion}},
+			MethodFact{Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnion}},
 			"receiver:none returns:union(?)",
 		},
 	}
@@ -297,7 +294,7 @@ func TestFactsEveryStringMethodBorrowsItsReceiver(t *testing.T) {
 		if !strings.HasPrefix(name, "String.prototype") {
 			continue
 		}
-		if !fact.Classified.Receiver {
+		if fact.Receiver == "" {
 			unread = append(unread, name)
 			continue
 		}
@@ -337,16 +334,11 @@ func TestFactsCoverEveryBuiltin(t *testing.T) {
 		fact, ok := f.Of(fn.Name)
 		require.True(t, ok, "%s has no fact", fn.Name)
 		// Every builtin resolves a return alias, warning or not.
-		require.True(t, fact.Classified.Returns, "%s has no return alias", fn.Name)
-		require.NotEmpty(t, fact.Returns.Kind, "%s covers a return alias it does not carry", fn.Name)
-		switch {
-		case fn.Kind != BuiltinMethod:
+		require.NotEmpty(t, fact.Returns.Kind, "%s has no return alias", fn.Name)
+		if fn.Kind != BuiltinMethod {
 			// `none` follows from the function kind, so no warning withholds it.
-			require.True(t, fact.Classified.Receiver, "%s has no receiver claim", fn.Name)
 			require.Equal(t, RecvNone, fact.Receiver, "%s has no receiver", fn.Name)
-		case !fact.Classified.Receiver:
-			require.Empty(t, fact.Receiver, "%s carries a receiver claim it is not classified for", fn.Name)
-		default:
+		} else {
 			require.Contains(t, []ReceiverKind{RecvBorrow, RecvMutBorrow}, fact.Receiver, fn.Name)
 		}
 		if fact.Returns.Kind != AliasParam {
@@ -395,7 +387,7 @@ func TestFactsUnionOverTwoReturnedParameters(t *testing.T) {
 	encoded, err := json.Marshal(fact)
 	require.NoError(t, err)
 	require.Equal(t,
-		`{"classified":{"receiver":true,"returns":true},"receiver":"none",`+
+		`{"receiver":"none",`+
 			`"returns":{"kind":"union","members":[{"kind":"param","index":0},{"kind":"param","index":1}]}}`,
 		string(encoded))
 }
@@ -409,37 +401,38 @@ func TestFactsOfAnAbsentName(t *testing.T) {
 	require.Equal(t, MethodFact{}, fact)
 }
 
-// A fact serializes as Appendix B describes. A determination its coverage
-// leaves unset omits its field, so the converter cannot read an absent claim
-// as a proven-empty one.
+// A fact serializes as Appendix B describes. Every published fact carries both
+// determinations, so a field absent from one is a hole Facts.Incomplete refuses
+// to write rather than a claim a consumer has to interpret.
 func TestFactsJSON(t *testing.T) {
 	tests := map[string]struct {
 		fact MethodFact
 		want string
 	}{
-		"Method": {factOf(t, "Array.prototype.fill"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":{"kind":"receiver"}}`},
-		// A withheld receiver falls through to FR5's `&mut self`, so the entry
-		// carries the return alias alone.
-		"WithheldReceiver": {analyzedFactOf(t, "Array.prototype.toLocaleString"), `{"classified":{"receiver":false,"returns":true},"returns":{"kind":"fresh"}}`},
+		"Method": {factOf(t, "Array.prototype.fill"), `{"receiver":"mutBorrow","returns":{"kind":"receiver"}}`},
+		// The analysis withheld this receiver, which is the shape Incomplete
+		// refuses. Curation answers it before anything is written, so this
+		// rendering only ever comes off an analyze result.
+		"WithheldReceiver": {analyzedFactOf(t, "Array.prototype.toLocaleString"), `{"returns":{"kind":"fresh"}}`},
 		// The first parameter is written out like any other position. Every
 		// parameter the committed graph returns sits at 0, so omitting it would
 		// leave the index absent from the whole file and spell the common case
 		// as missing data.
-		"ReturnedPositionZero": {factOf(t, "Object.freeze"), `{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":{"kind":"param","index":0}}`},
+		"ReturnedPositionZero": {factOf(t, "Object.freeze"), `{"receiver":"none","returns":{"kind":"param","index":0}}`},
 		"ReturnedPositionPastZero": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: returnsParam(2)},
-			`{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":{"kind":"param","index":2}}`,
+			MethodFact{Receiver: RecvNone, Returns: returnsParam(2)},
+			`{"receiver":"none","returns":{"kind":"param","index":2}}`,
 		},
 		// A fact that returns no parameter carries no position at all.
-		"NoReturnedPosition": {factOf(t, "Array.prototype.push"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":{"kind":"fresh"}}`},
+		"NoReturnedPosition": {factOf(t, "Array.prototype.push"), `{"receiver":"mutBorrow","returns":{"kind":"fresh"}}`},
 		// The §4.3 union gate. The `Object` constructor hands back an
 		// `OrdinaryObjectCreate` result on one path and `ToObject(value)` on
 		// another, and the entry names both so §8.2 can spell the lifetime
 		// union they seed.
-		"Union": {factOf(t, "Object"), `{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"param","index":0}]}}`},
-		// A fact covering no determination carries neither field. `returns` is
-		// a struct rather than a kind, so its absence is spelled by omitzero.
-		"NoDetermination": {MethodFact{}, `{"classified":{"receiver":false,"returns":false}}`},
+		"Union": {factOf(t, "Object"), `{"receiver":"none","returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"param","index":0}]}}`},
+		// The zero fact carries neither field, which is what Of returns for a
+		// name the graph does not hold.
+		"NoDetermination": {MethodFact{}, `{}`},
 	}
 
 	for name, test := range tests {
@@ -495,12 +488,12 @@ func TestFactsTallies(t *testing.T) {
 	counts := map[string]int{}
 	for _, fact := range testFacts(t).Methods {
 		counts["total"]++
-		if fact.Classified.Receiver {
+		if fact.Receiver != "" {
 			counts["receiver "+string(fact.Receiver)]++
 		} else {
 			counts["receiver unclassified"]++
 		}
-		if fact.Classified.Returns {
+		if fact.Returns.Kind != "" {
 			counts["returns "+string(fact.Returns.Kind)]++
 		} else {
 			counts["returns unclassified"]++

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -461,8 +461,26 @@ func TestFactsJSON(t *testing.T) {
 // curated.json, so nothing reaches §7's name heuristics, which is what the
 // second assertion holds.
 func TestFactsUnclassifiedMethodsAreListed(t *testing.T) {
-	snaps.MatchSnapshot(t, strings.Join(testAnalyzedFacts(t).Unclassified(), "\n"))
-	require.Empty(t, testFacts(t).Unclassified())
+	snaps.MatchSnapshot(t, strings.Join(testAnalyzedFacts(t).Unclassified(AxisReceiver), "\n"))
+	require.Empty(t, testFacts(t).Unclassified(AxisReceiver))
+}
+
+// The return axis is where the published surface still has gaps, and they are
+// visible rather than hidden behind a coverage flag returnAlias always sets.
+//
+// `Date.prototype.getTime` is off the list because an entry answered it. The
+// two `buffer` getters stay on it deliberately: what they hand back is a borrow
+// of state the receiver holds, and no member of the alias lattice spells that
+// without claiming the return is the receiver itself.
+func TestFactsUnclassifiedReturnsAreListed(t *testing.T) {
+	unresolved := testFacts(t).Unclassified(AxisReturns)
+
+	require.Contains(t, unresolved, "get DataView.prototype.buffer")
+	require.Contains(t, unresolved, "get TypedArray.prototype.buffer")
+	require.NotContains(t, unresolved, "Date.prototype.getTime")
+	require.NotContains(t, unresolved, "Date.prototype.valueOf")
+	// The same count the tallies below record as `returns unknown`.
+	require.Len(t, unresolved, 247)
 }
 
 // The tallies over every published builtin, which move when the mutation

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -13,11 +13,15 @@ import (
 )
 
 var (
-	factsOnce sync.Once
-	allFacts  *Facts
+	factsOnce     sync.Once
+	allFacts      *Facts
+	analyzedOnce  sync.Once
+	analyzedFacts *Facts
 )
 
-// testFacts classifies the committed graph once for the whole package.
+// testFacts is the published fact set over the committed graph, curated layer
+// merged in, classified once for the whole package. A test pinning what the
+// converter consumes reads this.
 func testFacts(t *testing.T) *Facts {
 	t.Helper()
 	cfg := testCFG(t)
@@ -25,6 +29,18 @@ func testFacts(t *testing.T) *Facts {
 		allFacts = NewFacts(cfg)
 	})
 	return allFacts
+}
+
+// testAnalyzedFacts is what the committed graph alone concludes, before
+// curated.json is merged over it. A test pinning what §4 can read off the graph
+// reads this, so a curated entry never disguises what the analysis found.
+func testAnalyzedFacts(t *testing.T) *Facts {
+	t.Helper()
+	cfg := testCFG(t)
+	analyzedOnce.Do(func() {
+		analyzedFacts = analyze(cfg)
+	})
+	return analyzedFacts
 }
 
 // fullCoverage is what NewFacts builds for a builtin it read whole.
@@ -42,11 +58,19 @@ func returnsParam(i int) ReturnFact {
 	return ReturnFact{Kind: AliasParam, Index: position(i)}
 }
 
-// factOf returns the fact for one builtin, failing when the graph does not
-// hold it.
+// factOf returns the published fact for one builtin, failing when the graph
+// does not hold it.
 func factOf(t *testing.T, name string) MethodFact {
 	t.Helper()
 	fact, ok := testFacts(t).Of(name)
+	require.True(t, ok, "no builtin named %s", name)
+	return fact
+}
+
+// analyzedFactOf returns what the analysis alone concluded about one builtin.
+func analyzedFactOf(t *testing.T, name string) MethodFact {
+	t.Helper()
+	fact, ok := testAnalyzedFacts(t).Of(name)
 	require.True(t, ok, "no builtin named %s", name)
 	return fact
 }
@@ -165,6 +189,10 @@ func TestAliasJoin(t *testing.T) {
 	}
 }
 
+// What §4.3 concludes from the graph alone, one method per shape. These read
+// the analysis rather than the published facts, so a curated entry that later
+// fills one of these determinations cannot hide what the graph does and does
+// not settle.
 func TestFactsSampleMethods(t *testing.T) {
 	tests := map[string]struct {
 		method string
@@ -252,7 +280,7 @@ func TestFactsSampleMethods(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.want, factOf(t, test.method).String())
+			require.Equal(t, test.want, analyzedFactOf(t, test.method).String())
 		})
 	}
 }
@@ -265,7 +293,7 @@ func TestFactsSampleMethods(t *testing.T) {
 func TestFactsEveryStringMethodBorrowsItsReceiver(t *testing.T) {
 	var borrowed int
 	var unread []string
-	for name, fact := range testFacts(t).Methods {
+	for name, fact := range testAnalyzedFacts(t).Methods {
 		if !strings.HasPrefix(name, "String.prototype") {
 			continue
 		}
@@ -392,7 +420,7 @@ func TestFactsJSON(t *testing.T) {
 		"Method": {factOf(t, "Array.prototype.fill"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":{"kind":"receiver"}}`},
 		// A withheld receiver falls through to FR5's `&mut self`, so the entry
 		// carries the return alias alone.
-		"WithheldReceiver": {factOf(t, "Array.prototype.toLocaleString"), `{"classified":{"receiver":false,"returns":true},"returns":{"kind":"fresh"}}`},
+		"WithheldReceiver": {analyzedFactOf(t, "Array.prototype.toLocaleString"), `{"classified":{"receiver":false,"returns":true},"returns":{"kind":"fresh"}}`},
 		// The first parameter is written out like any other position. Every
 		// parameter the committed graph returns sits at 0, so omitting it would
 		// leave the index absent from the whole file and spell the common case
@@ -423,22 +451,28 @@ func TestFactsJSON(t *testing.T) {
 	}
 }
 
-// The methods whose receiver claim FR5 hands to the converter's name
-// heuristics. Each carries a mutation the analysis could not place or a step it
-// could not read, so its mutability is withheld rather than guessed, and each
-// still publishes its return alias. A static is absent, having no receiver for
-// a warning to cost it.
+// The methods whose receiver the analysis withholds. Each carries a mutation it
+// could not place or a step it could not read, so the mutability is withheld
+// rather than guessed, and each still publishes its return alias. A static is
+// absent, having no receiver for a warning to cost it.
 //
-// This list is the §4 objective made visible. Shrinking it is what a change to
-// the analysis is measured by, and the tallies below record the same count.
+// This list is the §4 objective made visible, and shrinking it is what a change
+// to the analysis is measured by. Every name on it is answered by an entry in
+// curated.json, so nothing reaches §7's name heuristics, which is what the
+// second assertion holds.
 func TestFactsUnclassifiedMethodsAreListed(t *testing.T) {
-	snaps.MatchSnapshot(t, strings.Join(testFacts(t).Unclassified(), "\n"))
+	snaps.MatchSnapshot(t, strings.Join(testAnalyzedFacts(t).Unclassified(), "\n"))
+	require.Empty(t, testFacts(t).Unclassified())
 }
 
-// The tallies over every builtin, which move when the mutation analysis, the
-// origin map, or the classification changes. Each determination is counted on
-// its own, so the return-alias distribution spans every builtin while the
-// receiver one leaves out the methods that withhold it.
+// The tallies over every published builtin, which move when the mutation
+// analysis, the origin map, the classification, or curated.json changes. Each
+// determination is counted on its own, so the return-alias distribution spans
+// every builtin while the receiver one leaves out any method that withholds it.
+//
+// No method withholds one today. The analysis leaves 24 receivers open and the
+// curated layer answers all 24, which is why `receiver unclassified` is absent
+// rather than zero.
 func TestFactsTallies(t *testing.T) {
 	counts := map[string]int{}
 	for _, fact := range testFacts(t).Methods {
@@ -460,14 +494,13 @@ func TestFactsTallies(t *testing.T) {
 		lines = append(lines, fmt.Sprintf("%s: %d", key, count))
 	}
 	sort.Strings(lines)
-	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`receiver borrow: 226
-receiver mutBorrow: 63
+	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`receiver borrow: 246
+receiver mutBorrow: 67
 receiver none: 188
-receiver unclassified: 24
-returns fresh: 229
+returns fresh: 232
 returns param: 6
 returns receiver: 15
 returns union: 1
-returns unknown: 250
+returns unknown: 247
 total: 501`))
 }

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -38,17 +38,18 @@ const (
 )
 
 // CuratedEntry is one reviewed record, keyed in curated.json by the canonical
-// spec name of Appendix C. It carries the same determination fields as
-// MethodFact plus the provenance a reviewer needs.
+// spec name of Appendix C. It carries the determination fields of a MethodFact
+// plus the provenance a reviewer needs.
 //
-// Classified marks the axes this entry answers. That is not what the field
-// means on a MethodFact, where it marks the axes the analysis resolved. An axis
-// an entry leaves unset is simply not curated, and the analysis's answer for it
-// stands, settled or withheld alike.
+// An entry answers the axes it carries a value for, and no others. Neither
+// determination has a valid zero value — "" is not a ReceiverKind and not an
+// AliasKind — so a field left out is unambiguously an axis left to the
+// analysis, whose answer for it stands, settled or withheld alike.
 //
 // So the two axes of one method can come from different sources.
-// `Date.prototype.getTime` claims `returns` alone, because the analysis already
-// reads its receiver as `borrow` and only the return alias needs review.
+// `Date.prototype.getTime` carries a return alias and no receiver, because the
+// analysis already reads its receiver as `borrow` and only the return needs
+// review.
 type CuratedEntry struct {
 	// Reason is why the curated answer is right, in the reviewer's words. It
 	// is required, because a claim that outranks the analysis without a stated
@@ -62,10 +63,17 @@ type CuratedEntry struct {
 	// CurationReport lists that entry as stale.
 	ReviewedAt string `json:"reviewedAt"`
 
-	Classified Coverage     `json:"classified"`
-	Receiver   ReceiverKind `json:"receiver,omitempty"`
-	Returns    ReturnFact   `json:"returns,omitzero"`
+	Receiver ReceiverKind `json:"receiver,omitempty"`
+	Returns  ReturnFact   `json:"returns,omitzero"`
 }
+
+// claimsReceiver reports whether the entry answers the receiver axis.
+func (e CuratedEntry) claimsReceiver() bool { return e.Receiver != "" }
+
+// claimsReturns reports whether the entry answers the return axis. A fact that
+// carries a position or members but no kind is malformed rather than absent, so
+// it claims the axis and validate refuses it.
+func (e CuratedEntry) claimsReturns() bool { return !e.Returns.IsZero() }
 
 // Curation is the whole committed layer.
 type Curation struct {
@@ -208,24 +216,18 @@ func (e CuratedEntry) validate() error {
 	if e.ReviewedAt == "" {
 		return fmt.Errorf("has no reviewedAt digest")
 	}
-	if !e.Classified.Receiver && !e.Classified.Returns {
-		return fmt.Errorf("claims no determination")
+	if !e.claimsReceiver() && !e.claimsReturns() {
+		return fmt.Errorf("answers no determination")
 	}
-	if e.Classified.Receiver {
+	if e.claimsReceiver() {
 		switch e.Receiver {
 		case RecvBorrow, RecvMutBorrow, RecvNone:
 		default:
-			return fmt.Errorf("claims receiver %q, which is not a receiver kind", e.Receiver)
+			return fmt.Errorf("names receiver %q, which is not a receiver kind", e.Receiver)
 		}
 	}
-	if !e.Classified.Receiver && e.Receiver != "" {
-		return fmt.Errorf("names receiver %q on an axis its coverage leaves unclaimed", e.Receiver)
-	}
-	if e.Classified.Returns {
+	if e.claimsReturns() {
 		return e.Returns.validate()
-	}
-	if !e.Returns.IsZero() {
-		return fmt.Errorf("names returns %s on an axis its coverage leaves unclaimed", e.Returns)
 	}
 	return nil
 }
@@ -328,7 +330,7 @@ func mergeCuration(cfg *CFG, curation *Curation, methods map[string]MethodFact) 
 		}
 
 		fact := methods[name]
-		if entry.Classified.Receiver {
+		if entry.claimsReceiver() {
 			if reason := receiverConflict(fn, entry.Receiver); reason != "" {
 				report.Refused = append(report.Refused,
 					fmt.Sprintf("%s %s: curated %s, but %s", name, AxisReceiver, entry.Receiver, reason))
@@ -338,7 +340,7 @@ func mergeCuration(cfg *CFG, curation *Curation, methods map[string]MethodFact) 
 				fact.Classified.Receiver = true
 			}
 		}
-		if entry.Classified.Returns {
+		if entry.claimsReturns() {
 			report.Notes = append(report.Notes, returnsNote(name, fact, entry))
 			fact.Returns = entry.Returns
 			fact.Classified.Returns = true

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -87,9 +87,9 @@ type CurationNoteKind string
 const (
 	// CurationFillIn is a curated axis the analysis left open, so the entry
 	// adds a claim where there was none. It is the ordinary case and carries no
-	// conflict. An axis reads as open when its coverage is unset, and a return
-	// alias reads as open when it resolved to `unknown` too, since the top of
-	// the alias lattice names no value the return hands back.
+	// conflict. A receiver is open when the analysis carried no value for it,
+	// and a return alias is open when it resolved to `unknown` too, since the
+	// top of the alias lattice names no value the return hands back.
 	CurationFillIn CurationNoteKind = "fill-in"
 	// CurationCorrection is a curated axis contradicting a claim the analysis
 	// published. §6's validation diff reads these first, because a correction
@@ -285,8 +285,9 @@ func (r ReturnFact) validate() error {
 }
 
 // IsZero reports whether the fact carries no claim at all. encoding/json's
-// omitzero consults it, which is how a MethodFact with an uncovered return
-// omits the field entirely.
+// omitzero consults it, so a curated entry that answers only the receiver
+// leaves `returns` out. A published MethodFact never renders that way, because
+// generation refuses a fact with a hole in it.
 func (r ReturnFact) IsZero() bool {
 	return r.Kind == "" && r.Index == nil && len(r.Members) == 0
 }

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"sort"
+
+	"github.com/escalier-lang/escalier/internal/set"
 )
 
 // curated.go holds the hand-written fact layer described in
@@ -69,9 +71,11 @@ type Curation struct {
 type CurationNoteKind string
 
 const (
-	// CurationFillIn is a curated axis the analysis withheld, so the entry adds
-	// a claim where there was none. It is the ordinary case and carries no
-	// conflict.
+	// CurationFillIn is a curated axis the analysis left open, so the entry
+	// adds a claim where there was none. It is the ordinary case and carries no
+	// conflict. An axis reads as open when its coverage is unset, and a return
+	// alias reads as open when it resolved to `unknown` too, since the top of
+	// the alias lattice names no value the return hands back.
 	CurationFillIn CurationNoteKind = "fill-in"
 	// CurationCorrection is a curated axis contradicting a claim the analysis
 	// published. §6's validation diff reads these first, because a correction
@@ -121,6 +125,10 @@ type CurationReport struct {
 	// here, and TestCurationMatchesTheGraph is what turns the first into a
 	// failing build.
 	Unmatched []string
+	// Refused holds the curated axes the graph contradicts outright, one
+	// rendered line each, in the order the entries were read. The axis is not
+	// applied. See receiverConflict for the one contradiction there is.
+	Refused []string
 }
 
 // Counts renders the report's tallies by note kind, sorted, for the one-line
@@ -154,11 +162,36 @@ func ParseCuration(data []byte) (*Curation, error) {
 		return nil, fmt.Errorf("decoding curation: %w", err)
 	}
 	for _, name := range sortedNames(curation.Entries) {
-		if err := curation.Entries[name].validate(); err != nil {
+		entry := curation.Entries[name]
+		if err := entry.validate(); err != nil {
 			return nil, fmt.Errorf("curated entry %s: %w", name, err)
 		}
+		sortMembers(entry.Returns.Members)
+		curation.Entries[name] = entry
 	}
 	return &curation, nil
+}
+
+// sortMembers puts a union's members in the order newReturnFact leaves them,
+// by kind and then by position. A curated union is written by hand in whatever
+// order reads best, and every comparison against an analyzed fact and every
+// rendering assumes the one canonical order.
+func sortMembers(members []AliasRef) {
+	sort.Slice(members, func(i, j int) bool {
+		if members[i].Kind != members[j].Kind {
+			return members[i].Kind < members[j].Kind
+		}
+		return refPosition(members[i]) < refPosition(members[j])
+	})
+}
+
+// refPosition is the position a member sorts by. Only a parameter carries one,
+// and validate has already refused a parameter member without one.
+func refPosition(ref AliasRef) int {
+	if ref.Index == nil {
+		return 0
+	}
+	return *ref.Index
 }
 
 // validate reports why an entry cannot be applied, or nil.
@@ -179,8 +212,14 @@ func (e CuratedEntry) validate() error {
 			return fmt.Errorf("claims receiver %q, which is not a receiver kind", e.Receiver)
 		}
 	}
+	if !e.Classified.Receiver && e.Receiver != "" {
+		return fmt.Errorf("names receiver %q on an axis its coverage leaves unclaimed", e.Receiver)
+	}
 	if e.Classified.Returns {
 		return e.Returns.validate()
+	}
+	if !e.Returns.IsZero() {
+		return fmt.Errorf("names returns %s on an axis its coverage leaves unclaimed", e.Returns)
 	}
 	return nil
 }
@@ -201,7 +240,13 @@ func (r ReturnFact) validate() error {
 		if len(r.Members) < 2 {
 			return fmt.Errorf("returns a union of %d members", len(r.Members))
 		}
+		seen := set.NewSet[alias]()
 		for _, member := range r.Members {
+			value := alias{Kind: member.Kind, Index: refPosition(member)}
+			if seen.Contains(value) {
+				return fmt.Errorf("returns a union naming %s twice", member)
+			}
+			seen.Add(value)
 			// A union names the values its several returns hand back. Neither
 			// lattice point that stands for more than one value is such a
 			// value, so neither can be a member.
@@ -223,6 +268,13 @@ func (r ReturnFact) validate() error {
 		return fmt.Errorf("returns %s but names union members", r.Kind)
 	}
 	return nil
+}
+
+// IsZero reports whether the fact carries no claim at all. encoding/json's
+// omitzero consults it, which is how a MethodFact with an uncovered return
+// omits the field entirely.
+func (r ReturnFact) IsZero() bool {
+	return r.Kind == "" && r.Index == nil && len(r.Members) == 0
 }
 
 // equal reports whether two return facts make the same claim. Members are
@@ -247,11 +299,11 @@ func (r ReturnFact) equal(other ReturnFact) bool {
 	return true
 }
 
-// curate merges the layer over the analyzed facts in place and reports what
-// each curated axis did. A name the graph holds no builtin for is reported and
-// applied to nothing, so an entry from another spec revision degrades to a
+// mergeCuration merges the layer over the analyzed facts in place and reports
+// what each curated axis did. A name the graph holds no builtin for is reported
+// and applied to nothing, so an entry from another spec revision degrades to a
 // report line rather than inventing a method.
-func curate(cfg *CFG, curation *Curation, methods map[string]MethodFact) CurationReport {
+func mergeCuration(cfg *CFG, curation *Curation, methods map[string]MethodFact) CurationReport {
 	var report CurationReport
 	for _, name := range sortedNames(curation.Entries) {
 		entry := curation.Entries[name]
@@ -266,9 +318,14 @@ func curate(cfg *CFG, curation *Curation, methods map[string]MethodFact) Curatio
 
 		fact := methods[name]
 		if entry.Classified.Receiver {
-			report.Notes = append(report.Notes, receiverNote(name, fact, entry))
-			fact.Receiver = entry.Receiver
-			fact.Classified.Receiver = true
+			if reason := receiverConflict(fn, entry.Receiver); reason != "" {
+				report.Refused = append(report.Refused,
+					fmt.Sprintf("%s %s: curated %s, but %s", name, AxisReceiver, entry.Receiver, reason))
+			} else {
+				report.Notes = append(report.Notes, receiverNote(name, fact, entry))
+				fact.Receiver = entry.Receiver
+				fact.Classified.Receiver = true
+			}
 		}
 		if entry.Classified.Returns {
 			report.Notes = append(report.Notes, returnsNote(name, fact, entry))
@@ -278,6 +335,24 @@ func curate(cfg *CFG, curation *Curation, methods map[string]MethodFact) Curatio
 		methods[name] = fact
 	}
 	return report
+}
+
+// receiverConflict reports why fn cannot take the curated receiver kind, or "".
+//
+// Whether a builtin has a receiver at all follows from Func.Kind rather than
+// from any step, so the graph settles it outright and no review can move it.
+// §7 auto-applies the receiver claim, so a curated `borrow` on a static would
+// put a `&self` on a declaration that has no self, which is the one curated
+// mistake the converter cannot absorb.
+func receiverConflict(fn *Func, kind ReceiverKind) string {
+	switch {
+	case fn.Kind == BuiltinMethod && kind == RecvNone:
+		return "a " + string(fn.Kind) + " has a receiver"
+	case fn.Kind != BuiltinMethod && kind != RecvNone:
+		return "a " + string(fn.Kind) + " has no receiver"
+	default:
+		return ""
+	}
 }
 
 // receiverNote reads one curated receiver claim against what the analysis
@@ -299,10 +374,16 @@ func receiverNote(name string, analyzed MethodFact, entry CuratedEntry) Curation
 
 // returnsNote reads one curated return alias against what the analysis
 // concluded for the same method.
+//
+// returnAlias is total, so a builtin always carries a covered return. An
+// `unknown` one is nonetheless a return the walk could not tie to any value, so
+// a curated answer over it adds information rather than contradicting a claim.
+// It reads as a fill-in, which keeps the corrections list to the entries where
+// the two sources genuinely disagree.
 func returnsNote(name string, analyzed MethodFact, entry CuratedEntry) CurationNote {
 	note := CurationNote{Name: name, Axis: AxisReturns, Curated: entry.Returns.String()}
 	switch {
-	case !analyzed.Classified.Returns:
+	case !analyzed.Classified.Returns || analyzed.Returns.Kind == AliasUnknown:
 		note.Kind = CurationFillIn
 	case analyzed.Returns.equal(entry.Returns):
 		note.Kind = CurationRedundant
@@ -326,14 +407,14 @@ func sortedNames(entries map[string]CuratedEntry) []string {
 }
 
 // WriteCurationReport prints the merge's tallies and every line that needs a
-// reviewer. A fill-in is the ordinary case and is summarized rather than listed;
-// a correction, a redundant entry, a stale entry, and an unmatched name each
-// name something to act on, so each is printed in full.
+// reviewer. A fill-in is the ordinary case and is summarized rather than
+// listed. A correction, a redundant entry, a stale entry, an unmatched name,
+// and a refused axis each name something to act on, so each is printed in full.
 func WriteCurationReport(report CurationReport, w io.Writer) error {
 	counts := report.Counts()
-	_, err := fmt.Fprintf(w, "  curation: %d fill-ins, %d corrections, %d redundant, %d stale, %d unmatched\n",
+	_, err := fmt.Fprintf(w, "  curation: %d fill-ins, %d corrections, %d redundant, %d stale, %d unmatched, %d refused\n",
 		counts[CurationFillIn], counts[CurationCorrection], counts[CurationRedundant],
-		len(report.Stale), len(report.Unmatched))
+		len(report.Stale), len(report.Unmatched), len(report.Refused))
 	if err != nil {
 		return err
 	}
@@ -352,6 +433,11 @@ func WriteCurationReport(report CurationReport, w io.Writer) error {
 	}
 	for _, name := range report.Unmatched {
 		if _, err := fmt.Fprintf(w, "    %s: curated, but the graph holds no such builtin\n", name); err != nil {
+			return err
+		}
+	}
+	for _, line := range report.Refused {
+		if _, err := fmt.Fprintf(w, "    %s\n", line); err != nil {
 			return err
 		}
 	}

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -1,0 +1,359 @@
+package ecma262
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// curated.go holds the hand-written fact layer described in
+// planning/ecma-262/implementation_plan.md §4.4. The analyses in origin.go,
+// mutation.go, and throws.go answer the determinations they can read off the
+// control-flow graph; this layer answers the rest by review, so a determination
+// the graph does not settle costs a curated entry rather than more analyzer.
+//
+// The layer is merged per determination, never per method. A curated entry that
+// names the receiver leaves the same method's return alias to the analysis, so
+// the two sources compose instead of one shadowing the other.
+
+//go:embed curated.json
+var curatedJSON []byte
+
+// curated is the committed layer, parsed once. The file ships in the binary and
+// its shape is fixed at build time, so a parse failure is a defect in committed
+// data rather than a condition a caller can meet or recover from.
+var curated = mustParseCuration(curatedJSON)
+
+// Axis names one determination of a MethodFact. Coverage carries a flag per
+// axis, and a curated entry supplies or corrects the axes it names.
+type Axis string
+
+const (
+	AxisReceiver Axis = "receiver"
+	AxisReturns  Axis = "returns"
+)
+
+// CuratedEntry is one reviewed record, keyed in curated.json by the canonical
+// spec name of Appendix C. It carries the same determination fields as
+// MethodFact plus the provenance a reviewer needs.
+//
+// Classified says which determinations the entry claims, exactly as it does on
+// a MethodFact. An axis the entry leaves unset is not curated and keeps the
+// analysis's answer, whatever that was.
+type CuratedEntry struct {
+	// Reason is why the curated answer is right, in the reviewer's words. It
+	// is required, because a claim that outranks the analysis without a stated
+	// argument cannot be re-reviewed.
+	Reason string `json:"reason"`
+	// Evidence names where the reason was checked, such as a spec clause, an
+	// MDN page, or an engine the behavior was observed in.
+	Evidence string `json:"evidence,omitempty"`
+	// ReviewedAt is the Func.Digest of the algorithm at review time. When the
+	// graph's digest no longer matches, the algorithm was rewritten under the
+	// entry and curationReport lists it as stale.
+	ReviewedAt string `json:"reviewedAt"`
+
+	Classified Coverage     `json:"classified"`
+	Receiver   ReceiverKind `json:"receiver,omitempty"`
+	Returns    ReturnFact   `json:"returns,omitzero"`
+}
+
+// Curation is the whole committed layer.
+type Curation struct {
+	Entries map[string]CuratedEntry `json:"entries"`
+}
+
+// CurationNoteKind says what one curated axis did to the analysis's answer.
+type CurationNoteKind string
+
+const (
+	// CurationFillIn is a curated axis the analysis withheld, so the entry adds
+	// a claim where there was none. It is the ordinary case and carries no
+	// conflict.
+	CurationFillIn CurationNoteKind = "fill-in"
+	// CurationCorrection is a curated axis contradicting a claim the analysis
+	// published. §6's validation diff reads these first, because a correction
+	// is either a spec subtlety the graph cannot express or an analyzer bug,
+	// and the two look alike from here.
+	CurationCorrection CurationNoteKind = "correction"
+	// CurationRedundant is a curated axis repeating what the analysis already
+	// concluded. The entry can be deleted, which is how the layer shrinks as
+	// the analysis improves rather than accumulating.
+	CurationRedundant CurationNoteKind = "redundant"
+)
+
+// CurationNote records one curated axis and what it did.
+type CurationNote struct {
+	Name string
+	Axis Axis
+	Kind CurationNoteKind
+	// Analyzed renders the claim the analysis published, and is empty when it
+	// withheld the axis.
+	Analyzed string
+	// Curated renders the claim the entry supplied.
+	Curated string
+}
+
+func (n CurationNote) String() string {
+	if n.Kind == CurationFillIn {
+		return fmt.Sprintf("%s %s: %s %s", n.Name, n.Axis, n.Kind, n.Curated)
+	}
+	return fmt.Sprintf("%s %s: %s %s over %s", n.Name, n.Axis, n.Kind, n.Curated, n.Analyzed)
+}
+
+// CurationReport is what one merge of the layer did, for review rather than for
+// the wire. facts.json records the merged determinations and not where each one
+// came from, because the converter applies a curated receiver claim and an
+// analyzed one identically. Provenance is a reviewer's concern, so it lives
+// here.
+type CurationReport struct {
+	// Notes holds one entry per curated axis, sorted by name and then axis.
+	Notes []CurationNote
+	// Stale holds the names whose algorithm changed since the entry was
+	// reviewed, sorted. A stale entry is still applied. The spec rewriting an
+	// algorithm rarely invalidates the reviewed claim, and dropping the entry
+	// would trade a visible re-review prompt for a silent loss of coverage.
+	Stale []string
+	// Unmatched holds the curated names the graph holds no builtin for,
+	// sorted. A misspelled key and a key from another spec revision both land
+	// here, and TestCurationMatchesTheGraph is what turns the first into a
+	// failing build.
+	Unmatched []string
+}
+
+// Counts renders the report's tallies by note kind, sorted, for the one-line
+// summary WriteCurationReport prints.
+func (r CurationReport) Counts() map[CurationNoteKind]int {
+	counts := map[CurationNoteKind]int{}
+	for _, note := range r.Notes {
+		counts[note.Kind]++
+	}
+	return counts
+}
+
+// mustParseCuration parses the committed layer or panics, in the manner of
+// regexp.MustCompile. See the `curated` var for why a failure here is not a
+// recoverable condition.
+func mustParseCuration(data []byte) *Curation {
+	curation, err := ParseCuration(data)
+	if err != nil {
+		panic("ecma262: committed curated.json is invalid: " + err.Error())
+	}
+	return curation
+}
+
+// ParseCuration decodes the curated layer and rejects an entry that cannot be
+// reviewed or applied. A claim with no reason, no reviewed digest, no axis, or
+// an axis whose value is not one this package can spell is a defect in the data
+// rather than an entry to apply as written.
+func ParseCuration(data []byte) (*Curation, error) {
+	var curation Curation
+	if err := json.Unmarshal(data, &curation); err != nil {
+		return nil, fmt.Errorf("decoding curation: %w", err)
+	}
+	for _, name := range sortedNames(curation.Entries) {
+		if err := curation.Entries[name].validate(); err != nil {
+			return nil, fmt.Errorf("curated entry %s: %w", name, err)
+		}
+	}
+	return &curation, nil
+}
+
+// validate reports why an entry cannot be applied, or nil.
+func (e CuratedEntry) validate() error {
+	if e.Reason == "" {
+		return fmt.Errorf("has no reason")
+	}
+	if e.ReviewedAt == "" {
+		return fmt.Errorf("has no reviewedAt digest")
+	}
+	if !e.Classified.Receiver && !e.Classified.Returns {
+		return fmt.Errorf("claims no determination")
+	}
+	if e.Classified.Receiver {
+		switch e.Receiver {
+		case RecvBorrow, RecvMutBorrow, RecvNone:
+		default:
+			return fmt.Errorf("claims receiver %q, which is not a receiver kind", e.Receiver)
+		}
+	}
+	if e.Classified.Returns {
+		return e.Returns.validate()
+	}
+	return nil
+}
+
+// validate reports why a return fact cannot be applied, or nil. It holds the
+// same invariants newReturnFact builds: a parameter return names its position,
+// a union names its members, and no other kind carries either.
+func (r ReturnFact) validate() error {
+	switch r.Kind {
+	case AliasParam:
+		if r.Index == nil {
+			return fmt.Errorf("returns a parameter but names no position")
+		}
+		if *r.Index < 0 {
+			return fmt.Errorf("returns the parameter at position %d", *r.Index)
+		}
+	case AliasUnion:
+		if len(r.Members) < 2 {
+			return fmt.Errorf("returns a union of %d members", len(r.Members))
+		}
+		for _, member := range r.Members {
+			// A union names the values its several returns hand back. Neither
+			// lattice point that stands for more than one value is such a
+			// value, so neither can be a member.
+			if member.Kind == AliasUnion || member.Kind == AliasUnknown {
+				return fmt.Errorf("returns a union holding %s", member.Kind)
+			}
+			if err := (ReturnFact{Kind: member.Kind, Index: member.Index}).validate(); err != nil {
+				return fmt.Errorf("union member: %w", err)
+			}
+		}
+	case AliasReceiver, AliasFresh, AliasUnknown:
+	default:
+		return fmt.Errorf("returns %q, which is not an alias kind", r.Kind)
+	}
+	if r.Kind != AliasParam && r.Index != nil {
+		return fmt.Errorf("returns %s but names a position", r.Kind)
+	}
+	if r.Kind != AliasUnion && len(r.Members) > 0 {
+		return fmt.Errorf("returns %s but names union members", r.Kind)
+	}
+	return nil
+}
+
+// equal reports whether two return facts make the same claim. Members are
+// compared in order, which both newReturnFact and ParseCuration leave sorted by
+// kind and then position.
+func (r ReturnFact) equal(other ReturnFact) bool {
+	if r.Kind != other.Kind || len(r.Members) != len(other.Members) {
+		return false
+	}
+	if (r.Index == nil) != (other.Index == nil) {
+		return false
+	}
+	if r.Index != nil && *r.Index != *other.Index {
+		return false
+	}
+	for i, member := range r.Members {
+		if !(ReturnFact{Kind: member.Kind, Index: member.Index}).equal(
+			ReturnFact{Kind: other.Members[i].Kind, Index: other.Members[i].Index}) {
+			return false
+		}
+	}
+	return true
+}
+
+// curate merges the layer over the analyzed facts in place and reports what
+// each curated axis did. A name the graph holds no builtin for is reported and
+// applied to nothing, so an entry from another spec revision degrades to a
+// report line rather than inventing a method.
+func curate(cfg *CFG, curation *Curation, methods map[string]MethodFact) CurationReport {
+	var report CurationReport
+	for _, name := range sortedNames(curation.Entries) {
+		entry := curation.Entries[name]
+		fn := cfg.Builtin(name)
+		if fn == nil {
+			report.Unmatched = append(report.Unmatched, name)
+			continue
+		}
+		if fn.Digest != entry.ReviewedAt {
+			report.Stale = append(report.Stale, name)
+		}
+
+		fact := methods[name]
+		if entry.Classified.Receiver {
+			report.Notes = append(report.Notes, receiverNote(name, fact, entry))
+			fact.Receiver = entry.Receiver
+			fact.Classified.Receiver = true
+		}
+		if entry.Classified.Returns {
+			report.Notes = append(report.Notes, returnsNote(name, fact, entry))
+			fact.Returns = entry.Returns
+			fact.Classified.Returns = true
+		}
+		methods[name] = fact
+	}
+	return report
+}
+
+// receiverNote reads one curated receiver claim against what the analysis
+// concluded for the same method.
+func receiverNote(name string, analyzed MethodFact, entry CuratedEntry) CurationNote {
+	note := CurationNote{Name: name, Axis: AxisReceiver, Curated: string(entry.Receiver)}
+	switch {
+	case !analyzed.Classified.Receiver:
+		note.Kind = CurationFillIn
+	case analyzed.Receiver == entry.Receiver:
+		note.Kind = CurationRedundant
+		note.Analyzed = string(analyzed.Receiver)
+	default:
+		note.Kind = CurationCorrection
+		note.Analyzed = string(analyzed.Receiver)
+	}
+	return note
+}
+
+// returnsNote reads one curated return alias against what the analysis
+// concluded for the same method.
+func returnsNote(name string, analyzed MethodFact, entry CuratedEntry) CurationNote {
+	note := CurationNote{Name: name, Axis: AxisReturns, Curated: entry.Returns.String()}
+	switch {
+	case !analyzed.Classified.Returns:
+		note.Kind = CurationFillIn
+	case analyzed.Returns.equal(entry.Returns):
+		note.Kind = CurationRedundant
+		note.Analyzed = analyzed.Returns.String()
+	default:
+		note.Kind = CurationCorrection
+		note.Analyzed = analyzed.Returns.String()
+	}
+	return note
+}
+
+// sortedNames returns a curation's keys in order, so a report and a merge both
+// read the entries the same way whatever order the map hands them back.
+func sortedNames(entries map[string]CuratedEntry) []string {
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// WriteCurationReport prints the merge's tallies and every line that needs a
+// reviewer. A fill-in is the ordinary case and is summarized rather than listed;
+// a correction, a redundant entry, a stale entry, and an unmatched name each
+// name something to act on, so each is printed in full.
+func WriteCurationReport(report CurationReport, w io.Writer) error {
+	counts := report.Counts()
+	_, err := fmt.Fprintf(w, "  curation: %d fill-ins, %d corrections, %d redundant, %d stale, %d unmatched\n",
+		counts[CurationFillIn], counts[CurationCorrection], counts[CurationRedundant],
+		len(report.Stale), len(report.Unmatched))
+	if err != nil {
+		return err
+	}
+	for _, note := range report.Notes {
+		if note.Kind == CurationFillIn {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "    %s\n", note); err != nil {
+			return err
+		}
+	}
+	for _, name := range report.Stale {
+		if _, err := fmt.Fprintf(w, "    %s: reviewed against an algorithm the graph no longer holds\n", name); err != nil {
+			return err
+		}
+	}
+	for _, name := range report.Unmatched {
+		if _, err := fmt.Fprintf(w, "    %s: curated, but the graph holds no such builtin\n", name); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -242,13 +242,12 @@ func (r ReturnFact) validate() error {
 		if len(r.Members) < 2 {
 			return fmt.Errorf("returns a union of %d members", len(r.Members))
 		}
+		// Each member is checked whole before it is compared against the ones
+		// already seen, so a member missing its position is reported as
+		// malformed rather than colliding at the position refPosition falls
+		// back to.
 		seen := set.NewSet[alias]()
 		for _, member := range r.Members {
-			value := alias{Kind: member.Kind, Index: refPosition(member)}
-			if seen.Contains(value) {
-				return fmt.Errorf("returns a union naming %s twice", member)
-			}
-			seen.Add(value)
 			// A union names the values its several returns hand back.
 			// `union` names a set of them and `unknown` names none, so
 			// neither is a value a member could stand for.
@@ -258,6 +257,11 @@ func (r ReturnFact) validate() error {
 			if err := (ReturnFact{Kind: member.Kind, Index: member.Index}).validate(); err != nil {
 				return fmt.Errorf("union member: %w", err)
 			}
+			value := alias{Kind: member.Kind, Index: refPosition(member)}
+			if seen.Contains(value) {
+				return fmt.Errorf("returns a union naming %s twice", member)
+			}
+			seen.Add(value)
 		}
 	case AliasReceiver, AliasFresh, AliasUnknown:
 	default:

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -28,8 +28,9 @@ var curatedJSON []byte
 // data rather than a condition a caller can meet or recover from.
 var curated = mustParseCuration(curatedJSON)
 
-// Axis names one determination of a MethodFact. Coverage carries a flag per
-// axis, and a curated entry supplies or corrects the axes it names.
+// Axis names one determination of a MethodFact. A curated entry supplies or
+// corrects the axes it names, and every published fact carries a value on all
+// of them.
 type Axis string
 
 const (
@@ -337,13 +338,11 @@ func mergeCuration(cfg *CFG, curation *Curation, methods map[string]MethodFact) 
 			} else {
 				report.Notes = append(report.Notes, receiverNote(name, fact, entry))
 				fact.Receiver = entry.Receiver
-				fact.Classified.Receiver = true
 			}
 		}
 		if entry.claimsReturns() {
 			report.Notes = append(report.Notes, returnsNote(name, fact, entry))
 			fact.Returns = entry.Returns
-			fact.Classified.Returns = true
 		}
 		methods[name] = fact
 	}
@@ -374,7 +373,7 @@ func receiverConflict(fn *Func, kind ReceiverKind) string {
 func receiverNote(name string, analyzed MethodFact, entry CuratedEntry) CurationNote {
 	note := CurationNote{Name: name, Axis: AxisReceiver, Curated: string(entry.Receiver)}
 	switch {
-	case !analyzed.Classified.Receiver:
+	case analyzed.Receiver == "":
 		note.Kind = CurationFillIn
 	case analyzed.Receiver == entry.Receiver:
 		note.Kind = CurationRedundant
@@ -397,7 +396,7 @@ func receiverNote(name string, analyzed MethodFact, entry CuratedEntry) Curation
 func returnsNote(name string, analyzed MethodFact, entry CuratedEntry) CurationNote {
 	note := CurationNote{Name: name, Axis: AxisReturns, Curated: entry.Returns.String()}
 	switch {
-	case !analyzed.Classified.Returns || analyzed.Returns.Kind == AliasUnknown:
+	case analyzed.Returns.Kind == "" || analyzed.Returns.Kind == AliasUnknown:
 		note.Kind = CurationFillIn
 	case analyzed.Returns.equal(entry.Returns):
 		note.Kind = CurationRedundant

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -41,9 +41,14 @@ const (
 // spec name of Appendix C. It carries the same determination fields as
 // MethodFact plus the provenance a reviewer needs.
 //
-// Classified says which determinations the entry claims, exactly as it does on
-// a MethodFact. An axis the entry leaves unset is not curated and keeps the
-// analysis's answer, whatever that was.
+// Classified marks the axes this entry answers. That is not what the field
+// means on a MethodFact, where it marks the axes the analysis resolved. An axis
+// an entry leaves unset is simply not curated, and the analysis's answer for it
+// stands, settled or withheld alike.
+//
+// So the two axes of one method can come from different sources.
+// `Date.prototype.getTime` claims `returns` alone, because the analysis already
+// reads its receiver as `borrow` and only the return alias needs review.
 type CuratedEntry struct {
 	// Reason is why the curated answer is right, in the reviewer's words. It
 	// is required, because a claim that outranks the analysis without a stated

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -13,7 +13,7 @@ import (
 // curated.go holds the hand-written fact layer described in
 // planning/ecma-262/implementation_plan.md §4.4. The analyses in origin.go,
 // mutation.go, and throws.go answer the determinations they can read off the
-// control-flow graph; this layer answers the rest by review, so a determination
+// control-flow graph. This layer answers the rest by review, so a determination
 // the graph does not settle costs a curated entry rather than more analyzer.
 //
 // The layer is merged per determination, never per method. A curated entry that
@@ -52,9 +52,9 @@ type CuratedEntry struct {
 	// Evidence names where the reason was checked, such as a spec clause, an
 	// MDN page, or an engine the behavior was observed in.
 	Evidence string `json:"evidence,omitempty"`
-	// ReviewedAt is the Func.Digest of the algorithm at review time. When the
-	// graph's digest no longer matches, the algorithm was rewritten under the
-	// entry and curationReport lists it as stale.
+	// ReviewedAt is the Func.Digest of the algorithm at review time. A graph
+	// whose digest differs holds an algorithm rewritten since the review, and
+	// CurationReport lists that entry as stale.
 	ReviewedAt string `json:"reviewedAt"`
 
 	Classified Coverage     `json:"classified"`
@@ -80,7 +80,7 @@ const (
 	// CurationCorrection is a curated axis contradicting a claim the analysis
 	// published. §6's validation diff reads these first, because a correction
 	// is either a spec subtlety the graph cannot express or an analyzer bug,
-	// and the two look alike from here.
+	// and the report cannot tell the two apart.
 	CurationCorrection CurationNoteKind = "correction"
 	// CurationRedundant is a curated axis repeating what the analysis already
 	// concluded. The entry can be deleted, which is how the layer shrinks as
@@ -93,8 +93,8 @@ type CurationNote struct {
 	Name string
 	Axis Axis
 	Kind CurationNoteKind
-	// Analyzed renders the claim the analysis published, and is empty when it
-	// withheld the axis.
+	// Analyzed renders the claim the analysis published. It is empty on a
+	// fill-in, where there was no claim to displace.
 	Analyzed string
 	// Curated renders the claim the entry supplied.
 	Curated string
@@ -126,13 +126,13 @@ type CurationReport struct {
 	// failing build.
 	Unmatched []string
 	// Refused holds the curated axes the graph contradicts outright, one
-	// rendered line each, in the order the entries were read. The axis is not
-	// applied. See receiverConflict for the one contradiction there is.
+	// rendered line each, in the order the entries were read. A refused axis is
+	// not applied. receiverConflict is the only contradiction this can hold.
 	Refused []string
 }
 
-// Counts renders the report's tallies by note kind, sorted, for the one-line
-// summary WriteCurationReport prints.
+// Counts tallies the notes by kind, which is what WriteCurationReport's
+// one-line summary is built from.
 func (r CurationReport) Counts() map[CurationNoteKind]int {
 	counts := map[CurationNoteKind]int{}
 	for _, note := range r.Notes {
@@ -152,10 +152,10 @@ func mustParseCuration(data []byte) *Curation {
 	return curation
 }
 
-// ParseCuration decodes the curated layer and rejects an entry that cannot be
-// reviewed or applied. A claim with no reason, no reviewed digest, no axis, or
-// an axis whose value is not one this package can spell is a defect in the data
-// rather than an entry to apply as written.
+// ParseCuration decodes the curated layer, rejects an entry that cannot be
+// reviewed or applied, and puts each union's members in canonical order. An
+// entry validate refuses is a defect in committed data rather than one to merge
+// as written. See CuratedEntry.validate for what it refuses.
 func ParseCuration(data []byte) (*Curation, error) {
 	var curation Curation
 	if err := json.Unmarshal(data, &curation); err != nil {
@@ -172,10 +172,10 @@ func ParseCuration(data []byte) (*Curation, error) {
 	return &curation, nil
 }
 
-// sortMembers puts a union's members in the order newReturnFact leaves them,
-// by kind and then by position. A curated union is written by hand in whatever
-// order reads best, and every comparison against an analyzed fact and every
-// rendering assumes the one canonical order.
+// sortMembers puts a union's members in the order newReturnFact leaves them, by
+// kind and then by position. A curated union is written by hand in whatever
+// order reads best. Comparing one against an analyzed fact and rendering one
+// both assume the single canonical order, so parsing imposes it.
 func sortMembers(members []AliasRef) {
 	sort.Slice(members, func(i, j int) bool {
 		if members[i].Kind != members[j].Kind {
@@ -194,7 +194,8 @@ func refPosition(ref AliasRef) int {
 	return *ref.Index
 }
 
-// validate reports why an entry cannot be applied, or nil.
+// validate reports why an entry cannot be reviewed or applied, and nil when it
+// can.
 func (e CuratedEntry) validate() error {
 	if e.Reason == "" {
 		return fmt.Errorf("has no reason")
@@ -224,9 +225,10 @@ func (e CuratedEntry) validate() error {
 	return nil
 }
 
-// validate reports why a return fact cannot be applied, or nil. It holds the
-// same invariants newReturnFact builds: a parameter return names its position,
-// a union names its members, and no other kind carries either.
+// validate reports why a return fact cannot be applied, and nil when it can.
+// It holds the same invariants newReturnFact builds. A parameter return names
+// its position. A union names at least two distinct members, none of which is
+// itself a union or an `unknown`. No other kind carries a position or members.
 func (r ReturnFact) validate() error {
 	switch r.Kind {
 	case AliasParam:
@@ -247,9 +249,9 @@ func (r ReturnFact) validate() error {
 				return fmt.Errorf("returns a union naming %s twice", member)
 			}
 			seen.Add(value)
-			// A union names the values its several returns hand back. Neither
-			// lattice point that stands for more than one value is such a
-			// value, so neither can be a member.
+			// A union names the values its several returns hand back.
+			// `union` names a set of them and `unknown` names none, so
+			// neither is a value a member could stand for.
 			if member.Kind == AliasUnion || member.Kind == AliasUnknown {
 				return fmt.Errorf("returns a union holding %s", member.Kind)
 			}
@@ -337,13 +339,14 @@ func mergeCuration(cfg *CFG, curation *Curation, methods map[string]MethodFact) 
 	return report
 }
 
-// receiverConflict reports why fn cannot take the curated receiver kind, or "".
+// receiverConflict reports why fn cannot take the curated receiver kind, and ""
+// when it can.
 //
 // Whether a builtin has a receiver at all follows from Func.Kind rather than
-// from any step, so the graph settles it outright and no review can move it.
-// §7 auto-applies the receiver claim, so a curated `borrow` on a static would
-// put a `&self` on a declaration that has no self, which is the one curated
-// mistake the converter cannot absorb.
+// from any algorithm step, so the graph settles it outright and no review can
+// move it. §7 auto-applies the receiver claim, so a `borrow` curated onto a
+// static would put a `&self` on a declaration that has no self. That is the one
+// curated mistake the converter cannot absorb.
 func receiverConflict(fn *Func, kind ReceiverKind) string {
 	switch {
 	case fn.Kind == BuiltinMethod && kind == RecvNone:

--- a/internal/ecma262/curated.json
+++ b/internal/ecma262/curated.json
@@ -4,189 +4,162 @@
       "reason": "Reads the receiver's elements and calls toLocaleString on each. The one step the serializer left opaque binds the host's list separator, which writes nothing.",
       "evidence": "ECMA-262 \"Array.prototype.toLocaleString\"",
       "reviewedAt": "f3203d8f63ec",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "Date.prototype.getTime": {
       "reason": "Returns the Number held in [[DateValue]]. A primitive read out of a slot is a copy, so the return borrows nothing the caller holds. The analysis withholds the alias because telling a primitive slot from an object one needs the declared return type, which cfg.json does not carry.",
       "evidence": "ECMA-262 \"Date.prototype.getTime\"",
       "reviewedAt": "0d4b34259cd2",
-      "classified": { "receiver": false, "returns": true },
       "returns": { "kind": "fresh" }
     },
     "Date.prototype.getTimezoneOffset": {
       "reason": "Reads [[DateValue]] and computes an offset from it. The opaque step is the local time zone calculation, which writes nothing.",
       "evidence": "ECMA-262 \"Date.prototype.getTimezoneOffset\"",
       "reviewedAt": "0f3dbfa75247",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "Date.prototype.toISOString": {
       "reason": "Formats [[DateValue]] as a string. The opaque steps build that string and write nothing.",
       "evidence": "ECMA-262 \"Date.prototype.toISOString\"",
       "reviewedAt": "e0ab062821e6",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "Date.prototype.toUTCString": {
       "reason": "Formats [[DateValue]] as a string. The opaque steps build that string and write nothing.",
       "evidence": "ECMA-262 \"Date.prototype.toUTCString\"",
       "reviewedAt": "2a344681528d",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "Date.prototype.valueOf": {
       "reason": "Returns the Number held in [[DateValue]]. A primitive read out of a slot is a copy, so the return borrows nothing the caller holds.",
       "evidence": "ECMA-262 \"Date.prototype.valueOf\"",
       "reviewedAt": "f9599ef775ef",
-      "classified": { "receiver": false, "returns": true },
       "returns": { "kind": "fresh" }
     },
     "ForInIteratorPrototype.next": {
       "reason": "Advances the iterator by writing [[RemainingKeys]], [[VisitedKeys]], [[Object]], and [[ObjectWasVisited]] on the receiver. The opaque step is the assertion over those slots.",
       "evidence": "ECMA-262 \"%ForInIteratorPrototype%.next\"",
       "reviewedAt": "9ac59fc3b816",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "mutBorrow"
     },
     "Number.prototype.toExponential": {
       "reason": "Reads the receiver's number value and formats it. Every opaque step names a digit string it computes.",
       "evidence": "ECMA-262 \"Number.prototype.toExponential\"",
       "reviewedAt": "243e70d48235",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "Number.prototype.toFixed": {
       "reason": "Reads the receiver's number value and formats it. Every opaque step names a digit string it computes, such as \"Let a be the first k - f code units of m\".",
       "evidence": "ECMA-262 \"Number.prototype.toFixed\"",
       "reviewedAt": "1836cd89dd25",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "Number.prototype.toLocaleString": {
       "reason": "Reads the receiver's number value and formats it for the host locale. The formatting is implementation-defined and writes nothing.",
       "evidence": "ECMA-262 \"Number.prototype.toLocaleString\"",
       "reviewedAt": "3229a7c40342",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "Number.prototype.toPrecision": {
       "reason": "Reads the receiver's number value and formats it. Every opaque step names a digit string it computes.",
       "evidence": "ECMA-262 \"Number.prototype.toPrecision\"",
       "reviewedAt": "99d8cac517b0",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "RegExp.prototype [ @@matchAll ]": {
       "reason": "Reads flags and lastIndex off the receiver, then writes lastIndex on matcher, the object SpeciesConstructor built. The write the analysis could not place lands on matcher rather than on the receiver. A @@species that hands the receiver back would make the two one object, which is the documented species exception.",
       "evidence": "ECMA-262 \"RegExp.prototype [ %Symbol.matchAll% ]\"",
       "reviewedAt": "c2cb8f3fdb97",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "RegExp.prototype [ @@replace ]": {
       "reason": "Writes lastIndex on the receiver through Set(rx, \"lastIndex\", ...) when the pattern is global. The opaque steps build the replacement string.",
       "evidence": "ECMA-262 \"RegExp.prototype [ %Symbol.replace% ]\"",
       "reviewedAt": "4b29b7f53c9e",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "mutBorrow"
     },
     "RegExp.prototype [ @@split ]": {
       "reason": "Writes only into A, the array it allocates, and into splitter, the object SpeciesConstructor built. Every step touching the receiver reads it. Same species exception as RegExp.prototype [ @@matchAll ].",
       "evidence": "ECMA-262 \"RegExp.prototype [ %Symbol.split% ]\"",
       "reviewedAt": "64e67b1e3216",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "RegExpStringIteratorPrototype.next": {
       "reason": "Writes [[Done]] on the receiver. It also writes lastIndex on the regular expression held in [[IteratingRegExp]], which it reaches through the receiver.",
       "evidence": "ECMA-262 \"%RegExpStringIteratorPrototype%.next\"",
       "reviewedAt": "496d4222b7b1",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "mutBorrow"
     },
     "SharedArrayBuffer.prototype.grow": {
       "reason": "Grows the buffer by writing, through AtomicCompareExchangeInSharedBlock, the block it read out of the receiver's [[ArrayBufferByteLengthData]]. The new byte length is observable on the receiver afterwards.",
       "evidence": "ECMA-262 \"SharedArrayBuffer.prototype.grow\"",
       "reviewedAt": "78f695c8902d",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "mutBorrow"
     },
     "String.prototype.normalize": {
       "reason": "A String is an immutable primitive, so no step can write the receiver. The opaque step is the Unicode normalization itself.",
       "evidence": "ECMA-262 \"String.prototype.normalize\"",
       "reviewedAt": "9c0df67c56b0",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "String.prototype.repeat": {
       "reason": "A String is an immutable primitive, so no step can write the receiver. The opaque step builds the repeated string.",
       "evidence": "ECMA-262 \"String.prototype.repeat\"",
       "reviewedAt": "1a54e17c9f5e",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "String.prototype.split": {
       "reason": "A String is an immutable primitive, so no step can write the receiver. Reading @@split off separator can run arbitrary code, and that code reaches nothing the receiver holds.",
       "evidence": "ECMA-262 \"String.prototype.split\"",
       "reviewedAt": "3120ebfb8574",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "String.prototype.toLocaleLowerCase": {
       "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a locale-sensitive Unicode table lookup.",
       "evidence": "ECMA-262 \"String.prototype.toLocaleLowerCase\"",
       "reviewedAt": "d75a8d944557",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "String.prototype.toLocaleUpperCase": {
       "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a locale-sensitive Unicode table lookup.",
       "evidence": "ECMA-262 \"String.prototype.toLocaleUpperCase\"",
       "reviewedAt": "fc11d8ee1b51",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "String.prototype.toLowerCase": {
       "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a Unicode table lookup ESMeta does not formalize.",
       "evidence": "ECMA-262 \"String.prototype.toLowerCase\"",
       "reviewedAt": "2bf52d68c976",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "String.prototype.toUpperCase": {
       "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a Unicode table lookup ESMeta does not formalize.",
       "evidence": "ECMA-262 \"String.prototype.toUpperCase\"",
       "reviewedAt": "d1c5c3231872",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "TypedArray.prototype.slice": {
       "reason": "Reads the receiver's elements and writes into A, the array TypedArraySpeciesCreate built. The opaque step clamps endIndex against the receiver's length. Same species exception as RegExp.prototype [ @@matchAll ].",
       "evidence": "ECMA-262 \"%TypedArray%.prototype.slice\"",
       "reviewedAt": "b6c7f0d042a5",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "TypedArray.prototype.toLocaleString": {
       "reason": "Reads the receiver's elements and calls toLocaleString on each. The opaque step binds the host's list separator.",
       "evidence": "ECMA-262 \"%TypedArray%.prototype.toLocaleString\"",
       "reviewedAt": "cf74dfcb19a6",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "get RegExp.prototype.flags": {
       "reason": "Reads each flag off the receiver with Get and appends code units to codeUnits, a list the getter allocates. The opaque step turns that list into the returned String.",
       "evidence": "ECMA-262 \"get RegExp.prototype.flags\"",
       "reviewedAt": "c509f1f9469f",
-      "classified": { "receiver": true, "returns": false },
       "receiver": "borrow"
     },
     "get TypedArray.prototype [ @@toStringTag ]": {
       "reason": "Returns the String held in [[TypedArrayName]]. A primitive read out of a slot is a copy, so the return borrows nothing the caller holds.",
       "evidence": "ECMA-262 \"get %TypedArray%.prototype [ %Symbol.toStringTag% ]\"",
       "reviewedAt": "75c3313dedc9",
-      "classified": { "receiver": false, "returns": true },
       "returns": { "kind": "fresh" }
     }
   }

--- a/internal/ecma262/curated.json
+++ b/internal/ecma262/curated.json
@@ -1,0 +1,193 @@
+{
+  "entries": {
+    "Array.prototype.toLocaleString": {
+      "reason": "Reads the receiver's elements and calls toLocaleString on each. The one step the serializer left opaque binds the host's list separator, which writes nothing.",
+      "evidence": "ECMA-262 \"Array.prototype.toLocaleString\"",
+      "reviewedAt": "f3203d8f63ec",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "Date.prototype.getTime": {
+      "reason": "Returns the Number held in [[DateValue]]. A primitive read out of a slot is a copy, so the return borrows nothing the caller holds. The analysis withholds the alias because telling a primitive slot from an object one needs the declared return type, which cfg.json does not carry.",
+      "evidence": "ECMA-262 \"Date.prototype.getTime\"",
+      "reviewedAt": "0d4b34259cd2",
+      "classified": { "receiver": false, "returns": true },
+      "returns": { "kind": "fresh" }
+    },
+    "Date.prototype.getTimezoneOffset": {
+      "reason": "Reads [[DateValue]] and computes an offset from it. The opaque step is the local time zone calculation, which writes nothing.",
+      "evidence": "ECMA-262 \"Date.prototype.getTimezoneOffset\"",
+      "reviewedAt": "0f3dbfa75247",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "Date.prototype.toISOString": {
+      "reason": "Formats [[DateValue]] as a string. The opaque steps build that string and write nothing.",
+      "evidence": "ECMA-262 \"Date.prototype.toISOString\"",
+      "reviewedAt": "e0ab062821e6",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "Date.prototype.toUTCString": {
+      "reason": "Formats [[DateValue]] as a string. The opaque steps build that string and write nothing.",
+      "evidence": "ECMA-262 \"Date.prototype.toUTCString\"",
+      "reviewedAt": "2a344681528d",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "Date.prototype.valueOf": {
+      "reason": "Returns the Number held in [[DateValue]]. A primitive read out of a slot is a copy, so the return borrows nothing the caller holds.",
+      "evidence": "ECMA-262 \"Date.prototype.valueOf\"",
+      "reviewedAt": "f9599ef775ef",
+      "classified": { "receiver": false, "returns": true },
+      "returns": { "kind": "fresh" }
+    },
+    "ForInIteratorPrototype.next": {
+      "reason": "Advances the iterator by writing [[RemainingKeys]], [[VisitedKeys]], [[Object]], and [[ObjectWasVisited]] on the receiver. The opaque step is the assertion over those slots.",
+      "evidence": "ECMA-262 \"%ForInIteratorPrototype%.next\"",
+      "reviewedAt": "9ac59fc3b816",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "mutBorrow"
+    },
+    "Number.prototype.toExponential": {
+      "reason": "Reads the receiver's number value and formats it. Every opaque step names a digit string it computes.",
+      "evidence": "ECMA-262 \"Number.prototype.toExponential\"",
+      "reviewedAt": "243e70d48235",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "Number.prototype.toFixed": {
+      "reason": "Reads the receiver's number value and formats it. Every opaque step names a digit string it computes, such as \"Let a be the first k - f code units of m\".",
+      "evidence": "ECMA-262 \"Number.prototype.toFixed\"",
+      "reviewedAt": "1836cd89dd25",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "Number.prototype.toLocaleString": {
+      "reason": "Reads the receiver's number value and formats it for the host locale. The formatting is implementation-defined and writes nothing.",
+      "evidence": "ECMA-262 \"Number.prototype.toLocaleString\"",
+      "reviewedAt": "3229a7c40342",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "Number.prototype.toPrecision": {
+      "reason": "Reads the receiver's number value and formats it. Every opaque step names a digit string it computes.",
+      "evidence": "ECMA-262 \"Number.prototype.toPrecision\"",
+      "reviewedAt": "99d8cac517b0",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "RegExp.prototype [ @@matchAll ]": {
+      "reason": "Reads flags and lastIndex off the receiver, then writes lastIndex on matcher, the object SpeciesConstructor built. The write the analysis could not place lands on matcher rather than on the receiver. A @@species that hands the receiver back would make the two one object, which is the documented species exception.",
+      "evidence": "ECMA-262 \"RegExp.prototype [ %Symbol.matchAll% ]\"",
+      "reviewedAt": "c2cb8f3fdb97",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "RegExp.prototype [ @@replace ]": {
+      "reason": "Writes lastIndex on the receiver through Set(rx, \"lastIndex\", ...) when the pattern is global. The opaque steps build the replacement string.",
+      "evidence": "ECMA-262 \"RegExp.prototype [ %Symbol.replace% ]\"",
+      "reviewedAt": "4b29b7f53c9e",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "mutBorrow"
+    },
+    "RegExp.prototype [ @@split ]": {
+      "reason": "Writes only into A, the array it allocates, and into splitter, the object SpeciesConstructor built. Every step touching the receiver reads it. Same species exception as RegExp.prototype [ @@matchAll ].",
+      "evidence": "ECMA-262 \"RegExp.prototype [ %Symbol.split% ]\"",
+      "reviewedAt": "64e67b1e3216",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "RegExpStringIteratorPrototype.next": {
+      "reason": "Writes [[Done]] on the receiver. It also writes lastIndex on the regular expression held in [[IteratingRegExp]], which it reaches through the receiver.",
+      "evidence": "ECMA-262 \"%RegExpStringIteratorPrototype%.next\"",
+      "reviewedAt": "496d4222b7b1",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "mutBorrow"
+    },
+    "SharedArrayBuffer.prototype.grow": {
+      "reason": "Grows the buffer by writing, through AtomicCompareExchangeInSharedBlock, the block it read out of the receiver's [[ArrayBufferByteLengthData]]. The new byte length is observable on the receiver afterwards.",
+      "evidence": "ECMA-262 \"SharedArrayBuffer.prototype.grow\"",
+      "reviewedAt": "78f695c8902d",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "mutBorrow"
+    },
+    "String.prototype.normalize": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The opaque step is the Unicode normalization itself.",
+      "evidence": "ECMA-262 \"String.prototype.normalize\"",
+      "reviewedAt": "9c0df67c56b0",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "String.prototype.repeat": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The opaque step builds the repeated string.",
+      "evidence": "ECMA-262 \"String.prototype.repeat\"",
+      "reviewedAt": "1a54e17c9f5e",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "String.prototype.split": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. Reading @@split off separator can run arbitrary code, and that code reaches nothing the receiver holds.",
+      "evidence": "ECMA-262 \"String.prototype.split\"",
+      "reviewedAt": "3120ebfb8574",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "String.prototype.toLocaleLowerCase": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a locale-sensitive Unicode table lookup.",
+      "evidence": "ECMA-262 \"String.prototype.toLocaleLowerCase\"",
+      "reviewedAt": "d75a8d944557",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "String.prototype.toLocaleUpperCase": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a locale-sensitive Unicode table lookup.",
+      "evidence": "ECMA-262 \"String.prototype.toLocaleUpperCase\"",
+      "reviewedAt": "fc11d8ee1b51",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "String.prototype.toLowerCase": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a Unicode table lookup ESMeta does not formalize.",
+      "evidence": "ECMA-262 \"String.prototype.toLowerCase\"",
+      "reviewedAt": "2bf52d68c976",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "String.prototype.toUpperCase": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a Unicode table lookup ESMeta does not formalize.",
+      "evidence": "ECMA-262 \"String.prototype.toUpperCase\"",
+      "reviewedAt": "d1c5c3231872",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "TypedArray.prototype.slice": {
+      "reason": "Reads the receiver's elements and writes into A, the array TypedArraySpeciesCreate built. The opaque step clamps endIndex against the receiver's length. Same species exception as RegExp.prototype [ @@matchAll ].",
+      "evidence": "ECMA-262 \"%TypedArray%.prototype.slice\"",
+      "reviewedAt": "b6c7f0d042a5",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "TypedArray.prototype.toLocaleString": {
+      "reason": "Reads the receiver's elements and calls toLocaleString on each. The opaque step binds the host's list separator.",
+      "evidence": "ECMA-262 \"%TypedArray%.prototype.toLocaleString\"",
+      "reviewedAt": "cf74dfcb19a6",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "get RegExp.prototype.flags": {
+      "reason": "Reads each flag off the receiver with Get and appends code units to codeUnits, a list the getter allocates. The opaque step turns that list into the returned String.",
+      "evidence": "ECMA-262 \"get RegExp.prototype.flags\"",
+      "reviewedAt": "c509f1f9469f",
+      "classified": { "receiver": true, "returns": false },
+      "receiver": "borrow"
+    },
+    "get TypedArray.prototype [ @@toStringTag ]": {
+      "reason": "Returns the String held in [[TypedArrayName]]. A primitive read out of a slot is a copy, so the return borrows nothing the caller holds.",
+      "evidence": "ECMA-262 \"get %TypedArray%.prototype [ %Symbol.toStringTag% ]\"",
+      "reviewedAt": "75c3313dedc9",
+      "classified": { "receiver": false, "returns": true },
+      "returns": { "kind": "fresh" }
+    }
+  }
+}

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -99,6 +99,56 @@ func TestUnclassifiedReadsAnUnwiredAxisAsOpen(t *testing.T) {
 		facts.Unclassified(Axis("throws")))
 }
 
+// Every published fact carries a value on every axis, which is the invariant
+// that lets facts.json omit coverage flags entirely. The analysis alone does
+// not hold it — it withholds 24 receivers — and the curated layer is what
+// closes the gap.
+func TestFactsCarryEveryAxis(t *testing.T) {
+	require.Empty(t, testFacts(t).Incomplete())
+	require.Len(t, testAnalyzedFacts(t).Incomplete(), 24)
+}
+
+// A hole is named with the axis that has it, so the operator knows which
+// determination to curate rather than only which method.
+func TestIncompleteNamesTheAxis(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	facts := &Facts{SpecTarget: cfg.SpecTarget, Methods: methods}
+
+	// `opaque` has no receiver; its return is `unknown`, which is a value.
+	require.Equal(t,
+		[]string{"Demo.prototype.opaque: no receiver determination"},
+		facts.Incomplete())
+
+	mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvBorrow),
+	}}, methods)
+	require.Empty(t, facts.Incomplete())
+}
+
+// The two predicates read an axis they do not name in opposite directions, on
+// purpose. A determination §8 or §9 has not added yet must not make an
+// otherwise complete fact look like a hole that fails the run, and must show up
+// as open work for a reviewer.
+func TestCarriesAndAnswersDisagreeOnAnUnwiredAxis(t *testing.T) {
+	t.Parallel()
+
+	fact := MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}}
+	require.True(t, fact.carries(Axis("throws")))
+	require.False(t, fact.answers(Axis("throws")))
+}
+
+// They also disagree on an `unknown` return, which is a value the converter can
+// act on and an open question for a reviewer.
+func TestCarriesAndAnswersDisagreeOnAnUnknownReturn(t *testing.T) {
+	t.Parallel()
+
+	fact := MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnknown}}
+	require.True(t, fact.carries(AxisReturns))
+	require.False(t, fact.answers(AxisReturns))
+}
+
 // A curated axis reaches the published fact, and the note says what it did to
 // the analysis's answer.
 func TestMergeCuration(t *testing.T) {

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -84,6 +84,21 @@ func TestUnclassifiedReadsBothAxes(t *testing.T) {
 	require.Equal(t, []string{"Demo.prototype.opaque"}, facts.Unclassified(AxisReturns))
 }
 
+// An axis `answers` does not name reads as unanswered, so each determination §8
+// and §9 add shows up as wholly open until it is wired in. The alternative
+// would have a new axis read as complete for every builtin the moment it is
+// declared, which is the direction that hides work rather than surfacing it.
+func TestUnclassifiedReadsAnUnwiredAxisAsOpen(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	facts := &Facts{SpecTarget: cfg.SpecTarget, Methods: methods}
+
+	require.Equal(t,
+		[]string{"Demo.prototype.opaque", "Demo.prototype.read"},
+		facts.Unclassified(Axis("throws")))
+}
+
 // A curated axis reaches the published fact, and the note says what it did to
 // the analysis's answer.
 func TestMergeCuration(t *testing.T) {

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -1,6 +1,7 @@
 package ecma262
 
 import (
+	"errors"
 	"sort"
 	"strings"
 	"testing"
@@ -41,6 +42,17 @@ func entry(t *testing.T, cfg *CFG, name string, kind ReceiverKind) CuratedEntry 
 		Classified: Coverage{Receiver: true},
 		Receiver:   kind,
 	}
+}
+
+// returnsEntry builds a curated entry claiming one return alias, reviewed
+// against the digest the graph currently holds for name.
+func returnsEntry(t *testing.T, cfg *CFG, name string, returns ReturnFact) CuratedEntry {
+	t.Helper()
+	e := entry(t, cfg, name, RecvBorrow)
+	e.Classified = Coverage{Returns: true}
+	e.Receiver = ""
+	e.Returns = returns
+	return e
 }
 
 // The analysis leaves Demo.prototype.opaque's receiver open and settles
@@ -101,6 +113,29 @@ func TestMergeCuration(t *testing.T) {
 			name: "Demo.prototype.read",
 			want: "receiver:borrow returns:receiver",
 			note: "Demo.prototype.read receiver: redundant borrow over borrow",
+		},
+		// A return the analysis did name, contradicted. `read` ends in
+		// `Return this`, so the analysis calls it `receiver`.
+		"ReturnsCorrection": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.read": returnsEntry(t, cfg, "Demo.prototype.read", ReturnFact{Kind: AliasFresh}),
+				}
+			},
+			name: "Demo.prototype.read",
+			want: "receiver:borrow returns:fresh",
+			note: "Demo.prototype.read returns: correction fresh over receiver",
+		},
+		// The same claim the analysis made, so the entry is deletable.
+		"ReturnsRedundant": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.read": returnsEntry(t, cfg, "Demo.prototype.read", ReturnFact{Kind: AliasReceiver}),
+				}
+			},
+			name: "Demo.prototype.read",
+			want: "receiver:borrow returns:receiver",
+			note: "Demo.prototype.read returns: redundant receiver over receiver",
 		},
 		// Curating one axis leaves the other where the analysis left it, which
 		// is what makes the layer compose with the analysis rather than shadow
@@ -291,6 +326,14 @@ func TestParseCurationRejects(t *testing.T) {
 			`{"reason":"r","reviewedAt":"abc","classified":{"receiver":true},"receiver":"borrow","returns":{"kind":"fresh"}}`,
 			"curated entry Demo.m: names returns fresh on an axis its coverage leaves unclaimed",
 		},
+		"NegativeParamPosition": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"param","index":-1}}`,
+			"curated entry Demo.m: returns the parameter at position -1",
+		},
+		"UnionMemberWithNoPosition": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"param"}]}}`,
+			"curated entry Demo.m: union member: returns a parameter but names no position",
+		},
 		"UnionNamingOneValueTwice": {
 			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"param","index":1},{"kind":"param","index":1}]}}`,
 			"curated entry Demo.m: returns a union naming param(1) twice",
@@ -332,6 +375,109 @@ func TestParseCurationAcceptsEveryReturnShape(t *testing.T) {
 			curation, err := ParseCuration([]byte(`{"entries":{"Demo.m":` + body + returns + `}}}`))
 			require.NoError(t, err)
 			require.Equal(t, want[name], curation.Entries["Demo.m"].Returns.String())
+		})
+	}
+}
+
+// A layer that is not JSON at all fails before any entry is read, which is the
+// other way committed data can be wrong.
+func TestParseCurationRejectsMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCuration([]byte(`{"entries":`))
+	require.ErrorContains(t, err, "decoding curation:")
+}
+
+// The committed layer parses. mustParseCuration is what the package-level
+// `curated` var runs at init, and it panics rather than returning, so this
+// pins both halves of that contract.
+func TestMustParseCuration(t *testing.T) {
+	t.Parallel()
+
+	require.NotEmpty(t, mustParseCuration(curatedJSON).Entries)
+	require.PanicsWithValue(t,
+		"ecma262: committed curated.json is invalid: curated entry Demo.m: has no reason",
+		func() {
+			mustParseCuration([]byte(`{"entries":{"Demo.m":{"reviewedAt":"abc",` +
+				`"classified":{"receiver":true},"receiver":"borrow"}}}`))
+		})
+}
+
+// failAfter is a writer that accepts n writes and then fails, so a test can put
+// the failure on any one line of the report.
+type failAfter struct {
+	n int
+}
+
+func (w *failAfter) Write(p []byte) (int, error) {
+	if w.n == 0 {
+		return 0, errWriteFailed
+	}
+	w.n--
+	return len(p), nil
+}
+
+var errWriteFailed = errors.New("write failed")
+
+// Every line of the report propagates a writer error rather than reporting a
+// truncated merge as a clean one. The counts are one write and each listed line
+// is another, so failing after k writes puts the failure on line k.
+func TestWriteCurationReportPropagatesAWriteError(t *testing.T) {
+	t.Parallel()
+
+	report := CurationReport{
+		Notes: []CurationNote{
+			{Name: "Demo.a", Axis: AxisReceiver, Kind: CurationFillIn, Curated: "borrow"},
+			{Name: "Demo.b", Axis: AxisReceiver, Kind: CurationCorrection, Curated: "borrow", Analyzed: "mutBorrow"},
+		},
+		Stale:     []string{"Demo.c"},
+		Unmatched: []string{"Demo.d"},
+		Refused:   []string{"Demo.e receiver: curated borrow, but a builtin-static has no receiver"},
+	}
+
+	// Five writes succeed: the counts, the correction, the stale name, the
+	// unmatched name, and the refused axis. The fill-in is summarized rather
+	// than listed, so it is not one of them.
+	for writes := range 5 {
+		require.ErrorIs(t, WriteCurationReport(report, &failAfter{n: writes}), errWriteFailed,
+			"a failure on write %d was swallowed", writes)
+	}
+	require.NoError(t, WriteCurationReport(report, &failAfter{n: 5}))
+}
+
+// equal is what sorts a curated entry into redundant or correction, so every
+// way two return facts can differ has to register. Members are compared in
+// order, which parsing and newReturnFact both establish.
+func TestReturnFactEqual(t *testing.T) {
+	t.Parallel()
+
+	union := func(members ...AliasRef) ReturnFact {
+		return ReturnFact{Kind: AliasUnion, Members: members}
+	}
+	param := func(i int) AliasRef { return AliasRef{Kind: AliasParam, Index: position(i)} }
+	fresh := AliasRef{Kind: AliasFresh}
+
+	tests := map[string]struct {
+		a, b ReturnFact
+		want bool
+	}{
+		"SameKind":          {ReturnFact{Kind: AliasFresh}, ReturnFact{Kind: AliasFresh}, true},
+		"DifferingKind":     {ReturnFact{Kind: AliasFresh}, ReturnFact{Kind: AliasReceiver}, false},
+		"SamePosition":      {returnsParam(1), returnsParam(1), true},
+		"DifferingPosition": {returnsParam(0), returnsParam(1), false},
+		// A position on one side only. The fields are pointers, so this is the
+		// case a plain dereference would panic on.
+		"PositionOnOneSide":       {returnsParam(0), ReturnFact{Kind: AliasParam}, false},
+		"SameMembers":             {union(fresh, param(0)), union(fresh, param(0)), true},
+		"DifferingMemberKind":     {union(fresh, param(0)), union(AliasRef{Kind: AliasReceiver}, param(0)), false},
+		"DifferingMemberPosition": {union(fresh, param(0)), union(fresh, param(2)), false},
+		"DifferingMemberCount":    {union(fresh, param(0)), union(fresh, param(0), param(1)), false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, test.a.equal(test.b))
+			require.Equal(t, test.want, test.b.equal(test.a), "equal is not symmetric")
 		})
 	}
 }

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
 )
@@ -54,7 +55,7 @@ func TestDemoGraphClassification(t *testing.T) {
 
 // A curated axis reaches the published fact, and the note says what it did to
 // the analysis's answer.
-func TestCurateMerge(t *testing.T) {
+func TestMergeCuration(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -113,32 +114,68 @@ func TestCurateMerge(t *testing.T) {
 			},
 			name: "Demo.prototype.opaque",
 			want: "returns:fresh",
-			note: "Demo.prototype.opaque returns: correction fresh over unknown",
+			note: "Demo.prototype.opaque returns: fill-in fresh",
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			cfg, methods := demoFacts(t)
-			report := curate(cfg, &Curation{Entries: test.entries(cfg)}, methods)
+			report := mergeCuration(cfg, &Curation{Entries: test.entries(cfg)}, methods)
 
 			require.Equal(t, test.want, methods[test.name].String())
 			require.Len(t, report.Notes, 1)
 			require.Equal(t, test.note, report.Notes[0].String())
 			require.Empty(t, report.Stale)
 			require.Empty(t, report.Unmatched)
+			require.Empty(t, report.Refused)
 		})
 	}
+}
+
+// Whether a builtin has a receiver at all follows from its kind, so review
+// cannot move it. A curated claim that contradicts the kind is refused and
+// reported, and the analysis's answer stands.
+func TestMergeCurationRefusesAReceiverTheKindContradicts(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := ParseCFG([]byte(`{"specTarget":"abc","funcs":[` +
+		`{"name":"Demo.make","kind":"builtin-static","params":[],"nodes":[` +
+		`{"kind":"return","value":{"kind":"lit"}}]}]}`))
+	require.NoError(t, err)
+	methods := analyze(cfg).Methods
+	require.Equal(t, "receiver:none returns:fresh", methods["Demo.make"].String())
+
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.make": entry(t, cfg, "Demo.make", RecvBorrow),
+	}}, methods)
+
+	require.Equal(t, []string{"Demo.make receiver: curated borrow, but a builtin-static has no receiver"}, report.Refused)
+	require.Empty(t, report.Notes)
+	require.Equal(t, "receiver:none returns:fresh", methods["Demo.make"].String())
+}
+
+// The mirror case. A method has a receiver whatever the review says.
+func TestMergeCurationRefusesNoneOnAMethod(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvNone),
+	}}, methods)
+
+	require.Equal(t, []string{"Demo.prototype.opaque receiver: curated none, but a builtin-method has a receiver"}, report.Refused)
+	require.Equal(t, "returns:unknown", methods["Demo.prototype.opaque"].String())
 }
 
 // A name the graph holds no builtin for is reported and applied to nothing, so
 // an entry carried over from another spec revision degrades to a report line
 // rather than inventing a method.
-func TestCurateReportsAnUnmatchedName(t *testing.T) {
+func TestMergeCurationReportsAnUnmatchedName(t *testing.T) {
 	t.Parallel()
 
 	cfg, methods := demoFacts(t)
-	report := curate(cfg, &Curation{Entries: map[string]CuratedEntry{
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
 		"Demo.prototype.gone": {
 			Reason:     "stated for the test",
 			ReviewedAt: "000000000000",
@@ -155,13 +192,13 @@ func TestCurateReportsAnUnmatchedName(t *testing.T) {
 // An entry reviewed against an algorithm the graph no longer holds is applied
 // and reported. Dropping it would trade a visible re-review prompt for a silent
 // loss of coverage.
-func TestCurateAppliesAStaleEntry(t *testing.T) {
+func TestMergeCurationAppliesAStaleEntry(t *testing.T) {
 	t.Parallel()
 
 	cfg, methods := demoFacts(t)
 	stale := entry(t, cfg, "Demo.prototype.opaque", RecvMutBorrow)
 	stale.ReviewedAt = "000000000000"
-	report := curate(cfg, &Curation{Entries: map[string]CuratedEntry{
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
 		"Demo.prototype.opaque": stale,
 	}}, methods)
 
@@ -242,6 +279,21 @@ func TestParseCurationRejects(t *testing.T) {
 			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"unknown"}]}}`,
 			"curated entry Demo.m: returns a union holding unknown",
 		},
+		// A value on an axis the coverage leaves unclaimed would be dropped by
+		// the merge with no report line, so a reviewer would see silence rather
+		// than the claim they wrote.
+		"ReceiverOnAnUnclaimedAxis": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"fresh"},"receiver":"borrow"}`,
+			`curated entry Demo.m: names receiver "borrow" on an axis its coverage leaves unclaimed`,
+		},
+		"ReturnsOnAnUnclaimedAxis": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"receiver":true},"receiver":"borrow","returns":{"kind":"fresh"}}`,
+			"curated entry Demo.m: names returns fresh on an axis its coverage leaves unclaimed",
+		},
+		"UnionNamingOneValueTwice": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"param","index":1},{"kind":"param","index":1}]}}`,
+			"curated entry Demo.m: returns a union naming param(1) twice",
+		},
 		"MembersOnANonUnionReturn": {
 			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"fresh","members":[{"kind":"fresh"}]}}`,
 			"curated entry Demo.m: returns fresh but names union members",
@@ -283,6 +335,26 @@ func TestParseCurationAcceptsEveryReturnShape(t *testing.T) {
 	}
 }
 
+// A union is written by hand in whatever order reads best, and parsing puts its
+// members in the order the analysis leaves them. Without that, a curated union
+// would compare unequal to the analyzed fact it repeats and publish its members
+// in an order no other fact uses.
+func TestParseCurationSortsUnionMembers(t *testing.T) {
+	t.Parallel()
+
+	curation, err := ParseCuration([]byte(`{"entries":{"Demo.m":{"reason":"r","reviewedAt":"abc",` +
+		`"classified":{"returns":true},"returns":{"kind":"union","members":[` +
+		`{"kind":"receiver"},{"kind":"param","index":2},{"kind":"fresh"},{"kind":"param","index":0}]}}}}`))
+	require.NoError(t, err)
+
+	returns := curation.Entries["Demo.m"].Returns
+	require.Equal(t, "union(fresh, param(0), param(2), receiver)", returns.String())
+	require.True(t, returns.equal(newReturnFact(aliasSet{members: set.FromSlice([]alias{
+		{Kind: AliasReceiver}, {Kind: AliasParam, Index: 2},
+		{Kind: AliasFresh}, {Kind: AliasParam, Index: 0},
+	})})), "a curated union does not compare equal to the analyzed fact it repeats")
+}
+
 // Every name in curated.json addresses a builtin the committed graph holds, and
 // every entry was reviewed against the algorithm the graph holds now. This is
 // what turns a misspelled key and an algorithm rewritten under a reviewer into
@@ -292,6 +364,7 @@ func TestCurationMatchesTheGraph(t *testing.T) {
 
 	require.Empty(t, report.Unmatched, "curated names the committed graph holds no builtin for")
 	require.Empty(t, report.Stale, "curated entries reviewed against an algorithm the graph no longer holds")
+	require.Empty(t, report.Refused, "curated axes the graph contradicts")
 }
 
 // An entry the analysis has caught up with is deletable, and leaving it in
@@ -308,10 +381,13 @@ func TestCurationHasNoRedundantEntries(t *testing.T) {
 }
 
 // Every curated determination in one list, which is what a reviewer reads to
-// see the whole layer at once. A fill-in answers a determination the analysis
-// withheld. A correction contradicts one it published, and each of the three
-// here reads a primitive out of a slot, which is a copy the analysis cannot
-// recognize as one without the declared return type.
+// see the whole layer at once.
+//
+// All 27 are fill-ins. The 24 receivers answer an axis the analysis withheld.
+// The three returns answer one it resolved to `unknown`, which names no value,
+// and each reads a primitive out of a slot — a copy the analysis cannot
+// recognize as one without the declared return type. Nothing here corrects a
+// claim the analysis actually made, so §6 has no disagreement to triage yet.
 func TestCurationReportOverTheCommittedGraph(t *testing.T) {
 	lines := make([]string, 0, len(testFacts(t).Curation().Notes))
 	for _, note := range testFacts(t).Curation().Notes {
@@ -329,7 +405,7 @@ func TestWriteCurationReport(t *testing.T) {
 	cfg, methods := demoFacts(t)
 	stale := entry(t, cfg, "Demo.prototype.read", RecvBorrow)
 	stale.ReviewedAt = "000000000000"
-	report := curate(cfg, &Curation{Entries: map[string]CuratedEntry{
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
 		"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvMutBorrow),
 		"Demo.prototype.read":   stale,
 		"Demo.prototype.gone": {
@@ -342,7 +418,7 @@ func TestWriteCurationReport(t *testing.T) {
 
 	var out strings.Builder
 	require.NoError(t, WriteCurationReport(report, &out))
-	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  curation: 1 fill-ins, 0 corrections, 1 redundant, 1 stale, 1 unmatched
+	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  curation: 1 fill-ins, 0 corrections, 1 redundant, 1 stale, 1 unmatched, 0 refused
     Demo.prototype.read receiver: redundant borrow over borrow
     Demo.prototype.read: reviewed against an algorithm the graph no longer holds
     Demo.prototype.gone: curated, but the graph holds no such builtin

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -127,6 +127,19 @@ func TestIncompleteNamesTheAxis(t *testing.T) {
 	require.Empty(t, facts.Incomplete())
 }
 
+// Every axis Incomplete walks has a case in `carries`. Without this, adding one
+// to publishedAxes and forgetting the switch would leave `carries` returning
+// its permissive default, and the gate would pass a fact holding exactly the
+// hole it exists to catch.
+func TestCarriesCoversEveryPublishedAxis(t *testing.T) {
+	t.Parallel()
+
+	for _, axis := range publishedAxes {
+		require.Falsef(t, MethodFact{}.carries(axis),
+			"%s is a published axis that carries does not name", axis)
+	}
+}
+
 // The two predicates read an axis they do not name in opposite directions, on
 // purpose. A determination §8 or §9 has not added yet must not make an
 // otherwise complete fact look like a hole that fails the run, and must show up

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -39,7 +39,6 @@ func entry(t *testing.T, cfg *CFG, name string, kind ReceiverKind) CuratedEntry 
 	return CuratedEntry{
 		Reason:     "stated for the test",
 		ReviewedAt: fn.Digest,
-		Classified: Coverage{Receiver: true},
 		Receiver:   kind,
 	}
 }
@@ -49,7 +48,6 @@ func entry(t *testing.T, cfg *CFG, name string, kind ReceiverKind) CuratedEntry 
 func returnsEntry(t *testing.T, cfg *CFG, name string, returns ReturnFact) CuratedEntry {
 	t.Helper()
 	e := entry(t, cfg, name, RecvBorrow)
-	e.Classified = Coverage{Returns: true}
 	e.Receiver = ""
 	e.Returns = returns
 	return e
@@ -142,11 +140,9 @@ func TestMergeCuration(t *testing.T) {
 		// it.
 		"OneAxisLeavesTheOther": {
 			entries: func(cfg *CFG) map[string]CuratedEntry {
-				e := entry(t, cfg, "Demo.prototype.opaque", RecvBorrow)
-				e.Classified = Coverage{Returns: true}
-				e.Receiver = ""
-				e.Returns = ReturnFact{Kind: AliasFresh}
-				return map[string]CuratedEntry{"Demo.prototype.opaque": e}
+				return map[string]CuratedEntry{
+					"Demo.prototype.opaque": returnsEntry(t, cfg, "Demo.prototype.opaque", ReturnFact{Kind: AliasFresh}),
+				}
 			},
 			name: "Demo.prototype.opaque",
 			want: "returns:fresh",
@@ -215,7 +211,6 @@ func TestMergeCurationReportsAnUnmatchedName(t *testing.T) {
 		"Demo.prototype.gone": {
 			Reason:     "stated for the test",
 			ReviewedAt: "000000000000",
-			Classified: Coverage{Receiver: true},
 			Receiver:   RecvBorrow,
 		},
 	}}, methods)
@@ -276,70 +271,61 @@ func TestParseCurationRejects(t *testing.T) {
 		want  string
 	}{
 		"NoReason": {
-			`{"reviewedAt":"abc","classified":{"receiver":true},"receiver":"borrow"}`,
+			`{"reviewedAt":"abc","receiver":"borrow"}`,
 			"curated entry Demo.m: has no reason",
 		},
 		"NoReviewedAt": {
-			`{"reason":"r","classified":{"receiver":true},"receiver":"borrow"}`,
+			`{"reason":"r","receiver":"borrow"}`,
 			"curated entry Demo.m: has no reviewedAt digest",
 		},
 		"NoDetermination": {
-			`{"reason":"r","reviewedAt":"abc","classified":{}}`,
-			"curated entry Demo.m: claims no determination",
+			`{"reason":"r","reviewedAt":"abc"}`,
+			"curated entry Demo.m: answers no determination",
 		},
 		"UnknownReceiverKind": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"receiver":true},"receiver":"shared"}`,
-			`curated entry Demo.m: claims receiver "shared", which is not a receiver kind`,
+			`{"reason":"r","reviewedAt":"abc","receiver":"shared"}`,
+			`curated entry Demo.m: names receiver "shared", which is not a receiver kind`,
 		},
-		"MissingReceiverKind": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"receiver":true}}`,
-			`curated entry Demo.m: claims receiver "", which is not a receiver kind`,
+		// A return carrying a position but no kind is malformed rather than
+		// absent, so it answers the axis and is refused on the kind.
+		"ReturnsWithNoKind": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"index":0}}`,
+			`curated entry Demo.m: returns "", which is not an alias kind`,
 		},
 		"UnknownAliasKind": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"borrowed"}}`,
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"borrowed"}}`,
 			`curated entry Demo.m: returns "borrowed", which is not an alias kind`,
 		},
 		"ParamWithNoPosition": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"param"}}`,
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"param"}}`,
 			"curated entry Demo.m: returns a parameter but names no position",
 		},
 		"PositionOnANonParamReturn": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"fresh","index":0}}`,
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"fresh","index":0}}`,
 			"curated entry Demo.m: returns fresh but names a position",
 		},
 		"UnionOfOne": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"fresh"}]}}`,
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"union","members":[{"kind":"fresh"}]}}`,
 			"curated entry Demo.m: returns a union of 1 members",
 		},
 		"UnionHoldingUnknown": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"unknown"}]}}`,
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"unknown"}]}}`,
 			"curated entry Demo.m: returns a union holding unknown",
 		},
-		// A value on an axis the coverage leaves unclaimed would be dropped by
-		// the merge with no report line, so a reviewer would see silence rather
-		// than the claim they wrote.
-		"ReceiverOnAnUnclaimedAxis": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"fresh"},"receiver":"borrow"}`,
-			`curated entry Demo.m: names receiver "borrow" on an axis its coverage leaves unclaimed`,
-		},
-		"ReturnsOnAnUnclaimedAxis": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"receiver":true},"receiver":"borrow","returns":{"kind":"fresh"}}`,
-			"curated entry Demo.m: names returns fresh on an axis its coverage leaves unclaimed",
-		},
 		"NegativeParamPosition": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"param","index":-1}}`,
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"param","index":-1}}`,
 			"curated entry Demo.m: returns the parameter at position -1",
 		},
 		"UnionMemberWithNoPosition": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"param"}]}}`,
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"param"}]}}`,
 			"curated entry Demo.m: union member: returns a parameter but names no position",
 		},
 		"UnionNamingOneValueTwice": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"param","index":1},{"kind":"param","index":1}]}}`,
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"union","members":[{"kind":"param","index":1},{"kind":"param","index":1}]}}`,
 			"curated entry Demo.m: returns a union naming param(1) twice",
 		},
 		"MembersOnANonUnionReturn": {
-			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"fresh","members":[{"kind":"fresh"}]}}`,
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"fresh","members":[{"kind":"fresh"}]}}`,
 			"curated entry Demo.m: returns fresh but names union members",
 		},
 	}
@@ -357,7 +343,7 @@ func TestParseCurationRejects(t *testing.T) {
 func TestParseCurationAcceptsEveryReturnShape(t *testing.T) {
 	t.Parallel()
 
-	body := `{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":`
+	body := `{"reason":"r","reviewedAt":"abc","returns":`
 	tests := map[string]string{
 		"Fresh":    `{"kind":"fresh"}`,
 		"Receiver": `{"kind":"receiver"}`,
@@ -398,8 +384,7 @@ func TestMustParseCuration(t *testing.T) {
 	require.PanicsWithValue(t,
 		"ecma262: committed curated.json is invalid: curated entry Demo.m: has no reason",
 		func() {
-			mustParseCuration([]byte(`{"entries":{"Demo.m":{"reviewedAt":"abc",` +
-				`"classified":{"receiver":true},"receiver":"borrow"}}}`))
+			mustParseCuration([]byte(`{"entries":{"Demo.m":{"reviewedAt":"abc","receiver":"borrow"}}}`))
 		})
 }
 
@@ -490,7 +475,7 @@ func TestParseCurationSortsUnionMembers(t *testing.T) {
 	t.Parallel()
 
 	curation, err := ParseCuration([]byte(`{"entries":{"Demo.m":{"reason":"r","reviewedAt":"abc",` +
-		`"classified":{"returns":true},"returns":{"kind":"union","members":[` +
+		`"returns":{"kind":"union","members":[` +
 		`{"kind":"receiver"},{"kind":"param","index":2},{"kind":"fresh"},{"kind":"param","index":0}]}}}}`))
 	require.NoError(t, err)
 
@@ -558,7 +543,6 @@ func TestWriteCurationReport(t *testing.T) {
 		"Demo.prototype.gone": {
 			Reason:     "stated for the test",
 			ReviewedAt: "000000000000",
-			Classified: Coverage{Receiver: true},
 			Receiver:   RecvBorrow,
 		},
 	}}, methods)

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -12,8 +12,9 @@ import (
 
 // demoCFG is a two-method graph standing in for the shapes the committed one
 // holds. `read` returns its receiver and writes nothing, so the analysis
-// classifies both determinations. `opaque` is a step the serializer could not
-// lower, which withholds the receiver and leaves the return unresolved.
+// classifies both its determinations. `opaque`'s one step is prose the
+// serializer could not lower, which withholds its receiver and leaves its
+// return unresolved.
 const demoCFG = `{"specTarget":"abc","funcs":[` +
 	`{"name":"Demo.prototype.read","kind":"builtin-method","params":[],"nodes":[` +
 	`{"kind":"return","value":{"kind":"this"}}]},` +

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -64,6 +64,26 @@ func TestDemoGraphClassification(t *testing.T) {
 	require.Equal(t, "returns:unknown", methods["Demo.prototype.opaque"].String())
 }
 
+// Both axes report an open determination, each spelled the way that axis
+// spells it. `opaque` has its receiver withheld and its return resolved to the
+// lattice top, so it is open on both; `read` answers both.
+func TestUnclassifiedReadsBothAxes(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	facts := &Facts{SpecTarget: cfg.SpecTarget, Methods: methods}
+
+	require.Equal(t, []string{"Demo.prototype.opaque"}, facts.Unclassified(AxisReceiver))
+	require.Equal(t, []string{"Demo.prototype.opaque"}, facts.Unclassified(AxisReturns))
+
+	// Answering one axis takes the method off that list alone.
+	mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvBorrow),
+	}}, methods)
+	require.Empty(t, facts.Unclassified(AxisReceiver))
+	require.Equal(t, []string{"Demo.prototype.opaque"}, facts.Unclassified(AxisReturns))
+}
+
 // A curated axis reaches the published fact, and the note says what it did to
 // the analysis's answer.
 func TestMergeCuration(t *testing.T) {

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -1,0 +1,350 @@
+package ecma262
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// demoCFG is a two-method graph standing in for the shapes the committed one
+// holds. `read` returns its receiver and writes nothing, so the analysis
+// classifies both determinations. `opaque` is a step the serializer could not
+// lower, which withholds the receiver and leaves the return unresolved.
+const demoCFG = `{"specTarget":"abc","funcs":[` +
+	`{"name":"Demo.prototype.read","kind":"builtin-method","params":[],"nodes":[` +
+	`{"kind":"return","value":{"kind":"this"}}]},` +
+	`{"name":"Demo.prototype.opaque","kind":"builtin-method","params":[],"nodes":[` +
+	`{"kind":"opaque","text":["Let _x_ be whatever the host decides."]}]}]}`
+
+// demoFacts parses demoCFG and classifies it from the graph alone.
+func demoFacts(t *testing.T) (*CFG, map[string]MethodFact) {
+	t.Helper()
+	cfg, err := ParseCFG([]byte(demoCFG))
+	require.NoError(t, err)
+	return cfg, analyze(cfg).Methods
+}
+
+// entry builds a curated entry claiming one receiver, reviewed against the
+// digest the graph currently holds for name.
+func entry(t *testing.T, cfg *CFG, name string, kind ReceiverKind) CuratedEntry {
+	t.Helper()
+	fn := cfg.Builtin(name)
+	require.NotNil(t, fn, "no builtin named %s", name)
+	return CuratedEntry{
+		Reason:     "stated for the test",
+		ReviewedAt: fn.Digest,
+		Classified: Coverage{Receiver: true},
+		Receiver:   kind,
+	}
+}
+
+// The analysis leaves Demo.prototype.opaque's receiver open and settles
+// Demo.prototype.read's, which is what the merge cases below are written
+// against.
+func TestDemoGraphClassification(t *testing.T) {
+	t.Parallel()
+
+	_, methods := demoFacts(t)
+	require.Equal(t, "receiver:borrow returns:receiver", methods["Demo.prototype.read"].String())
+	require.Equal(t, "returns:unknown", methods["Demo.prototype.opaque"].String())
+}
+
+// A curated axis reaches the published fact, and the note says what it did to
+// the analysis's answer.
+func TestCurateMerge(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		entries func(*CFG) map[string]CuratedEntry
+		// want is the merged fact for the name the entry addresses.
+		name string
+		want string
+		note string
+	}{
+		// The ordinary case. The analysis withheld the axis, so the entry adds
+		// a claim rather than displacing one.
+		"FillIn": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvMutBorrow),
+				}
+			},
+			name: "Demo.prototype.opaque",
+			want: "receiver:mutBorrow returns:unknown",
+			note: "Demo.prototype.opaque receiver: fill-in mutBorrow",
+		},
+		// A claim the analysis published and the review contradicts. §6 reads
+		// these first, since one of the two sources is wrong.
+		"Correction": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.read": entry(t, cfg, "Demo.prototype.read", RecvMutBorrow),
+				}
+			},
+			name: "Demo.prototype.read",
+			want: "receiver:mutBorrow returns:receiver",
+			note: "Demo.prototype.read receiver: correction mutBorrow over borrow",
+		},
+		// An entry that repeats the analysis changes nothing and is reported so
+		// it can be deleted.
+		"Redundant": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.read": entry(t, cfg, "Demo.prototype.read", RecvBorrow),
+				}
+			},
+			name: "Demo.prototype.read",
+			want: "receiver:borrow returns:receiver",
+			note: "Demo.prototype.read receiver: redundant borrow over borrow",
+		},
+		// Curating one axis leaves the other where the analysis left it, which
+		// is what makes the layer compose with the analysis rather than shadow
+		// it.
+		"OneAxisLeavesTheOther": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				e := entry(t, cfg, "Demo.prototype.opaque", RecvBorrow)
+				e.Classified = Coverage{Returns: true}
+				e.Receiver = ""
+				e.Returns = ReturnFact{Kind: AliasFresh}
+				return map[string]CuratedEntry{"Demo.prototype.opaque": e}
+			},
+			name: "Demo.prototype.opaque",
+			want: "returns:fresh",
+			note: "Demo.prototype.opaque returns: correction fresh over unknown",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg, methods := demoFacts(t)
+			report := curate(cfg, &Curation{Entries: test.entries(cfg)}, methods)
+
+			require.Equal(t, test.want, methods[test.name].String())
+			require.Len(t, report.Notes, 1)
+			require.Equal(t, test.note, report.Notes[0].String())
+			require.Empty(t, report.Stale)
+			require.Empty(t, report.Unmatched)
+		})
+	}
+}
+
+// A name the graph holds no builtin for is reported and applied to nothing, so
+// an entry carried over from another spec revision degrades to a report line
+// rather than inventing a method.
+func TestCurateReportsAnUnmatchedName(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	report := curate(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.gone": {
+			Reason:     "stated for the test",
+			ReviewedAt: "000000000000",
+			Classified: Coverage{Receiver: true},
+			Receiver:   RecvBorrow,
+		},
+	}}, methods)
+
+	require.Equal(t, []string{"Demo.prototype.gone"}, report.Unmatched)
+	require.Empty(t, report.Notes)
+	require.NotContains(t, methods, "Demo.prototype.gone")
+}
+
+// An entry reviewed against an algorithm the graph no longer holds is applied
+// and reported. Dropping it would trade a visible re-review prompt for a silent
+// loss of coverage.
+func TestCurateAppliesAStaleEntry(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	stale := entry(t, cfg, "Demo.prototype.opaque", RecvMutBorrow)
+	stale.ReviewedAt = "000000000000"
+	report := curate(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": stale,
+	}}, methods)
+
+	require.Equal(t, []string{"Demo.prototype.opaque"}, report.Stale)
+	require.Equal(t, "receiver:mutBorrow returns:unknown", methods["Demo.prototype.opaque"].String())
+}
+
+// Two algorithms that differ fingerprint differently, and re-parsing the same
+// graph reproduces each fingerprint. Together those are what let a digest stand
+// in for "the algorithm this entry was reviewed against".
+func TestFuncDigestIdentifiesTheAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	first, _ := demoFacts(t)
+	second, err := ParseCFG([]byte(demoCFG))
+	require.NoError(t, err)
+
+	read := first.Builtin("Demo.prototype.read")
+	opaque := first.Builtin("Demo.prototype.opaque")
+	require.Len(t, read.Digest, digestLen)
+	require.NotEqual(t, read.Digest, opaque.Digest)
+	require.Equal(t, read.Digest, second.Builtin("Demo.prototype.read").Digest)
+
+	// Editing one step changes that algorithm's digest and leaves the other's
+	// alone, which is what keeps a spec bump from flagging every entry.
+	edited, err := ParseCFG([]byte(strings.Replace(demoCFG, "whatever the host decides", "something else", 1)))
+	require.NoError(t, err)
+	require.Equal(t, read.Digest, edited.Builtin("Demo.prototype.read").Digest)
+	require.NotEqual(t, opaque.Digest, edited.Builtin("Demo.prototype.opaque").Digest)
+}
+
+// An entry that cannot be reviewed or applied is a defect in committed data, so
+// parsing refuses it rather than merging it as written.
+func TestParseCurationRejects(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		entry string
+		want  string
+	}{
+		"NoReason": {
+			`{"reviewedAt":"abc","classified":{"receiver":true},"receiver":"borrow"}`,
+			"curated entry Demo.m: has no reason",
+		},
+		"NoReviewedAt": {
+			`{"reason":"r","classified":{"receiver":true},"receiver":"borrow"}`,
+			"curated entry Demo.m: has no reviewedAt digest",
+		},
+		"NoDetermination": {
+			`{"reason":"r","reviewedAt":"abc","classified":{}}`,
+			"curated entry Demo.m: claims no determination",
+		},
+		"UnknownReceiverKind": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"receiver":true},"receiver":"shared"}`,
+			`curated entry Demo.m: claims receiver "shared", which is not a receiver kind`,
+		},
+		"MissingReceiverKind": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"receiver":true}}`,
+			`curated entry Demo.m: claims receiver "", which is not a receiver kind`,
+		},
+		"UnknownAliasKind": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"borrowed"}}`,
+			`curated entry Demo.m: returns "borrowed", which is not an alias kind`,
+		},
+		"ParamWithNoPosition": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"param"}}`,
+			"curated entry Demo.m: returns a parameter but names no position",
+		},
+		"PositionOnANonParamReturn": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"fresh","index":0}}`,
+			"curated entry Demo.m: returns fresh but names a position",
+		},
+		"UnionOfOne": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"fresh"}]}}`,
+			"curated entry Demo.m: returns a union of 1 members",
+		},
+		"UnionHoldingUnknown": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"unknown"}]}}`,
+			"curated entry Demo.m: returns a union holding unknown",
+		},
+		"MembersOnANonUnionReturn": {
+			`{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":{"kind":"fresh","members":[{"kind":"fresh"}]}}`,
+			"curated entry Demo.m: returns fresh but names union members",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseCuration([]byte(`{"entries":{"Demo.m":` + test.entry + `}}`))
+			require.EqualError(t, err, test.want)
+		})
+	}
+}
+
+// The layer round-trips a fact of every shape the analysis builds, so an entry
+// can answer any determination the analysis can.
+func TestParseCurationAcceptsEveryReturnShape(t *testing.T) {
+	t.Parallel()
+
+	body := `{"reason":"r","reviewedAt":"abc","classified":{"returns":true},"returns":`
+	tests := map[string]string{
+		"Fresh":    `{"kind":"fresh"}`,
+		"Receiver": `{"kind":"receiver"}`,
+		"Unknown":  `{"kind":"unknown"}`,
+		"Param":    `{"kind":"param","index":0}`,
+		"Union":    `{"kind":"union","members":[{"kind":"fresh"},{"kind":"param","index":1}]}`,
+	}
+	want := map[string]string{
+		"Fresh": "fresh", "Receiver": "receiver", "Unknown": "unknown",
+		"Param": "param(0)", "Union": "union(fresh, param(1))",
+	}
+
+	for name, returns := range tests {
+		t.Run(name, func(t *testing.T) {
+			curation, err := ParseCuration([]byte(`{"entries":{"Demo.m":` + body + returns + `}}}`))
+			require.NoError(t, err)
+			require.Equal(t, want[name], curation.Entries["Demo.m"].Returns.String())
+		})
+	}
+}
+
+// Every name in curated.json addresses a builtin the committed graph holds, and
+// every entry was reviewed against the algorithm the graph holds now. This is
+// what turns a misspelled key and an algorithm rewritten under a reviewer into
+// a failing build rather than a line in a report nobody reads.
+func TestCurationMatchesTheGraph(t *testing.T) {
+	report := testFacts(t).Curation()
+
+	require.Empty(t, report.Unmatched, "curated names the committed graph holds no builtin for")
+	require.Empty(t, report.Stale, "curated entries reviewed against an algorithm the graph no longer holds")
+}
+
+// An entry the analysis has caught up with is deletable, and leaving it in
+// place would grow a second source of truth for a determination that no longer
+// needs one.
+func TestCurationHasNoRedundantEntries(t *testing.T) {
+	var redundant []string
+	for _, note := range testFacts(t).Curation().Notes {
+		if note.Kind == CurationRedundant {
+			redundant = append(redundant, note.String())
+		}
+	}
+	require.Empty(t, redundant)
+}
+
+// Every curated determination in one list, which is what a reviewer reads to
+// see the whole layer at once. A fill-in answers a determination the analysis
+// withheld. A correction contradicts one it published, and each of the three
+// here reads a primitive out of a slot, which is a copy the analysis cannot
+// recognize as one without the declared return type.
+func TestCurationReportOverTheCommittedGraph(t *testing.T) {
+	lines := make([]string, 0, len(testFacts(t).Curation().Notes))
+	for _, note := range testFacts(t).Curation().Notes {
+		lines = append(lines, note.String())
+	}
+	sort.Strings(lines)
+	snaps.MatchSnapshot(t, strings.Join(lines, "\n"))
+}
+
+// The report prints its tallies and then every line that needs a reviewer. A
+// fill-in is the ordinary case and is counted rather than listed.
+func TestWriteCurationReport(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	stale := entry(t, cfg, "Demo.prototype.read", RecvBorrow)
+	stale.ReviewedAt = "000000000000"
+	report := curate(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvMutBorrow),
+		"Demo.prototype.read":   stale,
+		"Demo.prototype.gone": {
+			Reason:     "stated for the test",
+			ReviewedAt: "000000000000",
+			Classified: Coverage{Receiver: true},
+			Receiver:   RecvBorrow,
+		},
+	}}, methods)
+
+	var out strings.Builder
+	require.NoError(t, WriteCurationReport(report, &out))
+	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  curation: 1 fill-ins, 0 corrections, 1 redundant, 1 stale, 1 unmatched
+    Demo.prototype.read receiver: redundant borrow over borrow
+    Demo.prototype.read: reviewed against an algorithm the graph no longer holds
+    Demo.prototype.gone: curated, but the graph holds no such builtin
+`))
+}

--- a/internal/ecma262/join.go
+++ b/internal/ecma262/join.go
@@ -58,7 +58,7 @@ func (f SignatureFact) String() string {
 // resolve, or ForSignature dropped a return naming a position this overload
 // does not declare. A fact with no return coverage makes no claim either way.
 func (f SignatureFact) unnamedReturn() bool {
-	return f.Fact.Classified.Returns && f.Fact.Returns.Kind == AliasUnknown
+	return f.Fact.Returns.Kind == AliasUnknown
 }
 
 // ForSignature resolves a fact against one overload. A return naming a
@@ -274,7 +274,7 @@ func WriteJoinReport(report JoinReport, w io.Writer) error {
 	// from the match count.
 	withReceiver := 0
 	for _, m := range report.Matched {
-		if m.Fact.Classified.Receiver {
+		if m.Fact.Receiver != "" {
 			withReceiver++
 		}
 	}

--- a/internal/ecma262/join.go
+++ b/internal/ecma262/join.go
@@ -54,9 +54,9 @@ func (f SignatureFact) String() string {
 }
 
 // unnamedReturn reports whether the resolved fact hands back a value the join
-// cannot name. Two things leave one. The walk read no return it could
-// resolve, or ForSignature dropped a return naming a position this overload
-// does not declare. A fact with no return coverage makes no claim either way.
+// cannot name. Two things leave one. The walk read no return it could resolve,
+// or ForSignature dropped a return naming a position this overload does not
+// declare.
 func (f SignatureFact) unnamedReturn() bool {
 	return f.Fact.Returns.Kind == AliasUnknown
 }

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -41,15 +41,13 @@ func TestMethodFactForSignature(t *testing.T) {
 	t.Parallel()
 
 	returnsParam1 := MethodFact{
-		Classified: Coverage{Receiver: true, Returns: true},
-		Receiver:   RecvBorrow,
-		Returns:    returnsParam(1),
+		Receiver: RecvBorrow,
+		Returns:  returnsParam(1),
 	}
 	// A union of two positions, which resolves only against a signature that
 	// declares both. No builtin in the committed graph has this shape.
 	returnsEitherParam := MethodFact{
-		Classified: Coverage{Receiver: true, Returns: true},
-		Receiver:   RecvBorrow,
+		Receiver: RecvBorrow,
 		Returns: ReturnFact{Kind: AliasUnion, Members: []AliasRef{
 			{Kind: AliasParam, Index: position(0)},
 			{Kind: AliasParam, Index: position(2)},
@@ -58,9 +56,8 @@ func TestMethodFactForSignature(t *testing.T) {
 	// An algorithm whose returns the walk never read, which is the shape
 	// `String.prototype.localeCompare` has in the committed graph.
 	readsNoReturn := MethodFact{
-		Classified: Coverage{Receiver: true, Returns: true},
-		Receiver:   RecvBorrow,
-		Returns:    ReturnFact{Kind: AliasUnknown},
+		Receiver: RecvBorrow,
+		Returns:  ReturnFact{Kind: AliasUnknown},
 	}
 
 	tests := map[string]struct {
@@ -87,7 +84,7 @@ func TestMethodFactForSignature(t *testing.T) {
 		},
 		// A claim that names no position applies to every overload as it is.
 		"NoPositionClaimed": {
-			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasReceiver}},
+			fact: MethodFact{Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasReceiver}},
 			sig:  Signature{},
 			want: "receiver:mutBorrow returns:receiver",
 		},
@@ -111,12 +108,12 @@ func TestMethodFactForSignature(t *testing.T) {
 		// cannot build. Neither states the value it claims to return, so both
 		// resolve to unknown.
 		"UnionWithNoMembers": {
-			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion}},
+			fact: MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion}},
 			sig:  Signature{Params: 2},
 			want: "receiver:borrow returns:unknown",
 		},
 		"ParamReturnWithNoPosition": {
-			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasParam}},
+			fact: MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasParam}},
 			sig:  Signature{Params: 2},
 			want: "receiver:borrow returns:unknown",
 		},
@@ -158,7 +155,7 @@ func TestMethodFactForSignature(t *testing.T) {
 		// A fact whose return the analysis never covered makes no claim, so
 		// the type settles nothing onto it.
 		"UncoveredReturnNotSettled": {
-			fact: MethodFact{Classified: Coverage{Receiver: true}, Receiver: RecvBorrow},
+			fact: MethodFact{Receiver: RecvBorrow},
 			sig:  Signature{PrimitiveReturn: true},
 			want: "receiver:borrow",
 		},
@@ -177,10 +174,10 @@ func TestMethodFactForSignature(t *testing.T) {
 func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 	t.Parallel()
 
-	fact := MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Returns: returnsParam(3)}
-	require.Equal(t, "returns:unknown", strings.TrimPrefix(
-		fact.ForSignature(Signature{Params: 1}).String(), "receiver: "))
-	require.Equal(t, "receiver: returns:param(3)", fact.String())
+	fact := MethodFact{Receiver: RecvNone, Returns: returnsParam(3)}
+	require.Equal(t, "receiver:none returns:unknown",
+		fact.ForSignature(Signature{Params: 1}).String())
+	require.Equal(t, "receiver:none returns:param(3)", fact.String())
 }
 
 // joinFixture is a hand-built fact set covering each keying shape the join has
@@ -205,35 +202,34 @@ func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 // that state. A `web:*` method, which has no ECMA-262 algorithm at all, is
 // where the shape returns.
 func joinFixture() *Facts {
-	covered := Coverage{Receiver: true, Returns: true}
 	return &Facts{
 		SpecTarget: "test",
 		Methods: map[string]MethodFact{
 			// An instance member, string-keyed and symbol-keyed.
-			"Array.prototype.push":            {Classified: covered, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasFresh}},
-			"String.prototype [ @@iterator ]": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
+			"Array.prototype.push":            {Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasFresh}},
+			"String.prototype [ @@iterator ]": {Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
 			// An accessor, whose fixed mutability the join must not overwrite.
-			"get Map.prototype.size": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
+			"get Map.prototype.size": {Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
 			// A static that hands back one of its own parameters.
-			"Object.assign": {Classified: covered, Receiver: RecvNone, Returns: returnsParam(0)},
+			"Object.assign": {Receiver: RecvNone, Returns: returnsParam(0)},
 			// A namespace function, which has no receiver.
-			"Math.max": {Classified: covered, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnknown}},
+			"Math.max": {Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnknown}},
 			// Two methods whose returns the walk never read, which the type
 			// source settles apart. `lib.es5.d.ts` declares
 			// `localeCompare(that: string): number`, a primitive, so the
 			// return is owned. It declares `exec(string: string):
 			// RegExpExecArray | null`, a union with a member that is not, so
 			// the `unknown` stands.
-			"String.prototype.localeCompare": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
-			"RegExp.prototype.exec":          {Classified: covered, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
+			"String.prototype.localeCompare": {Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
+			"RegExp.prototype.exec":          {Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
 			// A fact whose receiver claim is withheld while its return alias
 			// stands. See the note above.
-			"Fixture.prototype.withheldReceiver": {Classified: Coverage{Returns: true}, Returns: ReturnFact{Kind: AliasFresh}},
+			"Fixture.prototype.withheldReceiver": {Returns: ReturnFact{Kind: AliasFresh}},
 			// A function the global object holds, which addresses no owner and
 			// so is refused by Normalize.
-			"parseInt": {Classified: covered, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasFresh}},
+			"parseInt": {Receiver: RecvNone, Returns: ReturnFact{Kind: AliasFresh}},
 			// Not a builtin. See the note above.
-			"Fixture.prototype.returnsSecond": {Classified: covered, Receiver: RecvBorrow, Returns: returnsParam(1)},
+			"Fixture.prototype.returnsSecond": {Receiver: RecvBorrow, Returns: returnsParam(1)},
 		},
 	}
 }
@@ -280,7 +276,7 @@ func TestJoinLookup(t *testing.T) {
 			specName, fact, ok := join.Lookup(tc.ref)
 			require.True(t, ok, "%s should resolve", tc.ref)
 			require.Equal(t, tc.want, specName)
-			require.True(t, fact.Classified.Receiver)
+			require.NotEmpty(t, fact.Receiver)
 		})
 	}
 }
@@ -321,8 +317,8 @@ func TestJoinIndexesOneNamePerTriple(t *testing.T) {
 	join := NewJoin(&Facts{
 		SpecTarget: "test",
 		Methods: map[string]MethodFact{
-			"Array.prototype [ @@iterator ]":    {Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvBorrow},
-			"Array.prototype  [  @@iterator  ]": {Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvMutBorrow},
+			"Array.prototype [ @@iterator ]":    {Receiver: RecvBorrow},
+			"Array.prototype  [  @@iterator  ]": {Receiver: RecvMutBorrow},
 		},
 	})
 

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -184,18 +184,26 @@ func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 }
 
 // joinFixture is a hand-built fact set covering each keying shape the join has
-// to resolve. Every entry but one carries the fact the committed control-flow
-// graph really holds for that name, so the fixture doubles as a description of
-// the fact set rather than reading as a claim the graph does not make.
+// to resolve. Every entry naming a builtin carries the fact the published set
+// really holds for that name, so the fixture doubles as a description of that
+// set rather than reading as a claim the graph does not make.
 //
-// The exception is the Fixture owner, which names no builtin. No real fact
-// returns a parameter above position 0 — every one that returns a parameter is
-// an `Object.*` static at position 0 — so the case where a signature declares
-// no parameter at the position a fact names has no ECMA-262 instance yet. The
-// shape is real even though the fact is not: the spec's
-// `Array.prototype.splice(start, deleteCount, ...items)` meets a TypeScript
-// overload set whose shortest member is `splice(start: number): T[]`. The
-// position-keyed facts of §8.1 are what will populate it.
+// The two Fixture entries name no builtin, because no published fact has their
+// shape.
+//
+// `returnsSecond` returns a parameter above position 0. Every published fact
+// that returns a parameter is an `Object.*` static at position 0, so a
+// signature that declares no parameter at the position a fact names has no
+// ECMA-262 instance yet. The shape is real even though the fact is not: the
+// spec's `Array.prototype.splice(start, deleteCount, ...items)` meets a
+// TypeScript overload set whose shortest member is `splice(start: number):
+// T[]`. The position-keyed facts of §8.1 are what will populate it.
+//
+// `withheldReceiver` leaves its receiver unclassified, which the join has to
+// carry through to the report's receiver-claim count. The analysis withholds 24
+// receivers and curated.json answers every one, so no published fact is left in
+// that state. A `web:*` method, which has no ECMA-262 algorithm at all, is
+// where the shape returns.
 func joinFixture() *Facts {
 	covered := Coverage{Receiver: true, Returns: true}
 	return &Facts{
@@ -218,9 +226,9 @@ func joinFixture() *Facts {
 			// the `unknown` stands.
 			"String.prototype.localeCompare": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
 			"RegExp.prototype.exec":          {Classified: covered, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
-			// A method the mutation fixpoint could not read whole, so its
-			// receiver claim is withheld while its return alias stands.
-			"Array.prototype.toLocaleString": {Classified: Coverage{Returns: true}, Returns: ReturnFact{Kind: AliasFresh}},
+			// A fact whose receiver claim is withheld while its return alias
+			// stands. See the note above.
+			"Fixture.prototype.withheldReceiver": {Classified: Coverage{Returns: true}, Returns: ReturnFact{Kind: AliasFresh}},
 			// A function the global object holds, which addresses no owner and
 			// so is refused by Normalize.
 			"parseInt": {Classified: covered, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasFresh}},
@@ -397,7 +405,7 @@ get Map.prototype.size -> get instance Map.size receiverApplies:no [ receiver:bo
 String.prototype.localeCompare -> instance String.localeCompare receiverApplies:yes [ receiver:borrow returns:unknown settled:owned ]
 RegExp.prototype.exec -> instance RegExp.exec receiverApplies:yes [ receiver:mutBorrow returns:unknown ]
 no fact: instance Array.toSorted
-no declaration: Array.prototype.toLocaleString
+no declaration: Fixture.prototype.withheldReceiver
 no declaration: Math.max
 no declaration: Object.assign
 no declaration: String.prototype [ @@iterator ]
@@ -448,7 +456,7 @@ func TestWriteJoinReport(t *testing.T) {
 	report := NewJoin(joinFixture()).Match(Declarations{
 		Keyed: []Declaration{
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance}, Signatures: []Signature{{Params: 1, Rest: true}}},
-			{Ref: MemberRef{Owner: "Array", Member: StrMember("toLocaleString"), Sort: SortInstance}, Signatures: []Signature{{Params: 0}}},
+			{Ref: MemberRef{Owner: "Fixture", Member: StrMember("withheldReceiver"), Sort: SortInstance}, Signatures: []Signature{{Params: 0}}},
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("toSorted"), Sort: SortInstance}, Signatures: []Signature{{Params: 1}}},
 			// One return the declared type settles and one it leaves, so the
 			// report's return counts carry both.

--- a/internal/ecma262/mutation.go
+++ b/internal/ecma262/mutation.go
@@ -130,10 +130,10 @@ var readOnlyInternalMethods = set.FromSlice([]string{
 // sorted 0-based positions of the declared parameters it may mutate. A method's
 // receiver is not a parameter, so Receiver reports it separately.
 //
-// The two warnings name different failures, and §4.3 turns either into
-// `classified: false` so FR5's name-based heuristics decide the method instead.
-// Unattributable means the analysis saw a mutation it could not tie to the
-// receiver or to a parameter. Incomplete means it could not read the whole
+// The two warnings name different failures, and §4.3 turns either into a
+// method the analysis publishes no receiver for, which §4.4 then answers by
+// review. Unattributable means the analysis saw a mutation it could not tie to
+// the receiver or to a parameter. Incomplete means it could not read the whole
 // algorithm, so a mutation may be hiding in the part it missed.
 type Mutations struct {
 	Args           []int

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1344,10 +1344,23 @@ bump, where the fixpoints re-derive all 501 for free. The layer is for the
 tail. The mutation fixpoint and the origin map carry the bulk mechanically
 and stay as they are.
 
+**What is still open.** The unresolved-determination report reads per
+axis, because the two axes spell an unanswered determination differently
+and cost different things. A `ReceiverKind` has no member meaning "could
+not tell", so an unanswered receiver is one whose coverage is unset. The
+alias lattice has a top and `returnAlias` is total, so an unanswered return
+is a covered `unknown`. Summing them would hide the difference that
+matters: §7 auto-applies the receiver, so an open one is a soundness gap
+that falls to the name heuristics, while an open return costs only the
+lifetime precision §8.2 would have seeded.
+
+Published today: **0** receivers open, **247** returns open. The receiver
+axis is closed; the return axis is where the next curation batch goes.
+
 **Gate.** `curated.json` merges per determination; the published
-`receiver unclassified` tally is zero; each of the three guards and the
-receiver-kind refusal has a test; the report distinguishes a curated
-determination from an analyzed one.
+`receiver unclassified` tally is zero; the unresolved report reads both
+axes; each of the three guards and the receiver-kind refusal has a test;
+the report distinguishes a curated determination from an analyzed one.
 
 ## §5. Keying and join (FR7, FR15)
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1226,15 +1226,21 @@ lattice member for every method it cannot read.
 **Why the layer, rather than more analysis.** §4 is past the knee of its
 curve on the axis §7 auto-applies. 477 of 501 builtins carry a receiver
 claim. Every determination still open is curation-grade by §7's own
-design, reaching the generated `.esc` through review rather than straight
-from the facts, so sharpening the analyzer further improves the input to a
-review step that was going to happen anyway. The cost of doing that is
-measured: the origin-map refinement for the species allocators grew
-`origin.go` by 232 lines and moved three statics; the interior-return
-alias kind is five methods; the property-path origin is 47 builtins. The
-24 withheld receivers, by contrast, are an hour of review. Roughly twenty
-are read-only formatters and the mutating remainder is the two iterator
-`next` methods, `RegExp.prototype [ @@replace ]`, and
+design. Each reaches the generated `.esc` through review rather than
+straight from the facts. So sharpening the analyzer further only improves
+the input to a review step that happens either way. The cost of that
+sharpening is measured:
+
+| Analysis work | Cost | Methods it reaches |
+| --- | --- | --- |
+| Species-allocator origins | `origin.go` +232 lines | 3 statics |
+| The interior-return alias kind | a new lattice member, join and schema changes | 5 |
+| The property-path origin | a new lattice member, read by §4.1 and §4.3 | 47 |
+| The escape fixpoint of §8.1 | a second transitive fixpoint | ~20 |
+
+The 24 withheld receivers, by contrast, are an hour of review. Roughly
+twenty are read-only formatters. The mutating remainder is the two
+iterator `next` methods, `RegExp.prototype [ @@replace ]`, and
 `SharedArrayBuffer.prototype.grow`.
 
 This does not reverse FR5 or §11, both of which already reserve the tail

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1257,19 +1257,23 @@ does, plus the provenance a reviewer needs:
   "reason": "The receiver is statically a number, so ToNumber cannot throw.",
   "evidence": "ECMA-262 \"Number.prototype.toFixed\"",
   "reviewedAt": "1836cd89dd25",
-  "classified": { "receiver": true, "returns": false },
   "receiver": "borrow"
 }
 ```
+
+An entry answers the axes it carries a value for, and no others. Neither
+determination has a valid zero value, so a field left out is unambiguously
+an axis left to the analysis. The entry above answers the receiver and
+leaves the return alias where the analysis put it.
 
 `reason` is required. A claim that outranks the analysis without a stated
 argument cannot be re-reviewed later.
 
 **The merge is per determination, never per method.** `NewFacts` runs the
 analysis and then merges the layer over the result, one axis at a time.
-An axis an entry leaves unset keeps whatever the analysis concluded, so
-the two sources compose. `Date.prototype.getTime` is the shape: the
-analysis settles its receiver and the entry corrects only its return.
+An axis an entry leaves out keeps whatever the analysis concluded, so the
+two sources compose. `Date.prototype.getTime` is the shape: the analysis
+settles its receiver and the entry answers only its return.
 
 Each curated axis is one of three things, and the merge reports which:
 
@@ -2450,17 +2454,21 @@ type CuratedEntry struct {
     Evidence   string `json:"evidence,omitempty"` // where the reason was checked
     ReviewedAt string `json:"reviewedAt"`         // Func.Digest at review time
 
-    Classified Coverage     `json:"classified"`         // which determinations this entry claims
-    Receiver   ReceiverKind `json:"receiver,omitempty"` // borrow | mutBorrow | none
-    Returns    ReturnFact   `json:"returns,omitzero"`   // the return-borrow seed
+    Receiver ReceiverKind `json:"receiver,omitempty"` // borrow | mutBorrow | none
+    Returns  ReturnFact   `json:"returns,omitzero"`   // the return-borrow seed
 }
 ```
 
-`Classified` means on an entry exactly what it means on a `MethodFact`: it
-says which determinations the entry claims. An axis it leaves unset is not
-curated, and keeps whatever the analysis concluded. `Coverage` gains a
-flag per axis as §8 and §9 add one, and an entry claims the new axis by
-the same rule.
+An entry answers the axes it carries a value for. `""` is neither a
+`ReceiverKind` nor an `AliasKind`, so an omitted field is unambiguously an
+axis left to the analysis, and needs no flag beside it saying so.
+
+A published `MethodFact` does carry the `classified` flags, and the two
+records differ here on purpose. The fact gains three slice-valued axes in
+§8 and §9, where a proven-empty result and an unanalyzed one differ only
+by `[]` versus `null`. That is too easy a distinction to lose to rest a
+soundness contract on. A curated entry has no such axis, because a
+reviewer either writes an answer or does not.
 
 Three fields exist only for review and never reach `facts.json`.
 
@@ -2478,11 +2486,8 @@ real change to a step, a parameter, or a kind moves one. When the graph's
 digest no longer matches, the entry is reported stale and still applied.
 
 Parsing rejects an entry that cannot be reviewed or applied: one with no
-reason, no reviewed digest, no claimed determination, or a receiver kind
-or alias kind this package cannot spell. It also rejects a value written
-on an axis the entry's `classified` leaves unclaimed, which the merge
-would otherwise drop with no report line, leaving the reviewer to see
-silence where they wrote a claim.
+reason, no reviewed digest, no determination at all, or a receiver kind or
+alias kind this package cannot spell.
 
 A return fact holds the same invariants `newReturnFact` builds. A
 parameter return names its position. A union names at least two distinct

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -38,7 +38,7 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ✅      | §2         | `cfg.json` covers all 501 builtin algorithms plus the 701 functions reachable from them, at the pinned spec revision, and round-trips the schema check the run ends with — met |
 | §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ✅      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.2 | Origin map                                 | FR2, FR4   | ✅      | §3         | origins asserted for sample functions — `ToObject(this)`→Receiver, allocators→Fresh, reads→Unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
-| §4.3 | Method classification                      | FR4, FR5   | ✅      | §4.1, §4.2 | facts.json core — receiver / returns / per-determination coverage for the representative methods — met, see [internal/ecma262/](../../internal/ecma262/) |
+| §4.3 | Method classification                      | FR4, FR5   | ✅      | §4.1, §4.2 | facts.json core — receiver and returns resolved per determination for the representative methods — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.4 | Curated fact layer                         | FR5, FR7   | ✅      | §4.3       | `curated.json` merges per determination; published `receiver unclassified` is zero; each of the three guards tested — met, see [internal/ecma262/curated.go](../../internal/ecma262/curated.go) |
 | §5   | Keying and join                            | FR7, FR15  | ✅      | §4.3       | normalizer joins facts to `.d.ts` declarations; overloads share algorithm-level facts, type-dependent parts per signature; a primitive return type settles a return the analysis cannot name as owned; unmatched reported — met, see [internal/ecma262/key.go](../../internal/ecma262/key.go) and [internal/ecma262/join.go](../../internal/ecma262/join.go) |
 | §6   | Validation diff                            | FR9        | ⬜      | §5         | receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
@@ -1278,10 +1278,10 @@ settles its receiver and the entry answers only its return.
 Each curated axis is one of three things, and the merge reports which:
 
 - a **fill-in**, where the analysis left the axis open. This is the
-  ordinary case and carries no conflict. An axis is open when its coverage
-  is unset, and a return alias is open when it resolved to `unknown` as
-  well, since the top of the alias lattice names no value the return hands
-  back.
+  ordinary case and carries no conflict. A receiver is open when the
+  analysis carried no value for it, and a return alias is open when it
+  resolved to `unknown` as well, since the top of the alias lattice names no
+  value the return hands back.
 - a **correction**, where the analysis published a claim the review
   contradicts. §6 reads these first, because a correction is either a spec
   subtlety the graph cannot express or an analyzer bug, and the two look
@@ -1347,9 +1347,9 @@ and stay as they are.
 **What is still open.** The unresolved-determination report reads per
 axis, because the two axes spell an unanswered determination differently
 and cost different things. A `ReceiverKind` has no member meaning "could
-not tell", so an unanswered receiver is one whose coverage is unset. The
-alias lattice has a top and `returnAlias` is total, so an unanswered return
-is a covered `unknown`. Summing them would hide the difference that
+not tell", so an unanswered receiver is one the analysis carried no value
+for. The alias lattice has a top and `returnAlias` is total, so an
+unanswered return is a published `unknown`. Summing them would hide the difference that
 matters: §7 auto-applies the receiver, so an open one is a soundness gap
 that falls to the name heuristics, while an open return costs only the
 lifetime precision §8.2 would have seeded.
@@ -1358,9 +1358,11 @@ Published today: **0** receivers open, **247** returns open. The receiver
 axis is closed; the return axis is where the next curation batch goes.
 
 **Gate.** `curated.json` merges per determination; the published
-`receiver unclassified` tally is zero; the unresolved report reads both
-axes; each of the three guards and the receiver-kind refusal has a test;
-the report distinguishes a curated determination from an analyzed one.
+`receiver unclassified` tally is zero; every published fact carries a value
+on every axis, so `facts.json` needs no coverage flags and a hole fails the
+run instead; the unresolved report reads both axes; each of the three
+guards and the receiver-kind refusal has a test; the report distinguishes a
+curated determination from an analyzed one.
 
 ## §5. Keying and join (FR7, FR15)
 
@@ -1500,8 +1502,9 @@ entry. This is the gate that authorizes removing override entries in §7.
 - Insert the facts lookup into `dts_to_esc.Classify` at rung 2 (FR8):
   after explicit author signals, before the `get*` prefix and name
   heuristics.
-- Set receiver mutability from a fact whose `classified.receiver` is set;
-  leave the rest to the existing tiers. The lookup reads one merged source.
+- Set receiver mutability from the fact, and leave the rest to the existing
+  tiers. Every published fact carries one, so there is no coverage flag to
+  consult and no hole to fall through. The lookup reads one merged source:
   §4.4 merges the curated layer inside `NewFacts`, so the converter never
   sees the two halves apart and applies a curated claim and an analyzed one
   identically.
@@ -1537,7 +1540,7 @@ it. What differs is only how the two `facts.json` contributions reach the
 merge; that split is per determination, not per method:
 
 - **Auto-applied (trusted).** Receiver mutability is read straight from a
-  classified fact and written into the `.esc` — no human in the loop. It
+  published fact and written into the `.esc` — no human in the loop. It
   is the only determination §6 has validated (FR9) as trustworthy.
 - **Curation-grade (reviewed).** Parameter disposition, the return-borrow
   seed, `throws`, and `rejects` reach the `.esc` only through a
@@ -1557,8 +1560,8 @@ merge; that split is per determination, not per method:
   absent `throws` clause is `never`), so the human genuinely *adds* them.
 - Parameter **disposition** is the exception: every parameter must carry a
   disposition for the signature to be valid, so the converter writes a
-  **provisional baseline** — the analyzed disposition for a classified
-  method, the FR5 `&mut` default when uncertain — which the override
+  **provisional baseline** — the disposition the published fact carries, or
+  the FR5 `&mut` default where no fact addresses the method — which the override
   layer, if present, corrects. That is review-and-**correct**, not
   author-from-scratch. So disposition is written but not trusted; the
   other three are not written until curated.
@@ -1568,10 +1571,10 @@ path produces against observed behavior and feeds the disagreements back
 into the curated entries, rather than authorizing an extracted set to skip
 the review.
 
-**A determination `facts.json` does not carry falls back to a default.**
-When a `std:*` method is unmatched by the join (§5), or its fact leaves a
-determination uncovered after §4.4's merge, that part of the declaration
-is `.d.ts` types plus the FR5 defaults — `&mut self`, `&mut` parameters, empty
+**A method `facts.json` does not address falls back to a default.**
+This is now the only degraded path, because a published fact answers every
+determination it carries. When a `std:*` method is unmatched by the join
+(§5), the declaration is `.d.ts` types plus the FR5 defaults — `&mut self`, `&mut` parameters, empty
 `throws`/`rejects` — carrying no spec-derived effect. This is the degraded
 path, not a preferred one. FR5 lists every method with a withheld receiver
 and §5 reports every unmatched declaration, precisely so these are visible
@@ -2296,8 +2299,8 @@ const (
                                             // move or a lifetime-bounded borrow at curation (FR12)
     // A parameter the analysis PROVED read-only (&) is omitted from Params.
     // That omission is distinct from the FR5 uncertain default (&mut): it
-    // means "shown read-only", and reads that way only where
-    // Coverage.Params is set.
+    // means "shown read-only". A method whose parameters the analysis could
+    // not read is not written at all, per the totality rule below.
 )
 
 type ParamFact struct {
@@ -2329,33 +2332,49 @@ type ReturnFact struct {
     Members []AliasRef `json:"members,omitempty"` // set exactly when Kind == "union"
 }
 
-// Coverage says which determinations the analysis resolved. Each axis is
-// withheld on its own, so a method that hides a mutation still publishes
-// its return alias. An axis no step decides is always covered, such as a
-// static's "receiver": "none" (§4.3).
-type Coverage struct {
-    Receiver bool `json:"receiver"` // §4.3; always set for a static
-    Returns  bool `json:"returns"`  // returnAlias ran; true for every builtin
-    Params   bool `json:"params"`   // §8.1
-    Throws   bool `json:"throws"`   // §9.2
-    Rejects  bool `json:"rejects"`  // §9.3
-}
-
-// An uncovered determination is ABSENT from the JSON — an unanalyzed axis,
-// distinct from a proven-empty result, which is covered with an empty
-// effect field. Receiver is a kind with no empty member and Returns is a
-// struct, so omitempty and omitzero spell their absence. The three slices
-// carry neither, which would drop the [] that spells that second case.
-// Uncovered they encode as null.
+// MethodFact carries every determination. Neither Receiver nor Returns has
+// a valid zero value, and the three slices are written whenever their axis
+// is computed, so an absent field is a hole rather than a claim. Facts
+// records no coverage flags because a hole never reaches the file: the run
+// fails first.
 type MethodFact struct {
-    Classified Coverage     `json:"classified"`         // per-determination coverage (FR5)
-    Receiver   ReceiverKind `json:"receiver,omitempty"` // borrow | mutBorrow | none (FR2)
-    Params     []ParamFact  `json:"params"`             // only non-borrow parameters (FR12)
-    Returns    ReturnFact   `json:"returns,omitzero"`   // return-borrow lifetime seed (FR4)
-    Throws     []string     `json:"throws"`             // sync throws post-filter (FR10, FR11)
-    Rejects    []string     `json:"rejects"`            // async rejects → Promise<T,E>.Err (FR13)
+    Receiver ReceiverKind `json:"receiver,omitempty"` // borrow | mutBorrow | none (FR2)
+    Params   []ParamFact  `json:"params"`             // only non-borrow parameters (FR12)
+    Returns  ReturnFact   `json:"returns,omitzero"`   // return-borrow lifetime seed (FR4)
+    Throws   []string     `json:"throws"`             // sync throws post-filter (FR10, FR11)
+    Rejects  []string     `json:"rejects"`            // async rejects → Promise<T,E>.Err (FR13)
 }
 ```
+
+**Every published fact is total.** A determination neither the analysis nor
+§4.4's curated layer answers is not encoded — `Facts.Incomplete` names it
+and generation refuses to write the file. That is the rule the schema rests
+on, and it is why there is no `classified` object: an axis is present, or
+the run failed with the method and axis on stderr.
+
+The alternative was a per-axis coverage flag saying which determinations
+were resolved, so a consumer could tell "unanalyzed" from "proven none".
+Making the file total is stronger. A flag leaves a hole in the data that
+every consumer must remember to check, and §7 auto-applies the receiver, so
+a forgotten check there becomes a silent `&mut self`. Failing the run puts
+the same information in front of the one person who can act on it.
+
+**`unknown` is a value, not a hole.** The alias lattice's top says the walk
+read the returns and could tie none of them to a value the caller holds,
+which is a fact §8.2 acts on by leaving the lifetime to elision. 247 of the
+501 builtins publish it. The methods still wanting an answer there are
+`Facts.Unclassified(AxisReturns)`, a review report rather than a wire
+concern. The receiver axis has no counterpart, because `ReceiverKind` has
+no member meaning "could not tell" — which is exactly why a missing
+receiver is the case that fails the run.
+
+**A slice axis reads the same way once §8 and §9 add one.** `[]` is a
+proven-empty result and the axis being uncomputed fails the run, so a
+consumer never has to tell `null` from `[]`. The one wrinkle is FR5's
+deliberate under-reporting for `throws` and `rejects`: until §9.2 lands
+those axes are not computed at all, so they are absent from the schema
+rather than present-and-empty, and the totality rule starts applying to
+them when they are wired in.
 
 Each entry in `Throws` / `Rejects` is one of (requirements FR13): a
 standard error-class name the spec constructs (`TypeError`, `RangeError`,
@@ -2366,18 +2385,12 @@ form (`Promise.all`/`race`/`any` forwarding their element promises' `E`);
 the **effect ref** `"throwsOf:param:k"` for a method that propagates a
 callback parameter's throws (`Array.prototype.forEach`/`map`/…), resolved
 at the FR7 join to throws polymorphism; or the sentinel `"unknown"` for a
-propagated value the analysis can neither name nor trace. All origin and
-effect refs resolve to types at the FR7 join. An entry carries no receiver,
-disposition, throw, or reject claim its `classified` coverage does not
-cover — those fields are absent or null, never empty — so the converter
-cannot mistake "unanalyzed" for "proven none"; it applies the FR5 default
-for that axis itself. A method whose `receiver` is uncovered after §4.4's merge falls through to
-the name heuristics and is collected into a separate `unclassified` report
-alongside `facts.json` for auditing (FR5). No `std:*` method is in that
-state today. Where `classified.params` is
-set, a parameter absent from `Params` was proven read-only (`&`) — not to
-be confused with the FR5 `&mut` default the converter applies where it is
-not.
+propagated value the analysis can neither name nor trace. All origin and effect refs resolve to types at the FR7 join.
+
+A parameter absent from `Params` was proven read-only (`&`). That is a
+claim, not a gap, because a method whose parameters the analysis could not
+read is not published at all. It is distinct from the FR5 `&mut` default,
+which the converter applies only where no fact addresses the method.
 The receiver-returning and fresh-returning alias kinds carry the return's
 borrow lifetime per FR4.
 
@@ -2398,7 +2411,6 @@ two positions and a single field could name only one of them:
 
 ```json
 "Object": {
-  "classified": { "receiver": true, "returns": true },
   "receiver": "none",
   "returns": {
     "kind": "union",
@@ -2476,12 +2488,10 @@ An entry answers the axes it carries a value for. `""` is neither a
 `ReceiverKind` nor an `AliasKind`, so an omitted field is unambiguously an
 axis left to the analysis, and needs no flag beside it saying so.
 
-A published `MethodFact` does carry the `classified` flags, and the two
-records differ here on purpose. The fact gains three slice-valued axes in
-§8 and §9, where a proven-empty result and an unanalyzed one differ only
-by `[]` versus `null`. That is too easy a distinction to lose to rest a
-soundness contract on. A curated entry has no such axis, because a
-reviewer either writes an answer or does not.
+A published `MethodFact` reads the same way, for the same reason. The
+difference is what an omission means: on an entry it defers to the
+analysis, and on a published fact it is a hole that fails the run per
+Appendix B.
 
 Three fields exist only for review and never reach `facts.json`.
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -39,20 +39,27 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ✅      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.2 | Origin map                                 | FR2, FR4   | ✅      | §3         | origins asserted for sample functions — `ToObject(this)`→Receiver, allocators→Fresh, reads→Unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.3 | Method classification                      | FR4, FR5   | ✅      | §4.1, §4.2 | facts.json core — receiver / returns / per-determination coverage for the representative methods — met, see [internal/ecma262/](../../internal/ecma262/) |
+| §4.4 | Curated fact layer                         | FR5, FR7   | ✅      | §4.3       | `curated.json` merges per determination; published `receiver unclassified` is zero; each of the three guards tested — met, see [internal/ecma262/curated.go](../../internal/ecma262/curated.go) |
 | §5   | Keying and join                            | FR7, FR15  | ✅      | §4.3       | normalizer joins facts to `.d.ts` declarations; overloads share algorithm-level facts, type-dependent parts per signature; a primitive return type settles a return the analysis cannot name as owned; unmatched reported — met, see [internal/ecma262/key.go](../../internal/ecma262/key.go) and [internal/ecma262/join.go](../../internal/ecma262/join.go) |
 | §6   | Validation diff                            | FR9        | ⬜      | §5         | receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
 | §7   | Integration as classification source       | FR8        | ⬜      | §6         | converter ranks facts above name tiers; the two application paths wired; redundant overrides removed |
-| §8.1 | Parameter disposition                      | FR12       | ⬜      | §4.1, §7   | push/Map.set `escape`, Reflect.set `mutBorrow`+`escape`, indexOf `borrow` in facts.json |
+| §8.1 | Parameter disposition                      | FR12       | ⬜      | §4.1, §4.4, §7 | `MutArgs` supplies `mutBorrow`; `escape` is curated for the container methods that have one. The transitive `StoreEdges` fixpoint is dropped — see §8.1 |
 | §8.2 | Return-borrow seed                         | FR4        | ⬜      | §4.3       | documented `returns` → `&`/lifetime annotation mapping (small) |
 | §9.1 | Throw-set fixpoint                          | FR10       | ✅      | §4.2       | raw throw sets, `Exception` = class / origin / callback-effect / unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
-| §9.2 | Coercion filter                            | FR11       | ⬜      | §9.1, §5   | filtered throws — toFixed keeps RangeError, drops the receiver-coercion TypeError; param branch runs post-join |
+| §9.2 | Coercion filter                            | FR11       | ⬜      | §9.1, §5   | the receiver branch alone — toFixed keeps RangeError, drops the receiver-coercion TypeError. The parameter branch is dropped in favour of curated throws — see §9.2 |
 | §9.3 | Throw/reject split, parametric origins, combinators | FR10, FR13 | ✅ | §9.1  | `rejects` distinct from `throws`; Promise.reject `param:0`, forEach `throwsOf:param:k`; combinators hand-modeled — met, see [internal/ecma262/](../../internal/ecma262/) |
-| §9.4 | Throws validation + auto-apply gate        | FR14       | ⬜      | §9.1–§9.3, §7 | spec-independent (dynamically-observed) ground truth; false-negative rate report gates auto-apply |
+| §9.4 | Throws validation                          | FR14       | ⬜      | §9.1–§9.3, §4.4, §7 | spec-independent, dynamically-observed ground truth, run as a spot-check over the curated throws. The false-negative auto-apply gate is dropped — see §9.4 |
 | §10  | Maintenance workflow                       | NFR        | ⬜      | §7         | spec-bump runbook; `--check`-style drift report in CI |
-| §11  | Curation of the override layer             | FR12, FR4, FR13, FR14 | ⬜ | §7, §8, §9 | override layer populated per pseudo-package by review; fans out into per-package PRs |
+| §11  | Curation of the override layer             | FR12, FR4, FR13, FR14 | 🚧 | §4.4, §7, §8, §9 | override layer populated per pseudo-package by review; fans out into per-package PRs. The 24 receivers and three interior returns are curated; disposition and throws follow |
 
 Within a section the sub-section PRs sequence per the "Depends on" column —
 `§4.1` reads the origin map, so `§4.2` lands first despite the numbering.
+
+§4.4 changes the shape of the phases after it. A determination the graph
+does not settle is answered by a curated entry rather than by a new
+lattice member, so §8.1, §9.2, and §9.4 each carry less analysis than
+their original scope. Each row above names what it drops and its section
+gives the reasoning.
 
 **Dependency graph** (all PRs plus the external dependencies this plan
 names in other planning docs; edges are "must land before"):
@@ -65,6 +72,7 @@ flowchart TD
     S42["§4.2 Origin map"]
     S41["§4.1 Mutation-summary fixpoint"]
     S43["§4.3 Method classification"]
+    S44["§4.4 Curated fact layer"]
     S5["§5 Keying and join"]
     S6["§6 Validation diff"]
     S7["§7 Integration"]
@@ -73,7 +81,7 @@ flowchart TD
     S91["§9.1 Throw-set fixpoint"]
     S92["§9.2 Coercion filter"]
     S93["§9.3 Throw/reject split, origins, combinators"]
-    S94["§9.4 Throws validation + auto-apply gate"]
+    S94["§9.4 Throws validation"]
     S10["§10 Maintenance"]
     S11["§11 Curation (per-package PRs)"]
 
@@ -83,8 +91,9 @@ flowchart TD
     S42 --> S41
     S41 --> S43
     S42 --> S43
-    S43 --> S5 --> S6 --> S7
+    S43 --> S44 --> S5 --> S6 --> S7
     S41 --> S81
+    S44 --> S81
     S7 --> S81
     S43 --> S82
     S42 --> S91
@@ -93,8 +102,10 @@ flowchart TD
     S91 --> S93
     S92 --> S94
     S93 --> S94
+    S44 --> S94
     S7 --> S94
     S7 --> S10
+    S44 --> S11
     S81 --> S11
     S82 --> S11
     S93 --> S11
@@ -194,11 +205,11 @@ that would introduce new PRs:
   review sits between the fact and the committed annotation (see §7 "Two
   application paths"; `throws`/`rejects` and the `&`/lifetime annotations
   are added by the curator, disposition gets a provisional baseline the
-  curator corrects). These are not permanently curation-grade,
-  though: `throws`/`rejects` have a defined graduation path — §9.4
-  measures the false-negative rate, and a measured zero flips them to
-  auto-apply (FR14). Whether disposition is confident enough to auto-apply
-  like receiver mutability is a similar open call to settle when §8 lands.
+  curator corrects). §9.4 measures those annotations against observed
+  behavior rather than authorizing them to skip review; §4.4 explains why
+  the review is the cheaper half of that pair. Whether disposition is
+  confident enough to auto-apply like receiver mutability is an open call
+  to settle when §8 lands.
 - **`escape` spelling depends on external affine work.** §8 records the
   `escape` disposition; curation spells it a `move` (owning container) or
   a lifetime-bounded borrow (borrow-holding container), per requirements
@@ -1203,7 +1214,117 @@ because the alias is curated rather than applied.
 
 Methods with a withheld receiver are listed. The `returns` tally spans
 every builtin, and the `receiver` tally leaves out only the 24 methods
-whose mutability is withheld.
+whose mutability is withheld. §4.4 answers all 24 by review, so the
+published tally leaves out none.
+
+### §4.4. The curated fact layer (FR5, FR7)
+
+**Goal.** Answer a determination the graph does not settle by review,
+recorded as committed data, so the analysis does not have to grow a new
+lattice member for every method it cannot read.
+
+**Why the layer, rather than more analysis.** §4 is past the knee of its
+curve on the axis §7 auto-applies. 477 of 501 builtins carry a receiver
+claim. Every determination still open is curation-grade by §7's own
+design, reaching the generated `.esc` through review rather than straight
+from the facts, so sharpening the analyzer further improves the input to a
+review step that was going to happen anyway. The cost of doing that is
+measured: the origin-map refinement for the species allocators grew
+`origin.go` by 232 lines and moved three statics; the interior-return
+alias kind is five methods; the property-path origin is 47 builtins. The
+24 withheld receivers, by contrast, are an hour of review. Roughly twenty
+are read-only formatters and the mutating remainder is the two iterator
+`next` methods, `RegExp.prototype [ @@replace ]`, and
+`SharedArrayBuffer.prototype.grow`.
+
+This does not reverse FR5 or §11, both of which already reserve the tail
+for curation. It gives that reservation a mechanism early, where §11 would
+otherwise wait behind §7.
+
+**The layer.** `internal/ecma262/curated.json`, keyed by the Appendix C
+canonical spec names — the key space `cfg.json` and the §5 join already
+share. Each entry carries the same determination fields a `MethodFact`
+does, plus the provenance a reviewer needs:
+
+```json
+"Number.prototype.toFixed": {
+  "reason": "The receiver is statically a number, so ToNumber cannot throw.",
+  "evidence": "ECMA-262 \"Number.prototype.toFixed\"",
+  "reviewedAt": "1836cd89dd25",
+  "classified": { "receiver": true, "returns": false },
+  "receiver": "borrow"
+}
+```
+
+`reason` is required. A claim that outranks the analysis without a stated
+argument cannot be re-reviewed later.
+
+**The merge is per determination, never per method.** `NewFacts` runs the
+analysis and then merges the layer over the result, one axis at a time.
+An axis an entry leaves unset keeps whatever the analysis concluded, so
+the two sources compose. `Date.prototype.getTime` is the shape: the
+analysis settles its receiver and the entry corrects only its return.
+
+Each curated axis is one of three things, and the merge reports which:
+
+- a **fill-in**, where the analysis withheld the axis. This is the
+  ordinary case and carries no conflict.
+- a **correction**, where the analysis published a claim the review
+  contradicts. §6 reads these first, because a correction is either a spec
+  subtlety the graph cannot express or an analyzer bug, and the two look
+  alike from the report.
+- a **redundant** entry, repeating what the analysis already concluded.
+
+**Three guards keep the layer from becoming a second source of truth.**
+
+1. A curated name the graph holds no builtin for is reported and applied
+   to nothing, and `TestCurationMatchesTheGraph` fails the build on one.
+   A misspelled key and a key carried over from another spec revision both
+   land there.
+2. Each entry names the `Func.Digest` of the algorithm it was reviewed
+   against, a fingerprint over that one serialized algorithm. A spec bump
+   that rewrites the algorithm flags the entry for re-review and leaves
+   every untouched entry alone. A stale entry is still applied, since
+   dropping it would trade a visible prompt for a silent loss of coverage.
+3. A redundant entry is reported so it can be deleted, which is how the
+   layer shrinks as the analysis improves rather than accumulating.
+
+**Provenance is not on the wire.** `facts.json` records the merged
+determination and not which source produced it, because §7 applies a
+curated receiver claim and an analyzed one identically. The
+`CurationReport` is where a reviewer reads the split, and §6 diffs against
+it.
+
+**What the layer closes.** Curating the 24 receivers takes the published
+`receiver unclassified` tally to zero and retires the fallback to §7's
+name heuristics for `std:*`. Three of the five interior returns of §4.3
+are curated `fresh`, because a primitive read out of a slot is a copy —
+`Date.prototype.getTime`, `Date.prototype.valueOf`, and `get
+TypedArray.prototype [ @@toStringTag ]`. The two `buffer` getters stay
+`unknown`: what they hand back is a real borrow of an object the receiver
+holds, and no member of the alias lattice spells that without claiming
+identity. That residue is a type-system question rather than an analysis
+gap, which is the distinction the layer makes visible.
+
+**The species exception.** `Array.prototype.slice`, `TypedArray.prototype.slice`,
+`RegExp.prototype [ @@matchAll ]`, and `RegExp.prototype [ @@split ]`
+build their result through a constructor a caller can replace through
+`@@species`. A hostile `@@species` can hand back the receiver, which makes
+the write the algorithm aims at its fresh result land on the receiver
+instead. The curated entries record `borrow` and state that shape as out
+of scope. That is a policy decision a reviewer can make and the analysis
+cannot, and writing it down is what closes the question rather than
+another origin-lattice member.
+
+**The bound.** Curation is per-method human work that recurs on every spec
+bump, where the fixpoints re-derive all 501 for free. The layer is for the
+tail. The mutation fixpoint and the origin map carry the bulk mechanically
+and stay as they are.
+
+**Gate.** `curated.json` merges per determination; the published
+`receiver unclassified` tally is zero; each of the three guards has a
+test; the join report distinguishes a curated determination from an
+analyzed one.
 
 ## §5. Keying and join (FR7, FR15)
 
@@ -1344,7 +1465,10 @@ entry. This is the gate that authorizes removing override entries in §7.
   after explicit author signals, before the `get*` prefix and name
   heuristics.
 - Set receiver mutability from a fact whose `classified.receiver` is set;
-  leave the rest to the existing tiers.
+  leave the rest to the existing tiers. The lookup reads one merged source.
+  §4.4 merges the curated layer inside `NewFacts`, so the converter never
+  sees the two halves apart and applies a curated claim and an analyzed one
+  identically.
 - Apply the FR5 defaults for every determination a record leaves uncovered,
   whose field is absent. Receiver mutability falls through to the name
   tiers, defaulting to `&mut self`. For the curation-grade determinations
@@ -1403,14 +1527,15 @@ merge; that split is per determination, not per method:
   author-from-scratch. So disposition is written but not trusted; the
   other three are not written until curated.
 
-Once §9.4's FR14 gate measures a zero false-negative rate, `throws` /
-`rejects` graduate from the reviewed path to the auto-applied one for the
-covered subset.
+`throws` and `rejects` stay on the reviewed path. §9.4 measures what that
+path produces against observed behavior and feeds the disagreements back
+into the curated entries, rather than authorizing an extracted set to skip
+the review.
 
 **A determination `facts.json` does not carry falls back to a default.**
 When a `std:*` method is unmatched by the join (§5), or its fact leaves a
-determination uncovered (§4.3), that part of the declaration is `.d.ts`
-types plus the FR5 defaults — `&mut self`, `&mut` parameters, empty
+determination uncovered after §4.4's merge, that part of the declaration
+is `.d.ts` types plus the FR5 defaults — `&mut self`, `&mut` parameters, empty
 `throws`/`rejects` — carrying no spec-derived effect. This is the degraded
 path, not a preferred one. FR5 lists every method with a withheld receiver
 and §5 reports every unmatched declaration, precisely so these are visible
@@ -1482,16 +1607,19 @@ the call:
   does not default conservatively, and it is not treated as `Incomplete`.
   The parameter's mutation axis is decided separately by `MutArgs`.
 
-Escape is **transitive** by the same fixpoint as FR2. Define, per abstract
-operation `G`, `StoreEdges(G) ⊆ {(k, m)}` meaning `G` stores its `k`-th
-argument into its `m`-th argument. Seed it from direct stores —
-`Set(args[m], _, args[k])` yields `(k, m)` — and propagate along the call
-graph: if `G` calls `H`, and `H` has edge `(k', m')`, and `G` passes its
-own formals at `H`'s positions `k'` and `m'`, then `G` gains that edge.
-A method then has an escape whenever it passes a parameter value at `k`
-and an escaping destination at `m`. Value-typed arguments are copied at
-runtime regardless (requirements ownership section), so the fact records
-`escape` without committing to a spelling.
+**Escape is not chased through the call graph.** The direct check above
+reads the store sites one algorithm holds. Making it transitive would mean
+a second fixpoint in the shape of FR2: per abstract operation `G`, a set
+of edges `(k, m)` meaning `G` stores its `k`-th argument into its `m`-th,
+seeded from direct stores and propagated along the call graph. That is
+substantial machinery for a short list. The container methods with an
+escape are `push`, `unshift`, `splice`, `fill`, `Map.prototype.set`,
+`Set.prototype.add`, the two weak-collection setters, `Reflect.set`,
+`Object.assign`, and `Object.defineProperty`. §4.4 answers what the direct
+check misses with a curated entry, at a fraction of the cost and with a
+stated reason per method. Value-typed arguments are copied at runtime
+regardless per the requirements ownership section, so the fact records
+`escape` without committing to a spelling either way.
 
 ### §8.2. Return-borrow seed (FR4)
 
@@ -1645,17 +1773,23 @@ func precludedCoercion(M, site) bool:
     return false
 ```
 
-Receiver coercions are filtered unconditionally, because the receiver's
-type is always statically known. **Parameter coercions are filtered only
-when the joined declaration proves the parameter's type already is the
-coercion's target** — `ToNumber(p)` on a `p: number` cannot throw, but
-`ToNumber(p)` on a `p: unknown` can. That check needs the typed
-signature, which the shape-free facts do not carry (FR7), so the
-parameter branch of the filter **runs after the FR7 join** (or is fed the
-parameter types from it); the receiver branch can run earlier. A
+**Only the receiver branch is built.** A receiver coercion is filtered
+unconditionally, because the receiver's type is always statically known,
+and that check reads nothing the facts do not already carry. A
 `RangeError`, `SyntaxError`, `URIError`, or a `TypeError` from an explicit
-domain check survives. Each filter decision is recorded for review, since
-FR11 is a heuristic. Channel assignment is **per throw site, not per
+domain check survives it. Each filter decision is recorded for review,
+since FR11 is a heuristic.
+
+Filtering a **parameter** coercion is a different proposition. It is sound
+only where the joined declaration proves the parameter's type already is
+the coercion's target — `ToNumber(p)` on a `p: number` cannot throw, but
+`ToNumber(p)` on a `p: unknown` can. The shape-free facts carry no types
+per FR7, so that branch would have to run after the join or be fed the
+parameter types from it, which is the plumbing #1301 describes. §4.4
+answers it instead: the methods whose surviving throws are worth
+annotating are a short list, and a curated `throws` states the filtered
+set directly with the reasoning attached. The parameter branch and its
+typed-signature plumbing are dropped. Channel assignment is **per throw site, not per
 error type**: `filterThrows` sees only the synchronous sites, `rejectSet`
 (§9.3) only the rejection sites, so the same error type can legitimately
 appear in both `throws` and `rejects` when raised on both a synchronous
@@ -1797,12 +1931,21 @@ element-`E` / `AggregateError` / `never` rejects. Because concrete `std:*`
 domain rejections are rare (FR13), most `std:*` `rejects` sets are empty
 or a forwarded element `E`, and that is recorded as an origin, not hidden.
 
-### §9.4. Throws validation and the auto-apply gate (FR14)
+### §9.4. Throws validation (FR14)
 
-The throws counterpart of §6's mutability diff. It decides, by
-measurement, whether throws stay a reviewed candidate set or graduate to
-auto-apply — so it is the phase that could later retire the "Throws as a
-finished, unreviewed annotation" non-goal.
+The throws counterpart of §6's mutability diff: an empirical check on the
+`throws` and `rejects` a builtin carries, built from observed behavior
+rather than from the specification the extractor already reads.
+
+**The auto-apply gate is dropped.** It existed to decide, by measuring a
+false-negative rate, whether an *extracted* throw set could reach the
+generated `.esc` without a human. Under §4.4 the throw sets that matter
+are curated, so they are reviewed by construction and there is nothing for
+the gate to authorize. What remains worth building is the ground-truth
+corpus, run as a spot-check over the curated entries: it is the one source
+of evidence about throws that does not share the extractor's blind spots,
+and it catches a reviewer's mistake the same way it would have caught an
+extractor's.
 
 **Work.**
 
@@ -1832,22 +1975,20 @@ finished, unreviewed annotation" non-goal.
   Apply the documented host-throws exclusion throughout, so stack-overflow
   `RangeError` and OOM are filtered from the observations and never enter
   the ground truth. A human verifies and commits the result.
-- Diff the extracted sets against it and report two rates (FR14):
-  - the **false-negative rate** — real throws the emitted set omits —
-    measured in two layers: against the *raw* FR10 set (should be zero
-    when the CFG is faithful — isolates §9.1 soundness) and against the
-    *filtered* FR11 set (its false negatives are the coercion filter's
-    over-prunes);
-  - the **false-positive rate** — phantom throws — which costs only a
-    redundant handler and carries less weight.
-- Triage every filtered false negative: a genuine over-prune fixes the
-  §9.2 filter; a ground-truth error fixes the sample.
+- Diff the published sets against it, in two layers. Against the *raw*
+  FR10 set a false negative isolates a §9.1 soundness gap, and should be
+  zero where the control-flow graph is faithful. Against the *published*
+  set, curated entries and all, a false negative is a real throw a caller
+  would have to handle and nothing declares.
+- Report the false positives too. A phantom throw costs only a redundant
+  handler, so it carries less weight than a false negative.
+- Triage every published false negative to one of three causes: an
+  over-prune by §9.2's receiver branch, a curated entry that is wrong, or
+  an error in the sample.
 
-**Gate.** A reviewed rate report. While the filtered false-negative rate
-is above zero, the converter treats `throws`/`rejects` as curation input
-(§7 does not auto-apply them). A measured filtered false-negative rate of
-zero on the sample is the evidence that authorizes flipping throws to
-auto-apply, mirroring how §6 authorizes trusting the mutability facts.
+**Gate.** A reviewed disagreement report over the curated `throws` and
+`rejects`, with every disagreement triaged to a corrected curated entry or
+a corrected sample.
 
 ## §10. Maintenance workflow
 
@@ -1880,13 +2021,20 @@ recording the accepted or corrected annotations. It is data work, and
 treating it as such — its own PRs, reviewed on their own terms — keeps it
 legible.
 
-**Sequencing.** Curation cannot begin until the facts exist (§4, §8, §9)
-and the override-layer path is wired (§7 plus the builtins converter that
-generates `.esc`). It is independent of the M7.5 solver-side application —
-the override layer can be populated against the converter's output before
-the active checker ingests it. Some curation-adjacent review is embedded
-earlier: §6 triages the receiver-mutability diff, and §9.4 builds the FR14
-ground-truth corpus.
+**Sequencing.** Curation of the effect annotations cannot begin until the
+facts exist (§4, §8, §9) and the override-layer path is wired (§7 plus the
+builtins converter that generates `.esc`). It is independent of the M7.5
+solver-side application — the override layer can be populated against the
+converter's output before the active checker ingests it. Some
+curation-adjacent review is embedded earlier: §6 triages the
+receiver-mutability diff, and §9.4 builds the FR14 ground-truth corpus.
+
+The **fact-level** curation of §4.4 runs ahead of all of it, because it
+needs only the facts and not the converter. Its mechanism is the one this
+phase uses: a committed data file keyed by canonical spec name, merged per
+determination, with a stated reason per entry. §11 populates the effect
+axes of that same file as §8 and §9 make them available. The receiver
+axis is already done, and the three interior returns with it.
 
 **PR shape.** Curation lands as its own PRs, separate from the infra
 phases and incremental — one per pseudo-package or batch (`std:array`,
@@ -1896,11 +2044,13 @@ PRs because a diff of hand-reviewed annotations reviews on different terms
 than a diff that changes the analyzer, and because the volume is large and
 recurs as deltas on spec bumps.
 
-**A shrinking surface.** Receiver mutability is already auto-applied (no
-curation). Once §9.4's FR14 gate measures a zero false-negative rate,
-`throws`/`rejects` graduate to auto-apply for the covered subset. So the
-curation surface contracts over time toward mostly disposition and
-lifetime annotations.
+**A shrinking surface, in two directions.** Receiver mutability is
+auto-applied, whether the claim came from the analysis or from a curated
+entry. And a curated entry the analysis later catches up with is reported
+as redundant and deleted, so the layer contracts as §4 improves rather
+than accumulating. What is left grows toward disposition, lifetime, and
+throws annotations, which is where the spec states an effect no
+control-flow graph carries.
 
 **Where an assistant can and cannot stand in.** The labor is largely
 mechanical and an assistant (including Claude) can take much of it on:
@@ -2080,8 +2230,15 @@ closure argument prologues writing into `__args__`, as in
 
 ## Appendix B. `facts.json` schema
 
-The committed output of §4, consumed by the converter (§7). Small,
-reviewable, keyed by canonical spec name.
+The output of §4, consumed by the converter (§7). Small, reviewable, keyed
+by canonical spec name.
+
+The file is derived rather than committed. `NewFacts` runs the analysis
+over the committed `cfg.json` and merges the curated layer of §4.4 over
+the result, so nothing on disk holds a fact to hand-edit. That is what
+keeps a curated answer out of the generated artifact and in
+`curated.json`, where FR7 re-applies it on every run. The curated entry
+shape is Appendix D.
 
 ```go
 type Facts struct {
@@ -2178,9 +2335,10 @@ effect refs resolve to types at the FR7 join. An entry carries no receiver,
 disposition, throw, or reject claim its `classified` coverage does not
 cover — those fields are absent or null, never empty — so the converter
 cannot mistake "unanalyzed" for "proven none"; it applies the FR5 default
-for that axis itself. A method whose `receiver` is uncovered falls through to
+for that axis itself. A method whose `receiver` is uncovered after §4.4's merge falls through to
 the name heuristics and is collected into a separate `unclassified` report
-alongside `facts.json` for auditing (FR5). Where `classified.params` is
+alongside `facts.json` for auditing (FR5). No `std:*` method is in that
+state today. Where `classified.params` is
 set, a parameter absent from `Params` was proven read-only (`&`) — not to
 be confused with the FR5 `&mut` default the converter applies where it is
 not.
@@ -2256,3 +2414,53 @@ A prototype with no name of its own in the language is the root of the
 path rather than a `prototype` segment, so `%ArrayIteratorPrototype%`'s
 `next` is keyed `ArrayIteratorPrototype.next`. It still has a receiver
 and carries `Kind: builtin-method`.
+
+## Appendix D. `curated.json` schema
+
+The committed curated layer of §4.4, keyed by the same canonical spec
+names as Appendix C.
+
+```go
+// Curation is the whole committed layer.
+type Curation struct {
+    Entries map[string]CuratedEntry `json:"entries"`
+}
+
+type CuratedEntry struct {
+    Reason     string `json:"reason"`             // why the curated answer is right
+    Evidence   string `json:"evidence,omitempty"` // where the reason was checked
+    ReviewedAt string `json:"reviewedAt"`         // Func.Digest at review time
+
+    Classified Coverage     `json:"classified"`         // which determinations this entry claims
+    Receiver   ReceiverKind `json:"receiver,omitempty"` // borrow | mutBorrow | none
+    Returns    ReturnFact   `json:"returns,omitzero"`   // the return-borrow seed
+}
+```
+
+`Classified` means on an entry exactly what it means on a `MethodFact`: it
+says which determinations the entry claims. An axis it leaves unset is not
+curated, and keeps whatever the analysis concluded. `Coverage` gains a
+flag per axis as §8 and §9 add one, and an entry claims the new axis by
+the same rule.
+
+Three fields exist only for review and never reach `facts.json`.
+
+`Reason` is required. It is the argument for the curated answer in the
+reviewer's words, which is what makes the entry re-reviewable when the
+spec changes under it. `Evidence` names where that argument was checked, a
+specification heading, an MDN page, or an engine the behavior was observed
+in.
+
+`ReviewedAt` is the `Func.Digest` of the algorithm at review time, a
+fingerprint over that one serialized algorithm. It is taken over the
+decoded function rather than over the raw JSON text, so reformatting
+`cfg.json` or reordering its keys leaves every digest alone and only a
+real change to a step, a parameter, or a kind moves one. When the graph's
+digest no longer matches, the entry is reported stale and still applied.
+
+Parsing rejects an entry that cannot be reviewed or applied: one with no
+reason, no reviewed digest, no claimed determination, or a receiver kind
+or alias kind this package cannot spell. A return fact holds the same
+invariants `newReturnFact` builds — a parameter return names its position,
+a union names at least two members and holds neither a union nor an
+`unknown`, and no other kind carries either field.

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1120,13 +1120,13 @@ func classify(M) MethodFact:
     fact.Throws     = filterThrows(M)              // §9.2
     fact.Rejects    = rejectSet(M)                 // §9.3, published alongside Throws in §9.2
     // Soundness bias (FR5), applied per determination. A method the
-    // analysis could not fully cover OR could not fully attribute
-    // withholds the determinations that read the steps it missed. A
-    // static's RecvNone reads no step, so no warning withholds it.
-    fact.Classified.Receiver = M.Kind != BuiltinMethod
-        or (M not in Unattributable and M not in Incomplete)
-    fact.Classified.Returns  = true   // returnAlias is total, top Unknown
-    return fact
+    // analysis could not fully cover OR could not fully attribute leaves
+    // out the determinations that read the steps it missed, and §4.4's
+    // review answers them before anything is published. A static's
+    // RecvNone reads no step, so no warning withholds it.
+    if M.Kind == BuiltinMethod and (M in Unattributable or M in Incomplete):
+        fact.Receiver = <absent>       // §4.4 answers it, or generation fails
+    return fact                        // returnAlias is total, top Unknown
 
 func receiverKind(M):
     if M.Kind != BuiltinMethod: return RecvNone    // static / namespace function: no receiver
@@ -1156,18 +1156,19 @@ lifetime bounded, so §8.2 has nothing to emit for it.
 An `Unattributable` method has a mutation the analysis could not pin to
 a formal — a write through an `Unknown`-origin value, including deep
 mutation reached through a property read. Its receiver claim is withheld
-and its name listed, so the converter falls the method through to the
-name heuristics and the receiver defaults to `&mut self` (FR5).
+and its name listed, which is what §4.4 curates. Nothing is published for
+a method whose receiver neither source answers.
 
-**Coverage is per determination, not per method.** The two axes carry
-different risk. Receiver mutability is a soundness claim §7 auto-applies,
+**A withheld determination is per determination, not per method.** The two
+axes carry different risk. Receiver mutability is a soundness claim §7 auto-applies,
 and a wrong `borrow` lets an immutable value call a mutating method. The
 return alias is FR4's lifetime seed, which §7 records for curation rather
 than applies, so withholding it costs precision and buys no safety. A
 method whose only problem is a possible hidden mutation therefore keeps
 its `returns` and loses only its `receiver`. That is §2's per-signal
-finding — a determination is unclassified only when a `yet` sits on a step
-it reads.
+finding — a determination is withheld only when a `yet` sits on a step it
+reads. §4.4 then answers what the analysis withheld, so nothing reaches
+`facts.json` with a determination missing.
 
 A method's receiver mutability cannot be recovered the same way. An opaque
 node carries no operands, so there is no way to tell what a missed step

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1267,13 +1267,24 @@ analysis settles its receiver and the entry corrects only its return.
 
 Each curated axis is one of three things, and the merge reports which:
 
-- a **fill-in**, where the analysis withheld the axis. This is the
-  ordinary case and carries no conflict.
+- a **fill-in**, where the analysis left the axis open. This is the
+  ordinary case and carries no conflict. An axis is open when its coverage
+  is unset, and a return alias is open when it resolved to `unknown` as
+  well, since the top of the alias lattice names no value the return hands
+  back.
 - a **correction**, where the analysis published a claim the review
   contradicts. §6 reads these first, because a correction is either a spec
   subtlety the graph cannot express or an analyzer bug, and the two look
   alike from the report.
 - a **redundant** entry, repeating what the analysis already concluded.
+
+One curated claim is refused rather than merged. Whether a builtin has a
+receiver at all follows from `Func.Kind` and reads no algorithm step, so
+the graph settles it outright. A `borrow` curated onto a static would put
+a `&self` on a declaration that has no self, which is the one curated
+mistake §7 cannot absorb, since receiver mutability is the determination
+it auto-applies. The merge refuses that axis, reports it, and leaves the
+analysis's answer standing.
 
 **Three guards keep the layer from becoming a second source of truth.**
 
@@ -1297,8 +1308,10 @@ it.
 
 **What the layer closes.** Curating the 24 receivers takes the published
 `receiver unclassified` tally to zero and retires the fallback to §7's
-name heuristics for `std:*`. Three of the five interior returns of §4.3
-are curated `fresh`, because a primitive read out of a slot is a copy —
+name heuristics for `std:*`. All 27 committed entries are fill-ins, so
+nothing in the layer yet contradicts a claim the analysis made and §6 has
+no disagreement to triage. Three of the five interior returns of §4.3 are
+curated `fresh`, because a primitive read out of a slot is a copy —
 `Date.prototype.getTime`, `Date.prototype.valueOf`, and `get
 TypedArray.prototype [ @@toStringTag ]`. The two `buffer` getters stay
 `unknown`: what they hand back is a real borrow of an object the receiver
@@ -1322,9 +1335,9 @@ tail. The mutation fixpoint and the origin map carry the bulk mechanically
 and stay as they are.
 
 **Gate.** `curated.json` merges per determination; the published
-`receiver unclassified` tally is zero; each of the three guards has a
-test; the join report distinguishes a curated determination from an
-analyzed one.
+`receiver unclassified` tally is zero; each of the three guards and the
+receiver-kind refusal has a test; the report distinguishes a curated
+determination from an analyzed one.
 
 ## §5. Keying and join (FR7, FR15)
 
@@ -2460,7 +2473,16 @@ digest no longer matches, the entry is reported stale and still applied.
 
 Parsing rejects an entry that cannot be reviewed or applied: one with no
 reason, no reviewed digest, no claimed determination, or a receiver kind
-or alias kind this package cannot spell. A return fact holds the same
-invariants `newReturnFact` builds — a parameter return names its position,
-a union names at least two members and holds neither a union nor an
-`unknown`, and no other kind carries either field.
+or alias kind this package cannot spell. It also rejects a value written
+on an axis the entry's `classified` leaves unclaimed, which the merge
+would otherwise drop with no report line, leaving the reviewer to see
+silence where they wrote a claim.
+
+A return fact holds the same invariants `newReturnFact` builds. A
+parameter return names its position. A union names at least two distinct
+members and holds neither a union nor an `unknown`, since neither names a
+single value a return hands back. No other kind carries a position or
+members. Parsing sorts a union's members by kind and then position, the
+order `newReturnFact` leaves them in, so a curated union compares equal to
+the analyzed fact it repeats and publishes in the order every other fact
+uses.

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -468,8 +468,10 @@ merely stricter.
   function have `receiver: none` whatever the analysis missed.
 - An unclassified determination is answered by **review**, recorded as a
   curated entry keyed by the same canonical spec name and merged over the
-  analysis one axis at a time. Only what neither the analysis nor a curated
-  entry answers falls through to the name heuristics in the converter.
+  analysis one axis at a time. What neither the analysis nor a curated entry
+  answers is not published: generation fails, naming the method and the axis,
+  so the gap is closed before anything consumes it. The name heuristics stay
+  the fallback for a method no entry addresses at all.
   Curating an answer is the cheaper of the two ways to close a gap, and it
   states a reason the next reader can check, where a new lattice member in
   the analysis states only a result.

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -87,7 +87,10 @@ name heuristics.
   - **The filter needs type information ECMA-262 does not carry.** Whether
     a parameter coercion can throw depends on the parameter's declared
     type, available only at the FR7 join, plus a judgment about which
-    coercions the types truly preclude.
+    coercions the types truly preclude. Both are what a reviewer supplies,
+    so the parameter half of the filter is a curated entry rather than a
+    stage of the analysis. Only the receiver half, where the type is always
+    statically known, is filtered automatically.
 
   Host and implementation-defined throws are **out of scope**, not a
   review driver: stack-overflow `RangeError`, out-of-memory, and host
@@ -98,9 +101,8 @@ name heuristics.
   `RangeError` from an explicit spec domain check, such as
   `Number.prototype.toFixed`, is a tracked domain throw.
 
-  The claim is falsifiable and evidence-revisable: a measured
-  false-negative rate near zero from the FR14 validation would let throws
-  graduate to auto-apply. This refines the builtins workstream's
+  The claim is falsifiable and evidence-revisable, and the FR14 validation
+  is what would falsify it. This refines the builtins workstream's
   hand-curation plan rather than replacing it
   ([../builtins/requirements.md](../builtins/requirements.md), FR10
   "throws annotations are hand-curated for now"): the spec generates the
@@ -463,9 +465,14 @@ merely stricter.
   **unclassified**, not as a guess. Coverage is per determination, so a
   method withholds only the axes that read the step it could not resolve.
   An axis that reads no step is never withheld: a static and a namespace
-  function have `receiver: none` whatever the analysis missed. An
-  unclassified determination falls through to the existing name heuristics
-  and hand-curation in the converter.
+  function have `receiver: none` whatever the analysis missed.
+- An unclassified determination is answered by **review**, recorded as a
+  curated entry keyed by the same canonical spec name and merged over the
+  analysis one axis at a time. Only what neither the analysis nor a curated
+  entry answers falls through to the name heuristics in the converter.
+  Curating an answer is the cheaper of the two ways to close a gap, and it
+  states a reason the next reader can check, where a new lattice member in
+  the analysis states only a result.
 - Receiver mutability defaults to **mutating** (`&mut self`) when
   unclassified, consistent with the interop core principle "default to
   mutating"
@@ -500,8 +507,8 @@ impractical:**
   every `this`-touching method carries `throws TypeError` from its
   receiver coercion, pervasive noise a parameter default does not produce.
   So the throw set (FR10) and reject set (FR13) under-report instead,
-  accepting that this is the unsound direction, and both are curation-grade
-  and gated by the FR14 validation before they could ever auto-apply.
+  accepting that this is the unsound direction. Both are curation-grade,
+  and FR14 measures what reaches the `.esc` against observed behavior.
 
 These defaults are applied by the **converter**, not serialized as facts.
 A record's `classified` object marks each determination covered or not,
@@ -522,7 +529,10 @@ it. A static's `receiver: none` reads no step at all, so nothing the
 analysis missed can put it in doubt.
 
 Every method whose receiver mutability is unclassified is reported by name
-so the gap is visible and auditable rather than silent.
+so the gap is visible and auditable rather than silent. The report is
+taken over the analysis alone as well as over the merged result. The first
+is what the analysis is measured by, and the second is what actually
+reaches the heuristics.
 
 ### FR6. Output contract
 
@@ -639,7 +649,16 @@ bump — and the effect annotations come from this workstream's ECMA-262
 facts, regenerated on a spec bump. A generated `.esc` builtin is the join
 of those two, plus a small hand-curated override layer for the
 curation-grade residue (reviewed throws and lifetimes) that is re-applied
-at generation rather than edited into the output. This keeps signatures
+at generation rather than edited into the output.
+
+Curated data enters at two points, and they answer different questions.
+The **fact layer** answers a determination the spec extraction cannot
+settle, and it is keyed by canonical spec name and merged into the facts
+before the join. The **override layer** answers what the facts under-report
+by design, the annotations FR5 makes the extractor omit, and it is keyed
+by declaration and applied after the join. Both are committed data
+re-applied at generation. A determination the facts could carry belongs in
+the first, so the second never has to restate a fact. This keeps signatures
 out of hand-maintenance entirely, which is the whole point: hand-authored
 `.esc` signatures are the path to **avoid**, because they would drift from
 the upstream types and multiply the maintenance surface.
@@ -935,41 +954,43 @@ FR13 is specified here for completeness and to fix the
 `throws`-versus-`rejects` split, but it delivers most of its value once
 the WebIDL extractor lands.
 
-### FR14. Throws validation and the auto-apply gate
+### FR14. Throws validation
 
-Whether the extracted `throws`/`rejects` are trustworthy without review is
-an empirical question, settled by measurement, not asserted. FR14 is the
-throws counterpart of FR9's mutability validation: diff the extracted
-throw sets against a ground-truth sample of high-value methods and measure
-two rates. The sample must be **independent of the spec extraction** — a
-corpus read out of the same algorithm would agree by construction, so it
-is seeded by dynamic observation in a real engine (fuzzing each method and
-recording what it throws or rejects with) rather than by re-reading the
-spec, with only the parametric and combinator entries hand-authored (the
-plan's §9.4 gives the mechanics).
+Whether a method's published `throws`/`rejects` is right is an empirical
+question, settled by measurement rather than asserted. FR14 is the throws
+counterpart of FR9's mutability validation: diff the published throw sets
+against a ground-truth sample of high-value methods and measure two rates.
+The sample must be **independent of the spec extraction**. A corpus read
+out of the same algorithm would agree by construction, so it is seeded by
+dynamic observation in a real engine, fuzzing each method and recording
+what it throws or rejects with, rather than by re-reading the spec. Only
+the parametric and combinator entries are hand-authored. The plan's §9.4
+gives the mechanics.
+
+The check covers curated entries as much as extracted ones. Dynamic
+observation is the one source of evidence about throws that shares neither
+the extractor's blind spots nor a reviewer's, so it catches a wrong
+curated `throws` the same way it catches an over-prune.
 
 - **False-negative rate — the soundness metric.** Real throws that the
-  method can raise but the emitted set omits, almost always because the
-  FR11 coercion filter over-pruned. This is the rate that matters: a
-  false negative is an unsound `throws` clause. Measure it in two layers
-  so the blame is unambiguous:
-  - against the *raw* FR10 set (pre-filter), which should be zero when the
-    CFG is faithful — this isolates FR10 extraction soundness;
-  - against the *filtered* FR11 set, whose false negatives are exactly the
-    filter's over-prunes.
+  method can raise but the published set omits. This is the rate that
+  matters, since a false negative is an unsound `throws` clause. Measure
+  it in two layers so the blame is unambiguous:
+  - against the *raw* FR10 set, before the FR11 filter, which should be
+    zero when the control-flow graph is faithful. This isolates FR10
+    extraction soundness.
+  - against the *published* set, curated entries and all. A false negative
+    there is a real throw a caller has to handle and nothing declares, and
+    it is charged to the filter's over-prune or to the curated entry.
 - **False-positive rate — the ergonomics metric.** Phantom throws the
   method cannot actually raise. These only cost callers a redundant
-  handler; they are not a soundness problem, so they carry less weight.
+  handler, so they carry less weight than a false negative.
 
-The gate: while the filtered false-negative rate is above zero on the
-sample, throws remain a reviewed candidate set (the Non-goals entry
-stands). A measured filtered false-negative rate of zero on a
-representative sample is the evidence that would **graduate throws to
-auto-apply**, the same way FR9's diff authorizes trusting the mutability
-facts. Host and implementation-defined throws are excluded from the
-ground-truth sample by an explicit, documented policy so they do not
-register as false negatives against a spec-derived set that cannot
-contain them.
+Every published false negative is triaged and fixed, in the filter or in
+the curated entry it came from. Host and implementation-defined throws are
+excluded from the ground-truth sample by an explicit, documented policy so
+they do not register as false negatives against a set that cannot contain
+them.
 
 ### FR15. Overloaded methods
 
@@ -1038,8 +1059,11 @@ types and arity.
   per-directory `mise.toml`.
 - **Auditability.** Every classification carries its provenance, and
   every method whose receiver mutability is unclassified is listed, so a
-  reviewer can see exactly which methods the spec proved and which fell
-  through to heuristics.
+  reviewer can see exactly which methods the spec proved, which review
+  answered, and which fell through to heuristics. A curated answer that the
+  analysis later reaches on its own is reported so the entry can be
+  deleted, which keeps the curated layer from growing into a second source
+  of truth.
 
 ## Coverage and limitations
 
@@ -1051,12 +1075,13 @@ types and arity.
   This exclusion is only for those pervasive host errors: a `RangeError`
   raised by an explicit spec domain check (`Number.prototype.toFixed`
   out of range, `Array(-1)`) is a tracked domain throw. The exclusion is
-  what keeps the throw sets ergonomic and removes a would-be permanent
-  blocker to the FR14 auto-apply gate.
-- A handful of algorithms are prose-only or host-defined, so a method
-  among them has its receiver mutability fall through to the name
-  heuristic per FR5. The return alias is published regardless, since FR4
-  curates it rather than applying it.
+  what keeps the throw sets ergonomic and keeps FR14's false-negative rate
+  measuring something a reviewer can act on.
+- A handful of algorithms are prose-only or host-defined, so the analysis
+  withholds the receiver mutability of a method among them. A curated
+  entry answers it, and only what neither settles falls through to the
+  name heuristic per FR5. The return alias is published regardless, since
+  FR4 curates it rather than applying it.
 - Generic and array-like receivers operate on `O ← ? ToObject(this
   value)`; the analysis treats `ToObject(this value)` as
   receiver-origin so that a write to `O` is a write to the receiver.

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -72,7 +72,7 @@ name heuristics.
 - **Throws as a finished, unreviewed annotation.** Emitting the throw
   set is an in-scope deliverable (FR10, FR11), but it ships as a reviewed
   candidate set, not a trusted final annotation. The review need is not
-  that the extraction is inaccurate — where `classified.throws` is set,
+  that the extraction is inaccurate — where an entry carries `throws`,
   FR10's *raw* throw set is a sound, complete enumeration of what
   ECMA-262 models the algorithm as throwing, and could ship unreviewed at
   the cost of noise. Review guards the two things downstream of that,
@@ -510,15 +510,20 @@ impractical:**
   accepting that this is the unsound direction. Both are curation-grade,
   and FR14 measures what reaches the `.esc` against observed behavior.
 
-These defaults are applied by the **converter**, not serialized as facts.
-A record's `classified` object marks each determination covered or not,
-and an uncovered one omits its field — `receiver`, `params`, `throws`,
-`rejects` are absent, or null, on the wire. So the format never conflates
-"the analysis proved this method borrows and throws nothing" with "the
-analysis could not tell." A proven-empty result is a covered determination
-with an empty effect field; an unanalyzed one is an uncovered
-determination with its field absent. FR6 and Appendix B use this one
-contract.
+These defaults are applied by the **converter**, not serialized as facts,
+and the converter applies one only where no fact addresses the method at
+all. A published fact answers every determination it carries: an axis
+neither the analysis nor review settles fails generation, naming the method
+and the axis, rather than being written as a hole. So the format cannot
+conflate "the analysis proved this method borrows and throws nothing" with
+"the analysis could not tell" — the second never reaches the file. A
+proven-empty result is an empty effect field, and there is no encoding for
+an unanalyzed one. FR6 and Appendix B use this one contract.
+
+Failing generation is the loud direction, which is the same reasoning as
+the defaults above. A coverage flag would leave the hole in the data for
+every consumer to remember to check, and §7 auto-applies the receiver, so a
+forgotten check there becomes a silent `&mut self`.
 
 Splitting coverage this way keeps the conservative bias where it buys
 safety and drops it where it does not. A method's receiver mutability is
@@ -542,35 +547,40 @@ provenance. `receiver` is `borrow` (`&self`), `mutBorrow` (`&mut self`),
 or `none` (a static or namespace function with no receiver). `params`
 lists only the parameters the analysis found `mutBorrow` (`&mut`) or
 `escape` (stored into the receiver, spelled at curation — see FR12).
-Where `classified.params` is set, a parameter omitted from the entry was
-proven read-only (`borrow`). That proven-read-only omission is distinct
-from the FR5
-uncertain default, which is `&mut`: the omission means "the analysis
-showed this parameter is only read," whereas the FR5 default applies where
-`classified.params` is unset and the parameters are absent entirely.
+A parameter omitted from the entry was proven read-only (`borrow`). That
+omission is distinct from the FR5 uncertain default, which is `&mut`: the
+omission means "the analysis showed this parameter is only read," whereas
+the FR5 default applies only where no entry addresses the method.
+
+**Every entry is total.** A determination neither the analysis nor review
+settles is not encoded. Generation fails instead, naming the method and the
+axis on stderr, so the file carries no coverage flags and a consumer never
+has to tell a hole from a claim.
 
 ```json
 {
-  "Array.prototype.push":  { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"}], "returns": "fresh",    "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Array.prototype.fill":  { "receiver": "mutBorrow", "params": [],                                    "returns": "receiver", "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Array.prototype.slice": { "receiver": "borrow",    "params": [],                                    "returns": "fresh",    "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Map.prototype.set":     { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"},{"index":1,"disposition":"escape"}], "returns": "receiver", "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Number.prototype.toFixed": { "receiver": "borrow", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+  "Array.prototype.push":  { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"}], "returns": "fresh",    "throws": [], "rejects": [] },
+  "Array.prototype.fill":  { "receiver": "mutBorrow", "params": [],                                    "returns": "receiver", "throws": [], "rejects": [] },
+  "Array.prototype.slice": { "receiver": "borrow",    "params": [],                                    "returns": "fresh",    "throws": [], "rejects": [] },
+  "Map.prototype.set":     { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"},{"index":1,"disposition":"escape"}], "returns": "receiver", "throws": [], "rejects": [] },
+  "Number.prototype.toFixed": { "receiver": "borrow", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [] },
 
-  "Reflect.set":              { "receiver": "none", "params": [{"index":0,"disposition":"mutBorrow"},{"index":2,"disposition":"escape"}], "returns": "fresh", "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Intl.getCanonicalLocales": { "receiver": "none", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+  "Reflect.set":              { "receiver": "none", "params": [{"index":0,"disposition":"mutBorrow"},{"index":2,"disposition":"escape"}], "returns": "fresh", "throws": [], "rejects": [] },
+  "Intl.getCanonicalLocales": { "receiver": "none", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [] },
 
-  "String.prototype.toLowerCase": { "returns": "unknown", "classified": {"receiver":false,"params":false,"returns":true,"throws":false,"rejects":false} }
+  "String.prototype.toLowerCase": { "receiver": "borrow", "params": [], "returns": "unknown", "throws": [], "rejects": [] }
 }
 ```
 
-- `classified` marks each determination covered or not, and an uncovered
-  one leaves its field out. `String.prototype.toLowerCase` reaches the
-  Unicode case-mapping table through a prose step, so the analysis cannot
-  say what that step wrote and the entry carries no `receiver`. The return
-  alias survives, because FR4 curates it rather than applying it. A static
-  keeps `receiver: none` through the same warning, since its having no
-  receiver is a fact about the declaration rather than about a step.
+- Every entry carries every determination, so there is no coverage object
+  and no absent field to interpret. `String.prototype.toLowerCase` reaches
+  the Unicode case-mapping table through a prose step, so the analysis
+  cannot say what that step wrote; the `borrow` above comes from review,
+  and without it generation would fail rather than publish the method. Its
+  `returns: unknown` is a value the analysis did produce, meaning the walk
+  tied the return to nothing the caller holds. A static keeps
+  `receiver: none` through any warning, since its having no receiver is a
+  fact about the declaration rather than about a step.
 - `receiver` maps a non-mutating method to `&self` and a mutating one to
   `&mut self` (FR2). A method that stores an argument into the receiver
   marks that parameter `escape`, because the argument outlives the call
@@ -621,10 +631,10 @@ The key space therefore covers prototype methods
 (`X.prototype.method`), static methods (`X.method`), symbol-keyed
 methods, and namespace-qualified forms where `X` is a dotted path naming
 a namespace and optionally a nested constructor — all joined by FR7.
-The `classified` object marks each determination covered or not. An
-uncovered one is an FR5 fall-through, and its field — `receiver`,
-`params`, `throws`, or `rejects` — is absent, distinct from a proven-empty
-result (§FR5).
+Every entry answers every determination, so a fall-through to the FR5
+defaults happens only where no entry addresses the method — an unmatched
+`std:*` declaration, or the `web:*` and `node:*` surfaces that are out of
+scope by construction.
 
 ### FR7. Keying and join to typed declarations
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,10 +107,6 @@ importers:
 
   fixtures/class_field_name_collision: {}
 
-  fixtures/class_inheritance: {}
-
-  fixtures/class_inheritance_namespaces: {}
-
   fixtures/class_with_computed_members: {}
 
   fixtures/class_with_fluent_mutating_methods: {}
@@ -132,8 +128,6 @@ importers:
   fixtures/enum_script: {}
 
   fixtures/exception_handling: {}
-
-  fixtures/export_keyword_visibility: {}
 
   fixtures/extractor_arg_with_init: {}
 
@@ -169,8 +163,6 @@ importers:
 
   fixtures/generic_enum: {}
 
-  fixtures/grouping: {}
-
   fixtures/incomplete_fn: {}
 
   fixtures/interface: {}
@@ -186,8 +178,6 @@ importers:
   fixtures/member_access: {}
 
   fixtures/mut_class_reference: {}
-
-  fixtures/namespace_bin_import: {}
 
   fixtures/namespace_complex_chain: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,10 @@ importers:
 
   fixtures/class_field_name_collision: {}
 
+  fixtures/class_inheritance: {}
+
+  fixtures/class_inheritance_namespaces: {}
+
   fixtures/class_with_computed_members: {}
 
   fixtures/class_with_fluent_mutating_methods: {}
@@ -128,6 +132,8 @@ importers:
   fixtures/enum_script: {}
 
   fixtures/exception_handling: {}
+
+  fixtures/export_keyword_visibility: {}
 
   fixtures/extractor_arg_with_init: {}
 
@@ -163,6 +169,8 @@ importers:
 
   fixtures/generic_enum: {}
 
+  fixtures/grouping: {}
+
   fixtures/incomplete_fn: {}
 
   fixtures/interface: {}
@@ -178,6 +186,8 @@ importers:
   fixtures/member_access: {}
 
   fixtures/mut_class_reference: {}
+
+  fixtures/namespace_bin_import: {}
 
   fixtures/namespace_complex_chain: {}
 

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -42,6 +42,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
@@ -194,6 +195,13 @@ func runPartition(args []string, stderr io.Writer) error {
 			return fmt.Errorf("loading %s: %w", *cfgPath, err)
 		}
 		facts = ecma262.NewFacts(cfg)
+		// A fact with a hole in it would leave the converter to guess a
+		// determination nobody answered, and the receiver is auto-applied, so
+		// the guess would be silent. Refuse the run instead.
+		if holes := facts.Incomplete(); len(holes) > 0 {
+			return fmt.Errorf("%s leaves determinations unanswered:\n  %s",
+				*cfgPath, strings.Join(holes, "\n  "))
+		}
 		join = ecma262.NewJoin(facts)
 	}
 

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -169,7 +169,7 @@ func runPartition(args []string, stderr io.Writer) error {
 	// second time. Discarding its output leaves one report per error.
 	flags := flag.NewFlagSet("partition", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
-	cfgPath := flags.String("cfg", "", "path to the ECMA-262 cfg.json; adds the §5 effect-fact join report")
+	cfgPath := flags.String("cfg", "", "path to the ECMA-262 cfg.json; adds the §4.4 curation and §5 effect-fact join reports")
 	if err := flags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			fmt.Fprintln(stderr, partitionUsage)
@@ -186,13 +186,15 @@ func runPartition(args []string, stderr io.Writer) error {
 
 	// Derive the facts before any output is written, so a bad --cfg path
 	// fails the run before it leaves a half-joined tree on disk.
+	var facts *ecma262.Facts
 	var join *ecma262.Join
 	if *cfgPath != "" {
 		cfg, err := ecma262.LoadCFG(*cfgPath)
 		if err != nil {
 			return fmt.Errorf("loading %s: %w", *cfgPath, err)
 		}
-		join = ecma262.NewJoin(ecma262.NewFacts(cfg))
+		facts = ecma262.NewFacts(cfg)
+		join = ecma262.NewJoin(facts)
 	}
 
 	result, err := partitionLibDir(libDir, stderr)
@@ -220,8 +222,12 @@ func runPartition(args []string, stderr io.Writer) error {
 	if join == nil {
 		return nil
 	}
-	// The join is informational. The spec and the TypeScript lib drift
-	// independently, so a name on one side only is a gap to close rather than
-	// a failed run.
+	// Both reports are informational. A curated entry the analysis caught up
+	// with is an entry to delete, and the spec and the TypeScript lib drift
+	// independently, so a name on one side only is a gap to close. Neither is a
+	// failed run.
+	if err := ecma262.WriteCurationReport(facts.Curation(), stderr); err != nil {
+		return err
+	}
 	return ecma262.WriteJoinReport(join.Match(dts_to_esc.StdDeclarations(mods)), stderr)
 }

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -185,8 +185,10 @@ func runPartition(args []string, stderr io.Writer) error {
 	}
 	libDir, outDir := flags.Arg(0), flags.Arg(1)
 
-	// Derive the facts before any output is written, so a bad --cfg path
-	// fails the run before it leaves a half-joined tree on disk.
+	// Derive the facts before any output is written, so neither a bad --cfg
+	// path nor a fact with a hole in it leaves a half-joined tree on disk. The
+	// tree does not read the facts, but a run that ends in an error should not
+	// leave output behind that looks like it succeeded.
 	var facts *ecma262.Facts
 	var join *ecma262.Join
 	if *cfgPath != "" {
@@ -195,10 +197,16 @@ func runPartition(args []string, stderr io.Writer) error {
 			return fmt.Errorf("loading %s: %w", *cfgPath, err)
 		}
 		facts = ecma262.NewFacts(cfg)
-		// A fact with a hole in it would leave the converter to guess a
-		// determination nobody answered, and the receiver is auto-applied, so
-		// the guess would be silent. Refuse the run instead.
 		if holes := facts.Incomplete(); len(holes) > 0 {
+			// The curation report goes first, because a hole is often the
+			// downstream of a refused entry and that line names the cause. The
+			// error below names only the axis left unanswered.
+			if err := ecma262.WriteCurationReport(facts.Curation(), stderr); err != nil {
+				return err
+			}
+			// A hole would leave the converter to guess a determination nobody
+			// answered, and §7 auto-applies the receiver, so the guess would be
+			// silent. Refuse the run instead.
 			return fmt.Errorf("%s leaves determinations unanswered:\n  %s",
 				*cfgPath, strings.Join(holes, "\n  "))
 		}

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -74,34 +74,6 @@ export declare class Array<T> {
 `))
 }
 
-// treeOf lists every file under root as a slash-separated path relative
-// to it, sorted. Dropping the root keeps the listing free of the temp
-// directory the test ran in.
-func treeOf(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	require.NoError(t, filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return err
-		}
-		rel, relErr := filepath.Rel(root, path)
-		if relErr != nil {
-			return relErr
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	}))
-	sort.Strings(out)
-	return out
-}
-
-// TestRun_PartitionWritesTheTree covers the §6 PR A mode. The snapshot
-// holds the operator-facing report, the tree the run laid down, and the
-// one package file it emitted, so a change to any of the three shows up
-// in the diff rather than behind a Contains check.
-//
-// The out-dir is a fresh temp path on every run, so the report has it
-// replaced by a placeholder before the comparison.
 // committedCFG is the control-flow graph tools/spec-extract commits, which the
 // --cfg flag reads.
 const committedCFG = "../spec-extract/cfg.json"
@@ -132,6 +104,34 @@ func TestRun_PartitionRejectsABadCFGPath(t *testing.T) {
 	require.Empty(t, treeOf(t, outDir))
 }
 
+// treeOf lists every file under root as a slash-separated path relative
+// to it, sorted. Dropping the root keeps the listing free of the temp
+// directory the test ran in.
+func treeOf(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	require.NoError(t, filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	}))
+	sort.Strings(out)
+	return out
+}
+
+// TestRun_PartitionWritesTheTree covers the §6 PR A mode. The snapshot
+// holds the operator-facing report, the tree the run laid down, and the
+// one package file it emitted, so a change to any of the three shows up
+// in the diff rather than behind a Contains check.
+//
+// The out-dir is a fresh temp path on every run, so the report has it
+// replaced by a placeholder before the comparison.
 func TestRun_PartitionWritesTheTree(t *testing.T) {
 	t.Parallel()
 	libDir := seedLib(t, arrayLib)

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -102,6 +102,36 @@ func treeOf(t *testing.T, root string) []string {
 //
 // The out-dir is a fresh temp path on every run, so the report has it
 // replaced by a placeholder before the comparison.
+// committedCFG is the control-flow graph tools/spec-extract commits, which the
+// --cfg flag reads.
+const committedCFG = "../spec-extract/cfg.json"
+
+// The --cfg run adds both ECMA-262 reports. What each one says is pinned in
+// internal/ecma262; what this covers is that the partition command prints them,
+// since neither reaches stderr without the flag.
+func TestRun_PartitionWithCFGPrintsBothReports(t *testing.T) {
+	t.Parallel()
+	libDir := seedLib(t, arrayLib)
+
+	var stderr strings.Builder
+	require.NoError(t, run([]string{"partition", "--cfg", committedCFG, libDir, t.TempDir()}, io.Discard, &stderr))
+
+	require.Contains(t, stderr.String(), "  curation: ")
+	require.Contains(t, stderr.String(), "  join: ")
+}
+
+// A --cfg path that does not resolve fails the run before anything is written,
+// so a mistyped flag leaves no half-joined tree behind.
+func TestRun_PartitionRejectsABadCFGPath(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+
+	err := run([]string{"partition", "--cfg", "no/such/cfg.json", seedLib(t, arrayLib), outDir}, io.Discard, io.Discard)
+
+	require.ErrorContains(t, err, "loading no/such/cfg.json")
+	require.Empty(t, treeOf(t, outDir))
+}
+
 func TestRun_PartitionWritesTheTree(t *testing.T) {
 	t.Parallel()
 	libDir := seedLib(t, arrayLib)

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -100,7 +100,8 @@ func TestRun_PartitionRejectsABadCFGPath(t *testing.T) {
 
 	err := run([]string{"partition", "--cfg", "no/such/cfg.json", seedLib(t, arrayLib), outDir}, io.Discard, io.Discard)
 
-	require.ErrorContains(t, err, "loading no/such/cfg.json")
+	require.EqualError(t, err,
+		"loading no/such/cfg.json: reading no/such/cfg.json: open no/such/cfg.json: no such file or directory")
 	require.Empty(t, treeOf(t, outDir))
 }
 

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -92,6 +92,26 @@ func TestRun_PartitionWithCFGPrintsBothReports(t *testing.T) {
 	require.Contains(t, stderr.String(), "  join: ")
 }
 
+// A graph whose facts hold a determination neither the analysis nor the curated
+// layer answered fails the run rather than writing a hole. The committed graph
+// has none, so the case is built here: one method whose only step is prose the
+// serializer could not lower, which withholds its receiver.
+func TestRun_PartitionRejectsAnUnansweredDetermination(t *testing.T) {
+	t.Parallel()
+	cfgPath := filepath.Join(t.TempDir(), "cfg.json")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(
+		`{"specTarget":"abc","funcs":[`+
+			`{"name":"Demo.prototype.opaque","kind":"builtin-method","params":[],"nodes":[`+
+			`{"kind":"opaque","text":["Let _x_ be whatever the host decides."]}]}]}`), 0o644))
+	outDir := t.TempDir()
+
+	err := run([]string{"partition", "--cfg", cfgPath, seedLib(t, arrayLib), outDir}, io.Discard, io.Discard)
+
+	require.EqualError(t, err, cfgPath+" leaves determinations unanswered:\n"+
+		"  Demo.prototype.opaque: no receiver determination")
+	require.Empty(t, treeOf(t, outDir))
+}
+
 // A --cfg path that does not resolve fails the run before anything is written,
 // so a mistyped flag leaves no half-joined tree behind.
 func TestRun_PartitionRejectsABadCFGPath(t *testing.T) {


### PR DESCRIPTION
Fixes #1312

Implements §4.4 of the implementation plan: a committed layer of hand-reviewed determinations that answers method facts the control-flow graph cannot settle, merged over the analysis results one axis at a time.

**Summary**

The analysis in §4.1–§4.3 settles 477 of 501 builtin receiver claims and leaves 24 withheld. Rather than adding new lattice members to the analyzer for each remaining case, this PR introduces a curated fact layer (`curated.json`) that records reviewed answers as committed data. The layer composes with the analysis: an entry that claims only one axis leaves the other to the analysis, and an axis the entry leaves unset keeps whatever the analysis concluded.

Curating the 24 receivers takes the published `receiver unclassified` tally to zero, so no `std:*` method falls through to §7&#39;s name heuristics. The tallies move 226→246 `borrow` and 63→67 `mutBorrow`.

**Every published fact is total**

Because the curated layer closes the last hole, `facts.json` no longer needs per-axis coverage flags. Each published fact answers every determination it carries, so the flags would have been constant. `Facts.Incomplete()` names any fact that would not be, and `dts_to_esc partition --cfg` fails the run on one after printing the curation report, since a refused entry is the usual cause. Dropping the flags takes the derived `facts.json` from 100 KB to 60 KB.

**Key changes**

- `internal/ecma262/curated.go`: Core merge logic. `mergeCuration` applies the layer over analyzed facts one determination at a time, producing a `CurationReport` that tracks what each curated axis did (fill-in, correction, or redundant). `ParseCuration` validates entries and sorts union members into canonical order.
- `internal/ecma262/curated.json`: 24 receiver determinations and 3 return determinations, each with a reason and evidence. Entries are keyed by Appendix C canonical spec names and reviewed against algorithm digests.
- `internal/ecma262/cfg.go`: Added `Digest` field to `Func` to fingerprint algorithms. Computed as SHA-256 of the serialized algorithm, allowing curated entries to flag when a spec rewrite invalidates a review.
- `internal/ecma262/classify.go`: `NewFacts` merges the curated layer after analysis. `Facts` carries an unexported `curation` field for provenance tracking, and `Incomplete` reports any fact left with an unanswered determination.
- `internal/ecma262/classify_test.go`: Added `testAnalyzedFacts` helper to read pre-merge analysis results, so tests can verify what the graph alone concludes without curated entries masking it.
- `internal/ecma262/curated_test.go`: Test suite covering fill-in, correction, redundant, stale, unmatched, and refused cases. Tests validate entry structure and merge behavior.
- `planning/ecma-262/implementation_plan.md`: Updated §4.4 status to ✅, adjusted downstream sections (§8.1, §9.2, §9.4) to reflect reduced analysis scope, added Appendix D for the `curated.json` schema, and rewrote Appendix B around the totality rule.
- `planning/ecma-262/requirements.md`: Clarified that unclassified determinations are answered by review (curated entries) rather than falling through to name heuristics, and that FR14 validation measures curated throws against observed behavior.
- `tools/dts_to_esc/main.go` and `main_test.go`: Print the curation report alongside the effect-fact join report when `--cfg` is passed, and abort before writing any output when a fact is incomplete.

**Implementation details**

- Entries are validated at parse time: required `reason` and `reviewedAt`, at least one claimed determination, valid receiver/return kinds, and union invariants (≥2 distinct members, no nested unions or unknown).
- Members are sorted by kind then position to establish a canonical order for comparison and rendering.
- The merge reports three note kinds: `fill-in` (analysis withheld the axis), `correction` (analysis claimed something different), and `redundant` (entry repeats the analysis).
- Refused axes (e.g., curating a receiver on a static function) are reported but not applied; the analysis answer stands.
- Stale entries (algorithm digest mismatch) are applied and reported, trading a visible re-review prompt for silent loss of coverage.
- Unmatched names (no builtin in the graph) are reported and not applied, handling spec revisions and misspellings.
- A `returns` of `unknown` is a published value rather than a hole, so it passes the gate. `Unclassified(AxisReturns)` still lists it, because it remains an open question for review.

**Follow-ups this enables**

§4.4 changes the scope of the phases after it. The issue proposes closing #1286 (and its PR #1308), #1284, #1304, #1301, and #1300 outright, and reducing #1204, #1206, and #1201 — each curating the affected methods instead of growing the analyzer. Those are left open for the author to decide.

https://claude.ai/code/session_01FnsXWeGS456WxQx455nFBf



## Summary by CodeRabbit

- **New Features**
  - Added curated classifications for ECMAScript built-in methods, including receiver behavior and returned-value freshness.
  - Added curation reporting to CFG-enabled partitioning workflows, highlighting applied, corrected, redundant, and unresolved classifications.
  - Added stable fingerprints for decoded algorithms to support reliable change tracking.

- **Bug Fixes**
  - Improved handling and validation of unresolved, conflicting, stale, and unmatched classifications.
  - Refined analysis of parameter escapes and receiver-coercion behavior.

- **Documentation**
  - Updated implementation plans, requirements, command help, and coverage guidance to explain curated facts and reporting.

