### PR TITLE
Let ECMA-402 supersede the manual stubs that hide it

### DIFF
--- a/tools/spec-extract/README.md
+++ b/tools/spec-extract/README.md
@@ -173,6 +173,17 @@ step falls back to a `yet` and costs only itself. `MergedSpec.HeadRewrites`
 records what each restatement says and why it declares the same values, and the
 run fails if a pattern stops matching its head exactly once.
 
+ESMeta writes IR by hand for a handful of algorithms it cannot compile from
+`spec.html`, and `Compiler` prefers one of those to a compiled algorithm of the
+same name. Three stand in for locale-sensitive functions ECMA-262 leaves to the
+host and ECMA-402 defines in full, so on the merged specification the stub
+would hide a definition the graph could carry, and each is a single `yet` that
+the analysis reads as knowing nothing about the method. `MergedCompiler`
+declines to prefer those three and drops them from the compiled program, which
+leaves the vendored checkout alone: editing it would put the toolchain's own
+state in the way of a run. Which stubs those are is derived and the count is
+pinned, the same way the superseded clauses are.
+
 `Main` serializes ECMA-262 alone and writes the committed `cfg.json`.
 Committing a merged graph is
 [#1455](https://github.com/escalier-lang/escalier/issues/1455).
@@ -186,12 +197,17 @@ is published to a local repository and the vendored tree is never edited.
 `.scalafmt.conf` is the vendored tree's own configuration, so the Scala here
 reads like the Scala it is compiled against. `mise run format` applies it.
 
-`src/main/scala/escalier/specextract/` holds four files. `Main` runs the
-pipeline in process, `Lowering` turns `esmeta.cfg.CFG` into the schema,
-`Validation` reads the written file back and checks it, and `Schema` carries the
-case classes and the writer. The schema itself is Appendix A of the
-implementation plan, and the Go analysis reads the same shape, so a field
-renamed on one side has to be renamed on the other.
+`src/main/scala/escalier/specextract/` holds seven files. Four serialize
+ECMA-262: `Main` runs the pipeline in process, `Lowering` turns
+`esmeta.cfg.CFG` into the schema, `Validation` reads the written file back and
+checks it, and `Schema` carries the case classes and the writer. The schema
+itself is Appendix A of the implementation plan, and the Go analysis reads the
+same shape, so a field renamed on one side has to be renamed on the other.
+
+The other three read ECMA-402 in, and none of them is on the path `Main` takes.
+`MergedSpec` builds the merged document, `MergedCompiler` compiles it so
+ECMA-402's definitions win over the stubs that would hide them, and
+`MergeCheck` runs both and reports. See "The merged document" above.
 
 The lowering copies structure and makes no mutability or alias judgement. Three
 shapes need reconstruction rather than a copy, because the IR compiler has

--- a/tools/spec-extract/src/main/scala/escalier/specextract/MergeCheck.scala
+++ b/tools/spec-extract/src/main/scala/escalier/specextract/MergeCheck.scala
@@ -2,7 +2,6 @@ package escalier.specextract
 
 import esmeta.cfg.CFG
 import esmeta.cfgBuilder.CFGBuilder
-import esmeta.compiler.Compiler
 import esmeta.extractor.Extractor
 import esmeta.spec.Algorithm
 import esmeta.util.SystemUtils.dumpFile
@@ -50,7 +49,12 @@ object MergeCheck:
       println(s"    ${algos.length}\t${file.getOrElse("")}")
 
     println("compiling to IR and building the control-flow graph ...")
-    val cfg = new CFGBuilder(new Compiler(spec).result).result
+    val compiler = new MergedCompiler(spec)
+    val cfg = new CFGBuilder(compiler.program).result
+    println(
+      s"  ${compiler.supersededStubs.size} manual stubs ECMA-402 supersedes",
+    )
+    for (name <- compiler.supersededStubs.toList.sorted) println(s"    $name")
     println(s"  ${cfg.funcs.length} functions")
     report402(cfg)
     println("  merge OK")

--- a/tools/spec-extract/src/main/scala/escalier/specextract/MergedCompiler.scala
+++ b/tools/spec-extract/src/main/scala/escalier/specextract/MergedCompiler.scala
@@ -1,0 +1,95 @@
+package escalier.specextract
+
+import esmeta.compiler.Compiler
+import esmeta.ir.Program
+import esmeta.spec.Spec
+
+/** Compiles the merged specification, letting ECMA-402's definition of a
+  * function beat the IR ESMeta supplies for it by hand.
+  *
+  * ESMeta writes IR for a handful of algorithms it cannot compile from
+  * `spec.html`, and `Compiler` prefers one of those to a compiled algorithm of
+  * the same name. Three of them stand in for locale-sensitive functions that
+  * ECMA-262 leaves to the host and ECMA-402 defines in full, so on the merged
+  * specification the stub hides a definition the graph could carry. Each is a
+  * single `yet`, which the analysis reads as knowing nothing about the method.
+  *
+  * The stubs are left where they are and this compiler declines to prefer them.
+  * Editing the vendored checkout would put the toolchain's own state in the way
+  * of a run, and `Compiler` is written to be extended.
+  *
+  * Which stubs those are is derived rather than listed, so a revision that
+  * supersedes one more of them is handled. The count is pinned, so ESMeta
+  * dropping a stub or ECMA-402 taking on another one fails the run instead of
+  * changing what the graph holds unannounced.
+  */
+final class MergedCompiler(spec: Spec) extends Compiler(spec):
+
+  /** The manual stubs ECMA-402 supersedes, by compiled function name.
+    *
+    * A stub qualifies when the merged specification defines an algorithm of the
+    * same name and that algorithm came from ECMA-402. The ECMA-262 half of the
+    * document is left exactly as `Main` compiles it.
+    */
+  val supersededStubs: Set[String] = (for {
+    algo <- spec.algorithms
+    if MergedSpec.sourceOf(algo.elem).isDefined
+    // `compile` names a function by the normalized head name, and `excluded`
+    // is read against that, so the same spelling has to be derived here
+    name = normalize(algo.head.fname)
+    if manualFuncMap.contains(name)
+  } yield name).toSet
+
+  /** The names not to compile.
+    *
+    * This drops the superseded stubs from what `Compiler` refuses to compile,
+    * which is the whole of what this class changes.
+    *
+    * Overriding it is safe because `addFunc` reads it while `result` compiles,
+    * long after construction. Overriding a field the constructor itself reads
+    * would leave that field null for the constructor.
+    */
+  override val excluded: Set[String] =
+    (manualFuncMap.keySet -- supersededStubs) ++ shorthands
+
+  /** The compiled program, with each superseded stub dropped.
+    *
+    * Both the stub and the algorithm it stood in for are compiled by now, and
+    * they carry one name between them, so the stub is removed here rather than
+    * left for `Lowering.checkUniqueNames` to reject.
+    *
+    * The stub is picked out by identity. `Func` is a case class whose `algo`
+    * field the compiler assigns while it compiles, so a stub's hash changes
+    * under any collection that had already placed it.
+    */
+  lazy val program: Program =
+    checkSupersededStubCount()
+    val stubs = supersededStubs.toList.flatMap(manualFuncMap.get)
+    Program(result.funcs.filterNot(func => stubs.exists(_ eq func)), spec)
+
+  /** Fails the run when the number of superseded stubs leaves the reviewed
+    * count.
+    *
+    * The set is derived from two moving parts, the stubs ESMeta ships and the
+    * definitions ECMA-402 writes, and a change to either one is a change to
+    * what the graph says about a method. Read the algorithm that took a stub's
+    * place before moving this number.
+    */
+  private def checkSupersededStubCount(): Unit =
+    if (supersededStubs.size != MergedCompiler.SupersededStubs)
+      throw new IllegalStateException(
+        s"ECMA-402 supersedes ${supersededStubs.size} manual stubs, not " +
+        s"${MergedCompiler.SupersededStubs}: " +
+        s"${supersededStubs.toList.sorted.mkString(", ")}. Read what took " +
+        "each one's place before updating the count",
+      )
+
+object MergedCompiler:
+
+  /** How many manual stubs ECMA-402 supersedes at the pinned revisions:
+    * `Number.prototype.toLocaleString` and the two
+    * `String.prototype.toLocale*Case` methods. ESMeta's stub for
+    * `TypedArray.prototype.toLocaleString` stays, since ECMA-402 leaves that
+    * one alone.
+    */
+  private val SupersededStubs = 3


### PR DESCRIPTION
Fixes #1450. Refs #1448.

Stacked on #1461. Review #1460 and #1461 first — this PR's diff is only its own commit.

Stack, bottom to top:

1. #1460 — the spike, and the merged document (#1449)
2. #1461 — read the two ECMA-402 heads that abort extraction
3. **this PR** — let ECMA-402 supersede the manual stubs that hide it

## The problem

ESMeta writes IR by hand for a handful of algorithms it cannot compile from `spec.html`, and `Compiler` builds `excluded` from `manualFuncMap.keySet`, so a manual function wins over a compiled algorithm of the same name.

Three of those stubs stand in for locale-sensitive functions that ECMA-262 leaves to the host and ECMA-402 defines in full: `Number.prototype.toLocaleString` and the two `String.prototype.toLocale*Case` methods. On the merged specification the stub hides a definition the graph could carry, and each is a single `yet`, which the analysis reads as knowing nothing about the method.

This fails silently rather than loudly, which is what makes it worth a ticket of its own. In the spike all three arrived as one opaque node with the ECMA-402 algorithm discarded, and nothing said so.

`TypedArray.prototype.toLocaleString` keeps its stub. ECMA-402 leaves that one alone.

## The fix

`MergedCompiler` declines to prefer those three and drops them from the compiled program. The stubs stay where they are: editing the vendored checkout would put the toolchain's own state in the way of a run, and `Compiler` is documented as an extensible helper.

Two things worth a reviewer's eye:

- **Overriding `excluded` is init-safe.** `addFunc` reads it while `result` compiles, long after construction, so the overridden field is populated by then. Overriding a field the constructor itself reads would leave it null for the constructor.
- **The stub is dropped by identity, not by value.** `Func` is a case class whose `algo` field the compiler assigns while it compiles, so a stub's hash changes under any collection that had already placed it. Caught in review: a `Set[Func]` worked only because three elements make a linear `Set3`, and would have silently stopped dropping stubs at five.

Which stubs those are is derived from the merged specification rather than listed, keyed by the same normalized name `compile` uses, so a revision that supersedes one more is handled. The count is pinned, so ESMeta dropping a stub or ECMA-402 taking on another fails the run rather than changing what the graph holds unannounced.

## Verification

`MergeCheck` reports the three, and each now carries the body ECMA-402 writes rather than a lone `yet`:

| function | nodes before | nodes after |
| --- | ---: | ---: |
| `Number.prototype.toLocaleString` | 1 | 26 |
| `String.prototype.toLocaleLowerCase` | 1 | 21 |
| `String.prototype.toLocaleUpperCase` | 1 | 21 |

The function count is unchanged at 3140, since each stub dropped is one algorithm compiled. Setting the pinned count wrong fails the run with the three names in the message. `Main` and the committed `cfg.json` are untouched, `go test ./...` is green, and `scalafmtCheckAll` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQY5FHTPi3NtbvdTqn3JYw


---
_Generated by [Claude Code](https://claude.ai/code/session_01EQY5FHTPi3NtbvdTqn3JYw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved specification extraction to correctly merge ECMA-262 and ECMA-402 definitions.
  - Added validation to identify manual stubs replaced by merged locale-sensitive definitions.

- **Documentation**
  - Updated the specification extraction tool documentation to explain merged ECMA-402 processing and the expanded toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->