### PR TITLE
Visit a function parameter's type annotation

### DIFF
--- a/internal/ast/decl.go
+++ b/internal/ast/decl.go
@@ -196,6 +196,9 @@ func (d *FuncDecl) Accept(v Visitor) {
 	if v.EnterDecl(d) {
 		for _, param := range d.Params {
 			param.Pattern.Accept(v)
+			if param.TypeAnn != nil {
+				param.TypeAnn.Accept(v)
+			}
 		}
 		if d.Return != nil {
 			d.Return.Accept(v)
@@ -395,6 +398,9 @@ func (d *EnumDecl) Accept(v Visitor) {
 				e.Name.Accept(v)
 				for _, param := range e.Params {
 					param.Pattern.Accept(v)
+					if param.TypeAnn != nil {
+						param.TypeAnn.Accept(v)
+					}
 				}
 			case *EnumSpread:
 				e.Arg.Accept(v)

--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -465,6 +465,9 @@ func (e *FuncExpr) Accept(v Visitor) {
 	if v.EnterExpr(e) {
 		for _, param := range e.Params {
 			param.Pattern.Accept(v)
+			if param.TypeAnn != nil {
+				param.TypeAnn.Accept(v)
+			}
 		}
 		for _, tp := range e.TypeParams {
 			if tp.Constraint != nil {

--- a/internal/parser/attach_test.go
+++ b/internal/parser/attach_test.go
@@ -299,11 +299,8 @@ func TestAttachCommentsKeepsANonDocBlockLeading(t *testing.T) {
 // A comment written after a parameter attaches, but not to that parameter.
 // These cases pin what the pass does today so a fix announces itself.
 //
-// Two things put the comment on the wrong node. The pass reads nodes and line
-// breaks and never sees the comma, so a comment before one still leads the
-// parameter after it. And no traversal visits Param.TypeAnn, so a parameter's
-// type is not a node the pass can reach; the nearest node after a comment
-// following the last parameter is the return type. See #1381 and #1373.
+// The pass reads nodes and line breaks and never sees the comma, so a comment
+// written before one still leads the parameter after it. See #1373.
 func TestAttachCommentsAfterAFunctionParam(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -319,10 +316,19 @@ func TestAttachCommentsAfterAFunctionParam(t *testing.T) {
 			want: []string{"leading *ast.IdentPat /* m */"},
 		},
 		{
-			// Reads as a note about `b`. Its type is not a node, so the nearest
-			// node after the comment is the return type annotation.
+			// Reads as a note about `b`. Rule 1 runs before rule 2, so the
+			// return type annotation leads the comment instead of `b`'s own
+			// type annotation trailing it.
 			name: "after the last parameter",
 			src:  "fn g(a: number, b: number /* m */) -> number {\n    return a\n}\n",
+			want: []string{"leading *ast.NumberTypeAnn /* m */"},
+		},
+		{
+			// A parameter's type annotation is a node the pass reaches, so it
+			// takes a comment written just before it rather than the comment
+			// carrying past the parameter list to the return type.
+			name: "before a parameter type",
+			src:  "fn g(a: /* m */ number) -> string {\n    return \"\"\n}\n",
 			want: []string{"leading *ast.NumberTypeAnn /* m */"},
 		},
 	}


### PR DESCRIPTION
Fixes #1381

First of three stacked PRs. The other two are #1373 and #1371, each based on the one before it.

Every `Accept` that walks a parameter list walked `param.Pattern` and skipped `param.TypeAnn`, so a parameter's type was invisible to every visitor-based pass.

## What changed

`FuncDecl.Accept`, `FuncExpr.Accept`, and the `*EnumVariant` case of `EnumDecl.Accept` now visit the annotation when it is non-nil:

```go
for _, param := range d.Params {
    param.Pattern.Accept(v)
    if param.TypeAnn != nil {
        param.TypeAnn.Accept(v)
    }
}
```

The issue lists four sites. It is three: `internal/ast/type_ann.go:501` in `FuncTypeAnn.Accept` already did this, and it is what the three new sites are modelled on.

## Effect

`ast.AttachComments` can now give a parameter's type a comment. The new "before a parameter type" case in `TestAttachCommentsAfterAFunctionParam` covers `fn g(a: /* m */ number) -> string`, where the comment used to carry past the parameter list to the return type. That case fails without the traversal change.

`go test ./...` passes, and re-running with `UPDATE_SNAPS=true` and `UPDATE_FIXTURES=true` produces no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WwshtyzQcyLYJ5KbTeu8B

---
_Generated by [Claude Code](https://claude.ai/code/session_015WwshtyzQcyLYJ5KbTeu8B)_