### PR TITLE
Parse negative number literal types and keyword property names

### DIFF
--- a/internal/dts_to_esc/partition_e2e_test.go
+++ b/internal/dts_to_esc/partition_e2e_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPartitionLib_LibES5_EndToEnd is the §6 round-trip gate: every `.esc` file
-// the pipeline emits from the pinned TypeScript's lib.es5.d.ts must parse with
-// Escalier's own parser, because `check` and `regenerate` re-read each committed
-// file before diffing it. It covers 17 of the 22 packages the routed lib files
-// produce; two converter gaps block the rest, unmapped names such as `FlatArray`
-// and computed singleton keys such as `Atomics[Symbol.toStringTag]`.
+// TestPartitionLib_LibES5_EndToEnd runs the round-trip gate over lib.es5.d.ts
+// alone. Every `.esc` file the pipeline emits from it must parse with Escalier's
+// own parser. Naming one lib file keeps a failure readable. A break in the es5
+// surface fails here rather than only in
+// TestPartitionLib_PinnedLibSet_Bootstraps, which runs the whole pinned set.
+// This test also holds the unmapped-symbol fail-safe check at the end.
 func TestPartitionLib_LibES5_EndToEnd(t *testing.T) {
 	t.Parallel()
 
@@ -67,11 +67,15 @@ func TestPartitionLib_LibES5_EndToEnd(t *testing.T) {
 
 // TestPartitionLib_PinnedLibSet_Bootstraps gates the whole pinned
 // TypeScript lib set. Routing it must complete and write a tree rather
-// than abort on the §6.1 unmapped-symbol fail-safe. The test runs the
+// than abort on the §6.1 unmapped-symbol fail-safe, and every file the
+// run emits must parse with Escalier's own parser. The test runs the
 // three steps `dts_to_esc bootstrap` runs — route, convert, write —
 // against node_modules/typescript/lib.
 //
-// Whether the files it emits parse is a separate gate. See #1324.
+// The parse assertion is the §6 gate `check` and `regenerate` depend on,
+// since both re-read every file in the tree before diffing it. A file
+// they cannot re-read makes the tree unusable, so the printer must never
+// emit a construct the parser rejects.
 func TestPartitionLib_PinnedLibSet_Bootstraps(t *testing.T) {
 	t.Parallel()
 
@@ -129,7 +133,23 @@ func TestPartitionLib_PinnedLibSet_Bootstraps(t *testing.T) {
 	mods, err := ConvertBuckets(res)
 	require.NoError(t, err)
 
-	written, err := WriteConvertedTree(mods, t.TempDir())
+	outDir := t.TempDir()
+	written, err := WriteConvertedTree(mods, outDir)
 	require.NoError(t, err)
 	require.NotEmpty(t, written)
+
+	for _, uri := range written {
+		pkg, ok := PackageForURI(uri)
+		require.True(t, ok, "URI %q from result must be a known package", uri)
+		path := filepath.Join(outDir, filepath.FromSlash(pkg.File))
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err, "%s should be on disk", path)
+		require.NotEmpty(t, contents, "%s should not be empty", path)
+
+		_, parseErrs := parser.ParseDecls(context.Background(), &ast.Source{
+			Path:     path,
+			Contents: string(contents),
+		})
+		require.Empty(t, parseErrs, "%s must parse back", pkg.File)
+	}
 }

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -280,19 +280,11 @@ loop:
 }
 
 // keywordNamesAProperty reports whether the keyword at propToken names the
-// property read after dotToken. Everything after a `.` is a name position, so a
-// keyword belongs there. `Symbol.match` reads the well-known symbol `RegExp`
-// declares its matcher under, and `obj.catch` reads an ordinary property.
-//
-// The keyword has to sit on the same line as the dot. Someone mid-edit leaves
-// `obj.` dangling at the end of a line. Reading the next line's leading keyword
-// as the property name would swallow whatever that line starts, a declaration
-// or a `return` alike. Requiring the same line keeps that recovery whole.
-// RECOVERY.md states the same rule for the initializer of a `val`.
-//
-// A member chain broken before the dot is unaffected, since the break leaves the
-// dot and the name together on the line that reads `.match(x)`. An identifier
-// after the dot is accepted on any line, so this narrows only keywords.
+// property read after dotToken. Everything after a `.` is a name position, so
+// `Symbol.match` and `obj.catch` both read a property. The keyword must sit on
+// the dot's line. A dangling `obj.` left mid-edit would otherwise take the next
+// line's leading keyword and swallow the statement it opens, as RECOVERY.md
+// describes for the initializer of a `val`.
 func (p *Parser) keywordNamesAProperty(dotToken, propToken *Token) bool {
 	return isKeyword(propToken.Type) &&
 		propToken.Span.Start.Line == dotToken.Span.Start.Line

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -232,8 +232,9 @@ loop:
 			}
 			prop := p.lexer.peek()
 			// nolint: exhaustive
-			switch prop.Type {
-			case Identifier, Underscore, String, Number, Boolean, Bigint:
+			switch {
+			case prop.Type == Identifier || prop.Type == Underscore ||
+				p.keywordNamesAProperty(token, prop):
 				p.lexer.consume()
 				obj := expr
 				prop := ast.NewIdentifier(prop.Value, prop.Span)
@@ -276,6 +277,25 @@ loop:
 	}
 
 	return expr
+}
+
+// keywordNamesAProperty reports whether the keyword at propToken names the
+// property read after dotToken. Everything after a `.` is a name position, so a
+// keyword belongs there. `Symbol.match` reads the well-known symbol `RegExp`
+// declares its matcher under, and `obj.catch` reads an ordinary property.
+//
+// The keyword has to sit on the same line as the dot. Someone mid-edit leaves
+// `obj.` dangling at the end of a line. Reading the next line's leading keyword
+// as the property name would swallow whatever that line starts, a declaration
+// or a `return` alike. Requiring the same line keeps that recovery whole.
+// RECOVERY.md states the same rule for the initializer of a `val`.
+//
+// A member chain broken before the dot is unaffected, since the break leaves the
+// dot and the name together on the line that reads `.match(x)`. An identifier
+// after the dot is accepted on any line, so this narrows only keywords.
+func (p *Parser) keywordNamesAProperty(dotToken, propToken *Token) bool {
+	return isKeyword(propToken.Type) &&
+		propToken.Span.Start.Line == dotToken.Span.Start.Line
 }
 
 // objExprKey parses the name of an object member: a property in an object

--- a/internal/parser/keyword_names_test.go
+++ b/internal/parser/keyword_names_test.go
@@ -357,3 +357,96 @@ func TestGetAndSetInObjectLiterals(t *testing.T) {
 		})
 	}
 }
+
+// memberPropertyName returns the property name in `val a = <src>`, or "" when
+// the source did not parse to a member access. A `.d.ts` reaches this position
+// through a computed key such as `[Symbol.match]`, which the converter emits for
+// every well-known symbol a class declares a member under.
+func memberPropertyName(t *testing.T, src string) string {
+	t.Helper()
+	script, errors := parseScriptSrc(t, "val a = "+src)
+	if len(errors) > 0 {
+		return ""
+	}
+	decl, ok := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.VarDecl)
+	if !ok || decl.Init == nil {
+		return ""
+	}
+	member, ok := decl.Init.(*ast.MemberExpr)
+	if !ok {
+		return ""
+	}
+	return member.Prop.Name
+}
+
+// Everything after a `.` is a name position, so every keyword reads as the
+// property being accessed. `Symbol.match` is the case the converter needs, since
+// `RegExp` declares its matcher under that well-known symbol.
+func TestKeywordsNamePropertiesAfterADot(t *testing.T) {
+	t.Parallel()
+	for _, keyword := range keywordTexts() {
+		require.Equal(t, keyword, memberPropertyName(t, "Symbol."+keyword),
+			"Symbol.%s should read %q as the property", keyword, keyword)
+		require.Equal(t, keyword, memberPropertyName(t, "Symbol?."+keyword),
+			"Symbol?.%s should read %q as the property", keyword, keyword)
+	}
+}
+
+// The well-known symbols the converter emits as computed keys. Only `match` is a
+// keyword today, so the rest guard against a later keyword addition silently
+// breaking one of them.
+func TestWellKnownSymbolComputedKeys(t *testing.T) {
+	t.Parallel()
+	symbols := []string{
+		"asyncDispose", "asyncIterator", "dispose", "hasInstance", "iterator",
+		"match", "matchAll", "metadata", "replace", "search", "species", "split",
+		"toPrimitive", "toStringTag", "unscopables",
+	}
+	for _, symbol := range symbols {
+		t.Run(symbol, func(t *testing.T) {
+			t.Parallel()
+			src := fmt.Sprintf("{\n    [Symbol.%s](self) -> string\n}", symbol)
+			typeAnn, errors := parseTypeAnnSrc(t, src)
+			require.Empty(t, errors, "%s should parse", src)
+			require.NotNil(t, typeAnn)
+		})
+	}
+}
+
+// A dangling `.` left mid-edit must not take the next line's leading keyword as
+// its property name. Whatever that line starts survives as its own statement,
+// whether a declaration or a statement keyword such as `return`.
+func TestADanglingDotDoesNotSwallowTheNextLine(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"val", "val a = obj.\nval c = 1"},
+		{"declare fn", "val a = obj.\ndeclare fn f() -> undefined"},
+		{"fn", "val a = obj.\nfn g() {}"},
+		{"type", "val a = obj.\ntype T = number"},
+		{"return", "val a = obj.\nreturn 1"},
+		{"throw", "val a = obj.\nthrow 1"},
+		{"import", "val a = obj.\nimport \"foo\""},
+		{"try", "val a = obj.\ntry {} catch {}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			script, errors := parseScriptSrc(t, tt.input)
+			require.NotEmpty(t, errors)
+			require.Equal(t, "expected an identifier after .", errors[0].Message)
+			require.Len(t, script.Stmts, 2, "the line after the dot should survive")
+		})
+	}
+}
+
+// A chain broken before the dot keeps the dot and the name together, so a
+// keyword member still reads across lines the way it is normally written.
+func TestAChainBrokenBeforeTheDotNamesAProperty(t *testing.T) {
+	t.Parallel()
+	script, errors := parseScriptSrc(t, "val a = obj\n    .match(x)")
+	require.Empty(t, errors)
+	require.Len(t, script.Stmts, 1)
+}

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -26,11 +26,8 @@ type TypeAnnOp struct {
 }
 
 // noPrimaryTypeAnn is what primaryTypeAnn returns when the token it is looking
-// at starts no type annotation. A nil return tells the caller nothing was
-// consumed, so it is only correct while the parse really did consume nothing.
-// A lifetime prefix already read cannot be given back, so that case reports and
-// recovers to an ErrorTypeAnn spanning the lifetime instead. The nil path stays
-// silent because each caller writes its own message.
+// at starts no type annotation. Nil tells the caller nothing was consumed, so a
+// lifetime prefix already read recovers to an ErrorTypeAnn instead.
 func (p *Parser) noPrimaryTypeAnn(lifetime ast.LifetimeAnnNode) ast.TypeAnn {
 	if lifetime != nil {
 		p.reportError(lifetime.Span(), "expected a type annotation after lifetime")

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -25,6 +25,20 @@ type TypeAnnOp struct {
 	Arity int
 }
 
+// noPrimaryTypeAnn is what primaryTypeAnn returns when the token it is looking
+// at starts no type annotation. A nil return tells the caller nothing was
+// consumed, so it is only correct while the parse really did consume nothing.
+// A lifetime prefix already read cannot be given back, so that case reports and
+// recovers to an ErrorTypeAnn spanning the lifetime instead. The nil path stays
+// silent because each caller writes its own message.
+func (p *Parser) noPrimaryTypeAnn(lifetime ast.LifetimeAnnNode) ast.TypeAnn {
+	if lifetime != nil {
+		p.reportError(lifetime.Span(), "expected a type annotation after lifetime")
+		return ast.NewErrorTypeAnn(lifetime.Span())
+	}
+	return nil
+}
+
 // typeAnnRequired wraps typeAnn() and guarantees a non-nil return.
 // If typeAnn() returns nil, it reports an error and returns ErrorTypeAnn.
 // Use this in places where a type annotation is syntactically required
@@ -352,6 +366,30 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 		case Undefined:
 			p.lexer.consume()
 			typeAnn = ast.NewLitTypeAnn(ast.NewUndefined(token.Span), token.Span)
+		case Minus:
+			// A negative number literal type such as `-1`. The sign is part of the
+			// literal rather than an operator applied to a type, matching how
+			// TypeScript reads it, and the `.d.ts` surface depends on that:
+			// `readonly TIMEOUT_IGNORED: -1` on WebGL2, and the depth counter
+			// `[-1, 0, 1, … 20][Depth]` in `FlatArray`.
+			//
+			// The two mapped-type modifiers that also open with `-`, `-readonly [`
+			// and `-?`, each require their own following token and restore the lexer
+			// otherwise, so neither competes for a `-` that a number follows.
+			numToken := p.lexer.peek2()
+			if numToken.Type != NumLit {
+				return p.noPrimaryTypeAnn(lifetime)
+			}
+			p.lexer.consume() // consume '-'
+			p.lexer.consume() // consume the number
+			span := ast.NewSpan(token.Span.Start, numToken.Span.End, p.lexer.source.ID)
+			value, err := strconv.ParseFloat(numToken.Value, 64)
+			if err != nil {
+				p.reportError(span, "Expected a number")
+				typeAnn = ast.NewErrorTypeAnn(span)
+				break
+			}
+			typeAnn = ast.NewLitTypeAnn(ast.NewNumber(-value, span), span)
 		case NumLit:
 			p.lexer.consume()
 			value, err := strconv.ParseFloat(token.Value, 64)
@@ -507,18 +545,7 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 			span := ast.MergeSpans(token.Span, value.Span())
 			typeAnn = ast.NewRestSpreadTypeAnn(value, span)
 		default:
-			// If we already consumed a lifetime prefix, we can't return nil —
-			// that would violate the "nil means no consumption" contract.
-			// Report the missing type and return an ErrorTypeAnn whose span
-			// covers the lifetime we consumed.
-			if lifetime != nil {
-				p.reportError(lifetime.Span(),
-					"expected a type annotation after lifetime")
-				return ast.NewErrorTypeAnn(lifetime.Span())
-			}
-			// Return nil without consuming — signals "no type annotation found."
-			// Callers provide their own contextual error messages.
-			return nil
+			return p.noPrimaryTypeAnn(lifetime)
 		}
 	}
 

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/printer"
 	"github.com/escalier-lang/escalier/internal/snapshot"
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseTypeAnnNoErrors(t *testing.T) {
@@ -384,6 +386,103 @@ func TestParseTypeAnnErrorHandling(t *testing.T) {
 			snaps.MatchSnapshot(t, snapshot.String(typeAnn))
 			assert.Greater(t, len(parser.errors), 0, "Expected parsing errors but got none")
 			snaps.MatchSnapshot(t, snapshot.String(parser.errors))
+		})
+	}
+}
+
+// A negative number literal type. The sign belongs to the literal rather than to
+// an operator, so `-1` is one annotation. The `.d.ts` surface reaches it two
+// ways, and each fails through its own code path when the rule is missing. A
+// bare annotation reports through typeAnnRequired. A tuple element reports the
+// bracket mismatch instead.
+func TestParseNegativeNumberLiteralTypes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare annotation", "-1", "-1"},
+		{"fractional", "-1.5", "-1.5"},
+		{"negative zero", "-0", "-0"},
+		// `readonly TIMEOUT_IGNORED: -1` on WebGL2RenderingContext.
+		{"object property", "{readonly TIMEOUT_IGNORED: -1}",
+			"{\n    readonly TIMEOUT_IGNORED: -1\n}"},
+		// The depth counter `FlatArray` indexes, `[-1, 0, 1, … 20][Depth]`.
+		{"tuple element", "[-1, 0, 1]", "[-1, 0, 1]"},
+		{"indexed tuple element", "[-1, 0, 1][Depth]", "[-1, 0, 1][Depth]"},
+		{"union member", "-1 | 0 | 1", "-1 | 0 | 1"},
+		{"positive is unchanged", "[1, 2]", "[1, 2]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			typeAnn, errors := parseTypeAnnSrc(t, tt.input)
+			require.Empty(t, errors, "%s should parse", tt.input)
+			require.NotNil(t, typeAnn)
+
+			// The printer emits these, so the printed form has to parse back to
+			// the same thing. A parse-only test would pass while leaving the
+			// round-trip the converter depends on broken.
+			printed, err := printer.Print(typeAnn, printer.DefaultOptions())
+			require.NoError(t, err)
+			require.Equal(t, tt.want, printed)
+
+			reparsed, reparseErrors := parseTypeAnnSrc(t, printed)
+			require.Empty(t, reparseErrors, "%q should parse back", printed)
+			reprinted, err := printer.Print(reparsed, printer.DefaultOptions())
+			require.NoError(t, err)
+			require.Equal(t, printed, reprinted, "printing should be stable")
+		})
+	}
+}
+
+// A `-` that no number follows is not a type. Neither mapped-type modifier that
+// opens with `-` claims it either, so the annotation is still missing.
+func TestAMinusWithoutANumberIsNotAType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"minus then a name", "-Foo"},
+		{"minus alone", "-"},
+		{"minus then a string", `-"a"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, errors := parseTypeAnnSrc(t, "{x: "+tt.input+"}")
+			require.NotEmpty(t, errors, "%s should report", tt.input)
+			require.Equal(t, "expected a type annotation", errors[0].Message)
+		})
+	}
+
+	// A lifetime read before the `-` cannot be given back, so declining the
+	// token reports against the lifetime rather than returning nil, which the
+	// caller would read as "nothing was consumed".
+	t.Run("after a lifetime", func(t *testing.T) {
+		t.Parallel()
+		_, errors := parseTypeAnnSrc(t, "{x: 'a -Foo}")
+		require.NotEmpty(t, errors)
+		require.Equal(t, "expected a type annotation after lifetime", errors[0].Message)
+	})
+}
+
+// The mapped-type modifiers that open with `-` keep working, since each requires
+// its own following token rather than a number.
+func TestMappedTypeMinusModifiers(t *testing.T) {
+	t.Parallel()
+	tests := []struct{ name, input string }{
+		{"remove readonly", "{-readonly [K]: T[K] for K in keyof T}"},
+		{"remove optional", "{[K]-?: T[K] for K in keyof T}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			typeAnn, errors := parseTypeAnnSrc(t, tt.input)
+			require.Empty(t, errors, "%s should parse", tt.input)
+			require.NotNil(t, typeAnn)
 		})
 	}
 }


### PR DESCRIPTION
Refs #1227

`dts_to_esc bootstrap` writes 49 pseudo-package `.esc` files and 4 of them were rejected by Escalier's own parser, which blocks the §6 gate. `check` and `regenerate` both re-read every file before diffing it, so a tree holding one of them is unusable, and §7 would hand-edit files the tooling cannot read back.

Two printer/parser gaps account for all 4 failures.

## Gap 1 — negative number literal types

The type-annotation parser consumed a bare number token and had no rule for a leading `-`, so two files failed through different code paths:

- `web/webgl.esc:284` — `readonly TIMEOUT_IGNORED: -1` reported `expected a type annotation` through `typeAnnRequired`.
- `std/array.esc:395` — the `FlatArray` depth counter `[-1, 0, 1, … 20][Depth]` reported `Expected ] but got -` from the tuple parser.

`primaryTypeAnn` now accepts `-` immediately followed by a number literal and folds the sign into the value, matching how TypeScript reads `-1` as one literal rather than negation applied to a type.

**On the ambiguity check the issue asked for:** the two other type-level uses of `-` are the mapped-type modifiers `-readonly [` and `-?`. Each requires its own following token and restores the lexer otherwise, so neither competes for a `-` that a number follows. `TestMappedTypeMinusModifiers` pins both.

## Gap 2 — a keyword after `.`

`Symbol.match` is parsed as an expression, and `match` is a keyword token, so the member-access loop fell to its recovery arm:

- `std/regexp.esc:31` and `std/string.esc:130` — `[Symbol.match](…)` reported `expected an identifier after .`

Every position after a dot is a name position, so a keyword names the property there. This follows #1333's precedent and reuses its `isKeyword` helper rather than special-casing `Match`.

Of the well-known symbols the converter emits as computed keys — `replace`, `search`, `split`, `matchAll`, `iterator`, `toStringTag` and the rest — only `match` is a keyword today. `TestWellKnownSymbolComputedKeys` covers all 15 so a later keyword addition cannot silently break one.

**The keyword must sit on the same line as the dot.** A dangling `obj.` left mid-edit would otherwise take the next line's leading keyword as the property name and swallow the statement it opens. `RECOVERY.md:87` states the same rule for the initializer of a `val`. A chain broken before the dot is unaffected, since `obj` / `.match(x)` keeps the dot and name together. An identifier after the dot is still accepted on any line, so this narrows only keywords.

## Tests

- `TestParseNegativeNumberLiteralTypes` covers the bare annotation and the tuple element separately, since they fail through different paths, plus object, union, and indexed-tuple positions. Each case asserts print → parse → print is stable, not just that the input parses.
- `TestAMinusWithoutANumberIsNotAType` and `TestMappedTypeMinusModifiers` pin what the new rule must not claim.
- `TestKeywordsNamePropertiesAfterADot` sweeps every keyword the lexer knows through `Symbol.<kw>` and `Symbol?.<kw>`, so a keyword added later is covered without editing the test.
- `TestADanglingDotDoesNotSwallowTheNextLine` covers `val`, `declare fn`, `fn`, `type`, `return`, `throw`, `import`, and `try`, asserting the full error message and that both statements survive.
- `TestPartitionLib_PinnedLibSet_Bootstraps` now asserts every file the run emits parses. That is the §6 criterion stated as an assertion; it skips without the pinned TypeScript libs, so CI stays green.

## Verification

All 49 emitted files parse, and `check` runs to completion after a `bootstrap`:

```
$ /tmp/dts_to_esc bootstrap node_modules/typescript/lib /tmp/tree
$ /tmp/dts_to_esc check node_modules/typescript/lib /tmp/tree
discovered 88 lib files
check: 0 missing declarations, 0 missing members, 0 extra declarations
```

`go test ./...` passes. Re-running with `UPDATE_SNAPS=true` and `UPDATE_FIXTURES=true` produced no drift.

Each fix was mutation-checked: reverting either gap fails both its own unit test and the whole-set bootstrap gate, and removing the same-line guard fails the dangling-dot test.

https://claude.ai/code/session_016Focx7gpnHnhnuUHCdXkvo

---
_Generated by [Claude Code](https://claude.ai/code/session_016Focx7gpnHnhnuUHCdXkvo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of member access when property names match reserved keywords.
  - Prevented incomplete member expressions from incorrectly consuming content on the following line.
  - Added support for negative numeric literal types, including nested, union, and indexed type expressions.
  - Improved recovery and error reporting for incomplete or invalid type annotations.

- **Compatibility**
  - Enhanced handling of well-known symbol properties and multiline member chains.
  - Strengthened validation of converted declaration files to ensure generated output parses successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->