### PR TITLE
Make the tree's `Awaited` reduce

### DIFF
--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -252,5 +252,6 @@ export declare interface PromiseLike<T, E = never> {
  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
  */
 export declare type Awaited<T> = if T : null | undefined { T } else { if T : {...} & {
-    then(onfulfilled: infer F, ...args: infer _) -> any
+    then(onfulfilled: infer F, ...args: infer _) -> any,
+    ...
 } { if F : fn (value: infer V, ...args: infer _) -> any { Awaited<V> } else { never } } else { T } }

--- a/internal/interop/overlay/std/async.replace.digests.json
+++ b/internal/interop/overlay/std/async.replace.digests.json
@@ -6,6 +6,10 @@
     "digest": "1386f0dcfb074072"
   },
   {
+    "decl": "Awaited",
+    "digest": "fce3e28102d0c094"
+  },
+  {
     "decl": "Promise",
     "member": "catch",
     "kind": "method",

--- a/internal/interop/overlay/std/async.replace.esc
+++ b/internal/interop/overlay/std/async.replace.esc
@@ -61,3 +61,19 @@ export declare interface PromiseLike<T, E = never> {
 export declare interface AsyncGenerator<T = unknown, TReturn = any, TNext = any, E = never> {
     throw(e: E) -> Promise<IteratorResult<T, TReturn>, E>,
 }
+
+// The `then` operand has to be inexact. TypeScript's `{ then(…): any }` is
+// width-tolerant, so the check matches any object carrying a `then` member
+// whatever else it carries. The converter lowers a `.d.ts` object type literal
+// to an exact Escalier object, which matches only an object holding that one
+// member and nothing else, and no real thenable is that. `Awaited<T>` then took
+// the `else` arm for every promise and reduced to `T` instead of unwrapping it.
+// The `, ...` marker is what makes the operand say what TypeScript's says.
+//
+// This entry retires once the converter lowers a `.d.ts` object type literal to
+// an inexact Escalier object, which is the same fix for every inline object
+// annotation in the tree rather than for this one.
+export declare type Awaited<T> = if T : null | undefined { T } else { if T : {...} & {
+    then(onfulfilled: infer F, ...args: infer _) -> any,
+    ...
+} { if F : fn (value: infer V, ...args: infer _) -> any { Awaited<V> } else { never } } else { T } }

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2,6 +2,9 @@ package solver
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -4284,4 +4287,95 @@ func TestInferWildcardPatternRoundTrips(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, "if t0 : [_, infer B] { B } else { never }",
 		soltype.Print(expandAliasResidual(ctx, nodes["Second"])))
+}
+
+// committedAwaitedDecl returns the `Awaited` alias as the committed tree declares it, read out
+// of internal/interop/data/std/async.esc so the test and the tree cannot drift. The declaration
+// starts at its `export declare type Awaited` line and ends at the first line where its braces
+// balance, which is how the printer lays a multi-line alias out. Balance is read per line rather
+// than per character because the first branch, `{ T }`, closes on the opening line.
+func committedAwaitedDecl(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "interop", "data", "std", "async.esc")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	lines := strings.Split(string(data), "\n")
+	start := slices.IndexFunc(lines, func(l string) bool {
+		return strings.HasPrefix(l, "export declare type Awaited")
+	})
+	require.NotEqual(t, -1, start, "%s declares no Awaited", path)
+	depth := 0
+	for i := start; i < len(lines); i++ {
+		depth += strings.Count(lines[i], "{") - strings.Count(lines[i], "}")
+		if depth == 0 {
+			return strings.Join(lines[start:i+1], "\n")
+		}
+	}
+	t.Fatalf("%s: Awaited's braces never balance", path)
+	return ""
+}
+
+// `Awaited<T>` unwraps a thenable to the value its `then` callback is handed, recursively, and
+// leaves everything else alone. It is the recursive conditional TypeScript defines, and the tree
+// names it in `Promise.all`, `Promise.resolve`, and `Array.fromAsync` among others.
+//
+// TestInferAwaited above exercises the same recursion against a Promise-shaped definition written
+// for the test. These cases run the real one instead, which matches structurally on a `then`
+// member and so reaches rules that definition never touches.
+//
+// The cases run against the definition the committed tree carries, so a converter or overlay
+// change that stops it reducing fails here rather than only where a consumer reads it.
+func TestInferCommittedAwaited(t *testing.T) {
+	// A thenable and a thenable whose value is itself a thenable, which is what makes the
+	// recursion observable: `Awaited<Nested>` has to unwrap twice.
+	const thenables = "type Thenable = {then(onfulfilled: fn (value: number) -> unknown) -> unknown, ...}\n" +
+		"type Nested = {then(onfulfilled: fn (value: Thenable) -> unknown) -> unknown, ...}\n"
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// A non-thenable reduces to itself, which is the final `else` arm.
+			name: "NonThenableReducesToItself",
+			src:  `fn f(x: Awaited<number>) -> number { return x }`,
+		},
+		{
+			name: "ObjectWithNoThenReducesToItself",
+			src:  `fn f(x: Awaited<{a: number}>) -> {a: number} { return x }`,
+		},
+		{
+			// `null` and `undefined` take the first arm, before the thenable check, since
+			// neither has members to read a `then` off.
+			name: "UndefinedReducesToItself",
+			src:  `fn f(x: Awaited<undefined>) -> undefined { return x }`,
+		},
+		{
+			name: "ThenableReducesToItsValue",
+			src:  thenables + `fn f(x: Awaited<Thenable>) -> number { return x }`,
+		},
+		{
+			name: "NestedThenableReducesAllTheWay",
+			src:  thenables + `fn f(x: Awaited<Nested>) -> number { return x }`,
+		},
+		{
+			// The reduction is what the rejection blames, so a wrong expectation reports
+			// against the unwrapped value rather than against the unreduced alias.
+			name: "RejectsAgainstTheUnwrappedValue",
+			src:  thenables + `fn f(x: Awaited<Thenable>) -> string { return x }`,
+			want: "cannot constrain number <: string",
+		},
+	}
+	decl := committedAwaitedDecl(t) + "\n"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, decl+tt.src)
+			if tt.want == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, errs[0].Message())
+		})
+	}
 }


### PR DESCRIPTION
Fixes #1502. Part of #1232.

> **Stacked on #1506** (`claude/builtins-1498-any`). Review the top commit only. The `Awaited` definition writes `any` in its `then` signature, so without that arm every reference reports `Unsupported: AnyTypeAnn`. #1502 anticipated this dependency.

## The issue's premise was stale

#1502 says `Awaited<T>` is "referenced across the committed tree and declared nowhere" and asks for an overlay `add`. It is in fact generated from `lib.es5.d.ts` and sits at `internal/interop/data/std/async.esc:251`. What the issue measured was the reference dangling from *other* packages, which is #1403's missing imports, not a missing declaration.

The real defect is that the generated definition never reduced. Its thenable check matched nothing, so every reference took the final `else` arm and reduced to `T`. `Awaited<Promise<number>>` stayed `Promise<number>`.

## Cause

TypeScript's `{ then(…): any }` is width-tolerant and matches any object carrying a `then` member whatever else it carries. The converter lowers a `.d.ts` object type literal to an **exact** Escalier object, which matches only an object holding that one member and nothing else, and no real thenable is that. An overlay `replace` marks the operand inexact.

## This is a converter-wide lowering decision

`internal/dts_to_esc/helper.go` makes only the *empty* `{}` inexact; every non-empty `.d.ts` type literal becomes exact. That affects all ~26 inline object annotations in the committed tree, not just this one. §7 says a systematic wrong answer belongs in the converter rather than in a pile of overlay entries, so I have not changed the lowering here — whether Escalier wants converted TS type literals to be width-tolerant is a call for the maintainer, and it moves a lot of the tree. **Worth its own issue.** The overlay entry says so and retires when that lands.

## Tests

`TestInferCommittedAwaited` reads the alias out of `internal/interop/data/std/async.esc` rather than restating it, so the test and the tree cannot drift. It covers a non-thenable, an object with no `then`, `undefined`, a thenable, a nested thenable that needs two laps of the recursion, and a rejection blamed against the unwrapped value.

`go test ./...` passes, and `dts_to_esc generate` leaves the tree byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy)_