### PR TITLE
Keep a constructor-side interface out of singleton flattening

### DIFF
--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -247,6 +247,40 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 	return t
 }
 
+// hasConstructSignature reports whether iface declares at least one
+// `new (...)` member.
+func hasConstructSignature(iface *dts_parser.InterfaceDecl) bool {
+	for _, m := range iface.Members {
+		if _, ok := m.(*dts_parser.ConstructSignature); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// namesWithConstructSignature returns every interface name that some
+// top-level declaration gives a `new (...)` member. TypeScript merges
+// repeated `interface Foo` declarations, so reading a single statement
+// per name would miss a construct signature written on the second one.
+//
+// A signature inherited through `extends` is not counted. A heritage
+// clause can name a type alias, as `IteratorConstructor` does, so
+// following one takes name resolution this layer does not do. No
+// interface the singleton path can reach carries one today.
+func namesWithConstructSignature(stmts []dts_parser.Statement) set.Set[string] {
+	names := set.NewSet[string]()
+	for _, stmt := range stmts {
+		iface, ok := stmt.(*dts_parser.InterfaceDecl)
+		if !ok {
+			continue
+		}
+		if hasConstructSignature(iface) {
+			names.Add(iface.Name.Name)
+		}
+	}
+	return names
+}
+
 // singletonInfo records an interface+var-singleton pair recognized at
 // the module level: `interface Foo { ... }` + `declare var Foo: Foo`,
 // where the interface name is not referenced as a type anywhere else
@@ -275,7 +309,10 @@ type singletonTable struct {
 //   - A `declare var Foo: Foo` whose type annotation is a bare
 //     TypeReference to the same name as the var.
 //   - A matching top-level `interface Foo` declaration that is not
-//     already consumed by trio detection.
+//     already consumed by trio detection and that declares no
+//     `new (...)` member. Flattening turns each member into its own
+//     top-level decl, and a construct signature has no such form, so
+//     flattening one would drop it without a trace.
 //   - No other TypeReference to `Foo` anywhere else in the module
 //     (the candidate var's own type contributes the only legal
 //     reference). Self-references inside the interface body, references
@@ -301,9 +338,13 @@ func detectSingletons(stmts []dts_parser.Statement, trios *trioTable) *singleton
 			vars[s.Name.Name] = s
 		}
 	}
+	constructible := namesWithConstructSignature(stmts)
 
 	for name, iface := range interfaces {
 		if trios.byName[name] != nil || trios.consumedCtor.Contains(name) || trios.consumedVar.Contains(name) {
+			continue
+		}
+		if constructible.Contains(name) {
 			continue
 		}
 		v, hasVar := vars[name]

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -916,3 +916,137 @@ export declare class Promise<T, E = never> {
     static resolve<T>(value: T) -> Promise<T>
 }`))
 }
+
+// An interface carrying `new (...)` describes the constructor side of
+// a class: the object you call `new` on, not the instances it builds.
+// Recognising a class needs a separate instance interface too, which is
+// what the trio idiom supplies through `interface Foo` beside
+// `interface FooConstructor`. On its own such an interface is preserved
+// as written, never flattened and never fused.
+//
+// The flattening half is the one that used to go wrong. flattenSingleton
+// gives each member its own top-level decl and has no such form for a
+// `new`, so it dropped the construct signature and, for an interface
+// whose only member is a `new`, emitted nothing at all.
+func TestStandalone_InterfaceWithConstructSignatureIsPreserved(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		interfaces int
+		vars       int
+		contains   []string
+	}{
+		{
+			// Verbatim from lib.scripthost.d.ts. It is the only
+			// interface in TypeScript's shipped lib files that carries
+			// a construct signature alongside a `declare var` of the
+			// same name. Its sole member is the `new`, so before
+			// construct signatures excluded an interface from singleton
+			// detection both declarations vanished.
+			name: "ActiveXObject",
+			input: `
+interface ActiveXObject {
+    new (s: string): any;
+}
+declare var ActiveXObject: ActiveXObject;
+`,
+			interfaces: 1,
+			vars:       1,
+			contains: []string{
+				"new (s: string) -> any",
+				"export declare var ActiveXObject: ActiveXObject",
+			},
+		},
+		{
+			// Verbatim from lib.dom.d.ts. Other declarations reference
+			// it structurally, and it has no `declare var`, so it is a
+			// constructor-shaped type rather than a class.
+			name: "CustomElementConstructor",
+			input: `
+interface CustomElementConstructor {
+    new (...params: any[]): HTMLElement;
+}
+`,
+			interfaces: 1,
+			contains:   []string{"new (...params: Array<any>) -> HTMLElement"},
+		},
+		{
+			// A `new` returning the interface's own name says either
+			// that constructing yields the constructor object again or
+			// that it yields an instance which is itself constructible.
+			// Neither describes a class, so this is preserved like any
+			// other constructor-side interface.
+			name: "construct signature returning the interface itself",
+			input: `
+interface Foo {
+    new (s: string): Foo;
+    bar(): void;
+}
+declare var Foo: Foo;
+`,
+			interfaces: 1,
+			vars:       1,
+			contains:   []string{"new (s: string) -> Foo", "bar() -> unknown"},
+		},
+		{
+			// TypeScript merges the two declarations, and a map keyed
+			// by name keeps only the last. The construct signature sits
+			// on the first, so reading one declaration per name misses
+			// it and flattens `bar` to a top-level decl.
+			//
+			// The `new` returns `HTMLElement` rather than `Foo` so that
+			// detectSingletons' own reference count does not decline
+			// the pair for an unrelated reason. This case has to fail
+			// when the construct-signature scan reads a single
+			// declaration, not merely when it is absent.
+			name: "construct signature on a merged declaration",
+			input: `
+interface Foo {
+    new (s: string): HTMLElement;
+}
+interface Foo {
+    bar(): void;
+}
+declare var Foo: Foo;
+`,
+			interfaces: 2,
+			vars:       1,
+			contains:   []string{"new (s: string) -> HTMLElement"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			astModule, printed := convertSlice(t, test.input)
+			rootNS, ok := astModule.Module.Namespaces.Get("")
+			require.True(t, ok, "root namespace exists")
+
+			var classes, interfaces, vars, funcs int
+			for _, d := range rootNS.Decls {
+				switch d.(type) {
+				case *ast.ClassDecl:
+					classes++
+				case *ast.InterfaceDecl:
+					interfaces++
+				case *ast.VarDecl:
+					vars++
+				case *ast.FuncDecl:
+					funcs++
+				}
+			}
+			require.Equal(t, 0, classes, "no class is synthesized")
+			require.Equal(t, 0, funcs, "no member is flattened to a top-level decl")
+			require.Equal(t, test.interfaces, interfaces, "InterfaceDecl count")
+			require.Equal(t, test.vars, vars, "VarDecl count")
+
+			for _, want := range test.contains {
+				require.Contains(t, printed, want)
+			}
+
+			parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+				&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+			require.Empty(t, parseErrs, "printed output parses")
+			require.NotEmpty(t, parsedDecls)
+		})
+	}
+}


### PR DESCRIPTION
Refs #679.

This shape converts to **nothing at all**:

```ts
// lib.scripthost.d.ts
interface ActiveXObject {
    new (s: string): any;
}
declare var ActiveXObject: ActiveXObject;
```

`detectSingletons` matches the pair as `interface Foo` + `declare var Foo: Foo`, and `flattenSingleton` gives each member its own top-level declaration. A construct signature has no such form, so it skips the only member and both declarations vanish without a trace — no output, no diagnostic, and no entry in `StandaloneModule.KeyDrops`, which only records members skipped for an unnameable key.

`detectSingletons` now declines any interface that declares a `new (...)` member, so the pair survives as an interface plus a var. That is the right shape for it: an interface carrying `new (...)` describes the constructor side of a class — the object `new` is called on, not the instances it builds — which is the role `FooConstructor` plays in the trio idiom.

The check reads `namesWithConstructSignature`, which scans every statement rather than one interface per name. TypeScript merges repeated `interface Foo` declarations, so the construct signature can sit on the second one while a last-wins map sees only the first.

## Where this came from

#1391 implemented #679, which proposed recognising an interface carrying `new (...)` as a class. Working through the shapes showed that premise does not hold — such an interface is always the constructor side, and naming a class needs a separate instance interface beside it. #679 is closed as not planned, and this is the one real defect that surfaced along the way. It is a flattening bug rather than a fusion gap, so it stands on its own.

## Effect on the generated tree

None. `lib.scripthost.d.ts` is dropped by the partition, so the only corpus instance of this shape never reaches the converter. Generating the tree over `node_modules/typescript/lib` is byte-identical to `main`.

That makes this a converter-correctness fix rather than an output change: it stops a silent loss that the pinned corpus happens not to trigger today.

## Tests

`TestStandalone_InterfaceWithConstructSignatureIsPreserved` is a table over four shapes, asserting zero classes, zero flattened functions, and that the `new` survives in the printed output:

- `ActiveXObject` verbatim from `lib.scripthost.d.ts` — the shape that used to vanish.
- `CustomElementConstructor` verbatim from `lib.dom.d.ts` — a constructor-shaped type with no `declare var`, which other declarations reference structurally.
- An interface whose `new` returns the interface's own name.
- A construct signature on the second of two merged declarations, which is what `namesWithConstructSignature` exists for.

I checked the merged-declaration case is not vacuous by disabling the guard and confirming it fails.

## Stack

Bottom of a four-PR stack. #1405 is based on this branch and calls `hasConstructSignature`, which this adds, so it is a compile-time dependency rather than just branch order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where interfaces containing constructor signatures could be incorrectly simplified during declaration processing.
  - Constructor members are now preserved for standalone interfaces, interfaces paired with variables, self-returning constructors, and repeated interface declarations.
  - Generated declarations remain complete and parseable in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->