### PR TITLE
dts_to_esc: route type-only declarations to their family's package

### DIFF
--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -488,9 +488,6 @@ func countTypeRefs(stmts []dts_parser.Statement, name string) int {
 // reports both as referenced by nothing.
 func walkTypeParamTypes(params []*dts_parser.TypeParam, visit func(dts_parser.TypeAnn)) {
 	for _, tp := range params {
-		if tp == nil {
-			continue
-		}
 		if tp.Constraint != nil {
 			visit(tp.Constraint)
 		}

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -662,6 +662,16 @@ func walkTypeRefs(t dts_parser.TypeAnn, visit func(*dts_parser.TypeReference)) {
 		walkTypeRefs(n.FalseType, visit)
 	case *dts_parser.MappedType:
 		walkTypeRefs(n.ValueType, visit)
+	case *dts_parser.TemplateLiteralType:
+		// A template literal's interpolations are the only place some
+		// names appear. `type AutoFill = ...
+		// ${OptionalPrefixToken<AutoFillSection>}...` in lib.dom.d.ts is
+		// every reference AutoFillSection gets.
+		for _, part := range n.Parts {
+			if sub, ok := part.(*dts_parser.TemplateType); ok {
+				walkTypeRefs(sub.Type, visit)
+			}
+		}
 	case *dts_parser.KeyOfType:
 		walkTypeRefs(n.Type, visit)
 	case *dts_parser.TypePredicate:

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -604,86 +604,85 @@ func walkClassMemberTypes(m dts_parser.ClassMember, visit func(dts_parser.TypeAn
 	}
 }
 
-// countTypeRefsInTypeAnn recursively walks a TypeAnn and returns the
-// number of TypeReference nodes whose bare name equals `name`.
-func countTypeRefsInTypeAnn(t dts_parser.TypeAnn, name string) int {
+// walkTypeRefs invokes visit on every TypeReference reachable from t,
+// including the references inside a reference's own type arguments.
+//
+// Coverage is best-effort, on the same terms as walkClassMemberTypes
+// above. A node shape the switch misses makes a caller see fewer
+// references than the source holds, never more.
+func walkTypeRefs(t dts_parser.TypeAnn, visit func(*dts_parser.TypeReference)) {
 	if t == nil {
-		return 0
+		return
 	}
 	switch n := t.(type) {
 	case *dts_parser.TypeReference:
-		count := 0
-		if typeRefName(n) == name {
-			count++
-		}
+		visit(n)
 		for _, arg := range n.TypeArgs {
-			count += countTypeRefsInTypeAnn(arg, name)
+			walkTypeRefs(arg, visit)
 		}
-		return count
 	case *dts_parser.ArrayType:
-		return countTypeRefsInTypeAnn(n.ElementType, name)
+		walkTypeRefs(n.ElementType, visit)
 	case *dts_parser.TupleType:
-		count := 0
 		for _, e := range n.Elements {
-			count += countTypeRefsInTypeAnn(e.Type, name)
+			walkTypeRefs(e.Type, visit)
 		}
-		return count
 	case *dts_parser.UnionType:
-		count := 0
 		for _, sub := range n.Types {
-			count += countTypeRefsInTypeAnn(sub, name)
+			walkTypeRefs(sub, visit)
 		}
-		return count
 	case *dts_parser.IntersectionType:
-		count := 0
 		for _, sub := range n.Types {
-			count += countTypeRefsInTypeAnn(sub, name)
+			walkTypeRefs(sub, visit)
 		}
-		return count
 	case *dts_parser.FunctionType:
-		count := 0
 		for _, p := range n.Params {
-			count += countTypeRefsInTypeAnn(p.Type, name)
+			walkTypeRefs(p.Type, visit)
 		}
-		count += countTypeRefsInTypeAnn(n.ReturnType, name)
-		return count
+		walkTypeRefs(n.ReturnType, visit)
 	case *dts_parser.ConstructorType:
-		count := 0
 		for _, p := range n.Params {
-			count += countTypeRefsInTypeAnn(p.Type, name)
+			walkTypeRefs(p.Type, visit)
 		}
-		count += countTypeRefsInTypeAnn(n.ReturnType, name)
-		return count
+		walkTypeRefs(n.ReturnType, visit)
 	case *dts_parser.ObjectType:
-		count := 0
 		for _, m := range n.Members {
 			walkInterfaceMemberTypes(m, func(sub dts_parser.TypeAnn) {
-				count += countTypeRefsInTypeAnn(sub, name)
+				walkTypeRefs(sub, visit)
 			})
 		}
-		return count
 	case *dts_parser.ParenthesizedType:
-		return countTypeRefsInTypeAnn(n.Type, name)
+		walkTypeRefs(n.Type, visit)
 	case *dts_parser.IndexedAccessType:
-		return countTypeRefsInTypeAnn(n.ObjectType, name) +
-			countTypeRefsInTypeAnn(n.IndexType, name)
+		walkTypeRefs(n.ObjectType, visit)
+		walkTypeRefs(n.IndexType, visit)
 	case *dts_parser.ConditionalType:
-		return countTypeRefsInTypeAnn(n.CheckType, name) +
-			countTypeRefsInTypeAnn(n.ExtendsType, name) +
-			countTypeRefsInTypeAnn(n.TrueType, name) +
-			countTypeRefsInTypeAnn(n.FalseType, name)
+		walkTypeRefs(n.CheckType, visit)
+		walkTypeRefs(n.ExtendsType, visit)
+		walkTypeRefs(n.TrueType, visit)
+		walkTypeRefs(n.FalseType, visit)
 	case *dts_parser.MappedType:
-		return countTypeRefsInTypeAnn(n.ValueType, name)
+		walkTypeRefs(n.ValueType, visit)
 	case *dts_parser.KeyOfType:
-		return countTypeRefsInTypeAnn(n.Type, name)
+		walkTypeRefs(n.Type, visit)
 	case *dts_parser.TypePredicate:
-		return countTypeRefsInTypeAnn(n.Type, name)
+		walkTypeRefs(n.Type, visit)
 	case *dts_parser.RestType:
-		return countTypeRefsInTypeAnn(n.Type, name)
+		walkTypeRefs(n.Type, visit)
 	case *dts_parser.OptionalType:
-		return countTypeRefsInTypeAnn(n.Type, name)
+		walkTypeRefs(n.Type, visit)
 	}
-	return 0
+}
+
+// countTypeRefsInTypeAnn returns how many TypeReference nodes under t
+// carry the bare name `name`.
+func countTypeRefsInTypeAnn(t dts_parser.TypeAnn, name string) int {
+	count := 0
+	walkTypeRefs(t, func(ref *dts_parser.TypeReference) {
+		if typeRefName(ref) == name {
+			count++
+		}
+	})
+	return count
 }
 
 // typeRefName returns the bare identifier of a TypeReference's name, or

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -482,6 +482,24 @@ func countTypeRefs(stmts []dts_parser.Statement, name string) int {
 	return count
 }
 
+// walkTypeParamTypes invokes visit on the constraint and default of
+// each type parameter. `interface Foo<T extends Bar = Baz>` mentions
+// Bar and Baz nowhere else, so a walk that skips these two slots
+// reports both as referenced by nothing.
+func walkTypeParamTypes(params []*dts_parser.TypeParam, visit func(dts_parser.TypeAnn)) {
+	for _, tp := range params {
+		if tp == nil {
+			continue
+		}
+		if tp.Constraint != nil {
+			visit(tp.Constraint)
+		}
+		if tp.Default != nil {
+			visit(tp.Default)
+		}
+	}
+}
+
 // walkStatementTypes invokes visit on every top-level TypeAnn carried
 // by stmt. For composite statements (InterfaceDecl, ClassDecl,
 // NamespaceDecl) it descends into member type annotations too.
@@ -492,10 +510,12 @@ func walkStatementTypes(stmt dts_parser.Statement, visit func(dts_parser.TypeAnn
 			visit(s.TypeAnn)
 		}
 	case *dts_parser.TypeDecl:
+		walkTypeParamTypes(s.TypeParams, visit)
 		if s.TypeAnn != nil {
 			visit(s.TypeAnn)
 		}
 	case *dts_parser.FuncDecl:
+		walkTypeParamTypes(s.TypeParams, visit)
 		for _, p := range s.Params {
 			if p.Type != nil {
 				visit(p.Type)
@@ -505,6 +525,7 @@ func walkStatementTypes(stmt dts_parser.Statement, visit func(dts_parser.TypeAnn
 			visit(s.ReturnType)
 		}
 	case *dts_parser.InterfaceDecl:
+		walkTypeParamTypes(s.TypeParams, visit)
 		for _, ext := range s.Extends {
 			visit(ext)
 		}
@@ -512,6 +533,7 @@ func walkStatementTypes(stmt dts_parser.Statement, visit func(dts_parser.TypeAnn
 			walkInterfaceMemberTypes(m, visit)
 		}
 	case *dts_parser.ClassDecl:
+		walkTypeParamTypes(s.TypeParams, visit)
 		for _, m := range s.Members {
 			walkClassMemberTypes(m, visit)
 		}
@@ -531,6 +553,7 @@ func walkInterfaceMemberTypes(m dts_parser.InterfaceMember, visit func(dts_parse
 			visit(sig.TypeAnn)
 		}
 	case *dts_parser.MethodSignature:
+		walkTypeParamTypes(sig.TypeParams, visit)
 		for _, p := range sig.Params {
 			if p.Type != nil {
 				visit(p.Type)
@@ -548,6 +571,7 @@ func walkInterfaceMemberTypes(m dts_parser.InterfaceMember, visit func(dts_parse
 			visit(sig.Param.Type)
 		}
 	case *dts_parser.CallSignature:
+		walkTypeParamTypes(sig.TypeParams, visit)
 		for _, p := range sig.Params {
 			if p.Type != nil {
 				visit(p.Type)
@@ -557,6 +581,7 @@ func walkInterfaceMemberTypes(m dts_parser.InterfaceMember, visit func(dts_parse
 			visit(sig.ReturnType)
 		}
 	case *dts_parser.ConstructSignature:
+		walkTypeParamTypes(sig.TypeParams, visit)
 		for _, p := range sig.Params {
 			if p.Type != nil {
 				visit(p.Type)
@@ -587,6 +612,7 @@ func walkClassMemberTypes(m dts_parser.ClassMember, visit func(dts_parser.TypeAn
 			visit(member.TypeAnn)
 		}
 	case *dts_parser.MethodDecl:
+		walkTypeParamTypes(member.TypeParams, visit)
 		for _, p := range member.Params {
 			if p.Type != nil {
 				visit(p.Type)
@@ -635,11 +661,17 @@ func walkTypeRefs(t dts_parser.TypeAnn, visit func(*dts_parser.TypeReference)) {
 			walkTypeRefs(sub, visit)
 		}
 	case *dts_parser.FunctionType:
+		walkTypeParamTypes(n.TypeParams, func(sub dts_parser.TypeAnn) {
+			walkTypeRefs(sub, visit)
+		})
 		for _, p := range n.Params {
 			walkTypeRefs(p.Type, visit)
 		}
 		walkTypeRefs(n.ReturnType, visit)
 	case *dts_parser.ConstructorType:
+		walkTypeParamTypes(n.TypeParams, func(sub dts_parser.TypeAnn) {
+			walkTypeRefs(sub, visit)
+		})
 		for _, p := range n.Params {
 			walkTypeRefs(p.Type, visit)
 		}
@@ -661,6 +693,13 @@ func walkTypeRefs(t dts_parser.TypeAnn, visit func(*dts_parser.TypeReference)) {
 		walkTypeRefs(n.TrueType, visit)
 		walkTypeRefs(n.FalseType, visit)
 	case *dts_parser.MappedType:
+		// The key source and the `as` remapping name types the value
+		// slot does not. `{ [K in keyof Bag as Name<K>]: V }` mentions
+		// Bag and Name only here.
+		if n.TypeParam != nil {
+			walkTypeRefs(n.TypeParam.Constraint, visit)
+		}
+		walkTypeRefs(n.AsClause, visit)
 		walkTypeRefs(n.ValueType, visit)
 	case *dts_parser.TemplateLiteralType:
 		// A template literal's interpolations are the only place some

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -531,6 +531,15 @@ func walkStatementTypes(stmt dts_parser.Statement, visit func(dts_parser.TypeAnn
 		}
 	case *dts_parser.ClassDecl:
 		walkTypeParamTypes(s.TypeParams, visit)
+		// A superclass and an implemented interface are references the
+		// members repeat only by accident. `declare class Foo extends
+		// Base implements Iface` names both nowhere else.
+		if s.Extends != nil {
+			visit(s.Extends)
+		}
+		for _, impl := range s.Implements {
+			visit(impl)
+		}
 		for _, m := range s.Members {
 			walkClassMemberTypes(m, visit)
 		}
@@ -707,6 +716,11 @@ func walkTypeRefs(t dts_parser.TypeAnn, visit func(*dts_parser.TypeReference)) {
 			if sub, ok := part.(*dts_parser.TemplateType); ok {
 				walkTypeRefs(sub.Type, visit)
 			}
+		}
+	case *dts_parser.InferType:
+		// `infer U extends Bound` names Bound only in the constraint.
+		if n.TypeParam != nil {
+			walkTypeRefs(n.TypeParam.Constraint, visit)
 		}
 	case *dts_parser.KeyOfType:
 		walkTypeRefs(n.Type, visit)

--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -439,9 +439,13 @@ var webPackages = []struct {
 		"GLushort", "GLuint64EXT", "GLint64EXT",
 		"TexImageSource",
 		"Float32List", "Int32List", "Uint32List",
-		// The extension objects getExtension returns. MDN documents
-		// each one under the WebGL API, and the contexts that hand them
-		// back are already here.
+		// The WebGL extension interfaces. `getExtension` returns 34
+		// of them. `EXT_texture_norm16` and
+		// `OES_draw_buffers_indexed` have no overload returning them,
+		// and `WebGLVertexArrayObjectOES` is the handle
+		// `OES_vertex_array_object` hands out rather than an
+		// extension object. MDN documents all of these under the
+		// WebGL API.
 		"ANGLE_instanced_arrays",
 		"EXT_blend_minmax", "EXT_color_buffer_float",
 		"EXT_color_buffer_half_float", "EXT_float_blend",
@@ -805,16 +809,17 @@ var DroppedSources = set.FromSlice([]string{
 // regardless. ReportTypeOnlyRouting leaves them out, so every name it
 // prints is one that still needs a decision.
 //
-// A name earns a place here by one of two readings. Either it is a
-// deprecated alias of a type `web:dom` already holds, so nothing refers
-// to it and nothing new should. Or its family has no package of its
-// own, and §4.2 keeps the small one-off web APIs in `web:dom` for MVP.
+// A name earns a place here by one of three readings. It is deprecated,
+// so nothing refers to it and nothing new should. Or its family has no
+// package of its own, and §4.2 keeps the small one-off web APIs in
+// `web:dom` for MVP. Or the lib set declares it and never uses it.
 //
 // A TypeScript bump that stops declaring one of these leaves a stale
 // entry here rather than failing the run. The entry costs a line and
 // the report stays correct either way.
 var UnreferencedDOMTypes = set.FromSlice([]string{
-	// Deprecated aliases of types web:dom already holds.
+	// Deprecated. The inline note names the type to reach for
+	// instead, where the lib set has one.
 	"ClientRect",                 // DOMRect
 	"ElementTagNameMap",          // HTMLElementTagNameMap + SVGElementTagNameMap
 	"HTMLTableDataCellElement",   // HTMLTableCellElement
@@ -829,8 +834,12 @@ var UnreferencedDOMTypes = set.FromSlice([]string{
 	"ClipboardItemData",
 	"DisplayCaptureSurfaceType",
 	"GPUError",
-	"OnBeforeUnloadEventHandler",
 	"VideoFacingModeEnum",
+
+	// Declared and never used. lib.dom.d.ts names
+	// OnBeforeUnloadEventHandler nowhere else, and both
+	// `onbeforeunload` declarations spell the signature out instead.
+	"OnBeforeUnloadEventHandler",
 })
 
 // DOMResidualSources is the set of `.d.ts` source-file basenames whose

--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -343,6 +343,7 @@ var webPackages = []struct {
 		"ReferrerPolicy",
 		"RequestCache", "RequestCredentials", "RequestDestination",
 		"RequestMode", "RequestRedirect",
+		"HeadersIterator", "RequestPriority",
 		// FormData / FormDataEntryValue intentionally not listed:
 		// MDN classifies them under the XMLHttpRequest API, not
 		// Fetch. They are declared in lib.dom.d.ts so they route to
@@ -372,11 +373,16 @@ var webPackages = []struct {
 		"TransformerStartCallback", "TransformerTransformCallback",
 		"TransformerCancelCallback",
 		"GenericTransformStream",
+		"ReadableStreamAsyncIterator", "ReadableStreamController",
+		"ReadableStreamGetReaderOptions", "ReadableStreamIteratorOptions",
+		"ReadableStreamReader", "ReadableStreamType",
+		"ReadableStreamReaderMode",
 	}},
 	{"web:compression", "web/compression.esc", []string{
 		// MDN documents the Compression Streams API as its own API
 		// distinct from Streams: https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API
 		"CompressionStream", "DecompressionStream",
+		"CompressionFormat",
 	}},
 	{"web:crypto", "web/crypto.esc", []string{
 		"crypto", "Crypto", "SubtleCrypto", "CryptoKey", "CryptoKeyPair",
@@ -434,6 +440,29 @@ var webPackages = []struct {
 		"GLushort", "GLuint64EXT", "GLint64EXT",
 		"TexImageSource",
 		"Float32List", "Int32List", "Uint32List",
+		// The extension objects getExtension returns. MDN documents
+		// each one under the WebGL API, and the contexts that hand them
+		// back are already here.
+		"ANGLE_instanced_arrays",
+		"EXT_blend_minmax", "EXT_color_buffer_float",
+		"EXT_color_buffer_half_float", "EXT_float_blend",
+		"EXT_frag_depth", "EXT_sRGB", "EXT_shader_texture_lod",
+		"EXT_texture_compression_bptc", "EXT_texture_compression_rgtc",
+		"EXT_texture_filter_anisotropic", "EXT_texture_norm16",
+		"KHR_parallel_shader_compile",
+		"OES_draw_buffers_indexed", "OES_element_index_uint",
+		"OES_fbo_render_mipmap", "OES_standard_derivatives",
+		"OES_texture_float", "OES_texture_float_linear",
+		"OES_texture_half_float", "OES_texture_half_float_linear",
+		"OES_vertex_array_object",
+		"OVR_multiview2",
+		"WEBGL_color_buffer_float", "WEBGL_compressed_texture_astc",
+		"WEBGL_compressed_texture_etc", "WEBGL_compressed_texture_etc1",
+		"WEBGL_compressed_texture_pvrtc", "WEBGL_compressed_texture_s3tc",
+		"WEBGL_compressed_texture_s3tc_srgb", "WEBGL_debug_renderer_info",
+		"WEBGL_debug_shaders", "WEBGL_depth_texture", "WEBGL_draw_buffers",
+		"WEBGL_lose_context", "WEBGL_multi_draw",
+		"WebGLVertexArrayObjectOES",
 	}},
 	{"web:web_audio", "web/web_audio.esc", []string{
 		// Symbols MDN documents under Web Audio that are absent from
@@ -479,6 +508,7 @@ var webPackages = []struct {
 		"WaveShaperNode", "WaveShaperOptions", "OverSampleType",
 		"AutomationRate",
 		"DecodeErrorCallback", "DecodeSuccessCallback",
+		"AudioTimestamp",
 	}},
 	{"web:web_rtc", "web/web_rtc.esc", []string{
 		// Symbols MDN documents under WebRTC that are absent from the
@@ -537,6 +567,8 @@ var webPackages = []struct {
 		"RTCTransportStats",
 		"RTCPeerConnectionErrorCallback",
 		"RTCSessionDescriptionCallback",
+		"RTCCertificateExpiration", "RTCDtlsRole",
+		"RTCLocalSessionDescriptionInit", "RTCQualityLimitationReason",
 	}},
 	{"web:web_codecs", "web/web_codecs.esc", []string{
 		"AudioData", "AudioDataInit", "AudioDataCopyToOptions",
@@ -568,6 +600,14 @@ var webPackages = []struct {
 		"AlphaOption", "LatencyMode", "AvcBitstreamFormat",
 		"CodecState",
 		"BitrateMode",
+		"AudioDataOutputCallback", "AudioDecoderEventMap",
+		"AudioEncoderEventMap", "AvcEncoderConfig",
+		"EncodedAudioChunkOutputCallback",
+		"EncodedVideoChunkOutputCallback",
+		"ImageBufferSource", "OpusEncoderConfig",
+		"VideoDecoderEventMap", "VideoEncoderEventMap",
+		"VideoFrameOutputCallback",
+		"OpusBitstreamFormat",
 	}},
 	{"web:indexeddb", "web/indexeddb.esc", []string{
 		"IDBFactory", "IDBOpenDBRequest", "IDBOpenDBRequestEventMap",
@@ -600,6 +640,8 @@ var webPackages = []struct {
 		"RegistrationOptions",
 		"NavigationPreloadManager", "NavigationPreloadState",
 		"FrameType", "ClientType",
+		"ClientQueryOptions", "GetNotificationOptions",
+		"ClientTypes",
 	}},
 	{"web:push", "web/push.esc", []string{
 		// MDN documents Push as a separate API:
@@ -624,6 +666,7 @@ var webPackages = []struct {
 	}},
 	{"web:url", "web/url.esc", []string{
 		"URL", "URLSearchParams",
+		"URLSearchParamsIterator",
 	}},
 	{"web:encoding", "web/encoding.esc", []string{
 		"TextEncoder", "TextEncoderCommon", "TextEncoderEncodeIntoResult",
@@ -656,6 +699,7 @@ var webPackages = []struct {
 		"PerformancePaintTiming", "PerformanceResourceTiming",
 		"PerformanceServerTiming", "PerformanceTiming",
 		"performance",
+		"NavigationTimingType",
 	}},
 	{"web:webauthn", "web/webauthn.esc", []string{
 		"AuthenticatorAssertionResponse", "AuthenticatorAttestationResponse",
@@ -670,6 +714,18 @@ var webPackages = []struct {
 		"AttestationConveyancePreference",
 		"UserVerificationRequirement", "ResidentKeyRequirement",
 		"COSEAlgorithmIdentifier",
+		"AuthenticationExtensionsClientInputs",
+		"AuthenticationExtensionsClientOutputs",
+		"PublicKeyCredentialClientCapabilities",
+		"PublicKeyCredentialCreationOptionsJSON",
+		"PublicKeyCredentialRequestOptionsJSON",
+		"AuthenticationExtensionsClientInputsJSON",
+		"AuthenticationExtensionsPRFInputs",
+		"AuthenticationExtensionsPRFOutputs",
+		"CredentialPropertiesOutput",
+		"PublicKeyCredentialDescriptorJSON",
+		"PublicKeyCredentialUserEntityJSON",
+		"AuthenticationExtensionsPRFValues", "Base64URLString",
 	}},
 	{"web:payments", "web/payments.esc", []string{
 		// Symbols MDN documents under the Payment Request API that
@@ -688,6 +744,7 @@ var webPackages = []struct {
 		"PaymentValidationErrors",
 		"AddressErrors", "PayerErrors",
 		"ContactAddress",
+		"PaymentOptions",
 	}},
 }
 
@@ -793,6 +850,39 @@ var AllowedSingletonKeyDrops = set.FromSlice([]SingletonMember{
 // it emits — `ServiceWorkerGlobalScope` and `importScripts` name
 // nothing a document can reach. Serving a worker means its own set of
 // pseudo-packages, the same question Node raises, and §6.1 defers both.
+// UnreferencedDOMTypes names the type-only `web:dom` declarations that
+// nothing in the pinned lib set references and that belong in `web:dom`
+// regardless. ReportTypeOnlyRouting leaves them out, so every name it
+// prints is one that still needs a decision.
+//
+// A name earns a place here by one of two readings. Either it is a
+// deprecated alias of a type `web:dom` already holds, so nothing refers
+// to it and nothing new should. Or its family has no package of its
+// own, and §4.2 keeps the small one-off web APIs in `web:dom` for MVP.
+//
+// A TypeScript bump that stops declaring one of these leaves a stale
+// entry here rather than failing the run. The entry costs a line and
+// the report stays correct either way.
+var UnreferencedDOMTypes = set.FromSlice([]string{
+	// Deprecated aliases of types web:dom already holds.
+	"ClientRect",                 // DOMRect
+	"ElementTagNameMap",          // HTMLElementTagNameMap + SVGElementTagNameMap
+	"HTMLTableDataCellElement",   // HTMLTableCellElement
+	"HTMLTableHeaderCellElement", // HTMLTableCellElement
+	"StyleMedia",                 // dropped from the CSSOM spec
+
+	// Families with no package of their own. Clipboard, screen
+	// capture, and media-capture constraints are the §4.2 one-offs
+	// web:dom carries for MVP. GPUError is the one WebGPU name the
+	// pinned lib set declares, which is too little to route anywhere
+	// else.
+	"ClipboardItemData",
+	"DisplayCaptureSurfaceType",
+	"GPUError",
+	"OnBeforeUnloadEventHandler",
+	"VideoFacingModeEnum",
+})
+
 var DroppedSources = set.FromSlice([]string{
 	"lib.scripthost.d.ts",
 	"lib.webworker.d.ts",

--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -850,6 +850,14 @@ var AllowedSingletonKeyDrops = set.FromSlice([]SingletonMember{
 // it emits — `ServiceWorkerGlobalScope` and `importScripts` name
 // nothing a document can reach. Serving a worker means its own set of
 // pseudo-packages, the same question Node raises, and §6.1 defers both.
+var DroppedSources = set.FromSlice([]string{
+	"lib.scripthost.d.ts",
+	"lib.webworker.d.ts",
+	"lib.webworker.iterable.d.ts",
+	"lib.webworker.asynciterable.d.ts",
+	"lib.webworker.importscripts.d.ts",
+})
+
 // UnreferencedDOMTypes names the type-only `web:dom` declarations that
 // nothing in the pinned lib set references and that belong in `web:dom`
 // regardless. ReportTypeOnlyRouting leaves them out, so every name it
@@ -881,14 +889,6 @@ var UnreferencedDOMTypes = set.FromSlice([]string{
 	"GPUError",
 	"OnBeforeUnloadEventHandler",
 	"VideoFacingModeEnum",
-})
-
-var DroppedSources = set.FromSlice([]string{
-	"lib.scripthost.d.ts",
-	"lib.webworker.d.ts",
-	"lib.webworker.iterable.d.ts",
-	"lib.webworker.asynciterable.d.ts",
-	"lib.webworker.importscripts.d.ts",
 })
 
 // DOMResidualSources is the set of `.d.ts` source-file basenames whose

--- a/internal/dts_to_esc/type_only.go
+++ b/internal/dts_to_esc/type_only.go
@@ -245,9 +245,9 @@ func ReportTypeOnlyRouting(result *PartitionResult, w io.Writer) error {
 		for _, e := range routing.SoleReferrer[i:j] {
 			names = append(names, e.Name)
 		}
-		fmt.Fprintf(&b, "  %s: %d type-only decls only %s references (%s)\n",
-			WebDOM.URI, len(names), routing.SoleReferrer[i].ReferencedBy,
-			strings.Join(names, ", "))
+		fmt.Fprintf(&b, "  %s: %d type-only decl%s only %s references (%s)\n",
+			WebDOM.URI, len(names), plural(len(names)),
+			routing.SoleReferrer[i].ReferencedBy, strings.Join(names, ", "))
 		i = j
 	}
 
@@ -259,10 +259,18 @@ func ReportTypeOnlyRouting(result *PartitionResult, w io.Writer) error {
 		names = append(names, e.Name)
 	}
 	if len(names) > 0 {
-		fmt.Fprintf(&b, "  %s: %d type-only decls nothing references (%s)\n",
-			WebDOM.URI, len(names), strings.Join(names, ", "))
+		fmt.Fprintf(&b, "  %s: %d type-only decl%s nothing references (%s)\n",
+			WebDOM.URI, len(names), plural(len(names)), strings.Join(names, ", "))
 	}
 
 	_, err := io.WriteString(w, b.String())
 	return err
+}
+
+// plural returns the suffix that makes a count noun agree with n.
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }

--- a/internal/dts_to_esc/type_only.go
+++ b/internal/dts_to_esc/type_only.go
@@ -251,11 +251,14 @@ func ReportTypeOnlyRouting(result *PartitionResult, w io.Writer) error {
 		i = j
 	}
 
-	if len(routing.Unreferenced) > 0 {
-		names := make([]string, 0, len(routing.Unreferenced))
-		for _, e := range routing.Unreferenced {
-			names = append(names, e.Name)
+	var names []string
+	for _, e := range routing.Unreferenced {
+		if UnreferencedDOMTypes.Contains(e.Name) {
+			continue
 		}
+		names = append(names, e.Name)
+	}
+	if len(names) > 0 {
 		fmt.Fprintf(&b, "  %s: %d type-only decls nothing references (%s)\n",
 			WebDOM.URI, len(names), strings.Join(names, ", "))
 	}

--- a/internal/dts_to_esc/type_only.go
+++ b/internal/dts_to_esc/type_only.go
@@ -55,13 +55,9 @@ type UnreferencedDecl struct {
 	DeclaredIn string
 }
 
-// TypeOnlyRouting is what one pass over the routed buckets found: the
-// type-only declarations whose referrers disagree with where the
-// partition put them, and the ones no referrer speaks for at all.
-//
-// A type-only declaration two or more packages reference is shared
-// vocabulary and belongs in `web:dom`. `BufferSource` is the canonical
-// one. Neither field holds those.
+// TypeOnlyRouting holds the type-only declarations whose referrers
+// disagree with where the partition put them, and the ones nothing
+// references. A declaration two or more packages share is in neither.
 type TypeOnlyRouting struct {
 	// SoleReferrer is sorted by declaring package, then referrer, then
 	// name.
@@ -209,21 +205,11 @@ func referrersOf(
 	return referrers
 }
 
-// ReportTypeOnlyRouting prints what landed in `web:dom` that the
-// referrers disagree with: one line per sibling that is the sole
-// referrer of some of its type-only declarations, then one line for
-// the ones nothing references. Nothing is written when both are empty.
-//
-// Only `web:dom` is reported. It is the one package a name reaches
-// without anyone listing it, through the DOM residual rule, so it is
-// the one place a routing mistake is a side effect rather than a
-// decision. A sole referrer elsewhere is weaker evidence: `std:async`
-// declares `AsyncIterable` and only `std:array` references it, and the
-// protocol type still belongs where the partition puts it.
-//
-// The `generate` subcommand calls this alongside the drop counts, so a
-// TypeScript bump that adds a type-only companion surfaces it instead
-// of absorbing it into `web:dom`.
+// ReportTypeOnlyRouting prints the `web:dom` type-only declarations a
+// single sibling is the sole referrer of, then the ones nothing
+// references, and nothing at all when both are empty. Only `web:dom`
+// is reported, because the DOM residual rule puts a name there with
+// nobody deciding to, which is what makes a sole referrer evidence.
 func ReportTypeOnlyRouting(result *PartitionResult, w io.Writer) error {
 	routing := AnalyzeTypeOnlyRouting(result).forPackage(WebDOM.URI)
 

--- a/internal/dts_to_esc/type_only.go
+++ b/internal/dts_to_esc/type_only.go
@@ -21,7 +21,7 @@ import (
 // and hand-enumeration reaches for the names that have constructors. A
 // type-only companion left off a sibling's member list falls through to
 // `web:dom` under the DOM residual rule, and the sibling's own methods
-// then return a type the caller did not import. The 36 WebGL extension
+// then return a type the caller did not import. The 34 WebGL extension
 // interfaces `getExtension` returns are the largest such family, and
 // the partition names every one of them in `web:webgl`.
 //

--- a/internal/dts_to_esc/type_only.go
+++ b/internal/dts_to_esc/type_only.go
@@ -1,0 +1,265 @@
+package dts_to_esc
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/dts_parser"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// A declaration is type-only when the lib set binds no value of its
+// name. An `interface` with no companion `declare var`, and a `type`
+// alias, are both type-only. The static half of a trio is not:
+// TypeScript spells a class as `interface Foo`, `interface
+// FooConstructor`, and `declare var Foo`, and that binding gives all
+// three a runtime referent.
+//
+// The §6.1 partition table enumerates each package's members by hand,
+// and hand-enumeration reaches for the names that have constructors. A
+// type-only companion left off a sibling's member list falls through to
+// `web:dom` under the DOM residual rule, away from the family it
+// describes. `web:webgl` holds the rendering contexts while the
+// extension interfaces `getExtension` returns sit in `web:dom`, so the
+// return type comes from a package the caller did not import.
+//
+// The unmapped-symbol fail-safe cannot catch that. It trips on a name
+// with no home, and the residual rule gives every one of these a home.
+// The analysis below reports them instead.
+
+// SoleReferrer is a type-only declaration that exactly one package
+// other than its own references, with nothing else in the declaring
+// package referencing it. Sole reference from a sibling is evidence
+// the name belongs to that sibling rather than to where it landed.
+type SoleReferrer struct {
+	// Name is the bare TS declaration name.
+	Name string
+
+	// DeclaredIn is the package URI the partition routed Name to.
+	DeclaredIn string
+
+	// ReferencedBy is the package URI of the only referrer.
+	ReferencedBy string
+}
+
+// UnreferencedDecl is a type-only declaration nothing in the lib set
+// references. Each one needs a decision rather than a default: a
+// package that wants it, or an overlay drop.
+type UnreferencedDecl struct {
+	// Name is the bare TS declaration name.
+	Name string
+
+	// DeclaredIn is the package URI the partition routed Name to.
+	DeclaredIn string
+}
+
+// TypeOnlyRouting is what one pass over the routed buckets found: the
+// type-only declarations whose referrers disagree with where the
+// partition put them, and the ones no referrer speaks for at all.
+//
+// A type-only declaration two or more packages reference is shared
+// vocabulary and belongs in `web:dom`. `BufferSource` is the canonical
+// one. Neither field holds those.
+type TypeOnlyRouting struct {
+	// SoleReferrer is sorted by declaring package, then referrer, then
+	// name.
+	SoleReferrer []SoleReferrer
+
+	// Unreferenced is sorted by declaring package, then name.
+	Unreferenced []UnreferencedDecl
+}
+
+// forPackage keeps only the entries declared in the package at uri.
+func (r TypeOnlyRouting) forPackage(uri string) TypeOnlyRouting {
+	var out TypeOnlyRouting
+	for _, e := range r.SoleReferrer {
+		if e.DeclaredIn == uri {
+			out.SoleReferrer = append(out.SoleReferrer, e)
+		}
+	}
+	for _, e := range r.Unreferenced {
+		if e.DeclaredIn == uri {
+			out.Unreferenced = append(out.Unreferenced, e)
+		}
+	}
+	return out
+}
+
+// AnalyzeTypeOnlyRouting classifies every type-only declaration in the
+// routed buckets by who references it.
+func AnalyzeTypeOnlyRouting(result *PartitionResult) TypeOnlyRouting {
+	valueNames := valueBoundNames(result)
+	typeOnlyIn := typeOnlyDecls(result, valueNames)
+	referrers := referrersOf(result, typeOnlyIn)
+
+	var out TypeOnlyRouting
+	for name, declaredIn := range typeOnlyIn {
+		refs, ok := referrers[name]
+		if !ok || refs.Len() == 0 {
+			out.Unreferenced = append(out.Unreferenced,
+				UnreferencedDecl{Name: name, DeclaredIn: declaredIn})
+			continue
+		}
+		if refs.Len() != 1 || refs.Contains(declaredIn) {
+			continue
+		}
+		out.SoleReferrer = append(out.SoleReferrer, SoleReferrer{
+			Name:         name,
+			DeclaredIn:   declaredIn,
+			ReferencedBy: refs.ToSlice()[0],
+		})
+	}
+
+	sort.Slice(out.SoleReferrer, func(i, j int) bool {
+		a, b := out.SoleReferrer[i], out.SoleReferrer[j]
+		if a.DeclaredIn != b.DeclaredIn {
+			return a.DeclaredIn < b.DeclaredIn
+		}
+		if a.ReferencedBy != b.ReferencedBy {
+			return a.ReferencedBy < b.ReferencedBy
+		}
+		return a.Name < b.Name
+	})
+	sort.Slice(out.Unreferenced, func(i, j int) bool {
+		a, b := out.Unreferenced[i], out.Unreferenced[j]
+		if a.DeclaredIn != b.DeclaredIn {
+			return a.DeclaredIn < b.DeclaredIn
+		}
+		return a.Name < b.Name
+	})
+	return out
+}
+
+// valueBoundNames are the names the lib set binds a value to. An
+// interface sharing a name with one of them is a trio's instance side.
+func valueBoundNames(result *PartitionResult) set.Set[string] {
+	names := set.NewSet[string]()
+	for _, stmts := range result.Buckets {
+		for _, stmt := range stmts {
+			switch stmt.(type) {
+			case *dts_parser.VarDecl, *dts_parser.FuncDecl,
+				*dts_parser.ClassDecl, *dts_parser.EnumDecl,
+				*dts_parser.NamespaceDecl:
+				if name := topLevelName(stmt); name != "" {
+					names.Add(name)
+				}
+			}
+		}
+	}
+	return names
+}
+
+// typeOnlyDecls maps each type-only declaration to the package URI
+// declaring it. A `FooConstructor` whose `Foo` is value-bound is the
+// static half of a trio, so it is left out along with `Foo` itself.
+func typeOnlyDecls(result *PartitionResult, valueNames set.Set[string]) map[string]string {
+	declaredIn := map[string]string{}
+	for uri, stmts := range result.Buckets {
+		for _, stmt := range stmts {
+			switch stmt.(type) {
+			case *dts_parser.InterfaceDecl, *dts_parser.TypeDecl:
+			default:
+				continue
+			}
+			name := topLevelName(stmt)
+			if name == "" || valueNames.Contains(name) {
+				continue
+			}
+			if instance, ok := strings.CutSuffix(name, "Constructor"); ok &&
+				instance != "" && valueNames.Contains(instance) {
+				continue
+			}
+			declaredIn[name] = uri
+		}
+	}
+	return declaredIn
+}
+
+// referrersOf maps each type-only name to the packages whose
+// declarations reference it. A declaration's reference to itself does
+// not count, since a recursive interface says nothing about which
+// package wants the name.
+func referrersOf(
+	result *PartitionResult,
+	typeOnlyIn map[string]string,
+) map[string]set.Set[string] {
+	referrers := map[string]set.Set[string]{}
+	for uri, stmts := range result.Buckets {
+		for _, stmt := range stmts {
+			from := topLevelName(stmt)
+			walkStatementTypes(stmt, func(t dts_parser.TypeAnn) {
+				walkTypeRefs(t, func(ref *dts_parser.TypeReference) {
+					name := typeRefName(ref)
+					if name == "" || name == from {
+						return
+					}
+					if _, ok := typeOnlyIn[name]; !ok {
+						return
+					}
+					if _, ok := referrers[name]; !ok {
+						referrers[name] = set.NewSet[string]()
+					}
+					referrers[name].Add(uri)
+				})
+			})
+		}
+	}
+	return referrers
+}
+
+// ReportTypeOnlyRouting prints what landed in `web:dom` that the
+// referrers disagree with: one line per sibling that is the sole
+// referrer of some of its type-only declarations, then one line for
+// the ones nothing references. Nothing is written when both are empty.
+//
+// Only `web:dom` is reported. It is the one package a name reaches
+// without anyone listing it, through the DOM residual rule, so it is
+// the one place a routing mistake is a side effect rather than a
+// decision. A sole referrer elsewhere is weaker evidence: `std:async`
+// declares `AsyncIterable` and only `std:array` references it, and the
+// protocol type still belongs where the partition puts it.
+//
+// The `generate` subcommand calls this alongside the drop counts, so a
+// TypeScript bump that adds a type-only companion surfaces it instead
+// of absorbing it into `web:dom`.
+func ReportTypeOnlyRouting(result *PartitionResult, w io.Writer) error {
+	routing := AnalyzeTypeOnlyRouting(result).forPackage(WebDOM.URI)
+
+	// The report is assembled in memory and written once, matching
+	// ReportPartition. A strings.Builder write cannot fail, so the body
+	// stays free of error plumbing.
+	var b strings.Builder
+
+	// Consecutive entries share a referrer because AnalyzeTypeOnly
+	// Routing sorts by referrer within a declaring package, so one pass
+	// groups them.
+	for i := 0; i < len(routing.SoleReferrer); {
+		j := i
+		for j < len(routing.SoleReferrer) &&
+			routing.SoleReferrer[j].ReferencedBy == routing.SoleReferrer[i].ReferencedBy {
+			j++
+		}
+		names := make([]string, 0, j-i)
+		for _, e := range routing.SoleReferrer[i:j] {
+			names = append(names, e.Name)
+		}
+		fmt.Fprintf(&b, "  %s: %d type-only decls only %s references (%s)\n",
+			WebDOM.URI, len(names), routing.SoleReferrer[i].ReferencedBy,
+			strings.Join(names, ", "))
+		i = j
+	}
+
+	if len(routing.Unreferenced) > 0 {
+		names := make([]string, 0, len(routing.Unreferenced))
+		for _, e := range routing.Unreferenced {
+			names = append(names, e.Name)
+		}
+		fmt.Fprintf(&b, "  %s: %d type-only decls nothing references (%s)\n",
+			WebDOM.URI, len(names), strings.Join(names, ", "))
+	}
+
+	_, err := io.WriteString(w, b.String())
+	return err
+}

--- a/internal/dts_to_esc/type_only.go
+++ b/internal/dts_to_esc/type_only.go
@@ -20,10 +20,10 @@ import (
 // The §6.1 partition table enumerates each package's members by hand,
 // and hand-enumeration reaches for the names that have constructors. A
 // type-only companion left off a sibling's member list falls through to
-// `web:dom` under the DOM residual rule, away from the family it
-// describes. `web:webgl` holds the rendering contexts while the
-// extension interfaces `getExtension` returns sit in `web:dom`, so the
-// return type comes from a package the caller did not import.
+// `web:dom` under the DOM residual rule, and the sibling's own methods
+// then return a type the caller did not import. The 36 WebGL extension
+// interfaces `getExtension` returns are the largest such family, and
+// the partition names every one of them in `web:webgl`.
 //
 // The unmapped-symbol fail-safe cannot catch that. It trips on a name
 // with no home, and the residual rule gives every one of these a home.

--- a/internal/dts_to_esc/type_only.go
+++ b/internal/dts_to_esc/type_only.go
@@ -12,7 +12,7 @@ import (
 
 // A declaration is type-only when the lib set binds no value of its
 // name. An `interface` with no companion `declare var`, and a `type`
-// alias, are both type-only. The static half of a trio is not:
+// alias, are both type-only. The static half of a trio is not.
 // TypeScript spells a class as `interface Foo`, `interface
 // FooConstructor`, and `declare var Foo`, and that binding gives all
 // three a runtime referent.

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -70,17 +70,13 @@ type SharedOpts = string;
 	require.Empty(t, b.String())
 }
 
-// TestReportTypeOnlyRouting_PinnedLibSet is the §6.1 gate over the
-// real input: every web:dom type-only declaration is referenced by
-// web:dom itself or by two or more packages. Passing looks like an
-// empty report, so the test states the gate a second way. It asserts
-// the set of unreferenced declarations the report suppresses.
-//
-// That second assertion is what keeps the suppression honest. A
-// declaration UnreferencedDOMTypes does not cover fails here, and so
-// does an entry the lib set has stopped declaring.
-func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
-	t.Parallel()
+// pinnedRouting routes the pinned lib set through the committed
+// overlay, which is the input generate reports on. The overlay's root
+// drop file settles `eval` and the other whole-symbol drops before
+// routing, so a run without it fails the fail-safe on the first
+// dropped name.
+func pinnedRouting(t *testing.T) *PartitionResult {
+	t.Helper()
 	libDir := filepath.Join("..", "..", "node_modules", "typescript", "lib")
 	if _, err := os.Stat(libDir); err != nil {
 		t.Skipf("TypeScript lib dir not present at %s; run `pnpm install`: %v", libDir, err)
@@ -89,22 +85,44 @@ func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
 	require.NoError(t, err)
 	inputs, err := ParseLibFiles(libDir, basenames)
 	require.NoError(t, err)
-
-	// The committed overlay, which is the input generate reports on.
-	// Its root drop file settles `eval` and the other whole-symbol
-	// drops before routing, so a run without it fails the fail-safe on
-	// the first dropped name.
 	overlay, err := LoadOverlay(filepath.Join("..", "interop", "overlay"))
 	require.NoError(t, err)
 	res, err := PartitionLibWithOverlay(inputs, overlay)
 	require.NoError(t, err)
+	return res
+}
+
+// TestReportTypeOnlyRouting_PinnedLibSet is the §6.1 gate over the real
+// input: every web:dom type-only declaration is referenced by web:dom
+// itself or by two or more packages. The report prints only what still
+// needs a decision, so passing looks like an empty one.
+//
+// The second assertion states the misplacement half structurally. It
+// still fails if the report's grouping ever swallows a finding.
+func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
+	t.Parallel()
+	res := pinnedRouting(t)
 
 	var b strings.Builder
 	require.NoError(t, ReportTypeOnlyRouting(res, &b))
 	require.Empty(t, b.String())
 
-	routing := AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI)
-	require.Empty(t, routing.SoleReferrer)
+	require.Empty(t, AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI).SoleReferrer)
+}
+
+// TestUnreferencedDOMTypes_MatchesThePinnedLibSet keeps the gate above
+// honest. That report hides whatever UnreferencedDOMTypes covers, so an
+// empty report cannot on its own tell a clean tree from one whose new
+// orphan the list happens to hide.
+//
+// Comparing the two sets catches both directions. A declaration the
+// list does not cover is a new one needing a decision, and an entry
+// that no longer appears is stale because TypeScript stopped declaring
+// the name.
+func TestUnreferencedDOMTypes_MatchesThePinnedLibSet(t *testing.T) {
+	t.Parallel()
+	routing := AnalyzeTypeOnlyRouting(pinnedRouting(t)).forPackage(WebDOM.URI)
+
 	orphans := make([]string, 0, len(routing.Unreferenced))
 	for _, e := range routing.Unreferenced {
 		orphans = append(orphans, e.Name)

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -103,6 +103,33 @@ func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
   web:dom: 3 type-only decls only web:web_rtc references (RTCDtlsRole, RTCLocalSessionDescriptionInit, RTCQualityLimitationReason)
   web:dom: 5 type-only decls only web:webauthn references (AuthenticationExtensionsClientInputs, AuthenticationExtensionsClientOutputs, PublicKeyCredentialClientCapabilities, PublicKeyCredentialCreationOptionsJSON, PublicKeyCredentialRequestOptionsJSON)
   web:dom: 34 type-only decls only web:webgl references (ANGLE_instanced_arrays, EXT_blend_minmax, EXT_color_buffer_float, EXT_color_buffer_half_float, EXT_float_blend, EXT_frag_depth, EXT_sRGB, EXT_shader_texture_lod, EXT_texture_compression_bptc, EXT_texture_compression_rgtc, EXT_texture_filter_anisotropic, KHR_parallel_shader_compile, OES_element_index_uint, OES_fbo_render_mipmap, OES_standard_derivatives, OES_texture_float, OES_texture_float_linear, OES_texture_half_float, OES_texture_half_float_linear, OES_vertex_array_object, OVR_multiview2, WEBGL_color_buffer_float, WEBGL_compressed_texture_astc, WEBGL_compressed_texture_etc, WEBGL_compressed_texture_etc1, WEBGL_compressed_texture_pvrtc, WEBGL_compressed_texture_s3tc, WEBGL_compressed_texture_s3tc_srgb, WEBGL_debug_renderer_info, WEBGL_debug_shaders, WEBGL_depth_texture, WEBGL_draw_buffers, WEBGL_lose_context, WEBGL_multi_draw)
-  web:dom: 22 type-only decls nothing references (AutoFillAddressKind, AutoFillContactField, AutoFillContactKind, AutoFillCredentialField, AutoFillField, AutoFillSection, ClientQueryOptions, ClientRect, ClipboardItemData, DisplayCaptureSurfaceType, EXT_texture_norm16, ElementTagNameMap, GPUError, HTMLTableDataCellElement, HTMLTableHeaderCellElement, OES_draw_buffers_indexed, OnBeforeUnloadEventHandler, OptionalPostfixToken, OptionalPrefixToken, RTCCertificateExpiration, StyleMedia, VideoFacingModeEnum)
+  web:dom: 14 type-only decls nothing references (ClientQueryOptions, ClientRect, ClipboardItemData, DisplayCaptureSurfaceType, EXT_texture_norm16, ElementTagNameMap, GPUError, HTMLTableDataCellElement, HTMLTableHeaderCellElement, OES_draw_buffers_indexed, OnBeforeUnloadEventHandler, RTCCertificateExpiration, StyleMedia, VideoFacingModeEnum)
 `))
+}
+
+// TestAnalyzeTypeOnlyRouting_ReadsTemplateLiteralInterpolations pins
+// the one place a reference hides from a walk that stops at the type
+// annotation's surface. lib.dom.d.ts writes every reference to
+// `AutoFillSection` inside an interpolation:
+//
+//	type AutoFill = AutoFillBase | `${OptionalPrefixToken<AutoFillSection>}…`
+//
+// A walk that skips template literals reports such a name as
+// referenced by nothing, which reads as a drop candidate.
+func TestAnalyzeTypeOnlyRouting_ReadsTemplateLiteralInterpolations(t *testing.T) {
+	t.Parallel()
+	res, err := PartitionLib([]LibInput{parseLib(t, "lib.dom.d.ts",
+		"interface Request { section: Section; }\n"+
+			"type Section = `section-${Kind}`;\n"+
+			"type Kind = \"shipping\" | \"billing\";\n")})
+	require.NoError(t, err)
+
+	routing := AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI)
+
+	// Kind reaches web:dom only through Section's interpolation, so it
+	// is shared vocabulary rather than an orphan.
+	require.Empty(t, routing.Unreferenced)
+	require.Equal(t, []SoleReferrer{
+		{Name: "Section", DeclaredIn: "web:dom", ReferencedBy: "web:fetch"},
+	}, routing.SoleReferrer)
 }

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -233,3 +233,40 @@ interface QueuingStrategySize { size: number; }
 		{Name: "QueuingStrategySize", DeclaredIn: "web:streams", ReferencedBy: "web:fetch"},
 	}, routing.SoleReferrer)
 }
+
+// TestAnalyzeTypeOnlyRouting_ReadsClassHeritage covers a class's
+// superclass and the interfaces it implements. Both name a type the
+// members repeat only by accident, so a walk that reads members alone
+// reports the two heritage types as referenced by nothing.
+func TestAnalyzeTypeOnlyRouting_ReadsClassHeritage(t *testing.T) {
+	t.Parallel()
+	res, err := PartitionLib([]LibInput{parseLib(t, "lib.dom.d.ts", `
+declare class Holder extends BaseOpts implements IfaceOpts { x: number; }
+interface BaseOpts { b: number; }
+interface IfaceOpts { i: number; }
+`)})
+	require.NoError(t, err)
+
+	require.Empty(t, AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI).Unreferenced)
+}
+
+// TestAnalyzeTypeOnlyRouting_ReadsInferConstraint covers the bound on
+// an `infer`. `T extends Promise<infer U extends Bound>` names Bound
+// only there, so a walk that stops at the infer reports it as
+// referenced by nothing.
+func TestAnalyzeTypeOnlyRouting_ReadsInferConstraint(t *testing.T) {
+	t.Parallel()
+	res, err := PartitionLib([]LibInput{parseLib(t, "lib.dom.d.ts", `
+interface Request { u: Unwrap<Promise<string>>; }
+type Unwrap<T> = T extends Promise<infer U extends Bound> ? U : never;
+type Bound = string;
+`)})
+	require.NoError(t, err)
+
+	routing := AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI)
+
+	require.Empty(t, routing.Unreferenced)
+	require.Equal(t, []SoleReferrer{
+		{Name: "Unwrap", DeclaredIn: "web:dom", ReferencedBy: "web:fetch"},
+	}, routing.SoleReferrer)
+}

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -126,10 +126,38 @@ func TestAnalyzeTypeOnlyRouting_ReadsTemplateLiteralInterpolations(t *testing.T)
 
 	routing := AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI)
 
-	// Kind reaches web:dom only through Section's interpolation, so it
-	// is shared vocabulary rather than an orphan.
+	// Kind reaches web:dom only through Section's interpolation. Its
+	// one referrer is the package that declares it, which is the
+	// verdict a walk stopping at the template literal would miss.
 	require.Empty(t, routing.Unreferenced)
 	require.Equal(t, []SoleReferrer{
 		{Name: "Section", DeclaredIn: "web:dom", ReferencedBy: "web:fetch"},
+	}, routing.SoleReferrer)
+}
+
+// TestAnalyzeTypeOnlyRouting_ReadsTypeParameterBounds covers the other
+// two slots a reference hides in. A type parameter's constraint and its
+// default each name a type nothing else in the declaration mentions:
+//
+//	interface Request { pick<K extends Bag>(k: K): void }
+//	interface ReadableStream<T = Deflt> { value: T }
+//
+// Skipping either slot reports Bag and Deflt as referenced by nothing.
+func TestAnalyzeTypeOnlyRouting_ReadsTypeParameterBounds(t *testing.T) {
+	t.Parallel()
+	res, err := PartitionLib([]LibInput{parseLib(t, "lib.dom.d.ts", `
+interface Request { pick<K extends Bag>(k: K): void; }
+interface ReadableStream<T = Deflt> { value: T; }
+interface Bag { size: number; }
+interface Deflt { size: number; }
+`)})
+	require.NoError(t, err)
+
+	routing := AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI)
+
+	require.Empty(t, routing.Unreferenced)
+	require.Equal(t, []SoleReferrer{
+		{Name: "Bag", DeclaredIn: "web:dom", ReferencedBy: "web:fetch"},
+		{Name: "Deflt", DeclaredIn: "web:dom", ReferencedBy: "web:streams"},
 	}, routing.SoleReferrer)
 }

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -3,10 +3,10 @@ package dts_to_esc
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
-	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,12 +70,15 @@ type SharedOpts = string;
 	require.Empty(t, b.String())
 }
 
-// TestReportTypeOnlyRouting_PinnedLibSet is the §6.1 gate over the real
-// input: every web:dom type-only declaration is referenced by web:dom
-// itself or by two or more packages. The snapshot holds what the
-// partition has yet to place, so a TypeScript bump that adds a
-// type-only companion moves this test rather than absorbing the name
-// into web:dom unnoticed.
+// TestReportTypeOnlyRouting_PinnedLibSet is the §6.1 gate over the
+// real input: every web:dom type-only declaration is referenced by
+// web:dom itself or by two or more packages. An empty report is what
+// passing looks like, so the test states the gate twice — once as the
+// report, and once as the orphan set the report suppresses.
+//
+// The second assertion is what keeps the suppression honest. A name
+// UnreferencedDOMTypes no longer covers fails here as a new orphan, and
+// an entry the lib set stopped declaring fails as a stale one.
 func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
 	t.Parallel()
 	libDir := filepath.Join("..", "..", "node_modules", "typescript", "lib")
@@ -91,20 +94,17 @@ func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
 
 	var b strings.Builder
 	require.NoError(t, ReportTypeOnlyRouting(res, &b))
-	snaps.MatchInlineSnapshot(t, b.String(), snaps.Inline(`  web:dom: 1 type-only decls only web:compression references (CompressionFormat)
-  web:dom: 2 type-only decls only web:fetch references (HeadersIterator, RequestPriority)
-  web:dom: 1 type-only decls only web:payments references (PaymentOptions)
-  web:dom: 1 type-only decls only web:performance references (NavigationTimingType)
-  web:dom: 1 type-only decls only web:service_worker references (GetNotificationOptions)
-  web:dom: 6 type-only decls only web:streams references (ReadableStreamAsyncIterator, ReadableStreamController, ReadableStreamGetReaderOptions, ReadableStreamIteratorOptions, ReadableStreamReader, ReadableStreamType)
-  web:dom: 1 type-only decls only web:url references (URLSearchParamsIterator)
-  web:dom: 1 type-only decls only web:web_audio references (AudioTimestamp)
-  web:dom: 11 type-only decls only web:web_codecs references (AudioDataOutputCallback, AudioDecoderEventMap, AudioEncoderEventMap, AvcEncoderConfig, EncodedAudioChunkOutputCallback, EncodedVideoChunkOutputCallback, ImageBufferSource, OpusEncoderConfig, VideoDecoderEventMap, VideoEncoderEventMap, VideoFrameOutputCallback)
-  web:dom: 3 type-only decls only web:web_rtc references (RTCDtlsRole, RTCLocalSessionDescriptionInit, RTCQualityLimitationReason)
-  web:dom: 5 type-only decls only web:webauthn references (AuthenticationExtensionsClientInputs, AuthenticationExtensionsClientOutputs, PublicKeyCredentialClientCapabilities, PublicKeyCredentialCreationOptionsJSON, PublicKeyCredentialRequestOptionsJSON)
-  web:dom: 34 type-only decls only web:webgl references (ANGLE_instanced_arrays, EXT_blend_minmax, EXT_color_buffer_float, EXT_color_buffer_half_float, EXT_float_blend, EXT_frag_depth, EXT_sRGB, EXT_shader_texture_lod, EXT_texture_compression_bptc, EXT_texture_compression_rgtc, EXT_texture_filter_anisotropic, KHR_parallel_shader_compile, OES_element_index_uint, OES_fbo_render_mipmap, OES_standard_derivatives, OES_texture_float, OES_texture_float_linear, OES_texture_half_float, OES_texture_half_float_linear, OES_vertex_array_object, OVR_multiview2, WEBGL_color_buffer_float, WEBGL_compressed_texture_astc, WEBGL_compressed_texture_etc, WEBGL_compressed_texture_etc1, WEBGL_compressed_texture_pvrtc, WEBGL_compressed_texture_s3tc, WEBGL_compressed_texture_s3tc_srgb, WEBGL_debug_renderer_info, WEBGL_debug_shaders, WEBGL_depth_texture, WEBGL_draw_buffers, WEBGL_lose_context, WEBGL_multi_draw)
-  web:dom: 14 type-only decls nothing references (ClientQueryOptions, ClientRect, ClipboardItemData, DisplayCaptureSurfaceType, EXT_texture_norm16, ElementTagNameMap, GPUError, HTMLTableDataCellElement, HTMLTableHeaderCellElement, OES_draw_buffers_indexed, OnBeforeUnloadEventHandler, RTCCertificateExpiration, StyleMedia, VideoFacingModeEnum)
-`))
+	require.Empty(t, b.String())
+
+	routing := AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI)
+	require.Empty(t, routing.SoleReferrer)
+	orphans := make([]string, 0, len(routing.Unreferenced))
+	for _, e := range routing.Unreferenced {
+		orphans = append(orphans, e.Name)
+	}
+	acknowledged := UnreferencedDOMTypes.ToSlice()
+	sort.Strings(acknowledged)
+	require.Equal(t, acknowledged, orphans)
 }
 
 // TestAnalyzeTypeOnlyRouting_ReadsTemplateLiteralInterpolations pins

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -1,0 +1,108 @@
+package dts_to_esc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+// routingLib exercises every rule the type-only analysis applies, in
+// one lib.dom.d.ts. `Request` routes to web:fetch and `ReadableStream`
+// to web:streams by the §6.1 partition, so the referring declarations
+// sit in packages other than the web:dom the rest falls through to.
+const routingLib = `
+interface Request { sole: SoleOpts; shared: SharedOpts; }
+interface ReadableStream { shared: SharedOpts; }
+type SoleOpts = string;
+type SharedOpts = string;
+type Orphan = string;
+interface SelfRef { next: SelfRef; }
+interface Trio { length: number; }
+interface TrioConstructor { new (): Trio; }
+declare var Trio: TrioConstructor;
+`
+
+// TestAnalyzeTypeOnlyRouting covers the four verdicts the analysis
+// reaches over routingLib above.
+//
+//   - SoleOpts has one referrer outside web:dom, so it reads as
+//     misplaced.
+//   - SharedOpts has two, which makes it shared vocabulary that belongs
+//     in web:dom.
+//   - Orphan has none, and SelfRef's only reference is its own, which
+//     does not speak for any package.
+//   - Trio and TrioConstructor are the two halves of a class, so
+//     `declare var Trio` keeps both out of the analysis entirely.
+func TestAnalyzeTypeOnlyRouting(t *testing.T) {
+	t.Parallel()
+	res, err := PartitionLib([]LibInput{parseLib(t, "lib.dom.d.ts", routingLib)})
+	require.NoError(t, err)
+
+	routing := AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI)
+
+	require.Equal(t, []SoleReferrer{
+		{Name: "SoleOpts", DeclaredIn: "web:dom", ReferencedBy: "web:fetch"},
+	}, routing.SoleReferrer)
+	require.Equal(t, []UnreferencedDecl{
+		{Name: "Orphan", DeclaredIn: "web:dom"},
+		{Name: "SelfRef", DeclaredIn: "web:dom"},
+	}, routing.Unreferenced)
+}
+
+// TestReportTypeOnlyRouting_NamesNothing covers the quiet case: a lib
+// whose every type-only declaration is either shared vocabulary or
+// already in the package that references it writes no report at all.
+func TestReportTypeOnlyRouting_NamesNothing(t *testing.T) {
+	t.Parallel()
+	res, err := PartitionLib([]LibInput{parseLib(t, "lib.dom.d.ts", `
+interface Request { shared: SharedOpts; }
+interface ReadableStream { shared: SharedOpts; }
+type SharedOpts = string;
+`)})
+	require.NoError(t, err)
+
+	var b strings.Builder
+	require.NoError(t, ReportTypeOnlyRouting(res, &b))
+	require.Empty(t, b.String())
+}
+
+// TestReportTypeOnlyRouting_PinnedLibSet is the §6.1 gate over the real
+// input: every web:dom type-only declaration is referenced by web:dom
+// itself or by two or more packages. The snapshot holds what the
+// partition has yet to place, so a TypeScript bump that adds a
+// type-only companion moves this test rather than absorbing the name
+// into web:dom unnoticed.
+func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
+	t.Parallel()
+	libDir := filepath.Join("..", "..", "node_modules", "typescript", "lib")
+	if _, err := os.Stat(libDir); err != nil {
+		t.Skipf("TypeScript lib dir not present at %s; run `pnpm install`: %v", libDir, err)
+	}
+	basenames, err := DiscoverLibFiles(libDir)
+	require.NoError(t, err)
+	inputs, err := ParseLibFiles(libDir, basenames)
+	require.NoError(t, err)
+	res, err := PartitionLib(inputs)
+	require.NoError(t, err)
+
+	var b strings.Builder
+	require.NoError(t, ReportTypeOnlyRouting(res, &b))
+	snaps.MatchInlineSnapshot(t, b.String(), snaps.Inline(`  web:dom: 1 type-only decls only web:compression references (CompressionFormat)
+  web:dom: 2 type-only decls only web:fetch references (HeadersIterator, RequestPriority)
+  web:dom: 1 type-only decls only web:payments references (PaymentOptions)
+  web:dom: 1 type-only decls only web:performance references (NavigationTimingType)
+  web:dom: 1 type-only decls only web:service_worker references (GetNotificationOptions)
+  web:dom: 6 type-only decls only web:streams references (ReadableStreamAsyncIterator, ReadableStreamController, ReadableStreamGetReaderOptions, ReadableStreamIteratorOptions, ReadableStreamReader, ReadableStreamType)
+  web:dom: 1 type-only decls only web:url references (URLSearchParamsIterator)
+  web:dom: 1 type-only decls only web:web_audio references (AudioTimestamp)
+  web:dom: 11 type-only decls only web:web_codecs references (AudioDataOutputCallback, AudioDecoderEventMap, AudioEncoderEventMap, AvcEncoderConfig, EncodedAudioChunkOutputCallback, EncodedVideoChunkOutputCallback, ImageBufferSource, OpusEncoderConfig, VideoDecoderEventMap, VideoEncoderEventMap, VideoFrameOutputCallback)
+  web:dom: 3 type-only decls only web:web_rtc references (RTCDtlsRole, RTCLocalSessionDescriptionInit, RTCQualityLimitationReason)
+  web:dom: 5 type-only decls only web:webauthn references (AuthenticationExtensionsClientInputs, AuthenticationExtensionsClientOutputs, PublicKeyCredentialClientCapabilities, PublicKeyCredentialCreationOptionsJSON, PublicKeyCredentialRequestOptionsJSON)
+  web:dom: 34 type-only decls only web:webgl references (ANGLE_instanced_arrays, EXT_blend_minmax, EXT_color_buffer_float, EXT_color_buffer_half_float, EXT_float_blend, EXT_frag_depth, EXT_sRGB, EXT_shader_texture_lod, EXT_texture_compression_bptc, EXT_texture_compression_rgtc, EXT_texture_filter_anisotropic, KHR_parallel_shader_compile, OES_element_index_uint, OES_fbo_render_mipmap, OES_standard_derivatives, OES_texture_float, OES_texture_float_linear, OES_texture_half_float, OES_texture_half_float_linear, OES_vertex_array_object, OVR_multiview2, WEBGL_color_buffer_float, WEBGL_compressed_texture_astc, WEBGL_compressed_texture_etc, WEBGL_compressed_texture_etc1, WEBGL_compressed_texture_pvrtc, WEBGL_compressed_texture_s3tc, WEBGL_compressed_texture_s3tc_srgb, WEBGL_debug_renderer_info, WEBGL_debug_shaders, WEBGL_depth_texture, WEBGL_draw_buffers, WEBGL_lose_context, WEBGL_multi_draw)
+  web:dom: 22 type-only decls nothing references (AutoFillAddressKind, AutoFillContactField, AutoFillContactKind, AutoFillCredentialField, AutoFillField, AutoFillSection, ClientQueryOptions, ClientRect, ClipboardItemData, DisplayCaptureSurfaceType, EXT_texture_norm16, ElementTagNameMap, GPUError, HTMLTableDataCellElement, HTMLTableHeaderCellElement, OES_draw_buffers_indexed, OnBeforeUnloadEventHandler, OptionalPostfixToken, OptionalPrefixToken, RTCCertificateExpiration, StyleMedia, VideoFacingModeEnum)
+`))
+}

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -72,13 +72,13 @@ type SharedOpts = string;
 
 // TestReportTypeOnlyRouting_PinnedLibSet is the §6.1 gate over the
 // real input: every web:dom type-only declaration is referenced by
-// web:dom itself or by two or more packages. An empty report is what
-// passing looks like, so the test states the gate twice — once as the
-// report, and once as the orphan set the report suppresses.
+// web:dom itself or by two or more packages. Passing looks like an
+// empty report, so the test states the gate a second way. It asserts
+// the set of unreferenced declarations the report suppresses.
 //
-// The second assertion is what keeps the suppression honest. A name
-// UnreferencedDOMTypes no longer covers fails here as a new orphan, and
-// an entry the lib set stopped declaring fails as a stale one.
+// That second assertion is what keeps the suppression honest. A
+// declaration UnreferencedDOMTypes does not cover fails here, and so
+// does an entry the lib set has stopped declaring.
 func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
 	t.Parallel()
 	libDir := filepath.Join("..", "..", "node_modules", "typescript", "lib")

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -89,7 +89,14 @@ func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
 	require.NoError(t, err)
 	inputs, err := ParseLibFiles(libDir, basenames)
 	require.NoError(t, err)
-	res, err := PartitionLib(inputs)
+
+	// The committed overlay, which is the input generate reports on.
+	// Its root drop file settles `eval` and the other whole-symbol
+	// drops before routing, so a run without it fails the fail-safe on
+	// the first dropped name.
+	overlay, err := LoadOverlay(filepath.Join("..", "interop", "overlay"))
+	require.NoError(t, err)
+	res, err := PartitionLibWithOverlay(inputs, overlay)
 	require.NoError(t, err)
 
 	var b strings.Builder

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -168,3 +168,68 @@ interface Deflt { size: number; }
 		{Name: "Deflt", DeclaredIn: "web:dom", ReferencedBy: "web:streams"},
 	}, routing.SoleReferrer)
 }
+
+// TestReportTypeOnlyRouting_Renders pins the report's text. The other
+// report tests assert an empty one, which says nothing about what a
+// finding looks like when there is one.
+//
+// FnOpts also covers the type parameters a function type carries.
+// BoundOpts is named only by `<T extends BoundOpts>`, so a walk that
+// misses that slot puts it on the unreferenced line.
+func TestReportTypeOnlyRouting_Renders(t *testing.T) {
+	t.Parallel()
+	res, err := PartitionLib([]LibInput{parseLib(t, "lib.dom.d.ts", `
+interface Request { a: AlphaOpts; b: BetaOpts; f: FnOpts; }
+type AlphaOpts = string;
+type BetaOpts = string;
+type FnOpts = <T extends BoundOpts>(x: T) => void;
+type BoundOpts = string;
+type Orphan = string;
+`)})
+	require.NoError(t, err)
+
+	var b strings.Builder
+	require.NoError(t, ReportTypeOnlyRouting(res, &b))
+
+	require.Equal(t,
+		"  web:dom: 3 type-only decls only web:fetch references"+
+			" (AlphaOpts, BetaOpts, FnOpts)\n"+
+			"  web:dom: 1 type-only decl nothing references (Orphan)\n",
+		b.String())
+}
+
+// TestAnalyzeTypeOnlyRouting_ReadsEveryTypeShape covers the type
+// annotation shapes the other tests leave out: a constructor type's
+// type parameters, a tuple's rest element, and its optional element.
+// A name reachable only through one of those reads as referenced by
+// nothing if the walk skips that shape.
+//
+// QueuingStrategySize routes to web:streams by the §6.1 partition, so
+// the sole referrers span two declaring packages and the analysis has
+// to order them by that first.
+func TestAnalyzeTypeOnlyRouting_ReadsEveryTypeShape(t *testing.T) {
+	t.Parallel()
+	res, err := PartitionLib([]LibInput{parseLib(t, "lib.dom.d.ts", `
+interface Request { c: CtorOpts; t: TupOpts; q: QueuingStrategySize; }
+type CtorOpts = new <T extends CtorBound>(x: T) => void;
+type CtorBound = string;
+type TupOpts = [...RestOpts[], OptOpts?];
+type RestOpts = string;
+type OptOpts = string;
+interface QueuingStrategySize { size: number; }
+`)})
+	require.NoError(t, err)
+
+	routing := AnalyzeTypeOnlyRouting(res)
+
+	// CtorBound, RestOpts, and OptOpts each reach web:dom only through
+	// the shape under test, so an empty list is what proves the walk
+	// found them. The filter drops Request, which this lib declares
+	// without a `declare var` and nothing references.
+	require.Empty(t, routing.forPackage(WebDOM.URI).Unreferenced)
+	require.Equal(t, []SoleReferrer{
+		{Name: "CtorOpts", DeclaredIn: "web:dom", ReferencedBy: "web:fetch"},
+		{Name: "TupOpts", DeclaredIn: "web:dom", ReferencedBy: "web:fetch"},
+		{Name: "QueuingStrategySize", DeclaredIn: "web:streams", ReferencedBy: "web:fetch"},
+	}, routing.SoleReferrer)
+}

--- a/tools/dts_to_esc/main.go
+++ b/tools/dts_to_esc/main.go
@@ -157,6 +157,9 @@ func runGenerate(args []string, stderr io.Writer) error {
 	if err := dts_to_esc.ReportPartition(res.Partition, stderr); err != nil {
 		return err
 	}
+	if err := dts_to_esc.ReportTypeOnlyRouting(res.Partition, stderr); err != nil {
+		return err
+	}
 	if err := dts_to_esc.ReportSingletonKeyDrops(res.Modules, stderr); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #1337

Half the declarations in the pinned lib set have no runtime referent. The §6.1 partition table enumerates each package's members by hand, and hand-enumeration reaches for the names that have constructors, so a type-only companion left off a sibling's list falls through to `web:dom` under the DOM residual rule. `web:webgl` held the rendering contexts while the 34 extension interfaces `getExtension` returns sat in `web:dom`, so the return type came from a package the caller did not import.

The unmapped-symbol fail-safe cannot catch this, because the residual rule gives every one of these names a home.

## The analysis

`AnalyzeTypeOnlyRouting` in the new `internal/dts_to_esc/type_only.go` classifies every type-only declaration by who references it. A declaration is type-only when the lib set binds no value of its name; the static half of a trio is not, since `declare var Foo` gives all three of `Foo`, `FooConstructor`, and the binding a runtime referent.

`ReportTypeOnlyRouting` prints two things, and `generate` calls it alongside the drop counts: the `web:dom` declarations a single sibling is the sole referrer of, and the ones nothing references. Only `web:dom` is reported, because it is the one package a name reaches without anyone listing it, so it is the one place a routing mistake is a side effect rather than a decision. A sole referrer elsewhere is weaker evidence — `std:async` declares `AsyncIterable` and only `std:array` references it, and the protocol type still belongs where it is.

## The moves

78 names, worked to a fixpoint over three rounds of 67, 10, and 2. The moves cascade: a name two packages reference becomes a sole referrer once one of those referrers leaves `web:dom`. `web:webgl` gains 37 names: the 34 extension interfaces `getExtension` returns, `WebGLVertexArrayObjectOES` (the handle `OES_vertex_array_object` hands out), and `EXT_texture_norm16` and `OES_draw_buffers_indexed`, which are extension interfaces the lib set declares without a `getExtension` overload returning them. `web:webauthn` gains 14, among them `Base64URLString`, which the WebAuthn spec declares as its own typedef rather than a general string alias.

`UnreferencedDOMTypes` records the 10 that nothing references and `web:dom` keeps anyway: five deprecated declarations, four families with no package of their own, and `OnBeforeUnloadEventHandler`, an alias `lib.dom.d.ts` declares and never uses. The report suppresses them, so every name it prints still needs a decision.

Over the pinned lib set the report is now empty, which is the issue's gate — every `web:dom` type-only declaration is referenced by `web:dom` itself or by two or more packages.

## Four walk gaps the analysis exposed

A missed reference makes a live type read as referenced by nothing, which is the verdict that marks a declaration a drop candidate. Running the analysis turned up four places `walkTypeRefs` never looked. Each has a test that fails without its fix.

- **Template literal interpolations.** In `lib.dom.d.ts`, `type AutoFill = AutoFillBase | ...${OptionalPrefixToken<AutoFillSection>}...` is every reference `AutoFillSection` gets. Six `AutoFill*` names and the two `Optional*Token` wrappers read as unreferenced, so **eight of the 20 names #1337 listed as unreferenced were live types**.
- **Type-parameter constraints and defaults**, plus a mapped type's key source and `as` clause.
- **Class heritage.** A `ClassDecl`'s `Extends` and `Implements` were skipped, so `declare class Holder extends BaseOpts implements IfaceOpts` hid both names. Found by CodeRabbit, which named `Implements`; `Extends` has the same gap.
- **Constrained `infer`.** `T extends Promise<infer U extends Bound>` names `Bound` only in that constraint. Also found by CodeRabbit.

Only the first changes the report over the pinned lib set. The other three would have surfaced as wrong drop candidates on a future TypeScript bump.

`countTypeRefsInTypeAnn`'s 80-line switch became `walkTypeRefs`, which the analysis and the singleton detector now share; the count is a thin wrapper over it.

## Verification

`go test ./...` passes. The pinned-lib gate asserts both halves: the report is empty, and the unreferenced set equals `UnreferencedDOMTypes`, so a new orphan and a stale entry both fail. It loads the committed overlay and routes through `PartitionLibWithOverlay`, matching what `generate` reads — #1372 moved `ExplicitDrops` there, so a run without the overlay now trips the fail-safe.

Patch coverage is 98.8%. The two uncovered lines are `walkTypeRefs`'s `RestType` and `OptionalType` cases: `OptionalType` is never constructed anywhere in `dts_parser`, and `RestType` only from a syntax position these inputs don't reach. Both predate this PR and the refactor carried them over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW