### PR TITLE
Fuse normal-form atoms sharing an overloaded member

### DIFF
--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1742,33 +1742,57 @@ func (c *Context) joinObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bo
 // with, so two sets whose receivers disagree would fuse into a member mixing them. Such a
 // member is ill-formed for its readers: classes.go takes Signatures[0].SelfParam as the
 // receiver of the whole member, and buildMemberSigs reports
-// MethodOverloadReceiverMismatchError for the same mixture at a declaration. One arm of a
-// well-formed member therefore speaks for all of them, which is why comparing the two
-// representatives is enough.
+// MethodOverloadReceiverMismatchError for the same mixture at a declaration.
+//
+// Optionality meets the way a property's does. `m?` on both sides stays optional, since an
+// object omitting the member satisfies both; `m?` against a required `m` is required, since
+// the meet demands what either side demands. Dropping it would turn a value that omits the
+// member from a member of the meet into a non-member.
 func (c *Context) meetMethods(a, b *soltype.MethodElem) (soltype.ObjTypeElem, bool) {
 	if a.Static != b.Static {
 		return nil, false
 	}
-	if !equalSelfParam(methodReceiver(a), methodReceiver(b), &alphaCtx{}) {
+	aRecv, aAgrees := methodReceiver(a)
+	bRecv, bAgrees := methodReceiver(b)
+	if !aAgrees || !bAgrees || !equalSelfParam(aRecv, bRecv, &alphaCtx{}) {
 		return nil, false
 	}
 	sigs, ok := c.fuseSignatureSets(a.Signatures, b.Signatures, c.meetMethodSig)
 	if !ok {
 		return nil, false
 	}
-	return &soltype.MethodElem{Name: a.Name, Signatures: sigs, Static: a.Static}, true
+	return &soltype.MethodElem{
+		Name:       a.Name,
+		Signatures: sigs,
+		Static:     a.Static,
+		Optional:   a.Optional && b.Optional,
+	}, true
 }
 
-// methodReceiver returns the receiver a method member takes, read off its first arm.
-// buildMemberSigs rejects a declaration whose arms disagree on the receiver, so every arm
-// of a well-formed member carries the same one and the first speaks for all of them. This
-// is the reading classes.go gives the same field. An empty signature list has no receiver
-// to report and yields nil, which equalSelfParam accepts against another nil.
-func methodReceiver(m *soltype.MethodElem) *soltype.FuncParam {
+// methodReceiver returns the receiver a method member takes, and whether EVERY arm agrees on
+// it. classes.go reads the same field off the first arm alone, which is sound for a member
+// that agrees with itself.
+//
+// A member can fail to. buildMemberSigs rejects a declaration whose arms disagree on receiver
+// mutability, but it appends each arm to the member before reporting, so a class that drew
+// that error still carries the mixed receivers in its body. Reading the first arm alone here
+// would let two such members concatenate into one member mixing receivers — the shape the
+// guard in meetMethods exists to keep out, reached through the recovery path rather than
+// through a well-formed declaration.
+//
+// An empty signature list has no receiver to report and yields nil, which equalSelfParam
+// accepts against another nil.
+func methodReceiver(m *soltype.MethodElem) (*soltype.FuncParam, bool) {
 	if len(m.Signatures) == 0 {
-		return nil
+		return nil, true
 	}
-	return m.Signatures[0].SelfParam
+	recv := m.Signatures[0].SelfParam
+	for _, sig := range m.Signatures[1:] {
+		if !equalSelfParam(recv, sig.SelfParam, &alphaCtx{}) {
+			return nil, false
+		}
+	}
+	return recv, true
 }
 
 // fuseSignatureSets meets the signature sets of two members that share a name, returning

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1730,24 +1730,17 @@ func (c *Context) joinObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bo
 	return nil, false
 }
 
-// meetMethods fuses two methods that share a name by meeting their signature sets,
-// whether either side carries one signature or an overload set. Two identical methods
-// never reach here, since meetObjElem's equal-member check returns one of them first, so
-// the sets that do reach here always differ. Static-ness must agree, since a static method
-// lives on the constructor value and an instance method on the instance, so the two are
-// not the same member.
+// meetMethods fuses two methods that share a name by meeting their signature sets, whether
+// either side carries one signature or an overload set. meetObjElem's equal-member check
+// returns one side whole for two identical methods, so the sets reaching here always differ.
 //
-// The receivers must agree as well, and that check belongs here rather than inside
-// fuseSignatureSets. Under the concatenation each arm keeps the receiver it was written
-// with, so two sets whose receivers disagree would fuse into a member mixing them. Such a
-// member is ill-formed for its readers: classes.go takes Signatures[0].SelfParam as the
-// receiver of the whole member, and buildMemberSigs reports
-// MethodOverloadReceiverMismatchError for the same mixture at a declaration.
+// Static-ness must agree: a static method lives on the constructor value and an instance method
+// on the instance, so the two are not the same member. Receivers must agree too, and that check
+// belongs here rather than in fuseSignatureSets, since under the concatenation each arm keeps
+// its own — methodReceiver says what agreement means and how a member can lack it.
 //
-// Optionality meets the way a property's does. `m?` on both sides stays optional, since an
-// object omitting the member satisfies both; `m?` against a required `m` is required, since
-// the meet demands what either side demands. Dropping it would turn a value that omits the
-// member from a member of the meet into a non-member.
+// Optionality meets the way a property's does: optional on both sides stays optional, since an
+// object omitting the member satisfies both, and optional against required is required.
 func (c *Context) meetMethods(a, b *soltype.MethodElem) (soltype.ObjTypeElem, bool) {
 	if a.Static != b.Static {
 		return nil, false
@@ -1769,19 +1762,15 @@ func (c *Context) meetMethods(a, b *soltype.MethodElem) (soltype.ObjTypeElem, bo
 	}, true
 }
 
-// methodReceiver returns the receiver a method member takes, and whether EVERY arm agrees on
-// it. classes.go reads the same field off the first arm alone, which is sound for a member
-// that agrees with itself.
+// methodReceiver returns the receiver a method member takes, and whether EVERY arm agrees on it.
+// An empty signature list has no receiver and yields nil, which equalSelfParam accepts against
+// another nil. classes.go reads the same field off the first arm alone, sound for a member that
+// agrees with itself.
 //
 // A member can fail to. buildMemberSigs rejects a declaration whose arms disagree on receiver
-// mutability, but it appends each arm to the member before reporting, so a class that drew
-// that error still carries the mixed receivers in its body. Reading the first arm alone here
-// would let two such members concatenate into one member mixing receivers — the shape the
-// guard in meetMethods exists to keep out, reached through the recovery path rather than
-// through a well-formed declaration.
-//
-// An empty signature list has no receiver to report and yields nil, which equalSelfParam
-// accepts against another nil.
+// mutability, but it appends each arm BEFORE reporting, so a class that drew that error still
+// carries mixed receivers in its body. Reading the first arm alone here would let two such
+// members concatenate into one mixing receivers, which is what meetMethods' guard prevents.
 func methodReceiver(m *soltype.MethodElem) (*soltype.FuncParam, bool) {
 	if len(m.Signatures) == 0 {
 		return nil, true
@@ -1795,32 +1784,27 @@ func methodReceiver(m *soltype.MethodElem) (*soltype.FuncParam, bool) {
 	return recv, true
 }
 
-// fuseSignatureSets meets the signature sets of two members that share a name, returning
-// the arms of the fused member.
+// fuseSignatureSets meets the signature sets of two members that share a name, returning the
+// arms of the fused member.
 //
-// An overload set denotes the INTERSECTION of its arms — methodReadType and ctorReadType in
-// constrain.go build exactly that IntersectionType — so the meet of two sets is the
-// intersection of every arm of both:
+// An overload set denotes the INTERSECTION of its arms, which methodReadType and ctorReadType
+// build, so the meet of two sets is the intersection of every arm of both:
 //
 //	(A ∧ B) ∧ (C ∧ D)  =  A ∧ B ∧ C ∧ D
 //
-// which is the concatenation of the two lists. There is no question of which arm of one
-// pairs with which arm of the other, because ∧ is associative, commutative and idempotent.
-// Sets of different lengths, and arms that line up on nothing, fall out of that for free.
+// which is the concatenation of the two lists. ∧ being associative, commutative and idempotent
+// is what makes arm pairing a non-question, so sets of different lengths and arms that line up
+// on nothing fall out for free. newIntersection canonicalizes the result — flatten, dedupe,
+// drop an arm a sibling subsumes, sort — which also keeps the stored set deterministic for
+// resolveOverload.
 //
-// newIntersection canonicalizes the concatenation. It flattens a nested set, drops to one
-// copy of an arm both sides carry, drops an arm a sibling already subsumes, and sorts into
-// a canonical order so the stored set is deterministic for resolveOverload to read.
+// exact leads on a one-against-one pair, and is meetMethodSig for a method and meetFuncs for a
+// constructor. It fuses `(x: A) -> B` and `(x: A) -> C` into `(x: A) -> B ∧ C`, sharper than the
+// two-arm intersection, so the concatenation is the fallback rather than the rule everywhere.
 //
-// exact is tried first on a one-against-one pair, and is meetMethodSig for a method and
-// meetFuncs for a constructor. It fuses `(x: A) -> B` and `(x: A) -> C` into the single arm
-// `(x: A) -> B ∧ C`, which is sharper than the two-arm intersection, so the exact fuse
-// leads and the concatenation is the fallback rather than the rule everywhere.
-//
-// A canonicalized result that is not a function or an intersection of functions is not a
-// signature set, so this bails rather than build a member its readers could not use. That
-// costs an atom and no precision: meetObjects keeps the two unfused atoms, which denote the
-// meet exactly.
+// A canonicalized result that is not a function or an intersection of functions is no signature
+// set, so this bails rather than build a member its readers could not use. That costs an atom
+// and no precision, since the two unfused atoms denote the meet exactly.
 func (c *Context) fuseSignatureSets(
 	a, b []*soltype.FuncType, exact func(a, b *soltype.FuncType) (*soltype.FuncType, bool),
 ) ([]*soltype.FuncType, bool) {

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1676,23 +1676,15 @@ func (c *Context) meetObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bo
 		if !ok {
 			return nil, false
 		}
-		// Two constructors meet only when each carries a single signature, so an overloaded
-		// constructor keeps the objects apart instead. The two atoms denote the meet
-		// exactly, so the bail costs an atom rather than precision. #1517 carries the
-		// fusion, under the same evidence gate #1103 set: a set denotes the intersection of
-		// its arms, so meeting two of them concatenates the lists.
-		if len(a.Signatures) != 1 || len(b.Signatures) != 1 {
-			return nil, false
-		}
-		fused, ok := c.meetFuncs(a.Signatures[0], b.Signatures[0])
+		// Two constructors meet through the same signature-set rule a method's do. There is
+		// no receiver to guard here: a constructor's `mut self` is consumed at the
+		// declaration and never reaches the stored signature, so every arm carries a nil
+		// SelfParam.
+		sigs, ok := c.fuseSignatureSets(a.Signatures, b.Signatures, meetCtorSig(c))
 		if !ok {
 			return nil, false
 		}
-		fn, ok := fused.(*soltype.FuncType)
-		if !ok {
-			return nil, false
-		}
-		return &soltype.ConstructorElem{Signatures: []*soltype.FuncType{fn}}, true
+		return &soltype.ConstructorElem{Signatures: sigs}, true
 	}
 	return nil, false
 }
@@ -1738,31 +1730,96 @@ func (c *Context) joinObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bo
 	return nil, false
 }
 
-// meetMethods fuses two methods that share a name by meeting their signatures. It
-// fuses only single-signature methods, bailing when either carries an overload set.
-// Two identical methods never reach here, since meetObjElem's equal-member check
-// returns one of them first, so the overload sets that do reach here always differ.
-// Static-ness must agree, since a static method lives on the constructor value and an
-// instance method on the instance, so the two are not the same member.
+// meetMethods fuses two methods that share a name by meeting their signature sets,
+// whether either side carries one signature or an overload set. Two identical methods
+// never reach here, since meetObjElem's equal-member check returns one of them first, so
+// the sets that do reach here always differ. Static-ness must agree, since a static method
+// lives on the constructor value and an instance method on the instance, so the two are
+// not the same member.
 //
-// The bail costs an atom rather than precision, since the two unfused atoms denote the
-// meet exactly. #1517 carries the fusion, under the same evidence gate #1103 set. An
-// overload set denotes the intersection of its arms, which methodReadType builds, so
-// meeting two of them concatenates the lists and newIntersection's flatten, dedupe and
-// subsume steps canonicalize the result. The receiver check below still gates it, since
-// that algebra says nothing about which receiver the fused member takes.
+// The receivers must agree as well, and that check belongs here rather than inside
+// fuseSignatureSets. Under the concatenation each arm keeps the receiver it was written
+// with, so two sets whose receivers disagree would fuse into a member mixing them. Such a
+// member is ill-formed for its readers: classes.go takes Signatures[0].SelfParam as the
+// receiver of the whole member, and buildMemberSigs reports
+// MethodOverloadReceiverMismatchError for the same mixture at a declaration. One arm of a
+// well-formed member therefore speaks for all of them, which is why comparing the two
+// representatives is enough.
 func (c *Context) meetMethods(a, b *soltype.MethodElem) (soltype.ObjTypeElem, bool) {
 	if a.Static != b.Static {
 		return nil, false
 	}
-	if len(a.Signatures) != 1 || len(b.Signatures) != 1 {
+	if !equalSelfParam(methodReceiver(a), methodReceiver(b), &alphaCtx{}) {
 		return nil, false
 	}
-	fused, ok := c.meetMethodSig(a.Signatures[0], b.Signatures[0])
+	sigs, ok := c.fuseSignatureSets(a.Signatures, b.Signatures, c.meetMethodSig)
 	if !ok {
 		return nil, false
 	}
-	return &soltype.MethodElem{Name: a.Name, Signatures: []*soltype.FuncType{fused}, Static: a.Static}, true
+	return &soltype.MethodElem{Name: a.Name, Signatures: sigs, Static: a.Static}, true
+}
+
+// methodReceiver returns the receiver a method member takes, read off its first arm.
+// buildMemberSigs rejects a declaration whose arms disagree on the receiver, so every arm
+// of a well-formed member carries the same one and the first speaks for all of them. This
+// is the reading classes.go gives the same field. An empty signature list has no receiver
+// to report and yields nil, which equalSelfParam accepts against another nil.
+func methodReceiver(m *soltype.MethodElem) *soltype.FuncParam {
+	if len(m.Signatures) == 0 {
+		return nil
+	}
+	return m.Signatures[0].SelfParam
+}
+
+// fuseSignatureSets meets the signature sets of two members that share a name, returning
+// the arms of the fused member.
+//
+// An overload set denotes the INTERSECTION of its arms — methodReadType and ctorReadType in
+// constrain.go build exactly that IntersectionType — so the meet of two sets is the
+// intersection of every arm of both:
+//
+//	(A ∧ B) ∧ (C ∧ D)  =  A ∧ B ∧ C ∧ D
+//
+// which is the concatenation of the two lists. There is no question of which arm of one
+// pairs with which arm of the other, because ∧ is associative, commutative and idempotent.
+// Sets of different lengths, and arms that line up on nothing, fall out of that for free.
+//
+// newIntersection canonicalizes the concatenation. It flattens a nested set, drops to one
+// copy of an arm both sides carry, drops an arm a sibling already subsumes, and sorts into
+// a canonical order so the stored set is deterministic for resolveOverload to read.
+//
+// exact is tried first on a one-against-one pair, and is meetMethodSig for a method and
+// meetFuncs for a constructor. It fuses `(x: A) -> B` and `(x: A) -> C` into the single arm
+// `(x: A) -> B ∧ C`, which is sharper than the two-arm intersection, so the exact fuse
+// leads and the concatenation is the fallback rather than the rule everywhere.
+//
+// A canonicalized result that is not a function or an intersection of functions is not a
+// signature set, so this bails rather than build a member its readers could not use. That
+// costs an atom and no precision: meetObjects keeps the two unfused atoms, which denote the
+// meet exactly.
+func (c *Context) fuseSignatureSets(
+	a, b []*soltype.FuncType, exact func(a, b *soltype.FuncType) (*soltype.FuncType, bool),
+) ([]*soltype.FuncType, bool) {
+	if len(a) == 1 && len(b) == 1 {
+		if fused, ok := exact(a[0], b[0]); ok {
+			return []*soltype.FuncType{fused}, true
+		}
+	}
+	parts := make([]soltype.Type, 0, len(a)+len(b))
+	for _, sig := range a {
+		parts = append(parts, sig)
+	}
+	for _, sig := range b {
+		parts = append(parts, sig)
+	}
+	switch fused := newIntersection(c, parts).(type) {
+	case *soltype.FuncType:
+		// Every arm but one was dropped as redundant, so the set collapsed to a lone
+		// signature rather than an intersection.
+		return []*soltype.FuncType{fused}, true
+	default:
+		return funcIntersectionArms(fused)
+	}
 }
 
 // meetSetters fuses two setters that share a name. A setter is a one-input arrow
@@ -1816,6 +1873,22 @@ func (c *Context) meetMethodSig(a, b *soltype.FuncType) (*soltype.FuncType, bool
 	}
 	fn.SelfParam = a.SelfParam
 	return fn, true
+}
+
+// meetCtorSig adapts meetFuncs to the exact-fuse signature fuseSignatureSets takes. A
+// constructor signature carries no receiver, so it meets as a plain arrow, and the only
+// work here is narrowing meetFuncs's soltype.Type result back to a FuncType. A pair that
+// meets to anything else has no single signature that states both, which is the same
+// no-fuse answer meetFuncs gives directly.
+func meetCtorSig(c *Context) func(a, b *soltype.FuncType) (*soltype.FuncType, bool) {
+	return func(a, b *soltype.FuncType) (*soltype.FuncType, bool) {
+		fused, ok := c.meetFuncs(a, b)
+		if !ok {
+			return nil, false
+		}
+		fn, isFunc := fused.(*soltype.FuncType)
+		return fn, isFunc
+	}
 }
 
 // meetThrowsTypes meets two throws clauses, each read through the nil-is-never

--- a/internal/solver/normal_overload_merge_test.go
+++ b/internal/solver/normal_overload_merge_test.go
@@ -1,0 +1,132 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// #1517. Two normal-form atoms sharing a method or a constructor fuse whether the shared
+// member carries one signature or an overload set. An overload set denotes the intersection
+// of its arms, so the meet of two sets is the concatenation of their arms, canonicalized by
+// newIntersection.
+//
+// None of this changes what the compiler accepts or rejects. An unfused pair of atoms
+// denotes the meet exactly, so the fusion only shrinks the normal form.
+
+// TestObjectOverloadMethodMeet covers the method half through meetObjects. The objects are
+// written inexact so that neither caps out on a field the other lacks, which would settle
+// the meet as `never` before any member rule ran.
+func TestObjectOverloadMethodMeet(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "two overload sets concatenate every arm of both",
+			in: "{a: number, foo(self, x: number) -> number, foo(self, x: string) -> string, ...} & " +
+				"{b: number, foo(self, x: boolean) -> boolean, foo(self, x: null) -> null, ...}",
+			want: "{a: number, b: number, foo(self, x: number) -> number; " +
+				"foo(self, x: string) -> string; foo(self, x: boolean) -> boolean; " +
+				"foo(self, x: null) -> null, ...}",
+		},
+		{
+			name: "an arm both sides carry appears once",
+			in: "{a: number, foo(self, x: number) -> number, foo(self, x: string) -> string, ...} & " +
+				"{b: number, foo(self, x: number) -> number, ...}",
+			want: "{a: number, b: number, foo(self, x: number) -> number; " +
+				"foo(self, x: string) -> string, ...}",
+		},
+		{
+			name: "sets of different lengths fuse",
+			in: "{a: number, foo(self, x: number) -> number, foo(self, x: string) -> string, ...} & " +
+				"{b: number, foo(self, x: boolean) -> boolean, ...}",
+			want: "{a: number, b: number, foo(self, x: number) -> number; " +
+				"foo(self, x: string) -> string; foo(self, x: boolean) -> boolean, ...}",
+		},
+		{
+			name: "two single signatures that share a domain still fuse exactly, into one arm",
+			in: "{a: number, foo(self, x: number) -> number | string, ...} & " +
+				"{b: number, foo(self, x: number) -> string | boolean, ...}",
+			want: "{a: number, b: number, foo(self, x: number) -> string, ...}",
+		},
+		{
+			name: "two single signatures with no exact fuse concatenate instead of keeping both atoms",
+			in: "{a: number, foo(self, x: number) -> number, ...} & " +
+				"{b: number, foo(self, x: string) -> string, ...}",
+			want: "{a: number, b: number, foo(self, x: number) -> number; " +
+				"foo(self, x: string) -> string, ...}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, normDNF(c, parseType(t, tt.in)))
+		})
+	}
+}
+
+// TestObjectOverloadConstructorMeet covers the constructor half. An object type annotation
+// accepts at most one `new` signature, so an overloaded constructor cannot be written as a
+// type and the objects are built directly. A class declaring several constructors is where
+// the shape comes from, which #1501 gave a Signatures list to carry.
+func TestObjectOverloadConstructorMeet(t *testing.T) {
+	ctor := func(param soltype.Type, ret soltype.Type) *soltype.FuncType {
+		return &soltype.FuncType{
+			Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: param}},
+			Ret:    ret,
+		}
+	}
+	obj := func(field string, sigs ...*soltype.FuncType) *soltype.ObjectType {
+		return &soltype.ObjectType{
+			Elems: []soltype.ObjTypeElem{
+				&soltype.PropertyElem{Name: field, Type: num()},
+				&soltype.ConstructorElem{Signatures: sigs},
+			},
+			Inexact: true,
+		}
+	}
+	c := &Context{}
+	boolT := func() soltype.Type { return &soltype.PrimType{Prim: soltype.BoolPrim} }
+
+	fused, ok := c.meetObjects(
+		obj("a", ctor(num(), boolT()), ctor(str(), boolT())),
+		obj("b", ctor(boolT(), boolT())),
+	)
+	require.True(t, ok, "two objects sharing an overloaded constructor fuse to one atom")
+	require.Equal(t,
+		"{new (x: number) -> boolean; new (x: string) -> boolean; new (x: boolean) -> boolean, "+
+			"a: number, b: number, ...}",
+		soltype.Print(fused))
+}
+
+// TestOverloadReceiverMismatchStaysUnfused pins the receiver guard. Under the concatenation
+// each arm keeps the receiver it was written with, so two sets whose receivers disagree
+// would fuse into a member mixing them — a shape classes.go could not read, since it takes
+// the first arm's receiver as the receiver of the whole member. The guard keeps both atoms
+// instead, which denotes the meet just as exactly.
+//
+// The objects are built directly because an object type annotation has no `mut self`
+// receiver syntax.
+func TestOverloadReceiverMismatchStaysUnfused(t *testing.T) {
+	c := &Context{}
+	method := func(field string, mut bool) *soltype.ObjectType {
+		self := &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}}
+		if mut {
+			self.Type = &soltype.RefType{Mut: true}
+		}
+		return &soltype.ObjectType{
+			Elems: []soltype.ObjTypeElem{
+				&soltype.PropertyElem{Name: field, Type: num()},
+				&soltype.MethodElem{Name: "foo", Signatures: []*soltype.FuncType{
+					{SelfParam: self, Ret: num()},
+				}},
+			},
+			Inexact: true,
+		}
+	}
+	_, ok := c.meetObjects(method("a", true), method("b", false))
+	require.False(t, ok, "methods whose receivers disagree keep both atoms")
+}

--- a/internal/solver/normal_overload_merge_test.go
+++ b/internal/solver/normal_overload_merge_test.go
@@ -130,3 +130,72 @@ func TestOverloadReceiverMismatchStaysUnfused(t *testing.T) {
 	_, ok := c.meetObjects(method("a", true), method("b", false))
 	require.False(t, ok, "methods whose receivers disagree keep both atoms")
 }
+
+// Optionality meets the way a property's does. Two optional methods fuse to an optional one,
+// since an object omitting the member satisfies both sides of the meet; an optional against a
+// required one fuses to required, since the meet demands what either side demands. Dropping the
+// marker would turn a value that omits the member from a member of the meet into a non-member.
+func TestObjectMethodMeetKeepsOptionality(t *testing.T) {
+	method := func(field string, param soltype.Type, optional bool) *soltype.ObjectType {
+		return &soltype.ObjectType{
+			Elems: []soltype.ObjTypeElem{
+				&soltype.PropertyElem{Name: field, Type: num()},
+				&soltype.MethodElem{Name: "m", Optional: optional, Signatures: []*soltype.FuncType{
+					{Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: param}}, Ret: num()},
+				}},
+			},
+			Inexact: true,
+		}
+	}
+	tests := []struct {
+		name       string
+		aOpt, bOpt bool
+		want       string
+	}{
+		{"both optional stays optional", true, true,
+			"{a: number, b: number, m?(x: number | string) -> number, ...}"},
+		{"optional against required is required", true, false,
+			"{a: number, b: number, m(x: number | string) -> number, ...}"},
+		{"neither optional stays required", false, false,
+			"{a: number, b: number, m(x: number | string) -> number, ...}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			fused, ok := c.meetObjects(method("a", num(), tt.aOpt), method("b", str(), tt.bOpt))
+			require.True(t, ok)
+			require.Equal(t, tt.want, soltype.Print(fused))
+		})
+	}
+}
+
+// A member whose OWN arms disagree on the receiver keeps the objects apart. buildMemberSigs
+// rejects such a declaration, but it appends each arm before reporting, so a class that drew
+// that error still carries the mixed receivers in its body. Reading the first arm alone would
+// let two such members concatenate into a member mixing receivers, which is exactly what the
+// receiver guard exists to prevent.
+func TestSelfInconsistentOverloadStaysUnfused(t *testing.T) {
+	c := &Context{}
+	self := func(mut bool) *soltype.FuncParam {
+		p := &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}}
+		if mut {
+			p.Type = &soltype.RefType{Mut: true}
+		}
+		return p
+	}
+	// Both members agree on their FIRST arm, so a first-arm-only guard would pass them.
+	mixed := func(field string, param soltype.Type) *soltype.ObjectType {
+		return &soltype.ObjectType{
+			Elems: []soltype.ObjTypeElem{
+				&soltype.PropertyElem{Name: field, Type: num()},
+				&soltype.MethodElem{Name: "m", Signatures: []*soltype.FuncType{
+					{SelfParam: self(false), Params: []*soltype.FuncParam{{Type: param}}, Ret: num()},
+					{SelfParam: self(true), Params: []*soltype.FuncParam{{Type: param}}, Ret: str()},
+				}},
+			},
+			Inexact: true,
+		}
+	}
+	_, ok := c.meetObjects(mixed("a", num()), mixed("b", str()))
+	require.False(t, ok, "a member whose own arms disagree on the receiver keeps both atoms")
+}


### PR DESCRIPTION
Fixes #1517

`meetMethods` and `meetObjElem`'s `ConstructorElem` arm bailed when either side carried more than one signature, so two objects sharing an overloaded method or constructor stayed two atoms.

## The rule

An overload set denotes the intersection of its arms — `methodReadType` and `ctorReadType` build exactly that `IntersectionType` — so the meet of two sets is the intersection of every arm of both:

```
(A ∧ B) ∧ (C ∧ D)  =  A ∧ B ∧ C ∧ D
```

which is the concatenation of the two `Signatures` lists. Because ∧ is associative, commutative and idempotent, there is no "which arm of one pairs with which arm of the other" question to settle, and sets of different lengths or arms that line up on nothing fall out for free.

`newIntersection` canonicalizes the concatenation: it flattens a nested set, drops to one copy of an arm both sides carry, drops an arm a sibling already subsumes, and sorts into a canonical order so the stored set is deterministic for `resolveOverload` to read.

## The two things the algebra does not settle

`fuseSignatureSets` holds the rule for both members and tries the exact fuse FIRST on a one-against-one pair. `meetMethodSig` fuses `(x: A) -> B` and `(x: A) -> C` into the single arm `(x: A) -> B ∧ C`, which is sharper than the two-arm intersection, so the exact fuse leads and the concatenation is the fallback rather than the rule everywhere.

Receiver equality moves up from `meetMethodSig` to `meetMethods` and gates the whole fusion. Under the concatenation each arm keeps the receiver it was written with, so two sets whose receivers disagree would fuse into a member mixing them — a shape `classes.go` could not read, since it takes `Signatures[0].SelfParam` as the receiver of the whole member. A constructor needs no such guard: its `mut self` is consumed at the declaration and never reaches the stored signature.

## Against the issue's gate

Every clause is covered, by 12 passing subtests:

| gate clause | test |
| --- | --- |
| two objects sharing an overloaded method fuse to one atom carrying every arm of both | `TestObjectOverloadMethodMeet/two_overload_sets_concatenate_every_arm_of_both` |
| deduped | `.../an_arm_both_sides_carry_appears_once` |
| in canonical order | asserted by the expected string in each case |
| the same for a constructor | `TestObjectOverloadConstructorMeet` |
| a pair of arms that fuses exactly stays one arm rather than two | `.../two_single_signatures_that_share_a_domain_still_fuse_exactly` |
| two sets whose receivers disagree still keep both atoms | `TestOverloadReceiverMismatchStaysUnfused` |
| no program changes what it accepts or rejects | full suite green, no snapshot or fixture change |

Review also turned up two defects this fixes, each with its own test: the fused member dropped `MethodElem.Optional`, and `methodReceiver` read only the first arm where `buildMemberSigs` can leave a member carrying mixed receivers after reporting.

## Scheduling: the issue's suggested trigger is not met

Separate from the gate above, the issue asks for the work to be **evidence-driven** — "worth doing if a differential run shows conjunct or atom counts growing on class-heavy code, not before". That trigger is about *when* to schedule the work, not whether the implementation is correct.

I instrumented the concatenation path and ran the whole suite:

| | concatenation-path hits |
| --- | --- |
| this PR's own tests | 5 |
| everything else, including the fixture tests | **0** |

It never fires on the existing corpus. Two caveats on reading that: the fixture tests under `cmd/` drive `internal/checker` rather than `internal/solver`, and the solver does not yet type-check the committed stdlib tree, so the code that would exercise this — `Array.concat`, `Promise.then`, `Iterator.next` intersected with something — is not yet reachable from a solver run. The measurement says the trigger has not opened, not that the change is unexercised.

I also owe a correction to my own earlier recommendation, which called this the largest correctness gap in the recently merged overload work. It is not a correctness gap; the issue is explicit that the fusion buys no precision, and the code agrees.

So: implemented, tested, and gate-complete, with the scheduling trigger still closed. Merging now costs the review and buys a smaller normal form once the solver reaches class-heavy code; holding costs a rebase later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy