### PR TITLE
dts_to_esc: restore the empty quasis a template literal type needs

### DIFF
--- a/internal/dts_to_esc/__snapshots__/helper_test.snap
+++ b/internal/dts_to_esc/__snapshots__/helper_test.snap
@@ -1146,6 +1146,9 @@
             Value: "hello ",
             Span: 1-7,
         },
+        &ast.Quasi{
+            Span: 0-17,
+        },
     },
     TypeAnns: []ast.TypeAnn{
         &ast.StringTypeAnn{
@@ -1160,8 +1163,14 @@
 &ast.TemplateLitTypeAnn{
     Quasis: []*ast.Quasi{
         &ast.Quasi{
+            Span: 1-10,
+        },
+        &ast.Quasi{
             Value: "-",
             Span: 10-11,
+        },
+        &ast.Quasi{
+            Span: 0-21,
         },
     },
     TypeAnns: []ast.TypeAnn{
@@ -1772,6 +1781,9 @@
                     &ast.Quasi{
                         Value: "get",
                         Span: 13-16,
+                    },
+                    &ast.Quasi{
+                        Span: 12-21,
                     },
                 },
                 TypeAnns: []ast.TypeAnn{

--- a/internal/dts_to_esc/helper.go
+++ b/internal/dts_to_esc/helper.go
@@ -566,6 +566,15 @@ func convertTypeAnn(ta dts_parser.TypeAnn) (ast.TypeAnn, error) {
 		)
 		return ast.NewObjectTypeAnn([]ast.ObjTypeAnnElem{mappedElem}, t.Span()), nil
 	case *dts_parser.TemplateLiteralType:
+		// The printer walks the quasis and emits the interpolation after
+		// each, so it needs one more quasi than type. The dts parser
+		// omits an empty quasi rather than recording it, so
+		// `${string}-${string}` arrives as type, "-", type and the
+		// leading and trailing empties have to go back. Without them the
+		// printer runs out of quasis and drops the trailing
+		// interpolations: `${string}-${string}-${string}-${string}-${string}`
+		// on `Crypto.randomUUID` printed as
+		// `-${string}-${string}-${string}-${string}`, which matches no UUID.
 		quasis := []*ast.Quasi{}
 		typeAnns := []ast.TypeAnn{}
 		for _, part := range t.Parts {
@@ -573,12 +582,18 @@ func convertTypeAnn(ta dts_parser.TypeAnn) (ast.TypeAnn, error) {
 			case *dts_parser.TemplateString:
 				quasis = append(quasis, &ast.Quasi{Value: p.Value, Span: p.Span()})
 			case *dts_parser.TemplateType:
+				if len(quasis) == len(typeAnns) {
+					quasis = append(quasis, &ast.Quasi{Value: "", Span: p.Span()})
+				}
 				typeAnn, err := convertTypeAnn(p.Type)
 				if err != nil {
 					return nil, fmt.Errorf("converting template literal type part: %w", err)
 				}
 				typeAnns = append(typeAnns, typeAnn)
 			}
+		}
+		if len(quasis) == len(typeAnns) {
+			quasis = append(quasis, &ast.Quasi{Value: "", Span: t.Span()})
 		}
 		return ast.NewTemplateLitTypeAnn(quasis, typeAnns, t.Span()), nil
 	case *dts_parser.KeyOfType:

--- a/internal/dts_to_esc/helper_test.go
+++ b/internal/dts_to_esc/helper_test.go
@@ -972,3 +972,52 @@ func TestConvertComputedKeySimpleIdent(t *testing.T) {
 		t.Errorf("Expected identifier name %q, got %q", "key", identExpr.Name)
 	}
 }
+
+// TestConvertTemplateLiteralType_RestoresEmptyQuasis covers the
+// alternation the printer needs. It walks the quasis and emits the
+// interpolation after each, so a template needs one more quasi than
+// type. The dts parser omits an empty quasi rather than recording it, so
+// a template starting, ending, or joining two interpolations arrives
+// short and the conversion has to put the empties back.
+//
+// Every row here was wrong before: a template that is all interpolation
+// printed as an empty one, `${T} ` and ` ${T}` printed alike, and
+// `Crypto.randomUUID` lost its first interpolation and gained a leading
+// hyphen.
+func TestConvertTemplateLiteralType_RestoresEmptyQuasis(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"leading and trailing quasi", "`a${string}b`"},
+		{"nothing but an interpolation", "`${number}`"},
+		{"leading interpolation", "`${T} `"},
+		{"trailing interpolation", "` ${T}`"},
+		{"adjacent interpolations", "`${A}${B}`"},
+		{"interpolations either side of a separator",
+			"`${string}-${string}-${string}-${string}-${string}`"},
+		{"no interpolation at all", "`section-`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dtsTypeAnn := dts_parser.NewDtsParser(&ast.Source{
+				Path: "test.d.ts", Contents: tc.input,
+			}).ParseTypeAnn()
+			require.NotNil(t, dtsTypeAnn, "parse %s", tc.input)
+
+			converted, err := convertTypeAnn(dtsTypeAnn)
+			require.NoError(t, err)
+
+			lit, ok := converted.(*ast.TemplateLitTypeAnn)
+			require.True(t, ok, "want a TemplateLitTypeAnn, got %T", converted)
+			require.Len(t, lit.Quasis, len(lit.TypeAnns)+1,
+				"the printer emits one interpolation per quasi and needs one quasi left over")
+
+			printed, err := printer.Print(converted, printer.DefaultOptions())
+			require.NoError(t, err)
+			require.Equal(t, tc.input, printed)
+		})
+	}
+}

--- a/internal/interop/data/std/intl.esc
+++ b/internal/interop/data/std/intl.esc
@@ -771,7 +771,7 @@ export declare interface NumberRangeFormatPart extends NumberFormatPart {
     source: "startRange" | "endRange" | "shared"
 }
 
-export declare type StringNumericLiteral = `` | "Infinity" | "-Infinity" | "+Infinity"
+export declare type StringNumericLiteral = `${number}` | "Infinity" | "-Infinity" | "+Infinity"
 
 export declare interface CollatorOptions {
     usage?: "sort" | "search" | undefined,

--- a/internal/interop/data/web/crypto.esc
+++ b/internal/interop/data/web/crypto.esc
@@ -165,7 +165,7 @@ export declare interface Crypto {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID)
      */
-    randomUUID() -> `-${string}-${string}-${string}-${string}`
+    randomUUID() -> `${string}-${string}-${string}-${string}-${string}`
 }
 
 @js("Crypto")

--- a/internal/interop/data/web/dom.esc
+++ b/internal/interop/data/web/dom.esc
@@ -21707,9 +21707,9 @@ export declare fn removeEventListener(type: string, listener: EventListenerOrEve
 
 export declare type AllowSharedBufferSource = ArrayBuffer | ArrayBufferView
 
-export declare type AutoFill = AutoFillBase | ``
+export declare type AutoFill = AutoFillBase | `${OptionalPrefixToken<AutoFillSection>}${OptionalPrefixToken<AutoFillAddressKind>}${AutoFillField}${OptionalPostfixToken<AutoFillCredentialField>}`
 
-export declare type AutoFillField = AutoFillNormalField | ``
+export declare type AutoFillField = AutoFillNormalField | `${OptionalPrefixToken<AutoFillContactKind>}${AutoFillContactField}`
 
 export declare type AutoFillSection = `section-${string}`
 
@@ -21769,7 +21769,7 @@ export declare type OnErrorEventHandler = OnErrorEventHandlerNonNull | null
 
 export declare type OptionalPostfixToken<T: string> = ` ${T}` | ""
 
-export declare type OptionalPrefixToken<T: string> = ` ${T}` | ""
+export declare type OptionalPrefixToken<T: string> = `${T} ` | ""
 
 export declare type RenderingContext = CanvasRenderingContext2D | ImageBitmapRenderingContext | WebGLRenderingContext | WebGL2RenderingContext
 


### PR DESCRIPTION
Fixes #1419

The printer walks a template's quasis and emits the interpolation after each, so it needs one more quasi than type. The dts parser omits an empty quasi rather than recording it, so `` `${string}-${string}` `` arrives as type, `"-"`, type. The conversion passed that through, leaving the printer one quasi short of the interpolations it had.

`convertTypeAnn` now inserts an empty quasi wherever the alternation demands one: before an interpolation with no quasi of its own, and after a template that ends in one.

## Worse than the reported case

`Crypto.randomUUID` is what #1419 reported — it printed `` `-${string}-${string}-${string}-${string}` `` for a five-part pattern, matching no UUID. Four more were worse:

- **A template that is nothing but interpolation printed empty**, because the printer's loop over quasis never ran. `StringNumericLiteral` was `` `` `` rather than `` `${number}` ``, and `AutoFill` and `AutoFillField` lost their whole patterns the same way.
- **`OptionalPrefixToken` and `OptionalPostfixToken` both printed `` ` ${T}` ``.** Upstream they differ, `` `${T} ` `` against `` ` ${T}` ``, which is the only thing separating a prefix token from a postfix one.

All five now match the pinned lib set:

```
StringNumericLiteral = `${number}` | "Infinity" | "-Infinity" | "+Infinity"
randomUUID() -> `${string}-${string}-${string}-${string}-${string}`
OptionalPrefixToken<T: string>  = `${T} ` | ""
OptionalPostfixToken<T: string> = ` ${T}` | ""
```

## Tests

`TestConvertTemplateLiteralType_RestoresEmptyQuasis` covers each shape by round-tripping the printed form — leading and trailing quasi, nothing but an interpolation, leading interpolation, trailing interpolation, adjacent interpolations, the five-part pattern, and no interpolation at all — and asserts the quasi/type arity the printer relies on. Two existing snapshots picked up the restored empties.

## Note

One of six PRs split out of work that landed on one branch after #1409 merged. Its only generated-tree overlap with the others is that they all regenerate; whichever of the six merges second wants a rebase and a re-run of the generator, which `check_generated_tree` will insist on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW

---
_Generated by [Claude Code](https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW)_