### PR TITLE
Resolve a class method's own type parameters

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1378,7 +1378,19 @@ func (p *namedPrinter) typeParamBinders(tps []*TypeParam) []string {
 	binders := make([]string, len(tps))
 	for i, tp := range tps {
 		s := p.printType(tp.Var) // the registered source name, else t{ID}
-		if bounds := tp.Var.UpperBounds; len(bounds) > 0 {
+		// A substitution rewrites the declared constraint and cannot rewrite the
+		// variable's upper-bound list, since a type parameter's binder must stay a
+		// variable and the bounds hang off it. Reading the field is what lets a method
+		// bounded by its class's parameter render at the instance's argument: `pick<T: U>`
+		// on a `C<number>` shows `<T: number>` rather than the unsubstituted `U`.
+		//
+		// A parameter with no declared constraint falls back to the list, which carries a
+		// bound a body forced and the bounds a prelude parameter is built with.
+		bounds := tp.Var.UpperBounds
+		if tp.Constraint != nil {
+			bounds = []Type{tp.Constraint}
+		}
+		if len(bounds) > 0 {
 			rendered := make([]string, len(bounds))
 			for j, b := range bounds {
 				rendered[j] = p.printType(b)

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1378,14 +1378,10 @@ func (p *namedPrinter) typeParamBinders(tps []*TypeParam) []string {
 	binders := make([]string, len(tps))
 	for i, tp := range tps {
 		s := p.printType(tp.Var) // the registered source name, else t{ID}
-		// A substitution rewrites the declared constraint and cannot rewrite the
-		// variable's upper-bound list, since a type parameter's binder must stay a
-		// variable and the bounds hang off it. Reading the field is what lets a method
-		// bounded by its class's parameter render at the instance's argument: `pick<T: U>`
-		// on a `C<number>` shows `<T: number>` rather than the unsubstituted `U`.
-		//
-		// A parameter with no declared constraint falls back to the list, which carries a
-		// bound a body forced and the bounds a prelude parameter is built with.
+		// The declared constraint wins where there is one. A substitution rewrites it and
+		// cannot rewrite the variable's upper-bound list, so reading the field is what
+		// renders `pick<T: U>` on a `C<number>` as `<T: number>`. The list is the fallback,
+		// carrying a bound a body forced or a prelude parameter was built with.
 		bounds := tp.Var.UpperBounds
 		if tp.Constraint != nil {
 			bounds = []Type{tp.Constraint}

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -166,10 +166,9 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// `peer: &'a mut B` writes 'a once and in an output position, so the elision rule would
 	// drop it and leave an instance's lifetime argument with nothing to replace.
 	keepLts := classKeepLifetimes(shell.lifetimeParams)
-	// The keep set is read from the members as well as from the class's own `<…>` list, so a
-	// non-generic class carrying a generic method still keeps that method's parameters. An
-	// empty set coalesces everything, which is what a class with neither kind of parameter
-	// wants.
+	// The keep set reads the members as well as the class's own `<…>` list, so a non-generic
+	// class carrying a generic method still keeps that method's parameters. An empty set
+	// coalesces everything.
 	keep := classKeepVars(typeParams, body, static)
 	flow := keptFlowMap(keep)
 	c.freezeClassBody(body, keep, flow, keepLts)
@@ -909,9 +908,8 @@ type pendingMember struct {
 	stub   *soltype.FuncType
 	apply  func(bodyFt *soltype.FuncType)
 	// generic marks a member that may quantify type parameters of its own, which only a
-	// method may. A getter takes no arguments to infer one from, and a setter's single
-	// argument is the property's own type, which the class fixes. Either would carry a
-	// binder nothing could instantiate, so one written there is reported as unsupported.
+	// method may. A getter and a setter have no call site that could instantiate a binder,
+	// so one written there is reported as unsupported.
 	generic bool
 }
 
@@ -1045,17 +1043,13 @@ func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 	callable := func(ft *soltype.FuncType) *soltype.FuncType {
 		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Throws: ft.Throws, Inexact: ft.Inexact}
 	}
-	// A generic member is linked through ONE instantiation of its binder rather than through
-	// the binder itself. Comparing the binder directly would record the stub's fresh
-	// variables on the binder's own variable — a method returning `T` gives `T <: stubReturn`
-	// — and that edge stays, so the binder would read as bounded by a variable the source
-	// never wrote and the class value would quantify it as a phantom parameter.
-	//
-	// The instantiation carries the declared bounds, so a sibling call still meets them. It
-	// is shared by every sibling call, which is the same monomorphic approximation the stub
-	// already is for a non-generic member: a caller reads one signature rather than one per
-	// call. A call from outside the class reads the inferred signature the body pass installs
-	// over the stub, and instantiates the binder per call.
+	// A generic member is linked through ONE instantiation of its binder. Comparing the
+	// binder itself would record `T <: stubReturn` on the binder's own variable for a method
+	// returning `T`, and that edge stays, so `<T>` would read as bounded by a variable the
+	// source never wrote and the class value would quantify it as a phantom parameter. The
+	// instantiation carries the declared bounds, so a sibling call still meets them. A call
+	// from outside reads the inferred signature the body pass installs over the stub, and
+	// instantiates the binder per call.
 	if len(bodyFt.TypeParams) > 0 {
 		bodyFt = c.ctx.instantiateFuncBinder(bodyFt, bodyFt.TypeParams[0].Var.Level)
 	}
@@ -1131,9 +1125,8 @@ func (c *checker) inferMemberFunc(
 	if !static {
 		c.bindSelf(memberScope, recv, body)
 	}
-	// generic is true for a method and false for a getter or setter, which have no call
-	// site that could instantiate a binder. inferFunc reports a binder it is not allowed
-	// to resolve as an unsupported feature.
+	// generic is true for a method and false for a getter or setter. inferFunc reports a
+	// binder it is not allowed to resolve as an unsupported feature.
 	return c.inferFunc(memberScope, lvl, fn.FuncSig, fn.Body, fn, generic)
 }
 
@@ -1334,9 +1327,9 @@ func (v *selfMethodVisitor) EnterExpr(e ast.Expr) bool {
 // stay symbolic through the coalesce so member lookup can substitute an instance's
 // argument for a class parameter and instantiate a member's own parameters per call (B8).
 //
-// A binder nested inside a member's type counts too. A parameter typed `g: fn <V>(x: V)
-// -> V` is a rank-2 callback, and coalescing `V` to a non-variable trips the guard in
-// acceptTypeParamVar, which is a panic rather than a diagnostic.
+// A binder nested inside a member's type counts too. Coalescing the `V` of a rank-2
+// parameter `g: fn <V>(x: V) -> V` to a non-variable trips acceptTypeParamVar's guard,
+// which panics rather than reporting a diagnostic.
 func classKeepVars(typeParams []*soltype.TypeParam, bodies ...*soltype.ObjectType) set.Set[*soltype.TypeVarType] {
 	keep := set.NewSet[*soltype.TypeVarType]()
 	for _, tp := range typeParams {
@@ -1354,8 +1347,8 @@ func classKeepVars(typeParams []*soltype.TypeParam, bodies ...*soltype.ObjectTyp
 // descends into its children.
 //
 // A variable's bounds are a side graph rather than tree children, so a binder reachable
-// only through one is not collected. No binder is written there: resolveTypeParams is the
-// only thing that mints one, and it hangs it off the FuncType that quantifies it.
+// only through one is missed. No binder lives there. resolveTypeParams mints every one and
+// hangs it off the FuncType that quantifies it.
 type binderCollector struct {
 	keep set.Set[*soltype.TypeVarType]
 }

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -1045,18 +1045,19 @@ func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 	callable := func(ft *soltype.FuncType) *soltype.FuncType {
 		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Throws: ft.Throws, Inexact: ft.Inexact}
 	}
-	// A member's own `<T>` binder is not linked. The stub is monomorphic, so comparing a
-	// generic signature against it records the stub's fresh variables on the binder's own
-	// variable. A method returning `T` gives `T <: stubReturn`, and that edge stays. The
-	// binder then reads as bounded by a variable the source never wrote, and the class value
-	// quantifies that variable as a phantom parameter.
+	// A generic member is linked through ONE instantiation of its binder rather than through
+	// the binder itself. Comparing the binder directly would record the stub's fresh
+	// variables on the binder's own variable — a method returning `T` gives `T <: stubReturn`
+	// — and that edge stays, so the binder would read as bounded by a variable the source
+	// never wrote and the class value would quantify it as a phantom parameter.
 	//
-	// What the link buys is a sibling call made before this member's body is inferred, since
-	// such a call reads the stub. A sibling call to a generic member gets the stub's
-	// unconstrained variables instead. The signature the member ends up with is the inferred
-	// one either way, because the body pass installs it over the stub.
+	// The instantiation carries the declared bounds, so a sibling call still meets them. It
+	// is shared by every sibling call, which is the same monomorphic approximation the stub
+	// already is for a non-generic member: a caller reads one signature rather than one per
+	// call. A call from outside the class reads the inferred signature the body pass installs
+	// over the stub, and instantiates the binder per call.
 	if len(bodyFt.TypeParams) > 0 {
-		return
+		bodyFt = c.ctx.instantiateFuncBinder(bodyFt, bodyFt.TypeParams[0].Var.Level)
 	}
 	c.constrain(node, callable(bodyFt), callable(stub))
 }
@@ -1328,30 +1329,47 @@ func (v *selfMethodVisitor) EnterExpr(e ast.Expr) bool {
 	return true
 }
 
-// classKeepVars collects the type-parameter vars a generic class body coalesces around:
-// the class's own TypeParam vars plus every method signature's own TypeParam vars. These
+// classKeepVars collects the type-parameter vars a class body coalesces around: the
+// class's own TypeParam vars plus every binder written anywhere in its members. These
 // stay symbolic through the coalesce so member lookup can substitute an instance's
-// argument for a class parameter and instantiate a method's own parameters per call (B8).
+// argument for a class parameter and instantiate a member's own parameters per call (B8).
+//
+// A binder nested inside a member's type counts too. A parameter typed `g: fn <V>(x: V)
+// -> V` is a rank-2 callback, and coalescing `V` to a non-variable trips the guard in
+// acceptTypeParamVar, which is a panic rather than a diagnostic.
 func classKeepVars(typeParams []*soltype.TypeParam, bodies ...*soltype.ObjectType) set.Set[*soltype.TypeVarType] {
 	keep := set.NewSet[*soltype.TypeVarType]()
 	for _, tp := range typeParams {
 		keep.Add(tp.Var)
 	}
+	collector := &binderCollector{keep: keep}
 	for _, obj := range bodies {
-		for _, elem := range obj.Elems {
-			m, ok := elem.(*soltype.MethodElem)
-			if !ok {
-				continue
-			}
-			for _, sig := range m.Signatures {
-				for _, tp := range sig.TypeParams {
-					keep.Add(tp.Var)
-				}
-			}
-		}
+		obj.Accept(collector, soltype.Positive)
 	}
 	return keep
 }
+
+// binderCollector records every type-parameter binder the types it walks quantify. It
+// rewrites nothing, so EnterType returns the zero EnterResult, which keeps each node and
+// descends into its children.
+//
+// A variable's bounds are a side graph rather than tree children, so a binder reachable
+// only through one is not collected. No binder is written there: resolveTypeParams is the
+// only thing that mints one, and it hangs it off the FuncType that quantifies it.
+type binderCollector struct {
+	keep set.Set[*soltype.TypeVarType]
+}
+
+func (v *binderCollector) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if ft, isFunc := t.(*soltype.FuncType); isFunc {
+		for _, tp := range ft.TypeParams {
+			v.keep.Add(tp.Var)
+		}
+	}
+	return soltype.EnterResult{}
+}
+
+func (v *binderCollector) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // keptFlowMap maps each inference var to the kept type-parameter vars that flow into it —
 // the kept vars T for which T <: v is recorded transitively through the upper-bound graph.

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -166,15 +166,14 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// `peer: &'a mut B` writes 'a once and in an output position, so the elision rule would
 	// drop it and leave an instance's lifetime argument with nothing to replace.
 	keepLts := classKeepLifetimes(shell.lifetimeParams)
-	if len(typeParams) == 0 {
-		c.freezeClassBody(body, nil, nil, keepLts)
-		c.freezeClassBody(static, nil, nil, keepLts)
-	} else {
-		keep := classKeepVars(typeParams, body, static)
-		flow := keptFlowMap(keep)
-		c.freezeClassBody(body, keep, flow, keepLts)
-		c.freezeClassBody(static, keep, flow, keepLts)
-	}
+	// The keep set is read from the members as well as from the class's own `<…>` list, so a
+	// non-generic class carrying a generic method still keeps that method's parameters. An
+	// empty set coalesces everything, which is what a class with neither kind of parameter
+	// wants.
+	keep := classKeepVars(typeParams, body, static)
+	flow := keptFlowMap(keep)
+	c.freezeClassBody(body, keep, flow, keepLts)
+	c.freezeClassBody(static, keep, flow, keepLts)
 
 	// Freeze both per-parameter variance vectors once every member body has refined its
 	// signature, so the walk measures each type parameter at its final occurrences. The
@@ -909,6 +908,11 @@ type pendingMember struct {
 	static bool
 	stub   *soltype.FuncType
 	apply  func(bodyFt *soltype.FuncType)
+	// generic marks a member that may quantify type parameters of its own, which only a
+	// method may. A getter takes no arguments to infer one from, and a setter's single
+	// argument is the property's own type, which the class fixes. Either would carry a
+	// binder nothing could instantiate, so one written there is reported as unsupported.
+	generic bool
 }
 
 // buildMemberSigs is phase 1 of the member walk: it appends a signature stub — fresh vars
@@ -943,6 +947,7 @@ func (c *checker) buildMemberSigs(
 			}
 			pending = append(pending, pendingMember{
 				fn: elem.Fn, name: name, recv: elem.Receiver, static: elem.Static, stub: stub,
+				generic: true,
 				apply: func(bodyFt *soltype.FuncType) {
 					bodyFt.SelfParam = stub.SelfParam
 					method.Signatures[arm] = bodyFt
@@ -1026,7 +1031,7 @@ func (c *checker) inferMemberBodies(scope *Scope, lvl int, body *soltype.ObjectT
 		// Hand the member's name to the inferFunc call below, which sees only the member's
 		// *ast.FuncExpr and so cannot recover it. inferFunc takes and clears it.
 		c.memberName = m.name
-		bodyFt := c.inferMemberFunc(scope, lvl, m.fn, m.recv, m.static, body)
+		bodyFt := c.inferMemberFunc(scope, lvl, m.fn, m.recv, m.static, m.generic, body)
 		c.linkMemberSig(m.fn, bodyFt, m.stub)
 		m.apply(bodyFt)
 	}
@@ -1039,6 +1044,19 @@ func (c *checker) inferMemberBodies(scope *Scope, lvl int, body *soltype.ObjectT
 func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 	callable := func(ft *soltype.FuncType) *soltype.FuncType {
 		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Throws: ft.Throws, Inexact: ft.Inexact}
+	}
+	// A member's own `<T>` binder is not linked. The stub is monomorphic, so comparing a
+	// generic signature against it records the stub's fresh variables on the binder's own
+	// variable. A method returning `T` gives `T <: stubReturn`, and that edge stays. The
+	// binder then reads as bounded by a variable the source never wrote, and the class value
+	// quantifies that variable as a phantom parameter.
+	//
+	// What the link buys is a sibling call made before this member's body is inferred, since
+	// such a call reads the stub. A sibling call to a generic member gets the stub's
+	// unconstrained variables instead. The signature the member ends up with is the inferred
+	// one either way, because the body pass installs it over the stub.
+	if len(bodyFt.TypeParams) > 0 {
+		return
 	}
 	c.constrain(node, callable(bodyFt), callable(stub))
 }
@@ -1105,16 +1123,17 @@ func (c *checker) inferMemberFunc(
 	fn *ast.FuncExpr,
 	recv *ast.MethodReceiver,
 	static bool,
+	generic bool,
 	body *soltype.ObjectType,
 ) *soltype.FuncType {
 	memberScope := scope.Child()
 	if !static {
 		c.bindSelf(memberScope, recv, body)
 	}
-	// A method's own type parameters stay gated because their per-instance projection
-	// is not yet applied by the class-body freeze, so inferFunc reports them as
-	// unsupported.
-	return c.inferFunc(memberScope, lvl, fn.FuncSig, fn.Body, fn, false)
+	// generic is true for a method and false for a getter or setter, which have no call
+	// site that could instantiate a binder. inferFunc reports a binder it is not allowed
+	// to resolve as an unsupported feature.
+	return c.inferFunc(memberScope, lvl, fn.FuncSig, fn.Body, fn, generic)
 }
 
 // appendMethodSig installs a method signature under name, merging it into an existing

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -2131,26 +2131,20 @@ func TestInferMethodOverloadUniformMutReceiverAccepted(t *testing.T) {
 	require.Equal(t, "number", values["r"])
 }
 
-// TestInferClassMethodTypeParamsGated pins the gate on a method's own `<T>` binder.
-// inferMemberFunc calls inferFunc with allowTypeParams=false, because a member's type
-// parameter needs a per-instance projection the class-body freeze does not apply, so
-// resolving it would collapse two calls onto one shared var. The binder is reported as an
-// unsupported feature and the member infers monomorphically, which leaves each `T` in the
-// signature an unbound name.
+// A method's own `<T>` binder resolves through resolveTypeParams, the path a generic
+// function declaration and a generic function annotation already take, and is
+// instantiated per call so two calls do not share a var.
 //
-// A declared bound rides on the binder, so gating the binder gates the bound with it: the
-// call below passes 1 to a parameter written `T: string` and no mismatch is reported. The
-// class's own `<U: number>` binder is a separate mechanism and still enforces, which the
-// last case shows. Lifting the gate, tracked by issue #957, should flip this test and
-// enable TestInferClassMethodTypeParamBounds below.
-func TestInferClassMethodTypeParamsGated(t *testing.T) {
+// The class's own binder is a separate mechanism and enforces independently, which the
+// last case shows.
+func TestInferClassMethodTypeParams(t *testing.T) {
 	tests := []struct {
 		name string
 		src  string
 		want []string
 	}{
 		{
-			name: "InstanceMethodBinderIsGated",
+			name: "InstanceMethodBinderEnforcesItsBound",
 			src: `
 				class C {
 					pick<T: string>(self, x: T) -> T { return x },
@@ -2158,25 +2152,17 @@ func TestInferClassMethodTypeParamsGated(t *testing.T) {
 				val c = C()
 				val r = c.pick(1)
 			`,
-			want: []string{
-				"Unsupported: TypeParam",
-				"cannot find type `T`",
-				"cannot find type `T`",
-			},
+			want: []string{`cannot constrain 1 <: string`},
 		},
 		{
-			name: "StaticMethodBinderIsGated",
+			name: "StaticMethodBinderEnforcesItsBound",
 			src: `
 				class C {
 					static pick<T: string>(x: T) -> T { return x },
 				}
 				val r = C.pick(1)
 			`,
-			want: []string{
-				"Unsupported: TypeParam",
-				"cannot find type `T`",
-				"cannot find type `T`",
-			},
+			want: []string{`cannot constrain 1 <: string`},
 		},
 		{
 			name: "ClassBinderStillEnforcesItsBound",
@@ -2201,89 +2187,294 @@ func TestInferClassMethodTypeParamsGated(t *testing.T) {
 	}
 }
 
-// DISABLED until issue #957 lands support for a method's own type parameters — the
-// per-instance projection inferMemberFunc names, which lets two calls to one generic method
-// instantiate independently. Today the binder is reported as unsupported and the member
-// infers monomorphically, which TestInferClassMethodTypeParamsGated pins.
-//
-// Once the gate lifts, a method's `<T: string>` should enforce its bound at the call the
-// same way a generic function's does, since both route their binder through
-// resolveTypeParams. These cases carry that intended behavior: a satisfying argument is
-// accepted, a violating one reports the mismatch, an unbounded binder accepts anything, a
-// bound naming a sibling parameter resolves, and two calls to one method instantiate
-// independently rather than sharing a var. Re-enable by removing the comment wrapper.
+// A method's `<T: string>` enforces its bound at the call the same way a generic
+// function's does, since both route their binder through resolveTypeParams.
 func TestInferClassMethodTypeParamBounds(t *testing.T) {
-	/*
-		tests := []struct {
-			name string
-			src  string
-			want []string
-		}{
-			{
-				name: "ArgumentInsideBound",
-				src: `
-					class C {
-						pick<T: string>(self, x: T) -> T { return x },
-					}
-					val c = C()
-					val r = c.pick("a")
-				`,
-			},
-			{
-				name: "ArgumentOutsideBound",
-				src: `
-					class C {
-						pick<T: string>(self, x: T) -> T { return x },
-					}
-					val c = C()
-					val r = c.pick(1)
-				`,
-				want: []string{"cannot constrain 1 <: string"},
-			},
-			{
-				name: "UnboundedBinderAcceptsAnyArgument",
-				src: `
-					class C {
-						pick<T>(self, x: T) -> T { return x },
-					}
-					val c = C()
-					val r = c.pick(1)
-				`,
-			},
-			{
-				name: "SiblingBoundViolated",
-				src: `
-					class C {
-						pair<A, B: A>(self, a: A, b: B) -> A { return a },
-					}
-					val c = C()
-					val r = c.pair(1, "y")
-				`,
-				want: []string{`cannot constrain "y" <: 1`},
-			},
-			{
-				name: "TwoCallsInstantiateIndependently",
-				src: `
-					class C {
-						pick<T: string>(self, x: T) -> T { return x },
-					}
-					val c = C()
-					val a = c.pick("a")
-					val b = c.pick("b")
-				`,
-			},
-		}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, _, errs := inferSource(t, tt.src)
-				var msgs []string
-				for _, e := range errs {
-					msgs = append(msgs, e.Message())
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "ArgumentInsideBound",
+			src: `
+				class C {
+					pick<T: string>(self, x: T) -> T { return x },
 				}
-				require.Equal(t, tt.want, msgs)
-			})
+				val c = C()
+				val r = c.pick("a")
+			`,
+		},
+		{
+			name: "ArgumentOutsideBound",
+			src: `
+				class C {
+					pick<T: string>(self, x: T) -> T { return x },
+				}
+				val c = C()
+				val r = c.pick(1)
+			`,
+			want: []string{"cannot constrain 1 <: string"},
+		},
+		{
+			name: "UnboundedBinderAcceptsAnyArgument",
+			src: `
+				class C {
+					pick<T>(self, x: T) -> T { return x },
+				}
+				val c = C()
+				val r = c.pick(1)
+			`,
+		},
+		{
+			// A bound naming the class's own parameter resolves, since the method's scope
+			// sits under the class's. Enforcing it at the instance's argument is a further
+			// step: a call reads the bound off the binder's variable, which substitution
+			// cannot rewrite, so `T: U` on a `C<number>` admits any argument. #1547.
+			name: "ClassParameterBoundResolves",
+			src: `
+				class C<U> {
+					v: U,
+					pick<T: U>(self, x: T) -> T { return x },
+				}
+				val c: C<number> = C(1)
+				val r = c.pick(2)
+			`,
+		},
+		{
+			// A method binder may shadow the class's parameter of the same name. The
+			// inner binder wins inside the signature, which is what its child scope
+			// gives, and the class's own parameter is untouched outside it.
+			name: "MethodBinderShadowsAClassParameter",
+			src: `
+				class C<T> {
+					v: T,
+					pick<T>(self, x: T) -> T { return x },
+				}
+				val c: C<number> = C(1)
+				val r = c.pick("a")
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			var msgs []string
+			for _, e := range errs {
+				msgs = append(msgs, e.Message())
+			}
+			require.Equal(t, tt.want, msgs)
+		})
+	}
+}
+
+// Two calls to one generic method instantiate independently rather than sharing a var,
+// which is what makes the binder worth resolving at all.
+func TestInferClassMethodTypeParamsInstantiatePerCall(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class C {
+			pick<T: string>(self, x: T) -> T { return x },
 		}
-	*/
+		val c = C()
+		val a = c.pick("a")
+		val b = c.pick("b")
+	`)
+	require.Empty(t, messagesWithSpan(t, errs))
+	require.Equal(t, `"a"`, values["a"])
+	require.Equal(t, `"b"`, values["b"])
+}
+
+// A bound a BODY forces is enforced at the call, for a method as for a generic function.
+// It is recorded on the binder's variable rather than written in the source, so a rule
+// reading only the declared constraint would lose it.
+func TestInferMethodBodyInferredBoundMatchesTheFunctionForm(t *testing.T) {
+	const callee = "fn f<A: string>(a: A) -> A { return a }\n"
+	const want = "cannot constrain 1 <: string"
+
+	_, _, fnErrs := inferSource(t, callee+`
+		fn g<U>(u: U) -> U { return f(u) }
+		val r = g(1)
+	`)
+	_, _, methodErrs := inferSource(t, callee+`
+		class C {
+			g<U>(self, u: U) -> U { return f(u) },
+		}
+		val c = C()
+		val r = c.g(1)
+	`)
+	require.Equal(t, []string{want}, errorMessagesOf(fnErrs))
+	require.Equal(t, []string{want}, errorMessagesOf(methodErrs))
+}
+
+// A bound naming a SIBLING binder is resolved but not enforced, for a method exactly as
+// for a generic function. The two forms are written side by side here so the parity is
+// what the test asserts rather than the behavior of either alone.
+func TestInferMethodSiblingBoundMatchesTheFunctionForm(t *testing.T) {
+	_, _, fnErrs := inferSource(t, `
+		fn pair<A, B: A>(a: A, b: B) -> A { return a }
+		val r = pair(1, "y")
+	`)
+	_, _, methodErrs := inferSource(t, `
+		class C {
+			pair<A, B: A>(self, a: A, b: B) -> A { return a },
+		}
+		val c = C()
+		val r = c.pair(1, "y")
+	`)
+	require.Empty(t, messagesWithSpan(t, fnErrs))
+	require.Equal(t, messagesWithSpan(t, fnErrs), messagesWithSpan(t, methodErrs))
+}
+
+// The signature a caller reads carries the binder under its written name and the bound
+// the source declared. linkMemberSig records `T <: stubReturn` for a method returning
+// `T`, so the binder's variable also collects the stub's return variable; the freeze
+// drops it, which is what keeps `<T>` from rendering as `<T: T0>` and stops that stray
+// variable from being quantified onto the class value as a phantom parameter.
+func TestInferClassMethodTypeParamRendering(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		binding string
+		want    string
+	}{
+		{
+			name: "an instance method's bound",
+			src: `
+				class C { pick<T: string>(self, x: T) -> T { return x }, }
+				fn probe(c: C) { return c.pick }`,
+			binding: "probe",
+			want:    "fn (c: C) -> fn <T: string>(x: T) -> T",
+		},
+		{
+			name: "an unbounded binder",
+			src: `
+				class C { pick<T>(self, x: T) -> T { return x }, }
+				fn probe(c: C) { return c.pick }`,
+			binding: "probe",
+			want:    "fn (c: C) -> fn <T>(x: T) -> T",
+		},
+		{
+			name: "a bound naming the class's parameter",
+			src: `
+				class C<U> { v: U, pick<T: U>(self, x: T) -> T { return x }, }
+				fn probe(c: C<number>) { return c.pick }`,
+			binding: "probe",
+			want:    "fn <T0>(c: C<number>) -> fn <T: number>(x: T) -> T",
+		},
+		{
+			name: "a signature mixing both binders",
+			src: `
+				class C<U> { v: U, map<T>(self, x: T) -> [T, U] { return [x, self.v] }, }
+				fn probe(c: C<number>) { return c.map }`,
+			binding: "probe",
+			want:    "fn (c: C<number>) -> fn <T>(x: T) -> [T, number]",
+		},
+		{
+			// The class value carries the static member, and no phantom binder beside it.
+			name:    "a static method on the class value",
+			src:     `class C { static pick<T: string>(x: T) -> T { return x }, }`,
+			binding: "C",
+			want:    "{new () -> C, pick<T: string>(x: T) -> T}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, messagesWithSpan(t, errs))
+			require.Equal(t, tt.want, values[tt.binding])
+		})
+	}
+}
+
+// An overloaded method's arms each carry their own binder, and each is instantiated per
+// call. Wrapping an arm in a MonoScheme without instantiating leaves the binder's variable
+// shared, so the first call binds it and every later one is weighed against that binding.
+func TestInferOverloadedGenericMethod(t *testing.T) {
+	t.Run("one generic arm beside a plain one", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			class C {
+				pick<T: string>(self, x: T) -> T { return x },
+				pick(self, a: number, b: number) -> number { return a },
+			}
+			val c = C()
+			val a = c.pick("s")
+			val b = c.pick(1, 2)
+		`)
+		require.Empty(t, messagesWithSpan(t, errs))
+		require.Equal(t, `"s"`, values["a"])
+		require.Equal(t, "number", values["b"])
+	})
+	t.Run("two generic arms", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			class C {
+				pick<T: string>(self, x: T) -> T { return x },
+				pick<T: number>(self, x: T, y: T) -> T { return x },
+			}
+			val c = C()
+			val a = c.pick("s")
+			val b = c.pick(1, 2)
+		`)
+		require.Empty(t, messagesWithSpan(t, errs))
+		require.Equal(t, `"s"`, values["a"])
+		require.Equal(t, "1 | 2", values["b"])
+	})
+	t.Run("a call matching no arm", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class C {
+				pick<T: string>(self, x: T) -> T { return x },
+				pick(self, a: number, b: number) -> number { return a },
+			}
+			val c = C()
+			val r = c.pick(1)
+		`)
+		require.Equal(t,
+			[]string{"7:12-7:21: No matching overload for this call\n" +
+				"  fn <T: string>(x: T) -> T\n" +
+				"  fn (a: number, b: number) -> number"},
+			messagesWithSpan(t, errs))
+	})
+}
+
+// A getter and a setter cannot quantify a parameter of their own. A getter takes no
+// argument to infer one from, and a setter's single argument is the property's own type,
+// which the class fixes. Both report rather than accepting a binder nothing instantiates.
+func TestInferAccessorTypeParamsGated(t *testing.T) {
+	t.Run("a getter", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class C {
+				get value<T>(self) -> number { return 1 },
+			}
+		`)
+		require.Equal(t, []string{"Unsupported: TypeParam"}, errorMessagesOf(errs))
+	})
+	t.Run("a setter", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class C {
+				x: number,
+				set value<T>(mut self, v: T) { self.x = 1 },
+			}
+		`)
+		require.Equal(t,
+			[]string{"Unsupported: TypeParam", "cannot find type `T`"},
+			errorMessagesOf(errs))
+	})
+}
+
+// A constructor's own binder stays gated. The class's parameters are what a
+// constructor's arguments infer, so a binder of its own has nothing to quantify, and
+// TypeScript rejects one for the same reason.
+func TestInferClassConstructorTypeParamsGated(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class C {
+			x: number,
+			constructor<T>(mut self, x: number) { self.x = x },
+		}
+	`)
+	var msgs []string
+	for _, e := range errs {
+		msgs = append(msgs, e.Message())
+	}
+	require.Equal(t, []string{"Unsupported: TypeParam"}, msgs)
 }
 
 // A class may declare more than one constructor. Every arm binds under the one

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -2435,6 +2435,56 @@ func TestInferOverloadedGenericMethod(t *testing.T) {
 	})
 }
 
+// A binder nested inside a member's type is kept through the freeze as well as the
+// member's own. A parameter typed `fn <V>(x: V) -> V` is a rank-2 callback, and
+// coalescing `V` to a non-variable trips the guard in acceptTypeParamVar, which is a
+// panic rather than a diagnostic.
+func TestInferClassKeepsANestedCallbackBinder(t *testing.T) {
+	values, _, errs := inferSource(t, `class C {
+	apply(self, g: fn <V>(x: V) -> V, y: number) -> number { return g(y) },
+}
+fn probe(c: C) { return c.apply }`)
+	require.Empty(t, messagesWithSpan(t, errs))
+	require.Equal(t,
+		"fn (c: C) -> fn (g: fn <V>(x: V) -> V, y: number) -> number",
+		values["probe"])
+}
+
+// A sibling call reads the member's signature stub, which is built before any body is
+// inferred. A generic member is linked into its stub through one instantiation of its
+// binder, so the declared bound reaches a sibling whichever order the two are written
+// in. Linking the binder itself would instead record the stub's variables on it.
+func TestInferGenericMethodBoundReachesASiblingCall(t *testing.T) {
+	const want = "cannot constrain 1 <: string"
+	t.Run("the callee is declared after the caller", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class C {
+				caller(self) -> number { return self.pick(1) },
+				pick<T: string>(self, x: T) -> T { return x },
+			}
+		`)
+		require.Contains(t, errorMessagesOf(errs), want)
+	})
+	t.Run("the callee is declared before the caller", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class C {
+				pick<T: string>(self, x: T) -> T { return x },
+				caller(self) -> number { return self.pick(1) },
+			}
+		`)
+		require.Contains(t, errorMessagesOf(errs), want)
+	})
+	t.Run("a sibling call inside the bound is accepted", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class C {
+				caller(self) -> string { return self.pick("a") },
+				pick<T: string>(self, x: T) -> T { return x },
+			}
+		`)
+		require.Empty(t, messagesWithSpan(t, errs))
+	})
+}
+
 // A getter and a setter cannot quantify a parameter of their own. A getter takes no
 // argument to infer one from, and a setter's single argument is the property's own type,
 // which the class fixes. Both report rather than accepting a binder nothing instantiates.

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -2285,8 +2285,12 @@ func TestInferClassMethodTypeParamsInstantiatePerCall(t *testing.T) {
 }
 
 // A bound a BODY forces is enforced at the call, for a method as for a generic function.
-// It is recorded on the binder's variable rather than written in the source, so a rule
-// reading only the declared constraint would lose it.
+// What the body records is a link, not the bound itself. Calling `f` inside `g` freshens
+// `f`'s binder to a variable carrying `string`, then records `U <:` that variable. `U`
+// never gains `string` of its own, so `g` still renders as `fn <U>(u: U) -> U` and its
+// declared constraint stays empty. The call instantiates the whole chain and propagates
+// `1` along it, reaching `1 <: string`. A rule reading only the declared constraint would
+// see `U` unbounded and lose this.
 func TestInferMethodBodyInferredBoundMatchesTheFunctionForm(t *testing.T) {
 	const callee = "fn f<A: string>(a: A) -> A { return a }\n"
 	const want = "cannot constrain 1 <: string"
@@ -2306,9 +2310,16 @@ func TestInferMethodBodyInferredBoundMatchesTheFunctionForm(t *testing.T) {
 	require.Equal(t, []string{want}, errorMessagesOf(methodErrs))
 }
 
-// A bound naming a SIBLING binder is resolved but not enforced, for a method exactly as
-// for a generic function. The two forms are written side by side here so the parity is
-// what the test asserts rather than the behavior of either alone.
+// A bound naming a SIBLING binder is recorded and propagated, and still admits the call
+// below, for a method exactly as for a generic function. `B: A` becomes `B <: A` on the
+// binder's variable, so constraining `"y" <: B` propagates to `"y" <: A`. `A` is itself
+// an inference variable with no upper bound, so the argument joins the `1` that `a`
+// contributed and `A` solves to `1 | "y"`. The bound has nothing to fail against.
+// Bounding `A` in turn, as `<A: number, B: A>`, gives that propagation something to
+// reach. The second pair below writes it that way and the argument is rejected.
+//
+// The two forms are written side by side here so the parity is what the test asserts
+// rather than the behavior of either alone.
 func TestInferMethodSiblingBoundMatchesTheFunctionForm(t *testing.T) {
 	_, _, fnErrs := inferSource(t, `
 		fn pair<A, B: A>(a: A, b: B) -> A { return a }
@@ -2323,6 +2334,21 @@ func TestInferMethodSiblingBoundMatchesTheFunctionForm(t *testing.T) {
 	`)
 	require.Empty(t, messagesWithSpan(t, fnErrs))
 	require.Equal(t, messagesWithSpan(t, fnErrs), messagesWithSpan(t, methodErrs))
+
+	_, _, boundedFnErrs := inferSource(t, `
+		fn pair<A: number, B: A>(a: A, b: B) -> A { return a }
+		val r = pair(1, "y")
+	`)
+	_, _, boundedMethodErrs := inferSource(t, `
+		class C {
+			pair<A: number, B: A>(self, a: A, b: B) -> A { return a },
+		}
+		val c = C()
+		val r = c.pair(1, "y")
+	`)
+	want := []string{`cannot constrain "y" <: number`}
+	require.Equal(t, want, errorMessagesOf(boundedFnErrs))
+	require.Equal(t, want, errorMessagesOf(boundedMethodErrs))
 }
 
 // The signature a caller reads carries the binder under its written name and the bound

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -220,10 +220,10 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// FuncType.TypeParams and instantiate freshens it per call. A non-generic function
 	// reuses the enclosing scope and carries no type parameters.
 	//
-	// A method or constructor passes allowTypeParams=false. A member's own type
-	// parameters need the per-instance projection the class-body freeze does not yet
-	// apply, so resolving them would collapse two calls to one shared var. Report the
-	// feature as unsupported and infer monomorphically until that work lands.
+	// allowTypeParams is false for the positions that cannot quantify a parameter of their
+	// own: a constructor, whose arguments infer the class's parameters instead, and a getter
+	// or setter, which has no call site to instantiate a binder from. A binder written there
+	// is reported as an unsupported feature and the signature infers monomorphically.
 	declScope := scope
 	var typeParams []*soltype.TypeParam
 	if len(sig.TypeParams) > 0 {

--- a/internal/solver/infer_generic_func_test.go
+++ b/internal/solver/infer_generic_func_test.go
@@ -180,27 +180,18 @@ func TestInferGenericDeclareFuncNotProducibilityChecked(t *testing.T) {
 	require.Equal(t, "fn <T>(x: number) -> T", values["make"])
 }
 
-// A method's own type parameters stay gated at the rank-1 boundary: per-instance
-// projection is not yet applied by the class-body freeze, so resolving them would
-// collapse two calls to one shared var. The method reports the type-param feature as
-// unsupported and infers monomorphically rather than panicking in the body freeze.
-func TestInferGenericMethodStillGated(t *testing.T) {
-	_, _, errs := inferSource(t, `
+// A method's own type parameters resolve the way a generic function declaration's do,
+// so the signature renders under the written names rather than reporting the binder as
+// unsupported and leaving each `T` an unbound name.
+func TestInferGenericMethodResolves(t *testing.T) {
+	values, _, errs := inferSource(t, `
 		class Box {
 			wrap<T>(self, x: T) -> T { return x }
 		}
+		fn probe(b: Box) { return b.wrap }
 	`)
-	msgs := make([]string, len(errs))
-	for i, e := range errs {
-		msgs[i] = e.Message()
-	}
-	// The gate reports the type-param feature, then the two `T` references cascade to
-	// unsupported because the parameter was never declared in scope.
-	require.Equal(t, []string{
-		"Unsupported: TypeParam",
-		"cannot find type `T`",
-		"cannot find type `T`",
-	}, msgs)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (b: Box) -> fn <T>(x: T) -> T", values["probe"])
 }
 
 // A parameter whose own type is polymorphic — a rank-2 callback annotated `fn <V>(x: V) ->

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -72,6 +72,14 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 		// single-signature path reads, so an arm's rest slot means here what it means there.
 		// Probes nest, so a candidate that loses rolls back on its own and leaves the arm's
 		// instantiation intact for the next one.
+		// An arm carrying its own `<T>` binder is instantiated per trial, so two calls to one
+		// generic arm bind it independently. A method's arms reach here as MonoSchemes, which
+		// instantiate returns unchanged, so the binder would otherwise be shared and the first
+		// call's argument would fix it for every later one. Doing it here rather than at the
+		// scheme keeps b.Schemes carrying the declared arms, which the no-match report renders.
+		if len(arm.TypeParams) > 0 {
+			arm = c.ctx.instantiateFuncBinder(arm, lvl)
+		}
 		inst, matched, diags := c.tryArmCandidates(lvl, args, call.Args, arm)
 		c.closeProbe(p, matched)
 		if matched {


### PR DESCRIPTION
Fixes #957

`inferMemberFunc` passed `allowTypeParams=false`, so a method's `<T>` binder was reported as an unsupported feature and the member inferred monomorphically. A declared bound rides on the binder, so gating the binder gated the bound with it:

```
class C {
    pick<T: string>(self, x: T) -> T { return x },
}
val c = C()
val r = c.pick(1)     // accepted; no mismatch reported
```

Three diagnostics came out instead, none of them the bound mismatch: `Unsupported: TypeParam`, then `cannot find type T` twice, because the parameter was never declared in scope. `r` inferred as `never`.

A method's binder now resolves through `resolveTypeParams`, the path a generic function declaration and a generic function annotation already take, and is instantiated per call.

## What had to change with it

**`freezeClassBody` took the keep-set path only for a generic class.** A non-generic class with a generic method coalesced that method's binder to `never` and tripped the guard in `acceptTypeParamVar` — a panic, which is the "per-instance projection" hazard the gate's own comment named. `classKeepVars` already read each method signature's `TypeParams`, but that loop was a no-op while the gate left them nil. Computing the keep set unconditionally covers both kinds of parameter; an empty set coalesces everything, as before.

**`linkMemberSig` no longer links a member carrying its own binder.** The stub is monomorphic, so comparing a generic signature against it recorded the stub's fresh return variable on the binder's own variable, where it stayed. `<T>` then rendered as `<T: T0>`, and that stray variable was reachable from the class body, so generalizing the class value quantified it as a phantom parameter. What the link buys is a sibling call made before the member's body is inferred; such a call to a generic member gets the stub's unconstrained variables instead, and the signature the member ends up with is the inferred one either way.

**`resolveOverload` instantiates an arm's own binder inside the trial's probe.** A method's arms reach it as `MonoScheme`s, which `instantiate` returns unchanged, so an overloaded generic method bound its binder to the first call's argument and every later call was weighed against that — one generic arm gave `never` silently, two gave `No matching overload`. Doing it in the trial rather than at the scheme keeps `b.Schemes` carrying the declared arms, which the no-match report renders.

**The printer reads `TypeParam.Constraint`,** falling back to the variable's upper bounds. A substitution rewrites the field and cannot rewrite the list, since a binder must stay a variable and the bounds hang off it. That is what renders a method bounded by its class's parameter at the instance's argument: `pick<T: U>` on a `C<number>` shows `<T: number>`. The fallback still carries a bound a body forced and the bounds a prelude parameter is built with.

## The points #957 left to settle

| question | answer |
| --- | --- |
| Shadowing a class parameter | The inner binder wins inside the signature, which its child scope gives. `class C<T> { pick<T>(self, x: T) }` is accepted and the class's own `T` is untouched outside the method. |
| A bound naming a class parameter | Resolves, since the method's scope sits under the class's, and renders substituted. Enforcing it at the call is #1547 — a call reads the bound off the binder's variable, which substitution cannot reach. |
| Constructors | Stay gated. The class's parameters are what a constructor's arguments infer, so a binder of its own quantifies nothing; TypeScript rejects one for the same reason. |
| `classKeepVars` | Does the right thing, and is now reached for a non-generic class too. |

Getters and setters stay gated as well — neither has a call site that could instantiate a binder. `inferMemberFunc` is shared with them, so the flag is carried per member on `pendingMember`.

## Tests

`TestInferClassMethodTypeParamsGated` and `TestInferGenericMethodStillGated` pinned the gate and are flipped. `TestInferClassMethodTypeParamBounds` was disabled against this issue and is re-enabled.

One case in it is changed rather than restored. `SiblingBoundViolated` expected `pair<A, B: A>` to reject `c.pair(1, "y")`; that does not hold for the identical generic **function** either, so `TestInferMethodSiblingBoundMatchesTheFunctionForm` asserts the two agree rather than asserting a behavior neither has. Making a method match a function is what this issue asks for.

New beside them: `TestInferClassMethodTypeParamsInstantiatePerCall`, `TestInferClassMethodTypeParamRendering` (five shapes, including the class value carrying no phantom binder), `TestInferMethodBodyInferredBoundMatchesTheFunctionForm`, `TestInferOverloadedGenericMethod`, `TestInferAccessorTypeParamsGated`, and `TestInferClassConstructorTypeParamsGated`. Nineteen subtests fail with the gate restored.

## Gate

- [x] A method's `<…>` list resolves through `resolveTypeParams` and instantiates per call
- [x] A declared bound enforces at the call site, for an instance and a static method
- [x] An unbounded binder accepts anything
- [x] Two calls to one method instantiate independently
- [x] Shadowing and a class-parameter bound are settled deliberately
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generic class methods now support type parameters, including bounds, shadowing, overloaded methods, and per-call type inference.
  - Generic method signatures render declared type-parameter names correctly.

- **Bug Fixes**
  - Type constraints are now resolved and substituted more accurately.
  - Overloaded generic methods are instantiated independently for each resolution attempt, preventing type information from leaking between calls.

- **Compatibility**
  - Generic type parameters remain unsupported for constructors, getters, and setters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->