### PR TITLE
Support a call signature on an object type

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -603,6 +603,10 @@ func freeTypeVars(t Type) []*TypeVarType {
 					for _, sig := range e.Signatures {
 						walk(sig)
 					}
+				case *CallableElem:
+					for _, sig := range e.Signatures {
+						walk(sig)
+					}
 				case *SpreadElem:
 					walk(e.Type)
 				case *MappedElem:
@@ -1240,6 +1244,15 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 		arms := make([]string, len(e.Signatures))
 		for i, sig := range e.Signatures {
 			arms[i] = "new " + p.printFuncTail(sig)
+		}
+		return strings.Join(arms, "; ")
+	case *CallableElem:
+		// A call signature renders unnamed, `fn (params) -> ret`, the way the source writes
+		// it among an object's members. An overloaded one renders its arms joined by `; `,
+		// as a constructor and a method do.
+		arms := make([]string, len(e.Signatures))
+		for i, sig := range e.Signatures {
+			arms[i] = "fn " + p.printFuncTail(sig)
 		}
 		return strings.Join(arms, "; ")
 	case *SpreadElem:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -425,6 +425,19 @@ func (e *SetterElem) ThrowsOrNever() Type {
 // exactly one signature.
 type ConstructorElem struct{ Signatures []*FuncType }
 
+// CallableElem is the call signature an object carries, the `fn (params) -> ret` an object
+// type annotation writes among its members. An object holding one is callable, so
+// `f(1)` over `declare val f: {fn (n: number) -> string, tag: string}` reads `string`.
+//
+// It is the structural twin of ConstructorElem. A constructor answers `new`, a callable
+// answers a plain call, and an object may carry either, both, or neither. `SymbolConstructor`
+// in `std:prelude` is the case that needs one on its own: the specification forbids
+// `new Symbol()`, so its call signature is the only way to make a symbol.
+//
+// An overloaded call signature holds its arms in Signatures, ordered as the source declares
+// them, the same shape MethodElem and ConstructorElem use.
+type CallableElem struct{ Signatures []*FuncType }
+
 // SpreadElem is a `...A` object spread written as an element of an ObjectType, the object twin of
 // the tuple's RestSpreadType (M9 PR5). `{...A, x: T}` is an ObjectType whose first element is a
 // SpreadElem over A. An object carrying one is a residual: constrain passes it through untouched,
@@ -437,6 +450,7 @@ func (*MethodElem) isObjTypeElem()      {}
 func (*GetterElem) isObjTypeElem()      {}
 func (*SetterElem) isObjTypeElem()      {}
 func (*ConstructorElem) isObjTypeElem() {}
+func (*CallableElem) isObjTypeElem()    {}
 func (*MappedElem) isObjTypeElem()      {}
 func (*SpreadElem) isObjTypeElem()      {}
 
@@ -481,6 +495,12 @@ func ObjElemName(e ObjTypeElem) string {
 	case *SetterElem:
 		return e.Name
 	case *ConstructorElem:
+		return ""
+	case *CallableElem:
+		// A callable is unnamed for the reason a constructor is. The two share the empty key,
+		// so a name-keyed pairing can hand one to the other; every site that acts on either
+		// asserts the kind after the pairing rather than trusting the key. objElemKindOrder in
+		// the solver gives them separate ranks so an ordering never asserts across them.
 		return ""
 	case *SpreadElem:
 		// A spread is anonymous. It only appears in an unreduced object, and the name-keyed
@@ -716,6 +736,31 @@ func (o *ObjectType) Constructor() (*ConstructorElem, bool) {
 		}
 	}
 	return nil, false
+}
+
+// Callable returns the object's call signature element, and false when it carries none. It
+// is the plain-call twin of Constructor. An object type annotation declares at most one call
+// signature element, whose Signatures hold every arm it wrote.
+func (o *ObjectType) Callable() (*CallableElem, bool) {
+	for _, e := range o.Elems {
+		if call, ok := e.(*CallableElem); ok {
+			return call, true
+		}
+	}
+	return nil, false
+}
+
+// signaturesOf returns the overload arms of the two unnamed callable member kinds, and nil
+// for every other kind. A caller that treats a constructor and a call signature alike reads
+// this rather than switching on the kind twice.
+func signaturesOf(e ObjTypeElem) []*FuncType {
+	switch e := e.(type) {
+	case *ConstructorElem:
+		return e.Signatures
+	case *CallableElem:
+		return e.Signatures
+	}
+	return nil
 }
 
 // AsProperty narrows an ObjTypeElem to its *PropertyElem. It is used at sites that
@@ -1528,9 +1573,9 @@ func levelOfElem(e ObjTypeElem) int {
 		return max(selfLevel(e.SelfParam), LevelOf(e.Type), throwsLevel(e.Throws))
 	case *SetterElem:
 		return max(selfLevel(e.SelfParam), LevelOf(e.Param), throwsLevel(e.Throws))
-	case *ConstructorElem:
+	case *ConstructorElem, *CallableElem:
 		m := 0
-		for _, sig := range e.Signatures {
+		for _, sig := range signaturesOf(e) {
 			m = max(m, LevelOf(sig))
 		}
 		return m

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -750,19 +750,6 @@ func (o *ObjectType) Callable() (*CallableElem, bool) {
 	return nil, false
 }
 
-// signaturesOf returns the overload arms of the two unnamed callable member kinds, and nil
-// for every other kind. A caller that treats a constructor and a call signature alike reads
-// this rather than switching on the kind twice.
-func signaturesOf(e ObjTypeElem) []*FuncType {
-	switch e := e.(type) {
-	case *ConstructorElem:
-		return e.Signatures
-	case *CallableElem:
-		return e.Signatures
-	}
-	return nil
-}
-
 // AsProperty narrows an ObjTypeElem to its *PropertyElem. It is used at sites that
 // handle only properties and do not yet process the method, getter, and setter
 // kinds, so any other element reaching one is a wiring bug: a member kind added
@@ -1573,9 +1560,15 @@ func levelOfElem(e ObjTypeElem) int {
 		return max(selfLevel(e.SelfParam), LevelOf(e.Type), throwsLevel(e.Throws))
 	case *SetterElem:
 		return max(selfLevel(e.SelfParam), LevelOf(e.Param), throwsLevel(e.Throws))
-	case *ConstructorElem, *CallableElem:
+	case *ConstructorElem:
 		m := 0
-		for _, sig := range signaturesOf(e) {
+		for _, sig := range e.Signatures {
+			m = max(m, LevelOf(sig))
+		}
+		return m
+	case *CallableElem:
+		m := 0
+		for _, sig := range e.Signatures {
 			m = max(m, LevelOf(sig))
 		}
 		return m

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -691,6 +691,12 @@ func AcceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 			return e
 		}
 		return &ConstructorElem{Signatures: sigs}
+	case *CallableElem:
+		sigs, changed := acceptSignatures(e.Signatures, v, pol)
+		if !changed {
+			return e
+		}
+		return &CallableElem{Signatures: sigs}
 	case *SpreadElem:
 		// The operand walks in the current polarity, the covariant visit KeyofType applies to its
 		// single operand. The spread is inert — the visit rebuilds it around a rewritten operand

--- a/internal/solver/callable_object_test.go
+++ b/internal/solver/callable_object_test.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -172,4 +173,15 @@ func TestAnObjectWithBothCallableMembersStillFuses(t *testing.T) {
 	`)
 	require.Empty(t, errorMessagesOf(errs))
 	require.Equal(t, "number", values["r"])
+}
+
+// `keyof` yields an object's own named keys. A call signature is unnamed, so it contributes
+// none, the way a constructor contributes none.
+func TestKeyofSkipsTheUnnamedCallableMembers(t *testing.T) {
+	obj := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.CallableElem{Signatures: []*soltype.FuncType{{Ret: &soltype.PrimType{Prim: soltype.StrPrim}}}},
+		&soltype.ConstructorElem{Signatures: []*soltype.FuncType{{Ret: &soltype.PrimType{Prim: soltype.NumPrim}}}},
+		&soltype.PropertyElem{Name: "tag", Type: &soltype.PrimType{Prim: soltype.StrPrim}},
+	}}
+	require.Equal(t, `"tag"`, soltype.Print(keyofObjectNamed(obj)))
 }

--- a/internal/solver/callable_object_test.go
+++ b/internal/solver/callable_object_test.go
@@ -1,0 +1,175 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// An object type annotation may write a call signature among its members, which makes the
+// object callable. It is the plain-call twin of the `new (…) -> T` construct signature: a
+// constructor answers `new`, a call signature answers a plain call, and an object may carry
+// either, both, or neither.
+func TestACallSignatureMakesAnObjectCallable(t *testing.T) {
+	const decl = `type F = { fn (n: number) -> string, tag: string }`
+
+	t.Run("ItRendersAsWritten", func(t *testing.T) {
+		_, types, errs := inferSource(t, decl)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "{fn (n: number) -> string, tag: string}", types["F"])
+	})
+
+	t.Run("TheObjectIsCalled", func(t *testing.T) {
+		values, _, errs := inferSource(t, decl+`
+			declare val f: F
+			val r = f(1)
+		`)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "string", values["r"])
+	})
+
+	// The call signature does not displace the ordinary members beside it.
+	t.Run("AMemberBesideItStillReads", func(t *testing.T) {
+		values, _, errs := inferSource(t, decl+`
+			declare val f: F
+			val r = f.tag
+		`)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "string", values["r"])
+	})
+
+	// The signature says what the object is callable with, so an argument is checked against
+	// it the way it would be against a bare function.
+	t.Run("AnArgumentIsChecked", func(t *testing.T) {
+		_, _, errs := inferSource(t, decl+`
+			declare val f: F
+			val r = f("x")
+		`)
+		require.Equal(t, []string{`cannot constrain "x" <: number`}, errorMessagesOf(errs))
+	})
+}
+
+// An object carrying a call signature is a subtype of the function type it names, so it fills
+// a parameter declared as that function.
+func TestACallableObjectFillsAFunctionParameter(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		type F = { fn (n: number) -> string }
+		declare val f: F
+		declare fn take(g: fn (n: number) -> string) -> number
+		val r = take(f)
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "number", values["r"])
+}
+
+// A plain function is not callable-with-members, so it does not fill an object target naming a
+// call signature. The rule runs one way, as it does for a construct signature.
+func TestAFunctionDoesNotFillACallSignatureRequirement(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type F = { fn (n: number) -> string }
+		declare fn take(f: F) -> number
+		declare fn g(n: number) -> string
+		val r = take(g)
+	`)
+	require.Equal(t,
+		[]string{"cannot constrain function <: object"},
+		errorMessagesOf(errs))
+}
+
+// Several `fn (…) -> T` members are the arms of one overloaded call signature, the way
+// TypeScript writes one, rather than several members the object could not hold.
+func TestSeveralCallSignaturesAreOneOverloadedMember(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		type F = { fn (n: number) -> string, fn (s: string) -> number }
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "{fn (n: number) -> string; fn (s: string) -> number}", types["F"])
+}
+
+// A constructor and a call signature are separate members. `SymbolConstructor` needs the call
+// signature alone, since the specification forbids `new Symbol()`, and `DateConstructor` needs
+// both.
+func TestAConstructorAndACallSignatureAreSeparateMembers(t *testing.T) {
+	t.Run("BothAreKept", func(t *testing.T) {
+		_, types, errs := inferSource(t, `type F = { fn (n: number) -> string, new (n: number) -> string }`)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "{fn (n: number) -> string, new (n: number) -> string}", types["F"])
+	})
+
+	// A constructor does not answer a call-signature requirement.
+	t.Run("AConstructorDoesNotFillACallSignature", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			type Call = { fn (n: number) -> string }
+			type Ctor = { new (n: number) -> string }
+			declare fn take(f: Call) -> number
+			declare val c: Ctor
+			val r = take(c)
+		`)
+		require.Equal(t,
+			[]string{"cannot constrain object <: object"},
+			errorMessagesOf(errs))
+	})
+}
+
+// An overloaded call signature resolves an arm at the call site, and it decides the call even
+// when the object carries a constructor beside it. Reading the constructor instead would check
+// the call against the wrong member.
+func TestAnOverloadedCallSignatureResolvesAnArm(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "TheNullaryArm",
+			src: `
+				declare val f: { fn () -> string, fn (a: number, b: number) -> boolean }
+				val r = f()
+			`,
+			want: "string",
+		},
+		{
+			name: "TheTwoArgumentArm",
+			src: `
+				declare val f: { fn () -> string, fn (a: number, b: number) -> boolean }
+				val r = f(1, 2)
+			`,
+			want: "boolean",
+		},
+		{
+			// A constructor sits beside the arms and answers `new`, not this call.
+			name: "WithAConstructorBesideIt",
+			src: `
+				declare val f: {
+					fn () -> string,
+					fn (a: number, b: number) -> boolean,
+					new (a: number, b: number, c: number) -> number,
+				}
+				val r = f()
+			`,
+			want: "string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errorMessagesOf(errs))
+			require.Equal(t, tt.want, values["r"])
+		})
+	}
+}
+
+// A constructor and a call signature occupy separate merge slots, so an object carrying both
+// still fuses. Keying the repeat check on the member name alone read the two as one slot,
+// since both answer the empty name.
+func TestAnObjectWithBothCallableMembersStillFuses(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		type A = { fn () -> string, new () -> number, x: number }
+		type B = { fn () -> string, new () -> number, y: number }
+		declare fn take(v: A & B) -> number
+		declare val v: A & B
+		val r = take(v)
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "number", values["r"])
+}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1739,15 +1739,10 @@ func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
 			equalTypeWith(a.ThrowsOrNever(), b.ThrowsOrNever(), ctx)
 	case *soltype.ConstructorElem:
 		b, ok := b.(*soltype.ConstructorElem)
-		if !ok || len(a.Signatures) != len(b.Signatures) {
-			return false
-		}
-		for i := range a.Signatures {
-			if !equalTypeWith(a.Signatures[i], b.Signatures[i], ctx) {
-				return false
-			}
-		}
-		return true
+		return ok && equalSignaturesWith(a.Signatures, b.Signatures, ctx)
+	case *soltype.CallableElem:
+		b, ok := b.(*soltype.CallableElem)
+		return ok && equalSignaturesWith(a.Signatures, b.Signatures, ctx)
 	case *soltype.SpreadElem:
 		b, ok := b.(*soltype.SpreadElem)
 		return ok && equalTypeWith(a.Type, b.Type, ctx)
@@ -1836,6 +1831,20 @@ func sameLifetimeSlice(a, b []soltype.Lifetime, ctx *alphaCtx) bool {
 	}
 	for i := range a {
 		if !ctx.sameLifetime(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalSignaturesWith compares two overload sets arm by arm, the equality the two unnamed
+// callable member kinds share.
+func equalSignaturesWith(a, b []*soltype.FuncType, ctx *alphaCtx) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !equalTypeWith(a[i], b[i], ctx) {
 			return false
 		}
 	}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1159,10 +1159,15 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 			}
 		} else if sup, ok := super.(*soltype.FuncType); ok {
+			// An object with a call signature is a subtype of the matching function type. That
+			// is what the signature says: the object is callable with those parameters.
+			if call, ok := sub.Callable(); ok {
+				return c.constrain(overloadReadType(call.Signatures), sup, seen, mutCtx)
+			}
 			// An object with a constructor signature is a subtype of the matching function
 			// type; codegen makes the constructor behave as a plain function where expected.
 			if ctor, ok := sub.Constructor(); ok {
-				return c.constrain(ctorReadType(ctor), sup, seen, mutCtx)
+				return c.constrain(overloadReadType(ctor.Signatures), sup, seen, mutCtx)
 			}
 		} else if sup, ok := super.(*soltype.ObjectType); ok {
 			// One ObjectType <: ObjectType rule serves both uses the M2 arm
@@ -1201,7 +1206,21 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				// cannot fill one.
 				if superCtor, ok := superElem.(*soltype.ConstructorElem); ok {
 					if subCtor, has := sub.Constructor(); has {
-						errs = append(errs, c.constrain(ctorReadType(subCtor), ctorReadType(superCtor), seen, mutCtx)...)
+						errs = append(errs, c.constrain(overloadReadType(subCtor.Signatures), overloadReadType(superCtor.Signatures), seen, mutCtx)...)
+					} else {
+						errs = append(errs, &CannotConstrainError{Sub: sub, Super: sup})
+					}
+					continue
+				}
+				// A call-signature requirement is the plain-call twin of the constructor one
+				// above, satisfied by the source's own call signature checked covariantly. The
+				// two are separate members, so a constructor does not fill it.
+				if superCall, ok := superElem.(*soltype.CallableElem); ok {
+					if subCall, has := sub.Callable(); has {
+						errs = append(errs, c.constrain(
+							overloadReadType(subCall.Signatures),
+							overloadReadType(superCall.Signatures),
+							seen, mutCtx)...)
 					} else {
 						errs = append(errs, &CannotConstrainError{Sub: sub, Super: sup})
 					}
@@ -2165,24 +2184,24 @@ func methodReadType(elem *soltype.MethodElem) soltype.Type {
 	return &soltype.IntersectionType{Types: arms}
 }
 
-// ctorReadType returns the callable value a class value's constructor stands for. A single
-// signature reads as itself, and an overloaded constructor as the intersection of its arms, so
-// a comparison against it weighs the arms together through the arrow-decomposition rule rather
-// than picking one. It is the constructor twin of methodReadType, without the receiver strip,
-// since a constructor declares no receiver in its callable signature. An element carrying no
-// signature reads as the error sentinel.
+// overloadReadType returns the callable value an unnamed overload set stands for, the arms a
+// class value's constructor or an object's call signature carries. A single signature reads as
+// itself, and an overload set as the intersection of its arms, so a comparison against it
+// weighs the arms together through the arrow-decomposition rule rather than picking one. It is
+// the twin of methodReadType, without the receiver strip, since neither member declares a
+// receiver in its callable signature. An empty set reads as the error sentinel.
 //
 // This is the lattice's reading, which is what an assignment and a `super(…)` call take. A
 // direct call picks one arm instead, through inferArmOverloadCall.
-func ctorReadType(elem *soltype.ConstructorElem) soltype.Type {
-	switch len(elem.Signatures) {
+func overloadReadType(sigs []*soltype.FuncType) soltype.Type {
+	switch len(sigs) {
 	case 0:
 		return &soltype.ErrorType{}
 	case 1:
-		return elem.Signatures[0]
+		return sigs[0]
 	}
-	arms := make([]soltype.Type, len(elem.Signatures))
-	for i, sig := range elem.Signatures {
+	arms := make([]soltype.Type, len(sigs))
+	for i, sig := range sigs {
 		arms[i] = sig
 	}
 	return &soltype.IntersectionType{Types: arms}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1844,20 +1844,40 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 	case *soltype.FuncType:
 		return t, true
 	case *soltype.ObjectType:
-		if ctor, ok := t.Constructor(); ok && len(ctor.Signatures) == 1 {
-			return ctor.Signatures[0], true
-		}
+		return soleCallableSignature(t)
 	case *soltype.TypeVarType:
 		for _, lb := range t.LowerBounds {
 			switch lb := lb.(type) {
 			case *soltype.FuncType:
 				return lb, true
 			case *soltype.ObjectType:
-				if ctor, ok := lb.Constructor(); ok && len(ctor.Signatures) == 1 {
-					return ctor.Signatures[0], true
+				if sig, ok := soleCallableSignature(lb); ok {
+					return sig, true
 				}
 			}
 		}
+	}
+	return nil, false
+}
+
+// soleCallableSignature returns the one signature an object is called through, and false when
+// it carries none or carries an overload set. A call signature answers a plain call and a
+// constructor answers `new`, so an object carrying a call signature is called through that
+// one and every other object through its constructor.
+//
+// A call signature decides the call whether or not it is overloaded. An overloaded one yields
+// nothing here, the same as an overloaded constructor, since no one arm is the callee and
+// inferCall routes such a call to inferArmOverloadCall instead. Falling back to a constructor
+// beside it would check the call against the wrong member.
+func soleCallableSignature(t *soltype.ObjectType) (*soltype.FuncType, bool) {
+	if call, ok := t.Callable(); ok {
+		if len(call.Signatures) == 1 {
+			return call.Signatures[0], true
+		}
+		return nil, false
+	}
+	if ctor, ok := t.Constructor(); ok && len(ctor.Signatures) == 1 {
+		return ctor.Signatures[0], true
 	}
 	return nil, false
 }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -684,6 +684,8 @@ func compareObjElem(a, b soltype.ObjTypeElem) int {
 		return compareType(a.ThrowsOrNever(), b.ThrowsOrNever())
 	case *soltype.ConstructorElem:
 		return compareSignatures(a.Signatures, b.(*soltype.ConstructorElem).Signatures)
+	case *soltype.CallableElem:
+		return compareSignatures(a.Signatures, b.(*soltype.CallableElem).Signatures)
 	case *soltype.SpreadElem:
 		return compareType(a.Type, b.(*soltype.SpreadElem).Type)
 	case *soltype.MappedElem:
@@ -723,12 +725,14 @@ func objElemKindOrder(e soltype.ObjTypeElem) int {
 		return 3
 	case *soltype.ConstructorElem:
 		return 4
-	case *soltype.SpreadElem:
+	case *soltype.CallableElem:
 		return 5
-	case *soltype.MappedElem:
+	case *soltype.SpreadElem:
 		return 6
+	case *soltype.MappedElem:
+		return 7
 	}
-	return 7
+	return 8
 }
 
 // compareSelfParam orders two method or accessor receivers. A missing receiver

--- a/internal/solver/normal.go
+++ b/internal/solver/normal.go
@@ -1601,24 +1601,24 @@ func mergeableElems(o *soltype.ObjectType) ([]soltype.ObjTypeElem, bool) {
 func fusableMember(e soltype.ObjTypeElem) bool {
 	switch e.(type) {
 	case *soltype.PropertyElem, *soltype.MethodElem, *soltype.GetterElem,
-		*soltype.SetterElem, *soltype.ConstructorElem:
+		*soltype.SetterElem, *soltype.ConstructorElem, *soltype.CallableElem:
 		return true
 	}
 	return false
 }
 
-// hasRepeatedName reports whether two members of one object share a name. Its
-// callers rule out spread and mapped members first, so a constructor is the only
-// member that names the empty string, and an object holds at most one. The empty
-// key therefore never collides with itself here.
+// hasRepeatedName reports whether two members of one object occupy the same merge slot. It
+// keys on mergeKeyOf rather than on the name, because a constructor and a call signature both
+// answer the empty name and an object may carry one of each. Keying on the name alone would
+// read `{fn () -> string, new () -> Foo}` as a repeat and leave it unfused.
 func hasRepeatedName(elems []soltype.ObjTypeElem) bool {
-	seen := set.NewSet[string]()
+	seen := set.NewSet[mergeKey]()
 	for _, e := range elems {
-		name := soltype.ObjElemName(e)
-		if seen.Contains(name) {
+		key := mergeKeyOf(e)
+		if seen.Contains(key) {
 			return true
 		}
-		seen.Add(name)
+		seen.Add(key)
 	}
 	return false
 }
@@ -1692,6 +1692,18 @@ func (c *Context) meetObjElem(a, b soltype.ObjTypeElem) (soltype.ObjTypeElem, bo
 			return nil, false
 		}
 		return &soltype.ConstructorElem{Signatures: sigs}, true
+	case *soltype.CallableElem:
+		b, ok := b.(*soltype.CallableElem)
+		if !ok {
+			return nil, false
+		}
+		// Two call signatures meet through the signature-set rule a constructor's do. Neither
+		// carries a receiver, so there is nothing to guard beyond the arms.
+		sigs, ok := c.fuseSignatureSets(a.Signatures, b.Signatures, meetCtorSig(c))
+		if !ok {
+			return nil, false
+		}
+		return &soltype.CallableElem{Signatures: sigs}, true
 	}
 	return nil, false
 }

--- a/internal/solver/super.go
+++ b/internal/solver/super.go
@@ -73,7 +73,7 @@ func (c *checker) superConstructor(lvl int, ctx *superCtx) (soltype.Type, bool) 
 	if !ok {
 		return nil, false
 	}
-	return ctorReadType(ctor), true
+	return overloadReadType(ctor.Signatures), true
 }
 
 // superVarID is the synthetic binding the move dataflow tracks in place of "the superclass

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -253,22 +253,27 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 		}
 	}
 	if unsupported {
-		c.reportUnsupportedFeature(ta, "object type member other than a property, spread, mapped member, `new` signature, method, or accessor")
+		c.reportUnsupportedFeature(ta, "object type member other than a property, spread, mapped member, call or `new` signature, method, or accessor")
 	}
 	t := &soltype.ObjectType{Elems: elems, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }
 
-// objAnnLowering lowers the members of one object type annotation. It carries the only state a
-// member needs from its siblings, which is whether a construct signature was already seen: an
-// object type holds at most one, so a second is reported rather than emitted.
+// objAnnLowering lowers the members of one object type annotation. It carries the state a
+// member needs from its siblings, which is what has already been seen of the two unnamed
+// callable members. An object type holds at most one construct signature, so a second is
+// reported rather than emitted. It holds at most one call signature element, so a second call
+// signature becomes a further arm of the first rather than a second element.
 type objAnnLowering struct {
 	c     *checker
 	scope *Scope
 	lvl   int
 	// sawCtor records that a `new (…) -> T` member was already lowered.
 	sawCtor bool
+	// callable is the element the first `fn (…) -> T` member produced, nil until one is
+	// lowered. A later one appends its arm here.
+	callable *soltype.CallableElem
 }
 
 // lower turns one written member into the element it contributes to the object.
@@ -346,6 +351,17 @@ func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bo
 		return &soltype.ConstructorElem{
 			Signatures: []*soltype.FuncType{l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)},
 		}, true
+	case *ast.CallableTypeAnn:
+		// An overloaded call signature is written as several `fn (…) -> T` members, the way
+		// TypeScript writes one. They are arms of one element, so the second and later ones
+		// extend the first rather than adding an element the object could not hold.
+		sig := l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)
+		if l.callable != nil {
+			l.callable.Signatures = append(l.callable.Signatures, sig)
+			return nil, true
+		}
+		l.callable = &soltype.CallableElem{Signatures: []*soltype.FuncType{sig}}
+		return l.callable, true
 	case *ast.RestSpreadTypeAnn:
 		src, ok := l.c.resolveTypeAnn(l.scope, elem.Value, l.lvl)
 		if !ok {

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -718,13 +718,14 @@ type mergeKey struct {
 // objElemKind is the part of a mergeKey that says which group of members an element belongs to.
 // mergeKeyOf switches over every ObjTypeElem variant and panics on one it does not name, so a
 // new element kind has to state whether it merges by name or stands alone rather than silently
-// sharing another kind's key. The call signature escalier-lang/escalier#992 adds is the next
-// such kind, and it stands alone.
+// sharing another kind's key. A constructor and a call signature each stand alone, and on
+// separate keys, since an object may carry both.
 type objElemKind uint8
 
 const (
 	kindNamed objElemKind = iota
 	kindConstructor
+	kindCallable
 	kindMapped
 	kindSpread
 )
@@ -735,6 +736,10 @@ func mergeKeyOf(elem soltype.ObjTypeElem) mergeKey {
 		return mergeKey{kind: kindNamed, name: soltype.ObjElemName(elem)}
 	case *soltype.ConstructorElem:
 		return mergeKey{kind: kindConstructor}
+	case *soltype.CallableElem:
+		// A call signature is unnamed like a constructor, and the two are different members,
+		// so each gets its own key rather than sharing the unnamed one.
+		return mergeKey{kind: kindCallable}
 	case *soltype.MappedElem:
 		// A mapped member and a spread each stand for a group of members the evaluator has not
 		// computed yet, so neither reaches a merge: reduceObject expands both into field groups


### PR DESCRIPTION
Fixes #992
Refs #1412

Stacked on #1573. Review only the last two commits; the base branch carries the rest.

## Why this and not #1412

I went to work #1412 and found its premise does not hold. It says a fused class cannot carry a call signature "which is why an unfused `FooConstructor` keeps its call signature and a fused `class Foo` cannot". The unfused interface does not keep it either — `internal/solver` had no representation for the member at all:

```
type F = { fn (n: number) -> string, tag: string }
```

reported `Unsupported: object type member other than a property, spread, mapped member, ...` and dropped it. So `Symbol("x")` had no typed form today whether or not `Symbol` fuses, and that dropped member is one of the diagnostics `std:prelude` reports — `SymbolConstructor`'s `fn (description?: string | number) -> symbol` at `internal/interop/data/std/prelude.esc:416`.

That representation is #992, filed a month before #1412 and scoped to exactly this. It is the thing under #1412 rather than a step beside it, so it goes first.

## What lands

`soltype.CallableElem` is the plain-call twin of `ConstructorElem`. A constructor answers `new`, a call signature answers a plain call, and an object may carry either, both, or neither.

- The element gets the arms every other kind has: visitor, printer, `LevelOf`, `compareObjElem`, `meetObjElem`, `equalObjElem`, `mergeKeyOf`.
- It gets its own `objElemKindOrder` rank and its own `mergeKey`. It shares the empty name with a constructor and the two are different members, so `hasRepeatedName` keys on `mergeKeyOf` rather than on the name — otherwise `{fn () -> string, new () -> Foo}` read as a repeated member and never fused.
- `resolveFunc` reads the call signature in preference to a constructor beside it, so `f(1)` resolves through the member a plain call names.
- `constrain` takes a callable object to the function type it names, and answers a call-signature requirement from the source's own. A bare function does not fill a callable-object target, matching the constructor rule's direction.
- Several `fn (…) -> T` members in one annotation are the arms of one overloaded element, the way TypeScript writes one. #992 left this open between "at most one" and an overload set; the overload set is the closer fit and `Signatures []*FuncType` already models it for a method and a constructor.
- `ctorReadType` becomes `overloadReadType` over a signature slice, since both unnamed callable members read the same way.

#992's two other open items settle themselves. `keyofObjectNamed` allowlists a property, a getter and a setter, so a call signature contributes no key without a change; there is a test pinning it. And its parser item describes the bare-paren TypeScript spelling `{(x: number) -> T}` — Escalier writes `fn (x: number) -> T`, which the parser already handles, and which is how the committed tree writes it.

## Review fixes

Five findings, all fixed.

- `soleCallableSignature` fell through to a constructor when the call signature was overloaded, so `f()` on an object carrying both checked the call against the constructor. A call signature now decides the call whether or not it is overloaded, and an overloaded one resolves an arm at the call site as an overloaded constructor does.
- `hasRepeatedName` keyed on the member name, so an object carrying both `new` and `fn` read as a repeat and never fused.
- Three comment lines in `constrain.go` had their double backticks mangled into smart quotes. Restored.
- `Callable` and `signaturesOf` had been inserted between `Constructor`'s doc comment and its declaration. Moved below.
- A stale comment in `typeops.go` still called the call signature the kind "#992 adds next", directly above the constant this adds.

## What it clears

Real-prelude diagnostics: 5 → 4. The four left are `cannot find type intrinsic`, a tuple constraint, and `cannot find type ArrayConstructor` / `PromiseConstructor`.

## What is left of #1412

The class half. `ast.ClassElem` needs a callable arm with parser, printer and codegen support, `classValue` needs to put a `CallableElem` on the class value, and then `detectTrios` can drop its guard and `Symbol` and `BigInt` can fuse. The consumed-constructor rewrite to `typeof <Instance>` clears the other two prelude diagnostics and is unblocked by #1573.

## Testing

`go test ./...` passes with no snapshot or fixture changes. New tests in `internal/solver/callable_object_test.go` cover rendering, calling, a member beside the signature, argument checking, flowing into a function parameter, both rejection directions, the overload set and arm resolution, an object carrying both callable members fusing, and `keyof` skipping both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk

---
_Generated by [Claude Code](https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for callable object types with named and overloaded call signatures.
  * Callable objects can now be invoked, passed where functions are expected, and combined with constructor signatures.
  * Improved overload resolution, argument checking, member access, and type compatibility for callable objects.
* **Bug Fixes**
  * Preserved callable and constructor signatures correctly during object merging, inheritance, and type inference.
  * Excluded unnamed callable members from `keyof` results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->