### PR TITLE
Fix type predicate conversion to return runtime type

### DIFF
--- a/internal/dts_to_esc/__snapshots__/helper_test.snap
+++ b/internal/dts_to_esc/__snapshots__/helper_test.snap
@@ -1262,12 +1262,22 @@
 ---
 
 [TestConvertTypeAnn/type_predicate - 1]
-&ast.TypeRefTypeAnn{
-    Name: &ast.Ident{
-        Name: "x",
-        span: 1:1-1:2,
+&ast.FuncTypeAnn{
+    Params: []*ast.Param{
+        &ast.Param{
+            Pattern: &ast.IdentPat{
+                Name: "x",
+                span: 1:2-1:8,
+            },
+            TypeAnn: &ast.AnyTypeAnn{
+                span: 1:5-1:8,
+            },
+        },
     },
-    span: 1:1-1:2,
+    Return: &ast.BooleanTypeAnn{
+        span: 1:13-1:24,
+    },
+    span: 1:1-1:24,
 }
 ---
 

--- a/internal/dts_to_esc/helper.go
+++ b/internal/dts_to_esc/helper.go
@@ -622,11 +622,16 @@ func convertTypeAnn(ta dts_parser.TypeAnn) (ast.TypeAnn, error) {
 		}
 		return ast.NewImportType(t.Module, qualifier, typeArgs, t.Span()), nil
 	case *dts_parser.TypePredicate:
-		// Type predicates don't have a direct equivalent in Escalier
-		// Convert to the type being asserted
+		// A type predicate only ever appears as a return type, and Escalier has
+		// no surface for the narrowing it declares. The honest conversion is what
+		// the function returns at runtime, and the two predicate forms differ
+		// there. A guard, `arg is T`, returns a boolean. An assertion,
+		// `asserts arg is T`, either throws or returns no value, so it lowers to
+		// `undefined`. Converting the right-hand type instead would claim that
+		// `isArray(arg: any): arg is any[]` returns an array.
 		// TODO(#229): add support for type predicates to Escalier
-		if t.Type != nil {
-			return convertTypeAnn(t.Type)
+		if t.Asserts {
+			return ast.NewLitTypeAnn(ast.NewUndefined(t.Span()), t.Span()), nil
 		}
 		return ast.NewBooleanTypeAnn(t.Span()), nil
 	case *dts_parser.ThisType:

--- a/internal/dts_to_esc/helper_test.go
+++ b/internal/dts_to_esc/helper_test.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
+	"github.com/escalier-lang/escalier/internal/printer"
 	"github.com/escalier-lang/escalier/internal/snapshot"
 	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConvertIdent(t *testing.T) {
@@ -408,8 +410,8 @@ func TestConvertTypeAnn(t *testing.T) {
 		{"import type with member", `import("module").Foo`},
 		{"import type with type args", `import("module").Foo<T>`},
 
-		// Type predicates
-		{"type predicate", "x is string"},
+		// Type predicates. A predicate only parses in return position.
+		{"type predicate", "(x: any) => x is string"},
 
 		// This type
 		{"this type", "this"},
@@ -465,6 +467,37 @@ func TestConvertTypeAnn(t *testing.T) {
 			}
 
 			snaps.MatchSnapshot(t, snapshot.String(escalierTypeAnn))
+		})
+	}
+}
+
+// A TypeScript type predicate return converts to what the function returns at
+// runtime, never to the type it narrows to. A guard, `arg is T`, returns
+// `boolean`. An assertion, `asserts arg is T`, returns `undefined`.
+func TestConvertTypePredicateReturn(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"guard over a named type", "(arg: any) => arg is ArrayBufferView", "fn (arg: any) -> boolean"},
+		{"guard over an array type", "(arg: any) => arg is any[]", "fn (arg: any) -> boolean"},
+		{"assertion with a type", "(arg: any) => asserts arg is string", "fn (arg: any) -> undefined"},
+		{"assertion without a type", "(arg: any) => asserts arg", "fn (arg: any) -> undefined"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := &ast.Source{Path: "test.d.ts", Contents: tt.input, ID: 0}
+			dtsTypeAnn := dts_parser.NewDtsParser(source).ParseTypeAnn()
+			require.NotNil(t, dtsTypeAnn)
+
+			escTypeAnn, err := convertTypeAnn(dtsTypeAnn)
+			require.NoError(t, err)
+
+			printed, err := printer.Print(escTypeAnn, printer.DefaultOptions())
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, printed)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #1349

A TypeScript type predicate return converted to the type it narrows to. `isArray(arg: any): arg is any[]` in `lib.es5.d.ts` emitted `isArray(arg: any) -> mut Array`, so the declaration claimed the method returns the thing it was testing and every caller branching on it was typed against an array.

Escalier has no surface for the narrowing half of a predicate, so the conversion now emits what the function returns at runtime.

- A guard, `arg is T`, converts to `boolean`.
- An assertion, `asserts arg is T`, either throws or returns no value, so it converts to `undefined`.

`Array.isArray` and `ArrayBuffer.isView` now emit `-> boolean`.

The `TestConvertTypeAnn` entry for predicates parsed `x is string` standalone, which yields a bare type reference rather than a predicate. It now uses the return position, where predicates actually parse, and its snapshot changed accordingly. `TestConvertTypePredicateReturn` covers a guard over a named type and over an array type, plus both assertion forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MR6i5wPo5NoxLe7ms7kwNL