### PR TITLE
Recognize a trio by its names alone

### DIFF
--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -186,11 +186,44 @@ type trioTable struct {
 
 // detectTrios scans a module's top-level statements for the
 // `interface Foo` + `interface FooConstructor` + `declare var Foo: FooConstructor`
-// pattern. Recognition mirrors tryFuseTrio in internal/interop at the
-// dts layer:
-// the var's TypeAnn must be a TypeReference to FooConstructor, and the
-// constructor interface's `new (...)` signature(s) must return Foo.
-// Trios that fail any check pass through unchanged.
+// pattern. The three names and the var's type annotation are the whole
+// rule: `Foo` and `FooConstructor` must both be declared, and the var
+// named `Foo` must be a TypeReference to `FooConstructor`. Trios that
+// fail any check pass through unchanged.
+//
+// What the constructor interface declares does not enter recognition.
+// Its `new (...)` signatures become the class's constructors when it has
+// any, and the class has none when it does not. Two shapes in the
+// pinned lib set depend on that:
+//
+//   - `SymbolConstructor` and `BigIntConstructor` declare no `new` at
+//     all, because the specification forbids constructing them.
+//     `new Symbol()` throws a TypeError. A class with no constructor
+//     is the shape that makes it unrepresentable rather than merely
+//     discouraged.
+//   - `ArrayConstructor` declares `new (arrayLength?: number): any[]`
+//     and two more that return `T[]`. Shorthand is not a
+//     TypeReference, so a rule reading the return type has to know
+//     that `T[]` spells `Array<T>` before it can match the one name
+//     whose mutation story the planning/interop_mutability/ workstream
+//     is about. Reading the names spares it that.
+//
+// The shorthand itself needs no special handling past this point.
+// convertTypeAnn turns `T[]` into `Array<T>` and `readonly T[]` into
+// `ReadonlyArray<T>`, so every param and member type reaches the class
+// already written the long way. Recognition was the only place the two
+// spellings had to be told apart.
+//
+// One shape is held back, and for a reason that is about the class
+// form rather than about recognition. A constructor interface with a
+// call signature and no `new` describes something callable and not
+// constructible, and fuseTrio has no class elem for a call signature,
+// so the fused class could be neither called nor constructed.
+// `SymbolConstructor` and `BigIntConstructor` are the two, and the
+// guard comes out when #1412 gives a class somewhere to hold one.
+//
+// This matches tryFuseTrio in internal/interop/class_shapes.go, which
+// has never gated on a construct signature.
 func detectTrios(stmts []dts_parser.Statement) *trioTable {
 	t := &trioTable{
 		byName:       make(map[string]*trioInfo),
@@ -227,11 +260,14 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 		if typeRefName(ref) != ctorName {
 			continue
 		}
-		// Constructor interface must carry at least one `new (...)` signature
-		// whose return type is the instance name. (We allow other members
-		// alongside it; bare-call signatures and prototype properties pass
-		// through into static members or are skipped.)
-		if !hasCtorReturning(ctor, name) {
+		// A constructor interface whose only callable form is a call
+		// signature would lose it: fuseTrio has no class elem to put
+		// one on, so the fused class could be neither called nor
+		// constructed. `SymbolConstructor` and `BigIntConstructor` are
+		// the two, and the specification forbids `new` on both, so the
+		// call signature is the only way to make one. They stay
+		// interfaces until #1412 gives a class somewhere to hold it.
+		if hasCallSignature(ctor) && !hasConstructSignature(ctor) {
 			continue
 		}
 
@@ -245,6 +281,18 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 	}
 
 	return t
+}
+
+// hasCallSignature reports whether iface declares at least one bare
+// `(...)` member, the form that makes `Symbol("x")` a call rather than
+// a construction.
+func hasCallSignature(iface *dts_parser.InterfaceDecl) bool {
+	for _, m := range iface.Members {
+		if _, ok := m.(*dts_parser.CallSignature); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // hasConstructSignature reports whether iface declares at least one
@@ -794,38 +842,6 @@ func countTypeRefsInTypeAnn(t dts_parser.TypeAnn, name string) int {
 func typeRefName(ref *dts_parser.TypeReference) string {
 	if id, ok := ref.Name.(*dts_parser.Ident); ok {
 		return id.Name
-	}
-	return ""
-}
-
-// hasCtorReturning reports whether ctor has at least one ConstructSignature
-// whose return type names instanceName.
-func hasCtorReturning(ctor *dts_parser.InterfaceDecl, instanceName string) bool {
-	for _, m := range ctor.Members {
-		cs, ok := m.(*dts_parser.ConstructSignature)
-		if !ok {
-			continue
-		}
-		if ctorReturnNames(cs.ReturnType) == instanceName {
-			return true
-		}
-	}
-	return false
-}
-
-// ctorReturnNames is the instance name a `new` signature's return type
-// names, or "" for a shape that names none. `T[]` is `Array<T>` written
-// in shorthand, so ArrayConstructor's `new (): any[]` constructs an
-// Array even though no TypeReference says so.
-func ctorReturnNames(t dts_parser.TypeAnn) string {
-	switch r := t.(type) {
-	case *dts_parser.TypeReference:
-		return typeRefName(r)
-	case *dts_parser.ArrayType:
-		if r.Readonly {
-			return "ReadonlyArray"
-		}
-		return "Array"
 	}
 	return ""
 }

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -779,39 +779,6 @@ func TestStandalone_ArrayShorthandTrio(t *testing.T) {
 	require.Equal(t, 0, interfaceCount, "trio interfaces consumed")
 }
 
-// TestCtorReturnNames covers the return shapes trio detection reads.
-// A readonly array is `ReadonlyArray<T>`, which names a different
-// instance than `Array<T>` and so must not fuse an Array trio.
-func TestCtorReturnNames(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{"a type reference names its instance", "interface C { new (): Foo; }", "Foo"},
-		{"an array shorthand names Array", "interface C { new (): Foo[]; }", "Array"},
-		{"a readonly array names ReadonlyArray",
-			"interface C { new (): readonly Foo[]; }", "ReadonlyArray"},
-		{"a primitive names nothing", "interface C { new (): string; }", ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			source := &ast.Source{Path: "test.d.ts", Contents: tc.input, ID: 0}
-			mod, errs := dts_parser.NewDtsParser(source).ParseModule()
-			require.Empty(t, errs, "dts parse errors")
-
-			iface, ok := mod.Statements[0].(*dts_parser.InterfaceDecl)
-			require.True(t, ok)
-			cs, ok := iface.Members[0].(*dts_parser.ConstructSignature)
-			require.True(t, ok)
-
-			require.Equal(t, tc.want, ctorReturnNames(cs.ReturnType))
-		})
-	}
-}
-
 // immutableOwnerTrio is a String-shaped trio carrying the two member
 // kinds the owner rule has to separate: instance methods, which cannot
 // mutate a primitive, and a constructor, which initializes the object it
@@ -1049,4 +1016,167 @@ declare var Foo: Foo;
 			require.NotEmpty(t, parsedDecls)
 		})
 	}
+}
+
+// Recognition of the trio idiom reads the three names and the var's
+// type annotation, never the constructor interface's members. These are
+// the two pinned-lib shapes that depend on it: a `FooConstructor` with
+// no `new` at all, and one whose `new` returns an array type rather
+// than a reference to the instance name.
+func TestStandalone_TrioFusesWhateverTheConstructorDeclares(t *testing.T) {
+	tests := []struct {
+		name string
+		// input is the trio, trimmed from the pinned lib file named in
+		// each case's comment.
+		input string
+		// ctors is the number of ConstructorElem members the fused
+		// class should carry.
+		ctors    int
+		statics  []string
+		instance []string
+	}{
+		{
+			// lib.esnext.iterator.d.ts gives IteratorConstructor
+			// statics and no `new`. A class with no constructor is what
+			// makes constructing it unrepresentable rather than merely
+			// discouraged.
+			name: "constructor interface with no new",
+			input: `
+interface Iterator<T> {
+    next(): T;
+}
+
+interface IteratorConstructor {
+    readonly prototype: Iterator<any>;
+    from<T>(value: T): Iterator<T>;
+}
+
+declare var Iterator: IteratorConstructor;
+`,
+			ctors:    0,
+			statics:  []string{"static readonly prototype: Iterator<any>", "static from<T>(value: T) -> Iterator<T>"},
+			instance: []string{"next(mut self) -> T"},
+		},
+		{
+			// lib.es5.d.ts. `any[]` and `T[]` parse as an array type,
+			// not as a TypeReference named `Array`, so a rule reading
+			// the return type rejects the one name the
+			// planning/interop_mutability/ workstream is about.
+			name: "construct signatures returning an array type",
+			input: `
+interface Array<T> {
+    push(...items: T[]): number;
+    readonly length: number;
+}
+
+interface ArrayConstructor {
+    new (arrayLength?: number): any[];
+    new <T>(arrayLength: number): T[];
+    isArray(arg: any): boolean;
+    readonly prototype: any[];
+}
+
+declare var Array: ArrayConstructor;
+`,
+			ctors:    2,
+			statics:  []string{"static isArray(arg: any) -> boolean"},
+			instance: []string{"push(mut self, ...items: Array<T>) -> number"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			astModule, printed := convertSlice(t, test.input)
+			rootNS, ok := astModule.Module.Namespaces.Get("")
+			require.True(t, ok, "root namespace exists")
+
+			var classes []*ast.ClassDecl
+			var interfaces, vars int
+			for _, d := range rootNS.Decls {
+				switch dd := d.(type) {
+				case *ast.ClassDecl:
+					classes = append(classes, dd)
+				case *ast.InterfaceDecl:
+					interfaces++
+				case *ast.VarDecl:
+					vars++
+				}
+			}
+			require.Len(t, classes, 1, "the trio fused into one ClassDecl")
+			require.Equal(t, 0, interfaces, "both trio interfaces consumed")
+			require.Equal(t, 0, vars, "the trio var consumed")
+
+			ctors := 0
+			for _, elem := range classes[0].Body {
+				if _, ok := elem.(*ast.ConstructorElem); ok {
+					ctors++
+				}
+			}
+			require.Equal(t, test.ctors, ctors, "ConstructorElem count")
+
+			for _, want := range test.statics {
+				require.Contains(t, printed, want)
+			}
+			for _, want := range test.instance {
+				require.Contains(t, printed, want)
+			}
+
+			parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+				&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+			require.Empty(t, parseErrs, "printed output parses")
+			require.NotEmpty(t, parsedDecls)
+		})
+	}
+}
+
+// A constructor interface with a call signature and no `new` describes
+// something callable and not constructible. fuseTrio has no class elem
+// for a call signature, so the fused class could be neither called nor
+// constructed. The trio passes through instead, keeping the call
+// signature on the interface, until #1412 gives a class somewhere to
+// hold one.
+//
+// `SymbolConstructor` below is verbatim from lib.es2015.symbol.d.ts.
+// `BigIntConstructor` is the same shape and the only other one in the
+// pinned lib set.
+func TestStandalone_TrioNotFusedWhenTheConstructorIsOnlyCallable(t *testing.T) {
+	const slice = `
+interface Symbol {
+    toString(): string;
+}
+
+interface SymbolConstructor {
+    readonly prototype: Symbol;
+    (description?: string | number): symbol;
+    for(key: string): symbol;
+}
+
+declare var Symbol: SymbolConstructor;
+`
+	astModule, printed := convertSlice(t, slice)
+	rootNS, ok := astModule.Module.Namespaces.Get("")
+	require.True(t, ok, "root namespace exists")
+
+	var classes, interfaces, vars int
+	for _, d := range rootNS.Decls {
+		switch d.(type) {
+		case *ast.ClassDecl:
+			classes++
+		case *ast.InterfaceDecl:
+			interfaces++
+		case *ast.VarDecl:
+			vars++
+		}
+	}
+	require.Equal(t, 0, classes, "no class synthesized")
+	require.Equal(t, 2, interfaces, "both interfaces survive")
+	require.Equal(t, 1, vars, "the binding survives")
+
+	require.Contains(t, printed, "fn (description?: string | number) -> symbol",
+		"the call signature survives, which is the whole point of holding back")
+
+	parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+		&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+	require.Empty(t, parseErrs, "printed output parses")
+	require.NotEmpty(t, parsedDecls)
 }


### PR DESCRIPTION
Refs #1309.

**Rewritten after rebasing over #1409, which changed what this PR is for.** It no longer fixes #1350 and no longer changes a single line of the generated tree. It is now a simplification that the rest of the stack needs.

## What changed underneath

#1409 fixed #1350 by a different route: `hasCtorReturning` stayed, and `ctorReturnNames` taught it to read `T[]` as `Array<T>` in shorthand, so `ArrayConstructor` matches. #1409 also takes the position that `Symbol` and `BigInt` are correctly unfused, which is where the earlier discussion on this PR landed too.

That leaves this PR reaching the same output by a shorter road. Recognition drops the return-type condition entirely and reads only the three names and the var's annotation, which is the rule `tryFuseTrio` in `internal/interop/class_shapes.go` has always applied. `hasCtorReturning` and `ctorReturnNames` both lose their only caller and go, along with `TestCtorReturnNames`.

`Symbol` and `BigInt` still do not fuse, for a reason stated where it belongs. A constructor interface with a call signature and no `new` describes something callable and not constructible, and `fuseTrio` has no class elem for a call signature, so the fused class could be neither called nor constructed. The guard says that; the return-type check said it only by accident.

**Regenerating the tree on this branch produces no diff against `main`.** Same 49 files, byte for byte.

## Why it is still in the stack

`IteratorConstructor` declares no `new` at all, so `hasCtorReturning` rejects it however it reads return types. #1414 and #1410 make that interface and the `Iterator` binding visible in the first place, and this is what lets the three sides fuse once they are. Without it `Iterator` stays three declarations.

So this is a prerequisite rather than a fix on its own. If you would rather not carry a no-op PR, it folds into #1414 cleanly — say the word.

## Tests

`TestStandalone_TrioFusesWhateverTheConstructorDeclares` is a table over three shapes: a constructor interface with no `new`, one whose `new` returns an array type, and one callable but not constructible. #1409's `TestStandalone_ArrayShorthandTrio` still passes unchanged, since dropping the condition can only widen what matches.

## Stack

#1413 → **this** → #1414 → #1410 → #1421, all rebased onto `ed1b4ed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193