### PR TITLE
Read the two ECMA-402 heads that abort extraction

### DIFF
--- a/tools/spec-extract/README.md
+++ b/tools/spec-extract/README.md
@@ -165,9 +165,17 @@ output path, and it writes the merged document out:
 sbt 'runMain escalier.specextract.MergeCheck ecma402/spec merged.html'
 ```
 
-`Main` serializes ECMA-262 alone. Extracting from the merged document
-needs the two ECMA-402 abstract-operation heads whose type wording ends the run,
-which is [#1451](https://github.com/escalier-lang/escalier/issues/1451).
+Two ECMA-402 heads declare a type in wording ECMA-262 never uses, and ESMeta
+raises on a head it cannot parse. The raise ends extraction for the whole
+document, so one unreadable head costs every algorithm rather than its own,
+which is why the merge restates those two and leaves the unread steps alone. A
+step falls back to a `yet` and costs only itself. `MergedSpec.HeadRewrites`
+records what each restatement says and why it declares the same values, and the
+run fails if a pattern stops matching its head exactly once.
+
+`Main` serializes ECMA-262 alone and writes the committed `cfg.json`.
+Committing a merged graph is
+[#1455](https://github.com/escalier-lang/escalier/issues/1455).
 
 ## The serializer
 

--- a/tools/spec-extract/src/main/scala/escalier/specextract/MergeCheck.scala
+++ b/tools/spec-extract/src/main/scala/escalier/specextract/MergeCheck.scala
@@ -1,14 +1,20 @@
 package escalier.specextract
 
+import esmeta.cfg.CFG
+import esmeta.cfgBuilder.CFGBuilder
+import esmeta.compiler.Compiler
+import esmeta.extractor.Extractor
+import esmeta.spec.Algorithm
 import esmeta.util.SystemUtils.dumpFile
 
-/** Builds the merged ECMA-262 and ECMA-402 document and reports what went into
-  * it, without extracting from it.
+/** Reads the merged ECMA-262 and ECMA-402 document end to end and reports what
+  * ECMA-402 contributes to the graph.
   *
-  * [[Main]] serializes ECMA-262 alone. Extracting from the merged document
-  * needs the two ECMA-402 abstract-operation heads whose type wording ends the
-  * run, which is work of its own, so this entry point exercises and checks the
-  * merge until [[Main]] reads it.
+  * [[Main]] serializes ECMA-262 alone and writes the `cfg.json` the Go analysis
+  * embeds. Committing a merged graph is separate work, so this entry point runs
+  * the same `extract → compile → build-cfg` pipeline over the merged document
+  * and reports on it without writing anything. It is what says the merge and
+  * its head rewrites produce a graph the extractor can read.
   *
   * Usage: `runMain escalier.specextract.MergeCheck [ecma402/spec] [out.html]`.
   * Both arguments are optional. The second writes the merged document out,
@@ -21,16 +27,62 @@ object MergeCheck:
 
     println(s"merging ECMA-402 from $specDir into spec.html ...")
     val merged = new MergedSpec(specDir).result
-
     println(s"  ${merged.importedFiles.length} files imported")
     println(s"  ${merged.appendedElements} elements appended")
     println(s"  ${merged.supersededClauses.length} ECMA-262 clauses replaced")
     for (id <- merged.supersededClauses) println(s"    $id")
+    println(s"  ${merged.rewrittenHeads.length} algorithm heads rewritten")
+    for (id <- merged.rewrittenHeads) println(s"    $id")
+    println(s"  ECMA-262 at ${merged.version}")
 
-    val algorithms = merged.document.select("emu-alg:not([example])").size
-    println(s"  $algorithms algorithm bodies in the merged document")
-    println("  merge OK")
-
+    // written before anything reads the document, so a run that fails to read
+    // it leaves the document on disk to look at
     for (out <- args.drop(1).headOption)
       dumpFile(merged.document.outerHtml, out)
-      println(s"wrote $out")
+      println(s"  wrote $out")
+
+    println("extracting the merged specification ...")
+    val spec = new Extractor(merged.document).result
+    val from402 = spec.algorithms.filter(algo => sourceOf(algo).isDefined)
+    println(s"  ${spec.algorithms.length} algorithms")
+    println(s"  ${from402.length} of them from ECMA-402")
+    for ((file, algos) <- from402.groupBy(sourceOf).toList.sortBy(_._1))
+      println(s"    ${algos.length}\t${file.getOrElse("")}")
+
+    println("compiling to IR and building the control-flow graph ...")
+    val cfg = new CFGBuilder(new Compiler(spec).result).result
+    println(s"  ${cfg.funcs.length} functions")
+    report402(cfg)
+    println("  merge OK")
+
+  /** Reports the functions ECMA-402 contributed, by kind.
+    *
+    * The builtins outside the `Intl` namespace are listed one at a time, with
+    * the size of the body the graph holds for each. That size is what says
+    * whether the definition ECMA-402 writes reached the graph, since a stub
+    * standing in for one is a single node.
+    */
+  private def report402(cfg: CFG): Unit =
+    val funcs = cfg.funcs.filter(_.irFunc.algo.flatMap(sourceOf).isDefined)
+    println(s"  ${funcs.length} of them from ECMA-402")
+    val byKind = funcs.groupBy(_.irFunc.kind.toString).toList.sortBy(_._1)
+    for ((kind, group) <- byKind)
+      println(
+        s"    ${group.length}\t${if (kind.isEmpty) "abstract op" else kind}",
+      )
+    // Almost every builtin ECMA-402 defines hangs off `Intl`, so dropping
+    // those leaves the ECMA-262 methods it supersedes. Three anonymous
+    // function clauses come through here too, under the `yet:` name ESMeta
+    // gives a builtin path it cannot parse.
+    val outsideIntl = funcs
+      .filter(_.irFunc.kind == esmeta.ir.FuncKind.Builtin)
+      .filter(func => !func.irFunc.name.contains("Intl"))
+      .sortBy(_.irFunc.name)
+    println(s"  ${outsideIntl.length} builtins outside the Intl namespace")
+    for (func <- outsideIntl)
+      println(s"    ${func.nodes.size} nodes\t${func.irFunc.name}")
+
+  /** The ECMA-402 file an algorithm came from, or `None` for an ECMA-262 one.
+    */
+  private def sourceOf(algo: Algorithm): Option[String] =
+    MergedSpec.sourceOf(algo.elem)

--- a/tools/spec-extract/src/main/scala/escalier/specextract/MergedSpec.scala
+++ b/tools/spec-extract/src/main/scala/escalier/specextract/MergedSpec.scala
@@ -56,16 +56,18 @@ final class MergedSpec(specDir: String):
     * This is what `Extractor.from` does before it extracts, and reading the
     * file without it would build the graph from a different ECMA-262 than the
     * one `Main` serializes. ESMeta patches the file in place, reads it, and
-    * reverts it, so the read is forced while the patch is on disk. The patch is
-    * keyed by revision, so a bump that needs none finds none.
+    * reverts it, so the read is forced while the patch is on disk. The revert
+    * runs even when the read throws, since a patched `spec.html` left behind
+    * would change what the next run extracts, this build's and ESMeta's own.
+    * The patch is keyed by revision, so a bump that needs none finds none.
     */
   private def ecma262: (Spec.Version, Document) =
     Spec.getVersionWith(None) { version =>
       lazy val document = readFile(SPEC_HTML).toHtml
       for (patch <- ManualInfo.bugfixPatchMap.get(version.hash))
         Spec.applyPatch(patch)
-        document
-        Spec.clean
+        try document
+        finally Spec.clean
       document
     }
 

--- a/tools/spec-extract/src/main/scala/escalier/specextract/MergedSpec.scala
+++ b/tools/spec-extract/src/main/scala/escalier/specextract/MergedSpec.scala
@@ -1,12 +1,15 @@
 package escalier.specextract
 
 import esmeta.SPEC_HTML
+import esmeta.spec.Spec
 import esmeta.util.HtmlUtils.*
+import esmeta.util.ManualInfo
 import esmeta.util.SystemUtils.readFile
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters.*
+import scala.util.matching.Regex
 
 /** Builds the document the extractor reads: ECMA-262's `spec.html` with
   * ECMA-402's clauses spliced into it.
@@ -32,12 +35,39 @@ final class MergedSpec(specDir: String):
 
   /** The merged document and what went into it. */
   lazy val result: MergedSpec.Result =
-    val document = readFile(SPEC_HTML).toHtml
+    val (version, document) = ecma262
     val appended = append(document)
     val superseded = removeSuperseded(document, appended)
     checkSupersededCount(superseded)
     checkTableIds(document)
-    MergedSpec.Result(document, importedFiles, appended.length, superseded)
+    rewriteHeads(appended)
+    MergedSpec.Result(
+      document,
+      version,
+      importedFiles,
+      appended.length,
+      superseded,
+      MergedSpec.HeadRewrites.map(_.clause),
+    )
+
+  /** Reads `spec.html` at the pinned revision, with the bugfix patch ESMeta
+    * ships for that revision applied.
+    *
+    * This is what `Extractor.from` does before it extracts, and reading the
+    * file without it would build the graph from a different ECMA-262 than the
+    * one `Main` serializes. ESMeta patches the file in place, reads it, and
+    * reverts it, so the read is forced while the patch is on disk. The patch is
+    * keyed by revision, so a bump that needs none finds none.
+    */
+  private def ecma262: (Spec.Version, Document) =
+    Spec.getVersionWith(None) { version =>
+      lazy val document = readFile(SPEC_HTML).toHtml
+      for (patch <- ManualInfo.bugfixPatchMap.get(version.hash))
+        Spec.applyPatch(patch)
+        document
+        Spec.clean
+      document
+    }
 
   /** The ECMA-402 files `index.html` imports, in the order it names them. */
   private lazy val importedFiles: List[String] =
@@ -120,6 +150,41 @@ final class MergedSpec(specDir: String):
         "updating the count",
       )
 
+  /** Rewrites the ECMA-402 algorithm heads ESMeta's type vocabulary cannot
+    * read.
+    *
+    * ESMeta raises on a head it cannot parse, and the raise ends extraction for
+    * the whole document, so one unreadable head costs every algorithm rather
+    * than its own. A step is different: the metalanguage parser falls back to a
+    * `yet`, so an unreadable step costs only that step. That difference is why
+    * these two are rewritten and the unread steps are left alone.
+    *
+    * Each rewrite restates a declared type in ECMA-262's vocabulary and leaves
+    * the algorithm untouched, so what the graph carries is the operation
+    * ECMA-402 wrote. [[MergedSpec.HeadRewrites]] records what each one restates
+    * and why the restatement says the same thing.
+    */
+  private def rewriteHeads(appended: List[Element]): Unit =
+    for (rewrite <- MergedSpec.HeadRewrites)
+      val clause = appended
+        .flatMap(root => Option(root.getElementById(rewrite.clause)))
+        .headOption
+        .getOrElse(
+          fail(s"ECMA-402 no longer defines the clause '${rewrite.clause}'"),
+        )
+      val head = clause.children.asScala
+        .find(_.tagName == "h1")
+        .getOrElse(fail(s"the clause '${rewrite.clause}' has no head to read"))
+      val before = head.html
+      val matches = rewrite.pattern.findAllMatchIn(before).length
+      if (matches != 1)
+        fail(
+          s"the head of '${rewrite.clause}' has $matches places to rewrite, " +
+          "not 1. Re-read the head against the current wording before " +
+          "changing the pattern",
+        )
+      head.html(rewrite.pattern.replaceAllIn(before, rewrite.replacement))
+
   /** Rejects a table id the merged document carries twice.
     *
     * `Extractor.extractTables` keys every `emu-table` by its id in one map, so
@@ -153,6 +218,8 @@ object MergedSpec:
     * @param document
     *   the merged document, with every element taken from ECMA-402 carrying
     *   [[SourceAttr]]
+    * @param version
+    *   the ECMA-262 revision the document was read at
     * @param importedFiles
     *   the ECMA-402 files `index.html` imports
     * @param appendedElements
@@ -160,12 +227,76 @@ object MergedSpec:
     * @param supersededClauses
     *   the ids of the ECMA-262 clauses removed because ECMA-402 replaces them,
     *   sorted
+    * @param rewrittenHeads
+    *   the ids of the ECMA-402 clauses whose head was restated
     */
   final case class Result(
     document: Document,
+    version: Spec.Version,
     importedFiles: List[String],
     appendedElements: Int,
     supersededClauses: List[String],
+    rewrittenHeads: List[String],
+  )
+
+  /** The ECMA-402 file an element came from, or `None` for an ECMA-262 one. */
+  def sourceOf(elem: Element): Option[String] =
+    var current = elem
+    while (current != null)
+      if (current.hasAttr(SourceAttr)) return Some(current.attr(SourceAttr))
+      current = current.parent
+    None
+
+  /** One declared type restated in the vocabulary ESMeta's head parser reads.
+    *
+    * @param clause
+    *   the id of the ECMA-402 clause whose head is rewritten
+    * @param pattern
+    *   what to restate, which has to match the head exactly once
+    * @param replacement
+    *   the restatement
+    * @param reason
+    *   why the restatement declares the same values as the wording it replaces
+    */
+  private final case class HeadRewrite(
+    clause: String,
+    pattern: Regex,
+    replacement: String,
+    reason: String,
+  )
+
+  /** The heads ESMeta cannot read at the pinned ECMA-402 revision, reviewed one
+    * at a time.
+    *
+    * Both are ECMA-402 declaring a type in wording ECMA-262 never uses, and
+    * neither is about the algorithm under the head. A rewrite belongs here only
+    * when the restatement declares the same values, since the graph then
+    * carries the operation the specification wrote rather than a different one.
+    */
+  private val HeadRewrites = List(
+    HeadRewrite(
+      clause = "sec-canonicalizeuvalue",
+      pattern =
+        raw"a Unicode locale extension sequence key defined in <a [^>]*>[^<]*</a>".r,
+      replacement = "a String",
+      reason =
+        "A Unicode locale extension sequence key is a String. The algorithm " +
+        "reads _ukey_ only by comparing it with String literals, and every " +
+        "caller passes one.",
+    ),
+    HeadRewrite(
+      clause = "sec-getbooleanorstringnumberformatoption",
+      pattern =
+        raw"either a normal completion containing either a Boolean, String, or _fallback_, or a throw completion".r,
+      replacement =
+        "either a normal completion containing an ECMAScript language value, " +
+        "or a throw completion",
+      reason =
+        "The return type names the parameter _fallback_, which the head " +
+        "grammar has no way to spell. _fallback_ is declared an ECMAScript " +
+        "language value, and a Boolean and a String are both ECMAScript " +
+        "language values, so the union is one.",
+    ),
   )
 
   /** Marks an element as ECMA-402's and names the file it came from. */


### PR DESCRIPTION
Fixes #1451. Refs #1448.

Stacked on #1460. Review that one first — this PR's diff is only its own commit.

Stack, bottom to top:

1. #1460 — the spike, and the merged document (#1449)
2. **this PR** — read the two ECMA-402 heads that abort extraction
3. #1450 — let ECMA-402 supersede the manual stubs that hide it

## The problem

ESMeta raises on an algorithm head it cannot parse, and the raise ends extraction for the whole document. One unreadable head therefore costs every algorithm rather than its own. A step is different: the metalanguage parser falls back to a `yet`, so an unreadable step costs only that step. That asymmetry is why these two heads are worth rewriting and the 400 unread ECMA-402 steps are left alone.

Two clauses in `negotiation.html` hit it, and neither is about the algorithm under the head:

- `CanonicalizeUValue` types a parameter as "a Unicode locale extension sequence key defined in `<a href="…">Unicode Technical Standard #35 …</a>`". The parser expects a type from ECMA-262's own vocabulary and stops at the `_uvalue_` that follows.
- `GetBooleanOrStringNumberFormatOption` declares its return as "either a normal completion containing either a Boolean, String, or _fallback_, or a throw completion", naming one of its own parameters inside the return type.

## The fix

`MergedSpec.HeadRewrites` restates each declared type in ECMA-262's vocabulary and leaves the algorithm untouched, so the graph carries the operation ECMA-402 wrote. This is option 1 of the three #1451 lists, which that ticket ranks first.

Each entry records why the restatement declares the same values. A Unicode locale extension sequence key is a String, and the algorithm reads `_ukey_` only by comparing it against String literals. `_fallback_` is declared an ECMAScript language value, and a Boolean and a String are both ECMAScript language values, so the union is one.

The run fails when a pattern stops matching its head exactly once, so a reworded head is caught rather than silently left unrewritten — the same discipline `Lowering.recognizedPhrasings` uses.

## The bugfix patch

Reading `spec.html` now applies the bugfix patch ESMeta ships for the pinned revision, the way `Extractor.from` does. This is worth calling out: ECMA-262 has a head of its own that the type vocabulary cannot read, and that patch is how ESMeta fixes it. Without applying it, the merged document is a *different ECMA-262* from the one `Main` serializes, which would have surfaced in #1455 as unexplained diffs in the ECMA-262 half of the graph. Found in review, not by the tests.

## Verification

`MergeCheck` now reads the merged document end to end and reports what ECMA-402 contributes, which is what says the rewrites work:

- Extraction completes with no abort, at 195 ECMA-402 algorithms — the two the raise used to cost included, against the spike's 193 with them dropped.
- The graph holds 3140 functions, 195 from ECMA-402: 101 abstract operations, 77 builtins, 17 syntax-directed.
- The merged document carries the patched ECMA-262 wording, and the vendored `ecma262` checkout is clean after a run.

It writes nothing, so `Main` and the committed `cfg.json` are untouched. `go test ./...` is green and `scalafmtCheckAll` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQY5FHTPi3NtbvdTqn3JYw


---
_Generated by [Claude Code](https://claude.ai/code/session_01EQY5FHTPi3NtbvdTqn3JYw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation of merged specifications through extraction, compilation, and control-flow analysis.
  * Reports rewritten algorithm heads, source provenance, function counts, and ECMA-402 functions by category.
  * Supports revision-specific ECMA-262 versions and identifies the originating ECMA-402 source file for elements.
  * Validates that each supported rewrite matches exactly once.

* **Documentation**
  * Documented supported ECMA-402 rewrites and clarified ECMA-262 serialization behavior.
  * Noted that merged-graph serialization remains tracked for future work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->