### PR TITLE
Track and report singleton members dropped for non-name keys

### DIFF
--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -42,6 +42,12 @@ type StandaloneModule struct {
 	// and `TypeDecl` carry no Decorators field by design (§3.3), yet the
 	// ECMA-262 join still has to address the members an interface declares.
 	Paths map[ast.Decl]string
+
+	// KeyDrops lists every singleton member flattening skipped because
+	// the member's key has no plain-name form.
+	// ReportSingletonKeyDrops filters this against
+	// AllowedSingletonKeyDrops and names what is left.
+	KeyDrops []SingletonMember
 }
 
 // ConvertToStandaloneModule converts a dts_parser.Module to a form
@@ -66,6 +72,8 @@ type StandaloneModule struct {
 //     instance interface (the constructor interface's doc is dropped).
 //   - Records each emitted decl's dotted runtime path (see
 //     StandaloneModule.Paths).
+//   - Records every singleton member it skipped because the member's
+//     key has no plain-name form (see StandaloneModule.KeyDrops).
 func ConvertToStandaloneModule(dtsModule *dts_parser.Module) (*StandaloneModule, error) {
 	cctx := &convertCtx{}
 	trios := detectTrios(dtsModule.Statements)
@@ -93,9 +101,10 @@ func ConvertToStandaloneModule(dtsModule *dts_parser.Module) (*StandaloneModule,
 	var namespaces btree.Map[string, *ast.Namespace]
 	namespaces.Set("", &ast.Namespace{Decls: decls})
 	return &StandaloneModule{
-		Module: ast.NewModule(namespaces),
-		Docs:   docs,
-		Paths:  paths,
+		Module:   ast.NewModule(namespaces),
+		Docs:     docs,
+		Paths:    paths,
+		KeyDrops: cctx.keyDrops,
 	}, nil
 }
 
@@ -354,24 +363,37 @@ func detectSingletons(stmts []dts_parser.Statement, trios *trioTable) *singleton
 
 // flattenSingleton emits a top-level decl for each member of the
 // singleton interface, each decorated with `@js("<jsBase>.<member>")`.
-// MethodSignature → FuncDecl; PropertySignature → VarDecl. Other member
-// kinds (CallSignature, IndexSignature, GetterSignature, SetterSignature,
-// ConstructSignature) have no clean top-level lowering for a singleton
-// and are skipped silently for the MVP.
+// MethodSignature → FuncDecl; PropertySignature → VarDecl. The
+// remaining member kinds have no clean top-level lowering for a
+// singleton and are skipped for the MVP: CallSignature,
+// IndexSignature, GetterSignature, SetterSignature, ConstructSignature.
 //
-// A symbol-keyed member is skipped for the same reason. Flattening
-// needs a plain name to build both the Escalier binding and the
-// `@js(...)` path, and a computed key has neither. The corpus shape is
-// `interface Math { readonly [Symbol.toStringTag]: string }`, which
-// tags the object for `Object.prototype.toString` rather than
-// declaring anything a caller names.
-func flattenSingleton(info *singletonInfo, jsBase string) ([]docDecl, error) {
+// A member whose key has no plain-name form is skipped too, because
+// flattening needs a name for both the Escalier binding and the
+// `@js(...)` path. The corpus shape is
+// `interface Math { readonly [Symbol.toStringTag]: string }`. Every
+// such skip is recorded on cctx under jsBase, whatever the member
+// kind, which is what keeps a new one from passing unnoticed.
+func flattenSingleton(cctx *convertCtx, info *singletonInfo, jsBase string) ([]docDecl, error) {
 	var out []docDecl
 	for _, m := range info.iface.Members {
 		switch sig := m.(type) {
+		case *dts_parser.GetterSignature:
+			// An accessor has no top-level lowering whatever its key,
+			// so it is skipped either way. Only the ones under a key
+			// with no plain-name form belong in the report. A named
+			// accessor is the separate gap listed above.
+			if propertyKeyName(sig.Name) == "" {
+				cctx.noteSingletonKeyDrop(jsBase, sig.Name)
+			}
+		case *dts_parser.SetterSignature:
+			if propertyKeyName(sig.Name) == "" {
+				cctx.noteSingletonKeyDrop(jsBase, sig.Name)
+			}
 		case *dts_parser.MethodSignature:
 			member := propertyKeyName(sig.Name)
 			if member == "" {
+				cctx.noteSingletonKeyDrop(jsBase, sig.Name)
 				continue
 			}
 			decl, err := singletonMethodToFuncDecl(sig)
@@ -385,6 +407,7 @@ func flattenSingleton(info *singletonInfo, jsBase string) ([]docDecl, error) {
 		case *dts_parser.PropertySignature:
 			member := propertyKeyName(sig.Name)
 			if member == "" {
+				cctx.noteSingletonKeyDrop(jsBase, sig.Name)
 				continue
 			}
 			decl, err := singletonPropertyToVarDecl(sig)
@@ -773,7 +796,7 @@ func convertStandaloneStmt(
 		}
 		if singletons != nil {
 			if info, ok := singletons.byName[s.Name.Name]; ok {
-				return flattenSingleton(info, jsName(nsPath, s.Name.Name))
+				return flattenSingleton(cctx, info, jsName(nsPath, s.Name.Name))
 			}
 		}
 		decl, err := convertInterfaceDecl(s)

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -397,6 +397,31 @@ func TestStandalone_SingletonNumericKeyDropIsRecorded(t *testing.T) {
 	}, astModule.KeyDrops)
 }
 
+// literalKeyedSingletonSlice covers the computed-key shapes the dts
+// parser accepts that are not a `Symbol.*` member access. A literal in
+// the brackets names the same member a bare key would, so the report
+// renders it the same way rather than as a node type. The empty string
+// key is the one plain key with no name to borrow.
+const literalKeyedSingletonSlice = `
+interface Widget {
+    resize(n: number): void;
+    readonly ["ready"]: boolean;
+    readonly [0]: string;
+    readonly "": string;
+}
+
+declare var Widget: Widget;
+`
+
+func TestStandalone_SingletonLiteralKeyDropsAreRecorded(t *testing.T) {
+	astModule, _ := convertSlice(t, literalKeyedSingletonSlice)
+	require.Equal(t, []SingletonMember{
+		{Singleton: "Widget", Key: `"ready"`},
+		{Singleton: "Widget", Key: "0"},
+		{Singleton: "Widget", Key: `""`},
+	}, astModule.KeyDrops)
+}
+
 // nestedSingletonSlice puts a singleton inside a namespace, the shape
 // `declare namespace Intl { ... }` produces. A drop has to reach the
 // caller from the recursive conversion, not just from the module root.
@@ -443,6 +468,78 @@ func TestStandalone_SingletonAccessorKeyDropsAreRecorded(t *testing.T) {
 		{Singleton: "Atomics", Key: "Symbol.toStringTag"},
 		{Singleton: "Atomics", Key: "Symbol.dispose"},
 	}, astModule.KeyDrops)
+}
+
+// TestSingletonKeyLabel covers every shape the label can take. The
+// contract the drop report rests on is that no key renders as the
+// empty string, so a member is never named by a blank key.
+func TestSingletonKeyLabel(t *testing.T) {
+	t.Parallel()
+	symbolIterator := &dts_parser.MemberExpr{
+		Object: &dts_parser.IdentExpr{Name: "Symbol"},
+		Prop:   dts_parser.NewIdent("iterator", ast.Span{}),
+	}
+	tests := []struct {
+		name string
+		key  dts_parser.PropertyKey
+		want string
+	}{
+		{
+			name: "well-known symbol",
+			key:  &dts_parser.ComputedKey{Expr: symbolIterator},
+			want: "Symbol.iterator",
+		},
+		{
+			name: "computed string literal",
+			key: &dts_parser.ComputedKey{Expr: &dts_parser.LitExpr{
+				Lit: &dts_parser.StringLiteral{Value: "ready"},
+			}},
+			want: `"ready"`,
+		},
+		{
+			name: "computed number literal",
+			key: &dts_parser.ComputedKey{Expr: &dts_parser.LitExpr{
+				Lit: &dts_parser.NumberLiteral{Value: 2},
+			}},
+			want: "2",
+		},
+		{
+			// A member access rooted at a literal reduces to no dotted
+			// chain. The dts parser cannot produce one today, so this
+			// is the placeholder a future expression shape would take.
+			name: "computed expression with no dotted form",
+			key: &dts_parser.ComputedKey{Expr: &dts_parser.MemberExpr{
+				Object: &dts_parser.LitExpr{
+					Lit: &dts_parser.StringLiteral{Value: "x"},
+				},
+				Prop: dts_parser.NewIdent("y", ast.Span{}),
+			}},
+			want: "<computed *dts_parser.MemberExpr>",
+		},
+		{
+			name: "empty string key",
+			key:  &dts_parser.StringLiteral{Value: ""},
+			want: `""`,
+		},
+		{
+			name: "numeric key",
+			key:  &dts_parser.NumberLiteral{Value: 0},
+			want: "0",
+		},
+		{
+			// An identifier only reaches the label when its name is
+			// empty, since propertyKeyName returns any other name.
+			name: "identifier with no name",
+			key:  dts_parser.NewIdent("", ast.Span{}),
+			want: "<*dts_parser.Ident>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, singletonKeyLabel(tt.key))
+		})
+	}
 }
 
 // sharedInterfaceSlice pins the negative case for the singleton flattener:

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -369,6 +369,80 @@ func TestStandalone_SingletonSkipsSymbolKeyedMember(t *testing.T) {
 	require.Equal(t, "Math.abs", printDecoratorArg(t, fn.Decorators[0]))
 	require.NotContains(t, printed, "toStringTag")
 	require.NotContains(t, printed, "Symbol.iterator")
+
+	// Both skips are recorded in source order. Whether either one is
+	// expected is ReportSingletonKeyDrops's call.
+	require.Equal(t, []SingletonMember{
+		{Singleton: "Math", Key: "Symbol.toStringTag"},
+		{Singleton: "Math", Key: "Symbol.iterator"},
+	}, astModule.KeyDrops)
+}
+
+// numberKeyedSingletonSlice covers a key that is neither a plain name
+// nor a symbol. A numeric key has no plain-name form either, so the
+// member is dropped and reported under its literal text.
+const numberKeyedSingletonSlice = `
+interface Widget {
+    resize(n: number): void;
+    readonly 0: string;
+}
+
+declare var Widget: Widget;
+`
+
+func TestStandalone_SingletonNumericKeyDropIsRecorded(t *testing.T) {
+	astModule, _ := convertSlice(t, numberKeyedSingletonSlice)
+	require.Equal(t, []SingletonMember{
+		{Singleton: "Widget", Key: "0"},
+	}, astModule.KeyDrops)
+}
+
+// nestedSingletonSlice puts a singleton inside a namespace, the shape
+// `declare namespace Intl { ... }` produces. A drop has to reach the
+// caller from the recursive conversion, not just from the module root.
+const nestedSingletonSlice = `
+declare namespace Intl {
+    interface Collators {
+        compare(a: string, b: string): number;
+        [Symbol.dispose](): void;
+    }
+
+    var Collators: Collators;
+}
+`
+
+func TestStandalone_NestedSingletonKeyDropIsRecorded(t *testing.T) {
+	astModule, _ := convertSlice(t, nestedSingletonSlice)
+	// The singleton is named by its dotted runtime path, so a nested
+	// `Collators` cannot be mistaken for a top-level one of the same
+	// name.
+	require.Equal(t, []SingletonMember{
+		{Singleton: "Intl.Collators", Key: "Symbol.dispose"},
+	}, astModule.KeyDrops)
+}
+
+// accessorKeyedSingletonSlice covers the accessor member kinds. A
+// getter and a setter have no top-level lowering whatever their key.
+// The named pair is dropped without a note, and only the symbol-keyed
+// pair is recorded.
+const accessorKeyedSingletonSlice = `
+interface Atomics {
+    add(x: number): number;
+    get size(): number;
+    set size(n: number);
+    get [Symbol.toStringTag](): string;
+    set [Symbol.dispose](fn: () => void);
+}
+
+declare var Atomics: Atomics;
+`
+
+func TestStandalone_SingletonAccessorKeyDropsAreRecorded(t *testing.T) {
+	astModule, _ := convertSlice(t, accessorKeyedSingletonSlice)
+	require.Equal(t, []SingletonMember{
+		{Singleton: "Atomics", Key: "Symbol.toStringTag"},
+		{Singleton: "Atomics", Key: "Symbol.dispose"},
+	}, astModule.KeyDrops)
 }
 
 // sharedInterfaceSlice pins the negative case for the singleton flattener:

--- a/internal/dts_to_esc/module.go
+++ b/internal/dts_to_esc/module.go
@@ -32,19 +32,14 @@ type convertCtx struct {
 	namespacePath string
 
 	// keyDrops accumulates every singleton member flattenSingleton
-	// skipped because the member's key has no plain-name form. The
-	// slice is shared across the whole conversion, so a member dropped
-	// inside a nested namespace reaches the caller too. Which of these
-	// are expected is ReportSingletonKeyDrops's call, not the
-	// converter's.
+	// skipped because the member's key has no plain-name form.
+	// ReportSingletonKeyDrops decides which of these are expected.
 	keyDrops []SingletonMember
 }
 
 // noteSingletonKeyDrop records that flattenSingleton skipped a member
 // declared under key. The singleton is named by its dotted runtime
-// path, such as "Math", which carries the enclosing namespace when the
-// singleton is declared inside one. Two singletons that share a short
-// name therefore stay distinct.
+// path, so nested singletons stay distinct from top-level ones.
 func (c *convertCtx) noteSingletonKeyDrop(singleton string, key dts_parser.PropertyKey) {
 	c.keyDrops = append(c.keyDrops, SingletonMember{
 		Singleton: singleton,
@@ -53,16 +48,10 @@ func (c *convertCtx) noteSingletonKeyDrop(singleton string, key dts_parser.Prope
 }
 
 // singletonKeyLabel renders a property key that has no plain-name form
-// so a drop report can name it. A computed key renders as its dotted
-// expression, such as "Symbol.toStringTag". A string key renders
-// quoted and a numeric key as its literal text.
-//
-// Every computed key in the pinned TS lib is a `Symbol.*` member
-// access. The parser also accepts a literal inside the brackets, so
-// `["ready"]` renders the same as a bare `"ready"` key. Anything else
-// renders as its expression type, "<computed *dts_parser.CallExpr>".
-// That keeps the member in the report, and it reads as a placeholder
-// rather than as a member name someone could allow-list.
+// so a drop report can name it: a computed key as its dotted expression
+// ("Symbol.toStringTag") or its literal, a string key quoted, a numeric
+// key as its literal text, and any other shape as a placeholder naming
+// the node type so it cannot be mistaken for a real member key.
 func singletonKeyLabel(pk dts_parser.PropertyKey) string {
 	switch k := pk.(type) {
 	case *dts_parser.ComputedKey:

--- a/internal/dts_to_esc/module.go
+++ b/internal/dts_to_esc/module.go
@@ -54,21 +54,29 @@ func (c *convertCtx) noteSingletonKeyDrop(singleton string, key dts_parser.Prope
 
 // singletonKeyLabel renders a property key that has no plain-name form
 // so a drop report can name it. A computed key renders as its dotted
-// expression, such as "Symbol.toStringTag", and a numeric key as its
-// literal text.
+// expression, such as "Symbol.toStringTag". A string key renders
+// quoted and a numeric key as its literal text.
 //
 // Every computed key in the pinned TS lib is a `Symbol.*` member
-// access. A shape that does not reduce to a dotted chain renders as
-// its expression type, "<computed *dts_parser.CallExpr>". That keeps
-// the member in the report, and it reads as a placeholder rather than
-// as a member name someone could allow-list.
+// access. The parser also accepts a literal inside the brackets, so
+// `["ready"]` renders the same as a bare `"ready"` key. Anything else
+// renders as its expression type, "<computed *dts_parser.CallExpr>".
+// That keeps the member in the report, and it reads as a placeholder
+// rather than as a member name someone could allow-list.
 func singletonKeyLabel(pk dts_parser.PropertyKey) string {
 	switch k := pk.(type) {
 	case *dts_parser.ComputedKey:
 		if dotted := exprDottedName(k.Expr); dotted != "" {
 			return dotted
 		}
+		if lit, ok := k.Expr.(*dts_parser.LitExpr); ok {
+			if inner, ok := lit.Lit.(dts_parser.PropertyKey); ok {
+				return singletonKeyLabel(inner)
+			}
+		}
 		return fmt.Sprintf("<computed %T>", k.Expr)
+	case *dts_parser.StringLiteral:
+		return strconv.Quote(k.Value)
 	case *dts_parser.NumberLiteral:
 		return strconv.FormatFloat(k.Value, 'g', -1, 64)
 	}

--- a/internal/dts_to_esc/module.go
+++ b/internal/dts_to_esc/module.go
@@ -3,6 +3,7 @@ package dts_to_esc
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
@@ -29,6 +30,49 @@ type convertCtx struct {
 	// full chain to address a member declared inside nested
 	// namespaces.
 	namespacePath string
+
+	// keyDrops accumulates every singleton member flattenSingleton
+	// skipped because the member's key has no plain-name form. The
+	// slice is shared across the whole conversion, so a member dropped
+	// inside a nested namespace reaches the caller too. Which of these
+	// are expected is ReportSingletonKeyDrops's call, not the
+	// converter's.
+	keyDrops []SingletonMember
+}
+
+// noteSingletonKeyDrop records that flattenSingleton skipped a member
+// declared under key. The singleton is named by its dotted runtime
+// path, such as "Math", which carries the enclosing namespace when the
+// singleton is declared inside one. Two singletons that share a short
+// name therefore stay distinct.
+func (c *convertCtx) noteSingletonKeyDrop(singleton string, key dts_parser.PropertyKey) {
+	c.keyDrops = append(c.keyDrops, SingletonMember{
+		Singleton: singleton,
+		Key:       singletonKeyLabel(key),
+	})
+}
+
+// singletonKeyLabel renders a property key that has no plain-name form
+// so a drop report can name it. A computed key renders as its dotted
+// expression, such as "Symbol.toStringTag", and a numeric key as its
+// literal text.
+//
+// Every computed key in the pinned TS lib is a `Symbol.*` member
+// access. A shape that does not reduce to a dotted chain renders as
+// its expression type, "<computed *dts_parser.CallExpr>". That keeps
+// the member in the report, and it reads as a placeholder rather than
+// as a member name someone could allow-list.
+func singletonKeyLabel(pk dts_parser.PropertyKey) string {
+	switch k := pk.(type) {
+	case *dts_parser.ComputedKey:
+		if dotted := exprDottedName(k.Expr); dotted != "" {
+			return dotted
+		}
+		return fmt.Sprintf("<computed %T>", k.Expr)
+	case *dts_parser.NumberLiteral:
+		return strconv.FormatFloat(k.Value, 'g', -1, 64)
+	}
+	return fmt.Sprintf("<%T>", pk)
 }
 
 // classifyMember runs Classify for a member of the given enclosing class,

--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -745,33 +745,19 @@ var ExplicitDrops = set.FromSlice([]string{
 	"ParameterDecorator",
 })
 
-// SingletonMember identifies one member of a flattened singleton.
-// Singleton is the dotted runtime path of the singleton itself, such
-// as "Math", which carries the enclosing namespace when the singleton
-// is declared inside one. Key is the dotted form of a computed key,
-// such as "Symbol.toStringTag".
+// SingletonMember identifies one member of a flattened singleton by
+// the singleton's dotted runtime path, such as "Math", and the key it
+// is declared under, such as "Symbol.toStringTag".
 type SingletonMember struct {
 	Singleton string
 	Key       string
 }
 
 // AllowedSingletonKeyDrops names the singleton members flattenSingleton
-// skips without reporting. Flattening emits one top-level declaration
-// per member, and each needs a plain identifier twice over, once for
-// the Escalier binding and once for the `@js("Math.abs")` path. A
-// computed key has neither, so the member is dropped.
-//
-// The three entries below are the whole set over the pinned lib set.
-// Each declares `readonly [Symbol.toStringTag]: string`, which tags the
-// object for `Object.prototype.toString`. No Escalier program names
-// that member, so dropping it loses nothing a caller could reach.
-//
-// A skip outside this list is reported by ReportSingletonKeyDrops, so
-// a TypeScript bump that adds a callable symbol-keyed member to a
-// singleton surfaces instead of being absorbed. What such a member
-// lowers to is decided once one appears. §3.2 already makes
-// `@js("Math[Symbol.dispose]")` expressible, and the open question is
-// what to call the Escalier-side binding.
+// skips without reporting: the three `[Symbol.toStringTag]` tags the
+// pinned lib set declares, which no Escalier program can name.
+// ReportSingletonKeyDrops surfaces any skip outside this list, so a
+// TypeScript bump that adds one cannot be absorbed silently.
 var AllowedSingletonKeyDrops = set.FromSlice([]SingletonMember{
 	{Singleton: "Math", Key: "Symbol.toStringTag"},
 	{Singleton: "JSON", Key: "Symbol.toStringTag"},

--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -745,6 +745,39 @@ var ExplicitDrops = set.FromSlice([]string{
 	"ParameterDecorator",
 })
 
+// SingletonMember identifies one member of a flattened singleton.
+// Singleton is the dotted runtime path of the singleton itself, such
+// as "Math", which carries the enclosing namespace when the singleton
+// is declared inside one. Key is the dotted form of a computed key,
+// such as "Symbol.toStringTag".
+type SingletonMember struct {
+	Singleton string
+	Key       string
+}
+
+// AllowedSingletonKeyDrops names the singleton members flattenSingleton
+// skips without reporting. Flattening emits one top-level declaration
+// per member, and each needs a plain identifier twice over, once for
+// the Escalier binding and once for the `@js("Math.abs")` path. A
+// computed key has neither, so the member is dropped.
+//
+// The three entries below are the whole set over the pinned lib set.
+// Each declares `readonly [Symbol.toStringTag]: string`, which tags the
+// object for `Object.prototype.toString`. No Escalier program names
+// that member, so dropping it loses nothing a caller could reach.
+//
+// A skip outside this list is reported by ReportSingletonKeyDrops, so
+// a TypeScript bump that adds a callable symbol-keyed member to a
+// singleton surfaces instead of being absorbed. What such a member
+// lowers to is decided once one appears. §3.2 already makes
+// `@js("Math[Symbol.dispose]")` expressible, and the open question is
+// what to call the Escalier-side binding.
+var AllowedSingletonKeyDrops = set.FromSlice([]SingletonMember{
+	{Singleton: "Math", Key: "Symbol.toStringTag"},
+	{Singleton: "JSON", Key: "Symbol.toStringTag"},
+	{Singleton: "Atomics", Key: "Symbol.toStringTag"},
+})
+
 // DroppedSources is the set of `.d.ts` source-file basenames the
 // converter emits nothing from. Every top-level declaration in such a
 // file is recorded as a drop, whatever its name, so PartitionLib

--- a/internal/dts_to_esc/partition_e2e_test.go
+++ b/internal/dts_to_esc/partition_e2e_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
 	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,4 +134,56 @@ func TestPartitionLib_PinnedLibSet_Bootstraps(t *testing.T) {
 	written, err := WriteConvertedTree(mods, t.TempDir())
 	require.NoError(t, err)
 	require.NotEmpty(t, written)
+}
+
+// TestPartitionLib_SingletonKeyDropsMatchAllowList is the gate for the
+// symbol-keyed-singleton policy. Flattening emits one top-level
+// declaration per member and needs a plain identifier for both the
+// Escalier binding and the `@js(...)` path, so a member under a
+// computed key is dropped. AllowedSingletonKeyDrops names the drops
+// that are expected, and this test pins both directions over the whole
+// pinned lib set: no member outside the list is dropped, and every
+// entry in the list is a drop that actually happens.
+//
+// A TypeScript bump that adds, say, `[Symbol.dispose]` to `Atomics`
+// fails here, and `bootstrap` names it in the same run via
+// ReportSingletonKeyDrops.
+func TestPartitionLib_SingletonKeyDropsMatchAllowList(t *testing.T) {
+	t.Parallel()
+
+	libDir := filepath.Join("..", "..", "node_modules", "typescript", "lib")
+	if _, err := os.Stat(filepath.Join(libDir, "lib.es5.d.ts")); err != nil {
+		t.Skipf("TypeScript lib not present at %s; run `pnpm install`: %v", libDir, err)
+	}
+
+	basenames, err := DiscoverLibFiles(libDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, basenames)
+
+	inputs, err := ParseLibFiles(libDir, basenames)
+	require.NoError(t, err)
+
+	res, err := PartitionLib(inputs)
+	require.NoError(t, err)
+
+	mods, err := ConvertBuckets(res)
+	require.NoError(t, err)
+
+	dropped := set.NewSet[SingletonMember]()
+	for _, mod := range mods {
+		for _, m := range mod.KeyDrops {
+			dropped.Add(m)
+		}
+	}
+	require.ElementsMatch(t,
+		AllowedSingletonKeyDrops.ToSlice(), dropped.ToSlice(),
+		"AllowedSingletonKeyDrops must name exactly the singleton members "+
+			"the pinned lib set drops")
+
+	// The report is the operator-facing half of the gate: with the
+	// allow-list matching, a bootstrap run prints nothing about
+	// singleton keys.
+	var sb strings.Builder
+	require.NoError(t, ReportSingletonKeyDrops(mods, &sb))
+	require.Empty(t, sb.String())
 }

--- a/internal/dts_to_esc/partition_writer.go
+++ b/internal/dts_to_esc/partition_writer.go
@@ -787,3 +787,49 @@ func ReportPartition(result *PartitionResult, w io.Writer) error {
 	_, err := io.WriteString(w, b.String())
 	return err
 }
+
+// ReportSingletonKeyDrops prints one line per singleton member the
+// conversion skipped because the member's key has no plain-name form
+// and AllowedSingletonKeyDrops does not cover it. Nothing is written
+// when every skip was allow-listed, which is the state over the pinned
+// lib set.
+//
+// The bootstrap subcommand calls this after ReportPartition, so a
+// member a TypeScript bump adds under a computed key shows up next to
+// the top-level drop counts instead of vanishing into the flattener.
+func ReportSingletonKeyDrops(mods map[string]*StandaloneModule, w io.Writer) error {
+	type entry struct {
+		uri    string
+		member SingletonMember
+	}
+	var entries []entry
+	for uri, mod := range mods {
+		for _, m := range mod.KeyDrops {
+			if AllowedSingletonKeyDrops.Contains(m) {
+				continue
+			}
+			entries = append(entries, entry{uri: uri, member: m})
+		}
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.uri != b.uri {
+			return a.uri < b.uri
+		}
+		if a.member.Singleton != b.member.Singleton {
+			return a.member.Singleton < b.member.Singleton
+		}
+		return a.member.Key < b.member.Key
+	})
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "  singleton members skipped for a non-name key: %d\n", len(entries))
+	for _, e := range entries {
+		fmt.Fprintf(&b, "    %s %s[%s]\n", e.uri, e.member.Singleton, e.member.Key)
+	}
+	_, err := io.WriteString(w, b.String())
+	return err
+}

--- a/internal/dts_to_esc/partition_writer_test.go
+++ b/internal/dts_to_esc/partition_writer_test.go
@@ -647,6 +647,46 @@ func TestReportPartition_SeparatesDropCauses(t *testing.T) {
 	require.Contains(t, out, "dropped source lib.scripthost.d.ts: 2 decls")
 }
 
+func TestReportSingletonKeyDrops(t *testing.T) {
+	t.Parallel()
+	mods := map[string]*StandaloneModule{
+		"std:math": {KeyDrops: []SingletonMember{
+			{Singleton: "Math", Key: "Symbol.dispose"},
+		}},
+		"std:intl": {KeyDrops: []SingletonMember{
+			{Singleton: "Intl", Key: "Symbol.toStringTag"},
+			{Singleton: "Intl", Key: "Symbol.dispose"},
+		}},
+		"std:json": {},
+	}
+	var sb strings.Builder
+	require.NoError(t, ReportSingletonKeyDrops(mods, &sb))
+	require.Equal(t,
+		"  singleton members skipped for a non-name key: 3\n"+
+			"    std:intl Intl[Symbol.dispose]\n"+
+			"    std:intl Intl[Symbol.toStringTag]\n"+
+			"    std:math Math[Symbol.dispose]\n",
+		sb.String())
+}
+
+func TestReportSingletonKeyDrops_SilentWhenAllAllowListed(t *testing.T) {
+	t.Parallel()
+	// Every skip over the pinned lib set is in AllowedSingletonKeyDrops,
+	// so a run that reaches this state prints nothing at all rather than
+	// a "0 drops" line the operator has to read past.
+	mods := map[string]*StandaloneModule{
+		"std:math": {KeyDrops: []SingletonMember{
+			{Singleton: "Math", Key: "Symbol.toStringTag"},
+		}},
+		"std:json": {KeyDrops: []SingletonMember{
+			{Singleton: "JSON", Key: "Symbol.toStringTag"},
+		}},
+	}
+	var sb strings.Builder
+	require.NoError(t, ReportSingletonKeyDrops(mods, &sb))
+	require.Empty(t, sb.String())
+}
+
 func TestConvertBucketsAndWriteConvertedTree(t *testing.T) {
 	t.Parallel()
 	es5 := parseLib(t, "lib.es5.d.ts", `

--- a/internal/dts_to_esc/partition_writer_test.go
+++ b/internal/dts_to_esc/partition_writer_test.go
@@ -656,15 +656,19 @@ func TestReportSingletonKeyDrops(t *testing.T) {
 		"std:intl": {KeyDrops: []SingletonMember{
 			{Singleton: "Intl", Key: "Symbol.toStringTag"},
 			{Singleton: "Intl", Key: "Symbol.dispose"},
+			{Singleton: "Intl.DisplayNames", Key: "Symbol.dispose"},
 		}},
 		"std:json": {},
 	}
 	var sb strings.Builder
 	require.NoError(t, ReportSingletonKeyDrops(mods, &sb))
+	// Sorted by package, then singleton, then key, so two singletons in
+	// one package stay grouped.
 	require.Equal(t,
-		"  singleton members skipped for a non-name key: 3\n"+
+		"  singleton members skipped for a non-name key: 4\n"+
 			"    std:intl Intl[Symbol.dispose]\n"+
 			"    std:intl Intl[Symbol.toStringTag]\n"+
+			"    std:intl Intl.DisplayNames[Symbol.dispose]\n"+
 			"    std:math Math[Symbol.dispose]\n",
 		sb.String())
 }

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -245,6 +245,9 @@ func runBootstrap(args []string, stderr io.Writer) error {
 	if err := dts_to_esc.ReportPartition(result, stderr); err != nil {
 		return err
 	}
+	if err := dts_to_esc.ReportSingletonKeyDrops(mods, stderr); err != nil {
+		return err
+	}
 	if join == nil {
 		return nil
 	}


### PR DESCRIPTION
Fixes #1338

When flattening singleton interfaces, members under computed keys (like `[Symbol.toStringTag]`) or numeric keys are skipped because they have no plain identifier form for both the Escalier binding and the `@js(...)` path. This change makes those drops visible and auditable.

**Key changes:**

- Added `SingletonMember` type to identify dropped members by singleton name and key
- Added `AllowedSingletonKeyDrops` allow-list covering the three expected drops in the pinned TypeScript lib (all `Symbol.toStringTag` on Math, JSON, and Atomics)
- Extended `StandaloneModule` with a `KeyDrops` field to accumulate drops during conversion
- Modified `flattenSingleton` to record every skipped member via `noteSingletonKeyDrop`, including accessor members (getters/setters) under non-name keys
- Added `singletonKeyLabel` to render property keys for reporting: computed keys as dotted expressions (e.g., "Symbol.toStringTag"), numeric keys as their literal text
- Added `ReportSingletonKeyDrops` to print drops not in the allow-list, surfacing unexpected members from TypeScript bumps
- Integrated the report into the bootstrap subcommand after partition reporting
- Added comprehensive tests covering numeric keys, nested singletons, and accessor members

The allow-list gates the policy: a TypeScript bump adding a callable symbol-keyed member to a singleton will fail the new test and be named by the bootstrap report, preventing silent absorption into the flattener.

https://claude.ai/code/session_01Q25wV4wBtxSFVsY52kvrRU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reporting for singleton members skipped during standalone declaration conversion when their property keys cannot be represented by plain names.
  - Reports include the affected singleton and property key, sorted for easier review.
  - Recognized standard-library cases are suppressed from the report through an allowlist.
  - Conversion commands now display these findings and stop if the report cannot be written.

- **Tests**
  - Added coverage for nested members, computed and numeric keys, accessors, sorting, and allowlisted cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->