### PR TITLE
Pin the constructorless trio gate and state one fusion rule

### DIFF
--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -264,8 +264,23 @@ type trioTable struct {
 // already written the long way. Recognition was the only place the two
 // spellings had to be told apart.
 //
-// This matches tryFuseTrio in internal/interop/class_shapes.go, which
-// has never gated on a construct signature.
+// # The same rule at the type level
+//
+// internal/interop/class_shapes.go recognises the idiom a second time, over
+// inferred types rather than `.d.ts` statements, because the prelude reaches the
+// lib files through ConvertModule instead of this converter. The two now state
+// one rule, checked against each other name by name:
+//
+//   - The named constructor side is tryFuseTrio: `Types[Foo]`,
+//     `Types[FooConstructor]`, and `Values[Foo]` a reference resolving to that
+//     same alias. It reads what the constructor side declares no more than this
+//     does.
+//   - The constructor side written inline on the binding is tryFuseEscalierClass:
+//     `Values[Foo]` an object type carrying a construct signature, with
+//     `Types[Foo]` as the instance side. That matches constructorSide's
+//     requirement that an inline object type carry a `new` returning the
+//     instance.
+//
 //
 // # A `declare class` on the instance side
 //

--- a/internal/dts_to_esc/partition_e2e_test.go
+++ b/internal/dts_to_esc/partition_e2e_test.go
@@ -188,6 +188,82 @@ func TestPartitionLib_PinnedLibSet_RoutesConvertsAndWrites(t *testing.T) {
 	}
 }
 
+// A trio fuses on its three names alone, so a constructor side with no `new`
+// still produces a class. `SymbolConstructor`, `BigIntConstructor` and
+// `IteratorConstructor` are the pinned lib set's three, and the specification
+// forbids constructing all three: `new Symbol()` throws a TypeError. A class
+// with no `constructor` member is what makes that unrepresentable rather than
+// merely discouraged, and the call signature `SymbolConstructor` and
+// `BigIntConstructor` carry lands on the class as its `callable` member.
+//
+// The three names must also reach the tree as one declaration each. A surviving
+// `interface SymbolConstructor` or `declare var Symbol` beside the class would
+// mean the trio only half-fused.
+func TestPartitionLib_ConstructorlessTriosFuseIntoOneClass(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := findRepoRoot()
+	require.NoError(t, err)
+	libDir := filepath.Join(repoRoot, "node_modules", "typescript", "lib")
+	if _, err := os.Stat(libDir); err != nil {
+		t.Skipf("pinned TypeScript lib set not present at %s: %v", libDir, err)
+	}
+
+	basenames, err := DiscoverLibFiles(libDir)
+	require.NoError(t, err)
+	inputs, err := ParseLibFiles(libDir, basenames)
+	require.NoError(t, err)
+	res, err := PartitionLibWithOverlay(inputs, committedOverlay(t))
+	require.NoError(t, err)
+	mods, err := ConvertBuckets(res)
+	require.NoError(t, err)
+
+	// name → how the tree declares it, keyed so a duplicate is visible.
+	kinds := map[string][]string{}
+	callables := set.NewSet[string]()
+	constructed := set.NewSet[string]()
+	for _, mod := range mods {
+		mod.Module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+			for _, decl := range ns.Decls {
+				switch d := decl.(type) {
+				case *ast.ClassDecl:
+					kinds[d.Name.Name] = append(kinds[d.Name.Name], "class")
+					for _, elem := range d.Body {
+						switch elem.(type) {
+						case *ast.ConstructorElem:
+							constructed.Add(d.Name.Name)
+						case *ast.CallableElem:
+							callables.Add(d.Name.Name)
+						}
+					}
+				case *ast.InterfaceDecl:
+					kinds[d.Name.Name] = append(kinds[d.Name.Name], "interface")
+				case *ast.VarDecl:
+					if ident, ok := d.Pattern.(*ast.IdentPat); ok {
+						kinds[ident.Name] = append(kinds[ident.Name], "var")
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	for _, name := range []string{"Symbol", "BigInt", "Iterator"} {
+		require.Equal(t, []string{"class"}, kinds[name],
+			"%s must reach the tree as one class", name)
+		require.NotContains(t, constructed, name,
+			"%s must carry no constructor", name)
+		require.NotContains(t, kinds, name+"Constructor",
+			"%sConstructor must be consumed by the fusion", name)
+	}
+
+	// `IteratorConstructor` declares neither a `new` nor a call signature, so
+	// `Iterator` is the one of the three that stays uncallable.
+	require.Contains(t, callables, "Symbol")
+	require.Contains(t, callables, "BigInt")
+	require.NotContains(t, callables, "Iterator")
+}
+
 // TestPartitionLib_SingletonKeyDropsMatchAllowList is the gate for the
 // symbol-keyed-singleton policy. Flattening emits one top-level
 // declaration per member and needs a plain identifier for both the

--- a/internal/interop/class_shapes.go
+++ b/internal/interop/class_shapes.go
@@ -165,6 +165,15 @@ func fillContainer(c *Container, ns *type_system.Namespace) {
 // type-side sibling (`<name>Constructor`) is recorded in
 // consumedTypes and the value-side binding is recorded in
 // consumedValues so the caller's fall-through doesn't re-emit them.
+//
+// This is the type-level half of the rule detectTrios states over `.d.ts`
+// statements in internal/dts_to_esc/dts_to_esc.go. Both match on the three names
+// and the binding's type alone. What the constructor side declares does not enter
+// recognition: `SymbolConstructor`, `BigIntConstructor` and `IteratorConstructor`
+// declare no `new`, and each still fuses into a class that carries no
+// constructor, which is what makes `new Symbol()` unrepresentable. The other half
+// of the rule, a constructor side written inline on the binding rather than as a
+// named interface, is tryFuseEscalierClass below.
 func tryFuseTrio(
 	ns *type_system.Namespace,
 	name string,
@@ -213,6 +222,19 @@ func tryFuseTrio(
 // tryFuseEscalierClass recognises the Escalier-style class shape:
 // Values[name] is an ObjectType carrying a ConstructorElem. The
 // instance side, when present, is read from Types[name].
+//
+// It is also how the type level sees a constructor side written inline on the
+// binding, which is the form lib.dom.d.ts uses:
+//
+//	declare var AbortController: {
+//	    prototype: AbortController;
+//	    new (): AbortController;
+//	};
+//
+// Requiring a ConstructorElem matches constructorSide in
+// internal/dts_to_esc/dts_to_esc.go, which requires an inline object type to
+// carry a `new` returning the instance. The `new` is what ties an unnamed object
+// type to its interface, where the named form has the name to go on.
 //
 // Skips names whose value side already participated in a trio fusion
 // (in which case consumedValues[name] is set).


### PR DESCRIPTION
Fixes #1309

Stacked on #1440. Review only the top commit.

## What is left of #1309

The mechanism landed across the stack. #1405 dropped the `hasCtorReturning` gate so a trio fuses on its three names alone, and #1438 gave the fused class somewhere to put a call signature, which is what let `Symbol` and `BigInt` stop being held back. This PR closes the issue's remaining two gate items.

## The gate, held by a test

`Symbol`, `BigInt` and `Iterator` each reach the tree as one class with no `constructor` member. The specification forbids constructing all three — `new Symbol()` throws a `TypeError` — and a class with no constructor is what makes that unrepresentable rather than merely discouraged.

`TestPartitionLib_ConstructorlessTriosFuseIntoOneClass` runs over the pinned lib set and asserts each name reaches the tree as exactly one class, carries no constructor, and leaves no `*Constructor` interface or binding beside it. It also pins that `Symbol` and `BigInt` carry their call signature as `static fn` while `Iterator`, whose constructor side declares neither a `new` nor a call signature, stays uncallable.

## One rule, stated twice

The idiom is recognised a second time over inferred types in `internal/interop/class_shapes.go`, because the prelude reaches the lib files through `ConvertModule` rather than this converter. The two disagreed about whether the constructor side had to declare a `new`; neither requires it now. Each half of the rule is documented against its counterpart: the named constructor side against `tryFuseTrio`, the inline object type against `tryFuseEscalierClass`.

## The third gate item

`TestCheckPartition_HandFusedTrioIsSticky` fed a doctored `WeakRefConstructor` with its `new` line removed so the pair would reach the §6.4 diff unfused. #1392 removed the `check` subcommand and that test with it, so there is nothing left to rebuild.

## Verification

- `go test ./...` green.
- The generated tree is unchanged and regenerates identically twice; all 49 files reparse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuDVSmait8V1mjXnrJt193)_