### PR TITLE
Make a `mut` receiver reach a field, and require one for a `mut self` member

### DIFF
--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -842,7 +842,7 @@ func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walke
 // field-requirement path, which threads the read-through-borrow and read-after-write
 // rules a direct lookup would drop; a method or getter member reaches valueProp only
 // through a class instance, since class bodies are the only source of those elements.
-func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
+func (c *checker) projectedMember(lvl int, blame ast.Node, name string, recv, carrier soltype.Type) (pathResult, bool) {
 	ct, ok := classCarrier(carrier)
 	if !ok {
 		return pathResult{}, false
@@ -870,6 +870,11 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 		c.errs = append(c.errs, err)
 		return pathResult{value: &soltype.ErrorType{}}, true
 	}
+	// A member declaring `mut self` needs mutable access to the instance, on an instance
+	// reached from outside the class as much as on the `self` classBodyMember serves. Both
+	// call the same check, so `c.bump()` and `self.bump()` answer the same way for the same
+	// receiver.
+	c.checkReceiverMut(blame, recv, memberSelfParam(member))
 	return c.memberValue(lvl, blame, member), true
 }
 

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -907,26 +907,10 @@ func (c *checker) objectMember(lvl int, blame ast.Node, name string, carrier sol
 // classValueCarrier, and like them it declines a var whose bounds disagree, since there is no
 // one member list to read in that case.
 func objectCarrier(t soltype.Type) (*soltype.ObjectType, bool) {
-	switch t := t.(type) {
-	case *soltype.ObjectType:
-		return t, true
-	case *soltype.TypeVarType:
-		var found *soltype.ObjectType
-		for _, lb := range t.LowerBounds {
-			obj, ok := lb.(*soltype.ObjectType)
-			if !ok {
-				continue
-			}
-			if found != nil && !equalType(found, obj) {
-				return nil, false
-			}
-			found = obj
-		}
-		if found != nil {
-			return found, true
-		}
-	}
-	return nil, false
+	return soleLowerBound(t, func(x soltype.Type) (*soltype.ObjectType, bool) {
+		obj, ok := x.(*soltype.ObjectType)
+		return obj, ok
+	})
 }
 
 // projectedClassMember looks name up on ct's class body, then walks the declared
@@ -1062,6 +1046,44 @@ func (s *selfSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 
 func (s *selfSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
+// soleLowerBound resolves t to the single value pick accepts: t itself, or the one accepted
+// value among an unresolved variable's lower bounds. A class instance and an object both
+// flow through the bound graph as a variable carrying the concrete type among its bounds
+// rather than as a bare type, so a lookup off a binding has to read through one.
+//
+// A variable whose accepted bounds disagree resolves to nothing, since there is no one
+// value to read. That covers a join of two classes and a join of the same class at
+// different arguments. A bound pick rejects is skipped rather than failing the walk, which
+// is what a lookup wants: a member is read off whichever bound carries it.
+//
+// A vacuous `v <: v` self-edge names no value the variable holds and is skipped, the same
+// edge readCarrier drops.
+func soleLowerBound[T soltype.Type](t soltype.Type, pick func(soltype.Type) (T, bool)) (T, bool) {
+	if got, ok := pick(t); ok {
+		return got, true
+	}
+	var zero T
+	v, isVar := t.(*soltype.TypeVarType)
+	if !isVar {
+		return zero, false
+	}
+	found, seen := zero, false
+	for _, lb := range v.LowerBounds {
+		if lb == soltype.Type(v) {
+			continue
+		}
+		got, ok := pick(lb)
+		if !ok {
+			continue
+		}
+		if seen && !equalType(found, got) {
+			return zero, false
+		}
+		found, seen = got, true
+	}
+	return found, seen
+}
+
 // classCarrier resolves a receiver to the class instance it reads as: a ClassType
 // directly, or a type variable whose lower bounds carry one — the same look-through
 // resolveFunc uses to find a concrete callee behind a binding var, since a class
@@ -1075,26 +1097,10 @@ func (s *selfSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { 
 // different arguments such as `Box(1)` and `Box("s")`, whose members differ by
 // argument. Member access on such a union rides the nominal-vs-structural rule in C1.
 func classCarrier(t soltype.Type) (*soltype.ClassType, bool) {
-	switch t := t.(type) {
-	case *soltype.ClassType:
-		return t, true
-	case *soltype.TypeVarType:
-		var found *soltype.ClassType
-		for _, lb := range t.LowerBounds {
-			ct, ok := lb.(*soltype.ClassType)
-			if !ok {
-				continue
-			}
-			if found != nil && !equalType(found, ct) {
-				return nil, false
-			}
-			found = ct
-		}
-		if found != nil {
-			return found, true
-		}
-	}
-	return nil, false
+	return soleLowerBound(t, func(x soltype.Type) (*soltype.ClassType, bool) {
+		ct, ok := x.(*soltype.ClassType)
+		return ct, ok
+	})
 }
 
 // memberValue produces the value a member access yields: a property's or getter's
@@ -1366,31 +1372,14 @@ func (c *checker) classValueMember(lvl int, blame ast.Node, name string, carrier
 // same look-through classCarrier uses for an instance. A var with two different class-value
 // lower bounds is ambiguous and left to the structural path.
 func classValueCarrier(t soltype.Type) (*soltype.ObjectType, bool) {
-	switch t := t.(type) {
-	case *soltype.ObjectType:
-		if _, ok := t.Constructor(); ok {
-			return t, true
+	return soleLowerBound(t, func(x soltype.Type) (*soltype.ObjectType, bool) {
+		obj, ok := x.(*soltype.ObjectType)
+		if !ok {
+			return nil, false
 		}
-	case *soltype.TypeVarType:
-		var found *soltype.ObjectType
-		for _, lb := range t.LowerBounds {
-			obj, ok := lb.(*soltype.ObjectType)
-			if !ok {
-				continue
-			}
-			if _, hasCtor := obj.Constructor(); !hasCtor {
-				continue
-			}
-			if found != nil && !equalType(found, obj) {
-				return nil, false
-			}
-			found = obj
-		}
-		if found != nil {
-			return found, true
-		}
-	}
-	return nil, false
+		_, hasCtor := obj.Constructor()
+		return obj, hasCtor
+	})
 }
 
 // typeSubst rewrites a generic body's type-parameter and lifetime-parameter vars to

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -852,6 +852,15 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 		return pathResult{}, false
 	}
 	member, found := c.projectedClassMember(ct, ct, name, (*soltype.ObjectType).ReadMember, set.NewSet[string]())
+	// A field declines here, the way objectMember and classBodyMember decline one, so a
+	// class field read takes the structural path below in valueProp. That path is where
+	// the read-through-borrow rule lives, and reading a field's type straight off the
+	// projected body skips it: the field would come back bare and a write through a `mut`
+	// receiver would be rejected (#617). A method, getter, or setter still resolves here,
+	// since the structural requirement cannot express those.
+	if _, isProp := member.(*soltype.PropertyElem); found && isProp {
+		return pathResult{}, false
+	}
 	if !found {
 		// The miss is rare, so project the whole body here to render the diagnostic at
 		// the instance's arguments rather than the declared type parameters.

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -680,6 +680,33 @@ func TestValMutUpgradesAnOwnedCallResult(t *testing.T) {
 			src:  counter + "declare fn shared() -> Counter\nval d = shared()",
 			want: "Counter",
 		},
+		{
+			// An interface and an alias name what their body names, so the decision follows
+			// the chain and the handle is what the binding renders under.
+			name: "an interface return",
+			src:  "export declare interface I { n: number }\ndeclare fn make() -> I\nval mut d = make()",
+			want: "mut I",
+		},
+		{
+			name: "an alias return",
+			src:  "type A = {n: number}\ndeclare fn make() -> A\nval mut d = make()",
+			want: "mut A",
+		},
+		{
+			name: "an alias chain two deep",
+			src:  "type A0 = {n: number}\ntype A1 = A0\ndeclare fn make() -> A1\nval mut d = make()",
+			want: "mut A1",
+		},
+		{
+			name: "an alias naming a primitive has nothing to make mutable",
+			src:  "type N = number\ndeclare fn make() -> N\nval mut d = make()",
+			want: "N",
+		},
+		{
+			name: "a borrow return reached through an alias keeps its borrow",
+			src:  "type A = {n: number}\ndeclare fn make() -> &A\nval mut d = make()",
+			want: "&A",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -784,55 +811,84 @@ func TestMutReceiverFollowsAnAliasChain(t *testing.T) {
 // and `std:array` declares `push(mut self, ...items: mut Array<T>) -> number`.
 //
 // `config.certificates.push(cert)` exercises both halves of this change at once. The
-// receiver's mutability has to reach the field, which is part 1, and then satisfy `push`'s
-// own `mut self`, which is part 2. The carrier table above only writes a field, so it
-// stops short of the second half.
+// receiver's mutability has to reach the field, and then satisfy `push`'s own `mut self`.
+// The carrier table above only writes a field, so it stops short of the second half.
 //
-// A read and a `self` method stay reachable through an immutable receiver, since neither
-// asks for mutable access. `List` stands in for `Array` so the case does not depend on the
-// prelude, and the field is written without `mut` because that is the spelling #1554 moves
-// the tree to; inside an interface the two behave alike, #779 stripping the `mut`.
+// The receiver is a `&mut` borrow and the argument a `&` one, the borrowed forms a caller
+// holding neither value outright would write. `push` takes `item: &T` to match: with an
+// owned `item: T` the borrowed argument reports that it does not outlive the parameter,
+// which is the borrow checker doing its job and not what this test is about.
+//
+// `List` stands in for `Array` so the case does not depend on the prelude, and the field is
+// written without `mut` because that is the spelling #1554 moves the tree to; inside an
+// interface the two behave alike, #779 stripping the `mut`.
 func TestMutSelfMethodOnAGenericFieldOfAnInterface(t *testing.T) {
 	const decls = `
 		export declare class RTCCertificate { expires: number }
 		export declare class List<T> {
 			length: number,
-			push(mut self, item: T) -> number,
+			push(mut self, item: &T) -> number,
 			at(self, index: number) -> T,
 		}
 		export declare interface RTCConfiguration {
 			certificates: List<RTCCertificate>,
 		}
 `
+	const cannotMutate = "cannot constrain immutable List<RTCCertificate> <: mutable List<RTCCertificate>"
 	tests := []struct {
 		name string
 		src  string
 		errs []string
 	}{
 		{
-			name: "a mutator through a `mut` receiver",
-			src: decls + `fn go(config: mut RTCConfiguration, cert: RTCCertificate) -> number {
+			name: "a mutator through a `&mut` receiver",
+			src: decls + `fn go(config: &mut RTCConfiguration, cert: &RTCCertificate) -> number {
 				return config.certificates.push(cert)
 			}`,
 		},
 		{
-			name: "a mutator through an immutable receiver",
-			src: decls + `fn go(config: RTCConfiguration, cert: RTCCertificate) -> number {
+			name: "a mutator through a `&` receiver",
+			src: decls + `fn go(config: &RTCConfiguration, cert: &RTCCertificate) -> number {
 				return config.certificates.push(cert)
 			}`,
-			errs: []string{
-				"cannot constrain immutable List<RTCCertificate> <: mutable List<RTCCertificate>",
-			},
+			errs: []string{cannotMutate},
 		},
 		{
-			name: "a field read through an immutable receiver",
-			src:  decls + `fn go(config: RTCConfiguration) -> number { return config.certificates.length }`,
+			name: "a field read through a `&` receiver",
+			src:  decls + `fn go(config: &RTCConfiguration) -> number { return config.certificates.length }`,
 		},
 		{
-			name: "a `self` method through an immutable receiver",
-			src: decls + `fn go(config: RTCConfiguration) -> RTCCertificate {
+			name: "a `self` method through a `&` receiver",
+			src: decls + `fn go(config: &RTCConfiguration) -> RTCCertificate {
 				return config.certificates.at(0)
 			}`,
+		},
+		{
+			// The owned counterpart, where the caller holds both values outright rather
+			// than borrowing them. `declare fn` is what hands over an owned value today;
+			// `declare val` is the direct spelling and reports a missing initializer
+			// instead, which is #1260.
+			name: "a mutator on an owned `mut` receiver",
+			src: decls + `
+				declare fn makeConfig() -> RTCConfiguration
+				declare fn makeCert() -> RTCCertificate
+				fn go() -> number {
+					val mut config = makeConfig()
+					val cert = makeCert()
+					return config.certificates.push(&cert)
+				}`,
+		},
+		{
+			name: "a mutator on an owned immutable receiver",
+			src: decls + `
+				declare fn makeConfig() -> RTCConfiguration
+				declare fn makeCert() -> RTCCertificate
+				fn go() -> number {
+					val config = makeConfig()
+					val cert = makeCert()
+					return config.certificates.push(&cert)
+				}`,
+			errs: []string{cannotMutate},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -604,29 +604,112 @@ func TestOverloadedMutSelfMethodNeedsAMutableReceiver(t *testing.T) {
 	})
 }
 
-// A constructor call mints an instance the binding solely owns, so `val mut` upgrades it
-// the way it upgrades a fresh literal. An ordinary call may hand back something the callee
-// already held, so it does not upgrade.
-func TestValMutUpgradesAConstructorCall(t *testing.T) {
-	t.Run("a constructor call", func(t *testing.T) {
-		values, _, errs := inferSource(t, `
-			class Counter {
-				count: number,
-				constructor(mut self, count: number) { self.count = count },
-			}
-			val mut c = Counter(0)`)
+// An owned return type means the caller holds the only reference to the result, so a
+// `val mut` binding of a call upgrades it to an owned-mutable value. A borrow return says
+// the opposite — the callee kept the value and lent it — so that one does not upgrade.
+//
+// The result reaches the binding as a variable carrying the return among its lower bounds,
+// so the borrow test runs at every level of that walk. Peeling the reference first would
+// read `&Counter` as an owned `Counter` and hand the binding exclusive mutable access to a
+// value someone else still holds.
+func TestValMutUpgradesAnOwnedCallResult(t *testing.T) {
+	const counter = `
+		class Counter {
+			n: number,
+			constructor(mut self, n: number) { self.n = n },
+			bump(mut self) { self.n = 1 },
+		}
+`
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "a constructor call",
+			src:  counter + "val mut d = Counter(0)",
+			want: "mut Counter",
+		},
+		{
+			name: "a declared function returning an owned instance",
+			src:  counter + "declare fn shared() -> Counter\nval mut d = shared()",
+			want: "mut Counter",
+		},
+		{
+			name: "a factory returning a fresh instance",
+			src:  counter + "fn make() -> Counter { return Counter(0) }\nval mut d = make()",
+			want: "mut Counter",
+		},
+		{
+			name: "a static factory",
+			src:  counter + "class F { static of() -> Counter { return Counter(0) }, }\nval mut d = F.of()",
+			want: "mut Counter",
+		},
+		{
+			name: "a declared function already returning `mut`",
+			src:  counter + "declare fn made() -> mut Counter\nval mut d = made()",
+			want: "mut Counter",
+		},
+		{
+			name: "an owned object return",
+			src:  "declare fn obj() -> {x: number}\nval mut d = obj()",
+			want: "mut {x: number}",
+		},
+		{
+			name: "an owned tuple return",
+			src:  "declare fn tup() -> [number, number]\nval mut d = tup()",
+			want: "mut [number, number]",
+		},
+		{
+			name: "an immutable borrow return keeps its borrow",
+			src:  counter + "declare fn peek() -> &Counter\nval mut d = peek()",
+			want: "&Counter",
+		},
+		{
+			name: "a mutable borrow return keeps its borrow",
+			src:  counter + "declare fn peek() -> &mut Counter\nval mut d = peek()",
+			want: "&mut Counter",
+		},
+		{
+			name: "a primitive return has nothing to make mutable",
+			src:  "declare fn num() -> number\nval mut d = num()",
+			want: "number",
+		},
+		{
+			name: "a plain `val` binding does not upgrade",
+			src:  counter + "declare fn shared() -> Counter\nval d = shared()",
+			want: "Counter",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, messagesWithSpan(t, errs))
+			require.Equal(t, tt.want, values["d"])
+		})
+	}
+}
+
+// A `mut self` method is reachable on an owned call result bound with `val mut`, which is
+// the point of the upgrade above: a factory is how a class with validation or a private
+// constructor is written, and its result would otherwise be unusable.
+func TestMutSelfMethodReachableOnAnOwnedCallResult(t *testing.T) {
+	const src = `
+		class Counter {
+			n: number,
+			constructor(mut self, n: number) { self.n = n },
+			bump(mut self) { self.n = 1 },
+		}
+		fn make() -> Counter { return Counter(0) }
+		fn go() -> number { val %s d = make()  d.bump()  return 0 }`
+	t.Run("a `val mut` binding reaches it", func(t *testing.T) {
+		_, _, errs := inferSource(t, fmt.Sprintf(src, "mut"))
 		require.Empty(t, messagesWithSpan(t, errs))
-		require.Equal(t, "mut Counter", values["c"])
 	})
-	t.Run("an ordinary call returning an instance", func(t *testing.T) {
-		values, _, errs := inferSource(t, `
-			class Counter {
-				count: number,
-				constructor(mut self, count: number) { self.count = count },
-			}
-			declare fn shared() -> Counter
-			val mut c = shared()`)
-		require.Empty(t, messagesWithSpan(t, errs))
-		require.Equal(t, "Counter", values["c"])
+	t.Run("a plain `val` binding does not", func(t *testing.T) {
+		_, _, errs := inferSource(t, fmt.Sprintf(src, ""))
+		require.Equal(t,
+			[]string{"cannot constrain immutable Counter <: mutable Counter"},
+			errorMessagesOf(errs))
 	})
 }

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -690,6 +690,94 @@ func TestValMutUpgradesAnOwnedCallResult(t *testing.T) {
 	}
 }
 
+// An alias chain is followed to its end. expandAlias unfolds one level, so `type C2 = C1`
+// over `type C1 = Config` needs the walk to run twice before the field list appears. Only
+// the first hop resolved once, which left a receiver two aliases deep behaving like one of
+// unknown shape and losing its mutability.
+//
+// A cycle cannot reach the walk — the productivity check rejects `type A = A` and the
+// mutual pair at the declaration — so the case below pins that the walk terminates on one
+// rather than that it reports.
+func TestMutReceiverFollowsAnAliasChain(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		errs []string
+	}{
+		{
+			name: "two aliases over an object",
+			src: `
+				type A0 = {inner: {n: number}}
+				type A1 = A0
+				fn go(c: mut A1) -> number { c.inner.n = 1  return 0 }`,
+		},
+		{
+			name: "four aliases over an object",
+			src: `
+				type A0 = {inner: {n: number}}
+				type A1 = A0
+				type A2 = A1
+				type A3 = A2
+				fn go(c: mut A3) -> number { c.inner.n = 1  return 0 }`,
+		},
+		{
+			name: "two aliases over an interface",
+			src: `
+				export declare interface Config { inner: {n: number} }
+				type C1 = Config
+				type C2 = C1
+				fn go(c: mut C2) -> number { c.inner.n = 1  return 0 }`,
+		},
+		{
+			name: "two aliases over a class",
+			src: `
+				class Box {
+					inner: {n: number},
+					constructor(mut self, inner: {n: number}) { self.inner = inner },
+				}
+				type B1 = Box
+				type B2 = B1
+				fn go(c: mut B2) -> number { c.inner.n = 1  return 0 }`,
+		},
+		{
+			name: "a generic alias over a generic alias",
+			src: `
+				type Inner<T> = {inner: T}
+				type Holder<T> = Inner<T>
+				fn go(c: mut Holder<{n: number}>) -> number { c.inner.n = 1  return 0 }`,
+		},
+		{
+			name: "an immutable receiver still rejects through a chain",
+			src: `
+				type A0 = {inner: {n: number}}
+				type A1 = A0
+				fn go(c: A1) -> number { c.inner.n = 1  return 0 }`,
+			errs: []string{"cannot constrain immutable object <: mutable object"},
+		},
+		{
+			name: "a self-referential alias is rejected at the declaration",
+			src: `
+				type A = A
+				fn go(c: mut A) -> number { c.inner.n = 1  return 0 }`,
+			errs: []string{
+				"recursive type alias `A` reaches itself without passing under a type " +
+					"constructor, so no lap of the recursion emits any structure and the alias " +
+					"names no type; wrap the recursive reference in an object, tuple, or function type",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.errs == nil {
+				require.Empty(t, messagesWithSpan(t, errs))
+				return
+			}
+			require.Equal(t, tt.errs, errorMessagesOf(errs))
+		})
+	}
+}
+
 // The shape the committed stdlib tree writes, and the case #1554 needs before it can drop
 // the `mut` its fields carry: an interface whose field is a generic class carrying a
 // `mut self` mutator. `web:web_rtc` declares `certificates?: mut Array<RTCCertificate>`,

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -469,3 +469,164 @@ func TestAClassFieldReadKeepsItsProjectionAndItsMiss(t *testing.T) {
 			errorMessagesOf(errs))
 	})
 }
+
+// --- #1558: a `mut self` member needs a mutable receiver ---
+
+// A method declaring `mut self` needs mutable access to the instance, and the receiver it
+// is reached through decides whether there is any. The check runs on an instance reached
+// from outside the class as much as on the `self` a body reads, so `c.bump()` and
+// `self.bump()` answer the same way for the same receiver.
+func TestMutSelfMethodNeedsAMutableReceiver(t *testing.T) {
+	const items = `
+		class Items {
+			n: number,
+			constructor(mut self, n: number) { self.n = n },
+			bump(mut self) { self.n = 1 },
+			read(self) -> number { return self.n },
+		}
+`
+	const want = "cannot constrain immutable Items <: mutable Items"
+	tests := []struct {
+		name string
+		src  string
+		errs []string
+	}{
+		{
+			name: "a `mut` parameter lends",
+			src:  items + `fn go(i: mut Items) -> number { i.bump()  return 0 }`,
+		},
+		{
+			name: "an immutable parameter does not",
+			src:  items + `fn go(i: Items) -> number { i.bump()  return 0 }`,
+			errs: []string{want},
+		},
+		{
+			name: "a plain method needs nothing",
+			src:  items + `fn go(i: Items) -> number { return i.read() }`,
+		},
+		{
+			name: "a `val mut` binding of a constructor call lends",
+			src:  items + `fn go() -> number { val mut i = Items(1)  i.bump()  return 0 }`,
+		},
+		{
+			name: "a plain `val` binding of the same call does not",
+			src:  items + `fn go() -> number { val i = Items(1)  i.bump()  return 0 }`,
+			errs: []string{want},
+		},
+		{
+			name: "a `mut` receiver lends through a field",
+			src: items + `
+				class Config {
+					items: Items,
+					constructor(mut self, items: Items) { self.items = items },
+				}
+				fn go(c: mut Config) -> number { c.items.bump()  return 0 }`,
+		},
+		{
+			name: "an immutable receiver does not lend through a field",
+			src: items + `
+				class Config {
+					items: Items,
+					constructor(mut self, items: Items) { self.items = items },
+				}
+				fn go(c: Config) -> number { c.items.bump()  return 0 }`,
+			errs: []string{want},
+		},
+		{
+			name: "`mut self` inside a body lends to a field's method",
+			src: items + `
+				class Sub {
+					it: Items,
+					constructor(mut self, it: Items) { self.it = it },
+					go(mut self) { self.it.bump() },
+				}`,
+		},
+		{
+			name: "plain `self` inside a body does not",
+			src: items + `
+				class Sub {
+					it: Items,
+					constructor(mut self, it: Items) { self.it = it },
+					go(self) { self.it.bump() },
+				}`,
+			errs: []string{want},
+		},
+		{
+			name: "an inherited `mut self` method is checked at the subclass",
+			src: `
+				class Base {
+					n: number,
+					constructor(mut self, n: number) { self.n = n },
+					bump(mut self) { self.n = 1 },
+				}
+				class Derived extends Base {
+					constructor(mut self) { super(0) },
+				}
+				fn go(d: Derived) -> number { d.bump()  return 0 }`,
+			errs: []string{"cannot constrain immutable Base <: mutable Base"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.errs == nil {
+				require.Empty(t, messagesWithSpan(t, errs))
+				return
+			}
+			require.Equal(t, tt.errs, errorMessagesOf(errs))
+		})
+	}
+}
+
+// Every arm of an overloaded `mut self` method needs the same mutable receiver, since the
+// arms share one member and the check reads the receiver before an arm is chosen.
+func TestOverloadedMutSelfMethodNeedsAMutableReceiver(t *testing.T) {
+	const src = `
+		class C {
+			n: number,
+			constructor(mut self, n: number) { self.n = n },
+			f(mut self, x: number) -> number { return x },
+			f(mut self, x: string) -> string { return x },
+		}
+		val %s c = C(0)
+		val r = c.f(1)
+	`
+	t.Run("a `val mut` receiver lends", func(t *testing.T) {
+		values, _, errs := inferSource(t, fmt.Sprintf(src, "mut"))
+		require.Empty(t, messagesWithSpan(t, errs))
+		require.Equal(t, "number", values["r"])
+	})
+	t.Run("a plain `val` receiver does not", func(t *testing.T) {
+		_, _, errs := inferSource(t, fmt.Sprintf(src, ""))
+		require.Equal(t,
+			[]string{"cannot constrain immutable C <: mutable C"},
+			errorMessagesOf(errs))
+	})
+}
+
+// A constructor call mints an instance the binding solely owns, so `val mut` upgrades it
+// the way it upgrades a fresh literal. An ordinary call may hand back something the callee
+// already held, so it does not upgrade.
+func TestValMutUpgradesAConstructorCall(t *testing.T) {
+	t.Run("a constructor call", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			class Counter {
+				count: number,
+				constructor(mut self, count: number) { self.count = count },
+			}
+			val mut c = Counter(0)`)
+		require.Empty(t, messagesWithSpan(t, errs))
+		require.Equal(t, "mut Counter", values["c"])
+	})
+	t.Run("an ordinary call returning an instance", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			class Counter {
+				count: number,
+				constructor(mut self, count: number) { self.count = count },
+			}
+			declare fn shared() -> Counter
+			val mut c = shared()`)
+		require.Empty(t, messagesWithSpan(t, errs))
+		require.Equal(t, "Counter", values["c"])
+	})
+}

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -299,5 +300,172 @@ func TestNestedWriteInfersMutContainerAndRoundTrips(t *testing.T) {
 fn caller(a: mut {p: {x: number}}) { foo(a) }`
 		_, _, errs := inferSource(t, src)
 		require.Empty(t, errs)
+	})
+}
+
+// --- #617: receiver mutability reaches a field through every receiver shape ---
+
+// mutReceiverCarriers is the five ways a source can name the receiver a nested write goes
+// through. Each entry builds a program writing `c.inner.n = 1` through a receiver whose
+// mutability the caller picks, so one table exercises the mutable and immutable halves of
+// the same rule.
+//
+// An inline object annotation and a `mut self` receiver already carried mutability into a
+// field. An alias, an interface, and a class instance did not: an alias failed the object
+// assertion in fieldReadBorrow, and a class field never reached that function at all.
+var mutReceiverCarriers = []struct {
+	name string
+	// src takes the receiver's mutability, `mut ` or empty.
+	src func(mutability string) string
+}{
+	{
+		name: "inline object annotation",
+		src: func(m string) string {
+			return "fn go(c: " + m + "{inner: {n: number}}) -> number { c.inner.n = 1  return 0 }"
+		},
+	},
+	{
+		name: "type alias to an object",
+		src: func(m string) string {
+			return `
+				type Config = {inner: {n: number}}
+				fn go(c: ` + m + `Config) -> number { c.inner.n = 1  return 0 }`
+		},
+	},
+	{
+		name: "declare interface",
+		src: func(m string) string {
+			return `
+				export declare interface Config { inner: {n: number} }
+				fn go(c: ` + m + `Config) -> number { c.inner.n = 1  return 0 }`
+		},
+	},
+	{
+		name: "class instance",
+		src: func(m string) string {
+			return `
+				class Box {
+					inner: {n: number},
+					constructor(mut self, inner: {n: number}) { self.inner = inner },
+				}
+				fn go(b: ` + m + `Box) -> number { b.inner.n = 1  return 0 }`
+		},
+	},
+	{
+		name: "class body through the receiver",
+		src: func(m string) string {
+			return `
+				class Box {
+					inner: {n: number},
+					constructor(mut self, inner: {n: number}) { self.inner = inner },
+					grow(` + m + `self) { self.inner.n = 1 },
+				}`
+		},
+	},
+}
+
+// A `mut` receiver lends its mutability to a field, so a write through that field is
+// legal however the receiver's type is spelled.
+func TestMutReceiverReachesAFieldThroughEveryCarrier(t *testing.T) {
+	for _, tc := range mutReceiverCarriers {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src("mut "))
+			require.Empty(t, messagesWithSpan(t, errs))
+		})
+	}
+}
+
+// An immutable receiver lends nothing, so the same write is rejected. This is the half
+// that makes the rule a permission rather than a default, and it held for every carrier
+// before the mutable half did.
+func TestImmutableReceiverRejectsAFieldWriteThroughEveryCarrier(t *testing.T) {
+	const want = "cannot constrain immutable object <: mutable object"
+	for _, tc := range mutReceiverCarriers {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src(""))
+			require.Equal(t, []string{want}, errorMessagesOf(errs))
+		})
+	}
+}
+
+// Mutability carries through each link of a chained read, not just the first, so
+// `c.a.b.n = 1` is legal through a `mut` receiver and rejected through an immutable one.
+func TestMutReceiverReachesAChainedField(t *testing.T) {
+	const src = `
+		class Inner {
+			b: {n: number},
+			constructor(mut self, b: {n: number}) { self.b = b },
+		}
+		type Outer = {a: Inner}
+		fn go(c: %sOuter) -> number { c.a.b.n = 1  return 0 }`
+	t.Run("mut receiver", func(t *testing.T) {
+		_, _, errs := inferSource(t, fmt.Sprintf(src, "mut "))
+		require.Empty(t, messagesWithSpan(t, errs))
+	})
+	t.Run("immutable receiver", func(t *testing.T) {
+		_, _, errs := inferSource(t, fmt.Sprintf(src, ""))
+		require.Equal(t,
+			[]string{"cannot constrain immutable object <: mutable object"},
+			errorMessagesOf(errs))
+	})
+}
+
+// A field the source marked `mut` keeps its mutability under an immutable receiver. That
+// is interior mutability: the receiver decides for a field that did not ask, and this
+// field asked. Only a class body can write the shape, #779 rejecting it on an object type
+// annotation.
+func TestAnExplicitMutFieldSurvivesAnImmutableReceiver(t *testing.T) {
+	const src = `
+		class Cell { n: number }
+		class Holder { readonly inner: mut Cell }
+		fn poke(h: %sHolder) -> number { h.inner.n = 1  return 0 }`
+	for _, mutability := range []string{"mut ", ""} {
+		t.Run("receiver "+mutability, func(t *testing.T) {
+			_, _, errs := inferSource(t, fmt.Sprintf(src, mutability))
+			require.Empty(t, messagesWithSpan(t, errs))
+		})
+	}
+}
+
+// Routing a class field read through the structural path keeps what the projected-member
+// path did for it: the field's type still resolves at the instance's type arguments, and a
+// field no class in the chain declares still reports the miss.
+func TestAClassFieldReadKeepsItsProjectionAndItsMiss(t *testing.T) {
+	t.Run("a generic field projects to the instance's argument", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			class Box<T> {
+				inner: T,
+				constructor(mut self, inner: T) { self.inner = inner },
+			}
+			val b = Box({n: 1})
+			val r = b.inner`)
+		require.Empty(t, messagesWithSpan(t, errs))
+		require.Equal(t, "{n: 1}", values["r"])
+	})
+	t.Run("an inherited field reads through a subclass", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			class Animal {
+				name: string,
+				constructor(mut self, name: string) { self.name = name },
+			}
+			class Dog extends Animal {
+				constructor(mut self, name: string) { super(name) },
+			}
+			val d = Dog("rex")
+			val r = d.name`)
+		require.Empty(t, messagesWithSpan(t, errs))
+		require.Equal(t, "string", values["r"])
+	})
+	t.Run("a field no class declares still reports", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class Box {
+				n: number,
+				constructor(mut self, n: number) { self.n = n },
+			}
+			val b = Box(1)
+			val r = b.nope`)
+		require.Equal(t,
+			[]string{"object is missing property: nope"},
+			errorMessagesOf(errs))
 	})
 }

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -899,6 +900,80 @@ func TestMutSelfMethodOnAGenericFieldOfAnInterface(t *testing.T) {
 				return
 			}
 			require.Equal(t, tt.errs, errorMessagesOf(errs))
+		})
+	}
+}
+
+// ownedCarrier's walk guards the current path against a cycle through a variable as well as
+// through an alias. The bound graph is built by constraint solving rather than written by
+// hand, so it is a graph and not a tree: `v1 <: v2` with `v2 <: v1` walks between the two
+// until the stack runs out, which is a fatal error rather than a recoverable panic. The
+// skip for a direct `v <: v` edge does not catch that, being one hop shorter.
+//
+// The guard is path-scoped, so two lower bounds reaching the same variable stay independent.
+// These build the shapes directly, since constraint solving is what produces them and the
+// source that would is not obvious.
+func TestOwnedCarrierGuardsItsWalk(t *testing.T) {
+	obj := func() *soltype.ObjectType {
+		return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.PropertyElem{Name: "n", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
+		}}
+	}
+	tests := []struct {
+		name string
+		// build returns the type to resolve, and whether resolving it should find a value.
+		build func(c *checker) (soltype.Type, bool)
+	}{
+		{
+			name: "a two-variable cycle declines",
+			build: func(c *checker) (soltype.Type, bool) {
+				v1, v2 := c.freshAt(0), c.freshAt(0)
+				v1.LowerBounds = []soltype.Type{v2}
+				v2.LowerBounds = []soltype.Type{v1}
+				return v1, false
+			},
+		},
+		{
+			name: "a direct self-edge is skipped rather than declining the variable",
+			build: func(c *checker) (soltype.Type, bool) {
+				v := c.freshAt(0)
+				v.LowerBounds = []soltype.Type{v, obj()}
+				return v, true
+			},
+		},
+		{
+			name: "two bounds reaching one variable still resolve",
+			build: func(c *checker) (soltype.Type, bool) {
+				inner := c.freshAt(0)
+				inner.LowerBounds = []soltype.Type{obj()}
+				outer := c.freshAt(0)
+				outer.LowerBounds = []soltype.Type{inner, inner}
+				return outer, true
+			},
+		},
+		{
+			name: "a diamond resolves",
+			build: func(c *checker) (soltype.Type, bool) {
+				shared := c.freshAt(0)
+				shared.LowerBounds = []soltype.Type{obj()}
+				left, right := c.freshAt(0), c.freshAt(0)
+				left.LowerBounds = []soltype.Type{shared}
+				right.LowerBounds = []soltype.Type{shared}
+				top := c.freshAt(0)
+				top.LowerBounds = []soltype.Type{left, right}
+				return top, true
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestChecker()
+			ty, wantFound := tt.build(c)
+			if wantFound {
+				require.NotNil(t, c.ownedCarrier(ty))
+				return
+			}
+			require.Nil(t, c.ownedCarrier(ty))
 		})
 	}
 }

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -690,6 +690,75 @@ func TestValMutUpgradesAnOwnedCallResult(t *testing.T) {
 	}
 }
 
+// The shape the committed stdlib tree writes, and the case #1554 needs before it can drop
+// the `mut` its fields carry: an interface whose field is a generic class carrying a
+// `mut self` mutator. `web:web_rtc` declares `certificates?: mut Array<RTCCertificate>`,
+// and `std:array` declares `push(mut self, ...items: mut Array<T>) -> number`.
+//
+// `config.certificates.push(cert)` exercises both halves of this change at once. The
+// receiver's mutability has to reach the field, which is part 1, and then satisfy `push`'s
+// own `mut self`, which is part 2. The carrier table above only writes a field, so it
+// stops short of the second half.
+//
+// A read and a `self` method stay reachable through an immutable receiver, since neither
+// asks for mutable access. `List` stands in for `Array` so the case does not depend on the
+// prelude, and the field is written without `mut` because that is the spelling #1554 moves
+// the tree to; inside an interface the two behave alike, #779 stripping the `mut`.
+func TestMutSelfMethodOnAGenericFieldOfAnInterface(t *testing.T) {
+	const decls = `
+		export declare class RTCCertificate { expires: number }
+		export declare class List<T> {
+			length: number,
+			push(mut self, item: T) -> number,
+			at(self, index: number) -> T,
+		}
+		export declare interface RTCConfiguration {
+			certificates: List<RTCCertificate>,
+		}
+`
+	tests := []struct {
+		name string
+		src  string
+		errs []string
+	}{
+		{
+			name: "a mutator through a `mut` receiver",
+			src: decls + `fn go(config: mut RTCConfiguration, cert: RTCCertificate) -> number {
+				return config.certificates.push(cert)
+			}`,
+		},
+		{
+			name: "a mutator through an immutable receiver",
+			src: decls + `fn go(config: RTCConfiguration, cert: RTCCertificate) -> number {
+				return config.certificates.push(cert)
+			}`,
+			errs: []string{
+				"cannot constrain immutable List<RTCCertificate> <: mutable List<RTCCertificate>",
+			},
+		},
+		{
+			name: "a field read through an immutable receiver",
+			src:  decls + `fn go(config: RTCConfiguration) -> number { return config.certificates.length }`,
+		},
+		{
+			name: "a `self` method through an immutable receiver",
+			src: decls + `fn go(config: RTCConfiguration) -> RTCCertificate {
+				return config.certificates.at(0)
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.errs == nil {
+				require.Empty(t, messagesWithSpan(t, errs))
+				return
+			}
+			require.Equal(t, tt.errs, errorMessagesOf(errs))
+		})
+	}
+}
+
 // A `mut self` method is reachable on an owned call result bound with `val mut`, which is
 // the point of the upgrade above: a factory is how a class with validation or a private
 // constructor is written, and its result would otherwise be unusable.

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -93,6 +93,9 @@ func TestInferClassBasic(t *testing.T) {
 			},
 		},
 		{
+			// `val mut` on a constructor call builds an owned-mutable instance, which is
+			// what a `mut self` method needs. A plain `val` binding cannot reach one, which
+			// TestMutSelfMethodNeedsAMutableReceiver pins.
 			name: "MutSelfMethod",
 			src: `
 				class Counter {
@@ -100,10 +103,10 @@ func TestInferClassBasic(t *testing.T) {
 					constructor(mut self, count: number) { self.count = count },
 					increment(mut self) -> number { return self.count },
 				}
-				val c = Counter(0)
+				val mut c = Counter(0)
 				val n = c.increment()
 			`,
-			wantValues: map[string]string{"c": "Counter", "n": "number"},
+			wantValues: map[string]string{"c": "mut Counter", "n": "number"},
 		},
 		{
 			name: "Getter",

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -511,14 +511,27 @@ func (c *checker) callReturnsOwned(e ast.Expr, t soltype.Type) bool {
 // first would read `&Counter` as an owned `Counter` and hand the binding exclusive mutable
 // access to a value the callee kept.
 func (c *checker) ownedCarrier(t soltype.Type) soltype.RefInner {
-	return c.ownedCarrierSeen(t, set.NewSet[string]())
+	return c.ownedCarrierSeen(t, &ownedSeen{
+		aliases: set.NewSet[string](),
+		vars:    set.NewSet[*soltype.TypeVarType](),
+	})
 }
 
-// ownedCarrierSeen is ownedCarrier's walk, carrying the alias names already followed so a
-// cycle stops it. The productivity check rejects a cyclic alias at its declaration, so
-// nothing cyclic reaches here today; the set keeps the walk bounded rather than trusting
-// that check to stay in front of it.
-func (c *checker) ownedCarrierSeen(t soltype.Type, seen set.Set[string]) soltype.RefInner {
+// ownedSeen holds the aliases and variables on the CURRENT path of ownedCarrier's walk, so
+// a cycle through either stops it rather than recursing forever. It mirrors spreadSeen,
+// which guards the spread-operand walk the same way.
+//
+// Both sets are path-scoped: an entry is removed once its branch is done. A variable's
+// lower bounds are siblings rather than a chain, and two of them reaching the same alias or
+// the same variable is ordinary — a call result arrives with the same alias recorded twice.
+// A walk-scoped set would read the second as a cycle and decline the whole resolution.
+type ownedSeen struct {
+	aliases set.Set[string]
+	vars    set.Set[*soltype.TypeVarType]
+}
+
+// ownedCarrierSeen is ownedCarrier's walk, carrying the path it has followed so far.
+func (c *checker) ownedCarrierSeen(t soltype.Type, seen *ownedSeen) soltype.RefInner {
 	if isBorrowType(t) {
 		return nil
 	}
@@ -532,24 +545,29 @@ func (c *checker) ownedCarrierSeen(t soltype.Type, seen set.Set[string]) soltype
 		// naming a primitive has nothing to make mutable and declines here. The handle is
 		// what comes back rather than the body, so the binding renders under the name the
 		// source wrote: `mut RTCConfiguration`, not the field list it stands for.
-		if seen.Contains(t.Name) {
+		if seen.aliases.Contains(t.Name) {
 			return nil
 		}
-		seen.Add(t.Name)
-		// Removed once this branch is done, so the set holds the aliases on the CURRENT
-		// path rather than every alias the walk has ever reached. A variable's bounds are
-		// siblings, not a chain, and two of them naming the same alias is ordinary — the
-		// call result below arrives with the same alias recorded twice. Leaving the name in
-		// would read the second as a cycle and decline the whole resolution.
-		defer seen.Remove(t.Name)
+		seen.aliases.Add(t.Name)
+		defer seen.aliases.Remove(t.Name)
 		if c.ownedCarrierSeen(c.ctx.expandAlias(t), seen) == nil {
 			return nil
 		}
 		return t
 	case *soltype.TypeVarType:
+		// A variable reached twice on one path is a cycle in the bound graph, which the
+		// direct self-edge skip below does not catch: `v1 <: v2` with `v2 <: v1` walks
+		// between the two until the stack runs out.
+		if seen.vars.Contains(t) {
+			return nil
+		}
+		seen.vars.Add(t)
+		defer seen.vars.Remove(t)
 		var found soltype.RefInner
 		for _, lb := range t.LowerBounds {
 			if lb == soltype.Type(t) {
+				// A vacuous self-edge names no value the variable holds, so it is skipped
+				// rather than declining the variable the way a cycle does.
 				continue
 			}
 			inner := c.ownedCarrierSeen(lb, seen)

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -495,23 +495,29 @@ func (c *checker) callReturnsOwned(e ast.Expr, t soltype.Type) bool {
 	return ownedCarrier(t) != nil
 }
 
-// ownedCarrier resolves t to the value an owned result denotes: the carrier itself, or the
-// single concrete carrier among an unresolved variable's lower bounds. It mirrors
-// classCarrier's look-through, since a call result reaches a binding as a variable with the
-// result among its bounds rather than as a bare type. It declines a borrow, a variable whose
-// bounds disagree, and anything a borrow may not hold, such as a primitive.
+// ownedCarrier resolves t to the value an owned result denotes, or nil when the result is
+// not one the caller solely owns. It is the ownership twin of classCarrier and the other
+// lookup carriers, and differs from them in one way that matters: a lower bound it does not
+// accept fails the walk instead of being skipped.
+//
+// That difference is the soundness line. A lookup reads a member off whichever bound
+// carries it, so skipping the rest is right. This grants exclusive mutable access, so every
+// value the variable may hold at run time has to be owned. A variable joining an owned
+// result and a borrow must resolve to nothing, not to the owned half.
+//
+// A borrow is tested at every level rather than only at the top, since a call result reaches
+// the binding as a variable with the return among its lower bounds. Peeling the reference
+// first would read `&Counter` as an owned `Counter` and hand the binding exclusive mutable
+// access to a value the callee kept.
 func ownedCarrier(t soltype.Type) soltype.RefInner {
-	// A borrow is checked at every level rather than only at the top, since a call result
-	// reaches the binding as a variable and the borrow sits among its lower bounds. Peeling
-	// with CarrierOf first would drop the lifetime and read `&Counter` as an owned Counter,
-	// handing the binding exclusive mutable access to a value the callee kept.
-	if r, isRef := t.(*soltype.RefType); isRef {
-		if r.Lt != nil {
-			return nil
-		}
-		return ownedCarrier(r.Inner)
+	if isBorrowType(t) {
+		return nil
 	}
 	switch t := t.(type) {
+	case *soltype.RefType:
+		// An owned-mutable cell, already carrying what the upgrade grants. Its inner is the
+		// value, so the wrap is not nested.
+		return ownedCarrier(t.Inner)
 	case *soltype.TypeVarType:
 		var found soltype.RefInner
 		for _, lb := range t.LowerBounds {
@@ -519,10 +525,7 @@ func ownedCarrier(t soltype.Type) soltype.RefInner {
 				continue
 			}
 			inner := ownedCarrier(lb)
-			if inner == nil {
-				return nil
-			}
-			if found != nil && !equalType(found, inner) {
+			if inner == nil || (found != nil && !equalType(found, inner)) {
 				return nil
 			}
 			found = inner

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -138,17 +138,19 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	}
 	initT := c.inferExpr(scope, lvl, d.Init)
 	switch {
-	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && c.constructsFreshInstance(d.Init):
-		// An unannotated `val mut c = C(…)` constructs an owned-mutable instance, the class
-		// twin of the fresh-literal upgrade below. A constructor call mints an instance no
-		// one else holds, so granting it the mutable type aliases nothing, exactly the
-		// reasoning a fresh literal uses. Without this the binding stays immutable and a
-		// `mut self` method is unreachable on a value the caller just built and solely owns.
-		// The instance itself is wrapped, not the variable the call result arrives as.
-		// Wrapping the variable would leave its own name in the coalesced binding, so `c`
-		// would render `mut (T0 | Counter)` instead of `mut Counter`.
-		if ct, ok := classCarrier(initT); ok {
-			ref := soltype.NewRef(true, nil, ct)
+	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && c.callReturnsOwned(d.Init, initT):
+		// An unannotated `val mut d = f()` whose call returns an owned value binds it
+		// owned-mutable, the call twin of the fresh-literal upgrade below. An owned return
+		// type says the caller holds the only reference, so granting the binding mutable
+		// access aliases nothing, the same reasoning a fresh literal uses. Without this a
+		// `mut self` method would be unreachable on a value a factory just built and handed
+		// over, which is how a class with validation or a hidden constructor is written.
+		//
+		// The value is wrapped, not the variable the result arrives as. Wrapping the
+		// variable would leave its own name in the coalesced binding, so `d` would render
+		// `mut (T0 | Counter)` instead of `mut Counter`.
+		if inner := ownedCarrier(initT); inner != nil {
+			ref := soltype.NewRef(true, nil, inner)
 			c.recordProv(ref, d.Init, OwnedMutConstruction)
 			initT = ref
 		}
@@ -482,21 +484,58 @@ func (c *checker) acceptsBorrowLeaf(leaf ast.Expr) bool {
 	return ok
 }
 
-// constructsFreshInstance reports whether e is a call to a class value, which mints an
-// instance the binding solely owns. The callee's type carries a ConstructorElem, which is
-// what distinguishes `C(0)` from an ordinary call whose result may be an object the callee
-// already held and handed out. An ordinary call is not fresh and must not upgrade.
-func (c *checker) constructsFreshInstance(e ast.Expr) bool {
-	call, ok := e.(*ast.CallExpr)
-	if !ok {
+// callReturnsOwned reports whether e is a call whose result is an owned value. An owned
+// return type is the callee's statement that it kept nothing, so the caller holds the only
+// reference to what comes back. A callee that did keep the value returns a borrow instead,
+// which ownedCarrier declines.
+func (c *checker) callReturnsOwned(e ast.Expr, t soltype.Type) bool {
+	if _, ok := e.(*ast.CallExpr); !ok {
 		return false
 	}
-	callee := c.info.TypeOf(call.Callee)
-	if callee == nil {
-		return false
+	return ownedCarrier(t) != nil
+}
+
+// ownedCarrier resolves t to the value an owned result denotes: the carrier itself, or the
+// single concrete carrier among an unresolved variable's lower bounds. It mirrors
+// classCarrier's look-through, since a call result reaches a binding as a variable with the
+// result among its bounds rather than as a bare type. It declines a borrow, a variable whose
+// bounds disagree, and anything a borrow may not hold, such as a primitive.
+func ownedCarrier(t soltype.Type) soltype.RefInner {
+	// A borrow is checked at every level rather than only at the top, since a call result
+	// reaches the binding as a variable and the borrow sits among its lower bounds. Peeling
+	// with CarrierOf first would drop the lifetime and read `&Counter` as an owned Counter,
+	// handing the binding exclusive mutable access to a value the callee kept.
+	if r, isRef := t.(*soltype.RefType); isRef {
+		if r.Lt != nil {
+			return nil
+		}
+		return ownedCarrier(r.Inner)
 	}
-	_, isClassValue := classValueCarrier(callee)
-	return isClassValue
+	switch t := t.(type) {
+	case *soltype.TypeVarType:
+		var found soltype.RefInner
+		for _, lb := range t.LowerBounds {
+			if lb == soltype.Type(t) {
+				continue
+			}
+			inner := ownedCarrier(lb)
+			if inner == nil {
+				return nil
+			}
+			if found != nil && !equalType(found, inner) {
+				return nil
+			}
+			found = inner
+		}
+		return found
+	case *soltype.ObjectType:
+		return t
+	case *soltype.TupleType:
+		return t
+	case *soltype.ClassType:
+		return t
+	}
+	return nil
 }
 
 // freshLiteralShape reports whether e is a primitive literal, or an object/tuple literal

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -138,6 +138,20 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	}
 	initT := c.inferExpr(scope, lvl, d.Init)
 	switch {
+	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && c.constructsFreshInstance(d.Init):
+		// An unannotated `val mut c = C(…)` constructs an owned-mutable instance, the class
+		// twin of the fresh-literal upgrade below. A constructor call mints an instance no
+		// one else holds, so granting it the mutable type aliases nothing, exactly the
+		// reasoning a fresh literal uses. Without this the binding stays immutable and a
+		// `mut self` method is unreachable on a value the caller just built and solely owns.
+		// The instance itself is wrapped, not the variable the call result arrives as.
+		// Wrapping the variable would leave its own name in the coalesced binding, so `c`
+		// would render `mut (T0 | Counter)` instead of `mut Counter`.
+		if ct, ok := classCarrier(initT); ok {
+			ref := soltype.NewRef(true, nil, ct)
+			c.recordProv(ref, d.Init, OwnedMutConstruction)
+			initT = ref
+		}
 	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && freshLiteralShape(d.Init, c.acceptsBorrowLeaf):
 		// An unannotated `val mut q = {…}` / `var mut q = {…}` from a freshly
 		// constructed literal constructs an owned-mutable value. This mirrors the
@@ -466,6 +480,23 @@ func (c *checker) acceptsBorrowLeaf(leaf ast.Expr) bool {
 	}
 	_, ok := leaf.(*ast.BorrowExpr)
 	return ok
+}
+
+// constructsFreshInstance reports whether e is a call to a class value, which mints an
+// instance the binding solely owns. The callee's type carries a ConstructorElem, which is
+// what distinguishes `C(0)` from an ordinary call whose result may be an object the callee
+// already held and handed out. An ordinary call is not fresh and must not upgrade.
+func (c *checker) constructsFreshInstance(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	callee := c.info.TypeOf(call.Callee)
+	if callee == nil {
+		return false
+	}
+	_, isClassValue := classValueCarrier(callee)
+	return isClassValue
 }
 
 // freshLiteralShape reports whether e is a primitive literal, or an object/tuple literal

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -149,7 +150,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// The value is wrapped, not the variable the result arrives as. Wrapping the
 		// variable would leave its own name in the coalesced binding, so `d` would render
 		// `mut (T0 | Counter)` instead of `mut Counter`.
-		if inner := ownedCarrier(initT); inner != nil {
+		if inner := c.ownedCarrier(initT); inner != nil {
 			ref := soltype.NewRef(true, nil, inner)
 			c.recordProv(ref, d.Init, OwnedMutConstruction)
 			initT = ref
@@ -492,7 +493,7 @@ func (c *checker) callReturnsOwned(e ast.Expr, t soltype.Type) bool {
 	if _, ok := e.(*ast.CallExpr); !ok {
 		return false
 	}
-	return ownedCarrier(t) != nil
+	return c.ownedCarrier(t) != nil
 }
 
 // ownedCarrier resolves t to the value an owned result denotes, or nil when the result is
@@ -509,7 +510,15 @@ func (c *checker) callReturnsOwned(e ast.Expr, t soltype.Type) bool {
 // the binding as a variable with the return among its lower bounds. Peeling the reference
 // first would read `&Counter` as an owned `Counter` and hand the binding exclusive mutable
 // access to a value the callee kept.
-func ownedCarrier(t soltype.Type) soltype.RefInner {
+func (c *checker) ownedCarrier(t soltype.Type) soltype.RefInner {
+	return c.ownedCarrierSeen(t, set.NewSet[string]())
+}
+
+// ownedCarrierSeen is ownedCarrier's walk, carrying the alias names already followed so a
+// cycle stops it. The productivity check rejects a cyclic alias at its declaration, so
+// nothing cyclic reaches here today; the set keeps the walk bounded rather than trusting
+// that check to stay in front of it.
+func (c *checker) ownedCarrierSeen(t soltype.Type, seen set.Set[string]) soltype.RefInner {
 	if isBorrowType(t) {
 		return nil
 	}
@@ -517,14 +526,33 @@ func ownedCarrier(t soltype.Type) soltype.RefInner {
 	case *soltype.RefType:
 		// An owned-mutable cell, already carrying what the upgrade grants. Its inner is the
 		// value, so the wrap is not nested.
-		return ownedCarrier(t.Inner)
+		return c.ownedCarrierSeen(t.Inner, seen)
+	case *soltype.AliasType:
+		// An alias owns whatever its body owns, so the decision follows the chain. An alias
+		// naming a primitive has nothing to make mutable and declines here. The handle is
+		// what comes back rather than the body, so the binding renders under the name the
+		// source wrote: `mut RTCConfiguration`, not the field list it stands for.
+		if seen.Contains(t.Name) {
+			return nil
+		}
+		seen.Add(t.Name)
+		// Removed once this branch is done, so the set holds the aliases on the CURRENT
+		// path rather than every alias the walk has ever reached. A variable's bounds are
+		// siblings, not a chain, and two of them naming the same alias is ordinary — the
+		// call result below arrives with the same alias recorded twice. Leaving the name in
+		// would read the second as a cycle and decline the whole resolution.
+		defer seen.Remove(t.Name)
+		if c.ownedCarrierSeen(c.ctx.expandAlias(t), seen) == nil {
+			return nil
+		}
+		return t
 	case *soltype.TypeVarType:
 		var found soltype.RefInner
 		for _, lb := range t.LowerBounds {
 			if lb == soltype.Type(t) {
 				continue
 			}
-			inner := ownedCarrier(lb)
+			inner := c.ownedCarrierSeen(lb, seen)
 			if inner == nil || (found != nil && !equalType(found, inner)) {
 				return nil
 			}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2719,7 +2719,7 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	// field, resolves through the projected class body by direct member lookup rather
 	// than the structural field-requirement below — the constraint path reads only
 	// PropertyElems and cannot see a method or getter (M5 B1).
-	if res, ok := c.projectedMember(lvl, blame, name, recvCarrier); ok {
+	if res, ok := c.projectedMember(lvl, blame, name, recv, recvCarrier); ok {
 		return res
 	}
 	// A `self` receiver inside a class body binds to the full instance object, which

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2785,7 +2785,22 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 // the new borrow.
 func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Type, name string, lvl int) soltype.Type {
 	_, recvMut, recvLt := soltype.UnwrapRef(recv)
-	obj, ok := soltype.CarrierOf(recv).(*soltype.ObjectType)
+	carrier := soltype.CarrierOf(recv)
+	// An alias and a class name the same field list an object type writes inline, so each
+	// resolves to that list before the read. Without this a receiver annotated `mut Config`
+	// or `mut Box` would fall to the unknown-shape branch below and lose its mutability,
+	// while the inline `mut {…}` spelling of the same type kept it.
+	if at, isAlias := carrier.(*soltype.AliasType); isAlias {
+		carrier = c.ctx.expandAlias(at)
+	}
+	if ct, isClass := classCarrier(carrier); isClass {
+		// Projected at the instance's arguments, so a field typed `T` reads as the
+		// argument `Box<number>` supplies rather than as the declared parameter.
+		if body, ok := c.ctx.projectClassBody(ct); ok {
+			carrier = body
+		}
+	}
+	obj, ok := carrier.(*soltype.ObjectType)
 	if !ok {
 		return fieldVar
 	}
@@ -2796,18 +2811,18 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 	switch fieldType := prop.Type.(type) {
 	case *soltype.RefType:
 		if fieldType.Lt == nil {
-			// An owned-mutable field cell — formerly an explicit `mut {x}` field, the
-			// awkward interior-mutability shape now rejected at the annotation site
-			// (#779). Read it as a receiver-bounded borrow, capping `mut` by the
-			// receiver's mutability. The lazy deep-mut form does not mint these for a
-			// plain `mut {a: {x}}`; that field is bare, handled by the bare arm below.
-			// This arm is therefore defensive — kept for any owned-mut cell that still
-			// reaches a read.
+			// An owned-mutable field cell, which a class body writes as `mut Box<T>`. Read
+			// it as a receiver-bounded borrow that keeps the field's own mutability rather
+			// than capping it by the receiver's. That is interior mutability: a field the
+			// source marked `mut` stays writable through an immutable receiver, which is
+			// what `readonly inner: mut Box<T>` asks for. The receiver decides the
+			// mutability of a field that did NOT ask, and the bare arm below does that.
+			// An object type annotation cannot write this shape, #779 rejecting it there.
 			lt := recvLt
 			if lt == nil {
 				lt = c.ctx.freshLifetime(lvl)
 			}
-			return &soltype.RefType{Mut: fieldType.Mut && recvMut, Lt: lt, Inner: fieldType.Inner}
+			return &soltype.RefType{Mut: fieldType.Mut, Lt: lt, Inner: fieldType.Inner}
 		}
 		if !fieldType.Mut {
 			// Flat copy-out of an immutable borrow field. Immutable borrows are
@@ -2819,11 +2834,17 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 			return fieldType
 		}
 		return fieldVar
-	case *soltype.ObjectType, *soltype.TupleType:
+	case *soltype.ObjectType, *soltype.TupleType, *soltype.ClassType, *soltype.AliasType:
 		// A bare object/tuple field a borrowed receiver lends is read as a
 		// receiver-bounded borrow whose mutability follows the receiver (PR 14): a
 		// mutable borrow yields `&mut`, an immutable one `&`. This is where the lazy
 		// deep-mut rule lives — under a `&mut {a: {x}}` receiver, `p.a` reads `&mut {x}`.
+		//
+		// A class-typed or alias-typed field lends the same way, so a chain keeps carrying
+		// mutability when one of its links names a declaration instead of writing an object
+		// inline. `config.certificates.push(x)` is that case: `certificates` is typed
+		// `Array<T>`, a class, and capping the chain there would leave it unwritable
+		// through a `mut` receiver.
 		lt := recvLt
 		if lt == nil {
 			// An owned receiver yields the field's owned value, not a borrow, so a

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2790,7 +2790,17 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 	// resolves to that list before the read. Without this a receiver annotated `mut Config`
 	// or `mut Box` would fall to the unknown-shape branch below and lose its mutability,
 	// while the inline `mut {…}` spelling of the same type kept it.
-	if at, isAlias := carrier.(*soltype.AliasType); isAlias {
+	//
+	// expandAlias unfolds one level, so the chain is followed to its end: `type Config =
+	// Inner` names an alias whose own body may be another. Each name is recorded so a cycle
+	// stops the walk rather than spinning it.
+	seenAliases := set.NewSet[string]()
+	for {
+		at, isAlias := carrier.(*soltype.AliasType)
+		if !isAlias || seenAliases.Contains(at.Name) {
+			break
+		}
+		seenAliases.Add(at.Name)
 		carrier = c.ctx.expandAlias(at)
 	}
 	if ct, isClass := classCarrier(carrier); isClass {


### PR DESCRIPTION
Fixes #617.
Fixes #1558.

Two halves of the same rule: holding a `mut` receiver should let you mutate through it, and holding an immutable one should not.

## Part 1: a `mut` receiver reaches a field

Writing through a field, `c.inner.n = 1`:

| receiver carrier | before | after |
| --- | --- | --- |
| inline `mut {inner: {n: number}}` | OK | OK |
| `mut self` inside the class body | OK | OK |
| `mut Config`, an alias to an object | reports | OK |
| `mut Config`, a `declare interface` | reports | OK |
| `mut Box`, a class instance | reports | OK |

The immutable half was already right everywhere and stays right: each of the five rejects the same write when the receiver carries no `mut`.

`fieldReadBorrow` already implements the rule. Three things kept the other receivers from reaching it.

**An alias and an interface never matched.** The function opened with `CarrierOf(recv).(*ObjectType)` and returned the field var untouched when the assertion failed. An `AliasType` fails it, and an interface is an alias to an object type. Both expand first now.

**A class field never reached the function.** `valueProp` tries several member lookups before falling through to the structural field requirement that `fieldReadBorrow` follows. `objectMember` and `classBodyMember` decline a `PropertyElem` on purpose so a field read takes that path, which is why `mut self` already worked. `projectedMember` did not decline one; it returned the member's type raw and stopped. It declines a property now, and `fieldReadBorrow` projects the class body to the instance's arguments before reading the field's shape, so a field typed `T` still reads as the argument the instance supplies.

**A class-typed or alias-typed field did not lend.** The arm that hands a field out as a receiver-bounded borrow matched only `ObjectType` and `TupleType`, so a chain broke at the first link naming a declaration rather than writing an object inline. That is the case the stdlib tree needs: `config.certificates.push(x)` reads a field typed `Array<T>`, a class.

**One rule change.** The owned-mut cell arm returned `Mut: fieldType.Mut && recvMut`, capping a field's mutability by the receiver's. That arm was dead for a class field — its own comment called it defensive — and making it live stripped an explicitly written `mut` under an immutable receiver. That is the interior mutability `readonly inner: mut Box<T>` asks for, and `TestInferClassMutVariance/a_readonly_field_holding_a_mut_borrow_is_invariant_in_both_views` pins it. The cap is gone: the receiver decides for a field that did not ask, and a field that asked keeps what it asked for.

## Part 2: a `mut self` member requires a mutable receiver

The check ran only on the `self` a class body reads. Reached from outside, the same member was unchecked, so an immutable binding could call a mutating method while a direct write to the same field through the same receiver was rejected:

```
fn go(i: Items) -> number { i.bump()  return 0 }   // was accepted
fn go(i: Items) -> number { i.n = 1   return 0 }   // rejected
```

`projectedMember` now runs `checkReceiverMut`, the check `classBodyMember` already ran, so both paths answer the same way for the same receiver. It reaches through a field too, which is the other half of #617's motivating example — `c.items.bump()` where `c` is immutable.

## Part 3: `val mut` binds an owned call result owned-mutable

The check in part 2 is unusable without this. A caller could not reach a `mut self` method on a value a call had just handed it, because no call result was recognised as owned.

An owned return type is the callee's statement that it kept nothing, so the caller holds the only reference to what comes back and `val mut` may bind it mutable. A borrow return says the opposite and does not upgrade:

| `val mut d = …` | `d` |
| --- | --- |
| `Counter(0)` | `mut Counter` |
| `shared()`, where `declare fn shared() -> Counter` | `mut Counter` |
| `make()`, where `fn make() -> Counter { return Counter(0) }` | `mut Counter` |
| `obj()`, returning `{x: number}` | `mut {x: number}` |
| `peek()`, where `declare fn peek() -> &Counter` | `&Counter` |
| `peek()`, where `declare fn peek() -> &mut Counter` | `&mut Counter` |
| `num()`, returning `number` | `number` |
| any of the above under a plain `val` | unchanged |

The borrow test runs at every level of the lower-bound walk rather than only at the top. A call result reaches the binding as a variable carrying the return among its bounds, so peeling the reference first read `&Counter` as an owned `Counter` and granted the binding exclusive mutable access to a value the callee still held.

`TestInferClassBasic/MutSelfMethod` bound its receiver with a plain `val`, which part 2 correctly rejects, and now binds it `val mut`.

## Tests

`internal/solver/deep_mut_test.go` gains:

- one carrier table driving both halves of the field rule across all five receiver shapes;
- a chained write, `c.a.b.n = 1`, through links typed by a class and by an alias;
- an explicit `mut` field staying writable through an immutable receiver;
- a generic class field still projecting to the instance's argument, an inherited field still reading through a subclass, and a missing field still reporting;
- a `mut self` matrix over ten receivers, covering a direct call, a call through a field, `mut self` and plain `self` inside a body, a `val` and a `val mut` binding of a call, and an inherited `mut self` method checked at the subclass;
- an overloaded `mut self` method, where the arms share one member and the receiver is checked before an arm is chosen;
- the owned-return table above, borrow and primitive rows included;
- a `mut self` method reachable on a factory's result and not on the same result bound with a plain `val`.

`go test ./...` passes.

## Known limit

An owned return type is not yet enforced against the body: `fn shared() -> Counter { return kept }` returning a retained module-level value is accepted today, so the signature can claim sole ownership where the body hands out an alias. That is the #1503–#1505 cluster. This change trusts the signature, which is what the signature is for; tightening the body check is what makes the trust earned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaNfe55BmL4W3sX9LkC3hy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mutable receiver handling across objects, classes, interfaces, aliases, chained fields, and method calls.
  * Correctly preserves field-specific mutability and borrow behavior when accessing projected or aliased fields.
  * Enforces mutable receiver requirements for `mut self` methods and getters, including overloaded methods.
  * Mutable bindings now correctly retain mutability for owned values returned from calls.
  * Improved consistency when resolving type bounds and reporting ambiguous or unsupported cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->