### PR TITLE
Extract provenance field into declProvenance struct

### DIFF
--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -62,7 +62,7 @@ func NewClassDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams []*Ty
 		declare:        declare,
 		final:          final,
 		span:           span,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }

--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -1,7 +1,5 @@
 package ast
 
-import "github.com/escalier-lang/escalier/internal/provenance"
-
 type ClassDecl struct {
 	declDoc
 	Name           *Ident
@@ -16,7 +14,7 @@ type ClassDecl struct {
 	override       bool
 	final          bool
 	span           Span
-	provenance     provenance.Provenance
+	declProvenance
 	commentSlots
 }
 
@@ -64,7 +62,7 @@ func NewClassDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams []*Ty
 		declare:        declare,
 		final:          final,
 		span:           span,
-		provenance:     nil,
+		declProvenance: declProvenance{provenance: nil},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -96,14 +94,9 @@ func (d *ClassDecl) Accept(v Visitor) {
 	}
 	v.ExitDecl(d)
 }
-func (d *ClassDecl) Provenance() provenance.Provenance {
-	return d.provenance
-}
-func (d *ClassDecl) SetProvenance(p provenance.Provenance) {
-	d.provenance = p
-}
 
 type FieldElem struct {
+	declDoc
 	Name ObjKey
 	Type TypeAnn // required for class fields; optional for object-pattern shorthands
 	// Value is the field's initializer expression (`= expr`). Only valid
@@ -115,7 +108,6 @@ type FieldElem struct {
 	Private  bool // true if this field is private
 	Readonly bool // true if this field is readonly
 	Optional bool // true if this field is declared `name?: T`
-	doc      string
 	Span_    Span
 	commentSlots
 }
@@ -133,17 +125,15 @@ func (f *FieldElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(f)
 }
-func (f *FieldElem) Span() Span        { return f.Span_ }
-func (f *FieldElem) Doc() string       { return f.doc }
-func (f *FieldElem) SetDoc(doc string) { f.doc = doc }
+func (f *FieldElem) Span() Span { return f.Span_ }
 
 type MethodElem struct {
+	declDoc
 	Name     ObjKey
 	Fn       *FuncExpr
 	Receiver *MethodReceiver // nil if static / no receiver
 	Static   bool            // true if this is a static method
 	Private  bool            // true if this is a private method
-	doc      string
 	Span_    Span
 	commentSlots
 }
@@ -158,18 +148,16 @@ func (m *MethodElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(m)
 }
-func (m *MethodElem) Span() Span        { return m.Span_ }
-func (m *MethodElem) Doc() string       { return m.doc }
-func (m *MethodElem) SetDoc(doc string) { m.doc = doc }
+func (m *MethodElem) Span() Span { return m.Span_ }
 
 // GetterElem represents a getter in a class.
 type GetterElem struct {
+	declDoc
 	Name     ObjKey
 	Fn       *FuncExpr
 	Receiver *MethodReceiver // nil if static / no receiver
 	Static   bool            // true if this is a static getter
 	Private  bool            // true if this is a private getter
-	doc      string
 	Span_    Span
 	commentSlots
 }
@@ -184,9 +172,7 @@ func (g *GetterElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(g)
 }
-func (g *GetterElem) Span() Span        { return g.Span_ }
-func (g *GetterElem) Doc() string       { return g.doc }
-func (g *GetterElem) SetDoc(doc string) { g.doc = doc }
+func (g *GetterElem) Span() Span { return g.Span_ }
 
 // ConstructorElem represents an explicit `constructor(...) { ... }` block
 // inside a class body. The constructor's receiver is represented by
@@ -198,10 +184,10 @@ func (g *GetterElem) SetDoc(doc string) { g.doc = doc }
 // always `Self` and is not part of the AST; `Fn.Return` must remain nil.
 // `Fn.Throws` may be non-nil — constructors may declare a `throws` clause.
 type ConstructorElem struct {
+	declDoc
 	Fn       *FuncExpr
 	Receiver *MethodReceiver // nil if absent. Carried for diagnostics — a non-nil Lifetime is rejected by validation.
 	Private  bool            // reserved for future "Private Constructors" work
-	doc      string
 	Span_    Span
 	commentSlots
 }
@@ -215,18 +201,16 @@ func (c *ConstructorElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(c)
 }
-func (c *ConstructorElem) Span() Span        { return c.Span_ }
-func (c *ConstructorElem) Doc() string       { return c.doc }
-func (c *ConstructorElem) SetDoc(doc string) { c.doc = doc }
+func (c *ConstructorElem) Span() Span { return c.Span_ }
 
 // SetterElem represents a setter in a class.
 type SetterElem struct {
+	declDoc
 	Name     ObjKey
 	Fn       *FuncExpr
 	Receiver *MethodReceiver // nil if static / no receiver
 	Static   bool            // true if this is a static setter
 	Private  bool            // true if this is a private setter
-	doc      string
 	Span_    Span
 	commentSlots
 }
@@ -241,6 +225,4 @@ func (s *SetterElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(s)
 }
-func (s *SetterElem) Span() Span        { return s.Span_ }
-func (s *SetterElem) Doc() string       { return s.doc }
-func (s *SetterElem) SetDoc(doc string) { s.doc = doc }
+func (s *SetterElem) Span() Span { return s.Span_ }

--- a/internal/ast/decl.go
+++ b/internal/ast/decl.go
@@ -21,15 +21,25 @@ type Decl interface {
 	Node
 }
 
-// declDoc carries the leading JSDoc retained on a declaration. Every Decl
-// embeds it so the parser and the .d.ts converter can attach a doc without
-// each declaration kind repeating the field and its two accessors.
+// declDoc carries the leading JSDoc retained on a node. Every Decl embeds it,
+// as do the class elems and object-type-annotation elems that keep a doc.
+// Embedding lets the parser and the .d.ts converter attach a doc without each
+// kind repeating the field and its two accessors.
 type declDoc struct {
 	doc string
 }
 
 func (d *declDoc) Doc() string       { return d.doc }
 func (d *declDoc) SetDoc(doc string) { d.doc = doc }
+
+// declProvenance carries the provenance recorded on a declaration. Every Decl
+// embeds it so no declaration kind repeats the field and its two accessors.
+type declProvenance struct {
+	provenance provenance.Provenance
+}
+
+func (d *declProvenance) Provenance() provenance.Provenance     { return d.provenance }
+func (d *declProvenance) SetProvenance(p provenance.Provenance) { d.provenance = p }
 
 func (*VarDecl) isDecl()              {}
 func (*FuncDecl) isDecl()             {}
@@ -63,7 +73,7 @@ type VarDecl struct {
 	override     bool
 	span         Span
 	InferredType Type // optional, used to store the inferred pattern type
-	provenance   provenance.Provenance
+	declProvenance
 	commentSlots
 }
 
@@ -77,16 +87,16 @@ func NewVarDecl(
 	span Span,
 ) *VarDecl {
 	return &VarDecl{
-		Kind:         kind,
-		Pattern:      pattern,
-		TypeAnn:      typeAnn,
-		Init:         init,
-		export:       export,
-		declare:      declare,
-		span:         span,
-		InferredType: nil,
-		provenance:   nil,
-		commentSlots: commentSlots{},
+		Kind:           kind,
+		Pattern:        pattern,
+		TypeAnn:        typeAnn,
+		Init:           init,
+		export:         export,
+		declare:        declare,
+		span:           span,
+		InferredType:   nil,
+		declProvenance: declProvenance{provenance: nil},
+		commentSlots:   commentSlots{},
 	}
 }
 func (d *VarDecl) Export() bool       { return d.export }
@@ -110,12 +120,6 @@ func (d *VarDecl) Accept(v Visitor) {
 		}
 	}
 	v.ExitDecl(d)
-}
-func (d *VarDecl) Provenance() provenance.Provenance {
-	return d.provenance
-}
-func (d *VarDecl) SetProvenance(p provenance.Provenance) {
-	d.provenance = p
 }
 
 type Param struct {
@@ -145,7 +149,7 @@ type FuncDecl struct {
 	declare    bool
 	override   bool
 	span       Span
-	provenance provenance.Provenance
+	declProvenance
 	commentSlots
 }
 
@@ -172,12 +176,12 @@ func NewFuncDecl(
 			Throws:         throwsType,
 			Async:          async,
 		},
-		Body:         body,
-		export:       export,
-		declare:      declare,
-		span:         span,
-		provenance:   nil,
-		commentSlots: commentSlots{},
+		Body:           body,
+		export:         export,
+		declare:        declare,
+		span:           span,
+		declProvenance: declProvenance{provenance: nil},
+		commentSlots:   commentSlots{},
 	}
 }
 func (d *FuncDecl) Export() bool       { return d.export }
@@ -202,12 +206,6 @@ func (d *FuncDecl) Accept(v Visitor) {
 	}
 	v.ExitDecl(d)
 }
-func (d *FuncDecl) Provenance() provenance.Provenance {
-	return d.provenance
-}
-func (d *FuncDecl) SetProvenance(p provenance.Provenance) {
-	d.provenance = p
-}
 
 type TypeDecl struct {
 	declDoc
@@ -219,20 +217,20 @@ type TypeDecl struct {
 	declare        bool
 	override       bool
 	span           Span
-	provenance     provenance.Provenance
+	declProvenance
 	commentSlots
 }
 
 func NewTypeDecl(name *Ident, typeParams []*TypeParam, typeAnn TypeAnn, export, declare bool, span Span) *TypeDecl {
 	return &TypeDecl{
-		Name:         name,
-		TypeParams:   typeParams,
-		TypeAnn:      typeAnn,
-		export:       export,
-		declare:      declare,
-		span:         span,
-		provenance:   nil,
-		commentSlots: commentSlots{},
+		Name:           name,
+		TypeParams:     typeParams,
+		TypeAnn:        typeAnn,
+		export:         export,
+		declare:        declare,
+		span:           span,
+		declProvenance: declProvenance{provenance: nil},
+		commentSlots:   commentSlots{},
 	}
 }
 func (d *TypeDecl) Export() bool       { return d.export }
@@ -250,12 +248,6 @@ func (d *TypeDecl) Accept(v Visitor) {
 	}
 	v.ExitDecl(d)
 }
-func (d *TypeDecl) Provenance() provenance.Provenance {
-	return d.provenance
-}
-func (d *TypeDecl) SetProvenance(p provenance.Provenance) {
-	d.provenance = p
-}
 
 type InterfaceDecl struct {
 	declDoc
@@ -268,7 +260,7 @@ type InterfaceDecl struct {
 	declare        bool
 	override       bool
 	span           Span
-	provenance     provenance.Provenance
+	declProvenance
 	commentSlots
 }
 
@@ -282,7 +274,7 @@ func NewInterfaceDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams [
 		export:         export,
 		declare:        declare,
 		span:           span,
-		provenance:     nil,
+		declProvenance: declProvenance{provenance: nil},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -308,12 +300,6 @@ func (d *InterfaceDecl) Accept(v Visitor) {
 		d.TypeAnn.Accept(v)
 	}
 	v.ExitDecl(d)
-}
-func (d *InterfaceDecl) Provenance() provenance.Provenance {
-	return d.provenance
-}
-func (d *InterfaceDecl) SetProvenance(p provenance.Provenance) {
-	d.provenance = p
 }
 
 // EnumVariant represents a single variant of an enum
@@ -378,20 +364,20 @@ type EnumDecl struct {
 	declare    bool
 	override   bool
 	span       Span
-	provenance provenance.Provenance
+	declProvenance
 	commentSlots
 }
 
 func NewEnumDecl(name *Ident, typeParams []*TypeParam, elems []EnumElem, export, declare bool, span Span) *EnumDecl {
 	return &EnumDecl{
-		Name:         name,
-		TypeParams:   typeParams,
-		Elems:        elems,
-		export:       export,
-		declare:      declare,
-		span:         span,
-		provenance:   nil,
-		commentSlots: commentSlots{},
+		Name:           name,
+		TypeParams:     typeParams,
+		Elems:          elems,
+		export:         export,
+		declare:        declare,
+		span:           span,
+		declProvenance: declProvenance{provenance: nil},
+		commentSlots:   commentSlots{},
 	}
 }
 func (d *EnumDecl) Export() bool       { return d.export }
@@ -417,33 +403,27 @@ func (d *EnumDecl) Accept(v Visitor) {
 	}
 	v.ExitDecl(d)
 }
-func (d *EnumDecl) Provenance() provenance.Provenance {
-	return d.provenance
-}
-func (d *EnumDecl) SetProvenance(p provenance.Provenance) {
-	d.provenance = p
-}
 
 // ExportAssignmentStmt represents: export = identifier (TypeScript interop only)
 // This is used when converting TypeScript .d.ts files that use the CommonJS-style
 // export assignment pattern. Escalier's parser does not produce this node.
 type ExportAssignmentStmt struct {
 	declDoc
-	Name       *Ident
-	declare    bool
-	override   bool
-	span       Span
-	provenance provenance.Provenance
+	Name     *Ident
+	declare  bool
+	override bool
+	span     Span
+	declProvenance
 	commentSlots
 }
 
 func NewExportAssignmentStmt(name *Ident, declare bool, span Span) *ExportAssignmentStmt {
 	return &ExportAssignmentStmt{
-		Name:         name,
-		declare:      declare,
-		span:         span,
-		provenance:   nil,
-		commentSlots: commentSlots{},
+		Name:           name,
+		declare:        declare,
+		span:           span,
+		declProvenance: declProvenance{provenance: nil},
+		commentSlots:   commentSlots{},
 	}
 }
 func (e *ExportAssignmentStmt) Export() bool       { return true } // Always exported
@@ -458,8 +438,6 @@ func (e *ExportAssignmentStmt) Accept(v Visitor) {
 	}
 	v.ExitDecl(e)
 }
-func (e *ExportAssignmentStmt) Provenance() provenance.Provenance     { return e.provenance }
-func (e *ExportAssignmentStmt) SetProvenance(p provenance.Provenance) { e.provenance = p }
 
 // DeclareModuleDecl represents `declare module "<name>" { <decl>* }` written
 // in Escalier source (.esc files), optionally prefixed by `override`.
@@ -472,22 +450,22 @@ func (e *ExportAssignmentStmt) SetProvenance(p provenance.Provenance) { e.proven
 // exist solely for the Escalier override-file format.
 type DeclareModuleDecl struct {
 	declDoc
-	Name       *StrLit // module name as a string literal
-	Decls      []Decl
-	override   bool
-	span       Span
-	provenance provenance.Provenance
+	Name     *StrLit // module name as a string literal
+	Decls    []Decl
+	override bool
+	span     Span
+	declProvenance
 	commentSlots
 }
 
 func NewDeclareModuleDecl(name *StrLit, decls []Decl, override bool, span Span) *DeclareModuleDecl {
 	return &DeclareModuleDecl{
-		Name:         name,
-		Decls:        decls,
-		override:     override,
-		span:         span,
-		provenance:   nil,
-		commentSlots: commentSlots{},
+		Name:           name,
+		Decls:          decls,
+		override:       override,
+		span:           span,
+		declProvenance: declProvenance{provenance: nil},
+		commentSlots:   commentSlots{},
 	}
 }
 func (d *DeclareModuleDecl) Export() bool       { return false }
@@ -504,28 +482,26 @@ func (d *DeclareModuleDecl) Accept(v Visitor) {
 	}
 	v.ExitDecl(d)
 }
-func (d *DeclareModuleDecl) Provenance() provenance.Provenance     { return d.provenance }
-func (d *DeclareModuleDecl) SetProvenance(p provenance.Provenance) { d.provenance = p }
 
 // DeclareGlobalDecl represents `declare global { <decl>* }` written in
 // Escalier source (.esc files), optionally prefixed by `override`. See the
 // note on DeclareModuleDecl for how this differs from dts_parser.GlobalDecl.
 type DeclareGlobalDecl struct {
 	declDoc
-	Decls      []Decl
-	override   bool
-	span       Span
-	provenance provenance.Provenance
+	Decls    []Decl
+	override bool
+	span     Span
+	declProvenance
 	commentSlots
 }
 
 func NewDeclareGlobalDecl(decls []Decl, override bool, span Span) *DeclareGlobalDecl {
 	return &DeclareGlobalDecl{
-		Decls:        decls,
-		override:     override,
-		span:         span,
-		provenance:   nil,
-		commentSlots: commentSlots{},
+		Decls:          decls,
+		override:       override,
+		span:           span,
+		declProvenance: declProvenance{provenance: nil},
+		commentSlots:   commentSlots{},
 	}
 }
 func (d *DeclareGlobalDecl) Export() bool       { return false }
@@ -542,8 +518,6 @@ func (d *DeclareGlobalDecl) Accept(v Visitor) {
 	}
 	v.ExitDecl(d)
 }
-func (d *DeclareGlobalDecl) Provenance() provenance.Provenance     { return d.provenance }
-func (d *DeclareGlobalDecl) SetProvenance(p provenance.Provenance) { d.provenance = p }
 
 // NamespaceDecl represents `namespace Name { <decl>* }` inside a declare
 // block (e.g. inside `declare module "x" { ... }` or `declare global { ... }`).
@@ -552,24 +526,24 @@ func (d *DeclareGlobalDecl) SetProvenance(p provenance.Provenance) { d.provenanc
 // Declare() always returns true because namespaces are inherently ambient.
 type NamespaceDecl struct {
 	declDoc
-	Name       *Ident
-	Decls      []Decl
-	export     bool
-	override   bool
-	span       Span
-	provenance provenance.Provenance
+	Name     *Ident
+	Decls    []Decl
+	export   bool
+	override bool
+	span     Span
+	declProvenance
 	commentSlots
 }
 
 func NewNamespaceDecl(name *Ident, decls []Decl, export, override bool, span Span) *NamespaceDecl {
 	return &NamespaceDecl{
-		Name:         name,
-		Decls:        decls,
-		export:       export,
-		override:     override,
-		span:         span,
-		provenance:   nil,
-		commentSlots: commentSlots{},
+		Name:           name,
+		Decls:          decls,
+		export:         export,
+		override:       override,
+		span:           span,
+		declProvenance: declProvenance{provenance: nil},
+		commentSlots:   commentSlots{},
 	}
 }
 func (d *NamespaceDecl) Export() bool       { return d.export }
@@ -586,5 +560,3 @@ func (d *NamespaceDecl) Accept(v Visitor) {
 	}
 	v.ExitDecl(d)
 }
-func (d *NamespaceDecl) Provenance() provenance.Provenance     { return d.provenance }
-func (d *NamespaceDecl) SetProvenance(p provenance.Provenance) { d.provenance = p }

--- a/internal/ast/decl.go
+++ b/internal/ast/decl.go
@@ -95,7 +95,7 @@ func NewVarDecl(
 		declare:        declare,
 		span:           span,
 		InferredType:   nil,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -180,7 +180,7 @@ func NewFuncDecl(
 		export:         export,
 		declare:        declare,
 		span:           span,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -229,7 +229,7 @@ func NewTypeDecl(name *Ident, typeParams []*TypeParam, typeAnn TypeAnn, export, 
 		export:         export,
 		declare:        declare,
 		span:           span,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -274,7 +274,7 @@ func NewInterfaceDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams [
 		export:         export,
 		declare:        declare,
 		span:           span,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -376,7 +376,7 @@ func NewEnumDecl(name *Ident, typeParams []*TypeParam, elems []EnumElem, export,
 		export:         export,
 		declare:        declare,
 		span:           span,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -422,7 +422,7 @@ func NewExportAssignmentStmt(name *Ident, declare bool, span Span) *ExportAssign
 		Name:           name,
 		declare:        declare,
 		span:           span,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -464,7 +464,7 @@ func NewDeclareModuleDecl(name *StrLit, decls []Decl, override bool, span Span) 
 		Decls:          decls,
 		override:       override,
 		span:           span,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -500,7 +500,7 @@ func NewDeclareGlobalDecl(decls []Decl, override bool, span Span) *DeclareGlobal
 		Decls:          decls,
 		override:       override,
 		span:           span,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }
@@ -542,7 +542,7 @@ func NewNamespaceDecl(name *Ident, decls []Decl, export, override bool, span Spa
 		export:         export,
 		override:       override,
 		span:           span,
-		declProvenance: declProvenance{provenance: nil},
+		declProvenance: declProvenance{},
 		commentSlots:   commentSlots{},
 	}
 }

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -222,40 +222,34 @@ type ConstructorTypeAnn struct {
 	commentSlots
 }
 type MethodTypeAnn struct {
+	declDoc
 	Name     ObjKey
 	Fn       *FuncTypeAnn
 	Receiver *MethodReceiver // nil if no receiver
-	doc      string
 	commentSlots
 }
 
-func (m *MethodTypeAnn) Span() Span        { return m.Name.Span() }
-func (m *MethodTypeAnn) Doc() string       { return m.doc }
-func (m *MethodTypeAnn) SetDoc(doc string) { m.doc = doc }
+func (m *MethodTypeAnn) Span() Span { return m.Name.Span() }
 
 type GetterTypeAnn struct {
+	declDoc
 	Name     ObjKey
 	Fn       *FuncTypeAnn
 	Receiver *MethodReceiver // nil if no receiver
-	doc      string
 	commentSlots
 }
 
-func (g *GetterTypeAnn) Span() Span        { return g.Name.Span() }
-func (g *GetterTypeAnn) Doc() string       { return g.doc }
-func (g *GetterTypeAnn) SetDoc(doc string) { g.doc = doc }
+func (g *GetterTypeAnn) Span() Span { return g.Name.Span() }
 
 type SetterTypeAnn struct {
+	declDoc
 	Name     ObjKey
 	Fn       *FuncTypeAnn
 	Receiver *MethodReceiver // nil if no receiver
-	doc      string
 	commentSlots
 }
 
-func (s *SetterTypeAnn) Span() Span        { return s.Name.Span() }
-func (s *SetterTypeAnn) Doc() string       { return s.doc }
-func (s *SetterTypeAnn) SetDoc(doc string) { s.doc = doc }
+func (s *SetterTypeAnn) Span() Span { return s.Name.Span() }
 
 type MappedModifier string
 
@@ -269,17 +263,15 @@ const (
 // name's span so callers get a per-member position instead of the
 // enclosing container's span.
 type PropertyTypeAnn struct {
+	declDoc
 	Name     ObjKey
 	Optional bool
 	Readonly bool
 	Value    TypeAnn
-	doc      string
 	commentSlots
 }
 
-func (p *PropertyTypeAnn) Span() Span        { return p.Name.Span() }
-func (p *PropertyTypeAnn) Doc() string       { return p.doc }
-func (p *PropertyTypeAnn) SetDoc(doc string) { p.doc = doc }
+func (p *PropertyTypeAnn) Span() Span { return p.Name.Span() }
 
 type MappedTypeAnn struct {
 	TypeParam *IndexParamTypeAnn
@@ -303,8 +295,11 @@ type IndexParamTypeAnn struct {
 }
 
 type RestSpreadTypeAnn struct {
+	// A rest spread keeps a real doc field, where CallableTypeAnn,
+	// ConstructorTypeAnn, and MappedTypeAnn return a constant `""`. A
+	// hand-authored `interface F { /** doc */ ...Bar }` round-trips its JSDoc.
+	declDoc
 	Value        TypeAnn
-	doc          string
 	span         Span
 	inferredType Type
 	commentSlots
@@ -320,11 +315,6 @@ func (t *RestSpreadTypeAnn) Accept(v Visitor) {
 	}
 	v.ExitTypeAnn(t)
 }
-
-// RestSpreadTypeAnn carries a real doc field: a hand-authored
-// `interface F { /** doc */ ...Bar }` should round-trip the JSDoc.
-func (t *RestSpreadTypeAnn) Doc() string       { return t.doc }
-func (t *RestSpreadTypeAnn) SetDoc(doc string) { t.doc = doc }
 
 type ObjectTypeAnn struct {
 	Elems        []ObjTypeAnnElem


### PR DESCRIPTION
Consolidate the `provenance` field and its accessor methods across all declaration types by introducing a `declProvenance` struct that embeds in each `Decl` implementation, similar to the existing `declDoc` pattern.

This change eliminates code duplication across nine declaration types (`VarDecl`, `FuncDecl`, `TypeDecl`, `InterfaceDecl`, `EnumDecl`, `ExportAssignmentStmt`, `DeclareModuleDecl`, `DeclareGlobalDecl`, `NamespaceDecl`) and `ClassDecl`, each of which previously defined its own `provenance` field and `Provenance()`/`SetProvenance()` methods.

Key changes:
- Add `declProvenance` struct with `provenance` field and accessor methods in `internal/ast/decl.go`
- Replace individual `provenance` fields with embedded `declProvenance` in all declaration types
- Remove duplicate `Provenance()` and `SetProvenance()` method implementations from each declaration type
- Update all constructor functions to initialize `declProvenance` instead of `provenance`
- Apply the same pattern to class element types (`FieldElem`, `MethodElem`, `GetterElem`, `ConstructorElem`, `SetterElem`) and object type annotation elements (`MethodTypeAnn`, `GetterTypeAnn`, `SetterTypeAnn`, `PropertyTypeAnn`, `RestSpreadTypeAnn`) by embedding `declDoc` to provide doc accessors
- Remove unused import of `provenance` package from `internal/ast/class.go`

This follows the established pattern used by `declDoc` for JSDoc handling and reduces boilerplate across the AST.

https://claude.ai/code/session_011MR4RP7CLrACosRbwfdWaL