### PR TITLE
Bind a rest parameter written on a declaration

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -24,6 +24,19 @@ func hasRest(f *soltype.FuncType) bool {
 	return n > 0 && f.Params[n-1].Rest
 }
 
+// restSlotElem returns the element type a rest parameter's slot stands for, and false when the
+// slot is not an array. It looks through a borrow first, so `...items: mut Array<T>` binds the
+// same arguments `...items: Array<T>` does. The borrow describes the array a call gathers its
+// surplus arguments into and says nothing about the arguments, so it must not reach the element.
+// `std/array.esc` writes `push(mut self, ...items: mut Array<T>) -> number`, which is the form
+// this reads.
+func (c *Context) restSlotElem(slot soltype.Type) (soltype.Type, bool) {
+	if ref, ok := slot.(*soltype.RefType); ok {
+		return c.arrayElem(ref.Inner)
+	}
+	return c.arrayElem(slot)
+}
+
 // expandTupleRest returns f with a tuple-typed rest param replaced by one positional param per
 // tuple element, so the rules that walk a parameter list read ordinary positions instead of each
 // growing a rest case. The expanded form is never stored or printed, so a diagnostic still names
@@ -865,7 +878,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				slot := supX.Params[k].Type
 				if _, isVar := slot.(*soltype.TypeVarType); isVar {
 					absorbAt = k
-				} else if elem, isArray := c.arrayElem(slot); isArray {
+				} else if elem, isArray := c.restSlotElem(slot); isArray {
 					absorbAt, absorbElem = k, elem
 				}
 			}
@@ -923,7 +936,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			scatterAt, scatterElem := -1, soltype.Type(nil)
 			if absorbAt < 0 && !hasRest(supX) {
 				if j := restIndex(subX); j >= 0 {
-					if elem, isArray := c.arrayElem(subX.Params[j].Type); isArray {
+					if elem, isArray := c.restSlotElem(subX.Params[j].Type); isArray {
 						scatterAt, scatterElem = j, elem
 						n = min(j, len(supX.Params))
 					}

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -971,17 +971,23 @@ func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 func (c *checker) memberSigStub(lvl int, fn *ast.FuncExpr) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(fn.Params))
 	for i, p := range fn.Params {
+		// Read the `...` marker off the parameter without reporting, so a malformed rest
+		// slot draws its diagnostic once, from the body pass. The flag has to reach the stub
+		// because a stub and the signature that replaces it are compared by linkMemberSig,
+		// and a rest slot and a positional parameter accept different argument counts.
+		pat, rest, optional := restParamSlotShape(p, i == len(fn.Params)-1)
 		// A destructuring parameter has no single name, so the stub uses a positional
 		// placeholder. It never surfaces: the stub carries arity and fresh-var types only,
 		// and the body pass installs the real signature, whose inferFunc binds the pattern.
-		name, ok := identPatName(p.Pattern)
+		name, ok := identPatName(pat)
 		if !ok {
 			name = fmt.Sprintf("arg%d", i)
 		}
 		params[i] = &soltype.FuncParam{
 			Pattern:  &soltype.IdentPat{Name: name},
 			Type:     c.freshAt(lvl),
-			Optional: p.Optional,
+			Optional: optional,
+			Rest:     rest,
 		}
 	}
 	return &soltype.FuncType{

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -240,6 +240,11 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// G1 liveness pre-pass to seed parameter alias mutability.
 	paramTypes := make(map[string]soltype.Type, len(sig.Params))
 	for i, p := range sig.Params {
+		// A `...xs: Array<E>` parameter binds the slot rather than one argument. restParamSlot
+		// unwraps the marker to the pattern underneath and reports the forms that cannot carry
+		// it, so `...xs` binds `xs` at the slot's own type and the flag rides onto the
+		// FuncParam below.
+		pat, rest, optional := c.restParamSlot(p, i == len(sig.Params)-1)
 		pt := c.paramType(declScope, p, lvl)
 		// A generic function in parameter position is a rank-2 callback such as
 		// `g: <V>(x: V) -> V`. Its `<V>` binder is kept on the parameter's FuncType so a
@@ -259,17 +264,17 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 				v.Open = true
 			}
 		}
-		if name, ok := identPatName(p.Pattern); ok {
+		if name, ok := identPatName(pat); ok {
 			// The param's IdentPat IS its definition site, so record it as the binding's
 			// source — symmetric to a val/var/fn binding (inferVarDecl/module.go). This
 			// lets CannotAssignToImmutableError point "declared immutable here" at the
-			// parameter (see bindingDecl). p.Pattern is an ast.Node (*ast.Param is not).
-			sources := []provenance.Provenance{&ast.NodeProvenance{Node: p.Pattern}}
+			// parameter (see bindingDecl). pat is an ast.Node (*ast.Param is not).
+			sources := []provenance.Provenance{&ast.NodeProvenance{Node: pat}}
 			if p.TypeAnn == nil {
 				// An un-annotated param's type is the fresh var minted here, so a
 				// param-type mismatch blames the param. An annotated param's blame
 				// instead rides on its annotation, recorded by resolveTypeAnn.
-				c.recordProv(pt, p.Pattern, ParamBinding)
+				c.recordProv(pt, pat, ParamBinding)
 			}
 			// A parameter binding never generalizes — its var is fixed for the body — so
 			// it is a MonoScheme; instantiate returns pt unchanged at every use.
@@ -281,8 +286,8 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			// in-body binding keeps the param's declared type (pt), NOT widened to
 			// `pt | undefined`, so a body that reads an omitted optional sees it at the
 			// narrower type. Widening needs undefined/unions (M6); M3 has neither.
-			params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: p.Optional}
-		} else if p.Pattern != nil {
+			params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: optional, Rest: rest}
+		} else if pat != nil {
 			// M4 E1: a destructuring parameter such as `{x, y}` or `[a, b]`. bindPattern
 			// binds each leaf into the function scope against the param's type and returns
 			// the soltype mirror the printer renders. It also writes each leaf's type into
@@ -290,7 +295,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			// alias mutability. An un-annotated destructuring param mints a fresh var pt
 			// whose mismatch blame should point at the pattern.
 			if p.TypeAnn == nil {
-				c.recordProv(pt, p.Pattern, ParamBinding)
+				c.recordProv(pt, pat, ParamBinding)
 				// A pattern naming a `...rest` binds the properties its fields do not, so
 				// the parameter has to admit an argument that carries them. Policy A would
 				// otherwise close the usage-inferred object to exact, which rejects every
@@ -298,12 +303,12 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 				// would infer the parameter `{x: T0}` and reject `f({x: 1, y: 2})` for the
 				// extra y. Marking the var open keeps the folded object inexact, the same
 				// row-polymorphic shape the written `open` marker produces.
-				if v, ok := pt.(*soltype.TypeVarType); ok && objectPatNamesRest(p.Pattern) {
+				if v, ok := pt.(*soltype.TypeVarType); ok && objectPatNamesRest(pat) {
 					v.Open = true
 				}
 			}
-			mirror := c.bindPattern(fnScope, lvl, p.Pattern, pt, paramTypes)
-			params[i] = &soltype.FuncParam{Pattern: mirror, Type: pt, Optional: p.Optional}
+			mirror := c.bindPattern(fnScope, lvl, pat, pt, paramTypes)
+			params[i] = &soltype.FuncParam{Pattern: mirror, Type: pt, Optional: optional, Rest: rest}
 		} else {
 			// A pattern-less param is not reachable from the real parser, which
 			// synthesizes a placeholder. Blame the enclosing function rather than a nil
@@ -313,7 +318,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			name := fmt.Sprintf("arg%d", i)
 			fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}})
 			paramTypes[name] = pt
-			params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: p.Optional}
+			params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: optional, Rest: rest}
 		}
 	}
 
@@ -1473,6 +1478,15 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// strict path.
 	if resolved {
 		for i := 0; i < len(e.Args) && i < len(fn.Params); i++ {
+			if fn.Params[i].Rest {
+				// An argument at a rest slot fills one element of the gathered array, not the
+				// slot itself, so there is no parameter type to upgrade it against. Pairing the
+				// two would check the argument against the whole array: `f(1)` against
+				// `fn (...xs: mut Array<number>) -> R` would ask for `1 <: Array<number>`. The
+				// element check belongs to constrain's scatter rule, which the callee <:
+				// callShape constraint below reaches.
+				continue
+			}
 			if c.tryUpgradeToOwnedMut(e.Args[i], e.Args[i], demand[i].Type, fn.Params[i].Type) {
 				// The upgrade constrained the argument's shape against the parameter's
 				// immutable read view, so pin this argument's demand entry to the parameter's
@@ -1556,10 +1570,28 @@ func (c *checker) calleeReceiver(callee ast.Expr) (ast.Expr, *soltype.FuncParam)
 // tuple, or owned RefType consumes its argument. An extra argument beyond the declared
 // parameters, the surplus of a too-many-arguments call, has no parameter to move into,
 // so it is skipped.
+//
+// A rest slot is read through its element type, since each argument it gathers fills one
+// element of the array the callee owns rather than the array itself.
 func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType, ref liveness.StmtRef) {
 	for i, arg := range e.Args {
 		if i >= len(fn.Params) {
 			break
+		}
+		if fn.Params[i].Rest {
+			// The slot gathers this argument and every later one into an array the callee
+			// owns, so each is carried out of the frame the way a bare owned parameter's
+			// argument is. A slot that is not an array of a concrete owned element moves
+			// nothing, the same conservative reading a fixed position takes.
+			elem, isArray := c.ctx.restSlotElem(fn.Params[i].Type)
+			if !isArray || !isConcreteOwned(elem) {
+				return
+			}
+			for _, absorbed := range e.Args[i:] {
+				c.consumeOwned(absorbed, c.info.TypeOf(absorbed), absorbed, ref)
+				c.recordEscapeSite(absorbed, ref)
+			}
+			return
 		}
 		if !isConcreteOwned(fn.Params[i].Type) {
 			continue

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -688,3 +688,174 @@ func TestInferFunctionTopType(t *testing.T) {
 		})
 	}
 }
+
+// A rest parameter written on a function or method DECLARATION binds a slot, the same as one
+// written in a `fn(...) -> R` type annotation. The declaration path binds the pattern into the
+// body's scope, which the annotation path never does, so it reaches the marker separately and
+// needs its own coverage.
+func TestInferRestParamDeclaration(t *testing.T) {
+	const cls = "declare class Box<T> {\n  push(mut self, ...items: mut Array<T>) -> number,\n}\n"
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			// The declared slot survives onto the inferred type rather than degrading to a
+			// positional parameter typed `Array<number>`.
+			name: "KeepsTheSlotOnTheInferredType",
+			src:  `fn f(...xs: Array<number>) -> number { return 1 }`,
+		},
+		{
+			// The name binds at the slot's own type, so the body reads the gathered array.
+			name: "BindsTheNameAtTheSlotType",
+			src:  `fn f(...xs: Array<number>) -> number { return xs[0] }`,
+		},
+		{
+			name: "CallWithNoArguments",
+			src:  `fn f(...xs: Array<number>) -> number { return 1 }` + "\n" + `val r = f()`,
+		},
+		{
+			name: "CallWithSeveralArguments",
+			src:  `fn f(...xs: Array<number>) -> number { return 1 }` + "\n" + `val r = f(1, 2, 3)`,
+		},
+		{
+			name: "CallRejectsAWrongElement",
+			src:  `fn f(...xs: Array<number>) -> number { return 1 }` + "\n" + `val r = f(1, "a")`,
+			want: []string{`cannot constrain "a" <: number`},
+		},
+		{
+			// An owned-mutable slot binds the same arguments an owned one does. The borrow
+			// describes the array the call gathers its surplus arguments into and says nothing
+			// about the arguments, so it must not reach the element.
+			name: "OwnedMutableSlotChecksTheElement",
+			src:  `declare fn f(...xs: mut Array<number>) -> number` + "\n" + `val r = f(1, "a")`,
+			want: []string{`cannot constrain "a" <: number`},
+		},
+		{
+			// The shape `std/array.esc` writes for `Array.push`.
+			name: "MethodSlotAcceptsElements",
+			src:  cls + `fn g(xs: mut Box<number>) -> number { return xs.push(1, 2) }`,
+		},
+		{
+			name: "MethodSlotAcceptsNoArguments",
+			src:  cls + `fn g(xs: mut Box<number>) -> number { return xs.push() }`,
+		},
+		{
+			// The gap this case pins. A member's slot that degrades to a positional parameter
+			// demands the whole array, so the call is rejected for passing an element:
+			// `cannot constrain 1 <: Array<number>`.
+			name: "MethodSlotRejectsAWrongElement",
+			src:  cls + `fn g(xs: mut Box<number>) -> number { return xs.push("a") }`,
+			want: []string{`cannot constrain "a" <: number`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if len(tt.want) == 0 {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, len(tt.want))
+			for i, want := range tt.want {
+				require.Equal(t, want, errs[i].Message())
+			}
+		})
+	}
+}
+
+// A rest parameter on a function declaration renders with its `...` marker, which is what
+// shows the slot reached the inferred type rather than degrading to a positional parameter.
+func TestInferRestParamDeclarationRenders(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(...xs: Array<number>) -> number { return 1 }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (...xs: Array<number>) -> number", values["f"])
+}
+
+// Each malformed rest parameter on a class member reports once. A member is resolved twice,
+// as a signature stub and then as the signature that replaces it, so a report from both passes
+// would double every message. The stub reads the slot's shape without reporting, and it reads
+// the same recovery, so a recovered `...xs?` does not also draw an arity mismatch between the
+// stub and its replacement.
+func TestInferRestParamMalformedOnAMember(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "NotLast",
+			src:  "declare class Box {\n  m(self, ...xs: Array<number>, y: number) -> number,\n}",
+			want: "a rest parameter must be the last parameter of a function type",
+		},
+		{
+			name: "NoTypeAnnotation",
+			src:  "declare class Box {\n  m(self, ...xs) -> number,\n}",
+			want: "a rest parameter in a function type must have a type annotation",
+		},
+		{
+			name: "Optional",
+			src:  "declare class Box {\n  m(self, ...xs?: Array<number>) -> number,\n}",
+			want: "a rest parameter cannot be marked optional",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, errs[0].Message())
+		})
+	}
+}
+
+// An overload arm whose last parameter is an `Array<E>` rest slot checks every argument the
+// slot gathers against E. Resolution reads the arms one at a time rather than through the
+// callee <: callShape constraint, so the scatter rule constrain applies to a single-signature
+// callee is not what runs here and the element check has to be made per arm.
+func TestInferOverloadArmWithARestSlot(t *testing.T) {
+	const decl = "declare class Box {\n" +
+		"  m(self, n: number) -> number,\n" +
+		"  m(self, ...items: Array<string>) -> number,\n" +
+		"}\n"
+	const noMatch = "No matching overload for this call\n" +
+		"  fn (n: number) -> number\n" +
+		"  fn (...items: Array<string>) -> number"
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "SelectsTheFixedArm",
+			src:  decl + `fn g(b: Box) -> number { return b.m(3) }`,
+		},
+		{
+			name: "SelectsTheRestArm",
+			src:  decl + `fn g(b: Box) -> number { return b.m("x", "y") }`,
+		},
+		{
+			// Zero arguments fill the slot, so the rest arm still accepts.
+			name: "AcceptsNoArguments",
+			src:  decl + `fn g(b: Box) -> number { return b.m() }`,
+		},
+		{
+			// The gap this case pins. An arm accepted with its element unchecked takes any
+			// argument at all past the first, so the call resolves clean.
+			name: "RejectsAWrongElement",
+			src:  decl + `fn g(b: Box) -> number { return b.m("x", true) }`,
+			want: noMatch,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.want == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, errs[0].Message())
+		})
+	}
+}

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -432,3 +432,62 @@ func TestFreezeMoveAllowed(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, "fn (p: mut {x: number}) -> {x: number}", values["f"])
 }
+
+// An argument a rest slot gathers is carried out of the frame the way one passed to a bare
+// owned parameter is, so every argument the slot absorbs is consumed and not just the first.
+// The gathered array is what the callee owns, so the slot's element type is what says whether
+// an argument moves.
+func TestRestParamConsumesEveryArgument(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			// The gap this case pins. Where only a fixed position consumes its argument, both
+			// reads below stand and a value the callee owns stays readable here.
+			name: "SecondGatheredArgumentIsMoved",
+			src: `fn store(...xs: Array<{x: number}>) -> number { return 1 }
+fn f() {
+  val p = {x: 1}
+  val q = {x: 2}
+  store(p, q)
+  q.x
+}`,
+			want: []string{"6:3-6:6: use of moved value 'q'"},
+		},
+		{
+			name: "FirstGatheredArgumentIsMoved",
+			src: `fn store(...xs: Array<{x: number}>) -> number { return 1 }
+fn f() {
+  val p = {x: 1}
+  val q = {x: 2}
+  store(p, q)
+  p.x
+}`,
+			want: []string{"6:3-6:6: use of moved value 'p'"},
+		},
+		{
+			// A primitive element is not a concrete owned shape, so the slot moves nothing
+			// and a later read stands. That is the same conservative reading a fixed
+			// position of a primitive type takes.
+			name: "APrimitiveElementMovesNothing",
+			src: `fn store(...xs: Array<number>) -> number { return 1 }
+fn f() -> number {
+  val p = 1
+  store(p, 2)
+  return p
+}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if len(tt.want) == 0 {
+				require.Empty(t, errs)
+				return
+			}
+			require.Equal(t, tt.want, messagesWithSpan(t, errs))
+		})
+	}
+}

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -108,9 +108,9 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 // Arity follows the direct-call accept-set from #677, reusing acceptSet so the overload
 // arity gate and the FuncType<:FuncType constraint gate can never drift. A count below
 // acceptSet's lower bound is too few, and a count above its upper bound is too many.
-// Either is a non-match, unless the arm is inexact or has a rest. Extra arguments that
-// such an arm absorbs impose no per-element constraint here. That per-element check needs
-// Array types, which arrive in M4.
+// Either is a non-match, unless the arm is inexact or has a rest. An `Array<E>` rest slot
+// says what each argument it absorbs must be, so those are checked against E. An inexact
+// tail says nothing about what it absorbs, so those stay arity-only.
 func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) (bool, []SolverError) {
 	n := len(args)
 	if lo, hi := acceptSet(inst); n < lo || n > hi {
@@ -118,11 +118,26 @@ func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) (b
 	}
 	var diags []SolverError
 	for i, arg := range args {
-		if i >= len(inst.Params) || inst.Params[i].Rest {
-			// Past the fixed params, or AT a trailing rest param. The rest or inexact tail
-			// absorbs this and every later argument. Don't constrain a scalar argument
-			// against the rest param's ARRAY element type, since Params[i].Type is `T[]`.
-			// Per-element checking is M4.
+		if i >= len(inst.Params) {
+			// Past the fixed params. An inexact tail absorbs this argument and every later
+			// one and declares no type to check them against.
+			break
+		}
+		if inst.Params[i].Rest {
+			// A rest slot stands for this argument and every later one, so each is checked
+			// against the slot's element type rather than against the slot. A slot of any
+			// other shape declares no element type and stays arity-only.
+			elem, isArray := c.ctx.restSlotElem(inst.Params[i].Type)
+			if !isArray {
+				break
+			}
+			for _, absorbed := range args[i:] {
+				errs := c.ctx.Constrain(absorbed, elem)
+				if hasHardError(errs) {
+					return false, nil
+				}
+				diags = append(diags, errs...)
+			}
 			break
 		}
 		errs := c.ctx.Constrain(arg, inst.Params[i].Type)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -994,6 +994,68 @@ func (c *checker) typeofMember(recv soltype.Type, name string) (soltype.Type, bo
 	return read, true
 }
 
+// restParamSlot reads the `...` marker off one written parameter, returning the pattern to
+// bind, whether the parameter is a rest slot, and the optional marker to keep. A parameter
+// with no marker comes back unchanged. It is restParamSlotShape plus the diagnostics.
+//
+// The Rest flag it returns is what raises the function's accept-set ceiling and what an
+// `infer` clause in the slot captures the surplus arguments into. Three things the parser
+// accepts are rejected here, and each recovers the parameter to a positional one so the
+// function keeps its arity.
+//
+//  1. A rest parameter written anywhere but last, since acceptSet reads the flag off the last
+//     parameter only. last says whether this is that parameter.
+//  2. A rest parameter with no type annotation. The slot's type is what says how many
+//     arguments the parameter binds, and the fresh var an unannotated parameter recovers to
+//     says nothing, so keeping Rest would let the initializer decide the declared type's
+//     arity.
+//  3. A rest parameter marked `?`. A slot binding zero or more arguments is already omittable
+//     and a tuple slot fixes its count, so the marker changes nothing.
+//
+// Shared by the function type annotation and the function declaration, so `fn (...xs: T) -> R`
+// written as a type and `fn f(...xs: T) -> R` written as a declaration agree on the slot.
+func (c *checker) restParamSlot(p *ast.Param, last bool) (ast.Pat, bool, bool) {
+	pat, rest, optional := restParamSlotShape(p, last)
+	rp, isRest := p.Pattern.(*ast.RestPat)
+	if !isRest || rest {
+		return pat, rest, optional
+	}
+	switch {
+	case !last:
+		c.report(&RestParamNotLastError{Param: rp})
+	case p.TypeAnn == nil:
+		c.report(&RestParamNeedsTypeError{Param: rp})
+	default:
+		c.report(&OptionalRestParamError{Param: rp})
+	}
+	return pat, rest, optional
+}
+
+// restParamSlotShape reads the `...` marker off one written parameter without reporting,
+// returning the pattern to bind, whether the parameter is a well-formed rest slot, and the
+// optional marker to keep. last says whether p is the final parameter. restParamSlot layers
+// the diagnostics on top, so a caller that needs only the shape reads it here and the same
+// malformed slot is reported once. A member's signature stub is such a caller, and it needs
+// the same answer the signature that replaces it will carry, since linkMemberSig compares the
+// two and a differing arity would report on top of the diagnostic restParamSlot already filed.
+func restParamSlotShape(p *ast.Param, last bool) (ast.Pat, bool, bool) {
+	rp, ok := p.Pattern.(*ast.RestPat)
+	if !ok {
+		return p.Pattern, false, p.Optional
+	}
+	switch {
+	case !last, p.TypeAnn == nil:
+		return rp.Pattern, false, p.Optional
+	case p.Optional:
+		// The recovery drops the `?` marker along with Rest. Keeping it would give the
+		// parameter an accept-set the source never asked for, so `m(self, ...xs?: Array<T>)`
+		// would accept zero or one argument where its recovered signature accepts exactly one.
+		return rp.Pattern, false, false
+	default:
+		return rp.Pattern, true, p.Optional
+	}
+}
+
 // resolveFuncTypeAnn lowers a function type annotation `fn<T>(p: A, ...) -> R` into a
 // soltype.FuncType, recovering an unsupported part to a fresh var so the shape survives. A
 // `<T>` list resolves through resolveTypeParams into a child scope, so a parameter, return,
@@ -1025,39 +1087,7 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 
 	params := make([]*soltype.FuncParam, len(ta.Params))
 	for i, p := range ta.Params {
-		pat := p.Pattern
-		// A `...xs: T` parameter sets Rest. That flag is what raises the function's
-		// accept-set ceiling and what an `infer` clause in the slot captures the surplus
-		// arguments into. Three things the parser accepts are rejected here, and each
-		// recovers the parameter to a positional one so the function keeps its arity.
-		//
-		//  1. A rest parameter written anywhere but last, since acceptSet reads the flag off
-		//     the last parameter only.
-		//  2. A rest parameter with no type annotation. The slot's type is what says how many
-		//     arguments the parameter binds, and the fresh var an unannotated parameter
-		//     recovers to says nothing, so keeping Rest would let the initializer decide the
-		//     declared type's arity.
-		//  3. A rest parameter marked `?`. A slot binding zero or more arguments is already
-		//     omittable and a tuple slot fixes its count, so the marker changes nothing.
-		rest := false
-		optional := p.Optional
-		if rp, ok := pat.(*ast.RestPat); ok {
-			switch {
-			case i != len(ta.Params)-1:
-				c.report(&RestParamNotLastError{Param: rp})
-			case p.TypeAnn == nil:
-				c.report(&RestParamNeedsTypeError{Param: rp})
-			case p.Optional:
-				// The recovery drops the marker along with Rest. Keeping it would give the
-				// parameter an accept-set the source never asked for and cascade a second
-				// error out of the one just reported.
-				c.report(&OptionalRestParamError{Param: rp})
-				optional = false
-			default:
-				rest = true
-			}
-			pat = rp.Pattern
-		}
+		pat, rest, optional := c.restParamSlot(p, i == len(ta.Params)-1)
 		// A missing or unsupported parameter annotation recovers to a fresh var so
 		// the function keeps its arity and shape, cascade-safe like Promise<bad>.
 		var pt soltype.Type = c.freshAt(lvl)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,8 @@ importers:
 
   fixtures/do: {}
 
+  fixtures/doc_comments: {}
+
   fixtures/enum: {}
 
   fixtures/enum_script: {}


### PR DESCRIPTION
Fixes #1499. Part of #1232.

## Summary

A `...xs: T` parameter bound only in a `fn(...) -> R` type annotation. On a function declaration or a class member the marker reached `bindPattern`, which reports `Unsupported: RestPat` and binds nothing, so the slot degraded to an ordinary positional parameter. `push(mut self, ...items: mut Array<T>)` then demanded an array, and `xs.push(1)` was rejected with `cannot constrain 1 <: Array<number>`.

The gap is wider than the issue describes: `inferFunc` had no rest handling at all, so a plain `fn f(...xs: Array<number>)` declaration was broken the same way a class member was. `restParamSlot`, extracted from the annotation path, now serves both.

Five changes go with it:

- A member's signature stub carries the slot's shape, read without reporting, so the stub and the signature that replaces it agree on what the member accepts and a malformed slot draws one diagnostic rather than two.
- A rest slot's element is read through a borrow, so `mut Array<T>` scatters over `T` the way `Array<T>` does. The borrow describes the array a call gathers its surplus arguments into and says nothing about the arguments. `std/array.esc` writes `mut Array<T>` throughout, so nothing in the tree works without this.
- The owned-mutable argument upgrade skips a rest slot. An argument there fills one element, so pairing it with the slot asked for `1 <: Array<number>`.
- `consumeCallArgs` reads a rest slot through its element type, so every argument the slot gathers is consumed rather than none.
- An overload arm's `Array<E>` rest slot checks every argument it absorbs against `E`. `tryOverloadArm` broke at a rest parameter and constrained nothing past it, which predates the array element rule.

The last two came out of `/code-review` on the original combined branch.

## Tests

- `TestInferRestParamDeclaration` — the slot survives onto the inferred type, the name binds at the slot's type, calls accept zero and several arguments, a wrong element is rejected on the element, and an owned-mutable slot behaves like an owned one. The three method cases use the shape `std/array.esc` writes for `Array.push`.
- `TestInferRestParamDeclarationRenders` — the `...` marker reaches the rendered type.
- `TestInferRestParamMalformedOnAMember` — each of the three malformed forms reports exactly once, rather than twice from the two passes over a member.
- `TestInferOverloadArmWithARestSlot` — an overloaded method with a rest arm selects the right arm and rejects a wrong element.
- `TestRestParamConsumesEveryArgument` — every argument a rest slot gathers is moved, not just the first.

`go test ./...` passes.

## Base

Branches from `main`. #1501 builds on this one, for the `restSlotElem` its overload arm check reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for typed rest parameters in functions and methods, including destructured and mutable array rest parameters.
  * Rest arguments are now validated against their declared element types during calls and overload resolution.
  * Corrected ownership and consumption tracking for values gathered by rest parameters.
  * Improved handling and diagnostics for malformed rest-parameter declarations, including invalid placement, missing types, and optional rest parameters.
  * Preserved rest and optional parameter behavior in inferred function and method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->