### PR TITLE
Accept comments inside four delimited lists

### DIFF
--- a/internal/parser/attach_test.go
+++ b/internal/parser/attach_test.go
@@ -339,3 +339,103 @@ func TestAttachCommentsAfterAFunctionParam(t *testing.T) {
 		})
 	}
 }
+
+// A comment inside an object literal, a parameter list, an object pattern, or
+// a type parameter list parses and reaches the tree. Each of these four
+// productions used to read the comment token where the next member belonged
+// and report a syntax error. See #1373.
+//
+// Two owners here are the enclosing construct rather than the member the
+// comment was written about. An object pattern's bindings and a type parameter
+// are not offered by ast.Visitor, so ast.AttachComments cannot index them and
+// has to fall back. #1371 covers the same gap for object type annotation
+// members.
+func TestAttachCommentsInDelimitedLists(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "inline in an object literal",
+			src:  "val o = {a: 1, /* m */ b: 2}\n",
+			want: []string{"leading *ast.PropertyExpr /* m */"},
+		},
+		{
+			name: "on its own line in an object literal",
+			src:  "val o = {\n    // about b\n    b: 2,\n}\n",
+			want: []string{"leading *ast.PropertyExpr // about b"},
+		},
+		{
+			name: "after the last member of an object literal",
+			src:  "val o = {\n    a: 1,\n    // last\n}\n",
+			want: []string{"dangling *ast.ObjectExpr // last"},
+		},
+		{
+			name: "inline in a parameter list",
+			src:  "fn g(a: number, /* m */ b: number) -> number {\n    return a\n}\n",
+			want: []string{"leading *ast.IdentPat /* m */"},
+		},
+		{
+			name: "on its own line in a parameter list",
+			src:  "fn g(\n    // about b\n    b: number\n) -> number {\n    return b\n}\n",
+			want: []string{"leading *ast.IdentPat // about b"},
+		},
+		{
+			// The bindings of an object pattern are not nodes the pass reaches,
+			// so the pattern itself takes the comment.
+			name: "inline in an object pattern",
+			src:  "val {a, /* m */ b} = o\n",
+			want: []string{"dangling *ast.ObjectPat /* m */"},
+		},
+		{
+			name: "on its own line in an object pattern",
+			src:  "val {\n    // about b\n    b,\n} = o\n",
+			want: []string{"dangling *ast.ObjectPat // about b"},
+		},
+		{
+			name: "after the last binding of an object pattern",
+			src:  "val {a, b /* m */} = o\n",
+			want: []string{"dangling *ast.ObjectPat /* m */"},
+		},
+		{
+			// A type parameter is not a node the pass reaches either, so the
+			// comment carries past the list to the first value parameter.
+			name: "inline in a type parameter list",
+			src:  "fn h<T, /* m */ U>(a: T) -> T {\n    return a\n}\n",
+			want: []string{"leading *ast.IdentPat /* m */"},
+		},
+		{
+			name: "on its own line in a type parameter list",
+			src:  "fn h<\n    // about T\n    T,\n>(a: T) -> T {\n    return a\n}\n",
+			want: []string{"leading *ast.IdentPat // about T"},
+		},
+		{
+			name: "after the last type parameter",
+			src:  "fn h<T /* m */>(a: T) -> T {\n    return a\n}\n",
+			want: []string{"leading *ast.IdentPat /* m */"},
+		},
+		{
+			name: "alone in an empty object literal",
+			src:  "val o = {/* m */}\n",
+			want: []string{"dangling *ast.ObjectExpr /* m */"},
+		},
+		{
+			name: "alone in an empty object pattern",
+			src:  "val {/* m */} = o\n",
+			want: []string{"dangling *ast.ObjectPat /* m */"},
+		},
+		{
+			name: "alone in an empty parameter list",
+			src:  "fn g(/* m */) -> number {\n    return 1\n}\n",
+			want: []string{"leading *ast.NumberTypeAnn /* m */"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, nilIfEmpty(attachments(t, tc.src)))
+		})
+	}
+}

--- a/internal/parser/attach_test.go
+++ b/internal/parser/attach_test.go
@@ -341,15 +341,15 @@ func TestAttachCommentsAfterAFunctionParam(t *testing.T) {
 }
 
 // A comment inside an object literal, a parameter list, an object pattern, or
-// a type parameter list parses and reaches the tree. Each of these four
-// productions used to read the comment token where the next member belonged
-// and report a syntax error. See #1373.
+// a type parameter list parses, and the comment reaches the tree. Each of these
+// four productions consumes the comment before it dispatches on the token where
+// the next member belongs.
 //
 // Two owners here are the enclosing construct rather than the member the
 // comment was written about. An object pattern's bindings and a type parameter
 // are not offered by ast.Visitor, so ast.AttachComments cannot index them and
-// has to fall back. #1371 covers the same gap for object type annotation
-// members.
+// has to fall back. The members of an object type annotation have the same
+// gap.
 func TestAttachCommentsInDelimitedLists(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/parser/combinators.go
+++ b/internal/parser/combinators.go
@@ -41,11 +41,13 @@ func (p *Parser) parseFuncParams() (params []*ast.Param, inexact bool) {
 		}
 		params = append(params, param)
 
-		if p.lexer.peek().Type != Comma {
+		// A comment after a parameter precedes either the comma or the closing
+		// paren, so it belongs to the list rather than to the next parameter.
+		if p.skipComments().Type != Comma {
 			return params, inexact
 		}
 		p.lexer.consume() // consume separator
-		if p.lexer.peek().Type == CloseParen {
+		if p.skipComments().Type == CloseParen {
 			return params, inexact // tolerated trailing comma
 		}
 	}
@@ -135,7 +137,11 @@ func parseDelimSeqHelper[T any](
 		}
 		items = append(items, item)
 
-		if p.lexer.peek().Type != separator {
+		// A comment after an item precedes either the separator or the
+		// terminator, so it belongs to the list rather than to the next item.
+		// Consuming it here is what lets `val {a, b /* m */} = o` reach the
+		// closing brace.
+		if p.skipComments().Type != separator {
 			return items, inexact
 		}
 		p.lexer.consume() // consume separator

--- a/internal/parser/combinators.go
+++ b/internal/parser/combinators.go
@@ -25,11 +25,13 @@ func (p *Parser) parseFuncParams() (params []*ast.Param, inexact bool) {
 
 		// A bare `...` (the next token after it is the closing paren) marks the
 		// function inexact. Anything else after `...` is a rest param (`...rest`),
-		// which p.param parses, so back the lexer up and fall through.
-		if p.lexer.peek().Type == DotDotDot {
+		// which p.param parses, so back the lexer up and fall through. Both reads
+		// skip comments, so a comment written on either side of the marker, as in
+		// `fn f(a: number, ... /* open */)`, still reaches this branch.
+		if p.skipComments().Type == DotDotDot {
 			saved := p.lexer.saveState()
 			p.lexer.consume() // tentatively consume '...'
-			if p.lexer.peek().Type == CloseParen {
+			if p.skipComments().Type == CloseParen {
 				return params, true
 			}
 			p.lexer.restoreState(saved)

--- a/internal/parser/comments.go
+++ b/internal/parser/comments.go
@@ -107,3 +107,26 @@ func LexComments(source *ast.Source) []*ast.Comment {
 	lexer.Lex()
 	return lexer.comments.sorted()
 }
+
+// skipComments consumes the comment tokens ahead of the next non-comment
+// token and returns that token, without consuming it.
+//
+// A production that reads one member of a list calls this before it dispatches
+// on the token it finds. Without it the comment token itself is read where the
+// member belongs, and `{a: 1, /* m */ b: 2}` reports "Expected a property
+// name" on the comment. The comment stays in the parser's comment log either
+// way, and ast.AttachComments gives it an owner once the parse is done.
+func (p *Parser) skipComments() *Token {
+	for {
+		select {
+		case <-p.ctx.Done():
+			return p.lexer.peek()
+		default:
+		}
+		token := p.lexer.peek()
+		if token.Type != LineComment && token.Type != BlockComment {
+			return token
+		}
+		p.lexer.consume()
+	}
+}

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -124,7 +124,9 @@ func (p *Parser) maybeLifetimeAndTypeParams(allowVariance bool) ([]*ast.Lifetime
 			return lifetimeParams, typeParams
 		default:
 		}
-		token = p.lexer.peek()
+		// A comment between two binders, or before the closing `>`, is consumed
+		// here so it is not read where the next binder belongs.
+		token = p.skipComments()
 		if token.Type == GreaterThan {
 			break
 		}
@@ -137,7 +139,7 @@ func (p *Parser) maybeLifetimeAndTypeParams(allowVariance bool) ([]*ast.Lifetime
 			}
 			typeParams = append(typeParams, tp)
 		}
-		token = p.lexer.peek()
+		token = p.skipComments()
 		if token.Type == Comma {
 			p.lexer.consume()
 			continue

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -702,6 +702,13 @@ func (p *Parser) arrayElem() ast.Expr {
 }
 
 func (p *Parser) objExprElem() ast.ObjExprElem {
+	// A comment written between two members would otherwise be read where the
+	// next member's name belongs. Only a closing brace after it means the
+	// comment was the last thing in the literal, so there is no member to parse.
+	if p.skipComments().Type == CloseBrace {
+		return nil
+	}
+
 	token := p.lexer.peek()
 
 	if token.Type == DotDotDot {
@@ -817,6 +824,13 @@ func (p *Parser) objExprElem() ast.ObjExprElem {
 // <pattern>?
 // <pattern>
 func (p *Parser) param() *ast.Param {
+	// A comment written between two parameters would otherwise be read where
+	// the next parameter's pattern belongs. Only a closing paren after it means
+	// the comment was the last thing in the list.
+	if p.skipComments().Type == CloseParen {
+		return nil
+	}
+
 	// `open` is a provisional, context-sensitive keyword: it marks a
 	// row-polymorphic parameter only when a parameter pattern follows (`open p`,
 	// `open mut p`, `open {x}`). Otherwise it is an ordinary identifier — a param

--- a/internal/parser/inexact_test.go
+++ b/internal/parser/inexact_test.go
@@ -53,6 +53,71 @@ func TestParseInexactMarker(t *testing.T) {
 	})
 }
 
+// A comment written on either side of the inexact marker still leaves the marker
+// where parseFuncParams looks for it. Both reads of the token — the one that finds
+// the `...` and the one that checks for the closing paren behind it — skip
+// comments, so the list stays inexact and the `...` does not fall through to the
+// parameter parser as a malformed rest parameter.
+func TestParseInexactMarkerWithComments(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		src        string
+		wantParams int
+	}{
+		{
+			name:       "before the marker",
+			src:        "fn(x: number, /* open */ ...) -> number",
+			wantParams: 1,
+		},
+		{
+			name:       "after the marker",
+			src:        "fn(x: number, ... /* open */) -> number",
+			wantParams: 1,
+		},
+		{
+			name:       "before a nullary marker",
+			src:        "fn(/* open */ ...) -> number",
+			wantParams: 0,
+		},
+		{
+			name:       "after a nullary marker",
+			src:        "fn(... /* open */) -> number",
+			wantParams: 0,
+		},
+		{
+			name:       "on both sides of the marker",
+			src:        "fn(x: number, /* a */ ... /* b */) -> number",
+			wantParams: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ta, errs := ParseTypeAnn(context.Background(), tc.src)
+			require.Empty(t, errs)
+			fn, ok := ta.(*ast.FuncTypeAnn)
+			require.True(t, ok)
+			require.True(t, fn.Inexact)
+			require.Len(t, fn.Params, tc.wantParams)
+		})
+	}
+}
+
+// Skipping comments while looking for the marker must not swallow a rest
+// parameter. The lookahead restores the lexer to the `...` when what follows is
+// not the closing paren, so `...rest` still parses as a parameter and the list
+// stays exact.
+func TestParseRestParamIsNotTheInexactMarker(t *testing.T) {
+	t.Parallel()
+	ta, errs := ParseTypeAnn(context.Background(), "fn(x: number, ...rest: Array<number>) -> number")
+	require.Empty(t, errs)
+	fn, ok := ta.(*ast.FuncTypeAnn)
+	require.True(t, ok)
+	require.False(t, fn.Inexact)
+	require.Len(t, fn.Params, 2)
+}
+
 // A union is always closed, so a trailing `...` after a `|` is rejected. Openness is written as
 // `string`, `number`, or `unknown` in a member instead.
 func TestParseUnionTrailingDotsRejected(t *testing.T) {

--- a/internal/parser/pattern.go
+++ b/internal/parser/pattern.go
@@ -234,6 +234,13 @@ func (p *Parser) literalPat() ast.Pat {
 }
 
 func (p *Parser) objPatElem() ast.ObjPatElem {
+	// A comment written between two bindings would otherwise be read where the
+	// next binding belongs. Only a closing brace after it means the comment was
+	// the last thing in the pattern.
+	if p.skipComments().Type == CloseBrace {
+		return nil
+	}
+
 	token := p.lexer.peek()
 
 	// Shorthand `mut` prefix: `{ mut x }`. Mutability lives on the


### PR DESCRIPTION
Fixes #1373

Second of three stacked PRs. Based on https://github.com/escalier-lang/escalier/pull/1384 (#1381) — review that one first, and merge this into `main` only after it lands. https://github.com/escalier-lang/escalier/pull/1386 (#1371) is based on this one.

A comment written inside an object literal, a function parameter list, an object pattern, or a type parameter list was a parse error. Each of those productions dispatched on the token where the next member belonged and read the comment token there, reporting "Expected a property name", "Expected a pattern", "Expected identifier or '...'", or "expected type parameter".

## What changed

`Parser.skipComments` consumes the comments ahead of the next non-comment token and returns that token. It is called from five places:

- `objExprElem`, `param`, and `objPatElem` call it before dispatching, and return nil when only the list's terminator follows, so a comment after the last member ends the list rather than starting another.
- `maybeLifetimeAndTypeParams` calls it at both points its loop reads a token.
- `parseDelimSeqHelper` and `parseFuncParams` call it after an item, where a comment precedes either the separator or the terminator. This is what lets `val {a, b /* m */} = o` reach its closing brace.

## Effect

The comment was already in the parser's comment log, so it appeared in `Module.Comments` either way. It now also reaches the tree. `TestAttachCommentsInDelimitedLists` covers each of the four constructs inline, on its own line, after the last member, and alone in an empty list.

Two owners in that table are the enclosing construct rather than the member the comment was written about, because `ast.Visitor` offers neither an object pattern's bindings nor a type parameter. #1371 covers the same gap for object type annotation members; the other two are worth their own issue.

One case still does not parse: a block comment opening a type parameter list with no space after the `<`, so that the source reads `<` immediately followed by `/`. The lexer takes those two characters as one token, the JSX close-tag marker. That is a lexing ambiguity unrelated to comments in lists, and the same list parses with a space after the `<`:

```
fn h< /* m */ >(a: number) -> number {
    return a
}
```

`go test ./...` passes, and re-running with `UPDATE_SNAPS=true` and `UPDATE_FIXTURES=true` produces no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WwshtyzQcyLYJ5KbTeu8B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of comments in object literals, function parameter lists, object patterns, and type parameter lists.
  - Preserved correct comment placement for inline, trailing, line-separated, and empty-list comments.
  - Fixed handling of comments before closing delimiters, including cases where no list item follows.
  - Improved parsing of commented lists through their closing delimiter without treating comments as list elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->