### PR TITLE
Bind more than one constructor per class

### DIFF
--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -413,7 +413,7 @@ func TestAcceptConstructorElem(t *testing.T) {
 	paramT := &TypeVarType{ID: 1}
 	retT := &TypeVarType{ID: 2}
 	obj := &ObjectType{Elems: []ObjTypeElem{
-		&ConstructorElem{Fn: &FuncType{Params: []*FuncParam{identP("x", paramT)}, Ret: retT}},
+		&ConstructorElem{Signatures: []*FuncType{{Params: []*FuncParam{identP("x", paramT)}, Ret: retT}}},
 	}}
 
 	r := &recorder{seen: map[Type]Polarity{}}
@@ -425,13 +425,13 @@ func TestAcceptConstructorElem(t *testing.T) {
 	got := obj.Accept(&replaceVar{target: paramT, repl: str}, Positive).(*ObjectType)
 	require.NotSame(t, obj, got, "a changed constructor forces a new object")
 	gotCtor := got.Elems[0].(*ConstructorElem)
-	require.Same(t, str, gotCtor.Fn.Params[0].Type, "the constructor param took the replacement")
+	require.Same(t, str, gotCtor.Signatures[0].Params[0].Type, "the constructor param took the replacement")
 }
 
 // LevelOf on an object descends into a constructor's signature.
 func TestLevelOfConstructorElem(t *testing.T) {
 	obj := &ObjectType{Elems: []ObjTypeElem{
-		&ConstructorElem{Fn: &FuncType{Params: []*FuncParam{identP("x", &TypeVarType{ID: 1, Level: 6})}, Ret: numP()}},
+		&ConstructorElem{Signatures: []*FuncType{{Params: []*FuncParam{identP("x", &TypeVarType{ID: 1, Level: 6})}, Ret: numP()}}},
 	}}
 	require.Equal(t, 6, LevelOf(obj), "the level is the max over the constructor signature")
 }

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -600,7 +600,9 @@ func freeTypeVars(t Type) []*TypeVarType {
 						walk(e.Throws)
 					}
 				case *ConstructorElem:
-					walk(e.Fn)
+					for _, sig := range e.Signatures {
+						walk(sig)
+					}
 				case *SpreadElem:
 					walk(e.Type)
 				case *MappedElem:
@@ -1206,8 +1208,13 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 			p.printThrowsClause(e.ThrowsOrNever())
 	case *ConstructorElem:
 		// A class value's constructor renders as the unnamed call signature
-		// `new (params) -> ret`.
-		return "new " + p.printFuncTail(e.Fn)
+		// `new (params) -> ret`, one per declared constructor. An overloaded constructor
+		// renders its arms the way an overloaded method does, joined by `; `.
+		arms := make([]string, len(e.Signatures))
+		for i, sig := range e.Signatures {
+			arms[i] = "new " + p.printFuncTail(sig)
+		}
+		return strings.Join(arms, "; ")
 	case *SpreadElem:
 		// A `...A` spread renders inline among the object's fields, so `{...A, x: T}` round-trips
 		// to the source. The operand prints at precPrefix, so a looser one such as a union gets

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -350,10 +350,10 @@ func TestPrintGenericMethod(t *testing.T) {
 // alongside its static members, and round-trips through Accept unchanged.
 func TestPrintConstructorElem(t *testing.T) {
 	obj := &ObjectType{Elems: []ObjTypeElem{
-		&ConstructorElem{Fn: &FuncType{
+		&ConstructorElem{Signatures: []*FuncType{{
 			Params: []*FuncParam{identP("x", numP()), identP("y", numP())},
 			Ret:    &ClassType{Name: "Point"},
-		}},
+		}}},
 		&PropertyElem{Name: "count", Type: numP()},
 		&MethodElem{Name: "zero", Signatures: []*FuncType{{Ret: numP()}}, Static: true},
 	}}
@@ -368,7 +368,7 @@ func TestPrintConstructorElem(t *testing.T) {
 func TestFreeTypeVarsConstructorElem(t *testing.T) {
 	v := &TypeVarType{ID: 7, Level: 1}
 	obj := &ObjectType{Elems: []ObjTypeElem{
-		&ConstructorElem{Fn: &FuncType{Params: []*FuncParam{identP("x", v)}, Ret: &ClassType{Name: "Box"}}},
+		&ConstructorElem{Signatures: []*FuncType{{Params: []*FuncParam{identP("x", v)}, Ret: &ClassType{Name: "Box"}}}},
 	}}
 	require.Equal(t, []*TypeVarType{v}, freeTypeVars(obj))
 }
@@ -948,7 +948,7 @@ func TestPrintWithParams(t *testing.T) {
 // ctorObj wraps a constructor signature in the object a class value binds to, the
 // `{new (…) -> C}` shape classValue builds in internal/solver.
 func ctorObj(fn *FuncType) *ObjectType {
-	return &ObjectType{Elems: []ObjTypeElem{&ConstructorElem{Fn: fn}}}
+	return &ObjectType{Elems: []ObjTypeElem{&ConstructorElem{Signatures: []*FuncType{fn}}}}
 }
 
 // PrintElided renders a type like Print but stops at maxDepth, standing in ElisionMark for every

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -408,11 +408,17 @@ func (e *SetterElem) ThrowsOrNever() Type {
 }
 
 // ConstructorElem is the call signature a class value carries. It is the constructor a
-// class name resolves to as a value, so `Point(1, 2)` calls Fn. A class value holds
+// class name resolves to as a value, so `Point(1, 2)` calls it. A class value holds
 // exactly one, unnamed, alongside the class's static members. It is the single callable
 // element the structural lattice admits, scoped to the class-value carrier rather than a
 // general call-signature-in-any-object feature.
-type ConstructorElem struct{ Fn *FuncType }
+//
+// An overloaded constructor holds its arms in Signatures, the same shape MethodElem uses
+// for an overloaded method, ordered as the source declares them. `Array` is the case that
+// needs it: it declares both the length form and the element-list form, which is why
+// `Array(3)` and `Array(1, 2, 3)` mean different things. A class with one constructor has
+// exactly one signature.
+type ConstructorElem struct{ Signatures []*FuncType }
 
 // SpreadElem is a `...A` object spread written as an element of an ObjectType, the object twin of
 // the tuple's RestSpreadType (M9 PR5). `{...A, x: T}` is an ObjectType whose first element is a
@@ -428,6 +434,29 @@ func (*SetterElem) isObjTypeElem()      {}
 func (*ConstructorElem) isObjTypeElem() {}
 func (*MappedElem) isObjTypeElem()      {}
 func (*SpreadElem) isObjTypeElem()      {}
+
+// Instance returns the class instance every arm of this constructor produces, and false when
+// the element carries no signature. inferConstructor upholds the agreement by giving every arm
+// the one class handle it threads through them, and an object type annotation declares at most
+// one `new` signature, so no path builds a set whose arms disagree.
+//
+// The agreement covers the type and lifetime arguments, not just the class name. A reader may
+// act on them: coalesce's declaredTypeParams reads the handle's TypeArgs to name the display
+// binder after the vars the instance carries, so arms returning `Box<T0>` and `Box<T1>` would
+// render a binder over T0 and drop T1. Anything that builds a ConstructorElem has to keep the
+// arms agreeing on the whole handle.
+//
+// The instance is the ONLY thing the arms agree on. Params is what distinguishes them, and each
+// arm carries its own Throws and Inexact from its own body. A reader after any of those has no
+// arm the set endorses, so there is no accessor for one: it reads Signatures directly and owns
+// the arbitrary choice at its own call site, as ctorSignature in the solver does. #1516 replaces
+// the reason that one reads a constructor at all.
+func (e *ConstructorElem) Instance() (Type, bool) {
+	if len(e.Signatures) == 0 {
+		return nil, false
+	}
+	return e.Signatures[0].Ret, true
+}
 
 // ObjElemName returns the member name of any ObjTypeElem kind. It is the shared
 // name accessor for member lookup and structural equality, so those sites need no
@@ -670,10 +699,10 @@ func (o *ObjectType) preferredMember(name string, preferred func(ObjTypeElem) bo
 	return first, first != nil
 }
 
-// Constructor returns the object's constructor call signature and whether it carries
-// one. A class value carries exactly one ConstructorElem, so this is the lookup a call
-// site and the nominal-value constrain rule use to reach the constructor without a
-// type switch of their own.
+// Constructor returns the object's constructor element and whether it carries one. A class
+// value carries exactly one ConstructorElem, holding one signature per declared
+// constructor, so this is the lookup a call site and the nominal-value constrain rule use to
+// reach the constructor without a type switch of their own.
 func (o *ObjectType) Constructor() (*ConstructorElem, bool) {
 	for _, e := range o.Elems {
 		if ctor, ok := e.(*ConstructorElem); ok {
@@ -1495,7 +1524,11 @@ func levelOfElem(e ObjTypeElem) int {
 	case *SetterElem:
 		return max(selfLevel(e.SelfParam), LevelOf(e.Param), throwsLevel(e.Throws))
 	case *ConstructorElem:
-		return LevelOf(e.Fn)
+		m := 0
+		for _, sig := range e.Signatures {
+			m = max(m, LevelOf(sig))
+		}
+		return m
 	case *SpreadElem:
 		// A `...A` spread element's level is its operand's, so an out-of-level spread operand lifts
 		// the enclosing object's level and the freshener/extruder prune descends to freshen it.

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -682,14 +682,11 @@ func AcceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 		}
 		return &MethodElem{Name: e.Name, Signatures: sigs, Static: e.Static}
 	case *ConstructorElem:
-		nf, ok := e.Fn.Accept(v, pol).(*FuncType) // params contravariant, via FuncType.Accept
-		if !ok {
-			panic(fmt.Sprintf("AcceptObjElem: constructor signature rewrote to non-FuncType %T", e.Fn))
-		}
-		if nf == e.Fn {
+		sigs, changed := acceptSignatures(e.Signatures, v, pol) // params contravariant, via FuncType.Accept
+		if !changed {
 			return e
 		}
-		return &ConstructorElem{Fn: nf}
+		return &ConstructorElem{Signatures: sigs}
 	case *SpreadElem:
 		// The operand walks in the current polarity, the covariant visit KeyofType applies to its
 		// single operand. The spread is inert — the visit rebuilds it around a rewritten operand

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -742,7 +742,11 @@ func (c *checker) declaredTypeParams(t soltype.Type) []*soltype.TypeParam {
 			if !isCtor {
 				continue
 			}
-			if cls, isClass := ctor.Fn.Ret.(*soltype.ClassType); isClass {
+			inst, hasInst := ctor.Instance()
+			if !hasInst {
+				return nil
+			}
+			if cls, isClass := inst.(*soltype.ClassType); isClass {
 				return c.declaredTypeParams(cls)
 			}
 			return nil
@@ -771,7 +775,11 @@ func (c *checker) declaredLifetimeParams(t soltype.Type) []*soltype.LifetimePara
 			if !isCtor {
 				continue
 			}
-			if cls, isClass := ctor.Fn.Ret.(*soltype.ClassType); isClass {
+			inst, hasInst := ctor.Instance()
+			if !hasInst {
+				return nil
+			}
+			if cls, isClass := inst.(*soltype.ClassType); isClass {
 				return c.declaredLifetimeParams(cls)
 			}
 			return nil
@@ -1725,7 +1733,15 @@ func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
 			equalTypeWith(a.ThrowsOrNever(), b.ThrowsOrNever(), ctx)
 	case *soltype.ConstructorElem:
 		b, ok := b.(*soltype.ConstructorElem)
-		return ok && equalTypeWith(a.Fn, b.Fn, ctx)
+		if !ok || len(a.Signatures) != len(b.Signatures) {
+			return false
+		}
+		for i := range a.Signatures {
+			if !equalTypeWith(a.Signatures[i], b.Signatures[i], ctx) {
+				return false
+			}
+		}
+		return true
 	case *soltype.SpreadElem:
 		b, ok := b.(*soltype.SpreadElem)
 		return ok && equalTypeWith(a.Type, b.Type, ctx)

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -765,7 +765,7 @@ func TestEqualTypeConstructorElem(t *testing.T) {
 			Ret:        u,
 		}
 		return exactObj(
-			&soltype.ConstructorElem{Fn: ctor},
+			&soltype.ConstructorElem{Signatures: []*soltype.FuncType{ctor}},
 			&soltype.PropertyElem{Name: "count", Type: num()},
 		)
 	}
@@ -781,14 +781,14 @@ func TestEqualTypeConstructorElem(t *testing.T) {
 	require.False(t, equalType(value(10, nil, num()), value(20, nil, str())))
 	require.False(t, equalType(value(10, nil, num()), value(20, nil, nil)))
 	// A constructor whose parameter type differs structurally is not equal.
-	strCtor := exactObj(&soltype.ConstructorElem{Fn: &soltype.FuncType{
+	strCtor := exactObj(&soltype.ConstructorElem{Signatures: []*soltype.FuncType{{
 		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: str()}},
 		Ret:    &soltype.ClassType{Name: "Point"},
-	}})
-	numCtor := exactObj(&soltype.ConstructorElem{Fn: &soltype.FuncType{
+	}}})
+	numCtor := exactObj(&soltype.ConstructorElem{Signatures: []*soltype.FuncType{{
 		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: num()}},
 		Ret:    &soltype.ClassType{Name: "Point"},
-	}})
+	}}})
 	require.False(t, equalType(numCtor, strCtor))
 	// An object carrying a constructor never equals one without it.
 	require.False(t, equalType(numCtor, exactObj(&soltype.PropertyElem{Name: "count", Type: num()})))

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1046,7 +1046,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 			// An object with a constructor signature is a subtype of the matching function
 			// type; codegen makes the constructor behave as a plain function where expected.
 			if ctor, ok := sub.Constructor(); ok {
-				return c.constrain(ctor.Fn, sup, seen, mutCtx)
+				return c.constrain(ctorReadType(ctor), sup, seen, mutCtx)
 			}
 		} else if sup, ok := super.(*soltype.ObjectType); ok {
 			// One ObjectType <: ObjectType rule serves both uses the M2 arm
@@ -1085,7 +1085,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				// cannot fill one.
 				if superCtor, ok := superElem.(*soltype.ConstructorElem); ok {
 					if subCtor, has := sub.Constructor(); has {
-						errs = append(errs, c.constrain(subCtor.Fn, superCtor.Fn, seen, mutCtx)...)
+						errs = append(errs, c.constrain(ctorReadType(subCtor), ctorReadType(superCtor), seen, mutCtx)...)
 					} else {
 						errs = append(errs, &CannotConstrainError{Sub: sub, Super: sup})
 					}
@@ -2042,6 +2042,29 @@ func methodReadType(elem *soltype.MethodElem) soltype.Type {
 	arms := make([]soltype.Type, len(elem.Signatures))
 	for i, sig := range elem.Signatures {
 		arms[i] = callableView(sig)
+	}
+	return &soltype.IntersectionType{Types: arms}
+}
+
+// ctorReadType returns the callable value a class value's constructor stands for. A single
+// signature reads as itself, and an overloaded constructor as the intersection of its arms, so
+// a comparison against it weighs the arms together through the arrow-decomposition rule rather
+// than picking one. It is the constructor twin of methodReadType, without the receiver strip,
+// since a constructor declares no receiver in its callable signature. An element carrying no
+// signature reads as the error sentinel.
+//
+// This is the lattice's reading, which is what an assignment and a `super(…)` call take. A
+// direct call picks one arm instead, through inferArmOverloadCall.
+func ctorReadType(elem *soltype.ConstructorElem) soltype.Type {
+	switch len(elem.Signatures) {
+	case 0:
+		return &soltype.ErrorType{}
+	case 1:
+		return elem.Signatures[0]
+	}
+	arms := make([]soltype.Type, len(elem.Signatures))
+	for i, sig := range elem.Signatures {
+		arms[i] = sig
 	}
 	return &soltype.IntersectionType{Types: arms}
 }

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -872,7 +872,7 @@ func TestConstrainConstructorObjectAsFunction(t *testing.T) {
 		return &soltype.FuncType{Params: []*soltype.FuncParam{identParam("a", param)}, Ret: ret}
 	}
 	ctorObj := func(param, ret soltype.Type, extra ...soltype.ObjTypeElem) *soltype.ObjectType {
-		return exactObj(append([]soltype.ObjTypeElem{&soltype.ConstructorElem{Fn: fn(param, ret)}}, extra...)...)
+		return exactObj(append([]soltype.ObjTypeElem{&soltype.ConstructorElem{Signatures: []*soltype.FuncType{fn(param, ret)}}}, extra...)...)
 	}
 	x := &soltype.ClassType{Name: "X"}
 	tests := []struct {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1221,7 +1221,6 @@ func (*MixedOwnershipError) isSolverError()                 {}
 func (*MutLeafThroughSharedBorrowError) isSolverError()     {}
 func (*MissingSelfReceiverError) isSolverError()            {}
 func (*MethodOverloadReceiverMismatchError) isSolverError() {}
-func (*MultipleConstructorsError) isSolverError()           {}
 func (*DuplicateObjectMemberError) isSolverError()          {}
 func (*DuplicateConstructorSignatureError) isSolverError()  {}
 func (*FieldInitializerNotAllowedError) isSolverError()     {}
@@ -1644,18 +1643,6 @@ func expansionHeadName(t soltype.Type) string {
 		return at.Name
 	}
 	return describe(t)
-}
-
-// MultipleConstructorsError fires on the second and any later `constructor` block in
-// one class; a class declares at most one.
-type MultipleConstructorsError struct {
-	Ctor *ast.ConstructorElem
-}
-
-func (e *MultipleConstructorsError) Span() ast.Span      { return e.Ctor.Span() }
-func (e *MultipleConstructorsError) Related() []ast.Span { return nil }
-func (e *MultipleConstructorsError) Message() string {
-	return "Multiple constructors per class are not yet supported."
 }
 
 // DuplicateObjectMemberError fires on the second member of an object type annotation that

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -114,7 +114,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// with `self` bound to the full body, so a call between two methods of the same class
 	// resolves through the pre-declared sibling signature — self-recursive, mutually
 	// recursive, or a forward call to a member declared later.
-	ctors := c.collectConstructors(decl)
+	ctors := collectConstructors(decl)
 	c.checkClassBodyLifetimes(decl)
 	c.buildFieldSigs(declScope, lvl, decl, body, static)
 	pending := c.buildMemberSigs(declScope, lvl, decl, self, body, static)
@@ -127,7 +127,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// now, so the view is complete, and it shares each own element pointer so phase 2's
 	// signature installs and field refinements still land on the registered body.
 	c.inferMemberBodies(declScope, lvl, c.ctx.selfView(self, body), pending)
-	ctorType := c.inferConstructor(declScope, lvl, decl, self, body, ctors)
+	ctorFns := c.inferConstructor(declScope, lvl, decl, self, body, ctors)
 
 	// Coalesce each member so lookup reads concrete member types rather than the fresh
 	// vars a field held before a constructor assignment refined it. A non-generic class
@@ -165,21 +165,21 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	c.queueInheritedMemberCheck(def, self, decl)
 
 	if quiet() && paramsClean {
-		c.reportUnusedTypeParams(typeParams, decl.TypeParams, classDeclTypes(def, ctorType))
+		c.reportUnusedTypeParams(typeParams, decl.TypeParams, classDeclTypes(def, ctorFns))
 	}
 
-	return c.classValue(ctorType, static), &ast.NodeProvenance{Node: decl}, true
+	return c.classValue(ctorFns, static), &ast.NodeProvenance{Node: decl}, true
 }
 
 // classDeclTypes returns every type a class declaration writes, so a walk over them covers each
 // position that could name one of the class's type parameters. That is the instance and static
-// members, the constructor's signature, and the `extends` and `implements` targets.
+// members, every constructor signature, and the `extends` and `implements` targets.
 //
 // A method's `self` receiver is dropped, since every method names the class in it and counting
 // that would make each parameter look used. stripSelfReceiver is the same helper variance
 // inference uses for the same reason. Every other position of a member's signature counts,
 // `throws` included, since walking the object that holds them descends into the whole of each.
-func classDeclTypes(def *ClassDef, ctor soltype.Type) []soltype.Type {
+func classDeclTypes(def *ClassDef, ctors []*soltype.FuncType) []soltype.Type {
 	var out []soltype.Type
 	// The stripped members are handed back inside an object rather than one by one, so the
 	// caller walks a type and the visitor's own member traversal reaches each position.
@@ -203,7 +203,7 @@ func classDeclTypes(def *ClassDef, ctor soltype.Type) []soltype.Type {
 	// stripSelfReceiver drops a method's. The return is the class's own handle, minted with
 	// every type-parameter var as an argument, so walking it would mark them all; `never`
 	// stands in because it is a leaf that names nothing.
-	if fn, ok := ctor.(*soltype.FuncType); ok {
+	for _, fn := range ctors {
 		bare := *fn
 		bare.SelfParam = nil
 		bare.Ret = &soltype.NeverType{}
@@ -247,15 +247,12 @@ func (c *checker) bindScriptClass(scope *Scope, lvl int, decl *ast.ClassDecl) {
 // through constrain's ordinary object-against-object arm. A statics-free class bound to its bare
 // constructor function would need an arm of its own, and that arm could not tell a constructor
 // from an ordinary function, since a FuncType records nothing about constructibility.
-func (c *checker) classValue(ctorType soltype.Type, static *soltype.ObjectType) soltype.Type {
-	// inferConstructor always returns a FuncType, so anything else is a wiring bug.
-	// Fail loudly rather than drop the statics by returning the bare ctorType.
-	ctorFn, ok := ctorType.(*soltype.FuncType)
-	if !ok {
-		panic(fmt.Sprintf("classValue: constructor is %T, not *soltype.FuncType", ctorType))
-	}
+//
+// ctorFns holds one signature per declared constructor, in source order, so an overloaded
+// constructor binds every arm under the one element.
+func (c *checker) classValue(ctorFns []*soltype.FuncType, static *soltype.ObjectType) soltype.Type {
 	elems := make([]soltype.ObjTypeElem, 0, len(static.Elems)+1)
-	elems = append(elems, &soltype.ConstructorElem{Fn: ctorFn})
+	elems = append(elems, &soltype.ConstructorElem{Signatures: ctorFns})
 	elems = append(elems, static.Elems...)
 	return &soltype.ObjectType{Elems: elems}
 }
@@ -707,16 +704,13 @@ func (c *checker) resolveScopedTypeRef(scope *Scope, ref *ast.TypeRefTypeAnn, lv
 	return nil, false
 }
 
-// collectConstructors returns the explicit constructor elements of a class, reporting
-// each one past the first as a duplicate. A well-formed class has zero or one.
-func (c *checker) collectConstructors(decl *ast.ClassDecl) []*ast.ConstructorElem {
+// collectConstructors returns the explicit constructor elements of a class, in source order.
+// A class declaring more than one is overloaded, and each element becomes one arm of the
+// ConstructorElem the class value carries.
+func collectConstructors(decl *ast.ClassDecl) []*ast.ConstructorElem {
 	var ctors []*ast.ConstructorElem
 	for _, elem := range decl.Body {
 		if ctor, ok := elem.(*ast.ConstructorElem); ok {
-			if len(ctors) >= 1 {
-				c.report(&MultipleConstructorsError{Ctor: ctor})
-				continue
-			}
 			ctors = append(ctors, ctor)
 		}
 	}

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -9,28 +9,31 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferConstructor produces a class's constructor as a FuncType returning the
-// instance. With an explicit constructor it walks the constructor body so field
-// assignments refine the instance fields, then builds a callable signature from the
-// value parameters. With none it synthesizes one from the instance fields, unless the
-// class extends a superclass — a subclass must declare its own constructor to call
-// `super`, so a missing one is reported and a field-based constructor is synthesized
-// for recovery.
-func (c *checker) inferConstructor(scope *Scope, lvl int, decl *ast.ClassDecl, self *soltype.ClassType, body *soltype.ObjectType, ctors []*ast.ConstructorElem) soltype.Type {
+// inferConstructor produces a class's constructors as FuncTypes returning the instance, one
+// per declared constructor and in source order. Each explicit constructor has its body walked
+// so field assignments refine the instance fields, then a callable signature built from its
+// value parameters. With none it synthesizes one from the instance fields, unless the class
+// extends a superclass — a subclass must declare its own constructor to call `super`, so a
+// missing one is reported and a field-based constructor is synthesized for recovery.
+func (c *checker) inferConstructor(scope *Scope, lvl int, decl *ast.ClassDecl, self *soltype.ClassType, body *soltype.ObjectType, ctors []*ast.ConstructorElem) []*soltype.FuncType {
 	if len(ctors) == 0 {
 		if decl.Extends != nil {
 			c.report(&SubclassConstructorRequiredError{Decl: decl})
 		}
-		return c.synthesizeConstructor(self, body)
+		return []*soltype.FuncType{c.synthesizeConstructor(self, body)}
 	}
-	return c.walkConstructorBody(scope, lvl, self, body, ctors[0])
+	out := make([]*soltype.FuncType, len(ctors))
+	for i, ctor := range ctors {
+		out[i] = c.walkConstructorBody(scope, lvl, self, body, ctor)
+	}
+	return out
 }
 
 // synthesizeConstructor builds the implicit constructor of a class with no explicit
 // one: a function taking one parameter per required instance field, in declaration
 // order, and returning the instance. An optional field is omitted, matching its
 // omission from the required set.
-func (c *checker) synthesizeConstructor(self *soltype.ClassType, body *soltype.ObjectType) soltype.Type {
+func (c *checker) synthesizeConstructor(self *soltype.ClassType, body *soltype.ObjectType) *soltype.FuncType {
 	var params []*soltype.FuncParam
 	for _, e := range body.Elems {
 		prop, ok := e.(*soltype.PropertyElem)
@@ -53,7 +56,7 @@ func (c *checker) synthesizeConstructor(self *soltype.ClassType, body *soltype.O
 // After the body is walked it runs definite-assignment analysis so a required field
 // left unassigned on some path is a FieldNotInitializedError and a `self.f` read before
 // its assignment is a ReadBeforeInitError.
-func (c *checker) walkConstructorBody(scope *Scope, lvl int, self *soltype.ClassType, body *soltype.ObjectType, ctor *ast.ConstructorElem) soltype.Type {
+func (c *checker) walkConstructorBody(scope *Scope, lvl int, self *soltype.ClassType, body *soltype.ObjectType, ctor *ast.ConstructorElem) *soltype.FuncType {
 	// The parser materializes `mut self` as Fn.Params[0]; the callable signature is
 	// the params after it.
 	valueParams := ctor.Fn.Params

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1606,14 +1606,6 @@ func TestInferClassErrors(t *testing.T) {
 			want: "Setter 'value' must declare a `mut self` receiver; writing through it mutates the instance.",
 		},
 		{
-			name: "MultipleConstructors",
-			src: `class C {
-				constructor(mut self) {},
-				constructor(mut self) {},
-			}`,
-			want: "Multiple constructors per class are not yet supported.",
-		},
-		{
 			name: "FieldInitializerNotAllowed",
 			src:  `class C { x: number = 5 }`,
 			want: "Field 'x' cannot have a `= expr` initializer; only static fields may use this form. Initialize instance fields in the constructor body.",
@@ -2292,4 +2284,137 @@ func TestInferClassMethodTypeParamBounds(t *testing.T) {
 			})
 		}
 	*/
+}
+
+// A class may declare more than one constructor. Every arm binds under the one
+// ConstructorElem the class value carries, and a call resolves against the set the way a call
+// to an overloaded method does. `Array` is the case that needs it: it declares both the
+// length form and the element-list form, which is why `Array(3)` and `Array(1, 2, 3)` mean
+// different things.
+func TestInferClassConstructorOverloads(t *testing.T) {
+	const decl = "declare class Box {\n" +
+		"  constructor(mut self, n: number),\n" +
+		"  constructor(mut self, a: string, b: string),\n" +
+		"}\n"
+	const noMatch = "No matching overload for this call\n" +
+		"  fn (n: number) -> Box\n" +
+		"  fn (a: string, b: string) -> Box"
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "SelectsTheFirstArm",
+			src:  decl + `val v = Box(1)`,
+		},
+		{
+			name: "SelectsTheSecondArm",
+			src:  decl + `val v = Box("x", "y")`,
+		},
+		{
+			// Neither arm accepts the argument, so the report names the whole set rather than
+			// one arm's parameter.
+			name: "RejectsAgainstTheWholeSet",
+			src:  decl + `val v = Box(true)`,
+			want: noMatch,
+		},
+		{
+			name: "RejectsAnArityNoArmAccepts",
+			src:  decl + `val v = Box(1, 2, 3)`,
+			want: noMatch,
+		},
+		{
+			// The arity matches the second arm and the element does not, which is still a
+			// no-match rather than a per-argument mismatch against that arm.
+			name: "RejectsAWrongElementAtAMatchingArity",
+			src:  decl + `val v = Box("x", 2)`,
+			want: noMatch,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			if tt.want == "" {
+				require.Empty(t, errs)
+				require.Equal(t, "Box", values["v"])
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, errs[0].Message())
+		})
+	}
+}
+
+// A class value renders every constructor it declares, joined the way an overloaded method's
+// arms are, so the set is visible at a hover rather than collapsed to one arm.
+func TestInferClassConstructorOverloadsRender(t *testing.T) {
+	src := "declare class Box {\n" +
+		"  constructor(mut self, n: number),\n" +
+		"  constructor(mut self, a: string, b: string),\n" +
+		"}"
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "{new (n: number) -> Box; new (a: string, b: string) -> Box}", values["Box"])
+}
+
+// A class declaring one constructor keeps the single-signature shape, so the arity lints and
+// the per-argument blame a direct call gives are unaffected by the overload path above.
+func TestInferClassSingleConstructorUnaffected(t *testing.T) {
+	src := "declare class Box {\n  constructor(mut self, n: number),\n}\nval v = Box(\"x\")"
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, `cannot constrain "x" <: number`, errs[0].Message())
+}
+
+// An overload arm whose last parameter is an `Array<E>` rest slot checks every argument the
+// slot gathers against E. Resolution reads the arms one at a time rather than through the
+// callee <: callShape constraint, so the scatter rule constrain applies to a single-signature
+// callee is not what runs here and the element check has to be made per arm.
+func TestInferClassConstructorOverloadWithARestArm(t *testing.T) {
+	const decl = "declare class Arr {\n" +
+		"  constructor(mut self, arrayLength: number),\n" +
+		"  constructor(mut self, ...items: mut Array<string>),\n" +
+		"}\n"
+	const noMatch = "No matching overload for this call\n" +
+		"  fn (arrayLength: number) -> Arr\n" +
+		"  fn (...items: mut Array<string>) -> Arr"
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "SelectsTheLengthArm",
+			src:  decl + `val v = Arr(3)`,
+		},
+		{
+			name: "SelectsTheElementArm",
+			src:  decl + `val v = Arr("x", "y")`,
+		},
+		{
+			// Zero arguments fill the slot, so the element arm still accepts.
+			name: "AcceptsNoArguments",
+			src:  decl + `val v = Arr()`,
+		},
+		{
+			// The gap this case pins. An arm accepted with its element unchecked takes any
+			// argument at all past the first, so the call resolves clean.
+			name: "RejectsAWrongElement",
+			src:  decl + `val v = Arr("x", true)`,
+			want: noMatch,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			if tt.want == "" {
+				require.Empty(t, errs)
+				require.Equal(t, "Arr", values["v"])
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, errs[0].Message())
+		})
+	}
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1413,8 +1413,15 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// constrain.
 	if _, isMember := e.Callee.(*ast.MemberExpr); isMember {
 		if arms, ok := funcIntersectionArms(callee); ok {
-			return c.inferMethodOverloadCall(scope, lvl, e, arms)
+			return c.inferArmOverloadCall(scope, lvl, e, arms, consumeRef, hasConsumeRef)
 		}
+	}
+	// A class value whose constructor is overloaded resolves through the arms its
+	// ConstructorElem carries, for the reason an overloaded method does. `Array(3)` and
+	// `Array(1, 2, 3)` select different arms, so the set is weighed per arm rather than
+	// folded into one callee <: callShape constraint.
+	if arms, ok := ctorOverloadArms(callee); ok {
+		return c.inferArmOverloadCall(scope, lvl, e, arms, consumeRef, hasConsumeRef)
 	}
 	// Instantiate a generic callee so each call binds its type parameters independently. A
 	// rank-2 callback param is an unfreshened MonoScheme, so this keeps its `T` per-call.
@@ -1614,6 +1621,9 @@ func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType, ref liv
 // checking. The TooManyArgs and NotEnoughArgs lints don't apply – arity is the
 // per-arm gate, and a no-match becomes a NoMatchingOverloadError.
 func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b ValueBinding) soltype.Type {
+	// Read the statement point before the arguments are inferred, for the reason inferCall
+	// gives: an argument containing statements overwrites the current one.
+	consumeRef, hasConsumeRef := c.currentStmtRef()
 	args := make([]soltype.Type, len(e.Args))
 	for i, a := range e.Args {
 		args[i] = c.inferExpr(scope, lvl, a)
@@ -1622,18 +1632,23 @@ func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b 
 	// coalesces the schemes rather than instantiating them — resolveOverload below does
 	// the (only) per-arm instantiation needed to type the call.
 	c.recordType(e.Callee, overloadDisplayType(b))
-	ret := c.resolveOverload(lvl, b, args, e)
+	ret, winner := c.resolveOverload(lvl, b, args, e)
+	c.recordOverloadArgEffects(e, winner, consumeRef, hasConsumeRef)
 	c.recordType(e, ret)
 	return ret
 }
 
-// inferMethodOverloadCall types a call to an overloaded method reached through a member
-// callee, such as `p.m(args)` where `m` carries several signatures. It infers the
+// inferArmOverloadCall types a call whose callee carries several signatures rather than one:
+// an overloaded method reached through a member callee, such as `p.m(args)`, or an
+// overloaded constructor reached through a class value, such as `Array(3)`. It infers the
 // arguments, then resolves one arm through resolveOverload — the same machinery a direct
-// overloaded-name call uses, driven by the method's arms wrapped as monomorphic schemes.
-// Like inferOverloadedCall it emits no callee <: callShape constraint. Overload resolution
-// owns arity and argument checking, and a no-match becomes a NoMatchingOverloadError.
-func (c *checker) inferMethodOverloadCall(scope *Scope, lvl int, e *ast.CallExpr, arms []*soltype.FuncType) soltype.Type {
+// overloaded-name call uses, driven by the arms wrapped as monomorphic schemes. Like
+// inferOverloadedCall it emits no callee <: callShape constraint. Overload resolution owns
+// arity and argument checking, and a no-match becomes a NoMatchingOverloadError.
+func (c *checker) inferArmOverloadCall(
+	scope *Scope, lvl int, e *ast.CallExpr, arms []*soltype.FuncType,
+	consumeRef liveness.StmtRef, hasConsumeRef bool,
+) soltype.Type {
 	args := make([]soltype.Type, len(e.Args))
 	for i, a := range e.Args {
 		args[i] = c.inferExpr(scope, lvl, a)
@@ -1642,9 +1657,44 @@ func (c *checker) inferMethodOverloadCall(scope *Scope, lvl int, e *ast.CallExpr
 	for i, arm := range arms {
 		schemes[i] = &MonoScheme{Ty: arm}
 	}
-	ret := c.resolveOverload(lvl, ValueBinding{Schemes: schemes}, args, e)
+	ret, winner := c.resolveOverload(lvl, ValueBinding{Schemes: schemes}, args, e)
+	c.recordOverloadArgEffects(e, winner, consumeRef, hasConsumeRef)
 	c.recordType(e, ret)
 	return ret
+}
+
+// recordOverloadArgEffects moves the arguments a resolved overload call consumes and records
+// the borrow edges its signature stores, the two things inferCall does for a callee it
+// resolved to a single signature. Overload resolution owns the argument checking itself, so it
+// leaves inferCall before those run and has to do them here against the arm it picked.
+//
+// winner is nil when no arm accepted the call. Nothing is moved then, since no signature says
+// which arguments a call that does not type-check would have consumed.
+func (c *checker) recordOverloadArgEffects(
+	e *ast.CallExpr, winner *soltype.FuncType, consumeRef liveness.StmtRef, hasConsumeRef bool,
+) {
+	if winner == nil || !hasConsumeRef {
+		return
+	}
+	c.consumeCallArgs(e, winner, consumeRef)
+	recv, self := c.calleeReceiver(e.Callee)
+	c.recordCallStoreEdges(e, winner, recv, self, consumeRef)
+}
+
+// ctorOverloadArms returns the signatures of an overloaded constructor when t reads as a class
+// value carrying one, and false otherwise. A class declaring a single constructor is not an
+// overload set, so it stays on the ordinary callee <: callShape path where resolveFunc reads
+// its one signature and the arity lints apply.
+func ctorOverloadArms(t soltype.Type) ([]*soltype.FuncType, bool) {
+	obj, ok := classValueCarrier(t)
+	if !ok {
+		return nil, false
+	}
+	ctor, ok := obj.Constructor()
+	if !ok || len(ctor.Signatures) < 2 {
+		return nil, false
+	}
+	return ctor.Signatures, true
 }
 
 // funcIntersectionArms reports whether t is an IntersectionType whose members are all
@@ -1689,13 +1739,19 @@ func funcIntersectionArms(t soltype.Type) ([]*soltype.FuncType, bool) {
 // element. An inline object callee yields it directly.
 // A binding var yields it through an object lower bound, the same look-through the
 // FuncType arm runs for a named function.
+//
+// An OVERLOADED constructor yields nothing here, the same as an overloaded method, whose
+// value reads as an intersection this never sees a single FuncType in. No one arm is the
+// callee, so the arity lints and the argument upgrade have nothing to read. Such a call never
+// reaches them anyway: inferCall routes it to inferArmOverloadCall, which picks an arm and
+// owns both checks itself.
 func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 	switch t := t.(type) {
 	case *soltype.FuncType:
 		return t, true
 	case *soltype.ObjectType:
-		if ctor, ok := t.Constructor(); ok {
-			return ctor.Fn, true
+		if ctor, ok := t.Constructor(); ok && len(ctor.Signatures) == 1 {
+			return ctor.Signatures[0], true
 		}
 	case *soltype.TypeVarType:
 		for _, lb := range t.LowerBounds {
@@ -1703,8 +1759,8 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 			case *soltype.FuncType:
 				return lb, true
 			case *soltype.ObjectType:
-				if ctor, ok := lb.Constructor(); ok {
-					return ctor.Fn, true
+				if ctor, ok := lb.Constructor(); ok && len(ctor.Signatures) == 1 {
+					return ctor.Signatures[0], true
 				}
 			}
 		}

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -491,3 +491,74 @@ fn f() -> number {
 		})
 	}
 }
+
+// A call resolved through an overload set moves the arguments the winning arm consumes, the
+// way a call to a single signature does. Resolution owns the argument checking and leaves
+// inferCall before its move recording runs, so the arm it picks has to drive that separately.
+// All three overload callees take the same path: a named set, a method, and a constructor.
+func TestOverloadCallConsumesArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "NamedOverloadSet",
+			src: `fn take(a: {x: number}) -> number { return 1 }
+fn take(a: {x: number}, b: number) -> number { return 2 }
+fn f() {
+  val p = {x: 1}
+  take(p)
+  p.x
+}`,
+			want: []string{"6:3-6:6: use of moved value 'p'"},
+		},
+		{
+			name: "OverloadedMethod",
+			src: `declare class Box {
+  m(self, a: {x: number}) -> number,
+  m(self, a: {x: number}, b: number) -> number,
+}
+fn f(b: Box) {
+  val p = {x: 1}
+  b.m(p)
+  p.x
+}`,
+			want: []string{"8:3-8:6: use of moved value 'p'"},
+		},
+		{
+			name: "OverloadedConstructor",
+			src: `declare class Box {
+  constructor(mut self, a: {x: number}),
+  constructor(mut self, a: {x: number}, b: number),
+}
+fn f() {
+  val p = {x: 1}
+  Box(p)
+  p.x
+}`,
+			want: []string{"8:3-8:6: use of moved value 'p'"},
+		},
+		{
+			// No arm accepted the call, so no signature says which arguments it would have
+			// consumed. The no-match is the only diagnostic; the later read still stands.
+			name: "NoMatchingArmMovesNothing",
+			src: `declare class Box {
+  constructor(mut self, a: number),
+  constructor(mut self, a: number, b: number),
+}
+fn f() {
+  val p = {x: 1}
+  Box(p)
+  p.x
+}`,
+			want: []string{"7:3-7:9: No matching overload for this call\n  fn (a: number) -> Box\n  fn (a: number, b: number) -> Box"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(t, errs))
+		})
+	}
+}

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -362,7 +362,7 @@ func TestResolveOverloadRollsBackLosingArm(t *testing.T) {
 	argVar.LowerBounds = []soltype.Type{&soltype.LitType{Lit: &soltype.NumLit{Value: 5}}}
 
 	call := ast.NewCall(identExpr("f"), []ast.Expr{numExpr(5)}, false, testSpan())
-	ret := c.resolveOverload(0, b, []soltype.Type{argVar}, call)
+	ret, _ := c.resolveOverload(0, b, []soltype.Type{argVar}, call)
 
 	require.Empty(t, c.errs, "the losing arm's trial error is rolled back, not accumulated")
 	require.Equal(t, "number", soltype.Print(ret))
@@ -389,7 +389,7 @@ func TestResolveOverloadSurfacesWinningArmWarning(t *testing.T) {
 	b := ValueBinding{Schemes: []TypeScheme{monoScheme(arm)}}
 
 	call := ast.NewCall(identExpr("f"), []ast.Expr{numExpr(5)}, false, testSpan())
-	ret := c.resolveOverload(0, b, []soltype.Type{numLit(5)}, call)
+	ret, _ := c.resolveOverload(0, b, []soltype.Type{numLit(5)}, call)
 
 	require.Equal(t, "number", soltype.Print(ret))
 	require.Equal(t, []string{

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -608,15 +608,7 @@ func compareObjElem(a, b soltype.ObjTypeElem) int {
 		if a.Static != b.Static {
 			return boolOrder(a.Static) - boolOrder(b.Static)
 		}
-		if c := len(a.Signatures) - len(b.Signatures); c != 0 {
-			return c
-		}
-		for i := range a.Signatures {
-			if c := compareType(a.Signatures[i], b.Signatures[i]); c != 0 {
-				return c
-			}
-		}
-		return 0
+		return compareSignatures(a.Signatures, b.Signatures)
 	case *soltype.GetterElem:
 		b := b.(*soltype.GetterElem)
 		if c := compareSelfParam(a.SelfParam, b.SelfParam); c != 0 {
@@ -638,7 +630,7 @@ func compareObjElem(a, b soltype.ObjTypeElem) int {
 		}
 		return compareType(a.ThrowsOrNever(), b.ThrowsOrNever())
 	case *soltype.ConstructorElem:
-		return compareType(a.Fn, b.(*soltype.ConstructorElem).Fn)
+		return compareSignatures(a.Signatures, b.(*soltype.ConstructorElem).Signatures)
 	case *soltype.SpreadElem:
 		return compareType(a.Type, b.(*soltype.SpreadElem).Type)
 	case *soltype.MappedElem:
@@ -646,6 +638,20 @@ func compareObjElem(a, b soltype.ObjTypeElem) int {
 		// Ordering by its value type gives a stable key, and equalObjElem settles whether
 		// two are truly equal.
 		return compareType(a.Value, b.(*soltype.MappedElem).Value)
+	}
+	return 0
+}
+
+// compareSignatures orders two overload sets, shorter set first and then arm by arm. It is
+// the canonical ordering for the two members that carry one, a method and a constructor.
+func compareSignatures(a, b []*soltype.FuncType) int {
+	if c := len(a) - len(b); c != 0 {
+		return c
+	}
+	for i := range a {
+		if c := compareType(a[i], b[i]); c != 0 {
+			return c
+		}
 	}
 	return 0
 }

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1676,7 +1676,15 @@ func (c *Context) meetObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bo
 		if !ok {
 			return nil, false
 		}
-		fused, ok := c.meetFuncs(a.Fn, b.Fn)
+		// Two constructors meet only when each carries a single signature, so an overloaded
+		// constructor keeps the objects apart instead. The two atoms denote the meet
+		// exactly, so the bail costs an atom rather than precision. #1517 carries the
+		// fusion, under the same evidence gate #1103 set: a set denotes the intersection of
+		// its arms, so meeting two of them concatenates the lists.
+		if len(a.Signatures) != 1 || len(b.Signatures) != 1 {
+			return nil, false
+		}
+		fused, ok := c.meetFuncs(a.Signatures[0], b.Signatures[0])
 		if !ok {
 			return nil, false
 		}
@@ -1684,7 +1692,7 @@ func (c *Context) meetObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bo
 		if !ok {
 			return nil, false
 		}
-		return &soltype.ConstructorElem{Fn: fn}, true
+		return &soltype.ConstructorElem{Signatures: []*soltype.FuncType{fn}}, true
 	}
 	return nil, false
 }
@@ -1733,10 +1741,16 @@ func (c *Context) joinObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bo
 // meetMethods fuses two methods that share a name by meeting their signatures. It
 // fuses only single-signature methods, bailing when either carries an overload set.
 // Two identical methods never reach here, since meetObjElem's equal-member check
-// returns one of them first, so the overload sets that do reach here always differ,
-// and meeting two differing overload sets exactly is not attempted. Static-ness must
-// agree, since a static method lives on the constructor value and an instance method
-// on the instance, so the two are not the same member.
+// returns one of them first, so the overload sets that do reach here always differ.
+// Static-ness must agree, since a static method lives on the constructor value and an
+// instance method on the instance, so the two are not the same member.
+//
+// The bail costs an atom rather than precision, since the two unfused atoms denote the
+// meet exactly. #1517 carries the fusion, under the same evidence gate #1103 set. An
+// overload set denotes the intersection of its arms, which methodReadType builds, so
+// meeting two of them concatenates the lists and newIntersection's flatten, dedupe and
+// subsume steps canonicalize the result. The receiver check below still gates it, since
+// that algebra says nothing about which receiver the fused member takes.
 func (c *Context) meetMethods(a, b *soltype.MethodElem) (soltype.ObjTypeElem, bool) {
 	if a.Static != b.Static {
 		return nil, false

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -43,11 +43,15 @@ import (
 // documented MVP fallback, with no speculative pinning and backtracking. The first arm
 // whose argument constraints succeed wins. Its bounds are committed and the rest roll back.
 
-// resolveOverload picks one arm of the overload set b for the call and returns that
-// arm's instantiated return type. It commits the winning arm's argument constraints and
-// rolls back every losing trial. When no arm accepts the arguments, it reports a
-// NoMatchingOverloadError and returns the recovery placeholder.
-func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, call *ast.CallExpr) soltype.Type {
+// resolveOverload picks one arm of the overload set b for the call and returns that arm's
+// instantiated return type, together with the arm itself. It commits the winning arm's
+// argument constraints and rolls back every losing trial. When no arm accepts the arguments,
+// it reports a NoMatchingOverloadError and returns the recovery placeholder with a nil arm.
+//
+// The arm is returned because the caller has the rest of a call's bookkeeping left to do
+// against it: recordOverloadArgEffects moves the arguments it consumes and records the borrow
+// edges it stores.
+func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, call *ast.CallExpr) (soltype.Type, *soltype.FuncType) {
 	for _, idx := range c.overloadOrder(b.Schemes, args) {
 		// Open the probe BEFORE instantiating so the instantiation's side-table writes are
 		// journaled and rolled back with a losing trial. Those writes are freshenAbove's
@@ -83,14 +87,14 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 					c.markRaised()
 				}
 			}
-			return inst.Ret
+			return inst.Ret, inst
 		}
 	}
 	// No arm accepted the call, so nothing here shows it cannot raise. Count it as an
 	// exceptional exit, the reading inferCall gives a callee it cannot resolve, so the no-match
 	// error is not joined by a spurious unused-clause warning against a clause the call needs.
 	c.markRaised()
-	return c.report(&NoMatchingOverloadError{Call: call, Candidates: b.Schemes})
+	return c.report(&NoMatchingOverloadError{Call: call, Candidates: b.Schemes}), nil
 }
 
 // tryOverloadArm reports whether inst accepts a call with the given argument types,

--- a/internal/solver/parse_type_test.go
+++ b/internal/solver/parse_type_test.go
@@ -231,7 +231,7 @@ func objectToSoltype(t *testing.T, env map[string]soltype.Type, ta *ast.ObjectTy
 			require.Len(t, fn.Params, 1, "parseType: a setter takes one value parameter")
 			elems = append(elems, &soltype.SetterElem{Name: objKeyNameReq(t, e.Name), SelfParam: fn.SelfParam, Param: fn.Params[0].Type, Throws: fn.Throws})
 		case *ast.ConstructorTypeAnn:
-			elems = append(elems, &soltype.ConstructorElem{Fn: funcToSoltype(t, env, e.Fn)})
+			elems = append(elems, &soltype.ConstructorElem{Signatures: []*soltype.FuncType{funcToSoltype(t, env, e.Fn)}})
 		case *ast.MappedTypeAnn:
 			elems = append(elems, mappedToSoltype(t, env, e))
 		default:

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -902,17 +902,33 @@ func (c *checker) resolveQualClassType(scope *Scope, qi ast.QualIdent) (*soltype
 //
 // For `class Point { x: number, y: number }` the value `Point` resolves mid-inference to a var
 // whose lower bound is `{new (x: number, y: number) -> Point}`, and ctorSignature looks through
-// the var to that object, returning its Constructor().Fn. Every class value has that shape,
-// statics or not. The bare-FuncType arm is what an extractor pattern naming a plain function
-// resolves through. A var with two conflicting constructor lower bounds is ambiguous and left
+// the var to that object, returning that signature. Every class value has that shape, statics
+// or not. The bare-FuncType arm is what an extractor pattern naming a plain function resolves
+// through. A var with two conflicting constructor lower bounds is ambiguous and left
 // unresolved.
+//
+// An overloaded constructor resolves to its first arm. An extractor reads the parameter list
+// as the instance's positional shape, and only one list can serve as that shape.
+//
+// Reading a constructor at all is a placeholder. What an extractor deconstructs is not what a
+// constructor builds, so the signature to read is the `[Symbol.customMatcher]` method on the
+// extractor's type, and a class carrying none is not an extractor. Binding against constructor
+// parameters instead is why `Point(x, y)` is accepted against a plain two-field class. #1516
+// carries the replacement, and #1246 the symbol-keyed members it needs first.
 func ctorSignature(t soltype.Type) (*soltype.FuncType, bool) {
 	switch t := t.(type) {
 	case *soltype.FuncType:
 		return t, true
 	case *soltype.ObjectType:
 		if ctor, ok := t.Constructor(); ok {
-			return ctor.Fn, true
+			if len(ctor.Signatures) == 0 {
+				return nil, false
+			}
+			// Arm zero of an overloaded constructor, chosen arbitrarily. The arms agree on the
+			// instance they produce and on nothing else, so no arm speaks for the set's
+			// parameter list. Read here rather than through an accessor so the choice is
+			// visible where it is made.
+			return ctor.Signatures[0], true
 		}
 	case *soltype.TypeVarType:
 		// Scan the var's lower bounds for a constructor, requiring all that resolve to agree.

--- a/internal/solver/super.go
+++ b/internal/solver/super.go
@@ -47,15 +47,17 @@ func (c *checker) inferSuperCall(scope *Scope, lvl int, e *ast.SuperCallExpr) so
 	return &soltype.UndefinedType{}
 }
 
-// superConstructor returns the callable signature of a superclass's constructor, read off
-// the class's value binding, which is the object `Animal(…)` calls through. It returns
-// ok=false when the binding is absent or carries no constructor, which leaves the arguments
-// unchecked rather than reported against a signature that was never found.
+// superConstructor returns the callable a superclass's constructor stands for, read off the
+// class's value binding, which is the object `Animal(…)` calls through. An overloaded
+// superclass constructor reads as the intersection of its arms, so the constraint below weighs
+// them together rather than picking one. It returns ok=false when the binding is absent or
+// carries no constructor, which leaves the arguments unchecked rather than reported against a
+// signature that was never found.
 //
 // The name is looked up in the scope the subclass is declared in, not the constructor's own
 // scope. A parameter named after the superclass would shadow the class binding there, and the
 // arguments would go unchecked against a signature the lookup never found.
-func (c *checker) superConstructor(lvl int, ctx *superCtx) (*soltype.FuncType, bool) {
+func (c *checker) superConstructor(lvl int, ctx *superCtx) (soltype.Type, bool) {
 	if ctx.declScope == nil {
 		return nil, false
 	}
@@ -71,7 +73,7 @@ func (c *checker) superConstructor(lvl int, ctx *superCtx) (*soltype.FuncType, b
 	if !ok {
 		return nil, false
 	}
-	return ctor.Fn, true
+	return ctorReadType(ctor), true
 }
 
 // superVarID is the synthetic binding the move dataflow tracks in place of "the superclass

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -422,7 +422,9 @@ func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bo
 			return nil, true
 		}
 		l.sawCtor = true
-		return &soltype.ConstructorElem{Fn: l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)}, true
+		return &soltype.ConstructorElem{
+			Signatures: []*soltype.FuncType{l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)},
+		}, true
 	case *ast.RestSpreadTypeAnn:
 		src, ok := l.c.resolveTypeAnn(l.scope, elem.Value, l.lvl)
 		if !ok {


### PR DESCRIPTION
Fixes #1501. Part of #1232.

> **Stacked on #1507** (`claude/builtins-1499-rest`). Review the top commit only; the base branch carries #1499. Merge that one first, and this retargets to `main` on its own.

## Summary

A class declaring a second constructor reported "Multiple constructors per class are not yet supported" and kept only the first, so a call the source licenses was rejected. `Array` is the case that needs both: it declares the length form and the element-list form, which is why `Array(3)` and `Array(1, 2, 3)` mean different things.

`soltype.ConstructorElem` now holds `Signatures`, the shape `MethodElem` already uses for an overloaded method, and construction routes through the same overload resolution:

- `inferConstructor` walks every declared constructor and returns one signature per arm; `classValue` binds them under the one element.
- A call to an overloaded class value resolves per arm through `resolveOverload`, so a call matching none reports `NoMatchingOverloadError` against the whole set rather than one arm's parameter.
- A class value's constructor reads as the intersection of its arms wherever the lattice compares one — an assignment, an object target naming a `new` signature — and `super(…)` is checked against that.

## Two judgment calls worth a look

**An extractor pattern resolves against the first arm.** It reads the parameter list as the instance's positional shape, and only one list can serve as that shape. This matches what happened before, when everything past the first constructor was rejected outright.

**Codegen is unchanged and has a latent gap.** `internal/codegen/builder.go` emits one JS `constructor` per `ast.ConstructorElem`, so two constructors on a non-`declare` class would lower to invalid JS. It is unreachable today — `internal/checker` keeps its own `MultipleConstructorsNotYetSupportedError` and still drives `cmd/escalier` — and overloaded *methods* have the identical shape, so a constructor-only rule would be inconsistent. Flagging rather than inventing one.

## Tests

- `TestInferClassConstructorOverloads` — both arms bind, a call selects the matching arm, and a call matching neither reports against the whole set.
- `TestInferClassConstructorOverloadsRender` — a class value renders every constructor it declares.
- `TestInferClassSingleConstructorUnaffected` — a single-constructor class keeps the arity lints and per-argument blame a direct call gives.
- `TestInferClassConstructorOverloadWithARestArm` — an arm with an `Array<E>` rest slot checks the elements it absorbs. From `/code-review`: routing through `resolveOverload` had lost the check the scatter rule makes for a single-signature callee.

`go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overloaded class constructors.
  * Constructor calls now select the appropriate overload and report errors when no overload matches.
  * Constructor types and rendered declarations now include all available signatures.
  * Overloaded constructors are preserved when calling superclass constructors.

* **Bug Fixes**
  * Improved constructor compatibility, equality, inference, and type checking across overloads.
  * Preserved existing behavior for classes with a single constructor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->