### PR TITLE
Set object type member spans at construction and add Key

### DIFF
--- a/internal/ast/obj_type_ann_elem_test.go
+++ b/internal/ast/obj_type_ann_elem_test.go
@@ -1,0 +1,87 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func elemTestSpan() Span {
+	return Span{Start: Location{Offset: 3}, End: Location{Offset: 11}, SourceID: 0}
+}
+
+func elemTestFn() *FuncTypeAnn {
+	return NewFuncTypeAnn(nil, nil, nil, nil, nil, elemTestSpan())
+}
+
+// Every variant records the range its constructor was given, so a member's
+// position is fixed once it is built rather than written afterwards.
+func TestObjTypeAnnElemConstructorsRecordTheSpan(t *testing.T) {
+	t.Parallel()
+	span := elemTestSpan()
+	key := NewIdent("a", span)
+
+	elems := map[string]ObjTypeAnnElem{
+		"call signature":      NewCallableTypeAnn(elemTestFn(), span),
+		"construct signature": NewConstructorTypeAnn(elemTestFn(), span),
+		"method":              NewMethodTypeAnn(key, elemTestFn(), nil, span),
+		"getter":              NewGetterTypeAnn(key, elemTestFn(), nil, span),
+		"setter":              NewSetterTypeAnn(key, elemTestFn(), nil, span),
+		"property":            NewPropertyTypeAnn(key, false, false, NewNumberTypeAnn(span), span),
+		"mapped member": NewMappedTypeAnn(
+			&IndexParamTypeAnn{Name: "K", Constraint: NewStringTypeAnn(span)},
+			nil, NewNumberTypeAnn(span), nil, nil, nil, nil, false, span,
+		),
+		"rest spread": NewRestSpreadTypeAnn(NewNumberTypeAnn(span), span),
+	}
+	for name, elem := range elems {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, span, elem.Span())
+		})
+	}
+}
+
+// Key answers for a member's own name. The four variants that declare none
+// return nil, which is what lets a caller ask without a type switch.
+func TestObjTypeAnnElemKey(t *testing.T) {
+	t.Parallel()
+	span := elemTestSpan()
+	key := NewIdent("a", span)
+
+	t.Run("named variants return the key they were built with", func(t *testing.T) {
+		t.Parallel()
+		for name, elem := range map[string]ObjTypeAnnElem{
+			"method":   NewMethodTypeAnn(key, elemTestFn(), nil, span),
+			"getter":   NewGetterTypeAnn(key, elemTestFn(), nil, span),
+			"setter":   NewSetterTypeAnn(key, elemTestFn(), nil, span),
+			"property": NewPropertyTypeAnn(key, false, false, NewNumberTypeAnn(span), span),
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				require.Same(t, key, elem.Key())
+			})
+		}
+	})
+
+	t.Run("keyless variants return nil", func(t *testing.T) {
+		t.Parallel()
+		// A mapped member has a Name field, but it names the type a key is
+		// rewritten to rather than the key the member is addressed by, so it
+		// belongs with the keyless variants.
+		for name, elem := range map[string]ObjTypeAnnElem{
+			"call signature":      NewCallableTypeAnn(elemTestFn(), span),
+			"construct signature": NewConstructorTypeAnn(elemTestFn(), span),
+			"mapped member": NewMappedTypeAnn(
+				&IndexParamTypeAnn{Name: "K", Constraint: NewStringTypeAnn(span)},
+				NewStringTypeAnn(span), NewNumberTypeAnn(span), nil, nil, nil, nil, false, span,
+			),
+			"rest spread": NewRestSpreadTypeAnn(NewNumberTypeAnn(span), span),
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				require.Nil(t, elem.Key())
+			})
+		}
+	})
+}

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -187,11 +187,16 @@ func (t *NeverTypeAnn) Accept(v Visitor) {
 type ObjTypeAnnElem interface {
 	isObjTypeAnnElem()
 	Accept(v Visitor)
-	Span() Span
-	// SetSpan records the range the parser read the member from. A member a
+	// Span reports the range the member was read from, covering the whole
+	// member from its first modifier or name through its type. A member a
 	// converter synthesizes from a `.d.ts` file has no Escalier source to point
-	// at and keeps the zero Span, which ast.AttachComments skips.
-	SetSpan(Span)
+	// at and carries the zero Span, which ast.AttachComments skips.
+	Span() Span
+	// Key returns the key the member is addressed by, or nil for a member that
+	// declares none. A call signature, a construct signature, a mapped member,
+	// and a rest spread are the four without one. A diagnostic about a member's
+	// name underlines the key rather than the member's whole range.
+	Key() ObjKey
 	Commented
 	// Doc returns the leading JSDoc retained on the elem, verbatim
 	// with `/** ... */` delimiters, or "" if absent. Variants that
@@ -211,17 +216,25 @@ func (*PropertyTypeAnn) isObjTypeAnnElem()    {}
 func (*MappedTypeAnn) isObjTypeAnnElem()      {}
 func (*RestSpreadTypeAnn) isObjTypeAnnElem()  {}
 
-// elemSpan carries the range of one object type annotation member, covering
-// the whole member from its first modifier or name through its type. Seven of
+// elemSpan carries the range of one object type annotation member. Seven of
 // the eight ObjTypeAnnElem variants embed it, so the interface can require a
-// span without each variant repeating the field and its two accessors.
-// RestSpreadTypeAnn keeps its own span field, which it needs as a TypeAnn too.
+// span without each variant repeating the field and its accessor. Each
+// variant's constructor takes the range, so a member's position is fixed once
+// it is built. RestSpreadTypeAnn keeps its own span field, which it needs as a
+// TypeAnn too.
 type elemSpan struct {
 	span Span
 }
 
-func (e *elemSpan) Span() Span        { return e.span }
-func (e *elemSpan) SetSpan(span Span) { e.span = span }
+func (e *elemSpan) Span() Span { return e.span }
+
+// Key answers for the four variants that declare no member key. A mapped
+// member has a `Name` field, but it names the type a key is rewritten to
+// rather than the key the member is addressed by.
+func (*CallableTypeAnn) Key() ObjKey    { return nil }
+func (*ConstructorTypeAnn) Key() ObjKey { return nil }
+func (*MappedTypeAnn) Key() ObjKey      { return nil }
+func (*RestSpreadTypeAnn) Key() ObjKey  { return nil }
 
 // No-op Doc/SetDoc impls for the variants that don't carry a JSDoc.
 func (*CallableTypeAnn) Doc() string      { return "" }
@@ -236,11 +249,21 @@ type CallableTypeAnn struct {
 	elemSpan
 	commentSlots
 }
+
+func NewCallableTypeAnn(fn *FuncTypeAnn, span Span) *CallableTypeAnn {
+	return &CallableTypeAnn{Fn: fn, elemSpan: elemSpan{span: span}, commentSlots: commentSlots{}}
+}
+
 type ConstructorTypeAnn struct {
 	Fn *FuncTypeAnn
 	elemSpan
 	commentSlots
 }
+
+func NewConstructorTypeAnn(fn *FuncTypeAnn, span Span) *ConstructorTypeAnn {
+	return &ConstructorTypeAnn{Fn: fn, elemSpan: elemSpan{span: span}, commentSlots: commentSlots{}}
+}
+
 type MethodTypeAnn struct {
 	declDoc
 	Name     ObjKey
@@ -249,6 +272,19 @@ type MethodTypeAnn struct {
 	elemSpan
 	commentSlots
 }
+
+func NewMethodTypeAnn(name ObjKey, fn *FuncTypeAnn, receiver *MethodReceiver, span Span) *MethodTypeAnn {
+	return &MethodTypeAnn{
+		declDoc:      declDoc{},
+		Name:         name,
+		Fn:           fn,
+		Receiver:     receiver,
+		elemSpan:     elemSpan{span: span},
+		commentSlots: commentSlots{},
+	}
+}
+
+func (m *MethodTypeAnn) Key() ObjKey { return m.Name }
 
 type GetterTypeAnn struct {
 	declDoc
@@ -259,6 +295,19 @@ type GetterTypeAnn struct {
 	commentSlots
 }
 
+func NewGetterTypeAnn(name ObjKey, fn *FuncTypeAnn, receiver *MethodReceiver, span Span) *GetterTypeAnn {
+	return &GetterTypeAnn{
+		declDoc:      declDoc{},
+		Name:         name,
+		Fn:           fn,
+		Receiver:     receiver,
+		elemSpan:     elemSpan{span: span},
+		commentSlots: commentSlots{},
+	}
+}
+
+func (g *GetterTypeAnn) Key() ObjKey { return g.Name }
+
 type SetterTypeAnn struct {
 	declDoc
 	Name     ObjKey
@@ -267,6 +316,19 @@ type SetterTypeAnn struct {
 	elemSpan
 	commentSlots
 }
+
+func NewSetterTypeAnn(name ObjKey, fn *FuncTypeAnn, receiver *MethodReceiver, span Span) *SetterTypeAnn {
+	return &SetterTypeAnn{
+		declDoc:      declDoc{},
+		Name:         name,
+		Fn:           fn,
+		Receiver:     receiver,
+		elemSpan:     elemSpan{span: span},
+		commentSlots: commentSlots{},
+	}
+}
+
+func (s *SetterTypeAnn) Key() ObjKey { return s.Name }
 
 type MappedModifier string
 
@@ -285,6 +347,20 @@ type PropertyTypeAnn struct {
 	commentSlots
 }
 
+func NewPropertyTypeAnn(name ObjKey, optional, readonly bool, value TypeAnn, span Span) *PropertyTypeAnn {
+	return &PropertyTypeAnn{
+		declDoc:      declDoc{},
+		Name:         name,
+		Optional:     optional,
+		Readonly:     readonly,
+		Value:        value,
+		elemSpan:     elemSpan{span: span},
+		commentSlots: commentSlots{},
+	}
+}
+
+func (p *PropertyTypeAnn) Key() ObjKey { return p.Name }
+
 type MappedTypeAnn struct {
 	TypeParam *IndexParamTypeAnn
 	// Name is used to rename keys in the mapped type
@@ -302,6 +378,30 @@ type MappedTypeAnn struct {
 	elemSpan
 	commentSlots
 }
+
+func NewMappedTypeAnn(
+	typeParam *IndexParamTypeAnn,
+	name TypeAnn,
+	value TypeAnn,
+	optional, readOnly *MappedModifier,
+	check, extends TypeAnn,
+	shorthand bool,
+	span Span,
+) *MappedTypeAnn {
+	return &MappedTypeAnn{
+		TypeParam:    typeParam,
+		Name:         name,
+		Value:        value,
+		Optional:     optional,
+		ReadOnly:     readOnly,
+		Check:        check,
+		Extends:      extends,
+		Shorthand:    shorthand,
+		elemSpan:     elemSpan{span: span},
+		commentSlots: commentSlots{},
+	}
+}
+
 type IndexParamTypeAnn struct {
 	Name       string
 	Constraint TypeAnn
@@ -328,11 +428,6 @@ func (t *RestSpreadTypeAnn) Accept(v Visitor) {
 	}
 	v.ExitTypeAnn(t)
 }
-
-// SetSpan records the member's range the way elemSpan does for the other seven
-// variants. RestSpreadTypeAnn is a TypeAnn as well as a member, so one span
-// field serves both roles and it embeds no elemSpan.
-func (t *RestSpreadTypeAnn) SetSpan(span Span) { t.span = span }
 
 type ObjectTypeAnn struct {
 	Elems        []ObjTypeAnnElem

--- a/internal/dts_to_esc/__snapshots__/helper_test.snap
+++ b/internal/dts_to_esc/__snapshots__/helper_test.snap
@@ -474,6 +474,9 @@
                     Value: &ast.StringTypeAnn{
                         span: 4-10,
                     },
+                    elemSpan: ast.elemSpan{
+                        span: 1-10,
+                    },
                 },
             },
             span: 0-11,
@@ -487,6 +490,9 @@
                     },
                     Value: &ast.NumberTypeAnn{
                         span: 18-24,
+                    },
+                    elemSpan: ast.elemSpan{
+                        span: 15-24,
                     },
                 },
             },
@@ -746,6 +752,9 @@
             Value: &ast.StringTypeAnn{
                 span: 7-13,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-13,
+            },
         },
     },
     span: 0-14,
@@ -763,6 +772,9 @@
             Value: &ast.StringTypeAnn{
                 span: 7-13,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-13,
+            },
         },
         &ast.PropertyTypeAnn{
             Name: &ast.IdentExpr{
@@ -771,6 +783,9 @@
             },
             Value: &ast.NumberTypeAnn{
                 span: 20-26,
+            },
+            elemSpan: ast.elemSpan{
+                span: 15-26,
             },
         },
     },
@@ -790,6 +805,9 @@
             Value: &ast.StringTypeAnn{
                 span: 8-14,
             },
+            elemSpan: ast.elemSpan{
+                span: 1-14,
+            },
         },
     },
     span: 0-15,
@@ -807,6 +825,9 @@
             Readonly: true,
             Value: &ast.NumberTypeAnn{
                 span: 14-20,
+            },
+            elemSpan: ast.elemSpan{
+                span: 10-20,
             },
         },
     },
@@ -1180,6 +1201,9 @@
                 Value: &ast.StringTypeAnn{
                     span: 10-16,
                 },
+                elemSpan: ast.elemSpan{
+                    span: 7-16,
+                },
             },
             &ast.PropertyTypeAnn{
                 Name: &ast.IdentExpr{
@@ -1188,6 +1212,9 @@
                 },
                 Value: &ast.NumberTypeAnn{
                     span: 21-27,
+                },
+                elemSpan: ast.elemSpan{
+                    span: 18-27,
                 },
             },
         },
@@ -1561,6 +1588,9 @@
                 },
                 span: 11-12,
             },
+            elemSpan: ast.elemSpan{
+                span: 0-13,
+            },
         },
     },
     span: 0-13,
@@ -1589,6 +1619,9 @@
                 span: 20-21,
             },
             ReadOnly: &"add",
+            elemSpan: ast.elemSpan{
+                span: 0-22,
+            },
         },
     },
     span: 0-22,
@@ -1617,6 +1650,9 @@
                 span: 12-13,
             },
             Optional: &"add",
+            elemSpan: ast.elemSpan{
+                span: 0-14,
+            },
         },
     },
     span: 0-14,
@@ -1646,6 +1682,9 @@
             },
             Optional: &"add",
             ReadOnly: &"add",
+            elemSpan: ast.elemSpan{
+                span: 0-23,
+            },
         },
     },
     span: 0-23,
@@ -1674,6 +1713,9 @@
                 span: 21-22,
             },
             ReadOnly: &"remove",
+            elemSpan: ast.elemSpan{
+                span: 0-23,
+            },
         },
     },
     span: 0-23,
@@ -1702,6 +1744,9 @@
                 span: 13-14,
             },
             Optional: &"remove",
+            elemSpan: ast.elemSpan{
+                span: 0-15,
+            },
         },
     },
     span: 0-15,
@@ -1746,6 +1791,9 @@
                     span: 24-25,
                 },
                 span: 24-25,
+            },
+            elemSpan: ast.elemSpan{
+                span: 0-26,
             },
         },
     },
@@ -2218,6 +2266,9 @@
                     span: 5-9,
                 },
                 span: 5-9,
+            },
+            elemSpan: ast.elemSpan{
+                span: 2-9,
             },
         },
     },

--- a/internal/dts_to_esc/helper.go
+++ b/internal/dts_to_esc/helper.go
@@ -169,7 +169,7 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 			return nil, fmt.Errorf("converting call signature return type: %w", err)
 		}
 		fn := ast.NewFuncTypeAnn(nil, typeParams, params, returnType, nil, m.Span())
-		return &ast.CallableTypeAnn{Fn: fn}, nil
+		return ast.NewCallableTypeAnn(fn, m.Span()), nil
 	case *dts_parser.ConstructSignature:
 		typeParams := make([]*ast.TypeParam, len(m.TypeParams))
 		for i, tp := range m.TypeParams {
@@ -192,7 +192,7 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 			return nil, fmt.Errorf("converting construct signature return type: %w", err)
 		}
 		fn := ast.NewFuncTypeAnn(nil, typeParams, params, returnType, nil, m.Span())
-		return &ast.ConstructorTypeAnn{Fn: fn}, nil
+		return ast.NewConstructorTypeAnn(fn, m.Span()), nil
 	case *dts_parser.MethodSignature:
 		typeParams := make([]*ast.TypeParam, len(m.TypeParams))
 		for i, tp := range m.TypeParams {
@@ -219,10 +219,7 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 		if err != nil {
 			return nil, fmt.Errorf("converting method name: %w", err)
 		}
-		elem := &ast.MethodTypeAnn{
-			Name: name,
-			Fn:   fn,
-		}
+		elem := ast.NewMethodTypeAnn(name, fn, nil, m.Span())
 		elem.SetDoc(m.Doc())
 		return elem, nil
 	case *dts_parser.PropertySignature:
@@ -234,12 +231,7 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 		if err != nil {
 			return nil, fmt.Errorf("converting property name: %w", err)
 		}
-		elem := &ast.PropertyTypeAnn{
-			Name:     name,
-			Optional: m.Optional,
-			Readonly: m.Readonly,
-			Value:    typeAnn,
-		}
+		elem := ast.NewPropertyTypeAnn(name, m.Optional, m.Readonly, typeAnn, m.Span())
 		elem.SetDoc(m.Doc())
 		return elem, nil
 	case *dts_parser.GetterSignature:
@@ -253,10 +245,7 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 		if err != nil {
 			return nil, fmt.Errorf("converting getter name: %w", err)
 		}
-		elem := &ast.GetterTypeAnn{
-			Name: name,
-			Fn:   fn,
-		}
+		elem := ast.NewGetterTypeAnn(name, fn, nil, m.Span())
 		elem.SetDoc(m.Doc())
 		return elem, nil
 	case *dts_parser.SetterSignature:
@@ -271,10 +260,7 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 		if err != nil {
 			return nil, fmt.Errorf("converting setter name: %w", err)
 		}
-		elem := &ast.SetterTypeAnn{
-			Name: name,
-			Fn:   fn,
-		}
+		elem := ast.NewSetterTypeAnn(name, fn, nil, m.Span())
 		elem.SetDoc(m.Doc())
 		return elem, nil
 	case *dts_parser.IndexSignature:
@@ -573,15 +559,11 @@ func convertTypeAnn(ta dts_parser.TypeAnn) (ast.TypeAnn, error) {
 		}
 
 		// MappedTypeAnn is an ObjTypeAnnElem, so wrap it in an ObjectTypeAnn
-		mappedElem := &ast.MappedTypeAnn{
-			TypeParam: indexParam,
-			Name:      asClause,
-			Value:     valueType,
-			Optional:  optional,
-			ReadOnly:  readonly,
-			Check:     nil, // dts_parser doesn't have Check field
-			Extends:   nil, // dts_parser doesn't have Extends field
-		}
+		// dts_parser has no Check or Extends field, so a converted mapped member
+		// carries neither.
+		mappedElem := ast.NewMappedTypeAnn(
+			indexParam, asClause, valueType, optional, readonly, nil, nil, false, t.Span(),
+		)
 		return ast.NewObjectTypeAnn([]ast.ObjTypeAnnElem{mappedElem}, t.Span()), nil
 	case *dts_parser.TemplateLiteralType:
 		quasis := []*ast.Quasi{}

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -663,7 +663,7 @@ func simpleTypeRefName(t ast.TypeAnn) (string, bool) {
 // A decline leaves no trace of the modifier, so a caller that needs it has to hold onto
 // it across the call. objTypeAnnElemInner does that for `readonly`, the one spelling a
 // computed-key property can carry.
-func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
+func (p *Parser) tryParseMappedType(start ast.Location) *ast.MappedTypeAnn {
 	// Parse readonly modifiers: readonly, +readonly, or -readonly
 	var readonly *ast.MappedModifier
 	token := p.lexer.peek()
@@ -844,19 +844,17 @@ func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
 			mappedName = name
 		}
 
-		return &ast.MappedTypeAnn{
-			TypeParam: &ast.IndexParamTypeAnn{
-				Name:       key,
-				Constraint: constraint,
-			},
-			Name:      mappedName,
-			Value:     value,
-			Optional:  optional,
-			ReadOnly:  readonly,
-			Check:     check,
-			Extends:   extends,
-			Shorthand: shorthand,
-		}
+		return ast.NewMappedTypeAnn(
+			&ast.IndexParamTypeAnn{Name: key, Constraint: constraint},
+			mappedName,
+			value,
+			optional,
+			readonly,
+			check,
+			extends,
+			shorthand,
+			p.elemSpanFrom(start),
+		)
 	}
 
 	return nil
@@ -869,7 +867,6 @@ func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
 // shape of parseClassElem — see #663.
 func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 	doc := p.consumeLeadingDoc()
-	start := p.lexer.peek().Span.Start
 	// After consuming a leading JSDoc, if we're sitting on the object
 	// type's closing brace, there's no elem to attach the doc to.
 	// Surface that to the user as a parse error AND return nil so
@@ -883,22 +880,25 @@ func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 	}
 	elem := p.objTypeAnnElemInner()
 	attachDoc(elem, doc)
-	if elem != nil {
-		// The member runs from its first modifier or name through the last code
-		// token the inner read. Recording it here covers every variant at once,
-		// and it is what lets ast.AttachComments tell a comment written before a
-		// member from one written after it.
-		elem.SetSpan(ast.Span{
-			Start:    start,
-			End:      p.lexer.lastCodeLoc(),
-			SourceID: p.lexer.source.ID,
-		})
-	}
 	return elem
+}
+
+// elemSpanFrom closes an object type annotation member's range at the last code
+// token read. A member runs from its first modifier or name through its type,
+// and closing at the last code token rather than at the lexer's position keeps
+// a comment the type annotation parser consumed on its way to the comma outside
+// the member: in `{a: number /* m */, b: string}` the first member spans
+// `a: number`. ast.AttachComments reads that range to tell a comment written
+// before a member from one written after it.
+func (p *Parser) elemSpanFrom(start ast.Location) ast.Span {
+	return ast.Span{Start: start, End: p.lexer.lastCodeLoc(), SourceID: p.lexer.source.ID}
 }
 
 func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	token := p.lexer.peek()
+	// The member opens here, at its first modifier or name. Every branch below
+	// closes its range with elemSpanFrom.
+	start := token.Span.Start
 
 	// Handle rest spread syntax: ...T
 	if token.Type == DotDotDot {
@@ -908,8 +908,7 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 			p.reportError(token.Span, "expected type annotation after '...'")
 			return nil
 		}
-		span := ast.MergeSpans(token.Span, value.Span())
-		return ast.NewRestSpreadTypeAnn(value, span)
+		return ast.NewRestSpreadTypeAnn(value, p.elemSpanFrom(start))
 	}
 
 	// A `new (x: number) -> T` construct signature and a `fn (x: number) -> T` call
@@ -926,10 +925,11 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	// them type parameters, an inexact marker, and a `throws` clause for free.
 	if (token.Type == New || token.Type == Fn) && startsASignature(p.lexer.peek2().Type) {
 		p.lexer.consume() // consume 'new' or 'fn'
+		fn := p.funcTypeAnnTail(token)
 		if token.Type == New {
-			return &ast.ConstructorTypeAnn{Fn: p.funcTypeAnnTail(token)}
+			return ast.NewConstructorTypeAnn(fn, p.elemSpanFrom(start))
 		}
-		return &ast.CallableTypeAnn{Fn: p.funcTypeAnnTail(token)}
+		return ast.NewCallableTypeAnn(fn, p.elemSpanFrom(start))
 	}
 
 	mod := ""
@@ -977,7 +977,7 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		}
 	}
 
-	mappedElem := p.tryParseMappedType()
+	mappedElem := p.tryParseMappedType(start)
 	if mappedElem != nil {
 		return mappedElem
 	}
@@ -1038,54 +1038,27 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	case CloseBrace:
 		p.reportError(token.Span, "expected type annotation")
 
-		var property ast.ObjTypeAnnElem = &ast.PropertyTypeAnn{
-			Name:     objKey,
-			Optional: false,
-			Readonly: readonly,
-			Value:    recoveryNever(token.Span),
-		}
-		return property
+		return ast.NewPropertyTypeAnn(objKey, false, readonly, recoveryNever(token.Span), p.elemSpanFrom(start))
 	case Comma:
 		p.reportError(token.Span, "expected type annotation")
 
-		var property ast.ObjTypeAnnElem = &ast.PropertyTypeAnn{
-			Name:     objKey,
-			Optional: false,
-			Readonly: readonly,
-			Value:    recoveryNever(token.Span),
-		}
-		return property
+		return ast.NewPropertyTypeAnn(objKey, false, readonly, recoveryNever(token.Span), p.elemSpanFrom(start))
 	case Colon:
 		p.lexer.consume() // consume ':'
-
-		property := &ast.PropertyTypeAnn{
-			Name:     objKey,
-			Optional: false,
-			Readonly: readonly,
-			Value:    nil,
-		}
 
 		token = p.lexer.peek()
 		if token.Type == Comma {
 			p.reportError(token.Span, "expected type annotation")
-			property.Value = recoveryNever(token.Span)
-			return property
+			return ast.NewPropertyTypeAnn(objKey, false, readonly, recoveryNever(token.Span), p.elemSpanFrom(start))
 		}
 
 		value := p.typeAnnRequired()
-		property.Value = value
-
-		return property
+		return ast.NewPropertyTypeAnn(objKey, false, readonly, value, p.elemSpanFrom(start))
 	case Question:
 		p.lexer.consume() // consume '?'
 		p.expect(Colon, ConsumeOnMatch)
 		value := p.typeAnnRequired()
-		return &ast.PropertyTypeAnn{
-			Name:     objKey,
-			Optional: true,
-			Readonly: readonly,
-			Value:    value,
-		}
+		return ast.NewPropertyTypeAnn(objKey, true, readonly, value, p.elemSpanFrom(start))
 	case OpenParen:
 		p.lexer.consume() // consume '('
 
@@ -1138,23 +1111,11 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		// nolint: exhaustive
 		switch mod {
 		case "get":
-			return &ast.GetterTypeAnn{
-				Name:     objKey,
-				Fn:       fnTypeAnn,
-				Receiver: receiver,
-			}
+			return ast.NewGetterTypeAnn(objKey, fnTypeAnn, receiver, p.elemSpanFrom(start))
 		case "set":
-			return &ast.SetterTypeAnn{
-				Name:     objKey,
-				Fn:       fnTypeAnn,
-				Receiver: receiver,
-			}
+			return ast.NewSetterTypeAnn(objKey, fnTypeAnn, receiver, p.elemSpanFrom(start))
 		default:
-			return &ast.MethodTypeAnn{
-				Name:     objKey,
-				Fn:       fnTypeAnn,
-				Receiver: receiver,
-			}
+			return ast.NewMethodTypeAnn(objKey, fnTypeAnn, receiver, p.elemSpanFrom(start))
 		}
 	default:
 		// Report error for invalid property syntax instead of panicking

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -282,10 +282,10 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			if resolved == nil || !b.addElem(resolved) {
 				continue
 			}
-			// The name is what the diagnostic underlines, since a redeclaration is
-			// about the key rather than the type written after it. Every member that
-			// can displace another declares one.
-			if blame := memberKey(elem); blame != nil {
+			// The key is what the diagnostic underlines, since a redeclaration is
+			// about the name rather than the type written after it. Every member
+			// that can displace another declares one.
+			if blame := elem.Key(); blame != nil {
 				c.report(&DuplicateObjectMemberError{Name: soltype.ObjElemName(resolved), Elem: blame})
 			}
 		}
@@ -1323,24 +1323,4 @@ func (c *checker) annPrim(ta ast.TypeAnn, p soltype.Prim) soltype.Type {
 	t := &soltype.PrimType{Prim: p}
 	c.recordProv(t, ta, AnnotationType)
 	return t
-}
-
-// memberKey returns the key a named object type annotation member declares, or
-// nil for a member that declares none. A call signature, a construct signature,
-// a mapped member, and a rest spread are the four without one. A diagnostic
-// about a member's name underlines the key rather than the member's whole
-// range, which runs from its first modifier through the type written after it.
-func memberKey(elem ast.ObjTypeAnnElem) ast.ObjKey {
-	switch e := elem.(type) {
-	case *ast.PropertyTypeAnn:
-		return e.Name
-	case *ast.MethodTypeAnn:
-		return e.Name
-	case *ast.GetterTypeAnn:
-		return e.Name
-	case *ast.SetterTypeAnn:
-		return e.Name
-	default:
-		return nil
-	}
 }


### PR DESCRIPTION
Fixes #1389

Two pieces of per-variant boilerplate around `ObjTypeAnnElem`, fixed in one pass because they touch the same eight types.

## The span is now recorded at construction

`objTypeAnnElem` used to call `elem.SetSpan(...)` on whatever `objTypeAnnElemInner` returned. The seven variants had no constructors, so the parser built them as bare struct literals, and from another package the unexported `elemSpan` cannot be reached in a composite literal — a setter was the only way in.

Each variant now has a constructor taking the member's range, and `objTypeAnnElemInner` builds through it at all 10 of its construction sites. The inner captures the member's start before it reads anything and closes the range with a new helper:

```go
func (p *Parser) elemSpanFrom(start ast.Location) ast.Span {
	return ast.Span{Start: start, End: p.lexer.lastCodeLoc(), SourceID: p.lexer.source.ID}
}
```

Closing at the last code token rather than at the lexer's position is what keeps a comment the type annotation parser consumed on its way to the comma outside the member, so `{a: number /* m */, b: string}` still spans `a: number`. `tryParseMappedType` takes the start for the same reason.

With every member built through a constructor, `SetSpan` comes off the `ObjTypeAnnElem` interface, off `elemSpan`, and off `RestSpreadTypeAnn`. A member's position is fixed once it is built. That also removes the trap where `NewRestSpreadTypeAnn` took a span the wrapper immediately overwrote.

## `Key()` replaces a type switch

The interface exposed no accessor for a member's key, so a caller wanting one wrote a switch over the four named variants. `Key() ObjKey` now answers directly: the four named variants return their key, the other four return nil, following the precedent already set for `Doc`.

`memberKey` in `internal/solver/type_ann.go` is deleted; its one call site is now `elem.Key()`.

**The issue proposed `Name()`, which Go rejects.** These structs already have a `Name` field, and `field and method with the same name Name` is a compile error. `Key` matches the surrounding vocabulary anyway — the type is `ObjKey`, and `objKeyName` and `slotFor` already call it a key. I confirmed the conflict before choosing.

Two switches the issue named stay as they are.

- `collectObjTypeElem`, from step 6. Folding the name out would split three co-varying values across two constructs and read worse, and it would compute a key for `PropertyTypeAnn` only to discard it at the `default: return`.
- `objElemSlot` in `internal/dts_to_esc/decl_key.go`. #1377 gave `slotFor` a `memberKind` argument, and the kind is what the switch arm supplies — `Key()` returns the key alone, so a rewrite would need a second switch to recover the kind.

## Effect

`TestObjTypeAnnElemSpans` and `TestAttachCommentsOnObjectTypeMembers` pass unchanged, which is the evidence that moving the span to construction preserved every range. New `TestObjTypeAnnElemConstructorsRecordTheSpan` and `TestObjTypeAnnElemKey` in `internal/ast` cover all eight variants for both.

One snapshot changed. Converted `.d.ts` members now carry their source range rather than a zero span, matching the sibling nodes in `dts_to_esc/helper.go` that already pass `m.Span()` — better than the zero span the issue proposed, and consistent with the file around it.

`go test ./...` passes, and re-running with `UPDATE_SNAPS=true` and `UPDATE_FIXTURES=true` produces no further drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WwshtyzQcyLYJ5KbTeu8B

---
_Generated by [Claude Code](https://claude.ai/code/session_015WwshtyzQcyLYJ5KbTeu8B)_