### PR TITLE
CI: point the generated-tree check at internal/interop/data

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
 
   check_generated_tree:
     runs-on: ubuntu-latest
-    # The job reads the repository and commits its scratch tree to a
+    # The job reads the repository and stages what it regenerates into a
     # local index. Neither needs a writable token, and no step needs the
     # credentials the checkout would otherwise leave in .git/config.
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,25 +74,15 @@ jobs:
       - name: Build dts_to_esc
         run: go build -o ./bin/dts_to_esc ./tools/dts_to_esc
 
-      # internal/interop/data holds hand-written stubs rather than
-      # generated packages, so the tree the check reads is one this job
-      # seeds. What that gates is generator idempotence over the pinned
-      # lib set. Pointing the check at the committed tree gates that
-      # tree against its inputs, and waits on §7 committing one. See
-      # #1393.
-      - name: Seed a scratch tree
-        run: |
-          ./bin/dts_to_esc generate --overlay internal/interop/overlay \
-            node_modules/typescript/lib tmp/esc-tree
-          git add --all -- tmp/esc-tree
-          git -c user.email=ci@escalier.invalid -c user.name=CI \
-            commit -q -m 'seed the scratch tree'
-
+      # The check regenerates internal/interop/data in place and diffs
+      # the result against what the checkout carries. A hand-edited
+      # generated file, a TypeScript pin bump with no regenerated tree,
+      # and a converter change nobody re-ran all fail here.
       - name: Check the tree against its inputs
         run: |
-          .github/scripts/check-generated-tree.sh tmp/esc-tree -- \
+          .github/scripts/check-generated-tree.sh internal/interop/data -- \
             ./bin/dts_to_esc generate --overlay internal/interop/overlay \
-            node_modules/typescript/lib tmp/esc-tree
+            node_modules/typescript/lib internal/interop/data
 
   check_ts:
     runs-on: ubuntu-latest

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -2172,12 +2172,13 @@ naive check gets right.
 
 The check is
 [.github/scripts/check-generated-tree.sh](../../.github/scripts/check-generated-tree.sh),
-and the `check_generated_tree` job runs it. The tree that job
-reads is one it seeds, since `internal/interop/data` holds the
-§2-era stubs rather than generated packages, so what it gates is
-generator idempotence over the pinned lib set. Pointing the check
-at the committed tree gates that tree against its inputs and lands
-with §7, [#1393](https://github.com/escalier-lang/escalier/issues/1393).
+and the `check_generated_tree` job runs it over
+`internal/interop/data`. It regenerates the tree from the §6.4
+inputs and diffs the result against what the checkout carries, so
+a hand-edited generated file, a TypeScript pin bump with no
+regenerated tree, and a converter change nobody re-ran all fail
+there
+([#1393](https://github.com/escalier-lang/escalier/issues/1393)).
 
 **Review ergonomics.** `web/dom.esc` is roughly 22.5k lines, so a
 generator change rewrites it wholesale and the diff dominates
@@ -2281,11 +2282,10 @@ E. **Generate the tree instead of merging into it** (6.4, 6.6) ✅.
    SimpleSub M7.5.
 
    The gate's last clause, CI failing when the committed tree
-   does not match its inputs, needs a committed tree to read.
-   The job #1344 landed runs against a tree it seeds, which
-   gates generator idempotence over the pinned lib set.
+   does not match its inputs, needed a committed tree to read.
+   §7 committed one and
    [#1393](https://github.com/escalier-lang/escalier/issues/1393)
-   points it at `internal/interop/data` alongside §7.
+   pointed the job at it.
 
 6.5 (`throws`) is scope and policy rather than code — fold into
 whichever PR is convenient. §6.8 sequences the fact application,


### PR DESCRIPTION
Fixes #1393

The `check_generated_tree` job seeded a scratch tree and checked that, because `internal/interop/data` held the §2-era stubs rather than generated packages. What that gated was generator idempotence over the pinned lib set, not the currency of anything committed. #1409 committed the tree, so the job now regenerates `internal/interop/data` in place and diffs the result against what the checkout carries.

No new mechanism. The seeding step goes away and the two directory arguments change. `check_generated_tree_test.go` already covers the four cases the staged diff reports, and this drops the last committed scratch tree from the job.

## Verified end to end

Against the real tree, not just the unit tests. The check passes on a clean checkout, and on a commit that edits `std/math.esc` by hand it exits 1 naming the file and the line:

```
check-generated-tree: internal/interop/data does not match its inputs.
Re-run the generator and commit what it writes.
-export declare val PI: string
+export declare val PI: number
```

The job passes no `--cfg`. Confirmed that changes nothing it checks: the flag adds the curation, coercion-filter, receiver-validation, and join reports on stderr, and a run with it emits a byte-identical tree.

## Note

This is the first of six PRs split out of work that landed on one branch after #1409 merged. It touches no generated files, so it is independent of the other five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW

---
_Generated by [Claude Code](https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW)_