### PR TITLE
Add a call signature to the class surface so a fused class can be called

### DIFF
--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -226,3 +226,36 @@ func (s *SetterElem) Accept(v Visitor) {
 	v.ExitClassElem(s)
 }
 func (s *SetterElem) Span() Span { return s.Span_ }
+
+// CallableElem is a call signature on a class's static side: the class value
+// can be called without `new`. `Number("1")` and `Symbol("x")` have that shape.
+// A `.d.ts` writes it as a bare call signature on the constructor-side
+// interface, and Escalier writes it `callable(x: number) -> T`.
+//
+// `Fn.Body` is always nil, and only a `declare class` body produces one. The
+// parser reads `callable` as this member only there, and only where the member
+// writes no receiver and carries no modifier; anything else keeps the name. A
+// class the compiler emits is not callable, so there is nothing for the elem to
+// describe on one.
+//
+// Escalier spells construction as a call, so a class that declares both a
+// `constructor` and a `callable` gives one expression two readings. The checker
+// resolves `Foo(x)` against the first of the two the static object type holds,
+// which is the constructor.
+type CallableElem struct {
+	declDoc
+	Fn    *FuncExpr
+	Span_ Span
+	commentSlots
+}
+
+func (*CallableElem) IsClassElem() {}
+func (c *CallableElem) Accept(v Visitor) {
+	if v.EnterClassElem(c) {
+		if c.Fn != nil {
+			c.Fn.Accept(v)
+		}
+	}
+	v.ExitClassElem(c)
+}
+func (c *CallableElem) Span() Span { return c.Span_ }

--- a/internal/checker/infer_class_decl.go
+++ b/internal/checker/infer_class_decl.go
@@ -260,6 +260,13 @@ func (c *Checker) inferClassDecl(ctx Context, decl *ast.ClassDecl) []Error {
 				objTypeElems = append(objTypeElems,
 					type_system.NewSetterElem(*key, funcType))
 			}
+		case *ast.CallableElem:
+			// The class value itself is callable. Only a `declare class` body
+			// produces this elem; see the matching note in InferComponent.
+			fnType, _, _, sigErrors := c.inferFuncSig(
+				declCtx, &elem.Fn.FuncSig, elem.Fn, nil)
+			errors = slices.Concat(errors, sigErrors)
+			staticElems = append(staticElems, &type_system.CallableElem{Fn: fnType})
 		case *ast.ConstructorElem:
 			// Constructor signatures are handled separately below via
 			// inferConstructorSig; nothing to do during the element walk.
@@ -331,8 +338,13 @@ func (c *Checker) inferClassDecl(ctx Context, decl *ast.ClassDecl) []Error {
 
 	mergedStaticElems, staticMergeErrors := c.MergeMethodOverloads(staticElems, decl.Span())
 	errors = slices.Concat(errors, staticMergeErrors)
-	constructorElem := &type_system.ConstructorElem{Fn: ctorFuncType}
-	classObjTypeElems := []type_system.ObjTypeElem{constructorElem}
+	// See the matching note in InferComponent: a `declare class` with no
+	// `constructor` member is not constructible.
+	var classObjTypeElems []type_system.ObjTypeElem
+	if len(inBodyCtors) > 0 || !decl.Declare() {
+		classObjTypeElems = append(classObjTypeElems,
+			&type_system.ConstructorElem{Fn: ctorFuncType})
+	}
 	classObjTypeElems = append(classObjTypeElems, mergedStaticElems...)
 
 	classObjType := type_system.NewObjectType(provenance, classObjTypeElems)

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -722,6 +722,16 @@ func (c *Checker) InferComponent(
 								type_system.NewSetterElem(*key, funcType),
 							)
 						}
+					case *ast.CallableElem:
+						// A call signature makes the class value itself callable,
+						// so it joins the static object type rather than the
+						// instance type. Only a `declare class` body produces one:
+						// the parser reads `callable` as an ordinary member name
+						// everywhere else.
+						fnType, _, _, sigErrors := c.inferFuncSig(
+							declCtx, &elem.Fn.FuncSig, elem.Fn, nil)
+						errors = slices.Concat(errors, sigErrors)
+						staticElems = append(staticElems, &type_system.CallableElem{Fn: fnType})
 					case *ast.ConstructorElem:
 						// Constructors are not class-instance members and so
 						// do not contribute to `objTypeElems`. The callable
@@ -828,8 +838,19 @@ func (c *Checker) InferComponent(
 				// Create an object type with a constructor element and static methods/properties
 				mergedStaticElems, staticMergeErrors := c.MergeMethodOverloads(staticElems, decl.Span())
 				errors = slices.Concat(errors, staticMergeErrors)
-				constructorElem := &type_system.ConstructorElem{Fn: funcType}
-				classObjTypeElems := []type_system.ObjTypeElem{constructorElem}
+				// A `declare class` describes a binding some other code supplies, and
+				// its constructor is whatever it writes down. One that declares no
+				// `constructor` is not constructible: `Symbol` and `BigInt` fuse to
+				// that shape because the specification forbids `new` on them, and
+				// Escalier spells construction as a call, so an implicit zero-arg
+				// constructor would both make `Symbol()` legal and shadow the class's
+				// own `callable` call signature. A class the compiler emits always
+				// gets one, synthesised above when the body omits it.
+				var classObjTypeElems []type_system.ObjTypeElem
+				if len(inBodyCtors) > 0 || !decl.Declare() {
+					classObjTypeElems = append(classObjTypeElems,
+						&type_system.ConstructorElem{Fn: funcType})
+				}
 				classObjTypeElems = append(classObjTypeElems, mergedStaticElems...)
 
 				classObjType := type_system.NewObjectType(provenance, classObjTypeElems)

--- a/internal/checker/tests/callable_class_test.go
+++ b/internal/checker/tests/callable_class_test.go
@@ -1,0 +1,60 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A `callable` call signature makes the class value itself callable, which is
+// what `Symbol("x")` and `Number("1")` do in JavaScript. The signature joins the
+// class's static object type, so a call against the class name resolves through
+// it.
+//
+// A class with no `constructor` member also has to reach the call signature. The
+// checker gives an emitted class an implicit zero-argument constructor, and
+// Escalier spells construction as a call, so an implicit one on a `declare class`
+// would answer `Tag("hi")` before the signature ever saw it.
+//
+// The two cases cover the two class paths: InferComponent walks a top-level
+// class, inferClassDecl walks one declared inside a function body.
+func TestCallableClassIsCalledThroughItsCallSignature(t *testing.T) {
+	tests := map[string]struct {
+		input       string
+		bindingName string
+	}{
+		"TopLevel": {
+			input: `
+				declare class Tag {
+					callable(label: string) -> number,
+					readonly label: string,
+				}
+				val n = Tag("hi")
+			`,
+			bindingName: "n",
+		},
+		"InsideAFunctionBody": {
+			input: `
+				fn tag() -> number {
+					declare class Tag {
+						callable(label: string) -> number,
+					}
+					return Tag("hi")
+				}
+				val n = tag()
+			`,
+			bindingName: "n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ns := mustInferAsModule(t, test.input)
+			actual := collectBindingTypes(ns)
+			got, ok := actual[test.bindingName]
+			require.Truef(t, ok, "binding %q not found", test.bindingName)
+			require.Equal(t, "number", got)
+		})
+	}
+}

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -737,6 +737,10 @@ func (v *DependencyVisitor) EnterClassElem(elem ast.ClassElem) bool {
 		if e.Fn != nil {
 			e.Fn.Accept(v)
 		}
+	case *ast.CallableElem:
+		if e.Fn != nil {
+			e.Fn.Accept(v)
+		}
 	}
 	return false
 }

--- a/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
+++ b/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
@@ -7,6 +7,8 @@ export declare class Boolean {
     valueOf(self) -> boolean,
     /** Constructs a new Boolean wrapper around a value. */
     constructor(mut self, value?: any),
+    /** Coerces a value to a primitive boolean. */
+    callable<T>(value?: T) -> boolean,
     /** The Boolean prototype object. */
     static readonly prototype: Boolean
 }

--- a/internal/dts_to_esc/decl.go
+++ b/internal/dts_to_esc/decl.go
@@ -387,7 +387,9 @@ func addRaiseParamToClass(
 
 // classElemIsStatic reports whether elem belongs to the class rather
 // than to an instance of it. A constructor is neither: it runs before
-// there is an instance, and it binds no instance type parameter.
+// there is an instance, and it binds no instance type parameter. A call
+// signature describes the class value being called, so it is not an
+// instance member either.
 func classElemIsStatic(elem ast.ClassElem) bool {
 	switch e := elem.(type) {
 	case *ast.FieldElem:
@@ -399,6 +401,8 @@ func classElemIsStatic(elem ast.ClassElem) bool {
 	case *ast.SetterElem:
 		return e.Static
 	case *ast.ConstructorElem:
+		return true
+	case *ast.CallableElem:
 		return true
 	}
 	return false

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -223,14 +223,6 @@ type trioTable struct {
 // already written the long way. Recognition was the only place the two
 // spellings had to be told apart.
 //
-// One shape is held back, and for a reason that is about the class
-// form rather than about recognition. A constructor interface with a
-// call signature and no `new` describes something callable and not
-// constructible, and fuseTrio has no class elem for a call signature,
-// so the fused class could be neither called nor constructed.
-// `SymbolConstructor` and `BigIntConstructor` are the two, and the
-// guard comes out when #1412 gives a class somewhere to hold one.
-//
 // This matches tryFuseTrio in internal/interop/class_shapes.go, which
 // has never gated on a construct signature.
 //
@@ -274,24 +266,6 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 		}
 		ctorMembers, ctorName, ok := constructorSide(name, v, interfaces)
 		if !ok {
-			continue
-		}
-		// A constructor side whose only callable form is a call
-		// signature would lose it: fuseTrio has no class elem to put
-		// one on, so the fused class could be neither called nor
-		// constructed. `SymbolConstructor` and `BigIntConstructor` are
-		// the two, and the specification forbids `new` on both, so the
-		// call signature is the only way to make one. They stay
-		// interfaces until #1412 gives a class somewhere to hold it.
-		//
-		// This reaches only the named form. An inline constructor side
-		// is required to carry a `new`, so it never has a call
-		// signature as its only callable form. One that has both still
-		// loses the call — `CompileError`, `LinkError` and
-		// `RuntimeError` in `lib.dom.d.ts` are the three — which is
-		// the same loss the 19 named trios that already fuse take, and
-		// #1412 covers all of them together.
-		if hasCallSignature(ctorMembers) && !hasConstructSignature(ctorMembers) {
 			continue
 		}
 
@@ -372,18 +346,6 @@ func ctorsReturning(members []dts_parser.InterfaceMember, instanceName string) b
 		found = true
 	}
 	return found
-}
-
-// hasCallSignature reports whether members holds at least one bare
-// `(...)` member, the form that makes `Symbol("x")` a call rather than
-// a construction.
-func hasCallSignature(members []dts_parser.InterfaceMember) bool {
-	for _, m := range members {
-		if _, ok := m.(*dts_parser.CallSignature); ok {
-			return true
-		}
-	}
-	return false
 }
 
 // hasConstructSignature reports whether members holds at least one
@@ -1120,10 +1082,11 @@ func attachJSDecorator(decl ast.Decl, arg string) {
 //   - GetterSignature   → GetterElem
 //   - SetterSignature   → SetterElem
 //   - ConstructSignature (static side only) → ConstructorElem
-//   - CallSignature (static side: bare-call form like `Boolean(x)`) and
-//     IndexSignature are skipped for the MVP — they have no direct class-
-//     elem mapping. §6 may revisit (e.g. lower the bare-call form into a
-//     static factory).
+//   - CallSignature (static side) → CallableElem. On the instance side it says
+//     instances are callable, which no class elem expresses, so the conversion
+//     fails rather than dropping it.
+//   - IndexSignature is skipped. `ast` has no node for one, so an interface
+//     loses it too; #1464 covers giving it somewhere to go.
 func fuseTrio(info *trioInfo) (*ast.ClassDecl, error) {
 	className := info.instance.Name.Name
 	typeParams, err := convertTypeParams(info.instance.TypeParams)
@@ -1204,8 +1167,8 @@ func fuseTrio(info *trioInfo) (*ast.ClassDecl, error) {
 
 // interfaceMemberToClassElem converts an interface member to a class elem,
 // keying the static flag off the caller (instance side vs constructor side
-// of the trio). Returns (nil, nil) for member kinds with no class-elem
-// representation (CallSignature, IndexSignature).
+// of the trio). Returns (nil, nil) for an IndexSignature, which no class elem
+// holds, and for a ConstructSignature, which the caller reads itself.
 //
 // owner is the name of the class being fused, which the receiver
 // classification reads for the owner-wide tiers. See ReceiverMutates.
@@ -1326,9 +1289,57 @@ func interfaceMemberToClassElem(
 		elem.SetDoc(doc)
 		return elem, nil
 
-	case *dts_parser.CallSignature, *dts_parser.IndexSignature, *dts_parser.ConstructSignature:
-		// Skip — no direct class-elem mapping in the MVP. ConstructSignature
-		// is handled by the caller for the static side.
+	case *dts_parser.CallSignature:
+		// A call signature on the constructor side says the binding can be called
+		// without `new`, which is what `Number("1")` and `Symbol("x")` do. It lands
+		// on the class as its `callable` member.
+		//
+		// On the instance side it says instances are callable, which is not a shape
+		// a class has: `callable` describes the class value, and no class elem
+		// describes an instance being called. Fusing would have to drop it, so the
+		// converter refuses instead. 67 interfaces in the pinned lib set carry a
+		// call signature and none of them is the instance side of a trio, so this
+		// reports a `.d.ts` the converter has not seen rather than a shape it is
+		// choosing not to handle.
+		if !static {
+			return nil, fmt.Errorf(
+				"trio %s: the instance side declares a call signature, which says "+
+					"an instance is callable; no class elem expresses that", owner)
+		}
+		typeParams, err := convertTypeParams(m.TypeParams)
+		if err != nil {
+			return nil, fmt.Errorf("call signature: type params: %w", err)
+		}
+		params, err := convertParams(m.Params)
+		if err != nil {
+			return nil, fmt.Errorf("call signature: params: %w", err)
+		}
+		var ret ast.TypeAnn
+		if m.ReturnType != nil {
+			ret, err = convertReturnTypeAnn(m.ReturnType)
+			if err != nil {
+				return nil, fmt.Errorf("call signature: return: %w", err)
+			}
+		}
+		span := convertSpan(m.Span())
+		elem := &ast.CallableElem{
+			Fn:    ast.NewFuncExpr(nil, typeParams, params, ret, nil, false, nil, span),
+			Span_: span,
+		}
+		elem.SetDoc(doc)
+		return elem, nil
+
+	case *dts_parser.IndexSignature:
+		// Skipped, and unlike a call signature this one is a real loss: 51 fused
+		// classes declare an index signature, `Array`, `String` and every typed
+		// array among them, so `arr[0]` reaches the tree with no declared type.
+		// It is not a fusion problem to fix here. `ast` has no index-signature
+		// node at all, so an interface loses one too, and nothing in the emitted
+		// tree carries one. #1464 covers giving it somewhere to go.
+		return nil, nil
+
+	case *dts_parser.ConstructSignature:
+		// Handled by the caller for the static side.
 		return nil, nil
 
 	default:

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -1130,16 +1130,14 @@ declare var Array: ArrayConstructor;
 }
 
 // A constructor interface with a call signature and no `new` describes
-// something callable and not constructible. fuseTrio has no class elem
-// for a call signature, so the fused class could be neither called nor
-// constructed. The trio passes through instead, keeping the call
-// signature on the interface, until #1412 gives a class somewhere to
-// hold one.
+// something callable and not constructible. The fused class carries the call
+// signature as `callable` and no `constructor`, which is what makes
+// `Symbol("x")` typed and `new Symbol()` unrepresentable.
 //
 // `SymbolConstructor` below is verbatim from lib.es2015.symbol.d.ts.
 // `BigIntConstructor` is the same shape and the only other one in the
 // pinned lib set.
-func TestStandalone_TrioNotFusedWhenTheConstructorIsOnlyCallable(t *testing.T) {
+func TestStandalone_CallableConstructorFusesWithACallSignature(t *testing.T) {
 	const slice = `
 interface Symbol {
     toString(): string;
@@ -1153,27 +1151,16 @@ interface SymbolConstructor {
 
 declare var Symbol: SymbolConstructor;
 `
-	astModule, printed := convertSlice(t, slice)
-	rootNS, ok := astModule.Module.Namespaces.Get("")
-	require.True(t, ok, "root namespace exists")
+	_, printed := convertSlice(t, slice)
 
-	var classes, interfaces, vars int
-	for _, d := range rootNS.Decls {
-		switch d.(type) {
-		case *ast.ClassDecl:
-			classes++
-		case *ast.InterfaceDecl:
-			interfaces++
-		case *ast.VarDecl:
-			vars++
-		}
-	}
-	require.Equal(t, 0, classes, "no class synthesized")
-	require.Equal(t, 2, interfaces, "both interfaces survive")
-	require.Equal(t, 1, vars, "the binding survives")
-
-	require.Contains(t, printed, "fn (description?: string | number) -> symbol",
-		"the call signature survives, which is the whole point of holding back")
+	snaps.MatchInlineSnapshot(t, printed, snaps.Inline(`@js("Symbol")
+export declare class Symbol {
+    toString(self) -> string,
+    static readonly prototype: Symbol,
+    callable(description?: string | number) -> symbol,
+    static for(key: string) -> symbol
+}
+`))
 
 	parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
 		&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
@@ -1181,7 +1168,38 @@ declare var Symbol: SymbolConstructor;
 	require.NotEmpty(t, parsedDecls)
 }
 
-// ConvertToStandaloneModule converts every declaration a file holds,
+// A call signature on the instance side says instances are callable, which is
+// not a shape a class has: `callable` describes the class value, and no class
+// elem describes an instance being called. Fusing would have to drop it, so the
+// converter refuses.
+//
+// 67 interfaces in the pinned lib set carry a call signature and none of them is
+// the instance side of a trio, so the input below is written by hand and the
+// error names a `.d.ts` the converter has not seen.
+func TestStandalone_InstanceCallSignatureIsRejected(t *testing.T) {
+	const slice = `
+interface Handler {
+    (event: string): void;
+    name: string;
+}
+
+interface HandlerConstructor {
+    new (): Handler;
+}
+
+declare var Handler: HandlerConstructor;
+`
+	source := &ast.Source{Path: "test.d.ts", Contents: slice, ID: 0}
+	dtsModule, parseErrs := dts_parser.NewDtsParser(source).ParseModule()
+	require.Empty(t, parseErrs, "dts parse errors")
+
+	_, err := ConvertToStandaloneModule(dtsModule)
+	require.EqualError(t, err,
+		"fusing trio for Handler: trio Handler: the instance side declares a call "+
+			"signature, which says an instance is callable; no class elem expresses that")
+}
+
+// ConvertToStandaloneModule converts every declaration a file holds,// ConvertToStandaloneModule converts every declaration a file holds,
 // with each `declare global { ... }` block lifted so its contents are
 // converted as if written beside it. Whether those declarations are
 // actually global is a question only the global tree asks, and

--- a/internal/dts_to_esc/twin_rewrite.go
+++ b/internal/dts_to_esc/twin_rewrite.go
@@ -157,6 +157,10 @@ func (r *twinRewriter) rewriteClassElem(elem ast.ClassElem) {
 		if e.Fn != nil {
 			r.rewriteFuncSig(&e.Fn.FuncSig)
 		}
+	case *ast.CallableElem:
+		if e.Fn != nil {
+			r.rewriteFuncSig(&e.Fn.FuncSig)
+		}
 	default:
 		panic(fmt.Sprintf("twinRewriter.rewriteClassElem: unhandled class-elem type %T — extend this switch so the readonly-twin rewrite does not silently skip a new ClassElem variant", elem))
 	}

--- a/internal/interop/data/std/array.esc
+++ b/internal/interop/data/std/array.esc
@@ -367,6 +367,9 @@ export declare class Array<T> {
     constructor(mut self, arrayLength?: number),
     constructor(mut self, arrayLength: number),
     constructor(mut self, ...items: mut Array<T>),
+    callable(arrayLength?: number) -> mut Array<any>,
+    callable<T>(arrayLength: number) -> mut Array<T>,
+    callable<T>(...items: mut Array<T>) -> mut Array<T>,
     static isArray(arg: any) -> boolean,
     static readonly prototype: mut Array<any>,
     /**

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -224,8 +224,10 @@ export declare type PromiseSettledResult<T> = PromiseFulfilledResult<T> | Promis
 export declare class AggregateError extends Error {
     errors: mut Array<any>,
     constructor(mut self, errors: Iterable<any>, message?: string),
+    callable(errors: Iterable<any>, message?: string) -> AggregateError,
     static readonly prototype: AggregateError,
-    constructor(mut self, errors: Iterable<any>, message?: string, options?: ErrorOptions)
+    constructor(mut self, errors: Iterable<any>, message?: string, options?: ErrorOptions),
+    callable(errors: Iterable<any>, message?: string, options?: ErrorOptions) -> AggregateError
 }
 
 export declare interface PromiseWithResolvers<T> {

--- a/internal/interop/data/std/bigint.esc
+++ b/internal/interop/data/std/bigint.esc
@@ -76,37 +76,32 @@ export declare interface BigIntToLocaleStringOptions {
     compactDisplay?: string
 }
 
-export declare interface BigInt {
+@js("BigInt")
+export declare class BigInt {
     /**
      * Returns a string representation of an object.
      * @param radix Specifies a radix for converting numeric values to strings.
      */
-    toString(radix?: number) -> string,
+    toString(self, radix?: number) -> string,
     /** Returns a string representation appropriate to the host environment's current locale. */
-    toLocaleString(locales?: Intl.LocalesArgument, options?: BigIntToLocaleStringOptions) -> string,
+    toLocaleString(self, locales?: Intl.LocalesArgument, options?: BigIntToLocaleStringOptions) -> string,
     /** Returns the primitive value of the specified object. */
-    valueOf() -> bigint,
-    readonly [Symbol.toStringTag]: "BigInt"
-}
-
-export declare interface BigIntConstructor {
-    fn (value: bigint | boolean | number | string) -> bigint,
-    readonly prototype: BigInt,
+    valueOf(self) -> bigint,
+    readonly [Symbol.toStringTag]: "BigInt",
+    callable(value: bigint | boolean | number | string) -> bigint,
+    static readonly prototype: BigInt,
     /**
      * Interprets the low bits of a BigInt as a 2's-complement signed integer.
      * All higher bits are discarded.
      * @param bits The number of low bits to use
      * @param int The BigInt whose bits to extract
      */
-    asIntN(bits: number, int: bigint) -> bigint,
+    static asIntN(bits: number, int: bigint) -> bigint,
     /**
      * Interprets the low bits of a BigInt as an unsigned integer.
      * All higher bits are discarded.
      * @param bits The number of low bits to use
      * @param int The BigInt whose bits to extract
      */
-    asUintN(bits: number, int: bigint) -> bigint
+    static asUintN(bits: number, int: bigint) -> bigint
 }
-
-@js("BigInt")
-export declare var BigInt: BigIntConstructor

--- a/internal/interop/data/std/boolean.esc
+++ b/internal/interop/data/std/boolean.esc
@@ -7,5 +7,6 @@ export declare class Boolean {
     /** Returns the primitive value of the specified object. */
     valueOf(self) -> boolean,
     constructor(mut self, value?: any),
+    callable<T>(value?: T) -> boolean,
     static readonly prototype: Boolean
 }

--- a/internal/interop/data/std/date.esc
+++ b/internal/interop/data/std/date.esc
@@ -235,6 +235,7 @@ export declare class Date {
      * @param ms A number from 0 to 999 that specifies the milliseconds.
      */
     constructor(mut self, year: number, monthIndex: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number),
+    callable() -> string,
     static readonly prototype: Date,
     /**
      * Parses a string containing a date, and returns the number of milliseconds between that date and midnight, January 1, 1970.

--- a/internal/interop/data/std/error.esc
+++ b/internal/interop/data/std/error.esc
@@ -13,35 +13,45 @@ export declare class Error {
     message: string,
     stack?: string,
     constructor(mut self, message?: string, options?: ErrorOptions),
+    callable(message?: string, options?: ErrorOptions) -> Error,
     constructor(mut self, message?: string),
+    callable(message?: string) -> Error,
     static readonly prototype: Error
 }
 
 @js("RangeError")
 export declare class RangeError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    callable(message?: string, options?: ErrorOptions) -> RangeError,
     constructor(mut self, message?: string),
+    callable(message?: string) -> RangeError,
     static readonly prototype: RangeError
 }
 
 @js("ReferenceError")
 export declare class ReferenceError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    callable(message?: string, options?: ErrorOptions) -> ReferenceError,
     constructor(mut self, message?: string),
+    callable(message?: string) -> ReferenceError,
     static readonly prototype: ReferenceError
 }
 
 @js("SyntaxError")
 export declare class SyntaxError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    callable(message?: string, options?: ErrorOptions) -> SyntaxError,
     constructor(mut self, message?: string),
+    callable(message?: string) -> SyntaxError,
     static readonly prototype: SyntaxError
 }
 
 @js("TypeError")
 export declare class TypeError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    callable(message?: string, options?: ErrorOptions) -> TypeError,
     constructor(mut self, message?: string),
+    callable(message?: string) -> TypeError,
     static readonly prototype: TypeError
 }
 
@@ -50,5 +60,6 @@ export declare class SuppressedError extends Error {
     error: any,
     suppressed: any,
     constructor(mut self, error: any, suppressed: any, message?: string),
+    callable(error: any, suppressed: any, message?: string) -> SuppressedError,
     static readonly prototype: SuppressedError
 }

--- a/internal/interop/data/std/function.esc
+++ b/internal/interop/data/std/function.esc
@@ -47,6 +47,7 @@ export declare class Function {
      * @param args A list of arguments the function accepts.
      */
     constructor(mut self, ...args: mut Array<string>),
+    callable(...args: mut Array<string>) -> Function,
     static readonly prototype: Function
 }
 

--- a/internal/interop/data/std/intl.esc
+++ b/internal/interop/data/std/intl.esc
@@ -46,8 +46,10 @@ export declare class DateTimeFormat {
     format(mut self, date?: Date | number) -> string,
     resolvedOptions(mut self) -> ResolvedDateTimeFormatOptions,
     constructor(mut self, locales?: LocalesArgument, options?: DateTimeFormatOptions),
+    callable(locales?: LocalesArgument, options?: DateTimeFormatOptions) -> DateTimeFormat,
     static supportedLocalesOf(locales: LocalesArgument, options?: DateTimeFormatOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: DateTimeFormatOptions),
+    callable(locales?: string | mut Array<string>, options?: DateTimeFormatOptions) -> DateTimeFormat,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: DateTimeFormatOptions) -> mut Array<string>,
     static readonly prototype: DateTimeFormat
 }
@@ -82,10 +84,12 @@ export declare class PluralRules {
     resolvedOptions(mut self) -> ResolvedPluralRulesOptions,
     select(mut self, n: number) -> LDMLPluralRule,
     constructor(mut self, locales?: string | Array<string>, options?: PluralRulesOptions),
+    callable(locales?: string | Array<string>, options?: PluralRulesOptions) -> PluralRules,
     static supportedLocalesOf(locales: string | Array<string>, options?: {
         localeMatcher?: "lookup" | "best fit"
     }) -> mut Array<string>,
     constructor(mut self, locales?: LocalesArgument, options?: PluralRulesOptions),
+    callable(locales?: LocalesArgument, options?: PluralRulesOptions) -> PluralRules,
     static supportedLocalesOf(locales: LocalesArgument, options?: {
         localeMatcher?: "lookup" | "best fit"
     }) -> mut Array<string>
@@ -130,8 +134,10 @@ export declare class NumberFormat {
     format(mut self, value: number) -> string,
     resolvedOptions(mut self) -> ResolvedNumberFormatOptions,
     constructor(mut self, locales?: LocalesArgument, options?: NumberFormatOptions),
+    callable(locales?: LocalesArgument, options?: NumberFormatOptions) -> NumberFormat,
     static supportedLocalesOf(locales: LocalesArgument, options?: NumberFormatOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: NumberFormatOptions),
+    callable(locales?: string | mut Array<string>, options?: NumberFormatOptions) -> NumberFormat,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: NumberFormatOptions) -> mut Array<string>,
     static readonly prototype: NumberFormat
 }
@@ -806,8 +812,10 @@ export declare class Collator {
     compare(mut self, x: string, y: string) -> number,
     resolvedOptions(mut self) -> ResolvedCollatorOptions,
     constructor(mut self, locales?: LocalesArgument, options?: CollatorOptions),
+    callable(locales?: LocalesArgument, options?: CollatorOptions) -> Collator,
     static supportedLocalesOf(locales: LocalesArgument, options?: CollatorOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: CollatorOptions),
+    callable(locales?: string | mut Array<string>, options?: CollatorOptions) -> Collator,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: CollatorOptions) -> mut Array<string>
 }
 

--- a/internal/interop/data/std/number.esc
+++ b/internal/interop/data/std/number.esc
@@ -94,6 +94,7 @@ export declare class Number {
      */
     static parseInt(string: string, radix?: number) -> number,
     constructor(mut self, value?: any),
+    callable(value?: any) -> number,
     static readonly prototype: Number,
     /** The largest number that can be represented in JavaScript. Equal to approximately 1.79E+308. */
     static readonly MAX_VALUE: number,

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -143,6 +143,8 @@ export declare class Object {
      */
     static groupBy<K: PropertyKey, T>(items: Iterable<T>, keySelector: fn (item: T, index: number) -> K) -> Partial<Record<K, mut Array<T>>>,
     constructor(mut self, value?: any),
+    callable() -> any,
+    callable(value: any) -> any,
     /** A reference to the prototype for a class of objects. */
     static readonly prototype: Object,
     /**

--- a/internal/interop/data/std/regexp.esc
+++ b/internal/interop/data/std/regexp.esc
@@ -111,9 +111,12 @@ export declare class RegExp {
     /** @deprecated A legacy feature for browser compatibility */
     compile(mut self, pattern: string, flags?: string) -> Self,
     constructor(mut self, pattern: RegExp | string, flags?: string),
+    callable(pattern: RegExp | string, flags?: string) -> RegExp,
     static readonly [Symbol.species]: RegExpConstructor,
     constructor(mut self, pattern: RegExp | string),
     constructor(mut self, pattern: string, flags?: string),
+    callable(pattern: RegExp | string) -> RegExp,
+    callable(pattern: string, flags?: string) -> RegExp,
     static readonly "prototype": RegExp,
     /** @deprecated A legacy feature for browser compatibility */
     static "$1": string,

--- a/internal/interop/data/std/string.esc
+++ b/internal/interop/data/std/string.esc
@@ -366,6 +366,7 @@ export declare class String {
         raw: Array<string> | ArrayLike<string>
     }, ...substitutions: mut Array<any>) -> string,
     constructor(mut self, value?: any),
+    callable(value?: any) -> string,
     static readonly prototype: String,
     static fromCharCode(...codes: mut Array<number>) -> string
 }

--- a/internal/interop/data/std/symbol.esc
+++ b/internal/interop/data/std/symbol.esc
@@ -2,115 +2,114 @@
 // Its facts come from the pinned lib.*.d.ts set, the ECMA-262
 // derived facts, and the overlay. Change one of those and re-run.
 
-export declare interface SymbolConstructor {
-    /**
-     * A method that returns the default iterator for an object. Called by the semantics of the
-     * for-of statement.
-     */
-    readonly iterator: unique symbol,
-    /**
-     * A reference to the prototype.
-     */
-    readonly prototype: Symbol,
-    fn (description?: string | number) -> symbol,
-    /**
-     * Returns a Symbol object from the global symbol registry matching the given key if found.
-     * Otherwise, returns a new symbol with this key.
-     * @param key key to search for.
-     */
-    for(key: string) -> symbol,
-    /**
-     * Returns a key from the global symbol registry matching the given Symbol if found.
-     * Otherwise, returns a undefined.
-     * @param sym Symbol to find the key for.
-     */
-    keyFor(sym: symbol) -> string | undefined,
-    /**
-     * A method that determines if a constructor object recognizes an object as one of the
-     * constructor’s instances. Called by the semantics of the instanceof operator.
-     */
-    readonly hasInstance: unique symbol,
-    /**
-     * A Boolean value that if true indicates that an object should flatten to its array elements
-     * by Array.prototype.concat.
-     */
-    readonly isConcatSpreadable: unique symbol,
-    /**
-     * A regular expression method that matches the regular expression against a string. Called
-     * by the String.prototype.match method.
-     */
-    readonly match: unique symbol,
-    /**
-     * A regular expression method that replaces matched substrings of a string. Called by the
-     * String.prototype.replace method.
-     */
-    readonly replace: unique symbol,
-    /**
-     * A regular expression method that returns the index within a string that matches the
-     * regular expression. Called by the String.prototype.search method.
-     */
-    readonly search: unique symbol,
-    /**
-     * A function valued property that is the constructor function that is used to create
-     * derived objects.
-     */
-    readonly species: unique symbol,
-    /**
-     * A regular expression method that splits a string at the indices that match the regular
-     * expression. Called by the String.prototype.split method.
-     */
-    readonly split: unique symbol,
-    /**
-     * A method that converts an object to a corresponding primitive value.
-     * Called by the ToPrimitive abstract operation.
-     */
-    readonly toPrimitive: unique symbol,
-    /**
-     * A String value that is used in the creation of the default string description of an object.
-     * Called by the built-in method Object.prototype.toString.
-     */
-    readonly toStringTag: unique symbol,
-    /**
-     * An Object whose truthy properties are properties that are excluded from the 'with'
-     * environment bindings of the associated objects.
-     */
-    readonly unscopables: unique symbol,
-    /**
-     * A method that returns the default async iterator for an object. Called by the semantics of
-     * the for-await-of statement.
-     */
-    readonly asyncIterator: unique symbol,
-    /**
-     * A regular expression method that matches the regular expression against a string. Called
-     * by the String.prototype.matchAll method.
-     */
-    readonly matchAll: unique symbol,
-    readonly metadata: unique symbol,
-    /**
-     * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
-     */
-    readonly dispose: unique symbol,
-    /**
-     * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
-     */
-    readonly asyncDispose: unique symbol
-}
-
 @js("Symbol")
-export declare var Symbol: SymbolConstructor
-
-export declare interface Symbol {
+export declare class Symbol {
     /**
      * Converts a Symbol object to a symbol.
      */
-    [Symbol.toPrimitive](hint: string) -> symbol,
+    [Symbol.toPrimitive](self, hint: string) -> symbol,
     readonly [Symbol.toStringTag]: string,
     /**
      * Expose the [[Description]] internal slot of a symbol directly.
      */
     readonly description: string | undefined,
     /** Returns a string representation of an object. */
-    toString() -> string,
+    toString(self) -> string,
     /** Returns the primitive value of the specified object. */
-    valueOf() -> symbol
+    valueOf(self) -> symbol,
+    /**
+     * A method that returns the default iterator for an object. Called by the semantics of the
+     * for-of statement.
+     */
+    static readonly iterator: unique symbol,
+    /**
+     * A reference to the prototype.
+     */
+    static readonly prototype: Symbol,
+    /**
+     * Returns a new unique Symbol value.
+     * @param  description Description of the new Symbol object.
+     */
+    callable(description?: string | number) -> symbol,
+    /**
+     * Returns a Symbol object from the global symbol registry matching the given key if found.
+     * Otherwise, returns a new symbol with this key.
+     * @param key key to search for.
+     */
+    static for(key: string) -> symbol,
+    /**
+     * Returns a key from the global symbol registry matching the given Symbol if found.
+     * Otherwise, returns a undefined.
+     * @param sym Symbol to find the key for.
+     */
+    static keyFor(sym: symbol) -> string | undefined,
+    /**
+     * A method that determines if a constructor object recognizes an object as one of the
+     * constructor’s instances. Called by the semantics of the instanceof operator.
+     */
+    static readonly hasInstance: unique symbol,
+    /**
+     * A Boolean value that if true indicates that an object should flatten to its array elements
+     * by Array.prototype.concat.
+     */
+    static readonly isConcatSpreadable: unique symbol,
+    /**
+     * A regular expression method that matches the regular expression against a string. Called
+     * by the String.prototype.match method.
+     */
+    static readonly match: unique symbol,
+    /**
+     * A regular expression method that replaces matched substrings of a string. Called by the
+     * String.prototype.replace method.
+     */
+    static readonly replace: unique symbol,
+    /**
+     * A regular expression method that returns the index within a string that matches the
+     * regular expression. Called by the String.prototype.search method.
+     */
+    static readonly search: unique symbol,
+    /**
+     * A function valued property that is the constructor function that is used to create
+     * derived objects.
+     */
+    static readonly species: unique symbol,
+    /**
+     * A regular expression method that splits a string at the indices that match the regular
+     * expression. Called by the String.prototype.split method.
+     */
+    static readonly split: unique symbol,
+    /**
+     * A method that converts an object to a corresponding primitive value.
+     * Called by the ToPrimitive abstract operation.
+     */
+    static readonly toPrimitive: unique symbol,
+    /**
+     * A String value that is used in the creation of the default string description of an object.
+     * Called by the built-in method Object.prototype.toString.
+     */
+    static readonly toStringTag: unique symbol,
+    /**
+     * An Object whose truthy properties are properties that are excluded from the 'with'
+     * environment bindings of the associated objects.
+     */
+    static readonly unscopables: unique symbol,
+    /**
+     * A method that returns the default async iterator for an object. Called by the semantics of
+     * the for-await-of statement.
+     */
+    static readonly asyncIterator: unique symbol,
+    /**
+     * A regular expression method that matches the regular expression against a string. Called
+     * by the String.prototype.matchAll method.
+     */
+    static readonly matchAll: unique symbol,
+    static readonly metadata: unique symbol,
+    /**
+     * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
+     */
+    static readonly dispose: unique symbol,
+    /**
+     * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
+     */
+    static readonly asyncDispose: unique symbol
 }

--- a/internal/interop/data/std/url.esc
+++ b/internal/interop/data/std/url.esc
@@ -33,6 +33,8 @@ export declare fn encodeURIComponent(uriComponent: string | number | boolean) ->
 @js("URIError")
 export declare class URIError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    callable(message?: string, options?: ErrorOptions) -> URIError,
     constructor(mut self, message?: string),
+    callable(message?: string) -> URIError,
     static readonly prototype: URIError
 }

--- a/internal/interop/data/std/wasm.esc
+++ b/internal/interop/data/std/wasm.esc
@@ -5,7 +5,8 @@
 @js("WebAssembly.CompileError")
 export declare class CompileError extends Error {
     static prototype: CompileError,
-    constructor(mut self, message?: string)
+    constructor(mut self, message?: string),
+    callable(message?: string) -> CompileError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global) */
@@ -29,7 +30,8 @@ export declare class Instance {
 @js("WebAssembly.LinkError")
 export declare class LinkError extends Error {
     static prototype: LinkError,
-    constructor(mut self, message?: string)
+    constructor(mut self, message?: string),
+    callable(message?: string) -> LinkError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory) */
@@ -59,7 +61,8 @@ export declare class Module {
 @js("WebAssembly.RuntimeError")
 export declare class RuntimeError extends Error {
     static prototype: RuntimeError,
-    constructor(mut self, message?: string)
+    constructor(mut self, message?: string),
+    callable(message?: string) -> RuntimeError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table) */

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -612,7 +612,9 @@ func (p *Parser) classDecl(start ast.Location, export, declare, final bool) ast.
 	}
 	p.lexer.consume()
 
-	body := parseDelimSeq(p, CloseBrace, Comma, p.parseClassElem)
+	body := parseDelimSeq(p, CloseBrace, Comma, func() ast.ClassElem {
+		return p.parseClassElem(declare)
+	})
 	p.expect(CloseBrace, AlwaysConsume)
 
 	end := p.lexer.currentLoc()
@@ -770,7 +772,7 @@ func (p *Parser) parseConstructorElem(
 // and attaches any leading JSDoc block comment to the resulting elem's
 // Doc field. Non-JSDoc comments (line comments, plain block comments)
 // are still consumed but do not populate Doc.
-func (p *Parser) parseClassElem() ast.ClassElem {
+func (p *Parser) parseClassElem(declare bool) ast.ClassElem {
 	doc := p.consumeLeadingDoc()
 	// After consuming a leading JSDoc, if we're sitting on the class
 	// body's closing brace, there's no elem to attach the doc to.
@@ -783,12 +785,37 @@ func (p *Parser) parseClassElem() ast.ClassElem {
 		}
 		return nil
 	}
-	elem := p.parseClassElemInner()
+	elem := p.parseClassElemInner(declare)
 	attachDoc(elem, doc)
 	return elem
 }
 
-func (p *Parser) parseClassElemInner() ast.ClassElem {
+// callableSigName is the member name a `declare class` reads as its call
+// signature. It is a contextual keyword, the way `constructor` is: a member that
+// writes a receiver, carries a modifier, or spells the name with a string key
+// keeps it as an ordinary name.
+const callableSigName = "callable"
+
+// isCallableSig reports whether a parsed class member is the call signature
+// rather than a method named `callable`. See the call site for the rule.
+func isCallableSig(
+	declare bool,
+	name ast.ObjKey,
+	receiver *ast.MethodReceiver,
+	body *ast.Block,
+	isStatic, isAsync, isGen, isPrivate, isReadonly bool,
+) bool {
+	if !declare || receiver != nil || body != nil {
+		return false
+	}
+	if isStatic || isAsync || isGen || isPrivate || isReadonly {
+		return false
+	}
+	ident, ok := name.(*ast.IdentExpr)
+	return ok && ident.Name == callableSigName
+}
+
+func (p *Parser) parseClassElemInner(declare bool) ast.ClassElem {
 	token := p.lexer.peek()
 
 	isStatic := false
@@ -1036,6 +1063,20 @@ modifiers_done:
 		span := ast.Span{Start: start, End: p.lexer.currentLoc(), SourceID: p.lexer.source.ID}
 		fn := ast.NewFuncExpr(lifetimeParams, typeParams, params, returnType, throwsType, isAsync, body, span)
 		fn.Gen = isGen
+
+		// `callable(x: number) -> string` is the call signature that makes the class
+		// value callable, the member an object type writes as `fn (x: number) -> T`.
+		// It claims the one shape a member cannot otherwise take: an instance method
+		// declares `self` and a static carries `static`, so a member with neither is
+		// no member at all. A method of that name keeps it by writing its receiver.
+		//
+		// Only a `declare class` reads the name this way. A class the compiler emits
+		// is not callable, and a `callable` method ported into one would otherwise
+		// have to be spelled around.
+		if isCallableSig(declare, name, receiver, body, isStatic, isAsync, isGen, isPrivate, isReadonly) {
+			return &ast.CallableElem{Fn: fn, Span_: span}
+		}
+
 		return &ast.MethodElem{
 			Name:     name,
 			Fn:       fn,

--- a/internal/parser/keyword_names_test.go
+++ b/internal/parser/keyword_names_test.go
@@ -442,6 +442,132 @@ func TestADanglingDotDoesNotSwallowTheNextLine(t *testing.T) {
 	}
 }
 
+// `callable` opens a call signature in a `declare class` body, the member an
+// object type writes as `fn (…)`. It claims the one shape a member cannot
+// otherwise take: an instance method declares `self` and a static carries
+// `static`, so a member with neither is no member at all.
+func TestCallableOpensACallSignatureInADeclareClass(t *testing.T) {
+	t.Parallel()
+	sources := map[string]string{
+		"Receiverless":   "callable(x: number) -> string",
+		"WithTypeParams": "callable<T>(x: T) -> string",
+		"WithNoParams":   "callable() -> string",
+	}
+	for name, src := range sources {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			elem := parseOneClassElem(t, true /*declare*/, src)
+			require.IsType(t, &ast.CallableElem{}, elem)
+			_, named := classElemName(t, elem)
+			require.False(t, named, "a call signature carries no member name")
+		})
+	}
+}
+
+// Every other shape keeps `callable` as an ordinary member name, the way
+// `constructor` stays a name where a field's punctuation follows it. Each case
+// names what takes the member out of the call signature's shape.
+func TestAMemberNamedCallableKeepsItsName(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		src  string
+		want ast.ClassElem
+	}{
+		"WithAReceiver":       {"callable(mut self, x: number) -> string", &ast.MethodElem{}},
+		"WithASharedReceiver": {"callable(self, x: number) -> string", &ast.MethodElem{}},
+		"Static":              {"static callable(x: number) -> string", &ast.MethodElem{}},
+		"WithAStringKey":      {`"callable"(x: number) -> string`, &ast.MethodElem{}},
+		"WithAnotherModifier": {"readonly callable(x: number) -> string", &ast.MethodElem{}},
+		"WithABody":           {"callable(x: number) -> string { }", &ast.MethodElem{}},
+		"AsAField":            {"callable: number", &ast.FieldElem{}},
+		"AsAGetter":           {"get callable(self) -> number", &ast.GetterElem{}},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			requireKeepsTheName(t, parseOneClassElem(t, true /*declare*/, test.src), test.want)
+		})
+	}
+}
+
+// Outside a `declare class` the name is never claimed, whatever shape the member
+// takes. A class the compiler emits is not callable, so a `callable` method
+// ported into Escalier from an existing codebase is left alone rather than
+// having to be spelled around.
+func TestCallableIsAnOrdinaryNameOutsideADeclareClass(t *testing.T) {
+	t.Parallel()
+	sources := map[string]string{
+		"Receiverless":   "callable(x: number) -> string",
+		"WithTypeParams": "callable<T>(x: T) -> string",
+		"WithNoParams":   "callable() -> string",
+	}
+	for name, src := range sources {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			requireKeepsTheName(t, parseOneClassElem(t, false /*declare*/, src), &ast.MethodElem{})
+		})
+	}
+}
+
+// parseOneClassElem parses a class body holding a single member and returns it.
+// declare picks which kind of class the member is declared in, which is what
+// decides whether `callable` opens a call signature.
+func parseOneClassElem(t *testing.T, declare bool, src string) ast.ClassElem {
+	t.Helper()
+	header := "class C {\n    "
+	if declare {
+		header = "declare class C {\n    "
+	}
+	full := header + src + "\n}"
+	script, errors := parseScriptSrc(t, full)
+	require.Empty(t, errors, "%s should parse", full)
+	require.Len(t, script.Stmts, 1)
+	declStmt, ok := script.Stmts[0].(*ast.DeclStmt)
+	require.True(t, ok)
+	class, ok := declStmt.Decl.(*ast.ClassDecl)
+	require.True(t, ok)
+	require.Len(t, class.Body, 1)
+	return class.Body[0]
+}
+
+// requireKeepsTheName asserts a member reached the parser as want and is still
+// declared under the name `callable`.
+func requireKeepsTheName(t *testing.T, elem ast.ClassElem, want ast.ClassElem) {
+	t.Helper()
+	require.IsType(t, want, elem)
+	name, named := classElemName(t, elem)
+	require.True(t, named, "%T carries no member name", elem)
+	require.Equal(t, "callable", name)
+}
+
+// classElemName returns the name a class member is declared under, and false for
+// a member that has none. A call signature is the only nameless kind, which is
+// what tells it from every member the two tests above cover.
+func classElemName(t *testing.T, elem ast.ClassElem) (string, bool) {
+	t.Helper()
+	var key ast.ObjKey
+	switch e := elem.(type) {
+	case *ast.MethodElem:
+		key = e.Name
+	case *ast.FieldElem:
+		key = e.Name
+	case *ast.GetterElem:
+		key = e.Name
+	case *ast.CallableElem:
+		return "", false
+	default:
+		t.Fatalf("unexpected class elem %T", elem)
+	}
+	switch k := key.(type) {
+	case *ast.IdentExpr:
+		return k.Name, true
+	case *ast.StrLit:
+		return k.Value, true
+	}
+	t.Fatalf("unexpected member key %T", key)
+	return "", false
+}
+
 // A chain broken before the dot keeps the dot and the name together, so a
 // keyword member still reads across lines the way it is normally written.
 func TestAChainBrokenBeforeTheDotNamesAProperty(t *testing.T) {

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -917,9 +917,9 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	//
 	// A method does collide: `fn(x: number) -> T` differs from the call signature only in
 	// whitespace, and a signature must not hinge on that, so the signature wins. Write a
-	// method of either name with a string key, `"fn"(x: number) -> T`. A class body has
-	// no call or construct signature to compete with, so `fn` and `new` name methods
-	// there directly.
+	// method of either name with a string key, `"fn"(x: number) -> T`. A class body
+	// spells the call signature `callable(x: number) -> T` and has no construct
+	// signature at all, so `fn` and `new` name methods there directly.
 	//
 	// Both signatures parse through the same tail the `fn` annotation uses, which gives
 	// them type parameters, an inexact marker, and a `throws` clause for free.

--- a/internal/printer/print_member_test.go
+++ b/internal/printer/print_member_test.go
@@ -32,6 +32,8 @@ func TestPrintClassElem(t *testing.T) {
     indexOf(self, item: T) -> number,
     get first(self) -> T,
     set first(mut self, value: T),
+    callable(value: T) -> Foo<T>,
+    callable<U>(value: U) -> Foo<U>,
 }`)
 	class, ok := decl.(*ast.ClassDecl)
 	require.True(t, ok)
@@ -43,6 +45,8 @@ func TestPrintClassElem(t *testing.T) {
 		"indexOf(self, item: T) -> number",
 		"get first(self) -> T",
 		"set first(mut self, value: T)",
+		"callable(value: T) -> Foo<T>",
+		"callable<U>(value: U) -> Foo<U>",
 	}
 	require.Len(t, class.Body, len(expected))
 	for i, want := range expected {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -477,6 +477,11 @@ func (p *Printer) printClassElem(elem ast.ClassElem) {
 			p.space()
 			p.printBlock(e.Fn.Body)
 		}
+	case *ast.CallableElem:
+		// No receiver, which is what tells the call signature from a method of the
+		// same name. printMethodSig leaves the parameter list empty of one.
+		p.writeString("callable")
+		p.printMethodSig(&e.Fn.FuncSig, nil)
 	}
 }
 


### PR DESCRIPTION
Fixes #1412
Refs #1309

Stacked on #1421. Review only the top commit.

## What this adds

```
@js("BigInt")
export declare class BigInt {
    callable(value: bigint | boolean | number | string) -> bigint,
    static asIntN(bits: number, int: bigint) -> bigint,
    ...
}
```

A `callable` member declares that the class value itself is callable without construction. That is what `Symbol("x")`, `Number("1")`, `Boolean(x)`, `Array(3)` and every `Error` constructor called bare do in JavaScript.

The type system already models it. `type_system.CallableElem` is an `ObjTypeElem`, and `inferCallExpr` already dispatches a call through one, so the signature joins the class's static object type and nothing downstream needed teaching.

## Why a callable class rather than a sibling `declare fn`

#1412 lists three options. A sibling `declare fn Symbol(...)` beside the class would leave two declarations carrying `@js("Symbol")` and claiming one runtime binding. Not fusing keeps 24 names degraded. Making the class callable is the option the type system was already shaped for.

## How `callable` stays out of the way

It is a contextual keyword, the way `constructor` already is, and it claims the one shape a member cannot otherwise take. An instance method declares `self` and a static carries `static`, so a member with neither is no member at all — `MissingSelfReceiverError` rejects it today:

```
callable(mut self, x: number) -> string   // method
static callable(x: number) -> string      // static method
"callable"(mut self, x: number) -> string // method, string key
callable(x: number) -> string             // call signature
```

On top of that, only a `declare class` body reads the name this way, so a class ported into Escalier with a `callable` method is never reinterpreted — a call signature has nothing to describe on a class the compiler emits. Any modifier or a body also keeps the name.

That also makes the generated tree safe by construction: the converter gives every instance member a receiver and marks every static one `static`, so a `.d.ts` member named `callable` lands on the method side without the converter knowing the name is special.

No layer reinterprets silently, which is the part of the object-type `fn`/`new` rule I did not want to repeat — there the signature wins over a same-named method and the two differ only in whitespace.

## An instance-side call signature is now an error

A call signature on the instance interface says instances are callable, which is not a shape a class has: `callable` describes the class value, and no class elem describes an instance being called. Fusion would have to drop it, so the converter refuses.

67 interfaces in the pinned lib set carry a call signature and **none** of them is the instance side of a trio, so this reports a `.d.ts` the converter has not seen rather than a shape it is choosing not to handle. `Function` is unaffected — TypeScript deliberately gives `interface Function` no call signature, and `CallableFunction` / `NewableFunction` are not trios, so both stay interfaces and keep everything.

The neighbouring skip in that switch, `IndexSignature`, is left alone deliberately and is the one actually losing information: 51 fused classes declare one — `Array`, `String`, every typed array, `NodeList`, `Storage`, `Window` — and `internal/ast` has no node for one at all, so nothing in the emitted tree carries one. Filed as #1464.

## What it covers

21 `*Constructor` interfaces carry a call signature alongside a matching instance interface, and three inline-constructor bindings in `lib.dom.d.ts` do too. 41 call signatures across the generated tree now have a typed form where they had none.

`SymbolConstructor` and `BigIntConstructor` no longer have to stay unfused to keep theirs, so the guard #1405 added against fusing a call-signature-only constructor side comes out.

## A `declare class` with no `constructor` is no longer constructible

Escalier spells construction as a call, so the implicit zero-argument constructor the checker gave every class answered `Symbol("x")` before the call signature ever saw it. A `declare class` now gets a constructor only where it writes one; a class the compiler emits still gets one synthesised as before.

## Verification

- `go test ./...` green.
- The generated tree regenerates identically twice and all 49 files reparse.
- Each disambiguation guard was mutated and the matching case fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193