### PR TITLE
Resolve `any` and keep an `any` type parameter default

### DIFF
--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -491,3 +491,99 @@ func TestInferUnknownAnnotationTwiceInOneModule(t *testing.T) {
 	require.Equal(t, "unknown", values["u"])
 	require.Equal(t, "unknown", values["v"])
 }
+
+// `any` in annotation position resolves to `unknown`, the top of the lattice. A declaration
+// writes `any` where it places no constraint on a type, and `unknown` carries that meaning
+// without TypeScript's unsound assignment from `any` down to any other type.
+func TestInferAnyAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "AcceptsPrimitive",
+			src:  `val u: any = 5`,
+			want: "unknown",
+		},
+		{
+			name: "AcceptsObject",
+			src:  `val u: any = {a: 1}`,
+			want: "unknown",
+		},
+		{
+			// A nested position resolves the same way, so `any` composes rather than being
+			// special-cased at the top of an annotation.
+			name: "NestedInObject",
+			src:  `val u: {a: any} = {a: "s"}`,
+			want: "{a: unknown}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["u"])
+		})
+	}
+}
+
+// Two `any` annotations in one module each resolve without tripping the provenance table, for
+// the reason TestInferUnknownAnnotationTwiceInOneModule gives: both resolve to the shared
+// zero-size UnknownType singleton, so the arm records no provenance against it.
+func TestInferAnyAnnotationTwiceInOneModule(t *testing.T) {
+	values, _, errs := inferSource(t, "val u: any = 1\nval v: any = \"s\"")
+	require.Empty(t, errs)
+	require.Equal(t, "unknown", values["u"])
+	require.Equal(t, "unknown", values["v"])
+}
+
+// A type parameter defaulted to `any` keeps its default, so a reference omitting the argument
+// resolves rather than reporting an arity mismatch. Resolving the default is what makes the
+// parameter optional: resolveTypeParams drops a default it cannot resolve, and requiredArgCount
+// then counts the parameter as required.
+func TestInferAnyTypeParamDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "Interface",
+			src: `declare interface It<T, R = any> { a: T, b: R }
+				fn f(p: It<number>) -> number { return p.a }`,
+			want: "fn (p: It<number, unknown>) -> number",
+		},
+		{
+			name: "Alias",
+			src: `type It<T, R = any> = {a: T, b: R}
+				fn f(p: It<number>) -> number { return p.a }`,
+			want: "fn (p: It<number, unknown>) -> number",
+		},
+		{
+			// The control the `any` cases are compared against. An ordinary default fills
+			// the omitted argument the same way, so a difference between this case and the
+			// others would mean `any` is still being treated as a special case.
+			name: "OrdinaryDefault",
+			src: `declare interface It<T, R = string> { a: T, b: R }
+				fn f(p: It<number>) -> number { return p.a }`,
+			want: "fn (p: It<number, string>) -> number",
+		},
+		{
+			// The shape `std/iterator.esc` writes for `Iterable`, where two trailing
+			// parameters both default to `any` and every `Iterable<T>` elsewhere in the tree
+			// omits them.
+			name: "TwoTrailingDefaults",
+			src: `declare interface It<T, TReturn = any, TNext = any> { a: T, b: TReturn, c: TNext }
+				fn f(p: It<number>) -> number { return p.a }`,
+			want: "fn (p: It<number, unknown, unknown>) -> number",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -42,6 +42,19 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		t := &soltype.UnknownType{}
 		c.recordProvForResult(t, ta, AnnotationType)
 		return t, true
+	case *ast.AnyTypeAnn:
+		// `any` resolves to `unknown`, the top of the lattice. A declaration writes `any`
+		// where it places no constraint on a type, most often a type parameter's default such
+		// as the `TReturn = any` of `interface Iterable<T, TReturn = any, TNext = any>`.
+		// `unknown` carries that meaning and stays sound. TypeScript's `any` also assigns in
+		// the unsound direction, from `any` down to any other type, and nothing here relies on
+		// that.
+		//
+		// recordProvForResult records nothing here, for the reason the NeverTypeAnn arm gives:
+		// UnknownType is a shared zero-size singleton.
+		t := &soltype.UnknownType{}
+		c.recordProvForResult(t, ta, AnnotationType)
+		return t, true
 	case *ast.LitTypeAnn:
 		return c.resolveLitTypeAnn(ta)
 	case *ast.TypeRefTypeAnn:


### PR DESCRIPTION
Fixes #1498. Part of #1232.

## Summary

`any` in annotation position reported `Unsupported: AnyTypeAnn`. It now resolves to `unknown`, the top of the lattice, which is what a declaration means where it places no constraint on a type.

Resolving it also restores a type parameter defaulted to `any`. `resolveTypeParams` drops a default it cannot resolve, and `requiredArgCount` then counts the parameter as required, so `Iterable<T>` against `Iterable<T, TReturn = any, TNext = any>` reported an arity mismatch on top of the unsupported-feature diagnostic. That cascade is why the issue measured 20 of a `std:prelude`'s 158 diagnostics against this one gap.

`unknown` stays sound. TypeScript's `any` also assigns in the unsound direction, from `any` down to any other type, and nothing in the committed tree relies on that.

## Tests

- `TestInferAnyAnnotation` — `any` resolves in a binding, an object field, and a nested position.
- `TestInferAnyAnnotationTwiceInOneModule` — two `any` annotations in one module do not trip the provenance table, since both resolve to the shared zero-size `UnknownType` singleton.
- `TestInferAnyTypeParamDefault` — a parameter defaulted to `any` keeps its default on an interface and an alias, including the two-trailing-default shape `std/iterator.esc` writes for `Iterable`. An ordinary `= string` default is the control.

`go test ./...` passes.

## Base

Branches from `main`. #1502 builds on this one, since the `Awaited` definition writes `any` in its `then` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy)_