### PR TITLE
Accept keywords as names in declarations and signatures

### DIFF
--- a/internal/dts_to_esc/partition_e2e_test.go
+++ b/internal/dts_to_esc/partition_e2e_test.go
@@ -11,22 +11,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPartitionLib_LibES5_EndToEnd is the §6 PR A smoke gate: run the
-// full partitioning pipeline against the checked-in lib.es5.d.ts (kept
-// under playground/public/types/) and verify that every produced
-// `.esc` file parses with Escalier's own parser. Failures here are
-// usually partition-table gaps surfaced via the unmapped-symbol
-// fail-safe, or printer-side bugs that produce un-reparseable output.
+// TestPartitionLib_LibES5_EndToEnd runs the full partitioning pipeline over the
+// pinned TypeScript's lib.es5.d.ts and requires that every `.esc` file it emits
+// parses with Escalier's own parser. That is the §6 round-trip gate: the
+// printer must never emit a construct the parser rejects, because `check` and
+// `regenerate` both re-read every committed file before diffing it.
+//
+// The whole set of lib files the partition table routes produces 22 packages,
+// and lib.es5 alone covers 17 of them. The gate does not yet span the rest.
+// Two converter-side gaps block that: the partition table has no entry for
+// names such as `FlatArray` and `Disposable`, and flattening a singleton whose
+// key is computed, as in `Atomics[Symbol.toStringTag]`, is unsupported.
 func TestPartitionLib_LibES5_EndToEnd(t *testing.T) {
 	t.Parallel()
 
-	libPath := filepath.Join("..", "..", "playground", "public", "types", "lib.es5.d.ts")
+	libDir := filepath.Join("..", "..", "node_modules", "typescript", "lib")
+	libPath := filepath.Join(libDir, "lib.es5.d.ts")
 	if _, err := os.Stat(libPath); err != nil {
-		t.Skipf("lib.es5.d.ts not present at %s: %v", libPath, err)
+		t.Skipf("lib.es5.d.ts not present at %s; run `pnpm install`: %v", libPath, err)
 	}
-	libDir := filepath.Dir(libPath)
 
-	// Restrict discovery to just lib.es5.d.ts by parsing it directly —
+	// Restrict discovery to just lib.es5.d.ts by naming it directly —
 	// DiscoverLibFiles would pick up the full set under the same dir.
 	inputs, err := ParseLibFiles(libDir, []string{"lib.es5.d.ts"})
 	require.NoError(t, err)
@@ -40,7 +45,6 @@ func TestPartitionLib_LibES5_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, written)
 
-	parsed, unparsed := 0, 0
 	for _, uri := range written {
 		pkg, ok := PackageForURI(uri)
 		require.True(t, ok, "URI %q from result must be a known package", uri)
@@ -49,26 +53,12 @@ func TestPartitionLib_LibES5_EndToEnd(t *testing.T) {
 		require.NoError(t, err, "%s should be on disk", path)
 		require.NotEmpty(t, contents, "%s should not be empty", path)
 
-		// Soft gate: report parse status without failing. The full
-		// "every output parses" gate belongs in §6 PR B (`--check`
-		// mode) once §7 hand-edits close the remaining
-		// printer/parser asymmetries on real `lib.*.d.ts` surface.
-		// PR A's job is the routing + write pipeline; per-symbol
-		// roundtrip work happens in §7 review.
 		_, parseErrs := parser.ParseDecls(context.Background(), &ast.Source{
 			Path:     path,
 			Contents: string(contents),
 		})
-		if len(parseErrs) == 0 {
-			parsed++
-		} else {
-			unparsed++
-			t.Logf("[soft] %s did not parse cleanly (%d errors); first: %v",
-				path, len(parseErrs), parseErrs[0])
-		}
+		require.Empty(t, parseErrs, "%s must parse back", pkg.File)
 	}
-	t.Logf("lib.es5 partition: %d packages parsed, %d need §7 hand-edits",
-		parsed, unparsed)
 
 	// Gate: the unmapped fail-safe trips on a synthetic missing name —
 	// the same lib + one extra decl that no partition entry covers

--- a/internal/dts_to_esc/partition_e2e_test.go
+++ b/internal/dts_to_esc/partition_e2e_test.go
@@ -11,17 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPartitionLib_LibES5_EndToEnd runs the full partitioning pipeline over the
-// pinned TypeScript's lib.es5.d.ts and requires that every `.esc` file it emits
-// parses with Escalier's own parser. That is the §6 round-trip gate: the
-// printer must never emit a construct the parser rejects, because `check` and
-// `regenerate` both re-read every committed file before diffing it.
-//
-// The whole set of lib files the partition table routes produces 22 packages,
-// and lib.es5 alone covers 17 of them. The gate does not yet span the rest.
-// Two converter-side gaps block that: the partition table has no entry for
-// names such as `FlatArray` and `Disposable`, and flattening a singleton whose
-// key is computed, as in `Atomics[Symbol.toStringTag]`, is unsupported.
+// TestPartitionLib_LibES5_EndToEnd is the §6 round-trip gate: every `.esc` file
+// the pipeline emits from the pinned TypeScript's lib.es5.d.ts must parse with
+// Escalier's own parser, because `check` and `regenerate` re-read each committed
+// file before diffing it. It covers 17 of the 22 packages the routed lib files
+// produce; two converter gaps block the rest, unmapped names such as `FlatArray`
+// and computed singleton keys such as `Atomics[Symbol.toStringTag]`.
 func TestPartitionLib_LibES5_EndToEnd(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -780,6 +780,13 @@ func (p *Parser) parseClassElemInner() ast.ClassElem {
 			// continue
 		}
 
+		// A modifier keyword standing where the member's own name belongs is the name.
+		// `set(v: any) -> unknown` declares a method called `set`, so stop the loop and
+		// let objExprKey read the keyword as an identifier.
+		if followsAName(p.lexer.peek2().Type) {
+			goto modifiers_done
+		}
+
 		// nolint: exhaustive
 		switch token.Type {
 		case Static:
@@ -809,10 +816,26 @@ func (p *Parser) parseClassElemInner() ast.ClassElem {
 		token = p.lexer.peek()
 	}
 modifiers_done:
-	// `constructor` is a contextual keyword at the start of a class element.
-	// Anywhere else it is a regular identifier.
+	// `constructor` is a contextual keyword at the start of a class element. It names an
+	// instance field instead when a field's punctuation follows it, which is how a
+	// `.d.ts` spells the `constructor` property every prototype carries:
+	// `constructor: Function`. Anything else stays the constructor, so `constructor {}`
+	// keeps reporting its missing parameter list rather than a stray brace.
+	//
+	// A `static` member is never that field. JavaScript has no static member named
+	// `constructor` at all, and the `.d.ts` surface only declares the instance one.
 	if token.Type == Identifier && token.Value == "constructor" {
-		return p.parseConstructorElem(start, token, isStatic, isAsync, isGen, isPrivate, isReadonly, isGet, isSet)
+		isField := false
+		if !isStatic {
+			// nolint: exhaustive
+			switch p.lexer.peek2().Type {
+			case Colon, Question, Comma, CloseBrace, Equal:
+				isField = true
+			}
+		}
+		if !isField {
+			return p.parseConstructorElem(start, token, isStatic, isAsync, isGen, isPrivate, isReadonly, isGet, isSet)
+		}
 	}
 
 	name := p.objExprKey()
@@ -1139,7 +1162,9 @@ func (p *Parser) varDecl(
 func (p *Parser) fnDecl(start ast.Location, export bool, declare bool, async bool, gen bool) ast.Decl {
 	token := p.lexer.peek()
 	var ident *ast.Ident
-	if token.Type == Identifier {
+	// A keyword names the function when its signature follows. `Reflect.get`
+	// converts to `declare fn get<T, P>(…)`, where `get` is the name.
+	if token.Type == Identifier || (bindsAsAName(token.Type) && startsASignature(p.lexer.peek2().Type)) {
 		p.lexer.consume()
 		ident = ast.NewIdentifier(token.Value, token.Span)
 	} else {

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -278,12 +278,20 @@ loop:
 	return expr
 }
 
+// objExprKey parses the name of an object member: a property in an object
+// literal or type, a method or accessor in a class body. A keyword names a
+// member the way an identifier does when member punctuation follows it, so
+// `catch`, `match`, and `symbol` are all accepted here and carried through as
+// plain identifiers. The one exception is a keyword the enclosing form peels
+// off first. An object type reads `fn` and `new` as its call and construct
+// signatures, and a class body reads `get` and `set` as accessor modifiers, so
+// those callers look ahead before delegating here.
 func (p *Parser) objExprKey() ast.ObjKey {
 	token := p.lexer.peek()
 
 	// nolint: exhaustive
 	switch token.Type {
-	case Identifier, Underscore, String, Number, Boolean, Bigint:
+	case Identifier, Underscore:
 		p.lexer.consume()
 		return ast.NewIdent(token.Value, token.Span)
 	case StrLit:
@@ -305,6 +313,14 @@ func (p *Parser) objExprKey() ast.ObjKey {
 		}
 		return nil
 	default:
+		// A keyword names a member only when member punctuation follows it. That
+		// stops a body someone left unclosed from swallowing what comes after it. A
+		// `declare` or `fn` opening the next declaration is not read as a member
+		// name, so that declaration still parses.
+		if isKeyword(token.Type) && followsAName(p.lexer.peek2().Type) {
+			p.lexer.consume()
+			return ast.NewIdent(token.Value, token.Span)
+		}
 		p.reportError(token.Span, "Expected a property name")
 		return nil
 	}
@@ -794,10 +810,36 @@ func (p *Parser) param() *ast.Param {
 		}
 	}
 
+	// A keyword standing where the parameter's name belongs is the name. TypeScript
+	// declarations lean on this: `substr(from: number, length?: number)` names its first
+	// parameter `from`, which Escalier otherwise lexes as the import keyword. A pattern
+	// still rejects keywords, so a `match` arm reads `null` and `true` as the literals
+	// they are.
+	if tok := p.lexer.peek(); bindsAsAName(tok.Type) && followsAName(p.lexer.peek2().Type) {
+		p.lexer.consume()
+		return p.paramTail(ast.NewIdentPat(tok.Value, false, nil, nil, tok.Span), open)
+	}
+
+	// A rest parameter's name is a binding too, as in `f(...from: Array<number>)`. The
+	// `...` already fixes the position, so the keyword needs no lookahead past it.
+	if p.lexer.peek().Type == DotDotDot && bindsAsAName(p.lexer.peek2().Type) {
+		dots := p.lexer.next()
+		name := p.lexer.next()
+		inner := ast.NewIdentPat(name.Value, false, nil, nil, name.Span)
+		return p.paramTail(ast.NewRestPat(inner, ast.MergeSpans(dots.Span, name.Span)), open)
+	}
+
 	pat := p.pattern(true, false)
 	if pat == nil {
 		return nil
 	}
+
+	return p.paramTail(pat, open)
+}
+
+// paramTail parses what follows a parameter's pattern: the optional marker, the type
+// annotation, and the default value.
+func (p *Parser) paramTail(pat ast.Pat, open bool) *ast.Param {
 	token := p.lexer.peek()
 
 	opt := false

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -703,7 +703,9 @@ func (p *Parser) objExprElem() ast.ObjExprElem {
 		return ast.NewRestSpread(arg, ast.MergeSpans(token.Span, arg.Span()))
 	}
 
-	if token.Type == Get || token.Type == Set {
+	// `get` and `set` mark an accessor only when a name follows. `{get: 1}` and `{get}`
+	// name a property, the same way every other keyword does here.
+	if (token.Type == Get || token.Type == Set) && !followsAName(p.lexer.peek2().Type) {
 		p.reportError(token.Span, "Method shorthand is not allowed in object literals; use a class instead")
 		return nil
 	}

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -708,6 +708,7 @@ func (p *Parser) objExprElem() ast.ObjExprElem {
 		return nil
 	}
 
+	keyToken := p.lexer.peek()
 	objKey := p.objExprKey()
 	if objKey == nil {
 		return nil
@@ -756,6 +757,14 @@ func (p *Parser) objExprElem() ast.ObjExprElem {
 		case *ast.IdentExpr:
 			switch token.Type {
 			case Comma, CloseBrace:
+				// A shorthand property is a key and a variable reference at once, so
+				// its name has to work in both roles. Keywords name a key freely, but
+				// only the ones a binding accepts can be read as a variable, which
+				// leaves out `catch` and the literals `true`, `null`, and `undefined`.
+				if isKeyword(keyToken.Type) && !bindsAsAName(keyToken.Type) {
+					p.reportError(keyToken.Span, "`"+keyToken.Value+
+						"` cannot be a shorthand property because it is not a variable name")
+				}
 				property := ast.NewProperty(
 					objKey,
 					false,

--- a/internal/parser/keyword_names_test.go
+++ b/internal/parser/keyword_names_test.go
@@ -240,37 +240,91 @@ func TestKeywordsInBindingPositions(t *testing.T) {
 	})
 }
 
+// objectExprKeyName returns the name of the sole property key in
+// `val a = { … }`, or "" when the source did not parse to that shape. Asserting
+// the name rather than the absence of errors catches a key that parses but
+// carries the wrong text.
+func objectExprKeyName(t *testing.T, src string) string {
+	t.Helper()
+	script, errors := parseScriptSrc(t, src)
+	if len(errors) > 0 {
+		return ""
+	}
+	decl, ok := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.VarDecl)
+	if !ok || decl.Init == nil {
+		return ""
+	}
+	obj, ok := decl.Init.(*ast.ObjectExpr)
+	if !ok || len(obj.Elems) != 1 {
+		return ""
+	}
+	prop, ok := obj.Elems[0].(*ast.PropertyExpr)
+	if !ok {
+		return ""
+	}
+	ident, ok := prop.Name.(*ast.IdentExpr)
+	if !ok {
+		return ""
+	}
+	return ident.Name
+}
+
+// Every keyword names a property of an object literal, because `{ catch: 1 }`
+// and `obj.catch` are both valid JavaScript. This is the expression counterpart
+// of TestKeywordsNameObjectTypeMembers.
+func TestKeywordsNameObjectExpressionProperties(t *testing.T) {
+	t.Parallel()
+	forms := []struct{ name, tmpl string }{
+		{"property", "val a = {%[1]s: 1}"},
+		{"optional property", "val a = {%[1]s?: 1}"},
+		{"property whose value is another such object", "val a = {%[1]s: {%[1]s: 1}}"},
+	}
+	for _, form := range forms {
+		t.Run(form.name, func(t *testing.T) {
+			t.Parallel()
+			for _, keyword := range keywordTexts() {
+				src := fmt.Sprintf(form.tmpl, keyword)
+				require.Equal(t, keyword, objectExprKeyName(t, src),
+					"%s should name a property %q", src, keyword)
+			}
+		})
+	}
+}
+
+// An object literal has no method shorthand, and that holds for every keyword
+// rather than only the accessor pair. `{ catch() {} }` reports the same way
+// `{ get x() {} }` does.
+func TestObjectExpressionsRejectMethodShorthand(t *testing.T) {
+	t.Parallel()
+	for _, keyword := range keywordTexts() {
+		src := fmt.Sprintf("val a = {%s() {}}", keyword)
+		_, errors := parseScriptSrc(t, src)
+		require.NotEmpty(t, errors, "%s should report", src)
+		require.Equal(t,
+			"Method shorthand is not allowed in object literals; use a class instead",
+			errors[0].Message, "for %s", src)
+	}
+}
+
 // A shorthand property is a key and a variable reference at once, so it accepts
-// exactly the keywords a binding does. The keyed form accepts every keyword,
-// since `{ catch: 1 }` is valid JavaScript.
+// exactly the keywords a binding does.
 func TestKeywordShorthandProperties(t *testing.T) {
 	t.Parallel()
 	reserved := cannotBind()
 
-	t.Run("shorthand takes only binding names", func(t *testing.T) {
-		t.Parallel()
-		for _, keyword := range keywordTexts() {
-			src := fmt.Sprintf("val a = {%s}", keyword)
-			_, errors := parseScriptSrc(t, src)
-			if !reserved[keyword] {
-				require.Empty(t, errors, "%s should parse", src)
-				continue
-			}
-			require.NotEmpty(t, errors, "%s should report", src)
-			require.Equal(t, "`"+keyword+
-				"` cannot be a shorthand property because it is not a variable name",
-				errors[0].Message)
-		}
-	})
-
-	t.Run("a keyed property takes every keyword", func(t *testing.T) {
-		t.Parallel()
-		for _, keyword := range keywordTexts() {
-			src := fmt.Sprintf("val a = {%s: 1}", keyword)
-			_, errors := parseScriptSrc(t, src)
+	for _, keyword := range keywordTexts() {
+		src := fmt.Sprintf("val a = {%s}", keyword)
+		_, errors := parseScriptSrc(t, src)
+		if !reserved[keyword] {
 			require.Empty(t, errors, "%s should parse", src)
+			require.Equal(t, keyword, objectExprKeyName(t, src))
+			continue
 		}
-	})
+		require.NotEmpty(t, errors, "%s should report", src)
+		require.Equal(t, "`"+keyword+
+			"` cannot be a shorthand property because it is not a variable name",
+			errors[0].Message)
+	}
 }
 
 // `get` and `set` mark an accessor only when a name follows them, so the method

--- a/internal/parser/keyword_names_test.go
+++ b/internal/parser/keyword_names_test.go
@@ -1,0 +1,305 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// keywordTexts returns the source text of every keyword the lexer recognizes,
+// sorted. The sweeps below run over this rather than a list written out by hand,
+// so a keyword added to the lexer's table is covered without editing this file.
+func keywordTexts() []string {
+	texts := make([]string, 0, len(keywords))
+	for text := range keywords {
+		texts = append(texts, text)
+	}
+	sort.Strings(texts)
+	return texts
+}
+
+// parseTypeAnnSrc parses one type annotation and returns it with the errors the
+// parse reported.
+func parseTypeAnnSrc(t *testing.T, src string) (ast.TypeAnn, []*Error) {
+	t.Helper()
+	p := NewParser(context.Background(), &ast.Source{Path: "test.esc", Contents: src})
+	return p.typeAnn(), p.errors
+}
+
+// parseScriptSrc parses one script and returns its statements with the errors
+// the parse reported.
+func parseScriptSrc(t *testing.T, src string) (*ast.Script, []*Error) {
+	t.Helper()
+	p := NewParser(context.Background(), &ast.Source{Path: "test.esc", Contents: src})
+	script, errors := p.ParseScript()
+	return script, errors
+}
+
+// A keyword names a member of an object type the way an identifier does. The
+// TypeScript lib surface relies on this for `Promise.prototype.catch`,
+// `String.prototype.match`, and `Intl`'s `symbol` property, among others.
+func TestKeywordsNameObjectTypeMembers(t *testing.T) {
+	t.Parallel()
+	forms := []struct{ name, tmpl string }{
+		{"property", "{%s: number}"},
+		{"optional property", "{%s?: number}"},
+		{"readonly property", "{readonly %s: number}"},
+		{"method", "{%s() -> number}"},
+		{"getter", "{get %s() -> number}"},
+		{"setter", "{set %s(v: number)}"},
+	}
+	for _, form := range forms {
+		t.Run(form.name, func(t *testing.T) {
+			t.Parallel()
+			for _, keyword := range keywordTexts() {
+				src := fmt.Sprintf(form.tmpl, keyword)
+				typeAnn, errors := parseTypeAnnSrc(t, src)
+				require.Empty(t, errors, "%s should parse", src)
+				require.NotNil(t, typeAnn, "%s should produce a type annotation", src)
+			}
+		})
+	}
+}
+
+// The same holds in a class body, which routes through parseClassElemInner
+// rather than objTypeAnnElemInner and so needs its own sweep.
+func TestKeywordsNameClassMembers(t *testing.T) {
+	t.Parallel()
+	forms := []struct{ name, tmpl string }{
+		{"field", "declare class C {\n    %s: number\n}"},
+		{"static field", "declare class C {\n    static %s: number\n}"},
+		{"readonly field", "declare class C {\n    readonly %s: number\n}"},
+		{"method", "declare class C {\n    %s(self) -> number\n}"},
+		{"getter", "declare class C {\n    get %s(self) -> number\n}"},
+		{"setter", "declare class C {\n    set %s(mut self, v: number)\n}"},
+	}
+	for _, form := range forms {
+		t.Run(form.name, func(t *testing.T) {
+			t.Parallel()
+			for _, keyword := range keywordTexts() {
+				src := fmt.Sprintf(form.tmpl, keyword)
+				_, errors := parseScriptSrc(t, src)
+				require.Empty(t, errors, "%s should parse", src)
+			}
+		})
+	}
+}
+
+// `fn` and `new` are the two keywords an object type reads as a signature rather
+// than a member name, because `fn(…)` and `fn (…)` differ only in whitespace. A
+// property keeps the name, and a string key reaches the method.
+func TestFnAndNewClaimSignaturesInObjectTypes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want ast.ObjTypeAnnElem
+	}{
+		{"fn opens a call signature", "{fn () -> number}", &ast.CallableTypeAnn{}},
+		{"fn without a space is still a call signature", "{fn() -> number}", &ast.CallableTypeAnn{}},
+		{"new opens a construct signature", "{new () -> number}", &ast.ConstructorTypeAnn{}},
+		{"a string key reaches the fn method", `{"fn"() -> number}`, &ast.MethodTypeAnn{}},
+		{"a string key reaches the new method", `{"new"() -> number}`, &ast.MethodTypeAnn{}},
+		{"another keyword stays a method", "{catch() -> number}", &ast.MethodTypeAnn{}},
+		{"fn names a property", "{fn: number}", &ast.PropertyTypeAnn{}},
+		{"new names an optional property", "{new?: number}", &ast.PropertyTypeAnn{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			typeAnn, errors := parseTypeAnnSrc(t, tt.src)
+			require.Empty(t, errors)
+			obj, ok := typeAnn.(*ast.ObjectTypeAnn)
+			require.True(t, ok, "%s should be an object type", tt.src)
+			require.Len(t, obj.Elems, 1)
+			require.IsType(t, tt.want, obj.Elems[0])
+		})
+	}
+}
+
+// A class has no call or construct signature to compete with, so `fn` and `new`
+// name methods there. This asymmetry with an object type is deliberate.
+func TestFnAndNewNameClassMethods(t *testing.T) {
+	t.Parallel()
+	for _, keyword := range []string{"fn", "new"} {
+		t.Run(keyword, func(t *testing.T) {
+			t.Parallel()
+			src := fmt.Sprintf("declare class C {\n    %s(self) -> number\n}", keyword)
+			script, errors := parseScriptSrc(t, src)
+			require.Empty(t, errors)
+			decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.ClassDecl)
+			require.Len(t, decl.Body, 1)
+			method, ok := decl.Body[0].(*ast.MethodElem)
+			require.True(t, ok, "%s should be a method", src)
+			require.Equal(t, keyword, method.Name.(*ast.IdentExpr).Name)
+		})
+	}
+}
+
+// cannotBind lists the keywords that must never become a binding name. It is
+// written out rather than derived from bindingKeywords so the sweeps below have
+// an oracle independent of the code under test. Widening bindingKeywords by
+// mistake then fails here instead of moving both sides of the comparison
+// together.
+//
+// The first 28 are the words ECMAScript reserves, which codegen cannot emit as
+// an identifier: `fn f(in: number)` would lower to `const in = ...`. `undefined`
+// is here for a different reason. It is not reserved, but a pattern reads it as
+// the value it names, and a binding name must not shift meaning with position.
+func cannotBind() map[string]bool {
+	words := []string{
+		"await", "catch", "class", "do", "else", "enum", "export", "extends",
+		"false", "for", "if", "implements", "import", "in", "interface", "new",
+		"null", "private", "return", "static", "super", "throw", "true", "try",
+		"typeof", "var", "void", "yield",
+		"undefined",
+	}
+	set := make(map[string]bool, len(words))
+	for _, word := range words {
+		set[word] = true
+	}
+	return set
+}
+
+// Every keyword the lexer knows is either a binding name or one of the words
+// above. A keyword added to the lexer without a decision about which it is
+// fails here, which is the reminder to make that decision.
+func TestEveryKeywordIsClassifiedForBinding(t *testing.T) {
+	t.Parallel()
+	reserved := cannotBind()
+	for _, keyword := range keywordTexts() {
+		require.Equal(t, !reserved[keyword], bindsAsAName(keywords[keyword]),
+			"%q: bindingKeywords and the reserved list disagree; add %q to one of them",
+			keyword, keyword)
+	}
+}
+
+// A binding name reaches JavaScript verbatim, so only the keywords JavaScript
+// itself accepts as an identifier may name a parameter or a function.
+//
+// The negative direction checks the parsed pattern rather than the presence of
+// an error. `true` and the other literal keywords take the literal-pattern path
+// instead of failing outright, and what matters is that neither becomes a name.
+func TestKeywordsInBindingPositions(t *testing.T) {
+	t.Parallel()
+	reserved := cannotBind()
+
+	t.Run("parameter name", func(t *testing.T) {
+		t.Parallel()
+		for _, keyword := range keywordTexts() {
+			src := fmt.Sprintf("declare fn f(%s: number) -> number", keyword)
+			script, errors := parseScriptSrc(t, src)
+			bound := false
+			if len(errors) == 0 {
+				fn := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.FuncDecl)
+				if identPat, ok := fn.Params[0].Pattern.(*ast.IdentPat); ok {
+					bound = identPat.Name == keyword
+				}
+			}
+			require.Equal(t, !reserved[keyword], bound,
+				"%s: bound as a parameter name = %v", src, bound)
+		}
+	})
+
+	t.Run("rest parameter name", func(t *testing.T) {
+		t.Parallel()
+		for _, keyword := range keywordTexts() {
+			src := fmt.Sprintf("declare fn f(...%s: Array<number>) -> number", keyword)
+			script, errors := parseScriptSrc(t, src)
+			bound := false
+			if len(errors) == 0 {
+				fn := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.FuncDecl)
+				if rest, ok := fn.Params[0].Pattern.(*ast.RestPat); ok {
+					if identPat, isIdent := rest.Pattern.(*ast.IdentPat); isIdent {
+						bound = identPat.Name == keyword
+					}
+				}
+			}
+			require.Equal(t, !reserved[keyword], bound,
+				"%s: bound as a rest parameter name = %v", src, bound)
+		}
+	})
+
+	t.Run("function declaration name", func(t *testing.T) {
+		t.Parallel()
+		for _, keyword := range keywordTexts() {
+			src := fmt.Sprintf("declare fn %s() -> number", keyword)
+			script, errors := parseScriptSrc(t, src)
+			named := false
+			if len(errors) == 0 {
+				fn := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.FuncDecl)
+				named = fn.Name.Name == keyword
+			}
+			require.Equal(t, !reserved[keyword], named,
+				"%s: used as the function name = %v", src, named)
+		}
+	})
+}
+
+// A shorthand property is a key and a variable reference at once, so it accepts
+// exactly the keywords a binding does. The keyed form accepts every keyword,
+// since `{ catch: 1 }` is valid JavaScript.
+func TestKeywordShorthandProperties(t *testing.T) {
+	t.Parallel()
+	reserved := cannotBind()
+
+	t.Run("shorthand takes only binding names", func(t *testing.T) {
+		t.Parallel()
+		for _, keyword := range keywordTexts() {
+			src := fmt.Sprintf("val a = {%s}", keyword)
+			_, errors := parseScriptSrc(t, src)
+			if !reserved[keyword] {
+				require.Empty(t, errors, "%s should parse", src)
+				continue
+			}
+			require.NotEmpty(t, errors, "%s should report", src)
+			require.Equal(t, "`"+keyword+
+				"` cannot be a shorthand property because it is not a variable name",
+				errors[0].Message)
+		}
+	})
+
+	t.Run("a keyed property takes every keyword", func(t *testing.T) {
+		t.Parallel()
+		for _, keyword := range keywordTexts() {
+			src := fmt.Sprintf("val a = {%s: 1}", keyword)
+			_, errors := parseScriptSrc(t, src)
+			require.Empty(t, errors, "%s should parse", src)
+		}
+	})
+}
+
+// `get` and `set` mark an accessor only when a name follows them, so the method
+// shorthand an object literal rejects stays rejected while the property does not.
+func TestGetAndSetInObjectLiterals(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string
+	}{
+		{"get names a property", "val a = {get: 1}", ""},
+		{"set names a property", "val a = {set: 1}", ""},
+		{"get is a shorthand property", "val a = {get}", ""},
+		{"a getter is still rejected", "val a = {get x() {}}",
+			"Method shorthand is not allowed in object literals; use a class instead"},
+		{"a setter is still rejected", "val a = {set x(v) {}}",
+			"Method shorthand is not allowed in object literals; use a class instead"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, errors := parseScriptSrc(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errors)
+				return
+			}
+			require.NotEmpty(t, errors)
+			require.Equal(t, tt.wantErr, errors[0].Message)
+		})
+	}
+}

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -103,19 +103,11 @@ func isKeyword(tokenType TokenType) bool {
 	return keywordTokens.Contains(tokenType)
 }
 
-// bindingKeywords names the keywords a binding position accepts as an ordinary
-// name, meaning a parameter or a function declaration. Every entry is a word
-// JavaScript itself allows as an identifier, because codegen emits a binding
-// name verbatim: `fn f(in: number)` would become `const in = ...`, a syntax
-// error. A keyword JavaScript reserves is left out. A keyword added to Escalier
-// later stays out until someone adds it here, so an unchecked one is rejected
-// rather than emitted into invalid JavaScript.
-//
-// A property name has no such limit. `{ catch: 1 }` and `obj.catch` are both
-// valid JavaScript, so objExprKey accepts every keyword.
-// `undefined`, `null`, `true`, and `false` are left out for a second reason: a
-// pattern reads each of them as the literal it names, and a binding name must
-// not shift with position.
+// bindingKeywords names the keywords a parameter or function declaration
+// accepts as an ordinary name. Codegen emits a binding name verbatim, so every
+// entry is a word JavaScript allows as an identifier: `fn f(in: number)` would
+// become `const in = ...`. The literals `undefined`, `null`, `true`, and
+// `false` are out too, since a pattern reads each as the value it names.
 var bindingKeywords = set.FromSlice([]TokenType{
 	Any, Asserts, Async, Bigint, Boolean, Declare, Final, Fn, From, Gen, Get,
 	Infer, Is, Keyof, Match, Mut, Never, Number, Override, Readonly, Set,

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/lexer_util"
+	"github.com/escalier-lang/escalier/internal/set"
 )
 
 type Lexer struct {
@@ -82,6 +83,50 @@ var keywords = map[string]TokenType{
 	"implements": Implements,
 	"is":         Is,
 	"asserts":    Asserts,
+}
+
+// keywordTokens holds the token type of every entry in keywords. A keyword
+// token carries its source text in Value, so a parser position that accepts a
+// name can turn one back into an identifier.
+var keywordTokens = func() set.Set[TokenType] {
+	types := set.NewSet[TokenType]()
+	for _, tokenType := range keywords {
+		types.Add(tokenType)
+	}
+	return types
+}()
+
+// isKeyword reports whether tokenType is the type the lexer gives a keyword.
+// Property names accept keywords, so `catch`, `match`, and `symbol` name
+// members the way an identifier does.
+func isKeyword(tokenType TokenType) bool {
+	return keywordTokens.Contains(tokenType)
+}
+
+// bindingKeywords names the keywords a binding position accepts as an ordinary
+// name, meaning a parameter or a function declaration. Every entry is a word
+// JavaScript itself allows as an identifier, because codegen emits a binding
+// name verbatim: `fn f(in: number)` would become `const in = ...`, a syntax
+// error. A keyword JavaScript reserves is left out. A keyword added to Escalier
+// later stays out until someone adds it here, so an unchecked one is rejected
+// rather than emitted into invalid JavaScript.
+//
+// A property name has no such limit. `{ catch: 1 }` and `obj.catch` are both
+// valid JavaScript, so objExprKey accepts every keyword.
+// `undefined`, `null`, `true`, and `false` are left out for a second reason: a
+// pattern reads each of them as the literal it names, and a binding name must
+// not shift with position.
+var bindingKeywords = set.FromSlice([]TokenType{
+	Any, Asserts, Async, Bigint, Boolean, Declare, Final, Fn, From, Gen, Get,
+	Infer, Is, Keyof, Match, Mut, Never, Number, Override, Readonly, Set,
+	String, Symbol, Throws, Type, Unique, Unknown, Val,
+})
+
+// bindsAsAName reports whether a keyword can stand where a binding name
+// belongs. `String.prototype.substr(from, length)` converts to a parameter
+// named `from`, and `Reflect.get` to a function named `get`.
+func bindsAsAName(tokenType TokenType) bool {
+	return bindingKeywords.Contains(tokenType)
 }
 
 // isRegexContext determines if a '/' should be treated as the start of a regex literal

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -120,6 +120,35 @@ const (
 	Negation
 )
 
+// followsAName reports whether tokenType can come directly after a name in a
+// member or parameter position. A keyword that also marks a modifier is a
+// modifier only when a name follows it, so what comes next is what tells the
+// two apart. `set(v: any) -> unknown` names a method `set` because `(` opens
+// its parameter list, where `set value(v: any)` marks an accessor because a
+// name follows instead. The same rule reads `from` as a parameter name in
+// `substr(mut self, from: number)`.
+func followsAName(tokenType TokenType) bool {
+	// nolint: exhaustive
+	switch tokenType {
+	case OpenParen, CloseParen, LessThan, Colon, Question, Comma, CloseBrace, Equal:
+		return true
+	default:
+		return false
+	}
+}
+
+// startsASignature reports whether tokenType opens a function signature: the
+// type parameter list or the parameter list.
+func startsASignature(tokenType TokenType) bool {
+	// nolint: exhaustive
+	switch tokenType {
+	case OpenParen, LessThan:
+		return true
+	default:
+		return false
+	}
+}
+
 type Token struct {
 	Span  ast.Span
 	Type  TokenType

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -425,7 +425,10 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 		case Infer: // infer type
 			p.lexer.consume() // consume 'infer'
 			nameToken := p.lexer.peek()
-			if nameToken.Type != Identifier {
+			// `infer _` names a position the conditional type matches but never reads
+			// back, which is how TypeScript writes a rest element it only needs to
+			// consume: `then(onfulfilled: infer F, ...args: infer _) -> any`.
+			if nameToken.Type != Identifier && nameToken.Type != Underscore {
 				p.reportError(nameToken.Span, "expected identifier after 'infer'")
 				typeAnn = ast.NewErrorTypeAnn(token.Span)
 				break
@@ -854,13 +857,24 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		return ast.NewRestSpreadTypeAnn(value, span)
 	}
 
-	// A `new (x: number) -> T` construct signature. `new` is a keyword, so it can never be
-	// an object key and the arm needs no lookahead past it. The signature parses through the
-	// same tail the `fn` annotation uses, which gives it type parameters, an inexact marker,
-	// and a `throws` clause for free.
-	if token.Type == New {
-		p.lexer.consume() // consume 'new'
-		return &ast.ConstructorTypeAnn{Fn: p.funcTypeAnnTail(token)}
+	// A `new (x: number) -> T` construct signature and a `fn (x: number) -> T` call
+	// signature. Each claims its keyword only where a signature follows, so `fn: number`
+	// and `new?: T` still declare properties under those names.
+	//
+	// A method does collide: `fn(x: number) -> T` differs from the call signature only in
+	// whitespace, and a signature must not hinge on that, so the signature wins. Write a
+	// method of either name with a string key, `"fn"(x: number) -> T`. A class body has
+	// no call or construct signature to compete with, so `fn` and `new` name methods
+	// there directly.
+	//
+	// Both signatures parse through the same tail the `fn` annotation uses, which gives
+	// them type parameters, an inexact marker, and a `throws` clause for free.
+	if (token.Type == New || token.Type == Fn) && startsASignature(p.lexer.peek2().Type) {
+		p.lexer.consume() // consume 'new' or 'fn'
+		if token.Type == New {
+			return &ast.ConstructorTypeAnn{Fn: p.funcTypeAnnTail(token)}
+		}
+		return &ast.CallableTypeAnn{Fn: p.funcTypeAnnTail(token)}
 	}
 
 	mod := ""
@@ -868,7 +882,7 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 
 	// Check if this might be a mapped type before consuming 'readonly'
 	// Mapped types start with 'readonly [' or '+readonly [' or '-readonly ['
-	if token.Type == Readonly {
+	if token.Type == Readonly && !followsAName(p.lexer.peek2().Type) {
 		savedState := p.saveState()
 		p.lexer.consume() // tentatively consume 'readonly'
 		nextToken := p.lexer.peek()
@@ -882,15 +896,21 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		token = p.lexer.peek()
 	}
 
-	// Then check for 'get' or 'set' modifiers
+	// Then check for 'get' or 'set' modifiers. Each is a modifier only when a name
+	// follows it, so `get x() -> T` reads as an accessor while `get() -> T` reads as a
+	// method named `get`.
 	// nolint: exhaustive
 	switch token.Type {
 	case Get:
-		p.lexer.consume() // consume 'get'
-		mod = "get"
+		if !followsAName(p.lexer.peek2().Type) {
+			p.lexer.consume() // consume 'get'
+			mod = "get"
+		}
 	case Set:
-		p.lexer.consume() // consume 'set'
-		mod = "set"
+		if !followsAName(p.lexer.peek2().Type) {
+			p.lexer.consume() // consume 'set'
+			mod = "set"
+		}
 	}
 
 	mappedElem := p.tryParseMappedType()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2428,10 +2428,36 @@ func TestPrintRoundTripsConverterOutput(t *testing.T) {
 	})
 
 	// The keyed form of those same names is valid JavaScript and stays accepted.
+	// One case per class of keyword: a reserved word, a literal, an accessor
+	// modifier, a type name, and the two an object type reads as signatures. The
+	// printer emits each bare, so the output has to parse back as the same key.
 	t.Run("keyword keys in an object literal", func(t *testing.T) {
-		result, err := Print(parseDecl(t, "val a = {catch: 1, true: 2}"), opts)
-		require.NoError(t, err)
-		require.Equal(t, "val a = {\n    catch: 1,\n    true: 2\n}", result)
+		literalTests := []struct {
+			name  string
+			input string
+			want  string
+		}{
+			{"reserved word", "val a = {catch: 1}", "val a = {\n    catch: 1\n}"},
+			{"literal", "val a = {true: 1}", "val a = {\n    true: 1\n}"},
+			{"accessor modifier", "val a = {get: 1, set: 2}", "val a = {\n    get: 1,\n    set: 2\n}"},
+			{"type name", "val a = {symbol: 1}", "val a = {\n    symbol: 1\n}"},
+			{"signature keyword", "val a = {fn: 1, new: 2}", "val a = {\n    fn: 1,\n    new: 2\n}"},
+			{"shorthand", "val a = {type, from}", "val a = {\n    type,\n    from\n}"},
+			{"several at once", "val a = {catch: 1, true: 2}", "val a = {\n    catch: 1,\n    true: 2\n}"},
+		}
+		for _, tt := range literalTests {
+			t.Run(tt.name, func(t *testing.T) {
+				result, err := Print(parseDecl(t, tt.input), opts)
+				require.NoError(t, err)
+				require.Equal(t, tt.want, result)
+
+				// Round-trip: what the printer emitted has to parse again.
+				_, errors := parser.ParseDecls(context.Background(), &ast.Source{
+					Path: "test.esc", Contents: result,
+				})
+				require.Empty(t, errors, "printed output should parse back")
+			})
+		}
 	})
 
 	// A binding name reaches JavaScript verbatim, so a keyword JavaScript itself

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2403,6 +2403,37 @@ func TestPrintRoundTripsConverterOutput(t *testing.T) {
 		require.Equal(t, "constructors cannot be static", errors[0].Message)
 	})
 
+	// A shorthand property is a key and a variable reference at once, so a keyword
+	// that cannot be read as a variable is rejected in that position while still
+	// naming a keyed property.
+	t.Run("keyword shorthand properties", func(t *testing.T) {
+		shorthandTests := []struct {
+			name  string
+			input string
+			want  string
+		}{
+			{"reserved word", "val a = {catch}", "`catch` cannot be a shorthand property because it is not a variable name"},
+			{"literal", "val a = {true}", "`true` cannot be a shorthand property because it is not a variable name"},
+		}
+		for _, tt := range shorthandTests {
+			t.Run(tt.name, func(t *testing.T) {
+				script := parser.NewParser(context.Background(), &ast.Source{
+					Path: "test.esc", Contents: tt.input,
+				})
+				_, errors := script.ParseScript()
+				require.NotEmpty(t, errors)
+				require.Equal(t, tt.want, errors[0].Message)
+			})
+		}
+	})
+
+	// The keyed form of those same names is valid JavaScript and stays accepted.
+	t.Run("keyword keys in an object literal", func(t *testing.T) {
+		result, err := Print(parseDecl(t, "val a = {catch: 1, true: 2}"), opts)
+		require.NoError(t, err)
+		require.Equal(t, "val a = {\n    catch: 1,\n    true: 2\n}", result)
+	})
+
 	// A binding name reaches JavaScript verbatim, so a keyword JavaScript itself
 	// reserves is still rejected there. `catch` names a member freely and a
 	// parameter never.

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2301,3 +2301,126 @@ func TestPrintThrowsClause(t *testing.T) {
 		})
 	}
 }
+
+// Every declaration the `.d.ts` converter emits has to parse back, because both
+// `check` and `regenerate` re-read the committed tree before diffing it. Each
+// case round-trips one construct the TypeScript lib surface produces. The input
+// is what the printer writes, so an exact match on the output pins both halves
+// of the pair at once.
+func TestPrintRoundTripsConverterOutput(t *testing.T) {
+	opts := DefaultOptions()
+
+	declTests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			// The `fn (…) -> T` call signature, printed for a
+			// CallableTypeAnn. `ArrayConstructor` carries three of them.
+			name:  "call signature in an interface",
+			input: "declare interface C {\n    fn (n?: number) -> Array<any>\n}",
+			want:  "declare interface C {\n    fn (n?: number) -> Array<any>\n}",
+		},
+		{
+			name:  "generic call signature beside a construct signature",
+			input: "declare interface C {\n    new<T> (n: number) -> T,\n    fn<T> (n: number) -> T\n}",
+			want:  "declare interface C {\n    new<T> (n: number) -> T,\n    fn<T> (n: number) -> T\n}",
+		},
+		{
+			// `Promise.prototype.catch` and `String.prototype.match`.
+			name:  "keyword method names",
+			input: "declare class C {\n    catch(self) -> undefined,\n    match(self) -> undefined\n}",
+			want:  "declare class C {\n    catch(self) -> undefined,\n    match(self) -> undefined\n}",
+		},
+		{
+			// `Intl.NumberFormatOptionsStyleRegistry` has both.
+			name:  "keyword property names",
+			input: "declare interface C {\n    symbol: never,\n    string: never\n}",
+			want:  "declare interface C {\n    symbol: never,\n    string: never\n}",
+		},
+		{
+			// `PropertyDescriptor.get` and `TypedArray.prototype.set`, where
+			// `get` and `set` name a member rather than marking an accessor.
+			name:  "get and set as member names",
+			input: "declare interface C {\n    get() -> any,\n    set(v: any) -> unknown\n}",
+			want:  "declare interface C {\n    get() -> any,\n    set(v: any) -> unknown\n}",
+		},
+		{
+			name:  "get and set still mark accessors when a name follows",
+			input: "declare class C {\n    get x(self) -> number,\n    set x(mut self, v: number)\n}",
+			want:  "declare class C {\n    get x(self) -> number,\n    set x(mut self, v: number)\n}",
+		},
+		{
+			// Every prototype carries a `constructor` property, which a
+			// `.d.ts` declares as a field rather than a signature.
+			name:  "constructor as a field name",
+			input: "declare class C {\n    constructor: Function\n}",
+			want:  "declare class C {\n    constructor: Function\n}",
+		},
+		{
+			// `String.prototype.substr(from, length)`.
+			name:  "keyword parameter name",
+			input: "declare fn f(from: number, type: string) -> string",
+			want:  "declare fn f(from: number, type: string) -> string",
+		},
+		{
+			// `Reflect.get`.
+			name:  "keyword function name",
+			input: "declare fn get<T>(target: T) -> T",
+			want:  "declare fn get<T>(target: T) -> T",
+		},
+		{
+			name:  "keyword rest parameter name",
+			input: "declare fn f(...from: Array<number>) -> string",
+			want:  "declare fn f(...from: Array<number>) -> string",
+		},
+		{
+			// `fn` and `new` open a signature only when one follows, so an
+			// interface can still declare properties under those names.
+			name:  "fn and new as property names",
+			input: "declare interface C {\n    fn: number,\n    new?: string\n}",
+			want:  "declare interface C {\n    fn: number,\n    new?: string\n}",
+		},
+	}
+	for _, tt := range declTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Print(parseDecl(t, tt.input), opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, result)
+		})
+	}
+
+	// JavaScript has no static member named `constructor`, so a `static` element of
+	// that name is never the field. It stays a constructor and reports the modifier a
+	// constructor cannot carry.
+	t.Run("static constructor is not a field", func(t *testing.T) {
+		_, errors := parser.ParseDecls(context.Background(), &ast.Source{
+			Path:     "test.esc",
+			Contents: "declare class C {\n    static constructor: number\n}",
+		})
+		require.NotEmpty(t, errors)
+		require.Equal(t, "constructors cannot be static", errors[0].Message)
+	})
+
+	// A binding name reaches JavaScript verbatim, so a keyword JavaScript itself
+	// reserves is still rejected there. `catch` names a member freely and a
+	// parameter never.
+	t.Run("a JavaScript reserved word does not name a parameter", func(t *testing.T) {
+		_, errors := parser.ParseDecls(context.Background(), &ast.Source{
+			Path:     "test.esc",
+			Contents: "declare fn f(catch: number) -> string",
+		})
+		require.NotEmpty(t, errors)
+		require.Equal(t, "Expected a pattern", errors[0].Message)
+	})
+
+	// `Awaited<T>` matches a rest element it never reads back, which TypeScript
+	// writes as `...args: infer _`.
+	t.Run("infer _ in a conditional type", func(t *testing.T) {
+		input := "if T : {\n    then(onfulfilled: infer F, ...args: infer _) -> any\n} { F } else { T }"
+		result, err := Print(parseTypeAnn(t, input), opts)
+		require.NoError(t, err)
+		require.Equal(t, input, result)
+	})
+}


### PR DESCRIPTION
Refs #1324

The TypeScript `.d.ts` surface uses keywords as member and parameter names where JavaScript allows them. For example, `String.prototype.substr(from, length)` names its first parameter `from` (the import keyword), and `Reflect.get` is a function named `get`. The printer now emits these constructs, but the parser rejected them.

This change teaches the parser to accept keywords as binding names and property names in the right contexts, and adds round-trip tests to pin the printer-parser pair.

**Key changes:**

- **Keyword acceptance in bindings:** Parameters, function names, and rest parameter names now accept keywords that JavaScript itself allows as identifiers (`from`, `get`, `set`, `match`, etc.). A lookahead check ensures the keyword is followed by member or signature punctuation, so `fn: number` still parses as a property while `fn(x: number) -&gt; T` parses as a call signature.

- **Keyword acceptance in property names:** Object type and class body members can now be named with keywords when member punctuation follows. This allows `catch()`, `match()`, and `symbol:` to work as method and property names.

- **Call signatures in object types:** Added `CallableTypeAnn` support to parse `fn (x: number) -&gt; T` call signatures alongside existing construct signatures. Both are gated by lookahead to avoid colliding with property names.

- **Constructor as a field:** Class bodies now recognize `constructor: Type` as a field declaration (the prototype's constructor property) rather than always parsing it as a constructor signature. A `static constructor` still reports an error since JavaScript has no such member.

- **Infer with underscore:** Type inference in conditional types now accepts `infer _` to match positions that are never read back, as TypeScript uses in `then(onfulfilled: infer F, ...args: infer _) -&gt; any`.

- **Round-trip tests:** Added `TestPrintRoundTripsConverterOutput` to verify that every construct the `.d.ts` converter emits parses back cleanly. This gates the printer-parser pair at once and catches asymmetries before they reach committed files.

- **End-to-end gate:** Updated `TestPartitionLib_LibES5_EndToEnd` to require that all emitted `.esc` files parse, rather than reporting parse failures softly. This is the §6 round-trip gate: `check` and `regenerate` both re-read every committed file before diffing it. It also reads its input from the pinned TypeScript in `node_modules`, which CI installs before `go test`; the path it used no longer exists, so the gate had been skipping.

## Verified, and what is left

Bootstrapping the lib files the partition table routes produces 22 packages. All 22 parse back with this change, up from 9.

The end-to-end gate covers the 17 packages lib.es5 produces rather than all 22, because the full set cannot be bootstrapped at HEAD. Two converter-side gaps block it, both out of scope here and noted in the test's doc comment:

- The partition table has no entry for `FlatArray`, `BigIntToLocaleStringOptions`, `RegExpIndicesArray`, `PromiseWithResolvers`, `ReadonlySetLike`, or `Disposable`, so those lib files trip the unmapped-symbol fail-safe.
- Flattening a singleton whose key is computed, as in `Atomics[Symbol.toStringTag]` and `JSON[Symbol.toStringTag]`, fails with `unsupported singleton property key`.

The remaining 22-package figure above comes from a run with those nine lib files pruned by hand.

https://claude.ai/code/session_016Focx7gpnHnhnuUHCdXkvo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript declaration parsing for members, parameters, functions, accessors, constructors, and object keys that use keyword-like names.
  * Added support for conditional types using `_` as an `infer` binding.
  * Improved handling of construct and call signatures while preserving properties with names such as `new` and `fn`.

* **Tests**
  * Expanded validation to cover keyword names, accessor disambiguation, constructor fields, reserved identifiers, and converter output round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->