### PR TITLE
dts_to_esc: keep the optional marker on a method signature

### DIFF
--- a/internal/dts_to_esc/decl_test.go
+++ b/internal/dts_to_esc/decl_test.go
@@ -507,14 +507,16 @@ func TestConvertClassDecl(t *testing.T) {
 		// Note: Getter/setter test skipped - the class parser doesn't currently
 		// support getter/setter syntax in class declarations
 		{
-			name:      "class with index signature (should be skipped)",
+			// Skipped on both paths. convertInterfaceMember records why
+			// the interface one is held back; a class body has no member
+			// kind for an index signature either way, since the
+			// mapped-type shorthand is an ObjTypeAnnElem rather than a
+			// ClassElem.
+			name:      "class with index signature (skipped)",
 			input:     "declare class Dict { [key: string]: any }",
 			wantError: false,
 			checkFunc: func(t *testing.T, decl *ast.ClassDecl) {
-				// Index signatures should be skipped
-				if len(decl.Body) != 0 {
-					t.Errorf("expected index signature to be skipped, got %d body elements", len(decl.Body))
-				}
+				require.Empty(t, decl.Body)
 			},
 		},
 	}
@@ -642,7 +644,10 @@ func TestConvertInterfaceDecl(t *testing.T) {
 			},
 		},
 		{
-			name:      "interface with index signature (should be skipped)",
+			// Held back by the checker rather than by the grammar. See
+			// the IndexSignature case in convertInterfaceMember and
+			// #1417.
+			name:      "interface with index signature (skipped)",
 			input:     "interface Dictionary { [key: string]: any }",
 			wantError: false,
 			checkFunc: func(t *testing.T, decl ast.Decl) {
@@ -650,14 +655,8 @@ func TestConvertInterfaceDecl(t *testing.T) {
 				if !ok {
 					t.Fatalf("expected InterfaceDecl, got %T", decl)
 				}
-				objType := interfaceDecl.TypeAnn
-				if objType == nil {
-					t.Fatalf("expected ObjectTypeAnn, got nil")
-				}
-				// Index signatures return nil from convertInterfaceMember, so should be skipped
-				if len(objType.Elems) != 0 {
-					t.Errorf("expected index signature to be skipped, got %d elements", len(objType.Elems))
-				}
+				require.NotNil(t, interfaceDecl.TypeAnn)
+				require.Empty(t, interfaceDecl.TypeAnn.Elems)
 			},
 		},
 	}

--- a/internal/dts_to_esc/helper.go
+++ b/internal/dts_to_esc/helper.go
@@ -219,6 +219,22 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 		if err != nil {
 			return nil, fmt.Errorf("converting method name: %w", err)
 		}
+		if m.Optional {
+			// Escalier has no optional method syntax: `foo?(): T` does
+			// not parse. An optional property holding a function type
+			// says the same thing and does parse, so `apply?(t: T): any`
+			// becomes `apply?: fn (t: T) -> any`. Dropping the marker
+			// instead would make every ProxyHandler trap required, and
+			// a handler is meant to supply the traps it wants.
+			//
+			// Nothing is lost to the shape change. A method signature
+			// can be overloaded where a property cannot, and none of the
+			// 22 optional methods in the pinned lib set is: the repeated
+			// names sit in different interfaces.
+			prop := ast.NewPropertyTypeAnn(name, true, false, fn, m.Span())
+			prop.SetDoc(m.Doc())
+			return prop, nil
+		}
 		elem := ast.NewMethodTypeAnn(name, fn, nil, m.Span())
 		elem.SetDoc(m.Doc())
 		return elem, nil
@@ -264,10 +280,24 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 		elem.SetDoc(m.Doc())
 		return elem, nil
 	case *dts_parser.IndexSignature:
-		// Index signatures don't have a direct equivalent in Escalier's ObjTypeAnnElem
-		// We could potentially use a MappedTypeAnn or skip them for now
-		// For now, we'll skip index signatures
-		// TODO: determine how to properly represent index signatures
+		// Held back, not unrepresentable. Escalier writes an index
+		// signature as a mapped type in its shorthand spelling,
+		// `[key: K]: V`, and emitting one is five lines: convert the key
+		// and value types, carry `readonly` as a MappedModifier, and
+		// build a MappedTypeAnn with Shorthand set.
+		//
+		// The checker is what is not ready. A property access that
+		// reaches an unexpanded MappedElem panics in expand_type.go with
+		// "MappedElems should have been expanded before property
+		// access", and emitting these takes the interop_mutability
+		// fixture down that path. expandMappedElems already does the
+		// right thing when it runs — a primitive constraint becomes an
+		// IndexSignatureElem — so what is missing is the expansion
+		// reaching that access, not the representation.
+		//
+		// Until then PropertyDescriptorMap emits empty and
+		// Object.defineProperties takes an unconstrained object. See
+		// #1417.
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("convertInterfaceMember: unknown interface member type %T", member)

--- a/internal/dts_to_esc/helper_test.go
+++ b/internal/dts_to_esc/helper_test.go
@@ -1056,3 +1056,50 @@ func TestConvertTypeAnn_ObjectLowersToInexact(t *testing.T) {
 		})
 	}
 }
+
+// TestConvertInterfaceMember_KeepsWhatTheGrammarHasRoomFor covers the
+// optional method, which the converter used to drop because Escalier
+// has no `foo?(): T` syntax. An optional property holding a function
+// type says the same thing and does parse. Dropping the marker made
+// every ProxyHandler trap required.
+// The index signature is the other half of #1417 and is still dropped,
+// held back by the checker rather than by the grammar. See the
+// IndexSignature case in convertInterfaceMember.
+func TestConvertInterfaceMember_KeepsWhatTheGrammarHasRoomFor(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, input, want string
+	}{
+		{
+			"optional method becomes an optional function property",
+			"interface F { apply?(target: T, thisArg: any): any; }",
+			"apply?: fn (target: T, thisArg: any) -> any",
+		},
+		{
+			"a required method stays a method",
+			"interface F { apply(target: T): any; }",
+			"apply(target: T) -> any",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mod, errs := dts_parser.NewDtsParser(&ast.Source{
+				Path: "test.d.ts", Contents: tc.input,
+			}).ParseModule()
+			require.Empty(t, errs)
+
+			iface, ok := mod.Statements[0].(*dts_parser.InterfaceDecl)
+			require.True(t, ok)
+			require.Len(t, iface.Members, 1)
+
+			elem, err := convertInterfaceMember(iface.Members[0])
+			require.NoError(t, err)
+			require.NotNil(t, elem, "the member reached the output")
+
+			printed, err := printer.PrintObjTypeAnnElem(elem, printer.DefaultOptions())
+			require.NoError(t, err)
+			require.Equal(t, tc.want, printed)
+		})
+	}
+}

--- a/internal/dts_to_esc/tree_test.go
+++ b/internal/dts_to_esc/tree_test.go
@@ -1,0 +1,44 @@
+package dts_to_esc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommittedTreeParses is half of §7's gate: every emitted file
+// parses. The other half, that regenerating leaves the tree
+// byte-identical, is what the `check_generated_tree` CI job proves.
+//
+// The two catch different things. Regenerating proves the writer is
+// deterministic, and it stays green on output no reader can consume,
+// because it compares the generator against itself. This reads the
+// committed tree with the parser a consumer uses, so a converter that
+// starts emitting a shape the grammar has no room for fails here.
+func TestCommittedTreeParses(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join("..", "interop", "data")
+	for _, sub := range []string{"std", "web"} {
+		entries, err := os.ReadDir(filepath.Join(root, sub))
+		require.NoError(t, err)
+		for _, e := range entries {
+			if !strings.HasSuffix(e.Name(), ".esc") {
+				continue
+			}
+			path := filepath.Join(root, sub, e.Name())
+			t.Run(sub+"/"+e.Name(), func(t *testing.T) {
+				t.Parallel()
+				data, err := os.ReadFile(path)
+				require.NoError(t, err)
+				_, errs := parser.ParseLibFiles(t.Context(),
+					[]*ast.Source{{ID: 0, Path: path, Contents: string(data)}})
+				require.Empty(t, errs)
+			})
+		}
+	}
+}

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -186,8 +186,8 @@ export declare interface AsyncGeneratorFunctionConstructor {
 
 export declare interface AsyncIterator<T, TReturn = any, TNext = any> {
     next(...value: [] | [TNext]) -> Promise<IteratorResult<T, TReturn>>,
-    return(value?: TReturn | PromiseLike<TReturn>) -> Promise<IteratorResult<T, TReturn>>,
-    throw(e?: any) -> Promise<IteratorResult<T, TReturn>>
+    return?: fn (value?: TReturn | PromiseLike<TReturn>) -> Promise<IteratorResult<T, TReturn>>,
+    throw?: fn (e?: any) -> Promise<IteratorResult<T, TReturn>>
 }
 
 export declare interface AsyncIterable<T, TReturn = any, TNext = any> {

--- a/internal/interop/data/std/decorators.esc
+++ b/internal/interop/data/std/decorators.esc
@@ -258,17 +258,17 @@ export declare interface ClassAccessorDecoratorResult<This, Value> {
     /**
      * An optional replacement getter function. If not provided, the existing getter function is used instead.
      */
-    get(this: This) -> Value,
+    get?: fn (this: This) -> Value,
     /**
      * An optional replacement setter function. If not provided, the existing setter function is used instead.
      */
-    set(this: This, value: Value) -> unknown,
+    set?: fn (this: This, value: Value) -> unknown,
     /**
      * An optional initializer mutator that is invoked when the underlying field initializer is evaluated.
      * @param value The incoming initializer value.
      * @returns The replacement initializer value.
      */
-    init(this: This, value: Value) -> Value
+    init?: fn (this: This, value: Value) -> Value
 }
 
 /**

--- a/internal/interop/data/std/iterator.esc
+++ b/internal/interop/data/std/iterator.esc
@@ -58,8 +58,8 @@ export declare type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | 
 
 export declare interface Iterator<T, TReturn = any, TNext = any> extends globalThis.IteratorObject<T, TReturn, TNext> {
     next(...value: [] | [TNext]) -> IteratorResult<T, TReturn>,
-    return(value?: TReturn) -> IteratorResult<T, TReturn>,
-    throw(e?: any) -> IteratorResult<T, TReturn>
+    return?: fn (value?: TReturn) -> IteratorResult<T, TReturn>,
+    throw?: fn (e?: any) -> IteratorResult<T, TReturn>
 }
 
 export declare interface Iterable<T, TReturn = any, TNext = any> {

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -9,8 +9,8 @@ export declare interface PropertyDescriptor {
     enumerable?: boolean,
     value?: any,
     writable?: boolean,
-    get() -> any,
-    set(v: any) -> unknown
+    get?: fn () -> any,
+    set?: fn (v: any) -> unknown
 }
 
 export declare interface PropertyDescriptorMap {}

--- a/internal/interop/data/std/proxy.esc
+++ b/internal/interop/data/std/proxy.esc
@@ -7,65 +7,65 @@ export declare interface ProxyHandler<T: {...}> {
      * A trap method for a function call.
      * @param target The original callable object which is being proxied.
      */
-    apply(target: T, thisArg: any, argArray: mut Array<any>) -> any,
+    apply?: fn (target: T, thisArg: any, argArray: mut Array<any>) -> any,
     /**
      * A trap for the `new` operator.
      * @param target The original object which is being proxied.
      * @param newTarget The constructor that was originally called.
      */
-    construct(target: T, argArray: mut Array<any>, newTarget: Function) -> {...},
+    construct?: fn (target: T, argArray: mut Array<any>, newTarget: Function) -> {...},
     /**
      * A trap for `Object.defineProperty()`.
      * @param target The original object which is being proxied.
      * @returns A `Boolean` indicating whether or not the property has been defined.
      */
-    defineProperty(target: T, property: string | symbol, attributes: PropertyDescriptor) -> boolean,
+    defineProperty?: fn (target: T, property: string | symbol, attributes: PropertyDescriptor) -> boolean,
     /**
      * A trap for the `delete` operator.
      * @param target The original object which is being proxied.
      * @param p The name or `Symbol` of the property to delete.
      * @returns A `Boolean` indicating whether or not the property was deleted.
      */
-    deleteProperty(target: T, p: string | symbol) -> boolean,
+    deleteProperty?: fn (target: T, p: string | symbol) -> boolean,
     /**
      * A trap for getting a property value.
      * @param target The original object which is being proxied.
      * @param p The name or `Symbol` of the property to get.
      * @param receiver The proxy or an object that inherits from the proxy.
      */
-    get(target: T, p: string | symbol, receiver: any) -> any,
+    get?: fn (target: T, p: string | symbol, receiver: any) -> any,
     /**
      * A trap for `Object.getOwnPropertyDescriptor()`.
      * @param target The original object which is being proxied.
      * @param p The name of the property whose description should be retrieved.
      */
-    getOwnPropertyDescriptor(target: T, p: string | symbol) -> PropertyDescriptor | undefined,
+    getOwnPropertyDescriptor?: fn (target: T, p: string | symbol) -> PropertyDescriptor | undefined,
     /**
      * A trap for the `[[GetPrototypeOf]]` internal method.
      * @param target The original object which is being proxied.
      */
-    getPrototypeOf(target: T) -> {...} | null,
+    getPrototypeOf?: fn (target: T) -> {...} | null,
     /**
      * A trap for the `in` operator.
      * @param target The original object which is being proxied.
      * @param p The name or `Symbol` of the property to check for existence.
      */
-    has(target: T, p: string | symbol) -> boolean,
+    has?: fn (target: T, p: string | symbol) -> boolean,
     /**
      * A trap for `Object.isExtensible()`.
      * @param target The original object which is being proxied.
      */
-    isExtensible(target: T) -> boolean,
+    isExtensible?: fn (target: T) -> boolean,
     /**
      * A trap for `Reflect.ownKeys()`.
      * @param target The original object which is being proxied.
      */
-    ownKeys(target: T) -> ArrayLike<string | symbol>,
+    ownKeys?: fn (target: T) -> ArrayLike<string | symbol>,
     /**
      * A trap for `Object.preventExtensions()`.
      * @param target The original object which is being proxied.
      */
-    preventExtensions(target: T) -> boolean,
+    preventExtensions?: fn (target: T) -> boolean,
     /**
      * A trap for setting a property value.
      * @param target The original object which is being proxied.
@@ -73,13 +73,13 @@ export declare interface ProxyHandler<T: {...}> {
      * @param receiver The object to which the assignment was originally directed.
      * @returns A `Boolean` indicating whether or not the property was set.
      */
-    set(target: T, p: string | symbol, newValue: any, receiver: any) -> boolean,
+    set?: fn (target: T, p: string | symbol, newValue: any, receiver: any) -> boolean,
     /**
      * A trap for `Object.setPrototypeOf()`.
      * @param target The original object which is being proxied.
      * @param newPrototype The object's new prototype or `null`.
      */
-    setPrototypeOf(target: T, v: {...} | null) -> boolean
+    setPrototypeOf?: fn (target: T, v: {...} | null) -> boolean
 }
 
 export declare interface ProxyConstructor {


### PR DESCRIPTION
Refs #1417

Escalier has no optional method syntax: `foo?(): T` does not parse. The converter dropped the marker rather than translating it, so every `ProxyHandler` trap read as required and a handler would have had to implement all thirteen. `PropertyDescriptor` had the same problem, where `value?`, `get?`, and `set?` are the whole point of the type.

An optional property holding a function type says the same thing and does parse:

```
apply?: fn (target: T, thisArg: any, argArray: mut Array<any>) -> any,
construct?: fn (target: T, argArray: mut Array<any>, newTarget: Function) -> {},
```

Nothing is lost to the shape change. A method signature can be overloaded where a property cannot, and none of the 22 optional methods in the pinned lib set is — the repeated names (`get?`, `set?`, `throw?`, `return?`) sit in different interfaces.

## A new test for the other half of §7's gate

`TestCommittedTreeParses` reads all 49 committed packages with the parser a consumer uses. `check_generated_tree` covers the other half, that regenerating leaves the tree byte-identical, and the two catch different things: the CI check compares the generator against itself, so it stays green on output no reader can consume. A converter that starts emitting a shape the grammar has no room for fails here instead.

## The index-signature half of #1417 is not here

It is blocked on something the issue did not anticipate, so #1417 stays open and I have rewritten it with what I found.

The representation exists — Escalier writes an index signature as a mapped type in its shorthand spelling, and I confirmed 53 signatures reach the tree with all 49 packages still parsing. The **checker** is what is not ready. A property access reaching an unexpanded `MappedElem` panics:

```
panic: MappedElems should have been expanded before property access
```

from `expand_type.go` (sites 1247, 1344, 1481), and emitting these takes the `interop_mutability` fixture down that path. `expandMappedElems` at `expand_type.go:1952` already turns a primitive-constrained mapped type into an `IndexSignatureElem` when it runs, so the gap is expansion not reaching that access.

The `IndexSignature` case records all of that in place of the old "TODO: determine how to properly represent index signatures", which was the wrong diagnosis. Worth deciding whether to fix it in `internal/checker` at all given #1402's direction and the M12 flip — the solver's counterpart at `typeops.go:773` may have no such gap.

## Note

Last of six PRs split out of work that landed on one branch after #1409 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW

---
_Generated by [Claude Code](https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated standard library and web interop declarations to represent optional callbacks consistently.
  - Adjusted iterator, async iterator, decorator, proxy, and property descriptor typings to use function-valued properties where appropriate.
  - Optional iterator operations and decorator replacement hooks can now be omitted.

- **Tests**
  - Added coverage for optional interface methods and committed declaration parsing.
  - Improved validation of declaration conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->