### PR TITLE
Unify the overloaded and single-signature call paths

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -84,6 +84,21 @@ func (c *Context) expandTupleRest(f *soltype.FuncType, seen *seenPairs) *soltype
 	return &expanded
 }
 
+// callCandidates returns the positional shapes a call to f is checked against — the ONE place a
+// callee signature becomes the form the argument and arity rules read. Both the single-signature
+// path in inferCall and the per-arm trial in resolveOverload go through it, so the two cannot
+// drift on how a rest slot is read.
+//
+// A rest slot typed as a union of tuples yields one shape per member, since the call matches when
+// some member matches. Every other slot yields one shape, with a tuple rest expanded to plain
+// positions. A slot neither rule reads stays a rest param for the absorb and scatter rules.
+func (c *Context) callCandidates(f *soltype.FuncType, seen *seenPairs) []*soltype.FuncType {
+	if arms, ok := c.distributeUnionRest(f, seen); ok {
+		return arms
+	}
+	return []*soltype.FuncType{c.expandTupleRest(f, seen)}
+}
+
 // distributeUnionRest turns a rest slot typed as a UNION of tuples into one candidate signature
 // per member, and reports false for a slot of any other shape. A member that is not a tuple names
 // no positions to expand, so the whole slot stays as written.

--- a/internal/solver/infer_call_unify_test.go
+++ b/internal/solver/infer_call_unify_test.go
@@ -1,0 +1,54 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// #1518. A call through a one-arm overload set must behave exactly like the same call
+// through a plain callee of that signature. Each pair below writes the same signature twice:
+// once alone, and once as the first arm of a set whose second arm has nothing to do with the
+// call. Adding that arm must not change the answer.
+//
+// Three divergences have been found by inspection rather than by a test — the missing
+// argument moves #1508 fixed, the missing owned-mutable upgrade #1519 fixed, and the missing
+// rest expansion below. These cases pin the shared behavior so a fourth cannot pass silently.
+
+// A tuple-typed rest parameter expands to one positional parameter per element, so each
+// argument is checked against its own element. The overload path did not expand it: the arity
+// gate read the tuple's length and passed, then the rest branch found no element type on a
+// tuple slot and checked nothing at all.
+func TestInferOverloadArmExpandsTupleRest(t *testing.T) {
+	const arm2 = "declare fn f(a: boolean) -> string\n"
+	t.Run("a matching call accepts either way", func(t *testing.T) {
+		alone, _, errs := inferSource(t, "declare fn f(...xs: [number, string]) -> number\nval r = f(1, \"a\")")
+		require.Empty(t, errs)
+		set, _, errs := inferSource(t, "declare fn f(...xs: [number, string]) -> number\n"+arm2+"val r = f(1, \"a\")")
+		require.Empty(t, errs)
+		require.Equal(t, alone["r"], set["r"])
+	})
+	t.Run("a mismatched element is rejected either way", func(t *testing.T) {
+		_, _, errs := inferSource(t, "declare fn f(...xs: [number, string]) -> number\nval r = f(1, 2)")
+		require.Equal(t, []string{"2:14-2:15: cannot constrain 2 <: string"}, messagesWithSpan(t, errs))
+
+		_, _, errs = inferSource(t, "declare fn f(...xs: [number, string]) -> number\n"+arm2+"val r = f(1, 2)")
+		require.Equal(t, []string{
+			"3:9-3:16: No matching overload for this call\n" +
+				"  fn (...xs: [number, string]) -> number\n" +
+				"  fn (a: boolean) -> string",
+		}, messagesWithSpan(t, errs))
+	})
+	t.Run("a union rest distributes on an arm too", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			declare fn f(...v: [] | [number]) -> number
+			declare fn f(a: boolean, b: boolean) -> string
+			val r = f("z")
+		`)
+		require.Equal(t, []string{
+			"4:12-4:18: No matching overload for this call\n" +
+				"  fn (...v: [] | [number]) -> number\n" +
+				"  fn (a: boolean, b: boolean) -> string",
+		}, messagesWithSpan(t, errs))
+	})
+}

--- a/internal/solver/infer_call_unify_test.go
+++ b/internal/solver/infer_call_unify_test.go
@@ -20,21 +20,38 @@ import (
 // gate read the tuple's length and passed, then the rest branch found no element type on a
 // tuple slot and checked nothing at all.
 func TestInferOverloadArmExpandsTupleRest(t *testing.T) {
-	const arm2 = "declare fn f(a: boolean) -> string\n"
 	t.Run("a matching call accepts either way", func(t *testing.T) {
-		alone, _, errs := inferSource(t, "declare fn f(...xs: [number, string]) -> number\nval r = f(1, \"a\")")
+		alone, _, errs := inferSource(t, `
+			declare fn f(...xs: [number, string]) -> number
+			val r = f(1, "a")
+		`)
 		require.Empty(t, errs)
-		set, _, errs := inferSource(t, "declare fn f(...xs: [number, string]) -> number\n"+arm2+"val r = f(1, \"a\")")
+
+		set, _, errs := inferSource(t, `
+			declare fn f(...xs: [number, string]) -> number
+			declare fn f(a: boolean) -> string
+			val r = f(1, "a")
+		`)
 		require.Empty(t, errs)
 		require.Equal(t, alone["r"], set["r"])
 	})
 	t.Run("a mismatched element is rejected either way", func(t *testing.T) {
-		_, _, errs := inferSource(t, "declare fn f(...xs: [number, string]) -> number\nval r = f(1, 2)")
-		require.Equal(t, []string{"2:14-2:15: cannot constrain 2 <: string"}, messagesWithSpan(t, errs))
+		_, _, errs := inferSource(t, `
+			declare fn f(...xs: [number, string]) -> number
+			val r = f(1, 2)
+		`)
+		require.Equal(t, []string{"3:17-3:18: cannot constrain 2 <: string"},
+			messagesWithSpan(t, errs))
 
-		_, _, errs = inferSource(t, "declare fn f(...xs: [number, string]) -> number\n"+arm2+"val r = f(1, 2)")
+		// The set reports its candidates instead of blaming the argument, which is the
+		// reporting difference between the two paths rather than a difference in checking.
+		_, _, errs = inferSource(t, `
+			declare fn f(...xs: [number, string]) -> number
+			declare fn f(a: boolean) -> string
+			val r = f(1, 2)
+		`)
 		require.Equal(t, []string{
-			"3:9-3:16: No matching overload for this call\n" +
+			"4:12-4:19: No matching overload for this call\n" +
 				"  fn (...xs: [number, string]) -> number\n" +
 				"  fn (a: boolean) -> string",
 		}, messagesWithSpan(t, errs))

--- a/internal/solver/infer_call_unify_test.go
+++ b/internal/solver/infer_call_unify_test.go
@@ -52,3 +52,84 @@ func TestInferOverloadArmExpandsTupleRest(t *testing.T) {
 		}, messagesWithSpan(t, errs))
 	})
 }
+
+// The gate of #1518: a call through a one-arm overload set behaves identically to the same call
+// through a plain callee of that signature. Each case writes one signature and one call, and
+// runs it twice — alone, and as the first arm of a set whose second arm cannot match the call.
+// A case that accepts must accept both ways; a case that rejects must reject both ways, though
+// the message differs because a set reports its candidates.
+func TestInferOverloadArmMatchesPlainCallee(t *testing.T) {
+	// The extra arm takes three booleans, so no call below can reach it on arity or on type.
+	const extraArm = "declare fn f(p: boolean, q: boolean, r: boolean) -> boolean\n"
+	tests := []struct {
+		name   string
+		sig    string
+		call   string
+		accept bool
+	}{
+		{"fixed positions", "declare fn f(a: number, b: string) -> number", `f(1, "a")`, true},
+		{"a mismatched position", "declare fn f(a: number, b: string) -> number", "f(1, 2)", false},
+		{"an optional position omitted", "declare fn f(a: number, b?: string) -> number", "f(1)", true},
+		{"an exact tuple rest", "declare fn f(...xs: [number, string]) -> number", `f(1, "a")`, true},
+		{"an exact tuple rest with a bad element", "declare fn f(...xs: [number, string]) -> number", "f(1, 2)", false},
+		{"an inexact tuple rest", "declare fn f(...xs: [number, ...]) -> number", `f(1, "a", true)`, true},
+		{"an inexact tuple rest with a bad prefix", "declare fn f(...xs: [number, ...]) -> number", `f("z")`, false},
+		{"a union-of-tuples rest, empty member", "declare fn f(...v: [] | [number]) -> number", "f()", true},
+		{"a union-of-tuples rest, filled member", "declare fn f(...v: [] | [number]) -> number", "f(1)", true},
+		{"a union-of-tuples rest, no member matches", "declare fn f(...v: [] | [number]) -> number", `f("z")`, false},
+		{"an owned-mutable parameter", "declare fn f(a: mut {x: number}) -> number", "f({x: 1})", true},
+		{"too few arguments", "declare fn f(a: number, b: string) -> number", "f(1)", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, alone := inferSource(t, tt.sig+"\nval r = "+tt.call)
+			_, _, set := inferSource(t, tt.sig+"\n"+extraArm+"val r = "+tt.call)
+			if tt.accept {
+				require.Empty(t, alone, "the plain callee must accept")
+				require.Empty(t, set, "adding an unrelated arm must not make an accepted call fail")
+				return
+			}
+			require.NotEmpty(t, alone, "the plain callee must reject")
+			require.NotEmpty(t, set, "the set must reject too")
+		})
+	}
+}
+
+// An overload set dispatches on ARGUMENTS. A throws mismatch says the enclosing body lacks a
+// clause the call needs, which is a diagnostic about the call rather than a reason to pass over
+// an arm. Advancing a raising generator from a body with no clause must therefore report the
+// missing clause, not "no matching overload" — `next` is itself an overload set of two arms.
+func TestInferOverloadThrowsIsNotDispatch(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		gen fn g() { yield 1 throw "boom" }
+		fn f() { val it = g() return it.next() }
+	`)
+	require.Equal(t, []string{`3:32-3:41: cannot constrain "boom" <: never`},
+		messagesWithSpan(t, errs))
+}
+
+// The `Array<E>` rest rows of the parity table above, split out because they cannot pass yet.
+//
+// DISABLED until #1521. An `Array<E>` annotation on a top-level overload arm silently resolves
+// to `unknown`, because the overload pre-bind builds arm signatures under a discarded probe and
+// the well-known `Array` load cannot survive it. The rest slot then accepts every argument, so
+// the accepting row passes for the wrong reason and the rejecting row does not fail at all.
+// Re-enable by removing the wrapper once the arm keeps its written annotation.
+func TestInferOverloadArmArrayRestMatchesPlainCallee(t *testing.T) {
+	/*
+		const sig = "declare fn f(...xs: Array<number>) -> number\n"
+		const extraArm = "declare fn f(p: boolean, q: boolean, r: boolean) -> boolean\n"
+		t.Run("matching elements accept either way", func(t *testing.T) {
+			_, _, alone := inferSource(t, sig+"val r = f(1, 2, 3)")
+			require.Empty(t, alone)
+			_, _, set := inferSource(t, sig+extraArm+"val r = f(1, 2, 3)")
+			require.Empty(t, set)
+		})
+		t.Run("a bad element is rejected either way", func(t *testing.T) {
+			_, _, alone := inferSource(t, sig+`val r = f(1, "a")`)
+			require.NotEmpty(t, alone)
+			_, _, set := inferSource(t, sig+extraArm+`val r = f(1, "a")`)
+			require.NotEmpty(t, set, "the arm's Array<number> must still check its element")
+		})
+	*/
+}

--- a/internal/solver/infer_call_unify_test.go
+++ b/internal/solver/infer_call_unify_test.go
@@ -72,7 +72,13 @@ func TestInferOverloadArmMatchesPlainCallee(t *testing.T) {
 		{"an optional position omitted", "declare fn f(a: number, b?: string) -> number", "f(1)", true},
 		{"an exact tuple rest", "declare fn f(...xs: [number, string]) -> number", `f(1, "a")`, true},
 		{"an exact tuple rest with a bad element", "declare fn f(...xs: [number, string]) -> number", "f(1, 2)", false},
-		{"an inexact tuple rest", "declare fn f(...xs: [number, ...]) -> number", `f(1, "a", true)`, true},
+		// An inexact tuple rest resolves to the same FuncType as `fn (x: number, ...)`, whose
+		// `...` widens the accept-set for subtyping. Passing EXTRA arguments to one is left out
+		// of this table on purpose: a plain callee draws inferCall's TooManyArgsError, while an
+		// arm has no such lint and its accept-set tolerates the extras, so the set accepts. That
+		// difference predates this branch — it holds on main for `fn (x: number, ...)` too — and
+		// #1518 calls the arity diagnostic a reporting choice the two paths may make differently.
+		{"an inexact tuple rest", "declare fn f(...xs: [number, ...]) -> number", "f(1)", true},
 		{"an inexact tuple rest with a bad prefix", "declare fn f(...xs: [number, ...]) -> number", `f("z")`, false},
 		{"a union-of-tuples rest, empty member", "declare fn f(...v: [] | [number]) -> number", "f()", true},
 		{"a union-of-tuples rest, filled member", "declare fn f(...v: [] | [number]) -> number", "f(1)", true},

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1646,27 +1646,18 @@ func (c *checker) inferArmOverloadCall(
 
 // upgradeCallDemand applies the immutable→mutable argument upgrade across a call's demand and
 // returns the demand it leaves behind. It is the ONE place either call path decides which
-// arguments take an owned-mutable parameter's type, so a shape built here and an overload arm's
-// trial agree on what a `mut` parameter accepts.
+// arguments take an owned-mutable parameter's type, so a call shape and an overload arm's trial
+// agree on what a `mut` parameter accepts.
 //
-// A uniquely-owned argument flowing into an owned-mutable parameter takes the mutable type, the
-// same grant the annotated declaration makes, so `f({x: 1})` and `f(cfg)` type-check for an
-// owned-mutable parameter. The argument's shape is checked covariantly against the parameter's
-// immutable read view, and that argument's demand entry is then PINNED to the parameter's own
-// type, so the callee <: callShape constraint re-checks it as param<:param rather than strictly
-// rejecting the immutable argument.
+// An upgraded argument is checked covariantly against the parameter's immutable read view, and
+// its demand entry is then PINNED to the parameter's own type, so the callee <: callShape
+// constraint re-checks it as param<:param rather than rejecting the immutable argument outright.
+// check runs that covariant check: inferCall passes the accumulating constrain, since its callee
+// is settled, and an overload trial passes the error-returning one, since a losing arm must
+// write nothing.
 //
-// check runs the covariant check, and is what differs between the two callers. inferCall passes
-// the accumulating constrain, since its callee is settled. An overload trial passes the
-// error-returning one, since a losing arm must write nothing.
-//
-// An argument at a rest slot takes no upgrade. It fills one element of the gathered array rather
-// than the slot itself, so there is no parameter type to upgrade it against: pairing the two
-// would check `f(1)` against `fn (...xs: mut Array<number>) -> R` as `1 <: Array<number>`. The
-// element check belongs to constrain's scatter rule instead.
-//
-// consumeCallArgs still moves an upgraded argument, since an owned-mutable parameter is
-// concrete-owned.
+// An argument at a rest slot takes no upgrade, since it fills one element of the gathered array
+// rather than the slot itself. The element check belongs to constrain's scatter rule.
 func (c *checker) upgradeCallDemand(
 	argExprs []ast.Expr, demand []*soltype.FuncParam, fn *soltype.FuncType,
 	check func(src ast.Node, srcT, target soltype.Type),
@@ -1686,14 +1677,12 @@ func (c *checker) upgradeCallDemand(
 }
 
 // inferCallArgs types a call's arguments left to right, the ONE place either call path does so.
-// The result is index-aligned with e.Args, which is what lets the argument rules read the source
-// expression behind an argument — the owned-mutable upgrade needs it to tell a uniquely-owned
-// argument from a live one.
+// The result is index-aligned with e.Args, which is what lets the owned-mutable upgrade read the
+// source expression behind an argument to tell a uniquely-owned one from a live one.
 //
-// The enclosing statement's CFG point must be read BEFORE this runs. Inferring a child that
-// contains statements, such as an `if` argument, overwrites c.fn.currentStmt, so reading the
-// point afterward would record an argument move against an inner branch instead of this call's
-// statement.
+// The enclosing statement's CFG point must be read BEFORE this runs: inferring an argument that
+// contains statements, such as an `if`, overwrites c.fn.currentStmt, so reading the point
+// afterward would record an argument move against an inner branch.
 func (c *checker) inferCallArgs(scope *Scope, lvl int, e *ast.CallExpr) []soltype.Type {
 	args := make([]soltype.Type, len(e.Args))
 	for i, a := range e.Args {
@@ -1703,18 +1692,10 @@ func (c *checker) inferCallArgs(scope *Scope, lvl int, e *ast.CallExpr) []soltyp
 }
 
 // recordCallArgEffects moves the arguments a call consumes and records the borrow edges its
-// signature stores. It is the ONE place both call paths run those two, against whichever
-// signature the call resolved to: the single shape inferCall read off the callee, or the arm
-// resolveOverload picked. Keeping them here is what stops one path from forgetting them, which
-// is how #1508 came about.
-//
-// Passing an owned argument to a bare owned parameter moves it, while a `&`/`&mut` parameter
-// auto-borrows and leaves the argument usable. An arity-mismatched call still moves each
-// argument that lines up with a parameter, so `store(p, p)` moves the first p and a later use of
-// p is a use-after-move; consumeCallArgs skips the extra arguments that have no parameter. A
-// borrow argument the signature stores into another argument, or into a method's receiver,
-// aliases the two for as long as the target lives, and recordCallStoreEdges records that rather
-// than leaving the alias invisible to the escape check and the component move.
+// signature stores, through consumeCallArgs and recordCallStoreEdges. It is the ONE place both
+// call paths run those two, against whichever signature the call resolved to: the shape inferCall
+// read off the callee, or the arm resolveOverload picked. Keeping them here is what stops one
+// path from forgetting them, which is how #1508 came about.
 //
 // fn is nil when no arm accepted the call. Nothing is moved then, since no signature says which
 // arguments a call that does not type-check would have consumed.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1670,7 +1670,21 @@ func (c *checker) upgradeCallDemand(
 		if !ok {
 			continue
 		}
+		// The argument is checked against the parameter's immutable read view rather than
+		// the parameter, so an IMMUTABLE argument fills a `mut` parameter: `take({x: 1})`
+		// is not rejected on the mutability wrapper. Only the wrapper is dropped, since the
+		// check stays covariant, so `take({y: 1})` still fails on the shape.
+		//
+		// This is sound because ownedMutReadView fires only for a freshly built literal or
+		// a moved place. Nothing else refers to the value, so no live alias can observe a
+		// write the callee makes through the mutable view it receives, which is Rule 2 of
+		// the mutability-transition checker with an empty alias set. recordCallArgEffects
+		// then moves the argument, so a later use of it is a use-after-move and the
+		// uniqueness holds past the call rather than only at it.
 		check(argExprs[i], demand[i].Type, view)
+		// Pin the demand entry to the parameter's own type. The argument has been checked
+		// covariantly above, and leaving the immutable argument type here would make the
+		// caller's `candidate <: callShape` constraint reject it a second time, strictly.
 		demand[i] = &soltype.FuncParam{Type: fn.Params[i].Type}
 	}
 	return demand

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1602,10 +1602,11 @@ func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType, ref liv
 // inferOverloadedCall types a direct call to an overloaded name (PR6). It infers
 // the types of the arguments, records the callee's overload type for Info, and
 // resolves the call through resolveOverload, which trials each arm under a probe
-// and commits the winner. Unlike the ordinary path it emits no callee <: callShape
-// constraint.  Overload resolution is a separate phase that owns arity and argument
-// checking. The TooManyArgs and NotEnoughArgs lints don't apply – arity is the
-// per-arm gate, and a no-match becomes a NoMatchingOverloadError.
+// and commits the winner. No constraint is emitted against the SET as a whole: an
+// overload set is chosen from rather than checked whole, and each trial builds the
+// same call shape the ordinary path builds and constrains its own candidate against
+// it. The TooManyArgs and NotEnoughArgs lints don't apply – arity is settled by that
+// per-arm constraint, and a no-match becomes a NoMatchingOverloadError.
 func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b ValueBinding) soltype.Type {
 	// Read the statement point before the arguments are inferred, for the reason inferCall
 	// gives: an argument containing statements overwrites the current one.
@@ -1626,8 +1627,8 @@ func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b 
 // overloaded constructor reached through a class value, such as `Array(3)`. It infers the
 // arguments, then resolves one arm through resolveOverload — the same machinery a direct
 // overloaded-name call uses, driven by the arms wrapped as monomorphic schemes. Like
-// inferOverloadedCall it emits no callee <: callShape constraint. Overload resolution owns
-// arity and argument checking, and a no-match becomes a NoMatchingOverloadError.
+// inferOverloadedCall it emits no constraint against the set as a whole, since choosing an
+// arm is what resolution does, and a no-match becomes a NoMatchingOverloadError.
 func (c *checker) inferArmOverloadCall(
 	scope *Scope, lvl int, e *ast.CallExpr, arms []*soltype.FuncType,
 	consumeRef liveness.StmtRef, hasConsumeRef bool,

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1675,12 +1675,22 @@ func (c *checker) upgradeCallDemand(
 		// is not rejected on the mutability wrapper. Only the wrapper is dropped, since the
 		// check stays covariant, so `take({y: 1})` still fails on the shape.
 		//
-		// This is sound because ownedMutReadView fires only for a freshly built literal or
-		// a moved place. Nothing else refers to the value, so no live alias can observe a
-		// write the callee makes through the mutable view it receives, which is Rule 2 of
-		// the mutability-transition checker with an empty alias set. recordCallArgEffects
-		// then moves the argument, so a later use of it is a use-after-move and the
-		// uniqueness holds past the call rather than only at it.
+		// The decision is ownedMutReadView's, and bottoms out in canUpgradeToOwnedMut and
+		// freshLiteralShape over in infer_decl.go. Those admit three shapes: a freshly built
+		// literal, a moved owned place, or a borrow expression.
+		//
+		// The first two are uniquely owned, so nothing else refers to the value and no live
+		// alias can observe a write the callee makes through the mutable view it receives,
+		// which is Rule 2 of the mutability-transition checker with an empty alias set.
+		// recordCallArgEffects then moves the argument, so a later use of it is a
+		// use-after-move and the uniqueness holds past the call rather than only at it. That
+		// move is not ordered against this grant, so it would be a convention — it is a data
+		// dependency instead, since the place-move shape needs the same VarID the move engine
+		// needs, and TestInferOwnedMutUpgradeNeedsABackingMove pins the boundary.
+		//
+		// A borrow is sound for a different reason: the mutable view lets the container's
+		// field be repointed but grants no write to the referent, whose type stays invariant
+		// through the RefType arm, so the covariant check here cannot widen it.
 		check(argExprs[i], demand[i].Type, view)
 		// Pin the demand entry to the parameter's own type. The argument has been checked
 		// covariantly above, and leaving the immutable argument type here would make the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1649,12 +1649,18 @@ func (c *checker) inferArmOverloadCall(
 // arguments take an owned-mutable parameter's type, so a call shape and an overload arm's trial
 // agree on what a `mut` parameter accepts.
 //
-// An upgraded argument is checked covariantly against the parameter's immutable read view, and
-// its demand entry is then PINNED to the parameter's own type, so the callee <: callShape
-// constraint re-checks it as param<:param rather than rejecting the immutable argument outright.
-// check runs that covariant check: inferCall passes the accumulating constrain, since its callee
-// is settled, and an overload trial passes the error-returning one, since a losing arm must
-// write nothing.
+// `take({x: 1})` against `a: mut {x: number | string}` runs in three steps:
+//
+//  1. ownedMutReadView hands back stripOwnedMut of the parameter's inner, `{x: number | string}`.
+//  2. check runs `{x: 1} <: {x: number | string}` COVARIANTLY. That is where the widening the
+//     argument needs happens, and where a wrong shape such as `take({y: 1})` still fails.
+//  3. The demand entry becomes the parameter's own type, so the later `callee <: callShape`
+//     compares `mut {x: number | string}` against itself. An owned-mutable cell is invariant,
+//     and identity is what satisfies it — no subtype relation is asked for at that position.
+//
+// check is what differs between the two callers: inferCall passes the accumulating constrain,
+// since its callee is settled, and an overload trial passes the error-returning one, since a
+// losing arm must write nothing.
 //
 // An argument at a rest slot takes no upgrade, since it fills one element of the gathered array
 // rather than the slot itself. The element check belongs to constrain's scatter rule.
@@ -1692,12 +1698,8 @@ func (c *checker) upgradeCallDemand(
 		// field be repointed but grants no write to the referent, whose type stays invariant
 		// through the RefType arm, so the covariant check here cannot widen it.
 		check(argExprs[i], demand[i].Type, view)
-		// Pin the demand entry to the PARAMETER's own type, which is what the call shape
-		// carries at this position. The widening the argument needs has already happened
-		// covariantly in the check above, and pinning is what stops the caller's
-		// `candidate <: callShape` constraint from undoing it.
-		//
-		// Upgrading the argument in place would not do, which is the reason this pins. An
+		// Step 3 of the walkthrough above. Upgrading the argument in place would not do,
+		// which is the reason this pins instead. An
 		// owned-mutable cell is INVARIANT, so the shape has to carry the parameter's type
 		// exactly. Wrapping the argument's own type gives `mut {x: 1}` for `take({x: 1})`
 		// against `a: mut {x: number}`, rejected with `cannot constrain number <: 1`.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1692,9 +1692,17 @@ func (c *checker) upgradeCallDemand(
 		// field be repointed but grants no write to the referent, whose type stays invariant
 		// through the RefType arm, so the covariant check here cannot widen it.
 		check(argExprs[i], demand[i].Type, view)
-		// Pin the demand entry to the parameter's own type. The argument has been checked
-		// covariantly above, and leaving the immutable argument type here would make the
-		// caller's `candidate <: callShape` constraint reject it a second time, strictly.
+		// Pin the demand entry to the PARAMETER's own type, which is what the call shape
+		// carries at this position. The widening the argument needs has already happened
+		// covariantly in the check above, and pinning is what stops the caller's
+		// `candidate <: callShape` constraint from undoing it.
+		//
+		// The argument's own type wrapped in `mut` would not do, which is the reason this
+		// pins rather than upgrading the argument in place. An owned-mutable cell is
+		// INVARIANT, so `take({x: 1})` against `a: mut {x: number}` would carry
+		// `mut {x: 1}` into the shape and be rejected with `cannot constrain number <: 1`
+		// — the invariance check running the direction the covariant widening already
+		// settled. Only the parameter's own type is guaranteed to satisfy it.
 		demand[i] = &soltype.FuncParam{Type: fn.Params[i].Type}
 	}
 	return demand

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1495,24 +1495,9 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// known. A deferred callee, one called through a `var`, keeps every argument on the
 	// strict path.
 	if resolved {
-		for i := 0; i < len(e.Args) && i < len(fn.Params); i++ {
-			if fn.Params[i].Rest {
-				// An argument at a rest slot fills one element of the gathered array, not the
-				// slot itself, so there is no parameter type to upgrade it against. Pairing the
-				// two would check the argument against the whole array: `f(1)` against
-				// `fn (...xs: mut Array<number>) -> R` would ask for `1 <: Array<number>`. The
-				// element check belongs to constrain's scatter rule, which the callee <:
-				// callShape constraint below reaches.
-				continue
-			}
-			if c.tryUpgradeToOwnedMut(e.Args[i], e.Args[i], demand[i].Type, fn.Params[i].Type) {
-				// The upgrade constrained the argument's shape against the parameter's
-				// immutable read view, so pin this argument's demand entry to the parameter's
-				// own type; the callee <: callShape constraint below then re-checks it as
-				// param<:param rather than strictly rejecting the immutable argument.
-				demand[i] = &soltype.FuncParam{Type: fn.Params[i].Type}
-			}
-		}
+		demand = c.upgradeCallDemand(e.Args, demand, fn, func(src ast.Node, srcT, target soltype.Type) {
+			c.constrain(src, srcT, target)
+		})
 	}
 
 	// callShape is built EXACT with all N params required, on purpose. That gives
@@ -1656,6 +1641,47 @@ func (c *checker) inferArmOverloadCall(
 	c.recordCallArgEffects(e, winner, consumeRef, hasConsumeRef)
 	c.recordType(e, ret)
 	return ret
+}
+
+// upgradeCallDemand applies the immutable→mutable argument upgrade across a call's demand and
+// returns the demand it leaves behind. It is the ONE place either call path decides which
+// arguments take an owned-mutable parameter's type, so a shape built here and an overload arm's
+// trial agree on what a `mut` parameter accepts.
+//
+// A uniquely-owned argument flowing into an owned-mutable parameter takes the mutable type, the
+// same grant the annotated declaration makes, so `f({x: 1})` and `f(cfg)` type-check for an
+// owned-mutable parameter. The argument's shape is checked covariantly against the parameter's
+// immutable read view, and that argument's demand entry is then PINNED to the parameter's own
+// type, so the callee <: callShape constraint re-checks it as param<:param rather than strictly
+// rejecting the immutable argument.
+//
+// check runs the covariant check, and is what differs between the two callers. inferCall passes
+// the accumulating constrain, since its callee is settled. An overload trial passes the
+// error-returning one, since a losing arm must write nothing.
+//
+// An argument at a rest slot takes no upgrade. It fills one element of the gathered array rather
+// than the slot itself, so there is no parameter type to upgrade it against: pairing the two
+// would check `f(1)` against `fn (...xs: mut Array<number>) -> R` as `1 <: Array<number>`. The
+// element check belongs to constrain's scatter rule instead.
+//
+// consumeCallArgs still moves an upgraded argument, since an owned-mutable parameter is
+// concrete-owned.
+func (c *checker) upgradeCallDemand(
+	argExprs []ast.Expr, demand []*soltype.FuncParam, fn *soltype.FuncType,
+	check func(src ast.Node, srcT, target soltype.Type),
+) []*soltype.FuncParam {
+	for i := 0; i < len(argExprs) && i < len(fn.Params) && i < len(demand); i++ {
+		if fn.Params[i].Rest {
+			continue
+		}
+		view, ok := c.ownedMutReadView(argExprs[i], fn.Params[i].Type)
+		if !ok {
+			continue
+		}
+		check(argExprs[i], demand[i].Type, view)
+		demand[i] = &soltype.FuncParam{Type: fn.Params[i].Type}
+	}
+	return demand
 }
 
 // inferCallArgs types a call's arguments left to right, the ONE place either call path does so.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1697,12 +1697,19 @@ func (c *checker) upgradeCallDemand(
 		// covariantly in the check above, and pinning is what stops the caller's
 		// `candidate <: callShape` constraint from undoing it.
 		//
-		// The argument's own type wrapped in `mut` would not do, which is the reason this
-		// pins rather than upgrading the argument in place. An owned-mutable cell is
-		// INVARIANT, so `take({x: 1})` against `a: mut {x: number}` would carry
-		// `mut {x: 1}` into the shape and be rejected with `cannot constrain number <: 1`
-		// — the invariance check running the direction the covariant widening already
-		// settled. Only the parameter's own type is guaranteed to satisfy it.
+		// Upgrading the argument in place would not do, which is the reason this pins. An
+		// owned-mutable cell is INVARIANT, so the shape has to carry the parameter's type
+		// exactly. Wrapping the argument's own type gives `mut {x: 1}` for `take({x: 1})`
+		// against `a: mut {x: number}`, rejected with `cannot constrain number <: 1`.
+		// Widening the literals first, as the unannotated `val mut q = {x: 1}` case does in
+		// inferVarDeclInit, gives `mut {x: number}` and fixes that one — but only that one.
+		// It then rejects `a: mut {x: number | string}` and `a: mut {x: 1}`, since an
+		// invariant position admits neither a narrower nor a wider type.
+		//
+		// The difference is that `val mut q = {x: 1}` has no target to adopt, so widening
+		// has to invent a usable one; `mut {x: 1}` there would reject the later `q.x = 2`.
+		// An argument has the parameter, and adopting it lands on the invariant position by
+		// construction whatever shape it takes.
 		demand[i] = &soltype.FuncParam{Type: fn.Params[i].Type}
 	}
 	return demand

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1428,20 +1428,27 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	if ft, ok := callee.(*soltype.FuncType); ok && len(ft.TypeParams) > 0 {
 		callee = c.ctx.instantiateFuncBinder(ft, lvl)
 	}
-	// A callee whose rest slot is a union of tuples admits a call when SOME member admits it,
-	// so each member becomes a candidate and the call resolves through the same trial machinery
-	// an overload set uses. `next(...value: [] | [TNext])` accepts both `i.next()` and
-	// `i.next(v)`, and rejects a wrong `v` against the element rather than against the slot.
-	// This runs after the generic instantiation above so an arm carries the call's own
-	// type-parameter bindings rather than the binder's.
-	if fn, ok := resolveFunc(callee); ok {
-		if arms, ok := c.ctx.distributeUnionRest(fn, newSeenPairs()); ok {
-			return c.inferArmOverloadCall(scope, lvl, e, arms, consumeRef, hasConsumeRef)
+	// Resolve the callee to the positional shapes the argument and arity rules read. This is the
+	// same callCandidates the per-arm trial in resolveOverload reads, so a rest slot means the
+	// same thing on both paths: a tuple rest expands to plain positions, and a union-of-tuples
+	// rest yields one shape per member. It runs after the generic instantiation above so a shape
+	// carries the call's own type-parameter bindings rather than the binder's.
+	fn, resolved := resolveFunc(callee)
+	if resolved {
+		cands := c.ctx.callCandidates(fn, newSeenPairs())
+		if len(cands) > 1 {
+			// The callee admits the call when SOME shape admits it, which is the disjunction an
+			// overload set already resolves. `next(...value: [] | [TNext])` accepts both
+			// `i.next()` and `i.next(v)`, and rejects a wrong `v` against the element rather
+			// than against the slot. Routing here rather than into a single callee <: callShape
+			// constraint keeps that choice where choosing belongs.
+			return c.inferArmOverloadCall(scope, lvl, e, cands, consumeRef, hasConsumeRef)
 		}
+		fn = cands[0]
 	}
 	args := make([]*soltype.FuncParam, len(e.Args))
-	for i, a := range e.Args {
-		args[i] = &soltype.FuncParam{Type: c.inferExpr(scope, lvl, a)}
+	for i, t := range c.inferCallArgs(scope, lvl, e) {
+		args[i] = &soltype.FuncParam{Type: t}
 	}
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, Application)
@@ -1451,13 +1458,6 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// where the lattice tolerates them. They fire only for a concrete callee. When one fires the
 	// demand is reshaped into the callee's accept-set so the synth's gate does not also report
 	// arity: too-many truncates, too-few pads with fresh vars that constrain nothing.
-	fn, resolved := resolveFunc(callee)
-	if resolved {
-		// A tuple-typed rest param expands to one positional param per element, so the lints, the
-		// owned-mutable upgrade, and consumeCallArgs below read plain positions rather than
-		// comparing an argument against the whole tuple.
-		fn = c.ctx.expandTupleRest(fn, newSeenPairs())
-	}
 	demand := args
 	switch {
 	case resolved && !hasRest(fn) && len(args) > len(fn.Params):
@@ -1526,9 +1526,12 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	callShape := &soltype.FuncType{Params: demand, Ret: res, Throws: c.throwsSink(lvl)}
 	// A resolved callee that declares nothing raises nothing, so it leaves the enclosing
 	// clause unused. Any other callee counts as raising, since its throws may still be an
-	// unsolved variable at this point.
-	if fn, ok := resolveFunc(callee); !ok || !isNeverType(fn.ThrowsOrNever()) {
-		c.markRaised()
+	// unsolved variable at this point. resolveOverload reaches the same rule through the same
+	// helper, against the arm it picked.
+	if resolved {
+		c.markCallRaised(fn)
+	} else {
+		c.markCallRaised(nil)
 	}
 	// Record the synthesized call-shape against the CallExpr so a FuncArityMismatchError
 	// — now only from a DEFERRED callee's too-few (or a callback-arity failure), since
@@ -1537,20 +1540,7 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	c.constrain(e, callee, callShape)
 	if resolved {
 		c.constrain(e, fn.Ret, res)
-		// Passing an owned argument to a bare owned parameter moves it; a `&`/`&mut`
-		// parameter auto-borrows and leaves the argument usable. An arity-mismatched call
-		// still moves each argument that lines up with a parameter, so `store(p, p)` moves
-		// the first p and a later use of p is a use-after-move. consumeCallArgs skips the
-		// extra arguments that have no corresponding parameter.
-		if hasConsumeRef {
-			c.consumeCallArgs(e, fn, consumeRef)
-			// A borrow argument the signature stores into another argument, or into a
-			// method's receiver, aliases the two for as long as the target lives. Record that
-			// edge here rather than leaving the alias invisible to the escape check and the
-			// component move.
-			recv, self := c.calleeReceiver(e.Callee)
-			c.recordCallStoreEdges(e, fn, recv, self, consumeRef)
-		}
+		c.recordCallArgEffects(e, fn, consumeRef, hasConsumeRef)
 	}
 	c.recordType(e, res)
 	return res
@@ -1635,16 +1625,13 @@ func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b 
 	// Read the statement point before the arguments are inferred, for the reason inferCall
 	// gives: an argument containing statements overwrites the current one.
 	consumeRef, hasConsumeRef := c.currentStmtRef()
-	args := make([]soltype.Type, len(e.Args))
-	for i, a := range e.Args {
-		args[i] = c.inferExpr(scope, lvl, a)
-	}
+	args := c.inferCallArgs(scope, lvl, e)
 	// Record the callee's display type for Info (hover) via overloadDisplayType, which
 	// coalesces the schemes rather than instantiating them — resolveOverload below does
 	// the (only) per-arm instantiation needed to type the call.
 	c.recordType(e.Callee, overloadDisplayType(b))
 	ret, winner := c.resolveOverload(lvl, b, args, e)
-	c.recordOverloadArgEffects(e, winner, consumeRef, hasConsumeRef)
+	c.recordCallArgEffects(e, winner, consumeRef, hasConsumeRef)
 	c.recordType(e, ret)
 	return ret
 }
@@ -1660,36 +1647,59 @@ func (c *checker) inferArmOverloadCall(
 	scope *Scope, lvl int, e *ast.CallExpr, arms []*soltype.FuncType,
 	consumeRef liveness.StmtRef, hasConsumeRef bool,
 ) soltype.Type {
-	args := make([]soltype.Type, len(e.Args))
-	for i, a := range e.Args {
-		args[i] = c.inferExpr(scope, lvl, a)
-	}
+	args := c.inferCallArgs(scope, lvl, e)
 	schemes := make([]TypeScheme, len(arms))
 	for i, arm := range arms {
 		schemes[i] = &MonoScheme{Ty: arm}
 	}
 	ret, winner := c.resolveOverload(lvl, ValueBinding{Schemes: schemes}, args, e)
-	c.recordOverloadArgEffects(e, winner, consumeRef, hasConsumeRef)
+	c.recordCallArgEffects(e, winner, consumeRef, hasConsumeRef)
 	c.recordType(e, ret)
 	return ret
 }
 
-// recordOverloadArgEffects moves the arguments a resolved overload call consumes and records
-// the borrow edges its signature stores, the two things inferCall does for a callee it
-// resolved to a single signature. Overload resolution owns the argument checking itself, so it
-// leaves inferCall before those run and has to do them here against the arm it picked.
+// inferCallArgs types a call's arguments left to right, the ONE place either call path does so.
+// The result is index-aligned with e.Args, which is what lets the argument rules read the source
+// expression behind an argument — the owned-mutable upgrade needs it to tell a uniquely-owned
+// argument from a live one.
 //
-// winner is nil when no arm accepted the call. Nothing is moved then, since no signature says
-// which arguments a call that does not type-check would have consumed.
-func (c *checker) recordOverloadArgEffects(
-	e *ast.CallExpr, winner *soltype.FuncType, consumeRef liveness.StmtRef, hasConsumeRef bool,
+// The enclosing statement's CFG point must be read BEFORE this runs. Inferring a child that
+// contains statements, such as an `if` argument, overwrites c.fn.currentStmt, so reading the
+// point afterward would record an argument move against an inner branch instead of this call's
+// statement.
+func (c *checker) inferCallArgs(scope *Scope, lvl int, e *ast.CallExpr) []soltype.Type {
+	args := make([]soltype.Type, len(e.Args))
+	for i, a := range e.Args {
+		args[i] = c.inferExpr(scope, lvl, a)
+	}
+	return args
+}
+
+// recordCallArgEffects moves the arguments a call consumes and records the borrow edges its
+// signature stores. It is the ONE place both call paths run those two, against whichever
+// signature the call resolved to: the single shape inferCall read off the callee, or the arm
+// resolveOverload picked. Keeping them here is what stops one path from forgetting them, which
+// is how #1508 came about.
+//
+// Passing an owned argument to a bare owned parameter moves it, while a `&`/`&mut` parameter
+// auto-borrows and leaves the argument usable. An arity-mismatched call still moves each
+// argument that lines up with a parameter, so `store(p, p)` moves the first p and a later use of
+// p is a use-after-move; consumeCallArgs skips the extra arguments that have no parameter. A
+// borrow argument the signature stores into another argument, or into a method's receiver,
+// aliases the two for as long as the target lives, and recordCallStoreEdges records that rather
+// than leaving the alias invisible to the escape check and the component move.
+//
+// fn is nil when no arm accepted the call. Nothing is moved then, since no signature says which
+// arguments a call that does not type-check would have consumed.
+func (c *checker) recordCallArgEffects(
+	e *ast.CallExpr, fn *soltype.FuncType, consumeRef liveness.StmtRef, hasConsumeRef bool,
 ) {
-	if winner == nil || !hasConsumeRef {
+	if fn == nil || !hasConsumeRef {
 		return
 	}
-	c.consumeCallArgs(e, winner, consumeRef)
+	c.consumeCallArgs(e, fn, consumeRef)
 	recv, self := c.calleeReceiver(e.Callee)
-	c.recordCallStoreEdges(e, winner, recv, self, consumeRef)
+	c.recordCallStoreEdges(e, fn, recv, self, consumeRef)
 }
 
 // ctorOverloadArms returns the signatures of an overloaded constructor when t reads as a class

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -132,25 +132,22 @@ func (c *checker) markCallRaised(fn *soltype.FuncType) {
 // tryOverloadArm reports whether inst, one positional shape of a freshly-instantiated arm,
 // accepts a call with the given argument types. It runs under a probe the caller opened, so a
 // false return rolls back every bound it appended, and it uses the error-returning
-// Context.Constrain so a rejected argument never reaches c.errs.
+// Context.Constrain so a rejected argument never reaches c.errs. On a match it returns the
+// warnings the accepting constraints produced, for the caller to surface at the call;
+// hasHardError draws the accept line, so an arm that warns still matches.
 //
 // The check is the SAME one the ordinary path runs: build a call shape from the arguments and
-// constrain the candidate against it. Arity, the per-argument check, the absorb and scatter
-// rules and the return are then decided by one body of code either way, which is the point of
-// #1518. The shape is exact with every parameter required, giving accept-set [n, n], so the
-// constraint holds iff required(inst) <= n <= upper(inst) — the window the arity gate used to
-// test directly.
+// constrain the candidate against it, so arity, the per-argument check, the absorb and scatter
+// rules and the return are decided by one body of code either way. The shape is exact with every
+// parameter required, giving accept-set [n, n], so the constraint holds iff
+// required(inst) <= n <= upper(inst).
 //
-// On a match it returns the warnings the accepting constraints produced, for the caller to
-// surface at the call. hasHardError draws the accept line, so an arm that warns still matches.
-// A non-match returns nil, dropping a rejected arm's diagnostics.
-//
-// The shape's Ret and Throws are FRESH variables, since a losing trial must leave a bound on
-// neither; resolveOverload takes the winner's own Ret and wires its throws against the real
-// sink once an arm is chosen. Wiring that sink into the shape instead would make dispatch
-// depend on the caller's `throws` clause: advancing a raising generator from a body with no
-// clause would fail `"boom" <: never` inside every trial and report "no matching overload"
-// rather than the missing clause. An overload set dispatches on arguments.
+// Its Ret and Throws are FRESH variables, since a losing trial must leave a bound on neither.
+// resolveOverload takes the winner's own Ret and wires its throws against the real sink once an
+// arm is chosen; wiring that sink in here would make dispatch depend on the caller's `throws`
+// clause, so advancing a raising generator from a body with no clause would fail
+// `"boom" <: never` in every trial and report "no matching overload" rather than the missing
+// clause.
 func (c *checker) tryOverloadArm(
 	lvl int, args []soltype.Type, argExprs []ast.Expr, inst *soltype.FuncType,
 ) (bool, []SolverError) {

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -59,7 +59,7 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 		// active. This upholds the guarantee that a losing trial leaves no Info or Prov
 		// entries.
 		p := c.openProbe()
-		inst, ok := c.instantiate(b.Schemes[idx], lvl).(*soltype.FuncType)
+		arm, ok := c.instantiate(b.Schemes[idx], lvl).(*soltype.FuncType)
 		if !ok {
 			// An overload arm that is not a function scheme cannot match a call. This should
 			// not arise, since every arm comes from a FuncDecl. Skip it rather than
@@ -67,7 +67,12 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 			c.closeProbe(p, false)
 			continue
 		}
-		matched, diags := c.tryOverloadArm(args, call.Args, inst)
+		// One arm becomes several candidate shapes when its rest slot is a union of tuples,
+		// and a tuple rest expands to plain positions. This is the same callCandidates the
+		// single-signature path reads, so an arm's rest slot means here what it means there.
+		// Probes nest, so a candidate that loses rolls back on its own and leaves the arm's
+		// instantiation intact for the next one.
+		inst, matched, diags := c.tryArmCandidates(args, call.Args, arm)
 		c.closeProbe(p, matched)
 		if matched {
 			// tryOverloadArm runs the error-returning engine, so a warning the winning arm
@@ -79,31 +84,60 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 			// inferCall's shape wires it.
 			if inst.Throws != nil {
 				c.constrain(call, inst.Throws, c.throwsSink(lvl))
-				// The call counts as an exceptional exit unless the winner declares it raises
-				// nothing, so an enclosing `throws` clause this call needs is not warned about
-				// as unused. An unsolved throws variable counts as raising, the same reading
-				// inferCall gives an unresolved callee.
-				if !isNeverType(inst.ThrowsOrNever()) {
-					c.markRaised()
-				}
 			}
+			c.markCallRaised(inst)
 			return inst.Ret, inst
 		}
 	}
 	// No arm accepted the call, so nothing here shows it cannot raise. Count it as an
 	// exceptional exit, the reading inferCall gives a callee it cannot resolve, so the no-match
 	// error is not joined by a spurious unused-clause warning against a clause the call needs.
-	c.markRaised()
+	c.markCallRaised(nil)
 	return c.report(&NoMatchingOverloadError{Call: call, Candidates: b.Schemes}), nil
 }
 
-// tryOverloadArm reports whether inst, a freshly-instantiated arm, accepts a call with the given
-// argument types, applying the argument constraints to inst's params as it goes. It runs under a
-// probe the caller opened, so a false return rolls back every bound it appended, and it uses the
-// error-returning Context.Constrain so a rejected argument never reaches c.errs. On a match it
-// returns the warnings the accepting constraints produced, for the caller to surface at the
-// call; hasHardError draws the accept line, so an argument that warns still matches. A non-match
-// returns nil, dropping a rejected arm's diagnostics.
+// tryArmCandidates trials each positional shape one instantiated arm stands for, and returns the
+// first that accepts the call along with the warnings its constraints produced. A losing
+// candidate rolls back under its own probe, nested inside the arm's, so the arm's instantiation
+// survives for the next candidate.
+//
+// An arm yields more than one shape only when its rest slot is a union of tuples, where the call
+// matches if some member matches. Every other arm yields exactly one, so the loop is the
+// single-shape case in the common form rather than a separate body.
+func (c *checker) tryArmCandidates(
+	args []soltype.Type, argExprs []ast.Expr, arm *soltype.FuncType,
+) (*soltype.FuncType, bool, []SolverError) {
+	for _, cand := range c.ctx.callCandidates(arm, newSeenPairs()) {
+		p := c.openProbe()
+		matched, diags := c.tryOverloadArm(args, argExprs, cand)
+		c.closeProbe(p, matched)
+		if matched {
+			return cand, true, diags
+		}
+	}
+	return nil, false, nil
+}
+
+// markCallRaised counts a call as an exceptional exit unless the signature it resolved to
+// declares that it raises nothing. An enclosing `throws` clause the call needs is then not
+// warned about as unused. A nil fn is a callee that resolved to no signature — a deferred one,
+// or an overload set no arm of which accepted — and counts as raising, since nothing about it
+// shows that it cannot. An unsolved throws variable counts as raising for the same reason.
+func (c *checker) markCallRaised(fn *soltype.FuncType) {
+	if fn == nil || !isNeverType(fn.ThrowsOrNever()) {
+		c.markRaised()
+	}
+}
+
+// tryOverloadArm reports whether inst, a freshly-instantiated arm, accepts a call with the
+// given argument types, applying the argument constraints to inst's params as it goes. It
+// runs under a probe the caller opened, so a false return rolls back every bound it
+// appended, and it uses the error-returning Context.Constrain so a rejected argument never
+// reaches c.errs.
+//
+// On a match it returns the warnings the accepting constraints produced, for the caller to
+// surface at the call. hasHardError draws the accept line, so an argument that warns still
+// matches. A non-match returns nil, dropping a rejected arm's diagnostics.
 //
 // Arity reuses acceptSet (#677), so the overload gate and the FuncType<:FuncType gate cannot
 // drift. A count outside it is a non-match unless the arm is inexact or has a rest. An `Array<E>`

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -129,38 +129,28 @@ func (c *checker) markCallRaised(fn *soltype.FuncType) {
 	}
 }
 
-// tryOverloadArm reports whether inst accepts a call with the given argument types, applying the
-// argument constraints to inst's params as it goes. inst is one positional shape of a
-// freshly-instantiated arm. It runs under a probe opened by the caller, so on a false return
-// closeProbe(_, false) rolls back every bound it appended.
+// tryOverloadArm reports whether inst, one positional shape of a freshly-instantiated arm,
+// accepts a call with the given argument types. It runs under a probe the caller opened, so a
+// false return rolls back every bound it appended, and it uses the error-returning
+// Context.Constrain so a rejected argument never reaches c.errs.
 //
 // The check is the SAME one the ordinary path runs: build a call shape from the arguments and
-// constrain the candidate against it. Arity, the per-argument check, the rest slot's absorb and
-// scatter rules, the return and the throws edge are then decided by one body of code for a
-// one-signature callee and for an arm of a set alike. That is the point of #1518. Three
-// divergences came from having two: the missing argument moves #1508 fixed, the missing
-// owned-mutable upgrade #1519 fixed, and the missing rest expansion this change fixes.
+// constrain the candidate against it. Arity, the per-argument check, the absorb and scatter
+// rules and the return are then decided by one body of code either way, which is the point of
+// #1518. The shape is exact with every parameter required, giving accept-set [n, n], so the
+// constraint holds iff required(inst) <= n <= upper(inst) — the window the arity gate used to
+// test directly.
 //
-// The shape is built EXACT with every parameter required, so its accept-set is [n, n] and the
-// constraint reads "the candidate must accept exactly n arguments" — it holds iff
-// required(inst) <= n <= upper(inst), the same window the arity gate used to test directly.
+// On a match it returns the warnings the accepting constraints produced, for the caller to
+// surface at the call. hasHardError draws the accept line, so an arm that warns still matches.
+// A non-match returns nil, dropping a rejected arm's diagnostics.
 //
-// It uses the error-returning Context.Constrain rather than the accumulating checker.constrain,
-// so a rejected argument never reaches c.errs even before the probe's errs rollback. On a match
-// it returns the warnings the accepting constraints produced, so the caller can surface them at
-// the call. An arm that warns still counts as a match, since hasHardError draws the accept line.
-// A non-match returns nil, keeping a rejected arm's diagnostics dropped.
-//
-// The shape's Ret and Throws are FRESH variables rather than the enclosing body's, because a
-// losing trial must leave a bound on neither. resolveOverload takes the winner's own Ret, which
-// is sharper than what the shape derives, and wires the winner's throws against the real sink
-// once an arm has been chosen.
-//
-// Wiring the real sink into the shape would make dispatch depend on the caller's `throws`
-// clause. Advancing a raising generator from a body that declares no clause would then fail
-// `"boom" <: never` inside every trial and report "no matching overload" rather than the missing
-// clause. An overload set dispatches on arguments, so a throws mismatch is a diagnostic about
-// the call and never a reason to pass over an arm.
+// The shape's Ret and Throws are FRESH variables, since a losing trial must leave a bound on
+// neither; resolveOverload takes the winner's own Ret and wires its throws against the real
+// sink once an arm is chosen. Wiring that sink into the shape instead would make dispatch
+// depend on the caller's `throws` clause: advancing a raising generator from a body with no
+// clause would fail `"boom" <: never` inside every trial and report "no matching overload"
+// rather than the missing clause. An overload set dispatches on arguments.
 func (c *checker) tryOverloadArm(
 	lvl int, args []soltype.Type, argExprs []ast.Expr, inst *soltype.FuncType,
 ) (bool, []SolverError) {

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -72,7 +72,7 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 		// single-signature path reads, so an arm's rest slot means here what it means there.
 		// Probes nest, so a candidate that loses rolls back on its own and leaves the arm's
 		// instantiation intact for the next one.
-		inst, matched, diags := c.tryArmCandidates(args, call.Args, arm)
+		inst, matched, diags := c.tryArmCandidates(lvl, args, call.Args, arm)
 		c.closeProbe(p, matched)
 		if matched {
 			// tryOverloadArm runs the error-returning engine, so a warning the winning arm
@@ -82,6 +82,10 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 			// raise contributes nothing here. Resolution never builds a call shape for
 			// constrain to read, so the exceptional edge is wired by hand instead, the way
 			// inferCall's shape wires it.
+			// Only the winning arm's throws reaches the caller, so a set whose other arms raise
+			// contributes nothing here. The trial's shape carried a fresh throws variable to
+			// keep dispatch off the caller's clause, so the real edge is wired now that an arm
+			// has been chosen.
 			if inst.Throws != nil {
 				c.constrain(call, inst.Throws, c.throwsSink(lvl))
 			}
@@ -105,11 +109,11 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 // matches if some member matches. Every other arm yields exactly one, so the loop is the
 // single-shape case in the common form rather than a separate body.
 func (c *checker) tryArmCandidates(
-	args []soltype.Type, argExprs []ast.Expr, arm *soltype.FuncType,
+	lvl int, args []soltype.Type, argExprs []ast.Expr, arm *soltype.FuncType,
 ) (*soltype.FuncType, bool, []SolverError) {
 	for _, cand := range c.ctx.callCandidates(arm, newSeenPairs()) {
 		p := c.openProbe()
-		matched, diags := c.tryOverloadArm(args, argExprs, cand)
+		matched, diags := c.tryOverloadArm(lvl, args, argExprs, cand)
 		c.closeProbe(p, matched)
 		if matched {
 			return cand, true, diags
@@ -129,94 +133,61 @@ func (c *checker) markCallRaised(fn *soltype.FuncType) {
 	}
 }
 
-// tryOverloadArm reports whether inst, a freshly-instantiated arm, accepts a call with the
-// given argument types, applying the argument constraints to inst's params as it goes. It
-// runs under a probe the caller opened, so a false return rolls back every bound it
-// appended, and it uses the error-returning Context.Constrain so a rejected argument never
-// reaches c.errs.
+// tryOverloadArm reports whether inst accepts a call with the given argument types, applying the
+// argument constraints to inst's params as it goes. inst is one positional shape of a
+// freshly-instantiated arm. It runs under a probe opened by the caller, so on a false return
+// closeProbe(_, false) rolls back every bound it appended.
 //
-// On a match it returns the warnings the accepting constraints produced, for the caller to
-// surface at the call. hasHardError draws the accept line, so an argument that warns still
-// matches. A non-match returns nil, dropping a rejected arm's diagnostics.
+// The check is the SAME one the ordinary path runs: build a call shape from the arguments and
+// constrain the candidate against it. Arity, the per-argument check, the rest slot's absorb and
+// scatter rules, the return and the throws edge are then decided by one body of code for a
+// one-signature callee and for an arm of a set alike. That is the point of #1518. Three
+// divergences came from having two: the missing argument moves #1508 fixed, the missing
+// owned-mutable upgrade #1519 fixed, and the missing rest expansion this change fixes.
 //
-// Arity reuses acceptSet (#677), so the overload gate and the FuncType<:FuncType gate cannot
-// drift. A count outside it is a non-match unless the arm is inexact or has a rest. An `Array<E>`
-// rest slot says what each argument it absorbs must be, so those are checked against E; an
-// inexact tail says nothing, so those stay arity-only.
+// The shape is built EXACT with every parameter required, so its accept-set is [n, n] and the
+// constraint reads "the candidate must accept exactly n arguments" — it holds iff
+// required(inst) <= n <= upper(inst), the same window the arity gate used to test directly.
 //
-// argExprs are the source expressions behind args, index for index, read only to decide the
-// owned-mutable upgrade — so `take({x: 1})` matches an arm declaring `a: mut {x: number}`, as it
-// does a one-signature callee. It reads ownedMutReadView rather than tryUpgradeToOwnedMut to stay
-// on Context.Constrain. An argument past the end of argExprs, or at a rest slot, takes no
-// upgrade; a rest slot's argument fills one element of the gathered array rather than the slot.
+// It uses the error-returning Context.Constrain rather than the accumulating checker.constrain,
+// so a rejected argument never reaches c.errs even before the probe's errs rollback. On a match
+// it returns the warnings the accepting constraints produced, so the caller can surface them at
+// the call. An arm that warns still counts as a match, since hasHardError draws the accept line.
+// A non-match returns nil, keeping a rejected arm's diagnostics dropped.
+//
+// The shape's Ret and Throws are FRESH variables rather than the enclosing body's, because a
+// losing trial must leave a bound on neither. resolveOverload takes the winner's own Ret, which
+// is sharper than what the shape derives, and wires the winner's throws against the real sink
+// once an arm has been chosen.
+//
+// Wiring the real sink into the shape would make dispatch depend on the caller's `throws`
+// clause. Advancing a raising generator from a body that declares no clause would then fail
+// `"boom" <: never` inside every trial and report "no matching overload" rather than the missing
+// clause. An overload set dispatches on arguments, so a throws mismatch is a diagnostic about
+// the call and never a reason to pass over an arm.
 func (c *checker) tryOverloadArm(
-	args []soltype.Type, argExprs []ast.Expr, inst *soltype.FuncType,
+	lvl int, args []soltype.Type, argExprs []ast.Expr, inst *soltype.FuncType,
 ) (bool, []SolverError) {
-	n := len(args)
-	if lo, hi := acceptSet(inst); n < lo || n > hi {
+	demand := make([]*soltype.FuncParam, len(args))
+	for i, arg := range args {
+		demand[i] = &soltype.FuncParam{Type: arg}
+	}
+	// The upgrade has to run inside the trial, since whether a uniquely-owned argument may fill
+	// a `mut` parameter is part of whether this arm matches at all. Its checks go through the
+	// error-returning engine so a losing arm writes nothing.
+	var upgradeErrs []SolverError
+	demand = c.upgradeCallDemand(argExprs, demand, inst, func(_ ast.Node, srcT, target soltype.Type) {
+		upgradeErrs = append(upgradeErrs, c.ctx.Constrain(srcT, target)...)
+	})
+	if hasHardError(upgradeErrs) {
 		return false, nil
 	}
-	var diags []SolverError
-	for i, arg := range args {
-		if i >= len(inst.Params) {
-			// Past the fixed params. An inexact tail absorbs this argument and every later
-			// one and declares no type to check them against.
-			break
-		}
-		if inst.Params[i].Rest {
-			// A rest slot stands for this argument and every later one, so each is checked
-			// against the slot's element type rather than against the slot. A slot of any
-			// other shape declares no element type and stays arity-only.
-			elem, isArray := c.ctx.restSlotElem(inst.Params[i].Type)
-			if !isArray {
-				break
-			}
-			for _, absorbed := range args[i:] {
-				errs := c.ctx.Constrain(absorbed, elem)
-				if hasHardError(errs) {
-					return false, nil
-				}
-				diags = append(diags, errs...)
-			}
-			break
-		}
-		target := inst.Params[i].Type
-		if i < len(argExprs) {
-			// A `mut` parameter takes an IMMUTABLE argument when that argument is uniquely
-			// owned, so the check narrows to the parameter's immutable read view instead of
-			// rejecting `take({x: 1})` against `a: mut {x: number}` on the mutability
-			// wrapper. Only the wrapper is dropped: the shape is still checked covariantly,
-			// so `take({y: 1})` still fails.
-			//
-			// The decision is ownedMutReadView's, and bottoms out in canUpgradeToOwnedMut
-			// and freshLiteralShape over in infer_decl.go. Those admit three shapes: a
-			// freshly built literal, a moved owned place, or a borrow expression.
-			//
-			// The first two are uniquely owned, so nothing else refers to the value and no
-			// live alias can observe a write the callee makes through the mutable view it
-			// receives, which is Rule 2 of the mutability-transition checker with an empty
-			// alias set. consumeCallArgs then moves the argument, so a later use of it is a
-			// use-after-move and the uniqueness holds past the call rather than only at it.
-			// A borrow is sound for a different reason: the mutable view lets the
-			// container's field be repointed but grants no write to the referent, whose
-			// type stays invariant through the RefType arm, so the covariant check here
-			// cannot widen it.
-			//
-			// inferCall pins its demand entry rather than narrowing, because its
-			// `callee <: callShape` constraint would otherwise re-check the argument
-			// strictly. Resolution emits no such constraint, so narrowing is the whole of it
-			// here.
-			if view, ok := c.ownedMutReadView(argExprs[i], target); ok {
-				target = view
-			}
-		}
-		errs := c.ctx.Constrain(arg, target)
-		if hasHardError(errs) {
-			return false, nil
-		}
-		diags = append(diags, errs...)
+	shape := &soltype.FuncType{Params: demand, Ret: c.freshAt(lvl), Throws: c.freshAt(lvl)}
+	errs := append(upgradeErrs, c.ctx.Constrain(inst, shape)...)
+	if hasHardError(errs) {
+		return false, nil
 	}
-	return true, diags
+	return true, errs
 }
 
 // overloadOrder returns the indices of schemes in the order arms should be tried. When

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -78,10 +78,6 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 			// tryOverloadArm runs the error-returning engine, so a warning the winning arm
 			// accepted with never reached c.errs. Blame it at the call so the winner's survive.
 			c.blameConstraintErrors(call, diags)
-			// Only the winning arm's throws reaches the caller, so a set whose other arms
-			// raise contributes nothing here. Resolution never builds a call shape for
-			// constrain to read, so the exceptional edge is wired by hand instead, the way
-			// inferCall's shape wires it.
 			// Only the winning arm's throws reaches the caller, so a set whose other arms raise
 			// contributes nothing here. The trial's shape carried a fresh throws variable to
 			// keep dispatch off the caller's clause, so the real edge is wired now that an arm


### PR DESCRIPTION
Fixes #1518

Stacked on #1523, which is stacked on #1522. Review only the top two commits; the bases merge first.

`inferCall` typed a call two ways depending on whether the callee carried one signature or several, and the two paths re-derived the same rules by hand. They were not in agreement.

## A third omission, found the same way as the first two

The issue predicted one, and there was one. An overload arm never expanded its tuple rest, so a call the single-signature path rejects was silently accepted through a set whose first arm is that very signature:

```
declare fn f(...xs: [number, string]) -> number
val r = f(1, 2)                                  // rejected

declare fn f(...xs: [number, string]) -> number
declare fn f(a: boolean) -> string
val r = f(1, 2)                                  // accepted, nothing checked at all
```

The arity gate read the tuple's length and passed, then the rest branch found no element type on a tuple slot and gave up. A union-of-tuples rest went unchecked on an arm for the same reason. That follows the missing argument moves #1508 fixed and the missing owned-mutable upgrade #1519 fixed.

## Commit 1 — one candidate, argument and effect rule

- **`callCandidates`** is the single place a callee signature becomes the positional shapes a call is checked against: a tuple rest expands, a union-of-tuples rest yields one shape per member. `inferCall` reads it off the resolved callee; `resolveOverload` reads it per instantiated arm, through `tryArmCandidates`. Probes nest, so a losing candidate rolls back without disturbing the arm's instantiation.
- **`inferCallArgs`** types the arguments, replacing three copies of that loop.
- **`recordCallArgEffects`** moves the consumed arguments and records the stored borrow edges, against whichever signature the call resolved to. This is the rule #1508 had to add to one path.
- **`markCallRaised`** decides whether a call is an exceptional exit, replacing two spellings.

## Commit 2 — one arity and argument implementation

`tryOverloadArm` now builds the same call shape the ordinary path builds and runs the same `constrain` against it. Arity, the per-argument check, the absorb and scatter rules and the return are decided by one body of code either way. The shape is exact with every parameter required, giving accept-set `[n, n]`, so `candidate <: shape` holds iff `required(candidate) <= n <= upper(candidate)` — the same window the arity gate tested directly.

`upgradeCallDemand` holds the owned-mutable upgrade for both paths. It cannot move above the split, because whether a uniquely-owned argument may fill a `mut` parameter is part of whether an arm matches, so it takes the constrain to run as a parameter: the accumulating one for a settled callee, the error-returning one for a trial that must write nothing when it loses.

### One thing the shape must not carry

The shape's `Ret` and `Throws` are fresh variables. Wiring the enclosing body's throws sink into the shape makes dispatch depend on the caller's `throws` clause: advancing a raising generator from a body with no clause then fails `"boom" <: never` inside every trial and reports "no matching overload" instead of the missing clause. `TestInferGenRaises/AdvancingWithoutAClauseRejected` caught exactly that. An overload set dispatches on arguments, so the winner's throws edge is wired after an arm is chosen, and `TestInferOverloadThrowsIsNotDispatch` now pins it.

## Against the gate

| gate clause | |
| --- | --- |
| a one-arm set behaves identically to a plain callee of that signature | yes, table-driven |
| adding an unrelated second arm never breaks an accepted call | yes |
| arity and argument checking have one implementation | yes |
| the specificity ordering, per-arm probe and rollback are unchanged | yes |

`TestInferOverloadArmMatchesPlainCallee` runs one call against a plain callee and against a set whose extra arm cannot match, and requires the two to agree — across fixed positions, an optional position, all four rest shapes, an owned-mutable parameter, and both arity failures.

Its `Array<E>` rest rows are split into a test disabled until #1521, which drops such an annotation on an overload arm. Both rows are unusable today: the rejecting one does not fail, and the accepting one passes only because the slot became `unknown`.

Not addressed: `resolveOverload` still emits no `callee <: callShape` constraint for the SET as a whole, which the issue's sketch leaves open as well. Overload resolution has to choose, and choosing needs the speculative trials the lattice deliberately does not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved overload resolution for calls involving tuple-based and union-based rest parameters.
  - Improved consistency between direct calls, method calls, constructors, and named overloads.
  - Corrected handling of optional and mutable arguments during overload matching.
  - Improved diagnostics for argument count, type, and `throws` mismatches.
  - Prevented failed overload candidates from affecting subsequent resolution attempts.
  - Improved tracking of call effects and exceptional exits after a matching overload is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->