### PR TITLE
dts_to_esc: hold an overlay's member operation to the converted header

### DIFF
--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -201,6 +201,9 @@ func applyOverlayDecl(
 	switch hostDecl := host.(type) {
 	case *ast.ClassDecl:
 		if ovClass, ok := ovDecl.(*ast.ClassDecl); ok {
+			if err := checkMergeHeader(f, name, hostDecl.TypeParams, ovClass); err != nil {
+				return err
+			}
 			body, err := mergeMembers(
 				f, name, hostDecl.Body, ovClass.Body, classElemSlot)
 			if err != nil {
@@ -213,6 +216,9 @@ func applyOverlayDecl(
 		if ovIface, ok := ovDecl.(*ast.InterfaceDecl); ok {
 			if hostDecl.TypeAnn == nil || ovIface.TypeAnn == nil {
 				break
+			}
+			if err := checkMergeHeader(f, name, hostDecl.TypeParams, ovIface); err != nil {
+				return err
 			}
 			elems, err := mergeMembers(
 				f, name, hostDecl.TypeAnn.Elems, ovIface.TypeAnn.Elems, objElemSlot)
@@ -233,6 +239,89 @@ func applyOverlayDecl(
 	ns.Decls[idx] = ovDecl
 	carryDeclMetadata(mod, host, ovDecl)
 	return nil
+}
+
+// checkMergeHeader holds an overlay's member operation to the converted
+// declaration's header. A member `add` or `replace` substitutes members
+// and keeps everything around them, so the overlay writes the name and
+// the type parameters and nothing else.
+//
+// The type parameters have to agree, since the members the overlay
+// writes are read under the converted declaration's. An overlay binding
+// `<U>` would leave them referring to a name the generated declaration
+// does not bind, with nothing in the output to say so. The rest of the
+// header the overlay writes goes unread, so writing any of it fails
+// rather than being dropped in silence.
+func checkMergeHeader(f OverlayFile, name string, host []*ast.TypeParam, overlay ast.Decl) error {
+	if typeParamNames(host) != typeParamNames(overlayTypeParams(overlay)) {
+		return fmt.Errorf(
+			"overlay: %s writes %s%s, which the converted declaration binds as %s%s; "+
+				"a member operation keeps the converted declaration's type parameters, "+
+				"so the overlay restates them as they are",
+			f.Path, name, typeParamNames(overlayTypeParams(overlay)), name,
+			typeParamNames(host))
+	}
+	if part := unreadHeaderPart(overlay); part != "" {
+		return fmt.Errorf(
+			"overlay: %s writes %s on %s, which a member operation does not read; "+
+				"the converted declaration keeps its own header, so drop it from the "+
+				"overlay", f.Path, part, name)
+	}
+	return nil
+}
+
+// overlayTypeParams returns the type parameters of the one declaration
+// kind a member operation merges into, and nothing for any other.
+func overlayTypeParams(decl ast.Decl) []*ast.TypeParam {
+	switch d := decl.(type) {
+	case *ast.ClassDecl:
+		return d.TypeParams
+	case *ast.InterfaceDecl:
+		return d.TypeParams
+	}
+	return nil
+}
+
+// unreadHeaderPart names the first part of an overlay declaration's
+// header a member operation would drop, or "" when it writes none.
+func unreadHeaderPart(decl ast.Decl) string {
+	switch d := decl.(type) {
+	case *ast.ClassDecl:
+		switch {
+		case len(d.Decorators) > 0:
+			return "a decorator"
+		case d.Extends != nil:
+			return "an extends clause"
+		case len(d.Implements) > 0:
+			return "an implements clause"
+		case len(d.LifetimeParams) > 0:
+			return "a lifetime parameter"
+		}
+	case *ast.InterfaceDecl:
+		switch {
+		case len(d.Extends) > 0:
+			return "an extends clause"
+		case len(d.LifetimeParams) > 0:
+			return "a lifetime parameter"
+		}
+	}
+	return ""
+}
+
+// typeParamNames renders a type parameter list by name alone, as `<T>`.
+// Constraints and defaults are the converted declaration's to state, so
+// they take no part in the comparison. The empty list renders as the
+// empty string, so a declaration with no parameters reads as its own
+// name.
+func typeParamNames(params []*ast.TypeParam) string {
+	if len(params) == 0 {
+		return ""
+	}
+	names := make([]string, len(params))
+	for i, param := range params {
+		names[i] = param.Name
+	}
+	return "<" + strings.Join(names, ", ") + ">"
 }
 
 // carryDeclMetadata moves the converted declaration's JSDoc and dotted

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -290,6 +290,8 @@ func unreadHeaderPart(decl ast.Decl) string {
 		switch {
 		case len(d.Decorators) > 0:
 			return "a decorator"
+		case d.Final():
+			return "a final modifier"
 		case d.Extends != nil:
 			return "an extends clause"
 		case len(d.Implements) > 0:

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -201,7 +201,7 @@ func applyOverlayDecl(
 	switch hostDecl := host.(type) {
 	case *ast.ClassDecl:
 		if ovClass, ok := ovDecl.(*ast.ClassDecl); ok {
-			if err := checkMergeHeader(f, name, hostDecl.TypeParams, ovClass); err != nil {
+			if err := checkMergeDecl(f, name, hostDecl.TypeParams, ovClass); err != nil {
 				return err
 			}
 			body, err := mergeMembers(
@@ -217,7 +217,7 @@ func applyOverlayDecl(
 			if hostDecl.TypeAnn == nil || ovIface.TypeAnn == nil {
 				break
 			}
-			if err := checkMergeHeader(f, name, hostDecl.TypeParams, ovIface); err != nil {
+			if err := checkMergeDecl(f, name, hostDecl.TypeParams, ovIface); err != nil {
 				return err
 			}
 			elems, err := mergeMembers(
@@ -241,13 +241,14 @@ func applyOverlayDecl(
 	return nil
 }
 
-// checkMergeHeader holds an overlay's member operation to the converted
-// declaration's header, which the merge keeps whole. The type parameters
-// have to agree, since an overlay binding `<U>` would leave its members
-// referring to a name the generated declaration does not bind. The rest
-// of the header goes unread, so writing any of it fails rather than
-// being dropped in silence.
-func checkMergeHeader(f OverlayFile, name string, host []*ast.TypeParam, overlay ast.Decl) error {
+// checkMergeDecl holds an overlay's member operation to what a merge
+// reads: the members, and the type parameters they are read under. The
+// type parameters have to agree, since an overlay binding `<U>` would
+// leave its members referring to a name the generated declaration does
+// not bind. Everything else the overlay writes around its members goes
+// unread, so writing any of it fails rather than being dropped in
+// silence.
+func checkMergeDecl(f OverlayFile, name string, host []*ast.TypeParam, overlay ast.Decl) error {
 	if typeParamNames(host) != typeParamNames(overlayTypeParams(overlay)) {
 		return fmt.Errorf(
 			"overlay: %s writes %s%s, which the converted declaration binds as %s%s; "+
@@ -256,11 +257,11 @@ func checkMergeHeader(f OverlayFile, name string, host []*ast.TypeParam, overlay
 			f.Path, name, typeParamNames(overlayTypeParams(overlay)), name,
 			typeParamNames(host))
 	}
-	if part := unreadHeaderPart(overlay); part != "" {
+	if part := unreadDeclPart(overlay); part != "" {
 		return fmt.Errorf(
 			"overlay: %s writes %s on %s, which a member operation does not read; "+
-				"the converted declaration keeps its own header, so drop it from the "+
-				"overlay", f.Path, part, name)
+				"it contributes members alone, so drop it from the overlay",
+			f.Path, part, name)
 	}
 	return nil
 }
@@ -277,9 +278,12 @@ func overlayTypeParams(decl ast.Decl) []*ast.TypeParam {
 	return nil
 }
 
-// unreadHeaderPart names the first part of an overlay declaration's
-// header a member operation would drop, or "" when it writes none.
-func unreadHeaderPart(decl ast.Decl) string {
+// unreadDeclPart names the first thing an overlay declaration writes
+// around its members that a member operation would drop, or "" when it
+// writes none. A decorator, a `final` modifier, an `extends` or
+// `implements` clause, and a lifetime parameter all belong to the
+// converted declaration alone.
+func unreadDeclPart(decl ast.Decl) string {
 	switch d := decl.(type) {
 	case *ast.ClassDecl:
 		switch {

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -242,16 +242,11 @@ func applyOverlayDecl(
 }
 
 // checkMergeHeader holds an overlay's member operation to the converted
-// declaration's header. A member `add` or `replace` substitutes members
-// and keeps everything around them, so the overlay writes the name and
-// the type parameters and nothing else.
-//
-// The type parameters have to agree, since the members the overlay
-// writes are read under the converted declaration's. An overlay binding
-// `<U>` would leave them referring to a name the generated declaration
-// does not bind, with nothing in the output to say so. The rest of the
-// header the overlay writes goes unread, so writing any of it fails
-// rather than being dropped in silence.
+// declaration's header, which the merge keeps whole. The type parameters
+// have to agree, since an overlay binding `<U>` would leave its members
+// referring to a name the generated declaration does not bind. The rest
+// of the header goes unread, so writing any of it fails rather than
+// being dropped in silence.
 func checkMergeHeader(f OverlayFile, name string, host []*ast.TypeParam, overlay ast.Decl) error {
 	if typeParamNames(host) != typeParamNames(overlayTypeParams(overlay)) {
 		return fmt.Errorf(
@@ -312,9 +307,8 @@ func unreadHeaderPart(decl ast.Decl) string {
 
 // typeParamNames renders a type parameter list by name alone, as `<T>`.
 // Constraints and defaults are the converted declaration's to state, so
-// they take no part in the comparison. The empty list renders as the
-// empty string, so a declaration with no parameters reads as its own
-// name.
+// they take no part in the comparison. An empty list renders as "", so a
+// declaration with no parameters reads as its own name.
 func typeParamNames(params []*ast.TypeParam) string {
 	if len(params) == 0 {
 		return ""

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -766,6 +766,16 @@ func TestApplyOverlay_RejectsAHeaderAMemberOperationWouldDrop(t *testing.T) {
 				"keeps its own header, so drop it from the overlay",
 		},
 		{
+			name: "a final modifier on a class",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare final class Array<T> {\n" +
+					"    at(self, index: number) -> T,\n}\n",
+			},
+			want: "overlay: std/array.replace.esc writes a final modifier on Array, " +
+				"which a member operation does not read; the converted declaration " +
+				"keeps its own header, so drop it from the overlay",
+		},
+		{
 			name: "a decorator on a class",
 			overlay: map[string]string{
 				"std/array.replace.esc": "@js(\"Array\")\n" +

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -704,9 +704,9 @@ func TestApplyOverlay_ReportsWhichSideAMemberIsMissingFrom(t *testing.T) {
 }
 
 // TestApplyOverlay_HoldsAMemberOperationToTheConvertedTypeParameters
-// covers the header a member `add` or `replace` does not get to change.
-// The converted declaration keeps its own, so an overlay binding other
-// names would leave its members referring to nothing.
+// covers the one part of the declaration a merge does read besides the
+// members. The converted declaration keeps its own, so an overlay
+// binding other names would leave its members referring to nothing.
 func TestApplyOverlay_HoldsAMemberOperationToTheConvertedTypeParameters(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -744,11 +744,11 @@ func TestApplyOverlay_HoldsAMemberOperationToTheConvertedTypeParameters(t *testi
 	}
 }
 
-// TestApplyOverlay_RejectsAHeaderAMemberOperationWouldDrop covers what
-// an overlay writes around its members. The converted declaration keeps
-// its own header, so a clause the merge would not read is a report
-// rather than a silent omission.
-func TestApplyOverlay_RejectsAHeaderAMemberOperationWouldDrop(t *testing.T) {
+// TestApplyOverlay_RejectsWhatAMemberOperationDoesNotRead covers what an
+// overlay writes around its members. A merge contributes members alone,
+// so a clause it would not read is a report rather than a silent
+// omission.
+func TestApplyOverlay_RejectsWhatAMemberOperationDoesNotRead(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
@@ -762,8 +762,8 @@ func TestApplyOverlay_RejectsAHeaderAMemberOperationWouldDrop(t *testing.T) {
 					"extends Iterable<T> {\n    readonly first: T,\n}\n",
 			},
 			want: "overlay: std/array.add.esc writes an extends clause on ArrayLike, " +
-				"which a member operation does not read; the converted declaration " +
-				"keeps its own header, so drop it from the overlay",
+				"which a member operation does not read; it contributes members " +
+				"alone, so drop it from the overlay",
 		},
 		{
 			name: "a final modifier on a class",
@@ -772,8 +772,8 @@ func TestApplyOverlay_RejectsAHeaderAMemberOperationWouldDrop(t *testing.T) {
 					"    at(self, index: number) -> T,\n}\n",
 			},
 			want: "overlay: std/array.replace.esc writes a final modifier on Array, " +
-				"which a member operation does not read; the converted declaration " +
-				"keeps its own header, so drop it from the overlay",
+				"which a member operation does not read; it contributes members " +
+				"alone, so drop it from the overlay",
 		},
 		{
 			name: "a decorator on a class",
@@ -783,8 +783,8 @@ func TestApplyOverlay_RejectsAHeaderAMemberOperationWouldDrop(t *testing.T) {
 					"    at(self, index: number) -> T,\n}\n",
 			},
 			want: "overlay: std/array.replace.esc writes a decorator on Array, which " +
-				"a member operation does not read; the converted declaration keeps " +
-				"its own header, so drop it from the overlay",
+				"a member operation does not read; it contributes members alone, " +
+				"so drop it from the overlay",
 		},
 	}
 	for _, tt := range tests {
@@ -793,4 +793,52 @@ func TestApplyOverlay_RejectsAHeaderAMemberOperationWouldDrop(t *testing.T) {
 			require.Equal(t, tt.want, overlayError(t, tt.overlay))
 		})
 	}
+}
+
+// TestApplyOverlay_ComparesTypeParametersByNameAlone covers what the
+// merge asks of the one part of the declaration it reads besides the
+// members. The names have to line up, since the members are read under
+// them, and a constraint the overlay writes is the converted
+// declaration's to state, so it takes no part and reaches no output.
+func TestApplyOverlay_ComparesTypeParametersByNameAlone(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, `@js("Array")
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean
+}
+
+export declare interface ArrayLike<T> {
+    readonly length: number
+}
+`, renderPackage(t, overlayModules(t, map[string]string{
+		"std/array.replace.esc": "export declare class Array<T: unknown> {\n" +
+			"    at(self, index: number) -> T,\n}\n",
+	}), "std:array"))
+}
+
+// TestApplyOverlay_WholeDeclarationReplacementReadsWhatAMergeDoesNot is
+// the other side of the rule. Here the overlay writes a class where the
+// converted declaration is an interface, so the two disagree on kind and
+// the overlay stands in for the declaration entire. What it writes
+// around its members reaches the output, `extends` included.
+func TestApplyOverlay_WholeDeclarationReplacementReadsWhatAMergeDoesNot(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, `@js("Array")
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T | undefined,
+    constructor(mut self),
+    static isArray(arg: any) -> boolean
+}
+
+export declare class ArrayLike<T> extends Array<T> {
+    readonly length: number
+}
+`, renderPackage(t, overlayModules(t, map[string]string{
+		"std/array.replace.esc": "export declare class ArrayLike<T> extends Array<T> {\n" +
+			"    readonly length: number,\n}\n",
+	}), "std:array"))
 }

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -702,3 +702,85 @@ func TestApplyOverlay_ReportsWhichSideAMemberIsMissingFrom(t *testing.T) {
 		"overlay: std/array.replace.esc replaces static Array.at, which the "+
 			"converted declaration does not have")
 }
+
+// TestApplyOverlay_HoldsAMemberOperationToTheConvertedTypeParameters
+// covers the header a member `add` or `replace` does not get to change.
+// The converted declaration keeps its own, so an overlay binding other
+// names would leave its members referring to nothing.
+func TestApplyOverlay_HoldsAMemberOperationToTheConvertedTypeParameters(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		overlay map[string]string
+		want    string
+	}{
+		{
+			name: "replace binding another name",
+			overlay: map[string]string{
+				"std/array.replace.esc": "export declare class Array<U> {\n" +
+					"    at(self, index: number) -> U,\n}\n",
+			},
+			want: "overlay: std/array.replace.esc writes Array<U>, which the converted " +
+				"declaration binds as Array<T>; a member operation keeps the converted " +
+				"declaration's type parameters, so the overlay restates them as they are",
+		},
+		{
+			name: "add binding none at all",
+			overlay: map[string]string{
+				"std/array.add.esc": "export declare interface ArrayLike {\n" +
+					"    readonly first: unknown,\n}\n",
+			},
+			want: "overlay: std/array.add.esc writes ArrayLike, which the converted " +
+				"declaration binds as ArrayLike<T>; a member operation keeps the " +
+				"converted declaration's type parameters, so the overlay restates " +
+				"them as they are",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, overlayError(t, tt.overlay))
+		})
+	}
+}
+
+// TestApplyOverlay_RejectsAHeaderAMemberOperationWouldDrop covers what
+// an overlay writes around its members. The converted declaration keeps
+// its own header, so a clause the merge would not read is a report
+// rather than a silent omission.
+func TestApplyOverlay_RejectsAHeaderAMemberOperationWouldDrop(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		overlay map[string]string
+		want    string
+	}{
+		{
+			name: "an extends clause on an interface",
+			overlay: map[string]string{
+				"std/array.add.esc": "export declare interface ArrayLike<T> " +
+					"extends Iterable<T> {\n    readonly first: T,\n}\n",
+			},
+			want: "overlay: std/array.add.esc writes an extends clause on ArrayLike, " +
+				"which a member operation does not read; the converted declaration " +
+				"keeps its own header, so drop it from the overlay",
+		},
+		{
+			name: "a decorator on a class",
+			overlay: map[string]string{
+				"std/array.replace.esc": "@js(\"Array\")\n" +
+					"export declare class Array<T> {\n" +
+					"    at(self, index: number) -> T,\n}\n",
+			},
+			want: "overlay: std/array.replace.esc writes a decorator on Array, which " +
+				"a member operation does not read; the converted declaration keeps " +
+				"its own header, so drop it from the overlay",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, overlayError(t, tt.overlay))
+		})
+	}
+}

--- a/internal/interop/overlay/README.md
+++ b/internal/interop/overlay/README.md
@@ -117,8 +117,8 @@ since the members are read under them: writing `class Array<U>` where
 the generated file holds `class Array<T>` fails the run rather than
 emitting members that refer to a name nothing binds. The rest of the
 header goes unread, so an `extends` clause, an `implements` clause, a
-lifetime parameter, or a decorator on the overlay declaration fails
-rather than being dropped in silence. This holds for `add` as well as
+lifetime parameter, a `final` modifier, or a decorator on the overlay
+declaration fails rather than being dropped in silence. This holds for `add` as well as
 `replace`.
 
 A declaration the converter gets structurally wrong is replaced whole

--- a/internal/interop/overlay/README.md
+++ b/internal/interop/overlay/README.md
@@ -110,6 +110,17 @@ so a declaration TypeScript spells as the `interface Foo` +
 `interface FooConstructor` + `declare var Foo` trio is addressed as the
 single `class Foo` the generated file holds.
 
+A member operation keeps the converted declaration's header and
+substitutes members under it, so the overlay writes the name and the
+type parameters and nothing else. The type parameters have to agree,
+since the members are read under them: writing `class Array<U>` where
+the generated file holds `class Array<T>` fails the run rather than
+emitting members that refer to a name nothing binds. The rest of the
+header goes unread, so an `extends` clause, an `implements` clause, a
+lifetime parameter, or a decorator on the overlay declaration fails
+rather than being dropped in silence. This holds for `add` as well as
+`replace`.
+
 A declaration the converter gets structurally wrong is replaced whole
 rather than member by member. That happens when the overlay declaration
 and the converted one disagree on declaration kind, or when the kind
@@ -161,3 +172,5 @@ belong to none.
 - A drop entry carrying a type annotation, a signature, or an
   initializer, so that "the rest is ignored" does not become a trap for
   whoever writes a real signature and expects it to matter.
+- A member operation writing a header a merge does not read, so the same
+  trap does not open around the members.

--- a/internal/interop/overlay/README.md
+++ b/internal/interop/overlay/README.md
@@ -110,16 +110,19 @@ so a declaration TypeScript spells as the `interface Foo` +
 `interface FooConstructor` + `declare var Foo` trio is addressed as the
 single `class Foo` the generated file holds.
 
-A member operation keeps the converted declaration's header and
-substitutes members under it, so the overlay writes the name and the
-type parameters and nothing else. The type parameters have to agree,
-since the members are read under them: writing `class Array<U>` where
-the generated file holds `class Array<T>` fails the run rather than
-emitting members that refer to a name nothing binds. The rest of the
-header goes unread, so an `extends` clause, an `implements` clause, a
-lifetime parameter, a `final` modifier, or a decorator on the overlay
-declaration fails rather than being dropped in silence. This holds for `add` as well as
-`replace`.
+A member operation contributes members alone, so the overlay writes the
+name and the type parameters and nothing else. The type parameters have
+to agree, since the members are read under them: writing
+`class Array<U>` where the generated file holds `class Array<T>` fails
+the run rather than emitting members that refer to a name nothing binds.
+Everything else written around the members goes unread, so an `extends`
+clause, an `implements` clause, a lifetime parameter, a `final`
+modifier, or a decorator on the overlay declaration fails rather than
+being dropped in silence. This holds for `add` as well as `replace`.
+
+A whole-declaration replacement is the other case, and it does read all
+of that. The overlay stands in for the declaration entire, so what it
+writes around its members is what the generated file gets.
 
 A declaration the converter gets structurally wrong is replaced whole
 rather than member by member. That happens when the overlay declaration
@@ -172,5 +175,5 @@ belong to none.
 - A drop entry carrying a type annotation, a signature, or an
   initializer, so that "the rest is ignored" does not become a trap for
   whoever writes a real signature and expects it to matter.
-- A member operation writing a header a merge does not read, so the same
-  trap does not open around the members.
+- A member operation writing anything around its members that a merge
+  does not read, so the same trap does not open there.


### PR DESCRIPTION
Refs #1356.

Fourth of five stacked PRs. Based on [#1377](https://github.com/escalier-lang/escalier/pull/1377).

This one is independent of the rest of the stack and sits here only because a stack is linear. It can be pulled out and landed on its own if that reads better.

A member `add` or `replace` merges the overlay declaration's members into the converted one and keeps everything around them. The rest of what the overlay wrote at the top of that declaration was read by nobody and reported by nothing.

Two consequences, both silent:

- An overlay binding `<U>` where the generated file binds `<T>` left its members referring to a name the declaration does not bind, and the output said nothing about it.
- An `extends` clause, an `implements` clause, a lifetime parameter, or a decorator was dropped on the floor. A contributor writing `interface ArrayLike<T> extends Iterable<T>` got an `ArrayLike` that extends nothing.

`checkMergeHeader` closes both. The type parameters have to agree by name and order, since the members are read under them. Every other part of the header fails the run rather than going unread. A shape that genuinely needs a different header is a whole-declaration replacement, which does read what the overlay wrote.

## The stack

1. [#1375](https://github.com/escalier-lang/escalier/pull/1375) — the printer option.
2. [#1376](https://github.com/escalier-lang/escalier/pull/1376) — carry the converted member's doc.
3. [#1377](https://github.com/escalier-lang/escalier/pull/1377) — member kind and overload sets.
4. **This PR** — the converted declaration's header.
5. `claude/issue-1356-digests` — pin what an overlay `replace` stands in for. Closes #1356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Member-level overlay operations now validate declaration headers before applying changes.
  * Type parameter names must match the generated declaration.
  * Unsupported header details, such as inheritance clauses, decorators, and lifetime parameters, now cause generation to fail instead of being ignored.

* **Documentation**
  * Updated overlay guidance to describe header validation rules and failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->