### PR TITLE
Read a member through an alias or a `typeof`

### DIFF
--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -844,7 +844,7 @@ func (c *Context) ancestorInstanceWalk(ct *soltype.ClassType, name string, walke
 // rules a direct lookup would drop; a method or getter member reaches valueProp only
 // through a class instance, since class bodies are the only source of those elements.
 func (c *checker) projectedMember(lvl int, blame ast.Node, name string, recv, carrier soltype.Type) (pathResult, bool) {
-	ct, ok := classCarrier(carrier)
+	ct, ok := c.classCarrier(carrier)
 	if !ok {
 		return pathResult{}, false
 	}
@@ -889,7 +889,7 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, recv, ca
 // MissingPropertyError already live. Only the member kinds that requirement cannot express are
 // intercepted, so this adds a path rather than diverting one.
 func (c *checker) objectMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
-	obj, ok := objectCarrier(carrier)
+	obj, ok := c.objectCarrier(carrier)
 	if !ok {
 		return pathResult{}, false
 	}
@@ -903,13 +903,55 @@ func (c *checker) objectMember(lvl int, blame ast.Node, name string, carrier sol
 	return c.memberValue(lvl, blame, member), true
 }
 
+// memberCarrier peels a receiver to the shape a member lookup dispatches on. A transparent
+// alias is expanded to the type it stands for, and a `typeof v` residual is replaced by the
+// value's type. Both repeat, since an alias may name a `typeof` and a `typeof` may resolve to
+// an alias. A type that is neither is returned unchanged.
+//
+// Each lookup below asserts a kind: objectMember wants an ObjectType, projectedMember a
+// ClassType, classValueMember a class value's object. An alias handle and a `typeof` residual
+// are neither, so without this a receiver annotated `C` declines where the same object written
+// inline resolves. The read then falls through to the structural `{name: fieldVar}`
+// requirement, which is a PropertyElem, and a method or getter under that name is reported as
+// a missing property rather than read.
+//
+// A borrow an expansion uncovers is peeled, so `type M = mut {m(self) -> number}` reads as the
+// object the way the inline `mut {m(self) -> number}` spelling does. The receiver's own borrow
+// is already off by the time a lookup calls this, and the input is returned untouched when it
+// is not a handle, so nothing else loses one.
+//
+// The walk is bounded rather than guarded by the names it has expanded. `type Id<T> = T` over
+// `Id<Id<X>>` reaches the same name twice at different arguments and has to keep going, so a
+// name-keyed guard would cut it short. maxExpandDepth is the evaluator's budget for expansion
+// along one path, and it stops a chain that never settles. Stopping returns the handle, which
+// declines the lookup rather than answering wrongly. An alias that names no type reports that
+// where it is declared, so nothing is lost by declining here.
+func (c *checker) memberCarrier(t soltype.Type) soltype.Type {
+	for range maxExpandDepth {
+		switch cur := t.(type) {
+		case *soltype.AliasType:
+			t = peelBorrows(c.ctx.expandAlias(cur))
+		case *soltype.TypeofType:
+			t = peelBorrows(cur.Ty)
+		default:
+			return t
+		}
+	}
+	return t
+}
+
 // objectCarrier reads the object type a receiver denotes: the type itself, or the single
 // object among an unresolved var's lower bounds. It mirrors classCarrier and
 // classValueCarrier, and like them it declines a var whose bounds disagree, since there is no
 // one member list to read in that case.
-func objectCarrier(t soltype.Type) (*soltype.ObjectType, bool) {
+//
+// Each candidate goes through memberCarrier first, so a receiver written as an alias or a
+// `typeof` reads as the object it stands for. The peel is inside the pick rather than around
+// the call because a receiver reaches here as a variable carrying the alias among its lower
+// bounds, not as the alias itself.
+func (c *checker) objectCarrier(t soltype.Type) (*soltype.ObjectType, bool) {
 	return soleLowerBound(t, func(x soltype.Type) (*soltype.ObjectType, bool) {
-		obj, ok := x.(*soltype.ObjectType)
+		obj, ok := c.memberCarrier(x).(*soltype.ObjectType)
 		return obj, ok
 	})
 }
@@ -987,7 +1029,7 @@ type memberLookup func(*soltype.ObjectType, string) (soltype.ObjTypeElem, bool)
 // depends on the generic-function machinery outside this milestone, so no method carries them
 // yet and memberValue passes the field through unchanged.
 func (c *checker) classBodyMember(lvl int, blame ast.Node, name string, recv, carrier soltype.Type) (pathResult, bool) {
-	obj, ok := carrier.(*soltype.ObjectType)
+	obj, ok := c.memberCarrier(carrier).(*soltype.ObjectType)
 	if !ok {
 		return pathResult{}, false
 	}
@@ -1097,9 +1139,10 @@ func soleLowerBound[T soltype.Type](t soltype.Type, pick func(soltype.Type) (T, 
 // distinct classes such as `Foo(…)` and `Bar(…)`, and a join of the same class at
 // different arguments such as `Box(1)` and `Box("s")`, whose members differ by
 // argument. Member access on such a union rides the nominal-vs-structural rule in C1.
-func classCarrier(t soltype.Type) (*soltype.ClassType, bool) {
+// Each candidate goes through memberCarrier first, for the reason objectCarrier gives.
+func (c *checker) classCarrier(t soltype.Type) (*soltype.ClassType, bool) {
 	return soleLowerBound(t, func(x soltype.Type) (*soltype.ClassType, bool) {
-		ct, ok := x.(*soltype.ClassType)
+		ct, ok := c.memberCarrier(x).(*soltype.ClassType)
 		return ct, ok
 	})
 }
@@ -1173,13 +1216,13 @@ func (c *checker) writeAccessor(name string, carrier soltype.Type) (soltype.ObjT
 // whichever it resolves as, preferring the setter half of a getter/setter pair. It returns
 // found=false for any other receiver.
 func (c *checker) writeMember(name string, carrier soltype.Type) (soltype.ObjTypeElem, bool) {
-	if ct, ok := classCarrier(carrier); ok {
+	if ct, ok := c.classCarrier(carrier); ok {
 		return c.projectedClassMember(ct, ct, name, (*soltype.ObjectType).WriteMember, set.NewSet[string]())
 	}
-	if obj, ok := carrier.(*soltype.ObjectType); ok {
+	if obj, ok := c.memberCarrier(carrier).(*soltype.ObjectType); ok {
 		return obj.WriteMember(name)
 	}
-	if obj, ok := classValueCarrier(carrier); ok {
+	if obj, ok := c.classValueCarrier(carrier); ok {
 		return obj.WriteMember(name)
 	}
 	return nil, false
@@ -1357,7 +1400,7 @@ func receiverClass(t soltype.Type) soltype.RefInner {
 // memberValue. It returns ok=false when the receiver is not a class value or carries no
 // such member, leaving both cases to the structural field-requirement path.
 func (c *checker) classValueMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
-	obj, ok := classValueCarrier(carrier)
+	obj, ok := c.classValueCarrier(carrier)
 	if !ok {
 		return pathResult{}, false
 	}
@@ -1372,9 +1415,10 @@ func (c *checker) classValueMember(lvl int, blame ast.Node, name string, carrier
 // carrying a ConstructorElem directly, or a binding var whose lower bounds carry one, the
 // same look-through classCarrier uses for an instance. A var with two different class-value
 // lower bounds is ambiguous and left to the structural path.
-func classValueCarrier(t soltype.Type) (*soltype.ObjectType, bool) {
+// Each candidate goes through memberCarrier first, for the reason objectCarrier gives.
+func (c *checker) classValueCarrier(t soltype.Type) (*soltype.ObjectType, bool) {
 	return soleLowerBound(t, func(x soltype.Type) (*soltype.ObjectType, bool) {
-		obj, ok := x.(*soltype.ObjectType)
+		obj, ok := c.memberCarrier(x).(*soltype.ObjectType)
 		if !ok {
 			return nil, false
 		}

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -903,29 +903,19 @@ func (c *checker) objectMember(lvl int, blame ast.Node, name string, carrier sol
 	return c.memberValue(lvl, blame, member), true
 }
 
-// memberCarrier peels a receiver to the shape a member lookup dispatches on. A transparent
-// alias is expanded to the type it stands for, and a `typeof v` residual is replaced by the
-// value's type. Both repeat, since an alias may name a `typeof` and a `typeof` may resolve to
-// an alias. A type that is neither is returned unchanged.
+// memberCarrier peels a receiver to the shape a member lookup dispatches on, expanding a
+// transparent alias and unwrapping a `typeof v`. Both repeat, since either may name the other.
+// A type that is neither is returned unchanged.
 //
-// Each lookup below asserts a kind: objectMember wants an ObjectType, projectedMember a
-// ClassType, classValueMember a class value's object. An alias handle and a `typeof` residual
-// are neither, so without this a receiver annotated `C` declines where the same object written
-// inline resolves. The read then falls through to the structural `{name: fieldVar}`
-// requirement, which is a PropertyElem, and a method or getter under that name is reported as
-// a missing property rather than read.
+// Every lookup below asserts a kind, and neither a handle nor a residual is one. Without this
+// a receiver annotated `C` declines where the same object written inline resolves, and the read
+// falls through to the structural `{name: fieldVar}` requirement. That requirement is a
+// PropertyElem, so a method or getter under the name is reported as missing rather than read.
 //
-// A borrow an expansion uncovers is peeled, so `type M = mut {m(self) -> number}` reads as the
-// object the way the inline `mut {m(self) -> number}` spelling does. The receiver's own borrow
-// is already off by the time a lookup calls this, and the input is returned untouched when it
-// is not a handle, so nothing else loses one.
-//
-// The walk is bounded rather than guarded by the names it has expanded. `type Id<T> = T` over
-// `Id<Id<X>>` reaches the same name twice at different arguments and has to keep going, so a
-// name-keyed guard would cut it short. maxExpandDepth is the evaluator's budget for expansion
-// along one path, and it stops a chain that never settles. Stopping returns the handle, which
-// declines the lookup rather than answering wrongly. An alias that names no type reports that
-// where it is declared, so nothing is lost by declining here.
+// A borrow an expansion uncovers is peeled, so `type M = mut {m(self) -> number}` reads the way
+// the inline spelling does. The walk is bounded rather than guarded by the names it has
+// expanded, because `type Id<T> = T` over `Id<Id<X>>` reaches one name twice at different
+// arguments and has to keep going. Running out returns the handle, which declines the lookup.
 func (c *checker) memberCarrier(t soltype.Type) soltype.Type {
 	for range maxExpandDepth {
 		switch cur := t.(type) {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1442,7 +1442,7 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// ConstructorElem carries, for the reason an overloaded method does. `Array(3)` and
 	// `Array(1, 2, 3)` select different arms, so the set is weighed per arm rather than
 	// folded into one callee <: callShape constraint.
-	if arms, ok := ctorOverloadArms(callee); ok {
+	if arms, ok := c.ctorOverloadArms(callee); ok {
 		return c.inferArmOverloadCall(scope, lvl, e, arms, consumeRef, hasConsumeRef)
 	}
 	// Instantiate a generic callee so each call binds its type parameters independently. A
@@ -1779,8 +1779,8 @@ func (c *checker) recordCallArgEffects(
 // value carrying one, and false otherwise. A class declaring a single constructor is not an
 // overload set, so it stays on the ordinary callee <: callShape path where resolveFunc reads
 // its one signature and the arity lints apply.
-func ctorOverloadArms(t soltype.Type) ([]*soltype.FuncType, bool) {
-	obj, ok := classValueCarrier(t)
+func (c *checker) ctorOverloadArms(t soltype.Type) ([]*soltype.FuncType, bool) {
+	obj, ok := c.classValueCarrier(t)
 	if !ok {
 		return nil, false
 	}
@@ -2796,20 +2796,8 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 	// resolves to that list before the read. Without this a receiver annotated `mut Config`
 	// or `mut Box` would fall to the unknown-shape branch below and lose its mutability,
 	// while the inline `mut {…}` spelling of the same type kept it.
-	//
-	// expandAlias unfolds one level, so the chain is followed to its end: `type Config =
-	// Inner` names an alias whose own body may be another. Each name is recorded so a cycle
-	// stops the walk rather than spinning it.
-	seenAliases := set.NewSet[string]()
-	for {
-		at, isAlias := carrier.(*soltype.AliasType)
-		if !isAlias || seenAliases.Contains(at.Name) {
-			break
-		}
-		seenAliases.Add(at.Name)
-		carrier = c.ctx.expandAlias(at)
-	}
-	if ct, isClass := classCarrier(carrier); isClass {
+	carrier = c.memberCarrier(carrier)
+	if ct, isClass := c.classCarrier(carrier); isClass {
 		// Projected at the instance's arguments, so a field typed `T` reads as the
 		// argument `Box<number>` supplies rather than as the declared parameter.
 		if body, ok := c.ctx.projectClassBody(ct); ok {

--- a/internal/solver/member_carrier_test.go
+++ b/internal/solver/member_carrier_test.go
@@ -1,0 +1,174 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A member lookup asserts a kind: an object for a structural member, a class for an
+// instance member, a class value for a static. A receiver written as a type alias or as
+// `typeof v` is a handle naming one of those rather than the thing itself, so the lookup
+// reads through the handle first.
+//
+// A property is unaffected either way, since the structural `{name: fieldVar}` requirement
+// the read otherwise falls to is a property requirement and constrain expands an alias
+// itself. A method, getter, or setter has no such requirement, so before the peel the read
+// fell through and reported the member as missing.
+func TestAMemberResolvesThroughAnAliasOrTypeof(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		binding string
+		want    string
+	}{
+		{
+			name: "AMethodBehindAnAlias",
+			src: `
+				type C = { plain(n: number) -> number }
+				declare val c: C
+				val r = c.plain(1)
+			`,
+			binding: "r",
+			want:    "number",
+		},
+		{
+			name: "AGetterBehindAnAlias",
+			src: `
+				type C = { get tag(self) -> string }
+				declare val c: C
+				val r = c.tag
+			`,
+			binding: "r",
+			want:    "string",
+		},
+		{
+			// The alias names a class rather than an object, so the read goes through the
+			// projected class body.
+			name: "AClassInstanceBehindAnAlias",
+			src: `
+				declare class K { m(self) -> number }
+				type A = K
+				declare val k: A
+				val r = k.m()
+			`,
+			binding: "r",
+			want:    "number",
+		},
+		{
+			name: "AMemberThroughTypeofAValue",
+			src: `
+				declare class K { m(self) -> number }
+				declare val k: K
+				declare val k2: typeof k
+				val r = k2.m()
+			`,
+			binding: "r",
+			want:    "number",
+		},
+		{
+			// A class value is an object carrying the constructor and the statics, so
+			// `typeof K` reaches a static method the same way an alias reaches an ordinary
+			// one. This is the shape `[Symbol.species]: typeof Array` needs; see #1412.
+			name: "AStaticThroughTypeofAClass",
+			src: `
+				declare class K { static plain(n: number) -> number }
+				declare val c: typeof K
+				val r = c.plain(1)
+			`,
+			binding: "r",
+			want:    "number",
+		},
+		{
+			// An index read takes the same path as a dotted one.
+			name: "AnIndexReadBehindAnAlias",
+			src: `
+				type C = { plain(n: number) -> number }
+				declare val c: C
+				val r = c["plain"]
+			`,
+			binding: "r",
+			want:    "fn (n: number) -> number",
+		},
+		{
+			// A borrow the expansion uncovers is peeled, so the alias reads the way the
+			// inline `mut {…}` spelling of the same type does.
+			name: "AMethodBehindAnAliasNamingABorrow",
+			src: `
+				type M = mut { m(self) -> number }
+				declare val v: M
+				val r = v.m()
+			`,
+			binding: "r",
+			want:    "number",
+		},
+		{
+			// One name reached twice at different arguments is not a cycle, so the walk
+			// keeps going. A guard keyed on the name alone would stop after `Id<{…}>`.
+			name: "OneAliasNameReachedTwiceAtDifferentArguments",
+			src: `
+				type Id<T> = T
+				declare val v: Id<Id<{ m(self) -> number }>>
+				val r = v.m()
+			`,
+			binding: "r",
+			want:    "number",
+		},
+		{
+			// A property already resolved through the structural path, and still does.
+			name: "APropertyBehindAnAlias",
+			src: `
+				type C = { tag: string }
+				declare val c: C
+				val r = c.tag
+			`,
+			binding: "r",
+			want:    "string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errorMessagesOf(errs))
+			require.Equal(t, tt.want, values[tt.binding])
+		})
+	}
+}
+
+// A write to a setter behind an alias reaches the setter, so the write is accepted rather
+// than blamed on a property the object does not declare.
+func TestASetterWriteResolvesThroughAnAlias(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type C = { get v(self) -> number, set v(mut self, x: number) }
+		declare val c: mut C
+		fn f() { c.v = 5 }
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+}
+
+// Reading through the handle widens what resolves; it does not make a miss resolve. A name
+// no member carries is still reported, and reported once.
+func TestAMissBehindAnAliasIsStillReported(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type C = { tag: string }
+		declare val c: C
+		val r = c.nope
+	`)
+	require.Equal(t, []string{"object is missing property: nope"}, errorMessagesOf(errs))
+}
+
+// An alias naming itself stops the walk rather than spinning it. Its budget runs out and the
+// handle comes back, which declines the lookup. The alias is rejected where it is declared, so
+// the read reports nothing of its own.
+func TestASelfReferentialAliasDoesNotSpinTheWalk(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type A = A
+		declare val a: A
+		val r = a.m
+	`)
+	require.Equal(t, []string{
+		"recursive type alias `A` reaches itself without passing under a type constructor, " +
+			"so no lap of the recursion emits any structure and the alias names no type; " +
+			"wrap the recursive reference in an object, tuple, or function type",
+	}, errorMessagesOf(errs))
+}

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -702,7 +702,7 @@ func (c *checker) narrowToClass(
 	// Project the scrutinee's own instance when it names the same class, so its concrete
 	// arguments give the field types directly; a downcast falls back to the asserted instance.
 	projected := inst
-	if sc, ok := classCarrier(scrutinee); ok && sc.Name == ct.Name {
+	if sc, ok := c.classCarrier(scrutinee); ok && sc.Name == ct.Name {
 		projected = sc
 	}
 	if body, ok := c.ctx.projectClassBody(projected); ok {
@@ -762,7 +762,7 @@ func (c *checker) narrowToExtractor(blame ast.Node, ctor *soltype.FuncType, scru
 	c.constrain(blame, ctor.Ret, scrutinee)
 	// Read the parameters at the scrutinee's concrete arguments by substituting them
 	// directly, rather than relying on the narrowing constraint above to back-propagate them.
-	if sc, ok := classCarrier(scrutinee); ok {
+	if sc, ok := c.classCarrier(scrutinee); ok {
 		if ret, isClass := ctor.Ret.(*soltype.ClassType); isClass && ret.Name == sc.Name {
 			return ctorParamsAt(ctor.Params, ret, sc)
 		}

--- a/internal/solver/super.go
+++ b/internal/solver/super.go
@@ -65,7 +65,7 @@ func (c *checker) superConstructor(lvl int, ctx *superCtx) (soltype.Type, bool) 
 	if !found || len(binding.Schemes) == 0 {
 		return nil, false
 	}
-	obj, ok := classValueCarrier(c.instantiate(binding.Schemes[0], lvl))
+	obj, ok := c.classValueCarrier(c.instantiate(binding.Schemes[0], lvl))
 	if !ok {
 		return nil, false
 	}


### PR DESCRIPTION
Fixes #1572

Stacked on #1570. Review only the last commit; the base branch carries the rest.

## The bug

Reading a method or a getter off a value failed when the value's type was written as an alias or a `typeof` query rather than inline.

```
type C = { plain(n: number) -> number }
declare val c: C
val r = c.plain(1)          // object is missing property: plain
```

The same shape written inline resolves. A property was unaffected either way.

Wider than the issue first recorded. A class instance behind an alias, a setter write, and an index read all took the same path:

| receiver | before | after |
| --- | --- | --- |
| `type C = { m(self) -> number }` | missing property | resolves |
| `type A = K` over `declare class K` | missing property | resolves |
| `typeof v` where `v: K` | missing property | resolves |
| `typeof K`, reading a static | missing property | resolves |
| `c["plain"]` behind an alias | missing property | resolves |
| a setter write behind an alias | missing property | resolves |
| a property behind an alias | resolves | resolves |

## Where it came from

Each lookup asserts a kind. `objectMember` wants an `ObjectType`, `projectedMember` a `ClassType`, `classValueMember` a class value's object. An `AliasType` handle and a `TypeofType` residual are neither, so the lookup declined and the read fell through to the structural `{name: fieldVar}` requirement in `valueProp`.

That requirement is a `PropertyElem`. `constrain` does expand an alias and unwrap a `typeof`, so the receiver was compared against the right object — but the member found under the name was a `MethodElem`, and `constrainObjMember` reported `MissingPropertyError`. A property works because that requirement is exactly its shape.

## The fix

`memberCarrier` peels a receiver to the shape a lookup dispatches on: expand a transparent alias, unwrap a `typeof`, repeat.

The three carrier resolvers apply it **inside** their pick rather than around the call. A receiver reaches them as a type variable carrying the alias among its lower bounds rather than as the alias itself, so peeling the argument alone changes nothing — `soleLowerBound`'s pick rejects the bound before any expansion runs. `objectCarrier`, `classCarrier` and `classValueCarrier` become `checker` methods to reach it, and `ctorOverloadArms` follows since it calls one.

`fieldReadBorrow` had a hand-rolled alias walk doing half of this. It now calls the shared one.

## Two things review caught

A borrow an expansion uncovers is peeled, so `type M = mut { m(self) -> number }` reads the way the inline `mut { … }` spelling does. `readCarrier` strips only the receiver's own borrow, not one revealed by expanding the handle. The input is returned untouched when it is not a handle, so nothing else loses a borrow.

The walk is bounded by `maxExpandDepth` rather than guarded by the names it has expanded. `type Id<T> = T` over `Id<Id<X>>` reaches one name twice at different arguments and has to keep going, so a name-keyed seen-set cut it off after one expansion. Stopping at the budget returns the handle, which declines the lookup rather than answering wrongly; an alias that names no type reports that where it is declared.

## Not done here

There are now three near-identical alias walks — this one, `expandAliasChain` in `infer_expr.go`, and `iteratorReference` in `infer_for_in.go`. The other two keep their name-keyed guards, so they have the `Id<Id<X>>` gap this one fixed. Consolidating them is a cleanup rather than part of this fix.

## What it unblocks

#1412 rewrites a reference to a consumed constructor interface into `typeof <Instance>`. `ArrayConstructor` is nearly all static methods — `from`, `of`, `isArray` — so `[Symbol.species]: typeof Array` would have resolved to a type whose members were unreachable without this.

`std:prelude` still reports 5 diagnostics; this PR changes none of them.

## Testing

`go test ./...` passes with no snapshot or fixture changes. New tests in `internal/solver/member_carrier_test.go` cover each row of the table above, the uncovered borrow, the repeated alias name at different arguments, a genuine miss still reporting exactly one diagnostic, and `type A = A` terminating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk

---
_Generated by [Claude Code](https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved member and constructor resolution through type aliases and `typeof` references.
  - Improved handling of methods, properties, accessors, index reads, class instances, and static members.
  - Preserved accurate diagnostics for missing members and recursive aliases.
  - Improved type narrowing and `super` constructor resolution for aliased class references.
- **Tests**
  - Added coverage for aliased and `typeof` member access, setter writes, recursive aliases, and missing-member errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->