### PR TITLE
Convert what a `declare global` block holds

### DIFF
--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -57,6 +57,8 @@ type StandaloneModule struct {
 //     constructor from `FooConstructor`).
 //   - Flattens `declare namespace Foo { ... }` blocks: each member becomes
 //     a top-level declaration carrying `@js("Foo.member")`.
+//   - Lifts `declare global { ... }` blocks, converting what they hold
+//     as if it had been written beside the block. See liftGlobals.
 //   - Attaches an `@js("...")` decorator to every emitted top-level decl
 //     per planning/builtins/implementation_plan.md §3.3.
 //   - Forces `export` on every emitted decl.
@@ -71,12 +73,13 @@ type StandaloneModule struct {
 //     key has no plain-name form (see StandaloneModule.KeyDrops).
 func ConvertToStandaloneModule(dtsModule *dts_parser.Module) (*StandaloneModule, error) {
 	cctx := &convertCtx{}
-	trios := detectTrios(dtsModule.Statements)
-	singletons := detectSingletons(dtsModule.Statements, trios)
+	stmts := liftGlobals(dtsModule.Statements)
+	trios := detectTrios(stmts)
+	singletons := detectSingletons(stmts, trios)
 	paths := make(map[ast.Decl]string)
 
 	var decls []ast.Decl
-	for _, stmt := range dtsModule.Statements {
+	for _, stmt := range stmts {
 		emitted, err := convertStandaloneStmt(cctx, stmt, trios, singletons, "")
 		if err != nil {
 			return nil, err
@@ -224,6 +227,13 @@ type trioTable struct {
 //
 // This matches tryFuseTrio in internal/interop/class_shapes.go, which
 // has never gated on a construct signature.
+//
+// A name that a `declare class` already declares is left alone. That
+// is a backstop, not the right answer: TypeScript merges an interface
+// into a same-named class, and mergeDecls cannot, so the pair stays
+// split whatever this does. Declining keeps the converter from adding
+// a second class beside the one the source spells out. #1430 covers
+// the merge.
 func detectTrios(stmts []dts_parser.Statement) *trioTable {
 	t := &trioTable{
 		byName:       make(map[string]*trioInfo),
@@ -233,16 +243,25 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 
 	interfaces := make(map[string]*dts_parser.InterfaceDecl)
 	vars := make(map[string]*dts_parser.VarDecl)
+	classes := set.NewSet[string]()
 	for _, stmt := range stmts {
 		switch s := stmt.(type) {
 		case *dts_parser.InterfaceDecl:
 			interfaces[s.Name.Name] = s
 		case *dts_parser.VarDecl:
 			vars[s.Name.Name] = s
+		case *dts_parser.ClassDecl:
+			classes.Add(s.Name.Name)
 		}
 	}
 
 	for name, inst := range interfaces {
+		// A `declare class Foo` already declares the name as a class.
+		// Fusing would emit a second one beside it. See #1430 for why
+		// the pair stays split either way.
+		if classes.Contains(name) {
+			continue
+		}
 		ctorName := name + "Constructor"
 		ctor, hasCtor := interfaces[ctorName]
 		if !hasCtor {
@@ -964,7 +983,7 @@ func convertStandaloneStmt(
 	case *dts_parser.EnumDecl, *dts_parser.ImportDecl,
 		*dts_parser.NamedExportStmt, *dts_parser.ExportAllStmt,
 		*dts_parser.ExportAsNamespaceStmt, *dts_parser.ExportAssignmentStmt,
-		*dts_parser.ModuleDecl, *dts_parser.GlobalDecl:
+		*dts_parser.ModuleDecl:
 		// Skip MVP-out-of-scope statements silently. §6 will tighten
 		// the unmapped-symbol fail-safe; for the MVP we just drop.
 		return nil, nil

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -1180,3 +1180,102 @@ declare var Symbol: SymbolConstructor;
 	require.Empty(t, parseErrs, "printed output parses")
 	require.NotEmpty(t, parsedDecls)
 }
+
+// A `lib.*.d.ts` file carrying `export {}` is a module, so what it adds
+// to the global scope has to be written inside `declare global { ... }`.
+// liftGlobals converts that block's contents as if they had been
+// written beside it, which is what puts them in reach of declaration
+// merging and trio detection. `lib.esnext.iterator.d.ts` is the one file
+// in the pinned set that needs this.
+//
+// The snapshot carries what the counts and substring checks used to
+// assert separately: each member kind converts, the JSDoc inside the
+// block survives, and a lifted decl is addressed by its bare name with
+// no block prefix.
+func TestStandalone_DeclareGlobalIsLifted(t *testing.T) {
+	const slice = `
+export {};
+
+declare global {
+    /** A global interface. */
+    interface Widget {
+        spin(): void;
+    }
+
+    var widgetCount: number;
+
+    function makeWidget(): Widget;
+}
+`
+	_, printed := convertSlice(t, slice)
+	snaps.MatchInlineSnapshot(t, printed, snaps.Inline(`/** A global interface. */
+export declare interface Widget {
+    spin() -> unknown
+}
+
+@js("widgetCount")
+export declare var widgetCount: number
+
+@js("makeWidget")
+export declare fn makeWidget() -> Widget
+`))
+
+	parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+		&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+	require.Empty(t, parseErrs, "printed output parses")
+	require.Len(t, parsedDecls, 3)
+}
+
+// A trio whose instance name is already declared by a `declare class`
+// is left alone, so the converter does not add a second class beside
+// the one the source spells out. `lib.esnext.iterator.d.ts` writes
+// `Iterator` that way: an abstract class at module scope, and
+// `IteratorConstructor` plus the binding inside its `declare global`
+// block.
+//
+// The snapshot pins current behaviour, not the right answer. TypeScript
+// merges `interface Foo` into `class Foo`, so what this input means is
+// one class carrying `next` and `peek` as instance members and `from`
+// as a static. mergeDecls folds an interface into an interface and not
+// into a class, so the pair stays split whether or not the trio fuses,
+// and declining only keeps the split from getting wider. #1430 covers
+// the merge and takes this guard out with it.
+func TestStandalone_TrioDeclinedWhenNameIsAlreadyAClass(t *testing.T) {
+	const slice = `
+declare abstract class Foo {
+    next(): string;
+}
+
+interface Foo {
+    peek(): string;
+}
+
+interface FooConstructor {
+    from(s: string): Foo;
+}
+
+declare var Foo: FooConstructor;
+`
+	_, printed := convertSlice(t, slice)
+	snaps.MatchInlineSnapshot(t, printed, snaps.Inline(`@js("Foo")
+export declare class Foo {
+    next(mut self) -> string
+}
+
+export declare interface Foo {
+    peek() -> string
+}
+
+export declare interface FooConstructor {
+    from(s: string) -> Foo
+}
+
+@js("Foo")
+export declare var Foo: FooConstructor
+`))
+
+	parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+		&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+	require.Empty(t, parseErrs, "printed output parses")
+	require.Len(t, parsedDecls, 4)
+}

--- a/internal/dts_to_esc/partition_writer.go
+++ b/internal/dts_to_esc/partition_writer.go
@@ -114,7 +114,7 @@ func PartitionLibWithOverlay(inputs []LibInput, overlay *Overlay) (*PartitionRes
 			return nil, fmt.Errorf("partition: nil module for %s", in.SourceFile)
 		}
 		dropped := DroppedSources.Contains(in.SourceFile)
-		for _, stmt := range in.Module.Statements {
+		for _, stmt := range liftGlobals(in.Module.Statements) {
 			name := topLevelName(stmt)
 			if name == "" {
 				// Statement carries no addressable top-level name
@@ -221,6 +221,43 @@ func topLevelName(stmt dts_parser.Statement) string {
 		return s.Name.Name
 	}
 	return ""
+}
+
+// liftGlobals replaces each `declare global { ... }` block with the
+// statements it holds, leaving every other statement where it is. A
+// block has no addressable name, so topLevelName returns "" for it and
+// routing drops everything inside. What it holds is global
+// declarations, which is what the surrounding list already holds, so
+// lifting is the whole conversion. A block may hold another, and the
+// walk recurses through them.
+//
+// It does not reach into `declare module "x" { declare global { ... } }`.
+// convertStandaloneStmt skips ModuleDecl outright, so an ambient
+// module's contents are dropped whether or not a block sits inside one.
+// No file in the pinned lib set writes a block that way.
+func liftGlobals(stmts []dts_parser.Statement) []dts_parser.Statement {
+	// Most inputs carry no block at all, so return the original slice
+	// rather than copying every statement into a new one.
+	hasGlobal := false
+	for _, stmt := range stmts {
+		if _, ok := stmt.(*dts_parser.GlobalDecl); ok {
+			hasGlobal = true
+			break
+		}
+	}
+	if !hasGlobal {
+		return stmts
+	}
+
+	out := make([]dts_parser.Statement, 0, len(stmts))
+	for _, stmt := range stmts {
+		if g, ok := stmt.(*dts_parser.GlobalDecl); ok {
+			out = append(out, liftGlobals(g.Statements)...)
+			continue
+		}
+		out = append(out, stmt)
+	}
+	return out
 }
 
 // mergeDecls performs TS-style declaration merging within a routed

--- a/internal/interop/data/std/iterator.esc
+++ b/internal/interop/data/std/iterator.esc
@@ -77,7 +77,87 @@ export declare interface IterableIterator<T, TReturn = any, TNext = any> extends
  * Describes an {@link Iterator} produced by the runtime that inherits from the intrinsic `Iterator.prototype`.
  */
 export declare interface IteratorObject<T, TReturn = unknown, TNext = unknown> extends Iterator<T, TReturn, TNext>, Disposable {
-    [Symbol.iterator]() -> IteratorObject<T, TReturn, TNext>
+    [Symbol.iterator]() -> IteratorObject<T, TReturn, TNext>,
+    /**
+     * Returns this iterator.
+     */
+    [Symbol.iterator]() -> IteratorObject<T, TReturn, TNext>,
+    /**
+     * Creates an iterator whose values are the result of applying the callback to the values from this iterator.
+     * @param callbackfn A function that accepts up to two arguments to be used to transform values from the underlying iterator.
+     */
+    map<U>(callbackfn: fn (value: T, index: number) -> U) -> IteratorObject<U, undefined, unknown>,
+    /**
+     * Creates an iterator whose values are those from this iterator for which the provided predicate returns true.
+     * @param predicate A function that accepts up to two arguments to be used to test values from the underlying iterator.
+     */
+    filter<S: T>(predicate: fn (value: T, index: number) -> boolean) -> IteratorObject<S, undefined, unknown>,
+    /**
+     * Creates an iterator whose values are those from this iterator for which the provided predicate returns true.
+     * @param predicate A function that accepts up to two arguments to be used to test values from the underlying iterator.
+     */
+    filter(predicate: fn (value: T, index: number) -> unknown) -> IteratorObject<T, undefined, unknown>,
+    /**
+     * Creates an iterator whose values are the values from this iterator, stopping once the provided limit is reached.
+     * @param limit The maximum number of values to yield.
+     */
+    take(limit: number) -> IteratorObject<T, undefined, unknown>,
+    /**
+     * Creates an iterator whose values are the values from this iterator after skipping the provided count.
+     * @param count The number of values to drop.
+     */
+    drop(count: number) -> IteratorObject<T, undefined, unknown>,
+    /**
+     * Creates an iterator whose values are the result of applying the callback to the values from this iterator and then flattening the resulting iterators or iterables.
+     * @param callback A function that accepts up to two arguments to be used to transform values from the underlying iterator into new iterators or iterables to be flattened into the result.
+     */
+    flatMap<U>(callback: fn (value: T, index: number) -> Iterator<U, unknown, undefined> | Iterable<U, unknown, undefined>) -> IteratorObject<U, undefined, unknown>,
+    /**
+     * Calls the specified callback function for all the elements in this iterator. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to three arguments. The reduce method calls the callbackfn function one time for each element in the iterator.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of a value from the iterator.
+     */
+    reduce(callbackfn: fn (previousValue: T, currentValue: T, currentIndex: number) -> T) -> T,
+    reduce(callbackfn: fn (previousValue: T, currentValue: T, currentIndex: number) -> T, initialValue: T) -> T,
+    /**
+     * Calls the specified callback function for all the elements in this iterator. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to three arguments. The reduce method calls the callbackfn function one time for each element in the iterator.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of a value from the iterator.
+     */
+    reduce<U>(callbackfn: fn (previousValue: U, currentValue: T, currentIndex: number) -> U, initialValue: U) -> U,
+    /**
+     * Creates a new array from the values yielded by this iterator.
+     */
+    toArray() -> mut Array<T>,
+    /**
+     * Performs the specified action for each element in the iterator.
+     * @param callbackfn A function that accepts up to two arguments. forEach calls the callbackfn function one time for each element in the iterator.
+     */
+    forEach(callbackfn: fn (value: T, index: number) -> unknown) -> unknown,
+    /**
+     * Determines whether the specified callback function returns true for any element of this iterator.
+     * @param predicate A function that accepts up to two arguments. The some method calls
+     * the predicate function for each element in this iterator until the predicate returns a value
+     * true, or until the end of the iterator.
+     */
+    some(predicate: fn (value: T, index: number) -> unknown) -> boolean,
+    /**
+     * Determines whether all the members of this iterator satisfy the specified test.
+     * @param predicate A function that accepts up to two arguments. The every method calls
+     * the predicate function for each element in this iterator until the predicate returns
+     * false, or until the end of this iterator.
+     */
+    every(predicate: fn (value: T, index: number) -> unknown) -> boolean,
+    /**
+     * Returns the value of the first element in this iterator where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of this iterator, in
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     */
+    find<S: T>(predicate: fn (value: T, index: number) -> boolean) -> S | undefined,
+    find(predicate: fn (value: T, index: number) -> unknown) -> T | undefined,
+    readonly [Symbol.toStringTag]: string
 }
 
 /**
@@ -92,3 +172,15 @@ export declare class Iterator<T, TResult = undefined, TNext = unknown> {
 }
 
 export declare type IteratorObjectConstructor = typeof Iterator
+
+export declare interface IteratorConstructor extends IteratorObjectConstructor {
+    /**
+     * Creates a native iterator from an iterator or iterable object.
+     * Returns its input if the input already inherits from the built-in Iterator class.
+     * @param value An iterator or iterable object to convert a native iterator.
+     */
+    from<T>(value: Iterator<T, unknown, undefined> | Iterable<T, unknown, undefined>) -> IteratorObject<T, undefined, unknown>
+}
+
+@js("Iterator")
+export declare var Iterator: IteratorConstructor


### PR DESCRIPTION
Refs #1404.

First half of #1404. `convertStandaloneStmt` listed `*dts_parser.GlobalDecl` among the statements it skips silently, and `topLevelName` returns `""` for it, so routing dropped everything inside a `declare global { ... }` block.

A `lib.*.d.ts` file carrying `export {}` is a module, so the declarations it adds to the global scope have to be written inside such a block. `lib.esnext.iterator.d.ts` is the one file in the pinned set that does this, and it puts `IteratorObject`'s twelve iterator-helper members, `IteratorConstructor`, and the `Iterator` binding there.

`liftGlobals` replaces each block with the statements it holds. That is the whole conversion: what the block holds is global declarations, and that is what the surrounding statement list already holds. It runs before routing in `PartitionLibWithOverlay` and before detection in `ConvertToStandaloneModule`, so the lifted statements reach `mergeDecls` and `detectTrios`.

## Effect on the generated tree

Only `std/iterator.esc` changes, and only by addition:

- `IteratorObject` gains `map`, `filter` ×2, `take`, `drop`, `flatMap`, `reduce` ×3, `toArray`, `forEach`, `some`, `every`, `find` ×2, and `[Symbol.toStringTag]`. It carried one member before.
- `interface IteratorConstructor` appears, carrying `from`.
- `var Iterator: IteratorConstructor` appears.

Generating the tree twice is byte-identical.

## The second guard, and why it is here

Making those three visible immediately formed an `Iterator` trio, and it fused into this:

```
export declare class Iterator<T, TReturn = any, TNext = any> extends globalThis.IteratorObject<T, TResult, TNext> {
```

`TResult` is not in scope. `mergeDecls` had folded `interface Iterator<T, TResult, TNext>` from `lib.esnext.iterator.d.ts` into `interface Iterator<T, TReturn, TNext>` from `lib.es2015.iterable.d.ts`, keeping the first's type parameters and concatenating the second's extends clause. The dangling reference was already in the AST before this change; it never printed, because `printInterfaceDecl` emits no `extends` clause at all while `printClassDecl` does.

`detectTrios` now declines a name that a `declare class` already declares, so the converter does not emit a second class beside the one the source spells out. That keeps the tree strictly improving here.

It is not the root fix. #1410, stacked on this, settles which of a file's declarations are global in the first place, which dissolves the bad merge and makes `Iterator` fuse correctly into one class.

## Tests

- `TestStandalone_DeclareGlobalIsLifted` — a block's interface, var, and function are all converted, the JSDoc inside survives, and a lifted declaration is addressed by its bare name with no block prefix.
- `TestStandalone_TrioDeclinedWhenNameIsAlreadyAClass` — a `declare class Foo` plus `interface Foo` plus `interface FooConstructor` plus the binding emits one class, not two.

Both mutation-checked: disabling the lift and disabling the guard each make the matching test fail.

## Stack

`claude/dts-ctor-side-interfaces` (#1413) → `claude/issue-1309-trio-ctor-gate` (#1405) → **this** → `claude/issue-1404-merge-fidelity` (#1410).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of declarations inside global declaration blocks during standalone conversion and partitioning.
  * Prevented duplicate combined declarations when a matching class declaration already exists.
  * Preserved nested global declarations, documentation, members, and runtime decorators during conversion.

* **Tests**
  * Added regression coverage for global declaration handling and duplicate declaration prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->