### PR TITLE
dts_to_esc: read and validate the overlay tree

### DIFF
--- a/internal/dts_to_esc/overlay.go
+++ b/internal/dts_to_esc/overlay.go
@@ -1,0 +1,270 @@
+package dts_to_esc
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// OverlayOp is what an overlay file's declarations do to the generated
+// tree. Every declaration in a file takes the file's operation, which
+// comes from the filename rather than from a marker on the declaration:
+// `std/symbol.add.esc` carries OverlayAdd, `std/array.replace.esc`
+// carries OverlayReplace.
+//
+// The parser has no marker to carry this instead. Decorators are its
+// only annotation and internal/parser/decl.go rejects them on
+// `interface`, `type`, `enum`, and `namespace`, which is most of the
+// generated tree. See planning/builtins/implementation_plan.md §6.4.
+type OverlayOp string
+
+const (
+	// OverlayAdd contributes a declaration or member no upstream source
+	// has. A collision with a converted member fails the run.
+	OverlayAdd OverlayOp = "add"
+
+	// OverlayReplace stands in for what the upstream source expresses
+	// wrongly. Each overlay member substitutes the converted member
+	// sharing its key, in place, so a second run leaves the tree
+	// byte-identical.
+	OverlayReplace OverlayOp = "replace"
+
+	// OverlayDrop names what the generator must not emit. A drop file's
+	// declarations are read for their names alone.
+	OverlayDrop OverlayOp = "drop"
+)
+
+// RootDropFile is the one overlay file that sits at the overlay root
+// rather than under a package directory. Its entries are whole symbols
+// that belong to no package — `eval` and `globalThis` — so they resolve
+// during routing, before a package is assigned.
+const RootDropFile = "drop.esc"
+
+// OverlayFile is one parsed overlay fragment.
+type OverlayFile struct {
+	// Path is the file's slash-separated path relative to the overlay
+	// root, such as "std/symbol.add.esc". Error messages name it.
+	Path string
+
+	// Op is the operation the filename carries.
+	Op OverlayOp
+
+	// PkgURI is the package the file applies to, empty for RootDropFile.
+	PkgURI string
+
+	// Decls are the file's top-level declarations, parsed by Escalier's
+	// own parser.
+	Decls []ast.Decl
+}
+
+// Overlay is the parsed contents of internal/interop/overlay/, the third
+// generation input of §6.4 alongside the pinned `.d.ts` set and the
+// ECMA-262 derived facts.
+//
+// Files are sorted by path, so a run applies them in the same order
+// every time.
+type Overlay struct {
+	Files []OverlayFile
+}
+
+// LoadOverlay parses every `.esc` file under dir. These are the only
+// `.esc` files the generator reads, since it never reads a file it
+// wrote. One that does not parse is a defect in a committed input, so
+// the load stops and names it.
+//
+// Recognized layouts, both relative to dir:
+//
+//   - "drop.esc" — package-less whole-symbol drops.
+//   - "<scheme>/<package>.<op>.esc" — an operation on one package, where
+//     "<scheme>/<package>.esc" is that package's generated file. So
+//     "std/symbol.add.esc" applies to the package written to
+//     "std/symbol.esc".
+//
+// Any other `.esc` path is an error. Non-`.esc` files, README.md among
+// them, are ignored.
+func LoadOverlay(dir string) (*Overlay, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading overlay dir %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("overlay path %s is not a directory", dir)
+	}
+
+	var files []OverlayFile
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".esc") {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		op, uri, err := classifyOverlayPath(rel)
+		if err != nil {
+			return err
+		}
+		decls, err := parseOverlayFile(path, rel)
+		if err != nil {
+			return err
+		}
+		if op == OverlayDrop {
+			if err := validateDropDecls(rel, uri, decls); err != nil {
+				return err
+			}
+		}
+		files = append(files, OverlayFile{Path: rel, Op: op, PkgURI: uri, Decls: decls})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return &Overlay{Files: files}, nil
+}
+
+// classifyOverlayPath reads a file's operation and target package out of
+// its overlay-relative path. The empty URI is the root drop file, which
+// names no package.
+func classifyOverlayPath(rel string) (OverlayOp, string, error) {
+	if rel == RootDropFile {
+		return OverlayDrop, "", nil
+	}
+	dir, base, found := strings.Cut(rel, "/")
+	if !found || strings.Contains(base, "/") {
+		return "", "", fmt.Errorf(
+			"overlay: %s sits at neither the overlay root nor a package directory; "+
+				"write a package operation as <scheme>/<package>.<add|replace|drop>.esc "+
+				"and package-less drops as %s", rel, RootDropFile)
+	}
+	stem := strings.TrimSuffix(base, ".esc")
+	name, opText, found := cutLast(stem, ".")
+	if !found {
+		return "", "", fmt.Errorf(
+			"overlay: %s names no operation; the filename carries it, "+
+				"as in %s/%s.replace.esc", rel, dir, stem)
+	}
+	op := OverlayOp(opText)
+	switch op {
+	case OverlayAdd, OverlayReplace, OverlayDrop:
+	default:
+		return "", "", fmt.Errorf(
+			"overlay: %s names the unknown operation %q; the operations are "+
+				"add, replace, and drop", rel, opText)
+	}
+	pkgFile := dir + "/" + name + ".esc"
+	pkg, ok := PackageForFile(pkgFile)
+	if !ok {
+		return "", "", fmt.Errorf(
+			"overlay: %s targets %s, which is not a package in the partition "+
+				"table (see internal/dts_to_esc/partition.go)", rel, pkgFile)
+	}
+	return op, pkg.URI, nil
+}
+
+// cutLast splits s around the last instance of sep, the way strings.Cut
+// splits around the first.
+func cutLast(s, sep string) (before, after string, found bool) {
+	i := strings.LastIndex(s, sep)
+	if i < 0 {
+		return s, "", false
+	}
+	return s[:i], s[i+len(sep):], true
+}
+
+// parseOverlayFile reads and parses one overlay file. rel labels it in
+// errors so a report names the path a contributor typed rather than an
+// absolute one.
+func parseOverlayFile(path, rel string) ([]ast.Decl, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading overlay file %s: %w", rel, err)
+	}
+	decls, parseErrs := parser.ParseDecls(context.Background(), &ast.Source{
+		Path:     path,
+		Contents: string(contents),
+	})
+	if len(parseErrs) > 0 {
+		msgs := make([]string, 0, len(parseErrs))
+		for _, e := range parseErrs {
+			msgs = append(msgs, e.Message)
+		}
+		return nil, fmt.Errorf("overlay: %s does not parse: %s", rel, strings.Join(msgs, "; "))
+	}
+	for _, decl := range decls {
+		if escDeclName(decl) == "" {
+			return nil, fmt.Errorf(
+				"overlay: %s holds a %s with no addressable name; every overlay "+
+					"declaration is matched by name", rel, escDeclKind(decl))
+		}
+	}
+	return decls, nil
+}
+
+// GlobalDrops returns the names in the root drop file. They resolve
+// during routing, ahead of the partition lookup, because a whole-symbol
+// drop belongs to no package.
+func (o *Overlay) GlobalDrops() set.Set[string] {
+	names := set.NewSet[string]()
+	if o == nil {
+		return names
+	}
+	for _, f := range o.Files {
+		if f.Op != OverlayDrop || f.PkgURI != "" {
+			continue
+		}
+		for _, decl := range f.Decls {
+			names.Add(escDeclName(decl))
+		}
+	}
+	return names
+}
+
+// FilesFor returns the overlay files that apply to one package, in the
+// order a run applies them: drops first, then replacements, then
+// additions. Dropping ahead of the other two means an overlay may drop a
+// converted member and add its own in its place.
+func (o *Overlay) FilesFor(uri string) []OverlayFile {
+	if o == nil || uri == "" {
+		return nil
+	}
+	var out []OverlayFile
+	for _, op := range []OverlayOp{OverlayDrop, OverlayReplace, OverlayAdd} {
+		for _, f := range o.Files {
+			if f.PkgURI == uri && f.Op == op {
+				out = append(out, f)
+			}
+		}
+	}
+	return out
+}
+
+// PackageURIs returns every package URI the overlay names, sorted. A
+// package with an `add` file but no upstream declarations is generated
+// from the overlay alone, so the generator reads this to find those.
+func (o *Overlay) PackageURIs() []string {
+	if o == nil {
+		return nil
+	}
+	seen := set.NewSet[string]()
+	for _, f := range o.Files {
+		if f.PkgURI != "" {
+			seen.Add(f.PkgURI)
+		}
+	}
+	uris := seen.ToSlice()
+	sort.Strings(uris)
+	return uris
+}

--- a/internal/dts_to_esc/overlay_drop.go
+++ b/internal/dts_to_esc/overlay_drop.go
@@ -1,0 +1,117 @@
+package dts_to_esc
+
+import (
+	"fmt"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+// Minimal forms a drop entry is written in. A drop is read for names
+// alone, so these are the shortest spellings that parse and neither one
+// invites writing a signature the run would then ignore.
+const (
+	dropDeclForm   = "export declare val <name>"
+	dropMemberForm = "export declare interface <name> {\n    <member>: unknown,\n}"
+)
+
+// validateDropDecls rejects a drop entry carrying more than the minimal
+// form. Every type annotation, signature, and body in a drop file is
+// ignored. Accepting one would leave whoever wrote it expecting it to
+// matter.
+//
+// A `val` entry names a whole declaration. An `interface` entry names
+// members of the declaration it is titled with, one `<member>: unknown`
+// per line. The root drop file takes `val` entries alone, since its
+// names are whole symbols that belong to no package.
+func validateDropDecls(rel, pkgURI string, decls []ast.Decl) error {
+	for _, decl := range decls {
+		switch d := decl.(type) {
+		case *ast.VarDecl:
+			if err := validateDropVarDecl(rel, d); err != nil {
+				return err
+			}
+		case *ast.InterfaceDecl:
+			if pkgURI == "" {
+				return fmt.Errorf(
+					"overlay: %s drops members of %s, but the root drop file names "+
+						"whole symbols that belong to no package; move it to a "+
+						"<scheme>/<package>.drop.esc file",
+					rel, d.Name.Name)
+			}
+			if err := validateDropInterfaceDecl(rel, d); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf(
+				"overlay: %s drops the %s %s; write a whole declaration as `%s` "+
+					"and its members as `%s`",
+				rel, escDeclKind(decl), escDeclName(decl), dropDeclForm, dropMemberForm)
+		}
+	}
+	return nil
+}
+
+// validateDropVarDecl holds a whole-declaration drop to `export declare
+// val <name>`.
+func validateDropVarDecl(rel string, d *ast.VarDecl) error {
+	name := escDeclName(d)
+	switch {
+	case name == "":
+		return fmt.Errorf("overlay: %s drops a binding with no name; write `%s`", rel, dropDeclForm)
+	case d.TypeAnn != nil:
+		return fmt.Errorf(
+			"overlay: %s gives %s a type annotation, which a drop ignores; write `%s`",
+			rel, name, dropDeclForm)
+	case d.Init != nil:
+		return fmt.Errorf(
+			"overlay: %s gives %s an initializer, which a drop ignores; write `%s`",
+			rel, name, dropDeclForm)
+	case len(d.Decorators) > 0:
+		return fmt.Errorf(
+			"overlay: %s decorates %s, which a drop ignores; write `%s`",
+			rel, name, dropDeclForm)
+	}
+	return nil
+}
+
+// validateDropInterfaceDecl holds a member drop to one
+// `<member>: unknown` line per name. An empty body would name a whole
+// declaration, which is the `val` form's job.
+func validateDropInterfaceDecl(rel string, d *ast.InterfaceDecl) error {
+	owner := d.Name.Name
+	if len(d.TypeParams) > 0 || len(d.Extends) > 0 {
+		return fmt.Errorf(
+			"overlay: %s gives %s type parameters or an extends clause, which a "+
+				"drop ignores; write `%s`", rel, owner, dropMemberForm)
+	}
+	if d.TypeAnn == nil || len(d.TypeAnn.Elems) == 0 {
+		return fmt.Errorf(
+			"overlay: %s drops %s with an empty body; a drop naming a whole "+
+				"declaration is written `%s`", rel, owner, dropDeclForm)
+	}
+	for _, elem := range d.TypeAnn.Elems {
+		prop, ok := elem.(*ast.PropertyTypeAnn)
+		if !ok {
+			return fmt.Errorf(
+				"overlay: %s drops a member of %s as a signature, which a drop "+
+					"ignores; write `%s`", rel, owner, dropMemberForm)
+		}
+		slot, ok := slotFor(prop.Name, false)
+		if !ok {
+			return fmt.Errorf(
+				"overlay: %s drops a member of %s whose key has no textual name; "+
+					"write `%s`", rel, owner, dropMemberForm)
+		}
+		if _, ok := prop.Value.(*ast.UnknownTypeAnn); !ok {
+			return fmt.Errorf(
+				"overlay: %s types %s.%s, which a drop ignores; write `%s`",
+				rel, owner, slot.Name, dropMemberForm)
+		}
+		if prop.Optional || prop.Readonly {
+			return fmt.Errorf(
+				"overlay: %s marks %s.%s optional or readonly, which a drop "+
+					"ignores; write `%s`", rel, owner, slot.Name, dropMemberForm)
+		}
+	}
+	return nil
+}

--- a/internal/dts_to_esc/overlay_test.go
+++ b/internal/dts_to_esc/overlay_test.go
@@ -58,6 +58,127 @@ func TestLoadOverlay_ReadsOperationAndPackageFromTheFilename(t *testing.T) {
 	require.Equal(t, []string{"std:array", "std:date", "std:symbol"}, overlay.PackageURIs())
 }
 
+// TestLoadOverlay_Accepts is the happy-path twin of
+// TestLoadOverlay_Rejects: one overlay file per case, each naming the
+// operation and package the loader reads off its path, and the
+// declarations it parses out of the file.
+//
+// Between them the two tables are the accepted surface. This one covers
+// the filename-to-package mapping across both schemes, a multi-word
+// package name, and the file shapes each operation is written in.
+func TestLoadOverlay_Accepts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		path      string
+		body      string
+		wantOp    OverlayOp
+		wantPkg   string
+		wantDecls []string
+	}{
+		{
+			name:      "root drop file names symbols that belong to no package",
+			path:      "drop.esc",
+			body:      "export declare val eval\nexport declare val globalThis\n",
+			wantOp:    OverlayDrop,
+			wantPkg:   "",
+			wantDecls: []string{"eval", "globalThis"},
+		},
+		{
+			name:      "add extends a declaration of its package",
+			path:      "std/symbol.add.esc",
+			body:      "export declare interface SymbolConstructor {\n    readonly customMatcher: unique symbol,\n}\n",
+			wantOp:    OverlayAdd,
+			wantPkg:   "std:symbol",
+			wantDecls: []string{"SymbolConstructor"},
+		},
+		{
+			name:      "add contributes a decorated top-level declaration",
+			path:      "std/iterator.add.esc",
+			body:      "@js(\"Symbol.iterator\")\nexport declare val iteratorKey: unique symbol\n",
+			wantOp:    OverlayAdd,
+			wantPkg:   "std:iterator",
+			wantDecls: []string{"iteratorKey"},
+		},
+		{
+			name:      "replace restates the members it stands in for",
+			path:      "std/array.replace.esc",
+			body:      "export declare class Array<T> {\n    at(self, index: number) -> T,\n}\n",
+			wantOp:    OverlayReplace,
+			wantPkg:   "std:array",
+			wantDecls: []string{"Array"},
+		},
+		{
+			name:      "drop names a member of one of its package's declarations",
+			path:      "std/date.drop.esc",
+			body:      "export declare interface Date {\n    getYear: unknown,\n}\n",
+			wantOp:    OverlayDrop,
+			wantPkg:   "std:date",
+			wantDecls: []string{"Date"},
+		},
+		{
+			name:      "drop names whole declarations of its package",
+			path:      "std/error.drop.esc",
+			body:      "export declare val EvalError\nexport declare val EvalErrorConstructor\n",
+			wantOp:    OverlayDrop,
+			wantPkg:   "std:error",
+			wantDecls: []string{"EvalError", "EvalErrorConstructor"},
+		},
+		{
+			name:      "a multi-word package name keeps its underscores",
+			path:      "std/typed_arrays.add.esc",
+			body:      "export declare interface Int8Array {\n    readonly kind: string,\n}\n",
+			wantOp:    OverlayAdd,
+			wantPkg:   "std:typed_arrays",
+			wantDecls: []string{"Int8Array"},
+		},
+		{
+			name:      "the web scheme resolves the same way as std",
+			path:      "web/fetch.replace.esc",
+			body:      "export declare interface Headers {\n    get(self, name: string) -> string | null,\n}\n",
+			wantOp:    OverlayReplace,
+			wantPkg:   "web:fetch",
+			wantDecls: []string{"Headers"},
+		},
+		{
+			name:      "the catch-all dom package is addressable too",
+			path:      "web/dom.replace.esc",
+			body:      "export declare interface Element {\n    readonly tagName: string,\n}\n",
+			wantOp:    OverlayReplace,
+			wantPkg:   "web:dom",
+			wantDecls: []string{"Element"},
+		},
+		{
+			name: "one file carries several declarations, in source order",
+			path: "std/object.add.esc",
+			body: "export declare type Mutable<T> = T\n" +
+				"export declare interface ObjectConstructor {\n    readonly marker: string,\n}\n",
+			wantOp:    OverlayAdd,
+			wantPkg:   "std:object",
+			wantDecls: []string{"Mutable", "ObjectConstructor"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			overlay, err := LoadOverlay(seedOverlay(t, map[string]string{tt.path: tt.body}))
+			require.NoError(t, err)
+			require.Len(t, overlay.Files, 1)
+
+			f := overlay.Files[0]
+			require.Equal(t, tt.path, f.Path)
+			require.Equal(t, tt.wantOp, f.Op)
+			require.Equal(t, tt.wantPkg, f.PkgURI)
+
+			names := make([]string, 0, len(f.Decls))
+			for _, decl := range f.Decls {
+				names = append(names, escDeclName(decl))
+			}
+			require.Equal(t, tt.wantDecls, names)
+		})
+	}
+}
+
 // TestLoadOverlay_Rejects covers every way a committed overlay file can
 // be wrong. An overlay is an input the generator parses, so each of
 // these stops the run rather than being skipped.

--- a/internal/dts_to_esc/overlay_test.go
+++ b/internal/dts_to_esc/overlay_test.go
@@ -1,0 +1,158 @@
+package dts_to_esc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seedOverlay writes an overlay tree from a map of overlay-relative
+// paths to file contents, and returns the root it wrote them under.
+func seedOverlay(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, contents := range files {
+		path := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+	}
+	return dir
+}
+
+// TestLoadOverlay_ReadsOperationAndPackageFromTheFilename covers the
+// naming rule the overlay rests on: the operation and the target package
+// are both read off the path, and the file itself is ordinary `.esc`.
+func TestLoadOverlay_ReadsOperationAndPackageFromTheFilename(t *testing.T) {
+	t.Parallel()
+	dir := seedOverlay(t, map[string]string{
+		"README.md":             "not an overlay file\n",
+		"drop.esc":              "export declare val eval\n",
+		"std/symbol.add.esc":    "export declare interface SymbolConstructor {\n    readonly customMatcher: unique symbol,\n}\n",
+		"std/array.replace.esc": "export declare interface Array<T> {\n    length: number,\n}\n",
+		"std/date.drop.esc":     "export declare interface Date {\n    getYear: unknown,\n}\n",
+	})
+
+	overlay, err := LoadOverlay(dir)
+	require.NoError(t, err)
+
+	type entry struct {
+		Path   string
+		Op     OverlayOp
+		PkgURI string
+		Decls  int
+	}
+	got := make([]entry, 0, len(overlay.Files))
+	for _, f := range overlay.Files {
+		got = append(got, entry{Path: f.Path, Op: f.Op, PkgURI: f.PkgURI, Decls: len(f.Decls)})
+	}
+	require.Equal(t, []entry{
+		{Path: "drop.esc", Op: OverlayDrop, PkgURI: "", Decls: 1},
+		{Path: "std/array.replace.esc", Op: OverlayReplace, PkgURI: "std:array", Decls: 1},
+		{Path: "std/date.drop.esc", Op: OverlayDrop, PkgURI: "std:date", Decls: 1},
+		{Path: "std/symbol.add.esc", Op: OverlayAdd, PkgURI: "std:symbol", Decls: 1},
+	}, got)
+
+	require.Equal(t, []string{"eval"}, overlay.GlobalDrops().ToSlice())
+	require.Equal(t, []string{"std:array", "std:date", "std:symbol"}, overlay.PackageURIs())
+}
+
+// TestLoadOverlay_Rejects covers every way a committed overlay file can
+// be wrong. An overlay is an input the generator parses, so each of
+// these stops the run rather than being skipped.
+func TestLoadOverlay_Rejects(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		files map[string]string
+		want  string
+	}{
+		{
+			name:  "file at the overlay root that is not the root drop file",
+			files: map[string]string{"symbol.add.esc": "export declare val x\n"},
+			want: "overlay: symbol.add.esc sits at neither the overlay root nor a " +
+				"package directory; write a package operation as " +
+				"<scheme>/<package>.<add|replace|drop>.esc and package-less drops as drop.esc",
+		},
+		{
+			name:  "no operation in the filename",
+			files: map[string]string{"std/symbol.esc": "export declare val x\n"},
+			want: "overlay: std/symbol.esc names no operation; the filename carries it, " +
+				"as in std/symbol.replace.esc",
+		},
+		{
+			name:  "unknown operation",
+			files: map[string]string{"std/symbol.merge.esc": "export declare val x\n"},
+			want: "overlay: std/symbol.merge.esc names the unknown operation \"merge\"; " +
+				"the operations are add, replace, and drop",
+		},
+		{
+			name:  "package not in the partition table",
+			files: map[string]string{"std/nonesuch.add.esc": "export declare val x\n"},
+			want: "overlay: std/nonesuch.add.esc targets std/nonesuch.esc, which is not a " +
+				"package in the partition table (see internal/dts_to_esc/partition.go)",
+		},
+		{
+			name:  "file that does not parse",
+			files: map[string]string{"std/symbol.add.esc": "export declare fn (\n"},
+			want:  "overlay: std/symbol.add.esc does not parse: Expected identifier; Expected a pattern; Expected a closing paren",
+		},
+		{
+			name:  "drop entry carrying a type annotation",
+			files: map[string]string{"drop.esc": "export declare val eval: unknown\n"},
+			want: "overlay: drop.esc gives eval a type annotation, which a drop ignores; " +
+				"write `export declare val <name>`",
+		},
+		{
+			name:  "drop entry carrying a signature",
+			files: map[string]string{"std/date.drop.esc": "export declare fn getYear() -> number\n"},
+			want: "overlay: std/date.drop.esc drops the function getYear; write a whole " +
+				"declaration as `export declare val <name>` and its members as " +
+				"`export declare interface <name> {\n    <member>: unknown,\n}`",
+		},
+		{
+			name: "member drop carrying a real type",
+			files: map[string]string{
+				"std/date.drop.esc": "export declare interface Date {\n    getYear: number,\n}\n",
+			},
+			want: "overlay: std/date.drop.esc types Date.getYear, which a drop ignores; " +
+				"write `export declare interface <name> {\n    <member>: unknown,\n}`",
+		},
+		{
+			name: "member drop with an empty body",
+			files: map[string]string{
+				"std/date.drop.esc": "export declare interface Date {}\n",
+			},
+			want: "overlay: std/date.drop.esc drops Date with an empty body; a drop naming " +
+				"a whole declaration is written `export declare val <name>`",
+		},
+		{
+			name: "member drop in the root drop file",
+			files: map[string]string{
+				"drop.esc": "export declare interface Date {\n    getYear: unknown,\n}\n",
+			},
+			want: "overlay: drop.esc drops members of Date, but the root drop file names " +
+				"whole symbols that belong to no package; move it to a " +
+				"<scheme>/<package>.drop.esc file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadOverlay(seedOverlay(t, tt.files))
+			require.EqualError(t, err, tt.want)
+		})
+	}
+}
+
+// TestLoadOverlay_MissingDirectory names the path rather than returning
+// an empty overlay. A typo in the path would otherwise produce a tree
+// with every overlay entry silently missing.
+func TestLoadOverlay_MissingDirectory(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "nonesuch")
+	_, err := LoadOverlay(dir)
+	require.EqualError(t, err,
+		"reading overlay dir "+dir+": stat "+dir+": no such file or directory")
+}

--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -28,6 +28,9 @@ type Package struct {
 //
 // Lookup order at the routing site (see Route below):
 //
+//  0. The overlay's root drop file, applied by PartitionLibWithOverlay
+//     ahead of Route. A whole-symbol drop belongs to no package, so it
+//     is settled before a package is assigned.
 //  1. ExplicitDrops — symbols intentionally dropped (`globalThis`,
 //     `eval`). The routing site logs and skips emission.
 //  2. Partition (this map) — the hand-maintained, full enumeration of
@@ -933,6 +936,27 @@ func PackageForURI(uri string) (Package, bool) {
 		}
 	}
 	if uri == WebDOM.URI {
+		return WebDOM, true
+	}
+	return Package{}, false
+}
+
+// PackageForFile returns the Package whose generated file is the given
+// slash-separated path under internal/interop/data/, such as
+// "std/symbol.esc". The overlay reads this to turn a filename like
+// "std/symbol.add.esc" into the package it applies to.
+func PackageForFile(file string) (Package, bool) {
+	for _, p := range stdPackages {
+		if p.File == file {
+			return Package{URI: p.URI, File: p.File}, true
+		}
+	}
+	for _, p := range webPackages {
+		if p.File == file {
+			return Package{URI: p.URI, File: p.File}, true
+		}
+	}
+	if file == WebDOM.File {
 		return WebDOM, true
 	}
 	return Package{}, false

--- a/internal/interop/overlay/README.md
+++ b/internal/interop/overlay/README.md
@@ -1,0 +1,135 @@
+# Overlay
+
+Hand-written `.esc` fragments that `dts_to_esc generate` folds into the
+generated tree under [../data/](../data/). They are one of the three
+inputs a generated file's every fact comes from, alongside the pinned
+`lib.*.d.ts` set and the ECMA-262 derived facts in
+[../../ecma262/](../../ecma262/). See §6.4 of
+[planning/builtins/implementation_plan.md](../../../planning/builtins/implementation_plan.md).
+
+Files here are inputs. Files under `../data/` are build outputs and open
+with a `Code generated` banner saying so. Correcting the generated tree
+means editing an input and re-running, never editing the output.
+
+## The operation is in the filename
+
+An overlay file is ordinary `.esc`, and every declaration in it takes
+that file's operation:
+
+```
+overlay/drop.esc               drops whole symbols that belong to no package
+overlay/std/symbol.add.esc     adds to the package written to data/std/symbol.esc
+overlay/std/array.replace.esc  replaces members of that package's declarations
+overlay/std/date.drop.esc      drops declarations or members of that package
+```
+
+The name before the operation is the package's file basename, so
+`std/symbol.add.esc` applies to `std:symbol` and `web/dom.replace.esc`
+applies to `web:dom`.
+
+A per-declaration marker would be the alternative, and the parser has
+none to offer. Decorators are its only annotation and
+[internal/parser/decl.go](../../parser/decl.go) rejects them on
+`interface`, `type`, `enum`, and `namespace`, which is most of the
+generated tree. The class-member parser reads no decorators at all.
+
+## `add`
+
+A declaration or member no upstream source has. A declaration the
+package does not already have is appended whole; a declaration it has is
+extended member by member.
+
+```
+// overlay/std/symbol.add.esc
+export declare interface SymbolConstructor {
+    readonly customMatcher: unique symbol,
+}
+```
+
+The member needs no `@js` decorator of its own, since
+`export declare var Symbol: SymbolConstructor` already carries
+`@js("Symbol")` and members lower through it. A top-level addition does
+carry one:
+
+```
+@js("Symbol.iterator")
+export declare val iteratorKey: unique symbol
+```
+
+Adding a member the converted declaration already has fails the run.
+Correcting one is `replace`.
+
+## `replace`
+
+Takes the same file shape as `add` and differs only in what happens on a
+key collision. Each overlay member substitutes the converted member
+sharing its name, at that member's position, so a second run leaves the
+tree byte-identical.
+
+```
+// overlay/std/array.replace.esc
+export declare interface Array<T> {
+    sort(compareFn?: fn (a: T, b: T) -> number) -> Self,
+}
+```
+
+A name addresses a whole overload set, so an overlay that replaces
+`Array.find` restates every signature under that name.
+
+Write the overlay in the shape the generated file has. The generator
+converts the `.d.ts` first and matches the overlay against the result,
+so a declaration TypeScript spells as the `interface Foo` +
+`interface FooConstructor` + `declare var Foo` trio is addressed as the
+single `class Foo` the generated file holds.
+
+A declaration the converter gets structurally wrong is replaced whole
+rather than member by member. That happens when the overlay declaration
+and the converted one disagree on declaration kind, or when the kind
+holds no members at all — a `val`, `fn`, `type`, or `enum`.
+
+## `drop`
+
+Names what the generator must not emit. A drop file's declarations are
+read for their **names alone**. Every type annotation, signature, and
+body is ignored, so a drop is written in the shortest form that parses
+and a run rejects an entry carrying more:
+
+```
+// overlay/drop.esc — whole symbols, package-less
+export declare val eval
+export declare val globalThis
+
+// overlay/std/date.drop.esc — members of a package's declarations
+export declare interface Date {
+    getYear: unknown,
+}
+```
+
+`export declare val <name>` names a whole declaration and
+`<name>: unknown` names a member. A member drop removes every member
+under that name, overload set included, matching the rule `replace`
+follows.
+
+Both keywords are containers for the names inside them rather than
+claims about what is being dropped. `export declare type <name>` does
+not parse without `= …`, so a dropped type alias is named with the `val`
+form. And a declaration the converter emits as a class, `Array` and
+`Symbol` among them, has its members dropped with the `interface` form
+like any other.
+
+`drop.esc` sits at the overlay root because a whole-symbol drop resolves
+during routing, before a package is assigned — `eval` and `globalThis`
+belong to none.
+
+## What a run rejects
+
+- An overlay file that does not parse. It is a committed input, and the
+  generator reads no other `.esc`.
+- A `replace` or a `drop` naming a declaration or member the upstream
+  source no longer has. That is the TypeScript-side-removal signal,
+  keyed on the overlay rather than on the tree the run overwrites.
+- An `add` naming a declaration or member the upstream source already
+  has.
+- A drop entry carrying a type annotation, a signature, or an
+  initializer, so that "the rest is ignored" does not become a trap for
+  whoever writes a real signature and expects it to matter.


### PR DESCRIPTION
Refs #1342. Specified in §6.4 of [planning/builtins/implementation_plan.md](../blob/main/planning/builtins/implementation_plan.md). 3 of 5 in the split of that issue; see the map at the bottom.

**Base is #1362, not `main`.** Review the top commit alone.

## Summary

The overlay is hand-written `.esc` under `internal/interop/overlay/`, the third input a generated file's facts come from alongside the pinned `lib.*.d.ts` set and the ECMA-262 derived facts.

`LoadOverlay` reads the tree, resolves each filename to an operation and a package, and parses the file with Escalier's own parser. These are the only `.esc` files a generation reads, since it never reads a file it wrote, so a file that does not parse is a defect in a committed input and stops the load.

## The operation is in the filename

`std/symbol.add.esc` carries `add` for every declaration in it, and the name before the operation is the package's file basename, so that file applies to `std:symbol`. `drop.esc` at the overlay root holds whole-symbol drops, which belong to no package.

A per-declaration marker would need a parser change first. Decorators are the only annotation the parser has, and `internal/parser/decl.go` rejects them on `interface`, `type`, `enum`, and `namespace` — over the pinned lib set that is 1352 interfaces and 339 type aliases out of 2787 top-level declarations, so a decorator could not mark 61% of the tree. The class-member parser reads no decorators at all.

## Drop files are held to the minimal form

A drop file's declarations are read for their names alone, so `LoadOverlay` rejects an entry carrying a type annotation, a signature, or an initializer:

```
export declare val eval
export declare interface Date {
    getYear: unknown,
}
```

Otherwise "the rest is ignored" becomes a trap for whoever writes a real signature and expects it to matter.

## Review notes

Nothing consumes the loaded overlay yet. `LoadOverlay`, `FilesFor`, `PackageURIs`, and `GlobalDrops` go unused until the next PR applies them. That is the cost of the seam, and it buys a review that is entirely about what makes a valid overlay file, with no merging semantics in it.

`internal/interop/overlay/README.md` is here whole rather than split across this PR and the next, so the format spec reads alongside the parser that enforces it.

## Testing

`TestLoadOverlay_ReadsOperationAndPackageFromTheFilename` pins the path-to-operation mapping over a tree with one of each. `TestLoadOverlay_Rejects` is a table of the ten ways a committed overlay file can be wrong, each asserting the full message.

## The split of #1342

One linear stack, each PR based on the one above it.

| PR | Base |
| --- | --- |
| Move the member-slot and decl-name helpers out of `rerun.go` (#1361) | `main` |
| Raise parameter for `Generator` and `AsyncGenerator` (#1362) | #1361 |
| This one | #1362 |
| Apply the overlay to the converted packages (#1364) | this branch |
| Add the `generate` subcommand (#1365) | #1364 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4aGSoLXa2UMo39VoLffoU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `.esc` overlay files with `add`, `replace`, and `drop` operations.
  - Overlays can target global declarations or specific generated packages.
  - Added validation for overlay syntax and clear errors for invalid files or paths.
  - Overlay files are applied in a deterministic order, including support for package-specific routing.

- **Documentation**
  - Added guidance covering overlay formats, declaration matching, routing, and runtime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->