### PR TITLE
Document the curated fact layer and the totality rule

### DIFF
--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -38,21 +38,28 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ✅      | §2         | `cfg.json` covers all 501 builtin algorithms plus the 701 functions reachable from them, at the pinned spec revision, and round-trips the schema check the run ends with — met |
 | §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ✅      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §4.2 | Origin map                                 | FR2, FR4   | ✅      | §3         | origins asserted for sample functions — `ToObject(this)`→Receiver, allocators→Fresh, reads→Unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
-| §4.3 | Method classification                      | FR4, FR5   | ✅      | §4.1, §4.2 | facts.json core — receiver / returns / per-determination coverage for the representative methods — met, see [internal/ecma262/](../../internal/ecma262/) |
+| §4.3 | Method classification                      | FR4, FR5   | ✅      | §4.1, §4.2 | facts.json core — receiver and returns resolved per determination for the representative methods — met, see [internal/ecma262/](../../internal/ecma262/) |
+| §4.4 | Curated fact layer                         | FR5, FR7   | ✅      | §4.3       | `curated.json` merges per determination; published `receiver unclassified` is zero; each of the three guards tested — met, see [internal/ecma262/curated.go](../../internal/ecma262/curated.go) |
 | §5   | Keying and join                            | FR7, FR15  | ✅      | §4.3       | normalizer joins facts to `.d.ts` declarations; overloads share algorithm-level facts, type-dependent parts per signature; a primitive return type settles a return the analysis cannot name as owned; unmatched reported — met, see [internal/ecma262/key.go](../../internal/ecma262/key.go) and [internal/ecma262/join.go](../../internal/ecma262/join.go) |
 | §6   | Validation diff                            | FR9        | ⬜      | §5         | receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
 | §7   | Integration as classification source       | FR8        | ⬜      | §6         | converter ranks facts above name tiers; the two application paths wired; redundant overrides removed |
-| §8.1 | Parameter disposition                      | FR12       | ⬜      | §4.1, §7   | push/Map.set `escape`, Reflect.set `mutBorrow`+`escape`, indexOf `borrow` in facts.json |
+| §8.1 | Parameter disposition                      | FR12       | ⬜      | §4.1, §4.4, §7 | `MutArgs` supplies `mutBorrow`; `escape` is curated for the container methods that have one. The transitive `StoreEdges` fixpoint is dropped — see §8.1 |
 | §8.2 | Return-borrow seed                         | FR4        | ⬜      | §4.3       | documented `returns` → `&`/lifetime annotation mapping (small) |
 | §9.1 | Throw-set fixpoint                          | FR10       | ✅      | §4.2       | raw throw sets, `Exception` = class / origin / callback-effect / unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
-| §9.2 | Coercion filter                            | FR11       | ⬜      | §9.1, §5   | filtered throws — toFixed keeps RangeError, drops the receiver-coercion TypeError; param branch runs post-join |
+| §9.2 | Coercion filter                            | FR11       | ⬜      | §9.1, §5   | the receiver branch alone — toFixed keeps RangeError, drops the receiver-coercion TypeError. The parameter branch is dropped in favour of curated throws — see §9.2 |
 | §9.3 | Throw/reject split, parametric origins, combinators | FR10, FR13 | ✅ | §9.1  | `rejects` distinct from `throws`; Promise.reject `param:0`, forEach `throwsOf:param:k`; combinators hand-modeled — met, see [internal/ecma262/](../../internal/ecma262/) |
-| §9.4 | Throws validation + auto-apply gate        | FR14       | ⬜      | §9.1–§9.3, §7 | spec-independent (dynamically-observed) ground truth; false-negative rate report gates auto-apply |
+| §9.4 | Throws validation                          | FR14       | ⬜      | §9.1–§9.3, §4.4, §7 | spec-independent, dynamically-observed ground truth, run as a spot-check over the curated throws. The false-negative auto-apply gate is dropped — see §9.4 |
 | §10  | Maintenance workflow                       | NFR        | ⬜      | §7         | spec-bump runbook; `--check`-style drift report in CI |
-| §11  | Curation of the override layer             | FR12, FR4, FR13, FR14 | ⬜ | §7, §8, §9 | override layer populated per pseudo-package by review; fans out into per-package PRs |
+| §11  | Curation of the override layer             | FR12, FR4, FR13, FR14 | 🚧 | §4.4, §7, §8, §9 | override layer populated per pseudo-package by review; fans out into per-package PRs. The 24 receivers and three interior returns are curated; disposition and throws follow |
 
 Within a section the sub-section PRs sequence per the "Depends on" column —
 `§4.1` reads the origin map, so `§4.2` lands first despite the numbering.
+
+§4.4 changes the shape of the phases after it. A determination the graph
+does not settle is answered by a curated entry rather than by a new
+lattice member, so §8.1, §9.2, and §9.4 each carry less analysis than
+their original scope. Each row above names what it drops and its section
+gives the reasoning.
 
 **Dependency graph** (all PRs plus the external dependencies this plan
 names in other planning docs; edges are "must land before"):
@@ -65,6 +72,7 @@ flowchart TD
     S42["§4.2 Origin map"]
     S41["§4.1 Mutation-summary fixpoint"]
     S43["§4.3 Method classification"]
+    S44["§4.4 Curated fact layer"]
     S5["§5 Keying and join"]
     S6["§6 Validation diff"]
     S7["§7 Integration"]
@@ -73,7 +81,7 @@ flowchart TD
     S91["§9.1 Throw-set fixpoint"]
     S92["§9.2 Coercion filter"]
     S93["§9.3 Throw/reject split, origins, combinators"]
-    S94["§9.4 Throws validation + auto-apply gate"]
+    S94["§9.4 Throws validation"]
     S10["§10 Maintenance"]
     S11["§11 Curation (per-package PRs)"]
 
@@ -83,8 +91,9 @@ flowchart TD
     S42 --> S41
     S41 --> S43
     S42 --> S43
-    S43 --> S5 --> S6 --> S7
+    S43 --> S44 --> S5 --> S6 --> S7
     S41 --> S81
+    S44 --> S81
     S7 --> S81
     S43 --> S82
     S42 --> S91
@@ -93,8 +102,10 @@ flowchart TD
     S91 --> S93
     S92 --> S94
     S93 --> S94
+    S44 --> S94
     S7 --> S94
     S7 --> S10
+    S44 --> S11
     S81 --> S11
     S82 --> S11
     S93 --> S11
@@ -194,11 +205,11 @@ that would introduce new PRs:
   review sits between the fact and the committed annotation (see §7 "Two
   application paths"; `throws`/`rejects` and the `&`/lifetime annotations
   are added by the curator, disposition gets a provisional baseline the
-  curator corrects). These are not permanently curation-grade,
-  though: `throws`/`rejects` have a defined graduation path — §9.4
-  measures the false-negative rate, and a measured zero flips them to
-  auto-apply (FR14). Whether disposition is confident enough to auto-apply
-  like receiver mutability is a similar open call to settle when §8 lands.
+  curator corrects). §9.4 measures those annotations against observed
+  behavior rather than authorizing them to skip review; §4.4 explains why
+  the review is the cheaper half of that pair. Whether disposition is
+  confident enough to auto-apply like receiver mutability is an open call
+  to settle when §8 lands.
 - **`escape` spelling depends on external affine work.** §8 records the
   `escape` disposition; curation spells it a `move` (owning container) or
   a lifetime-bounded borrow (borrow-holding container), per requirements
@@ -1109,13 +1120,13 @@ func classify(M) MethodFact:
     fact.Throws     = filterThrows(M)              // §9.2
     fact.Rejects    = rejectSet(M)                 // §9.3, published alongside Throws in §9.2
     // Soundness bias (FR5), applied per determination. A method the
-    // analysis could not fully cover OR could not fully attribute
-    // withholds the determinations that read the steps it missed. A
-    // static's RecvNone reads no step, so no warning withholds it.
-    fact.Classified.Receiver = M.Kind != BuiltinMethod
-        or (M not in Unattributable and M not in Incomplete)
-    fact.Classified.Returns  = true   // returnAlias is total, top Unknown
-    return fact
+    // analysis could not fully cover OR could not fully attribute leaves
+    // out the determinations that read the steps it missed, and §4.4's
+    // review answers them before anything is published. A static's
+    // RecvNone reads no step, so no warning withholds it.
+    if M.Kind == BuiltinMethod and (M in Unattributable or M in Incomplete):
+        fact.Receiver = <absent>       // §4.4 answers it, or generation fails
+    return fact                        // returnAlias is total, top Unknown
 
 func receiverKind(M):
     if M.Kind != BuiltinMethod: return RecvNone    // static / namespace function: no receiver
@@ -1145,18 +1156,19 @@ lifetime bounded, so §8.2 has nothing to emit for it.
 An `Unattributable` method has a mutation the analysis could not pin to
 a formal — a write through an `Unknown`-origin value, including deep
 mutation reached through a property read. Its receiver claim is withheld
-and its name listed, so the converter falls the method through to the
-name heuristics and the receiver defaults to `&mut self` (FR5).
+and its name listed, which is what §4.4 curates. Nothing is published for
+a method whose receiver neither source answers.
 
-**Coverage is per determination, not per method.** The two axes carry
-different risk. Receiver mutability is a soundness claim §7 auto-applies,
+**A withheld determination is per determination, not per method.** The two
+axes carry different risk. Receiver mutability is a soundness claim §7 auto-applies,
 and a wrong `borrow` lets an immutable value call a mutating method. The
 return alias is FR4's lifetime seed, which §7 records for curation rather
 than applies, so withholding it costs precision and buys no safety. A
 method whose only problem is a possible hidden mutation therefore keeps
 its `returns` and loses only its `receiver`. That is §2's per-signal
-finding — a determination is unclassified only when a `yet` sits on a step
-it reads.
+finding — a determination is withheld only when a `yet` sits on a step it
+reads. §4.4 then answers what the analysis withheld, so nothing reaches
+`facts.json` with a determination missing.
 
 A method's receiver mutability cannot be recovered the same way. An opaque
 node carries no operands, so there is no way to tell what a missed step
@@ -1203,7 +1215,155 @@ because the alias is curated rather than applied.
 
 Methods with a withheld receiver are listed. The `returns` tally spans
 every builtin, and the `receiver` tally leaves out only the 24 methods
-whose mutability is withheld.
+whose mutability is withheld. §4.4 answers all 24 by review, so the
+published tally leaves out none.
+
+### §4.4. The curated fact layer (FR5, FR7)
+
+**Goal.** Answer a determination the graph does not settle by review,
+recorded as committed data, so the analysis does not have to grow a new
+lattice member for every method it cannot read.
+
+**Why the layer, rather than more analysis.** §4 is past the knee of its
+curve on the axis §7 auto-applies. 477 of 501 builtins carry a receiver
+claim. Every determination still open is curation-grade by §7's own
+design. Each reaches the generated `.esc` through review rather than
+straight from the facts. So sharpening the analyzer further only improves
+the input to a review step that happens either way. The cost of that
+sharpening is measured:
+
+| Analysis work | Cost | Methods it reaches |
+| --- | --- | --- |
+| Species-allocator origins | `origin.go` +232 lines | 3 statics |
+| The interior-return alias kind | a new lattice member, join and schema changes | 5 |
+| The property-path origin | a new lattice member, read by §4.1 and §4.3 | 47 |
+| The escape fixpoint of §8.1 | a second transitive fixpoint | ~20 |
+
+The 24 withheld receivers, by contrast, are an hour of review. Roughly
+twenty are read-only formatters. The mutating remainder is the two
+iterator `next` methods, `RegExp.prototype [ @@replace ]`, and
+`SharedArrayBuffer.prototype.grow`.
+
+This does not reverse FR5 or §11, both of which already reserve the tail
+for curation. It gives that reservation a mechanism early, where §11 would
+otherwise wait behind §7.
+
+**The layer.** `internal/ecma262/curated.json`, keyed by the Appendix C
+canonical spec names — the key space `cfg.json` and the §5 join already
+share. Each entry carries the same determination fields a `MethodFact`
+does, plus the provenance a reviewer needs:
+
+```json
+"Number.prototype.toFixed": {
+  "reason": "The receiver is statically a number, so ToNumber cannot throw.",
+  "evidence": "ECMA-262 \"Number.prototype.toFixed\"",
+  "reviewedAt": "1836cd89dd25",
+  "receiver": "borrow"
+}
+```
+
+An entry answers the axes it carries a value for, and no others. Neither
+determination has a valid zero value, so a field left out is unambiguously
+an axis left to the analysis. The entry above answers the receiver and
+leaves the return alias where the analysis put it.
+
+`reason` is required. A claim that outranks the analysis without a stated
+argument cannot be re-reviewed later.
+
+**The merge is per determination, never per method.** `NewFacts` runs the
+analysis and then merges the layer over the result, one axis at a time.
+An axis an entry leaves out keeps whatever the analysis concluded, so the
+two sources compose. `Date.prototype.getTime` is the shape: the analysis
+settles its receiver and the entry answers only its return.
+
+Each curated axis is one of three things, and the merge reports which:
+
+- a **fill-in**, where the analysis left the axis open. This is the
+  ordinary case and carries no conflict. A receiver is open when the
+  analysis carried no value for it, and a return alias is open when it
+  resolved to `unknown` as well, since the top of the alias lattice names no
+  value the return hands back.
+- a **correction**, where the analysis published a claim the review
+  contradicts. §6 reads these first, because a correction is either a spec
+  subtlety the graph cannot express or an analyzer bug, and the two look
+  alike from the report.
+- a **redundant** entry, repeating what the analysis already concluded.
+
+One curated claim is refused rather than merged. Whether a builtin has a
+receiver at all follows from `Func.Kind` and reads no algorithm step, so
+the graph settles it outright. A `borrow` curated onto a static would put
+a `&self` on a declaration that has no self, which is the one curated
+mistake §7 cannot absorb, since receiver mutability is the determination
+it auto-applies. The merge refuses that axis, reports it, and leaves the
+analysis's answer standing.
+
+**Three guards keep the layer from becoming a second source of truth.**
+
+1. A curated name the graph holds no builtin for is reported and applied
+   to nothing, and `TestCurationMatchesTheGraph` fails the build on one.
+   A misspelled key and a key carried over from another spec revision both
+   land there.
+2. Each entry names the `Func.Digest` of the algorithm it was reviewed
+   against, a fingerprint over that one serialized algorithm. A spec bump
+   that rewrites the algorithm flags the entry for re-review and leaves
+   every untouched entry alone. A stale entry is still applied, since
+   dropping it would trade a visible prompt for a silent loss of coverage.
+3. A redundant entry is reported so it can be deleted, which is how the
+   layer shrinks as the analysis improves rather than accumulating.
+
+**Provenance is not on the wire.** `facts.json` records the merged
+determination and not which source produced it, because §7 applies a
+curated receiver claim and an analyzed one identically. The
+`CurationReport` is where a reviewer reads the split, and §6 diffs against
+it.
+
+**What the layer closes.** Curating the 24 receivers takes the published
+`receiver unclassified` tally to zero and retires the fallback to §7's
+name heuristics for `std:*`. All 27 committed entries are fill-ins, so
+nothing in the layer yet contradicts a claim the analysis made and §6 has
+no disagreement to triage. Three of the five interior returns of §4.3 are
+curated `fresh`, because a primitive read out of a slot is a copy —
+`Date.prototype.getTime`, `Date.prototype.valueOf`, and `get
+TypedArray.prototype [ @@toStringTag ]`. The two `buffer` getters stay
+`unknown`: what they hand back is a real borrow of an object the receiver
+holds, and no member of the alias lattice spells that without claiming
+identity. That residue is a type-system question rather than an analysis
+gap, which is the distinction the layer makes visible.
+
+**The species exception.** `Array.prototype.slice`, `TypedArray.prototype.slice`,
+`RegExp.prototype [ @@matchAll ]`, and `RegExp.prototype [ @@split ]`
+build their result through a constructor a caller can replace through
+`@@species`. A hostile `@@species` can hand back the receiver, which makes
+the write the algorithm aims at its fresh result land on the receiver
+instead. The curated entries record `borrow` and state that shape as out
+of scope. That is a policy decision a reviewer can make and the analysis
+cannot, and writing it down is what closes the question rather than
+another origin-lattice member.
+
+**The bound.** Curation is per-method human work that recurs on every spec
+bump, where the fixpoints re-derive all 501 for free. The layer is for the
+tail. The mutation fixpoint and the origin map carry the bulk mechanically
+and stay as they are.
+
+**What is still open.** The unresolved-determination report reads per
+axis, because the two axes spell an unanswered determination differently
+and cost different things. A `ReceiverKind` has no member meaning "could
+not tell", so an unanswered receiver is one the analysis carried no value
+for. The alias lattice has a top and `returnAlias` is total, so an
+unanswered return is a published `unknown`. Summing them would hide the difference that
+matters: §7 auto-applies the receiver, so an open one is a soundness gap
+that falls to the name heuristics, while an open return costs only the
+lifetime precision §8.2 would have seeded.
+
+Published today: **0** receivers open, **247** returns open. The receiver
+axis is closed; the return axis is where the next curation batch goes.
+
+**Gate.** `curated.json` merges per determination; the published
+`receiver unclassified` tally is zero; every published fact carries a value
+on every axis, so `facts.json` needs no coverage flags and a hole fails the
+run instead; the unresolved report reads both axes; each of the three
+guards and the receiver-kind refusal has a test; the report distinguishes a
+curated determination from an analyzed one.
 
 ## §5. Keying and join (FR7, FR15)
 
@@ -1343,8 +1503,12 @@ entry. This is the gate that authorizes removing override entries in §7.
 - Insert the facts lookup into `dts_to_esc.Classify` at rung 2 (FR8):
   after explicit author signals, before the `get*` prefix and name
   heuristics.
-- Set receiver mutability from a fact whose `classified.receiver` is set;
-  leave the rest to the existing tiers.
+- Set receiver mutability from the fact, and leave the rest to the existing
+  tiers. Every published fact carries one, so there is no coverage flag to
+  consult and no hole to fall through. The lookup reads one merged source:
+  §4.4 merges the curated layer inside `NewFacts`, so the converter never
+  sees the two halves apart and applies a curated claim and an analyzed one
+  identically.
 - Apply the FR5 defaults for every determination a record leaves uncovered,
   whose field is absent. Receiver mutability falls through to the name
   tiers, defaulting to `&mut self`. For the curation-grade determinations
@@ -1377,7 +1541,7 @@ it. What differs is only how the two `facts.json` contributions reach the
 merge; that split is per determination, not per method:
 
 - **Auto-applied (trusted).** Receiver mutability is read straight from a
-  classified fact and written into the `.esc` — no human in the loop. It
+  published fact and written into the `.esc` — no human in the loop. It
   is the only determination §6 has validated (FR9) as trustworthy.
 - **Curation-grade (reviewed).** Parameter disposition, the return-borrow
   seed, `throws`, and `rejects` reach the `.esc` only through a
@@ -1397,20 +1561,21 @@ merge; that split is per determination, not per method:
   absent `throws` clause is `never`), so the human genuinely *adds* them.
 - Parameter **disposition** is the exception: every parameter must carry a
   disposition for the signature to be valid, so the converter writes a
-  **provisional baseline** — the analyzed disposition for a classified
-  method, the FR5 `&mut` default when uncertain — which the override
+  **provisional baseline** — the disposition the published fact carries, or
+  the FR5 `&mut` default where no fact addresses the method — which the override
   layer, if present, corrects. That is review-and-**correct**, not
   author-from-scratch. So disposition is written but not trusted; the
   other three are not written until curated.
 
-Once §9.4's FR14 gate measures a zero false-negative rate, `throws` /
-`rejects` graduate from the reviewed path to the auto-applied one for the
-covered subset.
+`throws` and `rejects` stay on the reviewed path. §9.4 measures what that
+path produces against observed behavior and feeds the disagreements back
+into the curated entries, rather than authorizing an extracted set to skip
+the review.
 
-**A determination `facts.json` does not carry falls back to a default.**
-When a `std:*` method is unmatched by the join (§5), or its fact leaves a
-determination uncovered (§4.3), that part of the declaration is `.d.ts`
-types plus the FR5 defaults — `&mut self`, `&mut` parameters, empty
+**A method `facts.json` does not address falls back to a default.**
+This is now the only degraded path, because a published fact answers every
+determination it carries. When a `std:*` method is unmatched by the join
+(§5), the declaration is `.d.ts` types plus the FR5 defaults — `&mut self`, `&mut` parameters, empty
 `throws`/`rejects` — carrying no spec-derived effect. This is the degraded
 path, not a preferred one. FR5 lists every method with a withheld receiver
 and §5 reports every unmatched declaration, precisely so these are visible
@@ -1482,16 +1647,19 @@ the call:
   does not default conservatively, and it is not treated as `Incomplete`.
   The parameter's mutation axis is decided separately by `MutArgs`.
 
-Escape is **transitive** by the same fixpoint as FR2. Define, per abstract
-operation `G`, `StoreEdges(G) ⊆ {(k, m)}` meaning `G` stores its `k`-th
-argument into its `m`-th argument. Seed it from direct stores —
-`Set(args[m], _, args[k])` yields `(k, m)` — and propagate along the call
-graph: if `G` calls `H`, and `H` has edge `(k', m')`, and `G` passes its
-own formals at `H`'s positions `k'` and `m'`, then `G` gains that edge.
-A method then has an escape whenever it passes a parameter value at `k`
-and an escaping destination at `m`. Value-typed arguments are copied at
-runtime regardless (requirements ownership section), so the fact records
-`escape` without committing to a spelling.
+**Escape is not chased through the call graph.** The direct check above
+reads the store sites one algorithm holds. Making it transitive would mean
+a second fixpoint in the shape of FR2: per abstract operation `G`, a set
+of edges `(k, m)` meaning `G` stores its `k`-th argument into its `m`-th,
+seeded from direct stores and propagated along the call graph. That is
+substantial machinery for a short list. The container methods with an
+escape are `push`, `unshift`, `splice`, `fill`, `Map.prototype.set`,
+`Set.prototype.add`, the two weak-collection setters, `Reflect.set`,
+`Object.assign`, and `Object.defineProperty`. §4.4 answers what the direct
+check misses with a curated entry, at a fraction of the cost and with a
+stated reason per method. Value-typed arguments are copied at runtime
+regardless per the requirements ownership section, so the fact records
+`escape` without committing to a spelling either way.
 
 ### §8.2. Return-borrow seed (FR4)
 
@@ -1645,17 +1813,23 @@ func precludedCoercion(M, site) bool:
     return false
 ```
 
-Receiver coercions are filtered unconditionally, because the receiver's
-type is always statically known. **Parameter coercions are filtered only
-when the joined declaration proves the parameter's type already is the
-coercion's target** — `ToNumber(p)` on a `p: number` cannot throw, but
-`ToNumber(p)` on a `p: unknown` can. That check needs the typed
-signature, which the shape-free facts do not carry (FR7), so the
-parameter branch of the filter **runs after the FR7 join** (or is fed the
-parameter types from it); the receiver branch can run earlier. A
+**Only the receiver branch is built.** A receiver coercion is filtered
+unconditionally, because the receiver's type is always statically known,
+and that check reads nothing the facts do not already carry. A
 `RangeError`, `SyntaxError`, `URIError`, or a `TypeError` from an explicit
-domain check survives. Each filter decision is recorded for review, since
-FR11 is a heuristic. Channel assignment is **per throw site, not per
+domain check survives it. Each filter decision is recorded for review,
+since FR11 is a heuristic.
+
+Filtering a **parameter** coercion is a different proposition. It is sound
+only where the joined declaration proves the parameter's type already is
+the coercion's target — `ToNumber(p)` on a `p: number` cannot throw, but
+`ToNumber(p)` on a `p: unknown` can. The shape-free facts carry no types
+per FR7, so that branch would have to run after the join or be fed the
+parameter types from it, which is the plumbing #1301 describes. §4.4
+answers it instead: the methods whose surviving throws are worth
+annotating are a short list, and a curated `throws` states the filtered
+set directly with the reasoning attached. The parameter branch and its
+typed-signature plumbing are dropped. Channel assignment is **per throw site, not per
 error type**: `filterThrows` sees only the synchronous sites, `rejectSet`
 (§9.3) only the rejection sites, so the same error type can legitimately
 appear in both `throws` and `rejects` when raised on both a synchronous
@@ -1797,12 +1971,21 @@ element-`E` / `AggregateError` / `never` rejects. Because concrete `std:*`
 domain rejections are rare (FR13), most `std:*` `rejects` sets are empty
 or a forwarded element `E`, and that is recorded as an origin, not hidden.
 
-### §9.4. Throws validation and the auto-apply gate (FR14)
+### §9.4. Throws validation (FR14)
 
-The throws counterpart of §6's mutability diff. It decides, by
-measurement, whether throws stay a reviewed candidate set or graduate to
-auto-apply — so it is the phase that could later retire the "Throws as a
-finished, unreviewed annotation" non-goal.
+The throws counterpart of §6's mutability diff: an empirical check on the
+`throws` and `rejects` a builtin carries, built from observed behavior
+rather than from the specification the extractor already reads.
+
+**The auto-apply gate is dropped.** It existed to decide, by measuring a
+false-negative rate, whether an *extracted* throw set could reach the
+generated `.esc` without a human. Under §4.4 the throw sets that matter
+are curated, so they are reviewed by construction and there is nothing for
+the gate to authorize. What remains worth building is the ground-truth
+corpus, run as a spot-check over the curated entries: it is the one source
+of evidence about throws that does not share the extractor's blind spots,
+and it catches a reviewer's mistake the same way it would have caught an
+extractor's.
 
 **Work.**
 
@@ -1832,22 +2015,20 @@ finished, unreviewed annotation" non-goal.
   Apply the documented host-throws exclusion throughout, so stack-overflow
   `RangeError` and OOM are filtered from the observations and never enter
   the ground truth. A human verifies and commits the result.
-- Diff the extracted sets against it and report two rates (FR14):
-  - the **false-negative rate** — real throws the emitted set omits —
-    measured in two layers: against the *raw* FR10 set (should be zero
-    when the CFG is faithful — isolates §9.1 soundness) and against the
-    *filtered* FR11 set (its false negatives are the coercion filter's
-    over-prunes);
-  - the **false-positive rate** — phantom throws — which costs only a
-    redundant handler and carries less weight.
-- Triage every filtered false negative: a genuine over-prune fixes the
-  §9.2 filter; a ground-truth error fixes the sample.
+- Diff the published sets against it, in two layers. Against the *raw*
+  FR10 set a false negative isolates a §9.1 soundness gap, and should be
+  zero where the control-flow graph is faithful. Against the *published*
+  set, curated entries and all, a false negative is a real throw a caller
+  would have to handle and nothing declares.
+- Report the false positives too. A phantom throw costs only a redundant
+  handler, so it carries less weight than a false negative.
+- Triage every published false negative to one of three causes: an
+  over-prune by §9.2's receiver branch, a curated entry that is wrong, or
+  an error in the sample.
 
-**Gate.** A reviewed rate report. While the filtered false-negative rate
-is above zero, the converter treats `throws`/`rejects` as curation input
-(§7 does not auto-apply them). A measured filtered false-negative rate of
-zero on the sample is the evidence that authorizes flipping throws to
-auto-apply, mirroring how §6 authorizes trusting the mutability facts.
+**Gate.** A reviewed disagreement report over the curated `throws` and
+`rejects`, with every disagreement triaged to a corrected curated entry or
+a corrected sample.
 
 ## §10. Maintenance workflow
 
@@ -1880,13 +2061,20 @@ recording the accepted or corrected annotations. It is data work, and
 treating it as such — its own PRs, reviewed on their own terms — keeps it
 legible.
 
-**Sequencing.** Curation cannot begin until the facts exist (§4, §8, §9)
-and the override-layer path is wired (§7 plus the builtins converter that
-generates `.esc`). It is independent of the M7.5 solver-side application —
-the override layer can be populated against the converter's output before
-the active checker ingests it. Some curation-adjacent review is embedded
-earlier: §6 triages the receiver-mutability diff, and §9.4 builds the FR14
-ground-truth corpus.
+**Sequencing.** Curation of the effect annotations cannot begin until the
+facts exist (§4, §8, §9) and the override-layer path is wired (§7 plus the
+builtins converter that generates `.esc`). It is independent of the M7.5
+solver-side application — the override layer can be populated against the
+converter's output before the active checker ingests it. Some
+curation-adjacent review is embedded earlier: §6 triages the
+receiver-mutability diff, and §9.4 builds the FR14 ground-truth corpus.
+
+The **fact-level** curation of §4.4 runs ahead of all of it, because it
+needs only the facts and not the converter. Its mechanism is the one this
+phase uses: a committed data file keyed by canonical spec name, merged per
+determination, with a stated reason per entry. §11 populates the effect
+axes of that same file as §8 and §9 make them available. The receiver
+axis is already done, and the three interior returns with it.
 
 **PR shape.** Curation lands as its own PRs, separate from the infra
 phases and incremental — one per pseudo-package or batch (`std:array`,
@@ -1896,11 +2084,13 @@ PRs because a diff of hand-reviewed annotations reviews on different terms
 than a diff that changes the analyzer, and because the volume is large and
 recurs as deltas on spec bumps.
 
-**A shrinking surface.** Receiver mutability is already auto-applied (no
-curation). Once §9.4's FR14 gate measures a zero false-negative rate,
-`throws`/`rejects` graduate to auto-apply for the covered subset. So the
-curation surface contracts over time toward mostly disposition and
-lifetime annotations.
+**A shrinking surface, in two directions.** Receiver mutability is
+auto-applied, whether the claim came from the analysis or from a curated
+entry. And a curated entry the analysis later catches up with is reported
+as redundant and deleted, so the layer contracts as §4 improves rather
+than accumulating. What is left grows toward disposition, lifetime, and
+throws annotations, which is where the spec states an effect no
+control-flow graph carries.
 
 **Where an assistant can and cannot stand in.** The labor is largely
 mechanical and an assistant (including Claude) can take much of it on:
@@ -2080,8 +2270,15 @@ closure argument prologues writing into `__args__`, as in
 
 ## Appendix B. `facts.json` schema
 
-The committed output of §4, consumed by the converter (§7). Small,
-reviewable, keyed by canonical spec name.
+The output of §4, consumed by the converter (§7). Small, reviewable, keyed
+by canonical spec name.
+
+The file is derived rather than committed. `NewFacts` runs the analysis
+over the committed `cfg.json` and merges the curated layer of §4.4 over
+the result, so nothing on disk holds a fact to hand-edit. That is what
+keeps a curated answer out of the generated artifact and in
+`curated.json`, where FR7 re-applies it on every run. The curated entry
+shape is Appendix D.
 
 ```go
 type Facts struct {
@@ -2103,8 +2300,8 @@ const (
                                             // move or a lifetime-bounded borrow at curation (FR12)
     // A parameter the analysis PROVED read-only (&) is omitted from Params.
     // That omission is distinct from the FR5 uncertain default (&mut): it
-    // means "shown read-only", and reads that way only where
-    // Coverage.Params is set.
+    // means "shown read-only". A method whose parameters the analysis could
+    // not read is not written at all, per the totality rule below.
 )
 
 type ParamFact struct {
@@ -2136,33 +2333,49 @@ type ReturnFact struct {
     Members []AliasRef `json:"members,omitempty"` // set exactly when Kind == "union"
 }
 
-// Coverage says which determinations the analysis resolved. Each axis is
-// withheld on its own, so a method that hides a mutation still publishes
-// its return alias. An axis no step decides is always covered, such as a
-// static's "receiver": "none" (§4.3).
-type Coverage struct {
-    Receiver bool `json:"receiver"` // §4.3; always set for a static
-    Returns  bool `json:"returns"`  // returnAlias ran; true for every builtin
-    Params   bool `json:"params"`   // §8.1
-    Throws   bool `json:"throws"`   // §9.2
-    Rejects  bool `json:"rejects"`  // §9.3
-}
-
-// An uncovered determination is ABSENT from the JSON — an unanalyzed axis,
-// distinct from a proven-empty result, which is covered with an empty
-// effect field. Receiver is a kind with no empty member and Returns is a
-// struct, so omitempty and omitzero spell their absence. The three slices
-// carry neither, which would drop the [] that spells that second case.
-// Uncovered they encode as null.
+// MethodFact carries every determination. Neither Receiver nor Returns has
+// a valid zero value, and the three slices are written whenever their axis
+// is computed, so an absent field is a hole rather than a claim. Facts
+// records no coverage flags because a hole never reaches the file: the run
+// fails first.
 type MethodFact struct {
-    Classified Coverage     `json:"classified"`         // per-determination coverage (FR5)
-    Receiver   ReceiverKind `json:"receiver,omitempty"` // borrow | mutBorrow | none (FR2)
-    Params     []ParamFact  `json:"params"`             // only non-borrow parameters (FR12)
-    Returns    ReturnFact   `json:"returns,omitzero"`   // return-borrow lifetime seed (FR4)
-    Throws     []string     `json:"throws"`             // sync throws post-filter (FR10, FR11)
-    Rejects    []string     `json:"rejects"`            // async rejects → Promise<T,E>.Err (FR13)
+    Receiver ReceiverKind `json:"receiver,omitempty"` // borrow | mutBorrow | none (FR2)
+    Params   []ParamFact  `json:"params"`             // only non-borrow parameters (FR12)
+    Returns  ReturnFact   `json:"returns,omitzero"`   // return-borrow lifetime seed (FR4)
+    Throws   []string     `json:"throws"`             // sync throws post-filter (FR10, FR11)
+    Rejects  []string     `json:"rejects"`            // async rejects → Promise<T,E>.Err (FR13)
 }
 ```
+
+**Every published fact is total.** A determination neither the analysis nor
+§4.4's curated layer answers is not encoded — `Facts.Incomplete` names it
+and generation refuses to write the file. That is the rule the schema rests
+on, and it is why there is no `classified` object: an axis is present, or
+the run failed with the method and axis on stderr.
+
+The alternative was a per-axis coverage flag saying which determinations
+were resolved, so a consumer could tell "unanalyzed" from "proven none".
+Making the file total is stronger. A flag leaves a hole in the data that
+every consumer must remember to check, and §7 auto-applies the receiver, so
+a forgotten check there becomes a silent `&mut self`. Failing the run puts
+the same information in front of the one person who can act on it.
+
+**`unknown` is a value, not a hole.** The alias lattice's top says the walk
+read the returns and could tie none of them to a value the caller holds,
+which is a fact §8.2 acts on by leaving the lifetime to elision. 247 of the
+501 builtins publish it. The methods still wanting an answer there are
+`Facts.Unclassified(AxisReturns)`, a review report rather than a wire
+concern. The receiver axis has no counterpart, because `ReceiverKind` has
+no member meaning "could not tell" — which is exactly why a missing
+receiver is the case that fails the run.
+
+**A slice axis reads the same way once §8 and §9 add one.** `[]` is a
+proven-empty result and the axis being uncomputed fails the run, so a
+consumer never has to tell `null` from `[]`. The one wrinkle is FR5's
+deliberate under-reporting for `throws` and `rejects`: until §9.2 lands
+those axes are not computed at all, so they are absent from the schema
+rather than present-and-empty, and the totality rule starts applying to
+them when they are wired in.
 
 Each entry in `Throws` / `Rejects` is one of (requirements FR13): a
 standard error-class name the spec constructs (`TypeError`, `RangeError`,
@@ -2173,17 +2386,12 @@ form (`Promise.all`/`race`/`any` forwarding their element promises' `E`);
 the **effect ref** `"throwsOf:param:k"` for a method that propagates a
 callback parameter's throws (`Array.prototype.forEach`/`map`/…), resolved
 at the FR7 join to throws polymorphism; or the sentinel `"unknown"` for a
-propagated value the analysis can neither name nor trace. All origin and
-effect refs resolve to types at the FR7 join. An entry carries no receiver,
-disposition, throw, or reject claim its `classified` coverage does not
-cover — those fields are absent or null, never empty — so the converter
-cannot mistake "unanalyzed" for "proven none"; it applies the FR5 default
-for that axis itself. A method whose `receiver` is uncovered falls through to
-the name heuristics and is collected into a separate `unclassified` report
-alongside `facts.json` for auditing (FR5). Where `classified.params` is
-set, a parameter absent from `Params` was proven read-only (`&`) — not to
-be confused with the FR5 `&mut` default the converter applies where it is
-not.
+propagated value the analysis can neither name nor trace. All origin and effect refs resolve to types at the FR7 join.
+
+A parameter absent from `Params` was proven read-only (`&`). That is a
+claim, not a gap, because a method whose parameters the analysis could not
+read is not published at all. It is distinct from the FR5 `&mut` default,
+which the converter applies only where no fact addresses the method.
 The receiver-returning and fresh-returning alias kinds carry the return's
 borrow lifetime per FR4.
 
@@ -2204,7 +2412,6 @@ two positions and a single field could name only one of them:
 
 ```json
 "Object": {
-  "classified": { "receiver": true, "returns": true },
   "receiver": "none",
   "returns": {
     "kind": "union",
@@ -2256,3 +2463,61 @@ A prototype with no name of its own in the language is the root of the
 path rather than a `prototype` segment, so `%ArrayIteratorPrototype%`'s
 `next` is keyed `ArrayIteratorPrototype.next`. It still has a receiver
 and carries `Kind: builtin-method`.
+
+## Appendix D. `curated.json` schema
+
+The committed curated layer of §4.4, keyed by the same canonical spec
+names as Appendix C.
+
+```go
+// Curation is the whole committed layer.
+type Curation struct {
+    Entries map[string]CuratedEntry `json:"entries"`
+}
+
+type CuratedEntry struct {
+    Reason     string `json:"reason"`             // why the curated answer is right
+    Evidence   string `json:"evidence,omitempty"` // where the reason was checked
+    ReviewedAt string `json:"reviewedAt"`         // Func.Digest at review time
+
+    Receiver ReceiverKind `json:"receiver,omitempty"` // borrow | mutBorrow | none
+    Returns  ReturnFact   `json:"returns,omitzero"`   // the return-borrow seed
+}
+```
+
+An entry answers the axes it carries a value for. `""` is neither a
+`ReceiverKind` nor an `AliasKind`, so an omitted field is unambiguously an
+axis left to the analysis, and needs no flag beside it saying so.
+
+A published `MethodFact` reads the same way, for the same reason. The
+difference is what an omission means: on an entry it defers to the
+analysis, and on a published fact it is a hole that fails the run per
+Appendix B.
+
+Three fields exist only for review and never reach `facts.json`.
+
+`Reason` is required. It is the argument for the curated answer in the
+reviewer's words, which is what makes the entry re-reviewable when the
+spec changes under it. `Evidence` names where that argument was checked, a
+specification heading, an MDN page, or an engine the behavior was observed
+in.
+
+`ReviewedAt` is the `Func.Digest` of the algorithm at review time, a
+fingerprint over that one serialized algorithm. It is taken over the
+decoded function rather than over the raw JSON text, so reformatting
+`cfg.json` or reordering its keys leaves every digest alone and only a
+real change to a step, a parameter, or a kind moves one. When the graph's
+digest no longer matches, the entry is reported stale and still applied.
+
+Parsing rejects an entry that cannot be reviewed or applied: one with no
+reason, no reviewed digest, no determination at all, or a receiver kind or
+alias kind this package cannot spell.
+
+A return fact holds the same invariants `newReturnFact` builds. A
+parameter return names its position. A union names at least two distinct
+members and holds neither a union nor an `unknown`, since neither names a
+single value a return hands back. No other kind carries a position or
+members. Parsing sorts a union's members by kind and then position, the
+order `newReturnFact` leaves them in, so a curated union compares equal to
+the analyzed fact it repeats and publishes in the order every other fact
+uses.

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -72,7 +72,7 @@ name heuristics.
 - **Throws as a finished, unreviewed annotation.** Emitting the throw
   set is an in-scope deliverable (FR10, FR11), but it ships as a reviewed
   candidate set, not a trusted final annotation. The review need is not
-  that the extraction is inaccurate — where `classified.throws` is set,
+  that the extraction is inaccurate — where an entry carries `throws`,
   FR10's *raw* throw set is a sound, complete enumeration of what
   ECMA-262 models the algorithm as throwing, and could ship unreviewed at
   the cost of noise. Review guards the two things downstream of that,
@@ -87,7 +87,10 @@ name heuristics.
   - **The filter needs type information ECMA-262 does not carry.** Whether
     a parameter coercion can throw depends on the parameter's declared
     type, available only at the FR7 join, plus a judgment about which
-    coercions the types truly preclude.
+    coercions the types truly preclude. Both are what a reviewer supplies,
+    so the parameter half of the filter is a curated entry rather than a
+    stage of the analysis. Only the receiver half, where the type is always
+    statically known, is filtered automatically.
 
   Host and implementation-defined throws are **out of scope**, not a
   review driver: stack-overflow `RangeError`, out-of-memory, and host
@@ -98,9 +101,8 @@ name heuristics.
   `RangeError` from an explicit spec domain check, such as
   `Number.prototype.toFixed`, is a tracked domain throw.
 
-  The claim is falsifiable and evidence-revisable: a measured
-  false-negative rate near zero from the FR14 validation would let throws
-  graduate to auto-apply. This refines the builtins workstream's
+  The claim is falsifiable and evidence-revisable, and the FR14 validation
+  is what would falsify it. This refines the builtins workstream's
   hand-curation plan rather than replacing it
   ([../builtins/requirements.md](../builtins/requirements.md), FR10
   "throws annotations are hand-curated for now"): the spec generates the
@@ -463,9 +465,16 @@ merely stricter.
   **unclassified**, not as a guess. Coverage is per determination, so a
   method withholds only the axes that read the step it could not resolve.
   An axis that reads no step is never withheld: a static and a namespace
-  function have `receiver: none` whatever the analysis missed. An
-  unclassified determination falls through to the existing name heuristics
-  and hand-curation in the converter.
+  function have `receiver: none` whatever the analysis missed.
+- An unclassified determination is answered by **review**, recorded as a
+  curated entry keyed by the same canonical spec name and merged over the
+  analysis one axis at a time. What neither the analysis nor a curated entry
+  answers is not published: generation fails, naming the method and the axis,
+  so the gap is closed before anything consumes it. The name heuristics stay
+  the fallback for a method no entry addresses at all.
+  Curating an answer is the cheaper of the two ways to close a gap, and it
+  states a reason the next reader can check, where a new lattice member in
+  the analysis states only a result.
 - Receiver mutability defaults to **mutating** (`&mut self`) when
   unclassified, consistent with the interop core principle "default to
   mutating"
@@ -500,18 +509,23 @@ impractical:**
   every `this`-touching method carries `throws TypeError` from its
   receiver coercion, pervasive noise a parameter default does not produce.
   So the throw set (FR10) and reject set (FR13) under-report instead,
-  accepting that this is the unsound direction, and both are curation-grade
-  and gated by the FR14 validation before they could ever auto-apply.
+  accepting that this is the unsound direction. Both are curation-grade,
+  and FR14 measures what reaches the `.esc` against observed behavior.
 
-These defaults are applied by the **converter**, not serialized as facts.
-A record's `classified` object marks each determination covered or not,
-and an uncovered one omits its field — `receiver`, `params`, `throws`,
-`rejects` are absent, or null, on the wire. So the format never conflates
-"the analysis proved this method borrows and throws nothing" with "the
-analysis could not tell." A proven-empty result is a covered determination
-with an empty effect field; an unanalyzed one is an uncovered
-determination with its field absent. FR6 and Appendix B use this one
-contract.
+These defaults are applied by the **converter**, not serialized as facts,
+and the converter applies one only where no fact addresses the method at
+all. A published fact answers every determination it carries: an axis
+neither the analysis nor review settles fails generation, naming the method
+and the axis, rather than being written as a hole. So the format cannot
+conflate "the analysis proved this method borrows and throws nothing" with
+"the analysis could not tell" — the second never reaches the file. A
+proven-empty result is an empty effect field, and there is no encoding for
+an unanalyzed one. FR6 and Appendix B use this one contract.
+
+Failing generation is the loud direction, which is the same reasoning as
+the defaults above. A coverage flag would leave the hole in the data for
+every consumer to remember to check, and §7 auto-applies the receiver, so a
+forgotten check there becomes a silent `&mut self`.
 
 Splitting coverage this way keeps the conservative bias where it buys
 safety and drops it where it does not. A method's receiver mutability is
@@ -522,7 +536,10 @@ it. A static's `receiver: none` reads no step at all, so nothing the
 analysis missed can put it in doubt.
 
 Every method whose receiver mutability is unclassified is reported by name
-so the gap is visible and auditable rather than silent.
+so the gap is visible and auditable rather than silent. The report is
+taken over the analysis alone as well as over the merged result. The first
+is what the analysis is measured by, and the second is what actually
+reaches the heuristics.
 
 ### FR6. Output contract
 
@@ -532,35 +549,40 @@ provenance. `receiver` is `borrow` (`&self`), `mutBorrow` (`&mut self`),
 or `none` (a static or namespace function with no receiver). `params`
 lists only the parameters the analysis found `mutBorrow` (`&mut`) or
 `escape` (stored into the receiver, spelled at curation — see FR12).
-Where `classified.params` is set, a parameter omitted from the entry was
-proven read-only (`borrow`). That proven-read-only omission is distinct
-from the FR5
-uncertain default, which is `&mut`: the omission means "the analysis
-showed this parameter is only read," whereas the FR5 default applies where
-`classified.params` is unset and the parameters are absent entirely.
+A parameter omitted from the entry was proven read-only (`borrow`). That
+omission is distinct from the FR5 uncertain default, which is `&mut`: the
+omission means "the analysis showed this parameter is only read," whereas
+the FR5 default applies only where no entry addresses the method.
+
+**Every entry is total.** A determination neither the analysis nor review
+settles is not encoded. Generation fails instead, naming the method and the
+axis on stderr, so the file carries no coverage flags and a consumer never
+has to tell a hole from a claim.
 
 ```json
 {
-  "Array.prototype.push":  { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"}], "returns": "fresh",    "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Array.prototype.fill":  { "receiver": "mutBorrow", "params": [],                                    "returns": "receiver", "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Array.prototype.slice": { "receiver": "borrow",    "params": [],                                    "returns": "fresh",    "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Map.prototype.set":     { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"},{"index":1,"disposition":"escape"}], "returns": "receiver", "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Number.prototype.toFixed": { "receiver": "borrow", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+  "Array.prototype.push":  { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"}], "returns": "fresh",    "throws": [], "rejects": [] },
+  "Array.prototype.fill":  { "receiver": "mutBorrow", "params": [],                                    "returns": "receiver", "throws": [], "rejects": [] },
+  "Array.prototype.slice": { "receiver": "borrow",    "params": [],                                    "returns": "fresh",    "throws": [], "rejects": [] },
+  "Map.prototype.set":     { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"},{"index":1,"disposition":"escape"}], "returns": "receiver", "throws": [], "rejects": [] },
+  "Number.prototype.toFixed": { "receiver": "borrow", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [] },
 
-  "Reflect.set":              { "receiver": "none", "params": [{"index":0,"disposition":"mutBorrow"},{"index":2,"disposition":"escape"}], "returns": "fresh", "throws": [], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
-  "Intl.getCanonicalLocales": { "receiver": "none", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": {"receiver":true,"params":true,"returns":true,"throws":true,"rejects":true} },
+  "Reflect.set":              { "receiver": "none", "params": [{"index":0,"disposition":"mutBorrow"},{"index":2,"disposition":"escape"}], "returns": "fresh", "throws": [], "rejects": [] },
+  "Intl.getCanonicalLocales": { "receiver": "none", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [] },
 
-  "String.prototype.toLowerCase": { "returns": "unknown", "classified": {"receiver":false,"params":false,"returns":true,"throws":false,"rejects":false} }
+  "String.prototype.toLowerCase": { "receiver": "borrow", "params": [], "returns": "unknown", "throws": [], "rejects": [] }
 }
 ```
 
-- `classified` marks each determination covered or not, and an uncovered
-  one leaves its field out. `String.prototype.toLowerCase` reaches the
-  Unicode case-mapping table through a prose step, so the analysis cannot
-  say what that step wrote and the entry carries no `receiver`. The return
-  alias survives, because FR4 curates it rather than applying it. A static
-  keeps `receiver: none` through the same warning, since its having no
-  receiver is a fact about the declaration rather than about a step.
+- Every entry carries every determination, so there is no coverage object
+  and no absent field to interpret. `String.prototype.toLowerCase` reaches
+  the Unicode case-mapping table through a prose step, so the analysis
+  cannot say what that step wrote; the `borrow` above comes from review,
+  and without it generation would fail rather than publish the method. Its
+  `returns: unknown` is a value the analysis did produce, meaning the walk
+  tied the return to nothing the caller holds. A static keeps
+  `receiver: none` through any warning, since its having no receiver is a
+  fact about the declaration rather than about a step.
 - `receiver` maps a non-mutating method to `&self` and a mutating one to
   `&mut self` (FR2). A method that stores an argument into the receiver
   marks that parameter `escape`, because the argument outlives the call
@@ -611,10 +633,10 @@ The key space therefore covers prototype methods
 (`X.prototype.method`), static methods (`X.method`), symbol-keyed
 methods, and namespace-qualified forms where `X` is a dotted path naming
 a namespace and optionally a nested constructor — all joined by FR7.
-The `classified` object marks each determination covered or not. An
-uncovered one is an FR5 fall-through, and its field — `receiver`,
-`params`, `throws`, or `rejects` — is absent, distinct from a proven-empty
-result (§FR5).
+Every entry answers every determination, so a fall-through to the FR5
+defaults happens only where no entry addresses the method — an unmatched
+`std:*` declaration, or the `web:*` and `node:*` surfaces that are out of
+scope by construction.
 
 ### FR7. Keying and join to typed declarations
 
@@ -639,7 +661,16 @@ bump — and the effect annotations come from this workstream's ECMA-262
 facts, regenerated on a spec bump. A generated `.esc` builtin is the join
 of those two, plus a small hand-curated override layer for the
 curation-grade residue (reviewed throws and lifetimes) that is re-applied
-at generation rather than edited into the output. This keeps signatures
+at generation rather than edited into the output.
+
+Curated data enters at two points, and they answer different questions.
+The **fact layer** answers a determination the spec extraction cannot
+settle, and it is keyed by canonical spec name and merged into the facts
+before the join. The **override layer** answers what the facts under-report
+by design, the annotations FR5 makes the extractor omit, and it is keyed
+by declaration and applied after the join. Both are committed data
+re-applied at generation. A determination the facts could carry belongs in
+the first, so the second never has to restate a fact. This keeps signatures
 out of hand-maintenance entirely, which is the whole point: hand-authored
 `.esc` signatures are the path to **avoid**, because they would drift from
 the upstream types and multiply the maintenance surface.
@@ -935,41 +966,43 @@ FR13 is specified here for completeness and to fix the
 `throws`-versus-`rejects` split, but it delivers most of its value once
 the WebIDL extractor lands.
 
-### FR14. Throws validation and the auto-apply gate
+### FR14. Throws validation
 
-Whether the extracted `throws`/`rejects` are trustworthy without review is
-an empirical question, settled by measurement, not asserted. FR14 is the
-throws counterpart of FR9's mutability validation: diff the extracted
-throw sets against a ground-truth sample of high-value methods and measure
-two rates. The sample must be **independent of the spec extraction** — a
-corpus read out of the same algorithm would agree by construction, so it
-is seeded by dynamic observation in a real engine (fuzzing each method and
-recording what it throws or rejects with) rather than by re-reading the
-spec, with only the parametric and combinator entries hand-authored (the
-plan's §9.4 gives the mechanics).
+Whether a method's published `throws`/`rejects` is right is an empirical
+question, settled by measurement rather than asserted. FR14 is the throws
+counterpart of FR9's mutability validation: diff the published throw sets
+against a ground-truth sample of high-value methods and measure two rates.
+The sample must be **independent of the spec extraction**. A corpus read
+out of the same algorithm would agree by construction, so it is seeded by
+dynamic observation in a real engine, fuzzing each method and recording
+what it throws or rejects with, rather than by re-reading the spec. Only
+the parametric and combinator entries are hand-authored. The plan's §9.4
+gives the mechanics.
+
+The check covers curated entries as much as extracted ones. Dynamic
+observation is the one source of evidence about throws that shares neither
+the extractor's blind spots nor a reviewer's, so it catches a wrong
+curated `throws` the same way it catches an over-prune.
 
 - **False-negative rate — the soundness metric.** Real throws that the
-  method can raise but the emitted set omits, almost always because the
-  FR11 coercion filter over-pruned. This is the rate that matters: a
-  false negative is an unsound `throws` clause. Measure it in two layers
-  so the blame is unambiguous:
-  - against the *raw* FR10 set (pre-filter), which should be zero when the
-    CFG is faithful — this isolates FR10 extraction soundness;
-  - against the *filtered* FR11 set, whose false negatives are exactly the
-    filter's over-prunes.
+  method can raise but the published set omits. This is the rate that
+  matters, since a false negative is an unsound `throws` clause. Measure
+  it in two layers so the blame is unambiguous:
+  - against the *raw* FR10 set, before the FR11 filter, which should be
+    zero when the control-flow graph is faithful. This isolates FR10
+    extraction soundness.
+  - against the *published* set, curated entries and all. A false negative
+    there is a real throw a caller has to handle and nothing declares, and
+    it is charged to the filter's over-prune or to the curated entry.
 - **False-positive rate — the ergonomics metric.** Phantom throws the
   method cannot actually raise. These only cost callers a redundant
-  handler; they are not a soundness problem, so they carry less weight.
+  handler, so they carry less weight than a false negative.
 
-The gate: while the filtered false-negative rate is above zero on the
-sample, throws remain a reviewed candidate set (the Non-goals entry
-stands). A measured filtered false-negative rate of zero on a
-representative sample is the evidence that would **graduate throws to
-auto-apply**, the same way FR9's diff authorizes trusting the mutability
-facts. Host and implementation-defined throws are excluded from the
-ground-truth sample by an explicit, documented policy so they do not
-register as false negatives against a spec-derived set that cannot
-contain them.
+Every published false negative is triaged and fixed, in the filter or in
+the curated entry it came from. Host and implementation-defined throws are
+excluded from the ground-truth sample by an explicit, documented policy so
+they do not register as false negatives against a set that cannot contain
+them.
 
 ### FR15. Overloaded methods
 
@@ -1038,8 +1071,11 @@ types and arity.
   per-directory `mise.toml`.
 - **Auditability.** Every classification carries its provenance, and
   every method whose receiver mutability is unclassified is listed, so a
-  reviewer can see exactly which methods the spec proved and which fell
-  through to heuristics.
+  reviewer can see exactly which methods the spec proved, which review
+  answered, and which fell through to heuristics. A curated answer that the
+  analysis later reaches on its own is reported so the entry can be
+  deleted, which keeps the curated layer from growing into a second source
+  of truth.
 
 ## Coverage and limitations
 
@@ -1051,12 +1087,13 @@ types and arity.
   This exclusion is only for those pervasive host errors: a `RangeError`
   raised by an explicit spec domain check (`Number.prototype.toFixed`
   out of range, `Array(-1)`) is a tracked domain throw. The exclusion is
-  what keeps the throw sets ergonomic and removes a would-be permanent
-  blocker to the FR14 auto-apply gate.
-- A handful of algorithms are prose-only or host-defined, so a method
-  among them has its receiver mutability fall through to the name
-  heuristic per FR5. The return alias is published regardless, since FR4
-  curates it rather than applying it.
+  what keeps the throw sets ergonomic and keeps FR14's false-negative rate
+  measuring something a reviewer can act on.
+- A handful of algorithms are prose-only or host-defined, so the analysis
+  withholds the receiver mutability of a method among them. A curated
+  entry answers it, and only what neither settles falls through to the
+  name heuristic per FR5. The return alias is published regardless, since
+  FR4 curates it rather than applying it.
 - Generic and array-like receivers operate on `O ← ? ToObject(this
   value)`; the analysis treats `ToObject(this value)` as
   receiver-origin so that a write to `O` is a write to the receiver.


### PR DESCRIPTION
Refs #1312

Fourth and last of the PRs splitting #1316. **Stacked on [#1320](https://github.com/escalier-lang/escalier/pull/1320)** → [#1319](https://github.com/escalier-lang/escalier/pull/1319) → [#1318](https://github.com/escalier-lang/escalier/pull/1318).

Prose only, no code. This records what the three PRs before it implement, so their diffs are Go and their rationale is here.

## `implementation_plan.md`

- New §4.4 for the curated fact layer, and new Appendix D for the `curated.json` schema.
- Appendix B rewritten around every published fact carrying every determination — no coverage object, and a hole fails generation.
- The §4.3 pseudocode and its surrounding prose follow both changes.
- The dependency graph gains the edge from §4.3 through §4.4 to §5, and the PR table gains a §4.4 row.
- §4.4 changes what the phases after it have to reach analytically, so §8.1, §9.2, §9.4, and §11 lose the scope the curated layer now covers. Each says what it curates instead of what it analyzes.

## `requirements.md`

- **FR5** gains review as the way an unclassified determination is answered, and drops the coverage object in favour of generation failing on a hole. A coverage flag would leave the hole in the data for every consumer to remember to check, and §7 auto-applies the receiver, so a forgotten check becomes a silent `&mut self`.
- **FR6**'s example and key-space paragraph follow from that.
- **FR7** separates the two places curated data enters, which answer different questions. The fact layer is keyed by canonical spec name and merged before the join; the override layer is keyed by declaration and applied after it. A determination the facts could carry belongs in the first, so the second never restates a fact.
- **FR14** is no longer the auto-apply gate for throws. The parameter half of the coercion filter needs type information plus a judgment about which coercions the types preclude, which is a curated entry rather than a stage of the analysis. FR14 now measures what reaches the `.esc` against observed behavior, curated entries included — dynamic observation is the one evidence source that shares neither the extractor's blind spots nor a reviewer's.

https://claude.ai/code/session_01FnsXWeGS456WxQx455nFBf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnsXWeGS456WxQx455nFBf)_