### PR TITLE
Make every published ECMA-262 fact total

### DIFF
--- a/internal/dts_to_esc/join_test.go
+++ b/internal/dts_to_esc/join_test.go
@@ -264,9 +264,8 @@ interface Fixture {
 		SpecTarget: "test",
 		Methods: map[string]ecma262.MethodFact{
 			"Fixture.prototype.withTail": {
-				Classified: ecma262.Coverage{Receiver: true, Returns: true},
-				Receiver:   ecma262.RecvBorrow,
-				Returns:    ecma262.ReturnFact{Kind: ecma262.AliasParam, Index: &tail},
+				Receiver: ecma262.RecvBorrow,
+				Returns:  ecma262.ReturnFact{Kind: ecma262.AliasParam, Index: &tail},
 			},
 		},
 	}
@@ -407,15 +406,14 @@ interface DataView {
 `).Module)
 	require.NoError(t, err)
 
-	covered := ecma262.Coverage{Receiver: true, Returns: true}
 	unnamed := ecma262.ReturnFact{Kind: ecma262.AliasUnknown}
 	facts := &ecma262.Facts{
 		SpecTarget: "test",
 		Methods: map[string]ecma262.MethodFact{
-			"String.prototype.localeCompare": {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: unnamed},
-			"DataView.prototype.getFloat64":  {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: unnamed},
-			"DataView.prototype.getUint8":    {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: unnamed},
-			"DataView.prototype.setFloat64":  {Classified: covered, Receiver: ecma262.RecvMutBorrow, Returns: unnamed},
+			"String.prototype.localeCompare": {Receiver: ecma262.RecvBorrow, Returns: unnamed},
+			"DataView.prototype.getFloat64":  {Receiver: ecma262.RecvBorrow, Returns: unnamed},
+			"DataView.prototype.getUint8":    {Receiver: ecma262.RecvBorrow, Returns: unnamed},
+			"DataView.prototype.setFloat64":  {Receiver: ecma262.RecvMutBorrow, Returns: unnamed},
 		},
 	}
 	report := ecma262.NewJoin(facts).Match(CollectDeclarations(mod))
@@ -463,18 +461,17 @@ declare function parseInt(string: string, radix?: number): number;
 	mods, err := ConvertBuckets(result)
 	require.NoError(t, err)
 
-	covered := ecma262.Coverage{Receiver: true, Returns: true}
 	facts := &ecma262.Facts{
 		SpecTarget: "test",
 		Methods: map[string]ecma262.MethodFact{
-			"Array.prototype.push":           {Classified: covered, Receiver: ecma262.RecvMutBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
-			"Array.prototype [ @@iterator ]": {Classified: covered, Receiver: ecma262.RecvBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
-			"Array.isArray":                  {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
-			"Math.max":                       {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
-			"Math.min":                       {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Array.prototype.push":           {Receiver: ecma262.RecvMutBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Array.prototype [ @@iterator ]": {Receiver: ecma262.RecvBorrow, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Array.isArray":                  {Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Math.max":                       {Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"Math.min":                       {Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
 			// A function the global object holds names no owner, so neither
 			// side of the join can key it.
-			"parseInt": {Classified: covered, Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
+			"parseInt": {Receiver: ecma262.RecvNone, Returns: ecma262.ReturnFact{Kind: ecma262.AliasFresh}},
 		},
 	}
 	report := ecma262.NewJoin(facts).Match(StdDeclarations(mods))

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -457,10 +457,11 @@ func (f MethodFact) answers(axis Axis) bool {
 // generation requires, and Unclassified's `answers` is the reviewer's stricter
 // reading of the same fact.
 //
-// An axis this does not name reads as carried, because a fact cannot be faulted
-// for a determination §8 or §9 has not added yet. That permissive default is
-// also how the switch could fall out of step with publishedAxes and let a hole
-// through, which TestCarriesCoversEveryPublishedAxis is there to catch.
+// An axis this does not name reads as a hole. Incomplete asks only about
+// publishedAxes, so that answer is reachable exactly when an axis joins that
+// list without gaining a case here. Failing the run on every method is the safe
+// reading of that drift; the alternative passes the hole the gate exists to
+// catch. TestCarriesCoversEveryPublishedAxis catches it one step earlier.
 func (f MethodFact) carries(axis Axis) bool {
 	switch axis {
 	case AxisReceiver:
@@ -468,7 +469,7 @@ func (f MethodFact) carries(axis Axis) bool {
 	case AxisReturns:
 		return f.Returns.Kind != ""
 	default:
-		return true
+		return false
 	}
 }
 

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -190,18 +190,6 @@ func receiverCovered(fn *Func, mutations Mutations) bool {
 	return !mutations.Unattributable && !mutations.Incomplete
 }
 
-// Coverage records which of MethodFact's determinations the analysis resolved.
-// A step it could not read withholds only the ones that read it (FR5).
-type Coverage struct {
-	// Receiver is set for a static or namespace function, which has no receiver
-	// to claim, and for a method the mutation fixpoint read whole.
-	Receiver bool `json:"receiver"`
-	// Returns is set for every builtin, since returnAlias is total. A return
-	// hidden in a step the analysis could not read drops out of the join, a
-	// loss FR4 accepts because §7 curates the alias rather than applying it.
-	Returns bool `json:"returns"`
-}
-
 // AliasRef names one value a return hands back, as Appendix B of
 // planning/ecma-262/implementation_plan.md serializes it. Index is the 0-based
 // position among the declared parameters, which do not include a method's
@@ -300,36 +288,34 @@ func newReturnFact(s aliasSet) ReturnFact {
 // as one entry of facts.json, described in Appendix B of
 // planning/ecma-262/implementation_plan.md.
 //
-// A determination Coverage leaves unset carries no claim, and its field is
-// absent from the JSON, so a consumer never reads "unanalyzed" as "proven
-// none". The converter applies requirements.md FR5's default instead, `&mut
-// self` for an absent receiver.
+// A published fact carries every determination. Neither field has a valid zero
+// value — "" is not a ReceiverKind and not an AliasKind — so a field a fact
+// does not carry is a hole rather than a claim, and Facts.Incomplete names the
+// methods that have one. Generation refuses to write those, which is why the
+// entries hold no coverage flags: an axis is present or the run failed.
 //
-// Receiver is a plain kind with no empty member, so omitempty encodes its
-// absence. Returns is a struct, and omitzero encodes the same absence for it.
+// `unknown` is a value, not a hole. The alias lattice's top says the walk read
+// the returns and could tie none of them to a value the caller holds, which is
+// something §8.2 can act on. The methods still waiting on an answer there are
+// Facts.Unclassified(AxisReturns), a review report rather than a wire concern.
 //
-// Params, Throws, and Rejects join this shape in §8 and §9. Until §8.1 fills
-// Params, no fact makes a parameter claim, so an absent Params is not yet
-// Appendix B's proven-read-only one.
-//
-// Both throw fields land together, in §9.2. ThrowSummary already computes each
-// channel, but publishing the reject set on its own would spell a method whose
-// synchronous throws are simply not published yet as one that throws nothing.
+// Params, Throws, and Rejects join this shape in §8 and §9, and the same rule
+// covers them: an axis a fact cannot answer fails the run rather than encoding
+// a hole a consumer might read as a proven-empty result.
 type MethodFact struct {
-	Classified Coverage     `json:"classified"`
-	Receiver   ReceiverKind `json:"receiver,omitempty"`
-	Returns    ReturnFact   `json:"returns,omitzero"`
+	Receiver ReceiverKind `json:"receiver,omitempty"`
+	Returns  ReturnFact   `json:"returns,omitzero"`
 }
 
-// String renders the covered determinations in one line, so a test can assert
-// a fact whole. An uncovered one is left out, and a fact covering nothing reads
+// String renders the determinations the fact carries in one line, so a test can
+// assert a fact whole. A hole is left out, and a fact with nothing in it reads
 // "unclassified".
 func (f MethodFact) String() string {
 	var parts []string
-	if f.Classified.Receiver {
+	if f.Receiver != "" {
 		parts = append(parts, "receiver:"+string(f.Receiver))
 	}
-	if f.Classified.Returns {
+	if f.Returns.Kind != "" {
 		parts = append(parts, "returns:"+f.Returns.String())
 	}
 	if len(parts) == 0 {
@@ -399,13 +385,9 @@ func analyze(cfg *CFG) *Facts {
 		}
 		mutations := summary.Of(fn)
 		fact := MethodFact{
-			Classified: Coverage{
-				Receiver: receiverCovered(fn, mutations),
-				Returns:  true,
-			},
 			Returns: newReturnFact(returnAlias(summary.originsOf(fn))),
 		}
-		if fact.Classified.Receiver {
+		if receiverCovered(fn, mutations) {
 			fact.Receiver = receiverKind(fn, mutations)
 		}
 		facts.Methods[fn.Name] = fact
@@ -432,13 +414,16 @@ const (
 	AxisReturns  Axis = "returns"
 )
 
-// Unclassified returns the names carrying no answer on axis, sorted. Shrinking
-// these lists is what §4 is measured by.
+// Unclassified returns the names carrying no answer on axis, sorted.
+//
+// Over an analyze result the list is what §4 is measured by. Over a NewFacts
+// result it is what neither the analysis nor the curated layer answers, which
+// is the surface still waiting on review.
 //
 // The two axes are worth reading apart rather than summed. §7 auto-applies the
-// receiver, so a name on that list is a method whose mutability falls to FR5's
-// name-based heuristics — a soundness gap. A name on the returns list costs
-// only the lifetime precision §8.2 would have seeded from it.
+// receiver, so a name on that list is a method whose mutability falls to the
+// converter's name heuristics — a soundness gap. A name on the returns list
+// costs only the lifetime precision §8.2 would have seeded from it.
 func (f *Facts) Unclassified(axis Axis) []string {
 	names := make([]string, 0, len(f.Methods))
 	for name, fact := range f.Methods {
@@ -451,21 +436,64 @@ func (f *Facts) Unclassified(axis Axis) []string {
 }
 
 // answers reports whether the fact settles axis, which is a stronger question
-// than whether Coverage marked it analyzed. A return of `unknown` is covered,
-// and it is a value §8.2 can act on, but it names nothing the caller holds. So
-// it stays an open question for a reviewer.
+// than whether it carries a value there. A return of `unknown` is a value the
+// converter can act on and an open question for a reviewer, so it is carried
+// but not settled.
 //
 // An axis this does not name reads as unsettled, so an axis §8 or §9 adds shows
-// up as wholly open until it is wired in here. The alternative would have a new
-// axis read as complete for every builtin the moment it is declared, which
-// hides work rather than surfacing it.
+// up as wholly open until it is wired in here.
 func (f MethodFact) answers(axis Axis) bool {
 	switch axis {
 	case AxisReceiver:
-		return f.Classified.Receiver
+		return f.Receiver != ""
 	case AxisReturns:
-		return f.Classified.Returns && f.Returns.Kind != AliasUnknown
+		return f.Returns.Kind != "" && f.Returns.Kind != AliasUnknown
 	default:
 		return false
 	}
+}
+
+// carries reports whether the fact holds a value on axis at all. This is what
+// generation requires, and Unclassified's `answers` is the reviewer's stricter
+// reading of the same fact.
+//
+// An axis this does not name reads as carried, because a fact cannot be faulted
+// for a determination §8 or §9 has not added yet. That permissive default is
+// also how the switch could fall out of step with publishedAxes and let a hole
+// through, which TestCarriesCoversEveryPublishedAxis is there to catch.
+func (f MethodFact) carries(axis Axis) bool {
+	switch axis {
+	case AxisReceiver:
+		return f.Receiver != ""
+	case AxisReturns:
+		return f.Returns.Kind != ""
+	default:
+		return true
+	}
+}
+
+// publishedAxes are the determinations every published fact must carry. §8 and
+// §9 add to it, and each axis added here needs a case in MethodFact.carries.
+var publishedAxes = []Axis{AxisReceiver, AxisReturns}
+
+// Incomplete returns the names whose fact holds a hole, one rendered line each,
+// sorted. A hole is a determination neither the analysis nor the curated layer
+// answered, and writing one to facts.json would leave a consumer to guess.
+//
+// The receiver axis is where this bites. §7 auto-applies it, so a hole there
+// would silently become the FR5 `&mut self` default, and a spec bump that
+// withholds a receiver nobody has curated is exactly the case that must be loud.
+// The list is empty for the committed graph, and TestFactsCarryEveryAxis holds
+// it that way.
+func (f *Facts) Incomplete() []string {
+	var holes []string
+	for name, fact := range f.Methods {
+		for _, axis := range publishedAxes {
+			if !fact.carries(axis) {
+				holes = append(holes, fmt.Sprintf("%s: no %s determination", name, axis))
+			}
+		}
+	}
+	sort.Strings(holes)
+	return holes
 }

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -573,28 +573,33 @@ func TestIncompleteNamesTheAxis(t *testing.T) {
 	require.Empty(t, facts.Incomplete())
 }
 
-// Every axis Incomplete walks has a case in `carries`. Without this, adding one
-// to publishedAxes and forgetting the switch would leave `carries` returning
-// its permissive default, and the gate would pass a fact holding exactly the
-// hole it exists to catch.
+// Every axis Incomplete walks has a case in `carries`. A fact populated on
+// every axis carries all of them, and an empty fact carries none. Adding an
+// axis to publishedAxes and forgetting the switch fails the first assertion,
+// because the fail-closed default reads that axis as a hole however the fact is
+// populated. Catching it here names the missing case; the gate would otherwise
+// report every method as incomplete.
 func TestCarriesCoversEveryPublishedAxis(t *testing.T) {
 	t.Parallel()
 
+	full := MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}}
 	for _, axis := range publishedAxes {
-		require.Falsef(t, MethodFact{}.carries(axis),
+		require.Truef(t, full.carries(axis),
 			"%s is a published axis that carries does not name", axis)
+		require.Falsef(t, MethodFact{}.carries(axis),
+			"%s reads as carried on a fact holding nothing", axis)
 	}
 }
 
-// The two predicates read an axis they do not name in opposite directions, on
-// purpose. A determination §8 or §9 has not added yet must not make an
-// otherwise complete fact look like a hole that fails the run, and must show up
-// as open work for a reviewer.
-func TestCarriesAndAnswersDisagreeOnAnUnwiredAxis(t *testing.T) {
+// An axis neither predicate names reads as a hole for generation and as open
+// work for a reviewer. Both directions fail closed, so an axis §8 or §9 adds to
+// publishedAxes without wiring up stops the run rather than shipping a
+// determination nothing populates.
+func TestCarriesReadsAnUnwiredAxisAsAHole(t *testing.T) {
 	t.Parallel()
 
 	fact := MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}}
-	require.True(t, fact.carries(Axis("throws")))
+	require.False(t, fact.carries(Axis("throws")))
 	require.False(t, fact.answers(Axis("throws")))
 }
 

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -46,9 +46,6 @@ func testAnalyzedFacts(t *testing.T) *Facts {
 	return analyzedFacts
 }
 
-// fullCoverage is what NewFacts builds for a builtin it read whole.
-var fullCoverage = Coverage{Receiver: true, Returns: true}
-
 // position is the 0-based parameter position a fact returns, as AliasRef
 // holds it.
 func position(i int) *int {
@@ -88,20 +85,20 @@ func TestMethodFactString(t *testing.T) {
 		// render, and a returned position past 0, which no builtin has.
 		"NoDetermination": {MethodFact{}, "unclassified"},
 		"ParamReturn": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: returnsParam(2)},
+			MethodFact{Receiver: RecvNone, Returns: returnsParam(2)},
 			"receiver:none returns:param(2)",
 		},
 		// A parameter return with no position reads as the missing position
 		// rather than as position 0. Nothing in the package builds such a fact;
 		// a hand-edited facts.json is where one would come from.
 		"ParamReturnWithNoPosition": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasParam}},
+			MethodFact{Receiver: RecvNone, Returns: ReturnFact{Kind: AliasParam}},
 			"receiver:none returns:param(?)",
 		},
 		// A union names every value it joined, which is what §8.2 spells the
 		// lifetime union from.
 		"UnionOverThreeValues": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion, Members: []AliasRef{
+			MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion, Members: []AliasRef{
 				{Kind: AliasFresh},
 				{Kind: AliasParam, Index: position(1)},
 				{Kind: AliasReceiver},
@@ -111,7 +108,7 @@ func TestMethodFactString(t *testing.T) {
 		// A union with no members is the counterpart of the positionless
 		// parameter return above, and comes from the same place.
 		"UnionWithNoMembers": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnion}},
+			MethodFact{Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnion}},
 			"receiver:none returns:union(?)",
 		},
 	}
@@ -300,7 +297,7 @@ func TestFactsEveryStringMethodBorrowsItsReceiver(t *testing.T) {
 		if !strings.HasPrefix(name, "String.prototype") {
 			continue
 		}
-		if !fact.Classified.Receiver {
+		if fact.Receiver == "" {
 			unread = append(unread, name)
 			continue
 		}
@@ -340,16 +337,11 @@ func TestFactsCoverEveryBuiltin(t *testing.T) {
 		fact, ok := f.Of(fn.Name)
 		require.True(t, ok, "%s has no fact", fn.Name)
 		// Every builtin resolves a return alias, warning or not.
-		require.True(t, fact.Classified.Returns, "%s has no return alias", fn.Name)
-		require.NotEmpty(t, fact.Returns.Kind, "%s covers a return alias it does not carry", fn.Name)
-		switch {
-		case fn.Kind != BuiltinMethod:
+		require.NotEmpty(t, fact.Returns.Kind, "%s has no return alias", fn.Name)
+		if fn.Kind != BuiltinMethod {
 			// `none` follows from the function kind, so no warning withholds it.
-			require.True(t, fact.Classified.Receiver, "%s has no receiver claim", fn.Name)
 			require.Equal(t, RecvNone, fact.Receiver, "%s has no receiver", fn.Name)
-		case !fact.Classified.Receiver:
-			require.Empty(t, fact.Receiver, "%s carries a receiver claim it is not classified for", fn.Name)
-		default:
+		} else {
 			require.Contains(t, []ReceiverKind{RecvBorrow, RecvMutBorrow}, fact.Receiver, fn.Name)
 		}
 		if fact.Returns.Kind != AliasParam {
@@ -400,7 +392,7 @@ func TestFactsUnionOverTwoReturnedParameters(t *testing.T) {
 	encoded, err := json.Marshal(fact)
 	require.NoError(t, err)
 	require.Equal(t,
-		`{"classified":{"receiver":true,"returns":true},"receiver":"none",`+
+		`{"receiver":"none",`+
 			`"returns":{"kind":"union","members":[{"kind":"param","index":0},{"kind":"param","index":1}]}}`,
 		string(encoded))
 }
@@ -414,38 +406,38 @@ func TestFactsOfAnAbsentName(t *testing.T) {
 	require.Equal(t, MethodFact{}, fact)
 }
 
-// A fact serializes as Appendix B describes. A determination its coverage
-// leaves unset omits its field, so the converter cannot read an absent claim
-// as a proven-empty one.
+// A fact serializes as Appendix B describes. Every published fact carries both
+// determinations, so a field absent from one is a hole Facts.Incomplete refuses
+// to write rather than a claim a consumer has to interpret.
 func TestFactsJSON(t *testing.T) {
 	tests := map[string]struct {
 		fact MethodFact
 		want string
 	}{
-		"Method": {factOf(t, "Array.prototype.fill"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":{"kind":"receiver"}}`},
-		// A receiver the analysis withheld carries the return alias alone. An
-		// entry in curated.json answers this one, so the rendering only ever
-		// comes off an analyze result.
-		"WithheldReceiver": {analyzedFactOf(t, "Array.prototype.toLocaleString"), `{"classified":{"receiver":false,"returns":true},"returns":{"kind":"fresh"}}`},
+		"Method": {factOf(t, "Array.prototype.fill"), `{"receiver":"mutBorrow","returns":{"kind":"receiver"}}`},
+		// The analysis withheld this receiver, which is the shape Incomplete
+		// refuses. Curation answers it before anything is written, so this
+		// rendering only ever comes off an analyze result.
+		"WithheldReceiver": {analyzedFactOf(t, "Array.prototype.toLocaleString"), `{"returns":{"kind":"fresh"}}`},
 		// The first parameter is written out like any other position. Every
 		// parameter the committed graph returns sits at 0, so omitting it would
 		// leave the index absent from the whole file and spell the common case
 		// as missing data.
-		"ReturnedPositionZero": {factOf(t, "Object.freeze"), `{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":{"kind":"param","index":0}}`},
+		"ReturnedPositionZero": {factOf(t, "Object.freeze"), `{"receiver":"none","returns":{"kind":"param","index":0}}`},
 		"ReturnedPositionPastZero": {
-			MethodFact{Classified: fullCoverage, Receiver: RecvNone, Returns: returnsParam(2)},
-			`{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":{"kind":"param","index":2}}`,
+			MethodFact{Receiver: RecvNone, Returns: returnsParam(2)},
+			`{"receiver":"none","returns":{"kind":"param","index":2}}`,
 		},
 		// A fact that returns no parameter carries no position at all.
-		"NoReturnedPosition": {factOf(t, "Array.prototype.push"), `{"classified":{"receiver":true,"returns":true},"receiver":"mutBorrow","returns":{"kind":"fresh"}}`},
+		"NoReturnedPosition": {factOf(t, "Array.prototype.push"), `{"receiver":"mutBorrow","returns":{"kind":"fresh"}}`},
 		// The §4.3 union gate. The `Object` constructor hands back an
 		// `OrdinaryObjectCreate` result on one path and `ToObject(value)` on
 		// another, and the entry names both so §8.2 can spell the lifetime
 		// union they seed.
-		"Union": {factOf(t, "Object"), `{"classified":{"receiver":true,"returns":true},"receiver":"none","returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"param","index":0}]}}`},
-		// A fact covering no determination carries neither field. `returns` is
-		// a struct rather than a kind, so its absence is spelled by omitzero.
-		"NoDetermination": {MethodFact{}, `{"classified":{"receiver":false,"returns":false}}`},
+		"Union": {factOf(t, "Object"), `{"receiver":"none","returns":{"kind":"union","members":[{"kind":"fresh"},{"kind":"param","index":0}]}}`},
+		// The zero fact carries neither field, which is what Of returns for a
+		// name the graph does not hold.
+		"NoDetermination": {MethodFact{}, `{}`},
 	}
 
 	for name, test := range tests {
@@ -471,10 +463,9 @@ func TestFactsUnclassifiedMethodsAreListed(t *testing.T) {
 	require.Empty(t, testFacts(t).Unclassified(AxisReceiver))
 }
 
-// The return axis is where the published surface still has gaps. `returnAlias`
-// is total, so the coverage flag is set for every builtin, and `answers` is what
-// separates a return naming a value the caller holds from an `unknown` naming
-// none.
+// The return axis is where the published surface still has gaps. Every fact
+// carries a return, and `answers` is what separates one naming a value the
+// caller holds from an `unknown` naming none.
 //
 // `Date.prototype.getTime` is off the list because an entry answered it. The
 // two `buffer` getters stay on it deliberately: what they hand back is a borrow
@@ -532,6 +523,13 @@ func TestUnclassifiedReadsBothAxes(t *testing.T) {
 
 	require.Equal(t, []string{"Demo.prototype.opaque"}, facts.Unclassified(AxisReceiver))
 	require.Equal(t, []string{"Demo.prototype.opaque"}, facts.Unclassified(AxisReturns))
+
+	// Answering one axis takes the method off that list alone.
+	mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvBorrow),
+	}}, methods)
+	require.Empty(t, facts.Unclassified(AxisReceiver))
+	require.Equal(t, []string{"Demo.prototype.opaque"}, facts.Unclassified(AxisReturns))
 }
 
 // An axis `answers` does not name reads as unanswered, so each determination §8
@@ -547,20 +545,87 @@ func TestUnclassifiedReadsAnUnwiredAxisAsOpen(t *testing.T) {
 		facts.Unclassified(Axis("throws")))
 }
 
+// Every published fact carries a value on every axis, which is the invariant
+// that lets facts.json omit coverage flags entirely. The analysis alone does
+// not hold it — it withholds 24 receivers — and the curated layer is what
+// closes the gap.
+func TestFactsCarryEveryAxis(t *testing.T) {
+	require.Empty(t, testFacts(t).Incomplete())
+	require.Len(t, testAnalyzedFacts(t).Incomplete(), 24)
+}
+
+// A hole is named with the axis that has it, so the operator knows which
+// determination to curate rather than only which method.
+func TestIncompleteNamesTheAxis(t *testing.T) {
+	t.Parallel()
+
+	cfg, methods := demoFacts(t)
+	facts := &Facts{SpecTarget: cfg.SpecTarget, Methods: methods}
+
+	// `opaque` has no receiver; its return is `unknown`, which is a value.
+	require.Equal(t,
+		[]string{"Demo.prototype.opaque: no receiver determination"},
+		facts.Incomplete())
+
+	mergeCuration(cfg, &Curation{Entries: map[string]CuratedEntry{
+		"Demo.prototype.opaque": entry(t, cfg, "Demo.prototype.opaque", RecvBorrow),
+	}}, methods)
+	require.Empty(t, facts.Incomplete())
+}
+
+// Every axis Incomplete walks has a case in `carries`. Without this, adding one
+// to publishedAxes and forgetting the switch would leave `carries` returning
+// its permissive default, and the gate would pass a fact holding exactly the
+// hole it exists to catch.
+func TestCarriesCoversEveryPublishedAxis(t *testing.T) {
+	t.Parallel()
+
+	for _, axis := range publishedAxes {
+		require.Falsef(t, MethodFact{}.carries(axis),
+			"%s is a published axis that carries does not name", axis)
+	}
+}
+
+// The two predicates read an axis they do not name in opposite directions, on
+// purpose. A determination §8 or §9 has not added yet must not make an
+// otherwise complete fact look like a hole that fails the run, and must show up
+// as open work for a reviewer.
+func TestCarriesAndAnswersDisagreeOnAnUnwiredAxis(t *testing.T) {
+	t.Parallel()
+
+	fact := MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}}
+	require.True(t, fact.carries(Axis("throws")))
+	require.False(t, fact.answers(Axis("throws")))
+}
+
+// They also disagree on an `unknown` return, which is a value the converter can
+// act on and an open question for a reviewer.
+func TestCarriesAndAnswersDisagreeOnAnUnknownReturn(t *testing.T) {
+	t.Parallel()
+
+	fact := MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnknown}}
+	require.True(t, fact.carries(AxisReturns))
+	require.False(t, fact.answers(AxisReturns))
+}
+
 // The tallies over every published builtin, which move when the mutation
 // analysis, the origin map, the classification, or curated.json changes. Each
-// determination is counted on its own. No `receiver unclassified` line appears,
-// because curated.json answers every receiver the analysis withheld.
+// determination is counted on its own, so the return-alias distribution spans
+// every builtin while the receiver one leaves out any method that withholds it.
+//
+// No method withholds one today. The analysis leaves 24 receivers open and the
+// curated layer answers all 24, which is why `receiver unclassified` is absent
+// rather than zero.
 func TestFactsTallies(t *testing.T) {
 	counts := map[string]int{}
 	for _, fact := range testFacts(t).Methods {
 		counts["total"]++
-		if fact.Classified.Receiver {
+		if fact.Receiver != "" {
 			counts["receiver "+string(fact.Receiver)]++
 		} else {
 			counts["receiver unclassified"]++
 		}
-		if fact.Classified.Returns {
+		if fact.Returns.Kind != "" {
 			counts["returns "+string(fact.Returns.Kind)]++
 		} else {
 			counts["returns unclassified"]++

--- a/internal/ecma262/curated.go
+++ b/internal/ecma262/curated.go
@@ -331,16 +331,11 @@ func mergeCuration(cfg *CFG, curation *Curation, methods map[string]MethodFact) 
 			} else {
 				report.Notes = append(report.Notes, receiverNote(name, fact, entry))
 				fact.Receiver = entry.Receiver
-				// A reviewed answer covers the axis as fully as an analyzed
-				// one, so the flag reads the same for both. Facts.Unclassified
-				// is what tells them apart, over analyze rather than NewFacts.
-				fact.Classified.Receiver = true
 			}
 		}
 		if entry.claimsReturns() {
 			report.Notes = append(report.Notes, returnsNote(name, fact, entry))
 			fact.Returns = entry.Returns
-			fact.Classified.Returns = true
 		}
 		methods[name] = fact
 	}

--- a/internal/ecma262/join.go
+++ b/internal/ecma262/join.go
@@ -54,11 +54,11 @@ func (f SignatureFact) String() string {
 }
 
 // unnamedReturn reports whether the resolved fact hands back a value the join
-// cannot name. Two things leave one. The walk read no return it could
-// resolve, or ForSignature dropped a return naming a position this overload
-// does not declare. A fact with no return coverage makes no claim either way.
+// cannot name. Two things leave one. The walk read no return it could resolve,
+// or ForSignature dropped a return naming a position this overload does not
+// declare.
 func (f SignatureFact) unnamedReturn() bool {
-	return f.Fact.Classified.Returns && f.Fact.Returns.Kind == AliasUnknown
+	return f.Fact.Returns.Kind == AliasUnknown
 }
 
 // ForSignature resolves a fact against one overload. A return naming a
@@ -274,7 +274,7 @@ func WriteJoinReport(report JoinReport, w io.Writer) error {
 	// from the match count.
 	withReceiver := 0
 	for _, m := range report.Matched {
-		if m.Fact.Classified.Receiver {
+		if m.Fact.Receiver != "" {
 			withReceiver++
 		}
 	}

--- a/internal/ecma262/join_test.go
+++ b/internal/ecma262/join_test.go
@@ -41,15 +41,13 @@ func TestMethodFactForSignature(t *testing.T) {
 	t.Parallel()
 
 	returnsParam1 := MethodFact{
-		Classified: Coverage{Receiver: true, Returns: true},
-		Receiver:   RecvBorrow,
-		Returns:    returnsParam(1),
+		Receiver: RecvBorrow,
+		Returns:  returnsParam(1),
 	}
 	// A union of two positions, which resolves only against a signature that
 	// declares both. No builtin in the committed graph has this shape.
 	returnsEitherParam := MethodFact{
-		Classified: Coverage{Receiver: true, Returns: true},
-		Receiver:   RecvBorrow,
+		Receiver: RecvBorrow,
 		Returns: ReturnFact{Kind: AliasUnion, Members: []AliasRef{
 			{Kind: AliasParam, Index: position(0)},
 			{Kind: AliasParam, Index: position(2)},
@@ -58,9 +56,8 @@ func TestMethodFactForSignature(t *testing.T) {
 	// An algorithm whose returns the walk never read, which is the shape
 	// `String.prototype.localeCompare` has in the committed graph.
 	readsNoReturn := MethodFact{
-		Classified: Coverage{Receiver: true, Returns: true},
-		Receiver:   RecvBorrow,
-		Returns:    ReturnFact{Kind: AliasUnknown},
+		Receiver: RecvBorrow,
+		Returns:  ReturnFact{Kind: AliasUnknown},
 	}
 
 	tests := map[string]struct {
@@ -87,7 +84,7 @@ func TestMethodFactForSignature(t *testing.T) {
 		},
 		// A claim that names no position applies to every overload as it is.
 		"NoPositionClaimed": {
-			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasReceiver}},
+			fact: MethodFact{Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasReceiver}},
 			sig:  Signature{},
 			want: "receiver:mutBorrow returns:receiver",
 		},
@@ -111,12 +108,12 @@ func TestMethodFactForSignature(t *testing.T) {
 		// cannot build. Neither states the value it claims to return, so both
 		// resolve to unknown.
 		"UnionWithNoMembers": {
-			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion}},
+			fact: MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnion}},
 			sig:  Signature{Params: 2},
 			want: "receiver:borrow returns:unknown",
 		},
 		"ParamReturnWithNoPosition": {
-			fact: MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasParam}},
+			fact: MethodFact{Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasParam}},
 			sig:  Signature{Params: 2},
 			want: "receiver:borrow returns:unknown",
 		},
@@ -158,7 +155,7 @@ func TestMethodFactForSignature(t *testing.T) {
 		// A fact whose return the analysis never covered makes no claim, so
 		// the type settles nothing onto it.
 		"UncoveredReturnNotSettled": {
-			fact: MethodFact{Classified: Coverage{Receiver: true}, Receiver: RecvBorrow},
+			fact: MethodFact{Receiver: RecvBorrow},
 			sig:  Signature{PrimitiveReturn: true},
 			want: "receiver:borrow",
 		},
@@ -177,10 +174,10 @@ func TestMethodFactForSignature(t *testing.T) {
 func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 	t.Parallel()
 
-	fact := MethodFact{Classified: Coverage{Receiver: true, Returns: true}, Returns: returnsParam(3)}
-	require.Equal(t, "returns:unknown", strings.TrimPrefix(
-		fact.ForSignature(Signature{Params: 1}).String(), "receiver: "))
-	require.Equal(t, "receiver: returns:param(3)", fact.String())
+	fact := MethodFact{Receiver: RecvNone, Returns: returnsParam(3)}
+	require.Equal(t, "receiver:none returns:unknown",
+		fact.ForSignature(Signature{Params: 1}).String())
+	require.Equal(t, "receiver:none returns:param(3)", fact.String())
 }
 
 // joinFixture is a hand-built fact set covering each keying shape the join has
@@ -205,35 +202,34 @@ func TestMethodFactForSignatureLeavesTheFactAlone(t *testing.T) {
 // that state. A `web:*` method, which has no ECMA-262 algorithm at all, is
 // where the shape returns.
 func joinFixture() *Facts {
-	covered := Coverage{Receiver: true, Returns: true}
 	return &Facts{
 		SpecTarget: "test",
 		Methods: map[string]MethodFact{
 			// An instance member, string-keyed and symbol-keyed.
-			"Array.prototype.push":            {Classified: covered, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasFresh}},
-			"String.prototype [ @@iterator ]": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
+			"Array.prototype.push":            {Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasFresh}},
+			"String.prototype [ @@iterator ]": {Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
 			// An accessor, whose fixed mutability the join must not overwrite.
-			"get Map.prototype.size": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
+			"get Map.prototype.size": {Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasFresh}},
 			// A static that hands back one of its own parameters.
-			"Object.assign": {Classified: covered, Receiver: RecvNone, Returns: returnsParam(0)},
+			"Object.assign": {Receiver: RecvNone, Returns: returnsParam(0)},
 			// A namespace function, which has no receiver.
-			"Math.max": {Classified: covered, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnknown}},
+			"Math.max": {Receiver: RecvNone, Returns: ReturnFact{Kind: AliasUnknown}},
 			// Two methods whose returns the walk never read, which the type
 			// source settles apart. `lib.es5.d.ts` declares
 			// `localeCompare(that: string): number`, a primitive, so the
 			// return is owned. It declares `exec(string: string):
 			// RegExpExecArray | null`, a union with a member that is not, so
 			// the `unknown` stands.
-			"String.prototype.localeCompare": {Classified: covered, Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
-			"RegExp.prototype.exec":          {Classified: covered, Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
+			"String.prototype.localeCompare": {Receiver: RecvBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
+			"RegExp.prototype.exec":          {Receiver: RecvMutBorrow, Returns: ReturnFact{Kind: AliasUnknown}},
 			// A fact whose receiver claim is withheld while its return alias
 			// stands. See the note above.
-			"Fixture.prototype.withheldReceiver": {Classified: Coverage{Returns: true}, Returns: ReturnFact{Kind: AliasFresh}},
+			"Fixture.prototype.withheldReceiver": {Returns: ReturnFact{Kind: AliasFresh}},
 			// A function the global object holds, which addresses no owner and
 			// so is refused by Normalize.
-			"parseInt": {Classified: covered, Receiver: RecvNone, Returns: ReturnFact{Kind: AliasFresh}},
+			"parseInt": {Receiver: RecvNone, Returns: ReturnFact{Kind: AliasFresh}},
 			// Not a builtin. See the note above.
-			"Fixture.prototype.returnsSecond": {Classified: covered, Receiver: RecvBorrow, Returns: returnsParam(1)},
+			"Fixture.prototype.returnsSecond": {Receiver: RecvBorrow, Returns: returnsParam(1)},
 		},
 	}
 }
@@ -280,7 +276,7 @@ func TestJoinLookup(t *testing.T) {
 			specName, fact, ok := join.Lookup(tc.ref)
 			require.True(t, ok, "%s should resolve", tc.ref)
 			require.Equal(t, tc.want, specName)
-			require.True(t, fact.Classified.Receiver)
+			require.NotEmpty(t, fact.Receiver)
 		})
 	}
 }
@@ -321,8 +317,8 @@ func TestJoinIndexesOneNamePerTriple(t *testing.T) {
 	join := NewJoin(&Facts{
 		SpecTarget: "test",
 		Methods: map[string]MethodFact{
-			"Array.prototype [ @@iterator ]":    {Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvBorrow},
-			"Array.prototype  [  @@iterator  ]": {Classified: Coverage{Receiver: true, Returns: true}, Receiver: RecvMutBorrow},
+			"Array.prototype [ @@iterator ]":    {Receiver: RecvBorrow},
+			"Array.prototype  [  @@iterator  ]": {Receiver: RecvMutBorrow},
 		},
 	})
 

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -43,6 +43,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
@@ -185,8 +186,10 @@ func runPartition(args []string, stderr io.Writer) error {
 	}
 	libDir, outDir := flags.Arg(0), flags.Arg(1)
 
-	// Derive the facts before any output is written, so a bad --cfg path
-	// fails the run before it leaves a half-joined tree on disk.
+	// Derive the facts before any output is written, so neither a bad --cfg
+	// path nor a fact with a hole in it leaves a half-joined tree on disk. The
+	// tree does not read the facts, but a run that ends in an error should not
+	// leave output behind that looks like it succeeded.
 	var facts *ecma262.Facts
 	var join *ecma262.Join
 	if *cfgPath != "" {
@@ -197,6 +200,19 @@ func runPartition(args []string, stderr io.Writer) error {
 		facts, err = ecma262.NewFacts(cfg)
 		if err != nil {
 			return err
+		}
+		if holes := facts.Incomplete(); len(holes) > 0 {
+			// The curation report goes first, because a hole is often the
+			// downstream of a refused entry and that line names the cause. The
+			// error below names only the axis left unanswered.
+			if err := ecma262.WriteCurationReport(facts.Curation(), stderr); err != nil {
+				return err
+			}
+			// A hole would leave the converter to guess a determination nobody
+			// answered, and §7 auto-applies the receiver, so the guess would be
+			// silent. Refuse the run instead.
+			return fmt.Errorf("%s leaves determinations unanswered:\n  %s",
+				*cfgPath, strings.Join(holes, "\n  "))
 		}
 		join = ecma262.NewJoin(facts)
 	}

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -111,6 +111,26 @@ func reportSummaries(stderr string) string {
 	return strings.Join(kept, "\n")
 }
 
+// A graph whose facts hold a determination neither the analysis nor the curated
+// layer answered fails the run rather than writing a hole. The committed graph
+// has none, so the case is built here: one method whose only step is prose the
+// serializer could not lower, which withholds its receiver.
+func TestRun_PartitionRejectsAnUnansweredDetermination(t *testing.T) {
+	t.Parallel()
+	cfgPath := filepath.Join(t.TempDir(), "cfg.json")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(
+		`{"specTarget":"abc","funcs":[`+
+			`{"name":"Demo.prototype.opaque","kind":"builtin-method","params":[],"nodes":[`+
+			`{"kind":"opaque","text":["Let _x_ be whatever the host decides."]}]}]}`), 0o644))
+	outDir := t.TempDir()
+
+	err := run([]string{"partition", "--cfg", cfgPath, seedLib(t, arrayLib), outDir}, io.Discard, io.Discard)
+
+	require.EqualError(t, err, cfgPath+" leaves determinations unanswered:\n"+
+		"  Demo.prototype.opaque: no receiver determination")
+	require.Empty(t, treeOf(t, outDir))
+}
+
 // A --cfg path that does not resolve fails the run before anything is written,
 // so a mistyped flag leaves no half-joined tree behind.
 func TestRun_PartitionRejectsABadCFGPath(t *testing.T) {


### PR DESCRIPTION
Refs #1312

Third of four PRs splitting #1316. **Stacked on [#1319](https://github.com/escalier-lang/escalier/pull/1319)**, which is stacked on [#1318](https://github.com/escalier-lang/escalier/pull/1318). Review those first. The planning-doc prose for this change is in [#1321](https://github.com/escalier-lang/escalier/pull/1321) at the top of the stack.

## What it does

With #1319 answering the last 24 receivers, every published fact carries both determinations and the `classified` object was constant. It cost 60 KB of `facts.json` and left every consumer a flag to remember to check.

Drop it and hold the invariant directly. `Facts.Incomplete` names any fact carrying a hole, one line per method and axis, and `dts_to_esc partition --cfg` fails the run on one before writing anything. A hole would otherwise leave the converter to guess, and §7 auto-applies the receiver, so the guess would be a silent `&mut self`.

The absence of a value is now the hole. Neither field has a valid zero — `""` is not a `ReceiverKind` and not an `AliasKind` — so `carries` reads a field's presence rather than a separate flag.

## Why this could not go first

`analyze` alone leaves 24 receiver holes, so the gate rejects the committed graph until `curated.json` exists. Landing this before #1319 would put a knowingly broken `partition --cfg` on `main` for a PR, and `TestFactsCarryEveryAxis` would have to pin `24` and then flip to `0`.

## `carries` versus `answers`

They split on an `unknown` return. `carries` is what generation requires, and an `unknown` return is a value the converter can act on. `answers` is the reviewer's question, and that same return is still open. 247 published returns sit there.

Both fail closed on an axis they do not name. `Incomplete` walks `publishedAxes` alone, so that answer is reachable only when an axis joins the list without gaining a case in `carries`. Reading it as a hole stops the run. Reading it as carried would pass exactly what the gate exists to catch. `TestCarriesCoversEveryPublishedAxis` fails on that drift first and names the missing case, rather than leaving the gate to report all 501 methods as incomplete.

## Order of the gate's output

The curation report prints before the error, because a hole is often downstream of a refused entry and that line names the cause. The error itself names only the axis left unanswered.

## `facts.json` shape

```json
"Array.prototype.fill": { "receiver": "mutBorrow", "returns": { "kind": "receiver" } }
```

https://claude.ai/code/session_01FnsXWeGS456WxQx455nFBf