### PR TITLE
printer: add an option that leaves doc comments out

### DIFF
--- a/internal/printer/print_decl_doc_test.go
+++ b/internal/printer/print_decl_doc_test.go
@@ -67,3 +67,28 @@ func TestPrintDeclDoc_CompactModeOmitsTheDoc(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "val x = 42", out)
 }
+
+// TestPrintDeclDoc_OmitDocCommentsLeavesTheDocOut covers the option a
+// caller sets to compare two renderings for a difference in shape. The
+// declaration and its members print in full, and every doc comment is
+// left out, so an edit to the prose does not read as a change to the
+// thing described.
+func TestPrintDeclDoc_OmitDocCommentsLeavesTheDocOut(t *testing.T) {
+	t.Parallel()
+	opts := DefaultOptions()
+	opts.OmitDocComments = true
+
+	decl := parseOneDecl(t, "/** a point */\ndeclare class Point {\n"+
+		"    /** the abscissa */\n    x: number,\n"+
+		"    /** moves it */\n    move(mut self, dx: number) -> undefined\n}")
+	out, err := Print(decl, opts)
+	require.NoError(t, err)
+	require.Equal(t, "declare class Point {\n    x: number,\n"+
+		"    move(mut self, dx: number) -> undefined\n}", out)
+
+	iface := parseOneDecl(t, "/** a point */\ninterface Point {\n"+
+		"    /** the abscissa */\n    x: number\n}")
+	out, err = Print(iface, opts)
+	require.NoError(t, err)
+	require.Equal(t, "interface Point {\n    x: number\n}", out)
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -23,6 +23,12 @@ type Options struct {
 	// written with the newline escaped as `\n` so the one-line guarantee holds. Compact
 	// output is meant to be read, not reparsed.
 	Compact bool
+
+	// OmitDocComments leaves every doc comment out of the output,
+	// printing the declaration or member alone. A caller comparing two
+	// renderings for a difference in shape sets it, so an edit to the
+	// prose above a member does not read as a change to the member.
+	OmitDocComments bool
 }
 
 // DefaultOptions returns default printer options
@@ -275,7 +281,7 @@ func (p *Printer) printImportStmt(s *ast.ImportStmt) {
 func (p *Printer) printDecl(decl ast.Decl) {
 	// Compact mode renders the declaration on one line, where a doc comment
 	// would either swallow the rest of the line or need escaping to avoid it.
-	if doc := decl.Doc(); doc != "" && !p.opts.Compact {
+	if doc := decl.Doc(); doc != "" && !p.opts.Compact && !p.opts.OmitDocComments {
 		p.writeDoc(doc)
 	}
 	switch d := decl.(type) {
@@ -388,7 +394,7 @@ func (p *Printer) writeDoc(doc string) {
 }
 
 func (p *Printer) printClassElem(elem ast.ClassElem) {
-	if doc := elem.Doc(); doc != "" {
+	if doc := elem.Doc(); doc != "" && !p.opts.OmitDocComments {
 		p.writeDoc(doc)
 	}
 	switch e := elem.(type) {
@@ -1517,7 +1523,7 @@ func (p *Printer) printObjectTypeAnn(typ *ast.ObjectTypeAnn) {
 }
 
 func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
-	if doc := elem.Doc(); doc != "" {
+	if doc := elem.Doc(); doc != "" && !p.opts.OmitDocComments {
 		p.writeDoc(doc)
 	}
 	switch e := elem.(type) {


### PR DESCRIPTION
Refs #1356.

First of five stacked PRs splitting the overlay `replace` work. This one is based on `main`.

`Print`, `PrintClassElem`, and `PrintObjTypeAnnElem` emit a node's JSDoc ahead of the node. A caller comparing two renderings for a difference in shape wants the node alone, so an edit to the prose above a member does not read as a change to the member.

`Options.OmitDocComments` is that switch. It leaves every doc comment out and prints the declaration and its members in full. `Compact` already drops a declaration's own doc, since a one-line rendering would swallow the rest of the line, but it reformats everything else and still emits member docs.

The option lands unused. Its first and only caller is the digest check in the last PR of this stack, which compares a converted member against the form an overlay was written against.

## The stack

1. **This PR** — the printer option.
2. `claude/issue-1356-member-docs` — carry the converted member's doc through a `replace`.
3. `claude/issue-1356-member-kind` — key an overlay member on its kind and its whole overload set.
4. `claude/issue-1356-merge-header` — hold a member operation to the converted declaration's header.
5. `claude/issue-1356-digests` — pin what an overlay `replace` stands in for. Closes #1356.

`go build ./...` and `go test ./...` pass on every commit in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM)_