### PR TITLE
dts_to_esc: apply the overlay to the converted packages

### DIFF
--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -1,0 +1,376 @@
+package dts_to_esc
+
+import (
+	"fmt"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/tidwall/btree"
+)
+
+// ApplyOverlay folds every package-scoped overlay operation into the
+// converted modules, in place. The package-less drops in the overlay's
+// root file are not handled here — they resolve during routing, ahead of
+// the partition lookup, so PartitionLibWithOverlay applies those.
+//
+// A package named by an `add` file that routed no upstream declaration
+// is created from the overlay alone, so an addition is never silently
+// lost. A `replace` or `drop` naming such a package fails, since there
+// is nothing to stand in for or remove.
+//
+// An overlay entry naming a declaration or member the converted module
+// does not have fails the run and names it. That is how a removal on the
+// TypeScript side reaches a contributor, keyed on the overlay rather
+// than on the tree the run overwrites.
+func ApplyOverlay(mods map[string]*StandaloneModule, o *Overlay) error {
+	for _, uri := range o.PackageURIs() {
+		files := o.FilesFor(uri)
+		mod, ok := mods[uri]
+		if !ok {
+			var err error
+			mod, err = emptyModuleFor(uri, files)
+			if err != nil {
+				return err
+			}
+			mods[uri] = mod
+		}
+		for _, f := range files {
+			if err := applyOverlayFile(mod, f); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// emptyModuleFor builds the module an overlay-only package starts from.
+// Only `add` can fill one, so a `replace` or `drop` on a package with no
+// upstream declarations is an error rather than an empty file.
+func emptyModuleFor(uri string, files []OverlayFile) (*StandaloneModule, error) {
+	for _, f := range files {
+		if f.Op != OverlayAdd {
+			return nil, fmt.Errorf(
+				"overlay: %s %ss in %s, which no upstream declaration routes to",
+				f.Path, f.Op, uri)
+		}
+	}
+	var namespaces btree.Map[string, *ast.Namespace]
+	namespaces.Set("", &ast.Namespace{})
+	return &StandaloneModule{
+		Module: ast.NewModule(namespaces),
+		Paths:  map[ast.Decl]string{},
+	}, nil
+}
+
+// applyOverlayFile applies one file's declarations to the module of the
+// package it targets.
+func applyOverlayFile(mod *StandaloneModule, f OverlayFile) error {
+	ns, ok := mod.Module.Namespaces.Get("")
+	if !ok {
+		return fmt.Errorf("overlay: %s targets %s, whose converted module has no root namespace",
+			f.Path, f.PkgURI)
+	}
+	if f.Op == OverlayDrop {
+		return applyDropFile(ns, f)
+	}
+	for _, ovDecl := range f.Decls {
+		if err := applyOverlayDecl(mod, ns, f, ovDecl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyDropFile removes the declarations and members one package's drop
+// files name. A name the converted module does not have fails the run.
+func applyDropFile(ns *ast.Namespace, f OverlayFile) error {
+	plan := newDropPlan([]OverlayFile{f})
+	if plan.empty() {
+		return nil
+	}
+
+	kept := make([]ast.Decl, 0, len(ns.Decls))
+	dropped := set.NewSet[string]()
+	for _, decl := range ns.Decls {
+		name := escDeclName(decl)
+		if plan.decls.Contains(name) {
+			dropped.Add(name)
+			continue
+		}
+		kept = append(kept, decl)
+	}
+	for _, name := range sortedNames(plan.decls) {
+		if !dropped.Contains(name) {
+			return fmt.Errorf(
+				"overlay: %s drops %s, which %s does not declare",
+				f.Path, name, f.PkgURI)
+		}
+	}
+	ns.Decls = kept
+
+	for _, owner := range sortedOwners(plan.members) {
+		host := findDecl(ns.Decls, owner)
+		if host == nil {
+			return fmt.Errorf(
+				"overlay: %s drops members of %s, which %s does not declare",
+				f.Path, owner, f.PkgURI)
+		}
+		if err := dropDeclMembers(f, owner, host, plan.members[owner]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// dropDeclMembers removes every member of host whose name is in names.
+// A name takes its whole overload set with it, and reaches a static
+// member as readily as an instance one. A name that matches nothing
+// fails the run.
+func dropDeclMembers(f OverlayFile, owner string, host ast.Decl, names set.Set[string]) error {
+	hit := set.NewSet[string]()
+	switch d := host.(type) {
+	case *ast.ClassDecl:
+		d.Body = dropByName(d.Body, classElemSlot, names, hit)
+	case *ast.InterfaceDecl:
+		if d.TypeAnn != nil {
+			d.TypeAnn.Elems = dropByName(d.TypeAnn.Elems, objElemSlot, names, hit)
+		}
+	default:
+		return fmt.Errorf(
+			"overlay: %s drops members of the %s %s, which holds none",
+			f.Path, escDeclKind(host), owner)
+	}
+	for _, name := range sortedNames(names) {
+		if !hit.Contains(name) {
+			return fmt.Errorf(
+				"overlay: %s drops %s.%s, which the converted declaration does not have",
+				f.Path, owner, name)
+		}
+	}
+	return nil
+}
+
+// dropByName keeps the members whose name is absent from names, and
+// records in hit every name it removed at least one member for.
+func dropByName[E any](
+	members []E,
+	slotOf func(E) (memberSlot, bool),
+	names set.Set[string],
+	hit set.Set[string],
+) []E {
+	kept := make([]E, 0, len(members))
+	for _, m := range members {
+		slot, ok := slotOf(m)
+		if ok && names.Contains(slot.Name) {
+			hit.Add(slot.Name)
+			continue
+		}
+		kept = append(kept, m)
+	}
+	return kept
+}
+
+// applyOverlayDecl applies one `add` or `replace` declaration.
+//
+// A declaration the converted module does not have is appended by `add`
+// and fails the run under `replace`. One it does have is merged member
+// by member when the two agree on declaration kind and that kind holds
+// members. Every other pair is a whole-declaration replacement, which is
+// how a shape the converter gets structurally wrong is corrected — an
+// `interface` the runtime exposes as a class, say.
+func applyOverlayDecl(mod *StandaloneModule, ns *ast.Namespace, f OverlayFile, ovDecl ast.Decl) error {
+	name := escDeclName(ovDecl)
+	idx := findDeclIndex(ns.Decls, name)
+	if idx < 0 {
+		if f.Op == OverlayReplace {
+			return fmt.Errorf(
+				"overlay: %s replaces %s, which %s does not declare",
+				f.Path, name, f.PkgURI)
+		}
+		ns.Decls = append(ns.Decls, ovDecl)
+		return nil
+	}
+
+	host := ns.Decls[idx]
+	switch hostDecl := host.(type) {
+	case *ast.ClassDecl:
+		if ovClass, ok := ovDecl.(*ast.ClassDecl); ok {
+			body, err := mergeMembers(f, name, hostDecl.Body, ovClass.Body, classElemSlot)
+			if err != nil {
+				return err
+			}
+			hostDecl.Body = body
+			return nil
+		}
+	case *ast.InterfaceDecl:
+		if ovIface, ok := ovDecl.(*ast.InterfaceDecl); ok {
+			if hostDecl.TypeAnn == nil || ovIface.TypeAnn == nil {
+				break
+			}
+			elems, err := mergeMembers(f, name, hostDecl.TypeAnn.Elems, ovIface.TypeAnn.Elems, objElemSlot)
+			if err != nil {
+				return err
+			}
+			hostDecl.TypeAnn.Elems = elems
+			return nil
+		}
+	}
+
+	if f.Op == OverlayAdd {
+		return fmt.Errorf(
+			"overlay: %s adds the %s %s, which %s already declares; correct an "+
+				"existing declaration with a replace overlay",
+			f.Path, escDeclKind(host), name, f.PkgURI)
+	}
+	ns.Decls[idx] = ovDecl
+	carryDeclMetadata(mod, host, ovDecl)
+	return nil
+}
+
+// carryDeclMetadata moves the converted declaration's JSDoc and dotted
+// runtime path onto the overlay declaration that stands in for it. The
+// prose is upstream documentation of the same name, and the path is what
+// the ECMA-262 join addresses the declaration's members by.
+//
+// An overlay declaration carrying its own doc comment keeps it. The
+// upstream prose fills in only where the overlay wrote none.
+func carryDeclMetadata(mod *StandaloneModule, host, replacement ast.Decl) {
+	if replacement.Doc() == "" {
+		replacement.SetDoc(host.Doc())
+	}
+	if path, ok := mod.Paths[host]; ok {
+		mod.Paths[replacement] = path
+		delete(mod.Paths, host)
+	}
+}
+
+// mergeMembers folds one overlay declaration's members into the
+// converted declaration's, and returns the merged list.
+//
+// Under `add` each overlay member is appended, and a member the
+// converted declaration already has fails the run. Under `replace` each
+// overlay member substitutes the converted member sharing its key, at
+// that member's position, and a key the converted declaration does not
+// have fails the run. Substituting in place rather than appending is
+// what keeps a second run byte-identical.
+//
+// A key addresses a whole overload set, since memberSlot returns `find`
+// for both of `Array.find`'s signatures. So a `replace` restates every
+// signature under the name it replaces, and the converted signatures
+// under that name all give way to the overlay's.
+func mergeMembers[E any](
+	f OverlayFile,
+	owner string,
+	host, overlay []E,
+	slotOf func(E) (memberSlot, bool),
+) ([]E, error) {
+	if f.Op == OverlayAdd {
+		return addMembers(f, owner, host, overlay, slotOf)
+	}
+	return replaceMembers(f, owner, host, overlay, slotOf)
+}
+
+// addMembers appends every overlay member, failing on a key the
+// converted declaration already fills.
+func addMembers[E any](
+	f OverlayFile,
+	owner string,
+	host, overlay []E,
+	slotOf func(E) (memberSlot, bool),
+) ([]E, error) {
+	filled := set.NewSet[memberSlot]()
+	for _, m := range host {
+		if slot, ok := slotOf(m); ok {
+			filled.Add(slot)
+		}
+	}
+	out := make([]E, 0, len(host)+len(overlay))
+	out = append(out, host...)
+	for _, m := range overlay {
+		slot, ok := slotOf(m)
+		if ok && filled.Contains(slot) {
+			return nil, fmt.Errorf(
+				"overlay: %s adds %s.%s, which the converted declaration already "+
+					"has; correct it with a replace overlay instead",
+				f.Path, owner, slot.Name)
+		}
+		if ok {
+			filled.Add(slot)
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+// replaceMembers substitutes each overlay member for the converted
+// member sharing its key, in place, and fails on a key the converted
+// declaration does not have.
+func replaceMembers[E any](
+	f OverlayFile,
+	owner string,
+	host, overlay []E,
+	slotOf func(E) (memberSlot, bool),
+) ([]E, error) {
+	groups := map[memberSlot][]E{}
+	var order []memberSlot
+	for _, m := range overlay {
+		slot, ok := slotOf(m)
+		if !ok {
+			return nil, fmt.Errorf(
+				"overlay: %s replaces a member of %s whose key has no textual name; "+
+					"a replace addresses a member by name", f.Path, owner)
+		}
+		if _, seen := groups[slot]; !seen {
+			order = append(order, slot)
+		}
+		groups[slot] = append(groups[slot], m)
+	}
+
+	substituted := set.NewSet[memberSlot]()
+	out := make([]E, 0, len(host)+len(overlay))
+	for _, m := range host {
+		slot, ok := slotOf(m)
+		if !ok {
+			out = append(out, m)
+			continue
+		}
+		group, replaced := groups[slot]
+		if !replaced {
+			out = append(out, m)
+			continue
+		}
+		// The first converted member under this name takes the overlay's
+		// whole overload set; the rest of the converted set gives way.
+		if !substituted.Contains(slot) {
+			substituted.Add(slot)
+			out = append(out, group...)
+		}
+	}
+	for _, slot := range order {
+		if !substituted.Contains(slot) {
+			return nil, fmt.Errorf(
+				"overlay: %s replaces %s.%s, which the converted declaration does "+
+					"not have", f.Path, owner, slot.Name)
+		}
+	}
+	return out, nil
+}
+
+// findDecl returns the declaration addressed by name, or nil.
+func findDecl(decls []ast.Decl, name string) ast.Decl {
+	if i := findDeclIndex(decls, name); i >= 0 {
+		return decls[i]
+	}
+	return nil
+}
+
+// findDeclIndex returns the index of the declaration addressed by name,
+// or -1.
+func findDeclIndex(decls []ast.Decl, name string) int {
+	for i, decl := range decls {
+		if escDeclName(decl) == name {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -1,0 +1,327 @@
+package dts_to_esc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// overlayLib is the synthetic `.d.ts` input the overlay tests route. It
+// holds one trio, which converts to `class Array`, one plain interface,
+// which stays an interface, and one free function, so the overlay's
+// member operations are exercised against each shape and the routing
+// produces two packages rather than one.
+const overlayLib = `
+interface Array<T> { length: number; at(index: number): T | undefined; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
+declare var Array: ArrayConstructor;
+interface ArrayLike<T> { readonly length: number; }
+declare function parseInt(string: string, radix?: number): number;
+`
+
+// convertWithOverlay routes overlayLib, converts every bucket, and folds
+// the given overlay files in. It runs the three steps a generation runs
+// before it writes anything to disk.
+func convertWithOverlay(t *testing.T, files map[string]string) (map[string]*StandaloneModule, error) {
+	t.Helper()
+	overlay, err := LoadOverlay(seedOverlay(t, files))
+	if err != nil {
+		return nil, err
+	}
+	res, err := PartitionLibWithOverlay(
+		[]LibInput{parseLib(t, "lib.es5.d.ts", overlayLib)}, overlay)
+	if err != nil {
+		return nil, err
+	}
+	mods, err := ConvertBuckets(res)
+	if err != nil {
+		return nil, err
+	}
+	return mods, ApplyOverlay(mods, overlay)
+}
+
+// overlayModules is convertWithOverlay for a case expected to succeed.
+func overlayModules(t *testing.T, files map[string]string) map[string]*StandaloneModule {
+	t.Helper()
+	mods, err := convertWithOverlay(t, files)
+	require.NoError(t, err)
+	return mods
+}
+
+// overlayError is convertWithOverlay for a case expected to fail, and
+// returns the message.
+func overlayError(t *testing.T, files map[string]string) string {
+	t.Helper()
+	_, err := convertWithOverlay(t, files)
+	require.Error(t, err)
+	return err.Error()
+}
+
+// renderPackage prints one converted package the way a generation writes
+// it, minus the header.
+func renderPackage(t *testing.T, mods map[string]*StandaloneModule, uri string) string {
+	t.Helper()
+	mod, ok := mods[uri]
+	require.True(t, ok, "no converted module for %s", uri)
+	text, err := RenderStandaloneModule(mod)
+	require.NoError(t, err)
+	return text
+}
+
+// TestApplyOverlay_Operations covers what each operation does to the
+// converted package. The `replace` cases also pin substitution in place
+// rather than append, which is what keeps a second run byte-identical.
+func TestApplyOverlay_Operations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		overlay map[string]string
+		want    string
+	}{
+		{
+			name: "add reaches a converted class",
+			overlay: map[string]string{
+				"std/array.add.esc": "export declare class Array<T> {\n" +
+					"    static of<T>(...items: Array<T>) -> Array<T>,\n}\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T | undefined,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean,
+    static of<T>(...items: Array<T>) -> Array<T>
+}
+
+export declare interface ArrayLike<T> {
+    readonly length: number
+}
+`,
+		},
+		{
+			name: "add reaches a converted interface",
+			overlay: map[string]string{
+				"std/array.add.esc": "export declare interface ArrayLike<T> {\n" +
+					"    readonly first: T,\n}\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T | undefined,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean
+}
+
+export declare interface ArrayLike<T> {
+    readonly length: number,
+    readonly first: T
+}
+`,
+		},
+		{
+			name: "add contributes a declaration no upstream source has",
+			overlay: map[string]string{
+				"std/array.add.esc": "@js(\"Symbol.iterator\")\n" +
+					"export declare val iteratorKey: unique symbol\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T | undefined,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean
+}
+
+export declare interface ArrayLike<T> {
+    readonly length: number
+}
+
+@js("Symbol.iterator")
+export declare val iteratorKey: unique symbol
+`,
+		},
+		{
+			name: "replace substitutes a member at its own position",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare class Array<T> {\n" +
+					"    at(self, index: number) -> T,\n}\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean
+}
+
+export declare interface ArrayLike<T> {
+    readonly length: number
+}
+`,
+		},
+		{
+			name: "replace stands in for a whole declaration of another kind",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare type ArrayLike<T> = { length: number }\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T | undefined,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean
+}
+
+export declare type ArrayLike<T> = {
+    length: number
+}
+`,
+		},
+		{
+			name: "drop keeps a member out of the output",
+			overlay: map[string]string{
+				"std/array.drop.esc": "export declare interface Array {\n" +
+					"    at: unknown,\n}\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    length: number,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean
+}
+
+export declare interface ArrayLike<T> {
+    readonly length: number
+}
+`,
+		},
+		{
+			name: "drop keeps a whole declaration out of the output",
+			overlay: map[string]string{
+				"std/array.drop.esc": "export declare val ArrayLike\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T | undefined,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean
+}
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want,
+				renderPackage(t, overlayModules(t, tt.overlay), "std:array"))
+		})
+	}
+}
+
+// TestApplyOverlay_RootDropKeepsASymbolOutOfEveryPackage covers the one
+// operation that resolves during routing rather than against a
+// converted module.
+func TestApplyOverlay_RootDropKeepsASymbolOutOfEveryPackage(t *testing.T) {
+	t.Parallel()
+	mods := overlayModules(t, map[string]string{
+		"drop.esc": "export declare val parseInt\n",
+	})
+	require.Contains(t, mods, "std:array")
+	require.NotContains(t, mods, "std:number",
+		"parseInt is the only declaration routing to std:number")
+}
+
+// TestApplyOverlay_RejectsAnOverlayTheUpstreamSourceNoLongerBacks is the
+// TypeScript-side-removal signal. A generation overwrites the tree
+// without reading it, so a stale overlay entry is the only place a
+// removal can be caught.
+func TestApplyOverlay_RejectsAnOverlayTheUpstreamSourceNoLongerBacks(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		overlay map[string]string
+		want    string
+	}{
+		{
+			name:    "root drop naming a symbol no lib file declares",
+			overlay: map[string]string{"drop.esc": "export declare val eval\n"},
+			want:    "overlay: drop.esc drops eval, which no lib.*.d.ts file declares",
+		},
+		{
+			name: "drop naming an absent declaration",
+			overlay: map[string]string{
+				"std/array.drop.esc": "export declare val ReadonlyArray\n",
+			},
+			want: "overlay: std/array.drop.esc drops ReadonlyArray, which std:array does not declare",
+		},
+		{
+			name: "drop naming an absent member",
+			overlay: map[string]string{
+				"std/array.drop.esc": "export declare interface Array {\n    sort: unknown,\n}\n",
+			},
+			want: "overlay: std/array.drop.esc drops Array.sort, which the converted " +
+				"declaration does not have",
+		},
+		{
+			name: "replace naming an absent declaration",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare val ReadonlyArray\n",
+			},
+			want: "overlay: std/array.replace.esc replaces ReadonlyArray, which std:array does not declare",
+		},
+		{
+			name: "replace naming an absent member",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare class Array<T> {\n" +
+					"    sort(mut self) -> Self,\n}\n",
+			},
+			want: "overlay: std/array.replace.esc replaces Array.sort, which the converted " +
+				"declaration does not have",
+		},
+		{
+			name: "add colliding with a converted member",
+			overlay: map[string]string{
+				"std/array.add.esc": "export declare class Array<T> {\n" +
+					"    at(mut self, index: number) -> T,\n}\n",
+			},
+			want: "overlay: std/array.add.esc adds Array.at, which the converted declaration " +
+				"already has; correct it with a replace overlay instead",
+		},
+		{
+			name: "add colliding with a converted declaration",
+			overlay: map[string]string{
+				"std/array.add.esc": "export declare val ArrayLike\n",
+			},
+			want: "overlay: std/array.add.esc adds the interface ArrayLike, which std:array " +
+				"already declares; correct an existing declaration with a replace overlay",
+		},
+		{
+			name: "replace on a package nothing routes to",
+			overlay: map[string]string{
+				"std/date.replace.esc": "export declare val Date\n",
+			},
+			want: "overlay: std/date.replace.esc replaces in std:date, which no upstream " +
+				"declaration routes to",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, overlayError(t, tt.overlay))
+		})
+	}
+}
+
+// TestApplyOverlay_AddCreatesAPackageNothingRoutesTo keeps an addition from
+// being silently lost when no upstream declaration lands in the package
+// it names.
+func TestApplyOverlay_AddCreatesAPackageNothingRoutesTo(t *testing.T) {
+	t.Parallel()
+	mods := overlayModules(t, map[string]string{
+		"std/date.add.esc": "@js(\"Date.now\")\nexport declare fn now() -> number\n",
+	})
+	require.Equal(t, `@js("Date.now")
+export declare fn now() -> number
+`, renderPackage(t, mods, "std:date"))
+}

--- a/internal/dts_to_esc/overlay_drop.go
+++ b/internal/dts_to_esc/overlay_drop.go
@@ -2,8 +2,10 @@ package dts_to_esc
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 )
 
 // Minimal forms a drop entry is written in. A drop is read for names
@@ -114,4 +116,77 @@ func validateDropInterfaceDecl(rel string, d *ast.InterfaceDecl) error {
 		}
 	}
 	return nil
+}
+
+// dropPlan is what one package's drop files ask of the converted module:
+// whole declarations by name, and members by owning declaration name.
+//
+// A member drop removes every member under that name. It takes the
+// whole overload set with it, and reaches a static member as readily as
+// an instance one. That is why the member sets hold bare names rather
+// than the memberSlot the add and replace paths key on, which also
+// records which side of the class a member lives on.
+type dropPlan struct {
+	decls   set.Set[string]
+	members map[string]set.Set[string]
+}
+
+// newDropPlan reads the drop entries of one package's overlay files.
+//
+// The declaration kind read here is the drop file's own grammar, not the
+// target's. validateDropDecls holds a drop file to `val` for a whole
+// declaration and `interface` for a member list, so an `interface` entry
+// names members of whatever the converted declaration turns out to be.
+// dropDeclMembers is where the target's kind matters, and it takes a
+// class as readily as an interface.
+func newDropPlan(files []OverlayFile) dropPlan {
+	plan := dropPlan{decls: set.NewSet[string](), members: map[string]set.Set[string]{}}
+	for _, f := range files {
+		if f.Op != OverlayDrop {
+			continue
+		}
+		for _, decl := range f.Decls {
+			iface, ok := decl.(*ast.InterfaceDecl)
+			if !ok {
+				plan.decls.Add(escDeclName(decl))
+				continue
+			}
+			owner := iface.Name.Name
+			names, ok := plan.members[owner]
+			if !ok {
+				names = set.NewSet[string]()
+				plan.members[owner] = names
+			}
+			for _, elem := range iface.TypeAnn.Elems {
+				if slot, ok := slotFor(elem.(*ast.PropertyTypeAnn).Name, false); ok {
+					names.Add(slot.Name)
+				}
+			}
+		}
+	}
+	return plan
+}
+
+// empty reports whether the plan asks for nothing.
+func (p dropPlan) empty() bool {
+	return p.decls.Len() == 0 && len(p.members) == 0
+}
+
+// sortedNames returns a set's members in sorted order, so a run that
+// fails on more than one of them names the same one every time.
+func sortedNames(names set.Set[string]) []string {
+	out := names.ToSlice()
+	sort.Strings(out)
+	return out
+}
+
+// sortedOwners returns the declaration names a member-drop map is keyed
+// by, sorted for the same reason sortedNames is.
+func sortedOwners(members map[string]set.Set[string]) []string {
+	out := make([]string, 0, len(members))
+	for owner := range members {
+		out = append(out, owner)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/dts_to_esc/partition_writer.go
+++ b/internal/dts_to_esc/partition_writer.go
@@ -52,8 +52,23 @@ type DropNote struct {
 }
 
 // PartitionLib routes every top-level declaration across the inputs
-// into its target package per Route. Returns an error on the first
-// unmapped symbol (§6.1 fail-safe).
+// into its target package per Route, with no overlay. Returns an error
+// on the first unmapped symbol (§6.1 fail-safe).
+func PartitionLib(inputs []LibInput) (*PartitionResult, error) {
+	return PartitionLibWithOverlay(inputs, nil)
+}
+
+// PartitionLibWithOverlay routes every top-level declaration across the
+// inputs into its target package per Route, and drops the names the
+// overlay's root drop file holds alongside the ones ExplicitDrops holds.
+// A whole-symbol drop resolves here rather than in Route because it
+// belongs to no package, so it has to be settled before the partition
+// lookup assigns one.
+//
+// A drop naming a symbol the lib set does not declare fails the run.
+// That is the TypeScript-side-removal signal for the overlay: the tree
+// the run overwrites is never consulted, so the overlay is the only
+// place a stale name can be caught.
 //
 // A file in DroppedSources contributes nothing. Every declaration in it
 // is recorded in Drops, including the ones that augment a type another
@@ -64,10 +79,12 @@ type DropNote struct {
 // SourceFile, not where a declaration physically lives in a nested
 // namespace — top-level `declare namespace Intl { ... }` routes as a
 // single unit to std:intl regardless of which lib file declared it.
-func PartitionLib(inputs []LibInput) (*PartitionResult, error) {
+func PartitionLibWithOverlay(inputs []LibInput, overlay *Overlay) (*PartitionResult, error) {
 	out := &PartitionResult{
 		Buckets: make(map[string][]dts_parser.Statement),
 	}
+	overlayDrops := overlay.GlobalDrops()
+	matched := set.NewSet[string]()
 	for _, in := range inputs {
 		if in.Module == nil {
 			return nil, fmt.Errorf("partition: nil module for %s", in.SourceFile)
@@ -83,7 +100,14 @@ func PartitionLib(inputs []LibInput) (*PartitionResult, error) {
 				// unroutable statements into a bucket.
 				continue
 			}
-			if dropped {
+			// A name declared in a DroppedSources file counts as
+			// matched even though the file contributes nothing, so an
+			// overlay drop of it is not reported as stale.
+			overlayDropped := overlayDrops.Contains(name)
+			if overlayDropped {
+				matched.Add(name)
+			}
+			if dropped || overlayDropped {
 				out.Drops = append(out.Drops,
 					DropNote{Name: name, SourceFile: in.SourceFile})
 				continue
@@ -97,6 +121,13 @@ func PartitionLib(inputs []LibInput) (*PartitionResult, error) {
 				return nil, UnmappedError(name, in.SourceFile)
 			}
 			out.Buckets[res.Pkg.URI] = append(out.Buckets[res.Pkg.URI], stmt)
+		}
+	}
+	for _, name := range sortedNames(overlayDrops) {
+		if !matched.Contains(name) {
+			return nil, fmt.Errorf(
+				"overlay: %s drops %s, which no lib.*.d.ts file declares",
+				RootDropFile, name)
 		}
 	}
 	for uri, stmts := range out.Buckets {


### PR DESCRIPTION
Refs #1342. Specified in §6.4 of [planning/builtins/implementation_plan.md](../blob/main/planning/builtins/implementation_plan.md). 4 of 5 in the split of that issue; see the map at the bottom.

**Base is #1363, not `main`.** Review the top commit alone.

## Summary

`ApplyOverlay` folds each package's overlay files into its converted module, drops first, then replacements, then additions. Dropping ahead of the other two lets an overlay drop a converted member and add its own in its place.

- **`add`** appends a declaration the package lacks, and appends members to one it has. A member the converted declaration already has fails the run and points at `replace`.
- **`replace`** substitutes each overlay member for the converted member sharing its name, at that member's position. Substituting in place rather than appending is what keeps a second run byte-identical. A declaration whose kind disagrees with the overlay's, or one that holds no members, is replaced whole — that is the escape hatch for a shape the converter gets structurally wrong.
- **`drop`** removes declarations and members by name, overload set included. Whole-symbol drops resolve in `PartitionLibWithOverlay` instead, ahead of the partition lookup, because a symbol such as `eval` belongs to no package.

A name addresses a whole overload set, since `memberSlot` returns `find` for both of `Array.find`'s signatures, so a `replace` restates every signature under the name it replaces.

## Where it runs, and why not `mergeDecls`

§6.4 has the overlay entering `mergeDecls`. It cannot: `mergeDecls` operates on `dts_parser.Statement`, and overlay files are `.esc` parsed by Escalier's own parser into `ast.Decl`. There is no conversion between the two.

So the overlay is matched against the *converted* declarations instead. In practice this reads better than the plan's version: an overlay is written in the shape the generated file has, so you copy the declaration out of the output, fix it, and save it as an overlay. The trio TypeScript spells as `interface Foo` plus `interface FooConstructor` plus `declare var Foo` is addressed as the single `class Foo` the output holds, rather than as the three parts.

Worth a look, since it is a deviation from what the plan says.

## Staleness

An overlay entry naming a declaration or member the upstream source no longer has fails the run and names it. A generation overwrites the tree without reading it, so the overlay is the only place a TypeScript-side removal can be caught. That covers absence; the digest check for a replaced member whose counterpart has *moved* is #1356, along with the overload-set and member-kind rules.

## Testing

`overlay_apply_test.go` drives `ConvertBuckets` → `ApplyOverlay` → `RenderStandaloneModule` over a synthetic lib holding one trio, one plain interface, and one free function, so each member shape is exercised. Two tables: seven cases for what each operation does to the rendered package, and eight for the ways an overlay entry fails the run, each asserting the full message.

## The split of #1342

One linear stack, each PR based on the one above it.

| PR | Base |
| --- | --- |
| Move the member-slot and decl-name helpers out of `rerun.go` (#1361) | `main` |
| Raise parameter for `Generator` and `AsyncGenerator` (#1362) | #1361 |
| Read and validate the overlay tree (#1363) | #1362 |
| This one | #1363 |
| Add the `generate` subcommand (#1365) | this branch |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4aGSoLXa2UMo39VoLffoU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for applying package-scoped overlays to generated TypeScript declaration packages.
  - Overlays can add, replace, or drop declarations and named members, including overload sets.
  - Additions can create packages even when no declarations are routed there automatically.
  - Compatible class and interface updates are merged while preserving documentation and runtime metadata.

- **Bug Fixes**
  - Added validation for duplicate additions, invalid targets, stale overlay entries, and unsupported unnamed replacements.
  - Root-level drops now consistently remove symbols from all generated packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->