### PR TITLE
Report ECMA-262 classification per determination axis

### DIFF
--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -390,17 +390,51 @@ func (f *Facts) Of(name string) (MethodFact, bool) {
 	return fact, ok
 }
 
-// Unclassified returns the names whose receiver claim FR5 hands to the
-// converter's name-based heuristics, sorted. Shrinking this list is what §4 is
-// measured by. Only a method appears, and it still publishes its return alias,
-// so the list marks a withheld determination rather than an empty fact.
-func (f *Facts) Unclassified() []string {
+// Axis names one determination a MethodFact carries. It is the unit the
+// classification is reported and reviewed in, because the analysis settles
+// each one independently and a method can be answered on one while still open
+// on another.
+type Axis string
+
+const (
+	AxisReceiver Axis = "receiver"
+	AxisReturns  Axis = "returns"
+)
+
+// Unclassified returns the names carrying no answer on axis, sorted. Shrinking
+// these lists is what §4 is measured by.
+//
+// The two axes are worth reading apart rather than summed. §7 auto-applies the
+// receiver, so a name on that list is a method whose mutability falls to FR5's
+// name-based heuristics — a soundness gap. A name on the returns list costs
+// only the lifetime precision §8.2 would have seeded from it.
+func (f *Facts) Unclassified(axis Axis) []string {
 	names := make([]string, 0, len(f.Methods))
 	for name, fact := range f.Methods {
-		if !fact.Classified.Receiver {
+		if !fact.answers(axis) {
 			names = append(names, name)
 		}
 	}
 	sort.Strings(names)
 	return names
+}
+
+// answers reports whether the fact settles axis, which is a stronger question
+// than whether Coverage marked it analyzed. A return of `unknown` is covered,
+// and it is a value §8.2 can act on, but it names nothing the caller holds. So
+// it stays an open question for a reviewer.
+//
+// An axis this does not name reads as unsettled, so an axis §8 or §9 adds shows
+// up as wholly open until it is wired in here. The alternative would have a new
+// axis read as complete for every builtin the moment it is declared, which
+// hides work rather than surfacing it.
+func (f MethodFact) answers(axis Axis) bool {
+	switch axis {
+	case AxisReceiver:
+		return f.Classified.Receiver
+	case AxisReturns:
+		return f.Classified.Returns && f.Returns.Kind != AliasUnknown
+	default:
+		return false
+	}
 }

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -432,7 +432,80 @@ func TestFactsJSON(t *testing.T) {
 // This list is the §4 objective made visible. Shrinking it is what a change to
 // the analysis is measured by, and the tallies below record the same count.
 func TestFactsUnclassifiedMethodsAreListed(t *testing.T) {
-	snaps.MatchSnapshot(t, strings.Join(testFacts(t).Unclassified(), "\n"))
+	snaps.MatchSnapshot(t, strings.Join(testFacts(t).Unclassified(AxisReceiver), "\n"))
+}
+
+// The return axis has its own gaps, and they are far wider than the receiver's.
+// `returnAlias` is total, so the coverage flag is set for every builtin. An
+// `unknown` return is a value the walk did produce, and it names nothing the
+// caller holds, which is the case `answers` reports as open.
+//
+// The two `buffer` getters are the shape behind most of the list. What they
+// hand back is a borrow of state the receiver holds, and no member of the alias
+// lattice spells that without claiming the return is the receiver itself.
+func TestFactsUnclassifiedReturnsAreListed(t *testing.T) {
+	unresolved := testFacts(t).Unclassified(AxisReturns)
+
+	require.Contains(t, unresolved, "get DataView.prototype.buffer")
+	require.Contains(t, unresolved, "get TypedArray.prototype.buffer")
+	// The same count the tallies below record as `returns unknown`.
+	require.Len(t, unresolved, 250)
+}
+
+// demoCFG is a two-method graph standing in for the shapes the committed one
+// holds. `read` returns its receiver and writes nothing, so the analysis
+// classifies both its determinations. `opaque`'s one step is prose the
+// serializer could not lower, which withholds its receiver and leaves its
+// return unresolved.
+const demoCFG = `{"specTarget":"abc","funcs":[` +
+	`{"name":"Demo.prototype.read","kind":"builtin-method","params":[],"nodes":[` +
+	`{"kind":"return","value":{"kind":"this"}}]},` +
+	`{"name":"Demo.prototype.opaque","kind":"builtin-method","params":[],"nodes":[` +
+	`{"kind":"opaque","text":["Let _x_ be whatever the host decides."]}]}]}`
+
+// demoFacts parses demoCFG and classifies it.
+func demoFacts(t *testing.T) (*CFG, map[string]MethodFact) {
+	t.Helper()
+	cfg, err := ParseCFG([]byte(demoCFG))
+	require.NoError(t, err)
+	return cfg, NewFacts(cfg).Methods
+}
+
+// The analysis leaves Demo.prototype.opaque's receiver open and settles
+// Demo.prototype.read's, which is what the axis cases below are written
+// against.
+func TestDemoGraphClassification(t *testing.T) {
+	t.Parallel()
+
+	_, methods := demoFacts(t)
+	require.Equal(t, "receiver:borrow returns:receiver", methods["Demo.prototype.read"].String())
+	require.Equal(t, "returns:unknown", methods["Demo.prototype.opaque"].String())
+}
+
+// Both axes report an open determination, each spelled the way that axis
+// spells it. `opaque` has its receiver withheld and its return resolved to the
+// lattice top, so it is open on both; `read` answers both.
+func TestUnclassifiedReadsBothAxes(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	facts := &Facts{SpecTarget: cfg.SpecTarget, Methods: methods}
+
+	require.Equal(t, []string{"Demo.prototype.opaque"}, facts.Unclassified(AxisReceiver))
+	require.Equal(t, []string{"Demo.prototype.opaque"}, facts.Unclassified(AxisReturns))
+}
+
+// An axis `answers` does not name reads as unanswered, so each determination §8
+// and §9 add shows up as wholly open until it is wired in.
+func TestUnclassifiedReadsAnUnwiredAxisAsOpen(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	facts := &Facts{SpecTarget: cfg.SpecTarget, Methods: methods}
+
+	require.Equal(t,
+		[]string{"Demo.prototype.opaque", "Demo.prototype.read"},
+		facts.Unclassified(Axis("throws")))
 }
 
 // The tallies over every builtin, which move when the mutation analysis, the


### PR DESCRIPTION
Refs #1312

First of four PRs splitting #1316. This one is the vocabulary the other three are written in; it changes no published fact.

## What it does

`Facts.Unclassified` read the receiver axis alone, so the returns axis had no report of its own. Its coverage flag is set for every builtin, because `returnAlias` is total, which left the 250 methods whose return resolves to the lattice top counted as classified.

Add `Axis` and `MethodFact.answers`, and take the axis as a parameter.

`answers` is stronger than the coverage flag on the returns axis. A return of `unknown` is a value §8.2 can act on, and it names nothing the caller holds, so it stays an open question for a reviewer.

## Why the two axes are read apart rather than summed

§7 auto-applies the receiver, so a name on that list is a method whose mutability falls to FR5's name heuristics — a soundness gap. A name on the returns list costs only the lifetime precision §8.2 would have seeded from it.

An axis `answers` does not name reads as open, so a determination §8 or §9 adds shows up as wholly unanswered until it is wired in. The alternative would have a new axis read as complete for every builtin the moment it is declared.

## What this does not change

`Coverage`/`classified` stays exactly as it is, and `facts.json` is byte-identical. The 24 withheld receivers are still withheld.

## Tests

`TestFactsUnclassifiedReturnsAreListed` pins the 250 open returns and the two `buffer` getters behind most of them. `TestUnclassifiedReadsBothAxes` and `TestUnclassifiedReadsAnUnwiredAxisAsOpen` run over a two-method demo graph, which the next PR reuses.

## The stack

Each PR is based on the one above it, so review bottom-up.

1. **This PR** — the axis vocabulary.
2. [#1319](https://github.com/escalier-lang/escalier/pull/1319) — the curated fact layer: `curated.json`, the algorithm digest, the merge, and the `analyze` seam.
3. [#1320](https://github.com/escalier-lang/escalier/pull/1320) — drop the coverage flags and fail generation on a hole.
4. [#1321](https://github.com/escalier-lang/escalier/pull/1321) — the planning-doc prose for all of it, Markdown only.

The split is by dependency rather than by file, and tests move with the code they cover. #1320 cannot precede #1319: `analyze` alone leaves 24 receiver holes, so its gate would reject the committed graph.

https://claude.ai/code/session_01FnsXWeGS456WxQx455nFBf