### PR TITLE
Respell a consumed constructor interface as `typeof &lt;Instance&gt;`

### DIFF
--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -14,6 +14,7 @@ package dts_to_esc
 import (
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
@@ -75,6 +76,19 @@ type StandaloneModule struct {
 //   - Records every singleton member it skipped because the member's
 //     key has no plain-name form (see StandaloneModule.KeyDrops).
 func ConvertToStandaloneModule(dtsModule *dts_parser.Module, facts *ReceiverFacts) (*StandaloneModule, error) {
+	return convertStandaloneModule(dtsModule, facts, nil)
+}
+
+// convertStandaloneModule is ConvertToStandaloneModule with the constructor interfaces fused
+// elsewhere in the tree. A bucket may reference one another bucket consumed, so the respelling
+// reads every name the tree fused rather than only this bucket's, the same way
+// rewriteReadonlyTwinRefs reads every twin. treeConsumedCtor is nil on the single-file path,
+// where this bucket is the whole tree.
+func convertStandaloneModule(
+	dtsModule *dts_parser.Module,
+	facts *ReceiverFacts,
+	treeConsumedCtor map[string]string,
+) (*StandaloneModule, error) {
 	cctx := &convertCtx{facts: facts}
 	stmts := liftGlobals(dtsModule.Statements)
 	trios := detectTrios(stmts)
@@ -98,11 +112,32 @@ func ConvertToStandaloneModule(dtsModule *dts_parser.Module, facts *ReceiverFact
 
 	var namespaces btree.Map[string, *ast.Namespace]
 	namespaces.Set("", &ast.Namespace{Decls: decls})
-	return &StandaloneModule{
+	mod := &StandaloneModule{
 		Module:   ast.NewModule(namespaces),
 		Paths:    paths,
 		KeyDrops: cctx.keyDrops,
-	}, nil
+	}
+	rewriteConsumedCtorRefs(mod, mergedConsumedCtor(trios.consumedCtor, treeConsumedCtor))
+	return mod, nil
+}
+
+// mergedConsumedCtor unions this bucket's consumed constructor interfaces with the tree's. The
+// two agree wherever they overlap, since both come from detectTrios over the same statements.
+func mergedConsumedCtor(own, tree map[string]string) map[string]string {
+	if len(tree) == 0 {
+		return own
+	}
+	merged := make(map[string]string, len(own)+len(tree))
+	maps.Copy(merged, tree)
+	maps.Copy(merged, own)
+	return merged
+}
+
+// ConsumedCtorNames returns the constructor interfaces trio fusion consumes in one bucket,
+// mapped to the instance each fuses into. ConvertBuckets unions these across the tree before
+// converting any bucket, so a reference reaching across a package boundary is respelled too.
+func ConsumedCtorNames(stmts []dts_parser.Statement) map[string]string {
+	return detectTrios(liftGlobals(stmts)).consumedCtor
 }
 
 // docDecl pairs a converted top-level declaration with the dotted runtime
@@ -185,12 +220,15 @@ type trioInfo struct {
 }
 
 // trioTable indexes trios by the instance type name. The constructor name
-// and var name are recorded in `consumedCtor` / `consumedVar` (keyed by
-// the same instance name) so the walk can skip them.
+// and var name are recorded in `consumedCtor` / `consumedVar` so the walk
+// can skip them. consumedVar is keyed by the instance name, which is the
+// var's own name. consumedCtor is keyed by the CONSUMED name and maps to
+// the instance it fused into, so rewriteConsumedCtorRefs can respell a
+// reference to the constructor interface as `typeof <Instance>`.
 type trioTable struct {
 	byName       map[string]*trioInfo
-	consumedCtor set.Set[string] // ctor interface names
-	consumedVar  set.Set[string] // var binding names
+	consumedCtor map[string]string // ctor interface name -> instance name
+	consumedVar  set.Set[string]   // var binding names
 }
 
 // detectTrios scans a module's top-level statements for the
@@ -243,7 +281,7 @@ type trioTable struct {
 func detectTrios(stmts []dts_parser.Statement) *trioTable {
 	t := &trioTable{
 		byName:       make(map[string]*trioInfo),
-		consumedCtor: set.NewSet[string](),
+		consumedCtor: make(map[string]string),
 		consumedVar:  set.NewSet[string](),
 	}
 
@@ -301,7 +339,7 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 			binding:     v,
 		}
 		if ctorName != "" {
-			t.consumedCtor.Add(ctorName)
+			t.consumedCtor[ctorName] = name
 		}
 		t.consumedVar.Add(name)
 	}
@@ -480,7 +518,7 @@ func detectSingletons(stmts []dts_parser.Statement, trios *trioTable) *singleton
 	constructible := namesWithConstructSignature(stmts)
 
 	for name, iface := range interfaces {
-		if trios.byName[name] != nil || trios.consumedCtor.Contains(name) || trios.consumedVar.Contains(name) {
+		if _, ctorConsumed := trios.consumedCtor[name]; trios.byName[name] != nil || ctorConsumed || trios.consumedVar.Contains(name) {
 			continue
 		}
 		if constructible.Contains(name) {
@@ -971,7 +1009,7 @@ func convertStandaloneStmt(
 		return out, nil
 
 	case *dts_parser.InterfaceDecl:
-		if trios.consumedCtor.Contains(s.Name.Name) {
+		if _, consumed := trios.consumedCtor[s.Name.Name]; consumed {
 			return nil, nil
 		}
 		if info, ok := trios.byName[s.Name.Name]; ok {

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -1466,3 +1466,92 @@ declare var CSSFontFaceRule: {
 	require.Empty(t, parseErrs, "printed output parses")
 	require.Len(t, parsedDecls, 1)
 }
+
+// Trio fusion folds `interface FooConstructor` into `class Foo`, so the constructor
+// interface's name no longer denotes anything. A reference to it is respelled `typeof Foo`,
+// which names what the interface named: the class value, carrying the constructor and the
+// statics. Without the respelling the emitted tree carries a dangling name, which is where
+// `cannot find type ArrayConstructor` came from.
+func TestStandalone_AConsumedConstructorReferenceBecomesTypeof(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			// The shape the committed tree writes, `[Symbol.species]` on the instance side
+			// naming the constructor interface.
+			name: "AStaticMemberNamingTheConstructorInterface",
+			input: `
+interface Box<T> {
+    readonly [Symbol.species]: BoxConstructor;
+}
+interface BoxConstructor {
+    new <T>(value: T): Box<T>;
+}
+declare var Box: BoxConstructor;
+`,
+			want: "typeof Box",
+		},
+		{
+			name: "AParameterNamingIt",
+			input: `
+interface Box<T> {
+    value: T;
+}
+interface BoxConstructor {
+    new <T>(value: T): Box<T>;
+    make(ctor: BoxConstructor): number;
+}
+declare var Box: BoxConstructor;
+`,
+			want: "typeof Box",
+		},
+		{
+			// `typeof X` takes no arguments, so a reference carrying some is left alone
+			// rather than respelled into something that says less. Nothing in the pinned
+			// lib set writes one.
+			name: "AReferenceCarryingTypeArgumentsIsLeftAlone",
+			input: `
+interface Box<T> {
+    value: T;
+}
+interface BoxConstructor<T> {
+    new (value: T): Box<T>;
+    self: BoxConstructor<number>;
+}
+declare var Box: BoxConstructor;
+`,
+			want: "BoxConstructor<number>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, printed := convertSlice(t, tt.input)
+			require.Contains(t, printed, tt.want)
+
+			parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+				&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+			require.Empty(t, parseErrs, "printed output parses")
+			require.NotEmpty(t, parsedDecls)
+		})
+	}
+}
+
+// An unfused constructor interface keeps its name, so a reference to it is left alone.
+// `SymbolConstructor` is the case that matters: it declares no `new`, so detectTrios declines
+// it and the interface stays.
+func TestStandalone_AnUnfusedConstructorReferenceIsUntouched(t *testing.T) {
+	_, printed := convertSlice(t, `
+interface Box<T> {
+    value: T;
+}
+interface BoxConstructor {
+    <T>(value: T): Box<T>;
+    readonly self: BoxConstructor;
+}
+declare var Box: BoxConstructor;
+`)
+	require.Contains(t, printed, "BoxConstructor")
+	require.NotContains(t, printed, "typeof Box")
+}

--- a/internal/dts_to_esc/partition_writer.go
+++ b/internal/dts_to_esc/partition_writer.go
@@ -3,6 +3,7 @@ package dts_to_esc
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -446,7 +447,7 @@ func mergeDecls(stmts []dts_parser.Statement) []dts_parser.Statement {
 // `ReadonlyArray<T>` for the same reason.
 func ConvertBucket(stmts []dts_parser.Statement, facts *ReceiverFacts) (*StandaloneModule, error) {
 	stmts, twins := fuseReadonlyTwins(stmts)
-	return convertFusedBucket(stmts, twins, twins, facts)
+	return convertFusedBucket(stmts, twins, twins, ConsumedCtorNames(stmts), facts)
 }
 
 // convertFusedBucket converts one already-fused bucket. `own` are the
@@ -461,9 +462,10 @@ func ConvertBucket(stmts []dts_parser.Statement, facts *ReceiverFacts) (*Standal
 func convertFusedBucket(
 	stmts []dts_parser.Statement,
 	own, all []readonlyTwin,
+	consumedCtor map[string]string,
 	facts *ReceiverFacts,
 ) (*StandaloneModule, error) {
-	mod, err := ConvertToStandaloneModule(&dts_parser.Module{Statements: stmts}, facts)
+	mod, err := convertStandaloneModule(&dts_parser.Module{Statements: stmts}, facts, consumedCtor)
 	if err != nil {
 		return nil, err
 	}
@@ -829,16 +831,20 @@ func ConvertBuckets(result *PartitionResult, facts *ReceiverFacts) (map[string]*
 	fused := make(map[string][]dts_parser.Statement, len(result.Buckets))
 	own := make(map[string][]readonlyTwin, len(result.Buckets))
 	var all []readonlyTwin
+	// consumedCtor is every constructor interface the tree fuses away, for the same reason
+	// `all` holds every twin: a bucket may reference one another bucket consumed.
+	consumedCtor := make(map[string]string)
 	for _, uri := range uris {
 		stmts, twins := fuseReadonlyTwins(result.Buckets[uri])
 		fused[uri] = stmts
 		own[uri] = twins
 		all = append(all, twins...)
+		maps.Copy(consumedCtor, ConsumedCtorNames(stmts))
 	}
 
 	mods := make(map[string]*StandaloneModule, len(result.Buckets))
 	for _, uri := range uris {
-		mod, err := convertFusedBucket(fused[uri], own[uri], all, facts)
+		mod, err := convertFusedBucket(fused[uri], own[uri], all, consumedCtor, facts)
 		if err != nil {
 			return nil, &BucketConvertError{pkgError{uri}, err}
 		}

--- a/internal/dts_to_esc/ref_rewrite.go
+++ b/internal/dts_to_esc/ref_rewrite.go
@@ -39,7 +39,7 @@ func rewriteReadonlyTwinRefs(mod *StandaloneModule, twins []readonlyTwin) {
 		readonlyToMutable[t.readonlyName] = t.mutableName
 		mutableSet.Add(t.mutableName)
 	}
-	rw := &twinRewriter{readonlyToMutable: readonlyToMutable, mutable: mutableSet}
+	rw := &refRewriter{readonlyToMutable: readonlyToMutable, mutable: mutableSet}
 	mod.Module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
 		for _, decl := range ns.Decls {
 			rw.rewriteDecl(decl)
@@ -48,15 +48,46 @@ func rewriteReadonlyTwinRefs(mod *StandaloneModule, twins []readonlyTwin) {
 	})
 }
 
-type twinRewriter struct {
+// rewriteConsumedCtorRefs respells every reference to a constructor interface trio fusion
+// consumed. `interface ArrayConstructor` is folded into `class Array`, so the name no longer
+// denotes anything and `static readonly [Symbol.species]: ArrayConstructor` would not resolve.
+// `typeof Array` names the same thing the interface did, the class value carrying the
+// constructor and the statics.
+//
+// It walks the same slots rewriteReadonlyTwinRefs walks, through the same rewriter, since both
+// rules replace a reference by name.
+//
+// A `*ast.TypeRefTypeAnn`-typed slot such as ClassDecl.Extends is not respelled, because the
+// slot has no room for a `typeof`. Nothing reaches it: six constructor interfaces in
+// lib.es5.d.ts do extend one, `RangeErrorConstructor extends ErrorConstructor` among them, but
+// each is itself consumed and fuseTrio does not carry a consumed interface's Extends onto the
+// class. An instance interface extending a constructor interface would dangle, and no
+// declaration in the pinned lib set does.
+func rewriteConsumedCtorRefs(mod *StandaloneModule, consumedCtor map[string]string) {
+	if len(consumedCtor) == 0 {
+		return
+	}
+	rw := &refRewriter{consumedCtor: consumedCtor}
+	mod.Module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		for _, decl := range ns.Decls {
+			rw.rewriteDecl(decl)
+		}
+		return true
+	})
+}
+
+type refRewriter struct {
 	readonlyToMutable map[string]string
 	mutable           set.Set[string]
+	// consumedCtor maps a fused constructor interface's name to the instance name it fused
+	// into. Empty when the pass is not respelling those references.
+	consumedCtor map[string]string
 }
 
 // rewriteDecl dispatches over every Decl variant. The default panics
 // so a newly-added Decl type cannot silently bypass the rewrite — see
 // the same canary rationale on `classElemName` in partition_writer.go.
-func (r *twinRewriter) rewriteDecl(decl ast.Decl) {
+func (r *refRewriter) rewriteDecl(decl ast.Decl) {
 	switch d := decl.(type) {
 	case *ast.VarDecl:
 		if d.TypeAnn != nil {
@@ -105,11 +136,11 @@ func (r *twinRewriter) rewriteDecl(decl ast.Decl) {
 			r.rewriteDecl(inner)
 		}
 	default:
-		panic(fmt.Sprintf("twinRewriter.rewriteDecl: unhandled decl type %T — extend this switch so the readonly-twin rewrite does not silently skip a new Decl variant", decl))
+		panic(fmt.Sprintf("refRewriter.rewriteDecl: unhandled decl type %T — extend this switch so the readonly-twin rewrite does not silently skip a new Decl variant", decl))
 	}
 }
 
-func (r *twinRewriter) rewriteFuncSig(sig *ast.FuncSig) {
+func (r *refRewriter) rewriteFuncSig(sig *ast.FuncSig) {
 	r.rewriteTypeParams(sig.TypeParams)
 	for _, p := range sig.Params {
 		if p.TypeAnn != nil {
@@ -124,7 +155,7 @@ func (r *twinRewriter) rewriteFuncSig(sig *ast.FuncSig) {
 	}
 }
 
-func (r *twinRewriter) rewriteTypeParams(tps []*ast.TypeParam) {
+func (r *refRewriter) rewriteTypeParams(tps []*ast.TypeParam) {
 	for _, tp := range tps {
 		if tp.Constraint != nil {
 			tp.Constraint = r.rewrite(tp.Constraint)
@@ -135,7 +166,7 @@ func (r *twinRewriter) rewriteTypeParams(tps []*ast.TypeParam) {
 	}
 }
 
-func (r *twinRewriter) rewriteClassElem(elem ast.ClassElem) {
+func (r *refRewriter) rewriteClassElem(elem ast.ClassElem) {
 	switch e := elem.(type) {
 	case *ast.FieldElem:
 		if e.Type != nil {
@@ -158,7 +189,7 @@ func (r *twinRewriter) rewriteClassElem(elem ast.ClassElem) {
 			r.rewriteFuncSig(&e.Fn.FuncSig)
 		}
 	default:
-		panic(fmt.Sprintf("twinRewriter.rewriteClassElem: unhandled class-elem type %T — extend this switch so the readonly-twin rewrite does not silently skip a new ClassElem variant", elem))
+		panic(fmt.Sprintf("refRewriter.rewriteClassElem: unhandled class-elem type %T — extend this switch so the readonly-twin rewrite does not silently skip a new ClassElem variant", elem))
 	}
 }
 
@@ -179,7 +210,7 @@ func (r *twinRewriter) rewriteClassElem(elem ast.ClassElem) {
 // Eight declarations in the pinned lib set take this shape,
 // `RegExpMatchArray`, `FontFaceSet`, and `HighlightRegistry` among
 // them.
-func (r *twinRewriter) renameTypeRefInPlace(ref *ast.TypeRefTypeAnn) {
+func (r *refRewriter) renameTypeRefInPlace(ref *ast.TypeRefTypeAnn) {
 	for i, arg := range ref.TypeArgs {
 		ref.TypeArgs[i] = r.rewrite(arg)
 	}
@@ -195,7 +226,7 @@ func (r *twinRewriter) renameTypeRefInPlace(ref *ast.TypeRefTypeAnn) {
 
 // rewrite walks a TypeAnn, rewriting twin references in every
 // reachable slot and returning the (possibly replaced) node.
-func (r *twinRewriter) rewrite(t ast.TypeAnn) ast.TypeAnn {
+func (r *refRewriter) rewrite(t ast.TypeAnn) ast.TypeAnn {
 	if t == nil {
 		return nil
 	}
@@ -207,6 +238,17 @@ func (r *twinRewriter) rewrite(t ast.TypeAnn) ast.TypeAnn {
 		id, ok := tt.Name.(*ast.Ident)
 		if !ok {
 			return tt
+		}
+		// The constructor interface is gone, fused into the class. `typeof Array` names what
+		// `ArrayConstructor` named: the class value, carrying the constructor and the statics.
+		//
+		// Only the argument-less spelling is respelled. `typeof X` takes no arguments, so
+		// rewriting `FooConstructor<number>` would drop the `number` and say something else.
+		// detectTrios matches on the name alone, so a generic constructor interface does fuse;
+		// none in the pinned lib set is referenced with arguments, and one left alone is a
+		// visibly dangling name rather than a silently wrong type.
+		if instance, ok := r.consumedCtor[id.Name]; ok && len(tt.TypeArgs) == 0 {
+			return ast.NewTypeOfTypeAnn(ast.NewIdentifier(instance, tt.Span()), tt.Span())
 		}
 		if mutableName, ok := r.readonlyToMutable[id.Name]; ok {
 			id.Name = mutableName
@@ -309,11 +351,11 @@ func (r *twinRewriter) rewrite(t ast.TypeAnn) ast.TypeAnn {
 		*ast.ErrorTypeAnn:
 		return tt
 	default:
-		panic(fmt.Sprintf("twinRewriter.rewrite: unhandled type-ann %T — extend this switch so the readonly-twin rewrite does not silently skip a new TypeAnn variant", t))
+		panic(fmt.Sprintf("refRewriter.rewrite: unhandled type-ann %T — extend this switch so the readonly-twin rewrite does not silently skip a new TypeAnn variant", t))
 	}
 }
 
-func (r *twinRewriter) rewriteObject(obj *ast.ObjectTypeAnn) {
+func (r *refRewriter) rewriteObject(obj *ast.ObjectTypeAnn) {
 	for _, elem := range obj.Elems {
 		switch e := elem.(type) {
 		case *ast.CallableTypeAnn:
@@ -349,12 +391,12 @@ func (r *twinRewriter) rewriteObject(obj *ast.ObjectTypeAnn) {
 		case *ast.RestSpreadTypeAnn:
 			e.Value = r.rewrite(e.Value)
 		default:
-			panic(fmt.Sprintf("twinRewriter.rewriteObject: unhandled object-type-ann elem %T — extend this switch so the readonly-twin rewrite does not silently skip a new ObjTypeAnnElem variant", elem))
+			panic(fmt.Sprintf("refRewriter.rewriteObject: unhandled object-type-ann elem %T — extend this switch so the readonly-twin rewrite does not silently skip a new ObjTypeAnnElem variant", elem))
 		}
 	}
 }
 
-func (r *twinRewriter) rewriteFnTypeAnn(fn *ast.FuncTypeAnn) {
+func (r *refRewriter) rewriteFnTypeAnn(fn *ast.FuncTypeAnn) {
 	if fn == nil {
 		return
 	}

--- a/internal/interop/data/std/map.esc
+++ b/internal/interop/data/std/map.esc
@@ -49,7 +49,7 @@ export declare class Map<K, V> {
     constructor(mut self, entries?: Array<[K, V]> | null),
     static readonly prototype: mut Map<any, any>,
     constructor(mut self, iterable?: Iterable<[K, V]> | null),
-    static readonly [Symbol.species]: MapConstructor,
+    static readonly [Symbol.species]: typeof Map,
     /**
      * Groups members of an iterable according to the return value of the passed callback.
      * @param items An iterable.

--- a/internal/interop/data/std/prelude.esc
+++ b/internal/interop/data/std/prelude.esc
@@ -374,7 +374,7 @@ export declare class Array<T> {
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
     static from<T, U>(iterable: Iterable<T> | ArrayLike<T>, mapfn: fn (v: T, k: number) -> U, thisArg?: unknown) -> mut Array<U>,
-    static readonly [Symbol.species]: ArrayConstructor,
+    static readonly [Symbol.species]: typeof Array,
     constructor(mut self, arrayLength?: number),
     constructor(mut self, arrayLength: number),
     constructor(mut self, ...items: mut Array<T>),
@@ -699,7 +699,7 @@ export declare class Promise<T, E = never> {
      * @returns A promise whose internal state matches the provided promise.
      */
     static resolve<T>(value: T | PromiseLike<T>) -> Promise<Awaited<T>>,
-    static readonly [Symbol.species]: PromiseConstructor,
+    static readonly [Symbol.species]: typeof Promise,
     /**
      * Creates a Promise that is resolved with an array of results when all
      * of the provided Promises resolve or reject.

--- a/internal/interop/data/std/regexp.esc
+++ b/internal/interop/data/std/regexp.esc
@@ -111,7 +111,7 @@ export declare class RegExp {
     /** @deprecated A legacy feature for browser compatibility */
     compile(mut self, pattern: string, flags?: string) -> Self,
     constructor(mut self, pattern: RegExp | string, flags?: string),
-    static readonly [Symbol.species]: RegExpConstructor,
+    static readonly [Symbol.species]: typeof RegExp,
     constructor(mut self, pattern: RegExp | string),
     constructor(mut self, pattern: string, flags?: string),
     static readonly "prototype": RegExp,

--- a/internal/interop/data/std/set.esc
+++ b/internal/interop/data/std/set.esc
@@ -72,7 +72,7 @@ export declare class Set<T> {
     constructor(mut self, values?: Array<T> | null),
     static readonly prototype: mut Set<any>,
     constructor(mut self, iterable?: Iterable<T> | null),
-    static readonly [Symbol.species]: SetConstructor
+    static readonly [Symbol.species]: typeof Set
 }
 
 @js("WeakSet")

--- a/internal/interop/data/std/typed_arrays.esc
+++ b/internal/interop/data/std/typed_arrays.esc
@@ -2983,7 +2983,7 @@ export declare class ArrayBuffer {
      * Returns a section of an ArrayBuffer.
      */
     slice(self, begin?: number, end?: number) -> ArrayBuffer,
-    static readonly [Symbol.species]: ArrayBufferConstructor,
+    static readonly [Symbol.species]: typeof ArrayBuffer,
     constructor(mut self),
     constructor(mut self, byteLength: number, options?: {
         maxByteLength?: number

--- a/internal/solver/callable_object_test.go
+++ b/internal/solver/callable_object_test.go
@@ -185,3 +185,19 @@ func TestKeyofSkipsTheUnnamedCallableMembers(t *testing.T) {
 	}}
 	require.Equal(t, `"tag"`, soltype.Print(keyofObjectNamed(obj)))
 }
+
+// `static readonly [Symbol.species]: typeof Arr` is the shape trio fusion emits where the
+// source named the constructor interface. The annotation resolves to the class value, so the
+// declaration carrying it reports nothing.
+func TestAStaticTypeofTheOwnClassResolves(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		declare class Arr {
+			static of(n: number) -> Arr,
+			static readonly [Symbol.species]: typeof Arr,
+		}
+		declare val species: typeof Arr
+		val made = species.of(1)
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "Arr", values["made"])
+}


### PR DESCRIPTION
Refs #1412

Step 4 of #1412. Stacked on #1574; review only the last commit.

## The gap

Trio fusion folds `interface ArrayConstructor` into `class Array` and stops emitting the interface. Nothing respelled references to the consumed name, so six survived in the generated tree, every one a `cannot find type` when the tree is inferred:

| file | line |
| --- | --- |
| `std/prelude.esc` | `static readonly [Symbol.species]: ArrayConstructor` |
| `std/prelude.esc` | `static readonly [Symbol.species]: PromiseConstructor` |
| `std/map.esc` | `static readonly [Symbol.species]: MapConstructor` |
| `std/regexp.esc` | `static readonly [Symbol.species]: RegExpConstructor` |
| `std/set.esc` | `static readonly [Symbol.species]: SetConstructor` |
| `std/typed_arrays.esc` | `static readonly [Symbol.species]: ArrayBufferConstructor` |

`consumedCtor` was a `set.Set[string]` consulted only when deciding whether to *emit* the interface declaration, so the converter knew a name was gone and never looked at who still named it.

## The fix

`typeof Array` names what `ArrayConstructor` named: the class value, carrying the constructor and the statics. `consumedCtor` becomes a `map[string]string` from the consumed name to the instance it fused into, and `rewriteConsumedCtorRefs` respells every reference.

The pass reuses the readonly-twin walk rather than duplicating a 150-line traversal, so `twinRewriter` carries two rules and is renamed `refRewriter` (`twin_rewrite.go` → `ref_rewrite.go`). Both rules replace a reference by name; only the rule table differs.

`ConvertBuckets` unions the consumed names across every bucket before converting any of it, the way it already unions the readonly twins. A reference may cross a package boundary, and today it doesn't only because the partition table co-routes each `XConstructor` with its instance.

## Two limits, both deliberate

**Only the argument-less spelling is respelled.** `typeof X` takes no arguments, so rewriting `FooConstructor<number>` would drop the `number` and say something else. `detectTrios` matches on the name alone, so a generic constructor interface does fuse; none in the pinned lib set is referenced with arguments, and one left alone is a visibly dangling name rather than a silently wrong type. Covered by a test.

**A `*ast.TypeRefTypeAnn`-typed slot such as `ClassDecl.Extends` is not respelled**, because the slot has no room for a `typeof`. Six constructor interfaces in `lib.es5.d.ts` do extend one — `RangeErrorConstructor extends ErrorConstructor` among them — but each is itself consumed, and `fuseTrio` does not carry a consumed interface's `Extends` onto the class. An *instance* interface extending a constructor interface would dangle, and none in the pinned set does.

## Review fixes

Five findings, all fixed.

- The pass was bucket-local while the sibling twin rewrite is deliberately tree-wide. Now unioned across buckets, through a `convertStandaloneModule` variant that takes the tree's names, mirroring `own`/`all`.
- The rewrite dropped `TypeArgs`. Now restricted to the argument-less form.
- The docstring claimed no pinned-lib declaration extends a constructor interface. Six do; corrected to state the real reason it is safe.
- `trioTable`'s docstring still said `consumedCtor` is keyed by the instance name.
- The field comment broke `gofmt` alignment on `byName`.

## Regenerated tree

```
 internal/interop/data/std/map.esc          | 2 +-
 internal/interop/data/std/prelude.esc      | 4 ++--
 internal/interop/data/std/regexp.esc       | 2 +-
 internal/interop/data/std/set.esc          | 2 +-
 internal/interop/data/std/typed_arrays.esc | 2 +-
```

Six lines, nothing else. Generation is stable across two runs, and no dangling `*Constructor` name is left — the only match remaining is `PromiseConstructorLike`, a declared alias.

## What it clears

Real-prelude diagnostics: 4 → 2. The two left are `cannot find type intrinsic` and a tuple constraint, neither related to fusion.

Across the stack that is 26 → 2.

## What is left of #1412

Steps 1 to 3: `ast.ClassElem` gains a callable arm with parser, printer and codegen support; `interfaceMemberToClassElem` returns it for a `CallSignature`; `detectTrios` drops its guard and `Symbol` and `BigInt` fuse. `soltype.CallableElem` from #1574 is the member a fused class value would carry.

## Testing

`go test ./...` passes, `gofmt` reports nothing new. New tests cover the respelling on a static member and on a parameter, a reference carrying type arguments being left alone, an unfused constructor interface being untouched, the printed output reparsing, and the respelled annotation resolving in the solver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk

---
_Generated by [Claude Code](https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected built-in species property types for `Map`, `Array`, `Promise`, `RegExp`, `Set`, and `ArrayBuffer`.
  * Improved handling of constructor references across module boundaries, including conversion to corresponding class types where appropriate.
  * Fixed resolution of static computed properties using `typeof` on their own class.

* **Tests**
  * Added regression coverage for fused and unfused constructor references and static class properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->