### PR TITLE
dts_to_esc: carry the converted member's doc through a replace

### DIFF
--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -304,7 +304,8 @@ func addMembers[E any](
 
 // replaceMembers substitutes each overlay member for the converted
 // member sharing its key, in place, and fails on a key the converted
-// declaration does not have.
+// declaration does not have. The converted member's doc comment carries
+// onto the overlay member standing in for it.
 func replaceMembers[E any](
 	f OverlayFile,
 	owner string,
@@ -324,6 +325,11 @@ func replaceMembers[E any](
 			order = append(order, slot)
 		}
 		groups[slot] = append(groups[slot], m)
+	}
+
+	hostGroups := groupMembers(host, slotOf)
+	for _, slot := range order {
+		carryMemberDocs(hostGroups[slot], groups[slot])
 	}
 
 	substituted := set.NewSet[memberSlot]()
@@ -354,6 +360,44 @@ func replaceMembers[E any](
 		}
 	}
 	return out, nil
+}
+
+// groupMembers collects a declaration's members by the slot each fills,
+// keeping each slot's members in the order the declaration lists them.
+func groupMembers[E any](members []E, slotOf func(E) (memberSlot, bool)) map[memberSlot][]E {
+	groups := map[memberSlot][]E{}
+	for _, m := range members {
+		if slot, ok := slotOf(m); ok {
+			groups[slot] = append(groups[slot], m)
+		}
+	}
+	return groups
+}
+
+// docHolder is a member carrying a JSDoc comment. Both ast.ClassElem and
+// ast.ObjTypeAnnElem declare the pair.
+type docHolder interface {
+	Doc() string
+	SetDoc(string)
+}
+
+// carryMemberDocs moves the converted members' JSDoc onto the overlay
+// members standing in for them, pairing the two lists by position. It is
+// the member-level counterpart of carryDeclMetadata, and fills in only
+// where the overlay member wrote no doc of its own.
+func carryMemberDocs[E any](converted, overlay []E) {
+	for i, m := range overlay {
+		if i >= len(converted) {
+			return
+		}
+		member, ok := any(m).(docHolder)
+		if !ok || member.Doc() != "" {
+			continue
+		}
+		if host, ok := any(converted[i]).(docHolder); ok {
+			member.SetDoc(host.Doc())
+		}
+	}
 }
 
 // findDecl returns the declaration addressed by name, or nil.

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -19,17 +19,38 @@ interface ArrayLike<T> { readonly length: number; }
 declare function parseInt(string: string, radix?: number): number;
 `
 
-// convertWithOverlay routes overlayLib, converts every bucket, and folds
-// the given overlay files in. It runs the three steps a generation runs
-// before it writes anything to disk.
+// overlayDocLib is overlayLib with a doc comment above the member the
+// overlay tests replace. Prose is the bulk of what a TypeScript version
+// bump moves, so what happens to it under a `replace` is worth pinning.
+const overlayDocLib = `
+interface Array<T> { length: number; /** Reads one element. */ at(index: number): T | undefined; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
+declare var Array: ArrayConstructor;
+interface ArrayLike<T> { readonly length: number; }
+`
+
+// convertWithOverlay folds an overlay tree into the converted
+// overlayLib.
 func convertWithOverlay(t *testing.T, files map[string]string) (map[string]*StandaloneModule, error) {
+	t.Helper()
+	return convertLibWithOverlay(t, overlayLib, files)
+}
+
+// convertLibWithOverlay routes one `.d.ts` input, converts every bucket,
+// and folds the given overlay files in. It runs the three steps a
+// generation runs before it writes anything to disk.
+func convertLibWithOverlay(
+	t *testing.T,
+	lib string,
+	files map[string]string,
+) (map[string]*StandaloneModule, error) {
 	t.Helper()
 	overlay, err := LoadOverlay(seedOverlay(t, files))
 	if err != nil {
 		return nil, err
 	}
 	res, err := PartitionLibWithOverlay(
-		[]LibInput{parseLib(t, "lib.es5.d.ts", overlayLib)}, overlay)
+		[]LibInput{parseLib(t, "lib.es5.d.ts", lib)}, overlay)
 	if err != nil {
 		return nil, err
 	}
@@ -324,4 +345,30 @@ func TestApplyOverlay_AddCreatesAPackageNothingRoutesTo(t *testing.T) {
 	require.Equal(t, `@js("Date.now")
 export declare fn now() -> number
 `, renderPackage(t, mods, "std:date"))
+}
+
+// TestApplyOverlay_ReplaceKeepsTheConvertedMemberDoc covers the prose a
+// member operation would otherwise drop. The overlay states the shape
+// and the upstream documentation of that member still reaches the
+// output, so a doc edit upstream lands even under a `replace`.
+func TestApplyOverlay_ReplaceKeepsTheConvertedMemberDoc(t *testing.T) {
+	t.Parallel()
+	mods, err := convertLibWithOverlay(t, overlayDocLib, map[string]string{
+		"std/array.replace.esc": "export declare class Array<T> {\n" +
+			"    at(self, index: number) -> T,\n}\n",
+	})
+	require.NoError(t, err)
+	require.Equal(t, `@js("Array")
+export declare class Array<T> {
+    length: number,
+    /** Reads one element. */
+    at(self, index: number) -> T,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean
+}
+
+export declare interface ArrayLike<T> {
+    readonly length: number
+}
+`, renderPackage(t, mods, "std:array"))
 }

--- a/internal/interop/overlay/README.md
+++ b/internal/interop/overlay/README.md
@@ -76,6 +76,11 @@ export declare interface Array<T> {
 A name addresses a whole overload set, so an overlay that replaces
 `Array.find` restates every signature under that name.
 
+The converted member's doc comment carries onto the overlay member
+replacing it, unless the overlay wrote one of its own. Upstream
+documentation therefore reaches the generated tree whether or not an
+overlay stands in for the member it describes.
+
 Write the overlay in the shape the generated file has. The generator
 converts the `.d.ts` first and matches the overlay against the result,
 so a declaration TypeScript spells as the `interface Foo` +


### PR DESCRIPTION
Refs #1356.

Second of five stacked PRs. Based on [#1375](https://github.com/escalier-lang/escalier/pull/1375), so review that one first.

`carryDeclMetadata` moves the converted declaration's JSDoc onto the overlay declaration standing in for it, so upstream prose survives a whole-declaration `replace`. A member `replace` had no counterpart. The overlay member went into the output with whatever doc it wrote itself, and the converted member's was dropped.

`carryMemberDocs` is that counterpart. It pairs the converted members under one key with the overlay members replacing them, by position, and fills in the doc of any overlay member that wrote none. An overlay member carrying its own keeps it, matching how the declaration-level carry works.

Upstream documentation now reaches the generated tree whether or not an overlay stands in for the member it describes. That is what lets the last PR in this stack judge a replaced member on its shape alone, and leave doc comments out of the digest it takes.

The PR also adds two pieces the next one builds on: `groupMembers`, which collects a declaration's members by the slot each fills, and a test helper that routes a chosen `.d.ts` input rather than the one fixed lib.

## The stack

1. [#1375](https://github.com/escalier-lang/escalier/pull/1375) — the printer option.
2. **This PR** — carry the converted member's doc.
3. `claude/issue-1356-member-kind` — key an overlay member on its kind and its whole overload set.
4. `claude/issue-1356-merge-header` — hold a member operation to the converted declaration's header.
5. `claude/issue-1356-digests` — pin what an overlay `replace` stands in for. Closes #1356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved converted member documentation when members are replaced by overlays.
  * Overlay-provided comments continue to take precedence over converted documentation.

* **Documentation**
  * Clarified the behavior of documentation comments for replacement overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->