### PR TITLE
Grant the owned-mutable upgrade in an overload arm

### DIFF
--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -426,6 +426,49 @@ func TestInferOwnedMutNestedOwnedMutRejected(t *testing.T) {
 		_, _, errs := inferSource(t, src)
 		require.Equal(t, []string{"1:15-1:16: cannot constrain immutable object <: mutable object"}, messagesWithSpan(t, errs))
 	})
+	t.Run("call argument", func(t *testing.T) {
+		src := `declare fn take(a: mut {p: {x: number | string}}) -> number
+fn f() -> number {
+	val inner: mut {x: number} = {x: 0}
+	return take({p: inner})
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"1:24-1:25: cannot constrain immutable object <: mutable object"},
+			messagesWithSpan(t, errs))
+	})
+}
+
+// The guard above is what makes a WIDER owned-mutable parameter safe to adopt. `take({x: 1})`
+// against `a: mut {x: number | string}` hands the callee a cell it may write a string into,
+// which is sound only because the argument is freshly built or moved, leaving the caller no
+// view of it at a narrower type.
+//
+// A pre-existing `mut` cell is exactly the case where such a view would survive, so it takes no
+// upgrade and falls through to the strict path, which rejects the widening.
+func TestInferOwnedMutArgumentIntoAWiderParam(t *testing.T) {
+	const take = "declare fn take(a: mut {x: number | string}) -> number\n"
+	t.Run("a fresh literal adopts the wider parameter", func(t *testing.T) {
+		_, _, errs := inferSource(t, take+"val r = take({x: 1})")
+		require.Empty(t, errs)
+	})
+	t.Run("a moved variable does too, and is consumed", func(t *testing.T) {
+		src := take + `fn g() -> number {
+	val cfg = {x: 1}
+	val n = take(cfg)
+	return cfg.x
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"5:9-5:14: use of moved value 'cfg'"}, messagesWithSpan(t, errs))
+	})
+	t.Run("a pre-existing mut cell does not, so the widening is rejected", func(t *testing.T) {
+		src := take + `fn g() -> number {
+	val cfg: mut {x: number} = {x: 1}
+	return take(cfg)
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"4:9-4:18: cannot constrain string <: number"},
+			messagesWithSpan(t, errs))
+	})
 }
 
 // A module-level `mut` global takes the upgrade on reassignment just like a local `mut`

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -364,6 +364,45 @@ func TestInferOwnedMutFieldWrite(t *testing.T) {
 	})
 }
 
+// The upgrade's soundness leans on the argument being MOVED, so a later use of it is a
+// use-after-move and the uniqueness holds past the flow site rather than only at it. Nothing
+// in the call chain enforces that ordering, which would make the coupling a convention. It is
+// enforced by a data dependency instead: the place-move branch of canUpgradeToOwnedMut goes
+// through exprPlace, which returns false unless the identifier carries a VarID, and the VarID
+// is assigned by the same liveness pre-pass that lets the move engine record a consume. Where
+// no move can be recorded, the upgrade cannot fire.
+//
+// Module top level is where the two come apart, since the pre-pass does not run there. A fresh
+// literal still upgrades: it carries no identifier, so there is no alias to invalidate and no
+// move to need. A place move does not, and is rejected on the mutability wrapper.
+func TestInferOwnedMutUpgradeNeedsABackingMove(t *testing.T) {
+	t.Run("a fresh literal upgrades at top level, needing no move", func(t *testing.T) {
+		_, _, errs := inferSource(t, `val m: mut {x: number} = {x: 1}`)
+		require.Empty(t, errs)
+	})
+	t.Run("a place move does not upgrade at top level", func(t *testing.T) {
+		_, _, errs := inferSource(t, "val cfg = {x: 1}\nval m: mut {x: number} = cfg")
+		require.Equal(t,
+			[]string{"2:12-2:13: cannot constrain immutable object <: mutable object"},
+			messagesWithSpan(t, errs))
+	})
+	t.Run("the same place move upgrades inside a function, and consumes", func(t *testing.T) {
+		const src = `fn f() {
+	val cfg = {x: 1}
+	val m: mut {x: number} = cfg
+}`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+
+		_, _, errs = inferSource(t, `fn f() {
+	val cfg = {x: 1}
+	val m: mut {x: number} = cfg
+	cfg.x
+}`)
+		require.Equal(t, []string{"4:2-4:7: use of moved value 'cfg'"}, messagesWithSpan(t, errs))
+	})
+}
+
 // A source carrying an already-owned-mutable cell is not upgraded, even when the cell is
 // nested inside a fresh literal. The covariant read view the upgrade constrains against
 // would widen that cell's element type, so the source falls through to the strict mut<:mut

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -365,14 +365,13 @@ func (c *checker) tryUpgradeToOwnedMut(site ast.Node, src ast.Expr, srcT, target
 }
 
 // ownedMutReadView returns the type a value built by src is checked against when it takes
-// target's owned-mutable type, and reports whether that upgrade applies. It is the decision
-// half of tryUpgradeToOwnedMut, which runs the check itself. The view is stripOwnedMut of
-// target's inner; a fully uniquely-owned source is owned at every level, so letting it flow
-// covariantly into that cell is sound the whole way down.
+// target's owned-mutable type, and reports whether that upgrade applies. It is the decision half
+// of tryUpgradeToOwnedMut, which runs the check itself. The view is stripOwnedMut of target's
+// inner, which is sound because a uniquely-owned source is owned at every level.
 //
-// The split exists for tryOverloadArm, which trials an arm under a probe with the
-// error-returning Context.Constrain so a losing arm writes nothing. Calling
-// tryUpgradeToOwnedMut there would run the accumulating checker.constrain instead.
+// The split exists for tryOverloadArm: it trials an arm with the error-returning
+// Context.Constrain so a losing arm writes nothing, where tryUpgradeToOwnedMut would run the
+// accumulating checker.constrain.
 func (c *checker) ownedMutReadView(src ast.Expr, target soltype.Type) (soltype.Type, bool) {
 	ref, ok := target.(*soltype.RefType)
 	if !ok || !ref.Mut || ref.Lt != nil || !c.canUpgradeToOwnedMut(src) {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -365,21 +365,14 @@ func (c *checker) tryUpgradeToOwnedMut(site ast.Node, src ast.Expr, srcT, target
 }
 
 // ownedMutReadView returns the type a value built by src is checked against when it takes
-// target's owned-mutable type, and reports whether that upgrade applies at all. It is the
-// decision half of tryUpgradeToOwnedMut, split out so a caller that must not write into
-// c.errs can run the same test and then check the source itself.
+// target's owned-mutable type, and reports whether that upgrade applies. It is the decision
+// half of tryUpgradeToOwnedMut, which runs the check itself. The view is stripOwnedMut of
+// target's inner; a fully uniquely-owned source is owned at every level, so letting it flow
+// covariantly into that cell is sound the whole way down.
 //
-// The view is stripOwnedMut of target's inner, the immutable read of the owned-mutable
-// cell. Under the lazy deep-mut form the inner is already bare, and a nested `mut {x}`
-// field inside a non-mut container is rejected at the annotation site (#779), so
-// stripOwnedMut is a defensive no-op for most target types. It still lets a uniquely-owned
-// source flow covariantly into any owned-mut cell that reaches here. A fully uniquely-owned
-// source is owned at every level, so the upgrade is sound the whole way down.
-//
-// tryOverloadArm is the caller that needs the split. It trials an arm under a probe with
-// the error-returning Context.Constrain, so a losing arm's rejected argument never reaches
-// c.errs. Calling tryUpgradeToOwnedMut there would run the accumulating checker.constrain
-// instead and blame a losing arm's failure at the call.
+// The split exists for tryOverloadArm, which trials an arm under a probe with the
+// error-returning Context.Constrain so a losing arm writes nothing. Calling
+// tryUpgradeToOwnedMut there would run the accumulating checker.constrain instead.
 func (c *checker) ownedMutReadView(src ast.Expr, target soltype.Type) (soltype.Type, bool) {
 	ref, ok := target.(*soltype.RefType)
 	if !ok || !ref.Mut || ref.Lt != nil || !c.canUpgradeToOwnedMut(src) {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -356,17 +356,36 @@ func (s *skolemizer) skolemizeBound(bounds []soltype.Type) soltype.Type {
 // canUpgradeToOwnedMut inspects for the syntactic fresh-literal fast path and the
 // place-move path.
 func (c *checker) tryUpgradeToOwnedMut(site ast.Node, src ast.Expr, srcT, target soltype.Type) bool {
-	ref, ok := target.(*soltype.RefType)
-	if !ok || !ref.Mut || ref.Lt != nil || !c.canUpgradeToOwnedMut(src) {
+	view, ok := c.ownedMutReadView(src, target)
+	if !ok {
 		return false
 	}
-	// Under the lazy deep-mut form the inner is already bare, and a nested `mut {x}` field
-	// inside a non-mut container is rejected at the annotation site (#779), so stripOwnedMut
-	// is a defensive no-op for most target types. It still lets a uniquely-owned source
-	// flow covariantly into any owned-mut cell that reaches here. A fully uniquely-owned
-	// source is owned at every level, so the upgrade is sound the whole way down.
-	c.constrain(site, srcT, stripOwnedMut(ref.Inner))
+	c.constrain(site, srcT, view)
 	return true
+}
+
+// ownedMutReadView returns the type a value built by src is checked against when it takes
+// target's owned-mutable type, and reports whether that upgrade applies at all. It is the
+// decision half of tryUpgradeToOwnedMut, split out so a caller that must not write into
+// c.errs can run the same test and then check the source itself.
+//
+// The view is stripOwnedMut of target's inner, the immutable read of the owned-mutable
+// cell. Under the lazy deep-mut form the inner is already bare, and a nested `mut {x}`
+// field inside a non-mut container is rejected at the annotation site (#779), so
+// stripOwnedMut is a defensive no-op for most target types. It still lets a uniquely-owned
+// source flow covariantly into any owned-mut cell that reaches here. A fully uniquely-owned
+// source is owned at every level, so the upgrade is sound the whole way down.
+//
+// tryOverloadArm is the caller that needs the split. It trials an arm under a probe with
+// the error-returning Context.Constrain, so a losing arm's rejected argument never reaches
+// c.errs. Calling tryUpgradeToOwnedMut there would run the accumulating checker.constrain
+// instead and blame a losing arm's failure at the call.
+func (c *checker) ownedMutReadView(src ast.Expr, target soltype.Type) (soltype.Type, bool) {
+	ref, ok := target.(*soltype.RefType)
+	if !ok || !ref.Mut || ref.Lt != nil || !c.canUpgradeToOwnedMut(src) {
+		return nil, false
+	}
+	return stripOwnedMut(ref.Inner), true
 }
 
 // canUpgradeToOwnedMut reports whether the value built by src may be granted an

--- a/internal/solver/infer_overload_mut_test.go
+++ b/internal/solver/infer_overload_mut_test.go
@@ -1,0 +1,118 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// #1519. A uniquely-owned argument fills an owned-mutable parameter of an OVERLOAD ARM,
+// the same grant inferCall makes for a callee it resolved to a single signature. Each arm
+// below is character-for-character a signature that accepts the call on its own, so
+// without the grant adding an unrelated second arm would break a call that compiled.
+//
+// Both halves of the upgrade are covered. A syntactically fresh literal is uniquely owned
+// because nothing else refers to it. A named binding that is dead after the call is
+// uniquely owned because the call moves it.
+func TestInferOverloadOwnedMutArgument(t *testing.T) {
+	t.Run("function, fresh literal", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn take(a: mut {x: number}) -> number { return 1 }
+			fn take(a: mut {x: number}, b: number) -> number { return 2 }
+			val r = take({x: 1})
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("function, moved variable", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn take(a: mut {x: number}) -> number { return 1 }
+			fn take(a: mut {x: number}, b: number) -> number { return 2 }
+			fn g() -> number {
+				val p = {x: 1}
+				return take(p)
+			}
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("method", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class C {
+				n: number,
+				m(self, a: mut {x: number}) -> number { return 1 },
+				m(self, a: mut {x: number}, b: number) -> number { return 2 },
+			}
+			val c = C(0)
+			val r = c.m({x: 1})
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("constructor", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			declare class Box {
+				constructor(mut self, a: mut {x: number}),
+				constructor(mut self, a: mut {x: number}, b: number),
+			}
+			val r = Box({x: 1})
+		`)
+		require.Empty(t, errs)
+	})
+}
+
+// A live source is not uniquely owned, so it takes no upgrade and the call finds no arm.
+// This is the boundary the grant must not cross: `p` is read after the call, so a second
+// owner would be observing writes made through the mutable view the arm asks for.
+func TestInferOverloadOwnedMutArgumentLiveSourceRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn take(a: mut {x: number}) -> number { return 1 }
+		fn take(a: mut {x: number}, b: number) -> number { return 2 }
+		fn g() -> number {
+			val p = {x: 1}
+			val n = take(p)
+			return p.x
+		}
+	`)
+	require.Equal(t, []string{"7:11-7:14: use of moved value 'p'"}, messagesWithSpan(t, errs))
+}
+
+// The upgrade runs inside a per-arm trial, so an arm that takes it and then fails on a
+// LATER argument has to roll back with the rest of the trial. The first arm below upgrades
+// `{x: 1}` and is rejected on `5 <: string`; the second arm then wins and gives the call
+// its own return type. A leaked bound or a leaked diagnostic from the losing trial would
+// show up as an error here or as the wrong type for `r`.
+func TestInferOverloadOwnedMutArgumentLosingArmRollsBack(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn take(a: mut {x: number}, b: string) -> string { return b }
+		fn take(a: mut {x: number}, b: number) -> number { return b }
+		val r = take({x: 1}, 5)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["r"])
+}
+
+// A rest slot takes no upgrade: an argument there fills one ELEMENT of the array the slot
+// gathers rather than the slot itself, so it is checked against the element type. inferCall
+// skips a rest slot for the same reason. The accepted call and the rejected one differ only
+// in an element, which is what shows the element is being read.
+//
+// Neither arm carries a return annotation, which keeps the set off the fully-annotated
+// pre-bind path. That path resolves an `Array<E>` annotation to `unknown`, so the rest
+// slot would have no element type to check against — see #1521.
+func TestInferOverloadRestSlotChecksElement(t *testing.T) {
+	const arms = `
+		fn g(...xs: mut Array<number>) { return 1 }
+		fn g(a: string, b: string) { return a }
+	`
+	t.Run("matching elements accept", func(t *testing.T) {
+		values, _, errs := inferSource(t, arms+`val r = g(1, 2)`)
+		require.Empty(t, errs)
+		require.Equal(t, "1", values["r"])
+	})
+	t.Run("a mismatched element rejects", func(t *testing.T) {
+		_, _, errs := inferSource(t, arms+`val r = g(1, true)`)
+		require.Equal(t,
+			[]string{"4:10-4:20: No matching overload for this call\n" +
+				"  fn (...xs: mut Array<number>) -> 1\n" +
+				"  fn (a: string, b: string) -> string"},
+			messagesWithSpan(t, errs))
+	})
+}

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -67,7 +67,7 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 			c.closeProbe(p, false)
 			continue
 		}
-		matched, diags := c.tryOverloadArm(args, inst)
+		matched, diags := c.tryOverloadArm(args, call.Args, inst)
 		c.closeProbe(p, matched)
 		if matched {
 			// tryOverloadArm runs the error-returning engine, so a warning the winning arm
@@ -115,7 +115,23 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 // Either is a non-match, unless the arm is inexact or has a rest. An `Array<E>` rest slot
 // says what each argument it absorbs must be, so those are checked against E. An inexact
 // tail says nothing about what it absorbs, so those stay arity-only.
-func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) (bool, []SolverError) {
+//
+// argExprs are the source expressions behind args, index for index, and are read only to
+// decide the owned-mutable upgrade — a uniquely-owned argument fills a `mut` parameter, so
+// `take({x: 1})` matches an arm declaring `a: mut {x: number}`. inferCall grants the same
+// thing through tryUpgradeToOwnedMut for a callee it resolved to one signature, and an
+// argument accepted there must be accepted here too, or adding an unrelated second arm to a
+// set would break a call that compiled. The upgrade is taken through ownedMutReadView rather
+// than tryUpgradeToOwnedMut so the check stays on Context.Constrain and a losing arm writes
+// no errors. A shorter argExprs, which a hand-built call in a test may give, leaves the
+// arguments past its end on the ordinary path.
+//
+// A rest slot takes no upgrade. An argument there fills one element of the array the slot
+// gathers rather than the slot itself, so there is no parameter type to upgrade it against.
+// inferCall skips a rest slot for the same reason.
+func (c *checker) tryOverloadArm(
+	args []soltype.Type, argExprs []ast.Expr, inst *soltype.FuncType,
+) (bool, []SolverError) {
 	n := len(args)
 	if lo, hi := acceptSet(inst); n < lo || n > hi {
 		return false, nil
@@ -144,7 +160,13 @@ func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) (b
 			}
 			break
 		}
-		errs := c.ctx.Constrain(arg, inst.Params[i].Type)
+		target := inst.Params[i].Type
+		if i < len(argExprs) {
+			if view, ok := c.ownedMutReadView(argExprs[i], target); ok {
+				target = view
+			}
+		}
+		errs := c.ctx.Constrain(arg, target)
 		if hasHardError(errs) {
 			return false, nil
 		}

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -148,6 +148,23 @@ func (c *checker) tryOverloadArm(
 		}
 		target := inst.Params[i].Type
 		if i < len(argExprs) {
+			// A `mut` parameter takes an IMMUTABLE argument when that argument is uniquely
+			// owned, so the check narrows to the parameter's immutable read view instead of
+			// rejecting `take({x: 1})` against `a: mut {x: number}` on the mutability
+			// wrapper. Only the wrapper is dropped: the shape is still checked covariantly,
+			// so `take({y: 1})` still fails.
+			//
+			// This is sound because ownedMutReadView fires only for a freshly built literal
+			// or a moved place. Nothing else refers to the value, so no live alias can
+			// observe a write the callee makes through the mutable view it receives, which
+			// is Rule 2 of the mutability-transition checker with an empty alias set.
+			// consumeCallArgs then moves the argument, so a later use of it is a
+			// use-after-move and the uniqueness holds past the call rather than only at it.
+			//
+			// inferCall pins its demand entry rather than narrowing, because its
+			// `callee <: callShape` constraint would otherwise re-check the argument
+			// strictly. Resolution emits no such constraint, so narrowing is the whole of it
+			// here.
 			if view, ok := c.ownedMutReadView(argExprs[i], target); ok {
 				target = view
 			}

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -97,38 +97,31 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 	return c.report(&NoMatchingOverloadError{Call: call, Candidates: b.Schemes}), nil
 }
 
-// tryOverloadArm reports whether inst accepts a call with the given argument types,
-// applying the argument constraints to inst's params as it goes. inst is a
-// freshly-instantiated arm. It runs under a probe opened by the caller, so on a false
-// return closeProbe(_, false) rolls back every bound it appended. It uses the
-// error-returning Context.Constrain rather than the accumulating checker.constrain, so a
-// rejected argument never reaches c.errs even before the probe's errs rollback.
+// tryOverloadArm reports whether inst, a freshly-instantiated arm, accepts a call with the
+// given argument types, applying the argument constraints to inst's params as it goes. It
+// runs under a probe the caller opened, so a false return rolls back every bound it
+// appended, and it uses the error-returning Context.Constrain so a rejected argument never
+// reaches c.errs.
 //
-// On a match it also returns the warnings the accepting constraints produced, so the
-// caller can surface them at the call. An arg that passes still counts as a match even when
-// it warns, since hasHardError draws the accept line, so the returned slice holds only
-// warnings. A non-match returns nil, keeping a rejected arm's diagnostics dropped.
+// On a match it returns the warnings the accepting constraints produced, for the caller to
+// surface at the call. hasHardError draws the accept line, so an argument that warns still
+// matches. A non-match returns nil, dropping a rejected arm's diagnostics.
 //
-// Arity follows the direct-call accept-set from #677, reusing acceptSet so the overload
-// arity gate and the FuncType<:FuncType constraint gate can never drift. A count below
-// acceptSet's lower bound is too few, and a count above its upper bound is too many.
-// Either is a non-match, unless the arm is inexact or has a rest. An `Array<E>` rest slot
-// says what each argument it absorbs must be, so those are checked against E. An inexact
-// tail says nothing about what it absorbs, so those stay arity-only.
+// Arity reuses acceptSet (#677), so the overload gate and the FuncType<:FuncType gate cannot
+// drift. A count outside it is a non-match unless the arm is inexact or has a rest. An
+// `Array<E>` rest slot says what each argument it absorbs must be, so those are checked
+// against E; an inexact tail says nothing, so those stay arity-only.
 //
-// argExprs are the source expressions behind args, index for index, and are read only to
-// decide the owned-mutable upgrade — a uniquely-owned argument fills a `mut` parameter, so
-// `take({x: 1})` matches an arm declaring `a: mut {x: number}`. inferCall grants the same
-// thing through tryUpgradeToOwnedMut for a callee it resolved to one signature, and an
-// argument accepted there must be accepted here too, or adding an unrelated second arm to a
-// set would break a call that compiled. The upgrade is taken through ownedMutReadView rather
-// than tryUpgradeToOwnedMut so the check stays on Context.Constrain and a losing arm writes
-// no errors. A shorter argExprs, which a hand-built call in a test may give, leaves the
-// arguments past its end on the ordinary path.
+// argExprs are the source expressions behind args, index for index, read only to decide the
+// owned-mutable upgrade: a uniquely-owned argument fills a `mut` parameter, so `take({x: 1})`
+// matches an arm declaring `a: mut {x: number}`. inferCall grants the same thing for a
+// one-signature callee, and an argument accepted there has to be accepted here — otherwise
+// adding an unrelated second arm breaks a call that compiled. It goes through
+// ownedMutReadView rather than tryUpgradeToOwnedMut to stay on Context.Constrain. An
+// argument past the end of argExprs takes the ordinary path.
 //
-// A rest slot takes no upgrade. An argument there fills one element of the array the slot
-// gathers rather than the slot itself, so there is no parameter type to upgrade it against.
-// inferCall skips a rest slot for the same reason.
+// A rest slot takes no upgrade, since an argument there fills one element of the gathered
+// array rather than the slot itself. inferCall skips one for the same reason.
 func (c *checker) tryOverloadArm(
 	args []soltype.Type, argExprs []ast.Expr, inst *soltype.FuncType,
 ) (bool, []SolverError) {

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -154,12 +154,19 @@ func (c *checker) tryOverloadArm(
 			// wrapper. Only the wrapper is dropped: the shape is still checked covariantly,
 			// so `take({y: 1})` still fails.
 			//
-			// This is sound because ownedMutReadView fires only for a freshly built literal
-			// or a moved place. Nothing else refers to the value, so no live alias can
-			// observe a write the callee makes through the mutable view it receives, which
-			// is Rule 2 of the mutability-transition checker with an empty alias set.
-			// consumeCallArgs then moves the argument, so a later use of it is a
+			// The decision is ownedMutReadView's, and bottoms out in canUpgradeToOwnedMut
+			// and freshLiteralShape over in infer_decl.go. Those admit three shapes: a
+			// freshly built literal, a moved owned place, or a borrow expression.
+			//
+			// The first two are uniquely owned, so nothing else refers to the value and no
+			// live alias can observe a write the callee makes through the mutable view it
+			// receives, which is Rule 2 of the mutability-transition checker with an empty
+			// alias set. consumeCallArgs then moves the argument, so a later use of it is a
 			// use-after-move and the uniqueness holds past the call rather than only at it.
+			// A borrow is sound for a different reason: the mutable view lets the
+			// container's field be repointed but grants no write to the referent, whose
+			// type stays invariant through the RefType arm, so the covariant check here
+			// cannot widen it.
 			//
 			// inferCall pins its demand entry rather than narrowing, because its
 			// `callee <: callShape` constraint would otherwise re-check the argument

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -97,31 +97,24 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 	return c.report(&NoMatchingOverloadError{Call: call, Candidates: b.Schemes}), nil
 }
 
-// tryOverloadArm reports whether inst, a freshly-instantiated arm, accepts a call with the
-// given argument types, applying the argument constraints to inst's params as it goes. It
-// runs under a probe the caller opened, so a false return rolls back every bound it
-// appended, and it uses the error-returning Context.Constrain so a rejected argument never
-// reaches c.errs.
-//
-// On a match it returns the warnings the accepting constraints produced, for the caller to
-// surface at the call. hasHardError draws the accept line, so an argument that warns still
-// matches. A non-match returns nil, dropping a rejected arm's diagnostics.
+// tryOverloadArm reports whether inst, a freshly-instantiated arm, accepts a call with the given
+// argument types, applying the argument constraints to inst's params as it goes. It runs under a
+// probe the caller opened, so a false return rolls back every bound it appended, and it uses the
+// error-returning Context.Constrain so a rejected argument never reaches c.errs. On a match it
+// returns the warnings the accepting constraints produced, for the caller to surface at the
+// call; hasHardError draws the accept line, so an argument that warns still matches. A non-match
+// returns nil, dropping a rejected arm's diagnostics.
 //
 // Arity reuses acceptSet (#677), so the overload gate and the FuncType<:FuncType gate cannot
-// drift. A count outside it is a non-match unless the arm is inexact or has a rest. An
-// `Array<E>` rest slot says what each argument it absorbs must be, so those are checked
-// against E; an inexact tail says nothing, so those stay arity-only.
+// drift. A count outside it is a non-match unless the arm is inexact or has a rest. An `Array<E>`
+// rest slot says what each argument it absorbs must be, so those are checked against E; an
+// inexact tail says nothing, so those stay arity-only.
 //
 // argExprs are the source expressions behind args, index for index, read only to decide the
-// owned-mutable upgrade: a uniquely-owned argument fills a `mut` parameter, so `take({x: 1})`
-// matches an arm declaring `a: mut {x: number}`. inferCall grants the same thing for a
-// one-signature callee, and an argument accepted there has to be accepted here — otherwise
-// adding an unrelated second arm breaks a call that compiled. It goes through
-// ownedMutReadView rather than tryUpgradeToOwnedMut to stay on Context.Constrain. An
-// argument past the end of argExprs takes the ordinary path.
-//
-// A rest slot takes no upgrade, since an argument there fills one element of the gathered
-// array rather than the slot itself. inferCall skips one for the same reason.
+// owned-mutable upgrade — so `take({x: 1})` matches an arm declaring `a: mut {x: number}`, as it
+// does a one-signature callee. It reads ownedMutReadView rather than tryUpgradeToOwnedMut to stay
+// on Context.Constrain. An argument past the end of argExprs, or at a rest slot, takes no
+// upgrade; a rest slot's argument fills one element of the gathered array rather than the slot.
 func (c *checker) tryOverloadArm(
 	args []soltype.Type, argExprs []ast.Expr, inst *soltype.FuncType,
 ) (bool, []SolverError) {


### PR DESCRIPTION
Fixes #1519

A uniquely-owned argument fills an owned-mutable parameter, so `take({x: 1})` matches `fn take(a: mut {x: number})`. `inferCall` grants that through `tryUpgradeToOwnedMut`, but only for a callee it resolved to a single signature. `tryOverloadArm` constrained each argument against the parameter directly, so an immutable argument never filled a `mut` parameter of an arm and every arm failed.

The effect was that adding an unrelated second arm broke a call that compiled:

```
fn take(a: mut {x: number}) -> number { return 1 }
val r = take({x: 1})                                   // accepted

fn take(a: mut {x: number}) -> number { return 1 }
fn take(a: mut {x: number}, b: number) -> number { return 2 }
val r = take({x: 1})                                   // No matching overload for this call
```

All four cases in the issue's table reproduced before the change: named function, method, and constructor, and both halves of the upgrade — a fresh literal and a moved variable.

## The change

`ownedMutReadView` splits out of `tryUpgradeToOwnedMut` and holds the decision: whether the upgrade applies, and what type the argument is checked against. `tryUpgradeToOwnedMut` keeps the constraining half, and `tryOverloadArm` reads the view to pick each argument's target.

The split matters because the trial must stay rollback-clean. `tryOverloadArm` runs under a probe with the error-returning `Context.Constrain`, so a losing arm's rejected argument never reaches `c.errs`. Calling `tryUpgradeToOwnedMut` there would run the accumulating `checker.constrain` instead and blame a losing arm's failure at the call. Sharing the predicate also keeps the two sites from drifting on when the upgrade applies, which is how this defect arose.

A rest slot takes no upgrade. An argument there fills one element of the array the slot gathers rather than the slot itself, so there is no parameter type to upgrade against — the reason `inferCall` skips a rest slot too.

## Tests

`TestInferOverloadOwnedMutArgument` covers a fresh literal and a moved variable through each callee kind. Three more pin the boundaries:

- a live source stays rejected, since a second owner would observe writes through the mutable view
- an arm that upgrades and then loses on a later argument rolls back, and the next arm still wins with its own return type
- a rest slot still checks its element

## Note

While writing the rest-slot test I found a separate pre-existing bug and filed it as #1521: an `Array<E>` annotation on a top-level overload arm silently resolves to `unknown`, because the overload pre-bind builds arm signatures under a discarded probe and the well-known `Array` load cannot survive it. The rest-slot test here works around it by omitting the return annotations, which keeps the set off that path, and says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved overload resolution for uniquely owned mutable arguments, including fresh values, moved variables, methods, and constructors.
  - Prevented live or otherwise ineligible sources from being accepted as owned mutable arguments.
  - Ensured failed overload candidates correctly roll back inferred constraints.
  - Improved validation for rest-parameter element types, including detection of mismatched argument types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->