### PR TITLE
Let object type annotation members own comments

### DIFF
--- a/internal/ast/attach.go
+++ b/internal/ast/attach.go
@@ -318,3 +318,7 @@ func (c *nodeCollector) EnterTypeAnn(t TypeAnn) bool         { c.add(t); return 
 func (c *nodeCollector) EnterPat(p Pat) bool                 { c.add(p); return true }
 func (c *nodeCollector) EnterClassElem(e ClassElem) bool     { c.add(e); return true }
 func (c *nodeCollector) EnterObjExprElem(e ObjExprElem) bool { c.add(e); return true }
+
+// A RestSpreadTypeAnn member reaches the collector through EnterTypeAnn, so
+// this covers the other seven ObjTypeAnnElem variants.
+func (c *nodeCollector) EnterObjTypeAnnElem(e ObjTypeAnnElem) bool { c.add(e); return true }

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -186,6 +186,12 @@ func (t *NeverTypeAnn) Accept(v Visitor) {
 
 type ObjTypeAnnElem interface {
 	isObjTypeAnnElem()
+	Accept(v Visitor)
+	Span() Span
+	// SetSpan records the range the parser read the member from. A member a
+	// converter synthesizes from a `.d.ts` file has no Escalier source to point
+	// at and keeps the zero Span, which ast.AttachComments skips.
+	SetSpan(Span)
 	Commented
 	// Doc returns the leading JSDoc retained on the elem, verbatim
 	// with `/** ... */` delimiters, or "" if absent. Variants that
@@ -205,6 +211,18 @@ func (*PropertyTypeAnn) isObjTypeAnnElem()    {}
 func (*MappedTypeAnn) isObjTypeAnnElem()      {}
 func (*RestSpreadTypeAnn) isObjTypeAnnElem()  {}
 
+// elemSpan carries the range of one object type annotation member, covering
+// the whole member from its first modifier or name through its type. Seven of
+// the eight ObjTypeAnnElem variants embed it, so the interface can require a
+// span without each variant repeating the field and its two accessors.
+// RestSpreadTypeAnn keeps its own span field, which it needs as a TypeAnn too.
+type elemSpan struct {
+	span Span
+}
+
+func (e *elemSpan) Span() Span        { return e.span }
+func (e *elemSpan) SetSpan(span Span) { e.span = span }
+
 // No-op Doc/SetDoc impls for the variants that don't carry a JSDoc.
 func (*CallableTypeAnn) Doc() string      { return "" }
 func (*CallableTypeAnn) SetDoc(string)    {}
@@ -215,10 +233,12 @@ func (*MappedTypeAnn) SetDoc(string)      {}
 
 type CallableTypeAnn struct {
 	Fn *FuncTypeAnn
+	elemSpan
 	commentSlots
 }
 type ConstructorTypeAnn struct {
 	Fn *FuncTypeAnn
+	elemSpan
 	commentSlots
 }
 type MethodTypeAnn struct {
@@ -226,30 +246,27 @@ type MethodTypeAnn struct {
 	Name     ObjKey
 	Fn       *FuncTypeAnn
 	Receiver *MethodReceiver // nil if no receiver
+	elemSpan
 	commentSlots
 }
-
-func (m *MethodTypeAnn) Span() Span { return m.Name.Span() }
 
 type GetterTypeAnn struct {
 	declDoc
 	Name     ObjKey
 	Fn       *FuncTypeAnn
 	Receiver *MethodReceiver // nil if no receiver
+	elemSpan
 	commentSlots
 }
-
-func (g *GetterTypeAnn) Span() Span { return g.Name.Span() }
 
 type SetterTypeAnn struct {
 	declDoc
 	Name     ObjKey
 	Fn       *FuncTypeAnn
 	Receiver *MethodReceiver // nil if no receiver
+	elemSpan
 	commentSlots
 }
-
-func (s *SetterTypeAnn) Span() Span { return s.Name.Span() }
 
 type MappedModifier string
 
@@ -258,20 +275,15 @@ const (
 	MMRemove MappedModifier = "remove"
 )
 
-// TODO: include a dedicated span covering the full property declaration
-// (including modifiers like `readonly`/`?`); for now Span() returns the
-// name's span so callers get a per-member position instead of the
-// enclosing container's span.
 type PropertyTypeAnn struct {
 	declDoc
 	Name     ObjKey
 	Optional bool
 	Readonly bool
 	Value    TypeAnn
+	elemSpan
 	commentSlots
 }
-
-func (p *PropertyTypeAnn) Span() Span { return p.Name.Span() }
 
 type MappedTypeAnn struct {
 	TypeParam *IndexParamTypeAnn
@@ -287,6 +299,7 @@ type MappedTypeAnn struct {
 	// `[K: Keys]: Value` rather than in a trailing `for K in Keys`. The two spellings lower to the
 	// same type, so this only tells the printer which one to write back.
 	Shorthand bool
+	elemSpan
 	commentSlots
 }
 type IndexParamTypeAnn struct {
@@ -316,6 +329,11 @@ func (t *RestSpreadTypeAnn) Accept(v Visitor) {
 	v.ExitTypeAnn(t)
 }
 
+// SetSpan records the member's range the way elemSpan does for the other seven
+// variants. RestSpreadTypeAnn is a TypeAnn as well as a member, so one span
+// field serves both roles and it embeds no elemSpan.
+func (t *RestSpreadTypeAnn) SetSpan(span Span) { t.span = span }
+
 type ObjectTypeAnn struct {
 	Elems        []ObjTypeAnnElem
 	Inexact      bool // trailing `...` marker: `{x: number, ...}` tolerates extra fields
@@ -329,40 +347,78 @@ func NewObjectTypeAnn(elems []ObjTypeAnnElem, span Span) *ObjectTypeAnn {
 }
 func (t *ObjectTypeAnn) Accept(v Visitor) {
 	if v.EnterTypeAnn(t) {
+		// Each member offers itself to EnterObjTypeAnnElem and then walks its own
+		// types, leaving its name alone. An ObjKey is an IdentExpr, a StrLit, or a
+		// NumLit, so offering one to EnterExpr would report a value reference where
+		// the source wrote a property name, and a pass such as dep_graph's
+		// DependencyVisitor would record a dependency on it. ClassElem visits its
+		// names because a class member's name sits in a value position.
 		for _, elem := range t.Elems {
-			switch e := (elem).(type) {
-			case *CallableTypeAnn:
-				e.Fn.Accept(v)
-			case *ConstructorTypeAnn:
-				e.Fn.Accept(v)
-			case *MethodTypeAnn:
-				e.Fn.Accept(v)
-			case *GetterTypeAnn:
-				e.Fn.Accept(v)
-			case *SetterTypeAnn:
-				e.Fn.Accept(v)
-			case *PropertyTypeAnn:
-				if e.Value != nil {
-					e.Value.Accept(v)
-				}
-			case *MappedTypeAnn:
-				e.TypeParam.Constraint.Accept(v)
-				if e.Name != nil {
-					e.Name.Accept(v)
-				}
-				e.Value.Accept(v)
-				if e.Check != nil {
-					e.Check.Accept(v)
-				}
-				if e.Extends != nil {
-					e.Extends.Accept(v)
-				}
-			case *RestSpreadTypeAnn:
-				e.Value.Accept(v)
-			}
+			elem.Accept(v)
 		}
 	}
 	v.ExitTypeAnn(t)
+}
+
+func (c *CallableTypeAnn) Accept(v Visitor) {
+	if v.EnterObjTypeAnnElem(c) {
+		c.Fn.Accept(v)
+	}
+	v.ExitObjTypeAnnElem(c)
+}
+
+func (c *ConstructorTypeAnn) Accept(v Visitor) {
+	if v.EnterObjTypeAnnElem(c) {
+		c.Fn.Accept(v)
+	}
+	v.ExitObjTypeAnnElem(c)
+}
+
+func (m *MethodTypeAnn) Accept(v Visitor) {
+	if v.EnterObjTypeAnnElem(m) {
+		m.Fn.Accept(v)
+	}
+	v.ExitObjTypeAnnElem(m)
+}
+
+func (g *GetterTypeAnn) Accept(v Visitor) {
+	if v.EnterObjTypeAnnElem(g) {
+		g.Fn.Accept(v)
+	}
+	v.ExitObjTypeAnnElem(g)
+}
+
+func (s *SetterTypeAnn) Accept(v Visitor) {
+	if v.EnterObjTypeAnnElem(s) {
+		s.Fn.Accept(v)
+	}
+	v.ExitObjTypeAnnElem(s)
+}
+
+func (p *PropertyTypeAnn) Accept(v Visitor) {
+	if v.EnterObjTypeAnnElem(p) {
+		if p.Value != nil {
+			p.Value.Accept(v)
+		}
+	}
+	v.ExitObjTypeAnnElem(p)
+}
+
+func (t *MappedTypeAnn) Accept(v Visitor) {
+	if v.EnterObjTypeAnnElem(t) {
+		t.TypeParam.Constraint.Accept(v)
+		if t.Name != nil {
+			t.Name.Accept(v)
+		}
+		t.Value.Accept(v)
+		if t.Check != nil {
+			t.Check.Accept(v)
+		}
+		if t.Extends != nil {
+			t.Extends.Accept(v)
+		}
+	}
+	v.ExitObjTypeAnnElem(t)
 }
 
 type TupleTypeAnn struct {

--- a/internal/ast/visitor.go
+++ b/internal/ast/visitor.go
@@ -10,6 +10,7 @@ type Visitor interface {
 	EnterTypeAnn(t TypeAnn) bool
 	EnterBlock(b Block) bool
 	EnterClassElem(e ClassElem) bool
+	EnterObjTypeAnnElem(e ObjTypeAnnElem) bool
 
 	ExitLit(l Lit)
 	ExitPat(p Pat)
@@ -20,6 +21,7 @@ type Visitor interface {
 	ExitTypeAnn(t TypeAnn)
 	ExitBlock(b Block)
 	ExitClassElem(e ClassElem)
+	ExitObjTypeAnnElem(e ObjTypeAnnElem)
 }
 
 type DefaultVisitor struct{}
@@ -34,12 +36,18 @@ func (v *DefaultVisitor) EnterTypeAnn(t TypeAnn) bool         { return true }
 func (v *DefaultVisitor) EnterBlock(b Block) bool             { return true }
 func (v *DefaultVisitor) EnterClassElem(e ClassElem) bool     { return true }
 
-func (v *DefaultVisitor) ExitLit(l Lit)                 {}
-func (v *DefaultVisitor) ExitPat(p Pat)                 {}
-func (v *DefaultVisitor) ExitExpr(e Expr)               {}
-func (v *DefaultVisitor) ExitObjExprElem(e ObjExprElem) {}
-func (v *DefaultVisitor) ExitStmt(s Stmt)               {}
-func (v *DefaultVisitor) ExitDecl(d Decl)               {}
-func (v *DefaultVisitor) ExitTypeAnn(t TypeAnn)         {}
-func (v *DefaultVisitor) ExitBlock(b Block)             {}
-func (v *DefaultVisitor) ExitClassElem(e ClassElem)     {}
+// EnterObjTypeAnnElem is offered a member of an object type annotation. A
+// RestSpreadTypeAnn member arrives through EnterTypeAnn instead, since it is a
+// TypeAnn as well as an ObjTypeAnnElem.
+func (v *DefaultVisitor) EnterObjTypeAnnElem(e ObjTypeAnnElem) bool { return true }
+
+func (v *DefaultVisitor) ExitLit(l Lit)                       {}
+func (v *DefaultVisitor) ExitPat(p Pat)                       {}
+func (v *DefaultVisitor) ExitExpr(e Expr)                     {}
+func (v *DefaultVisitor) ExitObjExprElem(e ObjExprElem)       {}
+func (v *DefaultVisitor) ExitStmt(s Stmt)                     {}
+func (v *DefaultVisitor) ExitDecl(d Decl)                     {}
+func (v *DefaultVisitor) ExitTypeAnn(t TypeAnn)               {}
+func (v *DefaultVisitor) ExitBlock(b Block)                   {}
+func (v *DefaultVisitor) ExitClassElem(e ClassElem)           {}
+func (v *DefaultVisitor) ExitObjTypeAnnElem(e ObjTypeAnnElem) {}

--- a/internal/ast/visitor_test.go
+++ b/internal/ast/visitor_test.go
@@ -2,6 +2,8 @@ package ast
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Mock visitor that tracks method calls
@@ -68,6 +70,11 @@ func (v *mockVisitor) EnterClassElem(e ClassElem) bool {
 	return !v.skipNodes["ClassElem"]
 }
 
+func (v *mockVisitor) EnterObjTypeAnnElem(e ObjTypeAnnElem) bool {
+	v.enterCalls = append(v.enterCalls, "EnterObjTypeAnnElem")
+	return !v.skipNodes["ObjTypeAnnElem"]
+}
+
 func (v *mockVisitor) ExitLit(l Lit) {
 	v.exitCalls = append(v.exitCalls, "ExitLit")
 }
@@ -104,6 +111,10 @@ func (v *mockVisitor) ExitClassElem(e ClassElem) {
 	v.exitCalls = append(v.exitCalls, "ExitClassElem")
 }
 
+func (v *mockVisitor) ExitObjTypeAnnElem(e ObjTypeAnnElem) {
+	v.exitCalls = append(v.exitCalls, "ExitObjTypeAnnElem")
+}
+
 func TestDefaultVisitor_AllEnterMethodsReturnTrue(t *testing.T) {
 	visitor := &DefaultVisitor{}
 
@@ -132,6 +143,9 @@ func TestDefaultVisitor_AllEnterMethodsReturnTrue(t *testing.T) {
 	if !visitor.EnterBlock(Block{Stmts: nil, Span: Span{Start: Location{Offset: 0}, End: Location{Offset: 0}, SourceID: 0}}) {
 		t.Error("EnterBlock should return true")
 	}
+	if !visitor.EnterObjTypeAnnElem(nil) {
+		t.Error("EnterObjTypeAnnElem should return true")
+	}
 }
 
 func TestDefaultVisitor_ExitMethodsDoNotPanic(t *testing.T) {
@@ -152,6 +166,7 @@ func TestDefaultVisitor_ExitMethodsDoNotPanic(t *testing.T) {
 	visitor.ExitDecl(nil)
 	visitor.ExitTypeAnn(nil)
 	visitor.ExitBlock(Block{Stmts: nil, Span: Span{Start: Location{Offset: 0}, End: Location{Offset: 0}, SourceID: 0}})
+	visitor.ExitObjTypeAnnElem(nil)
 }
 
 func TestErrorExpr_Accept(t *testing.T) {
@@ -301,6 +316,7 @@ func TestVisitorWithNilArguments(t *testing.T) {
 	visitor.EnterDecl(nil)
 	visitor.EnterTypeAnn(nil)
 	visitor.EnterBlock(Block{Stmts: nil, Span: Span{Start: Location{Offset: 0}, End: Location{Offset: 0}, SourceID: 0}})
+	visitor.EnterObjTypeAnnElem(nil)
 
 	// Test Exit methods with nil
 	visitor.ExitLit(nil)
@@ -311,6 +327,7 @@ func TestVisitorWithNilArguments(t *testing.T) {
 	visitor.ExitDecl(nil)
 	visitor.ExitTypeAnn(nil)
 	visitor.ExitBlock(Block{Stmts: nil, Span: Span{Start: Location{Offset: 0}, End: Location{Offset: 0}, SourceID: 0}})
+	visitor.ExitObjTypeAnnElem(nil)
 }
 
 // Benchmark basic visitor traversal
@@ -325,4 +342,55 @@ func BenchmarkDefaultVisitor_SimpleTraversal(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		binary.Accept(visitor)
 	}
+}
+
+// ObjectTypeAnn offers each member to EnterObjTypeAnnElem, then walks the
+// member's own types. A RestSpreadTypeAnn is a TypeAnn as well as a member, so
+// it arrives through EnterTypeAnn instead.
+func TestObjectTypeAnn_Accept_OffersEachMember(t *testing.T) {
+	span := Span{Start: Location{Offset: 0}, End: Location{Offset: 1}, SourceID: 0}
+	property := &PropertyTypeAnn{
+		Name:     NewIdent("a", span),
+		Optional: false,
+		Readonly: false,
+		Value:    NewNumberTypeAnn(span),
+	}
+	spread := NewRestSpreadTypeAnn(NewStringTypeAnn(span), span)
+	obj := NewObjectTypeAnn([]ObjTypeAnnElem{property, spread}, span)
+
+	visitor := newMockVisitor()
+	obj.Accept(visitor)
+
+	require.Equal(t, []string{
+		"EnterTypeAnn",        // the object type itself
+		"EnterObjTypeAnnElem", // the property
+		"EnterTypeAnn",        // the property's `number`
+		"EnterTypeAnn",        // the rest spread
+		"EnterTypeAnn",        // the rest spread's `string`
+	}, visitor.enterCalls)
+	require.Equal(t, []string{
+		"ExitTypeAnn",        // the property's `number`
+		"ExitObjTypeAnnElem", // the property
+		"ExitTypeAnn",        // the rest spread's `string`
+		"ExitTypeAnn",        // the rest spread
+		"ExitTypeAnn",        // the object type itself
+	}, visitor.exitCalls)
+}
+
+// A visitor that turns a member down keeps the walk out of the member's types.
+func TestObjectTypeAnn_Accept_SkipsMemberChildren(t *testing.T) {
+	span := Span{Start: Location{Offset: 0}, End: Location{Offset: 1}, SourceID: 0}
+	property := &PropertyTypeAnn{
+		Name:     NewIdent("a", span),
+		Optional: false,
+		Readonly: false,
+		Value:    NewNumberTypeAnn(span),
+	}
+	obj := NewObjectTypeAnn([]ObjTypeAnnElem{property}, span)
+
+	visitor := newMockVisitor()
+	visitor.skipNodes["ObjTypeAnnElem"] = true
+	obj.Accept(visitor)
+
+	require.Equal(t, []string{"EnterTypeAnn", "EnterObjTypeAnnElem"}, visitor.enterCalls)
 }

--- a/internal/parser/__snapshots__/lifetime_test.snap
+++ b/internal/parser/__snapshots__/lifetime_test.snap
@@ -531,6 +531,9 @@
                     Receiver: &ast.MethodReceiver{
                         Span_: 32-36,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 21-62,
+                    },
                 },
             },
             span: 19-64,
@@ -688,6 +691,9 @@
                             span: 26-28,
                         },
                         span: 29-34,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 23-34,
                     },
                 },
             },
@@ -1035,6 +1041,9 @@
                         },
                         Span_: 28-35,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 19-48,
+                    },
                 },
             },
             span: 17-50,
@@ -1103,6 +1112,9 @@
                             span: 36-38,
                         },
                         Span_: 32-43,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 20-74,
                     },
                 },
             },

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -2310,6 +2310,9 @@
                     Value: &ast.NumberTypeAnn{
                         span: 41-47,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 38-47,
+                    },
                 },
             },
             span: 31-53,
@@ -2353,6 +2356,9 @@
                     Value: &ast.NumberTypeAnn{
                         span: 46-52,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 43-52,
+                    },
                 },
             },
             span: 36-58,
@@ -2394,6 +2400,9 @@
                     },
                     Value: &ast.NumberTypeAnn{
                         span: 45-51,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 42-51,
                     },
                 },
             },
@@ -2450,6 +2459,9 @@
                         },
                         span: 51-52,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 44-52,
+                    },
                 },
             },
             span: 37-58,
@@ -2490,6 +2502,9 @@
                     },
                     Value: &ast.NumberTypeAnn{
                         span: 49-55,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 46-55,
                     },
                 },
             },
@@ -2544,6 +2559,9 @@
                     },
                     Value: &ast.NumberTypeAnn{
                         span: 58-64,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 55-64,
                     },
                 },
             },
@@ -2627,6 +2645,9 @@
                         },
                         span: 63-64,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 60-64,
+                    },
                 },
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
@@ -2639,6 +2660,9 @@
                             span: 74-75,
                         },
                         span: 74-75,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 71-75,
                     },
                 },
             },
@@ -2667,6 +2691,9 @@
                     Value: &ast.StringTypeAnn{
                         span: 42-48,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 36-48,
+                    },
                 },
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
@@ -2675,6 +2702,9 @@
                     },
                     Value: &ast.NumberTypeAnn{
                         span: 60-66,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 55-66,
                     },
                 },
             },
@@ -4945,6 +4975,9 @@
                     },
                     Value: &ast.NumberTypeAnn{
                         span: 36-42,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 33-42,
                     },
                 },
             },

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -697,6 +697,9 @@
                     Value: &ast.NumberTypeAnn{
                         span: 19-25,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 16-25,
+                    },
                 },
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
@@ -705,6 +708,9 @@
                     },
                     Value: &ast.StringTypeAnn{
                         span: 30-36,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 27-36,
                     },
                 },
             },
@@ -901,6 +907,9 @@
                         },
                         span: 37-38,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 30-38,
+                    },
                 },
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
@@ -913,6 +922,9 @@
                             span: 48-49,
                         },
                         span: 48-49,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 40-49,
                     },
                 },
             },
@@ -3267,6 +3279,9 @@
                     Value: &ast.StringTypeAnn{
                         span: 36-42,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 27-42,
+                    },
                 },
             },
             span: 25-44,
@@ -3309,6 +3324,9 @@
                         },
                         span: 30-31,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 23-31,
+                    },
                 },
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
@@ -3321,6 +3339,9 @@
                             span: 41-42,
                         },
                         span: 41-42,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 33-42,
                     },
                 },
             },
@@ -3349,6 +3370,9 @@
                     Value: &ast.StringTypeAnn{
                         span: 32-38,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 26-38,
+                    },
                 },
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
@@ -3357,6 +3381,9 @@
                     },
                     Value: &ast.NumberTypeAnn{
                         span: 45-51,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 40-51,
                     },
                 },
             },
@@ -3396,6 +3423,9 @@
                         },
                         span: 26-27,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 19-27,
+                    },
                 },
             },
             span: 17-29,
@@ -3423,6 +3453,9 @@
                     Value: &ast.NumberTypeAnn{
                         span: 21-27,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 18-27,
+                    },
                 },
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
@@ -3431,6 +3464,9 @@
                     },
                     Value: &ast.NumberTypeAnn{
                         span: 32-38,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 29-38,
                     },
                 },
             },
@@ -3864,6 +3900,9 @@
                     Receiver: &ast.MethodReceiver{
                         Span_: 22-26,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 18-59,
+                    },
                 },
             },
             span: 16-61,
@@ -3898,6 +3937,9 @@
                         Mut: true,
                         Span_: 30-38,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 20-49,
+                    },
                 },
             },
             span: 18-51,
@@ -3931,6 +3973,9 @@
                     Receiver: &ast.MethodReceiver{
                         Span_: 26-30,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 20-41,
+                    },
                 },
             },
             span: 18-43,
@@ -3960,6 +4005,9 @@
                             span: 27-33,
                         },
                         span: 21-33,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 17-33,
                     },
                 },
             },
@@ -4009,6 +4057,9 @@
                         Mut: true,
                         Span_: 31-39,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 21-64,
+                    },
                 },
             },
             span: 19-66,
@@ -4041,6 +4092,9 @@
                     },
                     Receiver: &ast.MethodReceiver{
                         Span_: 27-31,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 18-42,
                     },
                 },
             },
@@ -4075,6 +4129,9 @@
                     Receiver: &ast.MethodReceiver{
                         Mut: true,
                         Span_: 29-37,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 19-48,
                     },
                 },
             },
@@ -4158,6 +4215,9 @@
                             span: 37-43,
                         },
                         span: 18-43,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 14-43,
                     },
                 },
             },
@@ -4634,6 +4694,9 @@
                             span: 27-28,
                         },
                         span: 27-28,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 20-28,
                     },
                 },
             },

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -324,6 +324,9 @@
                 },
                 span: 4-5,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-5,
+            },
         },
         &ast.PropertyTypeAnn{
             Name: &ast.IdentExpr{
@@ -337,6 +340,9 @@
                     span: 11-12,
                 },
                 span: 11-12,
+            },
+            elemSpan: ast.elemSpan{
+                span: 7-12,
             },
         },
         &ast.PropertyTypeAnn{
@@ -353,6 +359,9 @@
                 },
                 span: 19-20,
             },
+            elemSpan: ast.elemSpan{
+                span: 14-20,
+            },
         },
         &ast.PropertyTypeAnn{
             Name: &ast.ComputedKey{
@@ -368,6 +377,9 @@
                     span: 28-29,
                 },
                 span: 28-29,
+            },
+            elemSpan: ast.elemSpan{
+                span: 22-29,
             },
         },
     },
@@ -414,6 +426,9 @@
                     span: 8-9,
                 },
                 span: 6-10,
+            },
+            elemSpan: ast.elemSpan{
+                span: 1-27,
             },
         },
     },
@@ -646,6 +661,9 @@
             Value: &ast.StringTypeAnn{
                 span: 4-10,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-10,
+            },
         },
         &ast.RestSpreadTypeAnn{
             Value: &ast.TypeRefTypeAnn{
@@ -691,6 +709,9 @@
             Value: &ast.StringTypeAnn{
                 span: 4-10,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-10,
+            },
         },
         &ast.RestSpreadTypeAnn{
             Value: &ast.TypeRefTypeAnn{
@@ -709,6 +730,9 @@
             },
             Value: &ast.NumberTypeAnn{
                 span: 21-27,
+            },
+            elemSpan: ast.elemSpan{
+                span: 18-27,
             },
         },
         &ast.RestSpreadTypeAnn{
@@ -844,6 +868,9 @@
                 Value: &ast.StringTypeAnn{
                     span: 10-16,
                 },
+                elemSpan: ast.elemSpan{
+                    span: 7-16,
+                },
             },
             &ast.PropertyTypeAnn{
                 Name: &ast.IdentExpr{
@@ -852,6 +879,9 @@
                 },
                 Value: &ast.NumberTypeAnn{
                     span: 21-27,
+                },
+                elemSpan: ast.elemSpan{
+                    span: 18-27,
                 },
             },
         },
@@ -921,6 +951,9 @@
                 span: 7-11,
             },
             Optional: &"add",
+            elemSpan: ast.elemSpan{
+                span: 1-28,
+            },
         },
     },
     span: 0-29,
@@ -982,6 +1015,9 @@
                 },
                 span: 18-22,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-39,
+            },
         },
     },
     span: 0-40,
@@ -1042,6 +1078,9 @@
             Extends: &ast.StringTypeAnn{
                 span: 38-44,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-44,
+            },
         },
     },
     span: 0-45,
@@ -1083,6 +1122,9 @@
                 span: 8-12,
             },
             Optional: &"remove",
+            elemSpan: ast.elemSpan{
+                span: 1-29,
+            },
         },
     },
     span: 0-30,
@@ -1124,6 +1166,9 @@
                 span: 8-12,
             },
             Optional: &"add",
+            elemSpan: ast.elemSpan{
+                span: 1-29,
+            },
         },
     },
     span: 0-30,
@@ -1158,6 +1203,9 @@
             Value: &ast.NumberTypeAnn{
                 span: 5-11,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-11,
+            },
         },
         &ast.PropertyTypeAnn{
             Name: &ast.IdentExpr{
@@ -1167,6 +1215,9 @@
             Readonly: true,
             Value: &ast.StringTypeAnn{
                 span: 28-34,
+            },
+            elemSpan: ast.elemSpan{
+                span: 13-34,
             },
         },
     },
@@ -1209,6 +1260,9 @@
                 span: 16-20,
             },
             ReadOnly: &"add",
+            elemSpan: ast.elemSpan{
+                span: 1-37,
+            },
         },
     },
     span: 0-38,
@@ -1250,6 +1304,9 @@
                 span: 15-19,
             },
             ReadOnly: &"add",
+            elemSpan: ast.elemSpan{
+                span: 1-36,
+            },
         },
     },
     span: 0-37,
@@ -1291,6 +1348,9 @@
                 span: 16-20,
             },
             ReadOnly: &"remove",
+            elemSpan: ast.elemSpan{
+                span: 1-37,
+            },
         },
     },
     span: 0-38,
@@ -1359,6 +1419,9 @@
             },
             Value: &ast.ErrorTypeAnn{
                 span: 4-5,
+            },
+            elemSpan: ast.elemSpan{
+                span: 1-3,
             },
         },
     },
@@ -1735,6 +1798,9 @@
             Value: &ast.NumberTypeAnn{
                 span: 4-10,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-10,
+            },
         },
         &ast.PropertyTypeAnn{
             Name: &ast.IdentExpr{
@@ -1743,6 +1809,9 @@
             },
             Value: &ast.NumberTypeAnn{
                 span: 15-21,
+            },
+            elemSpan: ast.elemSpan{
+                span: 12-21,
             },
         },
     },
@@ -1789,6 +1858,9 @@
                 },
                 Value: &ast.NumberTypeAnn{
                     span: 12-18,
+                },
+                elemSpan: ast.elemSpan{
+                    span: 9-18,
                 },
             },
         },
@@ -1883,6 +1955,9 @@
                 Value: &ast.NumberTypeAnn{
                     span: 9-15,
                 },
+                elemSpan: ast.elemSpan{
+                    span: 6-15,
+                },
             },
         },
         span: 5-16,
@@ -1919,6 +1994,9 @@
                 },
                 Value: &ast.NumberTypeAnn{
                     span: 8-14,
+                },
+                elemSpan: ast.elemSpan{
+                    span: 5-14,
                 },
             },
         },
@@ -1964,6 +2042,9 @@
                 },
                 Value: &ast.NumberTypeAnn{
                     span: 5-11,
+                },
+                elemSpan: ast.elemSpan{
+                    span: 2-11,
                 },
             },
         },
@@ -2028,6 +2109,9 @@
                 span: 30-36,
             },
             Shorthand: true,
+            elemSpan: ast.elemSpan{
+                span: 1-36,
+            },
         },
     },
     span: 0-37,
@@ -2045,6 +2129,9 @@
             Value: &ast.NumberTypeAnn{
                 span: 5-11,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-11,
+            },
         },
         &ast.MappedTypeAnn{
             TypeParam: &ast.IndexParamTypeAnn{
@@ -2058,6 +2145,9 @@
             },
             Optional: &"add",
             Shorthand: true,
+            elemSpan: ast.elemSpan{
+                span: 13-33,
+            },
         },
     },
     span: 0-34,
@@ -2079,6 +2169,9 @@
             },
             Optional: &"add",
             Shorthand: true,
+            elemSpan: ast.elemSpan{
+                span: 1-21,
+            },
         },
     },
     span: 0-22,
@@ -2120,6 +2213,9 @@
                 span: 15-19,
             },
             Shorthand: true,
+            elemSpan: ast.elemSpan{
+                span: 1-19,
+            },
         },
     },
     span: 0-20,
@@ -2162,6 +2258,9 @@
             },
             ReadOnly: &"add",
             Shorthand: true,
+            elemSpan: ast.elemSpan{
+                span: 1-28,
+            },
         },
     },
     span: 0-29,
@@ -2211,6 +2310,9 @@
             },
             Optional: &"add",
             Shorthand: true,
+            elemSpan: ast.elemSpan{
+                span: 1-21,
+            },
         },
         &ast.MappedTypeAnn{
             TypeParam: &ast.IndexParamTypeAnn{
@@ -2224,6 +2326,9 @@
             },
             Optional: &"add",
             Shorthand: true,
+            elemSpan: ast.elemSpan{
+                span: 23-44,
+            },
         },
     },
     span: 0-45,
@@ -2278,6 +2383,9 @@
             Value: &ast.NumberTypeAnn{
                 span: 19-25,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-25,
+            },
         },
     },
     span: 0-26,
@@ -2321,6 +2429,9 @@
             Value: &ast.NumberTypeAnn{
                 span: 18-24,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-24,
+            },
         },
     },
     span: 0-25,
@@ -2359,6 +2470,9 @@
             },
             Receiver: &ast.MethodReceiver{
                 Span_: 7-11,
+            },
+            elemSpan: ast.elemSpan{
+                span: 1-41,
             },
         },
     },
@@ -2437,6 +2551,9 @@
                 },
                 span: 1-24,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-24,
+            },
         },
     },
     span: 0-25,
@@ -2466,6 +2583,9 @@
                     },
                     span: 20-25,
                 },
+                span: 1-25,
+            },
+            elemSpan: ast.elemSpan{
                 span: 1-25,
             },
         },
@@ -2499,6 +2619,9 @@
                 },
                 span: 1-25,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-25,
+            },
         },
         &ast.PropertyTypeAnn{
             Name: &ast.IdentExpr{
@@ -2511,6 +2634,9 @@
                     span: 35-40,
                 },
                 span: 35-40,
+            },
+            elemSpan: ast.elemSpan{
+                span: 27-40,
             },
         },
     },
@@ -2554,6 +2680,9 @@
                 },
                 span: 1-41,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-41,
+            },
         },
     },
     span: 0-42,
@@ -2579,6 +2708,9 @@
                 Return: &ast.ErrorTypeAnn{
                     span: 17-17,
                 },
+                span: 1-17,
+            },
+            elemSpan: ast.elemSpan{
                 span: 1-17,
             },
         },
@@ -2643,6 +2775,9 @@
                 },
                 span: 5-16,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-16,
+            },
         },
     },
     span: 0-17,
@@ -2673,6 +2808,9 @@
                     span: 17-23,
                 },
                 span: 2-23,
+            },
+            elemSpan: ast.elemSpan{
+                span: 1-23,
             },
         },
     },
@@ -2705,6 +2843,9 @@
             Receiver: &ast.MethodReceiver{
                 Mut: true,
                 Span_: 7-15,
+            },
+            elemSpan: ast.elemSpan{
+                span: 1-27,
             },
         },
     },
@@ -2740,6 +2881,9 @@
             Receiver: &ast.MethodReceiver{
                 Mut: true,
                 Span_: 3-11,
+            },
+            elemSpan: ast.elemSpan{
+                span: 1-33,
             },
         },
     },
@@ -2779,6 +2923,9 @@
                 Mut: true,
                 Span_: 7-15,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-40,
+            },
         },
     },
     span: 0-41,
@@ -2801,6 +2948,9 @@
             },
             Receiver: &ast.MethodReceiver{
                 Span_: 7-11,
+            },
+            elemSpan: ast.elemSpan{
+                span: 1-22,
             },
         },
     },
@@ -2831,6 +2981,9 @@
             },
             Receiver: &ast.MethodReceiver{
                 Span_: 7-11,
+            },
+            elemSpan: ast.elemSpan{
+                span: 1-40,
             },
         },
     },
@@ -2870,6 +3023,9 @@
             Receiver: &ast.MethodReceiver{
                 Mut: true,
                 Span_: 7-15,
+            },
+            elemSpan: ast.elemSpan{
+                span: 1-45,
             },
         },
     },

--- a/internal/parser/attach_test.go
+++ b/internal/parser/attach_test.go
@@ -66,6 +66,10 @@ func (c *attachmentLister) EnterTypeAnn(t ast.TypeAnn) bool         { c.record(t
 func (c *attachmentLister) EnterPat(p ast.Pat) bool                 { c.record(p); return true }
 func (c *attachmentLister) EnterClassElem(e ast.ClassElem) bool     { c.record(e); return true }
 func (c *attachmentLister) EnterObjExprElem(e ast.ObjExprElem) bool { c.record(e); return true }
+func (c *attachmentLister) EnterObjTypeAnnElem(e ast.ObjTypeAnnElem) bool {
+	c.record(e)
+	return true
+}
 
 func TestAttachComments(t *testing.T) {
 	t.Parallel()
@@ -430,6 +434,71 @@ func TestAttachCommentsInDelimitedLists(t *testing.T) {
 			name: "alone in an empty parameter list",
 			src:  "fn g(/* m */) -> number {\n    return 1\n}\n",
 			want: []string{"leading *ast.NumberTypeAnn /* m */"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, nilIfEmpty(attachments(t, tc.src)))
+		})
+	}
+}
+
+// A member of an object type annotation owns the comments written beside it.
+// Before #1371 the pass could not reach a member at all, so a comment landed on
+// the member's own type annotation or on the enclosing ObjectTypeAnn.
+func TestAttachCommentsOnObjectTypeMembers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "above a property",
+			src:  "type T = {\n    // about b\n    b: string,\n}\n",
+			want: []string{"leading *ast.PropertyTypeAnn // about b"},
+		},
+		{
+			name: "after a property on the same line",
+			src:  "type T = {\n    b: string, // note\n}\n",
+			want: []string{"trailing *ast.PropertyTypeAnn // note"},
+		},
+		{
+			// The member's span ends at its type, so the comment falls between
+			// two members and rule 1 gives it to the one it opens.
+			name: "between two properties",
+			src:  "type T = {a: number /* m */, b: string}\n",
+			want: []string{"leading *ast.PropertyTypeAnn /* m */"},
+		},
+		{
+			name: "above a method",
+			src:  "type T = {\n    // about the method\n    m(self) -> number,\n}\n",
+			want: []string{"leading *ast.MethodTypeAnn // about the method"},
+		},
+		{
+			name: "above a rest spread",
+			src:  "type T = {\n    // about the spread\n    ...Other,\n}\n",
+			want: []string{"leading *ast.RestSpreadTypeAnn // about the spread"},
+		},
+		{
+			// No member encloses it and none follows, so the object type takes it.
+			name: "alone in an empty object type",
+			src:  "type T = {\n    // dangling\n}\n",
+			want: []string{"dangling *ast.ObjectTypeAnn // dangling"},
+		},
+		{
+			name: "after the last member",
+			src:  "type T = {\n    b: string,\n    // last\n}\n",
+			want: []string{"dangling *ast.ObjectTypeAnn // last"},
+		},
+		{
+			// The member retains a JSDoc as its Doc, which a printer writes
+			// ahead of its leading comments, so the pass leaves the slot empty
+			// rather than writing the text twice.
+			name: "a JSDoc above a property stays the member's doc",
+			src:  "type T = {\n    /** doc */\n    b: string,\n}\n",
+			want: nil,
 		},
 	}
 	for _, tc := range tests {

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -13,6 +13,11 @@ type Lexer struct {
 	source        *ast.Source
 	currentOffset int
 	lastToken     *Token // Track last token for regex context
+	// lastCodeEnd is the end offset of the last non-comment token read. Several
+	// productions consume a trailing comment on their way to the next token, so
+	// currentOffset can sit past one. A span closed at lastCodeEnd stops at the
+	// code instead.
+	lastCodeEnd int
 	// comments records every comment token this lexer produces. Save points
 	// share one log so backtracking neither loses a comment nor records it
 	// twice; see commentLog.
@@ -24,6 +29,7 @@ func NewLexer(source *ast.Source) *Lexer {
 		source:        source,
 		currentOffset: 0,
 		lastToken:     nil,
+		lastCodeEnd:   0,
 		comments:      newCommentLog(),
 	}
 }
@@ -463,6 +469,9 @@ func (lexer *Lexer) next() *Token {
 
 	lexer.currentOffset = endOffset
 	lexer.lastToken = token // Track the last token for regex context
+	if token.Type != LineComment && token.Type != BlockComment {
+		lexer.lastCodeEnd = endOffset
+	}
 	lexer.comments.record(token)
 
 	return token
@@ -473,6 +482,7 @@ func (lexer *Lexer) saveState() *Lexer {
 		source:        lexer.source,
 		currentOffset: lexer.currentOffset,
 		lastToken:     lexer.lastToken,
+		lastCodeEnd:   lexer.lastCodeEnd,
 		comments:      lexer.comments,
 	}
 }
@@ -481,12 +491,20 @@ func (lexer *Lexer) restoreState(saved *Lexer) {
 	lexer.source = saved.source
 	lexer.currentOffset = saved.currentOffset
 	lexer.lastToken = saved.lastToken
+	lexer.lastCodeEnd = saved.lastCodeEnd
 }
 
 // currentLoc returns the position the lexer will read from next. The parser
 // uses it to close a span it opened at an earlier token.
 func (lexer *Lexer) currentLoc() ast.Location {
 	return ast.Location{Offset: lexer.currentOffset}
+}
+
+// lastCodeLoc returns the end of the last non-comment token the lexer read.
+// The parser closes a span with it where currentLoc would reach past a comment
+// written after the construct, as in `{a: number /* m */, b: string}`.
+func (lexer *Lexer) lastCodeLoc() ast.Location {
+	return ast.Location{Offset: lexer.lastCodeEnd}
 }
 
 // sameLine reports whether two positions fall on the same source line. The

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -869,6 +869,7 @@ func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
 // shape of parseClassElem — see #663.
 func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 	doc := p.consumeLeadingDoc()
+	start := p.lexer.peek().Span.Start
 	// After consuming a leading JSDoc, if we're sitting on the object
 	// type's closing brace, there's no elem to attach the doc to.
 	// Surface that to the user as a parse error AND return nil so
@@ -882,6 +883,17 @@ func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 	}
 	elem := p.objTypeAnnElemInner()
 	attachDoc(elem, doc)
+	if elem != nil {
+		// The member runs from its first modifier or name through the last code
+		// token the inner read. Recording it here covers every variant at once,
+		// and it is what lets ast.AttachComments tell a comment written before a
+		// member from one written after it.
+		elem.SetSpan(ast.Span{
+			Start:    start,
+			End:      p.lexer.lastCodeLoc(),
+			SourceID: p.lexer.source.ID,
+		})
+	}
 	return elem
 }
 

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -486,3 +486,78 @@ func TestMappedTypeMinusModifiers(t *testing.T) {
 		})
 	}
 }
+
+// Every member of an object type annotation carries the range it was written
+// from, running from its first modifier or name through its type. ast.AttachComments
+// reads that range to tell a comment written before a member from one after it,
+// and a diagnostic about the member's name still underlines the name alone.
+func TestObjTypeAnnElemSpans(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "two properties on one line",
+			src:  "type T = {a: number, b: string}",
+			want: []string{"a: number", "b: string"},
+		},
+		{
+			name: "modifiers and the optional marker",
+			src:  "type T = {readonly a?: number}",
+			want: []string{"readonly a?: number"},
+		},
+		{
+			// The union type parser consumes a comment on its way to the comma,
+			// so the member's end comes from the last code token rather than
+			// from where the lexer stopped.
+			name: "a comment after a property",
+			src:  "type T = {a: number /* m */, b: string}",
+			want: []string{"a: number", "b: string"},
+		},
+		{
+			name: "a method, an accessor pair, and a rest spread",
+			src:  "type T = {m(self) -> number, get a(self) -> number, set a(mut self, v: number), ...Other}",
+			want: []string{
+				"m(self) -> number",
+				"get a(self) -> number",
+				"set a(mut self, v: number)",
+				"...Other",
+			},
+		},
+		{
+			name: "a call signature and a construct signature",
+			src:  "type T = {fn (a: number) -> string, new (a: number) -> string}",
+			want: []string{"fn (a: number) -> string", "new (a: number) -> string"},
+		},
+		{
+			name: "a mapped member",
+			src:  "type T = {[K]: string for K in Keys}",
+			want: []string{"[K]: string for K in Keys"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			source := &ast.Source{ID: 0, Path: "input.esc", Contents: tc.src}
+			script, errors := NewParser(ctx, source).ParseScript()
+			require.Empty(t, errors)
+
+			require.Len(t, script.Stmts, 1)
+			decl, ok := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.TypeDecl)
+			require.True(t, ok)
+			obj, ok := decl.TypeAnn.(*ast.ObjectTypeAnn)
+			require.True(t, ok)
+
+			got := make([]string, 0, len(obj.Elems))
+			for _, elem := range obj.Elems {
+				span := elem.Span()
+				got = append(got, tc.src[span.Start.Offset:span.End.Offset])
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -282,10 +282,10 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			if resolved == nil || !b.addElem(resolved) {
 				continue
 			}
-			// Every member that can displace another carries a span. ObjTypeAnnElem does
-			// not declare Span, since a callable signature and a mapped member have none,
-			// and neither of those reaches the builder.
-			if blame, hasSpan := elem.(spanned); hasSpan {
+			// The name is what the diagnostic underlines, since a redeclaration is
+			// about the key rather than the type written after it. Every member that
+			// can displace another declares one.
+			if blame := memberKey(elem); blame != nil {
 				c.report(&DuplicateObjectMemberError{Name: soltype.ObjElemName(resolved), Elem: blame})
 			}
 		}
@@ -379,7 +379,7 @@ func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bo
 		// first parameter, or from `unknown` when there is none, so the object still carries a
 		// member under the name the source wrote. This mirrors the class-member recovery.
 		if len(sig.Params) != 1 {
-			l.c.report(&SetterArityError{Name: name, Elem: elem, Count: len(sig.Params)})
+			l.c.report(&SetterArityError{Name: name, Elem: elem.Name, Count: len(sig.Params)})
 		}
 		var param soltype.Type = &soltype.UnknownType{}
 		if len(sig.Params) > 0 {
@@ -1323,4 +1323,24 @@ func (c *checker) annPrim(ta ast.TypeAnn, p soltype.Prim) soltype.Type {
 	t := &soltype.PrimType{Prim: p}
 	c.recordProv(t, ta, AnnotationType)
 	return t
+}
+
+// memberKey returns the key a named object type annotation member declares, or
+// nil for a member that declares none. A call signature, a construct signature,
+// a mapped member, and a rest spread are the four without one. A diagnostic
+// about a member's name underlines the key rather than the member's whole
+// range, which runs from its first modifier through the type written after it.
+func memberKey(elem ast.ObjTypeAnnElem) ast.ObjKey {
+	switch e := elem.(type) {
+	case *ast.PropertyTypeAnn:
+		return e.Name
+	case *ast.MethodTypeAnn:
+		return e.Name
+	case *ast.GetterTypeAnn:
+		return e.Name
+	case *ast.SetterTypeAnn:
+		return e.Name
+	default:
+		return nil
+	}
 }


### PR DESCRIPTION
Fixes #1371

Third of three stacked PRs. Based on https://github.com/escalier-lang/escalier/pull/1385 (#1373), which is based on https://github.com/escalier-lang/escalier/pull/1384 (#1381). Review those first, and merge this into `main` only after both land.

A member of an object type annotation could not own a comment. A comment written beside one landed on the member's own type annotation or on the enclosing `ObjectTypeAnn`, because `ast.Visitor` never offered the member and most variants had no range to index.

## What changed

Three things make a member reachable.

1. **Every variant carries a real range.** It runs from the member's first modifier or name through its type. Seven of the eight embed a new `elemSpan`; `RestSpreadTypeAnn` already had a span field it needs as a `TypeAnn`. `objTypeAnnElem` records the range once for every variant, closing it with a new `Lexer.lastCodeLoc` so a comment the union type parser consumed on its way to the comma stays outside the member: in `{a: number /* m */, b: string}` the first member spans `a: number`.

2. **The visitor offers each member.** `Visitor` gains `EnterObjTypeAnnElem` and `ExitObjTypeAnnElem`, and each variant gains an `Accept` that offers itself and then walks its own types. `ObjectTypeAnn.Accept` calls those in place of its inline type switch. A member's name is deliberately not visited: an `ObjKey` is an `IdentExpr`, a `StrLit`, or a `NumLit`, so offering one to `EnterExpr` would report a value reference where the source wrote a property name, and a pass such as `dep_graph`'s `DependencyVisitor` would record a dependency on it.

3. **`nodeCollector` records each member**, so `ast.AttachComments` can give it one.

## Effect

A comment above a member leads it, one after it on the same line trails it, and one alone in an empty object type dangles on the `ObjectTypeAnn`. A JSDoc stays the member's `Doc()` rather than being written twice. `TestAttachCommentsOnObjectTypeMembers` covers these, and `TestObjTypeAnnElemSpans` pins the range each variant records.

Because the members carry a real range, the duplicate-member and setter-arity diagnostics would have widened from the member's name to the whole member. Both now pass the name explicitly, through a new `memberKey` helper for the first, so the text they underline is unchanged.

Snapshots gained the new `elemSpan` field wherever a parsed object type annotation is recorded. `go test ./...` passes, and re-running with `UPDATE_SNAPS=true` and `UPDATE_FIXTURES=true` produces no further drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WwshtyzQcyLYJ5KbTeu8B

---
_Generated by [Claude Code](https://claude.ai/code/session_015WwshtyzQcyLYJ5KbTeu8B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved traversal and comment attachment for object type annotation members, including properties, methods, accessors, signatures, mapped members, and rest-spread members.
  * Added accurate source ranges for object type annotation members, including declarations with comments and modifiers.
  * Improved diagnostic highlighting for duplicate members and invalid setter parameter counts by targeting the relevant member key.
* **Tests**
  * Expanded coverage for traversal, comment attachment, source ranges, and diagnostic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->