### PR TITLE
dts_to_esc: pin what an overlay replace stands in for

### DIFF
--- a/internal/dts_to_esc/decl_key.go
+++ b/internal/dts_to_esc/decl_key.go
@@ -2,6 +2,7 @@ package dts_to_esc
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/printer"
 )
 
 // memberKind is the form a member takes: a field, a method, an
@@ -102,6 +103,42 @@ func slotFor(key ast.ObjKey, static bool, kind memberKind) (memberSlot, bool) {
 		}
 	}
 	return memberSlot{}, false
+}
+
+// memberOps is how the merge reads one member list: the slot a member
+// fills and the Escalier source a digest is taken over. The two member
+// lists a declaration can hold, a class body and an interface body, have
+// no element type in common, so each supplies its own pair.
+type memberOps[E any] struct {
+	slot func(E) (memberSlot, bool)
+	form func(E) (string, error)
+}
+
+// digestOptions returns the printer options a digest is taken under.
+// Doc comments are left out. An overlay stands in for a member's shape,
+// and carryMemberDocs hands the converted member's prose to the overlay
+// member replacing it wherever that member wrote none of its own. So an
+// upstream doc edit forks nothing and must not read as movement.
+func digestOptions() printer.Options {
+	opts := printer.DefaultOptions()
+	opts.OmitDocComments = true
+	return opts
+}
+
+// classMemberOps reads a class body.
+var classMemberOps = memberOps[ast.ClassElem]{
+	slot: classElemSlot,
+	form: func(elem ast.ClassElem) (string, error) {
+		return printer.PrintClassElem(elem, digestOptions())
+	},
+}
+
+// objMemberOps reads an interface or object-type body.
+var objMemberOps = memberOps[ast.ObjTypeAnnElem]{
+	slot: objElemSlot,
+	form: func(elem ast.ObjTypeAnnElem) (string, error) {
+		return printer.PrintObjTypeAnnElem(elem, digestOptions())
+	},
 }
 
 // escDeclName returns the name a top-level declaration is addressed by,

--- a/internal/dts_to_esc/generate.go
+++ b/internal/dts_to_esc/generate.go
@@ -38,6 +38,12 @@ type GenerateOptions struct {
 	// HandAuthored names the packages the run leaves alone. Callers pass
 	// HandAuthoredPackages; a nil set means the run owns every package.
 	HandAuthored set.Set[string]
+
+	// RecordDigests makes the run rewrite each `replace` file's digest
+	// sidecar from the converted forms it stands in for, rather than
+	// checking the recorded ones. It is how a contributor records what a
+	// new or revised overlay entry replaces.
+	RecordDigests bool
 }
 
 // GenerateResult reports what one run did, for the caller to print.
@@ -79,6 +85,7 @@ func Generate(opts GenerateOptions) (*GenerateResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	overlay.RecordDigests = opts.RecordDigests
 
 	basenames, err := DiscoverLibFiles(opts.LibDir)
 	if err != nil {

--- a/internal/dts_to_esc/generate_test.go
+++ b/internal/dts_to_esc/generate_test.go
@@ -111,7 +111,12 @@ func TestGenerate_IsIdempotent(t *testing.T) {
 	outDir := t.TempDir()
 	opts := GenerateOptions{LibDir: libDir, OverlayDir: overlayDir, OutDir: outDir}
 
-	_, err := Generate(opts)
+	record := opts
+	record.RecordDigests = true
+	_, err := Generate(record)
+	require.NoError(t, err)
+
+	_, err = Generate(opts)
 	require.NoError(t, err)
 	first := readPackage(t, outDir, "std/array.esc")
 

--- a/internal/dts_to_esc/overlay.go
+++ b/internal/dts_to_esc/overlay.go
@@ -63,6 +63,12 @@ type OverlayFile struct {
 	// Decls are the file's top-level declarations, parsed by Escalier's
 	// own parser.
 	Decls []ast.Decl
+
+	// Digests are the digests recorded in the sidecar beside a `replace`
+	// file, keyed by the declaration or member each one addresses. Every
+	// other operation leaves it empty, since only `replace` forks what
+	// the upstream source says.
+	Digests map[digestKey]string
 }
 
 // Overlay is the parsed contents of internal/interop/overlay/, the third
@@ -72,7 +78,23 @@ type OverlayFile struct {
 // Files are sorted by path, so a run applies them in the same order
 // every time.
 type Overlay struct {
+	// Dir is the overlay root the files were read from. A run that
+	// records digests writes the sidecars back under it.
+	Dir string
+
 	Files []OverlayFile
+
+	// Sidecars are the digest sidecars found under the root, by path
+	// relative to it and sorted. A run reads a sidecar through the
+	// `replace` file it pairs with, so this list is what turns up the
+	// ones that pair with none.
+	Sidecars []string
+
+	// RecordDigests makes a run take the digest of every converted
+	// declaration and member a `replace` stands in for as the current
+	// answer, and write the sidecars, instead of checking the recorded
+	// ones. `dts_to_esc generate --update-digests` sets it.
+	RecordDigests bool
 }
 
 // LoadOverlay parses every `.esc` file under dir. These are the only
@@ -88,8 +110,9 @@ type Overlay struct {
 //     "std/symbol.add.esc" applies to the package written to
 //     "std/symbol.esc".
 //
-// Any other `.esc` path is an error. Non-`.esc` files, README.md among
-// them, are ignored.
+// Any other `.esc` path is an error. A `replace` file also reads the
+// digest sidecar beside it, named by DigestSuffix. Every other file,
+// README.md among them, is ignored.
 func LoadOverlay(dir string) (*Overlay, error) {
 	info, err := os.Stat(dir)
 	if err != nil {
@@ -100,11 +123,12 @@ func LoadOverlay(dir string) (*Overlay, error) {
 	}
 
 	var files []OverlayFile
+	var sidecars []string
 	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() || !strings.HasSuffix(d.Name(), ".esc") {
+		if d.IsDir() {
 			return nil
 		}
 		rel, err := filepath.Rel(dir, path)
@@ -112,6 +136,13 @@ func LoadOverlay(dir string) (*Overlay, error) {
 			return err
 		}
 		rel = filepath.ToSlash(rel)
+		if strings.HasSuffix(d.Name(), DigestSuffix) {
+			sidecars = append(sidecars, rel)
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".esc") {
+			return nil
+		}
 		op, uri, err := classifyOverlayPath(rel)
 		if err != nil {
 			return err
@@ -125,14 +156,53 @@ func LoadOverlay(dir string) (*Overlay, error) {
 				return err
 			}
 		}
-		files = append(files, OverlayFile{Path: rel, Op: op, PkgURI: uri, Decls: decls})
+		file := OverlayFile{Path: rel, Op: op, PkgURI: uri, Decls: decls}
+		if op == OverlayReplace {
+			file.Digests, err = loadOverlayDigests(path)
+			if err != nil {
+				return err
+			}
+		}
+		files = append(files, file)
 		return nil
 	})
 	if walkErr != nil {
 		return nil, walkErr
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
-	return &Overlay{Files: files}, nil
+	sort.Strings(sidecars)
+	return &Overlay{Dir: dir, Files: files, Sidecars: sidecars}, nil
+}
+
+// unpairedSidecars returns the digest sidecars that pair with no
+// `replace` file, in path order. Nothing reads one, so leaving it would
+// let a renamed or retired overlay keep a record no run ever checks. A
+// run that records digests deletes them once it has applied the whole
+// overlay. Every other run fails and names the first.
+func (o *Overlay) unpairedSidecars() []string {
+	paired := set.NewSet[string]()
+	for _, f := range o.Files {
+		if f.Op == OverlayReplace {
+			paired.Add(digestPathFor(f.Path))
+		}
+	}
+	var unpaired []string
+	for _, rel := range o.Sidecars {
+		if !paired.Contains(rel) {
+			unpaired = append(unpaired, rel)
+		}
+	}
+	return unpaired
+}
+
+// unpairedSidecarError names a sidecar with no `replace` file to pair
+// with, and the file it would pair with if the overlay held one.
+func unpairedSidecarError(rel string) error {
+	return fmt.Errorf(
+		"overlay: %s records digests for %s, which is not a replace file the "+
+			"overlay holds; run `dts_to_esc generate --update-digests` to remove "+
+			"the sidecar, or restore the replace file it belongs beside",
+		rel, strings.TrimSuffix(rel, DigestSuffix)+".esc")
 }
 
 // classifyOverlayPath reads a file's operation and target package out of

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/printer"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/tidwall/btree"
 )
@@ -24,6 +25,13 @@ import (
 // TypeScript side reaches a contributor, keyed on the overlay rather
 // than on the tree the run overwrites.
 func ApplyOverlay(mods map[string]*StandaloneModule, o *Overlay) error {
+	if o == nil {
+		return nil
+	}
+	digests := newDigestPass(o.RecordDigests)
+	if unpaired := o.unpairedSidecars(); len(unpaired) > 0 && !o.RecordDigests {
+		return unpairedSidecarError(unpaired[0])
+	}
 	for _, uri := range o.PackageURIs() {
 		files := o.FilesFor(uri)
 		mod, ok := mods[uri]
@@ -36,12 +44,21 @@ func ApplyOverlay(mods map[string]*StandaloneModule, o *Overlay) error {
 			mods[uri] = mod
 		}
 		for _, f := range files {
-			if err := applyOverlayFile(mod, f); err != nil {
+			if err := applyOverlayFile(mod, f, digests); err != nil {
+				return err
+			}
+			if f.Op != OverlayReplace {
+				continue
+			}
+			if err := digests.finish(f); err != nil {
 				return err
 			}
 		}
 	}
-	return nil
+	if !o.RecordDigests {
+		return nil
+	}
+	return digests.write(o)
 }
 
 // emptyModuleFor builds the module an overlay-only package starts from.
@@ -65,7 +82,7 @@ func emptyModuleFor(uri string, files []OverlayFile) (*StandaloneModule, error) 
 
 // applyOverlayFile applies one file's declarations to the module of the
 // package it targets.
-func applyOverlayFile(mod *StandaloneModule, f OverlayFile) error {
+func applyOverlayFile(mod *StandaloneModule, f OverlayFile, digests *digestPass) error {
 	ns, ok := mod.Module.Namespaces.Get("")
 	if !ok {
 		return fmt.Errorf("overlay: %s targets %s, whose converted module has no root namespace",
@@ -75,7 +92,7 @@ func applyOverlayFile(mod *StandaloneModule, f OverlayFile) error {
 		return applyDropFile(ns, f)
 	}
 	for _, ovDecl := range f.Decls {
-		if err := applyOverlayDecl(mod, ns, f, ovDecl); err != nil {
+		if err := applyOverlayDecl(mod, ns, f, ovDecl, digests); err != nil {
 			return err
 		}
 	}
@@ -184,6 +201,7 @@ func applyOverlayDecl(
 	ns *ast.Namespace,
 	f OverlayFile,
 	ovDecl ast.Decl,
+	digests *digestPass,
 ) error {
 	name := escDeclName(ovDecl)
 	idx := findDeclIndex(ns.Decls, name)
@@ -205,7 +223,7 @@ func applyOverlayDecl(
 				return err
 			}
 			body, err := mergeMembers(
-				f, name, hostDecl.Body, ovClass.Body, classElemSlot)
+				f, name, hostDecl.Body, ovClass.Body, classMemberOps, digests)
 			if err != nil {
 				return err
 			}
@@ -221,7 +239,7 @@ func applyOverlayDecl(
 				return err
 			}
 			elems, err := mergeMembers(
-				f, name, hostDecl.TypeAnn.Elems, ovIface.TypeAnn.Elems, objElemSlot)
+				f, name, hostDecl.TypeAnn.Elems, ovIface.TypeAnn.Elems, objMemberOps, digests)
 			if err != nil {
 				return err
 			}
@@ -235,6 +253,13 @@ func applyOverlayDecl(
 			"overlay: %s adds the %s %s, which %s already declares; correct an "+
 				"existing declaration with a replace overlay",
 			f.Path, escDeclKind(host), name, f.PkgURI)
+	}
+	form, err := printer.Print(host, digestOptions())
+	if err != nil {
+		return err
+	}
+	if err := digests.visit(f, digestKey{Decl: name}, []string{form}); err != nil {
+		return err
 	}
 	ns.Decls[idx] = ovDecl
 	carryDeclMetadata(mod, host, ovDecl)
@@ -354,12 +379,13 @@ func mergeMembers[E any](
 	f OverlayFile,
 	owner string,
 	host, overlay []E,
-	slotOf func(E) (memberSlot, bool),
+	ops memberOps[E],
+	digests *digestPass,
 ) ([]E, error) {
 	if f.Op == OverlayAdd {
-		return addMembers(f, owner, host, overlay, slotOf)
+		return addMembers(f, owner, host, overlay, ops)
 	}
-	return replaceMembers(f, owner, host, overlay, slotOf)
+	return replaceMembers(f, owner, host, overlay, ops, digests)
 }
 
 // addMembers appends every overlay member, failing on a member the
@@ -372,14 +398,14 @@ func addMembers[E any](
 	f OverlayFile,
 	owner string,
 	host, overlay []E,
-	slotOf func(E) (memberSlot, bool),
+	ops memberOps[E],
 ) ([]E, error) {
-	converted, hostKinds := groupMembers(host, slotOf)
+	converted, hostKinds := groupMembers(host, ops.slot)
 	added := map[memberSlot][]memberKind{}
 	out := make([]E, 0, len(host)+len(overlay))
 	out = append(out, host...)
 	for _, m := range overlay {
-		slot, ok := slotOf(m)
+		slot, ok := ops.slot(m)
 		if !ok {
 			out = append(out, m)
 			continue
@@ -467,13 +493,14 @@ func replaceMembers[E any](
 	f OverlayFile,
 	owner string,
 	host, overlay []E,
-	slotOf func(E) (memberSlot, bool),
+	ops memberOps[E],
+	digests *digestPass,
 ) ([]E, error) {
-	hostGroups, hostKinds := groupMembers(host, slotOf)
+	hostGroups, hostKinds := groupMembers(host, ops.slot)
 	groups := map[memberSlot][]E{}
 	var order []memberSlot
 	for _, m := range overlay {
-		slot, ok := slotOf(m)
+		slot, ok := ops.slot(m)
 		if !ok {
 			return nil, fmt.Errorf(
 				"overlay: %s replaces a member of %s whose key has no textual name; "+
@@ -501,13 +528,20 @@ func replaceMembers[E any](
 					"restates the whole overload set, since a name is what addresses it",
 				f.Path, len(groups[slot]), len(converted), memberLabel(owner, slot))
 		}
+		forms, err := printMembers(converted, ops)
+		if err != nil {
+			return nil, err
+		}
+		if err := digests.visit(f, keyForSlot(owner, slot), forms); err != nil {
+			return nil, err
+		}
 		carryMemberDocs(converted, groups[slot])
 	}
 
 	substituted := set.NewSet[memberSlot]()
 	out := make([]E, 0, len(host)+len(overlay))
 	for _, m := range host {
-		slot, ok := slotOf(m)
+		slot, ok := ops.slot(m)
 		if !ok {
 			out = append(out, m)
 			continue
@@ -628,6 +662,20 @@ func joinKinds(kinds []memberKind) string {
 		return names[0]
 	}
 	return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+}
+
+// printMembers renders the converted members one overlay entry stands in
+// for, in the order the converted declaration lists them.
+func printMembers[E any](members []E, ops memberOps[E]) ([]string, error) {
+	forms := make([]string, len(members))
+	for i, m := range members {
+		form, err := ops.form(m)
+		if err != nil {
+			return nil, err
+		}
+		forms[i] = form
+	}
+	return forms, nil
 }
 
 // findDecl returns the declaration addressed by name, or nil.

--- a/internal/dts_to_esc/overlay_apply.go
+++ b/internal/dts_to_esc/overlay_apply.go
@@ -258,7 +258,7 @@ func applyOverlayDecl(
 	if err != nil {
 		return err
 	}
-	if err := digests.visit(f, digestKey{Decl: name}, []string{form}); err != nil {
+	if err := digests.compute(f, digestKey{Decl: name}, []string{form}); err != nil {
 		return err
 	}
 	ns.Decls[idx] = ovDecl
@@ -532,7 +532,7 @@ func replaceMembers[E any](
 		if err != nil {
 			return nil, err
 		}
-		if err := digests.visit(f, keyForSlot(owner, slot), forms); err != nil {
+		if err := digests.compute(f, keyForSlot(owner, slot), forms); err != nil {
 			return nil, err
 		}
 		carryMemberDocs(converted, groups[slot])

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -19,36 +19,19 @@ interface ArrayLike<T> { readonly length: number; }
 declare function parseInt(string: string, radix?: number): number;
 `
 
-// overlayDocLib is overlayLib with a doc comment above the member the
-// overlay tests replace. Prose is the bulk of what a TypeScript version
-// bump moves, so what happens to it under a `replace` is worth pinning.
-const overlayDocLib = `
-interface Array<T> { length: number; /** Reads one element. */ at(index: number): T | undefined; }
-interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
-declare var Array: ArrayConstructor;
-interface ArrayLike<T> { readonly length: number; }
-`
-
-// convertWithOverlay folds an overlay tree into the converted
-// overlayLib.
-func convertWithOverlay(t *testing.T, files map[string]string) (map[string]*StandaloneModule, error) {
+// applyOverlayIn routes lib, converts every bucket, and folds in the
+// overlay tree already seeded at dir. It runs the three steps a
+// generation runs before it writes anything to disk. Under record it
+// takes the digest of whatever the overlay replaces as the current
+// answer and writes the sidecars, the way
+// `dts_to_esc generate --update-digests` does.
+func applyOverlayIn(t *testing.T, dir, lib string, record bool) (map[string]*StandaloneModule, error) {
 	t.Helper()
-	return convertLibWithOverlay(t, overlayLib, files)
-}
-
-// convertLibWithOverlay routes one `.d.ts` input, converts every bucket,
-// and folds the given overlay files in. It runs the three steps a
-// generation runs before it writes anything to disk.
-func convertLibWithOverlay(
-	t *testing.T,
-	lib string,
-	files map[string]string,
-) (map[string]*StandaloneModule, error) {
-	t.Helper()
-	overlay, err := LoadOverlay(seedOverlay(t, files))
+	overlay, err := LoadOverlay(dir)
 	if err != nil {
 		return nil, err
 	}
+	overlay.RecordDigests = record
 	res, err := PartitionLibWithOverlay(
 		[]LibInput{parseLib(t, "lib.es5.d.ts", lib)}, overlay)
 	if err != nil {
@@ -59,6 +42,31 @@ func convertLibWithOverlay(
 		return nil, err
 	}
 	return mods, ApplyOverlay(mods, overlay)
+}
+
+// convertWithOverlay folds an overlay tree into the converted
+// overlayLib. It runs the two steps a contributor takes for a
+// `replace`: record what the overlay stands in for, then run the check
+// that reads those digests back. Every replace case therefore covers
+// the round trip as well as its own subject.
+func convertWithOverlay(t *testing.T, files map[string]string) (map[string]*StandaloneModule, error) {
+	t.Helper()
+	return convertLibWithOverlay(t, overlayLib, files)
+}
+
+// convertLibWithOverlay is convertWithOverlay over a chosen `.d.ts`
+// input, for the shapes overlayLib does not hold.
+func convertLibWithOverlay(
+	t *testing.T,
+	lib string,
+	files map[string]string,
+) (map[string]*StandaloneModule, error) {
+	t.Helper()
+	dir := seedOverlay(t, files)
+	if _, err := applyOverlayIn(t, dir, lib, true); err != nil {
+		return nil, err
+	}
+	return applyOverlayIn(t, dir, lib, false)
 }
 
 // overlayModules is convertWithOverlay for a case expected to succeed.

--- a/internal/dts_to_esc/overlay_digest.go
+++ b/internal/dts_to_esc/overlay_digest.go
@@ -29,11 +29,13 @@ type digestKey struct {
 }
 
 // label names what a key addresses, in the form the overlay errors use.
+// A member goes through memberLabel, so a sidecar report marks the
+// static side the way every other report does.
 func (k digestKey) label() string {
 	if k.Member == "" {
 		return k.Decl
 	}
-	return k.Decl + "." + k.Member
+	return memberLabel(k.Decl, memberSlot{Name: k.Member, Static: k.Static, Kind: k.Kind})
 }
 
 // keyForSlot addresses the digest of the converted members one overlay

--- a/internal/dts_to_esc/overlay_digest.go
+++ b/internal/dts_to_esc/overlay_digest.go
@@ -68,36 +68,38 @@ type OverlayDigest struct {
 // that silence into a failed run. It pins the converted form the
 // overlay was written against, and a run compares the two.
 //
-// Under record the pass takes each digest as the current answer instead
-// of comparing, and ApplyOverlay then writes the sidecars.
+// A recording run keeps each digest as the current answer instead of
+// comparing, and ApplyOverlay then writes the sidecars.
 // `dts_to_esc generate --update-digests` is how a contributor records
 // what a new or revised overlay entry stands in for.
 type digestPass struct {
-	record bool
+	recording bool
 
-	// observed holds the digests this run computed, keyed by the
-	// overlay file's path relative to the overlay root.
-	observed map[string][]OverlayDigest
+	// computed holds the digests this run computed, keyed by the overlay
+	// file's path relative to the overlay root. They are what a recording
+	// run writes to the sidecars, and what a checking run reads the
+	// recorded ones against.
+	computed map[string][]OverlayDigest
 }
 
-func newDigestPass(record bool) *digestPass {
-	return &digestPass{record: record, observed: map[string][]OverlayDigest{}}
+func newDigestPass(recording bool) *digestPass {
+	return &digestPass{recording: recording, computed: map[string][]OverlayDigest{}}
 }
 
-// visit takes the digest of the converted forms one `replace` entry
-// replaces, given their printed Escalier source. Outside record mode it
+// compute hashes the printed Escalier source of the converted forms one
+// `replace` entry replaces, and keeps the result. A checking run also
 // fails when the sidecar has no entry for the key or records a
 // different form.
-func (dp *digestPass) visit(f OverlayFile, key digestKey, forms []string) error {
-	found := digestOf(forms)
-	dp.observed[f.Path] = append(dp.observed[f.Path], OverlayDigest{
+func (dp *digestPass) compute(f OverlayFile, key digestKey, forms []string) error {
+	digest := digestOf(forms)
+	dp.computed[f.Path] = append(dp.computed[f.Path], OverlayDigest{
 		Decl:   key.Decl,
 		Member: key.Member,
 		Kind:   key.Kind,
 		Static: key.Static,
-		Digest: found,
+		Digest: digest,
 	})
-	if dp.record {
+	if dp.recording {
 		return nil
 	}
 	recorded, ok := f.Digests[key]
@@ -107,7 +109,7 @@ func (dp *digestPass) visit(f OverlayFile, key digestKey, forms []string) error 
 				"`dts_to_esc generate --update-digests` to record what the overlay "+
 				"stands in for", f.Path, key.label(), digestPathFor(f.Path))
 	}
-	if recorded != found {
+	if recorded != digest {
 		return fmt.Errorf(
 			"overlay: %s replaces %s, whose converted form has changed since %s "+
 				"recorded it; check the overlay against the upstream declaration, "+
@@ -119,14 +121,14 @@ func (dp *digestPass) visit(f OverlayFile, key digestKey, forms []string) error 
 
 // finish closes the pass over one overlay file, reporting a recorded
 // entry the file no longer replaces. Such an entry pins a form nothing
-// reads. Record mode rewrites the sidecar from what the file replaces
-// now, so it has nothing to report.
+// reads. A recording run rewrites the sidecar from what the file
+// replaces now, so it has nothing to report.
 func (dp *digestPass) finish(f OverlayFile) error {
-	if dp.record {
+	if dp.recording {
 		return nil
 	}
 	replaced := map[digestKey]bool{}
-	for _, e := range dp.observed[f.Path] {
+	for _, e := range dp.computed[f.Path] {
 		replaced[keyOf(e)] = true
 	}
 	for _, key := range sortedDigestKeys(f.Digests) {
@@ -154,7 +156,7 @@ func (dp *digestPass) write(o *Overlay) error {
 			continue
 		}
 		path := filepath.Join(o.Dir, filepath.FromSlash(digestPathFor(f.Path)))
-		if err := writeOverlayDigests(path, dp.observed[f.Path]); err != nil {
+		if err := writeOverlayDigests(path, dp.computed[f.Path]); err != nil {
 			return err
 		}
 	}

--- a/internal/dts_to_esc/overlay_digest.go
+++ b/internal/dts_to_esc/overlay_digest.go
@@ -85,8 +85,8 @@ func newDigestPass(record bool) *digestPass {
 }
 
 // visit takes the digest of the converted forms one `replace` entry
-// substitutes, given their printed Escalier source. Outside record mode
-// it fails when the sidecar has no entry for the key or records a
+// replaces, given their printed Escalier source. Outside record mode it
+// fails when the sidecar has no entry for the key or records a
 // different form.
 func (dp *digestPass) visit(f OverlayFile, key digestKey, forms []string) error {
 	found := digestOf(forms)

--- a/internal/dts_to_esc/overlay_digest.go
+++ b/internal/dts_to_esc/overlay_digest.go
@@ -1,0 +1,266 @@
+package dts_to_esc
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DigestSuffix is the suffix of the sidecar that records what one
+// `replace` file stands in for. The sidecar sits beside its overlay file, so
+// `std/array.replace.esc` pairs with `std/array.replace.digests.json`.
+const DigestSuffix = ".digests.json"
+
+// digestKey addresses one recorded digest. Member is empty for a whole
+// declaration a `replace` stands in for, and holds the member's name
+// otherwise. The remaining two fields are the rest of the member's
+// slot. Static separates the two sides of a class. Kind separates the
+// members one name can address, a `get x()` and a `set x()` among them.
+type digestKey struct {
+	Decl   string
+	Member string
+	Static bool
+	Kind   memberKind
+}
+
+// label names what a key addresses, in the form the overlay errors use.
+func (k digestKey) label() string {
+	if k.Member == "" {
+		return k.Decl
+	}
+	return k.Decl + "." + k.Member
+}
+
+// keyForSlot addresses the digest of the converted members one overlay
+// member stands in for.
+func keyForSlot(owner string, slot memberSlot) digestKey {
+	return digestKey{
+		Decl:   owner,
+		Member: slot.Name,
+		Static: slot.Static,
+		Kind:   slot.Kind,
+	}
+}
+
+// OverlayDigest is one entry of a sidecar. It records the digest of the
+// converted declaration or member an overlay `replace` entry stood in
+// for when the digest was taken.
+type OverlayDigest struct {
+	Decl   string     `json:"decl"`
+	Member string     `json:"member,omitempty"`
+	Kind   memberKind `json:"kind,omitempty"`
+	Static bool       `json:"static,omitempty"`
+	Digest string     `json:"digest"`
+}
+
+// digestPass records or checks the digest of every converted
+// declaration and member a `replace` stands in for.
+//
+// A `replace` forks its target. The overlay wins by construction, so a
+// change upstream stops reaching the output. The digest is what turns
+// that silence into a failed run. It pins the converted form the
+// overlay was written against, and a run compares the two.
+//
+// Under record the pass takes each digest as the current answer instead
+// of comparing, and ApplyOverlay then writes the sidecars.
+// `dts_to_esc generate --update-digests` is how a contributor records
+// what a new or revised overlay entry stands in for.
+type digestPass struct {
+	record bool
+
+	// observed holds the digests this run computed, keyed by the
+	// overlay file's path relative to the overlay root.
+	observed map[string][]OverlayDigest
+}
+
+func newDigestPass(record bool) *digestPass {
+	return &digestPass{record: record, observed: map[string][]OverlayDigest{}}
+}
+
+// visit takes the digest of the converted forms one `replace` entry
+// substitutes, given their printed Escalier source. Outside record mode
+// it fails when the sidecar has no entry for the key or records a
+// different form.
+func (dp *digestPass) visit(f OverlayFile, key digestKey, forms []string) error {
+	found := digestOf(forms)
+	dp.observed[f.Path] = append(dp.observed[f.Path], OverlayDigest{
+		Decl:   key.Decl,
+		Member: key.Member,
+		Kind:   key.Kind,
+		Static: key.Static,
+		Digest: found,
+	})
+	if dp.record {
+		return nil
+	}
+	recorded, ok := f.Digests[key]
+	if !ok {
+		return fmt.Errorf(
+			"overlay: %s replaces %s, and %s records no digest for it; run "+
+				"`dts_to_esc generate --update-digests` to record what the overlay "+
+				"stands in for", f.Path, key.label(), digestPathFor(f.Path))
+	}
+	if recorded != found {
+		return fmt.Errorf(
+			"overlay: %s replaces %s, whose converted form has changed since %s "+
+				"recorded it; check the overlay against the upstream declaration, "+
+				"then run `dts_to_esc generate --update-digests`",
+			f.Path, key.label(), digestPathFor(f.Path))
+	}
+	return nil
+}
+
+// finish closes the pass over one overlay file, reporting a recorded
+// entry the file no longer replaces. Such an entry pins a form nothing
+// reads. Record mode rewrites the sidecar from what the file replaces
+// now, so it has nothing to report.
+func (dp *digestPass) finish(f OverlayFile) error {
+	if dp.record {
+		return nil
+	}
+	replaced := map[digestKey]bool{}
+	for _, e := range dp.observed[f.Path] {
+		replaced[keyOf(e)] = true
+	}
+	for _, key := range sortedDigestKeys(f.Digests) {
+		if !replaced[key] {
+			return fmt.Errorf(
+				"overlay: %s records a digest for %s, which %s does not replace; run "+
+					"`dts_to_esc generate --update-digests` to bring the two back in step",
+				digestPathFor(f.Path), key.label(), f.Path)
+		}
+	}
+	return nil
+}
+
+// write rewrites every `replace` file's sidecar from the digests the
+// run took. It runs once the whole overlay has applied, so a run that
+// fails partway records nothing rather than leaving half the tree
+// rewritten.
+//
+// A file that replaces nothing any more loses its sidecar, and so does a
+// sidecar left beside no `replace` file at all. That is how
+// `--update-digests` clears a record a contributor has stopped needing.
+func (dp *digestPass) write(o *Overlay) error {
+	for _, f := range o.Files {
+		if f.Op != OverlayReplace {
+			continue
+		}
+		path := filepath.Join(o.Dir, filepath.FromSlash(digestPathFor(f.Path)))
+		if err := writeOverlayDigests(path, dp.observed[f.Path]); err != nil {
+			return err
+		}
+	}
+	for _, rel := range o.unpairedSidecars() {
+		path := filepath.Join(o.Dir, filepath.FromSlash(rel))
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing overlay digests %s: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+// digestOf hashes the printed Escalier source of what one entry stands
+// in for. A member name addresses a whole overload set, so forms holds
+// one string per signature and their order is the order the converted
+// declaration lists them in.
+//
+// The first 16 hex digits of the SHA-256 are enough to catch an upstream
+// edit and short enough to read in a diff.
+func digestOf(forms []string) string {
+	sum := sha256.Sum256([]byte(strings.Join(forms, "\n")))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// digestPathFor returns the sidecar path that pairs with an overlay
+// file, by swapping the `.esc` suffix. It answers in whichever form it
+// is asked, a path relative to the overlay root or one on disk.
+func digestPathFor(escPath string) string {
+	return strings.TrimSuffix(escPath, ".esc") + DigestSuffix
+}
+
+// loadOverlayDigests reads the sidecar beside one overlay file, given
+// that file's path on disk. A file with no sidecar yet has no recorded
+// entries, and the first run against it stops on the first entry it
+// cannot find.
+func loadOverlayDigests(escPath string) (map[digestKey]string, error) {
+	path := digestPathFor(escPath)
+	contents, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return map[digestKey]string{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading overlay digests %s: %w", filepath.Base(path), err)
+	}
+	var entries []OverlayDigest
+	if err := json.Unmarshal(contents, &entries); err != nil {
+		return nil, fmt.Errorf(
+			"overlay: %s does not parse as JSON: %w", filepath.Base(path), err)
+	}
+	digests := map[digestKey]string{}
+	for _, e := range entries {
+		digests[keyOf(e)] = e.Digest
+	}
+	return digests, nil
+}
+
+// writeOverlayDigests writes one sidecar, sorted so a run rewrites it
+// byte for byte. A file that replaces nothing gets no sidecar, and an
+// existing one is removed.
+func writeOverlayDigests(path string, entries []OverlayDigest) error {
+	if len(entries) == 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing overlay digests %s: %w", filepath.Base(path), err)
+		}
+		return nil
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return digestKeyLess(keyOf(entries[i]), keyOf(entries[j]))
+	})
+	contents, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding overlay digests %s: %w", filepath.Base(path), err)
+	}
+	contents = append(contents, '\n')
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		return fmt.Errorf("writing overlay digests %s: %w", filepath.Base(path), err)
+	}
+	return nil
+}
+
+// keyOf returns what one sidecar entry addresses.
+func keyOf(e OverlayDigest) digestKey {
+	return digestKey{Decl: e.Decl, Member: e.Member, Static: e.Static, Kind: e.Kind}
+}
+
+// digestKeyLess orders two keys by declaration, then by instance before
+// static, then by member name, then by kind. Both the sidecar and the
+// stale-entry report follow it, so a rewritten file is byte-identical
+// and a report names the first stale entry rather than an arbitrary one.
+func digestKeyLess(a, b digestKey) bool {
+	if a.Decl != b.Decl {
+		return a.Decl < b.Decl
+	}
+	if a.Static != b.Static {
+		return !a.Static
+	}
+	if a.Member != b.Member {
+		return a.Member < b.Member
+	}
+	return a.Kind < b.Kind
+}
+
+// sortedDigestKeys orders one sidecar's keys.
+func sortedDigestKeys(digests map[digestKey]string) []digestKey {
+	keys := make([]digestKey, 0, len(digests))
+	for key := range digests {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return digestKeyLess(keys[i], keys[j]) })
+	return keys
+}

--- a/internal/dts_to_esc/overlay_digest_test.go
+++ b/internal/dts_to_esc/overlay_digest_test.go
@@ -1,0 +1,228 @@
+package dts_to_esc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// overlayMovedLib is overlayLib with `at` retyped, standing in for a
+// TypeScript version that moves a member an overlay replaces. Recording
+// against one and checking against the other is what a version bump
+// does to a `replace`.
+const overlayMovedLib = `
+interface Array<T> { length: number; at(index: number): T | null; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
+declare var Array: ArrayConstructor;
+interface ArrayLike<T> { readonly length: number; }
+declare function parseInt(string: string, radix?: number): number;
+`
+
+// replaceOverlay is the overlay tree the digest tests record: one
+// member of the converted class and one whole declaration, the two
+// things a `replace` can stand in for.
+var replaceOverlay = map[string]string{
+	"std/array.replace.esc": "export declare class Array<T> {\n" +
+		"    at(self, index: number) -> T,\n}\n" +
+		"export declare type ArrayLike<T> = { length: number }\n",
+}
+
+// readDigests returns one sidecar's contents.
+func readDigests(t *testing.T, dir, rel string) string {
+	t.Helper()
+	contents, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+	require.NoError(t, err)
+	return string(contents)
+}
+
+// TestOverlayDigests_RecordWritesASidecarBesideTheReplaceFile pins the
+// file `dts_to_esc generate --update-digests` writes. Each entry
+// addresses one converted member or declaration and carries the digest
+// of its printed Escalier source.
+func TestOverlayDigests_RecordWritesASidecarBesideTheReplaceFile(t *testing.T) {
+	t.Parallel()
+	dir := seedOverlay(t, replaceOverlay)
+	_, err := applyOverlayIn(t, dir, overlayLib, true)
+	require.NoError(t, err)
+
+	snaps.MatchInlineSnapshot(t, readDigests(t, dir, "std/array.replace.digests.json"), snaps.Inline(`[
+  {
+    "decl": "Array",
+    "member": "at",
+    "kind": "method",
+    "digest": "fb2b83d0692345dc"
+  },
+  {
+    "decl": "ArrayLike",
+    "digest": "d971c35a9fcaa007"
+  }
+]
+`))
+}
+
+// TestOverlayDigests_RecordingTwiceLeavesTheSidecarByteIdentical keeps
+// the sidecar out of the churn a re-run would otherwise produce. It is
+// a committed input, so a run that changes nothing must leave it alone.
+func TestOverlayDigests_RecordingTwiceLeavesTheSidecarByteIdentical(t *testing.T) {
+	t.Parallel()
+	dir := seedOverlay(t, replaceOverlay)
+	_, err := applyOverlayIn(t, dir, overlayLib, true)
+	require.NoError(t, err)
+	first := readDigests(t, dir, "std/array.replace.digests.json")
+
+	_, err = applyOverlayIn(t, dir, overlayLib, true)
+	require.NoError(t, err)
+	require.Equal(t, first, readDigests(t, dir, "std/array.replace.digests.json"))
+}
+
+// TestOverlayDigests_ReportAConvertedFormThatMoved is the check the
+// granularity still needs. A `replace` forks its target, so upstream can
+// retype the member it stands in for and the output would not move. The
+// digest is what turns that silence into a failed run.
+func TestOverlayDigests_ReportAConvertedFormThatMoved(t *testing.T) {
+	t.Parallel()
+	dir := seedOverlay(t, replaceOverlay)
+	_, err := applyOverlayIn(t, dir, overlayLib, true)
+	require.NoError(t, err)
+
+	_, err = applyOverlayIn(t, dir, overlayMovedLib, false)
+	require.EqualError(t, err,
+		"overlay: std/array.replace.esc replaces Array.at, whose converted form has "+
+			"changed since std/array.replace.digests.json recorded it; check the "+
+			"overlay against the upstream declaration, then run "+
+			"`dts_to_esc generate --update-digests`")
+}
+
+// TestOverlayDigests_ReportAnUnrecordedReplace covers the first run
+// against a new overlay entry. Nothing pins what it stands in for yet,
+// so the run stops rather than forking silently.
+func TestOverlayDigests_ReportAnUnrecordedReplace(t *testing.T) {
+	t.Parallel()
+	_, err := applyOverlayIn(t, seedOverlay(t, replaceOverlay), overlayLib, false)
+	require.EqualError(t, err,
+		"overlay: std/array.replace.esc replaces Array.at, and "+
+			"std/array.replace.digests.json records no digest for it; run "+
+			"`dts_to_esc generate --update-digests` to record what the overlay "+
+			"stands in for")
+}
+
+// TestOverlayDigests_ReportAnEntryTheOverlayNoLongerReplaces keeps the
+// sidecar in step with the file beside it. An entry for a member the
+// overlay has stopped replacing pins a form nothing reads.
+func TestOverlayDigests_ReportAnEntryTheOverlayNoLongerReplaces(t *testing.T) {
+	t.Parallel()
+	dir := seedOverlay(t, map[string]string{
+		"std/array.replace.esc": "export declare class Array<T> {\n" +
+			"    length: number,\n    at(self, index: number) -> T,\n}\n",
+	})
+	_, err := applyOverlayIn(t, dir, overlayLib, true)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "std", "array.replace.esc"),
+		[]byte("export declare class Array<T> {\n    length: number,\n}\n"), 0o644))
+	_, err = applyOverlayIn(t, dir, overlayLib, false)
+	require.EqualError(t, err,
+		"overlay: std/array.replace.digests.json records a digest for Array.at, "+
+			"which std/array.replace.esc does not replace; run "+
+			"`dts_to_esc generate --update-digests` to bring the two back in step")
+}
+
+// TestOverlayDigests_ReportASidecarWithNoReplaceFile covers the sidecar
+// left behind when its overlay file is renamed or retired. Nothing reads
+// it, so it would otherwise sit in the tree recording a form no run
+// checks.
+func TestOverlayDigests_ReportASidecarWithNoReplaceFile(t *testing.T) {
+	t.Parallel()
+	seed := map[string]string{
+		"std/array.add.esc": "export declare class Array<T> {\n" +
+			"    static of<T>(...items: Array<T>) -> Array<T>,\n}\n",
+		"std/array.replace.digests.json": "[]\n",
+	}
+	dir := seedOverlay(t, seed)
+	_, err := applyOverlayIn(t, dir, overlayLib, false)
+	require.EqualError(t, err,
+		"overlay: std/array.replace.digests.json records digests for "+
+			"std/array.replace.esc, which is not a replace file the overlay holds; "+
+			"run `dts_to_esc generate --update-digests` to remove the sidecar, or "+
+			"restore the replace file it belongs beside")
+
+	// The recording run is the recovery the report names, so it removes
+	// the sidecar rather than stopping on it.
+	dir = seedOverlay(t, seed)
+	_, err = applyOverlayIn(t, dir, overlayLib, true)
+	require.NoError(t, err)
+	require.NoFileExists(t, filepath.Join(dir, "std", "array.replace.digests.json"))
+}
+
+// TestOverlayDigests_KeepAGetterAndASetterApart covers the one name that
+// addresses two members. Each gets its own sidecar entry, keyed on the
+// kind, and the check run reads each back against the member its digest
+// was taken from.
+func TestOverlayDigests_KeepAGetterAndASetterApart(t *testing.T) {
+	t.Parallel()
+	dir := seedOverlay(t, map[string]string{
+		"std/array.replace.esc": "export declare class Array<T> {\n" +
+			"    get size(self) -> number | undefined,\n" +
+			"    set size(mut self, v: number | undefined),\n}\n",
+	})
+	_, err := applyOverlayIn(t, dir, overlayKindLib, true)
+	require.NoError(t, err)
+
+	snaps.MatchInlineSnapshot(t, readDigests(t, dir, "std/array.replace.digests.json"), snaps.Inline(`[
+  {
+    "decl": "Array",
+    "member": "size",
+    "kind": "getter",
+    "digest": "306eee11108848af"
+  },
+  {
+    "decl": "Array",
+    "member": "size",
+    "kind": "setter",
+    "digest": "59a6dc0bffd1defa"
+  }
+]
+`))
+
+	_, err = applyOverlayIn(t, dir, overlayKindLib, false)
+	require.NoError(t, err)
+}
+
+// overlayDocLib and overlayEditedDocLib differ only in the prose above
+// the member `std/array.replace.esc` stands in for. Prose churn is the
+// bulk of a TypeScript version bump, and it moves no shape.
+const overlayDocLib = `
+interface Array<T> { length: number; /** Reads one element. */ at(index: number): T | undefined; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
+declare var Array: ArrayConstructor;
+interface ArrayLike<T> { readonly length: number; }
+`
+
+const overlayEditedDocLib = `
+interface Array<T> { length: number; /** Reads the element at index. */ at(index: number): T | undefined; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
+declare var Array: ArrayConstructor;
+interface ArrayLike<T> { readonly length: number; }
+`
+
+// TestOverlayDigests_IgnoreADocCommentEdit keeps the check on the shape
+// a `replace` stands in for. The doc comment is not part of that shape:
+// carryDeclMetadata moves the converted prose onto the overlay
+// declaration, so an upstream edit still reaches the output and forks
+// nothing.
+func TestOverlayDigests_IgnoreADocCommentEdit(t *testing.T) {
+	t.Parallel()
+	dir := seedOverlay(t, map[string]string{
+		"std/array.replace.esc": "export declare class Array<T> {\n" +
+			"    at(self, index: number) -> T,\n}\n",
+	})
+	_, err := applyOverlayIn(t, dir, overlayDocLib, true)
+	require.NoError(t, err)
+
+	_, err = applyOverlayIn(t, dir, overlayEditedDocLib, false)
+	require.NoError(t, err)
+}

--- a/internal/dts_to_esc/overlay_digest_test.go
+++ b/internal/dts_to_esc/overlay_digest_test.go
@@ -226,3 +226,41 @@ func TestOverlayDigests_IgnoreADocCommentEdit(t *testing.T) {
 	_, err = applyOverlayIn(t, dir, overlayEditedDocLib, false)
 	require.NoError(t, err)
 }
+
+// TestOverlayDigests_KeepTheTwoSidesOfAClassApart covers a name that
+// reaches an instance member and a static one. The sidecar records which
+// side each entry stands in for, and a report of a missing entry marks
+// the static side rather than naming a member the class holds on the
+// other one.
+func TestOverlayDigests_KeepTheTwoSidesOfAClassApart(t *testing.T) {
+	t.Parallel()
+	overlay := map[string]string{
+		"std/array.replace.esc": "export declare class Array<T> {\n" +
+			"    static isArray(arg: unknown) -> boolean,\n}\n",
+	}
+
+	dir := seedOverlay(t, overlay)
+	_, err := applyOverlayIn(t, dir, overlayLib, false)
+	require.EqualError(t, err,
+		"overlay: std/array.replace.esc replaces static Array.isArray, and "+
+			"std/array.replace.digests.json records no digest for it; run "+
+			"`dts_to_esc generate --update-digests` to record what the overlay "+
+			"stands in for")
+
+	dir = seedOverlay(t, overlay)
+	_, err = applyOverlayIn(t, dir, overlayLib, true)
+	require.NoError(t, err)
+	snaps.MatchInlineSnapshot(t, readDigests(t, dir, "std/array.replace.digests.json"), snaps.Inline(`[
+  {
+    "decl": "Array",
+    "member": "isArray",
+    "kind": "method",
+    "static": true,
+    "digest": "60de184c2c659aec"
+  }
+]
+`))
+
+	_, err = applyOverlayIn(t, dir, overlayLib, false)
+	require.NoError(t, err)
+}

--- a/internal/interop/overlay/README.md
+++ b/internal/interop/overlay/README.md
@@ -99,10 +99,41 @@ retyping the member under cover of replacing it. Changing a member's
 kind is a `drop` and an `add`, and supplying the missing half of an
 accessor is an `add` on its own.
 
-The converted member's doc comment carries onto the overlay member
-replacing it, unless the overlay wrote one of its own. Upstream
-documentation therefore reaches the generated tree whether or not an
-overlay stands in for the member it describes.
+## Digest sidecars
+
+A `replace` forks its target. The overlay wins by construction, so
+TypeScript can retype the member it stands in for and the generated tree
+would not move. The sidecar beside each `replace` file is what turns
+that silence into a failed run:
+
+```
+overlay/std/array.replace.esc
+overlay/std/array.replace.digests.json
+```
+
+The sidecar records the printed Escalier form of every converted
+declaration and member the file stands in for, one entry each. A run
+recomputes those digests and fails when one no longer matches, naming
+the member and the file.
+
+Recording is a separate run, so writing a new `replace` is two steps:
+
+1. Write the overlay file.
+2. Run `dts_to_esc generate --update-digests <lib-dir> <esc-dir>`, which
+   rewrites the sidecars from what the overlay currently replaces.
+
+Commit both files. The same two steps accept a member that moved
+upstream, after checking the overlay still says what it should about the
+new upstream form.
+
+A digest covers the converted form, not the overlay's own text, so
+editing the overlay alone needs no re-record. Doc comments are left out
+of the form, so the prose churn of a version bump moves no digest. Such
+an edit still reaches the output, since the converted member's comment
+carries onto the overlay member replacing it wherever that member wrote
+none of its own. Any change to the printer's output does invalidate
+every entry at once. The comparison that replaces this reads both sides
+through the solver's `constrain` and waits on SimpleSub M7.5.
 
 Write the overlay in the shape the generated file has. The generator
 converts the `.d.ts` first and matches the overlay against the result,
@@ -123,6 +154,11 @@ being dropped in silence. This holds for `add` as well as `replace`.
 A whole-declaration replacement is the other case, and it does read all
 of that. The overlay stands in for the declaration entire, so what it
 writes around its members is what the generated file gets.
+
+The converted member's doc comment carries onto the overlay member
+replacing it, unless the overlay wrote one of its own. Upstream
+documentation therefore reaches the generated tree whether or not an
+overlay stands in for the member it describes.
 
 A declaration the converter gets structurally wrong is replaced whole
 rather than member by member. That happens when the overlay declaration
@@ -170,6 +206,10 @@ belong to none.
 - A `replace` or a `drop` naming a declaration or member the upstream
   source no longer has. That is the TypeScript-side-removal signal,
   keyed on the overlay rather than on the tree the run overwrites.
+- A `replace` whose converted counterpart has moved since its digest was
+  recorded, or that has no recorded digest at all.
+- A sidecar entry the overlay file beside it no longer replaces, and a
+  sidecar with no `replace` file beside it.
 - An `add` naming a declaration or member the upstream source already
   has.
 - A drop entry carrying a type annotation, a signature, or an

--- a/internal/interop/overlay/README.md
+++ b/internal/interop/overlay/README.md
@@ -127,7 +127,10 @@ upstream, after checking the overlay still says what it should about the
 new upstream form.
 
 A digest covers the converted form, not the overlay's own text, so
-editing the overlay alone needs no re-record. Doc comments are left out
+editing the overlay alone needs no re-record. The converted form is
+what the generator makes of the `.d.ts` declaration, so the digest
+moves when the upstream type moves and when a derived fact the
+generator applies to that member moves. Doc comments are left out
 of the form, so the prose churn of a version bump moves no digest. Such
 an edit still reaches the output, since the converted member's comment
 carries onto the overlay member replacing it wherever that member wrote

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -1980,7 +1980,14 @@ how a contributor records a new entry or accepts a moved one.
 
 The digest is taken over the printed member with its doc comment left
 out, so the prose churn of a version bump moves nothing. A printer
-formatting change does invalidate every entry at once. The eventual answer is the comparison this section defers to
+formatting change does invalidate every entry at once.
+
+Taking it over the converted form rather than over any one input is
+what lets it widen on its own. It covers the `.d.ts` shape, the trio
+fusion, and every derived determination the generator has wired in, so
+a fact that starts shaping a declaration starts moving its digest with
+no change here. §6.8 keeps that true by applying each determination
+before the overlay. The eventual answer is the comparison this section defers to
 SimpleSub M7.5: infer both sides and ask the solver's `constrain`
 whether the overlay member is still compatible with the converted one.
 That is robust to formatting, and it is the one check §6.4 still wants
@@ -2273,6 +2280,22 @@ As of the pinned lib set the generated tree carries 394 `mut self`
 receivers, all of them from the name-tier classifier in
 [mutability.go](../../internal/dts_to_esc/mutability.go), and zero
 `throws` clauses, zero parameter `mut`, and zero `&` borrows.
+
+**Where the application runs.** Each determination is applied to the
+converted declarations before `ApplyOverlay` folds the overlay in. The
+digest §6.4 records for an overlay `replace` is taken over the printed
+converted member, so a determination applied at that point lands inside
+it. A `throws` set that widens or a parameter that becomes `mut` moves
+the digest, and the `replace` standing in for that member fails until a
+contributor re-records it.
+
+Applying a determination after the overlay would annotate the overlay's
+own member instead. The digest would have been taken from an
+un-annotated form, so the fact would reach no check for exactly the
+members an overlay forks. Receiver mutability already runs in the right
+place: `ConvertBuckets` decides it and `ApplyOverlay` follows, so a
+reclassified receiver already moves the digest of a member an overlay
+replaces.
 
 **Known fusion gaps.** A determination can only land on a fused
 class, since an `interface` member has no receiver to annotate.

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -1970,10 +1970,21 @@ name, and an overlay adds the missing half of one.
 Granularity shrinks the staleness hazard rather than removing it. A
 replaced member is still forked from upstream, but a change to any
 other member of the same declaration still flows through, which
-declaration-granular replacement swallows.
-[#1356](https://github.com/escalier-lang/escalier/issues/1356) carries
-both the granularity and the check that fails a run when a replaced
-member's upstream counterpart has moved.
+declaration-granular replacement swallows. What stays forked is pinned
+by a digest. Beside each `replace` file sits a `.digests.json` sidecar
+recording the printed Escalier form of every converted declaration and
+member that file stands in for, and a run whose converted form no
+longer matches the recorded one fails and names the member.
+`dts_to_esc generate --update-digests` rewrites the sidecars, which is
+how a contributor records a new entry or accepts a moved one.
+
+The digest is taken over the printed member with its doc comment left
+out, so the prose churn of a version bump moves nothing. A printer
+formatting change does invalidate every entry at once. The eventual answer is the comparison this section defers to
+SimpleSub M7.5: infer both sides and ask the solver's `constrain`
+whether the overlay member is still compatible with the converted one.
+That is robust to formatting, and it is the one check §6.4 still wants
+`constrain` for.
 
 **`drop` names what the generator must not emit.** A drop file's
 declarations are read for their **names alone** — every type
@@ -2043,9 +2054,11 @@ signature drift, and incompatible property-type drift. Checks 2 and
 `constrain`, which needs the solver to ingest a declaration module —
 SimpleSub M7.5. Regenerating and diffing catches all three at once
 and needs no checker, so drift detection comes off M7.5's critical
-path. One check still wants `constrain`: comparing an overlay
+path. One check still wants `constrain`, comparing an overlay
 `replace` against the upstream declaration it stands in for. Until
-M7.5 lands, an overlay `replace` is reviewed by hand.
+M7.5 lands, the digest sidecars above stand in for it: they catch a
+converted form that moved, at the cost of reporting a printer
+formatting change as movement too.
 
 **Declarations the generator drops on purpose** are the overlay's
 `drop` files above — `globalThis`, `eval`, and the `intrinsic`-typed

--- a/tools/dts_to_esc/README.md
+++ b/tools/dts_to_esc/README.md
@@ -43,7 +43,7 @@ the `std/`, `web/`, and `node/` subtrees.
 | Command                                          | Writes  | Use                                        |
 | ------------------------------------------------ | ------- | ------------------------------------------ |
 | `dts_to_esc <path-to-d.ts>`                      | stdout  | Convert one file, for trying things out.   |
-| `dts_to_esc generate [--cfg …] [--overlay …] <lib-dir> <esc-dir>` | tree | Write the whole tree from its inputs. |
+| `dts_to_esc generate [--cfg …] [--overlay …] [--update-digests] <lib-dir> <esc-dir>` | tree | Write the whole tree from its inputs. |
 | `dts_to_esc check <lib-dir> <esc-dir>`           | nothing | Verify the committed tree.                 |
 | `dts_to_esc regenerate <lib-dir> <esc-dir>`      | tree    | Fold upstream additions into that tree.    |
 | `dts_to_esc bootstrap [--cfg …] <lib-dir> <out>` | tree    | Seed a tree from scratch.                  |
@@ -71,6 +71,12 @@ The overlay defaults to the `overlay` directory beside `<esc-dir>`, so
 `internal/interop/overlay`. `--overlay` names another one.
 `internal/interop/overlay/README.md` covers what each operation does and
 how a file's name carries it.
+
+`--update-digests` rewrites the digest sidecar beside each `replace`
+overlay file instead of checking it, and writes nothing else differently.
+A `replace` records the converted form it stands in for so a later run
+fails when that form moves, and this is the flag that records it. Run it
+after writing a new `replace`, and again to accept a form that has moved.
 
 `check`, `regenerate`, and `bootstrap` are the additive re-run model
 `generate` replaces. They are removed in
@@ -119,7 +125,11 @@ against the hand-written mutability sources. See §5, §6, and §9.2 of
 An overlay `replace` or `drop` naming a declaration or member the
 upstream source no longer has fails the run and names it. That is the
 removal signal for the one input the diff cannot show, since the overlay
-wins by construction wherever it applies.
+wins by construction wherever it applies. A `replace` whose converted
+counterpart has been retyped rather than removed fails the same way, off
+the digest recorded beside it. Read the new upstream form, decide whether
+the overlay still says what it should, then re-run with
+`--update-digests` and commit the sidecar with the rest of the bump.
 
 ## The additive re-run workflow
 

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -10,7 +10,7 @@
 //	    recognition, namespace flattening, and `@js(...)` decorator
 //	    emission.
 //
-//	dts_to_esc generate [--cfg <cfg.json>] [--overlay <dir>] <lib-dir> <esc-dir>
+//	dts_to_esc generate [--cfg <cfg.json>] [--overlay <dir>] [--update-digests] <lib-dir> <esc-dir>
 //	    Writes the whole `.esc` tree under <esc-dir> from the three
 //	    inputs of §6.4: the pinned lib set under <lib-dir>, the
 //	    ECMA-262 derived facts the converter applies, and the overlay.
@@ -18,7 +18,10 @@
 //	    re-running against a populated one are the same operation and
 //	    `git diff` is the review surface for a version bump. Generated
 //	    packages the run no longer emits are deleted. The overlay
-//	    defaults to <esc-dir>/../overlay.
+//	    defaults to <esc-dir>/../overlay. --update-digests rewrites the
+//	    digest sidecar beside each overlay `replace` file, recording the
+//	    converted form it stands in for, instead of checking what those
+//	    sidecars already record.
 //
 //	dts_to_esc bootstrap [--cfg <cfg.json>] <lib-dir> <out-dir>
 //	    One-time seeding of a fresh `.esc` tree per §6.6: discover every
@@ -77,7 +80,7 @@ func main() {
 
 const usage = `usage:
   dts_to_esc <path-to-d.ts>
-  dts_to_esc generate [--cfg <cfg.json>] [--overlay <dir>] <lib-dir> <esc-dir>
+  dts_to_esc generate [--cfg <cfg.json>] [--overlay <dir>] [--update-digests] <lib-dir> <esc-dir>
   dts_to_esc bootstrap [--cfg <cfg.json>] <lib-dir> <out-dir>
   dts_to_esc check <lib-dir> <esc-dir>
   dts_to_esc regenerate <lib-dir> <esc-dir>`
@@ -184,7 +187,7 @@ func runSingleFile(args []string, out io.Writer) error {
 
 // generateUsage is the one-line synopsis every generate-mode argument
 // error ends with.
-const generateUsage = "usage: dts_to_esc generate [--cfg <cfg.json>] [--overlay <dir>] <lib-dir> <esc-dir>"
+const generateUsage = "usage: dts_to_esc generate [--cfg <cfg.json>] [--overlay <dir>] [--update-digests] <lib-dir> <esc-dir>"
 
 // defaultOverlayDirName is the overlay tree's directory name. It sits
 // beside the generated tree, so `internal/interop/data` as <esc-dir>
@@ -198,6 +201,7 @@ func runGenerate(args []string, stderr io.Writer) error {
 	flags.SetOutput(io.Discard)
 	cfgPath := flags.String("cfg", "", "path to the ECMA-262 cfg.json; adds the curation, coercion-filter, receiver-validation, and effect-fact join reports")
 	overlayDir := flags.String("overlay", "", "`path` to the overlay tree; defaults to the overlay directory beside <esc-dir>")
+	updateDigests := flags.Bool("update-digests", false, "record what every overlay replace stands in for, rather than checking the recorded digests")
 	if err := flags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			fmt.Fprintln(stderr, generateUsage)
@@ -225,10 +229,11 @@ func runGenerate(args []string, stderr io.Writer) error {
 	}
 
 	res, err := dts_to_esc.Generate(dts_to_esc.GenerateOptions{
-		LibDir:       libDir,
-		OverlayDir:   *overlayDir,
-		OutDir:       escDir,
-		HandAuthored: dts_to_esc.HandAuthoredPackages,
+		LibDir:        libDir,
+		OverlayDir:    *overlayDir,
+		OutDir:        escDir,
+		HandAuthored:  dts_to_esc.HandAuthoredPackages,
+		RecordDigests: *updateDigests,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #1356.

Last of five stacked PRs. Based on [#1378](https://github.com/escalier-lang/escalier/pull/1378), and the largest of the five.

A `replace` forks its target. The overlay wins by construction, so TypeScript can retype the member it stands in for and the generated tree does not move. Nothing in the run says so, and the `git diff` the §6.6 version-bump workflow reviews shows nothing either, because the tree does match its inputs.

## The sidecar

Beside each `replace` file now sits a `.digests.json` sidecar recording the printed Escalier form of every converted declaration and member that file stands in for:

```
overlay/std/array.replace.esc
overlay/std/array.replace.digests.json
```

A run recomputes those forms and fails when one no longer matches the recorded digest, naming the member and the file. A `replace` with no recorded digest fails the same way, so a new entry cannot fork silently either.

## Recording

Recording is a separate run. `dts_to_esc generate --update-digests` rewrites the sidecars from what the overlay currently replaces. Writing a new `replace` is therefore two steps, write the file then record, and both are committed. The same two steps accept a member that moved upstream, after checking the overlay still says what it should about the new form.

The sidecars are written once the whole overlay has applied, so a run that fails partway records nothing rather than leaving half the tree rewritten. A sidecar the overlay no longer pairs with is deleted by that run and fails every other one.

## Doc comments

The digested form leaves doc comments out, through the printer option added in [#1375](https://github.com/escalier-lang/escalier/pull/1375). Prose is the bulk of what a version bump moves and it moves no shape. The converted member's doc reaches the output either way, since [#1376](https://github.com/escalier-lang/escalier/pull/1376) carries it onto the overlay member replacing it.

## Where this goes next

This is the check §6.4 defers to SimpleSub M7.5, which will ask the solver's `constrain` whether the overlay member is still compatible with the converted one. That comparison is robust to formatting where a digest is not — any change to the printer's output invalidates every entry at once — and it replaces this one when it lands.

## One thing to flag

`overlayDocLib` moves from `overlay_apply_test.go` to `overlay_digest_test.go`, where it sits beside the edited-prose twin it pairs with. The move is cosmetic and unrelated to the rest of the diff.

## The stack

1. [#1375](https://github.com/escalier-lang/escalier/pull/1375) — the printer option.
2. [#1376](https://github.com/escalier-lang/escalier/pull/1376) — carry the converted member's doc.
3. [#1377](https://github.com/escalier-lang/escalier/pull/1377) — member kind and overload sets.
4. [#1378](https://github.com/escalier-lang/escalier/pull/1378) — the converted declaration's header.
5. **This PR** — the digest sidecars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFnFPWUDYkfxNdda2qBhmM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added digest sidecars for overlay replacement files to track converted declarations and members.
  - Added the `--update-digests` option to create or refresh digest records during generation.
  - Digest records are stable across repeated updates and ignore documentation-only changes.

- **Bug Fixes**
  - Generation now detects changed, missing, stale, or unmatched digest records and reports actionable errors.
  - Added validation for sidecars without corresponding replacement files.

- **Documentation**
  - Updated overlay and generation documentation with digest workflows, validation behavior, and refresh guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->