### PR TITLE
dts_to_esc: key an overlay member on its kind and its whole overload set

### DIFF
--- a/internal/dts_to_esc/decl_key.go
+++ b/internal/dts_to_esc/decl_key.go
@@ -4,21 +4,47 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 )
 
-// memberSlot identifies a member by the name it is addressed with plus
-// which side of the class it lives on. It is what an overlay `add` or
-// `replace` matches a member by, and what the re-run's member diff pairs
-// the two sides by.
+// memberKind is the form a member takes: a field, a method, an
+// accessor, or a constructor. It is part of the key an overlay
+// addresses a member by, so a `readonly x: T` field and a `get x() -> T`
+// getter do not silently occupy one slot.
+type memberKind string
+
+const (
+	kindField       memberKind = "field"
+	kindProperty    memberKind = "property"
+	kindMethod      memberKind = "method"
+	kindGetter      memberKind = "getter"
+	kindSetter      memberKind = "setter"
+	kindConstructor memberKind = "constructor"
+)
+
+// memberSlot identifies a member by the name it is addressed with, which
+// side of the class it lives on, and its kind. It is what an overlay
+// `add` or `replace` matches a member by.
 //
-// Member kind is not part of the slot, so a `readonly x: T` field and a
-// `get x() -> T` getter occupy the same one. Whether an overlay may
-// change a member's kind deliberately is settled in #1356.
-//
-// An overload set collapses to one slot as well: `Array.find` has two
-// signatures and one slot, so an overlay replacing that name restates
-// both.
+// An overload set collapses to one slot. `Array.find` has two signatures
+// and one slot, so an overlay replacing that name restates both.
 type memberSlot struct {
 	Name   string
 	Static bool
+	Kind   memberKind
+}
+
+// nameSlot is the slot with its kind dropped, leaving the name and the
+// side of the class the member lives on. Two members sharing that much
+// collide in the output whatever their kinds, so `add` rejects the
+// second and `replace` pairs the two sides on it before comparing kind.
+func (s memberSlot) nameSlot() memberSlot {
+	return memberSlot{Name: s.Name, Static: s.Static}
+}
+
+// accessorPartner reports whether two kinds are the two halves of one
+// accessor. A `get x()` and a `set x()` are the one pair of members that
+// share a name; every other pair under one name is two members the
+// declaration cannot hold at once.
+func accessorPartner(a, b memberKind) bool {
+	return (a == kindGetter && b == kindSetter) || (a == kindSetter && b == kindGetter)
 }
 
 // classElemSlot returns the slot a class member fills. The bool is
@@ -30,15 +56,15 @@ type memberSlot struct {
 func classElemSlot(elem ast.ClassElem) (memberSlot, bool) {
 	switch e := elem.(type) {
 	case *ast.FieldElem:
-		return slotFor(e.Name, e.Static)
+		return slotFor(e.Name, e.Static, kindField)
 	case *ast.MethodElem:
-		return slotFor(e.Name, e.Static)
+		return slotFor(e.Name, e.Static, kindMethod)
 	case *ast.GetterElem:
-		return slotFor(e.Name, e.Static)
+		return slotFor(e.Name, e.Static, kindGetter)
 	case *ast.SetterElem:
-		return slotFor(e.Name, e.Static)
+		return slotFor(e.Name, e.Static, kindSetter)
 	case *ast.ConstructorElem:
-		return memberSlot{Name: "constructor"}, true
+		return memberSlot{Name: "constructor", Kind: kindConstructor}, true
 	}
 	return memberSlot{}, false
 }
@@ -49,28 +75,28 @@ func classElemSlot(elem ast.ClassElem) (memberSlot, bool) {
 func objElemSlot(elem ast.ObjTypeAnnElem) (memberSlot, bool) {
 	switch e := elem.(type) {
 	case *ast.PropertyTypeAnn:
-		return slotFor(e.Name, false)
+		return slotFor(e.Name, false, kindProperty)
 	case *ast.MethodTypeAnn:
-		return slotFor(e.Name, false)
+		return slotFor(e.Name, false, kindMethod)
 	case *ast.GetterTypeAnn:
-		return slotFor(e.Name, false)
+		return slotFor(e.Name, false, kindGetter)
 	case *ast.SetterTypeAnn:
-		return slotFor(e.Name, false)
+		return slotFor(e.Name, false, kindSetter)
 	}
 	return memberSlot{}, false
 }
 
 // slotFor builds a memberSlot from a member key, reporting false for a
 // key with no stable textual name.
-func slotFor(key ast.ObjKey, static bool) (memberSlot, bool) {
+func slotFor(key ast.ObjKey, static bool, kind memberKind) (memberSlot, bool) {
 	switch k := key.(type) {
 	case *ast.IdentExpr:
-		return memberSlot{Name: k.Name, Static: static}, true
+		return memberSlot{Name: k.Name, Static: static, Kind: kind}, true
 	case *ast.StrLit:
-		return memberSlot{Name: k.Value, Static: static}, true
+		return memberSlot{Name: k.Value, Static: static, Kind: kind}, true
 	case *ast.ComputedKey:
 		if dotted := astExprDottedName(k.Expr); dotted != "" {
-			return memberSlot{Name: dotted, Static: static}, true
+			return memberSlot{Name: dotted, Static: static, Kind: kind}, true
 		}
 	}
 	return memberSlot{}, false

--- a/internal/dts_to_esc/decl_key.go
+++ b/internal/dts_to_esc/decl_key.go
@@ -31,11 +31,13 @@ type memberSlot struct {
 	Kind   memberKind
 }
 
-// nameSlot is the slot with its kind dropped, leaving the name and the
-// side of the class the member lives on. Two members sharing that much
-// collide in the output whatever their kinds, so `add` rejects the
-// second and `replace` pairs the two sides on it before comparing kind.
-func (s memberSlot) nameSlot() memberSlot {
+// nameAndSide is the slot with its kind dropped, leaving the name a
+// member is addressed with and which side of the class it lives on.
+// Two members sharing that much land on one name in the output whatever
+// their kinds, so `add` rejects the second and `replace` pairs the two
+// sides on it before comparing kind. A getter and a setter are the one
+// pair allowed to share it.
+func (s memberSlot) nameAndSide() memberSlot {
 	return memberSlot{Name: s.Name, Static: s.Static}
 }
 

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -274,17 +274,11 @@ func mergeMembers[E any](
 }
 
 // addMembers appends every overlay member, failing on a member the
-// converted declaration already holds.
-//
-// A name is not a slot, so the two are checked apart. An addition whose
-// whole slot is taken is a correction, and `replace` is what makes one.
-// An addition that only shares a name with a converted member is a kind
-// change, which is a `drop` and an `add`. The exception is the accessor
-// pair: an overlay may add the `set x()` beside a converted `get x()`.
-//
-// One overlay file may add several signatures under one name, which is
-// how it contributes an overload set the converted declaration has no
-// signature of.
+// converted declaration already holds. A taken slot is a correction, so
+// the report points at `replace`. A name taken under another kind is a
+// kind change, so it points at a `drop` and an `add` instead. One file
+// may add several signatures under one name, and may add the `set x()`
+// beside a converted `get x()`.
 func addMembers[E any](
 	f OverlayFile,
 	owner string,
@@ -325,10 +319,10 @@ func addMembers[E any](
 	return out, nil
 }
 
-// checkAddedKinds pairs one overlay member against the members the same
-// file already adds under that name. Two signatures of one method are an
-// overload set, and a getter and a setter are one accessor. Every other
-// repeat is two members under one name, which no declaration can hold.
+// checkAddedKinds pairs one overlay member against what the same file
+// already adds under that name. Signatures of one method overload and a
+// getter pairs with a setter; every other repeat is two members under
+// one name, which no declaration can hold.
 func checkAddedKinds(f OverlayFile, owner string, slot memberSlot, held []memberKind) error {
 	if containsKind(held, slot.Kind) {
 		if slot.Kind == kindMethod {
@@ -348,8 +342,8 @@ func checkAddedKinds(f OverlayFile, owner string, slot memberSlot, held []member
 }
 
 // unpairedKinds returns the kinds under one name that cannot stand
-// beside kind. The empty result means the name is free, or holds only
-// the other half of kind's accessor.
+// beside kind. Empty means the name is free, or holds only the other
+// half of kind's accessor.
 func unpairedKinds(held []memberKind, kind memberKind) []memberKind {
 	var clash []memberKind
 	for _, h := range held {
@@ -374,18 +368,12 @@ func containsKind(held []memberKind, kind memberKind) bool {
 // member sharing its key, in place, and fails on a key the converted
 // declaration does not have.
 //
-// A key is a name, a side of the class, and a member kind, so a
-// `readonly x: T` field and a `get x() -> T` getter do not silently
-// occupy one slot. An overlay that writes a name the converted
-// declaration holds under another kind fails rather than substituting
-// across kinds, so changing a member's kind is a drop and an add.
-//
-// A key addresses a whole overload set, since a name alone cannot pick
-// one of `Array.find`'s two signatures apart from the other. So a
-// `replace` restates every signature under the name it replaces, and
-// restating fewer than the converted declaration holds fails the run.
-// Only signatures overload, so a second field or accessor under one name
-// fails as well, the way it does under `add`.
+// The key carries the member's kind, so a `readonly x: T` and a
+// `get x()` do not occupy one slot and no substitution crosses kinds. It
+// addresses a whole overload set, since a name alone cannot pick one of
+// `Array.find`'s two signatures apart, so a `replace` restates every
+// signature under the name. Restating fewer fails, and so does a second
+// field or accessor under one name.
 func replaceMembers[E any](
 	f OverlayFile,
 	owner string,
@@ -477,10 +465,9 @@ func carryMemberDocs[E any](converted, overlay []E) {
 }
 
 // groupMembers collects a declaration's members by the slot each fills,
-// and records which kinds every name is declared under. An overlay
-// member that matches no slot is either a member the declaration does
-// not have or one written under the wrong kind. The recorded kinds are
-// what tells the two apart.
+// and records which kinds every name is declared under. The kinds are
+// what tells a member the declaration does not have from one the overlay
+// wrote under the wrong kind.
 func groupMembers[E any](
 	members []E,
 	slotOf func(E) (memberSlot, bool),
@@ -501,11 +488,10 @@ func groupMembers[E any](
 }
 
 // missingSlotError reports an overlay member the converted declaration
-// cannot be paired with. A name it holds under some other kind gets a
-// narrower message, since the overlay found its target and wrote it in a
-// form the declaration does not hold it in. Which form decides what to
-// do: the missing half of an accessor is an addition, and every other
-// mismatch is a kind change, which is a `drop` and an `add`.
+// cannot be paired with. A name held under another kind gets a narrower
+// message, since the overlay found its target and wrote it in the wrong
+// form. The missing half of an accessor is an addition; every other
+// mismatch is a kind change, so a `drop` and an `add`.
 func missingSlotError(
 	f OverlayFile,
 	owner string,

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -307,18 +307,18 @@ func addMembers[E any](
 					"has; correct it with a replace overlay instead",
 				f.Path, owner, slot.Name)
 		}
-		if clash := unpairedKinds(hostKinds[slot.nameSlot()], slot.Kind); len(clash) > 0 {
+		if clash := unpairedKinds(hostKinds[slot.nameAndSide()], slot.Kind); len(clash) > 0 {
 			return nil, fmt.Errorf(
 				"overlay: %s adds %s.%s as a %s, which the converted declaration "+
 					"declares as %s; drop the member and add the new form to change "+
 					"its kind", f.Path, owner, slot.Name, slot.Kind, joinKinds(clash))
 		}
-		held := added[slot.nameSlot()]
+		held := added[slot.nameAndSide()]
 		if err := checkAddedKinds(f, owner, slot, held); err != nil {
 			return nil, err
 		}
 		if !containsKind(held, slot.Kind) {
-			added[slot.nameSlot()] = append(held, slot.Kind)
+			added[slot.nameAndSide()] = append(held, slot.Kind)
 		}
 		out = append(out, m)
 	}
@@ -493,7 +493,7 @@ func groupMembers[E any](
 			continue
 		}
 		if _, seen := groups[slot]; !seen {
-			kinds[slot.nameSlot()] = append(kinds[slot.nameSlot()], slot.Kind)
+			kinds[slot.nameAndSide()] = append(kinds[slot.nameAndSide()], slot.Kind)
 		}
 		groups[slot] = append(groups[slot], m)
 	}
@@ -512,7 +512,7 @@ func missingSlotError(
 	slot memberSlot,
 	hostKinds map[memberSlot][]memberKind,
 ) error {
-	held := hostKinds[slot.nameSlot()]
+	held := hostKinds[slot.nameAndSide()]
 	if len(held) == 0 {
 		return fmt.Errorf(
 			"overlay: %s replaces %s.%s, which the converted declaration does "+

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -2,6 +2,7 @@ package dts_to_esc
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/set"
@@ -178,7 +179,12 @@ func dropByName[E any](
 // members. Every other pair is a whole-declaration replacement, which is
 // how a shape the converter gets structurally wrong is corrected — an
 // `interface` the runtime exposes as a class, say.
-func applyOverlayDecl(mod *StandaloneModule, ns *ast.Namespace, f OverlayFile, ovDecl ast.Decl) error {
+func applyOverlayDecl(
+	mod *StandaloneModule,
+	ns *ast.Namespace,
+	f OverlayFile,
+	ovDecl ast.Decl,
+) error {
 	name := escDeclName(ovDecl)
 	idx := findDeclIndex(ns.Decls, name)
 	if idx < 0 {
@@ -195,7 +201,8 @@ func applyOverlayDecl(mod *StandaloneModule, ns *ast.Namespace, f OverlayFile, o
 	switch hostDecl := host.(type) {
 	case *ast.ClassDecl:
 		if ovClass, ok := ovDecl.(*ast.ClassDecl); ok {
-			body, err := mergeMembers(f, name, hostDecl.Body, ovClass.Body, classElemSlot)
+			body, err := mergeMembers(
+				f, name, hostDecl.Body, ovClass.Body, classElemSlot)
 			if err != nil {
 				return err
 			}
@@ -207,7 +214,8 @@ func applyOverlayDecl(mod *StandaloneModule, ns *ast.Namespace, f OverlayFile, o
 			if hostDecl.TypeAnn == nil || ovIface.TypeAnn == nil {
 				break
 			}
-			elems, err := mergeMembers(f, name, hostDecl.TypeAnn.Elems, ovIface.TypeAnn.Elems, objElemSlot)
+			elems, err := mergeMembers(
+				f, name, hostDecl.TypeAnn.Elems, ovIface.TypeAnn.Elems, objElemSlot)
 			if err != nil {
 				return err
 			}
@@ -253,11 +261,6 @@ func carryDeclMetadata(mod *StandaloneModule, host, replacement ast.Decl) {
 // that member's position, and a key the converted declaration does not
 // have fails the run. Substituting in place rather than appending is
 // what keeps a second run byte-identical.
-//
-// A key addresses a whole overload set, since memberSlot returns `find`
-// for both of `Array.find`'s signatures. So a `replace` restates every
-// signature under the name it replaces, and the converted signatures
-// under that name all give way to the overlay's.
 func mergeMembers[E any](
 	f OverlayFile,
 	owner string,
@@ -270,48 +273,124 @@ func mergeMembers[E any](
 	return replaceMembers(f, owner, host, overlay, slotOf)
 }
 
-// addMembers appends every overlay member, failing on a key the
-// converted declaration already fills.
+// addMembers appends every overlay member, failing on a member the
+// converted declaration already holds.
+//
+// A name is not a slot, so the two are checked apart. An addition whose
+// whole slot is taken is a correction, and `replace` is what makes one.
+// An addition that only shares a name with a converted member is a kind
+// change, which is a `drop` and an `add`. The exception is the accessor
+// pair: an overlay may add the `set x()` beside a converted `get x()`.
+//
+// One overlay file may add several signatures under one name, which is
+// how it contributes an overload set the converted declaration has no
+// signature of.
 func addMembers[E any](
 	f OverlayFile,
 	owner string,
 	host, overlay []E,
 	slotOf func(E) (memberSlot, bool),
 ) ([]E, error) {
-	filled := set.NewSet[memberSlot]()
-	for _, m := range host {
-		if slot, ok := slotOf(m); ok {
-			filled.Add(slot)
-		}
-	}
+	converted, hostKinds := groupMembers(host, slotOf)
+	added := map[memberSlot][]memberKind{}
 	out := make([]E, 0, len(host)+len(overlay))
 	out = append(out, host...)
 	for _, m := range overlay {
 		slot, ok := slotOf(m)
-		if ok && filled.Contains(slot) {
+		if !ok {
+			out = append(out, m)
+			continue
+		}
+		if _, taken := converted[slot]; taken {
 			return nil, fmt.Errorf(
 				"overlay: %s adds %s.%s, which the converted declaration already "+
 					"has; correct it with a replace overlay instead",
 				f.Path, owner, slot.Name)
 		}
-		if ok {
-			filled.Add(slot)
+		if clash := unpairedKinds(hostKinds[slot.nameSlot()], slot.Kind); len(clash) > 0 {
+			return nil, fmt.Errorf(
+				"overlay: %s adds %s.%s as a %s, which the converted declaration "+
+					"declares as %s; drop the member and add the new form to change "+
+					"its kind", f.Path, owner, slot.Name, slot.Kind, joinKinds(clash))
+		}
+		held := added[slot.nameSlot()]
+		if err := checkAddedKinds(f, owner, slot, held); err != nil {
+			return nil, err
+		}
+		if !containsKind(held, slot.Kind) {
+			added[slot.nameSlot()] = append(held, slot.Kind)
 		}
 		out = append(out, m)
 	}
 	return out, nil
 }
 
+// checkAddedKinds pairs one overlay member against the members the same
+// file already adds under that name. Two signatures of one method are an
+// overload set, and a getter and a setter are one accessor. Every other
+// repeat is two members under one name, which no declaration can hold.
+func checkAddedKinds(f OverlayFile, owner string, slot memberSlot, held []memberKind) error {
+	if containsKind(held, slot.Kind) {
+		if slot.Kind == kindMethod {
+			return nil
+		}
+		return fmt.Errorf(
+			"overlay: %s adds %s.%s twice as a %s; only signatures overload",
+			f.Path, owner, slot.Name, slot.Kind)
+	}
+	if clash := unpairedKinds(held, slot.Kind); len(clash) > 0 {
+		return fmt.Errorf(
+			"overlay: %s adds %s.%s as a %s beside %s it adds under the same name; "+
+				"one name holds one member, or a getter and a setter",
+			f.Path, owner, slot.Name, slot.Kind, joinKinds(clash))
+	}
+	return nil
+}
+
+// unpairedKinds returns the kinds under one name that cannot stand
+// beside kind. The empty result means the name is free, or holds only
+// the other half of kind's accessor.
+func unpairedKinds(held []memberKind, kind memberKind) []memberKind {
+	var clash []memberKind
+	for _, h := range held {
+		if !accessorPartner(h, kind) {
+			clash = append(clash, h)
+		}
+	}
+	return clash
+}
+
+// containsKind reports whether kind is among held.
+func containsKind(held []memberKind, kind memberKind) bool {
+	for _, h := range held {
+		if h == kind {
+			return true
+		}
+	}
+	return false
+}
+
 // replaceMembers substitutes each overlay member for the converted
 // member sharing its key, in place, and fails on a key the converted
-// declaration does not have. The converted member's doc comment carries
-// onto the overlay member standing in for it.
+// declaration does not have.
+//
+// A key is a name, a side of the class, and a member kind, so a
+// `readonly x: T` field and a `get x() -> T` getter do not silently
+// occupy one slot. An overlay that writes a name the converted
+// declaration holds under another kind fails rather than substituting
+// across kinds, so changing a member's kind is a drop and an add.
+//
+// A key addresses a whole overload set, since a name alone cannot pick
+// one of `Array.find`'s two signatures apart from the other. So a
+// `replace` restates every signature under the name it replaces, and
+// restating fewer than the converted declaration holds fails the run.
 func replaceMembers[E any](
 	f OverlayFile,
 	owner string,
 	host, overlay []E,
 	slotOf func(E) (memberSlot, bool),
 ) ([]E, error) {
+	hostGroups, hostKinds := groupMembers(host, slotOf)
 	groups := map[memberSlot][]E{}
 	var order []memberSlot
 	for _, m := range overlay {
@@ -327,9 +406,18 @@ func replaceMembers[E any](
 		groups[slot] = append(groups[slot], m)
 	}
 
-	hostGroups := groupMembers(host, slotOf)
 	for _, slot := range order {
-		carryMemberDocs(hostGroups[slot], groups[slot])
+		converted, ok := hostGroups[slot]
+		if !ok {
+			return nil, missingSlotError(f, owner, slot, hostKinds)
+		}
+		if len(groups[slot]) < len(converted) {
+			return nil, fmt.Errorf(
+				"overlay: %s replaces %d of the %d signatures of %s.%s; a replace "+
+					"restates the whole overload set, since a name is what addresses it",
+				f.Path, len(groups[slot]), len(converted), owner, slot.Name)
+		}
+		carryMemberDocs(converted, groups[slot])
 	}
 
 	substituted := set.NewSet[memberSlot]()
@@ -345,33 +433,14 @@ func replaceMembers[E any](
 			out = append(out, m)
 			continue
 		}
-		// The first converted member under this name takes the overlay's
+		// The first converted member under this key takes the overlay's
 		// whole overload set; the rest of the converted set gives way.
 		if !substituted.Contains(slot) {
 			substituted.Add(slot)
 			out = append(out, group...)
 		}
 	}
-	for _, slot := range order {
-		if !substituted.Contains(slot) {
-			return nil, fmt.Errorf(
-				"overlay: %s replaces %s.%s, which the converted declaration does "+
-					"not have", f.Path, owner, slot.Name)
-		}
-	}
 	return out, nil
-}
-
-// groupMembers collects a declaration's members by the slot each fills,
-// keeping each slot's members in the order the declaration lists them.
-func groupMembers[E any](members []E, slotOf func(E) (memberSlot, bool)) map[memberSlot][]E {
-	groups := map[memberSlot][]E{}
-	for _, m := range members {
-		if slot, ok := slotOf(m); ok {
-			groups[slot] = append(groups[slot], m)
-		}
-	}
-	return groups
 }
 
 // docHolder is a member carrying a JSDoc comment. Both ast.ClassElem and
@@ -398,6 +467,74 @@ func carryMemberDocs[E any](converted, overlay []E) {
 			member.SetDoc(host.Doc())
 		}
 	}
+}
+
+// groupMembers collects a declaration's members by the slot each fills,
+// and records which kinds every name is declared under. An overlay
+// member that matches no slot is either a member the declaration does
+// not have or one written under the wrong kind. The recorded kinds are
+// what tells the two apart.
+func groupMembers[E any](
+	members []E,
+	slotOf func(E) (memberSlot, bool),
+) (map[memberSlot][]E, map[memberSlot][]memberKind) {
+	groups := map[memberSlot][]E{}
+	kinds := map[memberSlot][]memberKind{}
+	for _, m := range members {
+		slot, ok := slotOf(m)
+		if !ok {
+			continue
+		}
+		if _, seen := groups[slot]; !seen {
+			kinds[slot.nameSlot()] = append(kinds[slot.nameSlot()], slot.Kind)
+		}
+		groups[slot] = append(groups[slot], m)
+	}
+	return groups, kinds
+}
+
+// missingSlotError reports an overlay member the converted declaration
+// cannot be paired with. A name it holds under some other kind gets a
+// narrower message, since the overlay found its target and wrote it in a
+// form the declaration does not hold it in. Which form decides what to
+// do: the missing half of an accessor is an addition, and every other
+// mismatch is a kind change, which is a `drop` and an `add`.
+func missingSlotError(
+	f OverlayFile,
+	owner string,
+	slot memberSlot,
+	hostKinds map[memberSlot][]memberKind,
+) error {
+	held := hostKinds[slot.nameSlot()]
+	if len(held) == 0 {
+		return fmt.Errorf(
+			"overlay: %s replaces %s.%s, which the converted declaration does "+
+				"not have", f.Path, owner, slot.Name)
+	}
+	clash := unpairedKinds(held, slot.Kind)
+	if len(clash) == 0 {
+		return fmt.Errorf(
+			"overlay: %s replaces %s.%s as a %s, which the converted declaration "+
+				"declares only as %s; contribute the %s with an add overlay instead",
+			f.Path, owner, slot.Name, slot.Kind, joinKinds(held), slot.Kind)
+	}
+	return fmt.Errorf(
+		"overlay: %s replaces %s.%s as a %s, which the converted declaration "+
+			"declares as %s; drop the member and add the new form to change its kind",
+		f.Path, owner, slot.Name, slot.Kind, joinKinds(clash))
+}
+
+// joinKinds names the kinds one member name is declared under, as `a
+// getter and a setter`.
+func joinKinds(kinds []memberKind) string {
+	names := make([]string, len(kinds))
+	for i, kind := range kinds {
+		names[i] = "a " + string(kind)
+	}
+	if len(names) == 1 {
+		return names[0]
+	}
+	return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
 }
 
 // findDecl returns the declaration addressed by name, or nil.

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -297,15 +297,15 @@ func addMembers[E any](
 		}
 		if _, taken := converted[slot]; taken {
 			return nil, fmt.Errorf(
-				"overlay: %s adds %s.%s, which the converted declaration already "+
+				"overlay: %s adds %s, which the converted declaration already "+
 					"has; correct it with a replace overlay instead",
-				f.Path, owner, slot.Name)
+				f.Path, memberLabel(owner, slot))
 		}
 		if clash := unpairedKinds(hostKinds[slot.nameAndSide()], slot.Kind); len(clash) > 0 {
 			return nil, fmt.Errorf(
-				"overlay: %s adds %s.%s as a %s, which the converted declaration "+
+				"overlay: %s adds %s as a %s, which the converted declaration "+
 					"declares as %s; drop the member and add the new form to change "+
-					"its kind", f.Path, owner, slot.Name, slot.Kind, joinKinds(clash))
+					"its kind", f.Path, memberLabel(owner, slot), slot.Kind, joinKinds(clash))
 		}
 		held := added[slot.nameAndSide()]
 		if err := checkAddedKinds(f, owner, slot, held); err != nil {
@@ -329,14 +329,14 @@ func checkAddedKinds(f OverlayFile, owner string, slot memberSlot, held []member
 			return nil
 		}
 		return fmt.Errorf(
-			"overlay: %s adds %s.%s twice as a %s; only signatures overload",
-			f.Path, owner, slot.Name, slot.Kind)
+			"overlay: %s adds %s twice as a %s; only signatures overload",
+			f.Path, memberLabel(owner, slot), slot.Kind)
 	}
 	if clash := unpairedKinds(held, slot.Kind); len(clash) > 0 {
 		return fmt.Errorf(
-			"overlay: %s adds %s.%s as a %s beside %s it adds under the same name; "+
+			"overlay: %s adds %s as a %s beside %s it adds under the same name; "+
 				"one name holds one member, or a getter and a setter",
-			f.Path, owner, slot.Name, slot.Kind, joinKinds(clash))
+			f.Path, memberLabel(owner, slot), slot.Kind, joinKinds(clash))
 	}
 	return nil
 }
@@ -403,14 +403,14 @@ func replaceMembers[E any](
 		}
 		if len(groups[slot]) > 1 && slot.Kind != kindMethod {
 			return nil, fmt.Errorf(
-				"overlay: %s replaces %s.%s twice as a %s; only signatures overload",
-				f.Path, owner, slot.Name, slot.Kind)
+				"overlay: %s replaces %s twice as a %s; only signatures overload",
+				f.Path, memberLabel(owner, slot), slot.Kind)
 		}
 		if len(groups[slot]) < len(converted) {
 			return nil, fmt.Errorf(
-				"overlay: %s replaces %d of the %d signatures of %s.%s; a replace "+
+				"overlay: %s replaces %d of the %d signatures of %s; a replace "+
 					"restates the whole overload set, since a name is what addresses it",
-				f.Path, len(groups[slot]), len(converted), owner, slot.Name)
+				f.Path, len(groups[slot]), len(converted), memberLabel(owner, slot))
 		}
 		carryMemberDocs(converted, groups[slot])
 	}
@@ -501,20 +501,31 @@ func missingSlotError(
 	held := hostKinds[slot.nameAndSide()]
 	if len(held) == 0 {
 		return fmt.Errorf(
-			"overlay: %s replaces %s.%s, which the converted declaration does "+
-				"not have", f.Path, owner, slot.Name)
+			"overlay: %s replaces %s, which the converted declaration does "+
+				"not have", f.Path, memberLabel(owner, slot))
 	}
 	clash := unpairedKinds(held, slot.Kind)
 	if len(clash) == 0 {
 		return fmt.Errorf(
-			"overlay: %s replaces %s.%s as a %s, which the converted declaration "+
+			"overlay: %s replaces %s as a %s, which the converted declaration "+
 				"declares only as %s; contribute the %s with an add overlay instead",
-			f.Path, owner, slot.Name, slot.Kind, joinKinds(held), slot.Kind)
+			f.Path, memberLabel(owner, slot), slot.Kind, joinKinds(held), slot.Kind)
 	}
 	return fmt.Errorf(
-		"overlay: %s replaces %s.%s as a %s, which the converted declaration "+
+		"overlay: %s replaces %s as a %s, which the converted declaration "+
 			"declares as %s; drop the member and add the new form to change its kind",
-		f.Path, owner, slot.Name, slot.Kind, joinKinds(clash))
+		f.Path, memberLabel(owner, slot), slot.Kind, joinKinds(clash))
+}
+
+// memberLabel names a member the way an overlay report does. A static
+// member is marked, since one name reaches both sides of a class and
+// `Array.of` alone would read as the instance member of a declaration
+// that has both.
+func memberLabel(owner string, slot memberSlot) string {
+	if slot.Static {
+		return "static " + owner + "." + slot.Name
+	}
+	return owner + "." + slot.Name
 }
 
 // joinKinds names the kinds one member name is declared under, as `a

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -384,6 +384,8 @@ func containsKind(held []memberKind, kind memberKind) bool {
 // one of `Array.find`'s two signatures apart from the other. So a
 // `replace` restates every signature under the name it replaces, and
 // restating fewer than the converted declaration holds fails the run.
+// Only signatures overload, so a second field or accessor under one name
+// fails as well, the way it does under `add`.
 func replaceMembers[E any](
 	f OverlayFile,
 	owner string,
@@ -410,6 +412,11 @@ func replaceMembers[E any](
 		converted, ok := hostGroups[slot]
 		if !ok {
 			return nil, missingSlotError(f, owner, slot, hostKinds)
+		}
+		if len(groups[slot]) > 1 && slot.Kind != kindMethod {
+			return nil, fmt.Errorf(
+				"overlay: %s replaces %s.%s twice as a %s; only signatures overload",
+				f.Path, owner, slot.Name, slot.Kind)
 		}
 		if len(groups[slot]) < len(converted) {
 			return nil, fmt.Errorf(

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -496,6 +496,17 @@ export declare class Array<T> {
 		}), "std:array"))
 	})
 
+	t.Run("writing one name as two fields fails", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t,
+			"overlay: std/array.replace.esc replaces Array.length twice as a field; "+
+				"only signatures overload",
+			overlayError(t, map[string]string{
+				"std/array.replace.esc": "export declare class Array<T> {\n" +
+					"    length: number,\n    length: string,\n}\n",
+			}))
+	})
+
 	t.Run("restating one signature fails and names the member", func(t *testing.T) {
 		t.Parallel()
 		require.Equal(t,

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -372,3 +372,222 @@ export declare interface ArrayLike<T> {
 }
 `, renderPackage(t, mods, "std:array"))
 }
+
+// overlayKindLib converts to a class holding a getter and a setter under
+// one name plus a two-signature overload set. Those are the two shapes a
+// member key has to tell apart: one name over several kinds, and one
+// name over several signatures of one kind.
+const overlayKindLib = `
+interface Array<T> { get size(): number; set size(v: number); get first(): T; find(x: number): T; find(x: string): T; }
+interface ArrayConstructor { new <T>(): Array<T>; }
+declare var Array: ArrayConstructor;
+`
+
+// overlayKindModules folds an overlay into the converted overlayKindLib
+// for a case expected to succeed.
+func overlayKindModules(t *testing.T, files map[string]string) map[string]*StandaloneModule {
+	t.Helper()
+	mods, err := convertLibWithOverlay(t, overlayKindLib, files)
+	require.NoError(t, err)
+	return mods
+}
+
+// overlayKindError is overlayKindModules for a case expected to fail,
+// and returns the message.
+func overlayKindError(t *testing.T, files map[string]string) string {
+	t.Helper()
+	_, err := convertLibWithOverlay(t, overlayKindLib, files)
+	require.Error(t, err)
+	return err.Error()
+}
+
+// TestApplyOverlay_KeysAMemberOnItsKind pins the half of the member key
+// that is not the name. A `readonly x: T` and a `get x()` are two
+// members, so an overlay addresses one without disturbing the other and
+// cannot turn one into the other by writing the name in a new form.
+func TestApplyOverlay_KeysAMemberOnItsKind(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, `@js("Array")
+export declare class Array<T> {
+    get size(self) -> number | undefined,
+    set size(mut self, v: number) -> undefined,
+    get first(self) -> T,
+    find(self, x: number) -> T,
+    find(self, x: string) -> T,
+    constructor(mut self)
+}
+`, renderPackage(t, overlayKindModules(t, map[string]string{
+		"std/array.replace.esc": "export declare class Array<T> {\n" +
+			"    get size(self) -> number | undefined,\n}\n",
+	}), "std:array"))
+}
+
+// TestApplyOverlay_RejectsAKindChange covers the two ways an overlay can
+// write a name the converted declaration holds under another kind.
+// Neither substitutes across kinds, since that would retype a member
+// under cover of replacing it.
+func TestApplyOverlay_RejectsAKindChange(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		overlay map[string]string
+		want    string
+	}{
+		{
+			name: "replace writing a getter as a method",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare class Array<T> {\n" +
+					"    size(self) -> number,\n}\n",
+			},
+			want: "overlay: std/array.replace.esc replaces Array.size as a method, which " +
+				"the converted declaration declares as a getter and a setter; drop the " +
+				"member and add the new form to change its kind",
+		},
+		{
+			name: "replace writing the half of an accessor the declaration lacks",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare class Array<T> {\n" +
+					"    set first(mut self, v: T),\n}\n",
+			},
+			want: "overlay: std/array.replace.esc replaces Array.first as a setter, " +
+				"which the converted declaration declares only as a getter; " +
+				"contribute the setter with an add overlay instead",
+		},
+		{
+			name: "add writing a getter as a field",
+			overlay: map[string]string{
+				"std/array.add.esc": "export declare class Array<T> {\n" +
+					"    size: number,\n}\n",
+			},
+			want: "overlay: std/array.add.esc adds Array.size as a field, which the " +
+				"converted declaration declares as a getter and a setter; drop the " +
+				"member and add the new form to change its kind",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, overlayKindError(t, tt.overlay))
+		})
+	}
+}
+
+// TestApplyOverlay_ReplaceRestatesTheWholeOverloadSet covers the rule a
+// name-shaped key forces. `find` addresses both of the converted
+// signatures, so an overlay that restates one of them would drop the
+// other without saying so.
+func TestApplyOverlay_ReplaceRestatesTheWholeOverloadSet(t *testing.T) {
+	t.Parallel()
+	t.Run("restating every signature substitutes the set", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, `@js("Array")
+export declare class Array<T> {
+    get size(self) -> number,
+    set size(mut self, v: number) -> undefined,
+    get first(self) -> T,
+    find(self, x: number) -> T | undefined,
+    find(self, x: string) -> T | undefined,
+    constructor(mut self)
+}
+`, renderPackage(t, overlayKindModules(t, map[string]string{
+			"std/array.replace.esc": "export declare class Array<T> {\n" +
+				"    find(self, x: number) -> T | undefined,\n" +
+				"    find(self, x: string) -> T | undefined,\n}\n",
+		}), "std:array"))
+	})
+
+	t.Run("restating one signature fails and names the member", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t,
+			"overlay: std/array.replace.esc replaces 1 of the 2 signatures of "+
+				"Array.find; a replace restates the whole overload set, since a name "+
+				"is what addresses it",
+			overlayKindError(t, map[string]string{
+				"std/array.replace.esc": "export declare class Array<T> {\n" +
+					"    find(self, x: number) -> T | undefined,\n}\n",
+			}))
+	})
+}
+
+// TestApplyOverlay_AddContributesAnOverloadSet covers a name the
+// converted declaration has no signature of. The overlay writes each
+// signature as its own member, the way the declaration itself does.
+func TestApplyOverlay_AddContributesAnOverloadSet(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, `@js("Array")
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T | undefined,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean,
+    indexOf(self, item: T) -> number,
+    indexOf(self, item: T, from: number) -> number
+}
+
+export declare interface ArrayLike<T> {
+    readonly length: number
+}
+`, renderPackage(t, overlayModules(t, map[string]string{
+		"std/array.add.esc": "export declare class Array<T> {\n" +
+			"    indexOf(self, item: T) -> number,\n" +
+			"    indexOf(self, item: T, from: number) -> number,\n}\n",
+	}), "std:array"))
+}
+
+// TestApplyOverlay_AddsTheOtherHalfOfAnAccessor covers the one pair of
+// members that share a name. The converted declaration holds the getter
+// for `first` alone, so the setter is an addition rather than a kind
+// change.
+func TestApplyOverlay_AddsTheOtherHalfOfAnAccessor(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, `@js("Array")
+export declare class Array<T> {
+    get size(self) -> number,
+    set size(mut self, v: number) -> undefined,
+    get first(self) -> T,
+    find(self, x: number) -> T,
+    find(self, x: string) -> T,
+    constructor(mut self),
+    set first(mut self, v: T)
+}
+`, renderPackage(t, overlayKindModules(t, map[string]string{
+		"std/array.add.esc": "export declare class Array<T> {\n" +
+			"    set first(mut self, v: T),\n}\n",
+	}), "std:array"))
+}
+
+// TestApplyOverlay_RejectsAddingOneNameAsTwoMembers covers the clash an
+// overlay file can only have with itself. Neither member is in the
+// converted declaration, so the checks against it pass and the file's own
+// members are what carry the clash.
+func TestApplyOverlay_RejectsAddingOneNameAsTwoMembers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		overlay string
+		want    string
+	}{
+		{
+			name: "a field and a getter",
+			overlay: "export declare class Array<T> {\n" +
+				"    first: T,\n    get first(self) -> T,\n}\n",
+			want: "overlay: std/array.add.esc adds Array.first as a getter beside a " +
+				"field it adds under the same name; one name holds one member, or a " +
+				"getter and a setter",
+		},
+		{
+			name: "one name as two fields",
+			overlay: "export declare class Array<T> {\n" +
+				"    first: T,\n    first: number,\n}\n",
+			want: "overlay: std/array.add.esc adds Array.first twice as a field; " +
+				"only signatures overload",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want,
+				overlayError(t, map[string]string{"std/array.add.esc": tt.overlay}))
+		})
+	}
+}

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -602,3 +602,103 @@ func TestApplyOverlay_RejectsAddingOneNameAsTwoMembers(t *testing.T) {
 		})
 	}
 }
+
+// overlaySideLib converts to a class holding `of` on both sides, one
+// instance member and one static. Which side a member lives on is the
+// part of its key that neither its name nor its kind carries.
+const overlaySideLib = `
+interface Array<T> { of(x: number): T; at(x: number): T; }
+interface ArrayConstructor { new <T>(): Array<T>; of(x: string): Array<any>; }
+declare var Array: ArrayConstructor;
+`
+
+// overlaySideModules folds an overlay into the converted overlaySideLib
+// for a case expected to succeed.
+func overlaySideModules(t *testing.T, files map[string]string) map[string]*StandaloneModule {
+	t.Helper()
+	mods, err := convertLibWithOverlay(t, overlaySideLib, files)
+	require.NoError(t, err)
+	return mods
+}
+
+// TestApplyOverlay_KeysAMemberOnItsSideOfTheClass covers the one name
+// that reaches two members without either being an accessor. `Array.of`
+// is an instance member and a static one, so an overlay addresses each
+// on its own and neither operation disturbs the other side.
+func TestApplyOverlay_KeysAMemberOnItsSideOfTheClass(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		overlay map[string]string
+		want    string
+	}{
+		{
+			name: "replace reaches the instance member alone",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare class Array<T> {\n" +
+					"    of(mut self, x: number) -> T | undefined,\n}\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    of(mut self, x: number) -> T | undefined,
+    at(self, x: number) -> T,
+    constructor(mut self),
+    static of(x: string) -> Array<any>
+}
+`,
+		},
+		{
+			name: "replace reaches the static member alone",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare class Array<T> {\n" +
+					"    static of(x: string) -> Array<T>,\n}\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    of(mut self, x: number) -> T,
+    at(self, x: number) -> T,
+    constructor(mut self),
+    static of(x: string) -> Array<T>
+}
+`,
+		},
+		{
+			name: "add contributes the static half of a name the instance side holds",
+			overlay: map[string]string{
+				"std/array.add.esc": "export declare class Array<T> {\n" +
+					"    static at(x: number) -> T,\n}\n",
+			},
+			want: `@js("Array")
+export declare class Array<T> {
+    of(mut self, x: number) -> T,
+    at(self, x: number) -> T,
+    constructor(mut self),
+    static of(x: string) -> Array<any>,
+    static at(x: number) -> T
+}
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want,
+				renderPackage(t, overlaySideModules(t, tt.overlay), "std:array"))
+		})
+	}
+}
+
+// TestApplyOverlay_ReportsWhichSideAMemberIsMissingFrom keeps a report
+// from naming a member that visibly exists. `at` is on the class, so a
+// report of a missing `Array.at` would send a contributor looking at the
+// member they can already see rather than at the side they wrote.
+func TestApplyOverlay_ReportsWhichSideAMemberIsMissingFrom(t *testing.T) {
+	t.Parallel()
+	_, err := convertLibWithOverlay(t, overlaySideLib, map[string]string{
+		"std/array.replace.esc": "export declare class Array<T> {\n" +
+			"    static at(x: number) -> T,\n}\n",
+	})
+	require.EqualError(t, err,
+		"overlay: std/array.replace.esc replaces static Array.at, which the "+
+			"converted declaration does not have")
+}

--- a/internal/dts_to_esc/overlay_drop.go
+++ b/internal/dts_to_esc/overlay_drop.go
@@ -98,7 +98,7 @@ func validateDropInterfaceDecl(rel string, d *ast.InterfaceDecl) error {
 				"overlay: %s drops a member of %s as a signature, which a drop "+
 					"ignores; write `%s`", rel, owner, dropMemberForm)
 		}
-		slot, ok := slotFor(prop.Name, false)
+		slot, ok := slotFor(prop.Name, false, kindProperty)
 		if !ok {
 			return fmt.Errorf(
 				"overlay: %s drops a member of %s whose key has no textual name; "+
@@ -158,7 +158,7 @@ func newDropPlan(files []OverlayFile) dropPlan {
 				plan.members[owner] = names
 			}
 			for _, elem := range iface.TypeAnn.Elems {
-				if slot, ok := slotFor(elem.(*ast.PropertyTypeAnn).Name, false); ok {
+				if slot, ok := slotFor(elem.(*ast.PropertyTypeAnn).Name, false, kindProperty); ok {
 					names.Add(slot.Name)
 				}
 			}

--- a/internal/dts_to_esc/rerun.go
+++ b/internal/dts_to_esc/rerun.go
@@ -616,16 +616,16 @@ func missingMembers(name string, committed, converted ast.Decl) ([]NewMember, er
 		filled := set.NewSet[memberSlot]()
 		for _, elem := range host.Body {
 			if slot, ok := classElemSlot(elem); ok {
-				filled.Add(slot.nameSlot())
+				filled.Add(slot.nameAndSide())
 			}
 		}
 		var out []NewMember
 		for _, elem := range conv.Body {
 			slot, ok := classElemSlot(elem)
-			if !ok || filled.Contains(slot.nameSlot()) {
+			if !ok || filled.Contains(slot.nameAndSide()) {
 				continue
 			}
-			filled.Add(slot.nameSlot())
+			filled.Add(slot.nameAndSide())
 			text, err := printer.PrintClassElem(elem, opts)
 			if err != nil {
 				return nil, err
@@ -644,16 +644,16 @@ func missingMembers(name string, committed, converted ast.Decl) ([]NewMember, er
 		filled := set.NewSet[memberSlot]()
 		for _, elem := range host.TypeAnn.Elems {
 			if slot, ok := objElemSlot(elem); ok {
-				filled.Add(slot.nameSlot())
+				filled.Add(slot.nameAndSide())
 			}
 		}
 		var out []NewMember
 		for _, elem := range conv.TypeAnn.Elems {
 			slot, ok := objElemSlot(elem)
-			if !ok || filled.Contains(slot.nameSlot()) {
+			if !ok || filled.Contains(slot.nameAndSide()) {
 				continue
 			}
-			filled.Add(slot.nameSlot())
+			filled.Add(slot.nameAndSide())
 			text, err := printer.PrintObjTypeAnnElem(elem, opts)
 			if err != nil {
 				return nil, err

--- a/internal/dts_to_esc/rerun.go
+++ b/internal/dts_to_esc/rerun.go
@@ -599,6 +599,11 @@ func memberHost(committed []ast.Decl, converted ast.Decl) ast.Decl {
 //
 // Only classes and interfaces have members, and memberHost has already
 // paired the two sides by shape, so anything else yields nothing.
+//
+// A member is matched on name and side of the class, leaving its kind
+// out of the pairing. A committed `get x()` fills the name a converted
+// `readonly x: T` would take, and splicing the second one in beside it
+// would leave two members under one name.
 func missingMembers(name string, committed, converted ast.Decl) ([]NewMember, error) {
 	opts := printer.DefaultOptions()
 
@@ -611,16 +616,16 @@ func missingMembers(name string, committed, converted ast.Decl) ([]NewMember, er
 		filled := set.NewSet[memberSlot]()
 		for _, elem := range host.Body {
 			if slot, ok := classElemSlot(elem); ok {
-				filled.Add(slot)
+				filled.Add(slot.nameSlot())
 			}
 		}
 		var out []NewMember
 		for _, elem := range conv.Body {
 			slot, ok := classElemSlot(elem)
-			if !ok || filled.Contains(slot) {
+			if !ok || filled.Contains(slot.nameSlot()) {
 				continue
 			}
-			filled.Add(slot)
+			filled.Add(slot.nameSlot())
 			text, err := printer.PrintClassElem(elem, opts)
 			if err != nil {
 				return nil, err
@@ -639,16 +644,16 @@ func missingMembers(name string, committed, converted ast.Decl) ([]NewMember, er
 		filled := set.NewSet[memberSlot]()
 		for _, elem := range host.TypeAnn.Elems {
 			if slot, ok := objElemSlot(elem); ok {
-				filled.Add(slot)
+				filled.Add(slot.nameSlot())
 			}
 		}
 		var out []NewMember
 		for _, elem := range conv.TypeAnn.Elems {
 			slot, ok := objElemSlot(elem)
-			if !ok || filled.Contains(slot) {
+			if !ok || filled.Contains(slot.nameSlot()) {
 				continue
 			}
-			filled.Add(slot)
+			filled.Add(slot.nameSlot())
 			text, err := printer.PrintObjTypeAnnElem(elem, opts)
 			if err != nil {
 				return nil, err

--- a/internal/interop/overlay/README.md
+++ b/internal/interop/overlay/README.md
@@ -89,7 +89,8 @@ A name addresses a whole overload set, so an overlay that replaces
 `Array.find` restates both of its signatures. Restating fewer than the
 converted declaration holds fails the run and names the member, since a
 name is what addresses the set and there is no way to point at one
-signature in it.
+signature in it. Only signatures overload, so writing one name as two
+fields or two accessors fails as well.
 
 The kind is part of the key, so a `readonly x: T` and a `get x()` are
 two members rather than one. An overlay that writes a name under a kind

--- a/internal/interop/overlay/README.md
+++ b/internal/interop/overlay/README.md
@@ -59,6 +59,15 @@ export declare val iteratorKey: unique symbol
 Adding a member the converted declaration already has fails the run.
 Correcting one is `replace`.
 
+One file may add several signatures under one name, which is how it
+contributes an overload set the converted declaration has no signature
+of.
+
+A name holds one member, with one exception: a `get x()` and a
+`set x()` are two halves of one accessor and share a name. So an overlay
+may add the setter beside a converted getter, and adding any other form
+of a name the converted declaration holds fails.
+
 ## `replace`
 
 Takes the same file shape as `add` and differs only in what happens on a
@@ -73,8 +82,21 @@ export declare interface Array<T> {
 }
 ```
 
+A member is addressed by its name, which side of the class it lives on,
+and its kind. Two rules follow.
+
 A name addresses a whole overload set, so an overlay that replaces
-`Array.find` restates every signature under that name.
+`Array.find` restates both of its signatures. Restating fewer than the
+converted declaration holds fails the run and names the member, since a
+name is what addresses the set and there is no way to point at one
+signature in it.
+
+The kind is part of the key, so a `readonly x: T` and a `get x()` are
+two members rather than one. An overlay that writes a name under a kind
+the converted declaration does not hold it under fails, rather than
+retyping the member under cover of replacing it. Changing a member's
+kind is a `drop` and an `add`, and supplying the missing half of an
+accessor is an `add` on its own.
 
 The converted member's doc comment carries onto the overlay member
 replacing it, unless the overlay wrote one of its own. Upstream

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -1936,31 +1936,36 @@ export declare interface Array<T> {
 ```
 
 `add` and `replace` therefore differ only in what happens on a key
-collision, not in syntax. The pieces exist:
-[memberKey](../../internal/dts_to_esc/partition_writer.go) already
-gives a member its addressable key, covering idents, string literals,
-and `[Symbol.*]` computed keys, and the readonly-twin fold in the same
-file already walks one interface's members by that key and folds them
-into another. Member `replace` is that fold with substitution in place
-of append-if-absent.
+collision, not in syntax. A member's key is
+[memberSlot](../../internal/dts_to_esc/decl_key.go): its name, which
+side of the class it lives on, and its kind. Names cover idents, string
+literals, and `[Symbol.*]` computed keys.
 
-The substitution runs in `mergeDecls`, before trio fusion. At that
-point `Array`, `Map`, and `Promise` are all still interfaces, so
-overriding a member of an eventual class needs no post-fusion surgery.
-The pinned lib set holds two genuine `declare class` declarations, so
-the post-fusion path is a corner rather than the norm. Substituting in
-place rather than appending is what keeps regeneration byte-identical.
+The substitution runs in
+[ApplyOverlay](../../internal/dts_to_esc/overlay_apply.go), after the
+conversion and the trio fusion, so the overlay is matched against the
+converted declarations rather than against the `.d.ts` shapes. A trio
+TypeScript spells as `interface Foo` + `interface FooConstructor` +
+`declare var Foo` is therefore addressed as the single `class Foo` the
+generated file holds. Substituting in place rather than appending is
+what keeps regeneration byte-identical.
 
 Whole-declaration replacement stays available for a shape the converter
 gets structurally wrong, where restating members one at a time does not
 express the fix.
 
 Two rules the granularity needs. An overlay replaces a name's **entire
-overload set** and restates every signature in it, since `memberKey`
-returns `find` for both of `Array.find`'s signatures and a per-signature
-key would have to tiebreak the twelve overload sets that differ only in
-parameter types. And the key is name plus member kind, so a
-`readonly x: T` and a `get x()` do not collide silently.
+overload set** and restates every signature in it, since a name alone
+cannot pick one of `Array.find`'s two signatures apart and a
+per-signature key would have to tiebreak the twelve overload sets that
+differ only in parameter types. Restating fewer signatures than the
+converted declaration holds fails the run and names the member, and an
+`add` file contributes a whole set the same way. And the key carries
+member kind, so a `readonly x: T` and a `get x()` do not collide
+silently. An overlay that writes a name under another kind fails rather
+than substituting across kinds, so changing a member's kind is a `drop`
+and an `add`. A `get x()` and a `set x()` are the one pair that shares a
+name, and an overlay adds the missing half of one.
 
 Granularity shrinks the staleness hazard rather than removing it. A
 replaced member is still forked from upstream, but a change to any


### PR DESCRIPTION
Refs #1356.

Third of five stacked PRs. Based on [#1376](https://github.com/escalier-lang/escalier/pull/1376). This is the core of the issue, and the largest of the four that precede the digest work.

A member's key was its name and which side of the class it lives on. Two members can share that much, so an overlay addressed both at once and picked whichever came first.

## Member kind

The key gains the member's kind. A `readonly x: T` and a `get x()` are two members, and an overlay that writes a name under a kind the converted declaration does not hold it under fails rather than substituting across kinds. Changing a member's kind is a `drop` and an `add`.

The one exception is the accessor pair. A `get x()` and a `set x()` share a name, so an overlay adds the half the converted declaration lacks, and a `replace` naming the missing half is told to add it instead.

## Overload sets

A name still addresses a whole overload set, since nothing tells one of `Array.find`'s two signatures from the other. A `replace` restating fewer signatures than the converted declaration holds now fails and names the member, where before the unrestated ones were dropped in silence.

An `add` file contributes a whole set the same way. The old collision check counted the file's own members against each other, so a file adding two signatures under one name reported that the converted declaration already had a member it does not have.

## What is left alone

The re-run's member diff keeps pairing on name alone, through `nameSlot`. A committed `get x()` fills the name a converted `readonly x: T` would take, and splicing the second in beside it would leave two members under one name.

## The stack

1. [#1375](https://github.com/escalier-lang/escalier/pull/1375) — the printer option.
2. [#1376](https://github.com/escalier-lang/escalier/pull/1376) — carry the converted member's doc.
3. **This PR** — member kind and overload sets.
4. `claude/issue-1356-merge-header` — hold a member operation to the converted declaration's header.
5. `claude/issue-1356-digests` — pin what an overlay `replace` stands in for. Closes #1356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Overlay members now distinguish properties, methods, accessors, and constructors when matching declarations.
  - Method overloads can be added or replaced as complete overload sets.
  - Getter and setter members can be added independently and recognized as complementary pairs.
  - Member replacements must preserve the original member kind and declaration identity.
  - Conflicting, duplicate, incomplete, or incompatible overlay changes are now rejected with clearer diagnostics.

- **Documentation**
  - Updated overlay guidance to clarify member matching, overloads, accessors, and replacement requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->