### PR TITLE
Add the ECMA-262 curated fact layer

### DIFF
--- a/internal/ecma262/__snapshots__/curated_test.snap
+++ b/internal/ecma262/__snapshots__/curated_test.snap
@@ -1,0 +1,30 @@
+
+[TestCurationReportOverTheCommittedGraph - 1]
+Array.prototype.toLocaleString receiver: fill-in borrow
+Date.prototype.getTime returns: fill-in fresh
+Date.prototype.getTimezoneOffset receiver: fill-in borrow
+Date.prototype.toISOString receiver: fill-in borrow
+Date.prototype.toUTCString receiver: fill-in borrow
+Date.prototype.valueOf returns: fill-in fresh
+ForInIteratorPrototype.next receiver: fill-in mutBorrow
+Number.prototype.toExponential receiver: fill-in borrow
+Number.prototype.toFixed receiver: fill-in borrow
+Number.prototype.toLocaleString receiver: fill-in borrow
+Number.prototype.toPrecision receiver: fill-in borrow
+RegExp.prototype [ @@matchAll ] receiver: fill-in borrow
+RegExp.prototype [ @@replace ] receiver: fill-in mutBorrow
+RegExp.prototype [ @@split ] receiver: fill-in borrow
+RegExpStringIteratorPrototype.next receiver: fill-in mutBorrow
+SharedArrayBuffer.prototype.grow receiver: fill-in mutBorrow
+String.prototype.normalize receiver: fill-in borrow
+String.prototype.repeat receiver: fill-in borrow
+String.prototype.split receiver: fill-in borrow
+String.prototype.toLocaleLowerCase receiver: fill-in borrow
+String.prototype.toLocaleUpperCase receiver: fill-in borrow
+String.prototype.toLowerCase receiver: fill-in borrow
+String.prototype.toUpperCase receiver: fill-in borrow
+TypedArray.prototype.slice receiver: fill-in borrow
+TypedArray.prototype.toLocaleString receiver: fill-in borrow
+get RegExp.prototype.flags receiver: fill-in borrow
+get TypedArray.prototype [ @@toStringTag ] returns: fill-in fresh
+---

--- a/internal/ecma262/cfg.go
+++ b/internal/ecma262/cfg.go
@@ -11,6 +11,8 @@
 package ecma262
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -59,6 +61,12 @@ type Func struct {
 	Variadic *int     // rest-parameter position; nil when the head declares none
 	Promise  bool     // the algorithm returns a promise
 	Nodes    []Node   // CFG nodes in flat order
+
+	// Digest fingerprints this algorithm as cfg.json serializes it. A curated
+	// entry records the digest of the algorithm its author reviewed. A spec
+	// bump then flags the entries whose algorithm it rewrote and leaves the
+	// rest alone. See curated.go.
+	Digest string
 }
 
 // Node is one step of an algorithm.
@@ -302,8 +310,9 @@ func (c *CFG) Builtin(name string) *Func {
 // The decode types mirror the serialized schema in Appendix A, where a node and
 // an expression are each one object tagged by kind. encoding/json cannot pick a
 // variant of a sealed interface on its own, so decoding lands here first and the
-// conversions below rebuild the graph as the sum types above. Nothing marshals
-// back, so these types are read only when a graph is parsed.
+// conversions below rebuild the graph as the sum types above. A decoded
+// function marshals back once, to fingerprint it for Func.Digest; nothing else
+// writes this schema.
 
 type decodeCFG struct {
 	SpecTarget string        `json:"specTarget"`
@@ -408,6 +417,11 @@ func (d *decodeFunc) toFunc(index int) (*Func, error) {
 		return nil, fmt.Errorf("%s declares a rest parameter at position %d, outside its %d parameters", d.Name, *d.Variadic, len(d.Params))
 	}
 
+	digest, err := d.digest()
+	if err != nil {
+		return nil, fmt.Errorf("fingerprinting %s: %w", d.Name, err)
+	}
+
 	fn := &Func{
 		Name:     d.Name,
 		Kind:     d.Kind,
@@ -415,6 +429,7 @@ func (d *decodeFunc) toFunc(index int) (*Func, error) {
 		Variadic: d.Variadic,
 		Promise:  d.Promise,
 		Nodes:    make([]Node, 0, len(d.Nodes)),
+		Digest:   digest,
 	}
 	for i, dn := range d.Nodes {
 		if dn == nil {
@@ -594,4 +609,30 @@ func toExprs(ds []*decodeExpr) ([]Expr, error) {
 		exprs = append(exprs, e)
 	}
 	return exprs, nil
+}
+
+// digestLen is how much of the fingerprint Func.Digest keeps. Twelve hex digits
+// distinguish the roughly twelve hundred algorithms in one graph with room to
+// spare, and stay short enough to read in curated.json.
+const digestLen = 12
+
+// digest fingerprints one serialized algorithm. It changes when any step,
+// parameter, or kind does. It does not change when cfg.json's key order or
+// whitespace does. So a curated entry naming a digest is flagged for re-review
+// by a spec bump that rewrote its algorithm, and by nothing else.
+//
+// The fingerprint is taken over the decode type rather than over Func because
+// Node is a sealed interface. encoding/json writes no tag for the variant an
+// interface holds, so two different steps could fingerprint alike.
+//
+// The decode types hold only strings, ints, bools, and slices and pointers to
+// those, so the marshal cannot fail. The error is returned rather than dropped
+// in case a later field can, which leaves that path untestable as it stands.
+func (d *decodeFunc) digest() (string, error) {
+	encoded, err := json.Marshal(d)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])[:digestLen], nil
 }

--- a/internal/ecma262/cfg_test.go
+++ b/internal/ecma262/cfg_test.go
@@ -399,3 +399,27 @@ func renderExpr(e Expr) string {
 	}
 	return "none"
 }
+
+// Two algorithms that differ fingerprint differently, and re-parsing the same
+// graph reproduces each fingerprint. Together those are what let a digest stand
+// in for "the algorithm this entry was reviewed against".
+func TestFuncDigestIdentifiesTheAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	first, _ := demoFacts(t)
+	second, err := ParseCFG([]byte(demoCFG))
+	require.NoError(t, err)
+
+	read := first.Builtin("Demo.prototype.read")
+	opaque := first.Builtin("Demo.prototype.opaque")
+	require.Len(t, read.Digest, digestLen)
+	require.NotEqual(t, read.Digest, opaque.Digest)
+	require.Equal(t, read.Digest, second.Builtin("Demo.prototype.read").Digest)
+
+	// Editing one step changes that algorithm's digest and leaves the other's
+	// alone, which is what keeps a spec bump from flagging every entry.
+	edited, err := ParseCFG([]byte(strings.Replace(demoCFG, "whatever the host decides", "something else", 1)))
+	require.NoError(t, err)
+	require.Equal(t, read.Digest, edited.Builtin("Demo.prototype.read").Digest)
+	require.NotEqual(t, opaque.Digest, edited.Builtin("Demo.prototype.opaque").Digest)
+}

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -345,17 +345,48 @@ func (f MethodFact) String() string {
 type Facts struct {
 	SpecTarget string                `json:"specTarget"`
 	Methods    map[string]MethodFact `json:"methods"`
+
+	// curationReport is what the curated layer did to the analyzed
+	// determinations. It is unexported because facts.json records the merged
+	// answer and not where each half of it came from. The name says report to
+	// keep it distinct from the Curation the merge reads. See CurationReport.
+	curationReport CurationReport
 }
 
-// NewFacts classifies every builtin in cfg. It runs the mutation fixpoint
-// itself, which supplies the receiver axis and the two warnings that withhold
-// a method's mutability claim.
+// NewFacts is the published fact set for cfg, what the converter consumes. It
+// classifies every builtin from the graph and then merges the curated layer of
+// curated.go over the result, one determination at a time.
 //
-// A published receiver claim is only as strong as §4.1. A mutation the analysis
-// does not see leaves no warning, so the borrow is published rather than
-// withheld. §6's diff against the hand-written overrides is what authorizes §7
-// to trust this source.
-func NewFacts(cfg *CFG) *Facts {
+// A published receiver claim is only as strong as the mutation analysis or as
+// the review behind a curated entry. A mutation the analysis does not see
+// leaves no warning, so the borrow is published rather than withheld. What
+// authorizes the converter to trust this source is the validation diff against
+// the hand-written overrides, which reads Curation to tell a curated claim from
+// an analyzed one.
+func NewFacts(cfg *CFG) (*Facts, error) {
+	curation, err := parseCommitted(curatedJSON)
+	if err != nil {
+		return nil, err
+	}
+	facts := analyze(cfg)
+	facts.curationReport = mergeCuration(cfg, curation, facts.Methods)
+	return facts, nil
+}
+
+// Curation reports what the curated layer did to this run's analyzed
+// determinations.
+func (f *Facts) Curation() CurationReport {
+	return f.curationReport
+}
+
+// analyze classifies every builtin in cfg from the graph alone. It runs the
+// mutation fixpoint itself, which supplies the receiver axis and the two
+// warnings that withhold a method's mutability claim.
+//
+// This is what §4 is measured by, and Facts.Unclassified over its result is the
+// objective made visible, per axis. NewFacts is what a consumer reads, since a
+// determination §4 cannot reach is answered by review rather than left open.
+func analyze(cfg *CFG) *Facts {
 	summary := NewMutationSummary(cfg)
 
 	facts := &Facts{

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -13,18 +13,37 @@ import (
 )
 
 var (
-	factsOnce sync.Once
-	allFacts  *Facts
+	factsOnce     sync.Once
+	allFacts      *Facts
+	factsErr      error
+	analyzedOnce  sync.Once
+	analyzedFacts *Facts
 )
 
-// testFacts classifies the committed graph once for the whole package.
+// testFacts is the published fact set over the committed graph, curated layer
+// merged in, classified once for the whole package. A test pinning what the
+// converter consumes reads this.
 func testFacts(t *testing.T) *Facts {
 	t.Helper()
 	cfg := testCFG(t)
-	factsOnce.Do(func() {
-		allFacts = NewFacts(cfg)
-	})
+	// The error is stored rather than asserted inside the Once, so every caller
+	// sees a failure. Asserting in there would fail the first test to arrive and
+	// hand every later one a nil fact set to dereference.
+	factsOnce.Do(func() { allFacts, factsErr = NewFacts(cfg) })
+	require.NoError(t, factsErr)
 	return allFacts
+}
+
+// testAnalyzedFacts is what the committed graph alone concludes, before
+// curated.json is merged over it. A test pinning what §4 can read off the graph
+// reads this, so a curated entry never disguises what the analysis found.
+func testAnalyzedFacts(t *testing.T) *Facts {
+	t.Helper()
+	cfg := testCFG(t)
+	analyzedOnce.Do(func() {
+		analyzedFacts = analyze(cfg)
+	})
+	return analyzedFacts
 }
 
 // fullCoverage is what NewFacts builds for a builtin it read whole.
@@ -42,11 +61,19 @@ func returnsParam(i int) ReturnFact {
 	return ReturnFact{Kind: AliasParam, Index: position(i)}
 }
 
-// factOf returns the fact for one builtin, failing when the graph does not
-// hold it.
+// factOf returns the published fact for one builtin, failing when the graph
+// does not hold it.
 func factOf(t *testing.T, name string) MethodFact {
 	t.Helper()
 	fact, ok := testFacts(t).Of(name)
+	require.True(t, ok, "no builtin named %s", name)
+	return fact
+}
+
+// analyzedFactOf returns what the analysis alone concluded about one builtin.
+func analyzedFactOf(t *testing.T, name string) MethodFact {
+	t.Helper()
+	fact, ok := testAnalyzedFacts(t).Of(name)
 	require.True(t, ok, "no builtin named %s", name)
 	return fact
 }
@@ -165,6 +192,10 @@ func TestAliasJoin(t *testing.T) {
 	}
 }
 
+// What §4.3 concludes from the graph alone, one method per shape. These read
+// the analysis rather than the published facts, so a curated entry that later
+// fills one of these determinations cannot hide what the graph does and does
+// not settle.
 func TestFactsSampleMethods(t *testing.T) {
 	tests := map[string]struct {
 		method string
@@ -252,7 +283,7 @@ func TestFactsSampleMethods(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.want, factOf(t, test.method).String())
+			require.Equal(t, test.want, analyzedFactOf(t, test.method).String())
 		})
 	}
 }
@@ -265,7 +296,7 @@ func TestFactsSampleMethods(t *testing.T) {
 func TestFactsEveryStringMethodBorrowsItsReceiver(t *testing.T) {
 	var borrowed int
 	var unread []string
-	for name, fact := range testFacts(t).Methods {
+	for name, fact := range testAnalyzedFacts(t).Methods {
 		if !strings.HasPrefix(name, "String.prototype") {
 			continue
 		}
@@ -360,7 +391,9 @@ func TestFactsUnionOverTwoReturnedParameters(t *testing.T) {
 			`{"kind":"return","value":{"kind":"var","var":"b"}}]}]}`))
 	require.NoError(t, err)
 
-	fact, ok := NewFacts(cfg).Of("Demo.pick")
+	facts, err := NewFacts(cfg)
+	require.NoError(t, err)
+	fact, ok := facts.Of("Demo.pick")
 	require.True(t, ok)
 	require.Equal(t, "receiver:none returns:union(param(0), param(1))", fact.String())
 
@@ -390,9 +423,10 @@ func TestFactsJSON(t *testing.T) {
 		want string
 	}{
 		"Method": {factOf(t, "Array.prototype.fill"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":{"kind":"receiver"}}`},
-		// A withheld receiver falls through to FR5's `&mut self`, so the entry
-		// carries the return alias alone.
-		"WithheldReceiver": {factOf(t, "Array.prototype.toLocaleString"), `{"classified":{"receiver":false,"returns":true},"returns":{"kind":"fresh"}}`},
+		// A receiver the analysis withheld carries the return alias alone. An
+		// entry in curated.json answers this one, so the rendering only ever
+		// comes off an analyze result.
+		"WithheldReceiver": {analyzedFactOf(t, "Array.prototype.toLocaleString"), `{"classified":{"receiver":false,"returns":true},"returns":{"kind":"fresh"}}`},
 		// The first parameter is written out like any other position. Every
 		// parameter the committed graph returns sits at 0, so omitting it would
 		// leave the index absent from the whole file and spell the common case
@@ -423,33 +457,38 @@ func TestFactsJSON(t *testing.T) {
 	}
 }
 
-// The methods whose receiver claim FR5 hands to the converter's name
-// heuristics. Each carries a mutation the analysis could not place or a step it
-// could not read, so its mutability is withheld rather than guessed, and each
-// still publishes its return alias. A static is absent, having no receiver for
-// a warning to cost it.
+// The methods whose receiver the analysis withholds. Each carries a mutation it
+// could not place or a step it could not read, so the mutability is withheld
+// rather than guessed, and each still publishes its return alias. A static is
+// absent, having no receiver for a warning to cost it.
 //
-// This list is the §4 objective made visible. Shrinking it is what a change to
-// the analysis is measured by, and the tallies below record the same count.
+// This list is the §4 objective made visible, and shrinking it is what a change
+// to the analysis is measured by. Every name on it is answered by an entry in
+// curated.json, so nothing reaches §7's name heuristics, which is what the
+// second assertion holds.
 func TestFactsUnclassifiedMethodsAreListed(t *testing.T) {
-	snaps.MatchSnapshot(t, strings.Join(testFacts(t).Unclassified(AxisReceiver), "\n"))
+	snaps.MatchSnapshot(t, strings.Join(testAnalyzedFacts(t).Unclassified(AxisReceiver), "\n"))
+	require.Empty(t, testFacts(t).Unclassified(AxisReceiver))
 }
 
-// The return axis has its own gaps, and they are far wider than the receiver's.
-// `returnAlias` is total, so the coverage flag is set for every builtin. An
-// `unknown` return is a value the walk did produce, and it names nothing the
-// caller holds, which is the case `answers` reports as open.
+// The return axis is where the published surface still has gaps. `returnAlias`
+// is total, so the coverage flag is set for every builtin, and `answers` is what
+// separates a return naming a value the caller holds from an `unknown` naming
+// none.
 //
-// The two `buffer` getters are the shape behind most of the list. What they
-// hand back is a borrow of state the receiver holds, and no member of the alias
-// lattice spells that without claiming the return is the receiver itself.
+// `Date.prototype.getTime` is off the list because an entry answered it. The
+// two `buffer` getters stay on it deliberately: what they hand back is a borrow
+// of state the receiver holds, and no member of the alias lattice spells that
+// without claiming the return is the receiver itself.
 func TestFactsUnclassifiedReturnsAreListed(t *testing.T) {
 	unresolved := testFacts(t).Unclassified(AxisReturns)
 
 	require.Contains(t, unresolved, "get DataView.prototype.buffer")
 	require.Contains(t, unresolved, "get TypedArray.prototype.buffer")
+	require.NotContains(t, unresolved, "Date.prototype.getTime")
+	require.NotContains(t, unresolved, "Date.prototype.valueOf")
 	// The same count the tallies below record as `returns unknown`.
-	require.Len(t, unresolved, 250)
+	require.Len(t, unresolved, 247)
 }
 
 // demoCFG is a two-method graph standing in for the shapes the committed one
@@ -463,12 +502,12 @@ const demoCFG = `{"specTarget":"abc","funcs":[` +
 	`{"name":"Demo.prototype.opaque","kind":"builtin-method","params":[],"nodes":[` +
 	`{"kind":"opaque","text":["Let _x_ be whatever the host decides."]}]}]}`
 
-// demoFacts parses demoCFG and classifies it.
+// demoFacts parses demoCFG and classifies it from the graph alone.
 func demoFacts(t *testing.T) (*CFG, map[string]MethodFact) {
 	t.Helper()
 	cfg, err := ParseCFG([]byte(demoCFG))
 	require.NoError(t, err)
-	return cfg, NewFacts(cfg).Methods
+	return cfg, analyze(cfg).Methods
 }
 
 // The analysis leaves Demo.prototype.opaque's receiver open and settles
@@ -508,10 +547,10 @@ func TestUnclassifiedReadsAnUnwiredAxisAsOpen(t *testing.T) {
 		facts.Unclassified(Axis("throws")))
 }
 
-// The tallies over every builtin, which move when the mutation analysis, the
-// origin map, or the classification changes. Each determination is counted on
-// its own, so the return-alias distribution spans every builtin while the
-// receiver one leaves out the methods that withhold it.
+// The tallies over every published builtin, which move when the mutation
+// analysis, the origin map, the classification, or curated.json changes. Each
+// determination is counted on its own. No `receiver unclassified` line appears,
+// because curated.json answers every receiver the analysis withheld.
 func TestFactsTallies(t *testing.T) {
 	counts := map[string]int{}
 	for _, fact := range testFacts(t).Methods {
@@ -533,14 +572,13 @@ func TestFactsTallies(t *testing.T) {
 		lines = append(lines, fmt.Sprintf("%s: %d", key, count))
 	}
 	sort.Strings(lines)
-	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`receiver borrow: 226
-receiver mutBorrow: 63
+	snaps.MatchInlineSnapshot(t, strings.Join(lines, "\n"), snaps.Inline(`receiver borrow: 246
+receiver mutBorrow: 67
 receiver none: 188
-receiver unclassified: 24
-returns fresh: 229
+returns fresh: 232
 returns param: 6
 returns receiver: 15
 returns union: 1
-returns unknown: 250
+returns unknown: 247
 total: 501`))
 }

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -1,0 +1,456 @@
+package ecma262
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// curated.go holds the hand-written fact layer described in
+// planning/ecma-262/implementation_plan.md §4.4. The analyses in origin.go,
+// mutation.go, and throws.go answer the determinations they can read off the
+// control-flow graph. This layer answers the rest by review, so a determination
+// the graph does not settle costs a curated entry rather than more analyzer.
+//
+// The layer is merged per determination, never per method. A curated entry that
+// names the receiver leaves the same method's return alias to the analysis, so
+// the two sources compose instead of one shadowing the other.
+
+//go:embed curated.json
+var curatedJSON []byte
+
+// parseCommitted parses the committed layer and names the file in any failure,
+// so a caller that never chose the bytes is told which file to fix. The file
+// ships in the binary, so a failure is a defect in committed data rather than
+// something a caller can fix. It is still returned rather than raised: a bad
+// edit then reaches the caller instead of killing every binary that imports
+// this package before main runs, which matters most for the LSP server, where a
+// diagnostic beats a crash.
+//
+// It takes the bytes rather than reading curatedJSON directly, which is what
+// lets a test reach the failure path the embedded file cannot produce.
+func parseCommitted(data []byte) (*Curation, error) {
+	curation, err := ParseCuration(data)
+	if err != nil {
+		return nil, fmt.Errorf("committed curated.json is invalid: %w", err)
+	}
+	return curation, nil
+}
+
+// CuratedEntry is one reviewed record, keyed in curated.json by the canonical
+// spec name of Appendix C. It carries the determination fields of a MethodFact
+// plus the provenance a reviewer needs.
+//
+// An entry answers the axes it carries a value for, and no others. Neither
+// determination has a valid zero value — "" is not a ReceiverKind and not an
+// AliasKind — so a field left out is unambiguously an axis left to the
+// analysis, whose answer for it stands, settled or withheld alike.
+//
+// So the two axes of one method can come from different sources.
+// `Date.prototype.getTime` carries a return alias and no receiver, because the
+// analysis already reads its receiver as `borrow` and only the return needs
+// review.
+type CuratedEntry struct {
+	// Reason is why the curated answer is right, in the reviewer's words. It
+	// is required, because a claim that outranks the analysis without a stated
+	// argument cannot be re-reviewed.
+	Reason string `json:"reason"`
+	// Evidence names where the reason was checked, such as a spec clause, an
+	// MDN page, or an engine the behavior was observed in.
+	Evidence string `json:"evidence,omitempty"`
+	// ReviewedAt is the Func.Digest of the algorithm at review time. A graph
+	// whose digest differs holds an algorithm rewritten since the review, and
+	// CurationReport lists that entry as stale.
+	ReviewedAt string `json:"reviewedAt"`
+
+	Receiver ReceiverKind `json:"receiver,omitempty"`
+	Returns  ReturnFact   `json:"returns,omitzero"`
+}
+
+// claimsReceiver reports whether the entry answers the receiver axis.
+func (e CuratedEntry) claimsReceiver() bool { return e.Receiver != "" }
+
+// claimsReturns reports whether the entry answers the return axis. A fact that
+// carries a position or members but no kind is malformed rather than absent, so
+// it claims the axis and validate refuses it.
+func (e CuratedEntry) claimsReturns() bool { return !e.Returns.IsZero() }
+
+// Curation is the whole committed layer.
+type Curation struct {
+	Entries map[string]CuratedEntry `json:"entries"`
+}
+
+// CurationNoteKind says what one curated axis did to the analysis's answer.
+type CurationNoteKind string
+
+const (
+	// CurationFillIn is a curated axis the analysis left open, so the entry
+	// adds a claim where there was none. It is the ordinary case and carries no
+	// conflict. A receiver is open when the analysis carried no value for it,
+	// and a return alias is open when it resolved to `unknown` too, since the
+	// top of the alias lattice names no value the return hands back.
+	CurationFillIn CurationNoteKind = "fill-in"
+	// CurationCorrection is a curated axis contradicting a claim the analysis
+	// published. §6's validation diff reads these first, because a correction
+	// is either a spec subtlety the graph cannot express or an analyzer bug,
+	// and the report cannot tell the two apart.
+	CurationCorrection CurationNoteKind = "correction"
+	// CurationRedundant is a curated axis repeating what the analysis already
+	// concluded. The entry can be deleted, which is how the layer shrinks as
+	// the analysis improves rather than accumulating.
+	CurationRedundant CurationNoteKind = "redundant"
+)
+
+// CurationNote records one curated axis and what it did.
+type CurationNote struct {
+	Name string
+	Axis Axis
+	Kind CurationNoteKind
+	// Analyzed renders the claim the analysis published. It is empty on a
+	// fill-in, where there was no claim to displace.
+	Analyzed string
+	// Curated renders the claim the entry supplied.
+	Curated string
+}
+
+func (n CurationNote) String() string {
+	if n.Kind == CurationFillIn {
+		return fmt.Sprintf("%s %s: %s %s", n.Name, n.Axis, n.Kind, n.Curated)
+	}
+	return fmt.Sprintf("%s %s: %s %s over %s", n.Name, n.Axis, n.Kind, n.Curated, n.Analyzed)
+}
+
+// CurationReport is what one merge of the layer did, for review rather than for
+// the wire. facts.json records the merged determinations and not where each one
+// came from, because the converter applies a curated receiver claim and an
+// analyzed one identically. Provenance is a reviewer's concern, so it lives
+// here.
+type CurationReport struct {
+	// Notes holds one entry per curated axis, sorted by name and then axis.
+	Notes []CurationNote
+	// Stale holds the names whose algorithm changed since the entry was
+	// reviewed, sorted. A stale entry is still applied. The spec rewriting an
+	// algorithm rarely invalidates the reviewed claim, and dropping the entry
+	// would trade a visible re-review prompt for a silent loss of coverage.
+	Stale []string
+	// Unmatched holds the curated names the graph holds no builtin for,
+	// sorted. A misspelled key and a key from another spec revision both land
+	// here, and TestCurationMatchesTheGraph is what turns the first into a
+	// failing build.
+	Unmatched []string
+	// Refused holds the curated axes the graph contradicts outright, one
+	// rendered line each, in the order the entries were read. A refused axis is
+	// not applied. receiverConflict is the only contradiction this can hold.
+	Refused []string
+}
+
+// Counts tallies the notes by kind, which is what WriteCurationReport's
+// one-line summary is built from.
+func (r CurationReport) Counts() map[CurationNoteKind]int {
+	counts := map[CurationNoteKind]int{}
+	for _, note := range r.Notes {
+		counts[note.Kind]++
+	}
+	return counts
+}
+
+// ParseCuration decodes the curated layer, rejects an entry that cannot be
+// reviewed or applied, and puts each union's members in canonical order. An
+// entry validate refuses is a defect in committed data rather than one to merge
+// as written. See CuratedEntry.validate for what it refuses.
+func ParseCuration(data []byte) (*Curation, error) {
+	var curation Curation
+	if err := json.Unmarshal(data, &curation); err != nil {
+		return nil, fmt.Errorf("decoding curation: %w", err)
+	}
+	for _, name := range sortedNames(curation.Entries) {
+		entry := curation.Entries[name]
+		if err := entry.validate(); err != nil {
+			return nil, fmt.Errorf("curated entry %s: %w", name, err)
+		}
+		sortMembers(entry.Returns.Members)
+		curation.Entries[name] = entry
+	}
+	return &curation, nil
+}
+
+// sortMembers puts a union's members in the order newReturnFact leaves them, by
+// kind and then by position. A curated union is written by hand in whatever
+// order reads best. Comparing one against an analyzed fact and rendering one
+// both assume the single canonical order, so parsing imposes it.
+func sortMembers(members []AliasRef) {
+	sort.Slice(members, func(i, j int) bool {
+		if members[i].Kind != members[j].Kind {
+			return members[i].Kind < members[j].Kind
+		}
+		return refPosition(members[i]) < refPosition(members[j])
+	})
+}
+
+// refPosition is the position a member sorts by. Only a parameter carries one,
+// and validate has already refused a parameter member without one.
+func refPosition(ref AliasRef) int {
+	if ref.Index == nil {
+		return 0
+	}
+	return *ref.Index
+}
+
+// validate reports why an entry cannot be reviewed or applied, and nil when it
+// can.
+func (e CuratedEntry) validate() error {
+	if e.Reason == "" {
+		return fmt.Errorf("has no reason")
+	}
+	if e.ReviewedAt == "" {
+		return fmt.Errorf("has no reviewedAt digest")
+	}
+	if !e.claimsReceiver() && !e.claimsReturns() {
+		return fmt.Errorf("answers no determination")
+	}
+	if e.claimsReceiver() {
+		switch e.Receiver {
+		case RecvBorrow, RecvMutBorrow, RecvNone:
+		default:
+			return fmt.Errorf("names receiver %q, which is not a receiver kind", e.Receiver)
+		}
+	}
+	if e.claimsReturns() {
+		return e.Returns.validate()
+	}
+	return nil
+}
+
+// validate reports why a return fact cannot be applied, and nil when it can.
+// It holds the same invariants newReturnFact builds. A parameter return names
+// its position. A union names at least two distinct members, none of which is
+// itself a union or an `unknown`. No other kind carries a position or members.
+func (r ReturnFact) validate() error {
+	switch r.Kind {
+	case AliasParam:
+		if r.Index == nil {
+			return fmt.Errorf("returns a parameter but names no position")
+		}
+		if *r.Index < 0 {
+			return fmt.Errorf("returns the parameter at position %d", *r.Index)
+		}
+	case AliasUnion:
+		if len(r.Members) < 2 {
+			return fmt.Errorf("returns a union of %d members", len(r.Members))
+		}
+		// Each member is checked whole before it is compared against the ones
+		// already seen, so a member missing its position is reported as
+		// malformed rather than colliding at the position refPosition falls
+		// back to.
+		seen := set.NewSet[alias]()
+		for _, member := range r.Members {
+			// A union names the values its several returns hand back.
+			// `union` names a set of them and `unknown` names none, so
+			// neither is a value a member could stand for.
+			if member.Kind == AliasUnion || member.Kind == AliasUnknown {
+				return fmt.Errorf("returns a union holding %s", member.Kind)
+			}
+			if err := (ReturnFact{Kind: member.Kind, Index: member.Index}).validate(); err != nil {
+				return fmt.Errorf("union member: %w", err)
+			}
+			value := alias{Kind: member.Kind, Index: refPosition(member)}
+			if seen.Contains(value) {
+				return fmt.Errorf("returns a union naming %s twice", member)
+			}
+			seen.Add(value)
+		}
+	case AliasReceiver, AliasFresh, AliasUnknown:
+	default:
+		return fmt.Errorf("returns %q, which is not an alias kind", r.Kind)
+	}
+	if r.Kind != AliasParam && r.Index != nil {
+		return fmt.Errorf("returns %s but names a position", r.Kind)
+	}
+	if r.Kind != AliasUnion && len(r.Members) > 0 {
+		return fmt.Errorf("returns %s but names union members", r.Kind)
+	}
+	return nil
+}
+
+// IsZero reports whether the fact carries no claim at all. encoding/json's
+// omitzero consults it, so a curated entry that answers only the receiver
+// leaves `returns` out. A published MethodFact never renders that way, because
+// generation refuses a fact with a hole in it.
+func (r ReturnFact) IsZero() bool {
+	return r.Kind == "" && r.Index == nil && len(r.Members) == 0
+}
+
+// equal reports whether two return facts make the same claim. Members are
+// compared in order, which both newReturnFact and ParseCuration leave sorted by
+// kind and then position.
+func (r ReturnFact) equal(other ReturnFact) bool {
+	if r.Kind != other.Kind || len(r.Members) != len(other.Members) {
+		return false
+	}
+	if (r.Index == nil) != (other.Index == nil) {
+		return false
+	}
+	if r.Index != nil && *r.Index != *other.Index {
+		return false
+	}
+	for i, member := range r.Members {
+		if !(ReturnFact{Kind: member.Kind, Index: member.Index}).equal(
+			ReturnFact{Kind: other.Members[i].Kind, Index: other.Members[i].Index}) {
+			return false
+		}
+	}
+	return true
+}
+
+// mergeCuration merges the layer over the analyzed facts in place and reports
+// what each curated axis did. A name the graph holds no builtin for is reported
+// and applied to nothing, so an entry from another spec revision degrades to a
+// report line rather than inventing a method.
+func mergeCuration(cfg *CFG, curation *Curation, methods map[string]MethodFact) CurationReport {
+	var report CurationReport
+	for _, name := range sortedNames(curation.Entries) {
+		entry := curation.Entries[name]
+		fn := cfg.Builtin(name)
+		if fn == nil {
+			report.Unmatched = append(report.Unmatched, name)
+			continue
+		}
+		if fn.Digest != entry.ReviewedAt {
+			report.Stale = append(report.Stale, name)
+		}
+
+		fact := methods[name]
+		if entry.claimsReceiver() {
+			if reason := receiverConflict(fn, entry.Receiver); reason != "" {
+				report.Refused = append(report.Refused,
+					fmt.Sprintf("%s %s: curated %s, but %s", name, AxisReceiver, entry.Receiver, reason))
+			} else {
+				report.Notes = append(report.Notes, receiverNote(name, fact, entry))
+				fact.Receiver = entry.Receiver
+				// A reviewed answer covers the axis as fully as an analyzed
+				// one, so the flag reads the same for both. Facts.Unclassified
+				// is what tells them apart, over analyze rather than NewFacts.
+				fact.Classified.Receiver = true
+			}
+		}
+		if entry.claimsReturns() {
+			report.Notes = append(report.Notes, returnsNote(name, fact, entry))
+			fact.Returns = entry.Returns
+			fact.Classified.Returns = true
+		}
+		methods[name] = fact
+	}
+	return report
+}
+
+// receiverConflict reports why fn cannot take the curated receiver kind, and ""
+// when it can.
+//
+// Whether a builtin has a receiver at all follows from Func.Kind rather than
+// from any algorithm step, so the graph settles it outright and no review can
+// move it. §7 auto-applies the receiver claim, so a `borrow` curated onto a
+// static would put a `&self` on a declaration that has no self. That is the one
+// curated mistake the converter cannot absorb.
+func receiverConflict(fn *Func, kind ReceiverKind) string {
+	switch {
+	case fn.Kind == BuiltinMethod && kind == RecvNone:
+		return "a " + string(fn.Kind) + " has a receiver"
+	case fn.Kind != BuiltinMethod && kind != RecvNone:
+		return "a " + string(fn.Kind) + " has no receiver"
+	default:
+		return ""
+	}
+}
+
+// receiverNote reads one curated receiver claim against what the analysis
+// concluded for the same method.
+func receiverNote(name string, analyzed MethodFact, entry CuratedEntry) CurationNote {
+	note := CurationNote{Name: name, Axis: AxisReceiver, Curated: string(entry.Receiver)}
+	switch {
+	case analyzed.Receiver == "":
+		note.Kind = CurationFillIn
+	case analyzed.Receiver == entry.Receiver:
+		note.Kind = CurationRedundant
+		note.Analyzed = string(analyzed.Receiver)
+	default:
+		note.Kind = CurationCorrection
+		note.Analyzed = string(analyzed.Receiver)
+	}
+	return note
+}
+
+// returnsNote reads one curated return alias against what the analysis
+// concluded for the same method.
+//
+// returnAlias is total, so a builtin always carries a covered return. An
+// `unknown` one is nonetheless a return the walk could not tie to any value, so
+// a curated answer over it adds information rather than contradicting a claim.
+// It reads as a fill-in, which keeps the corrections list to the entries where
+// the two sources genuinely disagree.
+func returnsNote(name string, analyzed MethodFact, entry CuratedEntry) CurationNote {
+	note := CurationNote{Name: name, Axis: AxisReturns, Curated: entry.Returns.String()}
+	switch {
+	case analyzed.Returns.Kind == "" || analyzed.Returns.Kind == AliasUnknown:
+		note.Kind = CurationFillIn
+	case analyzed.Returns.equal(entry.Returns):
+		note.Kind = CurationRedundant
+		note.Analyzed = analyzed.Returns.String()
+	default:
+		note.Kind = CurationCorrection
+		note.Analyzed = analyzed.Returns.String()
+	}
+	return note
+}
+
+// sortedNames returns a curation's keys in order, so a report and a merge both
+// read the entries the same way whatever order the map hands them back.
+func sortedNames(entries map[string]CuratedEntry) []string {
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// WriteCurationReport prints the merge's tallies and every line that needs a
+// reviewer. A fill-in is the ordinary case and is summarized rather than
+// listed. A correction, a redundant entry, a stale entry, an unmatched name,
+// and a refused axis each name something to act on, so each is printed in full.
+func WriteCurationReport(report CurationReport, w io.Writer) error {
+	counts := report.Counts()
+	_, err := fmt.Fprintf(w, "  curation: %d fill-ins, %d corrections, %d redundant, %d stale, %d unmatched, %d refused\n",
+		counts[CurationFillIn], counts[CurationCorrection], counts[CurationRedundant],
+		len(report.Stale), len(report.Unmatched), len(report.Refused))
+	if err != nil {
+		return err
+	}
+	for _, note := range report.Notes {
+		if note.Kind == CurationFillIn {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "    %s\n", note); err != nil {
+			return err
+		}
+	}
+	for _, name := range report.Stale {
+		if _, err := fmt.Fprintf(w, "    %s: reviewed against an algorithm the graph no longer holds\n", name); err != nil {
+			return err
+		}
+	}
+	for _, name := range report.Unmatched {
+		if _, err := fmt.Fprintf(w, "    %s: curated, but the graph holds no such builtin\n", name); err != nil {
+			return err
+		}
+	}
+	for _, line := range report.Refused {
+		if _, err := fmt.Fprintf(w, "    %s\n", line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/ecma262/curated.json
+++ b/internal/ecma262/curated.json
@@ -1,0 +1,166 @@
+{
+  "entries": {
+    "Array.prototype.toLocaleString": {
+      "reason": "Reads the receiver's elements and calls toLocaleString on each. The one step the serializer left opaque binds the host's list separator, which writes nothing.",
+      "evidence": "ECMA-262 \"Array.prototype.toLocaleString\"",
+      "reviewedAt": "f3203d8f63ec",
+      "receiver": "borrow"
+    },
+    "Date.prototype.getTime": {
+      "reason": "Returns the Number held in [[DateValue]]. A primitive read out of a slot is a copy, so the return borrows nothing the caller holds. The analysis withholds the alias because telling a primitive slot from an object one needs the declared return type, which cfg.json does not carry.",
+      "evidence": "ECMA-262 \"Date.prototype.getTime\"",
+      "reviewedAt": "0d4b34259cd2",
+      "returns": { "kind": "fresh" }
+    },
+    "Date.prototype.getTimezoneOffset": {
+      "reason": "Reads [[DateValue]] and computes an offset from it. The opaque step is the local time zone calculation, which writes nothing.",
+      "evidence": "ECMA-262 \"Date.prototype.getTimezoneOffset\"",
+      "reviewedAt": "0f3dbfa75247",
+      "receiver": "borrow"
+    },
+    "Date.prototype.toISOString": {
+      "reason": "Formats [[DateValue]] as a string. The opaque steps build that string and write nothing.",
+      "evidence": "ECMA-262 \"Date.prototype.toISOString\"",
+      "reviewedAt": "e0ab062821e6",
+      "receiver": "borrow"
+    },
+    "Date.prototype.toUTCString": {
+      "reason": "Formats [[DateValue]] as a string. The opaque steps build that string and write nothing.",
+      "evidence": "ECMA-262 \"Date.prototype.toUTCString\"",
+      "reviewedAt": "2a344681528d",
+      "receiver": "borrow"
+    },
+    "Date.prototype.valueOf": {
+      "reason": "Returns the Number held in [[DateValue]]. A primitive read out of a slot is a copy, so the return borrows nothing the caller holds.",
+      "evidence": "ECMA-262 \"Date.prototype.valueOf\"",
+      "reviewedAt": "f9599ef775ef",
+      "returns": { "kind": "fresh" }
+    },
+    "ForInIteratorPrototype.next": {
+      "reason": "Advances the iterator by writing [[RemainingKeys]], [[VisitedKeys]], [[Object]], and [[ObjectWasVisited]] on the receiver. The opaque step is the assertion over those slots.",
+      "evidence": "ECMA-262 \"%ForInIteratorPrototype%.next\"",
+      "reviewedAt": "9ac59fc3b816",
+      "receiver": "mutBorrow"
+    },
+    "Number.prototype.toExponential": {
+      "reason": "Reads the receiver's number value and formats it. Every opaque step names a digit string it computes.",
+      "evidence": "ECMA-262 \"Number.prototype.toExponential\"",
+      "reviewedAt": "243e70d48235",
+      "receiver": "borrow"
+    },
+    "Number.prototype.toFixed": {
+      "reason": "Reads the receiver's number value and formats it. Every opaque step names a digit string it computes, such as \"Let a be the first k - f code units of m\".",
+      "evidence": "ECMA-262 \"Number.prototype.toFixed\"",
+      "reviewedAt": "1836cd89dd25",
+      "receiver": "borrow"
+    },
+    "Number.prototype.toLocaleString": {
+      "reason": "Reads the receiver's number value and formats it for the host locale. The formatting is implementation-defined and writes nothing.",
+      "evidence": "ECMA-262 \"Number.prototype.toLocaleString\"",
+      "reviewedAt": "3229a7c40342",
+      "receiver": "borrow"
+    },
+    "Number.prototype.toPrecision": {
+      "reason": "Reads the receiver's number value and formats it. Every opaque step names a digit string it computes.",
+      "evidence": "ECMA-262 \"Number.prototype.toPrecision\"",
+      "reviewedAt": "99d8cac517b0",
+      "receiver": "borrow"
+    },
+    "RegExp.prototype [ @@matchAll ]": {
+      "reason": "Reads flags and lastIndex off the receiver, then writes lastIndex on matcher, the object SpeciesConstructor built. The write the analysis could not place lands on matcher rather than on the receiver. A @@species that hands the receiver back would make the two one object, which is the documented species exception.",
+      "evidence": "ECMA-262 \"RegExp.prototype [ %Symbol.matchAll% ]\"",
+      "reviewedAt": "c2cb8f3fdb97",
+      "receiver": "borrow"
+    },
+    "RegExp.prototype [ @@replace ]": {
+      "reason": "Writes lastIndex on the receiver through Set(rx, \"lastIndex\", ...) when the pattern is global. The opaque steps build the replacement string.",
+      "evidence": "ECMA-262 \"RegExp.prototype [ %Symbol.replace% ]\"",
+      "reviewedAt": "4b29b7f53c9e",
+      "receiver": "mutBorrow"
+    },
+    "RegExp.prototype [ @@split ]": {
+      "reason": "Writes only into A, the array it allocates, and into splitter, the object SpeciesConstructor built. Every step touching the receiver reads it. Same species exception as RegExp.prototype [ @@matchAll ].",
+      "evidence": "ECMA-262 \"RegExp.prototype [ %Symbol.split% ]\"",
+      "reviewedAt": "64e67b1e3216",
+      "receiver": "borrow"
+    },
+    "RegExpStringIteratorPrototype.next": {
+      "reason": "Writes [[Done]] on the receiver. It also writes lastIndex on the regular expression held in [[IteratingRegExp]], which it reaches through the receiver.",
+      "evidence": "ECMA-262 \"%RegExpStringIteratorPrototype%.next\"",
+      "reviewedAt": "496d4222b7b1",
+      "receiver": "mutBorrow"
+    },
+    "SharedArrayBuffer.prototype.grow": {
+      "reason": "Grows the buffer by writing, through AtomicCompareExchangeInSharedBlock, the block it read out of the receiver's [[ArrayBufferByteLengthData]]. The new byte length is observable on the receiver afterwards.",
+      "evidence": "ECMA-262 \"SharedArrayBuffer.prototype.grow\"",
+      "reviewedAt": "78f695c8902d",
+      "receiver": "mutBorrow"
+    },
+    "String.prototype.normalize": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The opaque step is the Unicode normalization itself.",
+      "evidence": "ECMA-262 \"String.prototype.normalize\"",
+      "reviewedAt": "9c0df67c56b0",
+      "receiver": "borrow"
+    },
+    "String.prototype.repeat": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The opaque step builds the repeated string.",
+      "evidence": "ECMA-262 \"String.prototype.repeat\"",
+      "reviewedAt": "1a54e17c9f5e",
+      "receiver": "borrow"
+    },
+    "String.prototype.split": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. Reading @@split off separator can run arbitrary code, and that code reaches nothing the receiver holds.",
+      "evidence": "ECMA-262 \"String.prototype.split\"",
+      "reviewedAt": "3120ebfb8574",
+      "receiver": "borrow"
+    },
+    "String.prototype.toLocaleLowerCase": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a locale-sensitive Unicode table lookup.",
+      "evidence": "ECMA-262 \"String.prototype.toLocaleLowerCase\"",
+      "reviewedAt": "d75a8d944557",
+      "receiver": "borrow"
+    },
+    "String.prototype.toLocaleUpperCase": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a locale-sensitive Unicode table lookup.",
+      "evidence": "ECMA-262 \"String.prototype.toLocaleUpperCase\"",
+      "reviewedAt": "fc11d8ee1b51",
+      "receiver": "borrow"
+    },
+    "String.prototype.toLowerCase": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a Unicode table lookup ESMeta does not formalize.",
+      "evidence": "ECMA-262 \"String.prototype.toLowerCase\"",
+      "reviewedAt": "2bf52d68c976",
+      "receiver": "borrow"
+    },
+    "String.prototype.toUpperCase": {
+      "reason": "A String is an immutable primitive, so no step can write the receiver. The whole algorithm is opaque because the case mapping is a Unicode table lookup ESMeta does not formalize.",
+      "evidence": "ECMA-262 \"String.prototype.toUpperCase\"",
+      "reviewedAt": "d1c5c3231872",
+      "receiver": "borrow"
+    },
+    "TypedArray.prototype.slice": {
+      "reason": "Reads the receiver's elements and writes into A, the array TypedArraySpeciesCreate built. The opaque step clamps endIndex against the receiver's length. Same species exception as RegExp.prototype [ @@matchAll ].",
+      "evidence": "ECMA-262 \"%TypedArray%.prototype.slice\"",
+      "reviewedAt": "b6c7f0d042a5",
+      "receiver": "borrow"
+    },
+    "TypedArray.prototype.toLocaleString": {
+      "reason": "Reads the receiver's elements and calls toLocaleString on each. The opaque step binds the host's list separator.",
+      "evidence": "ECMA-262 \"%TypedArray%.prototype.toLocaleString\"",
+      "reviewedAt": "cf74dfcb19a6",
+      "receiver": "borrow"
+    },
+    "get RegExp.prototype.flags": {
+      "reason": "Reads each flag off the receiver with Get and appends code units to codeUnits, a list the getter allocates. The opaque step turns that list into the returned String.",
+      "evidence": "ECMA-262 \"get RegExp.prototype.flags\"",
+      "reviewedAt": "c509f1f9469f",
+      "receiver": "borrow"
+    },
+    "get TypedArray.prototype [ @@toStringTag ]": {
+      "reason": "Returns the String held in [[TypedArrayName]]. A primitive read out of a slot is a copy, so the return borrows nothing the caller holds.",
+      "evidence": "ECMA-262 \"get %TypedArray%.prototype [ %Symbol.toStringTag% ]\"",
+      "reviewedAt": "75c3313dedc9",
+      "returns": { "kind": "fresh" }
+    }
+  }
+}

--- a/internal/ecma262/curated_test.go
+++ b/internal/ecma262/curated_test.go
@@ -1,0 +1,512 @@
+package ecma262
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// entry builds a curated entry claiming one receiver, reviewed against the
+// digest the graph currently holds for name.
+func entry(t *testing.T, cfg *CFG, name string, kind ReceiverKind) CuratedEntry {
+	t.Helper()
+	fn := cfg.Builtin(name)
+	require.NotNil(t, fn, "no builtin named %s", name)
+	return CuratedEntry{
+		Reason:     "stated for the test",
+		ReviewedAt: fn.Digest,
+		Receiver:   kind,
+	}
+}
+
+// returnsEntry builds a curated entry claiming one return alias, reviewed
+// against the digest the graph currently holds for name.
+func returnsEntry(t *testing.T, cfg *CFG, name string, returns ReturnFact) CuratedEntry {
+	t.Helper()
+	e := entry(t, cfg, name, RecvBorrow)
+	e.Receiver = ""
+	e.Returns = returns
+	return e
+}
+
+// A curated axis reaches the published fact, and the note says what it did to
+// the analysis's answer.
+func TestMergeCuration(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		entries func(*CFG) map[string]CuratedEntry
+		// want is the merged fact for the name the entry addresses.
+		name string
+		want string
+		note string
+	}{
+		// The ordinary case. The analysis withheld the axis, so the entry adds
+		// a claim rather than displacing one.
+		"FillIn": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvMutBorrow),
+				}
+			},
+			name: "Demo.prototype.opaque",
+			want: "receiver:mutBorrow returns:unknown",
+			note: "Demo.prototype.opaque receiver: fill-in mutBorrow",
+		},
+		// A claim the analysis published and the review contradicts. §6 reads
+		// these first, since one of the two sources is wrong.
+		"Correction": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.read": entry(t, cfg, "Demo.prototype.read", RecvMutBorrow),
+				}
+			},
+			name: "Demo.prototype.read",
+			want: "receiver:mutBorrow returns:receiver",
+			note: "Demo.prototype.read receiver: correction mutBorrow over borrow",
+		},
+		// An entry that repeats the analysis changes nothing and is reported so
+		// it can be deleted.
+		"Redundant": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.read": entry(t, cfg, "Demo.prototype.read", RecvBorrow),
+				}
+			},
+			name: "Demo.prototype.read",
+			want: "receiver:borrow returns:receiver",
+			note: "Demo.prototype.read receiver: redundant borrow over borrow",
+		},
+		// A return the analysis did name, contradicted. `read` ends in
+		// `Return this`, so the analysis calls it `receiver`.
+		"ReturnsCorrection": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.read": returnsEntry(t, cfg, "Demo.prototype.read", ReturnFact{Kind: AliasFresh}),
+				}
+			},
+			name: "Demo.prototype.read",
+			want: "receiver:borrow returns:fresh",
+			note: "Demo.prototype.read returns: correction fresh over receiver",
+		},
+		// The same claim the analysis made, so the entry is deletable.
+		"ReturnsRedundant": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.read": returnsEntry(t, cfg, "Demo.prototype.read", ReturnFact{Kind: AliasReceiver}),
+				}
+			},
+			name: "Demo.prototype.read",
+			want: "receiver:borrow returns:receiver",
+			note: "Demo.prototype.read returns: redundant receiver over receiver",
+		},
+		// Curating one axis leaves the other where the analysis left it, which
+		// is what makes the layer compose with the analysis rather than shadow
+		// it.
+		"OneAxisLeavesTheOther": {
+			entries: func(cfg *CFG) map[string]CuratedEntry {
+				return map[string]CuratedEntry{
+					"Demo.prototype.opaque": returnsEntry(t, cfg, "Demo.prototype.opaque", ReturnFact{Kind: AliasFresh}),
+				}
+			},
+			name: "Demo.prototype.opaque",
+			want: "returns:fresh",
+			note: "Demo.prototype.opaque returns: fill-in fresh",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg, methods := demoFacts(t)
+			report := mergeCuration(cfg, &Curation{Entries: test.entries(cfg)}, methods)
+
+			require.Equal(t, test.want, methods[test.name].String())
+			require.Len(t, report.Notes, 1)
+			require.Equal(t, test.note, report.Notes[0].String())
+			require.Empty(t, report.Stale)
+			require.Empty(t, report.Unmatched)
+			require.Empty(t, report.Refused)
+		})
+	}
+}
+
+// Whether a builtin has a receiver at all follows from its kind, so review
+// cannot move it. A curated claim that contradicts the kind is refused and
+// reported, and the analysis's answer stands.
+func TestMergeCurationRefusesAReceiverTheKindContradicts(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := ParseCFG([]byte(`{"specTarget":"abc","funcs":[` +
+		`{"name":"Demo.make","kind":"builtin-static","params":[],"nodes":[` +
+		`{"kind":"return","value":{"kind":"lit"}}]}]}`))
+	require.NoError(t, err)
+	methods := analyze(cfg).Methods
+	require.Equal(t, "receiver:none returns:fresh", methods["Demo.make"].String())
+
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.make": entry(t, cfg, "Demo.make", RecvBorrow),
+	}}, methods)
+
+	require.Equal(t, []string{"Demo.make receiver: curated borrow, but a builtin-static has no receiver"}, report.Refused)
+	require.Empty(t, report.Notes)
+	require.Equal(t, "receiver:none returns:fresh", methods["Demo.make"].String())
+}
+
+// The mirror case. A method has a receiver whatever the review says.
+func TestMergeCurationRefusesNoneOnAMethod(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvNone),
+	}}, methods)
+
+	require.Equal(t, []string{"Demo.prototype.opaque receiver: curated none, but a builtin-method has a receiver"}, report.Refused)
+	require.Equal(t, "returns:unknown", methods["Demo.prototype.opaque"].String())
+}
+
+// A name the graph holds no builtin for is reported and applied to nothing, so
+// an entry carried over from another spec revision degrades to a report line
+// rather than inventing a method.
+func TestMergeCurationReportsAnUnmatchedName(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.gone": {
+			Reason:     "stated for the test",
+			ReviewedAt: "000000000000",
+			Receiver:   RecvBorrow,
+		},
+	}}, methods)
+
+	require.Equal(t, []string{"Demo.prototype.gone"}, report.Unmatched)
+	require.Empty(t, report.Notes)
+	require.NotContains(t, methods, "Demo.prototype.gone")
+}
+
+// An entry reviewed against an algorithm the graph no longer holds is applied
+// and reported. Dropping it would trade a visible re-review prompt for a silent
+// loss of coverage.
+func TestMergeCurationAppliesAStaleEntry(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	stale := entry(t, cfg, "Demo.prototype.opaque", RecvMutBorrow)
+	stale.ReviewedAt = "000000000000"
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": stale,
+	}}, methods)
+
+	require.Equal(t, []string{"Demo.prototype.opaque"}, report.Stale)
+	require.Equal(t, "receiver:mutBorrow returns:unknown", methods["Demo.prototype.opaque"].String())
+}
+
+// An entry that cannot be reviewed or applied is a defect in committed data, so
+// parsing refuses it rather than merging it as written.
+func TestParseCurationRejects(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		entry string
+		want  string
+	}{
+		"NoReason": {
+			`{"reviewedAt":"abc","receiver":"borrow"}`,
+			"curated entry Demo.m: has no reason",
+		},
+		"NoReviewedAt": {
+			`{"reason":"r","receiver":"borrow"}`,
+			"curated entry Demo.m: has no reviewedAt digest",
+		},
+		"NoDetermination": {
+			`{"reason":"r","reviewedAt":"abc"}`,
+			"curated entry Demo.m: answers no determination",
+		},
+		"UnknownReceiverKind": {
+			`{"reason":"r","reviewedAt":"abc","receiver":"shared"}`,
+			`curated entry Demo.m: names receiver "shared", which is not a receiver kind`,
+		},
+		// A return carrying a position but no kind is malformed rather than
+		// absent, so it answers the axis and is refused on the kind.
+		"ReturnsWithNoKind": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"index":0}}`,
+			`curated entry Demo.m: returns "", which is not an alias kind`,
+		},
+		"UnknownAliasKind": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"borrowed"}}`,
+			`curated entry Demo.m: returns "borrowed", which is not an alias kind`,
+		},
+		"ParamWithNoPosition": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"param"}}`,
+			"curated entry Demo.m: returns a parameter but names no position",
+		},
+		"PositionOnANonParamReturn": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"fresh","index":0}}`,
+			"curated entry Demo.m: returns fresh but names a position",
+		},
+		"UnionOfOne": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"union","members":[{"kind":"fresh"}]}}`,
+			"curated entry Demo.m: returns a union of 1 members",
+		},
+		"UnionHoldingUnknown": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"unknown"}]}}`,
+			"curated entry Demo.m: returns a union holding unknown",
+		},
+		"NegativeParamPosition": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"param","index":-1}}`,
+			"curated entry Demo.m: returns the parameter at position -1",
+		},
+		"UnionMemberWithNoPosition": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"param"}]}}`,
+			"curated entry Demo.m: union member: returns a parameter but names no position",
+		},
+		"UnionNamingOneValueTwice": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"union","members":[{"kind":"param","index":1},{"kind":"param","index":1}]}}`,
+			"curated entry Demo.m: returns a union naming param(1) twice",
+		},
+		"MembersOnANonUnionReturn": {
+			`{"reason":"r","reviewedAt":"abc","returns":{"kind":"fresh","members":[{"kind":"fresh"}]}}`,
+			"curated entry Demo.m: returns fresh but names union members",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseCuration([]byte(`{"entries":{"Demo.m":` + test.entry + `}}`))
+			require.EqualError(t, err, test.want)
+		})
+	}
+}
+
+// The layer round-trips a fact of every shape the analysis builds, so an entry
+// can answer any determination the analysis can.
+func TestParseCurationAcceptsEveryReturnShape(t *testing.T) {
+	t.Parallel()
+
+	body := `{"reason":"r","reviewedAt":"abc","returns":`
+	tests := []struct {
+		name    string
+		returns string
+		want    string
+	}{
+		{"Fresh", `{"kind":"fresh"}`, "fresh"},
+		{"Receiver", `{"kind":"receiver"}`, "receiver"},
+		{"Unknown", `{"kind":"unknown"}`, "unknown"},
+		{"Param", `{"kind":"param","index":0}`, "param(0)"},
+		{
+			"Union",
+			`{"kind":"union","members":[{"kind":"fresh"},{"kind":"param","index":1}]}`,
+			"union(fresh, param(1))",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			curation, err := ParseCuration([]byte(`{"entries":{"Demo.m":` + body + test.returns + `}}}`))
+			require.NoError(t, err)
+			require.Equal(t, test.want, curation.Entries["Demo.m"].Returns.String())
+		})
+	}
+}
+
+// A layer that is not JSON at all fails before any entry is read, which is the
+// other way committed data can be wrong.
+func TestParseCurationRejectsMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCuration([]byte(`{"entries":`))
+	require.EqualError(t, err, "decoding curation: unexpected end of JSON input")
+}
+
+// The committed layer parses, which is what every NewFacts call depends on.
+func TestCommittedLayerParses(t *testing.T) {
+	t.Parallel()
+
+	curation, err := parseCommitted(curatedJSON)
+	require.NoError(t, err)
+	require.NotEmpty(t, curation.Entries)
+}
+
+// A malformed layer reaches the caller as an error that names both the file and
+// the entry at fault, rather than taking the process down at init.
+func TestParseCommittedReportsAnInvalidFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseCommitted([]byte(`{"entries":{"Demo.m":{"reviewedAt":"abc","receiver":"borrow"}}}`))
+	require.EqualError(t, err,
+		"committed curated.json is invalid: curated entry Demo.m: has no reason")
+}
+
+// failAfter is a writer that accepts n writes and then fails, so a test can put
+// the failure on any one line of the report.
+type failAfter struct {
+	n int
+}
+
+func (w *failAfter) Write(p []byte) (int, error) {
+	if w.n == 0 {
+		return 0, errWriteFailed
+	}
+	w.n--
+	return len(p), nil
+}
+
+var errWriteFailed = errors.New("write failed")
+
+// Every line of the report propagates a writer error rather than reporting a
+// truncated merge as a clean one. The counts are one write and each listed line
+// is another, so failing after k writes puts the failure on line k.
+func TestWriteCurationReportPropagatesAWriteError(t *testing.T) {
+	t.Parallel()
+
+	report := CurationReport{
+		Notes: []CurationNote{
+			{Name: "Demo.a", Axis: AxisReceiver, Kind: CurationFillIn, Curated: "borrow"},
+			{Name: "Demo.b", Axis: AxisReceiver, Kind: CurationCorrection, Curated: "borrow", Analyzed: "mutBorrow"},
+		},
+		Stale:     []string{"Demo.c"},
+		Unmatched: []string{"Demo.d"},
+		Refused:   []string{"Demo.e receiver: curated borrow, but a builtin-static has no receiver"},
+	}
+
+	// Five writes succeed: the counts, the correction, the stale name, the
+	// unmatched name, and the refused axis. The fill-in is summarized rather
+	// than listed, so it is not one of them.
+	for writes := range 5 {
+		require.ErrorIs(t, WriteCurationReport(report, &failAfter{n: writes}), errWriteFailed,
+			"a failure on write %d was swallowed", writes)
+	}
+	require.NoError(t, WriteCurationReport(report, &failAfter{n: 5}))
+}
+
+// equal is what sorts a curated entry into redundant or correction, so every
+// way two return facts can differ has to register. Members are compared in
+// order, which parsing and newReturnFact both establish.
+func TestReturnFactEqual(t *testing.T) {
+	t.Parallel()
+
+	union := func(members ...AliasRef) ReturnFact {
+		return ReturnFact{Kind: AliasUnion, Members: members}
+	}
+	param := func(i int) AliasRef { return AliasRef{Kind: AliasParam, Index: position(i)} }
+	fresh := AliasRef{Kind: AliasFresh}
+
+	tests := map[string]struct {
+		a, b ReturnFact
+		want bool
+	}{
+		"SameKind":          {ReturnFact{Kind: AliasFresh}, ReturnFact{Kind: AliasFresh}, true},
+		"DifferingKind":     {ReturnFact{Kind: AliasFresh}, ReturnFact{Kind: AliasReceiver}, false},
+		"SamePosition":      {returnsParam(1), returnsParam(1), true},
+		"DifferingPosition": {returnsParam(0), returnsParam(1), false},
+		// A position on one side only. The fields are pointers, so this is the
+		// case a plain dereference would panic on.
+		"PositionOnOneSide":       {returnsParam(0), ReturnFact{Kind: AliasParam}, false},
+		"SameMembers":             {union(fresh, param(0)), union(fresh, param(0)), true},
+		"DifferingMemberKind":     {union(fresh, param(0)), union(AliasRef{Kind: AliasReceiver}, param(0)), false},
+		"DifferingMemberPosition": {union(fresh, param(0)), union(fresh, param(2)), false},
+		"DifferingMemberCount":    {union(fresh, param(0)), union(fresh, param(0), param(1)), false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, test.a.equal(test.b))
+			require.Equal(t, test.want, test.b.equal(test.a), "equal is not symmetric")
+		})
+	}
+}
+
+// A union is written by hand in whatever order reads best, and parsing puts its
+// members in the order the analysis leaves them. Without that, a curated union
+// would compare unequal to the analyzed fact it repeats and publish its members
+// in an order no other fact uses.
+func TestParseCurationSortsUnionMembers(t *testing.T) {
+	t.Parallel()
+
+	curation, err := ParseCuration([]byte(`{"entries":{"Demo.m":{"reason":"r","reviewedAt":"abc",` +
+		`"returns":{"kind":"union","members":[` +
+		`{"kind":"receiver"},{"kind":"param","index":2},{"kind":"fresh"},{"kind":"param","index":0}]}}}}`))
+	require.NoError(t, err)
+
+	returns := curation.Entries["Demo.m"].Returns
+	require.Equal(t, "union(fresh, param(0), param(2), receiver)", returns.String())
+	require.True(t, returns.equal(newReturnFact(aliasSet{members: set.FromSlice([]alias{
+		{Kind: AliasReceiver}, {Kind: AliasParam, Index: 2},
+		{Kind: AliasFresh}, {Kind: AliasParam, Index: 0},
+	})})), "a curated union does not compare equal to the analyzed fact it repeats")
+}
+
+// Every name in curated.json addresses a builtin the committed graph holds, and
+// every entry was reviewed against the algorithm the graph holds now. This is
+// what turns a misspelled key and an algorithm rewritten under a reviewer into
+// a failing build rather than a line in a report nobody reads.
+func TestCurationMatchesTheGraph(t *testing.T) {
+	report := testFacts(t).Curation()
+
+	require.Empty(t, report.Unmatched, "curated names the committed graph holds no builtin for")
+	require.Empty(t, report.Stale, "curated entries reviewed against an algorithm the graph no longer holds")
+	require.Empty(t, report.Refused, "curated axes the graph contradicts")
+}
+
+// An entry the analysis has caught up with is deletable, and leaving it in
+// place would grow a second source of truth for a determination that no longer
+// needs one.
+func TestCurationHasNoRedundantEntries(t *testing.T) {
+	var redundant []string
+	for _, note := range testFacts(t).Curation().Notes {
+		if note.Kind == CurationRedundant {
+			redundant = append(redundant, note.String())
+		}
+	}
+	require.Empty(t, redundant)
+}
+
+// Every curated determination in one list, which is what a reviewer reads to
+// see the whole layer at once.
+//
+// All 27 are fill-ins. The 24 receivers answer an axis the analysis withheld.
+// The three returns answer one it resolved to `unknown`, which names no value,
+// and each reads a primitive out of a slot — a copy the analysis cannot
+// recognize as one without the declared return type. Nothing here corrects a
+// claim the analysis actually made, so §6 has no disagreement to triage yet.
+func TestCurationReportOverTheCommittedGraph(t *testing.T) {
+	lines := make([]string, 0, len(testFacts(t).Curation().Notes))
+	for _, note := range testFacts(t).Curation().Notes {
+		lines = append(lines, note.String())
+	}
+	sort.Strings(lines)
+	snaps.MatchSnapshot(t, strings.Join(lines, "\n"))
+}
+
+// The report prints its tallies and then every line that needs a reviewer. A
+// fill-in is the ordinary case and is counted rather than listed.
+func TestWriteCurationReport(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	stale := entry(t, cfg, "Demo.prototype.read", RecvBorrow)
+	stale.ReviewedAt = "000000000000"
+	report := mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvMutBorrow),
+		"Demo.prototype.read":   stale,
+		"Demo.prototype.gone": {
+			Reason:     "stated for the test",
+			ReviewedAt: "000000000000",
+			Receiver:   RecvBorrow,
+		},
+	}}, methods)
+
+	var out strings.Builder
+	require.NoError(t, WriteCurationReport(report, &out))
+	snaps.MatchInlineSnapshot(t, out.String(), snaps.Inline(`  curation: 1 fill-ins, 0 corrections, 1 redundant, 1 stale, 1 unmatched, 0 refused
+    Demo.prototype.read receiver: redundant borrow over borrow
+    Demo.prototype.read: reviewed against an algorithm the graph no longer holds
+    Demo.prototype.gone: curated, but the graph holds no such builtin
+`))
+}

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -184,18 +184,26 @@ func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 }
 
 // joinFixture is a hand-built fact set covering each keying shape the join has
-// to resolve. Every entry but one carries the fact the committed control-flow
-// graph really holds for that name, so the fixture doubles as a description of
-// the fact set rather than reading as a claim the graph does not make.
+// to resolve. Every entry naming a builtin carries the fact the published set
+// really holds for that name, so the fixture doubles as a description of that
+// set rather than reading as a claim the graph does not make.
 //
-// The exception is the Fixture owner, which names no builtin. No real fact
-// returns a parameter above position 0 — every one that returns a parameter is
-// an `Object.*` static at position 0 — so the case where a signature declares
-// no parameter at the position a fact names has no ECMA-262 instance yet. The
-// shape is real even though the fact is not: the spec's
-// `Array.prototype.splice(start, deleteCount, ...items)` meets a TypeScript
-// overload set whose shortest member is `splice(start: number): T[]`. The
-// position-keyed facts of §8.1 are what will populate it.
+// The two Fixture entries name no builtin, because no published fact has their
+// shape.
+//
+// `returnsSecond` returns a parameter above position 0. Every published fact
+// that returns a parameter is an `Object.*` static at position 0, so a
+// signature that declares no parameter at the position a fact names has no
+// ECMA-262 instance yet. The shape is real even though the fact is not: the
+// spec's `Array.prototype.splice(start, deleteCount, ...items)` meets a
+// TypeScript overload set whose shortest member is `splice(start: number):
+// T[]`. The position-keyed facts of §8.1 are what will populate it.
+//
+// `withheldReceiver` leaves its receiver unclassified, which the join has to
+// carry through to the report's receiver-claim count. The analysis withholds 24
+// receivers and curated.json answers every one, so no published fact is left in
+// that state. A `web:*` method, which has no ECMA-262 algorithm at all, is
+// where the shape returns.
 func joinFixture() *Facts {
 	covered := Coverage{Receiver: true, Returns: true}
 	return &Facts{
@@ -218,9 +226,9 @@ func joinFixture() *Facts {
 			// the `unknown` stands.
 			"String.prototype.localeCompare": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
 			"RegExp.prototype.exec":          {Classified: covered, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
-			// A method the mutation fixpoint could not read whole, so its
-			// receiver claim is withheld while its return alias stands.
-			"Array.prototype.toLocaleString": {Classified: Coverage{Returns: true}, Returns: ReturnFact{Kind: AliasFresh}},
+			// A fact whose receiver claim is withheld while its return alias
+			// stands. See the note above.
+			"Fixture.prototype.withheldReceiver": {Classified: Coverage{Returns: true}, Returns: ReturnFact{Kind: AliasFresh}},
 			// A function the global object holds, which addresses no owner and
 			// so is refused by Normalize.
 			"parseInt": {Classified: covered, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasFresh}},
@@ -397,7 +405,7 @@ get Map.prototype.size -> get instance Map.size receiverApplies:no [ receiver:bo
 String.prototype.localeCompare -> instance String.localeCompare receiverApplies:yes [ receiver:borrow returns:unknown settled:owned ]
 RegExp.prototype.exec -> instance RegExp.exec receiverApplies:yes [ receiver:mutBorrow returns:unknown ]
 no fact: instance Array.toSorted
-no declaration: Array.prototype.toLocaleString
+no declaration: Fixture.prototype.withheldReceiver
 no declaration: Math.max
 no declaration: Object.assign
 no declaration: String.prototype [ @@iterator ]
@@ -448,7 +456,7 @@ func TestWriteJoinReport(t *testing.T) {
 	report := NewJoin(joinFixture()).Match(Declarations{
 		Keyed: []Declaration{
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("push"), Sort: SortInstance}, Signatures: []Signature{{Params: 1, Rest: true}}},
-			{Ref: MemberRef{Owner: "Array", Member: StrMember("toLocaleString"), Sort: SortInstance}, Signatures: []Signature{{Params: 0}}},
+			{Ref: MemberRef{Owner: "Fixture", Member: StrMember("withheldReceiver"), Sort: SortInstance}, Signatures: []Signature{{Params: 0}}},
 			{Ref: MemberRef{Owner: "Array", Member: StrMember("toSorted"), Sort: SortInstance}, Signatures: []Signature{{Params: 1}}},
 			// One return the declared type settles and one it leaves, so the
 			// report's return counts carry both.

--- a/internal/ecma262/mutation.go
+++ b/internal/ecma262/mutation.go
@@ -130,10 +130,10 @@ var readOnlyInternalMethods = set.FromSlice([]string{
 // sorted 0-based positions of the declared parameters it may mutate. A method's
 // receiver is not a parameter, so Receiver reports it separately.
 //
-// The two warnings name different failures, and §4.3 turns either into
-// `classified: false` so FR5's name-based heuristics decide the method instead.
-// Unattributable means the analysis saw a mutation it could not tie to the
-// receiver or to a parameter. Incomplete means it could not read the whole
+// The two warnings name different failures, and §4.3 turns either into a
+// method the analysis publishes no receiver for, which §4.4 then answers by
+// review. Unattributable means the analysis saw a mutation it could not tie to
+// the receiver or to a parameter. Incomplete means it could not read the whole
 // algorithm, so a mutation may be hiding in the part it missed.
 type Mutations struct {
 	Args           []int

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -20,8 +20,9 @@
 //
 //	    With --cfg, the run also joins every std:* member it emits
 //	    against the ECMA-262 effect facts derived from that control-flow
-//	    graph, and reports the names present on one side only. See
-//	    planning/ecma-262/implementation_plan.md §5.
+//	    graph, and reports the names present on one side only. It reports
+//	    what the curated layer did to those facts alongside it. See
+//	    planning/ecma-262/implementation_plan.md.
 //
 //	dts_to_esc check <lib-dir> <esc-dir>
 //	    Read-only verification per §6.4: convert the pinned lib set and
@@ -169,7 +170,7 @@ func runPartition(args []string, stderr io.Writer) error {
 	// second time. Discarding its output leaves one report per error.
 	flags := flag.NewFlagSet("partition", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
-	cfgPath := flags.String("cfg", "", "path to the ECMA-262 cfg.json; adds the §5 effect-fact join report")
+	cfgPath := flags.String("cfg", "", "path to the ECMA-262 cfg.json; adds the curation and effect-fact join reports")
 	if err := flags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			fmt.Fprintln(stderr, partitionUsage)
@@ -186,13 +187,18 @@ func runPartition(args []string, stderr io.Writer) error {
 
 	// Derive the facts before any output is written, so a bad --cfg path
 	// fails the run before it leaves a half-joined tree on disk.
+	var facts *ecma262.Facts
 	var join *ecma262.Join
 	if *cfgPath != "" {
 		cfg, err := ecma262.LoadCFG(*cfgPath)
 		if err != nil {
 			return fmt.Errorf("loading %s: %w", *cfgPath, err)
 		}
-		join = ecma262.NewJoin(ecma262.NewFacts(cfg))
+		facts, err = ecma262.NewFacts(cfg)
+		if err != nil {
+			return err
+		}
+		join = ecma262.NewJoin(facts)
 	}
 
 	result, err := partitionLibDir(libDir, stderr)
@@ -220,8 +226,12 @@ func runPartition(args []string, stderr io.Writer) error {
 	if join == nil {
 		return nil
 	}
-	// The join is informational. The spec and the TypeScript lib drift
-	// independently, so a name on one side only is a gap to close rather than
-	// a failed run.
+	// Both reports are informational. A curated entry the analysis caught up
+	// with is an entry to delete, and the spec and the TypeScript lib drift
+	// independently, so a name on one side only is a gap to close. Neither is a
+	// failed run.
+	if err := ecma262.WriteCurationReport(facts.Curation(), stderr); err != nil {
+		return err
+	}
 	return ecma262.WriteJoinReport(join.Match(dts_to_esc.StdDeclarations(mods)), stderr)
 }

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -74,6 +74,56 @@ export declare class Array<T> {
 `))
 }
 
+// committedCFG is the control-flow graph tools/spec-extract commits, which the
+// --cfg flag reads.
+const committedCFG = "../spec-extract/cfg.json"
+
+// Both ECMA-262 reports reach stderr, and neither does without the flag. The
+// rendering of each line is pinned in internal/ecma262 against a demo graph;
+// what the snapshot below adds is what a real run over the committed graph and
+// the seeded lib reports, the partition summary above them included.
+//
+// The counts move when curated.json or cfg.json changes, which is the point:
+// the diff shows what a data change did to the reports an operator reads.
+func TestRun_PartitionWithCFGPrintsBothReports(t *testing.T) {
+	libDir := seedLib(t, arrayLib)
+
+	var stderr strings.Builder
+	require.NoError(t, run([]string{"partition", "--cfg", committedCFG, libDir, t.TempDir()}, io.Discard, &stderr))
+
+	snaps.MatchInlineSnapshot(t, reportSummaries(stderr.String()), snaps.Inline(`  std:array: 3 decls
+  curation: 27 fill-ins, 0 corrections, 0 redundant, 0 stale, 0 unmatched, 0 refused
+  join: 1 matched (1 with a receiver claim), 0 declarations without a fact, 436 facts without a declaration, 0 unkeyed declarations, 64 unjoinable facts
+  returns: 1 settled as owned by the declared type, 0 left unknown`))
+}
+
+// reportSummaries keeps the summary line of each report and drops the per-name
+// detail under it. A summary carries two leading spaces and a detail line four,
+// so the indent is what tells them apart. The detail is every name the join
+// could not match, hundreds of lines that internal/ecma262 already pins.
+func reportSummaries(stderr string) string {
+	var kept []string
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   ") {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+// A --cfg path that does not resolve fails the run before anything is written,
+// so a mistyped flag leaves no half-joined tree behind.
+func TestRun_PartitionRejectsABadCFGPath(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+
+	err := run([]string{"partition", "--cfg", "no/such/cfg.json", seedLib(t, arrayLib), outDir}, io.Discard, io.Discard)
+
+	require.EqualError(t, err,
+		"loading no/such/cfg.json: reading no/such/cfg.json: open no/such/cfg.json: no such file or directory")
+	require.Empty(t, treeOf(t, outDir))
+}
+
 // treeOf lists every file under root as a slash-separated path relative
 // to it, sorted. Dropping the root keeps the listing free of the temp
 // directory the test ran in.


### PR DESCRIPTION
Refs #1312

Second of four PRs splitting #1316. **Stacked on [#1318](https://github.com/escalier-lang/escalier/pull/1318)** — review that one first; this PR's diff against it is the interesting part. The planning-doc prose for this change is in [#1321](https://github.com/escalier-lang/escalier/pull/1321) at the top of the stack.

## What it does

The analysis in §4.1–§4.3 settles 477 of 501 receiver claims and withholds 24. Each remaining one needs a different lattice member or a different fixpoint to reach analytically, and the receiver a reviewer would write down is not in doubt for any of them.

Add a committed layer of reviewed determinations, keyed by the canonical spec name of Appendix C and merged over the analysis one axis at a time. An entry that claims only one axis leaves the other to the analysis, so the two sources compose rather than replace each other.

## The data

`curated.json` carries 24 receivers and 3 return aliases. Each entry states a reason a reader can check and the digest of the algorithm its author reviewed, so a spec bump flags the entries whose algorithm it rewrote and leaves the rest alone.

`Func.Digest` is 12 hex characters of SHA-256 over the re-marshalled decode type. It is taken over the decode type rather than over `Func` because `Node` is a sealed interface and `encoding/json` writes no tag for the variant one holds.

## The merge

`mergeCuration` reports what each curated axis did — filled a hole, corrected the analysis, or repeated it — and refuses a claim the function kind contradicts, such as a receiver on a static. An entry naming no builtin in the graph is reported and applied to nothing, so an entry from another spec revision degrades to a report line rather than inventing a method. A stale entry is applied and reported, trading a visible re-review prompt for silent loss of coverage.

`ParseCuration` validates at parse time: a reason and a review digest, at least one claimed axis, valid kinds, and the union invariants.

## The analyze seam

`NewFacts` is the merged result the converter reads. `analyze` is the graph alone, which is what §4 is measured by, so a curated entry never disguises what the analysis found. Tests that pin the analysis read the second — `TestFactsSampleMethods` and `TestFactsUnclassifiedMethodsAreListed` among them.

## Results

The published `receiver unclassified` tally is now zero, so no `std:*` method falls through to §7's name heuristics. The tallies move 226→246 `borrow` and 63→67 `mutBorrow`, and open returns 250→247.

`dts_to_esc partition --cfg` prints the curation report alongside the join report. Both are informational.

## Known carve-out

Two curated `borrow` entries involve `@@species`, where a hostile constructor could alias the receiver. The analysis already publishes `borrow` from its own reading for the identical shape on `Array.prototype.slice/map/filter/flat/flatMap` and `TypedArray.prototype.map/filter/subarray`, so curating these two differently would be inconsistent. Tracked by #1307 for the whole class.

## Follow-ups this enables

§4.4 changes the scope of the phases after it. #1312 proposes closing #1286 (and its PR #1308), #1284, #1304, #1301, and #1300 outright, and reducing #1204, #1206, and #1201 — each curating the affected methods instead of growing the analyzer. Those are left open for the author to decide.

https://claude.ai/code/session_01FnsXWeGS456WxQx455nFBf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added curated ECMAScript method metadata covering receivers, return values, and specification evidence.
  - Added curation reports identifying applied, redundant, stale, conflicting, and unmatched entries.
  - `partition --cfg` now outputs curation results alongside the existing join report.
  - Added stable algorithm fingerprints to improve change tracking across analyses.

- **Bug Fixes**
  - Improved classification for previously unresolved built-in methods, including selected `Date` methods.

- **Validation**
  - Added comprehensive checks for malformed, inconsistent, or outdated curation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->