### PR TITLE
Point the --cfg tests at the bootstrap subcommand

### DIFF
--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -92,11 +92,11 @@ const committedCFG = "../spec-extract/cfg.json"
 //
 // The counts move when curated.json or cfg.json changes, which is the point:
 // the diff shows what a data change did to the reports an operator reads.
-func TestRun_PartitionWithCFGPrintsBothReports(t *testing.T) {
+func TestRun_BootstrapWithCFGPrintsBothReports(t *testing.T) {
 	libDir := seedLib(t, arrayLib)
 
 	var stderr strings.Builder
-	require.NoError(t, run([]string{"partition", "--cfg", committedCFG, libDir, t.TempDir()}, io.Discard, &stderr))
+	require.NoError(t, run([]string{"bootstrap", "--cfg", committedCFG, libDir, t.TempDir()}, io.Discard, &stderr))
 
 	snaps.MatchInlineSnapshot(t, reportSummaries(stderr.String()), snaps.Inline(`  std:array: 3 decls
   curation: 27 fill-ins, 0 corrections, 0 redundant, 0 stale, 0 unmatched, 0 refused
@@ -122,7 +122,7 @@ func reportSummaries(stderr string) string {
 // layer answered fails the run rather than writing a hole. The committed graph
 // has none, so the case is built here: one method whose only step is prose the
 // serializer could not lower, which withholds its receiver.
-func TestRun_PartitionRejectsAnUnansweredDetermination(t *testing.T) {
+func TestRun_BootstrapRejectsAnUnansweredDetermination(t *testing.T) {
 	t.Parallel()
 	cfgPath := filepath.Join(t.TempDir(), "cfg.json")
 	require.NoError(t, os.WriteFile(cfgPath, []byte(
@@ -131,7 +131,7 @@ func TestRun_PartitionRejectsAnUnansweredDetermination(t *testing.T) {
 			`{"kind":"opaque","text":["Let _x_ be whatever the host decides."]}]}]}`), 0o644))
 	outDir := t.TempDir()
 
-	err := run([]string{"partition", "--cfg", cfgPath, seedLib(t, arrayLib), outDir}, io.Discard, io.Discard)
+	err := run([]string{"bootstrap", "--cfg", cfgPath, seedLib(t, arrayLib), outDir}, io.Discard, io.Discard)
 
 	require.EqualError(t, err, cfgPath+" leaves determinations unanswered:\n"+
 		"  Demo.prototype.opaque: no receiver determination")
@@ -140,11 +140,11 @@ func TestRun_PartitionRejectsAnUnansweredDetermination(t *testing.T) {
 
 // A --cfg path that does not resolve fails the run before anything is written,
 // so a mistyped flag leaves no half-joined tree behind.
-func TestRun_PartitionRejectsABadCFGPath(t *testing.T) {
+func TestRun_BootstrapRejectsABadCFGPath(t *testing.T) {
 	t.Parallel()
 	outDir := t.TempDir()
 
-	err := run([]string{"partition", "--cfg", "no/such/cfg.json", seedLib(t, arrayLib), outDir}, io.Discard, io.Discard)
+	err := run([]string{"bootstrap", "--cfg", "no/such/cfg.json", seedLib(t, arrayLib), outDir}, io.Discard, io.Discard)
 
 	require.EqualError(t, err,
 		"loading no/such/cfg.json: reading no/such/cfg.json: open no/such/cfg.json: no such file or directory")


### PR DESCRIPTION
`go test ./...` fails on `main`.

```
--- FAIL: TestRun_PartitionWithCFGPrintsBothReports
--- FAIL: TestRun_PartitionRejectsAnUnansweredDetermination
--- FAIL: TestRun_PartitionRejectsABadCFGPath
        Received unexpected error: usage: dts_to_esc <path-to-d.ts>
```

Three tests invoke the seeding subcommand as `partition`. It is named
`bootstrap`, so `run` takes them for a `.d.ts` path, falls through to
single-file mode, and returns its usage error. This points them at the
right name and renames the three tests to match.

## How main went red

A semantic merge conflict rather than a bad merge. #1310 renamed the
subcommand; #1319 and #1320 added these tests against the old name.
Neither branch contained the other's change, so both were green on their
own and CI had nothing to catch. It only appears once both are on `main`.

Worth noting the shape, since the converter has one CLI and several
workstreams touching it: a rename of a string that only appears in test
call sites and a `switch` will not be caught by the compiler on either
side of a concurrent pair.

---
_Generated by [Claude Code](https://claude.ai/code/session_016xmbd1wcF3AKCm66FQAXYZ)_