### PR TITLE
Support optional method syntax `foo?(…) -> T` in an object type

### DIFF
--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -266,8 +266,11 @@ func NewConstructorTypeAnn(fn *FuncTypeAnn, span Span) *ConstructorTypeAnn {
 
 type MethodTypeAnn struct {
 	declDoc
-	Name     ObjKey
-	Fn       *FuncTypeAnn
+	Name ObjKey
+	Fn   *FuncTypeAnn
+	// Optional records the `?` in `m?(x: T) -> T`, which says an object
+	// satisfying this type need not carry the method at all.
+	Optional bool
 	Receiver *MethodReceiver // nil if no receiver
 	elemSpan
 	commentSlots
@@ -278,6 +281,7 @@ func NewMethodTypeAnn(name ObjKey, fn *FuncTypeAnn, receiver *MethodReceiver, sp
 		declDoc:      declDoc{},
 		Name:         name,
 		Fn:           fn,
+		Optional:     false,
 		Receiver:     receiver,
 		elemSpan:     elemSpan{span: span},
 		commentSlots: commentSlots{},

--- a/internal/checker/infer_type_ann.go
+++ b/internal/checker/infer_type_ann.go
@@ -428,7 +428,9 @@ func (c *Checker) inferObjectTypeAnn(
 			errors = slices.Concat(errors, recvErrs)
 			fn, fnErrors := c.inferFuncTypeAnn(ctx, elem.Fn, recv)
 			errors = slices.Concat(errors, fnErrors)
-			elems[i] = type_system.NewMethodElem(*key, fn)
+			method := type_system.NewMethodElem(*key, fn)
+			method.Optional = elem.Optional
+			elems[i] = method
 		case *ast.GetterTypeAnn:
 			key, keyErrors := c.astKeyToTypeKey(ctx, elem.Name)
 			errors = slices.Concat(errors, keyErrors)

--- a/internal/codegen/dts.go
+++ b/internal/codegen/dts.go
@@ -892,8 +892,9 @@ func (b *Builder) buildObjTypeAnnElems(elem type_sys.ObjTypeElem, symbolExprMap 
 		out := make([]ObjTypeAnnElem, len(me.Signatures))
 		for i, fn := range me.Signatures {
 			out[i] = &MethodTypeAnn{
-				Name: b.buildTypeAnnObjKey(me.Name, symbolExprMap),
-				Fn:   b.buildFuncTypeAnn(fn),
+				Name:     b.buildTypeAnnObjKey(me.Name, symbolExprMap),
+				Fn:       b.buildFuncTypeAnn(fn),
+				Optional: me.Optional,
 			}
 		}
 		return out
@@ -920,8 +921,9 @@ func (b *Builder) buildObjTypeAnnElem(elem type_sys.ObjTypeElem, symbolExprMap m
 		// so the plural builder owns the fan-out and this case only
 		// sees the degenerate single-arm shape.
 		return &MethodTypeAnn{
-			Name: b.buildTypeAnnObjKey(elem.Name, symbolExprMap),
-			Fn:   b.buildFuncTypeAnn(elem.Signatures[0]),
+			Name:     b.buildTypeAnnObjKey(elem.Name, symbolExprMap),
+			Fn:       b.buildFuncTypeAnn(elem.Signatures[0]),
+			Optional: elem.Optional,
 		}
 	case *type_sys.GetterElem:
 		return &GetterTypeAnn{
@@ -993,8 +995,9 @@ func (b *Builder) buildObjTypeAnnElemFromAST(elem ast.ObjTypeAnnElem) ObjTypeAnn
 		}
 	case *ast.MethodTypeAnn:
 		return &MethodTypeAnn{
-			Name: b.buildTypeAnnObjKeyFromAST(elem.Name),
-			Fn:   *b.buildFuncTypeAnnFromAST(elem.Fn),
+			Name:     b.buildTypeAnnObjKeyFromAST(elem.Name),
+			Fn:       *b.buildFuncTypeAnnFromAST(elem.Fn),
+			Optional: elem.Optional,
 		}
 	case *ast.GetterTypeAnn:
 		return &GetterTypeAnn{

--- a/internal/codegen/printer.go
+++ b/internal/codegen/printer.go
@@ -585,6 +585,9 @@ func (p *Printer) printObjTypeAnnElem(elem ObjTypeAnnElem) {
 		p.PrintTypeAnn(elem.Fn.Return)
 	case *MethodTypeAnn:
 		p.printObjKey(elem.Name)
+		if elem.Optional {
+			p.print("?")
+		}
 		// Print type parameters if present
 		if len(elem.Fn.TypeParams) > 0 {
 			p.print("<")

--- a/internal/codegen/type_ann.go
+++ b/internal/codegen/type_ann.go
@@ -199,6 +199,9 @@ type ConstructorTypeAnn struct{ Fn FuncTypeAnn }
 type MethodTypeAnn struct {
 	Name ObjKey
 	Fn   FuncTypeAnn
+	// Optional is the `?` of `m?(x: T): T`, which TypeScript writes
+	// between the name and the parameter list.
+	Optional bool
 }
 type GetterTypeAnn struct {
 	Name ObjKey

--- a/internal/dts_to_esc/helper.go
+++ b/internal/dts_to_esc/helper.go
@@ -229,9 +229,11 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 				return nil, fmt.Errorf("converting method signature type parameter: %w", err)
 			}
 		}
-		// An optional method is emitted below as a property holding a
-		// function type, which is a value whoever implements the
-		// interface writes. Its parameters read like a callback's.
+		// An optional method is one whoever implements the interface may
+		// supply, which makes it a body the caller writes rather than the
+		// runtime. Its parameters read like a callback's, so a `any`
+		// stays: widening `thisArg` on a ProxyHandler trap would make
+		// every handler narrow before touching the value.
 		convert := convertParam
 		if m.Optional {
 			convert = convertCallbackParam
@@ -253,23 +255,8 @@ func convertInterfaceMember(member dts_parser.InterfaceMember) (ast.ObjTypeAnnEl
 		if err != nil {
 			return nil, fmt.Errorf("converting method name: %w", err)
 		}
-		if m.Optional {
-			// Escalier has no optional method syntax: `foo?(): T` does
-			// not parse. An optional property holding a function type
-			// says the same thing and does parse, so `apply?(t: T): any`
-			// becomes `apply?: fn (t: T) -> any`. Dropping the marker
-			// instead would make every ProxyHandler trap required, and
-			// a handler is meant to supply the traps it wants.
-			//
-			// Nothing is lost to the shape change. A method signature
-			// can be overloaded where a property cannot, and none of the
-			// 22 optional methods in the pinned lib set is: the repeated
-			// names sit in different interfaces.
-			prop := ast.NewPropertyTypeAnn(name, true, false, fn, m.Span())
-			prop.SetDoc(m.Doc())
-			return prop, nil
-		}
 		elem := ast.NewMethodTypeAnn(name, fn, nil, m.Span())
+		elem.Optional = m.Optional
 		elem.SetDoc(m.Doc())
 		return elem, nil
 	case *dts_parser.PropertySignature:

--- a/internal/dts_to_esc/helper_test.go
+++ b/internal/dts_to_esc/helper_test.go
@@ -1066,10 +1066,14 @@ func TestConvertTypeAnn_ObjectLowersToInexact(t *testing.T) {
 }
 
 // TestConvertInterfaceMember_KeepsWhatTheGrammarHasRoomFor covers the
-// optional method, which the converter used to drop because Escalier
-// has no `foo?(): T` syntax. An optional property holding a function
-// type says the same thing and does parse. Dropping the marker made
-// every ProxyHandler trap required.
+// optional method. Escalier writes one as `foo?(): T`, so the marker
+// carries over rather than being dropped or traded for a property. A
+// dropped marker made every ProxyHandler trap required.
+//
+// An optional method keeps an `any` parameter. The implementer supplies
+// the body, so widening it to `unknown` would make every trap narrow
+// before touching the value.
+//
 // The index signature is the other half of #1417 and is still dropped,
 // held back by the checker rather than by the grammar. See the
 // IndexSignature case in convertInterfaceMember.
@@ -1079,9 +1083,9 @@ func TestConvertInterfaceMember_KeepsWhatTheGrammarHasRoomFor(t *testing.T) {
 		name, input, want string
 	}{
 		{
-			"optional method becomes an optional function property",
+			"an optional method keeps its marker",
 			"interface F { apply?(target: T, thisArg: any): any; }",
-			"apply?: fn (target: T, thisArg: any) -> any",
+			"apply?(target: T, thisArg: any) -> any",
 		},
 		{
 			"a required method stays a method",

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -187,8 +187,8 @@ export declare interface AsyncGeneratorFunctionConstructor {
 
 export declare interface AsyncIterator<T, TReturn = any, TNext = any> {
     next(...value: [] | [TNext]) -> Promise<IteratorResult<T, TReturn>>,
-    return?: fn (value?: TReturn | PromiseLike<TReturn>) -> Promise<IteratorResult<T, TReturn>>,
-    throw?: fn (e?: any) -> Promise<IteratorResult<T, TReturn>>
+    return?(value?: TReturn | PromiseLike<TReturn>) -> Promise<IteratorResult<T, TReturn>>,
+    throw?(e?: any) -> Promise<IteratorResult<T, TReturn>>
 }
 
 export declare interface AsyncIterable<T, TReturn = any, TNext = any> {

--- a/internal/interop/data/std/decorators.esc
+++ b/internal/interop/data/std/decorators.esc
@@ -258,17 +258,17 @@ export declare interface ClassAccessorDecoratorResult<This, Value> {
     /**
      * An optional replacement getter function. If not provided, the existing getter function is used instead.
      */
-    get?: fn (this: This) -> Value,
+    get?(this: This) -> Value,
     /**
      * An optional replacement setter function. If not provided, the existing setter function is used instead.
      */
-    set?: fn (this: This, value: Value) -> unknown,
+    set?(this: This, value: Value) -> unknown,
     /**
      * An optional initializer mutator that is invoked when the underlying field initializer is evaluated.
      * @param value The incoming initializer value.
      * @returns The replacement initializer value.
      */
-    init?: fn (this: This, value: Value) -> Value
+    init?(this: This, value: Value) -> Value
 }
 
 /**

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -9,8 +9,8 @@ export declare interface PropertyDescriptor {
     enumerable?: boolean,
     value?: any,
     writable?: boolean,
-    get?: fn () -> any,
-    set?: fn (v: any) -> unknown
+    get?() -> any,
+    set?(v: any) -> unknown
 }
 
 export declare interface PropertyDescriptorMap {}

--- a/internal/interop/data/std/proxy.esc
+++ b/internal/interop/data/std/proxy.esc
@@ -7,65 +7,65 @@ export declare interface ProxyHandler<T: {...}> {
      * A trap method for a function call.
      * @param target The original callable object which is being proxied.
      */
-    apply?: fn (target: T, thisArg: any, argArray: mut Array<any>) -> any,
+    apply?(target: T, thisArg: any, argArray: mut Array<any>) -> any,
     /**
      * A trap for the `new` operator.
      * @param target The original object which is being proxied.
      * @param newTarget The constructor that was originally called.
      */
-    construct?: fn (target: T, argArray: mut Array<any>, newTarget: Function) -> {...},
+    construct?(target: T, argArray: mut Array<any>, newTarget: Function) -> {...},
     /**
      * A trap for `Object.defineProperty()`.
      * @param target The original object which is being proxied.
      * @returns A `Boolean` indicating whether or not the property has been defined.
      */
-    defineProperty?: fn (target: T, property: string | symbol, attributes: PropertyDescriptor) -> boolean,
+    defineProperty?(target: T, property: string | symbol, attributes: PropertyDescriptor) -> boolean,
     /**
      * A trap for the `delete` operator.
      * @param target The original object which is being proxied.
      * @param p The name or `Symbol` of the property to delete.
      * @returns A `Boolean` indicating whether or not the property was deleted.
      */
-    deleteProperty?: fn (target: T, p: string | symbol) -> boolean,
+    deleteProperty?(target: T, p: string | symbol) -> boolean,
     /**
      * A trap for getting a property value.
      * @param target The original object which is being proxied.
      * @param p The name or `Symbol` of the property to get.
      * @param receiver The proxy or an object that inherits from the proxy.
      */
-    get?: fn (target: T, p: string | symbol, receiver: any) -> any,
+    get?(target: T, p: string | symbol, receiver: any) -> any,
     /**
      * A trap for `Object.getOwnPropertyDescriptor()`.
      * @param target The original object which is being proxied.
      * @param p The name of the property whose description should be retrieved.
      */
-    getOwnPropertyDescriptor?: fn (target: T, p: string | symbol) -> PropertyDescriptor | undefined,
+    getOwnPropertyDescriptor?(target: T, p: string | symbol) -> PropertyDescriptor | undefined,
     /**
      * A trap for the `[[GetPrototypeOf]]` internal method.
      * @param target The original object which is being proxied.
      */
-    getPrototypeOf?: fn (target: T) -> {...} | null,
+    getPrototypeOf?(target: T) -> {...} | null,
     /**
      * A trap for the `in` operator.
      * @param target The original object which is being proxied.
      * @param p The name or `Symbol` of the property to check for existence.
      */
-    has?: fn (target: T, p: string | symbol) -> boolean,
+    has?(target: T, p: string | symbol) -> boolean,
     /**
      * A trap for `Object.isExtensible()`.
      * @param target The original object which is being proxied.
      */
-    isExtensible?: fn (target: T) -> boolean,
+    isExtensible?(target: T) -> boolean,
     /**
      * A trap for `Reflect.ownKeys()`.
      * @param target The original object which is being proxied.
      */
-    ownKeys?: fn (target: T) -> ArrayLike<string | symbol>,
+    ownKeys?(target: T) -> ArrayLike<string | symbol>,
     /**
      * A trap for `Object.preventExtensions()`.
      * @param target The original object which is being proxied.
      */
-    preventExtensions?: fn (target: T) -> boolean,
+    preventExtensions?(target: T) -> boolean,
     /**
      * A trap for setting a property value.
      * @param target The original object which is being proxied.
@@ -73,13 +73,13 @@ export declare interface ProxyHandler<T: {...}> {
      * @param receiver The object to which the assignment was originally directed.
      * @returns A `Boolean` indicating whether or not the property was set.
      */
-    set?: fn (target: T, p: string | symbol, newValue: any, receiver: any) -> boolean,
+    set?(target: T, p: string | symbol, newValue: any, receiver: any) -> boolean,
     /**
      * A trap for `Object.setPrototypeOf()`.
      * @param target The original object which is being proxied.
      * @param newPrototype The object's new prototype or `null`.
      */
-    setPrototypeOf?: fn (target: T, v: {...} | null) -> boolean
+    setPrototypeOf?(target: T, v: {...} | null) -> boolean
 }
 
 export declare interface ProxyConstructor {

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -130,7 +130,8 @@ const (
 func followsAName(tokenType TokenType) bool {
 	// nolint: exhaustive
 	switch tokenType {
-	case OpenParen, CloseParen, LessThan, Colon, Question, Comma, CloseBrace, Equal:
+	case OpenParen, CloseParen, LessThan, Colon, Question, QuestionOpenParen,
+		Comma, CloseBrace, Equal:
 		return true
 	default:
 		return false

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -1016,7 +1016,7 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	// (the OpenParen branch). Properties — `p: T`, `p?: T`, or the
 	// recovery branches that build a PropertyTypeAnn with no value —
 	// can't carry them, so flag rather than silently dropping.
-	if token.Type != OpenParen {
+	if token.Type != OpenParen && token.Type != QuestionOpenParen {
 		for _, lp := range lifetimeParams {
 			p.reportError(lp.Span(),
 				"lifetime parameters are not supported in this context")
@@ -1032,6 +1032,10 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	recoveryNever := func(span ast.Span) ast.TypeAnn {
 		return ast.NewNeverTypeAnn(span)
 	}
+
+	// Set by the Question case when the marker turns out to sit on a
+	// method rather than a property, and read where the method is built.
+	optional := false
 
 	// nolint: exhaustive
 	switch token.Type {
@@ -1055,12 +1059,25 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		value := p.typeAnnRequired()
 		return ast.NewPropertyTypeAnn(objKey, false, readonly, value, p.elemSpanFrom(start))
 	case Question:
+		// A plain `?` here belongs to a property. An optional method
+		// arrives as QuestionOpenParen below, since `?(` is one token.
+		//
+		// A generic optional method, `m?<T>(x: T) -> T`, does not parse:
+		// `?<` is two tokens, so it reaches this case and fails on the
+		// missing `:`. TypeScript allows the form and the pinned lib set
+		// writes none, so the grammar leaves it out.
 		p.lexer.consume() // consume '?'
 		p.expect(Colon, ConsumeOnMatch)
 		value := p.typeAnnRequired()
 		return ast.NewPropertyTypeAnn(objKey, true, readonly, value, p.elemSpanFrom(start))
+	case QuestionOpenParen:
+		// `m?(…)` arrives as one token, since `?(` is also the optional-call
+		// operator. In a member position it marks the method optional, and
+		// the case below consumes the token for either spelling.
+		optional = true
+		fallthrough
 	case OpenParen:
-		p.lexer.consume() // consume '('
+		p.lexer.consume() // consume '(' or '?('
 
 		// Methods, getters, and setters all accept a leading `self` /
 		// `mut self` receiver (optionally with a lifetime: `'a self` /
@@ -1115,7 +1132,9 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		case "set":
 			return ast.NewSetterTypeAnn(objKey, fnTypeAnn, receiver, p.elemSpanFrom(start))
 		default:
-			return ast.NewMethodTypeAnn(objKey, fnTypeAnn, receiver, p.elemSpanFrom(start))
+			elem := ast.NewMethodTypeAnn(objKey, fnTypeAnn, receiver, p.elemSpanFrom(start))
+			elem.Optional = optional
+			return elem
 		}
 	default:
 		// Report error for invalid property syntax instead of panicking

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -561,3 +561,57 @@ func TestObjTypeAnnElemSpans(t *testing.T) {
 		})
 	}
 }
+
+// TestParseOptionalMethodTypeAnn covers the `?` on a method member. The
+// marker reads the same on a property and on a method, so what follows
+// it decides which one is being written, and `?(` arrives as one token
+// because it is also the optional-call operator.
+//
+// A keyword-named member is here because that token drives two rules.
+// `get?(…)` names a method `get` rather than opening an accessor, and
+// `return?(…)` names a method at all, both because `?(` is something
+// that follows a name.
+func TestParseOptionalMethodTypeAnn(t *testing.T) {
+	t.Parallel()
+	// Each case is one member. The printer writes an object type over
+	// several lines, so the expected output is built from the member
+	// rather than repeated.
+	members := map[string]string{
+		"optional method":            "m?(x: number) -> string",
+		"required method":            "m(x: number) -> string",
+		"optional property":          "m?: fn (x: number) -> string",
+		"optional method with self":  "m?(self, x: number) -> string",
+		"no parameters":              "m?() -> string",
+		"named get":                  "get?(x: number) -> string",
+		"named set":                  "set?(x: number) -> string",
+		"keyword name":               "return?(x: number) -> string",
+		"accessor is still accessor": "get m(self) -> string",
+	}
+	for name, member := range members {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := &ast.Source{Path: "test.esc", Contents: "{" + member + "}"}
+			p := NewParser(context.Background(), source)
+			typeAnn := p.typeAnn()
+			require.Empty(t, p.errors)
+			require.NotNil(t, typeAnn)
+
+			printed, err := printer.Print(typeAnn, printer.DefaultOptions())
+			require.NoError(t, err)
+			require.Equal(t, "{\n    "+member+"\n}", printed)
+		})
+	}
+}
+
+// TestParseOptionalMethodTypeAnn_GenericIsNotSupported pins the one form
+// the grammar leaves out. TypeScript writes `m?<T>(x: T): T`, where the
+// type parameters follow the marker. `?<` is two tokens rather than the
+// single `?(`, so the member reads as a property and fails on the
+// missing `:`. No declaration in the pinned TypeScript lib set writes it.
+func TestParseOptionalMethodTypeAnn_GenericIsNotSupported(t *testing.T) {
+	t.Parallel()
+	source := &ast.Source{Path: "test.esc", Contents: "{m?<T>(x: T) -> T}"}
+	p := NewParser(context.Background(), source)
+	p.typeAnn()
+	require.NotEmpty(t, p.errors)
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1574,6 +1574,11 @@ func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
 		p.printFuncTypeAnnTail(e.Fn)
 	case *ast.MethodTypeAnn:
 		p.printObjKey(e.Name)
+		if e.Optional {
+			// Before the type parameters, which is where the parser reads
+			// it back from.
+			p.writeString("?")
+		}
 		p.printGenericParams(e.Fn.LifetimeParams, e.Fn.TypeParams)
 		p.printAnnMemberParams(annMemberReceiver(e.Receiver, ""), e.Fn.Params)
 		p.printReturnAndThrows(e.Fn.Return, e.Fn.Throws)

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1135,9 +1135,13 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 		}
 		return ro + printObjectKeyName(e.Name) + opt + ": " + p.printType(e.Type)
 	case *MethodElem:
+		opt := ""
+		if e.Optional {
+			opt = "?"
+		}
 		arms := make([]string, len(e.Signatures))
 		for i, sig := range e.Signatures {
-			arms[i] = printObjectKeyName(e.Name) + p.printFuncTail(sig)
+			arms[i] = printObjectKeyName(e.Name) + opt + p.printFuncTail(sig)
 		}
 		return strings.Join(arms, "; ")
 	case *GetterElem:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -356,6 +356,10 @@ type MethodElem struct {
 	Name       string
 	Signatures []*FuncType // len 1 = ordinary; >1 = overload set (most-specific-first)
 	Static     bool
+	// Optional records the `?` in `m?(x: T) -> T`. An object type with an
+	// optional method is a supertype of one that omits the member, the
+	// same rule PropertyElem.Optional carries.
+	Optional bool
 }
 
 // GetterElem is a computed read property `get x(self) -> T`. Type is the value the

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1982,6 +1982,11 @@ func (c *Context) constrainObjMember(superElem soltype.ObjTypeElem, sub, sup *so
 	}
 	subElem, ok := lookup(sub, name)
 	if !ok {
+		// An optional method need not be there, so a source that omits it
+		// still satisfies the target. Same rule as an optional property.
+		if sm, isMethod := superElem.(*soltype.MethodElem); isMethod && sm.Optional {
+			return nil
+		}
 		return []SolverError{&MissingPropertyError{Sub: sub, Super: sup, Name: name}}
 	}
 	switch se := superElem.(type) {
@@ -1989,6 +1994,12 @@ func (c *Context) constrainObjMember(superElem soltype.ObjTypeElem, sub, sup *so
 		sm, ok := subElem.(*soltype.MethodElem)
 		if !ok || len(sm.Signatures) == 0 || len(se.Signatures) == 0 {
 			break
+		}
+		// A source that may omit the method cannot fill a target that
+		// requires one, the method counterpart of the optional-property
+		// check in constrainObj.
+		if sm.Optional && !se.Optional {
+			return []SolverError{&OptionalPropertyError{Sub: sub, Super: sup, Name: name}}
 		}
 		// Compares only the first arm of each overload set; full overload-set
 		// reconciliation is escalier-lang/escalier#865.

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -754,6 +754,11 @@ func TestConstrainObjectMethodMembers(t *testing.T) {
 			Params: []*soltype.FuncParam{identParam("a", param)}, Ret: ret,
 		}}}
 	}
+	optMethod := func(name string, param, ret soltype.Type) *soltype.MethodElem {
+		m := method(name, param, ret)
+		m.Optional = true
+		return m
+	}
 	tests := []struct {
 		name       string
 		sub, super soltype.Type
@@ -763,6 +768,37 @@ func TestConstrainObjectMethodMembers(t *testing.T) {
 			name:  "identical method members",
 			sub:   exactObj(method("m", num(), num())),
 			super: exactObj(method("m", num(), num())),
+		},
+		// MethodElem.Optional is part of the object shape the same way
+		// PropertyElem.Optional is, so the four presence cases mirror the
+		// property ones in TestConstrainObject.
+		{
+			// {} <: {m?(a: number) -> number}
+			name:  "absent source satisfies optional target method",
+			sub:   exactObj(),
+			super: exactObj(optMethod("m", num(), num())),
+		},
+		{
+			// {m?(…)} <: {m(…)}: the source may omit m, so it cannot fill a
+			// required method.
+			name:  "optional source method rejected by required target",
+			sub:   exactObj(optMethod("m", num(), num())),
+			super: exactObj(method("m", num(), num())),
+			want:  []string{"object property is optional but required: m"},
+		},
+		{
+			// {m(…)} <: {m?(…)}: a required method fills an optional one.
+			name:  "required source method fills optional target",
+			sub:   exactObj(method("m", num(), num())),
+			super: exactObj(optMethod("m", num(), num())),
+		},
+		{
+			// Optional on both sides still recurses into the signature, so an
+			// incompatible return is caught.
+			name:  "optional on both sides depth mismatch",
+			sub:   exactObj(optMethod("m", num(), str())),
+			super: exactObj(optMethod("m", num(), num())),
+			want:  []string{"cannot constrain string <: number"},
 		},
 		{
 			// A method's return is covariant, read through its callable value.

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -355,7 +355,11 @@ func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bo
 			return nil, true
 		}
 		sig := l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)
-		return &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}}, true
+		return &soltype.MethodElem{
+			Name:       name,
+			Signatures: []*soltype.FuncType{sig},
+			Optional:   elem.Optional,
+		}, true
 	case *ast.GetterTypeAnn:
 		name, ok := objKeyName(elem.Name)
 		if !ok {

--- a/internal/type_system/print_type.go
+++ b/internal/type_system/print_type.go
@@ -456,8 +456,15 @@ func printFuncType(t *FuncType, pt func(Type) string) string {
 	return printFuncSig("fn ", t, false, pt)
 }
 
-func printMethodSig(name ObjTypeKey, fn *FuncType, pt func(Type) string) string {
-	return printFuncSig(name.String(), fn, true, pt)
+// printMethodSig prints one arm of a method member. The `?` of an
+// optional method sits between the name and the parameter list, where
+// the parser reads it back from.
+func printMethodSig(name ObjTypeKey, optional bool, fn *FuncType, pt func(Type) string) string {
+	label := name.String()
+	if optional {
+		label += "?"
+	}
+	return printFuncSig(label, fn, true, pt)
 }
 
 func printObjectType(t *ObjectType, pt func(Type) string) string {
@@ -488,7 +495,7 @@ func printObjectType(t *ObjectType, pt func(Type) string) string {
 					if armIdx > 0 {
 						result += armSep
 					}
-					result += printMethodSig(elem.Name, fn, pt)
+					result += printMethodSig(elem.Name, elem.Optional, fn, pt)
 				}
 			case *GetterElem:
 				result += "get " + elem.Name.String() + "(" + printSelfReceiver(elem.Fn) + ") -> " + pt(elem.Fn.Return)

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -1065,6 +1065,10 @@ type ConstructorElem struct{ Fn *FuncType }
 type MethodElem struct {
 	Name       ObjTypeKey
 	Signatures []*FuncType
+	// Optional records the `?` in `m?(x: T) -> T`. An object type with an
+	// optional method is a supertype of one that omits the member, the
+	// same rule PropertyElem.Optional carries.
+	Optional bool
 }
 
 // SingleSig returns the sole signature for a method that is
@@ -1152,7 +1156,7 @@ type PropertyElem struct {
 }
 
 func NewMethodElem(name ObjTypeKey, fn *FuncType) *MethodElem {
-	return &MethodElem{Name: name, Signatures: []*FuncType{fn}}
+	return &MethodElem{Name: name, Signatures: []*FuncType{fn}, Optional: false}
 }
 func NewGetterElem(name ObjTypeKey, fn *FuncType) *GetterElem {
 	return &GetterElem{Name: name, Fn: fn}


### PR DESCRIPTION
Fixes #1433

Stacked on #1436, which is stacked on #1435. Review those first; this PR's diff against #1436 is the third commit only.

`m?(x: T) -> T` now parses, prints, and constrains.

## Why the workaround was not equivalent

#1429 emitted an optional TypeScript method as an optional property holding a function type, because Escalier had no syntax for the real thing. That loses two things a method carries.

**An overload set.** `soltype.MethodElem` holds `Signatures []*FuncType`; `PropertyElem` holds one `Type`. An optional method with more than one arm had no representation at all. The pinned lib set has none today, so nothing was lost — but the converter would have silently kept the last arm the day one appeared.

**A receiver.** A method's `self` is part of its signature. A property holding an `fn (…)` has none, so none of the 22 rewritten members could carry receiver mutability.

## The rules

An object type with an optional method is a supertype of one that omits the member, and a source that may omit the method cannot fill a target that requires one. The same two rules `PropertyElem.Optional` already carries, now in `constrainObjMember`.

## `?(` is one token

It is also the optional-call operator, so `m?(` lexes as a single `QuestionOpenParen` rather than `?` followed by `(`. The marker is read in a case of its own rather than by peeking past a `?`.

That token now follows a name, which fixes two members that would otherwise not parse:

- `get?(target: T, p: string | symbol, receiver: any) -> any` names a method `get` rather than opening an accessor
- `return?(value?: TReturn) -> IteratorResult<T, TReturn>` uses a keyword as a member name

Both are real members of `ProxyHandler` and `Iterator`.

## What the grammar leaves out

`m?<T>(x: T) -> T` does not parse. TypeScript writes the type parameters after the marker, and `?<` is two tokens rather than the single `?(`, so the member reads as a property and fails on the missing `:`. No declaration in the pinned lib set writes it, and `TestParseOptionalMethodTypeAnn_GenericIsNotSupported` pins the gap so it is a decision rather than a surprise.

Class bodies are not covered either. The issue raised them as a question, and a declared class member is the case #1351's fused classes would want; an optional method on a class with a body raises what an omitted method means at runtime. Object types are what the converter needs.

## The tree

The 22 optional methods are methods again:

```
export declare interface ProxyHandler<T: {...}> {
    apply?(target: T, thisArg: any, argArray: mut Array<any>) -> any,
    get?(target: T, p: string | symbol, receiver: any) -> any,
    set?(target: T, p: string | symbol, newValue: any, receiver: any) -> boolean,
}
```

Their parameters keep `any` rather than taking #1436's widening. An optional method is one whoever implements the interface supplies, so widening `thisArg` would make every trap narrow before touching the value. This is the case #1436's commit message flagged as its known limit, and it is settled here rather than left open.

## Changed layers

| layer | change |
| --- | --- |
| `internal/parser` | the `QuestionOpenParen` case, and `?(` added to `followsAName` |
| `internal/ast` | `MethodTypeAnn.Optional` |
| `internal/printer` | the marker, between the name and the type parameters |
| `internal/type_system`, `internal/soltype` | `MethodElem.Optional`, and both type printers |
| `internal/solver` | the two subtyping rules in `constrainObjMember` |
| `internal/codegen` | the marker on the `.d.ts` side |
| `internal/dts_to_esc` | emit the method instead of the property |

## Verification

`go test ./...` passes. The generated tree matches its inputs and is stable across two runs. `TestCommittedTreeParses` reads all 49 packages with the parser, which is what caught the `get?` and `return?` cases. New tests cover the parse and print round trip for nine member spellings, the unsupported generic form, and the four presence cases in `TestConstrainObjectMethodMembers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW

---
_Generated by [Claude Code](https://claude.ai/code/session_013JzBTDxdv56Co6XewUoaWW)_