### PR TITLE
Report unreadable .esc files separately from check failures

### DIFF
--- a/internal/dts_to_esc/errors.go
+++ b/internal/dts_to_esc/errors.go
@@ -1,0 +1,235 @@
+package dts_to_esc
+
+import (
+	"errors"
+	"fmt"
+)
+
+// This file names every way a pass over the committed `.esc` tree can
+// fail. The passes are in rerun.go: planning a package, checking it, and
+// writing it back.
+//
+// Each failure is its own type rather than a formatted string, so a
+// caller can ask what went wrong instead of matching on a message, and
+// so adding a failure mode means adding a type here rather than another
+// fmt.Errorf at the site. The passes return `[]Error`, which lets one
+// run report every package that failed instead of stopping at the first.
+//
+// Two things are deliberately outside this vocabulary. A pure printer
+// failure stays a plain `error` until the caller that knows the package
+// wraps it, since the printer knows nothing about packages. And the
+// argument and usage errors of the CLI are the command's own, not a
+// pass's.
+
+// Error is one failure a pass over the committed tree reports. The set
+// of implementations is closed to this file, so a type switch over an
+// Error covers every case the passes can produce.
+type Error interface {
+	error
+
+	// Pkg is the package URI the failure belongs to, e.g. "std:array".
+	// Every failure happens while one package is being planned,
+	// checked, or written.
+	Pkg() string
+
+	// rerunError closes the set. It has no behavior.
+	rerunError()
+}
+
+// pkgError holds the package URI every failure names, so each concrete
+// type states it once by embedding this.
+type pkgError struct {
+	// PkgURI is the package the failure happened under.
+	PkgURI string
+}
+
+func (e pkgError) Pkg() string { return e.PkgURI }
+
+func (e pkgError) rerunError() {}
+
+// ErrUnreadableTree marks a run that could not parse part of the
+// committed `.esc` tree. Both modes keep going and report every package
+// they could read, so this error is what a caller keys on to tell a tree
+// the tool could not read from a tree that is merely out of date.
+var ErrUnreadableTree = errors.New("committed .esc files could not be parsed")
+
+// UnparseableFileError is a committed `.esc` file the Escalier parser
+// rejected.
+//
+// It is the one failure a pass carries on from. Its package is left out
+// of the diff, since neither mode can tell what a file it cannot read
+// already declares, and every other package is planned as usual. It
+// reaches the caller in the report's Unreadable list rather than in the
+// error slice, so the run still prints what it found.
+type UnparseableFileError struct {
+	pkgError
+
+	// Path is the file's path relative to the `.esc` tree root, e.g.
+	// "std/array.esc". The reports print this, so their output does not
+	// depend on where the tree lives.
+	Path string
+
+	// File is the same file's path on disk, which the message names so a
+	// contributor can open it.
+	File string
+
+	// Reason is the first parse error, in the parser's own
+	// "line:col-line:col: message" form.
+	Reason string
+}
+
+func (e *UnparseableFileError) Error() string {
+	return fmt.Sprintf("parsing %s: %s", e.File, e.Reason)
+}
+
+// Is matches ErrUnreadableTree, so a caller can key an exit status on
+// the sentinel without walking the list for this type.
+func (e *UnparseableFileError) Is(target error) bool { return target == ErrUnreadableTree }
+
+// FileReadError is a committed file the process could not read at all,
+// as opposed to one the parser rejected. The tree is broken rather than
+// out of date, so the run stops.
+type FileReadError struct {
+	pkgError
+
+	// File is the path on disk that could not be read.
+	File string
+
+	// Cause is what the filesystem returned.
+	Cause error
+}
+
+func (e *FileReadError) Error() string {
+	return fmt.Sprintf("reading %s: %s", e.File, e.Cause)
+}
+
+func (e *FileReadError) Unwrap() error { return e.Cause }
+
+// FileWriteError is a package file the write pass could not replace.
+type FileWriteError struct {
+	pkgError
+
+	// File is the path on disk that could not be written.
+	File string
+
+	// Cause is what the filesystem returned.
+	Cause error
+}
+
+func (e *FileWriteError) Error() string {
+	return fmt.Sprintf("writing %s: %s", e.File, e.Cause)
+}
+
+func (e *FileWriteError) Unwrap() error { return e.Cause }
+
+// PackageDirError is the directory holding a package file that the write
+// pass could not create.
+type PackageDirError struct {
+	pkgError
+
+	// Dir is the path on disk that could not be created.
+	Dir string
+
+	// Cause is what the filesystem returned.
+	Cause error
+}
+
+func (e *PackageDirError) Error() string {
+	return fmt.Sprintf("creating package dir for %s: %s", e.Pkg(), e.Cause)
+}
+
+func (e *PackageDirError) Unwrap() error { return e.Cause }
+
+// BucketConvertError is a routed bucket the converter could not turn
+// into a module, so the package has no converted side to compare the
+// committed one against.
+type BucketConvertError struct {
+	pkgError
+
+	// Cause is what the converter returned.
+	Cause error
+}
+
+func (e *BucketConvertError) Error() string {
+	return fmt.Sprintf("converting bucket %s: %s", e.Pkg(), e.Cause)
+}
+
+func (e *BucketConvertError) Unwrap() error { return e.Cause }
+
+// UnknownPackageError is a bucket whose package URI is not in
+// PackageList. Route only ever returns URIs from that list, so this
+// marks a bug in the routing pass rather than anything about the tree.
+type UnknownPackageError struct {
+	pkgError
+}
+
+func (e *UnknownPackageError) Error() string {
+	return fmt.Sprintf("unknown package URI %q; every bucket should come from "+
+		"Route, which only returns URIs in PackageList", e.Pkg())
+}
+
+// DeclRenderError is a converted declaration the printer would not turn
+// into Escalier source, so the pass has no text to add for it.
+type DeclRenderError struct {
+	pkgError
+
+	// Name is the declaration's name.
+	Name string
+
+	// Cause is what the printer returned.
+	Cause error
+}
+
+func (e *DeclRenderError) Error() string {
+	return fmt.Sprintf("rendering %s in %s: %s", e.Name, e.Pkg(), e.Cause)
+}
+
+func (e *DeclRenderError) Unwrap() error { return e.Cause }
+
+// MemberCompareError is a declaration whose members could not be
+// compared against the committed side, because the printer would not
+// render one of them.
+type MemberCompareError struct {
+	pkgError
+
+	// Name is the name both sides share.
+	Name string
+
+	// Cause is what the printer returned.
+	Cause error
+}
+
+func (e *MemberCompareError) Error() string {
+	return fmt.Sprintf("comparing members of %s in %s: %s", e.Name, e.Pkg(), e.Cause)
+}
+
+func (e *MemberCompareError) Unwrap() error { return e.Cause }
+
+// DiffRenderError is a package whose unified diff could not be built, so
+// the check has the findings but not the patch that shows them.
+type DiffRenderError struct {
+	pkgError
+
+	// Cause is what the diff renderer returned.
+	Cause error
+}
+
+func (e *DiffRenderError) Error() string {
+	return fmt.Sprintf("rendering the diff for %s: %s", e.Pkg(), e.Cause)
+}
+
+func (e *DiffRenderError) Unwrap() error { return e.Cause }
+
+// Join folds a pass's failures into one error and returns nil when there
+// were none. errors.Is and errors.As see through the result, so a caller
+// that wants one failure back can still ask for it.
+func Join(errs []Error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	joined := make([]error, len(errs))
+	for i, err := range errs {
+		joined[i] = err
+	}
+	return errors.Join(joined...)
+}

--- a/internal/dts_to_esc/errors_test.go
+++ b/internal/dts_to_esc/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/dts_parser"
 	"github.com/stretchr/testify/require"
 )
 
@@ -191,4 +192,23 @@ func TestJoin(t *testing.T) {
 	var convert *BucketConvertError
 	require.ErrorAs(t, Join([]Error{first, second}), &convert)
 	require.Equal(t, "std:array", convert.Pkg())
+}
+
+// TestPlanPartition_ReportsABucketOutsideThePackageList covers the guard
+// on Route's output. Every bucket is supposed to carry a URI from
+// PackageList, so a bucket that does not is a routing bug: the pass
+// names it and moves on to the packages it can place, rather than
+// planning against a package it cannot locate on disk.
+func TestPlanPartition_ReportsABucketOutsideThePackageList(t *testing.T) {
+	t.Parallel()
+	res := &PartitionResult{
+		Buckets: map[string][]dts_parser.Statement{"std:nope": nil},
+	}
+
+	_, errs := CheckPartition(res, t.TempDir())
+	require.Len(t, errs, 1)
+	require.Equal(t, "std:nope", errs[0].Pkg())
+	require.EqualError(t, errs[0],
+		`unknown package URI "std:nope"; every bucket should come from `+
+			"Route, which only returns URIs in PackageList")
 }

--- a/internal/dts_to_esc/errors_test.go
+++ b/internal/dts_to_esc/errors_test.go
@@ -1,0 +1,194 @@
+package dts_to_esc
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// cause stands in for whatever the filesystem, the converter, or the
+// printer handed back.
+var cause = errors.New("disk on fire")
+
+// everyError is one value of each failure a pass can report, paired with
+// the package it names and the line it prints. A run that aborts prints
+// exactly these, so they are worth holding still.
+var everyError = []struct {
+	name    string
+	err     Error
+	pkg     string
+	message string
+}{
+	{
+		name: "unparseable file",
+		err: &UnparseableFileError{
+			pkgError: pkgError{PkgURI: "std:array"},
+			Path:     "std/array.esc",
+			File:     "/tmp/tree/std/array.esc",
+			Reason:   "313:5-313:9: Expected a property name",
+		},
+		pkg:     "std:array",
+		message: "parsing /tmp/tree/std/array.esc: 313:5-313:9: Expected a property name",
+	},
+	{
+		name: "unreadable file",
+		err: &FileReadError{
+			pkgError: pkgError{PkgURI: "std:array"},
+			File:     "/tmp/tree/std/array.esc",
+			Cause:    cause,
+		},
+		pkg:     "std:array",
+		message: "reading /tmp/tree/std/array.esc: disk on fire",
+	},
+	{
+		name: "unwritable file",
+		err: &FileWriteError{
+			pkgError: pkgError{PkgURI: "std:array"},
+			File:     "/tmp/tree/std/array.esc",
+			Cause:    cause,
+		},
+		pkg:     "std:array",
+		message: "writing /tmp/tree/std/array.esc: disk on fire",
+	},
+	{
+		name: "uncreatable package dir",
+		err: &PackageDirError{
+			pkgError: pkgError{PkgURI: "std:array"},
+			Dir:      "/tmp/tree/std",
+			Cause:    cause,
+		},
+		pkg:     "std:array",
+		message: "creating package dir for std:array: disk on fire",
+	},
+	{
+		name: "bucket that would not convert",
+		err: &BucketConvertError{
+			pkgError: pkgError{PkgURI: "std:array"},
+			Cause:    cause,
+		},
+		pkg:     "std:array",
+		message: "converting bucket std:array: disk on fire",
+	},
+	{
+		name: "URI outside PackageList",
+		err:  &UnknownPackageError{pkgError: pkgError{PkgURI: "std:nope"}},
+		pkg:  "std:nope",
+		message: `unknown package URI "std:nope"; every bucket should come from ` +
+			"Route, which only returns URIs in PackageList",
+	},
+	{
+		name: "declaration the printer refused",
+		err: &DeclRenderError{
+			pkgError: pkgError{PkgURI: "std:array"},
+			Name:     "Array",
+			Cause:    cause,
+		},
+		pkg:     "std:array",
+		message: "rendering Array in std:array: disk on fire",
+	},
+	{
+		name: "member the printer refused",
+		err: &MemberCompareError{
+			pkgError: pkgError{PkgURI: "std:array"},
+			Name:     "Array",
+			Cause:    cause,
+		},
+		pkg:     "std:array",
+		message: "comparing members of Array in std:array: disk on fire",
+	},
+	{
+		name: "diff that would not render",
+		err: &DiffRenderError{
+			pkgError: pkgError{PkgURI: "std:array"},
+			Cause:    cause,
+		},
+		pkg:     "std:array",
+		message: "rendering the diff for std:array: disk on fire",
+	},
+}
+
+// TestError_NamesItsPackageAndPrintsItsFailure covers every case of the
+// Error interface. The message is what a contributor reads when a run
+// aborts, and Pkg is what tells them which package to look at.
+func TestError_NamesItsPackageAndPrintsItsFailure(t *testing.T) {
+	t.Parallel()
+	for _, tc := range everyError {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.pkg, tc.err.Pkg())
+			require.EqualError(t, tc.err, tc.message)
+		})
+	}
+}
+
+// TestError_UnwrapsToTheUnderlyingFailure pins that a failure carrying a
+// cause hands it back, so a caller can ask what the filesystem or the
+// printer actually said rather than reading it out of the message.
+func TestError_UnwrapsToTheUnderlyingFailure(t *testing.T) {
+	t.Parallel()
+	for _, tc := range everyError {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// The two failures with nothing underneath them are the
+			// parse rejection, which carries the parser's message rather
+			// than an error, and the unknown URI, which is a routing bug
+			// with no cause to name.
+			switch tc.err.(type) {
+			case *UnparseableFileError, *UnknownPackageError:
+				require.NotErrorIs(t, tc.err, cause)
+				return
+			}
+			require.ErrorIs(t, tc.err, cause)
+		})
+	}
+}
+
+// TestUnparseableFileError_MatchesTheUnreadableTreeSentinel covers the
+// one failure a caller keys an exit status on: `check` and `regenerate`
+// end differently for a tree they could not read than for one that is
+// out of date.
+func TestUnparseableFileError_MatchesTheUnreadableTreeSentinel(t *testing.T) {
+	t.Parallel()
+	unparseable := &UnparseableFileError{
+		pkgError: pkgError{PkgURI: "std:array"},
+		Path:     "std/array.esc",
+		File:     "/tmp/tree/std/array.esc",
+		Reason:   "313:5-313:9: Expected a property name",
+	}
+	require.ErrorIs(t, unparseable, ErrUnreadableTree)
+	require.NotErrorIs(t, unparseable, fs.ErrNotExist)
+
+	// A different failure against the same file is not the same outcome.
+	read := &FileReadError{
+		pkgError: pkgError{PkgURI: "std:array"},
+		File:     "/tmp/tree/std/array.esc",
+		Cause:    fs.ErrPermission,
+	}
+	require.NotErrorIs(t, read, ErrUnreadableTree)
+	require.ErrorIs(t, read, fs.ErrPermission)
+}
+
+func TestJoin(t *testing.T) {
+	t.Parallel()
+	first := &BucketConvertError{
+		pkgError: pkgError{PkgURI: "std:array"},
+		Cause:    cause,
+	}
+	second := &UnknownPackageError{pkgError: pkgError{PkgURI: "std:nope"}}
+
+	require.NoError(t, Join(nil))
+	require.EqualError(t, Join([]Error{first}),
+		"converting bucket std:array: disk on fire")
+	require.EqualError(t, Join([]Error{first, second}),
+		"converting bucket std:array: disk on fire\n"+
+			`unknown package URI "std:nope"; every bucket should come from `+
+			"Route, which only returns URIs in PackageList")
+
+	// A caller that wants one failure back still gets it through the
+	// join, which is what the CLI's exit status depends on.
+	var convert *BucketConvertError
+	require.ErrorAs(t, Join([]Error{first, second}), &convert)
+	require.Equal(t, "std:array", convert.Pkg())
+}

--- a/internal/dts_to_esc/rerun.go
+++ b/internal/dts_to_esc/rerun.go
@@ -125,11 +125,51 @@ type NewMember struct {
 	Text string
 }
 
+// ErrUnreadableTree marks a run that could not parse part of the
+// committed `.esc` tree. Both modes keep going and report every package
+// they could read, so this error is what a caller keys on to tell a tree
+// the tool could not read from a tree that is merely out of date.
+var ErrUnreadableTree = errors.New("committed .esc files could not be parsed")
+
+// UnreadableFile names a committed `.esc` file the Escalier parser
+// rejected. Its package is left out of the diff, since neither mode can
+// tell what a file it cannot read already declares.
+type UnreadableFile struct {
+	// Pkg is the package URI, e.g. "std:array".
+	Pkg string
+
+	// Path is the file's path relative to the `.esc` tree root, e.g.
+	// "std/array.esc".
+	Path string
+
+	// Reason is the first parse error, in the parser's own
+	// "line:col-line:col: message" form.
+	Reason string
+}
+
+// unreadableErr wraps ErrUnreadableTree with the number of files that
+// failed to parse, and returns nil when none did. The files themselves
+// are named in the report, so the message stays one line.
+func unreadableErr(files []UnreadableFile) error {
+	if len(files) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d %w", len(files), ErrUnreadableTree)
+}
+
 // CheckReport is the outcome of a read-only check run: one PackageDiff
 // per package that produced a bucket, in package-URI order.
 type CheckReport struct {
 	Packages []PackageDiff
+
+	// Unreadable are the committed files the parser rejected, in the
+	// same order. Their packages have no entry in Packages.
+	Unreadable []UnreadableFile
 }
+
+// UnreadableErr returns ErrUnreadableTree when a committed file failed
+// to parse, and nil otherwise.
+func (r *CheckReport) UnreadableErr() error { return unreadableErr(r.Unreadable) }
 
 // CheckPartition converts every bucket in result and diffs it against
 // the committed `.esc` tree rooted at escDir, without touching disk.
@@ -141,12 +181,19 @@ type CheckReport struct {
 // Each package's diff carries the patch a regenerate run would apply,
 // so a contributor reads the same change here that the write mode
 // would make.
+//
+// A committed file the parser rejects is reported in the report's
+// Unreadable list and its package is skipped. Every other package is
+// still diffed, so one run names every unreadable file at once.
 func CheckPartition(result *PartitionResult, escDir string) (*CheckReport, error) {
-	plans, err := planPartition(result, escDir)
+	plans, unreadable, err := planPartition(result, escDir)
 	if err != nil {
 		return nil, err
 	}
-	report := &CheckReport{Packages: make([]PackageDiff, 0, len(plans))}
+	report := &CheckReport{
+		Packages:   make([]PackageDiff, 0, len(plans)),
+		Unreadable: unreadable,
+	}
 	for _, plan := range plans {
 		diff := plan.diff
 		spliced := plan.splice()
@@ -188,8 +235,9 @@ func (r *CheckReport) Counts() (decls, members, removed int) {
 
 // Write prints the report to w: the unified diff for every package the
 // re-run would change, then a note for each finding the diff cannot
-// show, then a summary. The footer names the drift checks that are not
-// implemented so a passing run is not read as full coverage.
+// show, then a line for every committed file the parser rejected, then
+// a summary. The footer names the drift checks that are not implemented
+// so a passing run is not read as full coverage.
 func (r *CheckReport) Write(w io.Writer) error {
 	for i := range r.Packages {
 		p := &r.Packages[i]
@@ -211,10 +259,18 @@ func (r *CheckReport) Write(w io.Writer) error {
 			}
 		}
 	}
+	for _, f := range r.Unreadable {
+		if _, err := fmt.Fprintf(w,
+			"error: %s: %s; %s was not checked\n",
+			f.Path, f.Reason, f.Pkg); err != nil {
+			return err
+		}
+	}
 	decls, members, removed := r.Counts()
 	if _, err := fmt.Fprintf(w,
-		"check: %d missing declarations, %d missing members, %d extra declarations\n",
-		decls, members, removed); err != nil {
+		"check: %d missing declarations, %d missing members, %d extra declarations, "+
+			"%d unreadable files\n",
+		decls, members, removed, len(r.Unreadable)); err != nil {
 		return err
 	}
 	_, err := fmt.Fprint(w,
@@ -228,7 +284,15 @@ func (r *CheckReport) Write(w io.Writer) error {
 // package that produced a bucket, in package-URI order.
 type RegenReport struct {
 	Packages []RegenResult
+
+	// Unreadable are the committed files the parser rejected, in the
+	// same order. Their packages were left on disk untouched.
+	Unreadable []UnreadableFile
 }
+
+// UnreadableErr returns ErrUnreadableTree when a committed file failed
+// to parse, and nil otherwise.
+func (r *RegenReport) UnreadableErr() error { return unreadableErr(r.Unreadable) }
 
 // RegenResult is what the write pass did to one package's file.
 type RegenResult struct {
@@ -261,13 +325,18 @@ type RegenResult struct {
 // hand-edits survive a re-run.
 //
 // A package whose file is absent is written in full — everything in it
-// is missing.
+// is missing. A package whose file is present but does not parse is
+// left on disk untouched and reported in the report's Unreadable list,
+// since a splice into source the pass cannot read would be blind.
 func RegeneratePartition(result *PartitionResult, escDir string) (*RegenReport, error) {
-	plans, err := planPartition(result, escDir)
+	plans, unreadable, err := planPartition(result, escDir)
 	if err != nil {
 		return nil, err
 	}
-	report := &RegenReport{Packages: make([]RegenResult, 0, len(plans))}
+	report := &RegenReport{
+		Packages:   make([]RegenResult, 0, len(plans)),
+		Unreadable: unreadable,
+	}
 	for i := range plans {
 		res, err := plans[i].apply(escDir)
 		if err != nil {
@@ -278,7 +347,8 @@ func RegeneratePartition(result *PartitionResult, escDir string) (*RegenReport, 
 	return report, nil
 }
 
-// Write prints one line per package the pass changed, then a summary.
+// Write prints one line per package the pass changed, then a line for
+// every committed file the parser rejected, then a summary.
 func (r *RegenReport) Write(w io.Writer) error {
 	var decls, members int
 	for i := range r.Packages {
@@ -310,7 +380,15 @@ func (r *RegenReport) Write(w io.Writer) error {
 			}
 		}
 	}
-	_, err := fmt.Fprintf(w, "regenerate: +%d declarations, +%d members\n", decls, members)
+	for _, f := range r.Unreadable {
+		if _, err := fmt.Fprintf(w,
+			"error: %s: %s; %s was left unchanged\n",
+			f.Path, f.Reason, f.Pkg); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(w, "regenerate: +%d declarations, +%d members, %d unreadable files\n",
+		decls, members, len(r.Unreadable))
 	return err
 }
 
@@ -346,10 +424,17 @@ type memberInsert struct {
 }
 
 // planPartition converts every bucket and diffs it against the
-// committed tree, returning one plan per package. Buckets are visited
-// in package-URI order so both modes report in the same sequence
-// regardless of map iteration.
-func planPartition(result *PartitionResult, escDir string) ([]packagePlan, error) {
+// committed tree, returning one plan per package it could read and one
+// UnreadableFile per package whose committed file the parser rejected.
+// Buckets are visited in package-URI order so both modes report in the
+// same sequence regardless of map iteration.
+//
+// A committed file that does not parse takes its own package out of the
+// run and leaves the rest of the tree diffed as usual. During §7 the
+// tree holds a mix of files that round-trip and files that do not, and
+// a contributor wants the whole list of the second kind plus whatever
+// the readable packages report, not the first failure alone.
+func planPartition(result *PartitionResult, escDir string) ([]packagePlan, []UnreadableFile, error) {
 	uris := make([]string, 0, len(result.Buckets))
 	for uri := range result.Buckets {
 		uris = append(uris, uri)
@@ -357,24 +442,34 @@ func planPartition(result *PartitionResult, escDir string) ([]packagePlan, error
 	sort.Strings(uris)
 
 	plans := make([]packagePlan, 0, len(uris))
+	var unreadable []UnreadableFile
 	for _, uri := range uris {
 		pkg, ok := PackageForURI(uri)
 		if !ok {
-			return nil, fmt.Errorf("planPartition: unknown package URI %q "+
+			return nil, nil, fmt.Errorf("planPartition: unknown package URI %q "+
 				"(every bucket should come from Route, which only returns "+
 				"URIs in PackageList)", uri)
 		}
 		mod, err := ConvertBucket(result.Buckets[uri])
 		if err != nil {
-			return nil, fmt.Errorf("converting bucket %s: %w", uri, err)
+			return nil, nil, fmt.Errorf("converting bucket %s: %w", uri, err)
 		}
 		plan, err := planPackage(pkg, mod, escDir)
 		if err != nil {
-			return nil, err
+			var unparseable *unparseableError
+			if errors.As(err, &unparseable) {
+				unreadable = append(unreadable, UnreadableFile{
+					Pkg:    uri,
+					Path:   pkg.File,
+					Reason: unparseable.reason,
+				})
+				continue
+			}
+			return nil, nil, err
 		}
 		plans = append(plans, *plan)
 	}
-	return plans, nil
+	return plans, unreadable, nil
 }
 
 // planPackage compares one converted bucket against its committed file
@@ -472,6 +567,23 @@ func readCommitted(path string) (string, bool, error) {
 	return string(contents), true, nil
 }
 
+// unparseableError reports a committed `.esc` file the Escalier parser
+// rejected. planPartition sorts it out of the errors that abort a run
+// and collects it instead, so one unreadable file costs its own package
+// and nothing more.
+type unparseableError struct {
+	// path is the file's path on disk.
+	path string
+
+	// reason is the first parse error, in the parser's own
+	// "line:col-line:col: message" form.
+	reason string
+}
+
+func (e *unparseableError) Error() string {
+	return fmt.Sprintf("parsing %s: %s", e.path, e.reason)
+}
+
 // parseCommitted parses a committed `.esc` file into its top-level
 // declarations. ParseLibFiles is used rather than ParseDecls because a
 // package file may open with `import "std:date"` and only ParseLibFiles
@@ -480,7 +592,7 @@ func parseCommitted(path, contents string) ([]ast.Decl, error) {
 	src := &ast.Source{Path: path, Contents: contents}
 	mod, errs := parser.ParseLibFiles(context.Background(), []*ast.Source{src})
 	if len(errs) > 0 {
-		return nil, fmt.Errorf("parsing %s: %s", path, errs[0].String())
+		return nil, &unparseableError{path: path, reason: errs[0].String()}
 	}
 	var decls []ast.Decl
 	mod.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {

--- a/internal/dts_to_esc/rerun.go
+++ b/internal/dts_to_esc/rerun.go
@@ -26,7 +26,8 @@ import (
 //
 // Both modes run the same diff. CheckPartition reports it and
 // RegeneratePartition applies it, so the two cannot disagree about what
-// a re-run would change.
+// a re-run would change. Both hand their failures back as []Error,
+// whose cases errors.go names.
 //
 // §6.4 states check 1 over declarations. Members are checked on the
 // same footing here. The §6.4 write mode adds them, so a check that
@@ -125,32 +126,10 @@ type NewMember struct {
 	Text string
 }
 
-// ErrUnreadableTree marks a run that could not parse part of the
-// committed `.esc` tree. Both modes keep going and report every package
-// they could read, so this error is what a caller keys on to tell a tree
-// the tool could not read from a tree that is merely out of date.
-var ErrUnreadableTree = errors.New("committed .esc files could not be parsed")
-
-// UnreadableFile names a committed `.esc` file the Escalier parser
-// rejected. Its package is left out of the diff, since neither mode can
-// tell what a file it cannot read already declares.
-type UnreadableFile struct {
-	// Pkg is the package URI, e.g. "std:array".
-	Pkg string
-
-	// Path is the file's path relative to the `.esc` tree root, e.g.
-	// "std/array.esc".
-	Path string
-
-	// Reason is the first parse error, in the parser's own
-	// "line:col-line:col: message" form.
-	Reason string
-}
-
 // unreadableErr wraps ErrUnreadableTree with the number of files that
 // failed to parse, and returns nil when none did. The files themselves
 // are named in the report, so the message stays one line.
-func unreadableErr(files []UnreadableFile) error {
+func unreadableErr(files []*UnparseableFileError) error {
 	if len(files) == 0 {
 		return nil
 	}
@@ -164,7 +143,7 @@ type CheckReport struct {
 
 	// Unreadable are the committed files the parser rejected, in the
 	// same order. Their packages have no entry in Packages.
-	Unreadable []UnreadableFile
+	Unreadable []*UnparseableFileError
 }
 
 // UnreadableErr returns ErrUnreadableTree when a committed file failed
@@ -185,25 +164,36 @@ func (r *CheckReport) UnreadableErr() error { return unreadableErr(r.Unreadable)
 // A committed file the parser rejects is reported in the report's
 // Unreadable list and its package is skipped. Every other package is
 // still diffed, so one run names every unreadable file at once.
-func CheckPartition(result *PartitionResult, escDir string) (*CheckReport, error) {
-	plans, unreadable, err := planPartition(result, escDir)
-	if err != nil {
-		return nil, err
+//
+// Any other failure comes back in the Error slice, one entry per
+// package that hit one, and the report is nil. The types are in
+// errors.go.
+func CheckPartition(result *PartitionResult, escDir string) (*CheckReport, []Error) {
+	planned, errs := planPartition(result, escDir)
+	if len(errs) > 0 {
+		return nil, errs
 	}
 	report := &CheckReport{
-		Packages:   make([]PackageDiff, 0, len(plans)),
-		Unreadable: unreadable,
+		Packages:   make([]PackageDiff, 0, len(planned.plans)),
+		Unreadable: planned.unreadable,
 	}
-	for _, plan := range plans {
+	for _, plan := range planned.plans {
 		diff := plan.diff
 		spliced := plan.splice()
 		patch, err := unifiedDiff(diff.Path, diff.Exists, plan.contents, spliced.edits)
 		if err != nil {
-			return nil, fmt.Errorf("rendering the diff for %s: %w", diff.Pkg, err)
+			errs = append(errs, &DiffRenderError{
+				pkgError: pkgError{PkgURI: diff.Pkg},
+				Cause:    err,
+			})
+			continue
 		}
 		diff.Patch = patch
 		diff.Skipped = spliced.skipped
 		report.Packages = append(report.Packages, diff)
+	}
+	if len(errs) > 0 {
+		return nil, errs
 	}
 	return report, nil
 }
@@ -262,7 +252,7 @@ func (r *CheckReport) Write(w io.Writer) error {
 	for _, f := range r.Unreadable {
 		if _, err := fmt.Fprintf(w,
 			"error: %s: %s; %s was not checked\n",
-			f.Path, f.Reason, f.Pkg); err != nil {
+			f.Path, f.Reason, f.Pkg()); err != nil {
 			return err
 		}
 	}
@@ -287,7 +277,7 @@ type RegenReport struct {
 
 	// Unreadable are the committed files the parser rejected, in the
 	// same order. Their packages were left on disk untouched.
-	Unreadable []UnreadableFile
+	Unreadable []*UnparseableFileError
 }
 
 // UnreadableErr returns ErrUnreadableTree when a committed file failed
@@ -328,21 +318,29 @@ type RegenResult struct {
 // is missing. A package whose file is present but does not parse is
 // left on disk untouched and reported in the report's Unreadable list,
 // since a splice into source the pass cannot read would be blind.
-func RegeneratePartition(result *PartitionResult, escDir string) (*RegenReport, error) {
-	plans, unreadable, err := planPartition(result, escDir)
-	if err != nil {
-		return nil, err
+//
+// Any other failure comes back in the Error slice and the report is
+// nil. Packages planned before the failure may already be on disk: the
+// write pass works one file at a time and does not roll back.
+func RegeneratePartition(result *PartitionResult, escDir string) (*RegenReport, []Error) {
+	planned, errs := planPartition(result, escDir)
+	if len(errs) > 0 {
+		return nil, errs
 	}
 	report := &RegenReport{
-		Packages:   make([]RegenResult, 0, len(plans)),
-		Unreadable: unreadable,
+		Packages:   make([]RegenResult, 0, len(planned.plans)),
+		Unreadable: planned.unreadable,
 	}
-	for i := range plans {
-		res, err := plans[i].apply(escDir)
+	for i := range planned.plans {
+		res, err := planned.plans[i].apply(escDir)
 		if err != nil {
-			return nil, err
+			errs = append(errs, err)
+			continue
 		}
 		report.Packages = append(report.Packages, res)
+	}
+	if len(errs) > 0 {
+		return nil, errs
 	}
 	return report, nil
 }
@@ -383,7 +381,7 @@ func (r *RegenReport) Write(w io.Writer) error {
 	for _, f := range r.Unreadable {
 		if _, err := fmt.Fprintf(w,
 			"error: %s: %s; %s was left unchanged\n",
-			f.Path, f.Reason, f.Pkg); err != nil {
+			f.Path, f.Reason, f.Pkg()); err != nil {
 			return err
 		}
 	}
@@ -423,62 +421,77 @@ type memberInsert struct {
 	text string
 }
 
+// partitionPlans is what one planning pass produced: a plan for every
+// package it could read, and the committed files the parser rejected.
+type partitionPlans struct {
+	plans      []packagePlan
+	unreadable []*UnparseableFileError
+}
+
 // planPartition converts every bucket and diffs it against the
-// committed tree, returning one plan per package it could read and one
-// UnreadableFile per package whose committed file the parser rejected.
-// Buckets are visited in package-URI order so both modes report in the
-// same sequence regardless of map iteration.
+// committed tree. Buckets are visited in package-URI order so both
+// modes report in the same sequence regardless of map iteration.
 //
 // A committed file that does not parse takes its own package out of the
 // run and leaves the rest of the tree diffed as usual. During §7 the
 // tree holds a mix of files that round-trip and files that do not, and
 // a contributor wants the whole list of the second kind plus whatever
 // the readable packages report, not the first failure alone.
-func planPartition(result *PartitionResult, escDir string) ([]packagePlan, []UnreadableFile, error) {
+func planPartition(result *PartitionResult, escDir string) (partitionPlans, []Error) {
 	uris := make([]string, 0, len(result.Buckets))
 	for uri := range result.Buckets {
 		uris = append(uris, uri)
 	}
 	sort.Strings(uris)
 
-	plans := make([]packagePlan, 0, len(uris))
-	var unreadable []UnreadableFile
+	planned := partitionPlans{plans: make([]packagePlan, 0, len(uris))}
+	var errs []Error
 	for _, uri := range uris {
 		pkg, ok := PackageForURI(uri)
 		if !ok {
-			return nil, nil, fmt.Errorf("planPartition: unknown package URI %q "+
-				"(every bucket should come from Route, which only returns "+
-				"URIs in PackageList)", uri)
+			errs = append(errs, &UnknownPackageError{pkgError: pkgError{PkgURI: uri}})
+			continue
 		}
 		mod, err := ConvertBucket(result.Buckets[uri])
 		if err != nil {
-			return nil, nil, fmt.Errorf("converting bucket %s: %w", uri, err)
+			errs = append(errs, &BucketConvertError{
+				pkgError: pkgError{PkgURI: uri},
+				Cause:    err,
+			})
+			continue
 		}
-		plan, err := planPackage(pkg, mod, escDir)
-		if err != nil {
-			var unparseable *unparseableError
-			if errors.As(err, &unparseable) {
-				unreadable = append(unreadable, UnreadableFile{
-					Pkg:    uri,
-					Path:   pkg.File,
-					Reason: unparseable.reason,
-				})
+		plan, planErrs := planPackage(pkg, mod, escDir)
+		for _, planErr := range planErrs {
+			// The parser rejecting a file costs that package and nothing
+			// more, so it travels in the report rather than in the
+			// failures that stop the run.
+			if unparseable, ok := planErr.(*UnparseableFileError); ok {
+				planned.unreadable = append(planned.unreadable, unparseable)
 				continue
 			}
-			return nil, nil, err
+			errs = append(errs, planErr)
 		}
-		plans = append(plans, *plan)
+		if len(planErrs) > 0 {
+			continue
+		}
+		planned.plans = append(planned.plans, *plan)
 	}
-	return plans, unreadable, nil
+	return planned, errs
 }
 
 // planPackage compares one converted bucket against its committed file
-// and returns the plan for closing the gap.
-func planPackage(pkg Package, mod *StandaloneModule, escDir string) (*packagePlan, error) {
+// and returns the plan for closing the gap. A package that produced any
+// failure returns no plan, since a plan missing the declarations that
+// failed to render would understate what the package needs.
+//
+// A file that cannot be read or parsed ends the package there. Past
+// that point the pass keeps going and collects every declaration the
+// printer refused, so one run names them all.
+func planPackage(pkg Package, mod *StandaloneModule, escDir string) (*packagePlan, []Error) {
 	dest := filepath.Join(escDir, filepath.FromSlash(pkg.File))
-	contents, exists, err := readCommitted(dest)
-	if err != nil {
-		return nil, err
+	contents, exists, readErr := readCommitted(pkg, dest)
+	if readErr != nil {
+		return nil, []Error{readErr}
 	}
 
 	plan := &packagePlan{
@@ -489,11 +502,16 @@ func planPackage(pkg Package, mod *StandaloneModule, escDir string) (*packagePla
 
 	var committed []ast.Decl
 	if exists {
-		committed, err = parseCommitted(dest, contents)
-		if err != nil {
-			return nil, err
+		var parseErr Error
+		committed, parseErr = parseCommitted(pkg, dest, contents)
+		if parseErr != nil {
+			return nil, []Error{parseErr}
 		}
 	}
+
+	// A declaration the printer refuses costs its own entry and no more,
+	// so the pass keeps going and hands back everything it found.
+	var errs []Error
 
 	byName := make(map[string][]ast.Decl, len(committed))
 	for _, decl := range committed {
@@ -512,7 +530,12 @@ func planPackage(pkg Package, mod *StandaloneModule, escDir string) (*packagePla
 		if !spaceCovered(byName[name], decl) {
 			text, err := renderStandaloneDecl(mod, decl)
 			if err != nil {
-				return nil, fmt.Errorf("rendering %s in %s: %w", name, pkg.URI, err)
+				errs = append(errs, &DeclRenderError{
+					pkgError: pkgError{PkgURI: pkg.URI},
+					Name:     name,
+					Cause:    err,
+				})
+				continue
 			}
 			diff.NewDecls = append(diff.NewDecls, NewDecl{
 				Name: name,
@@ -527,7 +550,12 @@ func planPackage(pkg Package, mod *StandaloneModule, escDir string) (*packagePla
 		}
 		members, err := missingMembers(name, host, decl)
 		if err != nil {
-			return nil, fmt.Errorf("comparing members of %s in %s: %w", name, pkg.URI, err)
+			errs = append(errs, &MemberCompareError{
+				pkgError: pkgError{PkgURI: pkg.URI},
+				Name:     name,
+				Cause:    err,
+			})
+			continue
 		}
 		for _, m := range members {
 			diff.NewMembers = append(diff.NewMembers, m)
@@ -550,49 +578,44 @@ func planPackage(pkg Package, mod *StandaloneModule, escDir string) (*packagePla
 		reported.Add(name)
 		diff.Removed = append(diff.Removed, name)
 	}
+	if len(errs) > 0 {
+		return nil, errs
+	}
 	return plan, nil
 }
 
 // readCommitted reads a committed `.esc` file. A file that is not on
 // disk is not an error — every declaration in its package is missing,
 // which is exactly what a first run against an unseeded tree means.
-func readCommitted(path string) (string, bool, error) {
+func readCommitted(pkg Package, path string) (string, bool, Error) {
 	contents, err := os.ReadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
 		return "", false, nil
 	}
 	if err != nil {
-		return "", false, fmt.Errorf("reading %s: %w", path, err)
+		return "", false, &FileReadError{
+			pkgError: pkgError{PkgURI: pkg.URI},
+			File:     path,
+			Cause:    err,
+		}
 	}
 	return string(contents), true, nil
-}
-
-// unparseableError reports a committed `.esc` file the Escalier parser
-// rejected. planPartition sorts it out of the errors that abort a run
-// and collects it instead, so one unreadable file costs its own package
-// and nothing more.
-type unparseableError struct {
-	// path is the file's path on disk.
-	path string
-
-	// reason is the first parse error, in the parser's own
-	// "line:col-line:col: message" form.
-	reason string
-}
-
-func (e *unparseableError) Error() string {
-	return fmt.Sprintf("parsing %s: %s", e.path, e.reason)
 }
 
 // parseCommitted parses a committed `.esc` file into its top-level
 // declarations. ParseLibFiles is used rather than ParseDecls because a
 // package file may open with `import "std:date"` and only ParseLibFiles
 // admits import statements.
-func parseCommitted(path, contents string) ([]ast.Decl, error) {
+func parseCommitted(pkg Package, path, contents string) ([]ast.Decl, Error) {
 	src := &ast.Source{Path: path, Contents: contents}
 	mod, errs := parser.ParseLibFiles(context.Background(), []*ast.Source{src})
 	if len(errs) > 0 {
-		return nil, &unparseableError{path: path, reason: errs[0].String()}
+		return nil, &UnparseableFileError{
+			pkgError: pkgError{PkgURI: pkg.URI},
+			Path:     pkg.File,
+			File:     path,
+			Reason:   errs[0].String(),
+		}
 	}
 	var decls []ast.Decl
 	mod.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
@@ -901,7 +924,7 @@ func escDeclKind(decl ast.Decl) string {
 // apply writes this package's additions to disk and returns what it
 // did. A package whose contents would not change is not rewritten, so
 // an unchanged file keeps its mtime.
-func (p *packagePlan) apply(escDir string) (RegenResult, error) {
+func (p *packagePlan) apply(escDir string) (RegenResult, Error) {
 	res := RegenResult{
 		Pkg:     p.diff.Pkg,
 		Path:    p.diff.Path,
@@ -914,7 +937,11 @@ func (p *packagePlan) apply(escDir string) (RegenResult, error) {
 
 	dest := filepath.Join(escDir, filepath.FromSlash(p.diff.Path))
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		return res, fmt.Errorf("creating package dir for %s: %w", p.diff.Pkg, err)
+		return res, &PackageDirError{
+			pkgError: pkgError{PkgURI: p.diff.Pkg},
+			Dir:      filepath.Dir(dest),
+			Cause:    err,
+		}
 	}
 
 	spliced := p.splice()
@@ -927,7 +954,11 @@ func (p *packagePlan) apply(escDir string) (RegenResult, error) {
 		return res, nil
 	}
 	if err := os.WriteFile(dest, []byte(updated), 0o644); err != nil {
-		return res, fmt.Errorf("writing %s: %w", dest, err)
+		return res, &FileWriteError{
+			pkgError: pkgError{PkgURI: p.diff.Pkg},
+			File:     dest,
+			Cause:    err,
+		}
 	}
 
 	res.AddedDecls = len(p.diff.NewDecls)

--- a/internal/dts_to_esc/rerun_test.go
+++ b/internal/dts_to_esc/rerun_test.go
@@ -74,8 +74,8 @@ interface Array<T> { length: number; }
 interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; readonly prototype: Array<any>; }
 declare var Array: ArrayConstructor;
 `)
-	report, err := CheckPartition(res, t.TempDir())
-	require.NoError(t, err)
+	report, errs := CheckPartition(res, t.TempDir())
+	require.Empty(t, errs)
 	require.True(t, report.Failed())
 
 	diff := findDiff(t, report, "std:array")
@@ -100,8 +100,8 @@ declare var Array: ArrayConstructor;
 	_, err := WritePartitionedTree(res, root)
 	require.NoError(t, err)
 
-	report, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	report, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 	require.False(t, report.Failed())
 
 	decls, members, removed := report.Counts()
@@ -128,8 +128,8 @@ declare var Math: Math;
 export declare val PI: number
 `)
 
-	report, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	report, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 	require.False(t, report.Failed(), "dropped declarations must not fail the check")
 
 	// The exemption is the routing pass's own decision — every one of
@@ -161,8 +161,8 @@ export declare class Array<T> {
 export type MyArrayHelper<T> = Array<T>
 `)
 
-	report, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	report, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 
 	// Nothing is missing on either side; the one finding is the `.esc`
 	// declaration the `.d.ts` has no counterpart for, which the report
@@ -193,8 +193,8 @@ export declare class Array<T> {
 }
 `)
 
-	report, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	report, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 	require.True(t, report.Failed())
 
 	// The rendered report carries every fact this test is about: no
@@ -239,8 +239,8 @@ export declare class Array<T> {
 }
 `)
 
-	report, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	report, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 	require.False(t, report.Failed())
 }
 
@@ -288,8 +288,8 @@ export declare interface WeakRefConstructor {
 }
 `)
 
-	report, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	report, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 	diff := findDiff(t, report, "std:weak_ref")
 	require.Empty(t, diff.NewDecls, "the fused class covers both converted halves")
 	require.Empty(t, diff.NewMembers)
@@ -323,13 +323,15 @@ func TestCheckPartition_ReportsEveryUnparseableFileAndChecksTheRest(t *testing.T
 	root := t.TempDir()
 	writeEsc(t, root, "std/math.esc", unparseableEsc)
 
-	report, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	report, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 
 	require.Len(t, report.Unreadable, 1)
-	require.Equal(t, "std:math", report.Unreadable[0].Pkg)
+	require.Equal(t, "std:math", report.Unreadable[0].Pkg())
 	require.Equal(t, "std/math.esc", report.Unreadable[0].Path)
+	require.Equal(t, filepath.Join(root, "std", "math.esc"), report.Unreadable[0].File)
 	require.Equal(t, "2:5-2:6: Expected a property name", report.Unreadable[0].Reason)
+	require.ErrorIs(t, report.Unreadable[0], ErrUnreadableTree)
 	require.ErrorIs(t, report.UnreadableErr(), ErrUnreadableTree)
 	require.EqualError(t, report.UnreadableErr(),
 		"1 committed .esc files could not be parsed")
@@ -358,8 +360,8 @@ func TestCheckPartition_ReportsNoUnreadableFilesForATreeThatParses(t *testing.T)
 	_, err := WritePartitionedTree(res, root)
 	require.NoError(t, err)
 
-	report, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	report, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 	require.Empty(t, report.Unreadable)
 	require.NoError(t, report.UnreadableErr())
 	require.False(t, report.Failed())
@@ -375,10 +377,10 @@ func TestRegeneratePartition_SkipsAnUnparseableFile(t *testing.T) {
 	root := t.TempDir()
 	dest := writeEsc(t, root, "std/math.esc", unparseableEsc)
 
-	report, err := RegeneratePartition(res, root)
-	require.NoError(t, err)
+	report, errs := RegeneratePartition(res, root)
+	require.Empty(t, errs)
 	require.Len(t, report.Unreadable, 1)
-	require.Equal(t, "std:math", report.Unreadable[0].Pkg)
+	require.Equal(t, "std:math", report.Unreadable[0].Pkg())
 	require.ErrorIs(t, report.UnreadableErr(), ErrUnreadableTree)
 
 	after, err := os.ReadFile(dest)
@@ -410,24 +412,34 @@ func TestCheckPartition_StillAbortsOnAnIOError(t *testing.T) {
 	dest := filepath.Join(root, "std", "math.esc")
 	require.NoError(t, os.MkdirAll(dest, 0o755))
 
-	_, err := CheckPartition(res, root)
-	require.EqualError(t, err,
+	_, errs := CheckPartition(res, root)
+	require.Len(t, errs, 1)
+	readErr, ok := errs[0].(*FileReadError)
+	require.True(t, ok, "an unreadable file is a FileReadError, got %T", errs[0])
+	require.Equal(t, "std:math", readErr.Pkg())
+	require.Equal(t, dest, readErr.File)
+	require.EqualError(t, readErr,
 		fmt.Sprintf("reading %s: read %s: is a directory", dest, dest))
-	require.NotErrorIs(t, err, ErrUnreadableTree)
+
+	// The tree is broken rather than unreadable in the parser's sense,
+	// so the run stops instead of reporting the package and carrying on.
+	require.NotErrorIs(t, Join(errs), ErrUnreadableTree)
 }
 
-// TestUnparseableError_NamesTheFileAndPosition pins the message the
-// error carries. planPartition reads its fields rather than the string,
-// so this is what a caller that propagated the error instead would
-// print.
-func TestUnparseableError_NamesTheFileAndPosition(t *testing.T) {
+// TestUnparseableFileError_NamesTheFileAndPosition pins the message the
+// error carries. The reports read its fields rather than the string, so
+// this is what a caller that propagated the error instead would print.
+func TestUnparseableFileError_NamesTheFileAndPosition(t *testing.T) {
 	t.Parallel()
-	err := &unparseableError{
-		path:   "/tmp/tree/std/array.esc",
-		reason: "313:5-313:9: Expected a property name",
+	err := &UnparseableFileError{
+		pkgError: pkgError{PkgURI: "std:array"},
+		Path:     "std/array.esc",
+		File:     "/tmp/tree/std/array.esc",
+		Reason:   "313:5-313:9: Expected a property name",
 	}
 	require.EqualError(t, err,
 		"parsing /tmp/tree/std/array.esc: 313:5-313:9: Expected a property name")
+	require.Equal(t, "std:array", err.Pkg())
 }
 
 func TestRegeneratePartition_CreatesMissingFile(t *testing.T) {
@@ -439,8 +451,8 @@ declare var Array: ArrayConstructor;
 `)
 	root := t.TempDir()
 
-	report, err := RegeneratePartition(res, root)
-	require.NoError(t, err)
+	report, errs := RegeneratePartition(res, root)
+	require.Empty(t, errs)
 	require.Len(t, report.Packages, 1)
 	require.True(t, report.Packages[0].Created)
 	require.Equal(t, 1, report.Packages[0].AddedDecls)
@@ -457,8 +469,8 @@ export declare class Array<T> {
 `))
 
 	// A second run has nothing left to add.
-	after, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	after, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 	require.False(t, after.Failed())
 }
 
@@ -479,8 +491,8 @@ export declare fn parse(text: string) -> unknown throws SyntaxError
 `
 	path := writeEsc(t, root, "std/json.esc", committed)
 
-	report, err := RegeneratePartition(res, root)
-	require.NoError(t, err)
+	report, errs := RegeneratePartition(res, root)
+	require.Empty(t, errs)
 	require.Len(t, report.Packages, 1)
 	require.False(t, report.Packages[0].Created)
 	require.Equal(t, 1, report.Packages[0].AddedDecls)
@@ -512,8 +524,8 @@ declare var Array: ArrayConstructor;
 export declare class Array<T> {}
 `)
 
-	report, err := RegeneratePartition(res, root)
-	require.NoError(t, err)
+	report, errs := RegeneratePartition(res, root)
+	require.Empty(t, errs)
 	require.Equal(t, 0, report.Packages[0].AddedDecls)
 	require.Equal(t, 4, report.Packages[0].AddedMembers)
 	require.Empty(t, report.Packages[0].Skipped)
@@ -528,8 +540,8 @@ export declare class Array<T> {
 }
 `))
 
-	after, err := CheckPartition(res, root)
-	require.NoError(t, err)
+	after, errs := CheckPartition(res, root)
+	require.Empty(t, errs)
 	require.False(t, after.Failed())
 }
 
@@ -548,8 +560,8 @@ export declare class Number {
 }
 `)
 
-	report, err := RegeneratePartition(res, root)
-	require.NoError(t, err)
+	report, errs := RegeneratePartition(res, root)
+	require.Empty(t, errs)
 	require.Equal(t, 1, report.Packages[0].AddedDecls)
 
 	// The committed class keeps its place and gains the two members it
@@ -582,8 +594,8 @@ declare var Array: ArrayConstructor;
 	require.NoError(t, err)
 	original := readEsc(t, path)
 
-	report, err := RegeneratePartition(res, root)
-	require.NoError(t, err)
+	report, errs := RegeneratePartition(res, root)
+	require.Empty(t, errs)
 	require.Equal(t, 0, report.Packages[0].AddedDecls)
 	require.Equal(t, 0, report.Packages[0].AddedMembers)
 
@@ -611,8 +623,8 @@ export declare class Array<T> {
 export type RemovedUpstream = number
 `)
 
-	report, err := RegeneratePartition(res, root)
-	require.NoError(t, err)
+	report, errs := RegeneratePartition(res, root)
+	require.Empty(t, errs)
 	require.Equal(t, []string{"RemovedUpstream"}, report.Packages[0].Removed)
 
 	// The file keeps the declaration the `.d.ts` dropped, and the report
@@ -695,8 +707,8 @@ export declare class Array<T> {
 		root := t.TempDir()
 		path := writeEsc(t, root, "std/array.esc", tc.committed)
 
-		report, err := RegeneratePartition(res, root)
-		require.NoError(t, err)
+		report, errs := RegeneratePartition(res, root)
+		require.Empty(t, errs)
 		require.Equal(t, 1, report.Packages[0].AddedMembers, tc.name)
 		require.Empty(t, report.Packages[0].Skipped, tc.name)
 
@@ -848,8 +860,8 @@ func TestCheckPartition_LibES5RoundTrips(t *testing.T) {
 	}
 	require.NotEmpty(t, reparsed.Buckets, "at least one package must reparse")
 
-	report, err := CheckPartition(reparsed, root)
-	require.NoError(t, err)
+	report, errs := CheckPartition(reparsed, root)
+	require.Empty(t, errs)
 
 	var sb strings.Builder
 	require.NoError(t, report.Write(&sb))
@@ -857,8 +869,8 @@ func TestCheckPartition_LibES5RoundTrips(t *testing.T) {
 		"a freshly written tree must have nothing missing:\n%s", sb.String())
 
 	// The write mode agrees: a re-run over the same tree adds nothing.
-	regen, err := RegeneratePartition(reparsed, root)
-	require.NoError(t, err)
+	regen, errs := RegeneratePartition(reparsed, root)
+	require.Empty(t, errs)
 	for _, p := range regen.Packages {
 		require.Equal(t, 0, p.AddedDecls, "%s should need no new declarations", p.Pkg)
 		require.Equal(t, 0, p.AddedMembers, "%s should need no new members", p.Pkg)

--- a/internal/dts_to_esc/rerun_test.go
+++ b/internal/dts_to_esc/rerun_test.go
@@ -2,9 +2,7 @@ package dts_to_esc
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -397,69 +395,6 @@ func TestRegeneratePartition_SkipsAnUnparseableFile(t *testing.T) {
 		"error: std/math.esc: 2:5-2:6: Expected a property name; std:math was left unchanged\n")
 	require.Contains(t, out.String(),
 		"regenerate: +1 declarations, +0 members, 1 unreadable files\n")
-}
-
-// errWriteFailed is what failWriter hands back once its budget runs
-// out.
-var errWriteFailed = errors.New("write failed")
-
-// failWriter accepts budget bytes in total and fails on the write that
-// would exceed it, so a test can cut a report off after any number of
-// bytes and watch the error propagate.
-type failWriter struct {
-	budget int
-}
-
-// Write accepts p while the budget covers it and fails otherwise,
-// reporting the partial byte count the way a short write does.
-func (w *failWriter) Write(p []byte) (int, error) {
-	if len(p) > w.budget {
-		n := w.budget
-		w.budget = 0
-		return n, errWriteFailed
-	}
-	w.budget -= len(p)
-	return len(p), nil
-}
-
-// TestReportWrite_PropagatesAWriterError cuts each report off after
-// every prefix length short of its full output. A report that swallowed
-// a writer error would tell its caller the run succeeded when part of
-// the report never reached the reader.
-func TestReportWrite_PropagatesAWriterError(t *testing.T) {
-	t.Parallel()
-	res := partitionOf(t, "lib.es5.d.ts", twoPackageLib)
-
-	checkRoot := t.TempDir()
-	writeEsc(t, checkRoot, "std/math.esc", unparseableEsc)
-	check, err := CheckPartition(res, checkRoot)
-	require.NoError(t, err)
-
-	regenRoot := t.TempDir()
-	writeEsc(t, regenRoot, "std/math.esc", unparseableEsc)
-	regen, err := RegeneratePartition(res, regenRoot)
-	require.NoError(t, err)
-
-	cases := []struct {
-		name  string
-		write func(io.Writer) error
-	}{
-		{"check", check.Write},
-		{"regenerate", regen.Write},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			var full strings.Builder
-			require.NoError(t, tc.write(&full))
-			require.NotEmpty(t, full.String())
-
-			for budget := 0; budget < full.Len(); budget++ {
-				require.ErrorIs(t, tc.write(&failWriter{budget: budget}), errWriteFailed,
-					"a writer that failed after %d bytes should surface its error", budget)
-			}
-		})
-	}
 }
 
 // TestCheckPartition_StillAbortsOnAnIOError separates the two ways a

--- a/internal/dts_to_esc/rerun_test.go
+++ b/internal/dts_to_esc/rerun_test.go
@@ -2,7 +2,9 @@ package dts_to_esc
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -388,6 +390,100 @@ func TestRegeneratePartition_SkipsAnUnparseableFile(t *testing.T) {
 		"error: std/math.esc: 2:5-2:6: Expected a property name; std:math was left unchanged\n")
 	require.Contains(t, out.String(),
 		"regenerate: +1 declarations, +0 members, 1 unreadable files\n")
+}
+
+// errWriteFailed is what failWriter hands back once its budget runs
+// out.
+var errWriteFailed = errors.New("write failed")
+
+// failWriter accepts budget bytes in total and fails on the write that
+// would exceed it, so a test can cut a report off after any number of
+// bytes and watch the error propagate.
+type failWriter struct {
+	budget int
+}
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	if len(p) > w.budget {
+		n := w.budget
+		w.budget = 0
+		return n, errWriteFailed
+	}
+	w.budget -= len(p)
+	return len(p), nil
+}
+
+// TestReportWrite_PropagatesAWriterError cuts each report off after
+// every prefix length short of its full output. A report that swallowed
+// a writer error would tell its caller the run succeeded when part of
+// the report never reached the reader.
+func TestReportWrite_PropagatesAWriterError(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", twoPackageLib)
+
+	checkRoot := t.TempDir()
+	writeEsc(t, checkRoot, "std/math.esc", unparseableEsc)
+	check, err := CheckPartition(res, checkRoot)
+	require.NoError(t, err)
+
+	regenRoot := t.TempDir()
+	writeEsc(t, regenRoot, "std/math.esc", unparseableEsc)
+	regen, err := RegeneratePartition(res, regenRoot)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name  string
+		write func(io.Writer) error
+	}{
+		{"check", check.Write},
+		{"regenerate", regen.Write},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var full strings.Builder
+			require.NoError(t, tc.write(&full))
+			require.NotEmpty(t, full.String())
+
+			for budget := 0; budget < full.Len(); budget++ {
+				require.ErrorIs(t, tc.write(&failWriter{budget: budget}), errWriteFailed,
+					"a writer that failed after %d bytes should surface its error", budget)
+			}
+		})
+	}
+}
+
+// TestCheckPartition_StillAbortsOnAnIOError separates the two ways a
+// committed file can be unreadable. A file the parser rejects is
+// collected and the run continues; a file the process cannot read at all
+// is a broken tree, and the run stops. A directory standing where a
+// package file belongs is the second case, since os.ReadFile fails on
+// it.
+func TestCheckPartition_StillAbortsOnAnIOError(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", twoPackageLib)
+	root := t.TempDir()
+	dest := filepath.Join(root, "std", "math.esc")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+
+	_, err := CheckPartition(res, root)
+	require.EqualError(t, err,
+		fmt.Sprintf("reading %s: read %s: is a directory", dest, dest))
+	require.NotErrorIs(t, err, ErrUnreadableTree)
+}
+
+// TestUnparseableError_NamesTheFileAndPosition pins the message the
+// error carries. planPartition reads its fields rather than the string,
+// so this is what a caller that propagated the error instead would
+// print.
+func TestUnparseableError_NamesTheFileAndPosition(t *testing.T) {
+	t.Parallel()
+	err := &unparseableError{
+		path:   "/tmp/tree/std/array.esc",
+		reason: "313:5-313:9: Expected a property name",
+	}
+	require.EqualError(t, err,
+		"parsing /tmp/tree/std/array.esc: 313:5-313:9: Expected a property name")
 }
 
 func TestRegeneratePartition_CreatesMissingFile(t *testing.T) {

--- a/internal/dts_to_esc/rerun_test.go
+++ b/internal/dts_to_esc/rerun_test.go
@@ -170,7 +170,7 @@ export type MyArrayHelper<T> = Array<T>
 	var sb strings.Builder
 	require.NoError(t, report.Write(&sb))
 	snaps.MatchInlineSnapshot(t, sb.String(), snaps.Inline(`note: std/array.esc: MyArrayHelper is absent from the .d.ts; the diff does not remove it
-check: 0 missing declarations, 0 missing members, 1 extra declarations
+check: 0 missing declarations, 0 missing members, 1 extra declarations, 0 unreadable files
 note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
 `))
 
@@ -215,7 +215,7 @@ export declare class Array<T> {
 +    static isArray(arg: any) -> boolean,
 +    static readonly prototype: Array<any>,
  }
-check: 0 missing declarations, 4 missing members, 0 extra declarations
+check: 0 missing declarations, 4 missing members, 0 extra declarations, 0 unreadable files
 note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
 `))
 }
@@ -294,6 +294,100 @@ export declare interface WeakRefConstructor {
 	require.Empty(t, diff.NewDecls, "the fused class covers both converted halves")
 	require.Empty(t, diff.NewMembers)
 	require.False(t, report.Failed())
+}
+
+// twoPackageLib routes into std:array and std:math, so a test can break
+// one committed file and still assert the other package is reported.
+const twoPackageLib = `
+interface Array<T> { length: number; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; readonly prototype: Array<any>; }
+declare var Array: ArrayConstructor;
+interface Math { max(...values: number[]): number; }
+declare var Math: Math;
+`
+
+// unparseableEsc is a committed file the Escalier parser rejects: a
+// member with a `+` where its name belongs.
+const unparseableEsc = `export declare interface Math {
+    + max(values: Array<number>) -> number
+}
+`
+
+func TestCheckPartition_ReportsEveryUnparseableFileAndChecksTheRest(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", twoPackageLib)
+	root := t.TempDir()
+	writeEsc(t, root, "std/math.esc", unparseableEsc)
+
+	report, err := CheckPartition(res, root)
+	require.NoError(t, err)
+
+	require.Len(t, report.Unreadable, 1)
+	require.Equal(t, "std:math", report.Unreadable[0].Pkg)
+	require.Equal(t, "std/math.esc", report.Unreadable[0].Path)
+	require.Equal(t, "2:5-2:6: Expected a property name", report.Unreadable[0].Reason)
+	require.ErrorIs(t, report.UnreadableErr(), ErrUnreadableTree)
+	require.EqualError(t, report.UnreadableErr(),
+		"1 committed .esc files could not be parsed")
+
+	// std:array is missing from the tree entirely and is still reported.
+	require.Len(t, report.Packages, 1)
+	diff := findDiff(t, report, "std:array")
+	require.Len(t, diff.NewDecls, 1)
+	require.Equal(t, "Array", diff.NewDecls[0].Name)
+
+	var out strings.Builder
+	require.NoError(t, report.Write(&out))
+	require.Contains(t, out.String(),
+		"error: std/math.esc: 2:5-2:6: Expected a property name; std:math was not checked\n")
+	require.Contains(t, out.String(),
+		"check: 1 missing declarations, 0 missing members, 0 extra declarations, 1 unreadable files\n")
+}
+
+func TestCheckPartition_ReportsNoUnreadableFilesForATreeThatParses(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", twoPackageLib)
+	root := t.TempDir()
+	_, err := WritePartitionedTree(res, root)
+	require.NoError(t, err)
+
+	report, err := CheckPartition(res, root)
+	require.NoError(t, err)
+	require.Empty(t, report.Unreadable)
+	require.NoError(t, report.UnreadableErr())
+	require.False(t, report.Failed())
+}
+
+// TestRegeneratePartition_SkipsAnUnparseableFile pins the write mode's
+// half of the same contract. The file the parser rejects is left
+// byte-for-byte alone rather than spliced blind, and the other package
+// is still written.
+func TestRegeneratePartition_SkipsAnUnparseableFile(t *testing.T) {
+	t.Parallel()
+	res := partitionOf(t, "lib.es5.d.ts", twoPackageLib)
+	root := t.TempDir()
+	dest := writeEsc(t, root, "std/math.esc", unparseableEsc)
+
+	report, err := RegeneratePartition(res, root)
+	require.NoError(t, err)
+	require.Len(t, report.Unreadable, 1)
+	require.Equal(t, "std:math", report.Unreadable[0].Pkg)
+	require.ErrorIs(t, report.UnreadableErr(), ErrUnreadableTree)
+
+	after, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	require.Equal(t, unparseableEsc, string(after))
+
+	require.Len(t, report.Packages, 1)
+	require.Equal(t, "std:array", report.Packages[0].Pkg)
+	require.True(t, report.Packages[0].Created)
+
+	var out strings.Builder
+	require.NoError(t, report.Write(&out))
+	require.Contains(t, out.String(),
+		"error: std/math.esc: 2:5-2:6: Expected a property name; std:math was left unchanged\n")
+	require.Contains(t, out.String(),
+		"regenerate: +1 declarations, +0 members, 1 unreadable files\n")
 }
 
 func TestRegeneratePartition_CreatesMissingFile(t *testing.T) {
@@ -496,7 +590,7 @@ export type RemovedUpstream = number
 --- report ---
 updated std:array (std/array.esc): +0 declarations, +1 members
   RemovedUpstream is absent from the .d.ts; left in place for review
-regenerate: +0 declarations, +1 members
+regenerate: +0 declarations, +1 members, 0 unreadable files
 `))
 }
 

--- a/internal/dts_to_esc/rerun_test.go
+++ b/internal/dts_to_esc/rerun_test.go
@@ -315,6 +315,10 @@ const unparseableEsc = `export declare interface Math {
 }
 `
 
+// TestCheckPartition_ReportsEveryUnparseableFileAndChecksTheRest is the
+// read-only half of the §7 contract. std:math does not parse and std:array
+// is missing from the tree; the run names the first and still reports the
+// second, rather than stopping at the parse failure.
 func TestCheckPartition_ReportsEveryUnparseableFileAndChecksTheRest(t *testing.T) {
 	t.Parallel()
 	res := partitionOf(t, "lib.es5.d.ts", twoPackageLib)
@@ -346,6 +350,9 @@ func TestCheckPartition_ReportsEveryUnparseableFileAndChecksTheRest(t *testing.T
 		"check: 1 missing declarations, 0 missing members, 0 extra declarations, 1 unreadable files\n")
 }
 
+// TestCheckPartition_ReportsNoUnreadableFilesForATreeThatParses pins the
+// other end: a tree the converter itself wrote parses, so the unreadable
+// list stays empty and the run reports the ordinary outcome.
 func TestCheckPartition_ReportsNoUnreadableFilesForATreeThatParses(t *testing.T) {
 	t.Parallel()
 	res := partitionOf(t, "lib.es5.d.ts", twoPackageLib)
@@ -403,6 +410,8 @@ type failWriter struct {
 	budget int
 }
 
+// Write accepts p while the budget covers it and fails otherwise,
+// reporting the partial byte count the way a short write does.
 func (w *failWriter) Write(p []byte) (int, error) {
 	if len(p) > w.budget {
 		n := w.budget

--- a/tools/dts_to_esc/README.md
+++ b/tools/dts_to_esc/README.md
@@ -63,6 +63,30 @@ receiver claim of every instance method against the hand-written mutability
 sources. See §5, §6, and §9.2 of
 [planning/ecma-262/implementation_plan.md](../../planning/ecma-262/implementation_plan.md).
 
+### Exit status
+
+`check` and `regenerate` read the committed tree, so their exit status
+has three values:
+
+| Status | Meaning                                                         |
+| ------ | --------------------------------------------------------------- |
+| 0      | The run finished and the tree covers the `.d.ts` inputs.          |
+| 1      | `check` found the tree out of date, or the run failed outright.   |
+| 2      | A committed `.esc` file did not parse.                            |
+
+A status of 2 is not a bump. It says the tool could not read part of the
+tree. Both modes leave the unreadable packages alone and carry on with
+the rest, so one run names every file the Escalier parser rejects:
+
+```
+error: std/array.esc: 313:5-313:9: Expected a property name; std:array was not checked
+check: 4 missing declarations, 0 missing members, 0 extra declarations, 1 unreadable files
+```
+
+`regenerate` reports the same files as `error: …; std:array was left
+unchanged` and writes nothing into them. Fix the source of each one and
+re-run.
+
 ## Bumping the pinned TypeScript version
 
 1. Raise the `typescript` version in `package.json` and run
@@ -87,6 +111,11 @@ sources. See §5, §6, and §9.2 of
    Review `git diff` and commit. `check` now reports nothing missing,
    unless it named a declaration whose body the write pass could not
    locate — step 4 covers those.
+
+   A package `regenerate` reports as unreadable is one it did not
+   write, so re-running it changes nothing there and the second run
+   looks like a clean no-op. Read the exit status rather than the
+   absence of a diff. A run that skipped a package ends with 2.
 
 4. Port the rest by hand. `regenerate` never deletes and never rewrites,
    so three kinds of upstream change are left for you:

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -118,9 +118,9 @@ func runCheck(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	report, err := dts_to_esc.CheckPartition(result, args[1])
-	if err != nil {
-		return err
+	report, errs := dts_to_esc.CheckPartition(result, args[1])
+	if len(errs) > 0 {
+		return dts_to_esc.Join(errs)
 	}
 	if err := report.Write(stdout); err != nil {
 		return err
@@ -145,9 +145,9 @@ func runRegenerate(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	report, err := dts_to_esc.RegeneratePartition(result, args[1])
-	if err != nil {
-		return err
+	report, errs := dts_to_esc.RegeneratePartition(result, args[1])
+	if len(errs) > 0 {
+		return dts_to_esc.Join(errs)
 	}
 	if err := report.Write(stdout); err != nil {
 		return err

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -41,6 +41,16 @@
 //	    Additive write per §6.4: add the declarations and members
 //	    `check` reports to the committed tree, leaving every existing
 //	    declaration byte-for-byte intact so hand-edits survive.
+//
+// The exit status of check and regenerate has three values, so the §6.6
+// CI job can tell a bump from a broken tool:
+//
+//	0  the run finished and the tree covers the .d.ts inputs
+//	1  check found the tree out of date, or the run failed outright
+//	2  a committed .esc file did not parse
+//
+// A status of 2 leaves the packages that did parse checked and reported
+// as usual; only the unreadable ones are left out.
 package main
 
 import (
@@ -57,9 +67,18 @@ import (
 	"github.com/escalier-lang/escalier/internal/ecma262"
 )
 
+// exitUnreadableTree is the status a run ends with when a committed
+// `.esc` file did not parse. It is distinct from the status a check
+// failure ends with so the §6.6 CI job does not read "the tool could not
+// read the tree" as "a bump is needed".
+const exitUnreadableTree = 2
+
 func main() {
 	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
 		fmt.Fprintln(os.Stderr, "dts_to_esc:", err)
+		if errors.Is(err, dts_to_esc.ErrUnreadableTree) {
+			os.Exit(exitUnreadableTree)
+		}
 		os.Exit(1)
 	}
 }
@@ -106,6 +125,12 @@ func runCheck(args []string, stdout, stderr io.Writer) error {
 	if err := report.Write(stdout); err != nil {
 		return err
 	}
+	// An unreadable file outranks a missing declaration: the packages it
+	// covers were never compared, so the run cannot claim the tree is
+	// merely out of date.
+	if err := report.UnreadableErr(); err != nil {
+		return err
+	}
 	if report.Failed() {
 		return errCheckFailed
 	}
@@ -124,7 +149,13 @@ func runRegenerate(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return report.Write(stdout)
+	if err := report.Write(stdout); err != nil {
+		return err
+	}
+	// A run that skipped packages wrote less than the report's counts
+	// suggest, and a second run over the same tree would skip them
+	// again. Ending non-zero keeps that from reading as a clean no-op.
+	return report.UnreadableErr()
 }
 
 // partitionLibDir discovers, parses, and routes every lib.*.d.ts under

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/dts_to_esc"
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +30,30 @@ interface Array<T> { length: number; }
 interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; readonly prototype: Array<any>; }
 declare var Array: ArrayConstructor;
 `
+
+// twoPackageLib routes into std:array and std:math, so a test can break
+// one committed file and still assert the other package is reported.
+const twoPackageLib = arrayLib + `
+interface Math { max(...values: number[]): number; }
+declare var Math: Math;
+`
+
+// unparseableEsc is a committed file the Escalier parser rejects: a
+// member with a `+` where its name belongs.
+const unparseableEsc = `export declare interface Math {
+    + max(values: Array<number>) -> number
+}
+`
+
+// writeEsc seeds one committed `.esc` file under the tree root and
+// returns its path.
+func writeEsc(t *testing.T, root, rel, contents string) string {
+	t.Helper()
+	dest := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, os.WriteFile(dest, []byte(contents), 0o644))
+	return dest
+}
 
 // TestRun_CheckFailsOnAnEmptyTree runs `check` against a committed
 // `.esc` tree with nothing in it. The two directories play opposite
@@ -54,7 +79,7 @@ func TestRun_CheckFailsOnAnEmptyTree(t *testing.T) {
 +    static isArray(arg: any) -> boolean,
 +    static readonly prototype: Array<any>
 +}
-check: 1 missing declarations, 0 missing members, 0 extra declarations
+check: 1 missing declarations, 0 missing members, 0 extra declarations, 0 unreadable files
 note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
 `))
 }
@@ -226,7 +251,7 @@ func TestRun_CheckPassesOnASeededTree(t *testing.T) {
 
 	var stdout strings.Builder
 	require.NoError(t, run([]string{"check", libDir, escDir}, &stdout, io.Discard))
-	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`check: 0 missing declarations, 0 missing members, 0 extra declarations
+	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`check: 0 missing declarations, 0 missing members, 0 extra declarations, 0 unreadable files
 note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
 `))
 }
@@ -263,6 +288,63 @@ func TestRun_RegenerateIsIdempotent(t *testing.T) {
 	var second strings.Builder
 	require.NoError(t, run([]string{"regenerate", libDir, escDir}, &second, io.Discard))
 	require.Contains(t, second.String(), "regenerate: +0 declarations, +0 members")
+}
+
+// TestRun_CheckReportsAnUnparseableFile is the §7 case: the committed
+// tree holds a mix of files that parse and files that do not. The run
+// diffs the packages it can read, lists the one it cannot, and ends with
+// ErrUnreadableTree so the CI job reads "the tool could not read the
+// tree" rather than "a bump is needed".
+func TestRun_CheckReportsAnUnparseableFile(t *testing.T) {
+	t.Parallel()
+	libDir := seedLib(t, twoPackageLib)
+	escDir := t.TempDir()
+	writeEsc(t, escDir, "std/math.esc", unparseableEsc)
+
+	var stdout strings.Builder
+	err := run([]string{"check", libDir, escDir}, &stdout, io.Discard)
+	require.ErrorIs(t, err, dts_to_esc.ErrUnreadableTree)
+	require.NotErrorIs(t, err, errCheckFailed)
+	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`--- /dev/null
++++ b/std/array.esc
+@@ -0,0 +1,7 @@
++@js("Array")
++export declare class Array<T> {
++    length: number,
++    constructor(mut self),
++    static isArray(arg: any) -> boolean,
++    static readonly prototype: Array<any>
++}
+error: std/math.esc: 2:5-2:6: Expected a property name; std:math was not checked
+check: 1 missing declarations, 0 missing members, 0 extra declarations, 1 unreadable files
+note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
+`))
+}
+
+// TestRun_RegenerateReportsAnUnparseableFile covers the false pass a
+// distinct outcome prevents: a second `regenerate` over a tree it cannot
+// read leaves that tree unchanged, which on its own looks exactly like
+// an idempotent no-op.
+func TestRun_RegenerateReportsAnUnparseableFile(t *testing.T) {
+	t.Parallel()
+	libDir := seedLib(t, twoPackageLib)
+	escDir := t.TempDir()
+	dest := writeEsc(t, escDir, "std/math.esc", unparseableEsc)
+
+	var stdout strings.Builder
+	err := run([]string{"regenerate", libDir, escDir}, &stdout, io.Discard)
+	require.ErrorIs(t, err, dts_to_esc.ErrUnreadableTree)
+	require.EqualError(t, err, "1 committed .esc files could not be parsed")
+	snaps.MatchInlineSnapshot(t, stdout.String(), snaps.Inline(`created std:array (std/array.esc): +1 declarations, +0 members
+error: std/math.esc: 2:5-2:6: Expected a property name; std:math was left unchanged
+regenerate: +1 declarations, +0 members, 1 unreadable files
+`))
+
+	// std:array was written even though std:math could not be read.
+	require.FileExists(t, filepath.Join(escDir, "std", "array.esc"))
+	after, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	require.Equal(t, unparseableEsc, string(after))
 }
 
 func TestRun_RejectsWrongArgumentCounts(t *testing.T) {
@@ -334,7 +416,7 @@ func TestRun_CheckDiffsACommittedFile(t *testing.T) {
 +export declare interface ArrayLike<T> {
 +    readonly length: number
 +}
-check: 1 missing declarations, 1 missing members, 0 extra declarations
+check: 1 missing declarations, 1 missing members, 0 extra declarations, 0 unreadable files
 note: signature and property-type drift are not checked yet; those compare both sides through the solver's constrain (SimpleSub M7.5)
 `))
 }

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -345,6 +346,29 @@ regenerate: +1 declarations, +0 members, 1 unreadable files
 	after, err := os.ReadFile(dest)
 	require.NoError(t, err)
 	require.Equal(t, unparseableEsc, string(after))
+}
+
+// failWriter fails every write, standing in for a closed pipe on stdout.
+type failWriter struct{}
+
+var errWriteFailed = errors.New("write failed")
+
+func (failWriter) Write([]byte) (int, error) { return 0, errWriteFailed }
+
+// TestRun_SurfacesAReportWriteError covers the run ending on a broken
+// stdout. The tree was written, but the caller hears about the failed
+// report rather than a clean exit.
+func TestRun_SurfacesAReportWriteError(t *testing.T) {
+	t.Parallel()
+	cases := []string{"check", "regenerate"}
+	for _, mode := range cases {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			err := run([]string{mode, seedLib(t, arrayLib), t.TempDir()},
+				failWriter{}, io.Discard)
+			require.ErrorIs(t, err, errWriteFailed)
+		})
+	}
 }
 
 func TestRun_RejectsWrongArgumentCounts(t *testing.T) {

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -353,6 +353,7 @@ type failWriter struct{}
 
 var errWriteFailed = errors.New("write failed")
 
+// Write always fails, so a report written to it never reaches its reader.
 func (failWriter) Write([]byte) (int, error) { return 0, errWriteFailed }
 
 // TestRun_SurfacesAReportWriteError covers the run ending on a broken


### PR DESCRIPTION
Fixes #1326

`check` and `regenerate` parse every committed `.esc` file before diffing, and a parse failure aborted the whole run naming one file. Learning which packages were affected took one run per package.

Both modes now collect the parse failures instead of returning on the first. A package whose committed file does not parse drops out of the run; every other package is diffed and written as usual, so one run names every unreadable file. This is the §7 case, where the committed tree holds a mix of files that round-trip and files that do not.

The two modes also end with a distinct exit status when that list is non-empty. A run that aborted and a run that found the tree out of date both exited 1, and only the absence of a report on stdout told them apart — that cost a false pass while testing `regenerate` idempotence, where an aborted second run left the tree unchanged and so looked like a no-op. `check` and `regenerate` now exit 2 for a tree they could not read, so the §6.6 CI job does not read "tool broke" as "bump needed".

## Changes

- `internal/dts_to_esc/errors.go` is new. It names every way a pass over the committed tree can fail as its own type behind an `Error` interface: a file the parser rejected, a file that could not be read, one that could not be written, the directory that could not be created, a bucket that would not convert, a URI outside `PackageList`, a declaration or member the printer refused, and a diff that would not render. Each carries the package URI it happened under, and an unexported marker closes the set, so a type switch over an `Error` reads as complete.
- `internal/dts_to_esc/rerun.go`: the passes return `[]Error` rather than one error, so a run reports every package that failed. `planPartition` sorts the parse rejections out of the failures that stop the run and collects them; `planPackage` collects every declaration the printer refuses instead of returning on the first. The reports carry the parse failures themselves rather than a parallel record of them, print one line per file, and count them in their summary line.
- `tools/dts_to_esc/main.go`: `main` exits 2 on `ErrUnreadableTree`. In `check` that outcome outranks the out-of-date one, since the skipped packages were never compared.
- `tools/dts_to_esc/README.md`: an exit-status table, and a note on the bump walkthrough's step 3 that a skipped package leaves the tree unchanged, so the status is what tells a clean re-run from a skipped one.

## Output

```
error: std/math.esc: 2:5-2:6: Expected a property name; std:math was not checked
check: 1 missing declarations, 0 missing members, 0 extra declarations, 1 unreadable files
```

`regenerate` reports the same files as `; std:math was left unchanged` and writes nothing into them.

## Testing

`go test ./...` passes, and re-running with `UPDATE_SNAPS=true UPDATE_FIXTURES=true` produces no drift beyond the summary-line field added here. The tests cover a tree with one unreadable package and one readable one, at both the package level and through the CLI, asserting the reports, the untouched file on disk, and the exit outcome; a file the process cannot read at all, which still stops the run; the message and cause of every `Error` case; and the guard on a bucket whose URI is not in `PackageList`.

`codecov/patch` is red at 68.91%. What it counts as missing is almost entirely the error-construction branches this change adds, which need the printer, the converter, or the diff renderer to fail on demand. Reaching them from a test would mean adding injection seams to the passes. `codecov/project` is even with base.

https://claude.ai/code/session_01PiJbYCAPEPeNCeZUqi9HxF



## Summary by CodeRabbit

- **Bug Fixes**
  - `check` and `regenerate` now continue processing readable packages when committed `.esc` files cannot be read.
  - Unreadable files are skipped during checks and left unchanged during regeneration.
  - Reports now identify affected files, explain the issue, and include unreadable-file counts.
  - Commands return exit status `2` when unreadable files are detected, making failures easier to identify.

- **Documentation**
  - Added guidance on exit statuses and handling unreadable files during TypeScript version upgrades.

