### PR TITLE
Add the `symbol` and `unique symbol` types to soltype

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1591,6 +1591,8 @@ func printPrim(p Prim) string {
 		return "string"
 	case BoolPrim:
 		return "boolean"
+	case SymPrim:
+		return "symbol"
 	}
 	panic(fmt.Sprintf("printPrim: unhandled Prim %d", p))
 }

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -819,16 +819,18 @@ func (p *namedPrinter) printTypeMinPrec(t Type, minPrec int) string {
 //
 // An InferType renders as a name in both forms, `infer U` at the binder and a bare `U` at a
 // reference, and a TypeofType renders as the identifier it names rather than the value's type, so
-// both are leaves. A RecursiveVarType renders as its binder's name, so it is one too. A SelfType
-// renders as the bare word `Self` and carries no argument list, so it is a leaf as well: eliding
-// it would replace the spelling the source wrote with an ellipsis that says less. An alias or
+// both are leaves. A UniqueSymbolType renders as the kind and the id that tells two symbols apart,
+// `unique symbol#0`, and the id is the whole of what it carries, so it is one as well. A
+// RecursiveVarType renders as its binder's name, so it is one too. A SelfType renders as the bare
+// word `Self` and carries no argument list, so it is a leaf as well: eliding it would replace the
+// spelling the source wrote with an ellipsis that says less. An alias or
 // class reference is NOT one, even though one with no type arguments renders as a bare name: its
 // argument list is exactly what a diagnostic needs bounded.
 func isPrintLeaf(t Type) bool {
 	switch t.(type) {
 	case *TypeVarType, *PrimType, *LitType, *NeverType, *UnknownType, *ErrorType,
 		*NullType, *UndefinedType, *MappedKeyType, *InferType, *TypeofType,
-		*RecursiveVarType, *SelfType:
+		*UniqueSymbolType, *RecursiveVarType, *SelfType:
 		return true
 	}
 	return false

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -951,6 +951,11 @@ func (p *namedPrinter) printType(t Type) string {
 			elems = append(elems, "...")
 		}
 		return "{" + strings.Join(elems, ", ") + "}"
+	case *UniqueSymbolType:
+		// A symbol has no written form, so the rendered one names the kind and the id that
+		// tells two apart. A reader comparing two rendered symbols is comparing the same
+		// thing the solver does.
+		return "unique symbol#" + strconv.Itoa(t.ID)
 	case *SelfType:
 		// A `Self` renders as the word the source wrote, not as the class it was declared in.
 		// That is the whole point of keeping it a kind of its own: `me(self) -> Self` on a

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -987,6 +987,9 @@ func TestPrintElided(t *testing.T) {
 			want:     "Grow<{a: {a: …}, b: {a: …}}>",
 		},
 		{"ZeroElidesNothing", alias(nest(3)), 0, "Grow<{a: {a: {a: number}}}>"},
+		// A unique symbol at the boundary keeps its id. An ellipsis would drop the only
+		// thing that tells one symbol from another.
+		{"AUniqueSymbolAtTheBoundary", alias(&UniqueSymbolType{ID: 3}), 1, "Grow<unique symbol#3>"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/soltype/symbol_key_test.go
+++ b/internal/soltype/symbol_key_test.go
@@ -51,3 +51,11 @@ func TestPrintObjectKeyNameRendersASymbolKey(t *testing.T) {
 	require.Equal(t, "length", printObjectKeyName("length"))
 	require.Equal(t, `"a-b"`, printObjectKeyName("a-b"))
 }
+
+// A unique symbol carries an id rather than a type, so a walk has nothing under it to
+// visit and an unchanged one keeps its pointer.
+func TestAcceptUniqueSymbolIsALeaf(t *testing.T) {
+	sym := &UniqueSymbolType{ID: 3}
+	require.Same(t, Type(sym), sym.Accept(identityVisitor{}, Positive))
+	require.Equal(t, "unique symbol#3", Print(sym))
+}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -571,12 +571,13 @@ func AsMapped(elems []ObjTypeElem) (*MappedElem, bool) {
 	return nil, false
 }
 
-// UncountableKeys reports whether a key set names infinitely many keys: a `string`/`number` prim or
-// a union holding one. The caller must ground it first, since an abstract operand reads as countable.
+// UncountableKeys reports whether a key set names infinitely many keys: a `string`, `number` or
+// `symbol` prim, or a union holding one. The caller must ground it first, since an abstract
+// operand reads as countable.
 func UncountableKeys(t Type) bool {
 	switch t := t.(type) {
 	case *PrimType:
-		return t.Prim == StrPrim || t.Prim == NumPrim
+		return t.Prim == StrPrim || t.Prim == NumPrim || t.Prim == SymPrim
 	case *UnionType:
 		for _, member := range t.Types {
 			if UncountableKeys(member) {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -62,18 +62,23 @@ func (v *TypeVarType) BoundsAt(pol Polarity) []Type {
 	return v.UpperBounds
 }
 
-// Prim is the closed set of primitives M1 carries. Mirrors the type_system
-// package's Prim enum, but only the three M1's tests exercise; M2+ extends
-// Prim (BigIntPrim, SymbolPrim) and Lit (BigIntLit, NullLit, UndefinedLit)
-// to the full type_system set as the parser bridge surfaces them. The
-// additions are inert from constrain's perspective — same prim/literal arms
-// with one more concrete each — so the deferral is purely scope, not design.
+// Prim is the closed set of primitives. Mirrors the type_system package's Prim
+// enum. BigIntPrim and the literal kinds BigIntLit, NullLit and UndefinedLit are
+// still absent, and each is inert from constrain's perspective — the same prim
+// and literal arms with one more concrete — so their absence is scope rather
+// than design.
+//
+// SymPrim is the type of every symbol, the one a `unique symbol` is a subtype
+// of. A symbol carries no literal kind: two symbols with the same description
+// are still different values, so nothing about a symbol is written down the way
+// a number or a string is.
 type Prim int
 
 const (
 	NumPrim Prim = iota
 	StrPrim
 	BoolPrim
+	SymPrim
 )
 
 type PrimType struct{ Prim Prim }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -1174,6 +1174,20 @@ type SelfType struct {
 	Class *ClassType
 }
 
+// UniqueSymbolType is one particular symbol, the type a `unique symbol` annotation
+// names. `SymbolConstructor` declares `readonly iterator: unique symbol`, and the type
+// of `Symbol.iterator` is that one symbol rather than the whole `symbol` primitive.
+//
+// ID is what tells two of them apart. A symbol has no written form a reader could
+// compare, so two are the same type exactly when they came from the same declaration,
+// and the id is what carries that. It is minted per run and means nothing across runs.
+//
+// Every unique symbol is a subtype of `symbol`, and no two distinct ones are subtypes of
+// each other. That pair of rules is the whole of its place in the lattice.
+type UniqueSymbolType struct {
+	ID int
+}
+
 // TemplateLitType is the residual template literal type operator, such as
 // `on${T}`. Quasis holds the fixed string segments and Interps the interpolated
 // types between them, so Quasis has exactly one more entry than Interps. Like KeyofType
@@ -1333,6 +1347,7 @@ func (*ClassType) isType()           {}
 func (*AliasType) isType()           {}
 func (*SkolemType) isType()          {}
 func (*SelfType) isType()            {}
+func (*UniqueSymbolType) isType()    {}
 
 // LevelOf is the max level of any TypeVarType inside t; concrete leaves are 0.
 // Trimmed to the M1 type set (grows back as later milestones add formers).

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -82,15 +82,11 @@ func (t *UndefinedType) Accept(v TypeVisitor, pol Polarity) Type { return accept
 func (t *NeverType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
 func (t *ErrorType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
-
-// A unique symbol carries an id rather than a type, so there is nothing under it to walk.
-func (t *UniqueSymbolType) Accept(v TypeVisitor, pol Polarity) Type {
-	return acceptLeaf(t, v, pol)
-}
 func (t *SkolemType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
 func (t *InferType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 func (t *MappedKeyType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
 
+func (t *UniqueSymbolType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
 func (t *RecursiveVarType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
 
 func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -82,6 +82,11 @@ func (t *UndefinedType) Accept(v TypeVisitor, pol Polarity) Type { return accept
 func (t *NeverType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
 func (t *ErrorType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
+
+// A unique symbol carries an id rather than a type, so there is nothing under it to walk.
+func (t *UniqueSymbolType) Accept(v TypeVisitor, pol Polarity) Type {
+	return acceptLeaf(t, v, pol)
+}
 func (t *SkolemType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
 func (t *InferType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 func (t *MappedKeyType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1524,6 +1524,12 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 			}
 		}
 		return true
+	case *soltype.UniqueSymbolType:
+		// Two unique symbols are the same type exactly when they carry the same id, which
+		// is what says they came from one declaration. A symbol has no written form to
+		// compare instead.
+		b, ok := b.(*soltype.UniqueSymbolType)
+		return ok && a.ID == b.ID
 	case *soltype.SelfType:
 		// A `Self` equals only another `Self` over the same declaring class. It never equals
 		// that class written out, which is the distinction the kind exists to keep: a member

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1428,6 +1428,23 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 		if _, ok := super.(*soltype.UndefinedType); ok {
 			return nil
 		}
+	case *soltype.UniqueSymbolType:
+		// A unique symbol is a subtype of `symbol` the way a literal is a subtype of its
+		// primitive, and of another unique symbol only when the two carry one id. A symbol
+		// has no written form, so nothing weaker than identity could relate two of them:
+		// two declarations of `unique symbol` are two different values however they read.
+		if sup, ok := super.(*soltype.UniqueSymbolType); ok {
+			if sub.ID == sup.ID {
+				return nil
+			}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
+		}
+		if sup, ok := super.(*soltype.PrimType); ok {
+			if sup.Prim == soltype.SymPrim {
+				return nil
+			}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
+		}
 	case *soltype.NullType:
 		// `null` relates only to itself, the twin of the UndefinedType arm above. It is
 		// unrelated to `undefined` and to every data type, matching TypeScript

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -21,7 +21,13 @@ import "github.com/escalier-lang/escalier/internal/soltype"
 // append would silently survive a Discard and corrupt committed state).
 type Context struct {
 	varCounter int
-	probe      *Probe
+
+	// symbolCounter mints the id a `unique symbol` annotation carries. Each written
+	// annotation is its own symbol, so the counter advances per annotation rather than
+	// per name, and two references to one declaration share an id because they share the
+	// resolved type rather than because they re-resolve to the same number.
+	symbolCounter int
+	probe         *Probe
 
 	// arrayClass is the qualified class name the prelude's `Array` binds to, read
 	// off the prelude scope once per run. The subtyping and iteration rules that single an
@@ -250,6 +256,16 @@ func (c *Context) freshVar(level int) *soltype.TypeVarType {
 	v := &soltype.TypeVarType{ID: c.varCounter, Level: level}
 	c.varCounter++
 	return v
+}
+
+// freshSymbol mints one particular symbol, the type a written `unique symbol` names. Each
+// call answers a symbol distinct from every other, which is what the annotation means: two
+// declarations of `unique symbol` are two values, and nothing about either is written down
+// for a reader to compare instead.
+func (c *Context) freshSymbol() *soltype.UniqueSymbolType {
+	s := &soltype.UniqueSymbolType{ID: c.symbolCounter}
+	c.symbolCounter++
+	return s
 }
 
 // freshSkolem mints a distinct rigid type parameter carrying the given source name. It

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -3073,6 +3073,11 @@ func describe(t soltype.Type) string {
 		// A skolem renders under its source parameter name, so a rejected `return 5`
 		// against `fn <T>(x: T) -> T` reads `cannot constrain 5 <: T`.
 		return t.Name
+	case *soltype.UniqueSymbolType:
+		// A rejected pair of symbols reads under the same form the printer gives, so the
+		// ids that tell them apart are what a reader compares. Without this arm both sides
+		// render `?` and the message says nothing about which symbols were involved.
+		return soltype.Print(t)
 	}
 	return "?"
 }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -3094,6 +3094,8 @@ func primName(p soltype.Prim) string {
 		return "string"
 	case soltype.BoolPrim:
 		return "boolean"
+	case soltype.SymPrim:
+		return "symbol"
 	}
 	return "?"
 }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -130,10 +130,27 @@ func (c *checker) inferModuleValElse(scope *Scope, lvl int, d *ast.VarDecl) (sol
 // Walks the initializer regardless so it still surfaces its own errors, and
 // binds nothing — the caller owns scope placement.
 //
-// A `val`/`var` with no initializer needs a type annotation (TypeAnn support lands
-// in a later PR); for now it reports MissingInitializerError and returns ok=false.
+// An ambient `declare val x: T` or `declare var x: T` binds its annotation. It describes a
+// value the runtime already provides, so there is nothing to initialize and the annotation
+// is the whole of what is known. `std:prelude` writes `declare var Symbol:
+// SymbolConstructor` this way, which is how the well-known symbols become reachable as
+// values.
+//
+// Every other initializer-free form reports MissingInitializerError and binds nothing. A
+// plain `val x` names a value nothing writes, and an ambient decl with no annotation names
+// one nothing describes.
 func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (soltype.Type, bool) {
 	if d.Init == nil {
+		if d.Declare() && d.TypeAnn != nil {
+			t, resolved := c.resolveTypeAnn(scope, d.TypeAnn, lvl)
+			if !resolved {
+				// The annotation reported its own diagnostic. Recover to a fresh var so
+				// every reader of the binding constrains against something rather than
+				// cascading on the one fault.
+				t = c.freshAt(lvl)
+			}
+			return t, true
+		}
 		c.report(&MissingInitializerError{Decl: d})
 		return nil, false
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -4271,13 +4271,14 @@ func narrowUnionMembers(shape soltype.Type, keep func(soltype.Type) bool) (solty
 
 // infiniteInhabitants reports whether a carrier admits infinitely many values, so no finite
 // set of value patterns ever covers it and only a catch-all arm makes a match over it
-// exhaustive. A bare `number` or `string` and `unknown` are such carriers. `boolean`, a
-// literal, `null`, and `undefined` each admit finitely many values that finite arms can
-// enumerate, so they are not.
+// exhaustive. A bare `number`, `string` or `symbol` and `unknown` are such carriers. A
+// program mints a fresh symbol whenever it likes, so no set of `unique symbol` arms
+// enumerates them. `boolean`, a literal, `null`, and `undefined` each admit finitely many
+// values that finite arms can enumerate, so they are not.
 func infiniteInhabitants(t soltype.Type) bool {
 	switch t := t.(type) {
 	case *soltype.PrimType:
-		return t.Prim == soltype.NumPrim || t.Prim == soltype.StrPrim
+		return t.Prim == soltype.NumPrim || t.Prim == soltype.StrPrim || t.Prim == soltype.SymPrim
 	case *soltype.UnknownType:
 		return true
 	default:

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -300,17 +300,53 @@ func TestInferModuleTypeAliasBinds(t *testing.T) {
 	require.Equal(t, "number", types["Foo"])
 }
 
-// A `val` with no initializer can't be inferred in M2 (annotation-driven binding
-// needs TypeAnn support that lands later); it reports MissingInitializerError and
-// binds NOTHING, so a later reference still fails as an unknown identifier rather
-// than silently resolving to a placeholder.
+// An ambient decl describes a value the runtime already provides, so its annotation is
+// the binding's type and there is nothing to initialize.
+func TestInferModuleAmbientDeclBindsItsAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			name: "AnAmbientVal",
+			src:  `declare val x: number`,
+			want: map[string]string{"x": "number"},
+		},
+		{
+			name: "AnAmbientVar",
+			src:  `declare var x: string`,
+			want: map[string]string{"x": "string"},
+		},
+		{
+			// The binding is reachable from the rest of the module, which is the point
+			// of declaring it.
+			name: "AndTheNameResolves",
+			src: `
+				declare val x: number
+				val y = x
+			`,
+			want: map[string]string{"x": "number", "y": "number"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errorMessagesOf(errs))
+			require.Equal(t, tt.want, values)
+		})
+	}
+}
+
+// Without an annotation an ambient decl says nothing about what the value holds, so it
+// reports MissingInitializerError and binds NOTHING. A later reference then fails as an
+// unknown identifier rather than silently resolving to a placeholder.
 func TestInferModuleVarDeclWithoutInitializer(t *testing.T) {
-	src := `declare val x: number`
+	src := `declare val x`
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "1:1-1:14: Variable declaration requires an initializer: x", msgWithSpan(t, errs[0]))
-	// M2.5: the error self-blames from the decl node (whose span, per the parser,
-	// covers the binder but not the trailing annotation).
+	// M2.5: the error self-blames from the decl node, whose span covers the binder.
 	require.Equal(t, "declare val x", spanText(src, errs[0].Span()))
 	require.Empty(t, values)
 }
@@ -319,7 +355,7 @@ func TestInferModuleVarDeclWithoutInitializer(t *testing.T) {
 // genuine unknown-identifier error, not a silent resolution to a placeholder.
 func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		declare val x: number
+		declare val x
 		val y = x
 	`)
 	require.Len(t, errs, 2)

--- a/internal/solver/infer_throws_test.go
+++ b/internal/solver/infer_throws_test.go
@@ -388,10 +388,10 @@ func TestInferThrowsOnClassMembers(t *testing.T) {
 func TestInferThrowsAnnotationRecovery(t *testing.T) {
 	runThrowsErrCases(t, []throwsErrCase{
 		{
-			// `symbol` stands in for any annotation resolveTypeAnn does not support.
+			// `bigint` stands in for any annotation resolveTypeAnn does not support.
 			name:     "UnsupportedAnnotationDoesNotCascade",
-			src:      `val f: fn() -> number throws symbol = fn () -> never throws _ { throw "x" }`,
-			wantErrs: []string{"1:30-1:36: Unsupported: SymbolTypeAnn"},
+			src:      `val f: fn() -> number throws bigint = fn () -> never throws _ { throw "x" }`,
+			wantErrs: []string{"1:30-1:36: Unsupported: BigintTypeAnn"},
 		},
 	})
 }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -526,6 +526,10 @@ func compareSameKind(a, b soltype.Type) int {
 		// Two `Self`s order by the class each was declared in, which is the only type they
 		// carry. A `Self` and a bare class never reach here: typeKindOrder separates them.
 		return compareType(a.Class, b.(*soltype.SelfType).Class)
+	case *soltype.UniqueSymbolType:
+		// Two unique symbols order by the id that tells them apart, the only thing either
+		// carries.
+		return a.ID - b.(*soltype.UniqueSymbolType).ID
 	case *soltype.ClassType:
 		// Two class instances order by every field their equality reads: the qualified
 		// name, the exactness flag, then the lifetime and type arguments positionally.
@@ -879,10 +883,12 @@ func typeKindOrder(t soltype.Type) int {
 		return 17
 	case *soltype.AliasType:
 		return 18
+	case *soltype.UniqueSymbolType:
+		return 19
 	}
 	// Every residual shares the last rank. compareSameKind asserts b to a's own type,
 	// so a kind reaching that function needs a rank of its own here: two kinds sharing
 	// one rank and both carrying a branch there would assert across them. The residuals
 	// are safe because none of them has a branch.
-	return 19
+	return 20
 }

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -889,6 +889,10 @@ func (c *Context) valueFamilyOf(t soltype.Type) valueFamily {
 		return primFamily(t.Prim)
 	case *soltype.LitType:
 		return litFamily(t.Lit)
+	case *soltype.UniqueSymbolType:
+		// A unique symbol is a symbol, so it draws from the same family the primitive does
+		// and is disjoint from every other primitive for the same reason.
+		return symbolFamily
 	case *soltype.NullType:
 		return nullFamily
 	case *soltype.UndefinedType:

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -860,8 +860,8 @@ func (f *knotFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ent
 func (f *knotFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
 
 // valueFamily is a set of runtime values no value outside it belongs to, so two atoms drawn
-// from different families are disjoint and their meet is `never`. Five families cover the
-// primitives and the two absence markers, and a sixth, refCellFamily, covers the borrows no
+// from different families are disjoint and their meet is `never`. Six families cover the
+// primitives and the two absence markers, and a seventh, refCellFamily, covers the borrows no
 // primitive can be.
 //
 // Objects, tuples, functions, and class instances are deliberately absent. They are disjoint
@@ -877,6 +877,7 @@ const (
 	booleanFamily
 	nullFamily
 	undefinedFamily
+	symbolFamily
 	refCellFamily
 )
 
@@ -932,6 +933,8 @@ func primFamily(p soltype.Prim) valueFamily {
 		return stringFamily
 	case soltype.BoolPrim:
 		return booleanFamily
+	case soltype.SymPrim:
+		return symbolFamily
 	}
 	return notValueAtom
 }

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -120,20 +120,21 @@ func (c *checker) preludeScope() *Scope {
 	return c.prelude
 }
 
-// preludeVarIDBase is the first variable id the prelude package's own inference
-// draws. It sits above any id a program reaches, so the two never collide and
-// the counter can be handed back to the program untouched. See
-// bindPreludeExports.
-const preludeVarIDBase = 1 << 20
+// preludeIDBase is the first id the prelude package's own inference draws, for both
+// the type-variable counter and the unique-symbol counter. It sits above any id a
+// program reaches, so the two never collide and each counter can be handed back to
+// the program untouched. See bindPreludeExports.
+const preludeIDBase = 1 << 20
 
 // bindPreludeExports loads the prelude package and copies what it exports into
 // scope.
 //
-// The package draws its variables from preludeVarIDBase and the program's
-// counter is put back afterwards, so a program's first variable is `t0` whether
-// or not a prelude loaded. Numbering a program's diagnostics from where the
-// standard library left off would put it in messages about code that never
-// mentions it.
+// The package draws its variables and its unique symbols from preludeIDBase and
+// the program's counters are put back afterwards, so a program's first variable is
+// `t0` and its first minted symbol is `unique symbol#0` whether or not a prelude
+// loaded. Numbering a program's diagnostics from where the standard library left off
+// would put it in messages about code that never mentions it. `SymbolConstructor`
+// alone declares seventeen unique symbols.
 //
 // A source that answers nothing for the URI binds nothing and reports nothing
 // here. The report belongs to resolvePreludeClasses, which names the classes it
@@ -145,10 +146,10 @@ const preludeVarIDBase = 1 << 20
 // while this layer is still empty. See the `std:prelude` entry in
 // internal/dts_to_esc/partition.go.
 func (c *checker) bindPreludeExports(scope *Scope) {
-	programVars := c.ctx.varCounter
-	c.ctx.varCounter = preludeVarIDBase
+	programVars, programSymbols := c.ctx.varCounter, c.ctx.symbolCounter
+	c.ctx.varCounter, c.ctx.symbolCounter = preludeIDBase, preludeIDBase
 	ns, errs := c.loadPackage(preludeURI, ast.Span{})
-	c.ctx.varCounter = programVars
+	c.ctx.varCounter, c.ctx.symbolCounter = programVars, programSymbols
 	if ns == nil {
 		return
 	}

--- a/internal/solver/prelude_test.go
+++ b/internal/solver/prelude_test.go
@@ -160,12 +160,14 @@ func TestPreludeSymbolsDoNotAdvanceTheProgramsNumbering(t *testing.T) {
 		files map[string]string
 	}{
 		{
+			// The shape the committed tree writes, so the fixture cannot drift from it.
 			name: "APreludeDeclaringSymbolsOfItsOwn",
 			files: map[string]string{"std/prelude.esc": `
-				export declare class SymbolConstructor {
+				export declare interface SymbolConstructor {
 					readonly iterator: unique symbol,
 					readonly asyncIterator: unique symbol,
 				}
+				export declare var Symbol: SymbolConstructor
 			`},
 		},
 		{

--- a/internal/solver/prelude_test.go
+++ b/internal/solver/prelude_test.go
@@ -143,3 +143,42 @@ func TestPreludeStdlibNamesAreTypesNotValues(t *testing.T) {
 	_, ok := s.GetValue("Promise")
 	require.False(t, ok)
 }
+
+// A program numbers its own unique symbols from zero however many the prelude declares,
+// the same way it numbers its type variables from `t0`. `SymbolConstructor` alone declares
+// seventeen, and a diagnostic about code that never names one should not start at
+// `unique symbol#17`.
+func TestPreludeSymbolsDoNotAdvanceTheProgramsNumbering(t *testing.T) {
+	const src = `
+		declare class C { readonly a: unique symbol, readonly b: unique symbol }
+		declare fn takeA(s: C["a"]) -> number
+		declare val c: C
+		val n = takeA(c.b)
+	`
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "APreludeDeclaringSymbolsOfItsOwn",
+			files: map[string]string{"std/prelude.esc": `
+				export declare class SymbolConstructor {
+					readonly iterator: unique symbol,
+					readonly asyncIterator: unique symbol,
+				}
+			`},
+		},
+		{
+			name:  "APreludeDeclaringNone",
+			files: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := inferAgainstStdlib(t, src, tt.files)
+			require.Equal(t,
+				[]string{"cannot constrain unique symbol#1 <: unique symbol#0"},
+				errorMessagesOf(res.Errors))
+		})
+	}
+}

--- a/internal/solver/symbol_prim_test.go
+++ b/internal/solver/symbol_prim_test.go
@@ -1,0 +1,75 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// `symbol` is the type of every symbol. It resolves, renders under its own name, and is
+// disjoint from every other primitive, so a value of one is not a value of the other.
+func TestSymbolPrimitive(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "ItResolvesAndRenders",
+			src:  `declare fn f(s: symbol) -> symbol`,
+			want: "fn (s: symbol) -> symbol",
+		},
+		{
+			name: "ItJoinsIntoAUnion",
+			src:  `type T = symbol | string`,
+			want: "string | symbol",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, types, errs := inferSource(t, tt.src)
+			require.Empty(t, errorMessagesOf(errs))
+			got, isValue := values["f"]
+			if !isValue {
+				got = types["T"]
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// A value of another type does not satisfy `symbol`. The report names it under the
+// surface spelling rather than a placeholder.
+func TestSymbolPrimitiveRejectsAnotherValue(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		declare fn take(s: symbol) -> number
+		val n = take("x")
+	`)
+	require.Equal(t, []string{`cannot constrain "x" <: symbol`}, errorMessagesOf(errs))
+}
+
+// A symbol draws its values from a family of its own, so an atom from another family is
+// disjoint from it and their meet is `never`. Without the arm a symbol would read as
+// notValueAtom, which decides nothing and would leave `symbol & string` inhabited.
+func TestSymbolIsItsOwnValueFamily(t *testing.T) {
+	c := &Context{}
+	symbol := &soltype.PrimType{Prim: soltype.SymPrim}
+
+	require.Equal(t, symbolFamily, c.valueFamilyOf(symbol))
+	for _, other := range []soltype.Type{
+		&soltype.PrimType{Prim: soltype.StrPrim},
+		&soltype.PrimType{Prim: soltype.NumPrim},
+		&soltype.PrimType{Prim: soltype.BoolPrim},
+		&soltype.NullType{},
+		&soltype.UndefinedType{},
+	} {
+		t.Run(soltype.Print(other), func(t *testing.T) {
+			require.NotEqual(t, symbolFamily, c.valueFamilyOf(other))
+
+			met, fused := c.meetValueAtoms(symbol, other)
+			require.True(t, fused, "two atoms from different families fuse")
+			require.Equal(t, "never", soltype.Print(met))
+		})
+	}
+}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -21,6 +21,8 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.annPrim(ta, soltype.StrPrim), true
 	case *ast.BooleanTypeAnn:
 		return c.annPrim(ta, soltype.BoolPrim), true
+	case *ast.SymbolTypeAnn:
+		return c.annPrim(ta, soltype.SymPrim), true
 	case *ast.NeverTypeAnn:
 		// `never` is the bottom of the lattice, the empty type. A mapped type's key-remapping
 		// expression names it to drop a field, `{[if K : "id" { never } else { K }]: … }`, which is

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -23,6 +23,13 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.annPrim(ta, soltype.BoolPrim), true
 	case *ast.SymbolTypeAnn:
 		return c.annPrim(ta, soltype.SymPrim), true
+	case *ast.UniqueSymbolTypeAnn:
+		// Each written `unique symbol` names its own symbol, so the annotation mints one
+		// rather than resolving to a shared type. Two references to the declaration that
+		// carries it share the symbol because they share the resolved type.
+		t := c.ctx.freshSymbol()
+		c.recordProv(t, ta, AnnotationType)
+		return t, true
 	case *ast.NeverTypeAnn:
 		// `never` is the bottom of the lattice, the empty type. A mapped type's key-remapping
 		// expression names it to drop a field, `{[if K : "id" { never } else { K }]: … }`, which is

--- a/internal/solver/unique_symbol_test.go
+++ b/internal/solver/unique_symbol_test.go
@@ -78,3 +78,21 @@ func TestUniqueSymbolIsALeafKeyedOnItsID(t *testing.T) {
 	// Its rank is its own, so the tie-breaker never asserts another kind to it.
 	require.NotEqual(t, typeKindOrder(first), typeKindOrder(&soltype.PrimType{Prim: soltype.SymPrim}))
 }
+
+// `std:prelude` reaches the well-known symbols through `declare var Symbol:
+// SymbolConstructor`, so a member off that binding is the particular symbol the
+// constructor declares rather than the whole `symbol` primitive.
+func TestAWellKnownSymbolReachesItsOwnType(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		declare class SymbolConstructor {
+			readonly iterator: unique symbol,
+			readonly asyncIterator: unique symbol,
+		}
+		declare var Symbol: SymbolConstructor
+		val it = Symbol.iterator
+		val asyncIt = Symbol.asyncIterator
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "unique symbol#0", values["it"])
+	require.Equal(t, "unique symbol#1", values["asyncIt"])
+}

--- a/internal/solver/unique_symbol_test.go
+++ b/internal/solver/unique_symbol_test.go
@@ -96,3 +96,44 @@ func TestAWellKnownSymbolReachesItsOwnType(t *testing.T) {
 	require.Equal(t, "unique symbol#0", values["it"])
 	require.Equal(t, "unique symbol#1", values["asyncIt"])
 }
+
+// A unique symbol names one particular symbol the way a literal names one particular
+// value, so the two follow the same rules for a mutable binding and for match coverage.
+func TestUniqueSymbolBehavesLikeALiteralOfItsPrimitive(t *testing.T) {
+	const decl = `
+		declare class C {
+			readonly a: unique symbol,
+			readonly b: unique symbol,
+		}
+		declare val c: C
+	`
+
+	// A `var` holding one widens to `symbol` so it can later hold another, the way
+	// `var n = 5` widens to `number`.
+	t.Run("AVarHoldingOneWidensToSymbol", func(t *testing.T) {
+		values, _, errs := inferSource(t, decl+`
+			fn f() {
+				var s = c.a
+				s = c.b
+				return s
+			}
+		`)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "fn () -> symbol", values["f"])
+	})
+
+	// A program mints a fresh symbol whenever it likes, so no set of `unique symbol` arms
+	// enumerates `symbol` and a match over it needs a catch-all.
+	t.Run("AMatchOverSymbolNeedsACatchAll", func(t *testing.T) {
+		_, _, errs := inferSource(t, decl+`
+			fn f(s: symbol) {
+				return match s {
+					x: C["a"] => 1
+				}
+			}
+		`)
+		require.Equal(t,
+			[]string{"match is not exhaustive; `symbol` admits values no pattern names, so add a catch-all branch"},
+			errorMessagesOf(errs))
+	})
+}

--- a/internal/solver/unique_symbol_test.go
+++ b/internal/solver/unique_symbol_test.go
@@ -1,0 +1,80 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// Each written `unique symbol` names one particular symbol. Two of them are the same type
+// only when they came from the same declaration, and every one is a subtype of `symbol`.
+func TestUniqueSymbol(t *testing.T) {
+	const decl = `
+		declare class C {
+			readonly a: unique symbol,
+			readonly b: unique symbol,
+		}
+	`
+	t.Run("EveryOneIsASymbol", func(t *testing.T) {
+		values, _, errs := inferSource(t, decl+`
+			declare fn take(s: symbol) -> number
+			fn use(c: C) { return take(c.a) }
+		`)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "fn (c: C) -> number", values["use"])
+	})
+
+	t.Run("OneReachesItself", func(t *testing.T) {
+		values, _, errs := inferSource(t, decl+`
+			declare fn takeA(s: C["a"]) -> number
+			fn use(c: C) { return takeA(c.a) }
+		`)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "fn (c: C) -> number", values["use"])
+	})
+
+	// Two declarations are two values however they read, so nothing weaker than identity
+	// relates them. The report names each under the id that tells them apart.
+	t.Run("TwoDistinctOnesAreUnrelated", func(t *testing.T) {
+		_, _, errs := inferSource(t, decl+`
+			declare fn takeA(s: C["a"]) -> number
+			fn use(c: C) { return takeA(c.b) }
+		`)
+		require.Equal(t,
+			[]string{"cannot constrain unique symbol#1 <: unique symbol#0"},
+			errorMessagesOf(errs))
+	})
+
+	// `symbol` is the whole primitive and a unique symbol is one of its values, so the
+	// subtyping runs one way only.
+	t.Run("ASymbolIsNotAParticularOne", func(t *testing.T) {
+		_, _, errs := inferSource(t, decl+`
+			declare fn takeA(s: C["a"]) -> number
+			fn use(s: symbol) { return takeA(s) }
+		`)
+		require.Equal(t,
+			[]string{"cannot constrain symbol <: unique symbol#0"},
+			errorMessagesOf(errs))
+	})
+}
+
+// The kind carries an id rather than a type, and the pieces that key on a type read that
+// id: equality holds on a match and ordering separates a mismatch. Its leaf visit lives in
+// the soltype package, where the identity visitor does.
+func TestUniqueSymbolIsALeafKeyedOnItsID(t *testing.T) {
+	first := &soltype.UniqueSymbolType{ID: 0}
+	same := &soltype.UniqueSymbolType{ID: 0}
+	other := &soltype.UniqueSymbolType{ID: 1}
+
+	require.True(t, equalType(first, same))
+	require.False(t, equalType(first, other))
+	require.Zero(t, compareType(first, same))
+
+	ab, ba := compareType(first, other), compareType(other, first)
+	require.NotZero(t, ab)
+	require.Equal(t, -ab, ba)
+
+	// Its rank is its own, so the tie-breaker never asserts another kind to it.
+	require.NotEqual(t, typeKindOrder(first), typeKindOrder(&soltype.PrimType{Prim: soltype.SymPrim}))
+}

--- a/internal/solver/widen.go
+++ b/internal/solver/widen.go
@@ -2,12 +2,12 @@ package solver
 
 import "github.com/escalier-lang/escalier/internal/soltype"
 
-// widen lowers literal types to their primitives, recursively through the
-// structural carriers, so a mutable cell can later hold a different value of the
-// same primitive. A number literal `5` widens to `number`, `"x"` to `string`,
-// `true` to `boolean`; an ObjectType/TupleType widens each property value /
-// element in place, preserving Inexact; a RefType is peeled, its inner widened,
-// and re-wrapped via NewRef. Every other type passes through unchanged.
+// widen lowers a type naming one particular value to its primitive, recursively
+// through the structural carriers, so a mutable cell can later hold a different value
+// of the same primitive. A number literal `5` widens to `number`, `"x"` to `string`,
+// `true` to `boolean`, and a unique symbol to `symbol`; an ObjectType/TupleType widens
+// each property value / element in place, preserving Inexact; a RefType is peeled, its
+// inner widened, and re-wrapped via NewRef. Every other type passes through unchanged.
 //
 // It is the new-checker analogue of internal/checker's widenLiteral /
 // widenObjectLiterals / widenTupleLiterals (unify.go). M4 B3 calls it in two
@@ -23,6 +23,11 @@ import "github.com/escalier-lang/escalier/internal/soltype"
 // through a `mut` receiver is itself a mutation, so the stored value widens too.
 func widen(t soltype.Type) soltype.Type {
 	switch t := t.(type) {
+	case *soltype.UniqueSymbolType:
+		// A unique symbol names one particular symbol the way a literal names one
+		// particular value, so a mutable cell holding one widens to `symbol` and can
+		// later hold another. `var s = Symbol.iterator; s = Symbol.asyncIterator`.
+		return &soltype.PrimType{Prim: soltype.SymPrim}
 	case *soltype.LitType:
 		switch t.Lit.(type) {
 		case *soltype.NumLit:


### PR DESCRIPTION
Refs #1246

Stacked on #1565. Review only the last four commits; the base branch carries the rest.

Adds the two type kinds #1246 names, plus the ambient-declaration binding they turned out to need. This is the `soltype` half of the issue. The element-key conversion is not here — see "What is left" below.

## The `symbol` primitive

`SymPrim` joins the `Prim` enum, with arms in `printPrim`, `primName`, `primFamily` and `resolveTypeAnn`. It gets its own `symbolFamily` in the value-family lattice, so `symbol` is disjoint from `number`, `string`, `boolean`, `null`, `undefined` and a reference cell the way those are from each other.

`TestInferThrowsAnnotationRecovery` used `symbol` as a name nothing resolved. It now uses `bigint`, which is still unresolved, so the test keeps asserting what it was written to assert.

## The `unique symbol` type

`soltype.UniqueSymbolType{ID int}` carries a stable id, so two references to the same declaration are one type. It is a leaf for the identity visitor and gets arms in `equalTypeWith`, `printType`, `valueFamilyOf`, `describe` and `constrain`. Every unique symbol is a subtype of `symbol`; two are subtypes of each other only when their ids match.

It gets its own `typeKindOrder` rank alongside a `compareSameKind` branch. `compareSameKind` asserts its second operand to the first's own type, so two kinds sharing one rank and both carrying a branch panic on a union holding one of each.

`Context.freshSymbol()` mints the ids.

## Ambient declarations bind their annotation

`declare val x: T` and `declare var x: T` reported `Variable declaration requires an initializer` and bound nothing. They describe a value the runtime already provides, so there is nothing to initialize and the annotation is the whole of what is known; `inferVarDeclInit` now binds it.

This is what makes the well-known symbols reachable as values. `std:prelude` writes `declare var Symbol: SymbolConstructor`, and until now that binding was dropped, so `Symbol.iterator` resolved to nothing.

Every other initializer-free form still reports and binds nothing. A plain `val x` names a value nothing writes, and an ambient decl with no annotation names one nothing describes.

## Review fixes

Four findings from `/code-review`, all fixed in the last commit.

- The prelude's inference draws unique-symbol ids from the same base the type-variable counter uses, so a program's first minted symbol is `unique symbol#0` whether or not a prelude loaded. `SymbolConstructor` alone declares seventeen, which would otherwise have shifted every id a program reports.
- `widen` gives the kind an arm, so `var s = c.a; s = c.b` widens to `symbol` rather than pinning the binding to the first symbol.
- `infiniteInhabitants` and `soltype.UncountableKeys` each count `symbol` as admitting infinitely many values, so a match over `symbol` needs a catch-all and a `symbol` key set names infinitely many keys.

A fifth finding is real but pre-existing and not this PR's: `unique symbol` is accepted in every annotation position and mints a fresh id per occurrence, so `declare fn take(x: unique symbol)` has an uninhabitable parameter. `internal/checker/infer_type_ann.go` does the same, so this mirrors the checker rather than diverging from it. Filed separately.

## What it clears

Diagnostics from inferring the committed `internal/interop/data/std/prelude.esc`:

| | count |
| --- | --- |
| before this PR | 26 |
| after the `symbol` primitive | 22 |
| after `unique symbol` | 6 |
| after ambient declarations | 5 |

The five that remain are the ones #1246 lists as unrelated: `cannot find type intrinsic`, `cannot find type ArrayConstructor` and `cannot find type PromiseConstructor` from the constructor interfaces trio fusion retires, one unsupported object member, and one tuple constraint.

Clearing the diagnostics does not by itself let the solver's own tests read the real tree. #1567 covers that.

## What is left of #1246

The element-key conversion, which the issue calls the bulk. `PropertyElem`, `MethodElem`, `GetterElem` and `SetterElem` each carry a bare `Name string`; replacing it with a kind-plus-payload key is what retires `internal/soltype/symbol_key.go` and makes `xs[Symbol.iterator]` reachable through `resolveIndexPath`.

The issue sizes it at roughly twenty-five keying sites. Counted against the tree it is 24 element constructions outside tests, 176 inside them, 23 `ObjElemName` callers and 7 `ReadMember` callers, so it is a separate change rather than a section of this one. #1246 stays open for it.

## Testing

`go test ./...` passes. New tests cover the `symbol` primitive's family disjointness, unique-symbol identity and subtyping, the leaf's equality and ordering, ambient binding for both `val` and `var`, the prelude's id numbering, widening, and match coverage over `symbol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk

---
_Generated by [Claude Code](https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `symbol` primitive type.
  - Added distinct `unique symbol` types with identity-aware type checking.
  - Added support for `symbol` and `unique symbol` annotations.
  - Ambient declarations with type annotations now use those annotations as binding types.
  - Improved symbol rendering and diagnostic messages.

- **Bug Fixes**
  - Corrected symbol handling in type inference, widening, unions, compatibility checks, and pattern matching.
  - Preserved consistent symbol numbering when loading preludes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->