### PR TITLE
Reach a checker-known type without importing it

### DIFF
--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -23,6 +23,12 @@ type Context struct {
 	varCounter int
 	probe      *Probe
 
+	// wellKnown caches the handle for each type the checker's own rules name, so a
+	// rule reaches `Promise` or `Array` without the file under inference importing
+	// it. A nil entry records a name whose package did not supply it, which keeps
+	// the diagnostic to one per run. well_known.go holds the closed set.
+	wellKnown map[wellKnownName]soltype.Type
+
 	// lifetimeCounter mints the next LifetimeVar id (M4 D1). Lifetimes are a
 	// SECOND bounded sort solved by the same machinery as types: a fresh lifetime
 	// gets the next id here, its bounds are extended only through

--- a/internal/solver/well_known.go
+++ b/internal/solver/well_known.go
@@ -1,0 +1,125 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// well_known.go resolves the handful of types the checker's own rules name.
+//
+// A rule such as "awaiting a value yields what its Promise carries" has to reach
+// `Promise` whether or not the file under inference imports it. A handle is
+// therefore independent of lexical scope: it is read from the package that
+// declares the type, not from the scope chain.
+//
+// The set is fixed and closed. It is not an ambient surface a program can grow,
+// and a name outside it is unreachable this way.
+
+// wellKnownName is one of the types the checker's rules name directly.
+type wellKnownName string
+
+const (
+	wellKnownArray          wellKnownName = "Array"
+	wellKnownPromise        wellKnownName = "Promise"
+	wellKnownIterable       wellKnownName = "Iterable"
+	wellKnownAsyncIterable  wellKnownName = "AsyncIterable"
+	wellKnownGenerator      wellKnownName = "Generator"
+	wellKnownAsyncGenerator wellKnownName = "AsyncGenerator"
+)
+
+// wellKnownOwner names the pseudo-package declaring each well-known type. The map
+// is the closed set: a name absent from it has no handle.
+var wellKnownOwner = map[wellKnownName]string{
+	wellKnownArray:          "std:array",
+	wellKnownPromise:        "std:async",
+	wellKnownIterable:       "std:iterator",
+	wellKnownAsyncIterable:  "std:async",
+	wellKnownGenerator:      "std:iterator",
+	wellKnownAsyncGenerator: "std:async",
+}
+
+// wellKnownType returns the type declared for name, loading its owning package on
+// first use and caching the answer for the rest of the run.
+//
+// It answers false when the package does not resolve or does not declare the name,
+// having reported one diagnostic naming both. A tree missing a package is a
+// legible failure rather than a panic, since a partial stdlib is a state the
+// converter can leave behind.
+func (c *checker) wellKnownType(name wellKnownName) (soltype.Type, bool) {
+	if t, cached := c.ctx.wellKnown[name]; cached {
+		// A miss is cached as a nil type, so a rule that consults one name many
+		// times reports its absence once rather than once per consultation.
+		return t, t != nil
+	}
+
+	uri, known := wellKnownOwner[name]
+	if !known {
+		return nil, false
+	}
+
+	t, ok := c.readWellKnown(uri, name)
+	if c.ctx.wellKnown == nil {
+		c.ctx.wellKnown = map[wellKnownName]soltype.Type{}
+	}
+	if !ok {
+		c.ctx.wellKnown[name] = nil
+		return nil, false
+	}
+	c.ctx.wellKnown[name] = t
+	return t, true
+}
+
+// readWellKnown loads uri and reads name off the package's exported surface. The
+// span it reports against is empty, since a handle is reached by a rule rather
+// than by anything the user wrote.
+func (c *checker) readWellKnown(uri string, name wellKnownName) (soltype.Type, bool) {
+	ns, errs := c.loadPackage(uri, ast.Span{})
+	if ns == nil {
+		c.report(&MissingWellKnownTypeError{
+			Name:   string(name),
+			URI:    uri,
+			Reason: firstMessage(errs),
+		})
+		return nil, false
+	}
+	b, found := ns.Types[string(name)]
+	if !found {
+		c.report(&MissingWellKnownTypeError{
+			Name:   string(name),
+			URI:    uri,
+			Reason: "the package declares no such type",
+		})
+		return nil, false
+	}
+	return b.Type, true
+}
+
+// firstMessage renders the first diagnostic in errs, or a fixed phrase when the
+// load failed without producing one.
+func firstMessage(errs []SolverError) string {
+	if len(errs) == 0 {
+		return "the package did not load"
+	}
+	return errs[0].Message()
+}
+
+// MissingWellKnownTypeError reports a type the checker's own rules name that the
+// stdlib tree does not supply. It names both the type and the package expected to
+// declare it, since the fix is to that tree rather than to the program.
+type MissingWellKnownTypeError struct {
+	// Name is the well-known type that was not found.
+	Name string
+	// URI is the package expected to declare it.
+	URI string
+	// Reason says what went wrong, in the loader's words.
+	Reason string
+	span   ast.Span
+}
+
+func (e *MissingWellKnownTypeError) Message() string {
+	return "the standard library does not supply " + e.Name +
+		", expected in " + e.URI + ": " + e.Reason
+}
+func (e *MissingWellKnownTypeError) Span() ast.Span      { return e.span }
+func (e *MissingWellKnownTypeError) Related() []ast.Span { return nil }
+func (e *MissingWellKnownTypeError) isSolverError()      {}

--- a/internal/solver/well_known.go
+++ b/internal/solver/well_known.go
@@ -57,7 +57,21 @@ func (c *checker) wellKnownType(name wellKnownName) (soltype.Type, bool) {
 		return nil, false
 	}
 
-	t, ok := c.readWellKnown(uri, name)
+	// A speculation trial journals every bound it appends and truncates them on a
+	// discard. Inferring a package under one would publish it to the registry and
+	// cache a handle whose bounds the discard then removes, so a trial answers
+	// nothing and leaves the load to a consultation outside one.
+	if c.ctx.probe != nil {
+		return nil, false
+	}
+
+	t, ok, retry := c.readWellKnown(uri, name)
+	if retry {
+		// The package is loading further up this call chain, so it has no surface to
+		// read yet. Leave the cache untouched: the load completes, and a later
+		// consultation answers from the finished package.
+		return nil, false
+	}
 	if c.ctx.wellKnown == nil {
 		c.ctx.wellKnown = map[wellKnownName]soltype.Type{}
 	}
@@ -72,15 +86,34 @@ func (c *checker) wellKnownType(name wellKnownName) (soltype.Type, bool) {
 // readWellKnown loads uri and reads name off the package's exported surface. The
 // span it reports against is empty, since a handle is reached by a rule rather
 // than by anything the user wrote.
-func (c *checker) readWellKnown(uri string, name wellKnownName) (soltype.Type, bool) {
+//
+// retry is true when the package is already loading further up the call chain,
+// which makes the absence temporary rather than a fact about the tree.
+func (c *checker) readWellKnown(uri string, name wellKnownName) (t soltype.Type, ok bool, retry bool) {
+	// bindFileImports installs the loaded module's file scopes over the caller's and
+	// does not put them back, since every other load runs before a walk starts
+	// rather than inside one. A handle is consulted by a rule mid-walk, so the
+	// caller's scopes are restored here or every later declaration loses its file's
+	// imports.
+	savedFileScopes := c.fileScopes
 	ns, errs := c.loadPackage(uri, ast.Span{})
+	c.fileScopes = savedFileScopes
+
 	if ns == nil {
+		if isCycleError(errs) {
+			return nil, false, true
+		}
 		c.report(&MissingWellKnownTypeError{
 			Name:   string(name),
 			URI:    uri,
 			Reason: firstMessage(errs),
 		})
-		return nil, false
+		return nil, false, false
+	}
+	// A package that published a surface may still have reported diagnostics of its
+	// own. Both import call sites pass those on, so a handle does too.
+	for _, err := range errs {
+		c.report(err)
 	}
 	b, found := ns.Types[string(name)]
 	if !found {
@@ -89,9 +122,20 @@ func (c *checker) readWellKnown(uri string, name wellKnownName) (soltype.Type, b
 			URI:    uri,
 			Reason: "the package declares no such type",
 		})
-		return nil, false
+		return nil, false, false
 	}
-	return b.Type, true
+	return b.Type, true, false
+}
+
+// isCycleError reports whether errs is the diagnostic loadPackage raises for a URI
+// already being loaded further up the call chain.
+func isCycleError(errs []SolverError) bool {
+	for _, err := range errs {
+		if _, isCycle := err.(*ImportCycleError); isCycle {
+			return true
+		}
+	}
+	return false
 }
 
 // firstMessage renders the first diagnostic in errs, or a fixed phrase when the

--- a/internal/solver/well_known_test.go
+++ b/internal/solver/well_known_test.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -11,9 +12,18 @@ import (
 // reaches a handle without inferring a module that imports anything.
 func wellKnownChecker(t *testing.T, files map[string]string) *checker {
 	t.Helper()
-	c := newChecker()
-	c.source = StdlibSource(seedStdlib(t, files))
+	c, _ := wellKnownCheckerIn(t, files)
 	return c
+}
+
+// wellKnownCheckerIn is wellKnownChecker plus the directory the tree was written to,
+// for a test asserting a message that names the file the loader reached for.
+func wellKnownCheckerIn(t *testing.T, files map[string]string) (*checker, string) {
+	t.Helper()
+	dir := seedStdlib(t, files)
+	c := newChecker()
+	c.source = StdlibSource(dir)
+	return c, dir
 }
 
 // A handle is read from the package declaring the type, so a rule reaches it with
@@ -76,12 +86,15 @@ func TestWellKnownTypeReportsAMissingDeclarationOnce(t *testing.T) {
 func TestWellKnownTypeReportsAMissingPackage(t *testing.T) {
 	t.Parallel()
 
-	c := wellKnownChecker(t, map[string]string{})
+	c, dir := wellKnownCheckerIn(t, map[string]string{})
 	_, ok := c.wellKnownType(wellKnownArray)
 	require.False(t, ok)
-	require.Len(t, c.errs, 1)
-	require.Contains(t, c.errs[0].Message(),
-		"the standard library does not supply Array, expected in std:array:")
+
+	require.Equal(t, []string{
+		"the standard library does not supply Array, expected in std:array: " +
+			`cannot resolve import "std:array": unknown package "array" in std: scheme ` +
+			"(no std/array.esc under " + dir + ")",
+	}, errorMessagesOf(c.errs))
 }
 
 // Every name in the closed set names a package, so no handle is unreachable by
@@ -122,7 +135,7 @@ func TestWellKnownTypeDeclinesANameOutsideTheSet(t *testing.T) {
 func TestWellKnownTypeReportsThePackagesOwnDiagnostics(t *testing.T) {
 	t.Parallel()
 
-	c := wellKnownChecker(t, map[string]string{
+	c, dir := wellKnownCheckerIn(t, map[string]string{
 		"std/array.esc": `
 			export declare class Array {
 				length: number,
@@ -133,11 +146,11 @@ func TestWellKnownTypeReportsThePackagesOwnDiagnostics(t *testing.T) {
 	got, ok := c.wellKnownType(wellKnownArray)
 	require.True(t, ok)
 	require.Equal(t, "Array", soltype.Print(got))
-	// The package wraps its diagnostics in one that names the file it loaded, whose
-	// path is a temp directory, so the two stable halves are matched separately.
-	require.Len(t, c.errs, 1)
-	require.Contains(t, c.errs[0].Message(), `package "std:array"`)
-	require.Contains(t, c.errs[0].Message(), `has 1 error(s):`+"\n"+`  cannot constrain "not a number" <: number`)
+
+	require.Equal(t, []string{
+		`package "std:array" (` + filepath.Join(dir, "std", "array.esc") + ") has 1 error(s):\n" +
+			`  cannot constrain "not a number" <: number`,
+	}, errorMessagesOf(c.errs))
 }
 
 // Loading a handle's package mid-walk must leave the caller's file scopes in

--- a/internal/solver/well_known_test.go
+++ b/internal/solver/well_known_test.go
@@ -98,6 +98,48 @@ func TestWellKnownOwnersAreComplete(t *testing.T) {
 	require.Len(t, wellKnownOwner, 6)
 }
 
+// The set is closed, so a name outside it names no package and is unreachable this
+// way. It reports nothing, since no tree could have supplied it and the caller asked
+// for something that does not exist.
+func TestWellKnownTypeDeclinesANameOutsideTheSet(t *testing.T) {
+	t.Parallel()
+
+	c := wellKnownChecker(t, map[string]string{
+		"std/array.esc": `
+			export declare class Array {
+				length: number,
+			}
+		`,
+	})
+	_, ok := c.wellKnownType(wellKnownName("Bogus"))
+	require.False(t, ok)
+	require.Empty(t, errorMessagesOf(c.errs))
+}
+
+// A package that published a surface may still have reported diagnostics of its own.
+// Both import call sites pass those on, so a handle does too: the type resolves and
+// the package's own diagnostic is not swallowed.
+func TestWellKnownTypeReportsThePackagesOwnDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	c := wellKnownChecker(t, map[string]string{
+		"std/array.esc": `
+			export declare class Array {
+				length: number,
+			}
+			export val broken: number = "not a number"
+		`,
+	})
+	got, ok := c.wellKnownType(wellKnownArray)
+	require.True(t, ok)
+	require.Equal(t, "Array", soltype.Print(got))
+	// The package wraps its diagnostics in one that names the file it loaded, whose
+	// path is a temp directory, so the two stable halves are matched separately.
+	require.Len(t, c.errs, 1)
+	require.Contains(t, c.errs[0].Message(), `package "std:array"`)
+	require.Contains(t, c.errs[0].Message(), `has 1 error(s):`+"\n"+`  cannot constrain "not a number" <: number`)
+}
+
 // Loading a handle's package mid-walk must leave the caller's file scopes in
 // place. bindFileImports installs the loaded module's over them, so without a
 // restore every later declaration would lose its own file's imports.

--- a/internal/solver/well_known_test.go
+++ b/internal/solver/well_known_test.go
@@ -1,0 +1,99 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// wellKnownChecker builds a checker over a seeded pseudo-package tree, so a test
+// reaches a handle without inferring a module that imports anything.
+func wellKnownChecker(t *testing.T, files map[string]string) *checker {
+	t.Helper()
+	c := newChecker()
+	c.source = StdlibSource(seedStdlib(t, files))
+	return c
+}
+
+// A handle is read from the package declaring the type, so a rule reaches it with
+// nothing imported.
+func TestWellKnownTypeLoadsWithoutAnImport(t *testing.T) {
+	t.Parallel()
+
+	c := wellKnownChecker(t, map[string]string{
+		"std/array.esc": `
+			export declare class Array {
+				length: number,
+			}
+		`,
+	})
+	got, ok := c.wellKnownType(wellKnownArray)
+	require.True(t, ok)
+	require.Equal(t, "Array", soltype.Print(got))
+	require.Empty(t, errorMessagesOf(c.errs))
+}
+
+// The second consultation reads the cache rather than loading again.
+func TestWellKnownTypeCachesTheHandle(t *testing.T) {
+	t.Parallel()
+
+	c := wellKnownChecker(t, map[string]string{
+		"std/array.esc": `
+			export declare class Array {
+				length: number,
+			}
+		`,
+	})
+	first, ok := c.wellKnownType(wellKnownArray)
+	require.True(t, ok)
+	second, ok := c.wellKnownType(wellKnownArray)
+	require.True(t, ok)
+	require.Same(t, first, second)
+}
+
+// A tree that does not declare the type reports once, naming both the type and the
+// package expected to supply it, and repeats nothing on a second consultation.
+func TestWellKnownTypeReportsAMissingDeclarationOnce(t *testing.T) {
+	t.Parallel()
+
+	c := wellKnownChecker(t, map[string]string{
+		"std/array.esc": `export val unrelated: number = 1`,
+	})
+	_, ok := c.wellKnownType(wellKnownArray)
+	require.False(t, ok)
+	_, ok = c.wellKnownType(wellKnownArray)
+	require.False(t, ok)
+
+	require.Equal(t, []string{
+		"the standard library does not supply Array, expected in std:array: " +
+			"the package declares no such type",
+	}, errorMessagesOf(c.errs))
+}
+
+// A tree missing the package altogether degrades the same way, carrying the
+// loader's own reason.
+func TestWellKnownTypeReportsAMissingPackage(t *testing.T) {
+	t.Parallel()
+
+	c := wellKnownChecker(t, map[string]string{})
+	_, ok := c.wellKnownType(wellKnownArray)
+	require.False(t, ok)
+	require.Len(t, c.errs, 1)
+	require.Contains(t, c.errs[0].Message(),
+		"the standard library does not supply Array, expected in std:array:")
+}
+
+// Every name in the closed set names a package, so no handle is unreachable by
+// construction.
+func TestWellKnownOwnersAreComplete(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []wellKnownName{
+		wellKnownArray, wellKnownPromise, wellKnownIterable,
+		wellKnownAsyncIterable, wellKnownGenerator, wellKnownAsyncGenerator,
+	} {
+		require.Contains(t, wellKnownOwner, name)
+	}
+	require.Len(t, wellKnownOwner, 6)
+}

--- a/internal/solver/well_known_test.go
+++ b/internal/solver/well_known_test.go
@@ -97,3 +97,79 @@ func TestWellKnownOwnersAreComplete(t *testing.T) {
 	}
 	require.Len(t, wellKnownOwner, 6)
 }
+
+// Loading a handle's package mid-walk must leave the caller's file scopes in
+// place. bindFileImports installs the loaded module's over them, so without a
+// restore every later declaration would lose its own file's imports.
+func TestWellKnownTypeLeavesFileScopesAlone(t *testing.T) {
+	t.Parallel()
+
+	c := wellKnownChecker(t, map[string]string{
+		"std/array.esc": `
+			export declare class Array {
+				length: number,
+			}
+		`,
+	})
+	before := map[int]*Scope{7: nil}
+	c.fileScopes = before
+
+	_, ok := c.wellKnownType(wellKnownArray)
+	require.True(t, ok)
+	require.Equal(t, before, c.fileScopes, "the caller's file scopes survive the load")
+}
+
+// A consultation raised while the owning package is itself loading finds no
+// surface yet. That absence is temporary, so it must not be cached as a fact
+// about the tree.
+func TestWellKnownTypeDoesNotCacheACycleMiss(t *testing.T) {
+	t.Parallel()
+
+	c := wellKnownChecker(t, map[string]string{
+		"std/array.esc": `
+			export declare class Array {
+				length: number,
+			}
+		`,
+	})
+	// Mark the package as in flight, which is the state loadPackage reads to
+	// recognize a cycle.
+	c.packages.markLoading("std:array", "std/array.esc")
+	c.loadStack = append(c.loadStack, "std:array")
+
+	_, ok := c.wellKnownType(wellKnownArray)
+	require.False(t, ok)
+	require.NotContains(t, c.ctx.wellKnown, wellKnownArray,
+		"a cycle leaves the cache untouched so a later consultation can answer")
+
+	// With the load finished, the same consultation answers.
+	c.loadStack = c.loadStack[:len(c.loadStack)-1]
+	c.packages = NewPackageRegistry()
+	got, ok := c.wellKnownType(wellKnownArray)
+	require.True(t, ok)
+	require.Equal(t, "Array", soltype.Print(got))
+}
+
+// A trial's bounds are truncated when it is discarded, so a handle resolved under
+// one would cache a type whose bounds no longer exist. A trial answers nothing and
+// leaves the load to a consultation outside one.
+func TestWellKnownTypeAnswersNothingInsideAProbe(t *testing.T) {
+	t.Parallel()
+
+	c := wellKnownChecker(t, map[string]string{
+		"std/array.esc": `
+			export declare class Array {
+				length: number,
+			}
+		`,
+	})
+	p := c.openProbe()
+	_, ok := c.wellKnownType(wellKnownArray)
+	require.False(t, ok)
+	require.NotContains(t, c.ctx.wellKnown, wellKnownArray)
+	c.closeProbe(p, false)
+
+	got, ok := c.wellKnownType(wellKnownArray)
+	require.True(t, ok)
+	require.Equal(t, "Array", soltype.Print(got))
+}


### PR DESCRIPTION
Refs #1239

Third of a stack, on top of #1483. The rest is #1480 → #1483.

**This is the first half of M7.5 PR5.** The plan marks that PR Large and says explicitly it is "the PR to split further if review drags — the handle mechanism and the `ArrayType` retirement are separable, in that order." This is the handle mechanism. The `ArrayType` retirement follows in its own PR.

## The problem

A rule such as "awaiting a value yields what its `Promise` carries" has to name `Promise` whether or not the file under inference imports it. Reading it from the scope chain cannot answer that, since the scope holds only what the file wrote.

## The mechanism

`Context.wellKnown` caches one handle per checker-known type, read from the package declaring it and independent of lexical scope. The set is fixed and closed — six names, each mapped to its owning pseudo-package:

| name | package |
| --- | --- |
| `Array` | `std:array` |
| `Promise`, `AsyncIterable`, `AsyncGenerator` | `std:async` |
| `Iterable`, `Generator` | `std:iterator` |

A tree that does not supply one degrades legibly rather than panicking: the diagnostic names both the type and the package expected to declare it, and a nil cache entry keeps it to one report per run rather than one per consultation.

## What review caught

A handle is **the first thing to load a package from inside the walk** rather than before it, and that breaks assumptions the loader could previously rely on. `/code-review` raised four findings and all are fixed:

- `bindFileImports` installs the loaded module's file scopes over the caller's and never restores them, since every other load runs before a walk starts. Mid-walk that left every later declaration without its own file's imports.
- A cycle sentinel was cached as a permanent miss, so a consultation raised while the owning package was still loading pinned `nil` for the run and silenced every later report.
- Diagnostics from a package that published a surface anyway were dropped, where both import call sites pass them on.
- A handle resolved inside a speculation trial would cache a type whose bounds the discard then truncates, so a trial answers nothing and leaves the load to a consultation outside one.

The first is exactly the hazard #1476 describes. The no-re-entry property held only because `bindImport` was the sole caller of `loadPackage`, and this PR is what stops that being true — which is the concrete argument for doing #1476 before much more of Lane B lands.

## Tests

`internal/solver/well_known_test.go` covers loading with nothing imported, caching, a missing declaration and a missing package each reporting once, the closed set being complete, and one regression test per review finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195c9jyZtaRu9utgAYy6DkC

---
_Generated by [Claude Code](https://claude.ai/code/session_0195c9jyZtaRu9utgAYy6DkC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Type checking now automatically resolves common standard-library types, including arrays, promises, iterables, and generators, even when their packages are not explicitly imported.
  - Resolved types are cached to improve consistency and reduce repeated lookups.
- **Bug Fixes**
  - Missing standard-library packages or declarations now produce clear diagnostics.
  - Type resolution remains reliable during package-loading cycles and speculative analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->