### PR TITLE
dts_to_esc: lower `object` to `{...}` rather than `{}`

### DIFF
--- a/internal/dts_to_esc/__snapshots__/helper_test.snap
+++ b/internal/dts_to_esc/__snapshots__/helper_test.snap
@@ -58,6 +58,7 @@
 
 [TestConvertTypeAnn/primitive_object - 1]
 &ast.ObjectTypeAnn{
+    Inexact: true,
     span: 0-6,
 }
 ---
@@ -2183,6 +2184,7 @@
                         span: 39-50,
                     },
                     TypeAnn: &ast.ObjectTypeAnn{
+                        Inexact: true,
                         span: 44-50,
                     },
                 },

--- a/internal/dts_to_esc/helper.go
+++ b/internal/dts_to_esc/helper.go
@@ -325,7 +325,17 @@ func convertTypeAnn(ta dts_parser.TypeAnn) (ast.TypeAnn, error) {
 		case dts_parser.PrimUniqueSymbol:
 			return ast.NewUniqueSymbolTypeAnn(span), nil
 		case dts_parser.PrimObject:
-			return ast.NewObjectTypeAnn([]ast.ObjTypeAnnElem{}, span), nil
+			// `object` is TypeScript's "any non-primitive", so it accepts
+			// an object with any properties. Escalier spells that `{...}`,
+			// an inexact object type. Plain `{}` is the exact empty
+			// object, which accepts one with no properties at all.
+			//
+			// The distinction is load-bearing. `ObjectConstructor`
+			// declares `keys(o: object)` and `keys(o: {})` as separate
+			// overloads, and only one spelling keeps them apart.
+			obj := ast.NewObjectTypeAnn([]ast.ObjTypeAnnElem{}, span)
+			obj.Inexact = true
+			return obj, nil
 		case dts_parser.PrimIntrinsic:
 			return ast.NewIntrinsicTypeAnn(span), nil
 		default:

--- a/internal/dts_to_esc/helper_test.go
+++ b/internal/dts_to_esc/helper_test.go
@@ -1021,3 +1021,38 @@ func TestConvertTemplateLiteralType_RestoresEmptyQuasis(t *testing.T) {
 		})
 	}
 }
+
+// TestConvertTypeAnn_ObjectLowersToInexact pins the two object types
+// apart. TypeScript's `object` is any non-primitive, so it accepts an
+// object with any properties, and Escalier spells that `{...}`. Plain
+// `{}` is the exact empty object.
+//
+// `ObjectConstructor` is where the difference shows: it declares
+// `keys(o: object)` and `keys(o: {})` as separate overloads, so one
+// spelling for both leaves it with a single signature.
+func TestConvertTypeAnn_ObjectLowersToInexact(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, input, want string
+	}{
+		{"object is inexact", "object", "{...}"},
+		{"empty object type is exact", "{}", "{}"},
+		{"object in an intersection", "object & { x: number }", "{...} & {\n    x: number\n}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dtsTypeAnn := dts_parser.NewDtsParser(&ast.Source{
+				Path: "test.d.ts", Contents: tc.input,
+			}).ParseTypeAnn()
+			require.NotNil(t, dtsTypeAnn, "parse %s", tc.input)
+
+			converted, err := convertTypeAnn(dtsTypeAnn)
+			require.NoError(t, err)
+
+			printed, err := printer.Print(converted, printer.DefaultOptions())
+			require.NoError(t, err)
+			require.Equal(t, tc.want, printed)
+		})
+	}
+}

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -249,6 +249,6 @@ export declare interface PromiseLike<T, E = never> {
 /**
  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
  */
-export declare type Awaited<T> = if T : null | undefined { T } else { if T : {} & {
+export declare type Awaited<T> = if T : null | undefined { T } else { if T : {...} & {
     then(onfulfilled: infer F, ...args: infer _) -> any
 } { if F : fn (value: infer V, ...args: infer _) -> any { Awaited<V> } else { never } } else { T } }

--- a/internal/interop/data/std/decorators.esc
+++ b/internal/interop/data/std/decorators.esc
@@ -12,7 +12,7 @@ export declare type ClassMemberDecoratorContext = ClassMethodDecoratorContext | 
  */
 export declare type DecoratorContext = ClassDecoratorContext | ClassMemberDecoratorContext
 
-export declare type DecoratorMetadataObject = Record<PropertyKey, unknown> & {}
+export declare type DecoratorMetadataObject = Record<PropertyKey, unknown> & {...}
 
 export declare type DecoratorMetadata = if typeof globalThis : {
     Symbol: {

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -70,7 +70,7 @@ export declare class Object {
      * @param target The target object to copy to.
      * @param sources One or more source objects from which to copy properties
      */
-    static assign(target: {}, ...sources: mut Array<any>) -> any,
+    static assign(target: {...}, ...sources: mut Array<any>) -> any,
     /**
      * Returns an array of all symbol properties found directly on object o.
      * @param o Object to retrieve the symbols from.
@@ -92,7 +92,7 @@ export declare class Object {
      * @param o The object to change its prototype.
      * @param proto The value of the new prototype or null.
      */
-    static setPrototypeOf(o: any, proto: {} | null) -> any,
+    static setPrototypeOf(o: any, proto: {...} | null) -> any,
     /**
      * Returns an array of values of the enumerable own properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -135,7 +135,7 @@ export declare class Object {
      * @param o An object.
      * @param v A property name.
      */
-    static hasOwn(o: {}, v: PropertyKey) -> boolean,
+    static hasOwn(o: {...}, v: PropertyKey) -> boolean,
     /**
      * Groups members of an iterable according to the return value of the passed callback.
      * @param items An iterable.
@@ -167,13 +167,13 @@ export declare class Object {
      * Creates an object that has the specified prototype or that has null prototype.
      * @param o Object to use as a prototype. May be null.
      */
-    static create(o: {} | null) -> any,
+    static create(o: {...} | null) -> any,
     /**
      * Creates an object that has the specified prototype, and that optionally contains specified properties.
      * @param o Object to use as a prototype. May be null
      * @param properties JavaScript object that contains one or more property descriptors.
      */
-    static create(o: {} | null, properties: PropertyDescriptorMap & ThisType<any>) -> any,
+    static create(o: {...} | null, properties: PropertyDescriptorMap & ThisType<any>) -> any,
     /**
      * Adds a property to an object, or modifies attributes of an existing property.
      * @param o Object on which to add or modify the property. This can be a native JavaScript object (that is, a user-defined object or a built in object) or a DOM object.
@@ -226,7 +226,12 @@ export declare class Object {
      * Returns a value that indicates whether new properties can be added to an object.
      * @param o Object to test.
      */
-    static isExtensible(o: any) -> boolean
+    static isExtensible(o: any) -> boolean,
+    /**
+     * Returns the names of the enumerable string properties and methods of an object.
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    static keys(o: {...}) -> mut Array<string>
 }
 
 export declare interface TypedPropertyDescriptor<T> {

--- a/internal/interop/data/std/proxy.esc
+++ b/internal/interop/data/std/proxy.esc
@@ -2,7 +2,7 @@
 // Its facts come from the pinned lib.*.d.ts set, the ECMA-262
 // derived facts, and the overlay. Change one of those and re-run.
 
-export declare interface ProxyHandler<T: {}> {
+export declare interface ProxyHandler<T: {...}> {
     /**
      * A trap method for a function call.
      * @param target The original callable object which is being proxied.
@@ -13,7 +13,7 @@ export declare interface ProxyHandler<T: {}> {
      * @param target The original object which is being proxied.
      * @param newTarget The constructor that was originally called.
      */
-    construct(target: T, argArray: mut Array<any>, newTarget: Function) -> {},
+    construct(target: T, argArray: mut Array<any>, newTarget: Function) -> {...},
     /**
      * A trap for `Object.defineProperty()`.
      * @param target The original object which is being proxied.
@@ -44,7 +44,7 @@ export declare interface ProxyHandler<T: {}> {
      * A trap for the `[[GetPrototypeOf]]` internal method.
      * @param target The original object which is being proxied.
      */
-    getPrototypeOf(target: T) -> {} | null,
+    getPrototypeOf(target: T) -> {...} | null,
     /**
      * A trap for the `in` operator.
      * @param target The original object which is being proxied.
@@ -79,7 +79,7 @@ export declare interface ProxyHandler<T: {}> {
      * @param target The original object which is being proxied.
      * @param newPrototype The object's new prototype or `null`.
      */
-    setPrototypeOf(target: T, v: {} | null) -> boolean
+    setPrototypeOf(target: T, v: {...} | null) -> boolean
 }
 
 export declare interface ProxyConstructor {
@@ -88,11 +88,11 @@ export declare interface ProxyConstructor {
      * @param target A target object to wrap with Proxy.
      * @param handler An object whose properties define the behavior of Proxy when an operation is attempted on it.
      */
-    revocable<T: {}>(target: T, handler: ProxyHandler<T>) -> {
+    revocable<T: {...}>(target: T, handler: ProxyHandler<T>) -> {
         proxy: T,
         revoke: fn () -> unknown
     },
-    new<T: {}> (target: T, handler: ProxyHandler<T>) -> T
+    new<T: {...}> (target: T, handler: ProxyHandler<T>) -> T
 }
 
 @js("Proxy")

--- a/internal/interop/data/std/reflect.esc
+++ b/internal/interop/data/std/reflect.esc
@@ -36,7 +36,7 @@ export declare fn construct(target: Function, argumentsList: ArrayLike<any>, new
  * @param attributes Descriptor for the property. It can be for a data property or an accessor property.
  */
 @js("Reflect.defineProperty")
-export declare fn defineProperty(target: {}, propertyKey: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) -> boolean
+export declare fn defineProperty(target: {...}, propertyKey: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) -> boolean
 
 /**
  * Removes a property from an object, equivalent to `delete target[propertyKey]`,
@@ -45,7 +45,7 @@ export declare fn defineProperty(target: {}, propertyKey: PropertyKey, attribute
  * @param propertyKey The property name.
  */
 @js("Reflect.deleteProperty")
-export declare fn deleteProperty(target: {}, propertyKey: PropertyKey) -> boolean
+export declare fn deleteProperty(target: {...}, propertyKey: PropertyKey) -> boolean
 
 /**
  * Gets the property of target, equivalent to `target[propertyKey]` when `receiver === target`.
@@ -55,7 +55,7 @@ export declare fn deleteProperty(target: {}, propertyKey: PropertyKey) -> boolea
  *        if `target[propertyKey]` is an accessor property.
  */
 @js("Reflect.get")
-export declare fn get<T: {}, P: PropertyKey>(target: T, propertyKey: P, receiver?: unknown) -> if P : keyof T { T[P] } else { any }
+export declare fn get<T: {...}, P: PropertyKey>(target: T, propertyKey: P, receiver?: unknown) -> if P : keyof T { T[P] } else { any }
 
 /**
  * Gets the own property descriptor of the specified object.
@@ -64,14 +64,14 @@ export declare fn get<T: {}, P: PropertyKey>(target: T, propertyKey: P, receiver
  * @param propertyKey The property name.
  */
 @js("Reflect.getOwnPropertyDescriptor")
-export declare fn getOwnPropertyDescriptor<T: {}, P: PropertyKey>(target: T, propertyKey: P) -> TypedPropertyDescriptor<if P : keyof T { T[P] } else { any }> | undefined
+export declare fn getOwnPropertyDescriptor<T: {...}, P: PropertyKey>(target: T, propertyKey: P) -> TypedPropertyDescriptor<if P : keyof T { T[P] } else { any }> | undefined
 
 /**
  * Returns the prototype of an object.
  * @param target The object that references the prototype.
  */
 @js("Reflect.getPrototypeOf")
-export declare fn getPrototypeOf(target: {}) -> {} | null
+export declare fn getPrototypeOf(target: {...}) -> {...} | null
 
 /**
  * Equivalent to `propertyKey in target`.
@@ -79,14 +79,14 @@ export declare fn getPrototypeOf(target: {}) -> {} | null
  * @param propertyKey Name of the property.
  */
 @js("Reflect.has")
-export declare fn has(target: {}, propertyKey: PropertyKey) -> boolean
+export declare fn has(target: {...}, propertyKey: PropertyKey) -> boolean
 
 /**
  * Returns a value that indicates whether new properties can be added to an object.
  * @param target Object to test.
  */
 @js("Reflect.isExtensible")
-export declare fn isExtensible(target: {}) -> boolean
+export declare fn isExtensible(target: {...}) -> boolean
 
 /**
  * Returns the string and symbol keys of the own properties of an object. The own properties of an object
@@ -94,7 +94,7 @@ export declare fn isExtensible(target: {}) -> boolean
  * @param target Object that contains the own properties.
  */
 @js("Reflect.ownKeys")
-export declare fn ownKeys(target: {}) -> mut Array<string | symbol>
+export declare fn ownKeys(target: {...}) -> mut Array<string | symbol>
 
 /**
  * Prevents the addition of new properties to an object.
@@ -102,7 +102,7 @@ export declare fn ownKeys(target: {}) -> mut Array<string | symbol>
  * @return Whether the object has been made non-extensible.
  */
 @js("Reflect.preventExtensions")
-export declare fn preventExtensions(target: {}) -> boolean
+export declare fn preventExtensions(target: {...}) -> boolean
 
 /**
  * Sets the property of target, equivalent to `target[propertyKey] = value` when `receiver === target`.
@@ -112,10 +112,10 @@ export declare fn preventExtensions(target: {}) -> boolean
  *        if `target[propertyKey]` is an accessor property.
  */
 @js("Reflect.set")
-export declare fn set<T: {}, P: PropertyKey>(target: T, propertyKey: P, value: if P : keyof T { T[P] } else { any }, receiver?: any) -> boolean
+export declare fn set<T: {...}, P: PropertyKey>(target: T, propertyKey: P, value: if P : keyof T { T[P] } else { any }, receiver?: any) -> boolean
 
 @js("Reflect.set")
-export declare fn set(target: {}, propertyKey: PropertyKey, value: any, receiver?: any) -> boolean
+export declare fn set(target: {...}, propertyKey: PropertyKey, value: any, receiver?: any) -> boolean
 
 /**
  * Sets the prototype of a specified object o to object proto or null.
@@ -124,4 +124,4 @@ export declare fn set(target: {}, propertyKey: PropertyKey, value: any, receiver
  * @return Whether setting the prototype was successful.
  */
 @js("Reflect.setPrototypeOf")
-export declare fn setPrototypeOf(target: {}, proto: {} | null) -> boolean
+export declare fn setPrototypeOf(target: {...}, proto: {...} | null) -> boolean

--- a/internal/interop/data/std/weak_ref.esc
+++ b/internal/interop/data/std/weak_ref.esc
@@ -50,7 +50,7 @@ export declare class FinalizationRegistry<T> {
 
 export declare interface WeakKeyTypes {
     symbol: symbol,
-    object: {}
+    object: {...}
 }
 
 export declare type WeakKey = WeakKeyTypes[keyof WeakKeyTypes]


### PR DESCRIPTION
Refs #1232

TypeScript's `object` is any non-primitive, so it accepts an object with any properties. Escalier spells that `{...}`, an inexact object type. Plain `{}` is the exact empty object, which accepts one with no properties at all, so lowering `object` to it said something narrower than the source.

`{...}` is `ObjectTypeAnn{Inexact: true}` and already round-trips through the parser and printer, so this is a one-flag change in `convertTypeAnn`.

## The two are separately observable

`ObjectConstructor` declares `keys(o: object)` and `keys(o: {})` as distinct overloads, and lowering both to `{}` collapsed them into one signature. Both are back:

```
static keys(o: {}) -> mut Array<string>,
static keys(o: {...}) -> mut Array<string>
```

`Awaited` reads correctly too. Its `T extends object & { then(…): any }` was emitting as `T : {} & { then(…) }` and now emits `T : {...} & { then(…) }`.

29 references across `std:object`, `std:proxy`, `std:reflect`, `std:decorators`, `std:async`, and `std:weak_ref`.

## Relationship to #1427

#1427 deduplicates members a declaration carries twice, and one of its removals was `Object.keys` — correctly, because the two overloads really were identical once `object` had been lowered to `{}`. This change is what makes them distinct again, so with both in, both `keys` overloads survive. Either order works; the tree just needs regenerating on whichever merges second.

## Not in scope

TypeScript's `{}` means "anything except null and undefined", including primitives, so lowering it to Escalier's exact empty object is not right either — just wrong in a different direction. Left alone here; worth its own decision.

`TestConvertTypeAnn_ObjectLowersToInexact` pins `object` → `{...}`, `{}` → `{}`, and the intersection case.

## Note

One of six PRs split out of work that landed on one branch after #1409 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW

---
_Generated by [Claude Code](https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW)_