### PR TITLE
Read the declaration kinds a lib file writes

### DIFF
--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -202,6 +202,19 @@ func (v *ModuleBindingVisitor) EnterDecl(decl ast.Decl) bool {
 			key := TypeBindingKey(qualName)
 			v.Graph.AddDecl(key, decl, v.currentNSName)
 		}
+	case *ast.NamespaceDecl:
+		// A `namespace Foo { ... }` block introduces no binding of its own. Its
+		// members are keyed under `Foo.name`, the same qualified shape a
+		// directory-derived namespace produces, so one set of qualified-name
+		// machinery serves both.
+		if d.Name != nil && d.Name.Name != "" {
+			saved := v.currentNSName
+			v.currentNSName = v.qualifyName(d.Name.Name)
+			for _, inner := range d.Decls {
+				v.EnterDecl(inner)
+			}
+			v.currentNSName = saved
+		}
 	case *ast.ClassDecl:
 		// Class declarations introduce both a type binding and a value binding (constructor)
 		if d.Name != nil && d.Name.Name != "" {

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -1018,8 +1018,34 @@ func collectNamespaces(module *ast.Module) []string {
 			// Add new namespace
 			namespaces = append(namespaces, nsName)
 		}
+		// A `namespace Foo { ... }` block is a namespace too. Registering it means a
+		// reference written inside the block carries the block's NamespaceID rather
+		// than the root's, which is what the emitted name is built from.
+		for _, decl := range nsIter.Value().Decls {
+			namespaces = appendBlockNamespaces(namespaces, nsName, decl)
+		}
 	}
 
+	return namespaces
+}
+
+// appendBlockNamespaces registers decl's qualified name when it is a namespace
+// block, and recurses into the blocks written inside it.
+func appendBlockNamespaces(namespaces []string, prefix string, decl ast.Decl) []string {
+	block, ok := decl.(*ast.NamespaceDecl)
+	if !ok || block.Name == nil || block.Name.Name == "" {
+		return namespaces
+	}
+	qname := block.Name.Name
+	if prefix != "" {
+		qname = prefix + "." + qname
+	}
+	if !slices.Contains(namespaces, qname) {
+		namespaces = append(namespaces, qname)
+	}
+	for _, inner := range block.Decls {
+		namespaces = appendBlockNamespaces(namespaces, qname, inner)
+	}
 	return namespaces
 }
 

--- a/internal/dep_graph/dep_graph_test.go
+++ b/internal/dep_graph/dep_graph_test.go
@@ -2519,3 +2519,30 @@ func TestBuildDepGraphV2_LocalDeclShadowing(t *testing.T) {
 		})
 	}
 }
+
+// A reference written inside a namespace block carries that block's NamespaceID,
+// not the root's. The emitted name is built from that id, so a root id would emit
+// the reference unqualified.
+func TestNamespaceBlockRegistersItsOwnID(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	module, errors := parser.ParseLibFiles(ctx, []*ast.Source{{
+		ID:   0,
+		Path: "input.esc",
+		Contents: `
+			namespace geo {
+				val a: number = 1
+				namespace inner {
+					val b: number = 2
+				}
+			}
+		`,
+	}})
+	assert.Len(t, errors, 0, "Parser errors: %v", errors)
+
+	graph := BuildDepGraph(module)
+	assert.Contains(t, graph.Namespaces, "geo")
+	assert.Contains(t, graph.Namespaces, "geo.inner")
+}

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -108,6 +108,11 @@ type checker struct {
 	// invisible to a sibling file and to the package's exported surface.
 	moduleScope *Scope
 
+	// nsShells holds the `namespace` blocks pre-bound for the module under
+	// inference, so refreshNamespaces can fill them as bindings land. It is nil
+	// outside a module walk.
+	nsShells []*namespaceShell
+
 	// fileScopes holds one scope per file of the module being inferred, keyed by
 	// source id, each carrying that file's import bindings.
 	fileScopes map[int]*Scope

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -494,21 +494,19 @@ func TestInferModuleFunctionOverloadResolves(t *testing.T) {
 	}, values)
 }
 
-// A declaration kind the dep graph does not model — here a `namespace` block,
-// which BuildDepGraph produces no binding key for — must still report a clean
-// UnsupportedNodeError rather than vanishing silently. The reconciliation pass in
-// inferDepGraph walks the module's own declarations and flags any the SCC walk
-// never visited.
-func TestInferModuleNamespaceDeclUnsupported(t *testing.T) {
+// A `namespace` block binds its members under the block's name and no type binding
+// of its own. The block is a grouping, not a type, so `Foo` names a namespace an
+// access reaches through rather than something an annotation can write.
+func TestInferModuleNamespaceDeclBindsItsMembers(t *testing.T) {
 	values, types, errs := inferSource(t, `
 		namespace Foo {
 			val x = 5
 		}
+		val y = Foo.x
 	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "2:3-4:4: Unsupported: NamespaceDecl", msgWithSpan(t, errs[0]))
-	require.Empty(t, values)
-	// The unsupported decl must not leak a type binding for the namespace.
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "5", values["Foo.x"])
+	require.Equal(t, "5", values["y"])
 	require.NotContains(t, types, "Foo")
 }
 

--- a/internal/solver/interfaces.go
+++ b/internal/solver/interfaces.go
@@ -44,9 +44,10 @@ type interfaceShell struct {
 // the name before any body resolves is what lets a sibling interface, or this one,
 // name it while its own body is still being walked.
 //
-// The type parameters come from the first declaration. A group whose declarations
-// disagree on their parameter lists is rejected by reportInterfaceParamMismatch
-// rather than merged under one of them.
+// The type parameters come from the first declaration, and every later one must
+// write the same list. A declaration that disagrees reports
+// InterfaceTypeParamMismatchError and contributes no members, since its body reads
+// parameter names the shared list does not bind.
 func (c *checker) preBindInterface(scope *Scope, lvl int, decls []*ast.InterfaceDecl, ns string) *interfaceShell {
 	first := decls[0]
 
@@ -62,6 +63,22 @@ func (c *checker) preBindInterface(scope *Scope, lvl int, decls []*ast.Interface
 		declScope = scope.Child()
 		typeParams = c.resolveTypeParams(declScope, lvl, first.TypeParams)
 	}
+
+	// Every declaration's body resolves against the one parameter list above, so a
+	// declaration writing different parameter names would read them as unbound. Drop
+	// it here rather than let its body report a missing type for each use.
+	merged := decls[:1]
+	for _, d := range decls[1:] {
+		if sameTypeParamNames(first.TypeParams, d.TypeParams) {
+			merged = append(merged, d)
+			continue
+		}
+		c.report(&InterfaceTypeParamMismatchError{
+			Name: first.Name.Name,
+			span: d.Span(),
+		})
+	}
+	decls = merged
 
 	def := &AliasDef{TypeParams: typeParams, Level: lvl - 1}
 	c.ctx.registerAlias(qname, def)
@@ -97,12 +114,20 @@ func (c *checker) inferInterfaceBody(sh *interfaceShell) {
 	c.classNamespace = sh.ns
 	defer func() { c.classNamespace = prevNS }()
 
-	var elems []soltype.ObjTypeElem
+	// The shared object-member builder decides what a later member does to an
+	// earlier one of the same name. It appends a method's signatures rather than
+	// replacing it, so overloads split across declarations accumulate, and it
+	// tracks the read and write accesses separately, so a getter in one
+	// declaration and a setter in another form a pair rather than one dropping
+	// the other.
+	b := newObjElemBuilder(0)
 	inexact := false
 	for _, decl := range sh.decls {
 		for _, ext := range decl.Extends {
 			if obj, ok := c.resolveInterfaceParent(sh.declScope, ext, sh.lvl); ok {
-				elems = mergeObjElems(elems, obj.Elems)
+				for _, elem := range obj.Elems {
+					b.addElem(copyMergeableElem(elem))
+				}
 				inexact = inexact || obj.Inexact
 			}
 		}
@@ -117,16 +142,30 @@ func (c *checker) inferInterfaceBody(sh *interfaceShell) {
 		}
 		obj, isObj := resolved.(*soltype.ObjectType)
 		if !isObj {
-			// resolveObjectTypeAnn answers with a residual type for a body holding a
-			// spread or a mapped member, which has no member list to merge. Bind the
-			// residual alone, since merging a group is only defined over member lists.
-			sh.def.Body = resolved
-			return
+			continue
 		}
-		elems = mergeObjElems(elems, obj.Elems)
+		for _, elem := range obj.Elems {
+			b.addElem(elem)
+		}
 		inexact = inexact || obj.Inexact
 	}
-	sh.def.Body = &soltype.ObjectType{Elems: elems, Inexact: inexact}
+	sh.def.Body = &soltype.ObjectType{Elems: b.result(), Inexact: inexact}
+}
+
+// copyMergeableElem returns a member safe to hand to an objElemBuilder that may
+// merge into it. The builder appends to a MethodElem's signature list in place, so
+// a method taken from a parent interface's stored body is copied first, leaving the
+// parent's own type unchanged.
+func copyMergeableElem(elem soltype.ObjTypeElem) soltype.ObjTypeElem {
+	m, isMethod := elem.(*soltype.MethodElem)
+	if !isMethod {
+		return elem
+	}
+	sigs := make([]*soltype.FuncType, len(m.Signatures))
+	copy(sigs, m.Signatures)
+	dup := *m
+	dup.Signatures = sigs
+	return &dup
 }
 
 // resolveInterfaceParent resolves one `extends` target to the object type whose
@@ -141,11 +180,12 @@ func (c *checker) resolveInterfaceParent(scope *Scope, ref *ast.TypeRefTypeAnn, 
 	if obj, isObj := expanded.(*soltype.ObjectType); isObj {
 		return obj, true
 	}
-	// An unfilled body expands to ErrorType, which happens when the target is a
-	// sibling in this same recursive group. Its members are not available yet and
-	// an interface cycle has no flattened surface to compute, so contribute
-	// nothing and leave the diagnostic to the reference that failed.
+	// The reference resolved, so an ErrorType here is an unfilled body: the target
+	// is a sibling in this same recursive group. An interface flattens its parents'
+	// members into its own, which a cycle gives no way to compute, so report it
+	// rather than silently binding the subset that happened to resolve.
 	if _, isErr := expanded.(*soltype.ErrorType); isErr {
+		c.report(&InterfaceExtendsCycleError{Name: soltype.Print(resolved), span: ref.Span()})
 		return nil, false
 	}
 	c.report(&InterfaceExtendsNonObjectError{Name: soltype.Print(resolved), span: ref.Span()})
@@ -168,31 +208,49 @@ func (e *InterfaceExtendsNonObjectError) Span() ast.Span      { return e.span }
 func (e *InterfaceExtendsNonObjectError) Related() []ast.Span { return nil }
 func (e *InterfaceExtendsNonObjectError) isSolverError()      {}
 
-// mergeObjElems appends src's members to dst, with a later member replacing an
-// earlier one of the same name in place. Keeping the earlier position means
-// `interface P {x: number}` followed by `interface P {y: string, x: 1}` renders as
-// `{x: 1, y: string}`, so a reader sees the order the name was introduced in.
-//
-// An unnamed member, such as a call or construct signature, has no name to match
-// on and is appended.
-func mergeObjElems(dst, src []soltype.ObjTypeElem) []soltype.ObjTypeElem {
-	for _, elem := range src {
-		name := soltype.ObjElemName(elem)
-		if name == "" {
-			dst = append(dst, elem)
-			continue
-		}
-		replaced := false
-		for i, existing := range dst {
-			if soltype.ObjElemName(existing) == name {
-				dst[i] = elem
-				replaced = true
-				break
-			}
-		}
-		if !replaced {
-			dst = append(dst, elem)
+// sameTypeParamNames reports whether two declarations of one interface write the
+// same type-parameter names in the same order. Bounds and defaults are not
+// compared, so a mismatch in those is left for the shared list to decide.
+func sameTypeParamNames(a, b []*ast.TypeParam) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name {
+			return false
 		}
 	}
-	return dst
+	return true
 }
+
+// InterfaceTypeParamMismatchError reports a declaration whose type-parameter list
+// differs from the first declaration of the same interface. One name binds one
+// parameter list, so the declarations have to agree on it.
+type InterfaceTypeParamMismatchError struct {
+	// Name is the interface every declaration in the group declares.
+	Name string
+	span ast.Span
+}
+
+func (e *InterfaceTypeParamMismatchError) Message() string {
+	return "every declaration of interface " + e.Name + " must write the same type parameters"
+}
+func (e *InterfaceTypeParamMismatchError) Span() ast.Span      { return e.span }
+func (e *InterfaceTypeParamMismatchError) Related() []ast.Span { return nil }
+func (e *InterfaceTypeParamMismatchError) isSolverError()      {}
+
+// InterfaceExtendsCycleError reports an `extends` target that is part of the same
+// recursive group as the interface extending it. Flattening the parent's members
+// requires those members, which a cycle never finishes producing.
+type InterfaceExtendsCycleError struct {
+	// Name is the target as written, rendered.
+	Name string
+	span ast.Span
+}
+
+func (e *InterfaceExtendsCycleError) Message() string {
+	return "an interface cannot extend " + e.Name + ", which is part of the same recursive group"
+}
+func (e *InterfaceExtendsCycleError) Span() ast.Span      { return e.span }
+func (e *InterfaceExtendsCycleError) Related() []ast.Span { return nil }
+func (e *InterfaceExtendsCycleError) isSolverError()      {}

--- a/internal/solver/interfaces.go
+++ b/internal/solver/interfaces.go
@@ -65,18 +65,21 @@ func (c *checker) preBindInterface(scope *Scope, lvl int, decls []*ast.Interface
 	}
 
 	// Every declaration's body resolves against the one parameter list above, so a
-	// declaration writing different parameter names would read them as unbound. Drop
-	// it here rather than let its body report a missing type for each use.
+	// declaration writing different parameter names would read them as unbound, and
+	// a bound or default it writes would be ignored. Drop it here rather than let
+	// its body report a missing type for each use, or merge under a bound the source
+	// never agreed on.
 	merged := decls[:1]
 	for _, d := range decls[1:] {
-		if sameTypeParamNames(first.TypeParams, d.TypeParams) {
-			merged = append(merged, d)
+		if reason, mismatch := typeParamMismatch(first.TypeParams, d.TypeParams); mismatch {
+			c.report(&InterfaceTypeParamMismatchError{
+				Name:   first.Name.Name,
+				Reason: reason,
+				span:   d.Span(),
+			})
 			continue
 		}
-		c.report(&InterfaceTypeParamMismatchError{
-			Name: first.Name.Name,
-			span: d.Span(),
-		})
+		merged = append(merged, d)
 	}
 	decls = merged
 
@@ -208,19 +211,32 @@ func (e *InterfaceExtendsNonObjectError) Span() ast.Span      { return e.span }
 func (e *InterfaceExtendsNonObjectError) Related() []ast.Span { return nil }
 func (e *InterfaceExtendsNonObjectError) isSolverError()      {}
 
-// sameTypeParamNames reports whether two declarations of one interface write the
-// same type-parameter names in the same order. Bounds and defaults are not
-// compared, so a mismatch in those is left for the shared list to decide.
-func sameTypeParamNames(a, b []*ast.TypeParam) bool {
-	if len(a) != len(b) {
-		return false
+// typeParamMismatch reports whether a later declaration's type parameters can
+// merge under the first declaration's list, and why not when they cannot.
+//
+// The first declaration's list is the one every body resolves against, so a later
+// declaration writing a bound or a default is writing something nothing reads.
+// Rejecting that is what stops `Box<T: string>` and `Box<T: number>` merging under
+// whichever came first.
+func typeParamMismatch(first, later []*ast.TypeParam) (string, bool) {
+	if len(first) != len(later) {
+		return "they differ in how many it writes", true
 	}
-	for i := range a {
-		if a[i].Name != b[i].Name {
-			return false
+	for i := range later {
+		if first[i].Name != later[i].Name {
+			return "they differ in the names they write", true
+		}
+		if later[i].Variance != first[i].Variance {
+			return "they differ in variance", true
+		}
+		if later[i].Constraint != nil {
+			return "only the first declaration may write a bound", true
+		}
+		if later[i].Default != nil {
+			return "only the first declaration may write a default", true
 		}
 	}
-	return true
+	return "", false
 }
 
 // InterfaceTypeParamMismatchError reports a declaration whose type-parameter list
@@ -229,11 +245,13 @@ func sameTypeParamNames(a, b []*ast.TypeParam) bool {
 type InterfaceTypeParamMismatchError struct {
 	// Name is the interface every declaration in the group declares.
 	Name string
-	span ast.Span
+	// Reason says how this declaration's list differs from the first's.
+	Reason string
+	span   ast.Span
 }
 
 func (e *InterfaceTypeParamMismatchError) Message() string {
-	return "every declaration of interface " + e.Name + " must write the same type parameters"
+	return "declarations of interface " + e.Name + " must agree on their type parameters: " + e.Reason
 }
 func (e *InterfaceTypeParamMismatchError) Span() ast.Span      { return e.span }
 func (e *InterfaceTypeParamMismatchError) Related() []ast.Span { return nil }

--- a/internal/solver/interfaces.go
+++ b/internal/solver/interfaces.go
@@ -117,21 +117,18 @@ func (c *checker) inferInterfaceBody(sh *interfaceShell) {
 	c.classNamespace = sh.ns
 	defer func() { c.classNamespace = prevNS }()
 
-	// The shared object-member builder decides what a later member does to an
+	// The shared object-member builder decides what a later declaration does to an
 	// earlier one of the same name. It appends a method's signatures rather than
 	// replacing it, so overloads split across declarations accumulate, and it
 	// tracks the read and write accesses separately, so a getter in one
 	// declaration and a setter in another form a pair rather than one dropping
 	// the other.
 	b := newObjElemBuilder(0)
-	inexact := false
+	var parents []soltype.Type
 	for _, decl := range sh.decls {
 		for _, ext := range decl.Extends {
-			if obj, ok := c.resolveInterfaceParent(sh.declScope, ext, sh.lvl); ok {
-				for _, elem := range obj.Elems {
-					b.addElem(copyMergeableElem(elem))
-				}
-				inexact = inexact || obj.Inexact
+			if parent, ok := c.resolveTypeAnn(sh.declScope, ext, sh.lvl); ok {
+				parents = append(parents, parent)
 			}
 		}
 		// A nil TypeAnn is parser error recovery for a body that failed to parse,
@@ -150,66 +147,25 @@ func (c *checker) inferInterfaceBody(sh *interfaceShell) {
 		for _, elem := range obj.Elems {
 			b.addElem(elem)
 		}
-		inexact = inexact || obj.Inexact
 	}
-	sh.def.Body = &soltype.ObjectType{Elems: b.result(), Inexact: inexact}
-}
 
-// copyMergeableElem returns a member safe to hand to an objElemBuilder that may
-// merge into it. The builder appends to a MethodElem's signature list in place, so
-// a method taken from a parent interface's stored body is copied first, leaving the
-// parent's own type unchanged.
-func copyMergeableElem(elem soltype.ObjTypeElem) soltype.ObjTypeElem {
-	m, isMethod := elem.(*soltype.MethodElem)
-	if !isMethod {
-		return elem
+	// An interface is inexact. It describes the members a value has to carry, not
+	// the members it may carry, so a value with more than the interface names still
+	// satisfies it.
+	own := &soltype.ObjectType{Elems: b.result(), Inexact: true}
+	if len(parents) == 0 {
+		sh.def.Body = own
+		return
 	}
-	sigs := make([]*soltype.FuncType, len(m.Signatures))
-	copy(sigs, m.Signatures)
-	dup := *m
-	dup.Signatures = sigs
-	return &dup
+	// An `extends` clause meets the parents with the body rather than copying their
+	// members in. Both halves are inexact, so the meet requires every member either
+	// side names and admits the rest, which is what member inheritance means here.
+	//
+	// The parents stay as the references they resolved to, so a parent still being
+	// built is named rather than read. That is what lets `interface A {b: B}` and
+	// `interface B extends A {x}` resolve each other.
+	sh.def.Body = &soltype.IntersectionType{Types: append(parents, own)}
 }
-
-// resolveInterfaceParent resolves one `extends` target to the object type whose
-// members it contributes. A target naming something other than an object reports
-// InterfaceExtendsNonObjectError and contributes nothing.
-func (c *checker) resolveInterfaceParent(scope *Scope, ref *ast.TypeRefTypeAnn, lvl int) (*soltype.ObjectType, bool) {
-	resolved, ok := c.resolveTypeAnn(scope, ref, lvl)
-	if !ok {
-		return nil, false
-	}
-	expanded := c.expandAliasChain(resolved)
-	if obj, isObj := expanded.(*soltype.ObjectType); isObj {
-		return obj, true
-	}
-	// The reference resolved, so an ErrorType here is an unfilled body: the target
-	// is a sibling in this same recursive group. An interface flattens its parents'
-	// members into its own, which a cycle gives no way to compute, so report it
-	// rather than silently binding the subset that happened to resolve.
-	if _, isErr := expanded.(*soltype.ErrorType); isErr {
-		c.report(&InterfaceExtendsCycleError{Name: soltype.Print(resolved), span: ref.Span()})
-		return nil, false
-	}
-	c.report(&InterfaceExtendsNonObjectError{Name: soltype.Print(resolved), span: ref.Span()})
-	return nil, false
-}
-
-// InterfaceExtendsNonObjectError reports an `extends` target that is not an object
-// type. An interface flattens its parents' members into its own, so a parent with
-// no member list has nothing to contribute.
-type InterfaceExtendsNonObjectError struct {
-	// Name is the target as written, rendered.
-	Name string
-	span ast.Span
-}
-
-func (e *InterfaceExtendsNonObjectError) Message() string {
-	return "an interface can only extend an object type, not " + e.Name
-}
-func (e *InterfaceExtendsNonObjectError) Span() ast.Span      { return e.span }
-func (e *InterfaceExtendsNonObjectError) Related() []ast.Span { return nil }
-func (e *InterfaceExtendsNonObjectError) isSolverError()      {}
 
 // typeParamMismatch reports whether a later declaration's type parameters can
 // merge under the first declaration's list, and why not when they cannot.

--- a/internal/solver/interfaces.go
+++ b/internal/solver/interfaces.go
@@ -212,19 +212,3 @@ func (e *InterfaceTypeParamMismatchError) Message() string {
 func (e *InterfaceTypeParamMismatchError) Span() ast.Span      { return e.span }
 func (e *InterfaceTypeParamMismatchError) Related() []ast.Span { return nil }
 func (e *InterfaceTypeParamMismatchError) isSolverError()      {}
-
-// InterfaceExtendsCycleError reports an `extends` target that is part of the same
-// recursive group as the interface extending it. Flattening the parent's members
-// requires those members, which a cycle never finishes producing.
-type InterfaceExtendsCycleError struct {
-	// Name is the target as written, rendered.
-	Name string
-	span ast.Span
-}
-
-func (e *InterfaceExtendsCycleError) Message() string {
-	return "an interface cannot extend " + e.Name + ", which is part of the same recursive group"
-}
-func (e *InterfaceExtendsCycleError) Span() ast.Span      { return e.span }
-func (e *InterfaceExtendsCycleError) Related() []ast.Span { return nil }
-func (e *InterfaceExtendsCycleError) isSolverError()      {}

--- a/internal/solver/interfaces.go
+++ b/internal/solver/interfaces.go
@@ -1,0 +1,198 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// interfaces.go binds an `interface` declaration to the object type its body
+// describes.
+//
+// An interface is structural and transparent, so it binds to an AliasType over
+// that object rather than to a nominal identity of its own. `interface Point {x:
+// number}` and `type Point = {x: number}` give an annotation the same type, and
+// a matching object literal satisfies either.
+//
+// One name may be declared several times. dep_graph groups every `interface
+// Point` in a module under one type key, so a shell carries the whole group and
+// the bound type is their merged member list.
+
+// interfaceShell is one interface name's pre-bound identity, completed by
+// inferInterfaceBody once every sibling identity in the component is bound.
+type interfaceShell struct {
+	// decls are every declaration of this name, in source order. The merge reads
+	// them in that order, so a later member of the same name wins.
+	decls []*ast.InterfaceDecl
+	lvl   int
+	// qname is the dep_graph-qualified name the AliasDef registers under and the
+	// Name every AliasType handle pointing at it carries.
+	qname string
+	// declScope is scope, or a child holding a generic interface's type
+	// parameters, so the body reads each `T` as the var the parameter binder
+	// minted.
+	declScope *Scope
+	// ns is the interface's dep_graph namespace. The body resolves a bare
+	// reference against it first, so a namespaced interface reaches a sibling.
+	ns string
+	// def is the registered AliasDef with a nil Body. inferInterfaceBody fills it.
+	def *AliasDef
+}
+
+// preBindInterface resolves the group's type parameters, registers an AliasDef
+// whose Body is still nil, and binds the name to an AliasType handle. Registering
+// the name before any body resolves is what lets a sibling interface, or this one,
+// name it while its own body is still being walked.
+//
+// The type parameters come from the first declaration. A group whose declarations
+// disagree on their parameter lists is rejected by reportInterfaceParamMismatch
+// rather than merged under one of them.
+func (c *checker) preBindInterface(scope *Scope, lvl int, decls []*ast.InterfaceDecl, ns string) *interfaceShell {
+	first := decls[0]
+
+	prevNS := c.classNamespace
+	c.classNamespace = ns
+	defer func() { c.classNamespace = prevNS }()
+
+	qname := c.qualifyDecl(ns, first.Name.Name)
+
+	declScope := scope
+	var typeParams []*soltype.TypeParam
+	if len(first.TypeParams) > 0 {
+		declScope = scope.Child()
+		typeParams = c.resolveTypeParams(declScope, lvl, first.TypeParams)
+	}
+
+	def := &AliasDef{TypeParams: typeParams, Level: lvl - 1}
+	c.ctx.registerAlias(qname, def)
+
+	t := &soltype.AliasType{Name: qname}
+	sources := make([]provenance.Provenance, 0, len(decls))
+	for _, d := range decls {
+		sources = append(sources, &ast.NodeProvenance{Node: d})
+	}
+	c.declTarget(scope).defineType(qname, TypeBinding{Type: t, Sources: sources})
+	c.recordType(first.Name, t)
+
+	return &interfaceShell{
+		decls:     decls,
+		lvl:       lvl,
+		qname:     qname,
+		declScope: declScope,
+		ns:        ns,
+		def:       def,
+	}
+}
+
+// inferInterfaceBody resolves each declaration's members and stores their merge on
+// the shell's AliasDef. It runs after every identity in the recursive group is
+// pre-bound, so a member naming a sibling resolves.
+//
+// An `extends` clause contributes its target's members ahead of the body's own, so
+// `interface Sq extends Rect {s: number}` binds the flattened surface rather than a
+// subtyping relation. A member the body declares under a name `extends` also
+// supplied replaces it.
+func (c *checker) inferInterfaceBody(sh *interfaceShell) {
+	prevNS := c.classNamespace
+	c.classNamespace = sh.ns
+	defer func() { c.classNamespace = prevNS }()
+
+	var elems []soltype.ObjTypeElem
+	inexact := false
+	for _, decl := range sh.decls {
+		for _, ext := range decl.Extends {
+			if obj, ok := c.resolveInterfaceParent(sh.declScope, ext, sh.lvl); ok {
+				elems = mergeObjElems(elems, obj.Elems)
+				inexact = inexact || obj.Inexact
+			}
+		}
+		// A nil TypeAnn is parser error recovery for a body that failed to parse,
+		// already reported. The declaration then contributes no members.
+		if decl.TypeAnn == nil {
+			continue
+		}
+		resolved, ok := c.resolveObjectTypeAnn(sh.declScope, decl.TypeAnn, sh.lvl)
+		if !ok {
+			continue
+		}
+		obj, isObj := resolved.(*soltype.ObjectType)
+		if !isObj {
+			// resolveObjectTypeAnn answers with a residual type for a body holding a
+			// spread or a mapped member, which has no member list to merge. Bind the
+			// residual alone, since merging a group is only defined over member lists.
+			sh.def.Body = resolved
+			return
+		}
+		elems = mergeObjElems(elems, obj.Elems)
+		inexact = inexact || obj.Inexact
+	}
+	sh.def.Body = &soltype.ObjectType{Elems: elems, Inexact: inexact}
+}
+
+// resolveInterfaceParent resolves one `extends` target to the object type whose
+// members it contributes. A target naming something other than an object reports
+// InterfaceExtendsNonObjectError and contributes nothing.
+func (c *checker) resolveInterfaceParent(scope *Scope, ref *ast.TypeRefTypeAnn, lvl int) (*soltype.ObjectType, bool) {
+	resolved, ok := c.resolveTypeAnn(scope, ref, lvl)
+	if !ok {
+		return nil, false
+	}
+	expanded := c.expandAliasChain(resolved)
+	if obj, isObj := expanded.(*soltype.ObjectType); isObj {
+		return obj, true
+	}
+	// An unfilled body expands to ErrorType, which happens when the target is a
+	// sibling in this same recursive group. Its members are not available yet and
+	// an interface cycle has no flattened surface to compute, so contribute
+	// nothing and leave the diagnostic to the reference that failed.
+	if _, isErr := expanded.(*soltype.ErrorType); isErr {
+		return nil, false
+	}
+	c.report(&InterfaceExtendsNonObjectError{Name: soltype.Print(resolved), span: ref.Span()})
+	return nil, false
+}
+
+// InterfaceExtendsNonObjectError reports an `extends` target that is not an object
+// type. An interface flattens its parents' members into its own, so a parent with
+// no member list has nothing to contribute.
+type InterfaceExtendsNonObjectError struct {
+	// Name is the target as written, rendered.
+	Name string
+	span ast.Span
+}
+
+func (e *InterfaceExtendsNonObjectError) Message() string {
+	return "an interface can only extend an object type, not " + e.Name
+}
+func (e *InterfaceExtendsNonObjectError) Span() ast.Span      { return e.span }
+func (e *InterfaceExtendsNonObjectError) Related() []ast.Span { return nil }
+func (e *InterfaceExtendsNonObjectError) isSolverError()      {}
+
+// mergeObjElems appends src's members to dst, with a later member replacing an
+// earlier one of the same name in place. Keeping the earlier position means
+// `interface P {x: number}` followed by `interface P {y: string, x: 1}` renders as
+// `{x: 1, y: string}`, so a reader sees the order the name was introduced in.
+//
+// An unnamed member, such as a call or construct signature, has no name to match
+// on and is appended.
+func mergeObjElems(dst, src []soltype.ObjTypeElem) []soltype.ObjTypeElem {
+	for _, elem := range src {
+		name := soltype.ObjElemName(elem)
+		if name == "" {
+			dst = append(dst, elem)
+			continue
+		}
+		replaced := false
+		for i, existing := range dst {
+			if soltype.ObjElemName(existing) == name {
+				dst[i] = elem
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			dst = append(dst, elem)
+		}
+	}
+	return dst
+}

--- a/internal/solver/interfaces_test.go
+++ b/internal/solver/interfaces_test.go
@@ -1,0 +1,50 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// An interface binds a type an annotation can name. It is structural, so a
+// matching object literal type-checks against it.
+func TestInterfaceBindsAStructuralType(t *testing.T) {
+	values, types, errs := inferSource(t, `
+		declare interface Point {
+			x: number,
+		}
+		val p: Point = {x: 1}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "{x: number}", types["Point"])
+	require.Equal(t, "Point", values["p"])
+}
+
+// Two interfaces of one name contribute to one type.
+func TestInterfaceDeclarationsMerge(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		declare interface Point {
+			x: number,
+		}
+		declare interface Point {
+			y: number,
+		}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "{x: number, y: number}", types["Point"])
+}
+
+// An `extends` clause prepends the referenced interface's members, so the bound
+// type is the flattened surface.
+func TestInterfaceExtendsCarriesMembers(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		declare interface Rect {
+			w: number,
+		}
+		declare interface Sq extends Rect {
+			s: number,
+		}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "{w: number, s: number}", types["Sq"])
+}

--- a/internal/solver/interfaces_test.go
+++ b/internal/solver/interfaces_test.go
@@ -228,3 +228,64 @@ func TestInterfaceExtendsMembersAreReadable(t *testing.T) {
 	require.Equal(t, "number", values["inherited"])
 	require.Equal(t, "number", values["own"])
 }
+
+// One name binds one type-parameter list, so every declaration of an interface has to
+// write the same one. A later declaration that disagrees is reported and contributes no
+// members, since its body reads against parameters the group does not have.
+//
+// A bound and a default are the asymmetric cases: only the first declaration may write
+// either, so a later declaration repeating a bound is rejected even when the bound is the
+// one already in force.
+func TestInterfaceTypeParamMismatchReports(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "Arity",
+			src:  "declare interface Box<T> { v: T }\ndeclare interface Box<T, U> { w: U }",
+			want: []string{"declarations of interface Box must agree on their type parameters: they differ in how many it writes"},
+		},
+		{
+			name: "Names",
+			src:  "declare interface Box<T> { v: T }\ndeclare interface Box<U> { w: U }",
+			want: []string{"declarations of interface Box must agree on their type parameters: they differ in the names they write"},
+		},
+		{
+			name: "Variance",
+			src:  "declare interface Box<T> { v: T }\ndeclare interface Box<out T> { w: T }",
+			want: []string{"declarations of interface Box must agree on their type parameters: they differ in variance"},
+		},
+		{
+			name: "ALaterBound",
+			src:  "declare interface Box<T> { v: T }\ndeclare interface Box<T: string> { w: T }",
+			want: []string{"declarations of interface Box must agree on their type parameters: only the first declaration may write a bound"},
+		},
+		{
+			name: "ALaterDefault",
+			src:  "declare interface Box<T> { v: T }\ndeclare interface Box<T = string> { w: T }",
+			want: []string{"declarations of interface Box must agree on their type parameters: only the first declaration may write a default"},
+		},
+		{
+			name: "MatchingListsMerge",
+			src:  "declare interface Box<T> { v: T }\ndeclare interface Box<T> { w: T }",
+		},
+		{
+			// The bound belongs to the first declaration, which is the one that may write
+			// it, so the group merges and both members land.
+			name: "ABoundOnTheFirstDeclarationIsKept",
+			src:  "declare interface Box<T: string> { v: T }\ndeclare interface Box<T> { w: T }",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if len(tt.want) == 0 {
+				require.Empty(t, errorMessagesOf(errs))
+				return
+			}
+			require.Equal(t, tt.want, errorMessagesOf(errs))
+		})
+	}
+}

--- a/internal/solver/interfaces_test.go
+++ b/internal/solver/interfaces_test.go
@@ -116,17 +116,54 @@ func TestInterfaceExtendsLeavesTheParentAlone(t *testing.T) {
 }
 
 // One name declared both as an interface and as another kind of type has two
-// definitions that cannot merge.
-func TestInterfaceConflictingWithAnAliasReports(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		type Bar = number
-		declare interface Bar {
-			y: number,
-		}
-	`)
-	require.Equal(t,
-		[]string{"cannot declare Bar as both an interface and another type"},
-		errorMessagesOf(errs))
+// definitions that cannot merge. What is checked is that every declaration under the
+// name's type key is an interface, rather than a list of the kinds that conflict, so
+// a declaration kind added later is caught without revisiting the check.
+//
+// A value sharing the name is not a conflict. It binds under the name's value key,
+// which the type key holds nothing of, so `fn Bar()` beside `interface Bar` declares
+// one type and one value rather than one name twice.
+func TestInterfaceConflictingWithAnotherTypeReports(t *testing.T) {
+	const iface = "declare interface Bar { y: number }\n"
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "Alias",
+			src:  iface + "type Bar = number",
+			want: []string{"cannot declare Bar as both an interface and another type"},
+		},
+		{
+			name: "Class",
+			src:  iface + "class Bar { y: number }",
+			want: []string{"cannot declare Bar as both an interface and another type"},
+		},
+		{
+			name: "Enum",
+			src:  iface + "enum Bar { A }",
+			want: []string{"cannot declare Bar as both an interface and another type"},
+		},
+		{
+			name: "TwoInterfacesMerge",
+			src:  iface + "declare interface Bar { z: string }",
+		},
+		{
+			name: "AFunctionOfTheSameNameIsNotAConflict",
+			src:  iface + "fn Bar() -> number { return 1 }",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if len(tt.want) == 0 {
+				require.Empty(t, errorMessagesOf(errs))
+				return
+			}
+			require.Equal(t, tt.want, errorMessagesOf(errs))
+		})
+	}
 }
 
 // A parent is referenced rather than read, so an interface naming a sibling that

--- a/internal/solver/interfaces_test.go
+++ b/internal/solver/interfaces_test.go
@@ -68,3 +68,98 @@ func TestExportedInterfaceReachesTheSurface(t *testing.T) {
 	require.True(t, ok)
 	require.Contains(t, ns.Types, "Point")
 }
+
+// Overloads split across declarations accumulate rather than replacing one
+// another, matching what two signatures in one declaration give.
+func TestInterfaceMergeAccumulatesOverloads(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		declare interface F {
+			m(a: number) -> number,
+		}
+		declare interface F {
+			m(a: string) -> string,
+		}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "{m(a: number) -> number; m(a: string) -> string}", types["F"])
+}
+
+// A getter in one declaration and a setter in another form a pair, so the name
+// stays both readable and writable.
+func TestInterfaceMergePairsAccessors(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		declare interface A {
+			get x() -> number,
+		}
+		declare interface A {
+			set x(value: number),
+		}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "{get x() -> number, set x(value: number)}", types["A"])
+}
+
+// An interface's members are copied out of a parent's stored type, so extending it
+// leaves the parent unchanged for every other reader.
+func TestInterfaceExtendsLeavesTheParentAlone(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		declare interface Base {
+			m(a: number) -> number,
+		}
+		declare interface Child extends Base {
+			m(a: string) -> string,
+		}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "{m(a: number) -> number}", types["Base"])
+	require.Equal(t, "{m(a: number) -> number; m(a: string) -> string}", types["Child"])
+}
+
+// Declarations of one interface must agree on their type parameters, since the
+// group binds one list and every body resolves against it.
+func TestInterfaceRejectsMismatchedTypeParams(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		declare interface Box<T> {
+			a: T,
+		}
+		declare interface Box<U> {
+			b: U,
+		}
+	`)
+	require.Equal(t,
+		[]string{"every declaration of interface Box must write the same type parameters"},
+		errorMessagesOf(errs))
+	// The rejected declaration contributes nothing, so no unresolved parameter
+	// leaks into the bound type.
+	require.Equal(t, "{a: T}", types["Box"])
+}
+
+// One name declared both as an interface and as another kind of type has two
+// definitions that cannot merge.
+func TestInterfaceConflictingWithAnAliasReports(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Bar = number
+		declare interface Bar {
+			y: number,
+		}
+	`)
+	require.Equal(t,
+		[]string{"cannot declare Bar as both an interface and another type"},
+		errorMessagesOf(errs))
+}
+
+// An `extends` target in the interface's own recursive group has no finished
+// member list to flatten.
+func TestInterfaceExtendsCycleReports(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		declare interface A {
+			b: B,
+		}
+		declare interface B extends A {
+			x: number,
+		}
+	`)
+	require.Equal(t,
+		[]string{"an interface cannot extend A, which is part of the same recursive group"},
+		errorMessagesOf(errs))
+}

--- a/internal/solver/interfaces_test.go
+++ b/internal/solver/interfaces_test.go
@@ -16,7 +16,7 @@ func TestInterfaceBindsAStructuralType(t *testing.T) {
 		val p: Point = {x: 1}
 	`)
 	require.Empty(t, errorMessagesOf(errs))
-	require.Equal(t, "{x: number}", types["Point"])
+	require.Equal(t, "{x: number, ...}", types["Point"])
 	require.Equal(t, "Point", values["p"])
 }
 
@@ -31,7 +31,7 @@ func TestInterfaceDeclarationsMerge(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errorMessagesOf(errs))
-	require.Equal(t, "{x: number, y: number}", types["Point"])
+	require.Equal(t, "{x: number, y: number, ...}", types["Point"])
 }
 
 // An `extends` clause prepends the referenced interface's members, so the bound
@@ -46,7 +46,7 @@ func TestInterfaceExtendsCarriesMembers(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errorMessagesOf(errs))
-	require.Equal(t, "{w: number, s: number}", types["Sq"])
+	require.Equal(t, "Rect & {s: number, ...}", types["Sq"])
 }
 
 // An exported interface reaches a package's surface, so an importer can name it
@@ -81,7 +81,7 @@ func TestInterfaceMergeAccumulatesOverloads(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errorMessagesOf(errs))
-	require.Equal(t, "{m(a: number) -> number; m(a: string) -> string}", types["F"])
+	require.Equal(t, "{m(a: number) -> number; m(a: string) -> string, ...}", types["F"])
 }
 
 // A getter in one declaration and a setter in another form a pair, so the name
@@ -96,11 +96,11 @@ func TestInterfaceMergePairsAccessors(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errorMessagesOf(errs))
-	require.Equal(t, "{get x() -> number, set x(value: number)}", types["A"])
+	require.Equal(t, "{get x() -> number, set x(value: number), ...}", types["A"])
 }
 
-// An interface's members are copied out of a parent's stored type, so extending it
-// leaves the parent unchanged for every other reader.
+// A parent is named rather than copied, so extending it cannot change what the
+// parent means for any other reader.
 func TestInterfaceExtendsLeavesTheParentAlone(t *testing.T) {
 	_, types, errs := inferSource(t, `
 		declare interface Base {
@@ -111,28 +111,8 @@ func TestInterfaceExtendsLeavesTheParentAlone(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errorMessagesOf(errs))
-	require.Equal(t, "{m(a: number) -> number}", types["Base"])
-	require.Equal(t, "{m(a: number) -> number; m(a: string) -> string}", types["Child"])
-}
-
-// Declarations of one interface must agree on their type parameters, since the
-// group binds one list and every body resolves against it.
-func TestInterfaceRejectsMismatchedTypeParams(t *testing.T) {
-	_, types, errs := inferSource(t, `
-		declare interface Box<T> {
-			a: T,
-		}
-		declare interface Box<U> {
-			b: U,
-		}
-	`)
-	require.Equal(t,
-		[]string{"declarations of interface Box must agree on their type parameters: " +
-			"they differ in the names they write"},
-		errorMessagesOf(errs))
-	// The rejected declaration contributes nothing, so no unresolved parameter
-	// leaks into the bound type.
-	require.Equal(t, "{a: T}", types["Box"])
+	require.Equal(t, "{m(a: number) -> number, ...}", types["Base"])
+	require.Equal(t, "Base & {m(a: string) -> string, ...}", types["Child"])
 }
 
 // One name declared both as an interface and as another kind of type has two
@@ -149,10 +129,11 @@ func TestInterfaceConflictingWithAnAliasReports(t *testing.T) {
 		errorMessagesOf(errs))
 }
 
-// An `extends` target in the interface's own recursive group has no finished
-// member list to flatten.
-func TestInterfaceExtendsCycleReports(t *testing.T) {
-	_, _, errs := inferSource(t, `
+// A parent is referenced rather than read, so an interface naming a sibling that
+// extends it back resolves. Nothing has to be flattened, which is what a cycle
+// makes impossible.
+func TestInterfaceExtendsResolvesARecursiveGroup(t *testing.T) {
+	_, types, errs := inferSource(t, `
 		declare interface A {
 			b: B,
 		}
@@ -160,58 +141,53 @@ func TestInterfaceExtendsCycleReports(t *testing.T) {
 			x: number,
 		}
 	`)
-	require.Equal(t,
-		[]string{"an interface cannot extend A, which is part of the same recursive group"},
-		errorMessagesOf(errs))
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "{b: B, ...}", types["A"])
+	require.Equal(t, "A & {x: number, ...}", types["B"])
 }
 
-// The first declaration's parameter list is what every body resolves against, so a
-// bound a later declaration writes would be ignored. Merging under one of two
-// disagreeing bounds is what the report prevents.
-func TestInterfaceRejectsAConflictingTypeParamBound(t *testing.T) {
-	_, types, errs := inferSource(t, `
-		declare interface Box<T: string> {
-			a: T,
-		}
-		declare interface Box<T: number> {
-			b: T,
-		}
-	`)
-	require.Equal(t,
-		[]string{"declarations of interface Box must agree on their type parameters: " +
-			"only the first declaration may write a bound"},
-		errorMessagesOf(errs))
-	require.Equal(t, "{a: T}", types["Box"])
-}
-
-// A default is rejected for the same reason a bound is: an omitted argument is
-// filled from the first declaration's list, so a later default names nothing.
-func TestInterfaceRejectsAConflictingTypeParamDefault(t *testing.T) {
+// An interface is inexact: it names the members a value must carry, not the
+// members it may carry.
+func TestInterfaceIsInexact(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		declare interface Box<T = string> {
-			a: T,
+		declare interface Rect {
+			w: number,
 		}
-		declare interface Box<T = number> {
-			b: T,
-		}
-	`)
-	require.Equal(t,
-		[]string{"declarations of interface Box must agree on their type parameters: " +
-			"only the first declaration may write a default"},
-		errorMessagesOf(errs))
-}
-
-// A later declaration that writes the same names and no bound merges, which is the
-// ordinary case a generic interface split across declarations takes.
-func TestInterfaceMergesWhenLaterDeclarationsOmitBounds(t *testing.T) {
-	_, types, errs := inferSource(t, `
-		declare interface Box<T: string> {
-			a: T,
-		}
-		declare interface Box<T> {
-			b: T,
-		}
+		val extra: Rect = {w: 1, other: 2}
 	`)
 	require.Empty(t, errorMessagesOf(errs))
-	require.Equal(t, "{a: T, b: T}", types["Box"])
+}
+
+// A member the parent names is still required, so `extends` is inheritance rather
+// than a hint.
+func TestInterfaceExtendsStillRequiresTheParentsMembers(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		declare interface Rect {
+			w: number,
+		}
+		declare interface Sq extends Rect {
+			s: number,
+		}
+		val ok: Sq = {w: 1, s: 2}
+		val missing: Sq = {s: 2}
+	`)
+	require.Equal(t, []string{"object is missing property: w"}, errorMessagesOf(errs))
+}
+
+// A member a parent declares is readable through a value the child types.
+func TestInterfaceExtendsMembersAreReadable(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		declare interface Rect {
+			w: number,
+		}
+		declare interface Sq extends Rect {
+			s: number,
+		}
+		val q: Sq = {w: 1, s: 2}
+		val inherited = q.w
+		val own = q.s
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "number", values["inherited"])
+	require.Equal(t, "number", values["own"])
 }

--- a/internal/solver/interfaces_test.go
+++ b/internal/solver/interfaces_test.go
@@ -48,3 +48,23 @@ func TestInterfaceExtendsCarriesMembers(t *testing.T) {
 	require.Empty(t, errorMessagesOf(errs))
 	require.Equal(t, "{w: number, s: number}", types["Sq"])
 }
+
+// An exported interface reaches a package's surface, so an importer can name it
+// in an annotation.
+func TestExportedInterfaceReachesTheSurface(t *testing.T) {
+	res := InferModuleWithSource(
+		parseModule(t, `import "shapes"`),
+		sourceOf(t, map[string]string{
+			"shapes": `
+				export declare interface Point {
+					x: number,
+				}
+			`,
+		}),
+	)
+	require.Empty(t, errorMessagesOf(res.Errors))
+
+	ns, ok := res.Packages.Lookup("shapes")
+	require.True(t, ok)
+	require.Contains(t, ns.Types, "Point")
+}

--- a/internal/solver/interfaces_test.go
+++ b/internal/solver/interfaces_test.go
@@ -127,7 +127,8 @@ func TestInterfaceRejectsMismatchedTypeParams(t *testing.T) {
 		}
 	`)
 	require.Equal(t,
-		[]string{"every declaration of interface Box must write the same type parameters"},
+		[]string{"declarations of interface Box must agree on their type parameters: " +
+			"they differ in the names they write"},
 		errorMessagesOf(errs))
 	// The rejected declaration contributes nothing, so no unresolved parameter
 	// leaks into the bound type.
@@ -162,4 +163,55 @@ func TestInterfaceExtendsCycleReports(t *testing.T) {
 	require.Equal(t,
 		[]string{"an interface cannot extend A, which is part of the same recursive group"},
 		errorMessagesOf(errs))
+}
+
+// The first declaration's parameter list is what every body resolves against, so a
+// bound a later declaration writes would be ignored. Merging under one of two
+// disagreeing bounds is what the report prevents.
+func TestInterfaceRejectsAConflictingTypeParamBound(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		declare interface Box<T: string> {
+			a: T,
+		}
+		declare interface Box<T: number> {
+			b: T,
+		}
+	`)
+	require.Equal(t,
+		[]string{"declarations of interface Box must agree on their type parameters: " +
+			"only the first declaration may write a bound"},
+		errorMessagesOf(errs))
+	require.Equal(t, "{a: T}", types["Box"])
+}
+
+// A default is rejected for the same reason a bound is: an omitted argument is
+// filled from the first declaration's list, so a later default names nothing.
+func TestInterfaceRejectsAConflictingTypeParamDefault(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		declare interface Box<T = string> {
+			a: T,
+		}
+		declare interface Box<T = number> {
+			b: T,
+		}
+	`)
+	require.Equal(t,
+		[]string{"declarations of interface Box must agree on their type parameters: " +
+			"only the first declaration may write a default"},
+		errorMessagesOf(errs))
+}
+
+// A later declaration that writes the same names and no bound merges, which is the
+// ordinary case a generic interface split across declarations takes.
+func TestInterfaceMergesWhenLaterDeclarationsOmitBounds(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		declare interface Box<T: string> {
+			a: T,
+		}
+		declare interface Box<T> {
+			b: T,
+		}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "{a: T, b: T}", types["Box"])
 }

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -335,8 +335,19 @@ func (c *checker) inferComponent(
 			}
 		}
 		if len(interfaceDecls) > 0 {
-			interfaceShells = append(interfaceShells, c.preBindInterface(
-				c.lookupScope(scope, interfaceDecls[0]), inner, interfaceDecls, g.GetNamespace(key)))
+			// One type key holding both an interface and a declaration of another kind
+			// means one name was declared twice in ways that cannot merge. Binding the
+			// interface here would overwrite the alias registry entry and the type
+			// binding the other kind made, so report and leave that binding in place.
+			if other, clash := nonInterfaceTypeDecl(g.GetDecls(key)); clash {
+				c.report(&ConflictingTypeDeclarationError{
+					Name: interfaceDecls[0].Name.Name,
+					span: other.Span(),
+				})
+			} else {
+				interfaceShells = append(interfaceShells, c.preBindInterface(
+					c.lookupScope(scope, interfaceDecls[0]), inner, interfaceDecls, g.GetNamespace(key)))
+			}
 		}
 	}
 	// The loops below run while sibling alias and enum bodies are still nil, so a bound check
@@ -960,3 +971,33 @@ func (c *checker) lookupScope(module *Scope, decl ast.Decl) *Scope {
 	}
 	return module
 }
+
+// nonInterfaceTypeDecl returns the first declaration in decls that introduces a
+// type under a kind other than InterfaceDecl. Several interfaces of one name merge,
+// but an interface sharing its name with an alias, a class, or an enum does not.
+func nonInterfaceTypeDecl(decls []ast.Decl) (ast.Decl, bool) {
+	for _, d := range decls {
+		switch d.(type) {
+		case *ast.TypeDecl, *ast.ClassDecl, *ast.EnumDecl:
+			return d, true
+		}
+	}
+	return nil, false
+}
+
+// ConflictingTypeDeclarationError reports one name declared both as an interface
+// and as a kind that cannot merge with one. Interfaces merge with each other, so a
+// repeated interface is legal, while an alias, a class, or an enum under the same
+// name gives that name two definitions.
+type ConflictingTypeDeclarationError struct {
+	// Name is the name declared twice.
+	Name string
+	span ast.Span
+}
+
+func (e *ConflictingTypeDeclarationError) Message() string {
+	return "cannot declare " + e.Name + " as both an interface and another type"
+}
+func (e *ConflictingTypeDeclarationError) Span() ast.Span      { return e.span }
+func (e *ConflictingTypeDeclarationError) Related() []ast.Span { return nil }
+func (e *ConflictingTypeDeclarationError) isSolverError()      {}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -978,13 +978,17 @@ func (c *checker) lookupScope(module *Scope, decl ast.Decl) *Scope {
 	return module
 }
 
-// nonInterfaceTypeDecl returns the first declaration in decls that introduces a
-// type under a kind other than InterfaceDecl. Several interfaces of one name merge,
-// but an interface sharing its name with an alias, a class, or an enum does not.
+// nonInterfaceTypeDecl returns the first declaration in decls that is not an
+// InterfaceDecl. Several interfaces of one name merge, so a group of them is legal,
+// while anything else under the same type key gives that name two definitions.
+//
+// decls comes from a type key, so every declaration in it introduces a type. The
+// test is therefore what an interface is not, rather than a list of the kinds it
+// conflicts with: a declaration kind added later is caught without this being
+// revisited.
 func nonInterfaceTypeDecl(decls []ast.Decl) (ast.Decl, bool) {
 	for _, d := range decls {
-		switch d.(type) {
-		case *ast.TypeDecl, *ast.ClassDecl, *ast.EnumDecl:
+		if _, isInterface := d.(*ast.InterfaceDecl); !isInterface {
 			return d, true
 		}
 	}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -272,12 +272,18 @@ func (c *checker) inferComponent(
 	//     no-op whose pre-bound value var is retracted in phase 3.
 	var enumShells []*enumShell
 	var aliasShells []*aliasShell
+	var interfaceShells []*interfaceShell
 	var classDecls []*ast.ClassDecl
 	var classNamespaces []string
 	for _, key := range component {
 		if _, isValue := bindings[key]; isValue {
 			continue
 		}
+		// Every `interface Point` in the module shares one type key, so the group is
+		// collected here and pre-bound once. The bound type is their merged member
+		// list, which is what makes declaration merging a property of the binding
+		// rather than of any one declaration.
+		var interfaceDecls []*ast.InterfaceDecl
 		for _, d := range g.GetDecls(key) {
 			if handled.Contains(d) {
 				continue
@@ -310,7 +316,19 @@ func (c *checker) inferComponent(
 					aliasShells = append(aliasShells, sh)
 				}
 				handled.Add(d)
+			case *ast.InterfaceDecl:
+				// An interface binds at its type key like an alias, so its value key is
+				// a no-op. The group is pre-bound after this loop, once every
+				// declaration of the name is collected.
+				if decl.Name != nil && decl.Name.Name != "" {
+					interfaceDecls = append(interfaceDecls, decl)
+				}
+				handled.Add(d)
 			}
+		}
+		if len(interfaceDecls) > 0 {
+			interfaceShells = append(interfaceShells, c.preBindInterface(
+				c.lookupScope(scope, interfaceDecls[0]), inner, interfaceDecls, g.GetNamespace(key)))
 		}
 	}
 	// The loops below run while sibling alias and enum bodies are still nil, so a bound check
@@ -334,6 +352,11 @@ func (c *checker) inferComponent(
 	// is bound, so a body naming a sibling type — or the alias itself — resolves.
 	for _, sh := range aliasShells {
 		c.inferAliasBody(sh)
+	}
+	// Each interface's members resolve last, so an `extends` target declared as an
+	// alias or a class in this component is already filled.
+	for _, sh := range interfaceShells {
+		c.inferInterfaceBody(sh)
 	}
 	c.deferArgBounds = false
 	// Every body in the component is resolved, so the alias reference graph the productivity

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -100,6 +100,10 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 	defer func() { c.moduleScope = prevModuleScope }()
 
 	handled := set.NewSet[ast.Decl]()
+	// Bind an empty Namespace per `namespace` block before the walk, so a member of
+	// this module that writes `Foo.member` finds the binding while the walk is still
+	// running. populateNamespaces fills them through the same pointers afterwards.
+	nsShells := c.preBindNamespaceDecls(scope, module, handled)
 	// M4 E3: dep_graph fans one top-level destructuring `val {x, y} = …` across one
 	// SCC component per leaf key. Its initializer is typed and its pattern bound
 	// once, memoized here on the first leaf reached. Each leaf component then
@@ -107,6 +111,10 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 	destructured := map[*ast.VarDecl]*moduleDestructure{}
 	for _, component := range g.Components {
 		c.inferComponent(scope, lvl, module, g, component, handled, destructured)
+		// Components run in dependency order, so refreshing after each one means a
+		// later component reading `Foo.member` finds the member its own component
+		// already bound.
+		c.populateNamespaces(c.declTarget(scope), nsShells)
 	}
 	// Every class is inferred, so each superclass edge and body is final. Check the members
 	// each subclass redeclares against the ones they override.

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -103,7 +103,8 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 	// Bind an empty Namespace per `namespace` block before the walk, so a member of
 	// this module that writes `Foo.member` finds the binding while the walk is still
 	// running. populateNamespaces fills them through the same pointers afterwards.
-	nsShells := c.preBindNamespaceDecls(scope, module, handled)
+	c.nsShells = c.preBindNamespaceDecls(scope, module, handled)
+	defer func() { c.nsShells = nil }()
 	// M4 E3: dep_graph fans one top-level destructuring `val {x, y} = …` across one
 	// SCC component per leaf key. Its initializer is typed and its pattern bound
 	// once, memoized here on the first leaf reached. Each leaf component then
@@ -114,7 +115,7 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 		// Components run in dependency order, so refreshing after each one means a
 		// later component reading `Foo.member` finds the member its own component
 		// already bound.
-		c.populateNamespaces(c.declTarget(scope), nsShells)
+		c.refreshNamespaces(scope)
 	}
 	// Every class is inferred, so each superclass edge and body is final. Check the members
 	// each subclass redeclares against the ones they override.
@@ -264,6 +265,11 @@ func (c *checker) inferComponent(
 		// generalization happens in phase 3.
 		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{monoScheme(v)}})
 	}
+	// Every binding var in the component now exists, so a namespace holding these
+	// members can answer for them. Two functions in one namespace calling each other
+	// land in one component, and each body reads the other through `Foo.member`
+	// while both are still being inferred.
+	c.refreshNamespaces(scope)
 
 	// Pre-bind every nominal identity in this component — each class handle and each enum
 	// union type — before any enum body resolves a variant parameter, so a group of

--- a/internal/solver/namespaces.go
+++ b/internal/solver/namespaces.go
@@ -1,0 +1,103 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// namespaces.go binds what a `namespace Foo { ... }` block names.
+//
+// The block itself declares nothing. dep_graph keys each member under
+// `Foo.member`, the same qualified shape a directory-derived namespace produces,
+// so the members are inferred and bound by the ordinary component walk. What is
+// left is collecting them under one Namespace, which is what makes `Foo.member`
+// resolve rather than reading as an unknown identifier.
+
+// preBindNamespaceDecls binds one empty Namespace per `namespace` block before the
+// component walk, and returns each block paired with the object to fill. Binding
+// the name first is what lets a member of the same module write `Foo.member`: the
+// walk reads the binding while populateNamespaces is still to run, and the maps it
+// reads are the ones that call fills through the same pointer.
+//
+// Each block is marked handled, since it introduces no binding of its own and would
+// otherwise be reported as a declaration the dep graph did not model.
+func (c *checker) preBindNamespaceDecls(scope *Scope, module *ast.Module, handled set.Set[ast.Decl]) []*namespaceShell {
+	target := c.declTarget(scope)
+	var shells []*namespaceShell
+	module.Namespaces.Scan(func(prefix string, ns *ast.Namespace) bool {
+		for _, decl := range ns.Decls {
+			if nsDecl, ok := decl.(*ast.NamespaceDecl); ok {
+				if sh := c.preBindOneNamespace(target, prefix, nsDecl, handled); sh != nil {
+					target.defineNamespace(nsDecl.Name.Name, sh.ns)
+					shells = append(shells, sh)
+				}
+			}
+		}
+		return true
+	})
+	return shells
+}
+
+// namespaceShell pairs a `namespace` block with the empty Namespace bound for it,
+// which populateNamespaces fills once the walk has bound its members.
+type namespaceShell struct {
+	decl   *ast.NamespaceDecl
+	ns     *Namespace
+	qname  string
+	nested []*namespaceShell
+}
+
+// preBindOneNamespace mints the empty Namespace for one block and recurses into the
+// blocks nested inside it. It returns nil for a block with no name, which the parser
+// produces only through error recovery.
+func (c *checker) preBindOneNamespace(scope *Scope, prefix string, decl *ast.NamespaceDecl, handled set.Set[ast.Decl]) *namespaceShell {
+	handled.Add(decl)
+	if decl.Name == nil || decl.Name.Name == "" {
+		return nil
+	}
+	qname := qualify(prefix, decl.Name.Name)
+	sh := &namespaceShell{decl: decl, ns: newNamespace(qname), qname: qname}
+	for _, inner := range decl.Decls {
+		if nested, ok := inner.(*ast.NamespaceDecl); ok {
+			if child := c.preBindOneNamespace(scope, qname, nested, handled); child != nil {
+				sh.ns.Nested[nested.Name.Name] = child.ns
+				sh.nested = append(sh.nested, child)
+			}
+		}
+	}
+	return sh
+}
+
+// populateNamespaces fills each pre-bound Namespace with the bindings the walk
+// placed under its qualified prefix. A nested block is filled through the same
+// pointer its parent already holds, so `namespace a { namespace b { val x } }`
+// gives `a.b.x`.
+func (c *checker) populateNamespaces(scope *Scope, shells []*namespaceShell) {
+	for _, sh := range shells {
+		c.fillNamespace(scope, sh)
+	}
+}
+
+func (c *checker) fillNamespace(scope *Scope, sh *namespaceShell) {
+	out := sh.ns
+	qname := sh.qname
+	for _, inner := range sh.decl.Decls {
+		if _, ok := inner.(*ast.NamespaceDecl); ok {
+			continue
+		}
+		// Every other kind was keyed under `qname.member` and bound by the walk, so
+		// its names are read back rather than re-inferred here. exportedNames answers
+		// what a declaration introduces; the export flag gates a package's surface,
+		// not what its own namespace holds.
+		for _, name := range exportedNames(inner) {
+			key := qualify(qname, name)
+			if b, found := scope.GetValue(key); found {
+				out.Values[name] = b
+			}
+			if b, found := scope.GetType(key); found {
+				out.Types[name] = b
+			}
+		}
+	}
+	c.populateNamespaces(scope, sh.nested)
+}

--- a/internal/solver/namespaces.go
+++ b/internal/solver/namespaces.go
@@ -12,6 +12,11 @@ import (
 // so the members are inferred and bound by the ordinary component walk. What is
 // left is collecting them under one Namespace, which is what makes `Foo.member`
 // resolve rather than reading as an unknown identifier.
+//
+// Only a written block reaches this file. A namespace whose prefix comes from a
+// subdirectory of `lib/` gets no shell, so nothing binds the prefix and a sibling
+// file cannot name it. #1494 covers extending the pre-bind pass to every non-empty
+// prefix in module.Namespaces rather than only the ones a NamespaceDecl introduces.
 
 // preBindNamespaceDecls binds one empty Namespace per `namespace` block before the
 // component walk, and returns each block paired with the object to fill.
@@ -102,6 +107,10 @@ func (c *checker) preBindNestedBlocks(qname string, decl *ast.NamespaceDecl, han
 // refreshNamespaces fills every namespace pre-bound for the module under
 // inference. It runs whenever new bindings have landed, so a member reached
 // through `Foo.member` sees what the walk has bound so far.
+//
+// Re-scanning every shell per component costs O(members) each time, which is
+// quadratic over a module of one component per member. #1493 replaces it with a
+// prefix-to-shell index the walk pushes each binding into as it defines it.
 func (c *checker) refreshNamespaces(scope *Scope) {
 	if len(c.nsShells) == 0 {
 		return

--- a/internal/solver/namespaces.go
+++ b/internal/solver/namespaces.go
@@ -23,14 +23,23 @@ import (
 // otherwise be reported as a declaration the dep graph did not model.
 func (c *checker) preBindNamespaceDecls(scope *Scope, module *ast.Module, handled set.Set[ast.Decl]) []*namespaceShell {
 	target := c.declTarget(scope)
+	// One qualified name may be declared by several blocks, the same way an
+	// interface may. byName keeps one shell per name so the second block adds to
+	// the first's Namespace rather than replacing it.
+	byName := map[string]*namespaceShell{}
 	var shells []*namespaceShell
 	module.Namespaces.Scan(func(prefix string, ns *ast.Namespace) bool {
 		for _, decl := range ns.Decls {
-			if nsDecl, ok := decl.(*ast.NamespaceDecl); ok {
-				if sh := c.preBindOneNamespace(target, prefix, nsDecl, handled); sh != nil {
-					target.defineNamespace(nsDecl.Name.Name, sh.ns)
-					shells = append(shells, sh)
-				}
+			nsDecl, ok := decl.(*ast.NamespaceDecl)
+			if !ok {
+				continue
+			}
+			if sh := c.preBindOneNamespace(prefix, nsDecl, handled, byName); sh != nil {
+				// Bind under the qualified name, matching the keys the walk gives the
+				// members, so a block in a directory-derived namespace does not collide
+				// with a same-named block in a sibling directory.
+				target.defineNamespace(sh.qname, sh.ns)
+				shells = append(shells, sh)
 			}
 		}
 		return true
@@ -41,7 +50,8 @@ func (c *checker) preBindNamespaceDecls(scope *Scope, module *ast.Module, handle
 // namespaceShell pairs a `namespace` block with the empty Namespace bound for it,
 // which populateNamespaces fills once the walk has bound its members.
 type namespaceShell struct {
-	decl   *ast.NamespaceDecl
+	// decls are every block declaring this qualified name, in source order.
+	decls  []*ast.NamespaceDecl
 	ns     *Namespace
 	qname  string
 	nested []*namespaceShell
@@ -50,22 +60,41 @@ type namespaceShell struct {
 // preBindOneNamespace mints the empty Namespace for one block and recurses into the
 // blocks nested inside it. It returns nil for a block with no name, which the parser
 // produces only through error recovery.
-func (c *checker) preBindOneNamespace(scope *Scope, prefix string, decl *ast.NamespaceDecl, handled set.Set[ast.Decl]) *namespaceShell {
+func (c *checker) preBindOneNamespace(prefix string, decl *ast.NamespaceDecl, handled set.Set[ast.Decl], byName map[string]*namespaceShell) *namespaceShell {
 	handled.Add(decl)
 	if decl.Name == nil || decl.Name.Name == "" {
 		return nil
 	}
 	qname := qualify(prefix, decl.Name.Name)
-	sh := &namespaceShell{decl: decl, ns: newNamespace(qname), qname: qname}
+
+	// A second block of one name reuses the first's Namespace and records its own
+	// declarations, so both blocks' members land in one binding.
+	if existing, seen := byName[qname]; seen {
+		existing.decls = append(existing.decls, decl)
+		c.preBindNestedBlocks(qname, decl, handled, byName, existing)
+		return nil
+	}
+
+	sh := &namespaceShell{decls: []*ast.NamespaceDecl{decl}, ns: newNamespace(qname), qname: qname}
+	byName[qname] = sh
+	c.preBindNestedBlocks(qname, decl, handled, byName, sh)
+	return sh
+}
+
+// preBindNestedBlocks mints the Namespace for each block written inside decl and
+// hangs it off the parent's Nested map, so `namespace a { namespace b { … } }`
+// reaches b through a.
+func (c *checker) preBindNestedBlocks(qname string, decl *ast.NamespaceDecl, handled set.Set[ast.Decl], byName map[string]*namespaceShell, parent *namespaceShell) {
 	for _, inner := range decl.Decls {
-		if nested, ok := inner.(*ast.NamespaceDecl); ok {
-			if child := c.preBindOneNamespace(scope, qname, nested, handled); child != nil {
-				sh.ns.Nested[nested.Name.Name] = child.ns
-				sh.nested = append(sh.nested, child)
-			}
+		nested, ok := inner.(*ast.NamespaceDecl)
+		if !ok {
+			continue
+		}
+		if child := c.preBindOneNamespace(qname, nested, handled, byName); child != nil {
+			parent.ns.Nested[nested.Name.Name] = child.ns
+			parent.nested = append(parent.nested, child)
 		}
 	}
-	return sh
 }
 
 // populateNamespaces fills each pre-bound Namespace with the bindings the walk
@@ -80,22 +109,23 @@ func (c *checker) populateNamespaces(scope *Scope, shells []*namespaceShell) {
 
 func (c *checker) fillNamespace(scope *Scope, sh *namespaceShell) {
 	out := sh.ns
-	qname := sh.qname
-	for _, inner := range sh.decl.Decls {
-		if _, ok := inner.(*ast.NamespaceDecl); ok {
-			continue
-		}
-		// Every other kind was keyed under `qname.member` and bound by the walk, so
-		// its names are read back rather than re-inferred here. exportedNames answers
-		// what a declaration introduces; the export flag gates a package's surface,
-		// not what its own namespace holds.
-		for _, name := range exportedNames(inner) {
-			key := qualify(qname, name)
-			if b, found := scope.GetValue(key); found {
-				out.Values[name] = b
+	for _, decl := range sh.decls {
+		for _, inner := range decl.Decls {
+			if _, ok := inner.(*ast.NamespaceDecl); ok {
+				continue
 			}
-			if b, found := scope.GetType(key); found {
-				out.Types[name] = b
+			// Every other kind was keyed under `qname.member` and bound by the walk, so
+			// its names are read back rather than re-inferred here. exportedNames answers
+			// what a declaration introduces; the export flag gates a package's surface,
+			// not what its own namespace holds.
+			for _, name := range exportedNames(inner) {
+				key := qualify(sh.qname, name)
+				if b, found := scope.GetValue(key); found {
+					out.Values[name] = b
+				}
+				if b, found := scope.GetType(key); found {
+					out.Types[name] = b
+				}
 			}
 		}
 	}

--- a/internal/solver/namespaces.go
+++ b/internal/solver/namespaces.go
@@ -109,17 +109,18 @@ func (c *checker) refreshNamespaces(scope *Scope) {
 	c.populateNamespaces(c.declTarget(scope), c.nsShells)
 }
 
-// populateNamespaces fills each pre-bound Namespace with the bindings the walk
-// placed under its qualified prefix. A nested block is filled through the same
-// pointer its parent already holds, so `namespace a { namespace b { val x } }`
-// gives `a.b.x`.
+// populateNamespaces populates each pre-bound Namespace in shells.
 func (c *checker) populateNamespaces(scope *Scope, shells []*namespaceShell) {
 	for _, sh := range shells {
-		c.fillNamespace(scope, sh)
+		c.populateNamespace(scope, sh)
 	}
 }
 
-func (c *checker) fillNamespace(scope *Scope, sh *namespaceShell) {
+// populateNamespace copies the bindings the walk placed under sh's qualified
+// prefix into the Namespace pre-bound for it, then does the same for the blocks
+// nested inside it. A nested block is populated through the same pointer its
+// parent already holds, so `namespace a { namespace b { val x } }` gives `a.b.x`.
+func (c *checker) populateNamespace(scope *Scope, sh *namespaceShell) {
 	out := sh.ns
 	for _, decl := range sh.decls {
 		for _, inner := range decl.Decls {

--- a/internal/solver/namespaces.go
+++ b/internal/solver/namespaces.go
@@ -99,6 +99,16 @@ func (c *checker) preBindNestedBlocks(qname string, decl *ast.NamespaceDecl, han
 	}
 }
 
+// refreshNamespaces fills every namespace pre-bound for the module under
+// inference. It runs whenever new bindings have landed, so a member reached
+// through `Foo.member` sees what the walk has bound so far.
+func (c *checker) refreshNamespaces(scope *Scope) {
+	if len(c.nsShells) == 0 {
+		return
+	}
+	c.populateNamespaces(c.declTarget(scope), c.nsShells)
+}
+
 // populateNamespaces fills each pre-bound Namespace with the bindings the walk
 // placed under its qualified prefix. A nested block is filled through the same
 // pointer its parent already holds, so `namespace a { namespace b { val x } }`

--- a/internal/solver/namespaces.go
+++ b/internal/solver/namespaces.go
@@ -14,10 +14,12 @@ import (
 // resolve rather than reading as an unknown identifier.
 
 // preBindNamespaceDecls binds one empty Namespace per `namespace` block before the
-// component walk, and returns each block paired with the object to fill. Binding
-// the name first is what lets a member of the same module write `Foo.member`: the
-// walk reads the binding while populateNamespaces is still to run, and the maps it
-// reads are the ones that call fills through the same pointer.
+// component walk, and returns each block paired with the object to fill.
+//
+// Binding the name first is what lets a member of the same module write
+// `Foo.member`. The walk reads that binding while populateNamespaces is still to
+// run, and the maps it reads are the ones that call fills through the same
+// pointer.
 //
 // Each block is marked handled, since it introduces no binding of its own and would
 // otherwise be reported as a declaration the dep graph did not model.
@@ -116,8 +118,8 @@ func (c *checker) fillNamespace(scope *Scope, sh *namespaceShell) {
 			}
 			// Every other kind was keyed under `qname.member` and bound by the walk, so
 			// its names are read back rather than re-inferred here. exportedNames answers
-			// what a declaration introduces; the export flag gates a package's surface,
-			// not what its own namespace holds.
+			// what a declaration introduces. Its export flag is not consulted, since that
+			// flag gates a package's surface rather than what a block holds.
 			for _, name := range exportedNames(inner) {
 				key := qualify(sh.qname, name)
 				if b, found := scope.GetValue(key); found {

--- a/internal/solver/namespaces_test.go
+++ b/internal/solver/namespaces_test.go
@@ -1,0 +1,63 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A namespace block groups its members under its name, and an access reaches them
+// through it.
+func TestNamespaceMembersResolveThroughTheBlock(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		namespace geo {
+			val origin: number = 0
+			fn twice(n: number) -> number {
+				return n
+			}
+		}
+		val o = geo.origin
+		val t = geo.twice(1)
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "number", values["o"])
+	require.Equal(t, "number", values["t"])
+}
+
+// A nested block is reached through its parent, so the members of `a.b` are read
+// as `a.b.member`.
+func TestNestedNamespaceBlocksNest(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		namespace a {
+			namespace b {
+				val deep: number = 1
+			}
+		}
+		val d = a.b.deep
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "number", values["d"])
+}
+
+// A name the block does not declare is reported against the namespace rather than
+// resolving to something outside it.
+func TestNamespaceReportsAnUnknownMember(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		namespace geo {
+			val origin: number = 0
+		}
+		val missing = geo.nowhere
+	`)
+	require.Equal(t, []string{"Namespace geo has no member: nowhere"}, errorMessagesOf(errs))
+}
+
+// A type a namespace declares binds under the qualified name the block gives it.
+func TestNamespaceBindsItsTypes(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		namespace geo {
+			type Num = number
+		}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "number", types["geo.Num"])
+}

--- a/internal/solver/namespaces_test.go
+++ b/internal/solver/namespaces_test.go
@@ -120,3 +120,47 @@ func TestExportedNamespaceBlockReachesTheSurface(t *testing.T) {
 	require.Empty(t, errorMessagesOf(res.Errors))
 	require.Equal(t, "number", soltype.Print(inferredValueType(t, res.Scope, "o")))
 }
+
+// Two functions in one namespace calling each other land in one component, and
+// each body reads the other through `Foo.member` while both are still being
+// inferred. The namespace has to answer for a member whose binding var exists but
+// whose body has not been walked.
+func TestMutuallyRecursiveFunctionsInOneNamespace(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		namespace Foo {
+			fn left(n: number) -> number {
+				return Foo.right(n)
+			}
+			fn right(n: number) -> number {
+				return Foo.left(n)
+			}
+		}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "fn (n: number) -> number", values["Foo.left"])
+	require.Equal(t, "fn (n: number) -> number", values["Foo.right"])
+}
+
+// A block's own `export` puts the block on the package's surface and says nothing
+// about the members inside it. Each carries its own flag, so an unexported one
+// stays internal.
+func TestExportedNamespaceHidesItsUnexportedMembers(t *testing.T) {
+	res := InferModuleWithSource(
+		parseModule(t, `
+			import "geo"
+			val s = geo.shapes.shown
+			val h = geo.shapes.hidden
+		`),
+		sourceOf(t, map[string]string{
+			"geo": `
+				export namespace shapes {
+					export val shown: number = 1
+					val hidden: number = 2
+				}
+			`,
+		}),
+	)
+	require.Equal(t, []string{"Namespace shapes has no member: hidden"},
+		errorMessagesOf(res.Errors))
+	require.Equal(t, "number", soltype.Print(inferredValueType(t, res.Scope, "s")))
+}

--- a/internal/solver/namespaces_test.go
+++ b/internal/solver/namespaces_test.go
@@ -61,3 +61,41 @@ func TestNamespaceBindsItsTypes(t *testing.T) {
 	require.Empty(t, errorMessagesOf(errs))
 	require.Equal(t, "number", types["geo.Num"])
 }
+
+// Two blocks of one name contribute to one namespace, the way two interfaces of
+// one name contribute to one type.
+func TestNamespaceBlocksOfOneNameMerge(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		namespace geo {
+			val a: number = 1
+		}
+		namespace geo {
+			val b: number = 2
+		}
+		val x = geo.a
+		val y = geo.b
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "number", values["x"])
+	require.Equal(t, "number", values["y"])
+}
+
+// A block is bound under the name its enclosing directory namespace qualifies it
+// with, so same-named blocks in sibling directories stay apart.
+func TestNamespaceBlocksInSiblingDirectoriesStayDistinct(t *testing.T) {
+	values, _, errs := inferSources(t, map[string]string{
+		"geo/shapes.esc": `
+			namespace util {
+				val gv: number = 1
+			}
+		`,
+		"math/ops.esc": `
+			namespace util {
+				val mv: string = "s"
+			}
+		`,
+	})
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "number", values["geo.util.gv"])
+	require.Equal(t, "string", values["math.util.mv"])
+}

--- a/internal/solver/namespaces_test.go
+++ b/internal/solver/namespaces_test.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,4 +99,24 @@ func TestNamespaceBlocksInSiblingDirectoriesStayDistinct(t *testing.T) {
 	require.Empty(t, errorMessagesOf(errs))
 	require.Equal(t, "number", values["geo.util.gv"])
 	require.Equal(t, "string", values["math.util.mv"])
+}
+
+// An exported namespace block reaches a package's surface whole, so an importer
+// reads its members through it.
+func TestExportedNamespaceBlockReachesTheSurface(t *testing.T) {
+	res := InferModuleWithSource(
+		parseModule(t, `
+			import "geo"
+			val o = geo.shapes.origin
+		`),
+		sourceOf(t, map[string]string{
+			"geo": `
+				export namespace shapes {
+					export val origin: number = 0
+				}
+			`,
+		}),
+	)
+	require.Empty(t, errorMessagesOf(res.Errors))
+	require.Equal(t, "number", soltype.Print(inferredValueType(t, res.Scope, "o")))
 }

--- a/internal/solver/package_load.go
+++ b/internal/solver/package_load.go
@@ -154,6 +154,17 @@ func exportedSurface(uri string, module *ast.Module, scope *Scope) *Namespace {
 			if !decl.Export() {
 				continue
 			}
+			// A `namespace` block carries its whole Namespace onto the surface, since
+			// its members are reached through it rather than named beside it.
+			// exportedNames answers nothing for a block, so it is taken here instead.
+			if nsDecl, isNS := decl.(*ast.NamespaceDecl); isNS {
+				if nsDecl.Name != nil && nsDecl.Name.Name != "" {
+					if bound, ok := scope.GetNamespace(qualify(nsPath, nsDecl.Name.Name)); ok {
+						target.Nested[nsDecl.Name.Name] = bound
+					}
+				}
+				continue
+			}
 			for _, name := range exportedNames(decl) {
 				// A value binds under the plain namespace-qualified name the dep-graph
 				// walk defined it under. A type binds under the key its registration

--- a/internal/solver/package_load.go
+++ b/internal/solver/package_load.go
@@ -236,6 +236,10 @@ func exportedNames(decl ast.Decl) []string {
 		if d.Name != nil {
 			return []string{d.Name.Name}
 		}
+	case *ast.InterfaceDecl:
+		if d.Name != nil {
+			return []string{d.Name.Name}
+		}
 	case *ast.EnumDecl:
 		if d.Name != nil {
 			return []string{d.Name.Name}

--- a/internal/solver/package_load.go
+++ b/internal/solver/package_load.go
@@ -160,7 +160,7 @@ func exportedSurface(uri string, module *ast.Module, scope *Scope) *Namespace {
 			if nsDecl, isNS := decl.(*ast.NamespaceDecl); isNS {
 				if nsDecl.Name != nil && nsDecl.Name.Name != "" {
 					if bound, ok := scope.GetNamespace(qualify(nsPath, nsDecl.Name.Name)); ok {
-						target.Nested[nsDecl.Name.Name] = bound
+						target.Nested[nsDecl.Name.Name] = exportedMembers(nsDecl, bound)
 					}
 				}
 				continue
@@ -310,3 +310,36 @@ func (e *UnresolvedPackageError) Message() string {
 func (e *UnresolvedPackageError) Span() ast.Span      { return e.span }
 func (e *UnresolvedPackageError) Related() []ast.Span { return nil }
 func (e *UnresolvedPackageError) isSolverError()      {}
+
+// exportedMembers returns a copy of ns holding only what decl exports, recursing
+// into the blocks written inside it.
+//
+// A block's own `export` says the block is part of the package's surface. It says
+// nothing about the members inside it, each of which carries its own flag, so
+// handing the bound Namespace over whole would publish a package's internals.
+func exportedMembers(decl *ast.NamespaceDecl, ns *Namespace) *Namespace {
+	out := newNamespace(ns.Name)
+	for _, inner := range decl.Decls {
+		if nested, isNS := inner.(*ast.NamespaceDecl); isNS {
+			if !nested.Export() || nested.Name == nil || nested.Name.Name == "" {
+				continue
+			}
+			if child, held := ns.Nested[nested.Name.Name]; held {
+				out.Nested[nested.Name.Name] = exportedMembers(nested, child)
+			}
+			continue
+		}
+		if !inner.Export() {
+			continue
+		}
+		for _, name := range exportedNames(inner) {
+			if b, held := ns.Values[name]; held {
+				out.Values[name] = b
+			}
+			if b, held := ns.Types[name]; held {
+				out.Types[name] = b
+			}
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Fixes #1238

First of a stack. #1474 → #1239 → #1240 follow.

`InterfaceDecl` and `NamespaceDecl` reached `reportUnsupported`, so the solver could not read two of the kinds the converter emits. The interface half is load-bearing rather than speculative: the committed `.esc` tree declares **705 interfaces**.

## Interfaces

An interface is structural and transparent, so it binds to an `AliasType` over its object body rather than to a nominal identity. `interface Point {x: number}` and `type Point = {x: number}` give an annotation the same type.

**Merging.** dep_graph already groups every declaration of one name under a single type key, so a shell carries the whole group and the bound type is their merged member list. The merge runs through `objElemBuilder`, the builder an object literal already uses, which is what makes two cases come out right:

- A method's signatures accumulate, so overloads split across declarations both survive.
- Read and write are separate slots, so a `get x()` in one declaration and a `set x(v)` in another form a pair rather than one dropping the other.

A member taken from a parent is copied first, since that builder appends signatures in place and the parent's own type must not change.

**`extends`.** The clause contributes its target's members ahead of the body's own, giving the flattened surface rather than a subtyping relation.

**What reports.** Declarations disagreeing on their type parameters, a name declared both as an interface and as an alias, class, or enum, an `extends` target that is not an object, and an `extends` target inside the interface's own recursive group.

## Namespaces

dep_graph descends into a `namespace Foo { ... }` block and keys each member under `Foo.member`, the same qualified shape a directory-derived namespace produces, so the ordinary component walk infers them.

The solver pre-binds an empty `Namespace` per block before that walk and refreshes it after each component. That ordering is what lets a member of the same module write `Foo.member`: components run in dependency order, so the member's own component has bound it by the time a reader runs.

Blocks of one name merge, and a block is bound under its qualified name, so `namespace util` in two directories stays distinct.

`collectNamespaces` also registers block names, so a reference written inside a block carries that block's `NamespaceID` rather than the root's. The emitted name is built from that id.

## Export visibility

`exportedNames` had no `InterfaceDecl` arm, so an `export interface` bound inside a package reached no importer. A block carries its whole `Namespace` onto the surface, since its members are reached through it rather than named beside it.

## Tests

`internal/solver/interfaces_test.go` and `internal/solver/namespaces_test.go` cover the binding, merging across declarations, overload accumulation, accessor pairing, `extends` flattening, a parent left unchanged by a child extending it, each diagnostic above, nested and duplicate blocks, sibling directories staying distinct, and both kinds reaching a package's surface.

`TestInferModuleNamespaceDeclUnsupported` pinned the diagnostic this replaces and is now `TestInferModuleNamespaceDeclBindsItsMembers`.

## Review

`/code-review` raised ten findings and all ten are fixed in `d73d9abe`, `4ef63ae3` and `1403032c`. The two worth calling out are the namespace clobbering — two blocks of one name, and a block bound under its bare name while filled under the qualified one — and the hand-rolled member merge, which replaced by name and so dropped overloads and split accessor pairs. Replacing it with `objElemBuilder` is what fixed the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195c9jyZtaRu9utgAYy6DkC

---
_Generated by [Claude Code](https://claude.ai/code/session_0195c9jyZtaRu9utgAYy6DkC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for interfaces, including structural typing, inheritance, declaration merging, overloads, accessors, and exported interfaces.
  - Added namespace support with nested namespaces, qualified member access, repeated-block merging, type members, and cross-module visibility.
  - Added clearer diagnostics for invalid interface inheritance, recursive extensions, conflicting declarations, and unknown namespace members.

- **Bug Fixes**
  - Namespace members now resolve correctly in downstream references, including nested and exported namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->