### PR TITLE
Fold an interface and its constructor side into a same-named class

### DIFF
--- a/internal/dts_to_esc/decl.go
+++ b/internal/dts_to_esc/decl.go
@@ -383,16 +383,22 @@ func addRaiseParamToClass(
 	declSpan ast.Span,
 ) []*ast.TypeParam {
 	threadRaiseParamThrough(body)
+	return append(typeParams, raiseParam(declSpan))
+}
+
+// raiseParam builds the trailing `E = never` parameter itself, for a caller that
+// has already threaded the raise through the members it is adding.
+func raiseParam(declSpan ast.Span) *ast.TypeParam {
 	param := ast.NewTypeParam(raiseParamName, nil, ast.NewNeverTypeAnn(synthSpan()), declSpan)
-	return append(typeParams, &param)
+	return &param
 }
 
 // threadRaiseParamThrough names the raise parameter in every reference the
 // instance members make to a declaration that carries one.
 //
 // It appends an argument rather than replacing one, so each elem must reach it
-// exactly once. fuseTrio calls it on the members it adds to a class
-// convertClassDecl already converted, whose own members are threaded by then.
+// exactly once. Members are threaded where they are converted, and the parameter
+// is appended once by whoever assembles the declaration.
 func threadRaiseParamThrough(body []ast.ClassElem) {
 	v := &raiseParamVisitor{}
 	for _, elem := range body {

--- a/internal/dts_to_esc/decl.go
+++ b/internal/dts_to_esc/decl.go
@@ -248,6 +248,14 @@ func convertClassDecl(cctx *convertCtx, dc *dts_parser.ClassDecl) (*ast.ClassDec
 		implements = append(implements, typeRef)
 	}
 
+	// A name in RaiseParamDecls takes the raise parameter whichever kind of
+	// declaration declares it. Adding it only where the name arrives as an
+	// interface would make the emitted arity depend on which form the `.d.ts`
+	// happened to use.
+	if RaiseParamDecls.Contains(dc.Name.Name) {
+		typeParams = addRaiseParamToClass(typeParams, bodyElems, convertSpan(dc.Span()))
+	}
+
 	return ast.NewClassDecl(
 		ast.NewIdentifier(dc.Name.Name, convertSpan(dc.Name.Span())),
 		nil,
@@ -361,8 +369,8 @@ func addRaiseParam(typeParams []*ast.TypeParam, body ast.Node, declSpan ast.Span
 	return append(typeParams, &param)
 }
 
-// addRaiseParamToClass is addRaiseParam for a fused class, threading the
-// raise through the instance members alone.
+// addRaiseParamToClass is addRaiseParam for a class, threading the raise
+// through the instance members alone.
 //
 // A static has no binding for the class's own type parameters, so
 // `static all<T>(…) -> Promise<Array<Awaited<T>>>` must keep its raise
@@ -374,6 +382,18 @@ func addRaiseParamToClass(
 	body []ast.ClassElem,
 	declSpan ast.Span,
 ) []*ast.TypeParam {
+	threadRaiseParamThrough(body)
+	param := ast.NewTypeParam(raiseParamName, nil, ast.NewNeverTypeAnn(synthSpan()), declSpan)
+	return append(typeParams, &param)
+}
+
+// threadRaiseParamThrough names the raise parameter in every reference the
+// instance members make to a declaration that carries one.
+//
+// It appends an argument rather than replacing one, so each elem must reach it
+// exactly once. fuseTrio calls it on the members it adds to a class
+// convertClassDecl already converted, whose own members are threaded by then.
+func threadRaiseParamThrough(body []ast.ClassElem) {
 	v := &raiseParamVisitor{}
 	for _, elem := range body {
 		if classElemIsStatic(elem) {
@@ -381,8 +401,6 @@ func addRaiseParamToClass(
 		}
 		elem.Accept(v)
 	}
-	param := ast.NewTypeParam(raiseParamName, nil, ast.NewNeverTypeAnn(synthSpan()), declSpan)
-	return append(typeParams, &param)
 }
 
 // classElemIsStatic reports whether elem belongs to the class rather

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -1202,8 +1202,8 @@ func fuseTrio(cctx *convertCtx, info *trioInfo) (*ast.ClassDecl, error) {
 	)
 
 	if info.instanceClass != nil {
-		// The class already converts to everything the instance side needs, so
-		// the merged interfaces only add members to what it produced.
+		// The class already converts to everything the instance side needs, so a
+		// merged interface only adds to what it produced.
 		decl, err := convertClassDecl(cctx, info.instanceClass)
 		if err != nil {
 			return nil, err
@@ -1218,22 +1218,13 @@ func fuseTrio(cctx *convertCtx, info *trioInfo) (*ast.ClassDecl, error) {
 			// read against, the same positional rename mergeDecls applies to a pair
 			// of interfaces.
 			renameTypeParams(iface, info.instanceClass.TypeParams)
-			ifaceBody, err := interfaceMembersToClassElems(iface.Members, className, false /*static*/)
+			elems, ifaceExtends, err := interfaceInstanceSide(iface, className)
 			if err != nil {
 				return nil, err
 			}
-			// convertClassDecl threaded the raise through the class's own
-			// members and appended the parameter. What the interface adds
-			// still has to name it.
-			if RaiseParamDecls.Contains(className) {
-				threadRaiseParamThrough(ifaceBody)
-			}
-			body = append(body, ifaceBody...)
-			if extends == nil && len(iface.Extends) > 0 {
-				extends, err = fusedExtends(iface.Extends[0], className)
-				if err != nil {
-					return nil, err
-				}
+			body = append(body, elems...)
+			if extends == nil {
+				extends = ifaceExtends
 			}
 		}
 	} else {
@@ -1242,15 +1233,9 @@ func fuseTrio(cctx *convertCtx, info *trioInfo) (*ast.ClassDecl, error) {
 		if err != nil {
 			return nil, fmt.Errorf("converting type parameters: %w", err)
 		}
-		body, err = interfaceMembersToClassElems(info.instance.Members, className, false /*static*/)
+		body, extends, err = interfaceInstanceSide(info.instance, className)
 		if err != nil {
 			return nil, err
-		}
-		if len(info.instance.Extends) > 0 {
-			extends, err = fusedExtends(info.instance.Extends[0], className)
-			if err != nil {
-				return nil, err
-			}
 		}
 		span, nameSpan = convertSpan(info.instance.Span()), convertSpan(info.instance.Name.Span())
 	}
@@ -1279,10 +1264,11 @@ func fuseTrio(cctx *convertCtx, info *trioInfo) (*ast.ClassDecl, error) {
 	// Without it the declaration reads `Promise<T>` while every raised use
 	// passes two arguments.
 	//
-	// A class instance side comes from convertClassDecl, which has already added
-	// it. Only an interface instance side reaches this.
+	// interfaceInstanceSide threaded it through the members it converted, and a
+	// class instance side carries the parameter already, appended by
+	// convertClassDecl. So this only appends, and only for an interface.
 	if info.instanceClass == nil && RaiseParamDecls.Contains(className) {
-		typeParams = addRaiseParamToClass(typeParams, body, span)
+		typeParams = append(typeParams, raiseParam(span))
 	}
 
 	return ast.NewClassDecl(
@@ -1297,6 +1283,33 @@ func fuseTrio(cctx *convertCtx, info *trioInfo) (*ast.ClassDecl, error) {
 		false, // final
 		span,
 	), nil
+}
+
+// interfaceInstanceSide converts an interface that declares a class's instance
+// side, whether it is the whole of that side or a declaration merged into a
+// `declare class`. It returns the members as class elems and the class the
+// interface extends, which the caller takes only where the class writes none.
+func interfaceInstanceSide(
+	iface *dts_parser.InterfaceDecl,
+	className string,
+) ([]ast.ClassElem, *ast.TypeRefTypeAnn, error) {
+	body, err := interfaceMembersToClassElems(iface.Members, className, false /*static*/)
+	if err != nil {
+		return nil, nil, err
+	}
+	// A member is threaded where it is converted, so the caller only appends the
+	// parameter. convertClassDecl does the same for a class's own members.
+	if RaiseParamDecls.Contains(className) {
+		threadRaiseParamThrough(body)
+	}
+	if len(iface.Extends) == 0 {
+		return body, nil, nil
+	}
+	extends, err := fusedExtends(iface.Extends[0], className)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, extends, nil
 }
 
 // interfaceMembersToClassElems converts every member of an interface that has a

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -76,7 +76,17 @@ type StandaloneModule struct {
 //     key has no plain-name form (see StandaloneModule.KeyDrops).
 func ConvertToStandaloneModule(dtsModule *dts_parser.Module) (*StandaloneModule, error) {
 	cctx := &convertCtx{}
-	stmts := liftGlobals(dtsModule.Statements)
+	// TypeScript merges same-named declarations, and every rule below reads one
+	// declaration per name: detectTrios resolves `FooConstructor` through a single
+	// entry, and the walk emits a fused class per matching statement. Merging here
+	// rather than leaving it to the caller means a name declared twice cannot lose
+	// the first declaration's members or produce two classes.
+	//
+	// PartitionLibWithOverlay already merges each bucket, so this is its second
+	// pass there. mergeDecls is idempotent, and running it after liftGlobals also
+	// reaches a declaration a `declare global` block contributes beside a
+	// same-named one at module scope.
+	stmts := mergeDecls(liftGlobals(dtsModule.Statements))
 	trios := detectTrios(stmts)
 	singletons := detectSingletons(stmts, trios)
 	paths := make(map[ast.Decl]string)
@@ -184,9 +194,10 @@ type trioInfo struct {
 	// type, so when the source writes both, the class holds the instance side
 	// and `merged` carries what the interfaces add to it.
 	instanceClass *dts_parser.ClassDecl
-	// merged are the same-named interfaces folded into instanceClass. Empty
-	// when the instance side is itself an interface.
-	merged []*dts_parser.InterfaceDecl
+	// merged is the `interface Foo` folded into instanceClass, or nil when the
+	// class stands alone. ConvertToStandaloneModule merges same-named
+	// declarations before this runs, so there is at most one.
+	merged *dts_parser.InterfaceDecl
 	// ctorMembers is the constructor side, whichever form declared it:
 	// the members of a named `FooConstructor` interface, or those of
 	// the object type written inline on the binding. Empty when the name has
@@ -275,20 +286,15 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 		consumedVar:  set.NewSet[string](),
 	}
 
-	// interfaces holds one declaration per name for constructorSide to resolve
-	// `FooConstructor` through; byName holds every declaration under a name, which
-	// is what a class absorbs. mergeDecls has already collapsed same-named
-	// interfaces on the partition path, so the two differ only for a caller that
-	// converts unmerged statements.
+	// One declaration per name: ConvertToStandaloneModule merges same-named
+	// interfaces, recursing into namespaces, before any of this runs.
 	interfaces := make(map[string]*dts_parser.InterfaceDecl)
-	interfacesByName := make(map[string][]*dts_parser.InterfaceDecl)
 	vars := make(map[string]*dts_parser.VarDecl)
 	classes := make(map[string]*dts_parser.ClassDecl)
 	for _, stmt := range stmts {
 		switch s := stmt.(type) {
 		case *dts_parser.InterfaceDecl:
 			interfaces[s.Name.Name] = s
-			interfacesByName[s.Name.Name] = append(interfacesByName[s.Name.Name], s)
 		case *dts_parser.VarDecl:
 			vars[s.Name.Name] = s
 		case *dts_parser.ClassDecl:
@@ -326,8 +332,8 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 				binding:     binding,
 			}
 		} else {
-			merged := interfacesByName[name]
-			if len(merged) == 0 && ctorMembers == nil {
+			merged := interfaces[name]
+			if merged == nil && ctorMembers == nil {
 				// Nothing to absorb, so the class converts on its own.
 				// fuseTrio would produce the same declaration; leaving the
 				// name out of the table keeps every plain class off the
@@ -429,10 +435,8 @@ func hasConstructSignature(members []dts_parser.InterfaceMember) bool {
 	return false
 }
 
-// namesWithConstructSignature returns every interface name that some
-// top-level declaration gives a `new (...)` member. TypeScript merges
-// repeated `interface Foo` declarations, so reading a single statement
-// per name would miss a construct signature written on the second one.
+// namesWithConstructSignature returns every interface name whose declaration
+// carries a `new (...)` member.
 //
 // A signature inherited through `extends` is not counted. A heritage
 // clause can name a type alias, as `IteratorConstructor` does, so
@@ -1209,7 +1213,7 @@ func fuseTrio(cctx *convertCtx, info *trioInfo) (*ast.ClassDecl, error) {
 		extends, implements = decl.Extends, decl.Implements
 		span, nameSpan = decl.Span(), decl.Name.Span()
 
-		for _, iface := range info.merged {
+		if iface := info.merged; iface != nil {
 			// The class's parameter names are the ones the merged members have to
 			// read against, the same positional rename mergeDecls applies to a pair
 			// of interfaces.

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -176,12 +176,42 @@ func writeStandaloneModule(m *StandaloneModule, w io.Writer) error {
 // keeps track of the constructor interface and the `declare var` binding
 // so the main pass skips them.
 type trioInfo struct {
+	// instance is the `interface Foo` that declares the instance side, or nil
+	// when a `declare class Foo` declares it.
 	instance *dts_parser.InterfaceDecl
+	// instanceClass is the `declare class Foo` that declares the instance side,
+	// or nil. TypeScript merges a class with a same-named interface into one
+	// type, so when the source writes both, the class holds the instance side
+	// and `merged` carries what the interfaces add to it.
+	instanceClass *dts_parser.ClassDecl
+	// merged are the same-named interfaces folded into instanceClass. Empty
+	// when the instance side is itself an interface.
+	merged []*dts_parser.InterfaceDecl
 	// ctorMembers is the constructor side, whichever form declared it:
 	// the members of a named `FooConstructor` interface, or those of
-	// the object type written inline on the binding.
+	// the object type written inline on the binding. Empty when the name has
+	// no constructor side, which is how a class-and-interface pair with no
+	// `FooConstructor` reaches fusion.
 	ctorMembers []dts_parser.InterfaceMember
 	binding     *dts_parser.VarDecl
+}
+
+// name returns the instance side's name, whichever kind of declaration
+// declared it.
+func (t *trioInfo) name() string {
+	if t.instanceClass != nil {
+		return t.instanceClass.Name.Name
+	}
+	return t.instance.Name.Name
+}
+
+// doc returns the JSDoc the fused class carries. The instance side is the one
+// users see and document, so the constructor interface's doc is dropped.
+func (t *trioInfo) doc() string {
+	if t.instanceClass != nil {
+		return t.instanceClass.Doc()
+	}
+	return t.instance.Doc()
 }
 
 // trioTable indexes trios by the instance type name. The constructor name
@@ -226,12 +256,18 @@ type trioTable struct {
 // This matches tryFuseTrio in internal/interop/class_shapes.go, which
 // has never gated on a construct signature.
 //
-// A name that a `declare class` already declares is left alone. That
-// is a backstop rather than the right answer. TypeScript merges an
-// interface into a same-named class and mergeDecls cannot, so the pair
-// stays split whatever this does. Declining only keeps the converter
-// from adding a second class beside the one the source spells out.
-// #1430 covers the merge.
+// # A `declare class` on the instance side
+//
+// TypeScript merges a class with a same-named interface: the interface's members
+// join the class's instance side, and a `declare var` of that name joins its
+// static side. A name declared both ways therefore has one instance side, the
+// class, and the interfaces and the constructor side both fold into it. The class
+// is what survives because it carries what an interface cannot, a constructor and
+// an `implements` clause.
+//
+// A class with neither a same-named interface nor a constructor side is not a
+// trio and converts on its own. `Iterator` in lib.esnext.iterator.d.ts is the
+// pinned lib set's one class-and-interface pair.
 func detectTrios(stmts []dts_parser.Statement) *trioTable {
 	t := &trioTable{
 		byName:       make(map[string]*trioInfo),
@@ -239,45 +275,79 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 		consumedVar:  set.NewSet[string](),
 	}
 
+	// interfaces holds one declaration per name for constructorSide to resolve
+	// `FooConstructor` through; byName holds every declaration under a name, which
+	// is what a class absorbs. mergeDecls has already collapsed same-named
+	// interfaces on the partition path, so the two differ only for a caller that
+	// converts unmerged statements.
 	interfaces := make(map[string]*dts_parser.InterfaceDecl)
+	interfacesByName := make(map[string][]*dts_parser.InterfaceDecl)
 	vars := make(map[string]*dts_parser.VarDecl)
-	classes := set.NewSet[string]()
+	classes := make(map[string]*dts_parser.ClassDecl)
 	for _, stmt := range stmts {
 		switch s := stmt.(type) {
 		case *dts_parser.InterfaceDecl:
 			interfaces[s.Name.Name] = s
+			interfacesByName[s.Name.Name] = append(interfacesByName[s.Name.Name], s)
 		case *dts_parser.VarDecl:
 			vars[s.Name.Name] = s
 		case *dts_parser.ClassDecl:
-			classes.Add(s.Name.Name)
+			classes[s.Name.Name] = s
 		}
 	}
 
-	for name, inst := range interfaces {
-		// A `declare class Foo` already declares the name as a class.
-		// Fusing would emit a second one beside it. See #1430 for why
-		// the pair stays split either way.
-		if classes.Contains(name) {
-			continue
-		}
-		v, hasVar := vars[name]
-		if !hasVar {
-			continue
-		}
-		ctorMembers, ctorName, ok := constructorSide(name, v, interfaces)
-		if !ok {
-			continue
+	names := set.NewSet[string]()
+	for name := range interfaces {
+		names.Add(name)
+	}
+	for name := range classes {
+		names.Add(name)
+	}
+
+	for _, name := range names.ToSlice() {
+		var ctorMembers []dts_parser.InterfaceMember
+		var ctorName string
+		binding := vars[name]
+		if binding != nil {
+			ctorMembers, ctorName, _ = constructorSide(name, binding, interfaces)
 		}
 
-		t.byName[name] = &trioInfo{
-			instance:    inst,
-			ctorMembers: ctorMembers,
-			binding:     v,
+		cls := classes[name]
+		if cls == nil {
+			// Without a class the instance side is the interface, and the
+			// constructor side is what makes the pair a class rather than two
+			// declarations.
+			if ctorMembers == nil {
+				continue
+			}
+			t.byName[name] = &trioInfo{
+				instance:    interfaces[name],
+				ctorMembers: ctorMembers,
+				binding:     binding,
+			}
+		} else {
+			merged := interfacesByName[name]
+			if len(merged) == 0 && ctorMembers == nil {
+				// Nothing to absorb, so the class converts on its own.
+				// fuseTrio would produce the same declaration; leaving the
+				// name out of the table keeps every plain class off the
+				// fusion path.
+				continue
+			}
+			t.byName[name] = &trioInfo{
+				instanceClass: cls,
+				merged:        merged,
+				ctorMembers:   ctorMembers,
+				binding:       binding,
+			}
 		}
+
 		if ctorName != "" {
 			t.consumedCtor.Add(ctorName)
 		}
-		t.consumedVar.Add(name)
+		if ctorMembers != nil {
+			t.consumedVar.Add(name)
+		}
 	}
 
 	return t
@@ -937,16 +1007,18 @@ func convertStandaloneStmt(
 			return nil, nil
 		}
 		if info, ok := trios.byName[s.Name.Name]; ok {
-			classDecl, err := fuseTrio(info)
+			// A `declare class` of this name holds the instance side, and its own
+			// branch below emits the one class the pair produces.
+			if info.instanceClass != nil {
+				return nil, nil
+			}
+			classDecl, err := fuseTrio(cctx, info)
 			if err != nil {
 				return nil, fmt.Errorf("fusing trio for %s: %w", s.Name.Name, err)
 			}
 			path := jsName(nsPath, s.Name.Name)
 			attachJSDecorator(classDecl, path)
-			// Trio class doc comes from the instance interface; the
-			// constructor interface's doc (if any) is dropped — the
-			// instance side is the one users see and document.
-			return []docDecl{{doc: info.instance.Doc(), path: path, decl: classDecl}}, nil
+			return []docDecl{{doc: info.doc(), path: path, decl: classDecl}}, nil
 		}
 		if singletons != nil {
 			if info, ok := singletons.byName[s.Name.Name]; ok {
@@ -1005,7 +1077,14 @@ func convertStandaloneStmt(
 		return []docDecl{{doc: s.Doc(), path: path, decl: decl}}, nil
 
 	case *dts_parser.ClassDecl:
-		decl, err := convertClassDecl(cctx, s)
+		var decl *ast.ClassDecl
+		var err error
+		if info, ok := trios.byName[s.Name.Name]; ok && info.instanceClass == s {
+			// Same-named interfaces and the constructor side fold into this class.
+			decl, err = fuseTrio(cctx, info)
+		} else {
+			decl, err = convertClassDecl(cctx, s)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -1070,9 +1149,15 @@ func attachJSDecorator(decl ast.Decl, arg string) {
 	}
 }
 
-// fuseTrio synthesises a ClassDecl from a matched trio. Instance members
-// come from `info.instance` (always non-static); static members and the
-// constructor come from `info.ctorMembers`.
+// fuseTrio synthesises a ClassDecl from a matched trio. Instance members come
+// from the instance side, always non-static; static members and the constructor
+// come from `info.ctorMembers`.
+//
+// The instance side is either an `interface Foo`, whose members convert here, or
+// a `declare class Foo`, which convertClassDecl already turns into everything the
+// instance side needs. In the second case the same-named interfaces in
+// `info.merged` add their members to what it produced, which is the merge
+// TypeScript performs between a class and an interface of one name.
 //
 // Mapping from interface members to class elems:
 //   - MethodSignature   → MethodElem (Static set per side; receiver from
@@ -1081,34 +1166,94 @@ func attachJSDecorator(decl ast.Decl, arg string) {
 //   - PropertySignature → FieldElem
 //   - GetterSignature   → GetterElem
 //   - SetterSignature   → SetterElem
-//   - ConstructSignature (static side only) → ConstructorElem
 //   - CallSignature (static side) → CallableElem. On the instance side it says
 //     instances are callable, which no class elem expresses, so the conversion
 //     fails rather than dropping it.
+//   - ConstructSignature (static side) → ConstructorElem
 //   - IndexSignature is skipped. `ast` has no node for one, so an interface
 //     loses it too; #1464 covers giving it somewhere to go.
-func fuseTrio(info *trioInfo) (*ast.ClassDecl, error) {
-	className := info.instance.Name.Name
-	typeParams, err := convertTypeParams(info.instance.TypeParams)
-	if err != nil {
-		return nil, fmt.Errorf("converting type parameters: %w", err)
-	}
+//
+// A `new` on a merged interface is skipped too. It is a construct signature on
+// the instance type, saying instances of the class can themselves construct,
+// which is not the class's own constructor. Nothing in the pinned lib set
+// declares one on an interface merged into a class.
+//
+// The class's own `extends` wins over a merged interface's, since a class states
+// its superclass where an interface states a type it widens. A merged clause is
+// taken only when the class writes none, which is how
+// `interface Iterator<T, TResult, TNext> extends globalThis.IteratorObject<…>`
+// reaches `declare abstract class Iterator<T, TResult, TNext>`.
+func fuseTrio(cctx *convertCtx, info *trioInfo) (*ast.ClassDecl, error) {
+	className := info.name()
 
-	var body []ast.ClassElem
+	var (
+		typeParams []*ast.TypeParam
+		dtsParams  []*dts_parser.TypeParam
+		body       []ast.ClassElem
+		extends    *ast.TypeRefTypeAnn
+		implements []*ast.TypeRefTypeAnn
+		span       ast.Span
+		nameSpan   ast.Span
+		err        error
+	)
 
-	for _, m := range info.instance.Members {
-		elem, err := interfaceMemberToClassElem(m, className, false /*static*/)
+	if info.instanceClass != nil {
+		// The class already converts to everything the instance side needs, so
+		// the merged interfaces only add members to what it produced.
+		decl, err := convertClassDecl(cctx, info.instanceClass)
 		if err != nil {
 			return nil, err
 		}
-		if elem != nil {
-			body = append(body, elem)
+		dtsParams = info.instanceClass.TypeParams
+		typeParams, body = decl.TypeParams, decl.Body
+		extends, implements = decl.Extends, decl.Implements
+		span, nameSpan = decl.Span(), decl.Name.Span()
+
+		for _, iface := range info.merged {
+			// The class's parameter names are the ones the merged members have to
+			// read against, the same positional rename mergeDecls applies to a pair
+			// of interfaces.
+			renameTypeParams(iface, info.instanceClass.TypeParams)
+			ifaceBody, err := interfaceMembersToClassElems(iface.Members, className, false /*static*/)
+			if err != nil {
+				return nil, err
+			}
+			// convertClassDecl threaded the raise through the class's own
+			// members and appended the parameter. What the interface adds
+			// still has to name it.
+			if RaiseParamDecls.Contains(className) {
+				threadRaiseParamThrough(ifaceBody)
+			}
+			body = append(body, ifaceBody...)
+			if extends == nil && len(iface.Extends) > 0 {
+				extends, err = fusedExtends(iface.Extends[0], className)
+				if err != nil {
+					return nil, err
+				}
+			}
 		}
+	} else {
+		dtsParams = info.instance.TypeParams
+		typeParams, err = convertTypeParams(dtsParams)
+		if err != nil {
+			return nil, fmt.Errorf("converting type parameters: %w", err)
+		}
+		body, err = interfaceMembersToClassElems(info.instance.Members, className, false /*static*/)
+		if err != nil {
+			return nil, err
+		}
+		if len(info.instance.Extends) > 0 {
+			extends, err = fusedExtends(info.instance.Extends[0], className)
+			if err != nil {
+				return nil, err
+			}
+		}
+		span, nameSpan = convertSpan(info.instance.Span()), convertSpan(info.instance.Name.Span())
 	}
 
 	for _, m := range info.ctorMembers {
 		if cs, ok := m.(*dts_parser.ConstructSignature); ok {
-			ctor, err := trioCtorElem(cs, className, info.instance.TypeParams)
+			ctor, err := trioCtorElem(cs, className, dtsParams)
 			if err != nil {
 				return nil, err
 			}
@@ -1124,45 +1269,68 @@ func fuseTrio(info *trioInfo) (*ast.ClassDecl, error) {
 		}
 	}
 
-	var extends *ast.TypeRefTypeAnn
-	if len(info.instance.Extends) > 0 {
-		// For the MVP we take only the first extends — Escalier's
-		// ClassDecl carries a single Extends (`*TypeRefTypeAnn`). TS
-		// interfaces can extend multiple bases; §6 handles the wider
-		// surface (likely by routing extras through `implements`).
-		conv, err := convertTypeAnn(info.instance.Extends[0])
-		if err != nil {
-			return nil, fmt.Errorf("converting extends: %w", err)
-		}
-		ref, ok := conv.(*ast.TypeRefTypeAnn)
-		if !ok {
-			return nil, fmt.Errorf("trio %s: extends is not a type ref", className)
-		}
-		extends = ref
-	}
-
 	// Escalier's `Promise` takes a raise parameter where the TypeScript
-	// declaration has no slot for one. The TypeDecl and InterfaceDecl
-	// paths add it in decl.go; a trio fuses into a class, so `Promise`
-	// needs it here too. Without it the declaration reads `Promise<T>`
-	// while every raised use passes two arguments.
-	if RaiseParamDecls.Contains(className) {
-		typeParams = addRaiseParamToClass(
-			typeParams, body, convertSpan(info.instance.Span()))
+	// declaration has no slot for one. The TypeDecl and InterfaceDecl paths add
+	// it in decl.go; a trio fuses into a class, so `Promise` needs it here too.
+	// Without it the declaration reads `Promise<T>` while every raised use
+	// passes two arguments.
+	//
+	// A class instance side comes from convertClassDecl, which has already added
+	// it. Only an interface instance side reaches this.
+	if info.instanceClass == nil && RaiseParamDecls.Contains(className) {
+		typeParams = addRaiseParamToClass(typeParams, body, span)
 	}
 
 	return ast.NewClassDecl(
-		ast.NewIdentifier(className, convertSpan(info.instance.Name.Span())),
+		ast.NewIdentifier(className, nameSpan),
 		nil, // lifetime params
 		typeParams,
 		extends,
-		nil, // implements
+		implements,
 		body,
 		true,  // export
 		true,  // declare
 		false, // final
-		convertSpan(info.instance.Span()),
+		span,
 	), nil
+}
+
+// interfaceMembersToClassElems converts every member of an interface that has a
+// class-elem counterpart, dropping the rest.
+func interfaceMembersToClassElems(
+	members []dts_parser.InterfaceMember,
+	className string,
+	static bool,
+) ([]ast.ClassElem, error) {
+	var out []ast.ClassElem
+	for _, m := range members {
+		elem, err := interfaceMemberToClassElem(m, className, static)
+		if err != nil {
+			return nil, err
+		}
+		if elem != nil {
+			out = append(out, elem)
+		}
+	}
+	return out, nil
+}
+
+// fusedExtends converts an interface's first `extends` clause into the fused
+// class's superclass.
+//
+// Escalier's ClassDecl carries a single Extends, where a TypeScript interface can
+// extend several. The rest are dropped; §6 handles the wider surface, likely by
+// routing them through `implements`.
+func fusedExtends(ext dts_parser.TypeAnn, className string) (*ast.TypeRefTypeAnn, error) {
+	conv, err := convertTypeAnn(ext)
+	if err != nil {
+		return nil, fmt.Errorf("converting extends: %w", err)
+	}
+	ref, ok := conv.(*ast.TypeRefTypeAnn)
+	if !ok {
+		return nil, fmt.Errorf("trio %s: extends is not a type ref", className)
+	}
+	return ref, nil
 }
 
 // interfaceMemberToClassElem converts an interface member to a class elem,

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -1412,21 +1412,16 @@ export declare var widgetCount: number
 	require.Len(t, parsedDecls, 3)
 }
 
-// A trio whose instance name is already declared by a `declare class`
-// is left alone, so the converter does not add a second class beside
-// the one the source spells out. `lib.esnext.iterator.d.ts` writes
-// `Iterator` that way: an abstract class at module scope, and
-// `IteratorConstructor` plus the binding inside its `declare global`
-// block.
+// TypeScript merges a class with a same-named interface, so a name declared both
+// ways has one instance side: the class, with the interface's members folded in.
+// A `FooConstructor` and its binding then become the class's statics, the same
+// way they do for a name declared only as an interface.
 //
-// The snapshot pins current behaviour, not the right answer. TypeScript
-// merges `interface Foo` into `class Foo`, so what this input means is
-// one class carrying `next` and `peek` as instance members and `from`
-// as a static. mergeDecls folds an interface into an interface and not
-// into a class, so the pair stays split whether or not the trio fuses,
-// and declining only keeps the split from getting wider. #1430 covers
-// the merge and takes this guard out with it.
-func TestStandalone_TrioDeclinedWhenNameIsAlreadyAClass(t *testing.T) {
+// `lib.esnext.iterator.d.ts` writes `Iterator` this way: an abstract class at
+// module scope, and `IteratorConstructor` plus the binding inside its
+// `declare global` block. It is the pinned lib set's one class-and-interface
+// pair.
+func TestStandalone_ClassAbsorbsItsInterfaceAndConstructorSide(t *testing.T) {
 	const slice = `
 declare abstract class Foo {
     next(): string;
@@ -1445,25 +1440,189 @@ declare var Foo: FooConstructor;
 	_, printed := convertSlice(t, slice)
 	snaps.MatchInlineSnapshot(t, printed, snaps.Inline(`@js("Foo")
 export declare class Foo {
-    next(mut self) -> string
+    next(mut self) -> string,
+    peek(mut self) -> string,
+    static from(s: string) -> Foo
 }
-
-export declare interface Foo {
-    peek() -> string
-}
-
-export declare interface FooConstructor {
-    from(s: string) -> Foo
-}
-
-@js("Foo")
-export declare var Foo: FooConstructor
 `))
 
 	parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
 		&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
 	require.Empty(t, parseErrs, "printed output parses")
-	require.Len(t, parsedDecls, 4)
+	require.Len(t, parsedDecls, 1)
+}
+
+// A class and a same-named interface merge whether or not a constructor side
+// exists. The class is what survives, wherever it stands relative to the
+// interface, since it carries what an interface cannot.
+func TestStandalone_ClassAbsorbsAnInterfaceDeclaredBeforeIt(t *testing.T) {
+	const slice = `
+interface Foo<T> {
+    peek(): T;
+}
+
+declare class Foo<U> {
+    constructor(value: U);
+    next(): U;
+}
+`
+	_, printed := convertSlice(t, slice)
+	snaps.MatchInlineSnapshot(t, printed, snaps.Inline(`@js("Foo")
+export declare class Foo<U> {
+    constructor(mut self, value: U),
+    next(mut self) -> U,
+    peek(mut self) -> U
+}
+`))
+
+	parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+		&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+	require.Empty(t, parseErrs, "printed output parses")
+	require.Len(t, parsedDecls, 1)
+}
+
+// Escalier's `Promise` and `Generator` take a raise parameter the TypeScript
+// declaration has no slot for. The parameter has to arrive whichever kind of
+// declaration declares the name, or the emitted arity would depend on whether
+// some other declaration happened to name it too.
+//
+// The pinned lib set declares all four names as interfaces, so a class form
+// reaches the converter only through an input written by hand. The threading is
+// what makes the cases differ: a reference in an instance member names `E`, and
+// one in a static leaves the argument off, since a static binds none of the
+// class's type parameters.
+func TestStandalone_ClassTakesTheRaiseParameter(t *testing.T) {
+	tests := map[string]struct {
+		slice string
+		want  string
+	}{
+		"BareClass": {
+			slice: `
+declare class Promise<T> {
+    then(): Promise<T>;
+    static resolve(): Promise<void>;
+}
+`,
+			want: `@js("Promise")
+export declare class Promise<T, E = never> {
+    then(mut self) -> Promise<T, E>,
+    static resolve() -> Promise<undefined>
+}
+`,
+		},
+		"ClassMergedWithAnInterface": {
+			slice: `
+declare class Promise<T> {
+    then(): Promise<T>;
+}
+
+interface Promise<T> {
+    finally(): Promise<T>;
+}
+`,
+			want: `@js("Promise")
+export declare class Promise<T, E = never> {
+    then(mut self) -> Promise<T, E>,
+    finally(mut self) -> Promise<T, E>
+}
+`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, printed := convertSlice(t, test.slice)
+			require.Equal(t, test.want, printed)
+
+			parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+				&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+			require.Empty(t, parseErrs, "printed output parses")
+			require.NotEmpty(t, parsedDecls)
+		})
+	}
+}
+
+// A class states its superclass where an interface states a type it widens, so
+// the class's own `extends` wins. A merged interface's is taken only when the
+// class writes none, which is the shape `lib.esnext.iterator.d.ts` gives
+// `Iterator`.
+func TestStandalone_ClassTakesAMergedInterfacesExtends(t *testing.T) {
+	tests := map[string]struct {
+		slice string
+		want  string
+	}{
+		"ClassWritesNone": {
+			slice: `
+interface Base {
+    id: number;
+}
+
+declare abstract class Foo {
+    next(): string;
+}
+
+interface Foo extends Base {
+    peek(): string;
+}
+`,
+			want: `export declare interface Base {
+    id: number
+}
+
+@js("Foo")
+export declare class Foo extends Base {
+    next(mut self) -> string,
+    peek(mut self) -> string
+}
+`,
+		},
+		"ClassWritesOne": {
+			slice: `
+interface Base {
+    id: number;
+}
+
+declare class Other {
+    tag: string;
+}
+
+declare class Foo extends Other {
+    next(): string;
+}
+
+interface Foo extends Base {
+    peek(): string;
+}
+`,
+			want: `export declare interface Base {
+    id: number
+}
+
+@js("Other")
+export declare class Other {
+    tag: string
+}
+
+@js("Foo")
+export declare class Foo extends Other {
+    next(mut self) -> string,
+    peek(mut self) -> string
+}
+`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, printed := convertSlice(t, test.slice)
+			require.Equal(t, test.want, printed)
+
+			parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+				&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+			require.Empty(t, parseErrs, "printed output parses")
+			require.NotEmpty(t, parsedDecls)
+		})
+	}
 }
 
 // lib.dom.d.ts writes the constructor side inline on the binding rather

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -51,6 +51,20 @@ declare namespace JSON {
 }
 `
 
+// convertSlice converts one `.d.ts` slice and returns the module and its
+// rendered form.
+//
+// It runs ConvertToStandaloneModule, which is one stage of what `generate`
+// does. Four passes run after it on the real path and none of them here:
+// fuseReadonlyTwins, applyReadonlyTwinReceivers, rewriteReadonlyTwinRefs and
+// dedupeMembers. So a member's mutability spelling, a twin name's rewrite and
+// a repeated member's removal are all absent from what this returns —
+// `ArrayConstructor` renders `-> Array<any>` here where the committed tree
+// carries `-> mut Array<any>`.
+//
+// That makes this the right level for a recognition rule and the wrong level
+// for pinning what a file in the tree holds. The PartitionLib tests and the
+// generated-tree check cover the latter.
 func convertSlice(t *testing.T, input string) (*StandaloneModule, string) {
 	t.Helper()
 	source := &ast.Source{Path: "test.d.ts", Contents: input, ID: 0}
@@ -956,17 +970,16 @@ declare var Foo: Foo;
 			contains:   []string{"new (s: string) -> Foo", "bar() -> unknown"},
 		},
 		{
-			// TypeScript merges the two declarations, and a map keyed
-			// by name keeps only the last. The construct signature sits
-			// on the first, so reading one declaration per name misses
-			// it and flattens `bar` to a top-level decl.
+			// The two declarations reach conversion as one, and the
+			// construct signature the first carries survives the merge,
+			// so the pair is preserved rather than flattened.
 			//
 			// The `new` returns `HTMLElement` rather than `Foo` so that
-			// detectSingletons' own reference count does not decline
-			// the pair for an unrelated reason. This case has to fail
-			// when the construct-signature scan reads a single
-			// declaration, not merely when it is absent.
-			name: "construct signature on a merged declaration",
+			// detectSingletons' own reference count does not decline the
+			// pair for an unrelated reason. This case has to fail when
+			// the construct signature is lost, not merely when it is
+			// absent from the source.
+			name: "construct signature merged in from another declaration",
 			input: `
 interface Foo {
     new (s: string): HTMLElement;
@@ -976,9 +989,9 @@ interface Foo {
 }
 declare var Foo: Foo;
 `,
-			interfaces: 2,
+			interfaces: 1,
 			vars:       1,
-			contains:   []string{"new (s: string) -> HTMLElement"},
+			contains:   []string{"new (s: string) -> HTMLElement", "bar() -> unknown"},
 		},
 	}
 
@@ -1538,6 +1551,98 @@ export declare class Promise<T, E = never> {
 				&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
 			require.Empty(t, parseErrs, "printed output parses")
 			require.NotEmpty(t, parsedDecls)
+		})
+	}
+}
+
+// A name declared more than once reaches conversion as one declaration,
+// whichever kind of instance side it has. Without the merge, detectTrios
+// resolves each name through a single entry: the trio's walk emits a fused
+// class per matching statement, and the constructor side keeps only the last
+// declaration's members.
+//
+// PartitionLibWithOverlay merges each bucket before converting it, so the tree
+// never saw either outcome. Merging inside the conversion means a caller cannot
+// reach one by skipping that step.
+func TestStandalone_SameNameDeclarationsConvertAsOne(t *testing.T) {
+	tests := map[string]struct {
+		slice string
+		want  string
+	}{
+		"InterfaceInstanceSide": {
+			slice: `
+interface Foo {
+    next(): string;
+}
+
+interface Foo {
+    peek(): string;
+}
+
+interface FooConstructor {
+    fromA(s: string): Foo;
+}
+
+interface FooConstructor {
+    fromB(s: string): Foo;
+}
+
+declare var Foo: FooConstructor;
+`,
+			want: `@js("Foo")
+export declare class Foo {
+    next(mut self) -> string,
+    peek(mut self) -> string,
+    static fromA(s: string) -> Foo,
+    static fromB(s: string) -> Foo
+}
+`,
+		},
+		"ClassInstanceSide": {
+			slice: `
+declare class Foo {
+    next(): string;
+}
+
+interface Foo {
+    peek(): string;
+}
+
+interface Foo {
+    poke(): string;
+}
+
+interface FooConstructor {
+    fromA(s: string): Foo;
+}
+
+interface FooConstructor {
+    fromB(s: string): Foo;
+}
+
+declare var Foo: FooConstructor;
+`,
+			want: `@js("Foo")
+export declare class Foo {
+    next(mut self) -> string,
+    peek(mut self) -> string,
+    poke(mut self) -> string,
+    static fromA(s: string) -> Foo,
+    static fromB(s: string) -> Foo
+}
+`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, printed := convertSlice(t, test.slice)
+			require.Equal(t, test.want, printed)
+
+			parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+				&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+			require.Empty(t, parseErrs, "printed output parses")
+			require.Len(t, parsedDecls, 1)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #1430

Stacked on #1439. Review the top two commits:

1. **`4cb55c5` Fold an interface and its constructor side into a same-named class** — the issue itself.
2. **`f09574f` dts_to_esc: merge same-named declarations inside the conversion** — a separate defect found while reviewing the first.

## 1. The gap

TypeScript merges a class with a same-named interface: the interface's members join the class's instance side, and a `declare var` of that name joins its static side. The converter emitted them as separate declarations sharing one name, and `detectTrios` declined to fuse a trio whose instance name a `declare class` already declared. The pair stayed split rather than becoming the one class the source means.

A name declared both ways now has one instance side, the class:

- The same-named interface folds its members into it, with its type parameters renamed onto the class's — the same positional rename `mergeDecls` already applies to a merged pair of interfaces.
- The constructor side becomes its statics, so a `FooConstructor` and its binding fuse into the declared class rather than being declined.
- The class is what survives, wherever it stands relative to the interface, since it carries what an interface cannot: a constructor and an `implements` clause.
- The class's own `extends` wins. A merged interface's is taken only where the class writes none, which is the shape `lib.esnext.iterator.d.ts` gives `Iterator`.

### The two open questions from the issue

A `new` on a merged interface is skipped. It is a construct signature on the instance type, saying instances can themselves construct, which is not the class's own constructor. A call signature there says instances are callable, which no class elem expresses. Nothing in the pinned lib set declares either on an interface merged into a class.

`abstract` is unchanged: `ast.ClassDecl` has no slot for it and `convertClassDecl` already drops it.

## 2. The converter merges same-named declarations itself

Every rule `ConvertToStandaloneModule` runs reads one declaration per name — `detectTrios` resolves `FooConstructor` through a single map entry, and the walk emits a fused class for each statement matching a trio. So an unmerged input failed two ways, both silently: the constructor side kept only the last declaration's members, and two `interface Foo` declarations produced two identical `class Foo` declarations.

`PartitionLibWithOverlay` merges each bucket before converting it, so the generated tree never saw either. The converter was correct for one caller rather than in itself, and the tests reach it through the other one.

It now runs `mergeDecls` itself. The pass is idempotent, so its second run on the partition path is free, and running it after `liftGlobals` also reaches a declaration a `declare global` block contributes beside a same-named one at module scope. With the merge guaranteed there is provably one declaration per name, so `detectTrios` no longer keeps a per-name slice of interfaces and `trioInfo.merged` is a single declaration — the class instance side, the interface instance side and the constructor side now all resolve alike.

### A note on the converter tests

`convertSlice` runs this one stage, where `generate` runs four more passes after it — `fuseReadonlyTwins`, `applyReadonlyTwinReceivers`, `rewriteReadonlyTwinRefs` and `dedupeMembers`. So `ArrayConstructor` renders `-> Array<any>` there where the committed tree carries `-> mut Array<any>`. Its doc comment now names them, so its output is not read as the tree's. The `PartitionLib` tests and the generated-tree check cover the whole pipeline.

## No output change

The generated tree regenerates byte-identical from both commits. `Iterator` is the pinned lib set's one class-and-interface pair, and since #1410 its module-scope declarations no longer route into the global tree, so it never reaches merging. This closes the gap rather than leaving the converter to depend on a scope rule to avoid a merge it could not perform.

## Verification

- `go test ./...` green at each commit.
- The generated tree is unchanged and regenerates identically twice; all 49 files reparse.
- Each new guard was mutated and the matching test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193