### PR TITLE
dts_to_esc: give TypeScript's `{}` a lowering that means what it says

### DIFF
--- a/internal/dts_to_esc/__snapshots__/helper_test.snap
+++ b/internal/dts_to_esc/__snapshots__/helper_test.snap
@@ -738,6 +738,7 @@
 
 [TestConvertTypeAnn/empty_object - 1]
 &ast.ObjectTypeAnn{
+    Inexact: true,
     span: 0-2,
 }
 ---

--- a/internal/dts_to_esc/helper.go
+++ b/internal/dts_to_esc/helper.go
@@ -508,7 +508,21 @@ func convertTypeAnn(ta dts_parser.TypeAnn) (ast.TypeAnn, error) {
 				elems = append(elems, elem)
 			}
 		}
-		return ast.NewObjectTypeAnn(elems, t.Span()), nil
+		obj := ast.NewObjectTypeAnn(elems, t.Span())
+		// TypeScript's `{}` is any value except `null` and `undefined`,
+		// so `Object.keys(o: {})` takes an object with any properties.
+		// Escalier's `{}` is the exact empty object and `{...}` is the
+		// inexact one that reads the way the source means. `{...}` stays
+		// narrower in one direction, since TypeScript's `{}` also admits
+		// a primitive.
+		//
+		// The count is read on the source rather than on `elems`, which
+		// leaves an index-signature-only type exact. That one wants its
+		// key and value types back instead (#1417).
+		if len(t.Members) == 0 {
+			obj.Inexact = true
+		}
+		return obj, nil
 	case *dts_parser.ParenthesizedType:
 		return convertTypeAnn(t.Type)
 	case *dts_parser.IndexedAccessType:

--- a/internal/dts_to_esc/helper_test.go
+++ b/internal/dts_to_esc/helper_test.go
@@ -1022,22 +1022,30 @@ func TestConvertTemplateLiteralType_RestoresEmptyQuasis(t *testing.T) {
 	}
 }
 
-// TestConvertTypeAnn_ObjectLowersToInexact pins the two object types
-// apart. TypeScript's `object` is any non-primitive, so it accepts an
-// object with any properties, and Escalier spells that `{...}`. Plain
-// `{}` is the exact empty object.
+// TestConvertTypeAnn_ObjectLowersToInexact covers the two spellings
+// TypeScript uses for "an object with any properties". `object` is any
+// non-primitive and `{}` is any value except `null` and `undefined`;
+// both accept an object carrying properties the annotation does not
+// name, which Escalier spells `{...}`.
 //
-// `ObjectConstructor` is where the difference shows: it declares
-// `keys(o: object)` and `keys(o: {})` as separate overloads, so one
-// spelling for both leaves it with a single signature.
+// Escalier's `{}` is the exact empty object, accepting one with no
+// properties at all, so it is what `Object.keys(o: {})` must not lower
+// to.
+//
+// The member count is read on the source rather than on the converted
+// elements. An object type whose only member is an index signature
+// converts to no elements, and it wants the key and value types back
+// rather than inexactness, so it stays exact and stays visibly wrong.
 func TestConvertTypeAnn_ObjectLowersToInexact(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name, input, want string
 	}{
 		{"object is inexact", "object", "{...}"},
-		{"empty object type is exact", "{}", "{}"},
+		{"an empty object type is inexact too", "{}", "{...}"},
 		{"object in an intersection", "object & { x: number }", "{...} & {\n    x: number\n}"},
+		{"a named member keeps the type exact", "{ x: number }", "{\n    x: number\n}"},
+		{"an index signature alone stays exact", "{ [k: string]: number }", "{}"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/interop/data/std/intl.esc
+++ b/internal/interop/data/std/intl.esc
@@ -815,6 +815,6 @@ export declare type NumberFormatOptionsStyle = keyof NumberFormatOptionsStyleReg
 
 export declare type NumberFormatOptionsCurrencyDisplay = keyof NumberFormatOptionsCurrencyDisplayRegistry
 
-export declare type NumberFormatOptionsUseGrouping = if {} : NumberFormatOptionsUseGroupingRegistry { boolean } else { keyof NumberFormatOptionsUseGroupingRegistry | "true" | "false" | boolean }
+export declare type NumberFormatOptionsUseGrouping = if {...} : NumberFormatOptionsUseGroupingRegistry { boolean } else { keyof NumberFormatOptionsUseGroupingRegistry | "true" | "false" | boolean }
 
-export declare type ResolvedNumberFormatOptionsUseGrouping = if {} : NumberFormatOptionsUseGroupingRegistry { boolean } else { keyof NumberFormatOptionsUseGroupingRegistry | false }
+export declare type ResolvedNumberFormatOptionsUseGrouping = if {...} : NumberFormatOptionsUseGroupingRegistry { boolean } else { keyof NumberFormatOptionsUseGroupingRegistry | false }

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -46,7 +46,7 @@ export declare class Object {
      * @param target The target object to copy to.
      * @param source The source object from which to copy properties.
      */
-    static assign<T: {}, U>(target: T, source: U) -> T & U,
+    static assign<T: {...}, U>(target: T, source: U) -> T & U,
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
      * target object. Returns the target object.
@@ -54,7 +54,7 @@ export declare class Object {
      * @param source1 The first source object from which to copy properties.
      * @param source2 The second source object from which to copy properties.
      */
-    static assign<T: {}, U, V>(target: T, source1: U, source2: V) -> T & U & V,
+    static assign<T: {...}, U, V>(target: T, source1: U, source2: V) -> T & U & V,
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
      * target object. Returns the target object.
@@ -63,7 +63,7 @@ export declare class Object {
      * @param source2 The second source object from which to copy properties.
      * @param source3 The third source object from which to copy properties.
      */
-    static assign<T: {}, U, V, W>(target: T, source1: U, source2: V, source3: W) -> T & U & V & W,
+    static assign<T: {...}, U, V, W>(target: T, source1: U, source2: V, source3: W) -> T & U & V & W,
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
      * target object. Returns the target object.
@@ -80,7 +80,7 @@ export declare class Object {
      * Returns the names of the enumerable string properties and methods of an object.
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    static keys(o: {}) -> mut Array<string>,
+    static keys(o: {...}) -> mut Array<string>,
     /**
      * Returns true if the values are the same value, false otherwise.
      * @param value1 The first value.
@@ -102,7 +102,7 @@ export declare class Object {
      * Returns an array of values of the enumerable own properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    static values(o: {}) -> mut Array<any>,
+    static values(o: {...}) -> mut Array<any>,
     /**
      * Returns an array of key/values of the enumerable own properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -112,7 +112,7 @@ export declare class Object {
      * Returns an array of key/values of the enumerable own properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    static entries(o: {}) -> mut Array<[string, any]>,
+    static entries(o: {...}) -> mut Array<[string, any]>,
     /**
      * Returns an object containing all own property descriptors of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -226,12 +226,7 @@ export declare class Object {
      * Returns a value that indicates whether new properties can be added to an object.
      * @param o Object to test.
      */
-    static isExtensible(o: any) -> boolean,
-    /**
-     * Returns the names of the enumerable string properties and methods of an object.
-     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
-     */
-    static keys(o: {...}) -> mut Array<string>
+    static isExtensible(o: any) -> boolean
 }
 
 export declare interface TypedPropertyDescriptor<T> {

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -296,4 +296,4 @@ export declare type Omit<T, K: keyof any> = Pick<T, Exclude<keyof T, K>>
 /**
  * Exclude null and undefined from T
  */
-export declare type NonNullable<T> = T & {}
+export declare type NonNullable<T> = T & ~(undefined | null)

--- a/internal/interop/overlay/std/object.replace.digests.json
+++ b/internal/interop/overlay/std/object.replace.digests.json
@@ -1,0 +1,6 @@
+[
+  {
+    "decl": "NonNullable",
+    "digest": "33bbf0b4b4584f67"
+  }
+]

--- a/internal/interop/overlay/std/object.replace.digests.json
+++ b/internal/interop/overlay/std/object.replace.digests.json
@@ -1,6 +1,6 @@
 [
   {
     "decl": "NonNullable",
-    "digest": "33bbf0b4b4584f67"
+    "digest": "cd845ace7ee44d0e"
   }
 ]

--- a/internal/interop/overlay/std/object.replace.esc
+++ b/internal/interop/overlay/std/object.replace.esc
@@ -1,0 +1,10 @@
+// TypeScript writes `NonNullable<T>` as `T & {}`, leaning on its own
+// reading of `{}` as any value except `null` and `undefined`. Escalier's
+// `{}` is the exact empty object, so the mechanical lowering computes
+// the wrong set: `NonNullable<string>` would come out empty rather than
+// `string`.
+//
+// The complement says it directly. `~(undefined | null)` admits every
+// value the union rejects, so the intersection subtracts exactly the two
+// members TypeScript means to exclude, primitives included.
+export declare type NonNullable<T> = T & ~(undefined | null)


### PR DESCRIPTION
Fixes #1431

TypeScript's `{}` is any value except `null` and `undefined`. Escalier's is the exact empty object, admitting one with no properties and nothing else. The converter lowered one to the other, so `Object.keys(o: {})` accepted only `{}` and `Object.keys({ a: 1 })` did not check.

Two commits, because the nine affected sites do not all want the same answer.

## `NonNullable` gets a complement

`std/object.esc` carried the TypeScript definition verbatim:

```
export declare type NonNullable<T> = T & {}
```

That computes the right set only under TypeScript's reading of `{}`. Under Escalier's it computes the empty set for every `T`. Escalier has `~T`, so the alias can say what it means:

```
export declare type NonNullable<T> = T & ~(undefined | null)
```

This is better than the definition it replaces, not merely a translation. `T & {}` excludes `null` and `undefined` only because TypeScript overloads `{}` that way; the complement states it, and it works on primitives without relying on the convention.

It lands as an overlay `replace` on `std:object` rather than a converter rule. Nothing in the `.d.ts` distinguishes the nullish-exclusion `{}` from an ordinary empty object type, so a converter rule would have to match the alias by name.

## The other eight lower to `{...}`

`convertTypeAnn` sets `Inexact` when the **source** object type has no members:

```
static assign<T: {...}, U>(target: T, source: U) -> T & U,     (and its 2- and 3-source overloads)
static assign(target: {...}, ...sources: mut Array<any>) -> any,
static keys(o: {...}) -> mut Array<string>,
static values(o: {...}) -> mut Array<any>,
static entries(o: {...}) -> mut Array<[string, any]>,
```

plus the two `Intl` grouping aliases.

**The member count is read on the source, not on the converted elements.** That is what keeps this change out of #1417's territory. An object type whose only member is an index signature converts to zero elements, so testing `elems` would sweep in five sites that want their key and value types back rather than inexactness — `Object.freeze`'s constraint, the generic `values<T>` and `entries<T>`, `fromEntries`'s return, and the `& {}` on `getOwnPropertyDescriptors`. Those stay exact and stay visibly wrong for #1417 to fix. The roughly 30 empty marker interfaces in `web/webgl.esc` and `web/dom.esc` are declaration bodies and never reach this path.

## What the narrowing costs

`{...}` is narrower than the source in one direction: TypeScript's `{}` also admits a primitive, so `Object.entries("ab")` checks there and does not here. Taken deliberately. Relaxing the parameter on whichever declaration a real call needs it on beats widening every `{}` in the tree for a case nothing has asked for. `Object.assign` with a primitive target has no valid use either way — the spec does `ToObject(target)`, so it returns a wrapper nobody wants.

## One site to watch

`std/intl.esc`'s two aliases are conditionals whose test probes an empty registry:

```
type NumberFormatOptionsUseGrouping = if {...} : NumberFormatOptionsUseGroupingRegistry { boolean } else { … }
```

TypeScript writes `{} extends Registry ? …` to ask whether anyone has declaration-merged into the registry. The probe should answer the same under `{...}`, since an inexact empty object cannot satisfy a registry with a required property any more than an exact one can. It is the one site where the change is not obviously inert, and it turns on Escalier's subtyping rather than TypeScript's.

## Verification

`go test ./...` passes. The generated tree matches its inputs under `check-generated-tree.sh` and is stable across two runs. `~T` parses and prints back byte-identical. `NonNullable`'s digest sidecar is re-recorded, since the digest covers the converted form and that form now reads `T & {...}`.

The user-visible effect waits on the checker reading `Inexact`, which is SimpleSub M7.5. `internal/soltype` carries the flag; the current checker does not read it. So this is about the tree being right when the checker starts reading it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW

---
_Generated by [Claude Code](https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW)_