### PR TITLE
Document return-annotation mapping from alias facts

### DIFF
--- a/internal/ecma262/__snapshots__/classify_test.snap
+++ b/internal/ecma262/__snapshots__/classify_test.snap
@@ -26,8 +26,8 @@ TypedArray.prototype.toLocaleString
 get RegExp.prototype.flags
 ---
 
-[TestFactsReturnSeedsAreListed - 1]
-  return seeds: 22 to annotate, 232 owned, 247 open
+[TestFactsBorrowingReturnsAreListed - 1]
+  return aliases: 22 borrowing, 232 owned, 247 open
     param(0): Object.assign
     param(0): Object.defineProperty
     param(0): Object.freeze

--- a/internal/ecma262/__snapshots__/classify_test.snap
+++ b/internal/ecma262/__snapshots__/classify_test.snap
@@ -25,3 +25,30 @@ TypedArray.prototype.slice
 TypedArray.prototype.toLocaleString
 get RegExp.prototype.flags
 ---
+
+[TestFactsReturnSeedsAreListed - 1]
+  return seeds: 22 to annotate, 232 owned, 247 open
+    param(0): Object.assign
+    param(0): Object.defineProperty
+    param(0): Object.freeze
+    param(0): Object.preventExtensions
+    param(0): Object.seal
+    param(0): Object.setPrototypeOf
+    receiver: Array.prototype.copyWithin
+    receiver: Array.prototype.fill
+    receiver: Array.prototype.reverse
+    receiver: Array.prototype.sort
+    receiver: AsyncIteratorPrototype [ @@asyncIterator ]
+    receiver: Iterator.prototype [ @@iterator ]
+    receiver: Map.prototype.set
+    receiver: Object.prototype.valueOf
+    receiver: Set.prototype.add
+    receiver: TypedArray.prototype.copyWithin
+    receiver: TypedArray.prototype.fill
+    receiver: TypedArray.prototype.reverse
+    receiver: TypedArray.prototype.sort
+    receiver: WeakMap.prototype.set
+    receiver: WeakSet.prototype.add
+    union(fresh, param(0)): Object
+
+---

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -555,45 +555,47 @@ func (f *Facts) Incomplete() []string {
 	return holes
 }
 
-// ReturnSeed is one builtin whose return borrows a value the caller holds, so
-// its declaration needs a lifetime annotation someone writes.
-type ReturnSeed struct {
+// BorrowingReturn is one builtin whose return borrows a value the caller
+// holds, so its declaration needs a lifetime annotation someone writes.
+type BorrowingReturn struct {
 	Name string
 	Fact ReturnFact
 }
 
-// ReturnsReport is FR4's seed surface for one run. Seeds names every builtin a
-// curator has to annotate. Owned and Open count the two kinds nobody annotates.
+// ReturnAliasReport sorts one run's published returns into what each one hands
+// back. A borrowing return names a value the caller holds. An owned return
+// hands back a value the algorithm made. An open return names nothing the
+// walk could resolve.
 //
-// That split is what makes this the counterpart of
+// The split is what makes this the counterpart of
 // Facts.Unclassified(AxisReturns) rather than a rephrasing of it. Unclassified
 // names the returns the analysis could not resolve, which is how §4 is
-// measured. Seeds names the returns it resolved to a borrow, which is the
+// measured. Borrowing names the returns it resolved to a borrow, which is the
 // curation those returns create.
-type ReturnsReport struct {
-	// Seeds holds the receiver, parameter, and union returns, sorted by alias
-	// kind, then by returned position, then by name.
-	Seeds []ReturnSeed
+type ReturnAliasReport struct {
+	// Borrowing holds the receiver, parameter, and union returns, sorted by
+	// alias kind, then by returned position, then by name.
+	Borrowing []BorrowingReturn
 	// Owned counts the `fresh` returns. An owned value has no lifetime to
 	// bound, so its declaration needs nothing.
 	Owned int
 	// Open counts the `unknown` returns. The lattice top names no value to
-	// borrow, so there is nothing to seed an annotation from. A fact carrying
-	// no return kind at all is counted here too. Facts.Incomplete refuses that
-	// hole before a run reaches this report, and reading it as open keeps a
-	// hand-built fact set out of the work list rather than in it.
+	// borrow, so no annotation follows from one. A fact carrying no return
+	// kind at all is counted here too. Facts.Incomplete refuses that hole
+	// before a run reaches this report, and reading it as open keeps a
+	// hand-built fact set out of the borrowing list rather than in it.
 	Open int
 }
 
-// ReturnSeeds groups the published returns by whether they seed an annotation.
+// BorrowingReturns groups the published returns by what each one hands back.
 //
 // §7 auto-applies the receiver determination and leaves this one to review, so
 // a curator needs the returns the analysis resolved rather than the ones it did
 // not. The alternative is a list of method names someone keeps current, which a
 // spec bump stales without saying so. See
 // planning/ecma-262/return_annotations.md.
-func (f *Facts) ReturnSeeds() ReturnsReport {
-	var report ReturnsReport
+func (f *Facts) BorrowingReturns() ReturnAliasReport {
+	var report ReturnAliasReport
 	for name, fact := range f.Methods {
 		switch fact.Returns.Kind {
 		case AliasFresh:
@@ -601,18 +603,18 @@ func (f *Facts) ReturnSeeds() ReturnsReport {
 		case AliasUnknown, "":
 			report.Open++
 		default:
-			report.Seeds = append(report.Seeds, ReturnSeed{Name: name, Fact: fact.Returns})
+			report.Borrowing = append(report.Borrowing, BorrowingReturn{Name: name, Fact: fact.Returns})
 		}
 	}
-	sort.Slice(report.Seeds, func(i, j int) bool {
-		a, b := report.Seeds[i], report.Seeds[j]
+	sort.Slice(report.Borrowing, func(i, j int) bool {
+		a, b := report.Borrowing[i], report.Borrowing[j]
 		if a.Fact.Kind != b.Fact.Kind {
 			return a.Fact.Kind < b.Fact.Kind
 		}
 		// A union carries no position, and two parameter returns at different
 		// positions are different annotations, so the position orders them
 		// ahead of the name.
-		if ai, bi := seedPosition(a.Fact), seedPosition(b.Fact); ai != bi {
+		if ai, bi := aliasPosition(a.Fact), aliasPosition(b.Fact); ai != bi {
 			return ai < bi
 		}
 		return a.Name < b.Name
@@ -620,29 +622,29 @@ func (f *Facts) ReturnSeeds() ReturnsReport {
 	return report
 }
 
-// seedPosition is the returned parameter's position, and -1 for a return that
+// aliasPosition is the returned parameter's position, and -1 for a return that
 // names none. It exists so the sort reads one comparable value for every kind.
-func seedPosition(r ReturnFact) int {
+func aliasPosition(r ReturnFact) int {
 	if r.Kind != AliasParam || r.Index == nil {
 		return -1
 	}
 	return *r.Index
 }
 
-// WriteReturnsReport prints the annotations FR4 seeds, one line per builtin
-// that needs one. The counts come first so the two kinds needing nothing are
-// accounted for without a line each.
-func WriteReturnsReport(report ReturnsReport, w io.Writer) error {
-	// The label is "return seeds" rather than "returns" because the join
+// WriteReturnAliasReport prints one line per borrowing return, which is one
+// line per annotation a curator writes. The counts come first so the two kinds
+// needing none are accounted for without a line each.
+func WriteReturnAliasReport(report ReturnAliasReport, w io.Writer) error {
+	// The label is "return aliases" rather than "returns" because the join
 	// report prints a "returns" line of its own, counting the returns the
 	// declared type settled as owned. The two answer different questions.
-	_, err := fmt.Fprintf(w, "  return seeds: %d to annotate, %d owned, %d open\n",
-		len(report.Seeds), report.Owned, report.Open)
+	_, err := fmt.Fprintf(w, "  return aliases: %d borrowing, %d owned, %d open\n",
+		len(report.Borrowing), report.Owned, report.Open)
 	if err != nil {
 		return err
 	}
-	for _, seed := range report.Seeds {
-		if _, err := fmt.Fprintf(w, "    %s: %s\n", seed.Fact, seed.Name); err != nil {
+	for _, ret := range report.Borrowing {
+		if _, err := fmt.Fprintf(w, "    %s: %s\n", ret.Fact, ret.Name); err != nil {
 			return err
 		}
 	}

--- a/internal/ecma262/classify.go
+++ b/internal/ecma262/classify.go
@@ -2,6 +2,7 @@ package ecma262
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -552,4 +553,98 @@ func (f *Facts) Incomplete() []string {
 	}
 	sort.Strings(holes)
 	return holes
+}
+
+// ReturnSeed is one builtin whose return borrows a value the caller holds, so
+// its declaration needs a lifetime annotation someone writes.
+type ReturnSeed struct {
+	Name string
+	Fact ReturnFact
+}
+
+// ReturnsReport is FR4's seed surface for one run. Seeds names every builtin a
+// curator has to annotate. Owned and Open count the two kinds nobody annotates.
+//
+// That split is what makes this the counterpart of
+// Facts.Unclassified(AxisReturns) rather than a rephrasing of it. Unclassified
+// names the returns the analysis could not resolve, which is how §4 is
+// measured. Seeds names the returns it resolved to a borrow, which is the
+// curation those returns create.
+type ReturnsReport struct {
+	// Seeds holds the receiver, parameter, and union returns, sorted by alias
+	// kind, then by returned position, then by name.
+	Seeds []ReturnSeed
+	// Owned counts the `fresh` returns. An owned value has no lifetime to
+	// bound, so its declaration needs nothing.
+	Owned int
+	// Open counts the `unknown` returns. The lattice top names no value to
+	// borrow, so there is nothing to seed an annotation from. A fact carrying
+	// no return kind at all is counted here too. Facts.Incomplete refuses that
+	// hole before a run reaches this report, and reading it as open keeps a
+	// hand-built fact set out of the work list rather than in it.
+	Open int
+}
+
+// ReturnSeeds groups the published returns by whether they seed an annotation.
+//
+// §7 auto-applies the receiver determination and leaves this one to review, so
+// a curator needs the returns the analysis resolved rather than the ones it did
+// not. The alternative is a list of method names someone keeps current, which a
+// spec bump stales without saying so. See
+// planning/ecma-262/return_annotations.md.
+func (f *Facts) ReturnSeeds() ReturnsReport {
+	var report ReturnsReport
+	for name, fact := range f.Methods {
+		switch fact.Returns.Kind {
+		case AliasFresh:
+			report.Owned++
+		case AliasUnknown, "":
+			report.Open++
+		default:
+			report.Seeds = append(report.Seeds, ReturnSeed{Name: name, Fact: fact.Returns})
+		}
+	}
+	sort.Slice(report.Seeds, func(i, j int) bool {
+		a, b := report.Seeds[i], report.Seeds[j]
+		if a.Fact.Kind != b.Fact.Kind {
+			return a.Fact.Kind < b.Fact.Kind
+		}
+		// A union carries no position, and two parameter returns at different
+		// positions are different annotations, so the position orders them
+		// ahead of the name.
+		if ai, bi := seedPosition(a.Fact), seedPosition(b.Fact); ai != bi {
+			return ai < bi
+		}
+		return a.Name < b.Name
+	})
+	return report
+}
+
+// seedPosition is the returned parameter's position, and -1 for a return that
+// names none. It exists so the sort reads one comparable value for every kind.
+func seedPosition(r ReturnFact) int {
+	if r.Kind != AliasParam || r.Index == nil {
+		return -1
+	}
+	return *r.Index
+}
+
+// WriteReturnsReport prints the annotations FR4 seeds, one line per builtin
+// that needs one. The counts come first so the two kinds needing nothing are
+// accounted for without a line each.
+func WriteReturnsReport(report ReturnsReport, w io.Writer) error {
+	// The label is "return seeds" rather than "returns" because the join
+	// report prints a "returns" line of its own, counting the returns the
+	// declared type settled as owned. The two answer different questions.
+	_, err := fmt.Fprintf(w, "  return seeds: %d to annotate, %d owned, %d open\n",
+		len(report.Seeds), report.Owned, report.Open)
+	if err != nil {
+		return err
+	}
+	for _, seed := range report.Seeds {
+		if _, err := fmt.Fprintf(w, "    %s: %s\n", seed.Fact, seed.Name); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -705,45 +705,45 @@ func TestCommittedFacts(t *testing.T) {
 	require.Same(t, facts, again)
 }
 
-// The seed surface §8.2 reads. Every name here is an annotation a curator
-// writes, so the snapshot is the work list, and a spec bump that adds or
-// retires a borrowing return moves it rather than staling a hand-kept list in
-// the planning docs.
-func TestFactsReturnSeedsAreListed(t *testing.T) {
-	report := testFacts(t).ReturnSeeds()
+// The returns §8.2 reads. Every name here is an annotation a curator writes,
+// so the snapshot is the work list, and a spec bump that adds or retires a
+// borrowing return moves it rather than staling a hand-kept list in the
+// planning docs.
+func TestFactsBorrowingReturnsAreListed(t *testing.T) {
+	report := testFacts(t).BorrowingReturns()
 
 	var sb strings.Builder
-	require.NoError(t, WriteReturnsReport(report, &sb))
+	require.NoError(t, WriteReturnAliasReport(report, &sb))
 	snaps.MatchSnapshot(t, sb.String())
 
 	// The three tallies partition the published builtins, so nothing falls
 	// between the returns that need an annotation and the two kinds that
 	// need none.
-	require.Equal(t, len(testFacts(t).Methods), len(report.Seeds)+report.Owned+report.Open)
+	require.Equal(t, len(testFacts(t).Methods), len(report.Borrowing)+report.Owned+report.Open)
 	// The open count is the same set Unclassified names on the returns axis.
 	require.Equal(t, len(testFacts(t).Unclassified(AxisReturns)), report.Open)
 }
 
 // A `fresh` return is owned and an `unknown` one names no value, so neither
-// reaches the seed list. `Demo.prototype.read` returns its receiver and
-// `Demo.prototype.opaque` resolves to the lattice top.
-func TestReturnSeedsExcludeTheKindsThatSeedNothing(t *testing.T) {
+// borrows and neither is listed. `Demo.prototype.read` returns its receiver
+// and `Demo.prototype.opaque` resolves to the lattice top.
+func TestBorrowingReturnsExcludeOwnedAndOpen(t *testing.T) {
 	_, methods := demoFacts(t)
 	facts := &Facts{Methods: methods}
 
-	report := facts.ReturnSeeds()
+	report := facts.BorrowingReturns()
 
-	require.Equal(t, []ReturnSeed{
+	require.Equal(t, []BorrowingReturn{
 		{Name: "Demo.prototype.read", Fact: ReturnFact{Kind: AliasReceiver}},
-	}, report.Seeds)
+	}, report.Borrowing)
 	require.Equal(t, 0, report.Owned)
 	require.Equal(t, 1, report.Open)
 }
 
-// Seeds sort by alias kind, then by the returned position, then by name, so a
-// curator reads the parameter returns in position order rather than in the
-// order `param(10)` would take lexically.
-func TestReturnSeedsSortByKindThenPositionThenName(t *testing.T) {
+// Borrowing returns sort by alias kind, then by the returned position, then by
+// name, so a curator reads the parameter returns in position order rather than
+// in the order `param(10)` would take lexically.
+func TestBorrowingReturnsSortByKindThenPositionThenName(t *testing.T) {
 	facts := &Facts{Methods: map[string]MethodFact{
 		"C.two":   {Returns: returnsParam(10)},
 		"C.one":   {Returns: returnsParam(2)},
@@ -753,8 +753,8 @@ func TestReturnSeedsSortByKindThenPositionThenName(t *testing.T) {
 	}}
 
 	var names []string
-	for _, seed := range facts.ReturnSeeds().Seeds {
-		names = append(names, seed.Fact.String()+" "+seed.Name)
+	for _, ret := range facts.BorrowingReturns().Borrowing {
+		names = append(names, ret.Fact.String()+" "+ret.Name)
 	}
 
 	require.Equal(t, []string{

--- a/internal/ecma262/classify_test.go
+++ b/internal/ecma262/classify_test.go
@@ -704,3 +704,64 @@ func TestCommittedFacts(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, facts, again)
 }
+
+// The seed surface §8.2 reads. Every name here is an annotation a curator
+// writes, so the snapshot is the work list, and a spec bump that adds or
+// retires a borrowing return moves it rather than staling a hand-kept list in
+// the planning docs.
+func TestFactsReturnSeedsAreListed(t *testing.T) {
+	report := testFacts(t).ReturnSeeds()
+
+	var sb strings.Builder
+	require.NoError(t, WriteReturnsReport(report, &sb))
+	snaps.MatchSnapshot(t, sb.String())
+
+	// The three tallies partition the published builtins, so nothing falls
+	// between the returns that need an annotation and the two kinds that
+	// need none.
+	require.Equal(t, len(testFacts(t).Methods), len(report.Seeds)+report.Owned+report.Open)
+	// The open count is the same set Unclassified names on the returns axis.
+	require.Equal(t, len(testFacts(t).Unclassified(AxisReturns)), report.Open)
+}
+
+// A `fresh` return is owned and an `unknown` one names no value, so neither
+// reaches the seed list. `Demo.prototype.read` returns its receiver and
+// `Demo.prototype.opaque` resolves to the lattice top.
+func TestReturnSeedsExcludeTheKindsThatSeedNothing(t *testing.T) {
+	_, methods := demoFacts(t)
+	facts := &Facts{Methods: methods}
+
+	report := facts.ReturnSeeds()
+
+	require.Equal(t, []ReturnSeed{
+		{Name: "Demo.prototype.read", Fact: ReturnFact{Kind: AliasReceiver}},
+	}, report.Seeds)
+	require.Equal(t, 0, report.Owned)
+	require.Equal(t, 1, report.Open)
+}
+
+// Seeds sort by alias kind, then by the returned position, then by name, so a
+// curator reads the parameter returns in position order rather than in the
+// order `param(10)` would take lexically.
+func TestReturnSeedsSortByKindThenPositionThenName(t *testing.T) {
+	facts := &Facts{Methods: map[string]MethodFact{
+		"C.two":   {Returns: returnsParam(10)},
+		"C.one":   {Returns: returnsParam(2)},
+		"C.three": {Returns: ReturnFact{Kind: AliasReceiver}},
+		"C.four":  {Returns: ReturnFact{Kind: AliasUnion, Members: []AliasRef{{Kind: AliasFresh}, {Kind: AliasParam, Index: position(0)}}}},
+		"C.five":  {Returns: returnsParam(2)},
+	}}
+
+	var names []string
+	for _, seed := range facts.ReturnSeeds().Seeds {
+		names = append(names, seed.Fact.String()+" "+seed.Name)
+	}
+
+	require.Equal(t, []string{
+		"param(2) C.five",
+		"param(2) C.one",
+		"param(10) C.two",
+		"receiver C.three",
+		"union(fresh, param(0)) C.four",
+	}, names)
+}

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -44,7 +44,7 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 | §6   | Validation diff                            | FR9        | ✅      | §5         | receiver facts diffed against the override entries and the name heuristics; every disagreement triaged — met, see [validation_diff.md](validation_diff.md) |
 | §7   | Integration as classification source       | FR8        | ✅      | §6         | converter ranks facts above name tiers; the two application paths wired — met, see [internal/dts_to_esc/facts.go](../../internal/dts_to_esc/facts.go). The redundant override entries wait on the M12 flip that deletes their one reader, per [validation_diff.md](validation_diff.md) |
 | §8.1 | Parameter disposition                      | FR12       | ⬜      | §4.1, §4.4, §7 | `MutArgs` supplies `mutBorrow`; `escape` is curated for the container methods that have one. The transitive `StoreEdges` fixpoint is dropped — see §8.1 |
-| §8.2 | Return-borrow seed                         | FR4        | ⬜      | §4.3       | documented `returns` → `&`/lifetime annotation mapping (small) |
+| §8.2 | Return-borrow seed                         | FR4        | ✅      | §4.3       | documented `returns` → `&`/lifetime annotation mapping — met, see [return_annotations.md](return_annotations.md) |
 | §9.1 | Throw-set fixpoint                          | FR10       | ✅      | §4.2       | raw throw sets, `Exception` = class / origin / callback-effect / unknown — met, see [internal/ecma262/](../../internal/ecma262/) |
 | §9.2 | Coercion filter                            | FR11       | ✅      | §9.1, §5   | the receiver branch alone — toFixed keeps RangeError, drops the receiver-coercion TypeError. The parameter branch is #1301, and curated throws cover the methods worth annotating meanwhile — met, see [internal/ecma262/filter.go](../../internal/ecma262/filter.go) |
 | §9.3 | Throw/reject split, parametric origins, combinators | FR10, FR13 | ✅ | §9.1  | `rejects` distinct from `throws`; Promise.reject `param:0`, forEach `throwsOf:param:k`; combinators hand-modeled — met, see [internal/ecma262/](../../internal/ecma262/) |
@@ -1332,7 +1332,8 @@ TypedArray.prototype [ @@toStringTag ]`. The two `buffer` getters stay
 `unknown`: what they hand back is a real borrow of an object the receiver
 holds, and no member of the alias lattice spells that without claiming
 identity. That residue is a type-system question rather than an analysis
-gap, which is the distinction the layer makes visible.
+gap, which is the distinction the layer makes visible. §8.2 answers it and
+says what adding the missing member would take.
 
 **The species exception.** `Array.prototype.slice`, `TypedArray.prototype.slice`,
 `RegExp.prototype [ @@matchAll ]`, and `RegExp.prototype [ @@split ]`
@@ -1735,6 +1736,11 @@ stated reason per method. Value-typed arguments are copied at runtime
 regardless per the requirements ownership section, so the fact records
 `escape` without committing to a spelling either way.
 
+**Gate.** Disposition present in `facts.json` — `Array.prototype.push`
+and `Map.prototype.set` mark their stored parameters `escape`,
+`Reflect.set` marks `target` `mutBorrow` and `value` `escape`,
+`Array.prototype.indexOf` leaves `searchElement` a borrow.
+
 ### §8.2. Return-borrow seed (FR4)
 
 Surface the `returns` alias kind to whoever curates the `&` and lifetime
@@ -1744,32 +1750,52 @@ the `.esc` is generated, not hand-edited into it. The checker's lifetime
 inference and elision rules
 ([../lifetimes/requirements.md](../lifetimes/requirements.md)) and the
 borrow model ([../affine_semantics/requirements.md](../affine_semantics/requirements.md))
-remain the mechanism; the facts only inform the curation. Document the
-mapping: `returns: receiver` ⇒ the return borrows the receiver
-(`-> &self` / `-> &mut self`); `returns: param` ⇒ the return borrows that
-parameter; `returns: fresh` ⇒ an owned return; `returns: union` ⇒ a
-lifetime union over the members the fact names.
+remain the mechanism; the facts only inform the curation.
 
-**What a union's members mean.** A union's members are the values the
-algorithm hands back on its several paths, and the annotation has to cover
-every one of them, so the return borrows all of them at once. The lifetime
-is the union of the members' lifetimes. `fresh` is the identity of that
-union rather than a member of it. An owned value has no lifetime to bound,
-so a caller holding it constrains nothing, and dropping `fresh` from the
-set leaves the same annotation the remaining members already require.
+**The mapping is [return_annotations.md](return_annotations.md).** It gives
+each alias kind the annotation it stands for, names the builtins carrying
+it, and compares each row against what the generated `.esc` gets without an
+override, so a curator can see which rows to write and which to leave
+alone. Three of its findings are worth restating here.
 
-`Object` is that shape. It publishes `{fresh, param(0)}`, and the
-annotation is the borrow of `value` alone, because a caller that keeps the
-returned object alive keeps the argument alive on the path that hands it
-back. A union of two input origins instead names both, and neither drops
-out.
+**Elision does not cover a return that borrows the receiver.** Per §7 the
+generated `.esc` omits the annotation unless the override layer supplies
+one, and lifetime elision then fills what is missing. It cannot fill this,
+for two reasons. `ApplyLifetimeElision` counts a signature's parameters,
+and a method's receiver is `FuncType.SelfParam`, a field of its own. And
+elision is wired into body-less `declare fn` declarations only, so a method
+emitted as an interface member never reaches it at all. All fifteen
+`returns: receiver` builtins therefore need a written annotation, and a
+method with exactly one reference-typed parameter is worse off than an
+unannotated one, because elision binds its return to that parameter
+instead. That raises what FR4 is worth, because the alias kind is the only
+thing in the pipeline that reaches these fifteen. requirements.md's
+confidence ranking carries the same correction.
 
-**Gate.** Disposition present in `facts.json` — `Array.prototype.push`
-and `Map.prototype.set` mark their stored parameters `escape`,
-`Reflect.set` marks `target` `mutBorrow` and `value` `escape`,
-`Array.prototype.indexOf` leaves `searchElement` a borrow. A documented
-`returns` → annotation mapping for the receiver-returning methods
-(`fill`, `sort`, `reverse`, `Map.set`).
+**Three receiver returns need mutability polymorphism, not none.**
+`Object.prototype.valueOf`, `Iterator.prototype [ @@iterator ]`, and
+`AsyncIteratorPrototype [ @@asyncIterator ]` publish `receiver: borrow`
+with `returns: receiver`. Each returns `this` without writing it, so the
+return-borrow rule gives `-> &Self` and a `mut` caller gets an immutable
+receiver back. requirements.md's ownership-model section names them. The
+annotation that preserves the caller's mutability is deferred to the
+affine_semantics workstream. The two `@@iterator` methods are
+also where §11's iterator-protocol decision lands, since a `&mut self`
+`next` cannot be called on a `-> &Self` result.
+
+**The §4.4 residue is answered.** A borrow carrying the receiver's lifetime
+without its identity annotates as the receiver's lifetime on the declared
+return type, `-> 'a ArrayBuffer` rather than a borrow of `Self`. Both
+`buffer` getters declare no parameter, so elision reads their return as
+freshly allocated, which is unsound. That gives the `receiverInterior`
+alias kind of
+[#1284](https://github.com/escalier-lang/escalier/issues/1284) the consumer
+it lacks, which is the reason that issue names for not adding it. Adding
+the member is its own change: `aliasOf` maps `Interior(Receiver)` to it, Appendix B
+and the tallies follow, and §5 resolves it against the joined return type.
+
+**Gate.** A documented `returns` → annotation mapping for the
+receiver-returning methods `fill`, `sort`, `reverse`, and `Map.set`.
 
 ## §9. Throw-set extraction, filter, and validation (FR10, FR11, FR13, FR14)
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1787,12 +1787,18 @@ also where §11's iterator-protocol decision lands, since a `&mut self`
 without its identity annotates as the receiver's lifetime on the declared
 return type, `-> 'a ArrayBuffer` rather than a borrow of `Self`. Both
 `buffer` getters declare no parameter, so elision reads their return as
-freshly allocated, which is unsound. That gives the `receiverInterior`
-alias kind of
-[#1284](https://github.com/escalier-lang/escalier/issues/1284) the consumer
-it lacks, which is the reason that issue names for not adding it. Adding
-the member is its own change: `aliasOf` maps `Interior(Receiver)` to it, Appendix B
-and the tallies follow, and §5 resolves it against the joined return type.
+freshly allocated, which is unsound. That gives `receiverInterior`, the
+alias kind
+[#1284](https://github.com/escalier-lang/escalier/issues/1284) proposes, a
+consumer. Having none is why that issue was closed with the member unbuilt.
+
+Adding it is its own change, and it adds no analysis. `NewOriginMap`
+already resolves both getters to `Interior(Receiver)`, and `aliasOf` reads
+that origin and drops the provenance, so the graph settles this today. The
+new member carries the origin out through the public alias lattice instead:
+`aliasOf` maps `Interior(Receiver)` to it, the schema and Appendix B gain
+the member, the tallies move, and §5 resolves it against the joined return
+type.
 
 **Gate.** A documented `returns` → annotation mapping for the
 receiver-returning methods `fill`, `sort`, `reverse`, and `Map.set`.

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -162,11 +162,14 @@ ranking.
    `return O` / `return M` aliases the receiver; a return of a
    freshly-allocated value from `ArrayCreate` / `OrdinaryObjectCreate` /
    `ArraySpeciesCreate` does not. This maps onto the signals the
-   checker's lifetime inference already uses, and the elision rules
-   (lifetimes Phase 11) already cover the common return-self and
-   return-fresh cases without per-method data. The alias facts are a
-   secondary output of the same analysis, surfaced to a human editing
-   lifetime annotations, not an automatic annotator.
+   checker's lifetime inference already uses. The elision rules of
+   lifetimes Phase 11 cover return-fresh without per-method data. They do
+   not cover return-self. Elision counts only a signature's parameters,
+   and a method's receiver is a field of its own, so a return that borrows
+   the receiver has to be annotated. Phase 11 also reaches body-less
+   `declare fn` declarations only, leaving interface methods to Phase 12.
+   The alias facts are a secondary output of the same analysis, surfaced
+   to a human editing lifetime annotations, not an automatic annotator.
 
 4. **Thrown exceptions — medium confidence, curation-grade.** The
    algorithm names the exception types it can raise, directly and
@@ -308,8 +311,12 @@ them:
   *non-mutating* method that returns self and should preserve whatever
   mutability the caller had — needs mutability polymorphism (a return
   mutability abstracted over the receiver's), which the affine checker
-  does not express today. No ECMA-262 builtin hits it: every builtin that
-  returns `this` mutates, so `-> &mut Self` covers them all. The
+  does not express today. Three ECMA-262 builtins hit it.
+  `Object.prototype.valueOf`, `Iterator.prototype [ @@iterator ]`, and
+  `AsyncIteratorPrototype [ @@asyncIterator ]` return `this` without
+  writing it, so each takes `&self` and annotates `-> &Self`, and a `mut`
+  caller gets an immutable receiver back. Every other `this`-returning
+  builtin mutates, so `-> &mut Self` covers the remaining twelve. The
   polymorphic case is deferred to the affine_semantics workstream, out of
   this workstream's scope.
 - **Whether a lifetime applies at all depends on the return type.** A
@@ -318,15 +325,23 @@ them:
   there. Only a reference-typed return carries a borrow/lifetime, and
   reference-versus-value is the return **type**, which comes from the
   typed source at the FR7 join, not from the shape-free fact.
-- **Elision already covers the common shapes.** Escalier's lifetime
-  elision infers the lifetime for return-self (`&self`/`&mut self` in,
-  borrow of self out) and needs none for return-fresh (owned). So FR4 adds
-  value only where elision gives up — a return that borrows a *non-receiver
-  parameter* (`param`) or mixes inputs (`union`) — and those are rare in
-  ECMA-262 (`Object.assign` returning its `target`; `Promise.resolve`
-  returning its argument or a fresh promise). Even there the concrete
-  annotation needs the typed signature (the borrow mutability, the union's
-  lifetime variables), so it is review input, not an auto-annotator.
+- **Elision covers return-fresh, and not return-self.** Escalier's
+  lifetime elision needs no annotation for an owned return. It never binds
+  a method's return to its receiver, though. It counts a signature's
+  parameters, and a method's receiver is a field of its own. So every
+  `receiver` return needs its annotation written. A method with exactly
+  one reference-typed parameter comes out worse still, because elision
+  binds its return to that parameter instead of leaving it alone.
+  The `.d.ts` import path skips elision and is annotated by the FR7
+  interop rules instead. Those rules read the declared types rather than
+  the algorithm, so they miss the aliasing wherever the declared return
+  type hides it. `Array.prototype.reverse` returns `this` and declares
+  `T[]`. `get DataView.prototype.buffer` hands out an object the receiver
+  holds and declares an array buffer. FR4 corrects both paths, alongside
+  the `param` and `union` shapes neither covers at all. Even there the
+  concrete annotation needs the typed signature for the borrow's
+  mutability and the union's lifetime variables, so it is review input,
+  not an auto-annotator.
 
 ### Synchronous throws versus asynchronous rejections
 
@@ -452,9 +467,10 @@ return is a borrow tied to that parameter's lifetime, `fresh` is an owned
 return, and `union` is a lifetime union. It is recorded but not
 automatically converted into a `&`/lifetime annotation: the alias edge
 under-determines the annotation (return type reference-vs-value from the
-FR7 join, the borrow mutability, union lifetime variables), and elision
-already covers `receiver` and `fresh`, so FR4 mainly informs the rare
-`param`/`union` cases. See the ownership-model section above.
+FR7 join, the borrow mutability, union lifetime variables). Where it does
+change the annotation is every `receiver` return, which elision cannot
+reach, plus `param` and `union`, which no rule covers. See the
+ownership-model section above.
 
 ### FR5. Soundness bias
 

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -325,23 +325,29 @@ them:
   there. Only a reference-typed return carries a borrow/lifetime, and
   reference-versus-value is the return **type**, which comes from the
   typed source at the FR7 join, not from the shape-free fact.
-- **Elision covers return-fresh, and not return-self.** Escalier's
-  lifetime elision needs no annotation for an owned return. It never binds
-  a method's return to its receiver, though. It counts a signature's
-  parameters, and a method's receiver is a field of its own. So every
-  `receiver` return needs its annotation written. A method with exactly
-  one reference-typed parameter comes out worse still, because elision
-  binds its return to that parameter instead of leaving it alone.
+- **Elision covers some return-fresh, and no return-self.** Escalier's
+  lifetime elision needs no annotation for a value-typed return, and none
+  for a reference-typed one whose signature declares no reference
+  parameter. Those are the owned returns it gets right. A signature with
+  exactly one reference-typed parameter is where it goes wrong: elision
+  binds the return to that parameter whatever the algorithm actually hands
+  back, so even a `fresh` return there is over-constrained and needs its
+  annotation written. Elision also never binds a method's return to its
+  receiver. It counts a signature's parameters, and a method's receiver is
+  a field of its own, so every `receiver` return needs one written too.
   The `.d.ts` import path skips elision and is annotated by the FR7
   interop rules instead. Those rules read the declared types rather than
   the algorithm, so they miss the aliasing wherever the declared return
   type hides it. `Array.prototype.reverse` returns `this` and declares
-  `T[]`. `get DataView.prototype.buffer` hands out an object the receiver
-  holds and declares an array buffer. FR4 corrects both paths, alongside
-  the `param` and `union` shapes neither covers at all. Even there the
-  concrete annotation needs the typed signature for the borrow's
-  mutability and the union's lifetime variables, so it is review input,
-  not an auto-annotator.
+  `T[]`, and its `receiver` fact corrects both paths. `get
+  DataView.prototype.buffer` hands out an object the receiver holds and
+  declares an array buffer, and there FR4 only names the gap. The fact it
+  publishes is `unknown`, so closing that one waits on the
+  `receiverInterior` alias kind or on a hand-written override entry. FR4
+  also reaches the `param` and `union` shapes neither path covers at all.
+  Even there the concrete annotation needs the typed signature for the
+  borrow's mutability and the union's lifetime variables, so it is review
+  input, not an auto-annotator.
 
 ### Synchronous throws versus asynchronous rejections
 
@@ -469,8 +475,10 @@ automatically converted into a `&`/lifetime annotation: the alias edge
 under-determines the annotation (return type reference-vs-value from the
 FR7 join, the borrow mutability, union lifetime variables). Where it does
 change the annotation is every `receiver` return, which elision cannot
-reach, plus `param` and `union`, which no rule covers. See the
-ownership-model section above.
+reach, a `fresh` reference return whose signature has one reference
+parameter, which elision over-constrains, and `param` and `union`, which
+no rule covers. A return the analysis leaves `unknown` is not among them.
+It names a gap without closing it. See the ownership-model section above.
 
 ### FR5. Soundness bias
 

--- a/planning/ecma-262/return_annotations.md
+++ b/planning/ecma-262/return_annotations.md
@@ -1,0 +1,289 @@
+# Return annotations from the `returns` fact
+
+§8.2 of [implementation_plan.md](implementation_plan.md) seeds the `&` and
+lifetime annotations of the override layer from FR4's `returns` fact. This file
+is that seed written out. It gives each member of the alias lattice the
+annotation it stands for, names the builtins that carry it, and separates the
+rows a curator has to act on from the rows the compiler already reaches on its
+own.
+
+The fact is review input rather than an annotator. Annotations are re-applied
+when the `.esc` is generated, so a curator edits the override layer and never
+the generated file. The checker's lifetime inference and elision rules,
+[../lifetimes/requirements.md](../lifetimes/requirements.md), and the borrow
+model, [../affine_semantics/requirements.md](../affine_semantics/requirements.md),
+stay the mechanism.
+
+**Notation.** `&self`, `&mut self`, and `-> &mut Self` are the shorthand these
+planning docs use for a borrowed receiver and for a return that borrows it. The
+declaration a curator writes spells the same relationship with an explicit
+lifetime parameter:
+
+```esc
+declare fn Array.fill<'a, T>(self: mut 'a Array<T>, value: T) -> mut 'a Array<T>
+```
+
+The lifetimes requirements define that form under
+[Lifetime Annotations](../lifetimes/requirements.md).
+
+## The mapping
+
+| `returns` | What the return hands back | Annotation | Builtins |
+| --- | --- | --- | --- |
+| `receiver` | the receiver itself | a borrow of the receiver, carrying the receiver's lifetime and its mutability | 15 |
+| `param:<n>` | the declared parameter at 0-based position `n` | a borrow tied to that parameter's lifetime | 6 |
+| `fresh` | a value the algorithm allocated, or a primitive it computed | an owned return, no lifetime | 232 |
+| `union` | a different value on different paths | a lifetime union over the members the fact names | 1 |
+| `unknown` | a value the walk could not tie to anything the caller holds | none the fact can seed | 247 |
+
+The counts are over the 501 builtins of the pinned graph, read from the merged
+facts of §4.4.
+
+Three things a `returns` value leaves open, which is why no row is applied
+without review:
+
+- **Whether a lifetime applies at all depends on the return type.** A
+  value-typed return has nothing to bound. `Array.prototype.indexOf` publishes
+  `fresh` and declares a number, so the row is moot there. The type arrives at
+  the §5 join, not from the shape-free fact.
+- **The borrow's mutability comes from the receiver or the parameter it
+  borrows**, not from the alias kind.
+- **A union's lifetime variables have to be named** in the declaration. The
+  `union` section below says which members get one.
+
+## `receiver`
+
+Fifteen builtins hand back the value they were called on. Twelve of them mutate
+it first, and those are the fluent chains:
+
+```
+Array.prototype.copyWithin   Array.prototype.fill   Array.prototype.reverse   Array.prototype.sort
+TypedArray.prototype.copyWithin   TypedArray.prototype.fill   TypedArray.prototype.reverse   TypedArray.prototype.sort
+Map.prototype.set   Set.prototype.add   WeakMap.prototype.set   WeakSet.prototype.add
+```
+
+Each already takes `&mut self`, so each returns `-> &mut Self`:
+
+```esc
+declare fn Array.fill<'a, T>(self: mut 'a Array<T>, value: T) -> mut 'a Array<T>
+declare fn Array.sort<'a, T>(self: mut 'a Array<T>, cmp?: fn(T, T) -> number) -> mut 'a Array<T>
+declare fn Array.reverse<'a, T>(self: mut 'a Array<T>) -> mut 'a Array<T>
+declare fn Map.set<'a, K, V>(self: mut 'a Map<K, V>, key: K, value: V) -> mut 'a Map<K, V>
+```
+
+The return-borrow carrying the receiver's mutability is what keeps a chain's
+mutability constant. Every link takes `&mut self` and hands back `&mut Self`,
+so `arr.fill(0).reverse()` stays `mut` from end to end. A fixed `-> &Self`
+would break the second call.
+
+The remaining three return the receiver without mutating it, and they are the
+open case of the section below.
+
+## `param:<n>`
+
+Six builtins hand back a declared parameter, all of them `Object` statics and
+all of them position 0:
+
+```
+Object.assign   Object.defineProperty   Object.freeze
+Object.preventExtensions   Object.seal   Object.setPrototypeOf
+```
+
+The return borrows that parameter's lifetime:
+
+```esc
+declare fn Object.seal<'a, T>(o: 'a T) -> 'a T
+```
+
+A static has no receiver, so nothing competes for the return's lifetime and one
+lifetime parameter is enough.
+
+## `union`
+
+One builtin publishes a union. `Object` returns an `OrdinaryObjectCreate`
+result on one path and `ToObject(value)` on another, so its fact is
+`union(fresh, param(0))`.
+
+A union's members are the values the algorithm hands back on its several paths.
+The annotation has to cover every one of them, so the return borrows all of
+them at once and the lifetime is the union of the members' lifetimes.
+
+`fresh` is the identity of that union rather than a member of it. An owned
+value has no lifetime to bound, so a caller holding it constrains nothing, and
+dropping `fresh` from the set leaves the same annotation the remaining members
+already require. `Object` therefore annotates as the borrow of `value` alone:
+
+```esc
+declare fn Object<'a, T>(value?: 'a T) -> 'a T
+```
+
+A caller that keeps the returned object alive keeps the argument alive on the
+path that hands it back. The types there come from the §5 join; the lifetime is
+what the fact contributes.
+
+A union of two input origins instead names both, and neither drops out.
+Escalier writes that with the parenthesized form, `('a | 'b) T`.
+
+## `fresh` and `unknown`
+
+`fresh` is an owned return and needs no annotation. `Array.prototype.slice`
+allocates the array it returns, and a caller may keep it after the receiver is
+gone.
+
+`unknown` is the lattice top. The walk read the returns and could tie none of
+them to a value the caller holds, so the fact seeds nothing. Two later stages
+narrow the 247:
+
+- The §5 join settles one as owned when the overload declares a primitive
+  return type, since a primitive cannot alias whatever the algorithm did.
+  `SignatureFact.ReturnOwned` carries that answer.
+- §4.4 curates one when a reviewer can read the return type the graph does not
+  carry. `Date.prototype.getTime`, `Date.prototype.valueOf`, and
+  `get TypedArray.prototype [ @@toStringTag ]` are curated `fresh`, because a
+  primitive read out of a slot is a copy.
+
+What is left after both is a return with no seed, and the curator writes the
+annotation from the declaration and the spec text.
+
+## Which rows a curator has to write
+
+Per §7, the generated `.esc` omits a lifetime annotation unless the override
+layer supplies one, and the result is then checked as ordinary Escalier source.
+So what a missing annotation costs is decided by lifetime elision, the rules
+that fill the lifetimes of a body-less declaration.
+[../../internal/checker/elision.go](../../internal/checker/elision.go) is all of
+it, and it does two things a curator has to know.
+
+**It reaches only body-less `declare fn` declarations.** Interface and class
+methods are deferred to Phase 12, because `inferInterface` is the same path
+that ingests a `.d.ts` and elision would misfire on the signatures there. A
+method the converter emits as an interface member gets no elision at all.
+
+**Where it does run, it never binds a return to the receiver.** `SelfParam` is
+a field of its own on `FuncType`, separate from `Params`, and elision counts
+only `Params`. `ApplyLifetimeElision` says so in as many words and points at
+the method-call machinery as where a receiver's lifetime comes from instead.
+The lifetimes requirements do list a method-receiver elision rule. The checker
+does not implement it. What is implemented is four cases:
+
+1. A non-reference return gets no lifetime.
+2. Exactly one reference-typed parameter, and the return takes that parameter's
+   lifetime.
+3. Zero reference-typed parameters, and the return is treated as freshly
+   allocated.
+4. More than one, and the signature is left unannotated.
+
+That decides the table:
+
+| `returns` | What an unannotated declaration gets | The curator |
+| --- | --- | --- |
+| `receiver` | never a borrow of the receiver. Where elision runs at all, a signature with no reference parameter reads as fresh, and one with exactly one takes that parameter's lifetime, naming the wrong source | writes all fifteen |
+| a receiver-lifetime borrow that is not `Self` | the same, and both `buffer` getters declare no parameter, so the return reads as fresh | writes both, once the lattice can spell the kind |
+| `param:<n>` | case 2 is right where the fact's position is the signature's only reference parameter | writes the rest, and the fact names which position |
+| `fresh`, value-typed | case 1, no lifetime | writes nothing |
+| `fresh`, reference-typed | case 3 is right where there is no reference parameter. Case 2 binds the return to a reference parameter that is not its source | writes the over-constrained ones |
+| `union` | no case joins two sources | writes it |
+
+A value-typed `fresh` return is the only row that needs nothing. Elision gets
+some of the others right, but by counting parameters rather than by knowing
+what the algorithm returns. So the fact is what tells a reviewer which of
+those to leave alone, as much as it is what corrects the rest.
+
+### The declared type does not carry the aliasing either
+
+A reader might expect the `.d.ts` to reveal a receiver return, since TypeScript
+spells one `this`. It does for eleven of the fifteen. Four declare a named type
+instead, at `typescript@5.7.2`, the version the repo pins:
+
+| Builtin | Declared return |
+| --- | --- |
+| `Array.prototype.reverse` | `T[]` |
+| `Object.prototype.valueOf` | `Object` |
+| `Iterator.prototype [ @@iterator ]` | `Iterator<T, TReturn, TNext>` |
+| `AsyncIteratorPrototype [ @@asyncIterator ]` | `AsyncIterator<T, TReturn, TNext>` |
+
+`Array.prototype.reverse` is the sharpest of them. Its own doc comment says the
+method "returns a reference to the same array" while its declared type says
+`T[]`.
+
+This matters for the other consumer of these declarations. A `.d.ts` imported
+directly skips elision, and the FR7 interop rules of
+[../lifetimes/requirements.md](../lifetimes/requirements.md) annotate it from
+the declared types. Rule D reads a `this` return as an alias of the receiver and
+covers the eleven. Rule C reads the four as returning a fresh value, and reads
+the two `buffer` getters the same way. The requirements reach the right answer
+for `reverse` anyway, by naming it in Rule D's example block rather than by the
+rule as written. That is a hand-maintained list of method names, which is the
+thing the fact replaces: the algorithm ends in `Return O`, and the fact says so
+for all fifteen without anyone keeping a list current.
+
+The second row of the table above is the residue §4.4 records by name, and the
+final section answers it.
+
+## Open case: a non-mutating method that returns its receiver
+
+Three of the fifteen publish `receiver: borrow` alongside `returns: receiver`:
+`Object.prototype.valueOf`, `Iterator.prototype [ @@iterator ]`, and
+`AsyncIteratorPrototype [ @@asyncIterator ]`. Each returns the `this` value
+without writing it.
+
+Under the rule that a return-borrow carries the receiver's mutability, each
+annotates `-> &Self`, and a caller holding a `mut` receiver gets an immutable
+one back. The annotation that would preserve the caller's mutability is a return
+abstracted over the receiver's mutability, which the affine checker does not
+express today.
+
+It bites on the two `@@iterator` methods. `for (x of it)` calls `@@iterator` and
+then `next`, and §11 decides whether Escalier's iterator protocol takes
+`&mut self`. If it does, an `@@iterator` annotated `-> &Self` hands back a
+receiver `next` cannot be called on. The two decisions have to be made together,
+and §11 is where both sit. `Object.prototype.valueOf` is unaffected, because
+nothing chains off it.
+
+Mutability polymorphism is out of this workstream's scope and belongs to
+[../affine_semantics/requirements.md](../affine_semantics/requirements.md).
+Until it lands, `-> &Self` is the annotation, and a `mut` caller that needs the
+mutability back re-borrows the original receiver.
+
+## Open case: a borrow of the receiver's lifetime that is not `Self`
+
+`get DataView.prototype.buffer` and `get TypedArray.prototype.buffer` return
+`[[ViewedArrayBuffer]]`, an object the receiver holds. Both publish
+`returns: unknown`, because no member of the alias lattice spells "reached
+through the receiver" and `receiver` would claim the getter hands back the view
+itself.
+
+**The annotation is the receiver's lifetime on the declared return type, with
+no claim that the return is `Self`:**
+
+```esc
+get buffer<'a>(self: 'a DataView) -> 'a ArrayBuffer
+```
+
+That is a third shape beside the two the mapping already has. `receiver` puts
+`Self` in the return position; this puts a different type there. `fresh` puts no
+lifetime in the return position; this puts the receiver's.
+
+Nothing else in the pipeline produces it. Both getters declare no parameter, so
+elision's case 3 reads the return as freshly allocated wherever it runs. Interop
+Rule C reaches the same answer down the `.d.ts` path, because the return type
+matches no parameter. Both are wrong here, and both fail quietly:
+
+```esc
+val view: mut DataView = new DataView(bytes)
+val buf = view.buffer         // buf is left out of view's alias set
+val frozen: DataView = view   // accepted, though buf still reaches the bytes
+```
+
+Both getters are accessors, so `Match.ReceiverApplies` keeps the join from
+writing a receiver claim onto them and the converter sets their mutability
+itself. The return lifetime is unaffected and stays a curated annotation.
+
+This is the accessor pattern, and the set grows with every such getter the spec
+adds. Answering it makes the `receiverInterior` alias kind proposed in
+[#1284](https://github.com/escalier-lang/escalier/issues/1284) worth adding,
+because this row is what would read it. `aliasOf` in
+[../../internal/ecma262/classify.go](../../internal/ecma262/classify.go)
+already resolves these returns to `Interior(Receiver)` and then discards the
+provenance, so the analysis holds the fact and the lattice has nowhere to put
+it.

--- a/planning/ecma-262/return_annotations.md
+++ b/planning/ecma-262/return_annotations.md
@@ -1,30 +1,31 @@
 # Return annotations from the `returns` fact
 
-§8.2 of [implementation_plan.md](implementation_plan.md) seeds the `&` and
-lifetime annotations of the override layer from FR4's `returns` fact. This file
-is that seed written out. It gives each member of the alias lattice the
-annotation it stands for, names the builtins that carry it, and separates the
-rows a curator has to act on from the rows the compiler already reaches on its
+§8.2 of [implementation_plan.md](implementation_plan.md) maps FR4's `returns`
+fact onto the `&` and lifetime annotation each alias kind stands for. This file
+is that mapping. It names the builtins carrying each kind and separates the
+rows needing an annotation from the rows the compiler already reaches on its
 own.
 
-The fact is review input rather than an annotator. Annotations are re-applied
-when the `.esc` is generated, so a curator edits committed data and never the
-generated file.
+**A generated `.esc` is a build output, so no annotation here is hand-written
+into one.** §6.8 of
+[../builtins/implementation_plan.md](../builtins/implementation_plan.md) routes
+the return borrow with the other three derived determinations:
+[#1352](https://github.com/escalier-lang/escalier/issues/1352) emits each one
+from its fact, and
+[../../internal/ecma262/curated.json](../../internal/ecma262/curated.json)
+answers what the control-flow graph does not settle. Curation is the correction
+channel, not the delivery channel.
 
-**Two committed layers hold that data, and an annotation belongs in one of
-them.** FR7 keys them differently because they answer different questions:
+That makes this file the specification the generator is written against, and
+the reference a reviewer reads a generated annotation against. A return the
+generator gets wrong costs a `curated.json` entry keyed by canonical spec name,
+which is also where the three curated `fresh` returns below already sit. A
+shape the generator cannot express costs an overlay `replace` under
+`internal/interop/overlay/`.
 
-- The **fact layer**,
-  [../../internal/ecma262/curated.json](../../internal/ecma262/curated.json),
-  is keyed by canonical spec name and merged into the facts before the §5 join.
-  It answers a determination the graph could not settle, so it is where a
-  `returns` value is corrected rather than where an annotation is written. §4.4
-  already uses it, and the three curated `fresh` returns below are its entries.
-- The **override layer** is keyed by declaration and applied after the join. It
-  holds the annotations this file maps to, because they are what FR5 makes the
-  extractor omit rather than something the facts get wrong. It does not exist
-  yet. §7 wires it into generation and §11 populates it, so every annotation
-  below is a decision recorded now and applied when those land.
+§7 and §11 of the ecma-262 plan still describe the older routing, where a
+hand-curated override layer keyed by declaration carried these annotations.
+Reconciling those sections with §6.8 is outside this file.
 
 The checker's lifetime inference and elision rules,
 [../lifetimes/requirements.md](../lifetimes/requirements.md), and the borrow
@@ -33,8 +34,8 @@ stay the mechanism.
 
 **Notation.** `&self`, `&mut self`, and `-> &mut Self` are the shorthand these
 planning docs use for a borrowed receiver and for a return that borrows it. The
-declaration a curator writes spells the same relationship with an explicit
-lifetime parameter:
+generated declaration spells the same relationship with an explicit lifetime
+parameter:
 
 ```esc
 declare fn Array.fill<'a, T>(self: mut 'a Array<T>, value: T) -> mut 'a Array<T>
@@ -168,17 +169,18 @@ narrow the 247:
   `get TypedArray.prototype [ @@toStringTag ]` are curated `fresh`, because a
   primitive read out of a slot is a copy.
 
-What is left after both is a return with no seed, and the curator writes the
-annotation from the declaration and the spec text.
+What is left after both seeds nothing, and a `curated.json` entry is what
+answers it, from the declaration and the spec text.
 
-## Which rows a curator has to write
+## Which rows need an explicit annotation
 
-Per §7, the generated `.esc` omits a lifetime annotation unless the override
-layer supplies one, and the result is then checked as ordinary Escalier source.
-So what a missing annotation costs is decided by lifetime elision, the rules
-that fill the lifetimes of a body-less declaration.
+A generated declaration that carries no lifetime is not thereby unconstrained.
+It is checked as ordinary Escalier source, so lifetime elision fills what the
+declaration leaves out. That is what decides which rows the generator has to
+write explicitly: a row elision would get right needs nothing, and a row it
+would get wrong needs the fact.
 [../../internal/checker/elision.go](../../internal/checker/elision.go) is all of
-it, and it does two things a curator has to know.
+elision, and it does two things worth knowing here.
 
 **It reaches only body-less `declare fn` declarations.** Interface and class
 methods are deferred to Phase 12, because `inferInterface` is the same path
@@ -201,14 +203,14 @@ does not implement it. What is implemented is four cases:
 
 That decides the table:
 
-| `returns` | What an unannotated declaration gets | The curator |
+| `returns` | What an unannotated declaration gets | Emit an annotation |
 | --- | --- | --- |
-| `receiver` | never a borrow of the receiver. Where elision runs at all, a signature with no reference parameter reads as fresh, and one with exactly one takes that parameter's lifetime, naming the wrong source | writes all fifteen |
-| a receiver-lifetime borrow that is not `Self` | the same, and both `buffer` getters declare no parameter, so the return reads as fresh | writes both, once the lattice can spell the kind |
-| `param:<n>` | case 2 is right where the fact's position is the signature's only reference parameter | writes the rest, and the fact names which position |
-| `fresh`, value-typed | case 1, no lifetime | writes nothing |
-| `fresh`, reference-typed | case 3 is right where there is no reference parameter. Case 2 binds the return to a reference parameter that is not its source | writes the over-constrained ones |
-| `union` | no case joins two sources | writes it |
+| `receiver` | never a borrow of the receiver. Where elision runs at all, a signature with no reference parameter reads as fresh, and one with exactly one takes that parameter's lifetime, naming the wrong source | for all fifteen |
+| a receiver-lifetime borrow that is not `Self` | the same, and both `buffer` getters declare no parameter, so the return reads as fresh | for both, once the lattice can spell the kind |
+| `param:<n>` | case 2 is right where the fact's position is the signature's only reference parameter | for the rest, at the position the fact names |
+| `fresh`, value-typed | case 1, no lifetime | never |
+| `fresh`, reference-typed | case 3 is right where there is no reference parameter. Case 2 binds the return to a reference parameter that is not its source | for the over-constrained ones |
+| `union` | no case joins two sources | always |
 
 A value-typed `fresh` return is the only row that needs nothing. Elision gets
 some of the others right, but by counting parameters rather than by knowing

--- a/planning/ecma-262/return_annotations.md
+++ b/planning/ecma-262/return_annotations.md
@@ -57,11 +57,11 @@ The counts are over the 501 builtins of the pinned graph, read from the merged
 facts of §4.4.
 
 **The roster is the converter's output, not this file.** Running
-`tools/dts_to_esc` with `--cfg` prints every builtin whose return seeds an
-annotation, one line per method, grouped by kind:
+`tools/dts_to_esc` with `--cfg` prints every builtin whose return borrows a
+value the caller holds, one line per method, grouped by kind:
 
 ```
-  return seeds: 22 to annotate, 232 owned, 247 open
+  return aliases: 22 borrowing, 232 owned, 247 open
     param(0): Object.assign
     ...
     receiver: Array.prototype.fill
@@ -69,10 +69,13 @@ annotation, one line per method, grouped by kind:
     union(fresh, param(0)): Object
 ```
 
-`Facts.ReturnSeeds` produces it and `TestFactsReturnSeedsAreListed` snapshots
-it, so a spec bump that adds or retires a borrowing return moves the list
-rather than staling this file. The methods named below are the ones the
-reasoning needs, not the list to work from.
+A borrowing return is one needing an annotation. The other two counts are the
+kinds needing none: an owned return has no lifetime to bound, and an open one
+names no value to borrow. `Facts.BorrowingReturns` produces the report and
+`TestFactsBorrowingReturnsAreListed` snapshots it, so a spec bump that adds or
+retires a borrowing return moves the list rather than staling this file. The
+methods named below are the ones the reasoning needs, not the list to work
+from.
 
 Three things a `returns` value leaves open, which is why no row is applied
 without review:

--- a/planning/ecma-262/return_annotations.md
+++ b/planning/ecma-262/return_annotations.md
@@ -8,8 +8,25 @@ rows a curator has to act on from the rows the compiler already reaches on its
 own.
 
 The fact is review input rather than an annotator. Annotations are re-applied
-when the `.esc` is generated, so a curator edits the override layer and never
-the generated file. The checker's lifetime inference and elision rules,
+when the `.esc` is generated, so a curator edits committed data and never the
+generated file.
+
+**Two committed layers hold that data, and an annotation belongs in one of
+them.** FR7 keys them differently because they answer different questions:
+
+- The **fact layer**,
+  [../../internal/ecma262/curated.json](../../internal/ecma262/curated.json),
+  is keyed by canonical spec name and merged into the facts before the §5 join.
+  It answers a determination the graph could not settle, so it is where a
+  `returns` value is corrected rather than where an annotation is written. §4.4
+  already uses it, and the three curated `fresh` returns below are its entries.
+- The **override layer** is keyed by declaration and applied after the join. It
+  holds the annotations this file maps to, because they are what FR5 makes the
+  extractor omit rather than something the facts get wrong. It does not exist
+  yet. §7 wires it into generation and §11 populates it, so every annotation
+  below is a decision recorded now and applied when those land.
+
+The checker's lifetime inference and elision rules,
 [../lifetimes/requirements.md](../lifetimes/requirements.md), and the borrow
 model, [../affine_semantics/requirements.md](../affine_semantics/requirements.md),
 stay the mechanism.

--- a/planning/ecma-262/return_annotations.md
+++ b/planning/ecma-262/return_annotations.md
@@ -39,6 +39,24 @@ The lifetimes requirements define that form under
 The counts are over the 501 builtins of the pinned graph, read from the merged
 facts of §4.4.
 
+**The roster is the converter's output, not this file.** Running
+`tools/dts_to_esc` with `--cfg` prints every builtin whose return seeds an
+annotation, one line per method, grouped by kind:
+
+```
+  return seeds: 22 to annotate, 232 owned, 247 open
+    param(0): Object.assign
+    ...
+    receiver: Array.prototype.fill
+    ...
+    union(fresh, param(0)): Object
+```
+
+`Facts.ReturnSeeds` produces it and `TestFactsReturnSeedsAreListed` snapshots
+it, so a spec bump that adds or retires a borrowing return moves the list
+rather than staling this file. The methods named below are the ones the
+reasoning needs, not the list to work from.
+
 Three things a `returns` value leaves open, which is why no row is applied
 without review:
 
@@ -53,16 +71,10 @@ without review:
 
 ## `receiver`
 
-Fifteen builtins hand back the value they were called on. Twelve of them mutate
-it first, and those are the fluent chains:
-
-```
-Array.prototype.copyWithin   Array.prototype.fill   Array.prototype.reverse   Array.prototype.sort
-TypedArray.prototype.copyWithin   TypedArray.prototype.fill   TypedArray.prototype.reverse   TypedArray.prototype.sort
-Map.prototype.set   Set.prototype.add   WeakMap.prototype.set   WeakSet.prototype.add
-```
-
-Each already takes `&mut self`, so each returns `-> &mut Self`:
+Fifteen builtins hand back the value they were called on. Twelve mutate it
+first — the four `Array` and four `TypedArray` in-place methods, plus the two
+map setters and the two set adders. Those are the fluent chains. Each already
+takes `&mut self`, so each returns `-> &mut Self`:
 
 ```esc
 declare fn Array.fill<'a, T>(self: mut 'a Array<T>, value: T) -> mut 'a Array<T>
@@ -81,15 +93,9 @@ open case of the section below.
 
 ## `param:<n>`
 
-Six builtins hand back a declared parameter, all of them `Object` statics and
-all of them position 0:
-
-```
-Object.assign   Object.defineProperty   Object.freeze
-Object.preventExtensions   Object.seal   Object.setPrototypeOf
-```
-
-The return borrows that parameter's lifetime:
+Six builtins hand back a declared parameter. All six are `Object` statics that
+take the object they operate on first and hand it back, and all six name
+position 0. The return borrows that parameter's lifetime:
 
 ```esc
 declare fn Object.seal<'a, T>(o: 'a T) -> 'a T

--- a/planning/ecma-262/return_annotations.md
+++ b/planning/ecma-262/return_annotations.md
@@ -288,8 +288,10 @@ itself. The return lifetime is unaffected and stays a curated annotation.
 This is the accessor pattern, and the set grows with every such getter the spec
 adds. Answering it makes the `receiverInterior` alias kind proposed in
 [#1284](https://github.com/escalier-lang/escalier/issues/1284) worth adding,
-because this row is what would read it. `aliasOf` in
-[../../internal/ecma262/classify.go](../../internal/ecma262/classify.go)
-already resolves these returns to `Interior(Receiver)` and then discards the
-provenance, so the analysis holds the fact and the lattice has nowhere to put
-it.
+because this row is what would read it. The provenance already exists:
+`NewOriginMap` in
+[../../internal/ecma262/origin.go](../../internal/ecma262/origin.go) resolves
+both getters to `Interior(Receiver)`, and `aliasOf` in
+[../../internal/ecma262/classify.go](../../internal/ecma262/classify.go) reads
+that origin and returns the lattice top. The graph settles this today, and the
+lattice has nowhere to carry it.

--- a/planning/ecma-262/return_annotations.md
+++ b/planning/ecma-262/return_annotations.md
@@ -23,9 +23,11 @@ which is also where the three curated `fresh` returns below already sit. A
 shape the generator cannot express costs an overlay `replace` under
 `internal/interop/overlay/`.
 
-§7 and §11 of the ecma-262 plan still describe the older routing, where a
-hand-curated override layer keyed by declaration carried these annotations.
-Reconciling those sections with §6.8 is outside this file.
+§7's receiver half is what landed, and §6.8 keeps it: receiver mutability is
+applied from the fact. What both it and §11 still describe for the other three
+determinations is the older routing, where a hand-curated override layer keyed
+by declaration carried them. Reconciling those sections with §6.8 is outside
+this file.
 
 The checker's lifetime inference and elision rules,
 [../lifetimes/requirements.md](../lifetimes/requirements.md), and the borrow

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -27,12 +27,13 @@
 //
 //	    The facts come from the control-flow graph internal/ecma262
 //	    commits. --cfg classifies from the graph at that path instead,
-//	    and prints four reports about it: the join of every std:* member
+//	    and prints five reports about it: the join of every std:* member
 //	    the run emits against those facts, naming what is present on one
 //	    side only, what the curated layer did to them, what the coercion
-//	    filter dropped, and how every receiver claim compares with the
-//	    hand-written mutability sources. It is how a spec bump is
-//	    previewed before its graph is committed. See
+//	    filter dropped, how every receiver claim compares with the
+//	    hand-written mutability sources, and which returns borrow a value
+//	    the caller holds and so need a lifetime annotation written. It is
+//	    how a spec bump is previewed before its graph is committed. See
 //	    planning/ecma-262/implementation_plan.md.
 package main
 
@@ -221,15 +222,16 @@ func loadFacts(cfgPath string, stderr io.Writer) (*ecma262.Facts, *ecma262.Join,
 	return facts, ecma262.NewJoin(facts), nil
 }
 
-// writeFactReports prints the four ECMA-262 reports for a run that named
+// writeFactReports prints the five ECMA-262 reports for a run that named
 // a cfg.json, and prints nothing for one that did not.
 //
-// All four are informational. A curated entry the analysis caught up
+// All five are informational. A curated entry the analysis caught up
 // with is an entry to delete. The spec and the TypeScript lib drift
 // independently, so a name on one side only is a gap to close. FR11's
 // coercion filter is a heuristic, so what it dropped is read rather than
 // trusted. A receiver the two sources answer differently is a triage
-// item. None of them is a failed run.
+// item. A return needing an annotation is review input. None of them is
+// a failed run.
 func writeFactReports(
 	facts *ecma262.Facts,
 	join *ecma262.Join,
@@ -243,6 +245,12 @@ func writeFactReports(
 		return err
 	}
 	if err := dts_to_esc.WriteValidationReport(dts_to_esc.ValidateReceivers(facts), stderr); err != nil {
+		return err
+	}
+	// §8.2's seed surface. Receiver mutability is auto-applied, so it needs no
+	// such list, while every return here is an annotation someone writes into
+	// the override layer. See planning/ecma-262/return_annotations.md.
+	if err := ecma262.WriteReturnsReport(facts.ReturnSeeds(), stderr); err != nil {
 		return err
 	}
 	return ecma262.WriteJoinReport(join.Match(dts_to_esc.StdDeclarations(mods)), stderr)

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -247,10 +247,11 @@ func writeFactReports(
 	if err := dts_to_esc.WriteValidationReport(dts_to_esc.ValidateReceivers(facts), stderr); err != nil {
 		return err
 	}
-	// §8.2's seed surface. Receiver mutability is auto-applied, so it needs no
-	// such list, while every return here is an annotation someone writes into
-	// the override layer. See planning/ecma-262/return_annotations.md.
-	if err := ecma262.WriteReturnsReport(facts.ReturnSeeds(), stderr); err != nil {
+	// The returns axis, printed with the other per-axis reports. Receiver
+	// mutability is auto-applied and needs no such list, while every borrowing
+	// return here is an annotation someone writes into the override layer. See
+	// planning/ecma-262/return_annotations.md.
+	if err := ecma262.WriteReturnAliasReport(facts.BorrowingReturns(), stderr); err != nil {
 		return err
 	}
 	return ecma262.WriteJoinReport(join.Match(dts_to_esc.StdDeclarations(mods)), stderr)

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -84,7 +84,7 @@ func TestRun_GenerateWithCFGPrintsEveryReport(t *testing.T) {
 	snaps.MatchInlineSnapshot(t, reportSummaries(stderr.String()), snaps.Inline(`  curation: 27 fill-ins, 0 corrections, 0 redundant, 0 stale, 0 unmatched, 0 refused
   coercion filter: 4882 TypeError sites adjudicated, 362 dropped
   receivers: 194 confirmed by a name tier, 0 heuristics corrected, 27 redundant overrides, 0 disagreements, 45 answered by the facts alone, 37 overrides no fact answers
-  return seeds: 22 to annotate, 232 owned, 247 open
+  return aliases: 22 borrowing, 232 owned, 247 open
   join: 1 matched (1 with a receiver claim), 0 declarations without a fact, 436 facts without a declaration, 0 unkeyed declarations, 64 unjoinable facts
   returns: 1 settled as owned by the declared type, 0 left unknown`))
 }

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -84,6 +84,7 @@ func TestRun_GenerateWithCFGPrintsEveryReport(t *testing.T) {
 	snaps.MatchInlineSnapshot(t, reportSummaries(stderr.String()), snaps.Inline(`  curation: 27 fill-ins, 0 corrections, 0 redundant, 0 stale, 0 unmatched, 0 refused
   coercion filter: 4882 TypeError sites adjudicated, 362 dropped
   receivers: 194 confirmed by a name tier, 0 heuristics corrected, 27 redundant overrides, 0 disagreements, 45 answered by the facts alone, 37 overrides no fact answers
+  return seeds: 22 to annotate, 232 owned, 247 open
   join: 1 matched (1 with a receiver claim), 0 declarations without a fact, 436 facts without a declaration, 0 unkeyed declarations, 64 unjoinable facts
   returns: 1 settled as owned by the declared type, 0 left unknown`))
 }


### PR DESCRIPTION
Fixes #1202

Completes §8.2 of the implementation plan by documenting the mapping from the `returns` alias fact to lifetime and borrow annotations.

**Changes:**

- Add `return_annotations.md` with a comprehensive guide to the five alias kinds (`receiver`, `param:`, `fresh`, `union`, `unknown`) and their corresponding annotations. The document maps each kind to concrete builtins, explains which rows need curator review versus which elision handles, and addresses three open cases: non-mutating receiver returns, receiver-interior borrows, and the `receiverInterior` alias kind proposed in #1284.

- Update `implementation_plan.md` §8.2 to reference the new document and expand the gate description with three key findings: elision cannot cover receiver returns (it counts parameters, not receivers, and only runs on body-less `declare fn`), three receiver returns need mutability polymorphism, and the §4.4 residue (buffer getters) is answered by the missing `receiverInterior` member.

- Update `requirements.md` ownership-model section to correct the confidence ranking: receiver returns do need annotation (all fifteen of them), and three builtins hit the non-mutating case that needs mutability polymorphism. Expand the elision discussion to explain why it covers `fresh` but not `receiver`, and why FR4 corrects both the `.esc` generation path and the `.d.ts` interop path where declared types hide the aliasing.

The document serves as review input for curators editing the override layer, making visible which rows the compiler already reaches and which require human judgment.

https://claude.ai/code/session_01JE6ESAqrdGT2SBD5wVfpoE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for deriving return and lifetime annotations from ECMA-262 specifications.
  * Documented receiver, parameter, fresh, union, and unknown return mappings.
  * Clarified lifetime elision limitations and annotation requirements for receiver aliases.
  * Added examples for iterator methods, buffer accessors, and TypeScript declaration interoperability.
  * Marked the return-borrow seed work as complete and documented remaining unresolved cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->