### PR TITLE
Retire the ArrayType concrete for the ingested Array class

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -84,8 +84,8 @@ func typePrec(t Type) int {
 		return precAtom
 	default:
 		// PrimType, LitType, TupleType, ObjectType, ClassType, AliasType, NullType,
-		// UndefinedType, NeverType, UnknownType — atoms. ObjectType is brace-delimited, and ClassType,
-		// ArrayType, and AliasType each render as a bare name or `Name<args>`, so none needs parens. A raw TypeVarType
+		// UndefinedType, NeverType, UnknownType — atoms. ObjectType is brace-delimited, and ClassType
+		// and AliasType each render as a bare name or `Name<args>`, so neither needs parens. A raw TypeVarType
 		// appears only when printing an un-coalesced type, see printType; it is also an
 		// atom rendered as `t{ID}`, so it lands here. A `mut 'a Point` borrow wraps the
 		// ClassType in a RefType, which carries the looser precPrefix precedence.
@@ -611,8 +611,6 @@ func freeTypeVars(t Type) []*TypeVarType {
 			if t.Throws != nil {
 				walk(t.Throws)
 			}
-		case *ArrayType:
-			walk(t.Elem)
 		case *RefType:
 			walk(t.Inner)
 		case *UnionType:
@@ -1004,8 +1002,6 @@ func (p *namedPrinter) printType(t Type) string {
 			slots += ", " + p.printType(t.Throws)
 		}
 		return t.Name() + "<" + slots + ">"
-	case *ArrayType:
-		return "Array<" + p.printType(t.Elem) + ">"
 	case *RefType:
 		// Ownership and the borrow `&` split on Lt. An owned value has Lt nil and
 		// renders bare. NewRef collapses the owned-immutable cell, so a surviving owned

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -843,13 +843,6 @@ func (t *GeneratorType) Name() string {
 	return "Generator"
 }
 
-// ArrayType is a homogeneous sequence of Elem, written `Array<T>`. It is a dedicated concrete
-// for the reason PromiseType is: one stdlib generic the milestone needs typed ahead of library
-// ingestion. It exists to give a rest parameter an element type, the arity-and-element pair a
-// tuple-typed rest cannot express. Elem is covariant, the read-only reading a rest parameter
-// needs. The minimal form carries no members, so `xs.length` and `xs[0]` do not resolve.
-type ArrayType struct{ Elem Type }
-
 // NullType is the type whose only inhabitant is the `null` literal. It
 // mirrors TypeScript's `null` type and sits alongside UndefinedType as a
 // distinct atomic kind. The canonical comparator sorts both kinds last so a
@@ -1309,7 +1302,6 @@ func (*ObjectType) isType()          {}
 func (*RefType) isType()             {}
 func (*PromiseType) isType()         {}
 func (*GeneratorType) isType()       {}
-func (*ArrayType) isType()           {}
 func (*NullType) isType()            {}
 func (*UndefinedType) isType()       {}
 func (*NeverType) isType()           {}
@@ -1443,9 +1435,6 @@ func LevelOf(t Type) int {
 			max(LevelOf(t.Yield), LevelOf(t.Ret)),
 			max(LevelOf(t.Next), throwsLevel(t.Throws)),
 		)
-	case *ArrayType:
-		// An array's level is its element's, the same single-child rule PromiseType follows.
-		return LevelOf(t.Elem)
 	case *RefType:
 		// A borrow's level is the max of its inner content's and its lifetime's (M4
 		// D2.5). The lifetime is a SECOND quantifiable variable on the wrapper: a

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -157,20 +157,6 @@ func (t *ObjectType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
-func (t *ArrayType) Accept(v TypeVisitor, pol Polarity) Type {
-	e := v.EnterType(t, pol)
-	if e.SkipChildren {
-		return v.ExitType(skipReplace(t, e), pol)
-	}
-	cur := descendReplacement(t, e)
-	elem := cur.Elem.Accept(v, pol) // covariant, the read-only reading
-	out := cur
-	if elem != cur.Elem {
-		out = &ArrayType{Elem: elem}
-	}
-	return v.ExitType(out, pol)
-}
-
 func (t *PromiseType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -143,7 +143,7 @@ func TestInferTypeAliasShadowingPromiseRejectsArgs(t *testing.T) {
 // subtyping rather than looping. inferTypeDecl registers before binding, so this never
 // arises from source, but the guard keeps a stray reference from diverging.
 func TestExpandAliasUnregisteredReturnsError(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	got := c.ctx.expandAlias(&soltype.AliasType{Name: "Missing"})
 	require.IsType(t, &soltype.ErrorType{}, got)
 }

--- a/internal/solver/array_test.go
+++ b/internal/solver/array_test.go
@@ -77,7 +77,7 @@ func TestArrayResolvesToTheIngestedClass(t *testing.T) {
 
 // `Array<T>` is covariant in T and `mut Array<T>` is invariant. `at(self, index)` is an
 // output position both views reach, and `push(mut self, item: T)` an input position only a
-// mutable reference reaches, so the widening holds for a shared array while two mutable
+// mutable reference reaches, so the widening holds for an immutable array while two mutable
 // ones over different elements stay unrelated.
 func TestArrayIsCovariantAndMutArrayIsNot(t *testing.T) {
 	t.Parallel()

--- a/internal/solver/array_test.go
+++ b/internal/solver/array_test.go
@@ -95,6 +95,27 @@ func TestArrayRestParamSurvivedTheRetirement(t *testing.T) {
 	require.Equal(t, []string{`cannot constrain "a" <: number`}, errorMessagesOf(errs))
 }
 
+// The handle refuses to load inside a speculation trial, since a discard truncates
+// every bound the load journaled. A written `Array` settles the name before the
+// reference resolves, so an annotation reached only through a trial still resolves —
+// here the sole `Array` in the module sits in a lambda an overload call speculates on.
+func TestArrayResolvesFromInsideAnOverloadTrial(t *testing.T) {
+	t.Parallel()
+
+	c := newTestChecker()
+	module := parseModuleFiles(t, map[string]string{
+		"input.esc": `
+			declare fn pick(f: fn (xs: Array<number>) -> number) -> number
+			declare fn pick(f: fn (s: string) -> number) -> number
+			val r = pick(fn (xs: Array<number>) { return xs.length })
+		`,
+	})
+	c.inferDepGraph(sharedPrelude().Child(), 0, module, dep_graph.BuildDepGraph(module))
+
+	require.Empty(t, errorMessagesOf(c.errs))
+	require.NotEmpty(t, c.ctx.arrayClass)
+}
+
 // Without a stdlib supplying `Array`, the name is simply unknown. Nothing claims an
 // arity for a declaration nothing provides, and no handle is cached.
 func TestArrayIsUnknownWithoutAStdlib(t *testing.T) {

--- a/internal/solver/array_test.go
+++ b/internal/solver/array_test.go
@@ -74,6 +74,43 @@ func TestArrayResolvesToTheIngestedClass(t *testing.T) {
 	}
 }
 
+// `Array<T>` is covariant in T and `mut Array<T>` is invariant. `at(self, index)` is an
+// output position both views reach, and `push(mut self, item: T)` an input position only a
+// mutable reference reaches, so the widening holds for a shared array while two mutable
+// ones over different elements stay unrelated.
+func TestArrayIsCovariantAndMutArrayIsNot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "SharedArrayWidens",
+			src: `fn take(xs: Array<number>) -> number { return 1 }
+				fn give(ys: Array<1>) { return take(ys) }`,
+		},
+		{
+			name: "MutArrayDoesNotWiden",
+			src: `fn take(xs: mut Array<number>) -> number { return 1 }
+				fn give(ys: mut Array<1>) { return take(ys) }`,
+			want: []string{"cannot constrain number <: 1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, errs := inferSource(t, tt.src)
+			if len(tt.want) == 0 {
+				require.Empty(t, errorMessagesOf(errs))
+				return
+			}
+			require.Equal(t, tt.want, errorMessagesOf(errs))
+		})
+	}
+}
+
 // A wrong element is rejected against the declaration's own signature, with the
 // message that signature produces.
 func TestArrayMethodRejectsAWrongElement(t *testing.T) {

--- a/internal/solver/array_test.go
+++ b/internal/solver/array_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -151,6 +152,39 @@ func TestArrayResolvesFromInsideAnOverloadTrial(t *testing.T) {
 
 	require.Empty(t, errorMessagesOf(c.errs))
 	require.NotEmpty(t, c.ctx.arrayClass)
+}
+
+// arrayElem and arrayOf both answer against the class name the run settled on, so
+// both decline when there is nothing to compare against. arrayElem also declines an
+// instance of that class carrying the wrong number of arguments, which is not an
+// array whatever its name says.
+func TestArrayHelpersDeclineWhatIsNotAnArray(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoArrayResolved", func(t *testing.T) {
+		t.Parallel()
+		c := &Context{}
+		_, ok := c.arrayOf(num())
+		require.False(t, ok)
+		_, ok = c.arrayElem(&soltype.ClassType{Name: "Array", TypeArgs: []soltype.Type{num()}})
+		require.False(t, ok)
+	})
+	t.Run("AnotherClassOfTheSameShape", func(t *testing.T) {
+		t.Parallel()
+		c := &Context{arrayClass: "Array"}
+		_, ok := c.arrayElem(&soltype.ClassType{Name: "List", TypeArgs: []soltype.Type{num()}})
+		require.False(t, ok)
+	})
+	t.Run("WrongArgumentCount", func(t *testing.T) {
+		t.Parallel()
+		c := &Context{arrayClass: "Array"}
+		_, ok := c.arrayElem(&soltype.ClassType{Name: "Array"})
+		require.False(t, ok)
+		_, ok = c.arrayElem(&soltype.ClassType{
+			Name: "Array", TypeArgs: []soltype.Type{num(), num()},
+		})
+		require.False(t, ok)
+	})
 }
 
 // Without a stdlib supplying `Array`, the name is simply unknown. Nothing claims an

--- a/internal/solver/array_test.go
+++ b/internal/solver/array_test.go
@@ -1,0 +1,111 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/stretchr/testify/require"
+)
+
+// `Array` is the ingested declaration rather than a wrapper carrying an element type,
+// so an array read resolves the members that declaration names. Each case takes the
+// array as a parameter, since the type is what is under test rather than any value.
+func TestArrayResolvesToTheIngestedClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			// The annotation resolves with nothing imported. The handle is read from the
+			// package declaring `Array`, so the file needs no import to name it.
+			name: "AnnotationResolvesWithNothingImported",
+			src:  `fn f(xs: Array<number>) -> number { return 1 }`,
+			want: map[string]string{"f": "fn (xs: Array<number>) -> number"},
+		},
+		{
+			// A member the declaration names, which the retired concrete could not answer.
+			name: "LengthReads",
+			src:  `fn f(xs: Array<number>) { return xs.length }`,
+			want: map[string]string{"f": "fn (xs: Array<number>) -> number"},
+		},
+		{
+			// A method the declaration names, checked against its signature.
+			name: "PushChecks",
+			src:  `fn f(xs: mut Array<number>) { return xs.push(1) }`,
+			want: map[string]string{"f": "fn (xs: mut Array<number>) -> number"},
+		},
+		{
+			// A numeric key reads the element. An array declares no position for the key to
+			// land on, so the element is the answer whatever the index is.
+			name: "NumericLiteralIndexYieldsTheElement",
+			src:  `fn f(xs: Array<number>) { return xs[0] }`,
+			want: map[string]string{"f": "fn (xs: Array<number>) -> number"},
+		},
+		{
+			name: "NumberTypedIndexYieldsTheElement",
+			src:  `fn f(xs: Array<string>, k: number) { return xs[k] }`,
+			want: map[string]string{"f": "fn (xs: Array<string>, k: number) -> string"},
+		},
+		{
+			// Iteration binds the loop variable at the element type.
+			name: "ForInBindsTheElement",
+			src: `
+				fn f(xs: Array<number>) {
+					for x in xs {
+						return x
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn (xs: Array<number>) -> number"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errorMessagesOf(errs))
+			for name, want := range tt.want {
+				require.Equal(t, want, values[name], "binding %q", name)
+			}
+		})
+	}
+}
+
+// A wrong element is rejected against the declaration's own signature, with the
+// message that signature produces.
+func TestArrayMethodRejectsAWrongElement(t *testing.T) {
+	t.Parallel()
+
+	_, _, errs := inferSource(t, `fn f(xs: mut Array<number>) { return xs.push("a") }`)
+	require.Equal(t, []string{`cannot constrain "a" <: number`}, errorMessagesOf(errs))
+}
+
+// A rest parameter still checks each trailing argument against the element, the
+// behavior #677 gave the retired concrete.
+func TestArrayRestParamSurvivedTheRetirement(t *testing.T) {
+	t.Parallel()
+
+	_, _, errs := inferSource(t, `
+		val g: fn (...xs: Array<number>) -> number = fn (...) { return 1 }
+		val r = g(1, "a")
+	`)
+	require.Equal(t, []string{`cannot constrain "a" <: number`}, errorMessagesOf(errs))
+}
+
+// Without a stdlib supplying `Array`, the name is simply unknown. Nothing claims an
+// arity for a declaration nothing provides, and no handle is cached.
+func TestArrayIsUnknownWithoutAStdlib(t *testing.T) {
+	t.Parallel()
+
+	c := newChecker()
+	module := parseModuleFiles(t, map[string]string{
+		"input.esc": `fn f(xs: Array<number>) -> number { return 1 }`,
+	})
+	c.inferDepGraph(sharedPrelude().Child(), 0, module, dep_graph.BuildDepGraph(module))
+
+	require.Equal(t, []string{"cannot find type `Array`"}, errorMessagesOf(c.errs))
+	require.Empty(t, c.ctx.arrayClass)
+}

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -274,7 +274,7 @@ func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
 	node := ast.NewIdent("site", tspan(40, 44))
 
 	t.Run("ExtraPropertyError", func(t *testing.T) {
-		c := newChecker()
+		c := newTestChecker()
 		// exact {x, y} <: exact {x}: y is an extra property on the source.
 		c.constrain(node, exactObj(propElem("x", num()), propElem("y", num())), exactObj(propElem("x", num())))
 		require.Len(t, c.errs, 1)
@@ -284,7 +284,7 @@ func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
 	})
 
 	t.Run("InexactIntoExactError", func(t *testing.T) {
-		c := newChecker()
+		c := newTestChecker()
 		// inexact {x, ...} <: exact {x}: an inexact source cannot fill an exact sink.
 		c.constrain(node, inexactObj(propElem("x", num())), exactObj(propElem("x", num())))
 		require.Len(t, c.errs, 1)
@@ -294,7 +294,7 @@ func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
 	})
 
 	t.Run("OptionalPropertyError", func(t *testing.T) {
-		c := newChecker()
+		c := newTestChecker()
 		// {x?: number} <: {x: number}: an optional source cannot fill a required property.
 		c.constrain(node,
 			exactObj(&soltype.PropertyElem{Name: "x", Type: num(), Optional: true}),
@@ -338,7 +338,7 @@ func TestUnsupportedAnnotationRecovers(t *testing.T) {
 // panicking — honoring M2's "never a panic" guarantee now that Span() is lazy
 // (it derefs the stored node on demand). Mirrors inferFunc's nil-param fallback.
 func TestNilVarDeclPatternBlamesDeclWithoutPanic(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	d := ast.NewVarDecl(ast.ValKind, nil, nil, numExpr(5), false, false, testSpan())
 	require.NotPanics(t, func() {
 		_, _, ok := c.inferDeclDef(NewScope(), 0, d, "")

--- a/internal/solver/borrow_store.go
+++ b/internal/solver/borrow_store.go
@@ -320,8 +320,6 @@ func (w *lifetimeWalk) walk(t soltype.Type, base []placeSeg) {
 		for _, elem := range t.Elems {
 			w.walk(elem, base)
 		}
-	case *soltype.ArrayType:
-		w.walk(t.Elem, base)
 	case *soltype.PromiseType:
 		w.walk(t.Inner, base)
 		w.walk(t.Err, base)

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -199,27 +199,29 @@ func modifierVariance(m ast.VarianceModifier) (Variance, bool) {
 // measured unsoundly.
 //
 // It returns two vectors, one per view a reference to an instance can offer. immut is the
-// variance an immutable reference sees, where every member is readable and none is
-// writable. mut is the variance a mutable reference sees, which additionally admits a
-// write to every non-`readonly` field.
+// variance an immutable reference sees, which reaches only the members such a reference
+// can use. mut is the variance a mutable reference sees, which additionally admits a write
+// to every non-`readonly` field and every member gated on a mutable receiver.
 //
-// The two vectors differ only at those writable fields. A field's read is an output
-// position in both views, so a parameter reaching one is covariant in immut. Its write is
-// an input position only mut has, so the same parameter is invariant in mut. Given `class
-// Box<T> { value: T }`, immut measures T covariant while mut measures it invariant. That
-// is what leaves `mut Box<number>` and `mut Box<number | string>` unrelated even though
-// `Box<number> <: Box<number | string>` holds.
+// A member an immutable reference cannot reach says nothing about the immutable view, so
+// it is walked into mut alone. Three members are gated that way: a write to a non-
+// `readonly` field, a setter, and a `mut self` method. An overloaded method is split per
+// signature, since one arm taking `mut self` does not gate the arms that do not.
+//
+// `Array<T>` is what this buys. Its `at(self, index) -> T | undefined` puts T in an output
+// position and its `push(mut self, item: T)` puts T in an input position. Folding both into
+// immut would measure T invariant and leave `Array<1> <: Array<number>` rejected. Reading
+// `push` only where it can be called measures T covariant in immut and invariant in mut, so
+// the widening holds for a shared array while `mut Array<1>` and `mut Array<number>` stay
+// unrelated.
+//
+// A field is the same shape of split. Its read is an output position in both views, its
+// write an input position only mut has, so `class Box<T> { value: T }` measures T covariant
+// in immut and invariant in mut.
 //
 // Every other member position has one variance both views share, so it is walked once and
-// folded into both. A method value parameter is contravariant whether or not the holder
-// can mutate the instance, and a method return or getter is covariant either way. The same
-// holds for a member only a mutable reference can reach, such as a setter or a `mut self`
-// method. Reaching such a member is a call, and a call's argument and result carry the
-// polarity its signature gives them regardless of what made the member reachable.
-//
-// Folding a mutability-gated member into immut as well is the conservative choice. An
-// owned value can later be bound mutably, so a parameter that is inert only while the
-// reference stays immutable is not safe to treat as a phantom.
+// folded into both. A method value parameter is contravariant whether or not the holder can
+// mutate the instance, and a method return or getter is covariant either way.
 func inferBodyVariance(def *ClassDef) (immut, mut []Variance) {
 	immut = make([]Variance, len(def.TypeParams))
 	mut = make([]Variance, len(def.TypeParams))
@@ -230,18 +232,24 @@ func inferBodyVariance(def *ClassDef) (immut, mut []Variance) {
 	for i, tp := range def.TypeParams {
 		targets[tp.Var] = i
 	}
-	// shared records the occurrences both views agree on. write records the field-write
-	// occurrences only a mutable reference adds.
+	// shared records the occurrences both views agree on. gated records the occurrences
+	// only a mutable reference can reach, which mut folds in and immut does not.
 	shared := newVarianceVisitor(targets, len(def.TypeParams))
-	write := newVarianceVisitor(targets, len(def.TypeParams))
+	gated := newVarianceVisitor(targets, len(def.TypeParams))
 	if def.Body != nil {
 		for _, elem := range def.Body.Elems {
-			soltype.AcceptObjElem(stripSelfReceiver(elem), shared, soltype.Positive)
+			shareable, mutOnly := splitByReceiverMut(elem)
+			if shareable != nil {
+				soltype.AcceptObjElem(shareable, shared, soltype.Positive)
+			}
+			if mutOnly != nil {
+				soltype.AcceptObjElem(mutOnly, gated, soltype.Positive)
+			}
 			if prop, ok := elem.(*soltype.PropertyElem); ok && !prop.Readonly {
 				// Walking the same field again at Negative records the input position
 				// `obj.f = …` occupies. A `readonly` field rejects that write, so it is
 				// skipped here and contributes only its output position to both vectors.
-				soltype.AcceptObjElem(prop, write, soltype.Negative)
+				soltype.AcceptObjElem(prop, gated, soltype.Negative)
 			}
 		}
 	}
@@ -254,7 +262,7 @@ func inferBodyVariance(def *ClassDef) (immut, mut []Variance) {
 	}
 	for i := range def.TypeParams {
 		immut[i] = collapseVariance(shared.pos[i], shared.neg[i])
-		mut[i] = collapseVariance(shared.pos[i] || write.pos[i], shared.neg[i] || write.neg[i])
+		mut[i] = collapseVariance(shared.pos[i] || gated.pos[i], shared.neg[i] || gated.neg[i])
 	}
 	return immut, mut
 }
@@ -272,6 +280,59 @@ func collapseVariance(pos, neg bool) Variance {
 	default:
 		return Bivariant
 	}
+}
+
+// splitByReceiverMut divides a class member into the part an immutable reference can
+// reach and the part only a mutable one can, each returned with its `self` receiver
+// stripped for the variance walk. Either half is nil when the member contributes nothing
+// to that view.
+//
+// A setter is a write, so no immutable reference reaches it. A method is split per
+// signature, since `find(self, …)` and `push(mut self, …)` on one name are reachable
+// under different views and an overload set may hold both. Every other member is readable
+// through either view and goes to the immutable half whole.
+func splitByReceiverMut(elem soltype.ObjTypeElem) (shareable, mutOnly soltype.ObjTypeElem) {
+	switch e := elem.(type) {
+	case *soltype.SetterElem:
+		return nil, stripSelfReceiver(e)
+	case *soltype.GetterElem:
+		if mutReceiver(e.SelfParam) {
+			return nil, stripSelfReceiver(e)
+		}
+		return stripSelfReceiver(e), nil
+	case *soltype.MethodElem:
+		var open, gated []*soltype.FuncType
+		for _, sig := range e.Signatures {
+			bare := *sig
+			bare.SelfParam = nil
+			if mutReceiver(sig.SelfParam) {
+				gated = append(gated, &bare)
+				continue
+			}
+			open = append(open, &bare)
+		}
+		if len(open) > 0 {
+			shareable = &soltype.MethodElem{Name: e.Name, Signatures: open, Static: e.Static}
+		}
+		if len(gated) > 0 {
+			mutOnly = &soltype.MethodElem{Name: e.Name, Signatures: gated, Static: e.Static}
+		}
+		return shareable, mutOnly
+	default:
+		return stripSelfReceiver(elem), nil
+	}
+}
+
+// mutReceiver reports whether a member's `self` receiver demands mutable access, which is
+// what makes the member unreachable through an immutable reference. Both `mut self` and
+// `&mut self` desugar to a mutable RefType over the class; a plain `self` or `&self` does
+// not, and a nil receiver is a static member or a plain function.
+func mutReceiver(self *soltype.FuncParam) bool {
+	if self == nil {
+		return false
+	}
+	ref, isRef := self.Type.(*soltype.RefType)
+	return isRef && ref.Mut
 }
 
 // stripSelfReceiver returns a copy of a class-body member with its `self` receiver

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -232,25 +232,25 @@ func inferBodyVariance(def *ClassDef) (immut, mut []Variance) {
 	for i, tp := range def.TypeParams {
 		targets[tp.Var] = i
 	}
-	// anyRef records the occurrences any reference reaches, which both vectors fold in.
-	// mutRef records the ones only a mutable reference reaches, which mut folds in and
-	// immut does not.
-	anyRef := newVarianceVisitor(targets, len(def.TypeParams))
-	mutRef := newVarianceVisitor(targets, len(def.TypeParams))
+	// immutRef records the occurrences an immutable reference reaches, which is the
+	// immutable view whole and the base the mutable one builds on. mutOnlyRef records
+	// what a mutable reference adds to that, which is why mut is the union of the two.
+	immutRef := newVarianceVisitor(targets, len(def.TypeParams))
+	mutOnlyRef := newVarianceVisitor(targets, len(def.TypeParams))
 	if def.Body != nil {
 		for _, elem := range def.Body.Elems {
-			anyPart, mutPart := splitByReceiverMut(elem)
-			if anyPart != nil {
-				soltype.AcceptObjElem(anyPart, anyRef, soltype.Positive)
+			immutPart, mutOnlyPart := splitByReceiverMut(elem)
+			if immutPart != nil {
+				soltype.AcceptObjElem(immutPart, immutRef, soltype.Positive)
 			}
-			if mutPart != nil {
-				soltype.AcceptObjElem(mutPart, mutRef, soltype.Positive)
+			if mutOnlyPart != nil {
+				soltype.AcceptObjElem(mutOnlyPart, mutOnlyRef, soltype.Positive)
 			}
 			if prop, ok := elem.(*soltype.PropertyElem); ok && !prop.Readonly {
 				// Walking the same field again at Negative records the input position
 				// `obj.f = …` occupies. A `readonly` field rejects that write, so it is
 				// skipped here and contributes only its output position to both vectors.
-				soltype.AcceptObjElem(prop, mutRef, soltype.Negative)
+				soltype.AcceptObjElem(prop, mutOnlyRef, soltype.Negative)
 			}
 		}
 	}
@@ -258,12 +258,15 @@ func inferBodyVariance(def *ClassDef) (immut, mut []Variance) {
 	// collapses to invariant — the sound conservative choice while inheritance variance is
 	// not composed precisely. Walking each super once per polarity records both.
 	for _, super := range def.Supers {
-		super.Accept(anyRef, soltype.Positive)
-		super.Accept(anyRef, soltype.Negative)
+		super.Accept(immutRef, soltype.Positive)
+		super.Accept(immutRef, soltype.Negative)
 	}
 	for i := range def.TypeParams {
-		immut[i] = collapseVariance(anyRef.pos[i], anyRef.neg[i])
-		mut[i] = collapseVariance(anyRef.pos[i] || mutRef.pos[i], anyRef.neg[i] || mutRef.neg[i])
+		immut[i] = collapseVariance(immutRef.pos[i], immutRef.neg[i])
+		mut[i] = collapseVariance(
+			immutRef.pos[i] || mutOnlyRef.pos[i],
+			immutRef.neg[i] || mutOnlyRef.neg[i],
+		)
 	}
 	return immut, mut
 }
@@ -283,15 +286,16 @@ func collapseVariance(pos, neg bool) Variance {
 	}
 }
 
-// splitByReceiverMut divides a class member into the part any reference can reach and
-// the part only a mutable one can, each returned with its `self` receiver stripped for
-// the variance walk. Either half is nil when the member contributes nothing to that view.
+// splitByReceiverMut divides a class member into the part an immutable reference can
+// reach and the part only a mutable one can, each returned with its `self` receiver
+// stripped for the variance walk. Either half is nil when the member contributes nothing
+// to that view.
 //
 // A setter is a write, so only a mutable reference reaches it. A method is split per
 // signature, since `find(self, …)` and `push(mut self, …)` on one name demand different
 // receivers and an overload set may hold both. Every other member is readable through
-// either view and goes to the any-reference half whole.
-func splitByReceiverMut(elem soltype.ObjTypeElem) (anyPart, mutPart soltype.ObjTypeElem) {
+// either view and goes to the immutable half whole.
+func splitByReceiverMut(elem soltype.ObjTypeElem) (immutPart, mutOnlyPart soltype.ObjTypeElem) {
 	switch e := elem.(type) {
 	case *soltype.SetterElem:
 		return nil, stripSelfReceiver(e)
@@ -301,23 +305,23 @@ func splitByReceiverMut(elem soltype.ObjTypeElem) (anyPart, mutPart soltype.ObjT
 		}
 		return stripSelfReceiver(e), nil
 	case *soltype.MethodElem:
-		var anySigs, mutSigs []*soltype.FuncType
+		var immutSigs, mutOnlySigs []*soltype.FuncType
 		for _, sig := range e.Signatures {
 			bare := *sig
 			bare.SelfParam = nil
 			if mutReceiver(sig.SelfParam) {
-				mutSigs = append(mutSigs, &bare)
+				mutOnlySigs = append(mutOnlySigs, &bare)
 				continue
 			}
-			anySigs = append(anySigs, &bare)
+			immutSigs = append(immutSigs, &bare)
 		}
-		if len(anySigs) > 0 {
-			anyPart = &soltype.MethodElem{Name: e.Name, Signatures: anySigs, Static: e.Static}
+		if len(immutSigs) > 0 {
+			immutPart = &soltype.MethodElem{Name: e.Name, Signatures: immutSigs, Static: e.Static}
 		}
-		if len(mutSigs) > 0 {
-			mutPart = &soltype.MethodElem{Name: e.Name, Signatures: mutSigs, Static: e.Static}
+		if len(mutOnlySigs) > 0 {
+			mutOnlyPart = &soltype.MethodElem{Name: e.Name, Signatures: mutOnlySigs, Static: e.Static}
 		}
-		return anyPart, mutPart
+		return immutPart, mutOnlyPart
 	default:
 		return stripSelfReceiver(elem), nil
 	}

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -212,7 +212,7 @@ func modifierVariance(m ast.VarianceModifier) (Variance, bool) {
 // position and its `push(mut self, item: T)` puts T in an input position. Folding both into
 // immut would measure T invariant and leave `Array<1> <: Array<number>` rejected. Reading
 // `push` only where it can be called measures T covariant in immut and invariant in mut, so
-// the widening holds for a shared array while `mut Array<1>` and `mut Array<number>` stay
+// the widening holds for an immutable array while `mut Array<1>` and `mut Array<number>` stay
 // unrelated.
 //
 // A field is the same shape of split. Its read is an output position in both views, its
@@ -232,24 +232,25 @@ func inferBodyVariance(def *ClassDef) (immut, mut []Variance) {
 	for i, tp := range def.TypeParams {
 		targets[tp.Var] = i
 	}
-	// shared records the occurrences both views agree on. gated records the occurrences
-	// only a mutable reference can reach, which mut folds in and immut does not.
-	shared := newVarianceVisitor(targets, len(def.TypeParams))
-	gated := newVarianceVisitor(targets, len(def.TypeParams))
+	// anyRef records the occurrences any reference reaches, which both vectors fold in.
+	// mutRef records the ones only a mutable reference reaches, which mut folds in and
+	// immut does not.
+	anyRef := newVarianceVisitor(targets, len(def.TypeParams))
+	mutRef := newVarianceVisitor(targets, len(def.TypeParams))
 	if def.Body != nil {
 		for _, elem := range def.Body.Elems {
-			shareable, mutOnly := splitByReceiverMut(elem)
-			if shareable != nil {
-				soltype.AcceptObjElem(shareable, shared, soltype.Positive)
+			anyPart, mutPart := splitByReceiverMut(elem)
+			if anyPart != nil {
+				soltype.AcceptObjElem(anyPart, anyRef, soltype.Positive)
 			}
-			if mutOnly != nil {
-				soltype.AcceptObjElem(mutOnly, gated, soltype.Positive)
+			if mutPart != nil {
+				soltype.AcceptObjElem(mutPart, mutRef, soltype.Positive)
 			}
 			if prop, ok := elem.(*soltype.PropertyElem); ok && !prop.Readonly {
 				// Walking the same field again at Negative records the input position
 				// `obj.f = …` occupies. A `readonly` field rejects that write, so it is
 				// skipped here and contributes only its output position to both vectors.
-				soltype.AcceptObjElem(prop, gated, soltype.Negative)
+				soltype.AcceptObjElem(prop, mutRef, soltype.Negative)
 			}
 		}
 	}
@@ -257,12 +258,12 @@ func inferBodyVariance(def *ClassDef) (immut, mut []Variance) {
 	// collapses to invariant — the sound conservative choice while inheritance variance is
 	// not composed precisely. Walking each super once per polarity records both.
 	for _, super := range def.Supers {
-		super.Accept(shared, soltype.Positive)
-		super.Accept(shared, soltype.Negative)
+		super.Accept(anyRef, soltype.Positive)
+		super.Accept(anyRef, soltype.Negative)
 	}
 	for i := range def.TypeParams {
-		immut[i] = collapseVariance(shared.pos[i], shared.neg[i])
-		mut[i] = collapseVariance(shared.pos[i] || gated.pos[i], shared.neg[i] || gated.neg[i])
+		immut[i] = collapseVariance(anyRef.pos[i], anyRef.neg[i])
+		mut[i] = collapseVariance(anyRef.pos[i] || mutRef.pos[i], anyRef.neg[i] || mutRef.neg[i])
 	}
 	return immut, mut
 }
@@ -282,16 +283,15 @@ func collapseVariance(pos, neg bool) Variance {
 	}
 }
 
-// splitByReceiverMut divides a class member into the part an immutable reference can
-// reach and the part only a mutable one can, each returned with its `self` receiver
-// stripped for the variance walk. Either half is nil when the member contributes nothing
-// to that view.
+// splitByReceiverMut divides a class member into the part any reference can reach and
+// the part only a mutable one can, each returned with its `self` receiver stripped for
+// the variance walk. Either half is nil when the member contributes nothing to that view.
 //
-// A setter is a write, so no immutable reference reaches it. A method is split per
-// signature, since `find(self, …)` and `push(mut self, …)` on one name are reachable
-// under different views and an overload set may hold both. Every other member is readable
-// through either view and goes to the immutable half whole.
-func splitByReceiverMut(elem soltype.ObjTypeElem) (shareable, mutOnly soltype.ObjTypeElem) {
+// A setter is a write, so only a mutable reference reaches it. A method is split per
+// signature, since `find(self, …)` and `push(mut self, …)` on one name demand different
+// receivers and an overload set may hold both. Every other member is readable through
+// either view and goes to the any-reference half whole.
+func splitByReceiverMut(elem soltype.ObjTypeElem) (anyPart, mutPart soltype.ObjTypeElem) {
 	switch e := elem.(type) {
 	case *soltype.SetterElem:
 		return nil, stripSelfReceiver(e)
@@ -301,23 +301,23 @@ func splitByReceiverMut(elem soltype.ObjTypeElem) (shareable, mutOnly soltype.Ob
 		}
 		return stripSelfReceiver(e), nil
 	case *soltype.MethodElem:
-		var open, gated []*soltype.FuncType
+		var anySigs, mutSigs []*soltype.FuncType
 		for _, sig := range e.Signatures {
 			bare := *sig
 			bare.SelfParam = nil
 			if mutReceiver(sig.SelfParam) {
-				gated = append(gated, &bare)
+				mutSigs = append(mutSigs, &bare)
 				continue
 			}
-			open = append(open, &bare)
+			anySigs = append(anySigs, &bare)
 		}
-		if len(open) > 0 {
-			shareable = &soltype.MethodElem{Name: e.Name, Signatures: open, Static: e.Static}
+		if len(anySigs) > 0 {
+			anyPart = &soltype.MethodElem{Name: e.Name, Signatures: anySigs, Static: e.Static}
 		}
-		if len(gated) > 0 {
-			mutOnly = &soltype.MethodElem{Name: e.Name, Signatures: gated, Static: e.Static}
+		if len(mutSigs) > 0 {
+			mutPart = &soltype.MethodElem{Name: e.Name, Signatures: mutSigs, Static: e.Static}
 		}
-		return shareable, mutOnly
+		return anyPart, mutPart
 	default:
 		return stripSelfReceiver(elem), nil
 	}

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -201,12 +201,12 @@ func modifierVariance(m ast.VarianceModifier) (Variance, bool) {
 // It returns two vectors, one per view a reference to an instance can offer. immut is the
 // variance an immutable reference sees, which reaches only the members such a reference
 // can use. mut is the variance a mutable reference sees, which additionally admits a write
-// to every non-`readonly` field and every member gated on a mutable receiver.
+// to every non-`readonly` field and every member that demands a mutable receiver.
 //
 // A member an immutable reference cannot reach says nothing about the immutable view, so
-// it is walked into mut alone. Three members are gated that way: a write to a non-
-// `readonly` field, a setter, and a `mut self` method. An overloaded method is split per
-// signature, since one arm taking `mut self` does not gate the arms that do not.
+// it is walked into mut alone. Three members demand a mutable receiver: a write to a
+// non-`readonly` field, a setter, and a `mut self` method. An overloaded method is split
+// per signature, since one arm taking `mut self` says nothing about the arms that do not.
 //
 // `Array<T>` is what this buys. Its `at(self, index) -> T | undefined` puts T in an output
 // position and its `push(mut self, item: T)` puts T in an input position. Folding both into

--- a/internal/solver/classes_test.go
+++ b/internal/solver/classes_test.go
@@ -112,8 +112,9 @@ func TestConstrainNominalArgVariance(t *testing.T) {
 // invariant.
 //
 // Each case asserts both measured vectors. want is the immutable view and wantMut the
-// mutable view, and they differ only where a non-`readonly` field's write view adds an
-// input position the immutable view does not have.
+// mutable view, and they differ where a member an immutable reference cannot reach adds a
+// position only the mutable view has: a non-`readonly` field's write, a setter, and a
+// `mut self` method.
 func TestInferBodyVariance(t *testing.T) {
 	// selfMethod builds a method whose receiver is the class instance at its own type
 	// parameter, plus one value parameter and a return, so the walk sees a genuine `self`
@@ -143,6 +144,18 @@ func TestInferBodyVariance(t *testing.T) {
 	// view never reaches the mutable-view vector.
 	readonlyProp := func(name string, t soltype.Type) *soltype.PropertyElem {
 		return &soltype.PropertyElem{Name: name, Type: t, Readonly: true}
+	}
+	// mutSelfMethod builds a `mut self` method, which only a mutable reference reaches.
+	// The receiver is a mutable borrow of the class instance, the shape `mut self`
+	// desugars to.
+	mutSelfMethod := func(name, cls string, tv *soltype.TypeVarType, param soltype.Type) *soltype.MethodElem {
+		self := mutRef(&soltype.ClassType{Name: cls, TypeArgs: []soltype.Type{tv}})
+		sig := &soltype.FuncType{
+			SelfParam: &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}, Type: self},
+			Params:    []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: param}},
+			Ret:       &soltype.UndefinedType{},
+		}
+		return &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}}
 	}
 	tests := []struct {
 		name    string
@@ -222,6 +235,59 @@ func TestInferBodyVariance(t *testing.T) {
 			}),
 			want:    []Variance{Bivariant},
 			wantMut: []Variance{Bivariant},
+		},
+		{
+			// The shape `Array<T>` has. `at(self, index) -> T | undefined` is an output
+			// position both views reach, and `push(mut self, item: T)` an input position
+			// only a mutable reference reaches. Folding the mutator into both views would
+			// measure T invariant and leave `Array<1> <: Array<number>` rejected.
+			name: "a mut self parameter drags a covariant return to invariant under mut only",
+			def: oneParam(func(tv *soltype.TypeVarType) (*soltype.ObjectType, []*soltype.ClassType) {
+				return exactObj(
+					selfMethod("at", "Array", tv, num(), tv),
+					mutSelfMethod("push", "Array", tv, tv),
+				), nil
+			}),
+			want:    []Variance{Covariant},
+			wantMut: []Variance{Invariant},
+		},
+		{
+			// One name may hold arms taking different receivers, so the split is per
+			// signature. The `self` arm returns T and the `mut self` arm consumes it.
+			name: "an overload set splits its arms by receiver",
+			def: oneParam(func(tv *soltype.TypeVarType) (*soltype.ObjectType, []*soltype.ClassType) {
+				read := selfMethod("slot", "Cell", tv, num(), tv)
+				write := mutSelfMethod("slot", "Cell", tv, tv)
+				return exactObj(&soltype.MethodElem{
+					Name:       read.Name,
+					Signatures: []*soltype.FuncType{read.Signatures[0], write.Signatures[0]},
+				}), nil
+			}),
+			want:    []Variance{Covariant},
+			wantMut: []Variance{Invariant},
+		},
+		{
+			// A setter is a write, so no immutable reference reaches it. A getter is a read
+			// and both views do.
+			name: "a setter is an input position only the mutable view has",
+			def: oneParam(func(tv *soltype.TypeVarType) (*soltype.ObjectType, []*soltype.ClassType) {
+				return exactObj(
+					&soltype.GetterElem{Name: "value", Type: tv},
+					&soltype.SetterElem{Name: "value", Param: tv},
+				), nil
+			}),
+			want:    []Variance{Covariant},
+			wantMut: []Variance{Invariant},
+		},
+		{
+			// A parameter reachable only through a mutator is inert in the immutable view,
+			// which reads as bivariant. Nothing an immutable reference can call names it.
+			name: "a parameter only a mut self method names is bivariant in the immutable view",
+			def: oneParam(func(tv *soltype.TypeVarType) (*soltype.ObjectType, []*soltype.ClassType) {
+				return exactObj(mutSelfMethod("push", "Sink", tv, tv)), nil
+			}),
+			want:    []Variance{Bivariant},
+			wantMut: []Variance{Contravariant},
 		},
 		{
 			name: "parameter reaching a super is invariant",

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1471,9 +1471,6 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 			return false
 		}
 		return equalTypeSliceWith(a.TypeArgs, b.TypeArgs, ctx)
-	case *soltype.ArrayType:
-		b, ok := b.(*soltype.ArrayType)
-		return ok && equalTypeWith(a.Elem, b.Elem, ctx)
 	case *soltype.PromiseType:
 		b, ok := b.(*soltype.PromiseType)
 		// ErrOrNever reads both sides through the nil-is-never collapse, so two promises

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -862,11 +862,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			// positions use. A written tuple never reaches here, expandTupleRest having split it.
 			absorbAt, absorbElem := -1, soltype.Type(nil)
 			if k := restIndex(supX); k >= 0 && canAbsorbRest(subX, k) {
-				switch slot := supX.Params[k].Type.(type) {
-				case *soltype.TypeVarType:
+				slot := supX.Params[k].Type
+				if _, isVar := slot.(*soltype.TypeVarType); isVar {
 					absorbAt = k
-				case *soltype.ArrayType:
-					absorbAt, absorbElem = k, slot.Elem
+				} else if elem, isArray := c.arrayElem(slot); isArray {
+					absorbAt, absorbElem = k, elem
 				}
 			}
 			var errs []SolverError
@@ -923,8 +923,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			scatterAt, scatterElem := -1, soltype.Type(nil)
 			if absorbAt < 0 && !hasRest(supX) {
 				if j := restIndex(subX); j >= 0 {
-					if arr, ok := subX.Params[j].Type.(*soltype.ArrayType); ok {
-						scatterAt, scatterElem = j, arr.Elem
+					if elem, isArray := c.arrayElem(subX.Params[j].Type); isArray {
+						scatterAt, scatterElem = j, elem
 						n = min(j, len(supX.Params))
 					}
 				}
@@ -1210,14 +1210,6 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			return c.constrain(body, sup, seen, mutCtx)
 		}
 		// A ClassType against any other concrete falls through to the var arms below.
-	case *soltype.ArrayType:
-		if sup, ok := super.(*soltype.ArrayType); ok {
-			// ArrayType is covariant in its Elem: Array<L> <: Array<R> iff L <: R. That is the
-			// read-only reading, which is what a rest parameter needs, since the callee only
-			// reads the arguments it gathers. An array's element is its own annotation context,
-			// so the deep-mut flag resets.
-			return c.constrain(sub.Elem, sup.Elem, seen, false)
-		}
 	case *soltype.PromiseType:
 		if sup, ok := super.(*soltype.PromiseType); ok {
 			// PromiseType is covariant in its Inner: Promise<L> <: Promise<R> iff

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -365,6 +365,11 @@ func TestConstrainRestParamElementChecking(t *testing.T) {
 	// An absorbing rest stands for the sub's whole tail, so each parameter it absorbs is
 	// checked against the element. The check is contravariant, the orientation the fixed
 	// positions use, so the element is the sub of each pair.
+	//
+	//	fn (a: number, b: string) -> number  <:  fn (...rest: Array<number>) -> number
+	//
+	// `b`'s string is what the rest absorbs at its second position, and `number <: string`
+	// is the check that fails.
 	t.Run("an absorbed parameter is rejected on the element", func(t *testing.T) {
 		c := arrayCtx()
 		super := restFn(num(), restParam("rest", arrayOf(num())))
@@ -374,6 +379,7 @@ func TestConstrainRestParamElementChecking(t *testing.T) {
 			Messages(c.Constrain(sub, super)))
 	})
 
+	//	fn (a: number, b: number) -> number  <:  fn (...rest: Array<number>) -> number
 	t.Run("an absorbed parameter matching the element is accepted", func(t *testing.T) {
 		c := arrayCtx()
 		super := restFn(num(), restParam("rest", arrayOf(num())))
@@ -383,6 +389,11 @@ func TestConstrainRestParamElementChecking(t *testing.T) {
 
 	// The named prefix ahead of the rest keeps its own positional check, so absorbing the
 	// tail does not loosen the parameters the super declares by position.
+	//
+	//	fn (a: number, b: number) -> number  <:  fn (a: string, ...rest: Array<number>) -> number
+	//
+	// The rest absorbs `b` and accepts it. Position `a` is checked on its own, and
+	// `string <: number` is what fails.
 	t.Run("the prefix ahead of the rest is still checked by position", func(t *testing.T) {
 		c := arrayCtx()
 		super := restFn(num(), identParam("a", str()), restParam("rest", arrayOf(num())))
@@ -395,6 +406,12 @@ func TestConstrainRestParamElementChecking(t *testing.T) {
 	// A Context that recognizes no array reads the same slot as an ordinary parameter
 	// type, so no element check fires and only the arity gate applies. This is what a run
 	// without a stdlib sees.
+	//
+	//	fn (a: number, b: string) -> number  <:  fn (...rest: Array<number>) -> number
+	//
+	// The same pair as the first case. Without an `Array` to recognize, the rest declares
+	// no element, so the two parameters are never checked and the arity gate rejects the
+	// pair on its own.
 	t.Run("an unrecognized array slot is not an element check", func(t *testing.T) {
 		c := &Context{}
 		super := restFn(num(), restParam("rest", arrayOf(num())))

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -320,10 +320,10 @@ func TestConstrainFunctionRestParam(t *testing.T) {
 	})
 
 	// A rest fn and an inexact fn have the same ∞ upper bound, so a rest fn fills an
-	// inexact callback parameter of matching required arity. Rest params are
-	// arity-only until M7, so the trailing element type is not checked here. The
-	// element check against `Array<T>` lands with M7, exercised by
-	// TestConstrainRestParamElementChecking.
+	// inexact callback parameter of matching required arity. The rest slot here is a
+	// bare `number` rather than an array, so nothing declares an element and the check
+	// is arity-only. TestConstrainRestParamElementChecking covers the array slot, where
+	// each absorbed argument is checked against the element.
 	t.Run("rest fn fills an inexact callback parameter", func(t *testing.T) {
 		c := &Context{}
 		g := restFn(num(), identParam("a", num()), restParam("rest", num()))
@@ -344,60 +344,65 @@ func TestConstrainFunctionRestParam(t *testing.T) {
 	})
 }
 
-// DISABLED until M7: rest-param element checking needs Array<T>, which the solver
-// gains in M7 (library type resolution). A typed rest param is written
-// `...rest: Array<T>`, and each trailing argument is checked against the element
-// type T. Until then rest params are arity-only and the element type is unchecked,
-// so the inexact-callback fill above succeeds regardless of the rest type. When M7
-// lands, build the rest type as Array<T>, teach the FuncType arm to read its
-// element, and remove the /* */ wrapper.
+// A typed rest parameter is written `...rest: Array<T>`, and each argument it stands
+// for is checked against the element T. This is what the element-carrying array buys
+// over an arity-only rest, and it is the behavior #677 gave the retired concrete.
+//
+// The cases build the check directly on Context, with no module to infer, so `Array` is
+// named rather than resolved: arrayClass is the name the rules compare against, and any
+// name serves as long as both sides agree.
 func TestConstrainRestParamElementChecking(t *testing.T) {
-	/*
-		restFn := func(ret soltype.Type, params ...*soltype.FuncParam) *soltype.FuncType {
-			return &soltype.FuncType{Params: params, Ret: ret}
-		}
+	// restFn is a rest-bearing function, exact in its accept-set the way a written one is.
+	restFn := func(ret soltype.Type, params ...*soltype.FuncParam) *soltype.FuncType {
+		return &soltype.FuncType{Params: params, Ret: ret}
+	}
+	// arrayCtx is a Context that recognizes arrayOf's instances as arrays.
+	arrayCtx := func() *Context { return &Context{arrayClass: "Array"} }
+	arrayOf := func(elem soltype.Type) soltype.Type {
+		return &soltype.ClassType{Name: "Array", TypeArgs: []soltype.Type{elem}}
+	}
 
-		// An inexact super's tail passes unknown-typed arguments, so a sub whose rest
-		// absorbs them must accept unknown at the element type. `...rest: Array<number>`
-		// is rejected, since unknown is not a subtype of number.
-		t.Run("number rest is rejected by an inexact callback parameter", func(t *testing.T) {
-			c := &Context{}
-			g := restFn(num(), identParam("a", num()), restParam("rest", arrayOf(num())))
-			f := inexactFn(num(), identParam("a", num()))
-			require.Equal(t,
-				[]string{"cannot constrain unknown <: number"},
-				Messages(c.Constrain(g, f)))
-		})
+	// An absorbing rest stands for the sub's whole tail, so each parameter it absorbs is
+	// checked against the element. The check is contravariant, the orientation the fixed
+	// positions use, so the element is the sub of each pair.
+	t.Run("an absorbed parameter is rejected on the element", func(t *testing.T) {
+		c := arrayCtx()
+		super := restFn(num(), restParam("rest", arrayOf(num())))
+		sub := exactFn(num(), identParam("a", num()), identParam("b", str()))
+		require.Equal(t,
+			[]string{"cannot constrain number <: string"},
+			Messages(c.Constrain(sub, super)))
+	})
 
-		// `...rest: Array<unknown>` accepts the unknown-typed tail, since unknown is a
-		// subtype of unknown.
-		t.Run("unknown rest fills an inexact callback parameter", func(t *testing.T) {
-			c := &Context{}
-			g := restFn(num(), identParam("a", num()), restParam("rest", arrayOf(&soltype.UnknownType{})))
-			f := inexactFn(num(), identParam("a", num()))
-			require.Empty(t, c.Constrain(g, f))
-		})
+	t.Run("an absorbed parameter matching the element is accepted", func(t *testing.T) {
+		c := arrayCtx()
+		super := restFn(num(), restParam("rest", arrayOf(num())))
+		sub := exactFn(num(), identParam("a", num()), identParam("b", num()))
+		require.Empty(t, c.Constrain(sub, super))
+	})
 
-		// A callback parameter with a typed rest passes its element type at every
-		// position past its named params. fn(a: number, ...rest: Array<string>) passes a
-		// string there, so a sub whose surplus param is number is rejected and one whose
-		// surplus param is string is accepted.
-		t.Run("typed-rest callback parameter rejects a mismatched surplus param", func(t *testing.T) {
-			c := &Context{}
-			super := restFn(num(), identParam("a", num()), restParam("rest", arrayOf(str())))
-			sub := inexactFn(num(), identParam("a", num()), optParam("b", str()), optParam("c", num()))
-			require.Equal(t,
-				[]string{"cannot constrain string <: number"},
-				Messages(c.Constrain(sub, super)))
-		})
+	// The named prefix ahead of the rest keeps its own positional check, so absorbing the
+	// tail does not loosen the parameters the super declares by position.
+	t.Run("the prefix ahead of the rest is still checked by position", func(t *testing.T) {
+		c := arrayCtx()
+		super := restFn(num(), identParam("a", str()), restParam("rest", arrayOf(num())))
+		sub := exactFn(num(), identParam("a", num()), identParam("b", num()))
+		require.Equal(t,
+			[]string{"cannot constrain string <: number"},
+			Messages(c.Constrain(sub, super)))
+	})
 
-		t.Run("typed-rest callback parameter accepts a matching surplus param", func(t *testing.T) {
-			c := &Context{}
-			super := restFn(num(), identParam("a", num()), restParam("rest", arrayOf(str())))
-			sub := inexactFn(num(), identParam("a", num()), optParam("b", str()), optParam("c", str()))
-			require.Empty(t, c.Constrain(sub, super))
-		})
-	*/
+	// A Context that recognizes no array reads the same slot as an ordinary parameter
+	// type, so no element check fires and only the arity gate applies. This is what a run
+	// without a stdlib sees.
+	t.Run("an unrecognized array slot is not an element check", func(t *testing.T) {
+		c := &Context{}
+		super := restFn(num(), restParam("rest", arrayOf(num())))
+		sub := exactFn(num(), identParam("a", num()), identParam("b", str()))
+		require.Equal(t,
+			[]string{"cannot constrain function of arity 2 <: function of arity 0 or more"},
+			Messages(c.Constrain(sub, super)))
+	})
 }
 
 func TestConstrainTuple(t *testing.T) {

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -29,6 +29,14 @@ type Context struct {
 	// the diagnostic to one per run. well_known.go holds the closed set.
 	wellKnown map[wellKnownName]soltype.Type
 
+	// arrayClass is the qualified class name the well-known `Array` binds to, read
+	// off the handle once per run. The subtyping and iteration rules that single an
+	// array out compare against it, so they cost a string comparison rather than a
+	// package load and answer the same inside a speculation trial as outside one.
+	// It is empty when the run resolved no `Array`, in which case no type in play is
+	// one and every such rule declines.
+	arrayClass string
+
 	// lifetimeCounter mints the next LifetimeVar id (M4 D1). Lifetimes are a
 	// SECOND bounded sort solved by the same machinery as types: a fresh lifetime
 	// gets the next id here, its bounds are extended only through

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -2855,8 +2855,6 @@ func describe(t soltype.Type) string {
 		// diagnostic naming it matches the printer's surface form rather than the expanded
 		// body the constraint actually compares.
 		return soltype.PrintElided(t, describeMaxDepth)
-	case *soltype.ArrayType:
-		return "Array<" + describe(t.Elem) + ">"
 	case *soltype.PromiseType:
 		// Rendered STRUCTURALLY (Promise<inner>), unlike the nominal function/tuple/
 		// object above. That is deliberate and consistent with the Union/Intersection

--- a/internal/solver/generalize_generic_func_test.go
+++ b/internal/solver/generalize_generic_func_test.go
@@ -87,7 +87,7 @@ func TestGeneralizeRetainsFuncTypeParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newChecker()
+			c := newTestChecker()
 			fn := tt.build(func() *soltype.TypeVarType { return c.freshAt(1) })
 			// Model the value-binding path: the SCC driver constrains the function value
 			// into a binding var, then generalizes that var at the component's level.
@@ -104,7 +104,7 @@ func TestGeneralizeRetainsFuncTypeParams(t *testing.T) {
 // funcTypeParamVars descends a binding var's bound side-graph to reach the value
 // FuncType, collecting a type parameter that is not a structural child of the var.
 func TestFuncTypeParamVarsDescendsBoundGraph(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	vT := c.freshAt(1)
 	fn := &soltype.FuncType{
 		TypeParams: []*soltype.TypeParam{{Name: "T", Var: vT}},

--- a/internal/solver/infer_alias_lifetime_test.go
+++ b/internal/solver/infer_alias_lifetime_test.go
@@ -54,7 +54,7 @@ func TestInferAliasInferredBorrowElidesLifetime(t *testing.T) {
 // borrow at the concrete argument the reference supplies. The parser does not yet bind a
 // lifetime parameter on a `type` declaration, so the def is built directly.
 func TestExpandAliasSubstitutesLifetimeArg(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	param := &soltype.LifetimeVar{ID: 0, Level: 1}
 	body := &soltype.RefType{Mut: true, Lt: param, Inner: objT()}
 	c.ctx.registerAlias("Borrow", &AliasDef{

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -204,7 +204,7 @@ func TestInferAssignUnionTargetVarRHSWidensToUnion(t *testing.T) {
 // namespace declarations are themselves unsupported in M3, so a namespace never
 // enters scope via real source — same construction as TestInferIdentNamespaceUsedAsValue.
 func TestInferAssignNamespaceTarget(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineNamespace("Foo", &Namespace{Name: "Foo"})
 	e := ast.NewBinary(identExpr("Foo"), numExpr(5), ast.Assign, testSpan())
@@ -250,7 +250,7 @@ func TestInferAssignImmutableWithBadRHSReportsBoth(t *testing.T) {
 // A malformed assignment node with a nil operand (hand-built; the real parser
 // substitutes ast.NewError) must not panic — it blames the whole expression.
 func TestInferAssignNilOperandDoesNotPanic(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	e := ast.NewBinary(nil, numExpr(5), ast.Assign, testSpan())
 	require.NotPanics(t, func() {
 		c.inferExpr(NewScope(), 0, e)

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -156,7 +156,7 @@ func TestInferAwaitOutsideAsyncBlamesEnclosingFn(t *testing.T) {
 // is nothing to mark `async`). Built directly so the awaited value resolves cleanly
 // and the only error is the await itself.
 func TestInferAwaitOutsideAsyncTopLevelNoRelated(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineValue("x", ValueBinding{Schemes: []TypeScheme{
 		monoScheme(&soltype.PromiseType{Inner: &soltype.PrimType{Prim: soltype.StrPrim}}),
@@ -324,7 +324,7 @@ func TestInferIfElseConditionMustBeBool(t *testing.T) {
 // external return is `Promise<undefined>`. Exercises the funcCtx collection of a
 // bare return.
 func TestInferAsyncBareReturnIsPromiseUndefined(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// async fn () { return }
 	e := ast.NewFuncExpr(nil, nil, nil, nil, nil, true,
 		block(returnStmt(nil)), testSpan())
@@ -338,7 +338,7 @@ func TestInferAsyncBareReturnIsPromiseUndefined(t *testing.T) {
 // same type, coalescing to plain `undefined` rather than a degenerate
 // `undefined | undefined` union.
 func TestInferFnMultipleBareReturnsCollapse(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn () { return; return; }
 	e := funcExpr(nil, nil, block(
 		returnStmt(nil),
@@ -354,7 +354,7 @@ func TestInferFnMultipleBareReturnsCollapse(t *testing.T) {
 // the inner fn ends, the outer's returns list holds only the outer's own
 // `return` of the inner fn — the inner's `return x` never leaks out.
 func TestInferNestedFnReturnsScoped(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn outer() { return fn (x: number) { return x } }
 	inner := funcExpr([]*ast.Param{param("x", numAnn())}, nil,
 		block(returnStmt(identExpr("x"))))

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1096,7 +1096,7 @@ func TestInferClassVariance(t *testing.T) {
 		require.Empty(t, errs)
 	})
 	t.Run("a field keeps the parameter covariant alongside a mut self reader", func(t *testing.T) {
-		// `take` is gated on a mutable receiver, but `slot` is not, and a field read is an
+		// `take` demands a mutable receiver, but `slot` does not, and a field read is an
 		// output position the immutable view has. So `T` is covariant rather than
 		// bivariant, and the narrowing this asks for is rejected. A `mut self` method can
 		// only hand back a `T` if the class holds one, and holding one is what puts `T` in

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1078,6 +1078,53 @@ func TestInferClassVariance(t *testing.T) {
 		require.Len(t, errs, 1)
 		require.Equal(t, "cannot constrain string <: number", errs[0].Message())
 	})
+	t.Run("a mut self parameter does not shape the immutable view", func(t *testing.T) {
+		// No immutable reference reaches `push`, so its parameter says nothing about how
+		// two `Sink` instances relate while shared. `T` is bivariant here: it reaches no
+		// member such a reference can use, which is what leaves both directions open.
+		//
+		// Nothing observable is widened. A parameter reachable only under a mutable
+		// receiver means the class declares no `T`-typed storage, so there is no read to
+		// come back at the wrong type. The case below adds one and the widening stops.
+		_, _, errs := inferSource(t, `
+			class Sink<T> {
+				push(mut self, item: T) -> undefined { return undefined },
+			}
+			fn widen(s: Sink<number>) -> Sink<number | string> { return s }
+			fn narrow(s: Sink<number | string>) -> Sink<number> { return s }
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("a field keeps the parameter covariant alongside a mut self reader", func(t *testing.T) {
+		// `take` is gated on a mutable receiver, but `slot` is not, and a field read is an
+		// output position the immutable view has. So `T` is covariant rather than
+		// bivariant, and the narrowing this asks for is rejected. A `mut self` method can
+		// only hand back a `T` if the class holds one, and holding one is what puts `T` in
+		// the immutable view.
+		_, _, errs := inferSource(t, `
+			class Cell<T> {
+				slot: T,
+				take(mut self) -> T { return self.slot },
+			}
+			fn narrow(c: Cell<number | string>) -> Cell<number> { return c }
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain string <: number", errs[0].Message())
+	})
+	t.Run("a self reader beside a mut self mutator stays covariant", func(t *testing.T) {
+		// The shape `Array<T>` has. `read` is an output position both views reach and
+		// `write` an input position only a mutable reference reaches, so the immutable
+		// view measures `T` covariant and the widening holds.
+		_, _, errs := inferSource(t, `
+			class Slot<T> {
+				value: T,
+				read(self) -> T { return self.value },
+				write(mut self, v: T) -> undefined { return undefined },
+			}
+			fn widen(s: Slot<number>) -> Slot<number | string> { return s }
+		`)
+		require.Empty(t, errs)
+	})
 }
 
 // TestInferClassCovariance demonstrates C2 covariance in the shapes that produce an
@@ -1294,6 +1341,73 @@ func TestInferClassMutVariance(t *testing.T) {
 			}
 			fn wide(r: mut Reader<number | string>) { }
 			fn narrow(r: mut Reader<number>) { wide(r) }
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("mut self method parameter is contravariant under mut", func(t *testing.T) {
+		// `push` is unreachable immutably, so it shapes the mutable view alone, where it is
+		// an input position like any method parameter. `narrow` can only call
+		// `push(<number>)`, and the instance behind it takes a `number | string`.
+		_, _, errs := inferSource(t, `
+			class Sink<T> {
+				push(mut self, item: T) -> undefined { return undefined },
+			}
+			fn narrow(s: mut Sink<number>) { }
+			fn wide(s: mut Sink<number | string>) { narrow(s) }
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("mut self method parameter rejects a widening", func(t *testing.T) {
+		// The other direction, which contravariance rejects: `wide` may call
+		// `push("s")`, and the instance's `number`-only `push` cannot take it.
+		_, _, errs := inferSource(t, `
+			class Sink<T> {
+				push(mut self, item: T) -> undefined { return undefined },
+			}
+			fn wide(s: mut Sink<number | string>) { }
+			fn narrow(s: mut Sink<number>) { wide(s) }
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain string <: number", errs[0].Message())
+	})
+	t.Run("a mut self mutator pins a parameter a self reader returns", func(t *testing.T) {
+		// The shape `Array<T>` has, and the reason it is covariant shared and invariant
+		// mutable. `read` is an output position both views have. `write` is an input
+		// position only the mutable view has, and it is what rejects the widening the
+		// immutable check accepts.
+		_, _, errs := inferSource(t, `
+			class Slot<T> {
+				value: T,
+				read(self) -> T { return self.value },
+				write(mut self, v: T) -> undefined { return undefined },
+			}
+			fn wide(s: mut Slot<number | string>) { }
+			fn narrow(s: mut Slot<number>) { wide(s) }
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain string <: number", errs[0].Message())
+	})
+	t.Run("a setter pins a parameter its getter returns", func(t *testing.T) {
+		// A setter is a write, so no immutable reference reaches it and it lands in the
+		// mutable view alone. The field is `readonly` and the getter is an output position,
+		// so the setter is the only input position here and the only thing that can reject
+		// this. The immutable case below is the same class, accepted.
+		const src = `
+			class Prop<T> {
+				readonly v: T,
+				get item(self) -> T { return self.v },
+				set item(mut self, x: T) { },
+			}
+		`
+		_, _, errs := inferSource(t, src+`
+			fn wide(p: mut Prop<number | string>) { }
+			fn narrow(p: mut Prop<number>) { wide(p) }
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain string <: number", errs[0].Message())
+
+		_, _, errs = inferSource(t, src+`
+			fn widen(p: Prop<number>) -> Prop<number | string> { return p }
 		`)
 		require.Empty(t, errs)
 	})

--- a/internal/solver/infer_declared_lifetime_bound_test.go
+++ b/internal/solver/infer_declared_lifetime_bound_test.go
@@ -147,7 +147,7 @@ func TestInferDeclaredTransitiveBoundSatisfied(t *testing.T) {
 // The check runs directly because current surface syntax does not put a lower-bound
 // 'static on a parameter lifetime. The store paths that would are deferred to M7.
 func TestCheckDeclaredBoundLowerBoundStaticNotForced(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	c.namedLifetimes = map[string]*soltype.LifetimeVar{"a": a, "b": b}

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -130,7 +130,7 @@ func TestInferCallRestCalleeArity(t *testing.T) {
 	}
 
 	t.Run("absorbs extra args (no too-many)", func(t *testing.T) {
-		c := newChecker()
+		c := newTestChecker()
 		scope := NewScope()
 		scope.defineValue("g", restCallee())
 		// g(1, 2, 3) — two args beyond the fixed param; the rest absorbs them.
@@ -140,7 +140,7 @@ func TestInferCallRestCalleeArity(t *testing.T) {
 	})
 
 	t.Run("still rejects too few (required fixed params)", func(t *testing.T) {
-		c := newChecker()
+		c := newTestChecker()
 		scope := NewScope()
 		scope.defineValue("g", restCallee())
 		// g() — zero args, but x is required (the rest may be empty, x may not).

--- a/internal/solver/infer_expr_test.go
+++ b/internal/solver/infer_expr_test.go
@@ -32,7 +32,7 @@ func TestInferLiteral(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newChecker()
+			c := newTestChecker()
 			e := ast.NewLitExpr(tt.lit)
 			got := c.inferExpr(NewScope(), 0, e)
 			require.Empty(t, c.errs)
@@ -46,7 +46,7 @@ func TestInferLiteral(t *testing.T) {
 // A literal kind with no soltype form, regex or bigint, is a subset miss rather than a
 // crash. Both wait on a soltype.Lit member of their own.
 func TestInferLiteralUnsupported(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	e := ast.NewLitExpr(ast.NewRegex("/a/", testSpan()))
 	got := c.inferExpr(NewScope(), 0, e)
 	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
@@ -56,7 +56,7 @@ func TestInferLiteralUnsupported(t *testing.T) {
 }
 
 func TestInferIdentResolvesBinding(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineValue("x", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.PrimType{Prim: soltype.NumPrim})}})
 
@@ -68,7 +68,7 @@ func TestInferIdentResolvesBinding(t *testing.T) {
 }
 
 func TestInferIdentResolvesThroughParent(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	parent := NewScope()
 	parent.defineValue("y", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.LitType{Lit: &soltype.StrLit{Value: "hi"}})}})
 	child := parent.Child()
@@ -80,7 +80,7 @@ func TestInferIdentResolvesThroughParent(t *testing.T) {
 }
 
 func TestInferIdentUnknown(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	e := ast.NewIdent("nope", testSpan())
 	got := c.inferExpr(NewScope(), 0, e)
 	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
@@ -90,7 +90,7 @@ func TestInferIdentUnknown(t *testing.T) {
 }
 
 func TestInferIdentNamespaceUsedAsValue(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineNamespace("Foo", &Namespace{Name: "Foo"})
 
@@ -103,7 +103,7 @@ func TestInferIdentNamespaceUsedAsValue(t *testing.T) {
 }
 
 func TestInferExprUnsupportedNode(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	left := ast.NewLitExpr(ast.NewNumber(1, testSpan()))
 	right := ast.NewLitExpr(ast.NewNumber(2, testSpan()))
 	e := ast.NewBinary(left, right, ast.Plus, testSpan())

--- a/internal/solver/infer_for_in.go
+++ b/internal/solver/infer_for_in.go
@@ -201,6 +201,15 @@ func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
 			return &soltype.UnknownType{}, true
 		}
 		return newUnion(c.ctx, t.Elems), true
+	case *soltype.ClassType:
+		// An array iterates its elements. This reads the element off the instance
+		// directly, which is the answer for the one container the milestone requires.
+		// The protocol lookup over the reserved symbol keys replaces it, at which point
+		// `Array` answers through its own `[Symbol.iterator]` like any other iterable.
+		if elem, isArray := c.ctx.arrayElem(t); isArray {
+			return elem, true
+		}
+		return nil, false
 	case *soltype.UnionType:
 		elems := make([]soltype.Type, 0, len(t.Types))
 		for _, branch := range t.Types {

--- a/internal/solver/infer_for_in_test.go
+++ b/internal/solver/infer_for_in_test.go
@@ -7,12 +7,13 @@ import (
 )
 
 // F1 — the `for (x in xs)` / `for await (x in xs)` iteration protocol. The loop
-// variable binds at the iterable's element type. M5 resolves that element type
-// structurally over the types the solver can represent — a tuple, the stand-in
-// for an array, and a union of tuples — since Array<T> and the `[Symbol.iterator]`
-// protocol land in M7. The element type is surfaced through a function's return
-// type: a `return x` inside the loop makes the loop variable's type the function's
-// return type, so `values["f"]` renders it.
+// variable binds at the iterable's element type, resolved structurally: a tuple, a
+// union of tuples, and a generator each answer from their own shape. An array answers
+// the same way, covered by TestArrayResolvesToTheIngestedClass, and the
+// `[Symbol.iterator]` protocol that generalizes all of them lands in M7.5 PR6. The
+// element type is surfaced through a function's return type: a `return x` inside the
+// loop makes the loop variable's type the function's return type, so `values["f"]`
+// renders it.
 
 func TestInferForInElementType(t *testing.T) {
 	tests := map[string]struct {
@@ -31,9 +32,7 @@ func TestInferForInElementType(t *testing.T) {
 			`,
 			want: map[string]string{"f": "fn () -> 1 | 2 | 3"},
 		},
-		// A single-element tuple binds the loop variable at that element's type — the
-		// milestone's `for (x in numbers)` where `numbers: Array<number>` binds
-		// `x: number`, expressed with the tuple that stands in for the array.
+		// A single-element tuple binds the loop variable at that element's type.
 		"SingleElementTupleBindsElement": {
 			src: `
 				fn f(xs: [number]) {

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -554,12 +554,11 @@ func TestInferArrayRestParamFuncAnnotation(t *testing.T) {
 		},
 		{
 			// Two array rest parameters pair as ordinary positions and compare element to
-			// element. `Array` declares `push(mut self, item: T)`, which puts `T` in an input
-			// position and makes it invariant, so the pair is checked in both directions and
-			// each direction reports its own failure.
+			// element. The pairing is contravariant and the array is covariant in its element,
+			// so the super's `string` is checked against the sub's `number`.
 			name: "ArrayRestAgainstArrayRest",
 			src:  `val a: fn(...xs: Array<number>) -> number = fn (...) { return 1 }` + "\n" + `val b: fn(...ys: Array<string>) -> number = a`,
-			want: []string{"cannot constrain string <: number", "cannot constrain number <: string"},
+			want: []string{"cannot constrain string <: number"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -554,11 +554,12 @@ func TestInferArrayRestParamFuncAnnotation(t *testing.T) {
 		},
 		{
 			// Two array rest parameters pair as ordinary positions and compare element to
-			// element. The pairing is contravariant and the array is covariant in its element,
-			// so the super's `string` is checked against the sub's `number`.
+			// element. `Array` declares `push(mut self, item: T)`, which puts `T` in an input
+			// position and makes it invariant, so the pair is checked in both directions and
+			// each direction reports its own failure.
 			name: "ArrayRestAgainstArrayRest",
 			src:  `val a: fn(...xs: Array<number>) -> number = fn (...) { return 1 }` + "\n" + `val b: fn(...ys: Array<string>) -> number = a`,
-			want: []string{"cannot constrain string <: number"},
+			want: []string{"cannot constrain string <: number", "cannot constrain number <: string"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -27,7 +27,7 @@ func renderBinding(b ValueBinding) string {
 // --- FuncExpr ---
 
 func TestInferFuncExprAnnotated(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn (x: number) { return x }
 	e := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 
@@ -42,7 +42,7 @@ func TestInferFuncExprAnnotated(t *testing.T) {
 // contravariant param position, never in covariant return position) rather than
 // a <T0> quantifier.
 func TestInferFuncExprUnannotatedIsMonomorphic(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn (x) { return x }
 	e := funcExpr([]*ast.Param{param("x", nil)}, nil, block(returnStmt(identExpr("x"))))
 
@@ -52,7 +52,7 @@ func TestInferFuncExprUnannotatedIsMonomorphic(t *testing.T) {
 }
 
 func TestInferFuncExprMultiParam(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn (x: number, y: string) { return y }
 	e := funcExpr(
 		[]*ast.Param{param("x", numAnn()), param("y", strAnn())},
@@ -66,7 +66,7 @@ func TestInferFuncExprMultiParam(t *testing.T) {
 }
 
 func TestInferFuncExprReturnAnnotationAccepted(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn (x: number) -> number { return x }
 	e := funcExpr([]*ast.Param{param("x", numAnn())}, numAnn(), block(returnStmt(identExpr("x"))))
 
@@ -76,7 +76,7 @@ func TestInferFuncExprReturnAnnotationAccepted(t *testing.T) {
 }
 
 func TestInferFuncExprReturnAnnotationMismatch(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn () -> number { return "hello" }
 	e := funcExpr(nil, numAnn(), block(returnStmt(strExpr("hello"))))
 
@@ -89,7 +89,7 @@ func TestInferFuncExprReturnAnnotationMismatch(t *testing.T) {
 // A body-level val is visible to later statements, including the return that
 // becomes the function's result.
 func TestInferFuncExprBodyValDecl(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn () { val y = 5; return y }
 	e := funcExpr(nil, nil, block(
 		ast.NewDeclStmt(valDecl("y", nil, numExpr(5)), testSpan()),
@@ -104,7 +104,7 @@ func TestInferFuncExprBodyValDecl(t *testing.T) {
 // A bodyless (declare/ambient) function adopts its return annotation without
 // constraining a synthetic `undefined` against it (which would error spuriously).
 func TestInferFuncDeclBodylessReturnAnnotation(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// declare fn now() -> number
 	d := ast.NewFuncDecl(
 		ast.NewIdentifier("now", testSpan()), nil, nil,
@@ -125,7 +125,7 @@ func TestInferFuncDeclBodylessReturnAnnotation(t *testing.T) {
 // body-free and this recovery path runs; the decl here is built with a nil body to
 // exercise it directly.
 func TestInferFuncDeclBodylessUnsupportedReturnRecoversToUnknown(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// declare fn now() -> bigint   (bigint is unsupported in M2)
 	d := ast.NewFuncDecl(
 		ast.NewIdentifier("now", testSpan()), nil, nil,
@@ -144,7 +144,7 @@ func TestInferFuncDeclBodylessUnsupportedReturnRecoversToUnknown(t *testing.T) {
 // p.Span() (which dereferences the nil pattern). Not reachable from the real
 // parser, but the walk must uphold M2's "never a panic" guarantee.
 func TestInferFuncExprNilParamPatternNoPanic(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	e := funcExpr([]*ast.Param{{Pattern: nil}}, nil, block(exprStmt(numExpr(1))))
 
 	require.NotPanics(t, func() { c.inferExpr(NewScope(), 0, e) })
@@ -156,7 +156,7 @@ func TestInferFuncExprNilParamPatternNoPanic(t *testing.T) {
 // leaves below go unused, so each element coalesces to `unknown`. The point is that
 // the param is accepted and rendered, not reported as unsupported.
 func TestInferFuncExprDestructuringParam(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn ([a, b]) { 1 }
 	tuplePat := ast.NewTuplePat([]ast.Pat{
 		ast.NewIdentPat("a", false, nil, nil, testSpan()),
@@ -173,7 +173,7 @@ func TestInferFuncExprDestructuringParam(t *testing.T) {
 // function's own FuncType.TypeParams, so the parameter and return read the one shared
 // `T` var rather than reporting the parameter feature as unsupported.
 func TestInferFuncExprGenericResolves(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn <T>(x: T) -> T { return x }
 	tp := ast.NewTypeParam("T", nil, nil, testSpan())
 	tRef := func() ast.TypeAnn { return ast.NewRefTypeAnn(ast.NewIdentifier("T", testSpan()), nil, testSpan()) }
@@ -194,7 +194,7 @@ func TestInferFuncExprGenericResolves(t *testing.T) {
 // --- CallExpr ---
 
 func TestInferCallResolvesReturn(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// (fn (x: number) { return x })(5)
 	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{numExpr(5)}, false, testSpan())
@@ -206,7 +206,7 @@ func TestInferCallResolvesReturn(t *testing.T) {
 }
 
 func TestInferCallArgMismatch(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// (fn (x: number) { return x })("hello")
 	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{strExpr("hello")}, false, testSpan())
@@ -223,7 +223,7 @@ func TestInferCallArgMismatch(t *testing.T) {
 // uniform too-many message), not a FuncArityMismatch — and the constraint receives
 // only the arity-matched prefix, so the lint is the SOLE diagnostic.
 func TestInferCallTooManyArgs(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// (fn (x: number) { return x })(1, 2)
 	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{numExpr(1), numExpr(2)}, false, testSpan())
@@ -240,7 +240,7 @@ func TestInferCallTooManyArgs(t *testing.T) {
 // symmetric twin of TooManyArgsError) — the demand is padded to the callee's arity
 // so the lint is the SOLE diagnostic, not a doubled lint + FuncArityMismatch.
 func TestInferCallTooFewArgs(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// (fn (x: number, y: number) { return x })(1)
 	callee := funcExpr([]*ast.Param{param("x", numAnn()), param("y", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{numExpr(1)}, false, testSpan())
@@ -254,7 +254,7 @@ func TestInferCallTooFewArgs(t *testing.T) {
 }
 
 func TestInferCallThroughBinding(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineValue("inc", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.FuncType{
 		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "n"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
@@ -271,7 +271,7 @@ func TestInferCallThroughBinding(t *testing.T) {
 // --- Block / statements ---
 
 func TestInferBlockResultIsLastStmt(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// { 1; "two" }
 	b := block(exprStmt(numExpr(1)), exprStmt(strExpr("two")))
 
@@ -282,7 +282,7 @@ func TestInferBlockResultIsLastStmt(t *testing.T) {
 }
 
 func TestInferBlockEmptyIsUndefined(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	got, diverges := c.inferBlock(NewScope(), 0, block())
 	require.Empty(t, c.errs)
 	require.False(t, diverges)
@@ -290,7 +290,7 @@ func TestInferBlockEmptyIsUndefined(t *testing.T) {
 }
 
 func TestInferBlockReturnStmt(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// A return is only legal inside a function body, so push a func context the way
 	// inferFunc does — otherwise the walk (correctly) reports ReturnOutsideFunction.
 	saved := c.pushFuncCtx(false, nil, 0)
@@ -310,7 +310,7 @@ func TestInferBlockReturnStmt(t *testing.T) {
 // rebinds it (overwrite, no constraint linking the two), so the tail sees the
 // later type even though it is unrelated to the earlier one (§3.2).
 func TestInferBlockRedeclarationRebinds(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// { val x = "hello"; val x = 5; x }
 	b := block(
 		ast.NewDeclStmt(valDecl("x", nil, strExpr("hello")), testSpan()),
@@ -324,7 +324,7 @@ func TestInferBlockRedeclarationRebinds(t *testing.T) {
 }
 
 func TestInferStmtBodyDeclNotAllowed(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// A nested FuncDecl as a body statement is a permanent language error.
 	inner := ast.NewFuncDecl(ast.NewIdentifier("f", testSpan()), nil, nil, nil, nil, nil,
 		block(), false, false, false, testSpan())
@@ -340,7 +340,7 @@ func TestInferStmtBodyDeclNotAllowed(t *testing.T) {
 // --- FuncDecl ---
 
 func TestInferFuncDecl(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn id(x: number) { return x }
 	d := ast.NewFuncDecl(
 		ast.NewIdentifier("id", testSpan()), nil, nil,
@@ -362,7 +362,7 @@ func TestInferFuncDecl(t *testing.T) {
 // (`foo(x + 1)` would be the textbook shape, but `+` is a BinaryExpr, which
 // PR-3 doesn't type yet; `foo(x)` exercises the same recursive-call path.)
 func TestInferFuncDeclSelfReference(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineValue("foo", ValueBinding{Schemes: []TypeScheme{monoScheme(c.freshAt(1))}})
 	// fn foo(x: number) { return foo(x) }
@@ -383,7 +383,7 @@ func TestInferFuncDeclSelfReference(t *testing.T) {
 // The bound name resolves to the function type, and the enclosing function
 // returns it.
 func TestInferFuncDeclBodyFuncValDecl(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// fn outer() { val f = fn (x: number) { return x }; return f }
 	inner := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	d := ast.NewFuncDecl(

--- a/internal/solver/infer_if_val_test.go
+++ b/internal/solver/infer_if_val_test.go
@@ -431,7 +431,7 @@ func TestInferValElseRecordsTheJoinedLeafType(t *testing.T) {
 			val {x: v} = p else { {x: "s"} }
 			return v
 		}`)
-	c := newChecker()
+	c := newTestChecker()
 	c.inferDepGraph(sharedPrelude().Child(), 0, module, dep_graph.BuildDepGraph(module))
 	require.Empty(t, c.errs)
 	leaf := findIdentPat(module, "v")
@@ -508,7 +508,7 @@ func TestInferValElseChecksAnAnnotatedLeafOfABorrowedUnion(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			module := parseModule(t, tt.src)
-			c := newChecker()
+			c := newTestChecker()
 			c.inferDepGraph(sharedPrelude().Child(), 0, module, dep_graph.BuildDepGraph(module))
 			require.Equal(t, tt.wantErrs, messagesWithSpan(t, c.errs))
 			leaf := findIdentPat(module, "v")

--- a/internal/solver/infer_namespace_test.go
+++ b/internal/solver/infer_namespace_test.go
@@ -23,7 +23,7 @@ func strScheme() []TypeScheme {
 
 // Foo.bar resolves to the member's type.
 func TestInferNamespaceMember(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineNamespace("Foo", &Namespace{
 		Name:   "Foo",
@@ -39,7 +39,7 @@ func TestInferNamespaceMember(t *testing.T) {
 
 // Foo["bar"] resolves a constant-keyed member — the bracket form of Foo.bar.
 func TestInferNamespaceConstantIndex(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineNamespace("Foo", &Namespace{
 		Name:   "Foo",
@@ -55,7 +55,7 @@ func TestInferNamespaceConstantIndex(t *testing.T) {
 
 // A.B.c walks through a nested namespace to the member's type.
 func TestInferNestedNamespaceMember(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	inner := &Namespace{
 		Name:   "A.B",
@@ -74,7 +74,7 @@ func TestInferNestedNamespaceMember(t *testing.T) {
 
 // f(Foo) — a bare namespace name in value position is rejected.
 func TestInferNamespaceAsValue(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineNamespace("Foo", &Namespace{Name: "Foo"})
 
@@ -88,7 +88,7 @@ func TestInferNamespaceAsValue(t *testing.T) {
 // f(A.B) — a partial chain stopping at a nested namespace is rejected once, with
 // the nested namespace's qualified name.
 func TestInferNestedNamespaceAsValue(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	inner := &Namespace{Name: "A.B"}
 	scope.defineNamespace("A", &Namespace{
@@ -106,7 +106,7 @@ func TestInferNestedNamespaceAsValue(t *testing.T) {
 
 // Foo.nope — an absent member is an UnknownNamespaceMemberError.
 func TestInferNamespaceUnknownMember(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineNamespace("Foo", &Namespace{
 		Name:   "Foo",
@@ -123,7 +123,7 @@ func TestInferNamespaceUnknownMember(t *testing.T) {
 
 // Foo[k] — a dynamic (non-constant) index into a namespace is rejected.
 func TestInferNamespaceDynamicIndex(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineValue("k", ValueBinding{Schemes: strScheme()})
 	scope.defineNamespace("Foo", &Namespace{
@@ -142,7 +142,7 @@ func TestInferNamespaceDynamicIndex(t *testing.T) {
 // An index into a value (array element / index-signature read) is M7, still
 // outside the supported subset — the namespace path doesn't accidentally accept it.
 func TestInferValueIndexUnsupported(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineValue("o", ValueBinding{Schemes: numScheme()})
 
@@ -161,7 +161,7 @@ func TestInferValueIndexUnsupported(t *testing.T) {
 // because the intercept routed the receiver through inferExpr, which rejects
 // a namespace in value position.
 func TestInferBorrowOfNamespaceMember(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	objT := &soltype.ObjectType{
 		Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{

--- a/internal/solver/infer_negation_test.go
+++ b/internal/solver/infer_negation_test.go
@@ -86,7 +86,7 @@ func TestResolveNegationFoldRecordsProvOnce(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newChecker()
+			c := newTestChecker()
 			c.debugProv = true
 			scope := NewScope()
 

--- a/internal/solver/infer_null_undefined_test.go
+++ b/internal/solver/infer_null_undefined_test.go
@@ -87,7 +87,7 @@ func TestResolveAtomAnnotationRecordsNoProvenance(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newChecker()
+			c := newTestChecker()
 			c.debugProv = true
 			scope := NewScope()
 			first := ast.NewLitTypeAnn(tt.lit, testSpan())

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -11,7 +11,7 @@ import (
 // --- TupleExpr ---
 
 func TestInferTuple(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// [1, "hi"]
 	e := tupleExpr(numExpr(1), strExpr("hi"))
 
@@ -22,7 +22,7 @@ func TestInferTuple(t *testing.T) {
 }
 
 func TestInferTupleEmpty(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	got := c.inferExpr(NewScope(), 0, tupleExpr())
 	require.Empty(t, c.errs)
 	require.Equal(t, "[]", render(got))
@@ -31,7 +31,7 @@ func TestInferTupleEmpty(t *testing.T) {
 // A spread element ([...pair]) splices the operand tuple's element types into the
 // literal: [...pair, 3] over pair: [number, string] builds [number, string, 3].
 func TestInferTupleSpread(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// [...[1, "hi"], 3]
 	pair := tupleExpr(numExpr(1), strExpr("hi"))
 	e := tupleExpr(ast.NewArraySpread(pair, testSpan()), numExpr(3))
@@ -44,7 +44,7 @@ func TestInferTupleSpread(t *testing.T) {
 // the spread, then the splice, then the elements after. [1, ...[2, 3], 4] builds
 // [1, 2, 3, 4].
 func TestInferTupleSpreadMiddle(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// [1, ...[2, 3], 4]
 	mid := tupleExpr(numExpr(2), numExpr(3))
 	e := tupleExpr(numExpr(1), ast.NewArraySpread(mid, testSpan()), numExpr(4))
@@ -58,7 +58,7 @@ func TestInferTupleSpreadMiddle(t *testing.T) {
 // operand has a known length, so the assertion checks the Inexact flag and the
 // element count directly rather than relying on the rendered form.
 func TestInferTupleSpreadMultipleExact(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// [...[1, 2], ...[3, 4]]
 	a := tupleExpr(numExpr(1), numExpr(2))
 	b := tupleExpr(numExpr(3), numExpr(4))
@@ -76,7 +76,7 @@ func TestInferTupleSpreadMultipleExact(t *testing.T) {
 // Spreading a non-tuple value is a typed error: M4 splices concrete tuple
 // literals only, so the operand must infer to a tuple.
 func TestInferTupleSpreadNonTuple(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// [...5]
 	e := tupleExpr(ast.NewArraySpread(numExpr(5), testSpan()))
 	got := c.inferExpr(NewScope(), 0, e)
@@ -118,7 +118,7 @@ func TestInferTupleSpreadInexactLast(t *testing.T) {
 // reports a single unknown-identifier error, and the spread does not layer a
 // SpreadNotTupleError on the recovery sentinel.
 func TestInferTupleSpreadErrorOperandAbsorbs(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// [...a]
 	e := tupleExpr(ast.NewArraySpread(identExpr("a"), testSpan()))
 	got := c.inferExpr(NewScope(), 0, e)
@@ -130,7 +130,7 @@ func TestInferTupleSpreadErrorOperandAbsorbs(t *testing.T) {
 // --- ObjectExpr ---
 
 func TestInferObject(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// {a: 5, b: "hi"}
 	e := objExpr(prop("a", numExpr(5)), prop("b", strExpr("hi")))
 
@@ -141,7 +141,7 @@ func TestInferObject(t *testing.T) {
 }
 
 func TestInferObjectEmpty(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	got := c.inferExpr(NewScope(), 0, objExpr())
 	require.Empty(t, c.errs)
 	require.Equal(t, "{}", render(got))
@@ -149,7 +149,7 @@ func TestInferObjectEmpty(t *testing.T) {
 
 // A string-literal key maps to a field name just like an identifier label.
 func TestInferObjectStringKey(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// {"a": 5}
 	strKey := ast.NewProperty(ast.NewString("a", testSpan()), false, false, numExpr(5), testSpan())
 	got := c.inferExpr(NewScope(), 0, objExpr(strKey))
@@ -161,7 +161,7 @@ func TestInferObjectStringKey(t *testing.T) {
 // string form, so {0: 5} names the field "0". The field name is not a valid
 // identifier, so it renders as a quoted key.
 func TestInferObjectNumericKey(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// {0: 5}
 	numKey := ast.NewProperty(ast.NewNumber(0, testSpan()), false, false, numExpr(5), testSpan())
 	got := c.inferExpr(NewScope(), 0, objExpr(numKey))
@@ -174,7 +174,7 @@ func TestInferObjectNumericKey(t *testing.T) {
 // dedup then collapses them to {"0": 2}, so the resolved name, not the syntactic
 // key kind, decides identity.
 func TestInferObjectNumericStringKeyCollision(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// {0: 1, "0": 2}
 	numKey := ast.NewProperty(ast.NewNumber(0, testSpan()), false, false, numExpr(1), testSpan())
 	strKey := ast.NewProperty(ast.NewString("0", testSpan()), false, false, numExpr(2), testSpan())
@@ -191,7 +191,7 @@ func TestInferObjectNumericStringKeyCollision(t *testing.T) {
 // earlier one while the field keeps its first position. This keeps field names
 // unique, so the record is well-formed (and equalType stays reflexive on it).
 func TestInferObjectDuplicateKeyLastWins(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// {a: 1, b: 2, a: "x"}  ⇒  {a: "x", b: 2}
 	e := objExpr(prop("a", numExpr(1)), prop("b", numExpr(2)), prop("a", strExpr("x")))
 
@@ -208,7 +208,7 @@ func TestInferObjectDuplicateKeyLastWins(t *testing.T) {
 // Shorthand ({x}) is a property with no value — deferred to M4. It reports a
 // clean UnsupportedNodeError and is skipped (the rest of the object still types).
 func TestInferObjectShorthandUnsupported(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	shorthand := ast.NewProperty(ast.NewIdent("x", testSpan()), false, false, nil, testSpan())
 	got := c.inferExpr(NewScope(), 0, objExpr(shorthand))
 	require.Equal(t, "{}", render(got))
@@ -251,7 +251,7 @@ func TestInferObjectSpread(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newChecker()
+			c := newTestChecker()
 			got := c.inferExpr(NewScope(), 0, objExpr(tt.elems...))
 			require.Equal(t, tt.wantRender, render(got))
 			if tt.wantErr == "" {
@@ -266,7 +266,7 @@ func TestInferObjectSpread(t *testing.T) {
 
 // A computed key ({[k]: v}) carries no static field name — M4.
 func TestInferObjectComputedKeyUnsupported(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	computed := ast.NewProperty(ast.NewComputedKey(identExpr("k")), false, false, numExpr(1), testSpan())
 	got := c.inferExpr(NewScope(), 0, objExpr(computed))
 	require.Equal(t, "{}", render(got))
@@ -277,7 +277,7 @@ func TestInferObjectComputedKeyUnsupported(t *testing.T) {
 // --- MemberExpr ---
 
 func TestInferMember(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// ({a: 5, b: "hi"}).a
 	recv := objExpr(prop("a", numExpr(5)), prop("b", strExpr("hi")))
 	e := memberExpr(recv, "a")
@@ -291,7 +291,7 @@ func TestInferMember(t *testing.T) {
 // Reading a field the receiver lacks fails with a MissingPropertyError carrying
 // the member node's span.
 func TestInferMemberMissingProperty(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// ({a: 5}).b
 	e := memberExpr(objExpr(prop("a", numExpr(5))), "b")
 
@@ -304,7 +304,7 @@ func TestInferMemberMissingProperty(t *testing.T) {
 
 // Optional chaining (recv?.prop) needs union/undefined handling — M6.
 func TestInferMemberOptionalChainUnsupported(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	e := ast.NewMember(objExpr(prop("a", numExpr(5))), ast.NewIdentifier("a", testSpan()), true, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
@@ -318,7 +318,7 @@ func TestInferMemberOptionalChainUnsupported(t *testing.T) {
 // an unbound receiver does not add a cascading "unknown identifier" error — the
 // single OptionalChain diagnostic stands for the whole unsupported construct.
 func TestInferMemberOptionalChainDoesNotDescendIntoReceiver(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// nope?.a — receiver `nope` is unbound and would error if typed.
 	e := ast.NewMember(identExpr("nope"), ast.NewIdentifier("a", testSpan()), true, testSpan())
 
@@ -334,7 +334,7 @@ func TestInferMemberOptionalChainDoesNotDescendIntoReceiver(t *testing.T) {
 // sink (`if recv. {}`, `await recv.`, `var x = recv.`) the sentinel absorbs in
 // constrain rather than cascading `never <: …`. It reports nothing itself.
 func TestInferMemberEmptyPropertyNameIsSilent(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// recv = {a: 5}; access with an empty property name (as the parser builds for `recv.`)
 	e := ast.NewMember(objExpr(prop("a", numExpr(5))), ast.NewIdentifier("", testSpan()), false, testSpan())
 
@@ -397,7 +397,7 @@ func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
 // reads the same property a dot access would, and lets the source name a key that
 // is not a valid identifier. The receiver here is a value, not a namespace.
 func TestInferIndexValueConstStringKey(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// {"foo-bar": 5, b: "hi"}["foo-bar"]
 	fooBar := ast.NewProperty(ast.NewString("foo-bar", testSpan()), false, false, numExpr(5), testSpan())
 	recv := objExpr(fooBar, prop("b", strExpr("hi")))
@@ -413,7 +413,7 @@ func TestInferIndexValueConstStringKey(t *testing.T) {
 // MissingPropertyError, the same as the dot form — the index path shares
 // valueProp's blame.
 func TestInferIndexValueMissingProperty(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// {a: 5}["foo-bar"]
 	e := ast.NewIndex(objExpr(prop("a", numExpr(5))), strExpr("foo-bar"), false, testSpan())
 

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -341,7 +341,7 @@ func TestInferOverloadThreeArmSpecificity(t *testing.T) {
 // the winning (number) arm's bound — never the loser's. Built directly so the
 // argument variable is inspectable.
 func TestResolveOverloadRollsBackLosingArm(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 
 	str := func() soltype.Type { return &soltype.PrimType{Prim: soltype.StrPrim} }
 	num := func() soltype.Type { return &soltype.PrimType{Prim: soltype.NumPrim} }
@@ -375,7 +375,7 @@ func TestResolveOverloadRollsBackLosingArm(t *testing.T) {
 // it win, but the accepting constraint against a union param is ambiguous, and that warning
 // must not be swallowed by overload matching.
 func TestResolveOverloadSurfacesWinningArmWarning(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 
 	num := func() soltype.Type { return &soltype.PrimType{Prim: soltype.NumPrim} }
 	// The single arm takes `(T | number)`, a union with a bare type-variable member. Calling

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -421,7 +421,7 @@ func TestBorrowUnionLeafBindsAsBorrow(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			module := parseModule(t, tc.src)
-			c := newChecker()
+			c := newTestChecker()
 			c.inferDepGraph(sharedPrelude().Child(), 0, module, dep_graph.BuildDepGraph(module))
 			require.Empty(t, messagesWithSpan(t, c.errs))
 			leaf := findIdentPat(module, "v")

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"context"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -95,7 +96,7 @@ func parseModule(t *testing.T, src string) *ast.Module {
 // stays reachable: a type-alias binding renders as its definition body, which lives on
 // the checker's Context, not on the AliasType handle in scope.
 func inferModule(module *ast.Module) (values, types map[string]string, errs []SolverError) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := sharedPrelude().Child()
 	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))
 	values = make(map[string]string, len(scope.values))
@@ -611,4 +612,23 @@ func TestInferModuleNamedCalleeArityMismatchRecoversReturn(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, "3:11-3:18: Too many arguments: expected at most 1, but got 2", msgWithSpan(t, errs[0]))
 	require.Equal(t, "number", values["r"], "the result recovers to the declared return, not never")
+}
+
+// testStdlibSource resolves the pseudo-packages the solver's own tests infer
+// against, read from testdata/stdlib.
+//
+// It supplies `std:array`, which is what makes a written `Array<T>` resolve to the
+// ingested class rather than to an unknown name. The committed
+// internal/interop/data tree is not used: it does not yet ingest cleanly, and its
+// diagnostics would land in front of every test's own.
+func testStdlibSource() ModuleSource {
+	return StdlibSource(filepath.Join("testdata", "stdlib"))
+}
+
+// newTestChecker is newChecker with the test pseudo-package tree attached, so a
+// test that writes `Array<T>` resolves it the way a real run does.
+func newTestChecker() *checker {
+	c := newChecker()
+	c.source = testStdlibSource()
+	return c
 }

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -39,7 +39,7 @@ func aliasLifetimeParams(ctx *Context, name string) []*soltype.LifetimeParam {
 func inferTypeNodes(t *testing.T, src string) (map[string]soltype.Type, *Context, []SolverError) {
 	t.Helper()
 	module := parseModule(t, src)
-	c := newChecker()
+	c := newTestChecker()
 	scope := sharedPrelude().Child()
 	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))
 	nodes := make(map[string]soltype.Type, len(scope.types))

--- a/internal/solver/inhabited.go
+++ b/internal/solver/inhabited.go
@@ -161,9 +161,6 @@ func finitelyInhabited(t soltype.Type) bool {
 		// A closure, a promise, and a generator each hold their payload unevaluated, so building one
 		// runs none of the code that would produce that payload.
 		return true
-	case *soltype.ArrayType:
-		// The empty array is a finite value of every array type.
-		return true
 	case *soltype.ObjectType:
 		// Only a required property and a spread are read. A method, a getter, a setter, and a
 		// constructor are function-valued, so they defer their bodies the way a property holding a

--- a/internal/solver/inhabited_test.go
+++ b/internal/solver/inhabited_test.go
@@ -304,11 +304,12 @@ func TestFinitelyInhabited(t *testing.T) {
 		{
 			// μX0.Array<X0>
 			//
-			// An array type is inhabited by the empty array, so a recursive element type imposes
-			// nothing on the value.
-			name: "an array of the binder is inhabited by the empty array",
+			// A class instance is one of the shapes the walk does not decide, so it reads as
+			// inhabited whatever its type arguments carry. That is the right answer for an
+			// array, which the empty array inhabits.
+			name: "a class instance over the binder reads as inhabited",
 			t: muKnot(0, "X0", func(ref *soltype.RecursiveVarType) soltype.Type {
-				return &soltype.ArrayType{Elem: ref}
+				return &soltype.ClassType{Name: "Array", TypeArgs: []soltype.Type{ref}}
 			}),
 			want: true,
 		},

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -494,8 +494,6 @@ func compareSameKind(a, b soltype.Type) int {
 			return c
 		}
 		return compareType(a.ThrowsOrNever(), b.ThrowsOrNever())
-	case *soltype.ArrayType:
-		return compareType(a.Elem, b.(*soltype.ArrayType).Elem)
 	case *soltype.FuncType:
 		b := b.(*soltype.FuncType)
 		if a.Inexact != b.Inexact {
@@ -810,20 +808,18 @@ func typeKindOrder(t soltype.Type) int {
 		return 9
 	case *soltype.GeneratorType:
 		return 10
-	case *soltype.ArrayType:
-		return 11
 	case *soltype.FuncType:
-		return 12
+		return 11
 	case *soltype.UnionType:
-		return 13
+		return 12
 	case *soltype.IntersectionType:
-		return 14
+		return 13
 	case *soltype.NegationType:
-		return 15
+		return 14
 	case *soltype.NullType:
-		return 16
+		return 15
 	case *soltype.UndefinedType:
-		return 17
+		return 16
 	}
-	return 18
+	return 17
 }

--- a/internal/solver/lifetime_bounds_test.go
+++ b/internal/solver/lifetime_bounds_test.go
@@ -230,7 +230,7 @@ func TestLtBoundSetSubsumesChecksStaticForcing(t *testing.T) {
 // sharing one lifetime between its parameter and return, but their lifetime variables are
 // distinct identities, so only alphaEqualTypes sees them as equal.
 func TestAlphaEqualTypesBorrowsAcrossSchemes(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	fnA := borrowFn(mutPointRef(a), a)
@@ -247,7 +247,7 @@ func TestAlphaEqualTypesBorrowsAcrossSchemes(t *testing.T) {
 // borrows but return the FIRST versus the SECOND are not alpha-equivalent, even though
 // both carry exactly two lifetimes.
 func TestAlphaEqualTypesPairingIsBijection(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
 	fnRetFirst := &soltype.FuncType{
 		Params: borrowFn(num(), a, b).Params, // p: &'a mut {x}, q: &'b mut {x}
@@ -275,7 +275,7 @@ func TestAlphaEqualTypesPairingIsBijection(t *testing.T) {
 // single borrow for both parameters. The bijection refuses to bind the reused lifetime
 // to two different partners.
 func TestAlphaEqualTypesIndependenceWithinScheme(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
 	distinct := borrowFn(num(), a, b) // two independent borrows
 	shared := borrowFn(num(), a, a)   // one borrow used for both parameters
@@ -288,7 +288,7 @@ func TestAlphaEqualTypesIndependenceWithinScheme(t *testing.T) {
 // two-borrow signatures are alpha-equivalent only when they carry the same outlives
 // bound; adding `'a: 'b` to one side breaks the equality.
 func TestAlphaEqualTypesComparesOutlivesRelation(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
 	c.ctx.constrainLt(a, b) // 'a outlives 'b
 	bound := borrowFn(num(), a, b)
@@ -311,7 +311,7 @@ func TestAlphaEqualTypesComparesOutlivesRelation(t *testing.T) {
 // name. equalType already treats objects as equal up to property order, and
 // alpha-equivalence must not regress that for borrow-typed fields.
 func TestAlphaEqualTypesObjectPropertyOrderInsensitive(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
 	objMN := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
 		&soltype.PropertyElem{Name: "m", Type: mutPointRef(a)},
@@ -334,7 +334,7 @@ func TestAlphaEqualTypesObjectPropertyOrderInsensitive(t *testing.T) {
 // with two independent borrows. The outlives comparison reads this equality through
 // implies, which reports a condensed cycle as equality in both directions.
 func TestAlphaEqualTypesMutualOutlivesSharesLifetime(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
 	c.ctx.constrainLt(a, b)
 	c.ctx.constrainLt(b, a) // 'a and 'b mutually outlive, hence are equal

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -54,7 +54,7 @@ func freshenLtOf(t *testing.T, out soltype.Type) (paramLt, retLt soltype.Lifetim
 // independently and the returned borrow would no longer carry the parameter's
 // lifetime.
 func TestFreshenSharesParamLifetimeAcrossOccurrences(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(1) // above the generalize-level (lim = 0)
 	body := identRefScheme(lt)
 
@@ -69,7 +69,7 @@ func TestFreshenSharesParamLifetimeAcrossOccurrences(t *testing.T) {
 // cross-site non-contamination property. Each call site gets its own cache, exactly
 // as instantiate allocates one per use.
 func TestFreshenTwoInstantiationsGetDistinctLifetimes(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(1)
 	body := identRefScheme(lt)
 
@@ -86,7 +86,7 @@ func TestFreshenTwoInstantiationsGetDistinctLifetimes(t *testing.T) {
 // shared LifetimeVar would have caused — before D2.5 both call sites aliased the
 // scheme's one lifetime var, so a bound from one site leaked into the other.
 func TestFreshenInstantiationsAreNonContaminating(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(1)
 	body := identRefScheme(lt)
 
@@ -106,7 +106,7 @@ func TestFreshenInstantiationsAreNonContaminating(t *testing.T) {
 // SHARED, not freshened — the lifetime-sort analogue of a captured type variable.
 // Only lifetimes minted above the scheme's level are quantified.
 func TestFreshenSharesCapturedLifetime(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	captured := c.ctx.freshLifetime(0) // at the generalize-level: not quantified
 	body := identRefScheme(captured)
 
@@ -121,7 +121,7 @@ func TestFreshenSharesCapturedLifetime(t *testing.T) {
 // probe is discarded the fresh var is unreachable, so there is nothing to roll back:
 // the probe journals nothing for it, and the original's bounds stay untouched.
 func TestFreshenCopiesLifetimeBoundsUnderProbe(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(1)
 	// 'static is the lattice bottom — a level-free bound, so recording lt <: 'static
 	// does not trip the level-extrusion the var-to-var case would.
@@ -193,7 +193,7 @@ func getRefScheme(lt *soltype.LifetimeVar) *soltype.FuncType {
 // freshening the LifetimeParams field exists to carry, the lifetime-sort twin of
 // TestFreshenAboveGenericFunc.
 func TestFreshenAboveFuncLifetimeParam(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	la := c.ctx.freshLifetime(1) // above the generalize-level (lim = 0)
 
 	out := c.freshenAbove(0, getRefScheme(la), 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
@@ -212,7 +212,7 @@ func TestFreshenAboveFuncLifetimeParam(t *testing.T) {
 // lifetimes, so a method's `<'a>` is fresh per call — the same non-contamination the
 // ordinary borrow-passing case relies on, here for an explicit lifetime parameter.
 func TestFreshenFuncLifetimeParamDistinctPerInstantiation(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	la := c.ctx.freshLifetime(1)
 	body := getRefScheme(la)
 
@@ -228,7 +228,7 @@ func TestFreshenFuncLifetimeParamDistinctPerInstantiation(t *testing.T) {
 // binder, and a `<'b: 'a>` bound resolves to the fresh 'a of the same instantiation, so
 // the outlives relation survives the copy intact.
 func TestFreshenFuncLifetimeParamBound(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	la := c.ctx.freshLifetime(1)
 	lb := c.ctx.freshLifetime(1)
 	body := &soltype.FuncType{
@@ -262,7 +262,7 @@ func TestFreshenFuncLifetimeParamBound(t *testing.T) {
 // ABOVE the fresh var (original <: fresh), mirroring the type-var extrude's
 // addUpperBound.
 func TestExtrudeFreshensHigherLevelLifetimePositive(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(2) // above the extrusion target (lvl = 1)
 
 	out := c.ctx.extrude(mutObjAt(lt), soltype.Positive, 1, map[extrudeKey]*soltype.TypeVarType{})
@@ -280,7 +280,7 @@ func TestExtrudeFreshensHigherLevelLifetimePositive(t *testing.T) {
 // addLowerBound. A var reached in both polarities therefore yields two distinct
 // fresh vars with opposite wiring — the reason the cache is keyed by polarity.
 func TestExtrudeFreshensHigherLevelLifetimeNegative(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(2)
 
 	out := c.ctx.extrude(mutObjAt(lt), soltype.Negative, 1, map[extrudeKey]*soltype.TypeVarType{})
@@ -293,7 +293,7 @@ func TestExtrudeFreshensHigherLevelLifetimeNegative(t *testing.T) {
 // A borrow whose lifetime is at or below the target level is extruded to itself:
 // the whole RefType is shared, since nothing in it outranks the level.
 func TestExtrudeSharesBelowLevelBorrow(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(1) // at the target level
 
 	out := c.ctx.extrude(mutObjAt(lt), soltype.Positive, 1, map[extrudeKey]*soltype.TypeVarType{})
@@ -307,7 +307,7 @@ func TestExtrudeSharesBelowLevelBorrow(t *testing.T) {
 // journaled bound write. Without this a failed overload trial that extruded a borrow
 // lifetime would leak a bound.
 func TestExtrudeLifetimeBoundRolledBackOnDiscard(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(2)
 
 	p := c.openProbe()
@@ -324,7 +324,7 @@ func TestExtrudeLifetimeBoundRolledBackOnDiscard(t *testing.T) {
 // it down first, so a variable's bound never outranks its own level — the invariant
 // the freshener/extruder level prune over the lifetime sort relies on.
 func TestConstrainLtMaintainsLevelInvariant(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	low := c.ctx.freshLifetime(0)
 	high := c.ctx.freshLifetime(2)
 
@@ -342,7 +342,7 @@ func TestConstrainLtMaintainsLevelInvariant(t *testing.T) {
 // level is strictly BELOW the variable's own. This exercises the strict side of the
 // invariant — a bound may rank lower than its variable, only never higher.
 func TestConstrainLtRecordsLowerLevelBoundDirectly(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	high := c.ctx.freshLifetime(2)
 	low := c.ctx.freshLifetime(0)
 
@@ -366,7 +366,7 @@ func TestConstrainLtRecordsLowerLevelBoundDirectly(t *testing.T) {
 // first proxy, so the bound count stays 1 across repeats — the lifetime-sort
 // analogue of the same-level dedup, restored for the cross-level path.
 func TestConstrainLtCrossLevelDoesNotAccumulateDuplicates(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	low := c.ctx.freshLifetime(0)
 	high := c.ctx.freshLifetime(2)
 
@@ -386,7 +386,7 @@ func TestConstrainLtCrossLevelDoesNotAccumulateDuplicates(t *testing.T) {
 // rolled-back one. This guards the probe-safety of the proxy-reuse dedup: the reuse
 // scan reads live bounds, so a proxy whose wiring a Discard reverted is never found.
 func TestConstrainLtProxyReuseIsProbeSafe(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	low := c.ctx.freshLifetime(0)
 	high := c.ctx.freshLifetime(2)
 
@@ -409,7 +409,7 @@ func TestConstrainLtProxyReuseIsProbeSafe(t *testing.T) {
 // scheme lifetime and the reassignment constraint would mutate it, contaminating
 // later uses. inferAssign relies on this isolation.
 func TestFreshenAllFreshensBorrowLifetime(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(3)
 	ref := mutObjAt(lt)
 
@@ -423,7 +423,7 @@ func TestFreshenAllFreshensBorrowLifetime(t *testing.T) {
 // target level, which freshenAbove would share. This is the lifetime-sort analogue
 // of allFreshener's no-prune treatment of type vars (lim = math.MinInt).
 func TestFreshenAllFreshensLowLevelBorrowLifetime(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(0) // freshenAbove(lim=0) would share this; freshenAll must not
 	ref := mutObjAt(lt)
 
@@ -441,7 +441,7 @@ func TestFreshenAllFreshensLowLevelBorrowLifetime(t *testing.T) {
 // rebuilds Inner — which the all-concrete-inner cases never reach (they are pruned
 // whole before the arm runs).
 func TestFreshenSharesCapturedLifetimeWhileFresheningInner(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	captured := c.ctx.freshLifetime(0) // captured: shared across instantiations
 	innerVar := c.freshAt(1)           // quantified inner type var: per-use fresh
 	ref := &soltype.RefType{

--- a/internal/solver/lifetime_negation_test.go
+++ b/internal/solver/lifetime_negation_test.go
@@ -100,7 +100,7 @@ func TestComplementedBorrowKeepsLifetimeName(t *testing.T) {
 // reaches no output. The assertion below carries one lifetime across both positions, so
 // the parameter keeps its name. That shared lifetime is the shape under test.
 func TestNestedComplementsKeepLifetimeName(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	num := &soltype.PrimType{Prim: soltype.NumPrim}
 	inner := &soltype.FuncType{
@@ -123,7 +123,7 @@ func TestNestedComplementsKeepLifetimeName(t *testing.T) {
 // coalescer the doubled form this test is about, and would pass whatever the coalescer
 // did with it.
 func TestDoubleComplementFoldsBeforeLifetimePass(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	fn := borrowFn(&soltype.NegationType{Inner: negRef(a)}, a)
 
@@ -158,7 +158,7 @@ func TestComplementFlipsExtrudedLifetimeDirection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newChecker()
+			c := newTestChecker()
 			a := c.ctx.freshLifetime(5)
 			var ty soltype.Type = mutPointRef(a)
 			if tt.complemented {
@@ -197,7 +197,7 @@ func TestComplementFlipsExtrudedLifetimeDirection(t *testing.T) {
 // instantiating a borrow-passing function at a call site, which would make this a test
 // about inference rather than about the classifier.
 func TestComplementedBorrowAssertsNoOutlivesRelation(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	m := c.ctx.freshJoinLifetime(0) // minted first so it holds the smallest ID
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
@@ -254,7 +254,7 @@ func TestComplementedBorrowGroupsLikeAnOrdinaryParam(t *testing.T) {
 	// build wires the graph above and returns the signature, wrapping the second
 	// parameter's borrow in a complement when complemented is set.
 	build := func(complemented bool) *soltype.FuncType {
-		c := newChecker()
+		c := newTestChecker()
 		m := c.ctx.freshJoinLifetime(0) // minted first so it holds the smallest ID
 		a := c.ctx.freshLifetime(0)
 		b := c.ctx.freshLifetime(0)

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -14,7 +14,7 @@ import (
 // upper bounds, and 'static is the bottom, so it absorbs that meet and a resolves to
 // 'static regardless of any other upper bound.
 func TestConstrainLtVarOutlivesStatic(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	static := &soltype.StaticLifetime{}
 
@@ -28,7 +28,7 @@ func TestConstrainLtVarOutlivesStatic(t *testing.T) {
 // A var-to-var constraint records BOTH directions so each variable sees the full
 // relationship at coalescing.
 func TestConstrainLtVarToVarRecordsBothDirections(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -43,7 +43,7 @@ func TestConstrainLtVarToVarRecordsBothDirections(t *testing.T) {
 // Transitivity: with a <: b already recorded, constraining x <: a propagates
 // through a's existing upper bounds so x <: b is recorded too.
 func TestConstrainLtPropagatesTransitively(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	x := c.ctx.freshLifetime(0)
@@ -60,7 +60,7 @@ func TestConstrainLtPropagatesTransitively(t *testing.T) {
 // value, not pointer. Origination sites mint a fresh &StaticLifetime{} per call, so
 // pointer-identity dedup would wrongly pile up duplicate 'static bounds.
 func TestConstrainLtStaticDedupsByValue(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(a, &soltype.StaticLifetime{})
@@ -73,7 +73,7 @@ func TestConstrainLtStaticDedupsByValue(t *testing.T) {
 
 // A repeated outlives constraint does not re-append a bound already present.
 func TestConstrainLtDedupsBounds(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -87,7 +87,7 @@ func TestConstrainLtDedupsBounds(t *testing.T) {
 // A transitive cycle terminates: 'a <: 'b together with 'b <: 'a must not loop,
 // and each direction is recorded exactly once.
 func TestConstrainLtCycleTerminates(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -104,7 +104,7 @@ func TestConstrainLtCycleTerminates(t *testing.T) {
 
 // Constraining a lifetime against ITSELF is a no-op — neither a bound nor a loop.
 func TestConstrainLtReflexiveIsNoOp(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(a, a)
@@ -120,7 +120,7 @@ func TestConstrainLtReflexiveIsNoOp(t *testing.T) {
 // construct routes a borrow into static storage yet, since a borrow originates only
 // at a parameter, so this exercises the rule's mechanism directly.
 func TestEscapingRefIntoStatic(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(0)
 	ref := &soltype.RefType{
 		Mut: true,
@@ -141,7 +141,7 @@ func TestEscapingRefIntoStatic(t *testing.T) {
 // escapes. constrainEscape walks the structural carriers, so the property's borrow
 // is constrained alongside any top-level one.
 func TestEscapingNestedRefIntoStatic(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	inner := c.ctx.freshLifetime(0)
 	stored := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
 		&soltype.PropertyElem{Name: "p", Type: &soltype.RefType{
@@ -193,7 +193,7 @@ func borrowFn(ret soltype.Type, paramLts ...soltype.Lifetime) *soltype.FuncType 
 // `<: 'static`, which propagates through its lower bounds to each member, and
 // coalesceLifetimes then absorbs every member to 'static rather than naming it.
 func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	join := c.ctx.freshJoinLifetime(0)
@@ -225,7 +225,7 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 // distinct bounded lifetime. Without excluding the 'static-forced source, the join
 // would keep its own name and render the weaker `<'b: 'c, 'c>`.
 func TestJoinWithOneStaticSourceCollapsesToRemaining(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	join := c.ctx.freshJoinLifetime(0)
@@ -244,7 +244,7 @@ func TestJoinWithOneStaticSourceCollapsesToRemaining(t *testing.T) {
 // still renders as `&{x}` rather than collapsing to the bare inner. The mutable
 // case keeps the `&mut` form for the same reason.
 func TestImmutableConnectNothingBorrowKeepsRef(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lt := c.ctx.freshLifetime(0)
 	param := &soltype.RefType{
 		Mut: false,
@@ -267,7 +267,7 @@ func TestImmutableConnectNothingBorrowKeepsRef(t *testing.T) {
 // by SCC representative, so a lifetime reaching the top join through two sub-joins
 // yields one `'a: 'd` bound. Without that dedup 'a would carry the bound twice.
 func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	d := c.ctx.freshLifetime(0)
@@ -293,7 +293,7 @@ func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 // directly, while 'b and 'c reach the second join only through the shared component.
 // Each param therefore carries `: 'd & 'e`.
 func TestParamFeedingTwoJoinsRendersMeetBound(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	d := c.ctx.freshLifetime(0)
@@ -316,7 +316,7 @@ func TestParamFeedingTwoJoinsRendersMeetBound(t *testing.T) {
 // The params keep their own names 'a and 'b from the borrows they originate on; only
 // the join lifetime resolves to the representative.
 func TestJoinOverMutualOutlivesCollapsesToOne(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	join := c.ctx.freshJoinLifetime(0)
@@ -353,7 +353,7 @@ func TestJoinOverMutualOutlivesCollapsesToOne(t *testing.T) {
 // the non-param minted first, which a freshener or extruder can do but top-level
 // inference cannot, so `m` is minted before `p` here.
 func TestJoinRepresentativeIsNonParamRendersParamName(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	m := c.ctx.freshJoinLifetime(0) // non-param, minted first so it holds the smaller ID
 	p := c.ctx.freshLifetime(0)     // param lifetime, larger ID
 	c.ctx.constrainLt(p, m)         // p outlives m
@@ -369,7 +369,7 @@ func TestJoinRepresentativeIsNonParamRendersParamName(t *testing.T) {
 // pre-probe length, exactly as it does for type-variable bounds — the second sort
 // rides the same journal discipline. Bounds added before the probe survive.
 func TestProbeDiscardRestoresLifetimeBounds(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -394,7 +394,7 @@ func TestProbeDiscardRestoresLifetimeBounds(t *testing.T) {
 // A committed lifetime-bound mutation survives — discard is what reverts, not the
 // journal's existence.
 func TestProbeCommitKeepsLifetimeBounds(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -409,7 +409,7 @@ func TestProbeCommitKeepsLifetimeBounds(t *testing.T) {
 // A committed child hands its lifetime-bound rollback obligation up to the parent,
 // so the parent's later discard still reverts the committed child's lifetime work.
 func TestProbeLifetimeCommittedChildCoveredByParentDiscard(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -429,7 +429,7 @@ func TestProbeLifetimeCommittedChildCoveredByParentDiscard(t *testing.T) {
 // distinct `subVar.LowerBounds` loop: with lb <: a already recorded, constraining
 // a <: super must propagate lb <: super through a's existing lower bound.
 func TestConstrainLtPropagatesThroughLowerBounds(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	lb := c.ctx.freshLifetime(0)
 	a := c.ctx.freshLifetime(0)
 	super := c.ctx.freshLifetime(0)
@@ -447,7 +447,7 @@ func TestConstrainLtPropagatesThroughLowerBounds(t *testing.T) {
 // constrainLt(x, a) under the probe touches x, a, AND b (x <: a <: b), and the
 // discard must truncate every probe-era bound while leaving the pre-probe ones.
 func TestProbeDiscardRollsBackTransitivelyTouchedLifetimes(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -478,7 +478,7 @@ func TestProbeDiscardRollsBackTransitivelyTouchedLifetimes(t *testing.T) {
 // constrainLt(a, …) also touches its super var, so the probe holds three entries
 // total; the point is that `a` appears in exactly one of them.
 func TestProbeRecordLtDedupsPerLifetimeVar(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	d := c.ctx.freshLifetime(0)
@@ -504,7 +504,7 @@ func TestProbeRecordLtDedupsPerLifetimeVar(t *testing.T) {
 // lifetime sort too: ltTouched is lazily created on first recordLt, so there is no
 // nil-map panic. Mirrors the type sort's TestProbeBareLiteralIsNilMapSafe.
 func TestProbeBareLiteralLifetimeIsNilMapSafe(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -523,7 +523,7 @@ func TestProbeBareLiteralLifetimeIsNilMapSafe(t *testing.T) {
 // parent's journal and the var's parent-era bounds intact. Mirrors the type sort's
 // TestDiscardedChildLeavesParentJournalIntact.
 func TestProbeLifetimeDiscardedChildLeavesParentJournalIntact(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 	d := c.ctx.freshLifetime(0)
@@ -547,7 +547,7 @@ func TestProbeLifetimeDiscardedChildLeavesParentJournalIntact(t *testing.T) {
 // the child's snapshot is inherited so the parent discard reverts the child's bound
 // to the var's pre-child length. Mirrors TestCommittedChildInheritsUntouchedVarSnapshot.
 func TestProbeLifetimeCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -567,7 +567,7 @@ func TestProbeLifetimeCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
 // clean no-op that leaves the pre-probe bound untouched. This verifies the
 // "no journal entry without an append" invariant for the lifetime sort.
 func TestProbeReconstrainingPresentLifetimeBoundJournalsNothing(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 
@@ -590,7 +590,7 @@ func TestProbeReconstrainingPresentLifetimeBoundJournalsNothing(t *testing.T) {
 // speculation discipline as a direct constrainLt call. Without journaling here, a
 // failed overload trial that constrained two borrows would leak a lifetime bound.
 func TestProbeRollsBackLifetimeBoundFromRefArm(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.ctx.freshLifetime(0)
 	b := c.ctx.freshLifetime(0)
 

--- a/internal/solver/poly_test.go
+++ b/internal/solver/poly_test.go
@@ -10,7 +10,7 @@ import (
 // A MonoScheme instantiates to its exact type — same pointer, no freshening — so a
 // monomorphic binding behaves as M2's plain type did.
 func TestInstantiateMonoSchemeReturnsSameType(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	ty := &soltype.PrimType{Prim: soltype.NumPrim}
 	got := c.instantiate(monoScheme(ty), 0)
 	require.Same(t, ty, got)
@@ -20,7 +20,7 @@ func TestInstantiateMonoSchemeReturnsSameType(t *testing.T) {
 // FRESH variable, so two uses never share a variable; the freshened function keeps
 // the same shape (param var == return var for identity).
 func TestInstantiatePolySchemeFreshensQuantifiedVars(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	// A generalized identity: fn(a) -> a, with `a` quantifiable (Level 1 > 0).
 	a := &soltype.TypeVarType{ID: 100, Level: 1}
 	body := &soltype.FuncType{
@@ -46,7 +46,7 @@ func TestInstantiatePolySchemeFreshensQuantifiedVars(t *testing.T) {
 // while freshening those above it — the level discipline that keeps a captured
 // param monomorphic when an inner function is instantiated.
 func TestFreshenAboveSharesCapturedVars(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	captured := &soltype.TypeVarType{ID: 1, Level: 1}   // at the limit → shared
 	quantified := &soltype.TypeVarType{ID: 2, Level: 2} // above the limit → freshened
 	body := &soltype.TupleType{Elems: []soltype.Type{captured, quantified}}
@@ -61,7 +61,7 @@ func TestFreshenAboveSharesCapturedVars(t *testing.T) {
 // freshenAbove freshens a variable's BOUNDS too, and terminates on a cyclic bound
 // graph (the fresh var is cached before its bounds are freshened).
 func TestFreshenAboveFreshensBoundsAndHandlesCycles(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	v := &soltype.TypeVarType{ID: 1, Level: 2}
 	v.LowerBounds = []soltype.Type{&soltype.PrimType{Prim: soltype.NumPrim}}
 	v.UpperBounds = []soltype.Type{v} // self-referential bound
@@ -82,7 +82,7 @@ func TestFreshenAboveFreshensBoundsAndHandlesCycles(t *testing.T) {
 // each instantiation of the generic gets its own U. This is the per-method
 // generalization the FuncType.TypeParams field exists to carry.
 func TestFreshenAboveGenericFunc(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	u := c.freshAt(2) // deeper than the limit 1, so it is a quantified parameter
 	u.UpperBounds = []soltype.Type{&soltype.PrimType{Prim: soltype.NumPrim}}
 	fn := &soltype.FuncType{
@@ -106,7 +106,7 @@ func TestFreshenAboveGenericFunc(t *testing.T) {
 // Origin (M3, PR1). A MonoScheme instantiation records nothing (it freshens no
 // variable).
 func TestInstantiateRecordsFromInstantiation(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := &soltype.TypeVarType{ID: 1, Level: 1}
 	scheme := &PolyScheme{Level: 0, Body: a}
 
@@ -125,7 +125,7 @@ func TestInstantiateRecordsFromInstantiation(t *testing.T) {
 // generalize wraps a type in a PolyScheme at the given level; the body is kept RAW
 // (the same variables, for instantiation) rather than coalesced.
 func TestGeneralizeWrapsRawBody(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := &soltype.TypeVarType{ID: 1, Level: 1}
 	scheme := c.generalize(a, 0)
 	ps, ok := scheme.(*PolyScheme)

--- a/internal/solver/probe_test.go
+++ b/internal/solver/probe_test.go
@@ -14,7 +14,7 @@ import (
 // bounds flow through the real constrain path (the append sites that call
 // recordMutation), not hand-appends, so this also proves the wiring.
 func TestProbeDiscardRestoresBoundLengths(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.freshAt(0)
 	b := c.freshAt(0)
 
@@ -39,7 +39,7 @@ func TestProbeDiscardRestoresBoundLengths(t *testing.T) {
 // A committed top-level probe keeps every mutation: discard is what reverts, not
 // the journal's existence.
 func TestProbeCommitKeepsBounds(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.freshAt(0)
 
 	p := c.openProbe()
@@ -54,7 +54,7 @@ func TestProbeCommitKeepsBounds(t *testing.T) {
 // record snapshots a variable at most once per probe (first touch), so repeated
 // appends to the same var all roll back to the single pre-touch length.
 func TestProbeRecordDedupsPerVariable(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.freshAt(0)
 
 	p := c.openProbe()
@@ -72,7 +72,7 @@ func TestProbeRecordDedupsPerVariable(t *testing.T) {
 // Prov keeps a stray entry from a losing trial — covering both the "node had no
 // prior entry" (delete) and "node had a prior entry" (restore) cases.
 func TestProbeDiscardRunsSideTableCleanups(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	fresh := &ast.IdentExpr{Name: "fresh"}
 	existing := &ast.IdentExpr{Name: "existing"}
 
@@ -106,7 +106,7 @@ func TestProbeDiscardRunsSideTableCleanups(t *testing.T) {
 
 // A committed probe's side-table writes survive — only a discard reverts them.
 func TestProbeCommitKeepsSideTableWrites(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	n := &ast.IdentExpr{Name: "x"}
 
 	p := c.openProbe()
@@ -122,7 +122,7 @@ func TestProbeCommitKeepsSideTableWrites(t *testing.T) {
 // A nested probe that COMMITS hands its rollback obligation up to its parent, so
 // the parent's later DISCARD still reverts the committed child's mutations.
 func TestCommittedChildCoveredByParentDiscard(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.freshAt(0)
 
 	parent := c.openProbe()
@@ -143,7 +143,7 @@ func TestCommittedChildCoveredByParentDiscard(t *testing.T) {
 // snapshot is inherited so the parent discard reverts the child's bounds to the
 // var's pre-child length (here: empty).
 func TestCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.freshAt(0) // only the child will touch a
 
 	parent := c.openProbe()
@@ -159,7 +159,7 @@ func TestCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
 // A discarded child leaves the parent's own journal — and the variable's
 // parent-era bounds — intact; only the child's appends are reverted.
 func TestDiscardedChildLeavesParentJournalIntact(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.freshAt(0)
 
 	parent := c.openProbe()
@@ -177,7 +177,7 @@ func TestDiscardedChildLeavesParentJournalIntact(t *testing.T) {
 // The active-probe pointer follows the open/close stack exactly: nil → p1 → p2 →
 // back to p1 → back to nil, regardless of commit/discard outcome.
 func TestProbePointerFollowsOpenCloseStack(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	require.Nil(t, c.ctx.probe)
 
 	p1 := c.openProbe()
@@ -198,7 +198,7 @@ func TestProbePointerFollowsOpenCloseStack(t *testing.T) {
 // Commit and Discard are idempotent and mutually exclusive: a second outcome call
 // is a no-op, so a double-close (or commit-then-discard) can't double-truncate.
 func TestProbeOutcomeIsIdempotent(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := c.freshAt(0)
 
 	p := c.openProbe()
@@ -224,7 +224,7 @@ func TestProbeOutcomeIsIdempotent(t *testing.T) {
 // discard must truncate those back. Constraining a low-level var against a
 // higher-level var forces extrusion through the recorded append sites.
 func TestProbeRollsBackExtrudeBounds(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	low := c.freshAt(0)
 	high := c.freshAt(1) // higher level ⇒ constraining low <: high extrudes high down
 
@@ -244,7 +244,7 @@ func TestProbeRollsBackExtrudeBounds(t *testing.T) {
 // error-collecting walk (c.report / c.constrain), so a losing speculative
 // candidate leaves no spurious errors behind; a committed probe keeps them.
 func TestProbeRollsBackErrs(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	n := &ast.IdentExpr{Name: "boom"}
 
 	// A pre-probe diagnostic stays regardless of the trial's outcome.
@@ -266,7 +266,7 @@ func TestProbeRollsBackErrs(t *testing.T) {
 // A committed child's diagnostics are covered by a later parent discard, exactly
 // like its bound mutations — the errs snapshot rides the same nesting handoff.
 func TestProbeErrsCommittedChildCoveredByParentDiscard(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	n := &ast.IdentExpr{Name: "boom"}
 
 	parent := c.openProbe()
@@ -284,7 +284,7 @@ func TestProbeErrsCommittedChildCoveredByParentDiscard(t *testing.T) {
 // A probe built directly as &Probe{} (bypassing newProbe) is still safe: touched
 // is lazily created on first record, so there is no nil-map panic.
 func TestProbeBareLiteralIsNilMapSafe(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	v := c.freshAt(0)
 
 	c.ctx.probe = &Probe{} // deliberately skip newProbe

--- a/internal/solver/productivity.go
+++ b/internal/solver/productivity.go
@@ -210,7 +210,7 @@ func (v *unguardedRefCollector) ExitType(t soltype.Type, _ soltype.Polarity) sol
 func guardsEveryOperand(t soltype.Type) bool {
 	switch t.(type) {
 	case *soltype.FuncType, *soltype.RefType, *soltype.PromiseType, *soltype.GeneratorType,
-		*soltype.ArrayType, *soltype.TemplateLitType, *soltype.ClassType, *soltype.AliasType:
+		*soltype.TemplateLitType, *soltype.ClassType, *soltype.AliasType:
 		return true
 	default:
 		return false

--- a/internal/solver/prov_test.go
+++ b/internal/solver/prov_test.go
@@ -45,7 +45,7 @@ func requireFromNormalization(t *testing.T, c *checker, ty soltype.Type, sources
 // written by an AST node, so without the edge a diagnostic naming one falls back to
 // the constraint site's span.
 func TestProvFusedArrowAndDomain(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := parseType(t, "fn (x: number) -> boolean")
 	b := parseType(t, "fn (x: string) -> boolean")
 
@@ -65,7 +65,7 @@ func TestProvFusedArrowAndDomain(t *testing.T) {
 // The record came from the two source records, and the field `never` from the meet
 // of the two source field types.
 func TestProvFusedRecordAndField(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := parseType(t, "{x: number, ...}")
 	b := parseType(t, "{x: string, ...}")
 
@@ -83,7 +83,7 @@ func TestProvFusedRecordAndField(t *testing.T) {
 // still reach the two atoms whose intersection is uninhabited. `5 & 6` fuses to
 // `never` naming the two literals.
 func TestProvFusedNeverNamesSources(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	a := parseType(t, "5")
 	b := parseType(t, "6")
 
@@ -96,7 +96,7 @@ func TestProvFusedNeverNamesSources(t *testing.T) {
 
 // A literal mints a LitType recorded against its LiteralExpr.
 func TestProvLiteralInference(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	e := numExpr(5)
 	ty := c.inferExpr(NewScope(), 0, e)
 	requireOrigin(t, c, ty, e, LiteralInference)
@@ -104,7 +104,7 @@ func TestProvLiteralInference(t *testing.T) {
 
 // A tuple/object literal records its aggregate type against the literal node.
 func TestProvTupleAndObject(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	tup := tupleExpr(numExpr(1), strExpr("hi"))
 	tupTy := c.inferExpr(NewScope(), 0, tup)
 	requireOrigin(t, c, tupTy, tup, TupleElem)
@@ -117,7 +117,7 @@ func TestProvTupleAndObject(t *testing.T) {
 // A call records its fresh result var (Application) against the CallExpr and the
 // synthesized call-shape (CallShape) against the same node.
 func TestProvCallResultAndShape(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineValue("inc", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.FuncType{
 		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "n"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
@@ -145,7 +145,7 @@ func TestProvCallResultAndShape(t *testing.T) {
 // A member read records its fresh result var against the .prop IDENTIFIER, not the
 // whole MemberExpr — so missing-property blame is the property, not the receiver.
 func TestProvMemberAccessRecordedAgainstProp(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	e := memberExpr(objExpr(prop("a", numExpr(5))), "a")
 	res := c.inferExpr(NewScope(), 0, e)
 	requireOrigin(t, c, res, e.Prop, MemberAccess)
@@ -154,7 +154,7 @@ func TestProvMemberAccessRecordedAgainstProp(t *testing.T) {
 // A function records its own FuncType (FuncInference) against the function node and
 // each un-annotated param's fresh var (ParamBinding) against the param's pattern.
 func TestProvFuncTypeAndParamBinding(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	e := funcExpr([]*ast.Param{param("x", nil)}, nil, block(exprStmt(identExpr("x"))))
 	ty := c.inferExpr(NewScope(), 0, e)
 	requireOrigin(t, c, ty, e, FuncInference)
@@ -168,7 +168,7 @@ func TestProvFuncTypeAndParamBinding(t *testing.T) {
 // (AnnotationType), and the ParamBinding origin is NOT recorded for it — its blame
 // rides on the annotation (the fresh-atom discipline, §3.3).
 func TestProvAnnotatedParamUsesAnnotationOrigin(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	ann := numAnn()
 	e := funcExpr([]*ast.Param{param("x", ann)}, nil, block(exprStmt(identExpr("x"))))
 	ty := c.inferExpr(NewScope(), 0, e)
@@ -181,7 +181,7 @@ func TestProvAnnotatedParamUsesAnnotationOrigin(t *testing.T) {
 // (AnnotationType) — the fresh-atom discipline that makes a shared `number` no
 // longer a blind spot.
 func TestProvAnnotationType(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	ta := numAnn()
 	ty, ok := c.resolveTypeAnn(NewScope(), ta, 0)
 	require.True(t, ok)
@@ -192,7 +192,7 @@ func TestProvAnnotationType(t *testing.T) {
 // atom would overwrite the definition's origin. So inferring a bare ident over a
 // pre-bound atom leaves the table empty.
 func TestProvIdentRecordsNothing(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := NewScope()
 	scope.defineValue("x", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.PrimType{Prim: soltype.NumPrim})}})
 	c.inferExpr(scope, 0, identExpr("x"))
@@ -202,7 +202,7 @@ func TestProvIdentRecordsNothing(t *testing.T) {
 // The honest absence (§3.2): a synthesized (coalesced) type has no Prov entry, so
 // NodeFor reports a miss rather than lying.
 func TestProvCoalescedTypeHasNoEntry(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	v := c.freshAt(0)
 	co := coalesce(v, soltype.Positive) // empty bounds → never, a fresh synthesized atom
 	_, ok := c.prov.NodeFor(co)
@@ -236,7 +236,7 @@ func TestProvSharedSingletonRecordsNothing(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newChecker()
+			c := newTestChecker()
 			c.debugProv = true
 			ty, ok := c.resolveTypeAnn(NewScope(), tt.ann(), 0)
 			require.True(t, ok)
@@ -251,7 +251,7 @@ func TestProvSharedSingletonRecordsNothing(t *testing.T) {
 // interned/coalesced-pointer reuse that would silently mis-blame), while
 // re-recording against the same node is idempotent and allowed.
 func TestProvDebugGuardCatchesConflictingOverwrite(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	c.debugProv = true
 	ty := &soltype.PrimType{Prim: soltype.NumPrim}
 	nodeA := numAnn()
@@ -265,7 +265,7 @@ func TestProvDebugGuardCatchesConflictingOverwrite(t *testing.T) {
 // With the guard OFF (production default), a conflicting overwrite does not panic —
 // a span bug must never crash the compiler (it degrades to last-write-wins blame).
 func TestProvDebugGuardOffDoesNotPanic(t *testing.T) {
-	c := newChecker() // debugProv defaults false
+	c := newTestChecker() // debugProv defaults false
 	ty := &soltype.PrimType{Prim: soltype.NumPrim}
 	c.recordProv(ty, numAnn(), AnnotationType)
 	require.NotPanics(t, func() { c.recordProv(ty, strAnn(), AnnotationType) })

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -731,7 +731,7 @@ func TestComponentEscapeCyclicGraph(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			c := newChecker()
+			c := newTestChecker()
 			c.fn = &funcCtx{
 				paramVarIDs: set.NewSet[liveness.VarID](),
 			}

--- a/internal/solver/simplify_negation_test.go
+++ b/internal/solver/simplify_negation_test.go
@@ -142,7 +142,7 @@ func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newChecker()
+			c := newTestChecker()
 			in := tt.build(c)
 			require.Equal(t, tt.unsimplified, soltype.Print(in), "input to the pass")
 			require.Equal(t, tt.want, soltype.Print(c.subsumeFinal(in)))
@@ -154,7 +154,7 @@ func TestSimplifyNegationsDropsDisjointComplements(t *testing.T) {
 // from the excluded tag, so the pass must render it faithfully rather than drop it. The
 // scheme goes through generalize, the path a real binding takes to its display type.
 func TestSimplifyNegationsKeepsIrreducibleComplement(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	c.ctx.registerClass("Tag", &ClassDef{})
 	param := c.freshAt(1)
 	// The unsimplified body is `fn (x: T) -> T & ~Tag`. T occurs in both polarities, so
@@ -175,7 +175,7 @@ func TestSimplifyNegationsKeepsIrreducibleComplement(t *testing.T) {
 // the meet has an inhabitant. A false means the pass reached no derivation, which for a
 // meet the concreteness gate keeps it away from says nothing either way.
 func TestSimplifyNegationsMemberRewrites(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 
 	// `string & ~string` admits no value and the pass derives it. The empty meet is
 	// reported rather than returned as a `never` member, so the caller decides what an

--- a/internal/solver/subsume_test.go
+++ b/internal/solver/subsume_test.go
@@ -139,7 +139,7 @@ func TestInferSubsumedTypePreservesAssignability(t *testing.T) {
 // An inferred intersection collapses to its narrowest member: `{x, ...} & {x, y, ...}`
 // reduces to `{x, y, ...}`. It has no source form that survives combine's fold, so it is built directly.
 func TestSubsumeFinalIntersectionObjects(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	in := newIntersection(nil, parseTypes(t, "{x: number, ...}", "{x: number, y: string, ...}"))
 	require.IsType(t, &soltype.IntersectionType{}, in, "precondition: combine leaves both members")
 	got := c.subsumeFinal(in)
@@ -150,7 +150,7 @@ func TestSubsumeFinalIntersectionObjects(t *testing.T) {
 // gate skips it, so a scheme whose union is not yet ground is unchanged. The free
 // var has no surface form parseType can author, so the union is built directly.
 func TestSubsumeFinalLeavesFreeVar(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	v := c.ctx.freshVar(0)
 	got := c.subsumeFinal(newUnion(nil, []soltype.Type{parseType(t, "number"), v}))
 	require.IsType(t, &soltype.UnionType{}, got, "got %s", soltype.Print(got))
@@ -161,7 +161,7 @@ func TestSubsumeFinalLeavesFreeVar(t *testing.T) {
 // preserved up the spine rather than reallocating an equal node. `1 | 2` has no
 // subsumable member, so subsumeFinal returns the same union pointer.
 func TestSubsumeFinalPreservesIdentityWhenUnchanged(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	in := newUnion(nil, parseTypes(t, "1", "2"))
 	require.IsType(t, &soltype.UnionType{}, in)
 	require.Same(t, in, c.subsumeFinal(in))

--- a/internal/solver/testdata/stdlib/std/array.esc
+++ b/internal/solver/testdata/stdlib/std/array.esc
@@ -1,0 +1,12 @@
+// The `Array` the solver's own tests resolve `Array<T>` against.
+//
+// This is a hand-written stand-in for the committed `internal/interop/data/std/array.esc`,
+// which declares over four hundred lines and does not yet ingest cleanly. Reading it here
+// would put its diagnostics in front of every test that writes an array annotation. The
+// members below are the ones the tests exercise: a length, an element read, and a mutator
+// that makes `T` invariant the way the real declaration does.
+export declare class Array<T> {
+    length: number,
+    at(self, index: number) -> T | undefined,
+    push(mut self, item: T) -> number,
+}

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -100,7 +100,7 @@ func transitionFixture(
 	aliases *liveness.AliasTracker,
 	live set.Set[liveness.VarID],
 ) *checker {
-	c := newChecker()
+	c := newTestChecker()
 	c.fn = &funcCtx{
 		liveness: &liveness.LivenessInfo{
 			LiveAfter: [][]set.Set[liveness.VarID]{{live}},
@@ -527,7 +527,7 @@ func TestTransitionWiringReportsMoveError(t *testing.T) {
 // prelude's operator names are included, and the prelude cache makes repeated calls
 // return the same result.
 func TestCollectOuterBindingsPreludeCache(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	scope := sharedPrelude().Child()
 	scope.defineValue("myLocal", ValueBinding{})
 

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -45,6 +45,15 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 	case *ast.LitTypeAnn:
 		return c.resolveLitTypeAnn(ta)
 	case *ast.TypeRefTypeAnn:
+		// A written `Array` settles the well-known class name before anything is resolved,
+		// so the subtyping rules that single an array out compare against a name that is
+		// already cached. It runs ahead of the scope lookup because both outcomes need it:
+		// an imported `Array` resolves below and is the same ingested class, and the
+		// fallback further down instantiates the handle directly. Warming here rather than
+		// once per run keeps a program that never writes `Array` from loading the package.
+		if namesArray(ta.Name) {
+			c.warmArrayClass()
+		}
 		// Resolve through the type scope first so a user-defined alias, class, or type
 		// parameter takes precedence over the built-in Promise stub below. A bare alias or
 		// class reference resolves here; the prelude Promise placeholder is not a class, so
@@ -137,12 +146,12 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 			c.recordProv(t, ta, AnnotationType)
 			return t, true
 		}
-		// The built-in Array<T>, the element-typed sequence a rest parameter binds its trailing
-		// arguments into. It is minimal by design: it carries the element type and nothing else, so
-		// `xs.length` and `xs[0]` do not resolve. A local `Array` shadows the stub today, since
-		// resolution reaches here only after resolveScopedTypeRef finds nothing. That ends once
-		// `Array` and `Promise` are imported from the `std:collection` and `std:async` pseudo-packages.
-		if ast.QualIdentToString(ta.Name) == "Array" && len(ta.TypeArgs) == 1 {
+		// A written `Array<T>` the file did not import. Resolution reaches here only
+		// after resolveScopedTypeRef finds nothing, so an imported or locally declared
+		// Array has already answered and this is the stdlib one. It resolves to the same
+		// ingested class either way, so `xs.length` and `xs.push(v)` read off the
+		// declaration rather than off a wrapper carrying only an element type.
+		if ast.QualIdentToString(ta.Name) == "Array" && len(ta.TypeArgs) == 1 && c.ctx.arrayClass != "" {
 			if len(ta.LifetimeArgs) > 0 || ta.Lifetime != nil {
 				return c.reportUnsupportedFeature(ta, "lifetime annotation on Array"), false
 			}
@@ -153,7 +162,7 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 				// is cascade-safe where `never` or `unknown` would provoke a second failure.
 				elem = c.freshAt(lvl)
 			}
-			t := &soltype.ArrayType{Elem: elem}
+			t, _ := c.ctx.arrayOf(elem)
 			c.recordProv(t, ta, AnnotationType)
 			return t, true
 		}
@@ -163,12 +172,15 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		if t, ok := c.resolveExactnessIntrinsic(scope, ta, lvl); ok {
 			return t, true
 		}
-		// Nothing claimed the name. Either it names no declaration at all, or it names one of
-		// the two built-in stubs above with an argument count neither accepts. Those stubs take
-		// exactly one, and a user-defined Promise or Array would have resolved through the scope
-		// before reaching here, so the name here is the built-in.
+		// Nothing claimed the name. Either it names no declaration at all, or it names a
+		// built-in above with an argument count that one does not accept. Promise takes
+		// exactly one, and a user-defined Promise would have resolved through the scope
+		// before reaching here, so the name here is the built-in. Array reports the same
+		// way, but only when the run resolved one: without a stdlib the name is simply
+		// unknown, and claiming an arity for a declaration nothing supplies would say the
+		// wrong thing.
 		name := ast.QualIdentToString(ta.Name)
-		if name == "Promise" || name == "Array" {
+		if name == "Promise" || (name == "Array" && c.ctx.arrayClass != "") {
 			c.report(&TypeArgArityMismatchError{
 				Ref: ta, Kind: BuiltinDeclKind, Name: name,
 				Required: 1, Total: 1, Got: len(ta.TypeArgs),

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -49,10 +49,11 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		// so the subtyping rules that single an array out compare against a name that is
 		// already cached. It runs ahead of the scope lookup because both outcomes need it:
 		// an imported `Array` resolves below and is the same ingested class, and the
-		// fallback further down instantiates the handle directly. Warming here rather than
-		// once per run keeps a program that never writes `Array` from loading the package.
+		// fallback further down instantiates the handle directly. Resolving on a written
+		// reference rather than once per run keeps a program that never writes `Array`
+		// from loading the package at all.
 		if namesArray(ta.Name) {
-			c.warmArrayClass()
+			c.resolveArrayClass()
 		}
 		// Resolve through the type scope first so a user-defined alias, class, or type
 		// parameter takes precedence over the built-in Promise stub below. A bare alias or

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1848,7 +1848,7 @@ func (e *typeEvaluator) reduceExactness(kind soltype.ExactnessKind, operand solt
 		return op
 	case *soltype.PrimType, *soltype.LitType, *soltype.NeverType, *soltype.UnknownType,
 		*soltype.NullType, *soltype.UndefinedType, *soltype.PromiseType,
-		*soltype.GeneratorType, *soltype.ArrayType, *soltype.ErrorType:
+		*soltype.GeneratorType, *soltype.ErrorType:
 		return reduced
 	}
 	return &soltype.ExactnessType{Kind: kind, Operand: reduced}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1448,6 +1448,14 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, inexact bool) so
 		}
 		return &soltype.IndexType{Target: target, Index: idx, Inexact: inexact}
 	case *soltype.ClassType:
+		// An array read at a numeric key yields its element type. A tuple answers this from
+		// its listed positions, but an array declares no position for the key to land on, so
+		// the element is the whole answer whatever the index is. The declaration itself
+		// carries no numeric member, so without this arm the read would report the key as
+		// absent.
+		if elem, isArray := e.ctx.arrayElem(tgt); isArray && isNumericKey(idx) {
+			return elem
+		}
 		obj, ok := e.ctx.projectClassBody(tgt)
 		if !ok {
 			return &soltype.IndexType{Target: target, Index: idx, Inexact: inexact}
@@ -1598,6 +1606,19 @@ func (e *typeEvaluator) indexSignatureRead(obj *soltype.ObjectType, index soltyp
 		return &soltype.ErrorType{}
 	}
 	return newUnion(nil, []soltype.Type{idx.Value, &soltype.UndefinedType{}})
+}
+
+// isNumericKey reports whether t is a key that reads a position rather than a named
+// member: the `number` primitive, or a number literal.
+func isNumericKey(t soltype.Type) bool {
+	switch t := t.(type) {
+	case *soltype.PrimType:
+		return t.Prim == soltype.NumPrim
+	case *soltype.LitType:
+		_, isNum := t.Lit.(*soltype.NumLit)
+		return isNum
+	}
+	return false
 }
 
 // indexTuple reduces `tup[n]` for a ground tuple. A numeric-literal key selects the element at

--- a/internal/solver/typeops_negation_test.go
+++ b/internal/solver/typeops_negation_test.go
@@ -602,30 +602,38 @@ func TestInferMatchesPositiveSkeleton(t *testing.T) {
 	const src = `
 		type Elem<T> = if T : Array<infer R> { R } else { never }
 	`
+	// `Array` is a nominal class the run resolves, so a scrutinee naming one is built
+	// from the class name that run settled on rather than from a literal.
+	arrayOfNum := func(t *testing.T, ctx *Context) soltype.Type {
+		t.Helper()
+		at, ok := ctx.arrayOf(num())
+		require.True(t, ok, "the test stdlib supplies Array")
+		return at
+	}
 	tests := []struct {
 		name  string
-		scrut soltype.Type
+		scrut func(t *testing.T, ctx *Context) soltype.Type
 		want  string
 	}{
 		{
 			// `Elem<Array<number> & ~string>`. The positive member is what the pattern aligns
 			// with, so the capture binds the element type of the array the meet carries.
 			name:  "ComplementMemberIsSkipped",
-			scrut: meet(&soltype.ArrayType{Elem: num()}, negate(str())),
+			scrut: func(t *testing.T, ctx *Context) soltype.Type { return meet(arrayOfNum(t, ctx), negate(str())) },
 			want:  "number",
 		},
 		{
 			// `Elem<~Array<number>>`. A scrutinee that is nothing but a complement has no
 			// skeleton to align, so the match fails and the conditional takes its Else branch.
 			name:  "BareComplementMatchesNothing",
-			scrut: negate(&soltype.ArrayType{Elem: num()}),
+			scrut: func(t *testing.T, ctx *Context) soltype.Type { return negate(arrayOfNum(t, ctx)) },
 			want:  "never",
 		},
 		{
 			// `Elem<number & ~string>`. The positive part is what decides a failed match too. No
 			// array is a number, so the pattern rejects the meet whatever it excludes.
 			name:  "PositivePartStillDecidesAFailedMatch",
-			scrut: meet(num(), negate(str())),
+			scrut: func(_ *testing.T, _ *Context) soltype.Type { return meet(num(), negate(str())) },
 			want:  "never",
 		},
 	}
@@ -633,7 +641,7 @@ func TestInferMatchesPositiveSkeleton(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx, errs := inferTypeNodes(t, src)
 			require.Empty(t, errs)
-			inst := &soltype.AliasType{Name: "Elem", TypeArgs: []soltype.Type{tt.scrut}}
+			inst := &soltype.AliasType{Name: "Elem", TypeArgs: []soltype.Type{tt.scrut(t, ctx)}}
 			require.Equal(t, tt.want, soltype.Print(expandAliasResidual(ctx, inst)))
 		})
 	}

--- a/internal/solver/ucs_bind_test.go
+++ b/internal/solver/ucs_bind_test.go
@@ -21,7 +21,7 @@ import (
 // built by hand.
 func newPathChecker(t *testing.T, src string) (*checker, *Scope) {
 	t.Helper()
-	c := newChecker()
+	c := newTestChecker()
 	scope := sharedPrelude().Child()
 	module := parseModule(t, src)
 	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))

--- a/internal/solver/well_known.go
+++ b/internal/solver/well_known.go
@@ -170,20 +170,21 @@ func (e *MissingWellKnownTypeError) Span() ast.Span      { return e.span }
 func (e *MissingWellKnownTypeError) Related() []ast.Span { return nil }
 func (e *MissingWellKnownTypeError) isSolverError()      {}
 
-// warmArrayClass resolves the well-known `Array` once and records its qualified
+// resolveArrayClass resolves the well-known `Array` once and records its qualified
 // class name on the Context, leaving the name empty when the run supplies no
-// `Array`.
+// `Array`. A second call reads the cached handle rather than loading again.
 //
 // The rules that single an array out run deep inside constraint solving, where a
 // package load would be unsafe: a speculation trial truncates every bound it
 // journals, so a load raised under one would publish a package whose bounds the
-// discard then removes. Resolving here, before the walk, keeps those rules to a
-// string comparison over a name that is already settled.
+// discard then removes. Settling the name at the annotation that writes `Array`
+// keeps those rules to a string comparison. An annotation resolves while its
+// declaration is being bound, which is ahead of any constraint an array can reach.
 //
 // Diagnostics are dropped. A tree without a stdlib supplies no `Array` and needs
 // no report for one it never mentions. A program that does mention `Array` gets
 // the ordinary unknown-type diagnostic at the reference instead.
-func (c *checker) warmArrayClass() {
+func (c *checker) resolveArrayClass() {
 	saved := c.errs
 	t, ok := c.wellKnownType(wellKnownArray)
 	c.errs = saved

--- a/internal/solver/well_known.go
+++ b/internal/solver/well_known.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"strings"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -167,3 +169,59 @@ func (e *MissingWellKnownTypeError) Message() string {
 func (e *MissingWellKnownTypeError) Span() ast.Span      { return e.span }
 func (e *MissingWellKnownTypeError) Related() []ast.Span { return nil }
 func (e *MissingWellKnownTypeError) isSolverError()      {}
+
+// warmArrayClass resolves the well-known `Array` once and records its qualified
+// class name on the Context, leaving the name empty when the run supplies no
+// `Array`.
+//
+// The rules that single an array out run deep inside constraint solving, where a
+// package load would be unsafe: a speculation trial truncates every bound it
+// journals, so a load raised under one would publish a package whose bounds the
+// discard then removes. Resolving here, before the walk, keeps those rules to a
+// string comparison over a name that is already settled.
+//
+// Diagnostics are dropped. A tree without a stdlib supplies no `Array` and needs
+// no report for one it never mentions. A program that does mention `Array` gets
+// the ordinary unknown-type diagnostic at the reference instead.
+func (c *checker) warmArrayClass() {
+	saved := c.errs
+	t, ok := c.wellKnownType(wellKnownArray)
+	c.errs = saved
+	if !ok {
+		return
+	}
+	if cls, isClass := t.(*soltype.ClassType); isClass {
+		c.ctx.arrayClass = cls.Name
+	}
+}
+
+// arrayElem returns the element type of t when t is an instance of the well-known
+// `Array`, and false otherwise. It lives on Context rather than on the checker
+// because the subtyping core does, and that is where the rest-parameter rules read
+// it.
+func (c *Context) arrayElem(t soltype.Type) (soltype.Type, bool) {
+	cls, isClass := t.(*soltype.ClassType)
+	if !isClass || c.arrayClass == "" || cls.Name != c.arrayClass {
+		return nil, false
+	}
+	if len(cls.TypeArgs) != 1 {
+		return nil, false
+	}
+	return cls.TypeArgs[0], true
+}
+
+// arrayOf returns an instance of the well-known `Array` over elem, and false when
+// the run resolved no `Array` to instantiate.
+func (c *Context) arrayOf(elem soltype.Type) (soltype.Type, bool) {
+	if c.arrayClass == "" {
+		return nil, false
+	}
+	return &soltype.ClassType{Name: c.arrayClass, TypeArgs: []soltype.Type{elem}}, true
+}
+
+// namesArray reports whether a written type reference names `Array`, bare or
+// qualified by the namespace an import bound it under.
+func namesArray(name ast.QualIdent) bool {
+	written := ast.QualIdentToString(name)
+	return written == "Array" || strings.HasSuffix(written, ".Array")
+}

--- a/internal/solver/well_known_test.go
+++ b/internal/solver/well_known_test.go
@@ -11,7 +11,7 @@ import (
 // reaches a handle without inferring a module that imports anything.
 func wellKnownChecker(t *testing.T, files map[string]string) *checker {
 	t.Helper()
-	c := newChecker()
+	c := newTestChecker()
 	c.source = StdlibSource(seedStdlib(t, files))
 	return c
 }

--- a/internal/solver/widen_test.go
+++ b/internal/solver/widen_test.go
@@ -284,7 +284,7 @@ func TestWidenVar(t *testing.T) {
 // it is pinned here directly as the defensive contract that keeps Widenable
 // parallel to Open. See the freshener note in poly.go.
 func TestFreshenCopiesWidenable(t *testing.T) {
-	c := newChecker()
+	c := newTestChecker()
 	v := c.freshAt(1)
 	v.Widenable = true
 	out := c.freshenAbove(0, v, 0, map[*soltype.TypeVarType]*soltype.TypeVarType{})


### PR DESCRIPTION
Refs #1239

Fourth of a stack, on top of #1484. The rest is #1480 → #1483 → #1484.

**This is the second half of M7.5 PR5**, the half the plan named when it said that PR is "the PR to split further if review drags — the handle mechanism and the `ArrayType` retirement are separable, in that order." #1484 was the handle mechanism. This is the retirement.

## What changes

`soltype.ArrayType` is deleted. A written `Array<T>` resolves through the ordinary scope path, falling back to the handle #1484 added when the file imported nothing, so an array carries the ingested declaration's members instead of an element type alone. `xs.length`, `xs.push(v)`, `xs[i]`, and `for x in xs` all resolve.

`Context.arrayClass` holds the qualified class name the handle settled on. The rules that single an array out compare against it, which costs a string comparison rather than a package load. That matters because those rules run inside constraint solving, where a load is unsafe: a speculation trial truncates every bound it journals, so a package inferred under one would have its bounds removed by the discard. A written `Array` warms the name before the reference resolves, so a program that never writes one loads nothing, and an annotation reached only through an overload trial still resolves.

Every arm that switched on the concrete either deletes, its `ClassType` neighbour already covering the case, or reads the element through the handle:

| site | what happens |
| --- | --- |
| `constrain` rest absorb and scatter | reads the element through `arrayElem` |
| `constrain` `Array <: Array` | deletes; `constrainNominal` covers it with the declared variance |
| `coalesce`, `lattice` compare and kind order | delete; the `ClassType` arms cover them |
| `inhabited`, `productivity`, `typeops` exactness | delete; a class instance already lands where an array needs to |
| `errors.describe` | deletes; the `ClassType` arm renders `Array<number>` identically |
| `reduceIndex` | grows an array arm for a numeric key |
| `syncElemType` | grows an array arm for the element |
| `resolveTypeAnn` | instantiates the handle instead of minting the concrete |

## The variance fix this forced

Retiring the concrete surfaced a bug in `inferBodyVariance`. It walked every member into both variance vectors, so a member no immutable reference can reach still shaped the immutable view. Under that rule the ingested `Array` measured `T` **invariant**: `at(self, index) -> T | undefined` is an output position and `push(mut self, item: T)` an input one. `Array<1> <: Array<number>` was rejected, where the retired concrete had been covariant.

A member an immutable reference cannot reach now contributes to the mutable vector alone. Three are gated that way — a write to a non-`readonly` field, which already was; a setter; and a method whose receiver is `mut self` or `&mut self`. An overloaded method splits per signature, since one arm taking a mutable receiver does not gate the arms that do not.

So `Array<T>` is covariant in `T` and `mut Array<T>` is invariant, which is the same split `class Box<T> { value: T }` already got from its field. The widening holds for a shared array, and two mutable arrays over different elements stay unrelated.

## The test stdlib

The committed `internal/interop/data/std/array.esc` does not ingest. It loads in about three milliseconds and produces a `ClassType`, but reports seventy diagnostics along the way — `RestPat`, `Self`, `ComputedKey`, `AnyTypeAnn`, multiple constructors, and unresolved type parameters. That is the #1232 gap. Reading it here would put those seventy in front of every test that writes an array annotation, so `internal/solver/testdata/stdlib/std/array.esc` holds a three-member stand-in: a `length`, the element read, and the mutator that gates the mutable view. The solver's test harness resolves against that tree.

## Tests

`internal/solver/array_test.go` covers the milestone's acceptance list: the annotation resolving with nothing imported, `xs.length`, `xs.push(1)` checking and `xs.push("a")` rejecting with the full message, `xs[0]` and `xs[k]`, `for x in xs` binding at the element, a rest parameter still rejecting a wrong trailing argument, an `Array` reached only through an overload trial still resolving, and `Array` reading as an unknown name when no stdlib supplies one. `TestArrayIsCovariantAndMutArrayIsNot` drives both variance directions end to end.

`TestInferBodyVariance` gains four cases over hand-built bodies: the `Array` shape itself, an overload set splitting its arms by receiver, a getter and setter pair, and a parameter only a mutator names, which reads as bivariant in the immutable view.

`TestConstrainRestParamElementChecking` was disabled pending exactly this milestone and is re-enabled. Two of the cases its disabled body carried are dropped rather than enabled: both gave the sub an inexact accept-set, which `canAbsorbRest` excludes by design, so they asserted an absorb that does not happen rather than an element check that was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195c9jyZtaRu9utgAYy6DkC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving `Array<T>` through the standard library, including typed annotations, numeric indexing, iteration, member access, and array methods.
  * Added support for array-aware rest parameters and overload resolution.
  * Array covariance and mutable-array invariance are now enforced consistently.
* **Bug Fixes**
  * Improved variance inference for mutable members, setters, and mutable methods.
  * Array types are treated as unknown when no standard library definition is available.
* **Tests**
  * Expanded coverage for array behavior, indexing, iteration, variance, rest parameters, and overload resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->