### PR TITLE
Route only what a lib file contributes to the global scope

### DIFF
--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -58,7 +58,10 @@ type StandaloneModule struct {
 //   - Flattens `declare namespace Foo { ... }` blocks: each member becomes
 //     a top-level declaration carrying `@js("Foo.member")`.
 //   - Lifts `declare global { ... }` blocks, converting what they hold
-//     as if it had been written beside the block. See liftGlobals.
+//     as if it had been written beside the block. Every other
+//     declaration is converted too, whatever the file's scope. Only the
+//     global tree cares which of them are actually global, and
+//     PartitionLibWithOverlay decides that through globalStatements.
 //   - Attaches an `@js("...")` decorator to every emitted top-level decl
 //     per planning/builtins/implementation_plan.md §3.3.
 //   - Forces `export` on every emitted decl.
@@ -229,11 +232,11 @@ type trioTable struct {
 // has never gated on a construct signature.
 //
 // A name that a `declare class` already declares is left alone. That
-// is a backstop, not the right answer: TypeScript merges an interface
-// into a same-named class, and mergeDecls cannot, so the pair stays
-// split whatever this does. Declining keeps the converter from adding
-// a second class beside the one the source spells out. #1430 covers
-// the merge.
+// is a backstop rather than the right answer. TypeScript merges an
+// interface into a same-named class and mergeDecls cannot, so the pair
+// stays split whatever this does. Declining only keeps the converter
+// from adding a second class beside the one the source spells out.
+// #1430 covers the merge.
 func detectTrios(stmts []dts_parser.Statement) *trioTable {
 	t := &trioTable{
 		byName:       make(map[string]*trioInfo),

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -1181,20 +1181,25 @@ declare var Symbol: SymbolConstructor;
 	require.NotEmpty(t, parsedDecls)
 }
 
-// A `lib.*.d.ts` file carrying `export {}` is a module, so what it adds
-// to the global scope has to be written inside `declare global { ... }`.
-// liftGlobals converts that block's contents as if they had been
-// written beside it, which is what puts them in reach of declaration
-// merging and trio detection. `lib.esnext.iterator.d.ts` is the one file
-// in the pinned set that needs this.
+// ConvertToStandaloneModule converts every declaration a file holds,
+// with each `declare global { ... }` block lifted so its contents are
+// converted as if written beside it. Whether those declarations are
+// actually global is a question only the global tree asks, and
+// PartitionLibWithOverlay answers it through globalStatements. Most
+// real `.d.ts` files are modules, so a single-file conversion that
+// emitted only their blocks would emit almost nothing.
 //
 // The snapshot carries what the counts and substring checks used to
-// assert separately: each member kind converts, the JSDoc inside the
-// block survives, and a lifted decl is addressed by its bare name with
-// no block prefix.
+// assert separately: the file's own interface converts alongside the
+// block's, the JSDoc inside the block survives, and a lifted decl is
+// addressed by its bare name with no block prefix.
 func TestStandalone_DeclareGlobalIsLifted(t *testing.T) {
 	const slice = `
 export {};
+
+interface Gadget {
+    tick(): void;
+}
 
 declare global {
     /** A global interface. */
@@ -1203,21 +1208,20 @@ declare global {
     }
 
     var widgetCount: number;
-
-    function makeWidget(): Widget;
 }
 `
 	_, printed := convertSlice(t, slice)
-	snaps.MatchInlineSnapshot(t, printed, snaps.Inline(`/** A global interface. */
+	snaps.MatchInlineSnapshot(t, printed, snaps.Inline(`export declare interface Gadget {
+    tick() -> unknown
+}
+
+/** A global interface. */
 export declare interface Widget {
     spin() -> unknown
 }
 
 @js("widgetCount")
 export declare var widgetCount: number
-
-@js("makeWidget")
-export declare fn makeWidget() -> Widget
 `))
 
 	parsedDecls, parseErrs := parser.ParseDecls(context.Background(),

--- a/internal/dts_to_esc/partition_writer.go
+++ b/internal/dts_to_esc/partition_writer.go
@@ -114,7 +114,7 @@ func PartitionLibWithOverlay(inputs []LibInput, overlay *Overlay) (*PartitionRes
 			return nil, fmt.Errorf("partition: nil module for %s", in.SourceFile)
 		}
 		dropped := DroppedSources.Contains(in.SourceFile)
-		for _, stmt := range liftGlobals(in.Module.Statements) {
+		for _, stmt := range globalStatements(in.Module.Statements) {
 			name := topLevelName(stmt)
 			if name == "" {
 				// Statement carries no addressable top-level name
@@ -223,13 +223,85 @@ func topLevelName(stmt dts_parser.Statement) string {
 	return ""
 }
 
+// globalStatements returns the declarations a lib file contributes to
+// the global scope.
+//
+// Which those are depends on whether the file is a script or a module.
+// A file with no import or export statement is a script, and everything
+// it declares is global, so a `declare global` block inside one adds
+// nothing and is simply lifted. A file carrying `export {}` or any
+// other import or export form is a module: its top-level declarations
+// are scoped to the module and are not global at all, so only what its
+// `declare global` blocks hold reaches the global scope.
+//
+// `lib.esnext.iterator.d.ts` is the one module in the pinned set, and
+// the distinction is what keeps its `Iterator` apart from the global one:
+//
+//	export {};
+//
+//	declare abstract class Iterator<T, TResult = undefined, TNext = unknown> { ... }
+//	interface Iterator<T, TResult, TNext> extends globalThis.IteratorObject<T, TResult, TNext> {}
+//	type IteratorObjectConstructor = typeof Iterator;
+//
+//	declare global {
+//	    interface IteratorObject<T, TReturn, TNext> { ... }
+//	    interface IteratorConstructor extends IteratorObjectConstructor { ... }
+//	    var Iterator: IteratorConstructor;
+//	}
+//
+// Those three module-scope declarations are a different `Iterator` from
+// the `interface Iterator<T, TReturn, TNext>` that `lib.es2015.iterable.d.ts`
+// declares globally. Routing them alongside it put two declarations
+// under one name in `std/iterator.esc` and gave mergeDecls a pair whose
+// type parameters TypeScript would never have merged, one written
+// `TResult` and the other `TReturn`.
+//
+// A block may legally name something from the module's own scope, and
+// dropping that scope leaves such a reference pointing at nothing. Here
+// `IteratorConstructor extends IteratorObjectConstructor` is the one
+// case, and trio fusion consumes that interface before anything reads
+// its bases, so no dangling name reaches the output. A module that
+// leaned harder on its own scope would need those declarations carried
+// over under generated names instead.
+func globalStatements(stmts []dts_parser.Statement) []dts_parser.Statement {
+	if !isModule(stmts) {
+		return liftGlobals(stmts)
+	}
+	var out []dts_parser.Statement
+	for _, stmt := range stmts {
+		if g, ok := stmt.(*dts_parser.GlobalDecl); ok {
+			out = append(out, liftGlobals(g.Statements)...)
+		}
+	}
+	return out
+}
+
+// isModule reports whether a statement list carries an import or export
+// form, which is what makes a `.d.ts` file a module rather than a script.
+// Both spellings count: a standalone statement such as `export {}` or
+// `import ...`, and an `export` modifier on a declaration. This mirrors
+// isTopLevelExport in internal/dts_parser/classifier.go.
+func isModule(stmts []dts_parser.Statement) bool {
+	for _, stmt := range stmts {
+		switch stmt.(type) {
+		case *dts_parser.ImportDecl, *dts_parser.NamedExportStmt,
+			*dts_parser.ExportAllStmt, *dts_parser.ExportAssignmentStmt,
+			*dts_parser.ExportAsNamespaceStmt:
+			return true
+		}
+		if decl, ok := stmt.(dts_parser.Decl); ok && decl.Export() {
+			return true
+		}
+	}
+	return false
+}
+
 // liftGlobals replaces each `declare global { ... }` block with the
-// statements it holds, leaving every other statement where it is. A
-// block has no addressable name, so topLevelName returns "" for it and
-// routing drops everything inside. What it holds is global
-// declarations, which is what the surrounding list already holds, so
-// lifting is the whole conversion. A block may hold another, and the
-// walk recurses through them.
+// statements it holds, leaving every other statement where it is.
+// globalStatements calls it for a script, where the surrounding
+// declarations are global too, and for the blocks of a module, where
+// they are the only global declarations the file has. A block may hold
+// another, and the walk recurses through them.
 //
 // It does not reach into `declare module "x" { declare global { ... } }`.
 // convertStandaloneStmt skips ModuleDecl outright, so an ambient

--- a/internal/dts_to_esc/partition_writer_test.go
+++ b/internal/dts_to_esc/partition_writer_test.go
@@ -1033,3 +1033,73 @@ func TestDedupeMembers_UnprintableMember(t *testing.T) {
 		require.EqualError(t, err, "cannot print a nil object type member")
 	})
 }
+
+// What a lib file contributes to the global scope depends on whether it
+// is a script or a module. A module's `declare global` block completes a
+// trio whose instance interface another file declares globally, while
+// the module's own top-level declarations stay out of the global scope.
+// `lib.esnext.iterator.d.ts` is the one module in the pinned set, and
+// this is what keeps its `Iterator` apart from the global `Iterator`
+// that `lib.es2015.iterable.d.ts` declares.
+//
+// The snapshot is the assertion. One declaration named `Iterator` reaches
+// the bucket, carrying the script's `TReturn` parameter and its `next`,
+// with `prototype` from the block's constructor interface as a static.
+// The module's own `Iterator` class and its `IteratorObjectConstructor`
+// alias are absent, which is what routing only the block achieves.
+func TestPartitionLib_ModuleContributesOnlyItsGlobalBlock(t *testing.T) {
+	t.Parallel()
+	script := parseLib(t, "lib.es2015.iterable.d.ts", `
+interface Iterator<T, TReturn = any> { next(): T; }
+`)
+	module_ := parseLib(t, "lib.esnext.iterator.d.ts", `
+export {};
+
+declare abstract class Iterator<T, TResult = undefined> { abstract next(): T; }
+type IteratorObjectConstructor = typeof Iterator;
+
+declare global {
+    interface IteratorConstructor { readonly prototype: Iterator<any>; }
+    var Iterator: IteratorConstructor;
+}
+`)
+
+	res, err := PartitionLib([]LibInput{script, module_})
+	require.NoError(t, err)
+
+	mod, err := ConvertBucket(res.Buckets["std:iterator"])
+	require.NoError(t, err)
+	printed, err := RenderStandaloneModule(mod)
+	require.NoError(t, err)
+	snaps.MatchInlineSnapshot(t, printed, snaps.Inline(`@js("Iterator")
+export declare class Iterator<T, TReturn = any> {
+    next(mut self) -> T,
+    static readonly prototype: Iterator<any>
+}
+`))
+}
+
+// A script's `declare global` block adds nothing to what is already
+// global, so lifting it leaves every declaration routable.
+func TestPartitionLib_ScriptKeepsItsOwnDeclarations(t *testing.T) {
+	t.Parallel()
+	lib := parseLib(t, "lib.es5.d.ts", `
+interface Boolean { valueOf(): boolean; }
+
+declare global {
+    interface Number { toFixed(digits?: number): string; }
+}
+`)
+
+	res, err := PartitionLib([]LibInput{lib})
+	require.NoError(t, err)
+
+	var names []string
+	for _, stmts := range res.Buckets {
+		for _, stmt := range stmts {
+			names = append(names, topLevelName(stmt))
+		}
+	}
+	require.ElementsMatch(t, []string{"Boolean", "Number"}, names,
+		"the block is lifted and the script's own declaration is kept")
+}

--- a/internal/interop/data/std/iterator.esc
+++ b/internal/interop/data/std/iterator.esc
@@ -56,10 +56,17 @@ export declare interface IteratorReturnResult<TReturn> {
 
 export declare type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | IteratorReturnResult<TReturn>
 
-export declare interface Iterator<T, TReturn = any, TNext = any> extends globalThis.IteratorObject<T, TReturn, TNext> {
-    next(...value: [] | [TNext]) -> IteratorResult<T, TReturn>,
-    return?: fn (value?: TReturn) -> IteratorResult<T, TReturn>,
-    throw?: fn (e?: any) -> IteratorResult<T, TReturn>
+@js("Iterator")
+export declare class Iterator<T, TReturn = any, TNext = any> {
+    next(mut self, ...value: [] | [TNext]) -> IteratorResult<T, TReturn>,
+    return(mut self, value?: TReturn) -> IteratorResult<T, TReturn>,
+    throw(mut self, e?: any) -> IteratorResult<T, TReturn>,
+    /**
+     * Creates a native iterator from an iterator or iterable object.
+     * Returns its input if the input already inherits from the built-in Iterator class.
+     * @param value An iterator or iterable object to convert a native iterator.
+     */
+    static from<T>(value: Iterator<T, unknown, undefined> | Iterable<T, unknown, undefined>) -> IteratorObject<T, undefined, unknown>
 }
 
 export declare interface Iterable<T, TReturn = any, TNext = any> {
@@ -165,22 +172,3 @@ export declare interface IteratorObject<T, TReturn = unknown, TNext = unknown> e
  * This is `undefined` when `strictBuiltInIteratorReturn` is `true`; otherwise, this is `any`.
  */
 export declare type BuiltinIteratorReturn = intrinsic
-
-@js("Iterator")
-export declare class Iterator<T, TResult = undefined, TNext = unknown> {
-    next(mut self, value?: TNext) -> IteratorResult<T, TResult>
-}
-
-export declare type IteratorObjectConstructor = typeof Iterator
-
-export declare interface IteratorConstructor extends IteratorObjectConstructor {
-    /**
-     * Creates a native iterator from an iterator or iterable object.
-     * Returns its input if the input already inherits from the built-in Iterator class.
-     * @param value An iterator or iterable object to convert a native iterator.
-     */
-    from<T>(value: Iterator<T, unknown, undefined> | Iterable<T, unknown, undefined>) -> IteratorObject<T, undefined, unknown>
-}
-
-@js("Iterator")
-export declare var Iterator: IteratorConstructor


### PR DESCRIPTION
Fixes #1404.

Second half of #1404. The first half, on the branch this is based on, lifted `declare global` blocks so their contents route at all. This settles which of a file's declarations are global in the first place.

## The rule

A `.d.ts` file with no import or export form is a **script**, and everything it declares is global. A file carrying `export {}`, any other import or export statement, or an `export` modifier on a declaration is a **module**: its top-level declarations are scoped to the module and are not global at all, so only its `declare global` blocks reach the global scope. `PartitionLibWithOverlay` now routes on that distinction.

## Why it is the root fix

`lib.esnext.iterator.d.ts` is the one module in the pinned set:

```ts
export {};

declare abstract class Iterator<T, TResult = undefined, TNext = unknown> { ... }
interface Iterator<T, TResult, TNext> extends globalThis.IteratorObject<T, TResult, TNext> {}
type IteratorObjectConstructor = typeof Iterator;

declare global {
    interface IteratorObject<T, TReturn, TNext> { /* the iterator helpers */ }
    interface IteratorConstructor extends IteratorObjectConstructor { from<T>(...): ... }
    var Iterator: IteratorConstructor;
}
```

Those three module-scope declarations describe a **different** `Iterator` from the `interface Iterator<T, TReturn, TNext>` that `lib.es2015.iterable.d.ts` declares globally. Routing them alongside it caused both problems the first half exposed:

1. Two declarations named `Iterator` in `std/iterator.esc`.
2. `mergeDecls` folded `interface Iterator<T, TResult, TNext>` into `interface Iterator<T, TReturn, TNext>`, keeping the first's type parameters and concatenating the second's extends clause. The result named `TResult` with nothing declaring it. TypeScript never merges those two — merging requires identical type parameters, and these are in different scopes.

I scanned the pinned set for the general form of problem 2: of 145 interface names declared more than once, `Iterator` is the **only** one whose later declaration uses different type-parameter names. So the scope rule removes the sole case rather than papering over a class of them.

## Result

`std/iterator.esc` now carries one declaration named `Iterator`, and it is a class. The globally declared interface is the instance side, and `IteratorConstructor` plus the binding from inside the block complete the trio:

```
@js("Iterator")
export declare class Iterator<T, TReturn = any, TNext = any> {
    next(mut self, ...value: [] | [TNext]) -> IteratorResult<T, TReturn>,
    return(mut self, value?: TReturn) -> IteratorResult<T, TReturn>,
    throw(mut self, e?: any) -> IteratorResult<T, TReturn>,
    static from<T>(value: Iterator<T, unknown, undefined> | Iterable<T, unknown, undefined>) -> IteratorObject<T, undefined, unknown>
}
```

`IteratorObject` carries every member its two declarations give it. Generating the tree twice is byte-identical.

Against #1404's gate: `IteratorObject` has all its members ✅, `IteratorConstructor` and the `Iterator` binding are no longer lost ✅ — better than the gate asked, since fusion consumes them into the class rather than emitting them loose — and there is one declaration named `Iterator` rather than two ✅.

## Scope of the change

`ConvertToStandaloneModule` keeps converting everything a file holds, with blocks lifted. Most real `.d.ts` files are modules, so a single-file conversion that emitted only their blocks would emit almost nothing. Only the global tree asks which declarations are global, so only the partition path applies the rule.

## Known limitation

A `declare global` block may legally name something from its module's own scope, and dropping that scope leaves such a reference pointing at nothing. Here `interface IteratorConstructor extends IteratorObjectConstructor` is the one case, and trio fusion consumes that interface before anything reads its bases, so no dangling name reaches the output. A module that leaned harder on its own scope would need those declarations carried over under generated names instead. This is stated in the comment on `globalStatements`.

## Left for separate issues

- **`IteratorObject` carries `[Symbol.iterator]()` twice**, once from each of its two declarations. This is faithful — TypeScript merges both into the overload set — but redundant. `Map`'s `constructor(mut self)` and `Object.keys` are duplicated the same way on `main`, so it is a pre-existing merge wart rather than anything this introduces. Deduping needs structural member equality, which `dts_parser` has no facility for.
- **`printInterfaceDecl` never emits an `extends` clause**, though `convertInterfaceDecl` populates `InterfaceDecl.Extends`. Every interface in the generated tree is missing its bases. Unrelated to scope and much wider than `Iterator`.

## Review

`/code-review` at high raised seven findings; five are fixed here. `isModule` now also counts an `export` modifier on a declaration, matching `isTopLevelExport` in `internal/dts_parser/classifier.go`. The single-file path no longer applies the module rule, which was the finding that it would emit an empty file for any module `.d.ts`. Three comment defects are corrected.

The two not fixed are called out above and in the stack note below.

## Stack

Based on `claude/issue-1404-declare-global` → `claude/issue-1309-trio-ctor-gate` (#1405) → `claude/dts-ctor-side-interfaces` → `main`.

**One finding from this review lands on #1405, not here, and it is a regression that PR should settle before merging.** Dropping the construct-signature gate makes `SymbolConstructor` and `BigIntConstructor` fuse, and `fuseTrio` drops `CallSignature`, so `Symbol("x")` and `BigInt(1)` lose their only typed form. On `main` they survive as `fn (description?: string | number) -> symbol` on the interface. I described this as pre-existing in #1405's body; that is wrong for these two names, and I have corrected it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193)_