### PR TITLE
Fix readonly modifier on computed-key interface members

### DIFF
--- a/internal/parser/readonly_computed_key_test.go
+++ b/internal/parser/readonly_computed_key_test.go
@@ -122,6 +122,51 @@ func TestReadonlyOnComputedKeyClassField(t *testing.T) {
 	}
 }
 
+// `+readonly` and `-readonly` add and remove the modifier on the members a mapped type
+// generates. Neither means anything on the property a computed key names, so a member
+// carrying one without the `for` clause that makes it a mapped type is reported rather
+// than read as an unmodified property. The members after it still parse.
+func TestAddAndRemoveModifiersNeedAMappedType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string
+	}{
+		{"add", "{+readonly [Symbol.toStringTag]: string}", "'+readonly' is only valid on a mapped type"},
+		{"remove", "{-readonly [Symbol.toStringTag]: string}", "'-readonly' is only valid on a mapped type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			typeAnn, errors := parseTypeAnnSrc(t, tt.src)
+			require.Len(t, errors, 1)
+			require.Equal(t, tt.wantErr, errors[0].Message)
+			obj, ok := typeAnn.(*ast.ObjectTypeAnn)
+			require.True(t, ok, "%s should be an object type", tt.src)
+			require.Len(t, obj.Elems, 1)
+			prop, ok := obj.Elems[0].(*ast.PropertyTypeAnn)
+			require.True(t, ok, "%s should be a property", tt.src)
+			require.IsType(t, &ast.ComputedKey{}, prop.Name)
+			require.False(t, prop.Readonly)
+		})
+	}
+}
+
+// Reporting the modifier leaves the member readable, so the rest of the object type
+// still parses instead of being discarded with it.
+func TestAddModifierKeepsTheMembersAfterIt(t *testing.T) {
+	t.Parallel()
+	src := "{+readonly [Symbol.toStringTag]: string, baz: string}"
+	typeAnn, errors := parseTypeAnnSrc(t, src)
+	require.Len(t, errors, 1)
+	require.Equal(t, "'+readonly' is only valid on a mapped type", errors[0].Message)
+	obj, ok := typeAnn.(*ast.ObjectTypeAnn)
+	require.True(t, ok)
+	require.Len(t, obj.Elems, 2)
+	require.IsType(t, &ast.PropertyTypeAnn{}, obj.Elems[1])
+}
+
 // The mapped-type reading of `readonly [` still wins where a mapped type follows.
 func TestReadonlyBracketStillOpensMappedTypes(t *testing.T) {
 	t.Parallel()

--- a/internal/parser/readonly_computed_key_test.go
+++ b/internal/parser/readonly_computed_key_test.go
@@ -1,0 +1,152 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// `readonly [` opens a mapped type and a computed-key property alike, and only what
+// follows the brackets tells the two apart. The modifier has to survive the attempt to
+// read the member as a mapped type, so assert it on the parsed AST rather than through
+// the printer.
+func TestReadonlyOnComputedKeyInterfaceMember(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		src      string
+		readonly bool
+	}{
+		{"computed key", "{readonly [Symbol.toStringTag]: string}", true},
+		{"computed key, optional", "{readonly [Symbol.toStringTag]?: string}", true},
+		{"computed key, no modifier", "{[Symbol.toStringTag]: string}", false},
+		{"named key", "{readonly bar: string}", true},
+		{"named key, no modifier", "{bar: string}", false},
+		{"string key", `{readonly "bar": string}`, true},
+		{"computed key on a method's own type", "{readonly [Symbol.species]: fn () -> number}", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			typeAnn, errors := parseTypeAnnSrc(t, tt.src)
+			require.Empty(t, errors)
+			obj, ok := typeAnn.(*ast.ObjectTypeAnn)
+			require.True(t, ok, "%s should be an object type", tt.src)
+			require.Len(t, obj.Elems, 1)
+			prop, ok := obj.Elems[0].(*ast.PropertyTypeAnn)
+			require.True(t, ok, "%s should be a property", tt.src)
+			require.Equal(t, tt.readonly, prop.Readonly)
+		})
+	}
+}
+
+// A computed key and a named key in the same interface body each keep their own
+// modifier, and reading the computed member leaves the members after it alone.
+func TestReadonlyOnMixedInterfaceMembers(t *testing.T) {
+	t.Parallel()
+	src := "declare interface Foo {\n" +
+		"    readonly [Symbol.toStringTag]: string,\n" +
+		"    readonly bar: string,\n" +
+		"    baz: string,\n" +
+		"}"
+	script, errors := parseScriptSrc(t, src)
+	require.Empty(t, errors)
+	decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.InterfaceDecl)
+	require.Len(t, decl.TypeAnn.Elems, 3)
+
+	computed := decl.TypeAnn.Elems[0].(*ast.PropertyTypeAnn)
+	require.IsType(t, &ast.ComputedKey{}, computed.Name)
+	require.True(t, computed.Readonly)
+
+	named := decl.TypeAnn.Elems[1].(*ast.PropertyTypeAnn)
+	require.True(t, named.Readonly)
+
+	plain := decl.TypeAnn.Elems[2].(*ast.PropertyTypeAnn)
+	require.False(t, plain.Readonly)
+}
+
+// A mapped type is told from a computed-key property by the `for K in Keys` clause that
+// closes it. Without that clause the brackets name a computed key, and the member that
+// follows has to stay a member of its own rather than be read as the key variable.
+func TestBracketWithoutForClauseIsAComputedKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"readonly, named member next", "{readonly [Symbol.toStringTag]: string, baz: string}"},
+		{"no modifier, named member next", "{[Symbol.toStringTag]: string, baz: string}"},
+		{"readonly, keyword-named member next", "{readonly [Symbol.toStringTag]: string, catch: string}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			typeAnn, errors := parseTypeAnnSrc(t, tt.src)
+			require.Empty(t, errors)
+			obj, ok := typeAnn.(*ast.ObjectTypeAnn)
+			require.True(t, ok, "%s should be an object type", tt.src)
+			require.Len(t, obj.Elems, 2)
+			require.IsType(t, &ast.PropertyTypeAnn{}, obj.Elems[0])
+			require.IsType(t, &ast.PropertyTypeAnn{}, obj.Elems[1])
+		})
+	}
+}
+
+// A class body reaches the same members through parseClassElemInner, so it needs its
+// own assertions to keep the two paths in agreement.
+func TestReadonlyOnComputedKeyClassField(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		member   string
+		readonly bool
+	}{
+		{"computed key", "readonly [Symbol.toStringTag]: string", true},
+		{"computed key, no modifier", "[Symbol.toStringTag]: string", false},
+		{"named key", "readonly bar: string", true},
+		{"named key, no modifier", "bar: string", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			src := "declare class C {\n    " + tt.member + "\n}"
+			script, errors := parseScriptSrc(t, src)
+			require.Empty(t, errors)
+			decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.ClassDecl)
+			require.Len(t, decl.Body, 1)
+			field, ok := decl.Body[0].(*ast.FieldElem)
+			require.True(t, ok, "%s should be a field", src)
+			require.Equal(t, tt.readonly, field.Readonly)
+		})
+	}
+}
+
+// The mapped-type reading of `readonly [` still wins where a mapped type follows.
+func TestReadonlyBracketStillOpensMappedTypes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want ast.MappedModifier
+	}{
+		{"key remapping", "{readonly [K]: T[K] for K in keyof T}", ast.MMAdd},
+		{"index signature shorthand", "{readonly [K: keyof T]: T[K]}", ast.MMAdd},
+		{"added modifier", "{+readonly [K]: T[K] for K in keyof T}", ast.MMAdd},
+		{"removed modifier", "{-readonly [K]: T[K] for K in keyof T}", ast.MMRemove},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			typeAnn, errors := parseTypeAnnSrc(t, tt.src)
+			require.Empty(t, errors)
+			obj, ok := typeAnn.(*ast.ObjectTypeAnn)
+			require.True(t, ok, "%s should be an object type", tt.src)
+			require.Len(t, obj.Elems, 1)
+			mapped, ok := obj.Elems[0].(*ast.MappedTypeAnn)
+			require.True(t, ok, "%s should be a mapped type", tt.src)
+			require.NotNil(t, mapped.ReadOnly)
+			require.Equal(t, tt.want, *mapped.ReadOnly)
+		})
+	}
+}

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -923,6 +923,11 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	mod := ""
 	readonly := false
 
+	// tryParseMappedType consumes a leading `readonly`, `+readonly`, or `-readonly` on
+	// its way to the brackets and rewinds only to them, so once it has run this is the
+	// only record of what the member opened with.
+	firstToken := token
+
 	// `readonly [` opens two different members. A mapped type spells its modifier that
 	// way, and so does a property whose key is computed, as in
 	// `readonly [Symbol.toStringTag]: string`. Only what follows the brackets tells the
@@ -965,11 +970,24 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		return mappedElem
 	}
 
-	// The member is not a mapped type. tryParseMappedType rewound to the brackets and
-	// consumed the `readonly` on its way there. Those brackets hold a computed key, and
-	// the modifier belongs to the property they name.
+	// The member is not a mapped type, so tryParseMappedType rewound to the brackets it
+	// reached, and those brackets hold a computed key.
 	if pendingReadonly {
+		// `readonly` modifies the property the brackets name.
 		readonly = true
+	} else if firstToken.Type == Plus || firstToken.Type == Minus {
+		// `+readonly` and `-readonly` add and remove the modifier on the members a
+		// mapped type generates, and neither means anything on a property. Sitting on
+		// the bracket is what says the prefix was consumed rather than left in place,
+		// so a `+` or `-` that opened something else is not reported here. Name the
+		// prefix and read the member without it, which keeps the members after it.
+		if p.lexer.peek().Type == OpenBracket {
+			modifier := "+readonly"
+			if firstToken.Type == Minus {
+				modifier = "-readonly"
+			}
+			p.reportError(firstToken.Span, "'"+modifier+"' is only valid on a mapped type")
+		}
 	}
 
 	objKey := p.objExprKey()

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -653,6 +653,16 @@ func simpleTypeRefName(t ast.TypeAnn) (string, bool) {
 	return ident.Name, true
 }
 
+// tryParseMappedType parses a mapped type and reports nil when the member ahead is not
+// one. How far a decline rewinds depends on how far the attempt got. Where a bracket
+// follows the leading `readonly`, `+readonly`, or `-readonly`, the rewind stops at that
+// bracket and leaves the modifier consumed, so the caller can read the same brackets as
+// a computed key. Where no bracket follows, nothing was consumed and the modifier stays
+// in place. Either way the diagnostics the attempt produced are dropped.
+//
+// A decline leaves no trace of the modifier, so a caller that needs it has to hold onto
+// it across the call. objTypeAnnElemInner does that for `readonly`, the one spelling a
+// computed-key property can carry.
 func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
 	// Parse readonly modifiers: readonly, +readonly, or -readonly
 	var readonly *ast.MappedModifier
@@ -780,7 +790,16 @@ func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
 
 		key, constraint := shorthandKey, shorthandConstraint
 		if !shorthand {
-			p.expect(For, AlwaysConsume)
+			// A mapped type names its key variable in a trailing `for K in Keys`.
+			// Without that clause the brackets hold a computed key instead, so
+			// decline and leave the member to the property path. Consuming through
+			// the missing `for` would read the next member's name as the key
+			// variable and swallow that member.
+			if p.lexer.peek().Type != For {
+				p.restoreState(savedState)
+				return nil
+			}
+			p.lexer.consume() // consume 'for'
 			token = p.lexer.peek()
 			if token.Type == Identifier {
 				p.lexer.consume() // consume identifier
@@ -904,17 +923,21 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	mod := ""
 	readonly := false
 
-	// Check if this might be a mapped type before consuming 'readonly'
-	// Mapped types start with 'readonly [' or '+readonly [' or '-readonly ['
+	// `readonly [` opens two different members. A mapped type spells its modifier that
+	// way, and so does a property whose key is computed, as in
+	// `readonly [Symbol.toStringTag]: string`. Only what follows the brackets tells the
+	// two apart. So leave the modifier in place for tryParseMappedType to read, and
+	// note that it is still pending. A `readonly` followed by anything else modifies a
+	// property and is consumed here.
+	pendingReadonly := false
 	if token.Type == Readonly && !followsAName(p.lexer.peek2().Type) {
 		savedState := p.saveState()
 		p.lexer.consume() // tentatively consume 'readonly'
 		nextToken := p.lexer.peek()
 		if nextToken.Type == OpenBracket {
-			// This is a mapped type, restore state and let tryParseMappedType handle it
 			p.restoreState(savedState)
+			pendingReadonly = true
 		} else {
-			// This is a regular readonly property, keep the token consumed
 			readonly = true
 		}
 		token = p.lexer.peek()
@@ -940,6 +963,13 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	mappedElem := p.tryParseMappedType()
 	if mappedElem != nil {
 		return mappedElem
+	}
+
+	// The member is not a mapped type. tryParseMappedType rewound to the brackets and
+	// consumed the `readonly` on its way there. Those brackets hold a computed key, and
+	// the modifier belongs to the property they name.
+	if pendingReadonly {
+		readonly = true
 	}
 
 	objKey := p.objExprKey()


### PR DESCRIPTION
Fixes #1346

`readonly [` opens two different members. A mapped type spells its modifier that way, and so does a property whose key is computed, as in `readonly [Symbol.toStringTag]: string`. Only what follows the brackets tells the two apart, so `objTypeAnnElemInner` put the modifier back for `tryParseMappedType` to read. It kept no record of it, so a declined read dropped the modifier and the member parsed as writable.

Every `readonly` computed-key member in the committed `.esc` stdlib loaded that way: `readonly [Symbol.toStringTag]` in `std/bigint.esc`, `std/iterator.esc`, and `std/symbol.esc`, and `readonly [Symbol.unscopables]` and `readonly [Symbol.species]` in `std/array.esc`.

## Changes

- `objTypeAnnElemInner` holds the pending modifier across the call in a `pendingReadonly` flag and applies it to the property the brackets name when the mapped-type read declines. `tryParseMappedType` consumes the `readonly` on its way to those brackets and rewinds only to them, so the flag is what carries the modifier across.
- `tryParseMappedType` peeks for `for` instead of consuming through a missing one. It used `expect(For, AlwaysConsume)`, which swallowed the comma and then read the next member's name as the mapped type's key variable, so `{readonly [Symbol.toStringTag]: string, baz: string}` collapsed into one bogus `MappedTypeAnn` and `baz` disappeared. Both diagnostics were then truncated by the backtrack, which is why nothing surfaced. Without this the first change only works when a keyword-named member happens to follow.
- `+readonly` and `-readonly` on a computed-key property are now reported. They add and remove the modifier on the members a mapped type generates and mean nothing on a property, but the prefix was consumed on the way to the brackets and then silently discarded, so `{+readonly [Symbol.toStringTag]: string}` parsed as an unmodified property with no diagnostic. The member is still read without the prefix, which keeps the members after it. Raised by CodeRabbit in [this thread](https://github.com/escalier-lang/escalier/pull/1348#discussion_r3908480518).
- `internal/parser/readonly_computed_key_test.go` asserts the modifier on the parsed AST rather than through the printer: the object-type path, the class-body counterpart so the two stay in agreement, the `for`-clause case above, both add and remove prefixes, and a check that `readonly [`, `+readonly [`, and `-readonly [` still reach mapped types carrying the right modifier.

`export declare interface Foo { readonly [Symbol.toStringTag]: string, readonly bar: string }` now round-trips through `print ∘ parse` unchanged.

https://claude.ai/code/session_01TkggJqHs2HqQEyNW7eroWo

🤖 Generated with [Claude Code](https://claude.com/claude-code)