### PR TITLE
dts_to_esc: lower a declared parameter typed `any` to `unknown`

### DIFF
--- a/internal/checker/tests/intersection_test.go
+++ b/internal/checker/tests/intersection_test.go
@@ -704,7 +704,7 @@ func TestIntersectionMemberAccess(t *testing.T) {
 			`,
 			expectedVars: map[string]string{
 				// TODO: look into why `argArray?: any` isn't `...argArray?: Array<any>`
-				"apply": "fn (this: Function, thisArg: any, argArray?: any) -> any",
+				"apply": "fn (this: Function, thisArg: unknown, argArray?: unknown) -> any",
 			},
 			wantErr: false,
 		},
@@ -728,7 +728,7 @@ func TestIntersectionMemberAccess(t *testing.T) {
 			`,
 			expectedVars: map[string]string{
 				"tag":  "string",
-				"call": "fn (this: Function, thisArg: any, ...argArray: Array<any>) -> any",
+				"call": "fn (this: Function, thisArg: unknown, ...argArray: Array<any>) -> any",
 			},
 			wantErr: false,
 		},

--- a/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
+++ b/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
@@ -6,7 +6,7 @@ export declare class Boolean {
     /** Returns the primitive value of the specified object. */
     valueOf(self) -> boolean,
     /** Constructs a new Boolean wrapper around a value. */
-    constructor(mut self, value?: any),
+    constructor(mut self, value?: unknown),
     /** The Boolean prototype object. */
     static readonly prototype: Boolean
 }
@@ -20,6 +20,6 @@ export declare fn parse(text: string, reviver?: fn (this: any, key: string, valu
 
 /** Serializes a value to JSON. */
 @js("JSON.stringify")
-export declare fn stringify(value: any, replacer?: fn (this: any, key: string, value: any) -> any, space?: string | number) -> string
+export declare fn stringify(value: unknown, replacer?: fn (this: any, key: string, value: any) -> any, space?: string | number) -> string
 
 ---

--- a/internal/dts_to_esc/__snapshots__/helper_test.snap
+++ b/internal/dts_to_esc/__snapshots__/helper_test.snap
@@ -2218,7 +2218,7 @@
                         Name: "d",
                         span: 38-44,
                     },
-                    TypeAnn: &ast.AnyTypeAnn{
+                    TypeAnn: &ast.UnknownTypeAnn{
                         span: 41-44,
                     },
                 },

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -743,7 +743,7 @@ interface Array<T> {
 interface ArrayConstructor {
     new (arrayLength?: number): any[];
     new <T>(...items: T[]): T[];
-    isArray(arg: any): boolean;
+    isArray(arg: unknown): boolean;
 }
 declare var Array: ArrayConstructor;
 `
@@ -1072,14 +1072,14 @@ interface Array<T> {
 interface ArrayConstructor {
     new (arrayLength?: number): any[];
     new <T>(arrayLength: number): T[];
-    isArray(arg: any): boolean;
+    isArray(arg: unknown): boolean;
     readonly prototype: any[];
 }
 
 declare var Array: ArrayConstructor;
 `,
 			ctors:    2,
-			statics:  []string{"static isArray(arg: any) -> boolean"},
+			statics:  []string{"static isArray(arg: unknown) -> boolean"},
 			instance: []string{"push(mut self, ...items: Array<T>) -> number"},
 		},
 	}
@@ -1315,7 +1315,7 @@ declare var AbortController: {
 			want: `@js("AbortController")
 export declare class AbortController {
     readonly signal: AbortSignal,
-    abort(mut self, reason?: any) -> unknown,
+    abort(mut self, reason?: unknown) -> unknown,
     static prototype: AbortController,
     constructor(mut self)
 }

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -877,7 +877,7 @@ func TestStandalone_RaiseParamOnAFusedClass(t *testing.T) {
 	require.NoError(t, err)
 	snaps.MatchInlineSnapshot(t, printed, snaps.Inline(`@js("Promise")
 export declare class Promise<T, E = never> {
-    then<R>(mut self, onfulfilled?: fn (value: T) -> R) -> Promise<R, E>,
+    then<R>(self, onfulfilled?: fn (value: T) -> R) -> Promise<R, E>,
     constructor(mut self, executor: fn (resolve: fn (value: T) -> unknown) -> unknown),
     static readonly prototype: Promise<any>,
     static resolve<T>(value: T) -> Promise<T>

--- a/internal/dts_to_esc/generate_test.go
+++ b/internal/dts_to_esc/generate_test.go
@@ -86,7 +86,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T | undefined,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 
 export declare interface ArrayLike<T> {

--- a/internal/dts_to_esc/helper.go
+++ b/internal/dts_to_esc/helper.go
@@ -58,7 +58,34 @@ func convertTypeParam(tp *dts_parser.TypeParam) (*ast.TypeParam, error) {
 }
 
 // TODO(#259): Handle all function param patterns
+// convertParam converts a parameter of a function the runtime supplies the
+// body for — a declared function, a method, a constructor, a setter. The
+// caller only passes a value in, so a parameter TypeScript types `any`
+// lowers to `unknown`: both accept every argument, and `unknown` does not
+// hand an unchecked value back out if someone binds it.
+//
+// Only a parameter whose whole type is `any` widens. An `any` nested in
+// `mut Array<any>` stays, since widening it would change what the array
+// accepts rather than what the parameter does.
+//
+// A callback the caller writes the body for takes convertCallbackParam
+// instead, which leaves `any` alone.
 func convertParam(p *dts_parser.Param) (*ast.Param, error) {
+	param, err := convertCallbackParam(p)
+	if err != nil {
+		return nil, err
+	}
+	if _, isAny := param.TypeAnn.(*ast.AnyTypeAnn); isAny {
+		param.TypeAnn = ast.NewUnknownTypeAnn(param.TypeAnn.Span())
+	}
+	return param, nil
+}
+
+// convertCallbackParam converts a parameter of a function type the caller
+// supplies the body for, as in `onrejected?: (reason: any) => void`. The
+// type flows the other way there: widening `reason` to `unknown` would
+// make the caller narrow before touching it. See convertParam.
+func convertCallbackParam(p *dts_parser.Param) (*ast.Param, error) {
 	// Convert the parameter name to an IdentPat pattern
 	var pattern ast.Pat = ast.NewIdentPat(p.Name.Name, false, nil, nil, p.Span())
 	if p.Rest {
@@ -159,7 +186,7 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 		params := make([]*ast.Param, len(m.Params))
 		for i, p := range m.Params {
 			var err error
-			params[i], err = convertParam(p)
+			params[i], err = convertCallbackParam(p)
 			if err != nil {
 				return nil, fmt.Errorf("converting call signature parameter: %w", err)
 			}
@@ -182,7 +209,7 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 		params := make([]*ast.Param, len(m.Params))
 		for i, p := range m.Params {
 			var err error
-			params[i], err = convertParam(p)
+			params[i], err = convertCallbackParam(p)
 			if err != nil {
 				return nil, fmt.Errorf("converting construct signature parameter: %w", err)
 			}
@@ -202,10 +229,17 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 				return nil, fmt.Errorf("converting method signature type parameter: %w", err)
 			}
 		}
+		// An optional method is emitted below as a property holding a
+		// function type, which is a value whoever implements the
+		// interface writes. Its parameters read like a callback's.
+		convert := convertParam
+		if m.Optional {
+			convert = convertCallbackParam
+		}
 		params := make([]*ast.Param, len(m.Params))
 		for i, p := range m.Params {
 			var err error
-			params[i], err = convertParam(p)
+			params[i], err = convert(p)
 			if err != nil {
 				return nil, fmt.Errorf("converting method signature parameter: %w", err)
 			}
@@ -463,7 +497,7 @@ func convertTypeAnn(ta dts_parser.TypeAnn) (ast.TypeAnn, error) {
 		params := make([]*ast.Param, len(t.Params))
 		for i, p := range t.Params {
 			var err error
-			params[i], err = convertParam(p)
+			params[i], err = convertCallbackParam(p)
 			if err != nil {
 				return nil, fmt.Errorf("converting function parameter %d: %w", i, err)
 			}
@@ -487,7 +521,7 @@ func convertTypeAnn(ta dts_parser.TypeAnn) (ast.TypeAnn, error) {
 		params := make([]*ast.Param, len(t.Params))
 		for i, p := range t.Params {
 			var err error
-			params[i], err = convertParam(p)
+			params[i], err = convertCallbackParam(p)
 			if err != nil {
 				return nil, fmt.Errorf("converting constructor parameter %d: %w", i, err)
 			}
@@ -679,7 +713,7 @@ func convertTypeAnn(ta dts_parser.TypeAnn) (ast.TypeAnn, error) {
 		// there. A guard, `arg is T`, returns a boolean. An assertion,
 		// `asserts arg is T`, either throws or returns no value, so it lowers to
 		// `undefined`. Converting the right-hand type instead would claim that
-		// `isArray(arg: any): arg is any[]` returns an array.
+		// `isArray(arg: unknown): arg is any[]` returns an array.
 		// TODO(#229): add support for type predicates to Escalier
 		if t.Asserts {
 			return ast.NewLitTypeAnn(ast.NewUndefined(t.Span()), t.Span()), nil

--- a/internal/dts_to_esc/helper_test.go
+++ b/internal/dts_to_esc/helper_test.go
@@ -1111,3 +1111,57 @@ func TestConvertInterfaceMember_KeepsWhatTheGrammarHasRoomFor(t *testing.T) {
 		})
 	}
 }
+
+// TestConvertParam_AnyWidensOnlyWhereTheRuntimeSuppliesTheBody covers
+// which `any` parameters lower to `unknown`. A declared function's own
+// parameter widens, since the caller only passes a value in and both
+// types accept every argument. A parameter of a function type the caller
+// writes the body for does not, since widening it would make that body
+// narrow before touching the value.
+func TestConvertParam_AnyWidensOnlyWhereTheRuntimeSuppliesTheBody(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, input, want string
+	}{
+		{
+			"a declared parameter widens",
+			"interface F { is(value1: any, value2: any): boolean; }",
+			"is(value1: unknown, value2: unknown) -> boolean",
+		},
+		{
+			"a nested any stays, and so does a return",
+			"interface F { assign(target: object, ...sources: any[]): any; }",
+			"assign(target: {...}, ...sources: Array<any>) -> any",
+		},
+		{
+			"a callback's parameter stays",
+			"interface F { catch(onrejected: (reason: any) => void): void; }",
+			"catch(onrejected: fn (reason: any) -> unknown) -> unknown",
+		},
+		{
+			"a property holding a function type stays",
+			"interface F { onerror: (event: any) => void; }",
+			"onerror: fn (event: any) -> unknown",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mod, errs := dts_parser.NewDtsParser(&ast.Source{
+				Path: "test.d.ts", Contents: tc.input,
+			}).ParseModule()
+			require.Empty(t, errs)
+
+			iface, ok := mod.Statements[0].(*dts_parser.InterfaceDecl)
+			require.True(t, ok)
+			require.Len(t, iface.Members, 1)
+
+			elem, err := convertInterfaceMember(iface.Members[0])
+			require.NoError(t, err)
+
+			printed, err := printer.PrintObjTypeAnnElem(elem, printer.DefaultOptions())
+			require.NoError(t, err)
+			require.Equal(t, tc.want, printed)
+		})
+	}
+}

--- a/internal/dts_to_esc/join_test.go
+++ b/internal/dts_to_esc/join_test.go
@@ -75,7 +75,7 @@ interface Array<T> {
 }
 interface ArrayConstructor {
     new <T>(arrayLength: number): T[];
-    isArray(arg: any): arg is any[];
+    isArray(arg: unknown): arg is any[];
 }
 declare var Array: ArrayConstructor;
 `)
@@ -447,7 +447,7 @@ interface Array<T> {
 }
 interface ArrayConstructor {
     new <T>(arrayLength: number): T[];
-    isArray(arg: any): arg is any[];
+    isArray(arg: unknown): arg is any[];
 }
 declare var Array: ArrayConstructor;
 interface Math {

--- a/internal/dts_to_esc/mutability.go
+++ b/internal/dts_to_esc/mutability.go
@@ -242,7 +242,7 @@ var ImmutableOwners = set.FromSlice([]string{
 //
 // The key is the name of the interface the `.d.ts` declares the member on.
 //
-// TODO(#500): extend this for Promise, Error, and other classes whose
+// TODO(#500): extend this for Error and the other classes whose
 // non-mutating methods should be callable on a non-mut receiver.
 var nonMutatingOverrides = map[string]MethodNames{
 	"String": set.FromSlice([]string{
@@ -288,6 +288,19 @@ var nonMutatingOverrides = map[string]MethodNames{
 		"apply",
 		"bind",
 		"call",
+	}),
+	"Promise": set.FromSlice([]string{
+		// Attaching a handler appends to the promise's reaction lists,
+		// which is a write the specification makes and no reader can
+		// observe: nothing reachable through `Promise<T, E>` differs
+		// before and after. A `mut self` receiver would fail the ordinary
+		// use of a promise, since it demands unique mutable access to
+		// attach a handler at all. `val p = fetch(url)` could not call
+		// `p.then(…)`, and two consumers of one promise could not each
+		// attach their own.
+		"catch",
+		"finally",
+		"then",
 	}),
 	// `Number`, `Boolean`, and `Date` need no entry. The name-only tiers
 	// answer every non-mutating method they declare, through the `get*` and

--- a/internal/dts_to_esc/mutability_test.go
+++ b/internal/dts_to_esc/mutability_test.go
@@ -590,6 +590,13 @@ func TestReceiverMutates_ImmutableOwner(t *testing.T) {
 		{"Array", "push", true},
 		{"Array", "slice", false},
 		{"Map", "set", true},
+		// Attaching a handler writes only the promise's reaction lists,
+		// which no reader can observe, so the override keeps the receiver
+		// callable through an immutable binding. The constructor is not
+		// on the list and keeps `mut self`.
+		{"Promise", "then", false},
+		{"Promise", "catch", false},
+		{"Promise", "finally", false},
 		// An owner with no rule and a name no tier matches falls to the
 		// mutating default.
 		{"Widget", "frobnicate", true},

--- a/internal/dts_to_esc/overlay_apply_test.go
+++ b/internal/dts_to_esc/overlay_apply_test.go
@@ -13,7 +13,7 @@ import (
 // produces two packages rather than one.
 const overlayLib = `
 interface Array<T> { length: number; at(index: number): T | undefined; }
-interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: unknown): boolean; }
 declare var Array: ArrayConstructor;
 interface ArrayLike<T> { readonly length: number; }
 declare function parseInt(string: string, radix?: number): number;
@@ -118,7 +118,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T | undefined,
     constructor(mut self),
-    static isArray(arg: any) -> boolean,
+    static isArray(arg: unknown) -> boolean,
     static of<T>(...items: Array<T>) -> Array<T>
 }
 
@@ -138,7 +138,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T | undefined,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 
 export declare interface ArrayLike<T> {
@@ -158,7 +158,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T | undefined,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 
 export declare interface ArrayLike<T> {
@@ -180,7 +180,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 
 export declare interface ArrayLike<T> {
@@ -198,7 +198,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T | undefined,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 
 export declare type ArrayLike<T> = {
@@ -216,7 +216,7 @@ export declare type ArrayLike<T> = {
 export declare class Array<T> {
     length: number,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 
 export declare interface ArrayLike<T> {
@@ -234,7 +234,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T | undefined,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 `,
 		},
@@ -372,7 +372,7 @@ export declare class Array<T> {
     /** Reads one element. */
     at(self, index: number) -> T,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 
 export declare interface ArrayLike<T> {
@@ -538,7 +538,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T | undefined,
     constructor(mut self),
-    static isArray(arg: any) -> boolean,
+    static isArray(arg: unknown) -> boolean,
     indexOf(self, item: T) -> number,
     indexOf(self, item: T, from: number) -> number
 }
@@ -815,7 +815,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 
 export declare interface ArrayLike<T> {
@@ -839,7 +839,7 @@ export declare class Array<T> {
     length: number,
     at(self, index: number) -> T | undefined,
     constructor(mut self),
-    static isArray(arg: any) -> boolean
+    static isArray(arg: unknown) -> boolean
 }
 
 export declare class ArrayLike<T> extends Array<T> {

--- a/internal/dts_to_esc/overlay_digest_test.go
+++ b/internal/dts_to_esc/overlay_digest_test.go
@@ -15,7 +15,7 @@ import (
 // does to a `replace`.
 const overlayMovedLib = `
 interface Array<T> { length: number; at(index: number): T | null; }
-interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: unknown): boolean; }
 declare var Array: ArrayConstructor;
 interface ArrayLike<T> { readonly length: number; }
 declare function parseInt(string: string, radix?: number): number;
@@ -197,14 +197,14 @@ func TestOverlayDigests_KeepAGetterAndASetterApart(t *testing.T) {
 // bulk of a TypeScript version bump, and it moves no shape.
 const overlayDocLib = `
 interface Array<T> { length: number; /** Reads one element. */ at(index: number): T | undefined; }
-interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: unknown): boolean; }
 declare var Array: ArrayConstructor;
 interface ArrayLike<T> { readonly length: number; }
 `
 
 const overlayEditedDocLib = `
 interface Array<T> { length: number; /** Reads the element at index. */ at(index: number): T | undefined; }
-interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: unknown): boolean; }
 declare var Array: ArrayConstructor;
 interface ArrayLike<T> { readonly length: number; }
 `
@@ -256,7 +256,7 @@ func TestOverlayDigests_KeepTheTwoSidesOfAClassApart(t *testing.T) {
     "member": "isArray",
     "kind": "method",
     "static": true,
-    "digest": "60de184c2c659aec"
+    "digest": "242e253f0166ec98"
   }
 ]
 `))

--- a/internal/dts_to_esc/validate_test.go
+++ b/internal/dts_to_esc/validate_test.go
@@ -188,6 +188,9 @@ func TestCommittedGraphRedundantOverrides(t *testing.T) {
 Function.bind
 Function.call
 Object.propertyIsEnumerable
+Promise.catch
+Promise.finally
+Promise.then
 String.charAt
 String.charCodeAt
 String.codePointAt
@@ -276,7 +279,7 @@ func TestWriteValidationReport(t *testing.T) {
 	// override entry lands in the third list. The lines below are the head of
 	// it, and the assertion after them covers the rest.
 	require.True(t, strings.HasPrefix(out.String(),
-		`  receivers: 1 confirmed by a heuristic, 1 redundant overrides, 1 disagreements, 1 answered by the facts alone, 59 overrides no fact answers
+		`  receivers: 1 confirmed by a heuristic, 1 redundant overrides, 1 disagreements, 1 answered by the facts alone, 62 overrides no fact answers
     disagreement: String.prototype.trim: fact mutBorrow, override borrow
     redundant override: String.charAt
     override with no fact: Body.arrayBuffer

--- a/internal/interop/data/std/array.esc
+++ b/internal/interop/data/std/array.esc
@@ -13,8 +13,8 @@ export declare class Array<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find<S: T>(self, predicate: fn (value: T, index: number, obj: mut Array<T>) -> boolean, thisArg?: any) -> S | undefined,
-    find(self, predicate: fn (value: T, index: number, obj: mut Array<T>) -> unknown, thisArg?: any) -> T | undefined,
+    find<S: T>(self, predicate: fn (value: T, index: number, obj: mut Array<T>) -> boolean, thisArg?: unknown) -> S | undefined,
+    find(self, predicate: fn (value: T, index: number, obj: mut Array<T>) -> unknown, thisArg?: unknown) -> T | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -24,7 +24,7 @@ export declare class Array<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: T, index: number, obj: mut Array<T>) -> unknown, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: T, index: number, obj: mut Array<T>) -> unknown, thisArg?: unknown) -> number,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -104,8 +104,8 @@ export declare class Array<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: T>(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: any) -> T | undefined,
+    findLast<S: T>(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: unknown) -> T | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -115,7 +115,7 @@ export declare class Array<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: unknown) -> number,
     /**
      * Returns a copy of an array with its elements reversed.
      */
@@ -265,7 +265,7 @@ export declare class Array<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every<S: T>(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> boolean, thisArg?: any) -> boolean,
+    every<S: T>(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> boolean, thisArg?: unknown) -> boolean,
     /**
      * Determines whether all the members of an array satisfy the specified test.
      * @param predicate A function that accepts up to three arguments. The every method calls
@@ -274,7 +274,7 @@ export declare class Array<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Determines whether the specified callback function returns true for any element of an array.
      * @param predicate A function that accepts up to three arguments. The some method calls
@@ -283,31 +283,31 @@ export declare class Array<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Calls a defined callback function on each element of an array, and returns an array that contains the results.
      * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    map<U>(self, callbackfn: fn (value: T, index: number, array: mut Array<T>) -> U, thisArg?: any) -> mut Array<U>,
+    map<U>(self, callbackfn: fn (value: T, index: number, array: mut Array<T>) -> U, thisArg?: unknown) -> mut Array<U>,
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter<S: T>(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> boolean, thisArg?: any) -> mut Array<S>,
+    filter<S: T>(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> boolean, thisArg?: unknown) -> mut Array<S>,
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: any) -> mut Array<T>,
+    filter(self, predicate: fn (value: T, index: number, array: mut Array<T>) -> unknown, thisArg?: unknown) -> mut Array<T>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
@@ -345,7 +345,7 @@ export declare class Array<T> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T, U>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> U, thisArg?: any) -> mut Array<U>,
+    static from<T, U>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> U, thisArg?: unknown) -> mut Array<U>,
     /**
      * Returns a new array from a set of elements.
      * @param items A set of elements to include in the new array object.
@@ -362,12 +362,12 @@ export declare class Array<T> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T, U>(iterable: Iterable<T> | ArrayLike<T>, mapfn: fn (v: T, k: number) -> U, thisArg?: any) -> mut Array<U>,
+    static from<T, U>(iterable: Iterable<T> | ArrayLike<T>, mapfn: fn (v: T, k: number) -> U, thisArg?: unknown) -> mut Array<U>,
     static readonly [Symbol.species]: ArrayConstructor,
     constructor(mut self, arrayLength?: number),
     constructor(mut self, arrayLength: number),
     constructor(mut self, ...items: mut Array<T>),
-    static isArray(arg: any) -> boolean,
+    static isArray(arg: unknown) -> boolean,
     static readonly prototype: mut Array<any>,
     /**
      * Creates an array from an async iterator or iterable object.
@@ -382,7 +382,7 @@ export declare class Array<T> {
      *      Each return value is awaited before being added to result array.
      * @param thisArg Value of 'this' used when executing mapfn.
      */
-    static fromAsync<T, U>(iterableOrArrayLike: AsyncIterable<T> | Iterable<T> | ArrayLike<T>, mapFn: fn (value: Awaited<T>, index: number) -> U, thisArg?: any) -> Promise<mut Array<Awaited<U>>>
+    static fromAsync<T, U>(iterableOrArrayLike: AsyncIterable<T> | Iterable<T> | ArrayLike<T>, mapFn: fn (value: Awaited<T>, index: number) -> U, thisArg?: unknown) -> Promise<mut Array<Awaited<U>>>
 }
 
 export declare interface ArrayIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -146,7 +146,7 @@ export declare class Promise<T, E = never> {
 export declare interface AsyncGenerator<T = unknown, TReturn = any, TNext = any, E = never> extends AsyncIteratorObject<T, TReturn, TNext> {
     next(...value: [] | [TNext]) -> Promise<IteratorResult<T, TReturn>, E>,
     return(value: TReturn | PromiseLike<TReturn, E>) -> Promise<IteratorResult<T, TReturn>, E>,
-    throw(e: any) -> Promise<IteratorResult<T, TReturn>, E>,
+    throw(e: unknown) -> Promise<IteratorResult<T, TReturn>, E>,
     [Symbol.asyncIterator]() -> AsyncGenerator<T, TReturn, TNext, E>
 }
 

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -11,21 +11,21 @@ export declare class Promise<T, E = never> {
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally<F = never>(mut self, onfinally: fn () -> unknown throws F) -> Promise<T, E | F>,
+    finally<F = never>(self, onfinally: fn () -> unknown throws F) -> Promise<T, E | F>,
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, F = never>(mut self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F) -> Promise<TResult1, E | F>,
-    then<TResult1 = T, TResult2 = never, F = never, G = never>(mut self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F, onrejected: fn (reason: E) -> TResult2 | PromiseLike<TResult2, G> throws G) -> Promise<TResult1 | TResult2, F | G>,
+    then<TResult1 = T, F = never>(self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F) -> Promise<TResult1, E | F>,
+    then<TResult1 = T, TResult2 = never, F = never, G = never>(self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F, onrejected: fn (reason: E) -> TResult2 | PromiseLike<TResult2, G> throws G) -> Promise<TResult1 | TResult2, F | G>,
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never, G = never>(mut self, onrejected: fn (reason: E) -> TResult | PromiseLike<TResult, G> throws G) -> Promise<T | TResult, G>,
+    catch<TResult = never, G = never>(self, onrejected: fn (reason: E) -> TResult | PromiseLike<TResult, G> throws G) -> Promise<T | TResult, G>,
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
      * resolve, or rejected when any Promise is rejected.

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -146,7 +146,7 @@ export declare class Promise<T, E = never> {
 export declare interface AsyncGenerator<T = unknown, TReturn = any, TNext = any, E = never> extends AsyncIteratorObject<T, TReturn, TNext> {
     next(...value: [] | [TNext]) -> Promise<IteratorResult<T, TReturn>, E>,
     return(value: TReturn | PromiseLike<TReturn, E>) -> Promise<IteratorResult<T, TReturn>, E>,
-    throw(e: unknown) -> Promise<IteratorResult<T, TReturn>, E>,
+    throw(e: E) -> Promise<IteratorResult<T, TReturn>, E>,
     [Symbol.asyncIterator]() -> AsyncGenerator<T, TReturn, TNext, E>
 }
 

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -11,20 +11,21 @@ export declare class Promise<T, E = never> {
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(mut self, onfinally?: (fn () -> unknown) | undefined | null) -> Promise<T, E>,
+    finally<F = never>(mut self, onfinally: fn () -> unknown throws F) -> Promise<T, E | F>,
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(mut self, onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: E) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> Promise<TResult1 | TResult2, E>,
+    then<TResult1 = T, F = never>(mut self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F) -> Promise<TResult1, E | F>,
+    then<TResult1 = T, TResult2 = never, F = never, G = never>(mut self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F, onrejected: fn (reason: E) -> TResult2 | PromiseLike<TResult2, G> throws G) -> Promise<TResult1 | TResult2, F | G>,
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(mut self, onrejected?: (fn (reason: E) -> TResult | PromiseLike<TResult, E>) | undefined | null) -> Promise<T | TResult, E>,
+    catch<TResult = never, G = never>(mut self, onrejected: fn (reason: E) -> TResult | PromiseLike<TResult, G> throws G) -> Promise<T | TResult, G>,
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
      * resolve, or rejected when any Promise is rejected.
@@ -243,7 +244,8 @@ export declare interface PromiseLike<T, E = never> {
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: E) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> PromiseLike<TResult1 | TResult2, E>
+    then<TResult1 = T, F = never>(onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F) -> PromiseLike<TResult1, E | F>,
+    then<TResult1 = T, TResult2 = never, F = never, G = never>(onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F, onrejected: fn (reason: E) -> TResult2 | PromiseLike<TResult2, G> throws G) -> PromiseLike<TResult1 | TResult2, F | G>
 }
 
 /**

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -18,13 +18,13 @@ export declare class Promise<T, E = never> {
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(mut self, onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: any) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> Promise<TResult1 | TResult2, E>,
+    then<TResult1 = T, TResult2 = never>(mut self, onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: E) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> Promise<TResult1 | TResult2, E>,
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(mut self, onrejected?: (fn (reason: any) -> TResult | PromiseLike<TResult, E>) | undefined | null) -> Promise<T | TResult, E>,
+    catch<TResult = never>(mut self, onrejected?: (fn (reason: E) -> TResult | PromiseLike<TResult, E>) | undefined | null) -> Promise<T | TResult, E>,
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
      * resolve, or rejected when any Promise is rejected.
@@ -49,7 +49,7 @@ export declare class Promise<T, E = never> {
      * a resolve callback used to resolve the promise with a value or the result of another promise,
      * and a reject callback used to reject the promise with a provided reason or error.
      */
-    constructor(mut self, executor: fn (resolve: fn (value: T | PromiseLike<T>) -> unknown, reject: fn (reason?: any) -> unknown) -> unknown),
+    constructor(mut self, executor: fn (resolve: fn (value: T | PromiseLike<T>) -> unknown, reject: fn (reason?: E) -> unknown) -> unknown),
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
      * resolve, or rejected when any Promise is rejected.
@@ -243,7 +243,7 @@ export declare interface PromiseLike<T, E = never> {
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: any) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> PromiseLike<TResult1 | TResult2, E>
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: E) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> PromiseLike<TResult1 | TResult2, E>
 }
 
 /**

--- a/internal/interop/data/std/boolean.esc
+++ b/internal/interop/data/std/boolean.esc
@@ -6,6 +6,6 @@
 export declare class Boolean {
     /** Returns the primitive value of the specified object. */
     valueOf(self) -> boolean,
-    constructor(mut self, value?: any),
+    constructor(mut self, value?: unknown),
     static readonly prototype: Boolean
 }

--- a/internal/interop/data/std/console.esc
+++ b/internal/interop/data/std/console.esc
@@ -15,7 +15,7 @@ export declare interface Console {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
     debug(...data: mut Array<any>) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/dir_static) */
-    dir(item?: any, options?: any) -> unknown,
+    dir(item?: unknown, options?: unknown) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/dirxml_static) */
     dirxml(...data: mut Array<any>) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/error_static) */
@@ -31,7 +31,7 @@ export declare interface Console {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/log_static) */
     log(...data: mut Array<any>) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/table_static) */
-    table(tabularData?: any, properties?: mut Array<string>) -> unknown,
+    table(tabularData?: unknown, properties?: mut Array<string>) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
     time(label?: string) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */

--- a/internal/interop/data/std/date.esc
+++ b/internal/interop/data/std/date.esc
@@ -191,7 +191,7 @@ export declare class Date {
     /** Returns a date as a string value in ISO format. */
     toISOString(self) -> string,
     /** Used by the JSON.stringify method to enable the transformation of an object's data for JavaScript Object Notation (JSON) serialization. */
-    toJSON(self, key?: any) -> string,
+    toJSON(self, key?: unknown) -> string,
     /**
      * Converts a date and time to a string by using the current or specified locale.
      * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.

--- a/internal/interop/data/std/error.esc
+++ b/internal/interop/data/std/error.esc
@@ -49,6 +49,6 @@ export declare class TypeError extends Error {
 export declare class SuppressedError extends Error {
     error: any,
     suppressed: any,
-    constructor(mut self, error: any, suppressed: any, message?: string),
+    constructor(mut self, error: unknown, suppressed: unknown, message?: string),
     static readonly prototype: SuppressedError
 }

--- a/internal/interop/data/std/function.esc
+++ b/internal/interop/data/std/function.esc
@@ -15,26 +15,26 @@ export declare class Function {
      * A constructor function can control which objects are recognized as its instances by
      * 'instanceof' by overriding this method.
      */
-    [Symbol.hasInstance](mut self, value: any) -> boolean,
+    [Symbol.hasInstance](mut self, value: unknown) -> boolean,
     /**
      * Calls the function, substituting the specified object for the this value of the function, and the specified array for the arguments of the function.
      * @param thisArg The object to be used as the this object.
      * @param argArray A set of arguments to be passed to the function.
      */
-    apply(self, this: Function, thisArg: any, argArray?: any) -> any,
+    apply(self, this: Function, thisArg: unknown, argArray?: unknown) -> any,
     /**
      * Calls a method of an object, substituting another object for the current object.
      * @param thisArg The object to be used as the current object.
      * @param argArray A list of arguments to be passed to the method.
      */
-    call(self, this: Function, thisArg: any, ...argArray: mut Array<any>) -> any,
+    call(self, this: Function, thisArg: unknown, ...argArray: mut Array<any>) -> any,
     /**
      * For a given function, creates a bound function that has the same body as the original function.
      * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
      * @param thisArg An object to which the this keyword can refer inside the new function.
      * @param argArray A list of arguments to be passed to the new function.
      */
-    bind(self, this: Function, thisArg: any, ...argArray: mut Array<any>) -> any,
+    bind(self, this: Function, thisArg: unknown, ...argArray: mut Array<any>) -> any,
     /** Returns a string representation of a function. */
     toString(self) -> string,
     prototype: any,
@@ -123,14 +123,14 @@ export declare interface NewableFunction extends Function {
      * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
      * @param thisArg The object to be used as the this object.
      */
-    bind<T>(this: T, thisArg: any) -> T,
+    bind<T>(this: T, thisArg: unknown) -> T,
     /**
      * For a given function, creates a bound function that has the same body as the original function.
      * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
      * @param thisArg The object to be used as the this object.
      * @param args Arguments to bind to the parameters of the function.
      */
-    bind<A: mut Array<any>, B: mut Array<any>, R>(this: fn (...args: [...A, ...B]) -> R, thisArg: any, ...args: A) -> fn (...args: B) -> R
+    bind<A: mut Array<any>, B: mut Array<any>, R>(this: fn (...args: [...A, ...B]) -> R, thisArg: unknown, ...args: A) -> fn (...args: B) -> R
 }
 
 /**

--- a/internal/interop/data/std/iterator.esc
+++ b/internal/interop/data/std/iterator.esc
@@ -5,7 +5,7 @@
 export declare interface Generator<T = unknown, TReturn = any, TNext = any, E = never> extends IteratorObject<T, TReturn, TNext> {
     next(...value: [] | [TNext]) -> IteratorResult<T, TReturn>,
     return(value: TReturn) -> IteratorResult<T, TReturn>,
-    throw(e: any) -> IteratorResult<T, TReturn>,
+    throw(e: unknown) -> IteratorResult<T, TReturn>,
     [Symbol.iterator]() -> Generator<T, TReturn, TNext, E>
 }
 
@@ -60,7 +60,7 @@ export declare type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | 
 export declare class Iterator<T, TReturn = any, TNext = any> {
     next(mut self, ...value: [] | [TNext]) -> IteratorResult<T, TReturn>,
     return(mut self, value?: TReturn) -> IteratorResult<T, TReturn>,
-    throw(mut self, e?: any) -> IteratorResult<T, TReturn>,
+    throw(mut self, e?: unknown) -> IteratorResult<T, TReturn>,
     /**
      * Creates a native iterator from an iterator or iterable object.
      * Returns its input if the input already inherits from the built-in Iterator class.

--- a/internal/interop/data/std/iterator.esc
+++ b/internal/interop/data/std/iterator.esc
@@ -5,7 +5,7 @@
 export declare interface Generator<T = unknown, TReturn = any, TNext = any, E = never> extends IteratorObject<T, TReturn, TNext> {
     next(...value: [] | [TNext]) -> IteratorResult<T, TReturn>,
     return(value: TReturn) -> IteratorResult<T, TReturn>,
-    throw(e: unknown) -> IteratorResult<T, TReturn>,
+    throw(e: E) -> IteratorResult<T, TReturn>,
     [Symbol.iterator]() -> Generator<T, TReturn, TNext, E>
 }
 

--- a/internal/interop/data/std/json.esc
+++ b/internal/interop/data/std/json.esc
@@ -18,7 +18,7 @@ export declare fn parse(text: string, reviver?: fn (this: any, key: string, valu
  * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
  */
 @js("JSON.stringify")
-export declare fn stringify(value: any, replacer?: fn (this: any, key: string, value: any) -> any, space?: string | number) -> string
+export declare fn stringify(value: unknown, replacer?: fn (this: any, key: string, value: any) -> any, space?: string | number) -> string
 
 /**
  * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
@@ -27,4 +27,4 @@ export declare fn stringify(value: any, replacer?: fn (this: any, key: string, v
  * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
  */
 @js("JSON.stringify")
-export declare fn stringify(value: any, replacer?: mut Array<number | string> | null, space?: string | number) -> string
+export declare fn stringify(value: unknown, replacer?: mut Array<number | string> | null, space?: string | number) -> string

--- a/internal/interop/data/std/map.esc
+++ b/internal/interop/data/std/map.esc
@@ -12,7 +12,7 @@ export declare class Map<K, V> {
     /**
      * Executes a provided function once per each key/value pair in the Map, in insertion order.
      */
-    forEach(self, callbackfn: fn (value: V, key: K, map: mut Map<K, V>) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: V, key: K, map: mut Map<K, V>) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns a specified element from the Map object. If the value that is associated to the provided key is an object, then you will get a reference to that object and any change made to that object will effectively modify it inside the Map.
      * @returns Returns the element associated with the specified key. If no element is associated with the specified key, undefined is returned.

--- a/internal/interop/data/std/number.esc
+++ b/internal/interop/data/std/number.esc
@@ -93,7 +93,7 @@ export declare class Number {
      * All other strings are considered decimal.
      */
     static parseInt(string: string, radix?: number) -> number,
-    constructor(mut self, value?: any),
+    constructor(mut self, value?: unknown),
     static readonly prototype: Number,
     /** The largest number that can be represented in JavaScript. Equal to approximately 1.79E+308. */
     static readonly MAX_VALUE: number,

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -75,7 +75,7 @@ export declare class Object {
      * Returns an array of all symbol properties found directly on object o.
      * @param o Object to retrieve the symbols from.
      */
-    static getOwnPropertySymbols(o: any) -> mut Array<symbol>,
+    static getOwnPropertySymbols(o: unknown) -> mut Array<symbol>,
     /**
      * Returns the names of the enumerable string properties and methods of an object.
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -86,13 +86,13 @@ export declare class Object {
      * @param value1 The first value.
      * @param value2 The second value.
      */
-    static is(value1: any, value2: any) -> boolean,
+    static is(value1: unknown, value2: unknown) -> boolean,
     /**
      * Sets the prototype of a specified object o to object proto or null. Returns the object o.
      * @param o The object to change its prototype.
      * @param proto The value of the new prototype or null.
      */
-    static setPrototypeOf(o: any, proto: {...} | null) -> any,
+    static setPrototypeOf(o: unknown, proto: {...} | null) -> any,
     /**
      * Returns an array of values of the enumerable own properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -142,27 +142,27 @@ export declare class Object {
      * @param keySelector A callback which will be invoked for each item in items.
      */
     static groupBy<K: PropertyKey, T>(items: Iterable<T>, keySelector: fn (item: T, index: number) -> K) -> Partial<Record<K, mut Array<T>>>,
-    constructor(mut self, value?: any),
+    constructor(mut self, value?: unknown),
     /** A reference to the prototype for a class of objects. */
     static readonly prototype: Object,
     /**
      * Returns the prototype of an object.
      * @param o The object that references the prototype.
      */
-    static getPrototypeOf(o: any) -> any,
+    static getPrototypeOf(o: unknown) -> any,
     /**
      * Gets the own property descriptor of the specified object.
      * An own property descriptor is one that is defined directly on the object and is not inherited from the object's prototype.
      * @param o Object that contains the property.
      * @param p Name of the property.
      */
-    static getOwnPropertyDescriptor(o: any, p: PropertyKey) -> PropertyDescriptor | undefined,
+    static getOwnPropertyDescriptor(o: unknown, p: PropertyKey) -> PropertyDescriptor | undefined,
     /**
      * Returns the names of the own properties of an object. The own properties of an object are those that are defined directly
      * on that object, and are not inherited from the object's prototype. The properties of an object include both fields (objects) and functions.
      * @param o Object that contains the own properties.
      */
-    static getOwnPropertyNames(o: any) -> mut Array<string>,
+    static getOwnPropertyNames(o: unknown) -> mut Array<string>,
     /**
      * Creates an object that has the specified prototype or that has null prototype.
      * @param o Object to use as a prototype. May be null.
@@ -216,17 +216,17 @@ export declare class Object {
      * Returns true if existing property attributes cannot be modified in an object and new properties cannot be added to the object.
      * @param o Object to test.
      */
-    static isSealed(o: any) -> boolean,
+    static isSealed(o: unknown) -> boolean,
     /**
      * Returns true if existing property attributes and values cannot be modified in an object, and new properties cannot be added to the object.
      * @param o Object to test.
      */
-    static isFrozen(o: any) -> boolean,
+    static isFrozen(o: unknown) -> boolean,
     /**
      * Returns a value that indicates whether new properties can be added to an object.
      * @param o Object to test.
      */
-    static isExtensible(o: any) -> boolean
+    static isExtensible(o: unknown) -> boolean
 }
 
 export declare interface TypedPropertyDescriptor<T> {

--- a/internal/interop/data/std/reflect.esc
+++ b/internal/interop/data/std/reflect.esc
@@ -13,7 +13,7 @@
 export declare fn apply<T, A: Array<any>, R>(target: fn (this: T, ...args: A) -> R, thisArgument: T, argumentsList: Readonly<A>) -> R
 
 @js("Reflect.apply")
-export declare fn apply(target: Function, thisArgument: any, argumentsList: ArrayLike<any>) -> any
+export declare fn apply(target: Function, thisArgument: unknown, argumentsList: ArrayLike<any>) -> any
 
 /**
  * Constructs the target with the elements of specified array as the arguments
@@ -112,10 +112,10 @@ export declare fn preventExtensions(target: {...}) -> boolean
  *        if `target[propertyKey]` is an accessor property.
  */
 @js("Reflect.set")
-export declare fn set<T: {...}, P: PropertyKey>(target: T, propertyKey: P, value: if P : keyof T { T[P] } else { any }, receiver?: any) -> boolean
+export declare fn set<T: {...}, P: PropertyKey>(target: T, propertyKey: P, value: if P : keyof T { T[P] } else { any }, receiver?: unknown) -> boolean
 
 @js("Reflect.set")
-export declare fn set(target: {...}, propertyKey: PropertyKey, value: any, receiver?: any) -> boolean
+export declare fn set(target: {...}, propertyKey: PropertyKey, value: unknown, receiver?: unknown) -> boolean
 
 /**
  * Sets the prototype of a specified object o to object proto or null.

--- a/internal/interop/data/std/set.esc
+++ b/internal/interop/data/std/set.esc
@@ -17,7 +17,7 @@ export declare class Set<T> {
     /**
      * Executes a provided function once per each value in the Set object, in insertion order.
      */
-    forEach(self, callbackfn: fn (value: T, value2: T, set: mut Set<T>) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: T, value2: T, set: mut Set<T>) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * @returns a boolean indicating whether an element with the specified value exists in the Set or not.
      */

--- a/internal/interop/data/std/string.esc
+++ b/internal/interop/data/std/string.esc
@@ -365,7 +365,7 @@ export declare class String {
     static raw(template: {
         raw: Array<string> | ArrayLike<string>
     }, ...substitutions: mut Array<any>) -> string,
-    constructor(mut self, value?: any),
+    constructor(mut self, value?: unknown),
     static readonly prototype: String,
     static fromCharCode(...codes: mut Array<number>) -> string
 }

--- a/internal/interop/data/std/typed_arrays.esc
+++ b/internal/interop/data/std/typed_arrays.esc
@@ -39,8 +39,8 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -50,7 +50,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -108,7 +108,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -125,7 +125,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Int8Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Int8Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -135,7 +135,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -145,7 +145,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -153,7 +153,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -186,7 +186,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Int8Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Int8Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -257,7 +257,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -297,7 +297,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Int8Array<ArrayBuffer>,
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Int8Array<ArrayBuffer>,
     constructor(mut self),
     static readonly prototype: Int8Array<ArrayBufferLike>,
     constructor(mut self, length: number),
@@ -325,7 +325,7 @@ export declare class Int8Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Int8Array<ArrayBuffer>
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Int8Array<ArrayBuffer>
 }
 
 @js("Uint8Array")
@@ -365,8 +365,8 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -376,7 +376,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -434,7 +434,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -451,7 +451,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Uint8Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Uint8Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -461,7 +461,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -471,7 +471,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -479,7 +479,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -512,7 +512,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Uint8Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Uint8Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -583,7 +583,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -623,7 +623,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Uint8Array<ArrayBuffer>,
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Uint8Array<ArrayBuffer>,
     constructor(mut self),
     static readonly prototype: Uint8Array<ArrayBufferLike>,
     constructor(mut self, length: number),
@@ -651,7 +651,7 @@ export declare class Uint8Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Uint8Array<ArrayBuffer>
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Uint8Array<ArrayBuffer>
 }
 
 @js("Uint8ClampedArray")
@@ -691,8 +691,8 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -702,7 +702,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -760,7 +760,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -777,7 +777,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Uint8ClampedArray<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Uint8ClampedArray<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -787,7 +787,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -797,7 +797,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -805,7 +805,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -838,7 +838,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Uint8ClampedArray<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Uint8ClampedArray<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -909,7 +909,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -949,7 +949,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Uint8ClampedArray<ArrayBuffer>,
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Uint8ClampedArray<ArrayBuffer>,
     constructor(mut self),
     static readonly prototype: Uint8ClampedArray<ArrayBufferLike>,
     constructor(mut self, length: number),
@@ -977,7 +977,7 @@ export declare class Uint8ClampedArray<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Uint8ClampedArray<ArrayBuffer>
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Uint8ClampedArray<ArrayBuffer>
 }
 
 @js("Int16Array")
@@ -1017,8 +1017,8 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -1028,7 +1028,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -1086,7 +1086,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -1103,7 +1103,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Int16Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Int16Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -1113,7 +1113,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -1123,7 +1123,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -1131,7 +1131,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -1164,7 +1164,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Int16Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Int16Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -1235,7 +1235,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -1275,7 +1275,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Int16Array<ArrayBuffer>,
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Int16Array<ArrayBuffer>,
     constructor(mut self),
     static readonly prototype: Int16Array<ArrayBufferLike>,
     constructor(mut self, length: number),
@@ -1303,7 +1303,7 @@ export declare class Int16Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Int16Array<ArrayBuffer>
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Int16Array<ArrayBuffer>
 }
 
 @js("Uint16Array")
@@ -1343,8 +1343,8 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -1354,7 +1354,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -1412,7 +1412,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -1429,7 +1429,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Uint16Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Uint16Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -1439,7 +1439,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -1449,7 +1449,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -1457,7 +1457,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -1490,7 +1490,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Uint16Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Uint16Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -1561,7 +1561,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -1601,7 +1601,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Uint16Array<ArrayBuffer>,
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Uint16Array<ArrayBuffer>,
     constructor(mut self),
     static readonly prototype: Uint16Array<ArrayBufferLike>,
     constructor(mut self, length: number),
@@ -1629,7 +1629,7 @@ export declare class Uint16Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Uint16Array<ArrayBuffer>
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Uint16Array<ArrayBuffer>
 }
 
 @js("Int32Array")
@@ -1669,8 +1669,8 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -1680,7 +1680,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -1738,7 +1738,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -1755,7 +1755,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Int32Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Int32Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -1765,7 +1765,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -1775,7 +1775,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -1783,7 +1783,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -1816,7 +1816,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Int32Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Int32Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -1887,7 +1887,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -1927,7 +1927,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Int32Array<ArrayBuffer>,
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Int32Array<ArrayBuffer>,
     constructor(mut self),
     static readonly prototype: Int32Array<ArrayBufferLike>,
     constructor(mut self, length: number),
@@ -1955,7 +1955,7 @@ export declare class Int32Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Int32Array<ArrayBuffer>
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Int32Array<ArrayBuffer>
 }
 
 @js("Uint32Array")
@@ -1995,8 +1995,8 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -2006,7 +2006,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -2064,7 +2064,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -2081,7 +2081,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Uint32Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Uint32Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -2091,7 +2091,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -2101,7 +2101,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -2109,7 +2109,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -2142,7 +2142,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Uint32Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Uint32Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -2213,7 +2213,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -2253,7 +2253,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Uint32Array<ArrayBuffer>,
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Uint32Array<ArrayBuffer>,
     constructor(mut self),
     static readonly prototype: Uint32Array<ArrayBufferLike>,
     constructor(mut self, length: number),
@@ -2281,7 +2281,7 @@ export declare class Uint32Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Uint32Array<ArrayBuffer>
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Uint32Array<ArrayBuffer>
 }
 
 @js("Float32Array")
@@ -2321,8 +2321,8 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -2332,7 +2332,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -2390,7 +2390,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -2407,7 +2407,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Float32Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Float32Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -2417,7 +2417,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -2427,7 +2427,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -2435,7 +2435,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -2468,7 +2468,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Float32Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Float32Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -2539,7 +2539,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -2579,7 +2579,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Float32Array<ArrayBuffer>,
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Float32Array<ArrayBuffer>,
     constructor(mut self),
     static readonly prototype: Float32Array<ArrayBufferLike>,
     constructor(mut self, length: number),
@@ -2607,7 +2607,7 @@ export declare class Float32Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Float32Array<ArrayBuffer>
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Float32Array<ArrayBuffer>
 }
 
 @js("Float64Array")
@@ -2647,8 +2647,8 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -2658,7 +2658,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -2716,7 +2716,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -2733,7 +2733,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Float64Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Float64Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -2743,7 +2743,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -2753,7 +2753,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -2761,7 +2761,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -2794,7 +2794,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Float64Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Float64Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -2865,7 +2865,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -2905,7 +2905,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Float64Array<ArrayBuffer>,
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Float64Array<ArrayBuffer>,
     constructor(mut self),
     static readonly prototype: Float64Array<ArrayBufferLike>,
     constructor(mut self, length: number),
@@ -2933,7 +2933,7 @@ export declare class Float64Array<TArrayBuffer: ArrayBufferLike> {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Float64Array<ArrayBuffer>
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Float64Array<ArrayBuffer>
 }
 
 @js("ArrayBuffer")
@@ -2990,7 +2990,7 @@ export declare class ArrayBuffer {
     }),
     static readonly prototype: ArrayBuffer,
     constructor(mut self, byteLength: number),
-    static isView(arg: any) -> boolean
+    static isView(arg: unknown) -> boolean
 }
 
 @js("DataView")
@@ -3449,7 +3449,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> boolean, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> boolean, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -3466,7 +3466,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> any, thisArg?: any) -> BigInt64Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> any, thisArg?: unknown) -> BigInt64Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -3476,7 +3476,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> boolean, thisArg?: any) -> bigint | undefined,
+    find(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> boolean, thisArg?: unknown) -> bigint | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -3486,7 +3486,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -3494,7 +3494,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Determines whether an array includes a certain element, returning true or false as appropriate.
      * @param searchElement The element to search for.
@@ -3533,7 +3533,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> bigint, thisArg?: any) -> BigInt64Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> bigint, thisArg?: unknown) -> BigInt64Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -3600,7 +3600,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> boolean, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) -> boolean, thisArg?: unknown) -> boolean,
     /**
      * Sorts the array.
      * @param compareFn The function used to determine the order of the elements. If omitted, the elements are sorted in ascending order.
@@ -3637,8 +3637,8 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: bigint>(self, predicate: fn (value: bigint, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: bigint, index: number, array: Self) -> unknown, thisArg?: any) -> bigint | undefined,
+    findLast<S: bigint>(self, predicate: fn (value: bigint, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: bigint, index: number, array: Self) -> unknown, thisArg?: unknown) -> bigint | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -3648,7 +3648,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: bigint, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: bigint, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -3696,7 +3696,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<U>(arrayLike: ArrayLike<U>, mapfn: fn (v: U, k: number) -> bigint, thisArg?: any) -> BigInt64Array<ArrayBuffer>,
+    static from<U>(arrayLike: ArrayLike<U>, mapfn: fn (v: U, k: number) -> bigint, thisArg?: unknown) -> BigInt64Array<ArrayBuffer>,
     /**
      * Creates an array from an array-like or iterable object.
      * @param elements An iterable object to convert to an array.
@@ -3708,7 +3708,7 @@ export declare class BigInt64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLi
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> bigint, thisArg?: any) -> BigInt64Array<ArrayBuffer>
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> bigint, thisArg?: unknown) -> BigInt64Array<ArrayBuffer>
 }
 
 /**
@@ -3745,7 +3745,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> boolean, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> boolean, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -3762,7 +3762,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> any, thisArg?: any) -> BigUint64Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> any, thisArg?: unknown) -> BigUint64Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -3772,7 +3772,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> boolean, thisArg?: any) -> bigint | undefined,
+    find(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> boolean, thisArg?: unknown) -> bigint | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -3782,7 +3782,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> boolean, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -3790,7 +3790,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Determines whether an array includes a certain element, returning true or false as appropriate.
      * @param searchElement The element to search for.
@@ -3829,7 +3829,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> bigint, thisArg?: any) -> BigUint64Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> bigint, thisArg?: unknown) -> BigUint64Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -3896,7 +3896,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> boolean, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) -> boolean, thisArg?: unknown) -> boolean,
     /**
      * Sorts the array.
      * @param compareFn The function used to determine the order of the elements. If omitted, the elements are sorted in ascending order.
@@ -3933,8 +3933,8 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: bigint>(self, predicate: fn (value: bigint, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: bigint, index: number, array: Self) -> unknown, thisArg?: any) -> bigint | undefined,
+    findLast<S: bigint>(self, predicate: fn (value: bigint, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: bigint, index: number, array: Self) -> unknown, thisArg?: unknown) -> bigint | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -3944,7 +3944,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: bigint, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: bigint, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Copies the array and returns the copy with the elements in reverse order.
      */
@@ -3992,7 +3992,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<U>(arrayLike: ArrayLike<U>, mapfn: fn (v: U, k: number) -> bigint, thisArg?: any) -> BigUint64Array<ArrayBuffer>,
+    static from<U>(arrayLike: ArrayLike<U>, mapfn: fn (v: U, k: number) -> bigint, thisArg?: unknown) -> BigUint64Array<ArrayBuffer>,
     /**
      * Creates an array from an array-like or iterable object.
      * @param elements An iterable object to convert to an array.
@@ -4004,7 +4004,7 @@ export declare class BigUint64Array<TArrayBuffer: ArrayBufferLike = ArrayBufferL
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> bigint, thisArg?: any) -> BigUint64Array<ArrayBuffer>
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> bigint, thisArg?: unknown) -> BigUint64Array<ArrayBuffer>
 }
 
 export declare type ArrayBufferLike = ArrayBufferTypes[keyof ArrayBufferTypes]
@@ -4069,7 +4069,7 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    every(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
      * @param value value to fill array section with
@@ -4086,7 +4086,7 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: any) -> Float16Array<ArrayBuffer>,
+    filter(self, predicate: fn (value: number, index: number, array: Self) -> any, thisArg?: unknown) -> Float16Array<ArrayBuffer>,
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
      * otherwise.
@@ -4096,7 +4096,7 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number | undefined,
+    find(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
      * otherwise.
@@ -4106,7 +4106,7 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: any) -> number,
+    findIndex(self, predicate: fn (value: number, index: number, obj: Self) -> boolean, thisArg?: unknown) -> number,
     /**
      * Returns the value of the last element in the array where predicate is true, and undefined
      * otherwise.
@@ -4116,8 +4116,8 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: any) -> S | undefined,
-    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number | undefined,
+    findLast<S: number>(self, predicate: fn (value: number, index: number, array: Self) -> boolean, thisArg?: unknown) -> S | undefined,
+    findLast(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number | undefined,
     /**
      * Returns the index of the last element in the array where predicate is true, and -1
      * otherwise.
@@ -4127,7 +4127,7 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> number,
+    findLastIndex(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> number,
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -4135,7 +4135,7 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> unknown,
     /**
      * Determines whether an array includes a certain element, returning true or false as appropriate.
      * @param searchElement The element to search for.
@@ -4174,7 +4174,7 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: any) -> Float16Array<ArrayBuffer>,
+    map(self, callbackfn: fn (value: number, index: number, array: Self) -> number, thisArg?: unknown) -> Float16Array<ArrayBuffer>,
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
      * the callback function is the accumulated result, and is provided as an argument in the next
@@ -4245,7 +4245,7 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: any) -> boolean,
+    some(self, predicate: fn (value: number, index: number, array: Self) -> unknown, thisArg?: unknown) -> boolean,
     /**
      * Sorts an array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
@@ -4334,7 +4334,7 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: any) -> Float16Array<ArrayBuffer>,
+    static from<T>(arrayLike: ArrayLike<T>, mapfn: fn (v: T, k: number) -> number, thisArg?: unknown) -> Float16Array<ArrayBuffer>,
     /**
      * Creates an array from an array-like or iterable object.
      * @param elements An iterable object to convert to an array.
@@ -4346,5 +4346,5 @@ export declare class Float16Array<TArrayBuffer: ArrayBufferLike = ArrayBufferLik
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: any) -> Float16Array<ArrayBuffer>
+    static from<T>(elements: Iterable<T>, mapfn?: fn (v: T, k: number) -> number, thisArg?: unknown) -> Float16Array<ArrayBuffer>
 }

--- a/internal/interop/data/std/wasm.esc
+++ b/internal/interop/data/std/wasm.esc
@@ -70,11 +70,11 @@ export declare class Table {
     /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/get) */
     get(self, index: number) -> any,
     /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/grow) */
-    grow(mut self, delta: number, value?: any) -> number,
+    grow(mut self, delta: number, value?: unknown) -> number,
     /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/set) */
-    set(mut self, index: number, value?: any) -> unknown,
+    set(mut self, index: number, value?: unknown) -> unknown,
     static prototype: Table,
-    constructor(mut self, descriptor: TableDescriptor, value?: any)
+    constructor(mut self, descriptor: TableDescriptor, value?: unknown)
 }
 
 export declare interface GlobalDescriptor<T: ValueType = ValueType> {

--- a/internal/interop/data/web/dom.esc
+++ b/internal/interop/data/web/dom.esc
@@ -1192,7 +1192,7 @@ export declare class AbortController {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortController/abort)
      */
-    abort(mut self, reason?: any) -> unknown,
+    abort(mut self, reason?: unknown) -> unknown,
     static prototype: AbortController,
     constructor(mut self)
 }
@@ -1227,7 +1227,7 @@ export declare class AbortSignal extends EventTarget {
     static prototype: AbortSignal,
     constructor(mut self),
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_static) */
-    static abort(reason?: any) -> AbortSignal,
+    static abort(reason?: unknown) -> AbortSignal,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
     static any(signals: mut Array<AbortSignal>) -> AbortSignal,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout_static) */
@@ -1496,7 +1496,7 @@ export declare class BroadcastChannel extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/BroadcastChannel/postMessage)
      */
-    postMessage(mut self, message: any) -> unknown,
+    postMessage(mut self, message: unknown) -> unknown,
     addEventListener<K: keyof BroadcastChannelEventMap>(mut self, type: K, listener: fn (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) -> any, options?: boolean | AddEventListenerOptions) -> unknown,
     addEventListener(mut self, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) -> unknown,
     removeEventListener<K: keyof BroadcastChannelEventMap>(mut self, type: K, listener: fn (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) -> any, options?: boolean | EventListenerOptions) -> unknown,
@@ -1850,7 +1850,7 @@ export declare class CSSNestedDeclarations extends CSSRule {
 export declare class CSSNumericArray {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSNumericArray/length) */
     readonly length: number,
-    forEach(self, callbackfn: fn (value: CSSNumericValue, key: number, parent: CSSNumericArray) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: CSSNumericValue, key: number, parent: CSSNumericArray) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> ArrayIterator<CSSNumericValue>,
     entries(self) -> ArrayIterator<[number, CSSNumericValue]>,
     keys(self) -> ArrayIterator<number>,
@@ -3482,7 +3482,7 @@ export declare class CSSTransformValue extends CSSStyleValue {
     readonly length: number,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSTransformValue/toMatrix) */
     toMatrix(self) -> DOMMatrix,
-    forEach(self, callbackfn: fn (value: CSSTransformComponent, key: number, parent: CSSTransformValue) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: CSSTransformComponent, key: number, parent: CSSTransformValue) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> ArrayIterator<CSSTransformComponent>,
     entries(self) -> ArrayIterator<[number, CSSTransformComponent]>,
     keys(self) -> ArrayIterator<number>,
@@ -3533,7 +3533,7 @@ export declare class CSSUnitValue extends CSSNumericValue {
 export declare class CSSUnparsedValue extends CSSStyleValue {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/length) */
     readonly length: number,
-    forEach(self, callbackfn: fn (value: CSSUnparsedSegment, key: number, parent: CSSUnparsedValue) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: CSSUnparsedSegment, key: number, parent: CSSUnparsedValue) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> ArrayIterator<CSSUnparsedSegment>,
     entries(self) -> ArrayIterator<[number, CSSUnparsedSegment]>,
     keys(self) -> ArrayIterator<number>,
@@ -4068,7 +4068,7 @@ export declare class CustomEvent<T = any> extends Event {
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CustomStateSet) */
 @js("CustomStateSet")
 export declare class CustomStateSet extends Set<string> {
-    forEach(self, callbackfn: fn (value: string, key: string, parent: CustomStateSet) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: string, key: string, parent: CustomStateSet) -> unknown, thisArg?: unknown) -> unknown,
     static prototype: CustomStateSet,
     constructor(mut self)
 }
@@ -4613,7 +4613,7 @@ export declare class DOMTokenList {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMTokenList/toggle)
      */
     toggle(mut self, token: string, force?: boolean) -> boolean,
-    forEach(self, callbackfn: fn (value: string, key: number, parent: DOMTokenList) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: string, key: number, parent: DOMTokenList) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> ArrayIterator<string>,
     entries(self) -> ArrayIterator<[number, string]>,
     keys(self) -> ArrayIterator<number>,
@@ -6113,7 +6113,7 @@ export declare class Event {
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventCounts) */
 @js("EventCounts")
 export declare class EventCounts extends Map<string, number> {
-    forEach(self, callbackfn: fn (value: number, key: string, parent: EventCounts) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: number, key: string, parent: EventCounts) -> unknown, thisArg?: unknown) -> unknown,
     static prototype: EventCounts,
     constructor(mut self)
 }
@@ -6413,7 +6413,7 @@ export declare class FontFaceSet extends EventTarget {
     check(mut self, font: string, text?: string) -> boolean,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FontFaceSet/load) */
     load(mut self, font: string, text?: string) -> Promise<mut Array<FontFace>>,
-    forEach(self, callbackfn: fn (value: FontFace, key: FontFace, parent: FontFaceSet) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: FontFace, key: FontFace, parent: FontFaceSet) -> unknown, thisArg?: unknown) -> unknown,
     addEventListener<K: keyof FontFaceSetEventMap>(mut self, type: K, listener: fn (this: FontFaceSet, ev: FontFaceSetEventMap[K]) -> any, options?: boolean | AddEventListenerOptions) -> unknown,
     addEventListener(mut self, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) -> unknown,
     removeEventListener<K: keyof FontFaceSetEventMap>(mut self, type: K, listener: fn (this: FontFaceSet, ev: FontFaceSetEventMap[K]) -> any, options?: boolean | EventListenerOptions) -> unknown,
@@ -6459,7 +6459,7 @@ export declare class FormData {
     set(mut self, name: string, value: string | Blob) -> unknown,
     set(mut self, name: string, value: string) -> unknown,
     set(mut self, name: string, blobValue: Blob, filename?: string) -> unknown,
-    forEach(self, callbackfn: fn (value: FormDataEntryValue, key: string, parent: FormData) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: FormDataEntryValue, key: string, parent: FormData) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> FormDataIterator<[string, FormDataEntryValue]>,
     /** Returns an array of key, value pairs for every entry in the list. */
     entries(self) -> FormDataIterator<[string, FormDataEntryValue]>,
@@ -7590,7 +7590,7 @@ export declare class HTMLCanvasElement extends HTMLElement {
     getContext(self, contextId: "bitmaprenderer", options?: ImageBitmapRenderingContextSettings) -> ImageBitmapRenderingContext | null,
     getContext(self, contextId: "webgl", options?: WebGLContextAttributes) -> WebGLRenderingContext | null,
     getContext(self, contextId: "webgl2", options?: WebGLContextAttributes) -> WebGL2RenderingContext | null,
-    getContext(self, contextId: string, options?: any) -> RenderingContext | null,
+    getContext(self, contextId: string, options?: unknown) -> RenderingContext | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/toBlob) */
     toBlob(self, callback: BlobCallback, type?: string, quality?: number) -> unknown,
     /**
@@ -11260,7 +11260,7 @@ export declare class Highlight extends Set<AbstractRange> {
     priority: number,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Highlight/type) */
     type: HighlightType,
-    forEach(self, callbackfn: fn (value: AbstractRange, key: AbstractRange, parent: Highlight) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: AbstractRange, key: AbstractRange, parent: Highlight) -> unknown, thisArg?: unknown) -> unknown,
     static prototype: Highlight,
     constructor(mut self, ...initialRanges: mut Array<AbstractRange>)
 }
@@ -11268,7 +11268,7 @@ export declare class Highlight extends Set<AbstractRange> {
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HighlightRegistry) */
 @js("HighlightRegistry")
 export declare class HighlightRegistry extends Map<string, Highlight> {
-    forEach(self, callbackfn: fn (value: Highlight, key: string, parent: HighlightRegistry) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: Highlight, key: string, parent: HighlightRegistry) -> unknown, thisArg?: unknown) -> unknown,
     static prototype: HighlightRegistry,
     constructor(mut self)
 }
@@ -11293,9 +11293,9 @@ export declare class History {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/History/go) */
     go(mut self, delta?: number) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/History/pushState) */
-    pushState(mut self, data: any, unused: string, url?: string | URL | null) -> unknown,
+    pushState(mut self, data: unknown, unused: string, url?: string | URL | null) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/History/replaceState) */
-    replaceState(mut self, data: any, unused: string, url?: string | URL | null) -> unknown,
+    replaceState(mut self, data: unknown, unused: string, url?: string | URL | null) -> unknown,
     static prototype: History,
     constructor(mut self)
 }
@@ -11775,7 +11775,7 @@ export declare class MIDIInput extends MIDIPort {
  */
 @js("MIDIInputMap")
 export declare class MIDIInputMap extends Map<string, MIDIInput> {
-    forEach(self, callbackfn: fn (value: MIDIInput, key: string, parent: MIDIInputMap) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: MIDIInput, key: string, parent: MIDIInputMap) -> unknown, thisArg?: unknown) -> unknown,
     static prototype: MIDIInputMap,
     constructor(mut self)
 }
@@ -11819,7 +11819,7 @@ export declare class MIDIOutput extends MIDIPort {
  */
 @js("MIDIOutputMap")
 export declare class MIDIOutputMap extends Map<string, MIDIOutput> {
-    forEach(self, callbackfn: fn (value: MIDIOutput, key: string, parent: MIDIOutputMap) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: MIDIOutput, key: string, parent: MIDIOutputMap) -> unknown, thisArg?: unknown) -> unknown,
     static prototype: MIDIOutputMap,
     constructor(mut self)
 }
@@ -12046,7 +12046,7 @@ export declare class MediaKeyStatusMap {
     get(self, keyId: BufferSource) -> MediaKeyStatus | undefined,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap/has) */
     has(self, keyId: BufferSource) -> boolean,
-    forEach(self, callbackfn: fn (value: MediaKeyStatus, key: BufferSource, parent: MediaKeyStatusMap) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: MediaKeyStatus, key: BufferSource, parent: MediaKeyStatusMap) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> MediaKeyStatusMapIterator<[BufferSource, MediaKeyStatus]>,
     entries(self) -> MediaKeyStatusMapIterator<[BufferSource, MediaKeyStatus]>,
     keys(self) -> MediaKeyStatusMapIterator<BufferSource>,
@@ -12466,9 +12466,9 @@ export declare class MessageEvent<T = any> extends Event {
      */
     readonly source: MessageEventSource | null,
     /** @deprecated */
-    initMessageEvent(mut self, type: string, bubbles?: boolean, cancelable?: boolean, data?: any, origin?: string, lastEventId?: string, source?: MessageEventSource | null, ports?: mut Array<MessagePort>) -> unknown,
+    initMessageEvent(mut self, type: string, bubbles?: boolean, cancelable?: boolean, data?: unknown, origin?: string, lastEventId?: string, source?: MessageEventSource | null, ports?: mut Array<MessagePort>) -> unknown,
     /** @deprecated */
-    initMessageEvent(mut self, type: string, bubbles?: boolean, cancelable?: boolean, data?: any, origin?: string, lastEventId?: string, source?: MessageEventSource | null, ports?: Iterable<MessagePort>) -> unknown,
+    initMessageEvent(mut self, type: string, bubbles?: boolean, cancelable?: boolean, data?: unknown, origin?: string, lastEventId?: string, source?: MessageEventSource | null, ports?: Iterable<MessagePort>) -> unknown,
     static prototype: MessageEvent,
     constructor(mut self, type: string, eventInitDict?: MessageEventInit<T>)
 }
@@ -12514,8 +12514,8 @@ export declare class MessagePort extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessagePort/postMessage)
      */
-    postMessage(mut self, message: any, transfer: mut Array<Transferable>) -> unknown,
-    postMessage(mut self, message: any, options?: StructuredSerializeOptions) -> unknown,
+    postMessage(mut self, message: unknown, transfer: mut Array<Transferable>) -> unknown,
+    postMessage(mut self, message: unknown, options?: StructuredSerializeOptions) -> unknown,
     /**
      * Begins dispatching messages received on the port.
      *
@@ -13290,7 +13290,7 @@ export declare class NodeList {
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(self, callbackfn: fn (value: Node, key: number, parent: NodeList) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: Node, key: number, parent: NodeList) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> ArrayIterator<Node>,
     /** Returns an array of key, value pairs for every entry in the list. */
     entries(self) -> ArrayIterator<[number, Node]>,
@@ -13309,7 +13309,7 @@ export declare interface NodeListOf<TNode: Node> extends NodeList {
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: fn (value: TNode, key: number, parent: NodeListOf<TNode>) -> unknown, thisArg?: any) -> unknown,
+    forEach(callbackfn: fn (value: TNode, key: number, parent: NodeListOf<TNode>) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator]() -> ArrayIterator<TNode>,
     /** Returns an array of key, value pairs for every entry in the list. */
     entries() -> ArrayIterator<[number, TNode]>,
@@ -13444,11 +13444,11 @@ export declare class OffscreenCanvas extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/getContext)
      */
-    getContext(self, contextId: "2d", options?: any) -> OffscreenCanvasRenderingContext2D | null,
-    getContext(self, contextId: "bitmaprenderer", options?: any) -> ImageBitmapRenderingContext | null,
-    getContext(self, contextId: "webgl", options?: any) -> WebGLRenderingContext | null,
-    getContext(self, contextId: "webgl2", options?: any) -> WebGL2RenderingContext | null,
-    getContext(self, contextId: OffscreenRenderingContextId, options?: any) -> OffscreenRenderingContext | null,
+    getContext(self, contextId: "2d", options?: unknown) -> OffscreenCanvasRenderingContext2D | null,
+    getContext(self, contextId: "bitmaprenderer", options?: unknown) -> ImageBitmapRenderingContext | null,
+    getContext(self, contextId: "webgl", options?: unknown) -> WebGLRenderingContext | null,
+    getContext(self, contextId: "webgl2", options?: unknown) -> WebGL2RenderingContext | null,
+    getContext(self, contextId: OffscreenRenderingContextId, options?: unknown) -> OffscreenRenderingContext | null,
     /**
      * Returns a newly created ImageBitmap object with the image in the OffscreenCanvas object. The image in the OffscreenCanvas object is replaced with a new blank image.
      *
@@ -16752,7 +16752,7 @@ export declare class StylePropertyMapReadOnly {
     getAll(self, property: string) -> mut Array<CSSStyleValue>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/has) */
     has(self, property: string) -> boolean,
-    forEach(self, callbackfn: fn (value: mut Array<CSSStyleValue>, key: string, parent: StylePropertyMapReadOnly) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: mut Array<CSSStyleValue>, key: string, parent: StylePropertyMapReadOnly) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> StylePropertyMapReadOnlyIterator<[string, Iterable<CSSStyleValue>]>,
     entries(self) -> StylePropertyMapReadOnlyIterator<[string, Iterable<CSSStyleValue>]>,
     keys(self) -> StylePropertyMapReadOnlyIterator<string>,
@@ -17496,7 +17496,7 @@ export declare class ViewTransition {
 
 @js("ViewTransitionTypeSet")
 export declare class ViewTransitionTypeSet extends Set<string> {
-    forEach(self, callbackfn: fn (value: string, key: string, parent: ViewTransitionTypeSet) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: string, key: string, parent: ViewTransitionTypeSet) -> unknown, thisArg?: unknown) -> unknown,
     static prototype: ViewTransitionTypeSet,
     constructor(mut self)
 }
@@ -17867,7 +17867,7 @@ export declare class Window extends EventTarget {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/window) */
     readonly window: Window & typeof globalThis,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/alert) */
-    alert(mut self, message?: any) -> unknown,
+    alert(mut self, message?: unknown) -> unknown,
     /**
      * @deprecated
      *
@@ -17921,8 +17921,8 @@ export declare class Window extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
      */
-    postMessage(mut self, message: any, targetOrigin: string, transfer?: mut Array<Transferable>) -> unknown,
-    postMessage(mut self, message: any, options?: WindowPostMessageOptions) -> unknown,
+    postMessage(mut self, message: unknown, targetOrigin: string, transfer?: mut Array<Transferable>) -> unknown,
+    postMessage(mut self, message: unknown, options?: WindowPostMessageOptions) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/print) */
     print(mut self) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/prompt) */
@@ -18076,7 +18076,7 @@ export declare interface WindowOrWorkerGlobalScope {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/queueMicrotask) */
     queueMicrotask(callback: VoidFunction) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/reportError) */
-    reportError(e: any) -> unknown,
+    reportError(e: unknown) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/setInterval) */
     setInterval(handler: TimerHandler, timeout?: number, ...arguments: mut Array<any>) -> number,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/setTimeout) */
@@ -18432,7 +18432,7 @@ export declare class XSLTProcessor {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/XSLTProcessor/reset) */
     reset(mut self) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/XSLTProcessor/setParameter) */
-    setParameter(mut self, namespaceURI: string | null, localName: string, value: any) -> unknown,
+    setParameter(mut self, namespaceURI: string | null, localName: string, value: unknown) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/XSLTProcessor/transformToDocument) */
     transformToDocument(mut self, source: Node) -> Document,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/XSLTProcessor/transformToFragment) */
@@ -19320,7 +19320,7 @@ export declare var window: Window & typeof globalThis
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/alert) */
 @js("alert")
-export declare fn alert(message?: any) -> unknown
+export declare fn alert(message?: unknown) -> unknown
 
 /**
  * @deprecated
@@ -19400,10 +19400,10 @@ export declare fn open(url?: string | URL, target?: string, features?: string) -
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
  */
 @js("postMessage")
-export declare fn postMessage(message: any, targetOrigin: string, transfer?: mut Array<Transferable>) -> unknown
+export declare fn postMessage(message: unknown, targetOrigin: string, transfer?: mut Array<Transferable>) -> unknown
 
 @js("postMessage")
-export declare fn postMessage(message: any, options?: WindowPostMessageOptions) -> unknown
+export declare fn postMessage(message: unknown, options?: WindowPostMessageOptions) -> unknown
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/print) */
 @js("print")
@@ -20256,7 +20256,7 @@ export declare fn queueMicrotask(callback: VoidFunction) -> unknown
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/reportError) */
 @js("reportError")
-export declare fn reportError(e: any) -> unknown
+export declare fn reportError(e: unknown) -> unknown
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/setInterval) */
 @js("setInterval")

--- a/internal/interop/data/web/fetch.esc
+++ b/internal/interop/data/web/fetch.esc
@@ -76,7 +76,7 @@ export declare class Headers {
     has(self, name: string) -> boolean,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/set) */
     set(mut self, name: string, value: string) -> unknown,
-    forEach(self, callbackfn: fn (value: string, key: string, parent: Headers) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: string, key: string, parent: Headers) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> HeadersIterator<[string, string]>,
     /** Returns an iterator allowing to go through all key/value pairs contained in this object. */
     entries(self) -> HeadersIterator<[string, string]>,
@@ -207,7 +207,7 @@ export declare class Response extends Body {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/error_static) */
     static error() -> Response,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/json_static) */
-    static json(data: any, init?: ResponseInit) -> Response,
+    static json(data: unknown, init?: ResponseInit) -> Response,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/redirect_static) */
     static redirect(url: string | URL, status?: number) -> Response
 }

--- a/internal/interop/data/web/indexeddb.esc
+++ b/internal/interop/data/web/indexeddb.esc
@@ -94,7 +94,7 @@ export declare class IDBCursor {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBCursor/update)
      */
-    update(mut self, value: any) -> IDBRequest<IDBValidKey>,
+    update(mut self, value: unknown) -> IDBRequest<IDBValidKey>,
     static prototype: IDBCursor,
     constructor(mut self)
 }
@@ -210,7 +210,7 @@ export declare class IDBFactory {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBFactory/cmp)
      */
-    cmp(mut self, first: any, second: any) -> number,
+    cmp(mut self, first: unknown, second: unknown) -> number,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBFactory/databases) */
     databases(mut self) -> Promise<mut Array<IDBDatabaseInfo>>,
     /**
@@ -350,7 +350,7 @@ export declare class IDBKeyRange {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBKeyRange/includes)
      */
-    includes(self, key: any) -> boolean,
+    includes(self, key: unknown) -> boolean,
     static prototype: IDBKeyRange,
     constructor(mut self),
     /**
@@ -358,25 +358,25 @@ export declare class IDBKeyRange {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBKeyRange/bound_static)
      */
-    static bound(lower: any, upper: any, lowerOpen?: boolean, upperOpen?: boolean) -> IDBKeyRange,
+    static bound(lower: unknown, upper: unknown, lowerOpen?: boolean, upperOpen?: boolean) -> IDBKeyRange,
     /**
      * Returns a new IDBKeyRange starting at key with no upper bound. If open is true, key is not included in the range.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBKeyRange/lowerBound_static)
      */
-    static lowerBound(lower: any, open?: boolean) -> IDBKeyRange,
+    static lowerBound(lower: unknown, open?: boolean) -> IDBKeyRange,
     /**
      * Returns a new IDBKeyRange spanning only key.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBKeyRange/only_static)
      */
-    static only(value: any) -> IDBKeyRange,
+    static only(value: unknown) -> IDBKeyRange,
     /**
      * Returns a new IDBKeyRange with no lower bound and ending at key. If open is true, key is not included in the range.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBKeyRange/upperBound_static)
      */
-    static upperBound(upper: any, open?: boolean) -> IDBKeyRange
+    static upperBound(upper: unknown, open?: boolean) -> IDBKeyRange
 }
 
 /**
@@ -427,7 +427,7 @@ export declare class IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/add)
      */
-    add(mut self, value: any, key?: IDBValidKey) -> IDBRequest<IDBValidKey>,
+    add(mut self, value: unknown, key?: IDBValidKey) -> IDBRequest<IDBValidKey>,
     /**
      * Deletes all records in store.
      *
@@ -529,7 +529,7 @@ export declare class IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/put)
      */
-    put(mut self, value: any, key?: IDBValidKey) -> IDBRequest<IDBValidKey>,
+    put(mut self, value: unknown, key?: IDBValidKey) -> IDBRequest<IDBValidKey>,
     /**
      * Creates a new index in store with the given name, keyPath and options and returns a new IDBIndex. If the keyPath and options define constraints that cannot be satisfied with the data already in store the upgrade transaction will abort with a "ConstraintError" DOMException.
      *

--- a/internal/interop/data/web/service_worker.esc
+++ b/internal/interop/data/web/service_worker.esc
@@ -60,8 +60,8 @@ export declare class ServiceWorker extends EventTarget {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorker/state) */
     readonly state: ServiceWorkerState,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorker/postMessage) */
-    postMessage(mut self, message: any, transfer: mut Array<Transferable>) -> unknown,
-    postMessage(mut self, message: any, options?: StructuredSerializeOptions) -> unknown,
+    postMessage(mut self, message: unknown, transfer: mut Array<Transferable>) -> unknown,
+    postMessage(mut self, message: unknown, options?: StructuredSerializeOptions) -> unknown,
     addEventListener<K: keyof ServiceWorkerEventMap>(mut self, type: K, listener: fn (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) -> any, options?: boolean | AddEventListenerOptions) -> unknown,
     addEventListener(mut self, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) -> unknown,
     removeEventListener<K: keyof ServiceWorkerEventMap>(mut self, type: K, listener: fn (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) -> any, options?: boolean | EventListenerOptions) -> unknown,

--- a/internal/interop/data/web/streams.esc
+++ b/internal/interop/data/web/streams.esc
@@ -13,7 +13,7 @@ export declare class ReadableStream<R = any> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/locked) */
     readonly locked: boolean,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/cancel) */
-    cancel(mut self, reason?: any) -> Promise<undefined>,
+    cancel(mut self, reason?: unknown) -> Promise<undefined>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader) */
     getReader(self, options: {
         mode: "byob"
@@ -200,7 +200,7 @@ export declare class ReadableByteStreamController {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/enqueue) */
     enqueue(mut self, chunk: ArrayBufferView) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/error) */
-    error(mut self, e?: any) -> unknown,
+    error(mut self, e?: unknown) -> unknown,
     static prototype: ReadableByteStreamController,
     constructor(mut self)
 }
@@ -239,7 +239,7 @@ export declare class ReadableStreamDefaultController<R = any> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/enqueue) */
     enqueue(mut self, chunk?: R) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/error) */
-    error(mut self, e?: any) -> unknown,
+    error(mut self, e?: unknown) -> unknown,
     static prototype: ReadableStreamDefaultController,
     constructor(mut self)
 }
@@ -259,7 +259,7 @@ export declare interface ReadableStreamGenericReader {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader/closed) */
     readonly closed: Promise<undefined>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader/cancel) */
-    cancel(reason?: any) -> Promise<undefined>
+    cancel(reason?: unknown) -> Promise<undefined>
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStream) */
@@ -281,7 +281,7 @@ export declare class TransformStreamDefaultController<O = any> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/enqueue) */
     enqueue(mut self, chunk?: O) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/error) */
-    error(mut self, reason?: any) -> unknown,
+    error(mut self, reason?: unknown) -> unknown,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/terminate) */
     terminate(mut self) -> unknown,
     static prototype: TransformStreamDefaultController,
@@ -298,7 +298,7 @@ export declare class WritableStream<W = any> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/locked) */
     readonly locked: boolean,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/abort) */
-    abort(mut self, reason?: any) -> Promise<undefined>,
+    abort(mut self, reason?: unknown) -> Promise<undefined>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/close) */
     close(mut self) -> Promise<undefined>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/getWriter) */
@@ -317,7 +317,7 @@ export declare class WritableStreamDefaultController {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/signal) */
     readonly signal: AbortSignal,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/error) */
-    error(mut self, e?: any) -> unknown,
+    error(mut self, e?: unknown) -> unknown,
     static prototype: WritableStreamDefaultController,
     constructor(mut self)
 }
@@ -336,7 +336,7 @@ export declare class WritableStreamDefaultWriter<W = any> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/ready) */
     readonly ready: Promise<undefined>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/abort) */
-    abort(mut self, reason?: any) -> Promise<undefined>,
+    abort(mut self, reason?: unknown) -> Promise<undefined>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/close) */
     close(mut self) -> Promise<undefined>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/releaseLock) */

--- a/internal/interop/data/web/url.esc
+++ b/internal/interop/data/web/url.esc
@@ -93,7 +93,7 @@ export declare class URLSearchParams {
     sort(mut self) -> unknown,
     /** Returns a string containing a query string suitable for use in a URL. Does not include the question mark. */
     toString(self) -> string,
-    forEach(self, callbackfn: fn (value: string, key: string, parent: URLSearchParams) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: string, key: string, parent: URLSearchParams) -> unknown, thisArg?: unknown) -> unknown,
     [Symbol.iterator](mut self) -> URLSearchParamsIterator<[string, string]>,
     /** Returns an array of key, value pairs for every entry in the search params. */
     entries(self) -> URLSearchParamsIterator<[string, string]>,

--- a/internal/interop/data/web/web_audio.esc
+++ b/internal/interop/data/web/web_audio.esc
@@ -404,7 +404,7 @@ export declare class AudioParam {
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AudioParamMap) */
 @js("AudioParamMap")
 export declare class AudioParamMap extends Map<string, AudioParam> {
-    forEach(self, callbackfn: fn (value: AudioParam, key: string, parent: AudioParamMap) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: AudioParam, key: string, parent: AudioParamMap) -> unknown, thisArg?: unknown) -> unknown,
     static prototype: AudioParamMap,
     constructor(mut self)
 }

--- a/internal/interop/data/web/web_rtc.esc
+++ b/internal/interop/data/web/web_rtc.esc
@@ -760,7 +760,7 @@ export declare class RTCRtpReceiver {
 @js("RTCRtpScriptTransform")
 export declare class RTCRtpScriptTransform {
     static prototype: RTCRtpScriptTransform,
-    constructor(mut self, worker: Worker, options?: any, transfer?: mut Array<any>)
+    constructor(mut self, worker: Worker, options?: unknown, transfer?: mut Array<any>)
 }
 
 /**
@@ -862,7 +862,7 @@ export declare class RTCSessionDescription {
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCStatsReport) */
 @js("RTCStatsReport")
 export declare class RTCStatsReport extends Map<string, any> {
-    forEach(self, callbackfn: fn (value: any, key: string, parent: RTCStatsReport) -> unknown, thisArg?: any) -> unknown,
+    forEach(self, callbackfn: fn (value: any, key: string, parent: RTCStatsReport) -> unknown, thisArg?: unknown) -> unknown,
     static prototype: RTCStatsReport,
     constructor(mut self)
 }

--- a/internal/interop/data/web/workers.esc
+++ b/internal/interop/data/web/workers.esc
@@ -48,8 +48,8 @@ export declare class Worker extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Worker/postMessage)
      */
-    postMessage(mut self, message: any, transfer: mut Array<Transferable>) -> unknown,
-    postMessage(mut self, message: any, options?: StructuredSerializeOptions) -> unknown,
+    postMessage(mut self, message: unknown, transfer: mut Array<Transferable>) -> unknown,
+    postMessage(mut self, message: unknown, options?: StructuredSerializeOptions) -> unknown,
     /**
      * Aborts worker's associated global environment.
      *

--- a/internal/interop/overlay/std/async.replace.digests.json
+++ b/internal/interop/overlay/std/async.replace.digests.json
@@ -1,5 +1,11 @@
 [
   {
+    "decl": "AsyncGenerator",
+    "member": "throw",
+    "kind": "method",
+    "digest": "1386f0dcfb074072"
+  },
+  {
     "decl": "Promise",
     "member": "reject",
     "kind": "method",

--- a/internal/interop/overlay/std/async.replace.digests.json
+++ b/internal/interop/overlay/std/async.replace.digests.json
@@ -7,9 +7,33 @@
   },
   {
     "decl": "Promise",
+    "member": "catch",
+    "kind": "method",
+    "digest": "498391d6534d65da"
+  },
+  {
+    "decl": "Promise",
+    "member": "constructor",
+    "kind": "constructor",
+    "digest": "456519da26d0db0b"
+  },
+  {
+    "decl": "Promise",
+    "member": "then",
+    "kind": "method",
+    "digest": "8894daa091d8b71b"
+  },
+  {
+    "decl": "Promise",
     "member": "reject",
     "kind": "method",
     "static": true,
     "digest": "e600e2e52c7f2fd1"
+  },
+  {
+    "decl": "PromiseLike",
+    "member": "then",
+    "kind": "method",
+    "digest": "0143ef3631f4a9e9"
   }
 ]

--- a/internal/interop/overlay/std/async.replace.digests.json
+++ b/internal/interop/overlay/std/async.replace.digests.json
@@ -19,6 +19,12 @@
   },
   {
     "decl": "Promise",
+    "member": "finally",
+    "kind": "method",
+    "digest": "1c3039dbc5a1621e"
+  },
+  {
+    "decl": "Promise",
     "member": "then",
     "kind": "method",
     "digest": "8894daa091d8b71b"

--- a/internal/interop/overlay/std/async.replace.digests.json
+++ b/internal/interop/overlay/std/async.replace.digests.json
@@ -9,7 +9,7 @@
     "decl": "Promise",
     "member": "catch",
     "kind": "method",
-    "digest": "498391d6534d65da"
+    "digest": "3763268b9467176f"
   },
   {
     "decl": "Promise",
@@ -21,13 +21,13 @@
     "decl": "Promise",
     "member": "finally",
     "kind": "method",
-    "digest": "1c3039dbc5a1621e"
+    "digest": "2cef3bf8da94b7fc"
   },
   {
     "decl": "Promise",
     "member": "then",
     "kind": "method",
-    "digest": "8894daa091d8b71b"
+    "digest": "bcbaab6e20298969"
   },
   {
     "decl": "Promise",

--- a/internal/interop/overlay/std/async.replace.digests.json
+++ b/internal/interop/overlay/std/async.replace.digests.json
@@ -4,6 +4,6 @@
     "member": "reject",
     "kind": "method",
     "static": true,
-    "digest": "21f5e5c510490abc"
+    "digest": "e600e2e52c7f2fd1"
   }
 ]

--- a/internal/interop/overlay/std/async.replace.esc
+++ b/internal/interop/overlay/std/async.replace.esc
@@ -25,6 +25,11 @@
 // promise contributes that promise's rejection type rather than this
 // one's. Each callback carries its own raise variable for both.
 //
+// The receiver is `self`. Attaching a handler appends to the promise's
+// reaction lists, a write no reader can observe, and `mut self` would
+// demand unique mutable access to attach one at all. See the `Promise`
+// entry in mutability.go.
+//
 // **A handler is required.** TypeScript types every one of them
 // `| undefined | null`, so `p.finally()` is a promise that settles the
 // way `p` did and nothing else — a no-op that allocates. Requiring the
@@ -34,10 +39,10 @@
 // parameter cannot say both, and `then(null, g)` is `catch(g)` anyway.
 export declare class Promise<T, E = never> {
     static reject<T = never, E = undefined>(reason?: E) -> Promise<T, E>,
-    finally<F = never>(mut self, onfinally: fn () -> unknown throws F) -> Promise<T, E | F>,
-    then<TResult1 = T, F = never>(mut self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F) -> Promise<TResult1, E | F>,
-    then<TResult1 = T, TResult2 = never, F = never, G = never>(mut self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F, onrejected: fn (reason: E) -> TResult2 | PromiseLike<TResult2, G> throws G) -> Promise<TResult1 | TResult2, F | G>,
-    catch<TResult = never, G = never>(mut self, onrejected: fn (reason: E) -> TResult | PromiseLike<TResult, G> throws G) -> Promise<T | TResult, G>,
+    finally<F = never>(self, onfinally: fn () -> unknown throws F) -> Promise<T, E | F>,
+    then<TResult1 = T, F = never>(self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F) -> Promise<TResult1, E | F>,
+    then<TResult1 = T, TResult2 = never, F = never, G = never>(self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F, onrejected: fn (reason: E) -> TResult2 | PromiseLike<TResult2, G> throws G) -> Promise<TResult1 | TResult2, F | G>,
+    catch<TResult = never, G = never>(self, onrejected: fn (reason: E) -> TResult | PromiseLike<TResult, G> throws G) -> Promise<T | TResult, G>,
     constructor(mut self, executor: fn (resolve: fn (value: T | PromiseLike<T>) -> unknown, reject: fn (reason?: E) -> unknown) -> unknown),
 }
 

--- a/internal/interop/overlay/std/async.replace.esc
+++ b/internal/interop/overlay/std/async.replace.esc
@@ -10,29 +10,42 @@
 // which is why the converter threads the raise parameter through
 // instance members alone.
 //
-// `then`, `catch`, and the constructor's `reject` callback all name the
-// rejection reason, and `E` is what this promise rejects with, so that
-// is the type each of them carries. TypeScript writes `any` at all
-// three, which says nothing.
+// The rest of the block settles what `then`, `catch`, and `finally`
+// yield. TypeScript writes `any` for every reason and threads the
+// original rejection type through unchanged, so three separate facts go
+// unsaid.
 //
-// `E` beats `unknown` in both directions. A handler body gets a usable
-// type instead of having to narrow, and a handler declaring a narrower
-// parameter still checks: parameters are contravariant, and `E`
-// defaults to `never`, which every parameter type accepts. Constraining
-// the `reject` callback is the same rule as `AsyncGenerator.throw`
-// below — a reject that took any value would let one escape past what
-// `E` claims.
+// **A handler discharges the rejection.** After `p.catch(h)` the promise
+// cannot reject with `E` any more; that is the whole point of the call.
+// The same holds for the two-handler `then`. `E` survives only where
+// nothing handles it.
+//
+// **A handler raises on its own account.** A callback that throws `F`
+// makes the result reject with `F`, and a callback returning a different
+// promise contributes that promise's rejection type rather than this
+// one's. Each callback carries its own raise variable for both.
+//
+// **A handler is required.** TypeScript types every one of them
+// `| undefined | null`, so `p.finally()` is a promise that settles the
+// way `p` did and nothing else — a no-op that allocates. Requiring the
+// callback costs no real call and is what lets `then` state the
+// discharge rule: one overload leaves `E` alone because nothing handles
+// it, the other replaces it because something does. An optional
+// parameter cannot say both, and `then(null, g)` is `catch(g)` anyway.
 export declare class Promise<T, E = never> {
     static reject<T = never, E = undefined>(reason?: E) -> Promise<T, E>,
-    then<TResult1 = T, TResult2 = never>(mut self, onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: E) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> Promise<TResult1 | TResult2, E>,
-    catch<TResult = never>(mut self, onrejected?: (fn (reason: E) -> TResult | PromiseLike<TResult, E>) | undefined | null) -> Promise<T | TResult, E>,
+    finally<F = never>(mut self, onfinally: fn () -> unknown throws F) -> Promise<T, E | F>,
+    then<TResult1 = T, F = never>(mut self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F) -> Promise<TResult1, E | F>,
+    then<TResult1 = T, TResult2 = never, F = never, G = never>(mut self, onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F, onrejected: fn (reason: E) -> TResult2 | PromiseLike<TResult2, G> throws G) -> Promise<TResult1 | TResult2, F | G>,
+    catch<TResult = never, G = never>(mut self, onrejected: fn (reason: E) -> TResult | PromiseLike<TResult, G> throws G) -> Promise<T | TResult, G>,
     constructor(mut self, executor: fn (resolve: fn (value: T | PromiseLike<T>) -> unknown, reject: fn (reason?: E) -> unknown) -> unknown),
 }
 
-// `PromiseLike.then` names the same reason its `Promise` counterpart
+// `PromiseLike.then` states the same two rules its `Promise` counterpart
 // does.
 export declare interface PromiseLike<T, E = never> {
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: E) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> PromiseLike<TResult1 | TResult2, E>,
+    then<TResult1 = T, F = never>(onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F) -> PromiseLike<TResult1, E | F>,
+    then<TResult1 = T, TResult2 = never, F = never, G = never>(onfulfilled: fn (value: T) -> TResult1 | PromiseLike<TResult1, F> throws F, onrejected: fn (reason: E) -> TResult2 | PromiseLike<TResult2, G> throws G) -> PromiseLike<TResult1 | TResult2, F | G>,
 }
 
 // `throw` injects an exception at the generator's suspended yield. A

--- a/internal/interop/overlay/std/async.replace.esc
+++ b/internal/interop/overlay/std/async.replace.esc
@@ -9,8 +9,30 @@
 // `E`, as `T` already shadows the class's `T`: a static binds neither,
 // which is why the converter threads the raise parameter through
 // instance members alone.
+//
+// `then`, `catch`, and the constructor's `reject` callback all name the
+// rejection reason, and `E` is what this promise rejects with, so that
+// is the type each of them carries. TypeScript writes `any` at all
+// three, which says nothing.
+//
+// `E` beats `unknown` in both directions. A handler body gets a usable
+// type instead of having to narrow, and a handler declaring a narrower
+// parameter still checks: parameters are contravariant, and `E`
+// defaults to `never`, which every parameter type accepts. Constraining
+// the `reject` callback is the same rule as `AsyncGenerator.throw`
+// below — a reject that took any value would let one escape past what
+// `E` claims.
 export declare class Promise<T, E = never> {
     static reject<T = never, E = undefined>(reason?: E) -> Promise<T, E>,
+    then<TResult1 = T, TResult2 = never>(mut self, onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: E) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> Promise<TResult1 | TResult2, E>,
+    catch<TResult = never>(mut self, onrejected?: (fn (reason: E) -> TResult | PromiseLike<TResult, E>) | undefined | null) -> Promise<T | TResult, E>,
+    constructor(mut self, executor: fn (resolve: fn (value: T | PromiseLike<T>) -> unknown, reject: fn (reason?: E) -> unknown) -> unknown),
+}
+
+// `PromiseLike.then` names the same reason its `Promise` counterpart
+// does.
+export declare interface PromiseLike<T, E = never> {
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: (fn (value: T) -> TResult1 | PromiseLike<TResult1, E>) | undefined | null, onrejected?: (fn (reason: E) -> TResult2 | PromiseLike<TResult2, E>) | undefined | null) -> PromiseLike<TResult1 | TResult2, E>,
 }
 
 // `throw` injects an exception at the generator's suspended yield. A

--- a/internal/interop/overlay/std/async.replace.esc
+++ b/internal/interop/overlay/std/async.replace.esc
@@ -12,3 +12,12 @@
 export declare class Promise<T, E = never> {
     static reject<T = never, E = undefined>(reason?: E) -> Promise<T, E>,
 }
+
+// `throw` injects an exception at the generator's suspended yield. A
+// body that does not catch it rethrows it to the caller, so a value the
+// caller may pass freely would escape past what `E` says this generator
+// raises. Constraining the parameter to `E` is what keeps that claim
+// true. TypeScript writes `e: any`, which carries no such rule.
+export declare interface AsyncGenerator<T = unknown, TReturn = any, TNext = any, E = never> {
+    throw(e: E) -> Promise<IteratorResult<T, TReturn>, E>,
+}

--- a/internal/interop/overlay/std/iterator.replace.digests.json
+++ b/internal/interop/overlay/std/iterator.replace.digests.json
@@ -1,0 +1,8 @@
+[
+  {
+    "decl": "Generator",
+    "member": "throw",
+    "kind": "method",
+    "digest": "e207885967150b58"
+  }
+]

--- a/internal/interop/overlay/std/iterator.replace.esc
+++ b/internal/interop/overlay/std/iterator.replace.esc
@@ -1,0 +1,8 @@
+// `throw` injects an exception at the generator's suspended yield. A
+// body that does not catch it rethrows it to the caller, so a value the
+// caller may pass freely would escape past what `E` says this generator
+// raises. Constraining the parameter to `E` is what keeps that claim
+// true. TypeScript writes `e: any`, which carries no such rule.
+export declare interface Generator<T = unknown, TReturn = any, TNext = any, E = never> {
+    throw(e: E) -> IteratorResult<T, TReturn>,
+}

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -74,7 +74,7 @@ func TestRun_GenerateWithCFGPrintsEveryReport(t *testing.T) {
 
 	snaps.MatchInlineSnapshot(t, reportSummaries(stderr.String()), snaps.Inline(`  curation: 27 fill-ins, 0 corrections, 0 redundant, 0 stale, 0 unmatched, 0 refused
   coercion filter: 4882 TypeError sites adjudicated, 362 dropped
-  receivers: 194 confirmed by a heuristic, 24 redundant overrides, 0 disagreements, 48 answered by the facts alone, 37 overrides no fact answers
+  receivers: 194 confirmed by a heuristic, 27 redundant overrides, 0 disagreements, 45 answered by the facts alone, 37 overrides no fact answers
   join: 1 matched (1 with a receiver claim), 0 declarations without a fact, 436 facts without a declaration, 0 unkeyed declarations, 64 unjoinable facts
   returns: 1 settled as owned by the declared type, 0 left unknown`))
 }

--- a/tools/dts_to_esc/main_test.go
+++ b/tools/dts_to_esc/main_test.go
@@ -27,7 +27,7 @@ func seedLib(t *testing.T, contents string) string {
 
 const arrayLib = `
 interface Array<T> { length: number; }
-interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: any): boolean; readonly prototype: Array<any>; }
+interface ArrayConstructor { new <T>(): Array<T>; isArray(arg: unknown): boolean; readonly prototype: Array<any>; }
 declare var Array: ArrayConstructor;
 `
 
@@ -47,7 +47,7 @@ func TestRun_SingleFileWritesEscToStdout(t *testing.T) {
 export declare class Array<T> {
     length: number,
     constructor(mut self),
-    static isArray(arg: any) -> boolean,
+    static isArray(arg: unknown) -> boolean,
     static readonly prototype: Array<any>
 }
 `))
@@ -230,7 +230,7 @@ std/array.esc
 export declare class Array<T> {
     length: number,
     constructor(mut self),
-    static isArray(arg: any) -> boolean,
+    static isArray(arg: unknown) -> boolean,
     static readonly prototype: Array<any>
 }
 


### PR DESCRIPTION
Fixes #1432

Stacked on #1435. Review that one first; this PR's diff against it is the second commit only.

A declaration has no body, so a parameter TypeScript types `any` is only ever a value the caller passes in. `unknown` accepts every argument `any` does and does not hand an unchecked value back out if someone binds it, so the widening costs callers nothing.

279 parameters move and the tree loses 273 `any`s, 1545 down to 1272. `thisArg?: any` on the `Array` predicates is the most common single case.

```
static is(value1: unknown, value2: unknown) -> boolean,
static isFrozen(o: unknown) -> boolean,
static getPrototypeOf(o: unknown) -> any,
find<S: T>(self, predicate: fn (…) -> boolean, thisArg?: unknown) -> S | undefined,
```

## What the parameter is emitted as decides

A named method or a declared function widens, since the runtime supplies its body. Anything printed as an `fn (...)` type keeps `any`, because the value holding it is one the caller writes:

- a function type in a parameter position — `convertCallbackParam` in `convertTypeAnn`'s `FunctionType` and `ConstructorType` cases
- a call or construct signature on an interface
- an optional method, which the converter emits as a property holding a function type

So these are untouched, and should be:

```
catch<TResult = never>(mut self, onrejected?: (fn (reason: any) -> …) | undefined | null) -> …,
apply?: fn (target: T, thisArg: any, argArray: mut Array<any>) -> any,
```

Widening `reason` on `Promise.catch` or `thisArg` on a `ProxyHandler` trap would make every handler narrow before touching the value. The type flows the other way in those positions.

**The emitted shape is a proxy for who writes the body, not a decision procedure.** A required method on an interface the user implements widens along with the rest, and nothing in a `.d.ts` marks that interface apart. No such method in the pinned lib set takes an `any` parameter, so the corpus does not exercise the gap.

## What does not move

Only a parameter whose whole type is `any` widens. An `any` nested in `mut Array<any>` stays, since widening it would change what the array accepts rather than what the parameter does. A return typed `any` stays too — 952 of those — which is a larger question about what callers have to narrow, and out of scope here.

Properties typed `any` are untouched. `std/intl.esc`'s `DateTimeFormatPartTypeRegistry` fields and `Function.prototype` are properties, not parameters.

## Knock-on

`Promise.reject`'s overlay digest is re-recorded, since the digest covers the converted form and that form now reads `reason?: unknown`. The guard caught it on the first regeneration, which is the sidecar doing its job.

Two assertions in `internal/checker/tests/intersection_test.go` move, because the prelude reads the same lib set: `Function.apply` and `Function.call` now report `thisArg: unknown`.

## Verification

`go test ./...` passes. The generated tree matches its inputs under `check-generated-tree.sh` and is stable across two runs. Snapshots and fixtures regenerated with both update vars set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW

---
_Generated by [Claude Code](https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW)_