### PR TITLE
Let a class declare a call signature, and fuse `Symbol` and `BigInt`

### DIFF
--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -227,7 +227,7 @@ func (s *SetterElem) Accept(v Visitor) {
 }
 func (s *SetterElem) Span() Span { return s.Span_ }
 
-// CallableElem represents an unnamed `callable(...) -> T` call signature in a class body. It makes
+// CallableElem represents an unnamed `(...) -> T` call signature in a class body. It makes
 // the class value callable: `Symbol("desc")` calls it where `Symbol()` alone would construct.
 //
 // The specification forbids constructing `Symbol` and `BigInt`, so a call signature is the

--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -227,7 +227,7 @@ func (s *SetterElem) Accept(v Visitor) {
 }
 func (s *SetterElem) Span() Span { return s.Span_ }
 
-// CallableElem represents an unnamed `fn (...) -> T` call signature in a class body. It makes
+// CallableElem represents an unnamed `callable(...) -> T` call signature in a class body. It makes
 // the class value callable: `Symbol("desc")` calls it where `Symbol()` alone would construct.
 //
 // The specification forbids constructing `Symbol` and `BigInt`, so a call signature is the

--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -226,3 +226,28 @@ func (s *SetterElem) Accept(v Visitor) {
 	v.ExitClassElem(s)
 }
 func (s *SetterElem) Span() Span { return s.Span_ }
+
+// CallableElem represents an unnamed `fn (...) -> T` call signature in a class body. It makes
+// the class value callable: `Symbol("desc")` calls it where `Symbol()` alone would construct.
+//
+// The specification forbids constructing `Symbol` and `BigInt`, so a call signature is the
+// only way to make one, and trio fusion has nowhere else to put the `SymbolConstructor` member
+// that declares it. `Fn.Body` is nil: a call signature declares a shape rather than an
+// implementation, so only a `declare class` may carry one.
+type CallableElem struct {
+	declDoc
+	Fn    *FuncExpr
+	Span_ Span
+	commentSlots
+}
+
+func (*CallableElem) IsClassElem() {}
+func (c *CallableElem) Accept(v Visitor) {
+	if v.EnterClassElem(c) {
+		if c.Fn != nil {
+			c.Fn.Accept(v)
+		}
+	}
+	v.ExitClassElem(c)
+}
+func (c *CallableElem) Span() Span { return c.Span_ }

--- a/internal/checker/tests/substitute_test.go
+++ b/internal/checker/tests/substitute_test.go
@@ -411,8 +411,8 @@ func TestSubstituteTypeParamsInObjElem(t *testing.T) {
 	// Substitute type parameters in the entire object
 	result := SubstituteTypeParams(objType, substitutions)
 
-	assert.Equal(t, "{readonly test?: T, method(self, x: T) -> U, get getter(self) -> T, set setter(mut self, value: V) -> undefined, fn (x: T) -> U, new fn (init: V) -> U, ...T}", objType.String())
-	assert.Equal(t, "{readonly test?: number, method(self, x: number) -> string, get getter(self) -> number, set setter(mut self, value: boolean) -> undefined, fn (x: number) -> string, new fn (init: boolean) -> string, ...number}", result.String())
+	assert.Equal(t, "{readonly test?: T, method(self, x: T) -> U, get getter(self) -> T, set setter(mut self, value: V) -> undefined, (x: T) -> U, new fn (init: V) -> U, ...T}", objType.String())
+	assert.Equal(t, "{readonly test?: number, method(self, x: number) -> string, get getter(self) -> number, set setter(mut self, value: boolean) -> undefined, (x: number) -> string, new fn (init: boolean) -> string, ...number}", result.String())
 }
 
 // Phase 10.5 regression: when the same type-parameter substitute is used

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -2368,6 +2368,13 @@ func (b *Builder) buildClassElems(inElems []ast.ClassElem, derived bool) ([]Clas
 				e,
 			)
 			outElems = append(outElems, constructorMethod)
+
+		case *ast.CallableElem:
+			// A call signature emits nothing. It says the class value is callable, which
+			// only an ambient declaration can describe, and an ambient declaration emits no
+			// JavaScript. A class with a body carrying one is rejected before codegen runs;
+			// see CallSignatureRequiresDeclareError.
+			continue
 		}
 	}
 

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -750,6 +750,12 @@ func (v *DependencyVisitor) EnterClassElem(elem ast.ClassElem) bool {
 		if e.Fn != nil {
 			e.Fn.Accept(v)
 		}
+	case *ast.CallableElem:
+		// A call signature has no name to skip, so only its signature is walked. Its
+		// annotations name types the class depends on the same way a constructor's do.
+		if e.Fn != nil {
+			e.Fn.Accept(v)
+		}
 	}
 	return false
 }

--- a/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
+++ b/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
@@ -7,6 +7,8 @@ export declare class Boolean {
     valueOf(self) -> boolean,
     /** Constructs a new Boolean wrapper around a value. */
     constructor(mut self, value?: unknown),
+    /** Coerces a value to a primitive boolean. */
+    fn<T> (value?: T) -> boolean,
     /** The Boolean prototype object. */
     static readonly prototype: Boolean
 }

--- a/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
+++ b/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
@@ -8,7 +8,7 @@ export declare class Boolean {
     /** Constructs a new Boolean wrapper around a value. */
     constructor(mut self, value?: unknown),
     /** Coerces a value to a primitive boolean. */
-    callable<T>(value?: T) -> boolean,
+    <T>(value?: T) -> boolean,
     /** The Boolean prototype object. */
     static readonly prototype: Boolean
 }

--- a/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
+++ b/internal/dts_to_esc/__snapshots__/dts_to_esc_test.snap
@@ -8,7 +8,7 @@ export declare class Boolean {
     /** Constructs a new Boolean wrapper around a value. */
     constructor(mut self, value?: unknown),
     /** Coerces a value to a primitive boolean. */
-    fn<T> (value?: T) -> boolean,
+    callable<T>(value?: T) -> boolean,
     /** The Boolean prototype object. */
     static readonly prototype: Boolean
 }

--- a/internal/dts_to_esc/decl.go
+++ b/internal/dts_to_esc/decl.go
@@ -399,6 +399,10 @@ func classElemIsStatic(elem ast.ClassElem) bool {
 		return e.Static
 	case *ast.ConstructorElem:
 		return true
+	case *ast.CallableElem:
+		// A call signature is reached through the class value, the same side a static is
+		// on, so it sorts with the statics.
+		return true
 	}
 	return false
 }

--- a/internal/dts_to_esc/decl_key.go
+++ b/internal/dts_to_esc/decl_key.go
@@ -68,6 +68,10 @@ func classElemSlot(elem ast.ClassElem) (memberSlot, bool) {
 		return slotFor(e.Name, e.Static, kindSetter)
 	case *ast.ConstructorElem:
 		return memberSlot{Name: "constructor", Kind: kindConstructor}, true
+	case *ast.CallableElem:
+		// A call signature carries no name, so it fills no slot. Callers pass over it the
+		// same way they pass over an unnameable key.
+		return memberSlot{}, false
 	}
 	return memberSlot{}, false
 }

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -314,25 +314,6 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 		if !ok {
 			continue
 		}
-		// A constructor side whose only callable form is a call
-		// signature would lose it: fuseTrio has no class elem to put
-		// one on, so the fused class could be neither called nor
-		// constructed. `SymbolConstructor` and `BigIntConstructor` are
-		// the two, and the specification forbids `new` on both, so the
-		// call signature is the only way to make one. They stay
-		// interfaces until #1412 gives a class somewhere to hold it.
-		//
-		// This reaches only the named form. An inline constructor side
-		// is required to carry a `new`, so it never has a call
-		// signature as its only callable form. One that has both still
-		// loses the call — `CompileError`, `LinkError` and
-		// `RuntimeError` in `lib.dom.d.ts` are the three — which is
-		// the same loss the 19 named trios that already fuse take, and
-		// #1412 covers all of them together.
-		if hasCallSignature(ctorMembers) && !hasConstructSignature(ctorMembers) {
-			continue
-		}
-
 		t.byName[name] = &trioInfo{
 			instance:    inst,
 			ctorMembers: ctorMembers,
@@ -410,18 +391,6 @@ func ctorsReturning(members []dts_parser.InterfaceMember, instanceName string) b
 		found = true
 	}
 	return found
-}
-
-// hasCallSignature reports whether members holds at least one bare
-// `(...)` member, the form that makes `Symbol("x")` a call rather than
-// a construction.
-func hasCallSignature(members []dts_parser.InterfaceMember) bool {
-	for _, m := range members {
-		if _, ok := m.(*dts_parser.CallSignature); ok {
-			return true
-		}
-	}
-	return false
 }
 
 // hasConstructSignature reports whether members holds at least one
@@ -1158,10 +1127,8 @@ func attachJSDecorator(decl ast.Decl, arg string) {
 //   - GetterSignature   → GetterElem
 //   - SetterSignature   → SetterElem
 //   - ConstructSignature (static side only) → ConstructorElem
-//   - CallSignature (static side: bare-call form like `Boolean(x)`) and
-//     IndexSignature are skipped for the MVP — they have no direct class-
-//     elem mapping. §6 may revisit (e.g. lower the bare-call form into a
-//     static factory).
+//   - CallSignature (static side: bare-call form like `Boolean(x)`) → CallableElem
+//   - IndexSignature is skipped for the MVP — it has no direct class-elem mapping.
 func fuseTrio(info *trioInfo, nsPath string, facts *ReceiverFacts) (*ast.ClassDecl, error) {
 	className := info.instance.Name.Name
 	typeParams, err := convertTypeParams(info.instance.TypeParams)
@@ -1243,7 +1210,7 @@ func fuseTrio(info *trioInfo, nsPath string, facts *ReceiverFacts) (*ast.ClassDe
 // interfaceMemberToClassElem converts an interface member to a class elem,
 // keying the static flag off the caller (instance side vs constructor side
 // of the trio). Returns (nil, nil) for member kinds with no class-elem
-// representation (CallSignature, IndexSignature).
+// representation (IndexSignature).
 //
 // nsPath and className address the class being fused. The receiver
 // classification reads them for the tiers keyed by an owner, which are the
@@ -1373,7 +1340,42 @@ func interfaceMemberToClassElem(
 		elem.SetDoc(doc)
 		return elem, nil
 
-	case *dts_parser.CallSignature, *dts_parser.IndexSignature, *dts_parser.ConstructSignature:
+	case *dts_parser.CallSignature:
+		// A bare-call form such as `Boolean(x)`. It carries no name and no receiver, so it
+		// becomes the class's own call signature, which is what makes the fused class
+		// callable as well as constructible.
+		//
+		// Only the constructor side declares one. A call signature on the instance side
+		// would say an instance is callable, which a class body cannot express, so it is
+		// skipped the way an index signature is. No trio instance interface in the pinned
+		// lib set declares one; a converted third-party `.d.ts` can.
+		if !static {
+			return nil, nil
+		}
+		typeParams, err := convertTypeParams(m.TypeParams)
+		if err != nil {
+			return nil, fmt.Errorf("call signature: type params: %w", err)
+		}
+		params, err := convertParams(m.Params)
+		if err != nil {
+			return nil, fmt.Errorf("call signature: params: %w", err)
+		}
+		var ret ast.TypeAnn
+		if m.ReturnType != nil {
+			ret, err = convertReturnTypeAnn(m.ReturnType)
+			if err != nil {
+				return nil, fmt.Errorf("call signature: return: %w", err)
+			}
+		}
+		span := convertSpan(m.Span())
+		elem := &ast.CallableElem{
+			Fn:    ast.NewFuncExpr(nil, typeParams, params, ret, nil, false, nil, span),
+			Span_: span,
+		}
+		elem.SetDoc(doc)
+		return elem, nil
+
+	case *dts_parser.IndexSignature, *dts_parser.ConstructSignature:
 		// Skip — no direct class-elem mapping in the MVP. ConstructSignature
 		// is handled by the caller for the static side.
 		return nil, nil

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -314,6 +314,18 @@ func detectTrios(stmts []dts_parser.Statement) *trioTable {
 		if !ok {
 			continue
 		}
+		// An instance-side call signature says instances are callable. A class cannot say
+		// that: ast.CallableElem describes the class VALUE, which is what `Symbol("x")`
+		// calls, and there is no syntax for a callable instance. Fusing would drop the
+		// member in silence, so the trio stays split and the interface keeps it as an
+		// ast.CallableTypeAnn.
+		//
+		// No trio in the pinned lib set reaches this. The 47 interfaces carrying an
+		// instance-side call signature are callbacks such as `EventListener`, none of which
+		// has a matching constructor interface and var. A converted third-party `.d.ts` can.
+		if hasCallSignature(inst.Members) {
+			continue
+		}
 		t.byName[name] = &trioInfo{
 			instance:    inst,
 			ctorMembers: ctorMembers,
@@ -391,6 +403,17 @@ func ctorsReturning(members []dts_parser.InterfaceMember, instanceName string) b
 		found = true
 	}
 	return found
+}
+
+// hasCallSignature reports whether members holds at least one bare `(...)` member, the form
+// that makes `Symbol("x")` a call rather than a construction.
+func hasCallSignature(members []dts_parser.InterfaceMember) bool {
+	for _, m := range members {
+		if _, ok := m.(*dts_parser.CallSignature); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // hasConstructSignature reports whether members holds at least one
@@ -975,6 +998,15 @@ func convertStandaloneStmt(
 			}
 			out = append(out, children...)
 		}
+		// The namespace's own trios are detected above and consumed here, so a sibling
+		// naming one of its constructor interfaces is respelled before the children leave
+		// the namespace. The module-level pass reads the top level's mapping and cannot see
+		// this one.
+		inner := make([]ast.Decl, 0, len(out))
+		for _, dd := range out {
+			inner = append(inner, dd.decl)
+		}
+		rewriteConsumedCtorRefsIn(inner, innerTrios.consumedCtor)
 		return out, nil
 
 	case *dts_parser.InterfaceDecl:
@@ -1127,7 +1159,8 @@ func attachJSDecorator(decl ast.Decl, arg string) {
 //   - GetterSignature   → GetterElem
 //   - SetterSignature   → SetterElem
 //   - ConstructSignature (static side only) → ConstructorElem
-//   - CallSignature (static side: bare-call form like `Boolean(x)`) → CallableElem
+//   - CallSignature → CallableElem, from the constructor side only. It is the bare-call
+//     form, `Boolean(x)`.
 //   - IndexSignature is skipped for the MVP — it has no direct class-elem mapping.
 func fuseTrio(info *trioInfo, nsPath string, facts *ReceiverFacts) (*ast.ClassDecl, error) {
 	className := info.instance.Name.Name
@@ -1345,10 +1378,9 @@ func interfaceMemberToClassElem(
 		// becomes the class's own call signature, which is what makes the fused class
 		// callable as well as constructible.
 		//
-		// Only the constructor side declares one. A call signature on the instance side
-		// would say an instance is callable, which a class body cannot express, so it is
-		// skipped the way an index signature is. No trio instance interface in the pinned
-		// lib set declares one; a converted third-party `.d.ts` can.
+		// Only the constructor side reaches here. detectTrios declines a trio whose
+		// instance interface declares a call signature, since a class cannot say that
+		// instances are callable, so this guard is a backstop rather than a live path.
 		if !static {
 			return nil, nil
 		}

--- a/internal/dts_to_esc/dts_to_esc.go
+++ b/internal/dts_to_esc/dts_to_esc.go
@@ -1158,7 +1158,8 @@ func attachJSDecorator(decl ast.Decl, arg string) {
 //   - PropertySignature → FieldElem
 //   - GetterSignature   → GetterElem
 //   - SetterSignature   → SetterElem
-//   - ConstructSignature (static side only) → ConstructorElem
+//   - ConstructSignature → ConstructorElem, built by fuseTrio rather than here, since
+//     one `constructor` holds every arm
 //   - CallSignature → CallableElem, from the constructor side only. It is the bare-call
 //     form, `Boolean(x)`.
 //   - IndexSignature is skipped for the MVP — it has no direct class-elem mapping.
@@ -1407,9 +1408,17 @@ func interfaceMemberToClassElem(
 		elem.SetDoc(doc)
 		return elem, nil
 
-	case *dts_parser.IndexSignature, *dts_parser.ConstructSignature:
-		// Skip — no direct class-elem mapping in the MVP. ConstructSignature
-		// is handled by the caller for the static side.
+	case *dts_parser.ConstructSignature:
+		// Reached only from the instance loop, where a `new (…)` member describes
+		// something an instance cannot be. The constructor side never arrives here:
+		// fuseTrio intercepts its construct signatures and passes them to
+		// constructSignatureToCtorElem, because a class carries exactly one
+		// `constructor` holding every arm as an overload, so the arms have to be
+		// gathered by the caller rather than converted one at a time.
+		return nil, nil
+
+	case *dts_parser.IndexSignature:
+		// Skipped for the MVP — it has no class-elem mapping at all. See #1417.
 		return nil, nil
 
 	default:

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -1169,7 +1169,7 @@ declare var Symbol: SymbolConstructor;
 	require.Equal(t, 0, interfaces, "both interfaces consumed")
 	require.Equal(t, 0, vars, "the binding consumed")
 
-	require.Contains(t, printed, "callable(description?: string | number) -> symbol",
+	require.Contains(t, printed, "(description?: string | number) -> symbol",
 		"the call signature reaches the class, which is what makes the fused Symbol callable")
 	// No `new` is declared, so the class has no constructor. That is the shape that makes
 	// `new Symbol()` unrepresentable rather than merely discouraged.

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -1169,7 +1169,7 @@ declare var Symbol: SymbolConstructor;
 	require.Equal(t, 0, interfaces, "both interfaces consumed")
 	require.Equal(t, 0, vars, "the binding consumed")
 
-	require.Contains(t, printed, "fn (description?: string | number) -> symbol",
+	require.Contains(t, printed, "callable(description?: string | number) -> symbol",
 		"the call signature reaches the class, which is what makes the fused Symbol callable")
 	// No `new` is declared, so the class has no constructor. That is the shape that makes
 	// `new Symbol()` unrepresentable rather than merely discouraged.

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -1470,8 +1470,7 @@ declare var CSSFontFaceRule: {
 // Trio fusion folds `interface FooConstructor` into `class Foo`, so the constructor
 // interface's name no longer denotes anything. A reference to it is respelled `typeof Foo`,
 // which names what the interface named: the class value, carrying the constructor and the
-// statics. Without the respelling the emitted tree carries a dangling name, which is where
-// `cannot find type ArrayConstructor` came from.
+// statics. That respelling is what keeps the emitted tree free of a dangling name.
 func TestStandalone_AConsumedConstructorReferenceBecomesTypeof(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -1553,4 +1552,49 @@ interface BoxConstructor {
 `)
 	require.Contains(t, printed, "BoxConstructor")
 	require.NotContains(t, printed, "typeof Box")
+}
+
+// A namespace detects its own trios, so a sibling naming one of the constructor interfaces it
+// consumed is respelled against that namespace's mapping. The module-level pass reads the top
+// level's mapping and cannot see a namespace-local one.
+func TestStandalone_ANamespaceLocalConsumedConstructorIsRespelled(t *testing.T) {
+	_, printed := convertSlice(t, `
+declare namespace N {
+    interface Box {
+        value: number;
+    }
+    interface BoxConstructor {
+        new (v: number): Box;
+    }
+    var Box: BoxConstructor;
+    interface Other {
+        maker: BoxConstructor;
+    }
+}
+`)
+	require.Contains(t, printed, "maker: typeof Box")
+	require.NotContains(t, printed, "BoxConstructor")
+}
+
+// An instance-side call signature says instances are callable, which a class cannot say:
+// `ast.CallableElem` describes the class value. Fusing would drop the member in silence, so the
+// trio stays split and the interface keeps it.
+func TestStandalone_ATrioWithACallableInstanceStaysSplit(t *testing.T) {
+	astModule, printed := convertSlice(t, `
+interface Callable {
+    (x: number): string;
+    tag: string;
+}
+interface CallableConstructor {
+    new (): Callable;
+}
+declare var Callable: CallableConstructor;
+`)
+	rootNS, ok := astModule.Module.Namespaces.Get("")
+	require.True(t, ok, "root namespace exists")
+	for _, d := range rootNS.Decls {
+		_, isClass := d.(*ast.ClassDecl)
+		require.False(t, isClass, "the trio must not fuse")
+	}
+	require.Contains(t, printed, "(x: number) -> string", "the instance callable survives")
 }

--- a/internal/dts_to_esc/dts_to_esc_test.go
+++ b/internal/dts_to_esc/dts_to_esc_test.go
@@ -1129,17 +1129,14 @@ declare var Array: ArrayConstructor;
 	}
 }
 
-// A constructor interface with a call signature and no `new` describes
-// something callable and not constructible. fuseTrio has no class elem
-// for a call signature, so the fused class could be neither called nor
-// constructed. The trio passes through instead, keeping the call
-// signature on the interface, until #1412 gives a class somewhere to
-// hold one.
+// A constructor interface with a call signature and no `new` describes something callable and
+// not constructible. It fuses like every other trio, and the call signature becomes the class's
+// own, so the fused class is callable even though nothing can construct it. The specification
+// forbids `new Symbol()`, which is why the call signature is the only way to make one.
 //
-// `SymbolConstructor` below is verbatim from lib.es2015.symbol.d.ts.
-// `BigIntConstructor` is the same shape and the only other one in the
-// pinned lib set.
-func TestStandalone_TrioNotFusedWhenTheConstructorIsOnlyCallable(t *testing.T) {
+// `SymbolConstructor` below is verbatim from lib.es2015.symbol.d.ts. `BigIntConstructor` is the
+// same shape and the only other one in the pinned lib set.
+func TestStandalone_ACallSignatureOnlyConstructorStillFuses(t *testing.T) {
 	const slice = `
 interface Symbol {
     toString(): string;
@@ -1168,12 +1165,15 @@ declare var Symbol: SymbolConstructor;
 			vars++
 		}
 	}
-	require.Equal(t, 0, classes, "no class synthesized")
-	require.Equal(t, 2, interfaces, "both interfaces survive")
-	require.Equal(t, 1, vars, "the binding survives")
+	require.Equal(t, 1, classes, "the trio fuses into one class")
+	require.Equal(t, 0, interfaces, "both interfaces consumed")
+	require.Equal(t, 0, vars, "the binding consumed")
 
 	require.Contains(t, printed, "fn (description?: string | number) -> symbol",
-		"the call signature survives, which is the whole point of holding back")
+		"the call signature reaches the class, which is what makes the fused Symbol callable")
+	// No `new` is declared, so the class has no constructor. That is the shape that makes
+	// `new Symbol()` unrepresentable rather than merely discouraged.
+	require.NotContains(t, printed, "constructor(")
 
 	parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
 		&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
@@ -1538,19 +1538,18 @@ declare var Box: BoxConstructor;
 	}
 }
 
-// An unfused constructor interface keeps its name, so a reference to it is left alone.
-// `SymbolConstructor` is the case that matters: it declares no `new`, so detectTrios declines
-// it and the interface stays.
+// An unfused constructor interface keeps its name, so a reference to it is left alone. A
+// constructor interface with no matching `declare var` is not a trio at all, so nothing
+// consumes it.
 func TestStandalone_AnUnfusedConstructorReferenceIsUntouched(t *testing.T) {
 	_, printed := convertSlice(t, `
 interface Box<T> {
     value: T;
 }
 interface BoxConstructor {
-    <T>(value: T): Box<T>;
+    new <T>(value: T): Box<T>;
     readonly self: BoxConstructor;
 }
-declare var Box: BoxConstructor;
 `)
 	require.Contains(t, printed, "BoxConstructor")
 	require.NotContains(t, printed, "typeof Box")

--- a/internal/dts_to_esc/facts_test.go
+++ b/internal/dts_to_esc/facts_test.go
@@ -72,7 +72,7 @@ func TestStdReceiversMatchTheFacts(t *testing.T) {
 
 	sort.Strings(mismatched)
 	require.Empty(t, mismatched)
-	snaps.MatchInlineSnapshot(t, compared, snaps.Inline("int(233)"))
+	snaps.MatchInlineSnapshot(t, compared, snaps.Inline("int(238)"))
 }
 
 // eachEmittedMethod calls visit for every instance method of every class the

--- a/internal/dts_to_esc/ref_rewrite.go
+++ b/internal/dts_to_esc/ref_rewrite.go
@@ -188,6 +188,10 @@ func (r *refRewriter) rewriteClassElem(elem ast.ClassElem) {
 		if e.Fn != nil {
 			r.rewriteFuncSig(&e.Fn.FuncSig)
 		}
+	case *ast.CallableElem:
+		if e.Fn != nil {
+			r.rewriteFuncSig(&e.Fn.FuncSig)
+		}
 	default:
 		panic(fmt.Sprintf("refRewriter.rewriteClassElem: unhandled class-elem type %T — extend this switch so the readonly-twin rewrite does not silently skip a new ClassElem variant", elem))
 	}

--- a/internal/dts_to_esc/ref_rewrite.go
+++ b/internal/dts_to_esc/ref_rewrite.go
@@ -67,13 +67,25 @@ func rewriteConsumedCtorRefs(mod *StandaloneModule, consumedCtor map[string]stri
 	if len(consumedCtor) == 0 {
 		return
 	}
-	rw := &refRewriter{consumedCtor: consumedCtor}
 	mod.Module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
-		for _, decl := range ns.Decls {
-			rw.rewriteDecl(decl)
-		}
+		rewriteConsumedCtorRefsIn(ns.Decls, consumedCtor)
 		return true
 	})
+}
+
+// rewriteConsumedCtorRefsIn respells the references in one group of declarations against one
+// mapping. A `declare namespace` detects its own trios, so its children are rewritten against
+// that namespace's mapping alone, before they are flattened into the module. Two namespaces may
+// each declare a `FooConstructor`, and the two name different trios, so the mappings are never
+// merged.
+func rewriteConsumedCtorRefsIn(decls []ast.Decl, consumedCtor map[string]string) {
+	if len(consumedCtor) == 0 {
+		return
+	}
+	rw := &refRewriter{consumedCtor: consumedCtor}
+	for _, decl := range decls {
+		rw.rewriteDecl(decl)
+	}
 }
 
 type refRewriter struct {

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -4,7 +4,7 @@
 
 export declare interface AsyncGeneratorFunction {
     new (...args: mut Array<any>) -> AsyncGenerator,
-    fn (...args: mut Array<any>) -> AsyncGenerator,
+    (...args: mut Array<any>) -> AsyncGenerator,
     /**
      * The length of the arguments.
      */
@@ -21,7 +21,7 @@ export declare interface AsyncGeneratorFunction {
 
 export declare interface AsyncGeneratorFunctionConstructor {
     new (...args: mut Array<string>) -> AsyncGeneratorFunction,
-    fn (...args: mut Array<string>) -> AsyncGeneratorFunction,
+    (...args: mut Array<string>) -> AsyncGeneratorFunction,
     /**
      * The length of the arguments.
      */
@@ -47,10 +47,10 @@ export declare interface AsyncIterableIterator<T, TReturn = any, TNext = any> ex
 export declare class AggregateError extends Error {
     errors: mut Array<any>,
     constructor(mut self, errors: Iterable<any>, message?: string),
-    callable(errors: Iterable<any>, message?: string) -> AggregateError,
+    (errors: Iterable<any>, message?: string) -> AggregateError,
     static readonly prototype: AggregateError,
     constructor(mut self, errors: Iterable<any>, message?: string, options?: ErrorOptions),
-    callable(errors: Iterable<any>, message?: string, options?: ErrorOptions) -> AggregateError
+    (errors: Iterable<any>, message?: string, options?: ErrorOptions) -> AggregateError
 }
 
 export declare type PromiseConstructorLike = fn<T> (executor: fn (resolve: fn (value: T | PromiseLike<T>) -> unknown, reject: fn (reason?: any) -> unknown) -> unknown) -> PromiseLike<T>

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -47,8 +47,10 @@ export declare interface AsyncIterableIterator<T, TReturn = any, TNext = any> ex
 export declare class AggregateError extends Error {
     errors: mut Array<any>,
     constructor(mut self, errors: Iterable<any>, message?: string),
+    fn (errors: Iterable<any>, message?: string) -> AggregateError,
     static readonly prototype: AggregateError,
-    constructor(mut self, errors: Iterable<any>, message?: string, options?: ErrorOptions)
+    constructor(mut self, errors: Iterable<any>, message?: string, options?: ErrorOptions),
+    fn (errors: Iterable<any>, message?: string, options?: ErrorOptions) -> AggregateError
 }
 
 export declare type PromiseConstructorLike = fn<T> (executor: fn (resolve: fn (value: T | PromiseLike<T>) -> unknown, reject: fn (reason?: any) -> unknown) -> unknown) -> PromiseLike<T>

--- a/internal/interop/data/std/async.esc
+++ b/internal/interop/data/std/async.esc
@@ -47,10 +47,10 @@ export declare interface AsyncIterableIterator<T, TReturn = any, TNext = any> ex
 export declare class AggregateError extends Error {
     errors: mut Array<any>,
     constructor(mut self, errors: Iterable<any>, message?: string),
-    fn (errors: Iterable<any>, message?: string) -> AggregateError,
+    callable(errors: Iterable<any>, message?: string) -> AggregateError,
     static readonly prototype: AggregateError,
     constructor(mut self, errors: Iterable<any>, message?: string, options?: ErrorOptions),
-    fn (errors: Iterable<any>, message?: string, options?: ErrorOptions) -> AggregateError
+    callable(errors: Iterable<any>, message?: string, options?: ErrorOptions) -> AggregateError
 }
 
 export declare type PromiseConstructorLike = fn<T> (executor: fn (resolve: fn (value: T | PromiseLike<T>) -> unknown, reject: fn (reason?: any) -> unknown) -> unknown) -> PromiseLike<T>

--- a/internal/interop/data/std/bigint.esc
+++ b/internal/interop/data/std/bigint.esc
@@ -76,37 +76,32 @@ export declare interface BigIntToLocaleStringOptions {
     compactDisplay?: string
 }
 
-export declare interface BigInt {
+@js("BigInt")
+export declare class BigInt {
     /**
      * Returns a string representation of an object.
      * @param radix Specifies a radix for converting numeric values to strings.
      */
-    toString(radix?: number) -> string,
+    toString(self, radix?: number) -> string,
     /** Returns a string representation appropriate to the host environment's current locale. */
-    toLocaleString(locales?: Intl.LocalesArgument, options?: BigIntToLocaleStringOptions) -> string,
+    toLocaleString(self, locales?: Intl.LocalesArgument, options?: BigIntToLocaleStringOptions) -> string,
     /** Returns the primitive value of the specified object. */
-    valueOf() -> bigint,
-    readonly [Symbol.toStringTag]: "BigInt"
-}
-
-export declare interface BigIntConstructor {
+    valueOf(self) -> bigint,
+    readonly [Symbol.toStringTag]: "BigInt",
     fn (value: bigint | boolean | number | string) -> bigint,
-    readonly prototype: BigInt,
+    static readonly prototype: BigInt,
     /**
      * Interprets the low bits of a BigInt as a 2's-complement signed integer.
      * All higher bits are discarded.
      * @param bits The number of low bits to use
      * @param int The BigInt whose bits to extract
      */
-    asIntN(bits: number, int: bigint) -> bigint,
+    static asIntN(bits: number, int: bigint) -> bigint,
     /**
      * Interprets the low bits of a BigInt as an unsigned integer.
      * All higher bits are discarded.
      * @param bits The number of low bits to use
      * @param int The BigInt whose bits to extract
      */
-    asUintN(bits: number, int: bigint) -> bigint
+    static asUintN(bits: number, int: bigint) -> bigint
 }
-
-@js("BigInt")
-export declare var BigInt: BigIntConstructor

--- a/internal/interop/data/std/bigint.esc
+++ b/internal/interop/data/std/bigint.esc
@@ -88,7 +88,7 @@ export declare class BigInt {
     /** Returns the primitive value of the specified object. */
     valueOf(self) -> bigint,
     readonly [Symbol.toStringTag]: "BigInt",
-    fn (value: bigint | boolean | number | string) -> bigint,
+    callable(value: bigint | boolean | number | string) -> bigint,
     static readonly prototype: BigInt,
     /**
      * Interprets the low bits of a BigInt as a 2's-complement signed integer.

--- a/internal/interop/data/std/bigint.esc
+++ b/internal/interop/data/std/bigint.esc
@@ -88,7 +88,7 @@ export declare class BigInt {
     /** Returns the primitive value of the specified object. */
     valueOf(self) -> bigint,
     readonly [Symbol.toStringTag]: "BigInt",
-    callable(value: bigint | boolean | number | string) -> bigint,
+    (value: bigint | boolean | number | string) -> bigint,
     static readonly prototype: BigInt,
     /**
      * Interprets the low bits of a BigInt as a 2's-complement signed integer.

--- a/internal/interop/data/std/boolean.esc
+++ b/internal/interop/data/std/boolean.esc
@@ -7,5 +7,6 @@ export declare class Boolean {
     /** Returns the primitive value of the specified object. */
     valueOf(self) -> boolean,
     constructor(mut self, value?: unknown),
+    fn<T> (value?: T) -> boolean,
     static readonly prototype: Boolean
 }

--- a/internal/interop/data/std/boolean.esc
+++ b/internal/interop/data/std/boolean.esc
@@ -7,6 +7,6 @@ export declare class Boolean {
     /** Returns the primitive value of the specified object. */
     valueOf(self) -> boolean,
     constructor(mut self, value?: unknown),
-    fn<T> (value?: T) -> boolean,
+    callable<T>(value?: T) -> boolean,
     static readonly prototype: Boolean
 }

--- a/internal/interop/data/std/boolean.esc
+++ b/internal/interop/data/std/boolean.esc
@@ -7,6 +7,6 @@ export declare class Boolean {
     /** Returns the primitive value of the specified object. */
     valueOf(self) -> boolean,
     constructor(mut self, value?: unknown),
-    callable<T>(value?: T) -> boolean,
+    <T>(value?: T) -> boolean,
     static readonly prototype: Boolean
 }

--- a/internal/interop/data/std/date.esc
+++ b/internal/interop/data/std/date.esc
@@ -235,7 +235,7 @@ export declare class Date {
      * @param ms A number from 0 to 999 that specifies the milliseconds.
      */
     constructor(mut self, year: number, monthIndex: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number),
-    fn () -> string,
+    callable() -> string,
     static readonly prototype: Date,
     /**
      * Parses a string containing a date, and returns the number of milliseconds between that date and midnight, January 1, 1970.

--- a/internal/interop/data/std/date.esc
+++ b/internal/interop/data/std/date.esc
@@ -235,7 +235,7 @@ export declare class Date {
      * @param ms A number from 0 to 999 that specifies the milliseconds.
      */
     constructor(mut self, year: number, monthIndex: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number),
-    callable() -> string,
+    () -> string,
     static readonly prototype: Date,
     /**
      * Parses a string containing a date, and returns the number of milliseconds between that date and midnight, January 1, 1970.

--- a/internal/interop/data/std/date.esc
+++ b/internal/interop/data/std/date.esc
@@ -235,6 +235,7 @@ export declare class Date {
      * @param ms A number from 0 to 999 that specifies the milliseconds.
      */
     constructor(mut self, year: number, monthIndex: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number),
+    fn () -> string,
     static readonly prototype: Date,
     /**
      * Parses a string containing a date, and returns the number of milliseconds between that date and midnight, January 1, 1970.

--- a/internal/interop/data/std/error.esc
+++ b/internal/interop/data/std/error.esc
@@ -13,45 +13,45 @@ export declare class Error {
     message: string,
     stack?: string,
     constructor(mut self, message?: string, options?: ErrorOptions),
-    fn (message?: string, options?: ErrorOptions) -> Error,
+    callable(message?: string, options?: ErrorOptions) -> Error,
     constructor(mut self, message?: string),
-    fn (message?: string) -> Error,
+    callable(message?: string) -> Error,
     static readonly prototype: Error
 }
 
 @js("RangeError")
 export declare class RangeError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    fn (message?: string, options?: ErrorOptions) -> RangeError,
+    callable(message?: string, options?: ErrorOptions) -> RangeError,
     constructor(mut self, message?: string),
-    fn (message?: string) -> RangeError,
+    callable(message?: string) -> RangeError,
     static readonly prototype: RangeError
 }
 
 @js("ReferenceError")
 export declare class ReferenceError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    fn (message?: string, options?: ErrorOptions) -> ReferenceError,
+    callable(message?: string, options?: ErrorOptions) -> ReferenceError,
     constructor(mut self, message?: string),
-    fn (message?: string) -> ReferenceError,
+    callable(message?: string) -> ReferenceError,
     static readonly prototype: ReferenceError
 }
 
 @js("SyntaxError")
 export declare class SyntaxError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    fn (message?: string, options?: ErrorOptions) -> SyntaxError,
+    callable(message?: string, options?: ErrorOptions) -> SyntaxError,
     constructor(mut self, message?: string),
-    fn (message?: string) -> SyntaxError,
+    callable(message?: string) -> SyntaxError,
     static readonly prototype: SyntaxError
 }
 
 @js("TypeError")
 export declare class TypeError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    fn (message?: string, options?: ErrorOptions) -> TypeError,
+    callable(message?: string, options?: ErrorOptions) -> TypeError,
     constructor(mut self, message?: string),
-    fn (message?: string) -> TypeError,
+    callable(message?: string) -> TypeError,
     static readonly prototype: TypeError
 }
 
@@ -60,6 +60,6 @@ export declare class SuppressedError extends Error {
     error: any,
     suppressed: any,
     constructor(mut self, error: unknown, suppressed: unknown, message?: string),
-    fn (error: unknown, suppressed: unknown, message?: string) -> SuppressedError,
+    callable(error: unknown, suppressed: unknown, message?: string) -> SuppressedError,
     static readonly prototype: SuppressedError
 }

--- a/internal/interop/data/std/error.esc
+++ b/internal/interop/data/std/error.esc
@@ -13,45 +13,45 @@ export declare class Error {
     message: string,
     stack?: string,
     constructor(mut self, message?: string, options?: ErrorOptions),
-    callable(message?: string, options?: ErrorOptions) -> Error,
+    (message?: string, options?: ErrorOptions) -> Error,
     constructor(mut self, message?: string),
-    callable(message?: string) -> Error,
+    (message?: string) -> Error,
     static readonly prototype: Error
 }
 
 @js("RangeError")
 export declare class RangeError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    callable(message?: string, options?: ErrorOptions) -> RangeError,
+    (message?: string, options?: ErrorOptions) -> RangeError,
     constructor(mut self, message?: string),
-    callable(message?: string) -> RangeError,
+    (message?: string) -> RangeError,
     static readonly prototype: RangeError
 }
 
 @js("ReferenceError")
 export declare class ReferenceError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    callable(message?: string, options?: ErrorOptions) -> ReferenceError,
+    (message?: string, options?: ErrorOptions) -> ReferenceError,
     constructor(mut self, message?: string),
-    callable(message?: string) -> ReferenceError,
+    (message?: string) -> ReferenceError,
     static readonly prototype: ReferenceError
 }
 
 @js("SyntaxError")
 export declare class SyntaxError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    callable(message?: string, options?: ErrorOptions) -> SyntaxError,
+    (message?: string, options?: ErrorOptions) -> SyntaxError,
     constructor(mut self, message?: string),
-    callable(message?: string) -> SyntaxError,
+    (message?: string) -> SyntaxError,
     static readonly prototype: SyntaxError
 }
 
 @js("TypeError")
 export declare class TypeError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    callable(message?: string, options?: ErrorOptions) -> TypeError,
+    (message?: string, options?: ErrorOptions) -> TypeError,
     constructor(mut self, message?: string),
-    callable(message?: string) -> TypeError,
+    (message?: string) -> TypeError,
     static readonly prototype: TypeError
 }
 
@@ -60,6 +60,6 @@ export declare class SuppressedError extends Error {
     error: any,
     suppressed: any,
     constructor(mut self, error: unknown, suppressed: unknown, message?: string),
-    callable(error: unknown, suppressed: unknown, message?: string) -> SuppressedError,
+    (error: unknown, suppressed: unknown, message?: string) -> SuppressedError,
     static readonly prototype: SuppressedError
 }

--- a/internal/interop/data/std/error.esc
+++ b/internal/interop/data/std/error.esc
@@ -13,35 +13,45 @@ export declare class Error {
     message: string,
     stack?: string,
     constructor(mut self, message?: string, options?: ErrorOptions),
+    fn (message?: string, options?: ErrorOptions) -> Error,
     constructor(mut self, message?: string),
+    fn (message?: string) -> Error,
     static readonly prototype: Error
 }
 
 @js("RangeError")
 export declare class RangeError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    fn (message?: string, options?: ErrorOptions) -> RangeError,
     constructor(mut self, message?: string),
+    fn (message?: string) -> RangeError,
     static readonly prototype: RangeError
 }
 
 @js("ReferenceError")
 export declare class ReferenceError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    fn (message?: string, options?: ErrorOptions) -> ReferenceError,
     constructor(mut self, message?: string),
+    fn (message?: string) -> ReferenceError,
     static readonly prototype: ReferenceError
 }
 
 @js("SyntaxError")
 export declare class SyntaxError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    fn (message?: string, options?: ErrorOptions) -> SyntaxError,
     constructor(mut self, message?: string),
+    fn (message?: string) -> SyntaxError,
     static readonly prototype: SyntaxError
 }
 
 @js("TypeError")
 export declare class TypeError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    fn (message?: string, options?: ErrorOptions) -> TypeError,
     constructor(mut self, message?: string),
+    fn (message?: string) -> TypeError,
     static readonly prototype: TypeError
 }
 
@@ -50,5 +60,6 @@ export declare class SuppressedError extends Error {
     error: any,
     suppressed: any,
     constructor(mut self, error: unknown, suppressed: unknown, message?: string),
+    fn (error: unknown, suppressed: unknown, message?: string) -> SuppressedError,
     static readonly prototype: SuppressedError
 }

--- a/internal/interop/data/std/function.esc
+++ b/internal/interop/data/std/function.esc
@@ -47,6 +47,7 @@ export declare class Function {
      * @param args A list of arguments the function accepts.
      */
     constructor(mut self, ...args: mut Array<string>),
+    fn (...args: mut Array<string>) -> Function,
     static readonly prototype: Function
 }
 

--- a/internal/interop/data/std/function.esc
+++ b/internal/interop/data/std/function.esc
@@ -47,7 +47,7 @@ export declare class Function {
      * @param args A list of arguments the function accepts.
      */
     constructor(mut self, ...args: mut Array<string>),
-    callable(...args: mut Array<string>) -> Function,
+    (...args: mut Array<string>) -> Function,
     static readonly prototype: Function
 }
 

--- a/internal/interop/data/std/function.esc
+++ b/internal/interop/data/std/function.esc
@@ -47,7 +47,7 @@ export declare class Function {
      * @param args A list of arguments the function accepts.
      */
     constructor(mut self, ...args: mut Array<string>),
-    fn (...args: mut Array<string>) -> Function,
+    callable(...args: mut Array<string>) -> Function,
     static readonly prototype: Function
 }
 

--- a/internal/interop/data/std/intl.esc
+++ b/internal/interop/data/std/intl.esc
@@ -46,10 +46,10 @@ export declare class DateTimeFormat {
     format(mut self, date?: Date | number) -> string,
     resolvedOptions(mut self) -> ResolvedDateTimeFormatOptions,
     constructor(mut self, locales?: LocalesArgument, options?: DateTimeFormatOptions),
-    callable(locales?: LocalesArgument, options?: DateTimeFormatOptions) -> DateTimeFormat,
+    (locales?: LocalesArgument, options?: DateTimeFormatOptions) -> DateTimeFormat,
     static supportedLocalesOf(locales: LocalesArgument, options?: DateTimeFormatOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: DateTimeFormatOptions),
-    callable(locales?: string | mut Array<string>, options?: DateTimeFormatOptions) -> DateTimeFormat,
+    (locales?: string | mut Array<string>, options?: DateTimeFormatOptions) -> DateTimeFormat,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: DateTimeFormatOptions) -> mut Array<string>,
     static readonly prototype: DateTimeFormat
 }
@@ -84,12 +84,12 @@ export declare class PluralRules {
     resolvedOptions(mut self) -> ResolvedPluralRulesOptions,
     select(mut self, n: number) -> LDMLPluralRule,
     constructor(mut self, locales?: string | Array<string>, options?: PluralRulesOptions),
-    callable(locales?: string | Array<string>, options?: PluralRulesOptions) -> PluralRules,
+    (locales?: string | Array<string>, options?: PluralRulesOptions) -> PluralRules,
     static supportedLocalesOf(locales: string | Array<string>, options?: {
         localeMatcher?: "lookup" | "best fit"
     }) -> mut Array<string>,
     constructor(mut self, locales?: LocalesArgument, options?: PluralRulesOptions),
-    callable(locales?: LocalesArgument, options?: PluralRulesOptions) -> PluralRules,
+    (locales?: LocalesArgument, options?: PluralRulesOptions) -> PluralRules,
     static supportedLocalesOf(locales: LocalesArgument, options?: {
         localeMatcher?: "lookup" | "best fit"
     }) -> mut Array<string>
@@ -134,10 +134,10 @@ export declare class NumberFormat {
     format(mut self, value: number) -> string,
     resolvedOptions(mut self) -> ResolvedNumberFormatOptions,
     constructor(mut self, locales?: LocalesArgument, options?: NumberFormatOptions),
-    callable(locales?: LocalesArgument, options?: NumberFormatOptions) -> NumberFormat,
+    (locales?: LocalesArgument, options?: NumberFormatOptions) -> NumberFormat,
     static supportedLocalesOf(locales: LocalesArgument, options?: NumberFormatOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: NumberFormatOptions),
-    callable(locales?: string | mut Array<string>, options?: NumberFormatOptions) -> NumberFormat,
+    (locales?: string | mut Array<string>, options?: NumberFormatOptions) -> NumberFormat,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: NumberFormatOptions) -> mut Array<string>,
     static readonly prototype: NumberFormat
 }
@@ -812,10 +812,10 @@ export declare class Collator {
     compare(mut self, x: string, y: string) -> number,
     resolvedOptions(mut self) -> ResolvedCollatorOptions,
     constructor(mut self, locales?: LocalesArgument, options?: CollatorOptions),
-    callable(locales?: LocalesArgument, options?: CollatorOptions) -> Collator,
+    (locales?: LocalesArgument, options?: CollatorOptions) -> Collator,
     static supportedLocalesOf(locales: LocalesArgument, options?: CollatorOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: CollatorOptions),
-    callable(locales?: string | mut Array<string>, options?: CollatorOptions) -> Collator,
+    (locales?: string | mut Array<string>, options?: CollatorOptions) -> Collator,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: CollatorOptions) -> mut Array<string>
 }
 

--- a/internal/interop/data/std/intl.esc
+++ b/internal/interop/data/std/intl.esc
@@ -46,8 +46,10 @@ export declare class DateTimeFormat {
     format(mut self, date?: Date | number) -> string,
     resolvedOptions(mut self) -> ResolvedDateTimeFormatOptions,
     constructor(mut self, locales?: LocalesArgument, options?: DateTimeFormatOptions),
+    fn (locales?: LocalesArgument, options?: DateTimeFormatOptions) -> DateTimeFormat,
     static supportedLocalesOf(locales: LocalesArgument, options?: DateTimeFormatOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: DateTimeFormatOptions),
+    fn (locales?: string | mut Array<string>, options?: DateTimeFormatOptions) -> DateTimeFormat,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: DateTimeFormatOptions) -> mut Array<string>,
     static readonly prototype: DateTimeFormat
 }
@@ -82,10 +84,12 @@ export declare class PluralRules {
     resolvedOptions(mut self) -> ResolvedPluralRulesOptions,
     select(mut self, n: number) -> LDMLPluralRule,
     constructor(mut self, locales?: string | Array<string>, options?: PluralRulesOptions),
+    fn (locales?: string | Array<string>, options?: PluralRulesOptions) -> PluralRules,
     static supportedLocalesOf(locales: string | Array<string>, options?: {
         localeMatcher?: "lookup" | "best fit"
     }) -> mut Array<string>,
     constructor(mut self, locales?: LocalesArgument, options?: PluralRulesOptions),
+    fn (locales?: LocalesArgument, options?: PluralRulesOptions) -> PluralRules,
     static supportedLocalesOf(locales: LocalesArgument, options?: {
         localeMatcher?: "lookup" | "best fit"
     }) -> mut Array<string>
@@ -130,8 +134,10 @@ export declare class NumberFormat {
     format(mut self, value: number) -> string,
     resolvedOptions(mut self) -> ResolvedNumberFormatOptions,
     constructor(mut self, locales?: LocalesArgument, options?: NumberFormatOptions),
+    fn (locales?: LocalesArgument, options?: NumberFormatOptions) -> NumberFormat,
     static supportedLocalesOf(locales: LocalesArgument, options?: NumberFormatOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: NumberFormatOptions),
+    fn (locales?: string | mut Array<string>, options?: NumberFormatOptions) -> NumberFormat,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: NumberFormatOptions) -> mut Array<string>,
     static readonly prototype: NumberFormat
 }
@@ -806,8 +812,10 @@ export declare class Collator {
     compare(mut self, x: string, y: string) -> number,
     resolvedOptions(mut self) -> ResolvedCollatorOptions,
     constructor(mut self, locales?: LocalesArgument, options?: CollatorOptions),
+    fn (locales?: LocalesArgument, options?: CollatorOptions) -> Collator,
     static supportedLocalesOf(locales: LocalesArgument, options?: CollatorOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: CollatorOptions),
+    fn (locales?: string | mut Array<string>, options?: CollatorOptions) -> Collator,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: CollatorOptions) -> mut Array<string>
 }
 

--- a/internal/interop/data/std/intl.esc
+++ b/internal/interop/data/std/intl.esc
@@ -46,10 +46,10 @@ export declare class DateTimeFormat {
     format(mut self, date?: Date | number) -> string,
     resolvedOptions(mut self) -> ResolvedDateTimeFormatOptions,
     constructor(mut self, locales?: LocalesArgument, options?: DateTimeFormatOptions),
-    fn (locales?: LocalesArgument, options?: DateTimeFormatOptions) -> DateTimeFormat,
+    callable(locales?: LocalesArgument, options?: DateTimeFormatOptions) -> DateTimeFormat,
     static supportedLocalesOf(locales: LocalesArgument, options?: DateTimeFormatOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: DateTimeFormatOptions),
-    fn (locales?: string | mut Array<string>, options?: DateTimeFormatOptions) -> DateTimeFormat,
+    callable(locales?: string | mut Array<string>, options?: DateTimeFormatOptions) -> DateTimeFormat,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: DateTimeFormatOptions) -> mut Array<string>,
     static readonly prototype: DateTimeFormat
 }
@@ -84,12 +84,12 @@ export declare class PluralRules {
     resolvedOptions(mut self) -> ResolvedPluralRulesOptions,
     select(mut self, n: number) -> LDMLPluralRule,
     constructor(mut self, locales?: string | Array<string>, options?: PluralRulesOptions),
-    fn (locales?: string | Array<string>, options?: PluralRulesOptions) -> PluralRules,
+    callable(locales?: string | Array<string>, options?: PluralRulesOptions) -> PluralRules,
     static supportedLocalesOf(locales: string | Array<string>, options?: {
         localeMatcher?: "lookup" | "best fit"
     }) -> mut Array<string>,
     constructor(mut self, locales?: LocalesArgument, options?: PluralRulesOptions),
-    fn (locales?: LocalesArgument, options?: PluralRulesOptions) -> PluralRules,
+    callable(locales?: LocalesArgument, options?: PluralRulesOptions) -> PluralRules,
     static supportedLocalesOf(locales: LocalesArgument, options?: {
         localeMatcher?: "lookup" | "best fit"
     }) -> mut Array<string>
@@ -134,10 +134,10 @@ export declare class NumberFormat {
     format(mut self, value: number) -> string,
     resolvedOptions(mut self) -> ResolvedNumberFormatOptions,
     constructor(mut self, locales?: LocalesArgument, options?: NumberFormatOptions),
-    fn (locales?: LocalesArgument, options?: NumberFormatOptions) -> NumberFormat,
+    callable(locales?: LocalesArgument, options?: NumberFormatOptions) -> NumberFormat,
     static supportedLocalesOf(locales: LocalesArgument, options?: NumberFormatOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: NumberFormatOptions),
-    fn (locales?: string | mut Array<string>, options?: NumberFormatOptions) -> NumberFormat,
+    callable(locales?: string | mut Array<string>, options?: NumberFormatOptions) -> NumberFormat,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: NumberFormatOptions) -> mut Array<string>,
     static readonly prototype: NumberFormat
 }
@@ -812,10 +812,10 @@ export declare class Collator {
     compare(mut self, x: string, y: string) -> number,
     resolvedOptions(mut self) -> ResolvedCollatorOptions,
     constructor(mut self, locales?: LocalesArgument, options?: CollatorOptions),
-    fn (locales?: LocalesArgument, options?: CollatorOptions) -> Collator,
+    callable(locales?: LocalesArgument, options?: CollatorOptions) -> Collator,
     static supportedLocalesOf(locales: LocalesArgument, options?: CollatorOptions) -> mut Array<string>,
     constructor(mut self, locales?: string | mut Array<string>, options?: CollatorOptions),
-    fn (locales?: string | mut Array<string>, options?: CollatorOptions) -> Collator,
+    callable(locales?: string | mut Array<string>, options?: CollatorOptions) -> Collator,
     static supportedLocalesOf(locales: string | mut Array<string>, options?: CollatorOptions) -> mut Array<string>
 }
 

--- a/internal/interop/data/std/iterator.esc
+++ b/internal/interop/data/std/iterator.esc
@@ -4,7 +4,7 @@
 
 export declare interface GeneratorFunction {
     new (...args: mut Array<any>) -> Generator,
-    fn (...args: mut Array<any>) -> Generator,
+    (...args: mut Array<any>) -> Generator,
     /**
      * The length of the arguments.
      */
@@ -22,7 +22,7 @@ export declare interface GeneratorFunction {
 
 export declare interface GeneratorFunctionConstructor {
     new (...args: mut Array<string>) -> GeneratorFunction,
-    fn (...args: mut Array<string>) -> GeneratorFunction,
+    (...args: mut Array<string>) -> GeneratorFunction,
     /**
      * The length of the arguments.
      */

--- a/internal/interop/data/std/number.esc
+++ b/internal/interop/data/std/number.esc
@@ -94,7 +94,7 @@ export declare class Number {
      */
     static parseInt(string: string, radix?: number) -> number,
     constructor(mut self, value?: unknown),
-    fn (value?: unknown) -> number,
+    callable(value?: unknown) -> number,
     static readonly prototype: Number,
     /** The largest number that can be represented in JavaScript. Equal to approximately 1.79E+308. */
     static readonly MAX_VALUE: number,

--- a/internal/interop/data/std/number.esc
+++ b/internal/interop/data/std/number.esc
@@ -94,7 +94,7 @@ export declare class Number {
      */
     static parseInt(string: string, radix?: number) -> number,
     constructor(mut self, value?: unknown),
-    callable(value?: unknown) -> number,
+    (value?: unknown) -> number,
     static readonly prototype: Number,
     /** The largest number that can be represented in JavaScript. Equal to approximately 1.79E+308. */
     static readonly MAX_VALUE: number,

--- a/internal/interop/data/std/number.esc
+++ b/internal/interop/data/std/number.esc
@@ -94,6 +94,7 @@ export declare class Number {
      */
     static parseInt(string: string, radix?: number) -> number,
     constructor(mut self, value?: unknown),
+    fn (value?: unknown) -> number,
     static readonly prototype: Number,
     /** The largest number that can be represented in JavaScript. Equal to approximately 1.79E+308. */
     static readonly MAX_VALUE: number,

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -143,8 +143,8 @@ export declare class Object {
      */
     static groupBy<K: PropertyKey, T>(items: Iterable<T>, keySelector: fn (item: T, index: number) -> K) -> Partial<Record<K, mut Array<T>>>,
     constructor(mut self, value?: unknown),
-    callable() -> any,
-    callable(value: unknown) -> any,
+    () -> any,
+    (value: unknown) -> any,
     /** A reference to the prototype for a class of objects. */
     static readonly prototype: Object,
     /**

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -143,6 +143,8 @@ export declare class Object {
      */
     static groupBy<K: PropertyKey, T>(items: Iterable<T>, keySelector: fn (item: T, index: number) -> K) -> Partial<Record<K, mut Array<T>>>,
     constructor(mut self, value?: unknown),
+    fn () -> any,
+    fn (value: unknown) -> any,
     /** A reference to the prototype for a class of objects. */
     static readonly prototype: Object,
     /**

--- a/internal/interop/data/std/object.esc
+++ b/internal/interop/data/std/object.esc
@@ -143,8 +143,8 @@ export declare class Object {
      */
     static groupBy<K: PropertyKey, T>(items: Iterable<T>, keySelector: fn (item: T, index: number) -> K) -> Partial<Record<K, mut Array<T>>>,
     constructor(mut self, value?: unknown),
-    fn () -> any,
-    fn (value: unknown) -> any,
+    callable() -> any,
+    callable(value: unknown) -> any,
     /** A reference to the prototype for a class of objects. */
     static readonly prototype: Object,
     /**

--- a/internal/interop/data/std/prelude.esc
+++ b/internal/interop/data/std/prelude.esc
@@ -378,9 +378,9 @@ export declare class Array<T> {
     constructor(mut self, arrayLength?: number),
     constructor(mut self, arrayLength: number),
     constructor(mut self, ...items: mut Array<T>),
-    fn (arrayLength?: number) -> mut Array<any>,
-    fn<T> (arrayLength: number) -> mut Array<T>,
-    fn<T> (...items: mut Array<T>) -> mut Array<T>,
+    callable(arrayLength?: number) -> mut Array<any>,
+    callable<T>(arrayLength: number) -> mut Array<T>,
+    callable<T>(...items: mut Array<T>) -> mut Array<T>,
     static isArray(arg: unknown) -> boolean,
     static readonly prototype: mut Array<any>,
     /**
@@ -690,7 +690,7 @@ export declare class Symbol {
      * Returns a new unique Symbol value.
      * @param  description Description of the new Symbol object.
      */
-    fn (description?: string | number) -> symbol,
+    callable(description?: string | number) -> symbol,
     /**
      * Returns a Symbol object from the global symbol registry matching the given key if found.
      * Otherwise, returns a new symbol with this key.

--- a/internal/interop/data/std/prelude.esc
+++ b/internal/interop/data/std/prelude.esc
@@ -378,9 +378,9 @@ export declare class Array<T> {
     constructor(mut self, arrayLength?: number),
     constructor(mut self, arrayLength: number),
     constructor(mut self, ...items: mut Array<T>),
-    callable(arrayLength?: number) -> mut Array<any>,
-    callable<T>(arrayLength: number) -> mut Array<T>,
-    callable<T>(...items: mut Array<T>) -> mut Array<T>,
+    (arrayLength?: number) -> mut Array<any>,
+    <T>(arrayLength: number) -> mut Array<T>,
+    <T>(...items: mut Array<T>) -> mut Array<T>,
     static isArray(arg: unknown) -> boolean,
     static readonly prototype: mut Array<any>,
     /**
@@ -690,7 +690,7 @@ export declare class Symbol {
      * Returns a new unique Symbol value.
      * @param  description Description of the new Symbol object.
      */
-    callable(description?: string | number) -> symbol,
+    (description?: string | number) -> symbol,
     /**
      * Returns a Symbol object from the global symbol registry matching the given key if found.
      * Otherwise, returns a new symbol with this key.

--- a/internal/interop/data/std/prelude.esc
+++ b/internal/interop/data/std/prelude.esc
@@ -378,6 +378,9 @@ export declare class Array<T> {
     constructor(mut self, arrayLength?: number),
     constructor(mut self, arrayLength: number),
     constructor(mut self, ...items: mut Array<T>),
+    fn (arrayLength?: number) -> mut Array<any>,
+    fn<T> (arrayLength: number) -> mut Array<T>,
+    fn<T> (...items: mut Array<T>) -> mut Array<T>,
     static isArray(arg: unknown) -> boolean,
     static readonly prototype: mut Array<any>,
     /**
@@ -401,100 +404,6 @@ export declare interface Generator<T = unknown, TReturn = any, TNext = any, E = 
     return(value: TReturn) -> IteratorResult<T, TReturn>,
     throw(e: E) -> IteratorResult<T, TReturn>,
     [Symbol.iterator]() -> Generator<T, TReturn, TNext, E>
-}
-
-export declare interface SymbolConstructor {
-    /**
-     * A method that returns the default iterator for an object. Called by the semantics of the
-     * for-of statement.
-     */
-    readonly iterator: unique symbol,
-    /**
-     * A reference to the prototype.
-     */
-    readonly prototype: Symbol,
-    fn (description?: string | number) -> symbol,
-    /**
-     * Returns a Symbol object from the global symbol registry matching the given key if found.
-     * Otherwise, returns a new symbol with this key.
-     * @param key key to search for.
-     */
-    for(key: string) -> symbol,
-    /**
-     * Returns a key from the global symbol registry matching the given Symbol if found.
-     * Otherwise, returns a undefined.
-     * @param sym Symbol to find the key for.
-     */
-    keyFor(sym: symbol) -> string | undefined,
-    /**
-     * A method that determines if a constructor object recognizes an object as one of the
-     * constructor’s instances. Called by the semantics of the instanceof operator.
-     */
-    readonly hasInstance: unique symbol,
-    /**
-     * A Boolean value that if true indicates that an object should flatten to its array elements
-     * by Array.prototype.concat.
-     */
-    readonly isConcatSpreadable: unique symbol,
-    /**
-     * A regular expression method that matches the regular expression against a string. Called
-     * by the String.prototype.match method.
-     */
-    readonly match: unique symbol,
-    /**
-     * A regular expression method that replaces matched substrings of a string. Called by the
-     * String.prototype.replace method.
-     */
-    readonly replace: unique symbol,
-    /**
-     * A regular expression method that returns the index within a string that matches the
-     * regular expression. Called by the String.prototype.search method.
-     */
-    readonly search: unique symbol,
-    /**
-     * A function valued property that is the constructor function that is used to create
-     * derived objects.
-     */
-    readonly species: unique symbol,
-    /**
-     * A regular expression method that splits a string at the indices that match the regular
-     * expression. Called by the String.prototype.split method.
-     */
-    readonly split: unique symbol,
-    /**
-     * A method that converts an object to a corresponding primitive value.
-     * Called by the ToPrimitive abstract operation.
-     */
-    readonly toPrimitive: unique symbol,
-    /**
-     * A String value that is used in the creation of the default string description of an object.
-     * Called by the built-in method Object.prototype.toString.
-     */
-    readonly toStringTag: unique symbol,
-    /**
-     * An Object whose truthy properties are properties that are excluded from the 'with'
-     * environment bindings of the associated objects.
-     */
-    readonly unscopables: unique symbol,
-    /**
-     * A method that returns the default async iterator for an object. Called by the semantics of
-     * the for-await-of statement.
-     */
-    readonly asyncIterator: unique symbol,
-    /**
-     * A regular expression method that matches the regular expression against a string. Called
-     * by the String.prototype.matchAll method.
-     */
-    readonly matchAll: unique symbol,
-    readonly metadata: unique symbol,
-    /**
-     * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
-     */
-    readonly dispose: unique symbol,
-    /**
-     * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
-     */
-    readonly asyncDispose: unique symbol
 }
 
 @js("Iterator")
@@ -754,22 +663,115 @@ export declare class Promise<T, E = never> {
 }
 
 @js("Symbol")
-export declare var Symbol: SymbolConstructor
-
-export declare interface Symbol {
+export declare class Symbol {
     /**
      * Converts a Symbol object to a symbol.
      */
-    [Symbol.toPrimitive](hint: string) -> symbol,
+    [Symbol.toPrimitive](self, hint: string) -> symbol,
     readonly [Symbol.toStringTag]: string,
     /**
      * Expose the [[Description]] internal slot of a symbol directly.
      */
     readonly description: string | undefined,
     /** Returns a string representation of an object. */
-    toString() -> string,
+    toString(self) -> string,
     /** Returns the primitive value of the specified object. */
-    valueOf() -> symbol
+    valueOf(self) -> symbol,
+    /**
+     * A method that returns the default iterator for an object. Called by the semantics of the
+     * for-of statement.
+     */
+    static readonly iterator: unique symbol,
+    /**
+     * A reference to the prototype.
+     */
+    static readonly prototype: Symbol,
+    /**
+     * Returns a new unique Symbol value.
+     * @param  description Description of the new Symbol object.
+     */
+    fn (description?: string | number) -> symbol,
+    /**
+     * Returns a Symbol object from the global symbol registry matching the given key if found.
+     * Otherwise, returns a new symbol with this key.
+     * @param key key to search for.
+     */
+    static for(key: string) -> symbol,
+    /**
+     * Returns a key from the global symbol registry matching the given Symbol if found.
+     * Otherwise, returns a undefined.
+     * @param sym Symbol to find the key for.
+     */
+    static keyFor(sym: symbol) -> string | undefined,
+    /**
+     * A method that determines if a constructor object recognizes an object as one of the
+     * constructor’s instances. Called by the semantics of the instanceof operator.
+     */
+    static readonly hasInstance: unique symbol,
+    /**
+     * A Boolean value that if true indicates that an object should flatten to its array elements
+     * by Array.prototype.concat.
+     */
+    static readonly isConcatSpreadable: unique symbol,
+    /**
+     * A regular expression method that matches the regular expression against a string. Called
+     * by the String.prototype.match method.
+     */
+    static readonly match: unique symbol,
+    /**
+     * A regular expression method that replaces matched substrings of a string. Called by the
+     * String.prototype.replace method.
+     */
+    static readonly replace: unique symbol,
+    /**
+     * A regular expression method that returns the index within a string that matches the
+     * regular expression. Called by the String.prototype.search method.
+     */
+    static readonly search: unique symbol,
+    /**
+     * A function valued property that is the constructor function that is used to create
+     * derived objects.
+     */
+    static readonly species: unique symbol,
+    /**
+     * A regular expression method that splits a string at the indices that match the regular
+     * expression. Called by the String.prototype.split method.
+     */
+    static readonly split: unique symbol,
+    /**
+     * A method that converts an object to a corresponding primitive value.
+     * Called by the ToPrimitive abstract operation.
+     */
+    static readonly toPrimitive: unique symbol,
+    /**
+     * A String value that is used in the creation of the default string description of an object.
+     * Called by the built-in method Object.prototype.toString.
+     */
+    static readonly toStringTag: unique symbol,
+    /**
+     * An Object whose truthy properties are properties that are excluded from the 'with'
+     * environment bindings of the associated objects.
+     */
+    static readonly unscopables: unique symbol,
+    /**
+     * A method that returns the default async iterator for an object. Called by the semantics of
+     * the for-await-of statement.
+     */
+    static readonly asyncIterator: unique symbol,
+    /**
+     * A regular expression method that matches the regular expression against a string. Called
+     * by the String.prototype.matchAll method.
+     */
+    static readonly matchAll: unique symbol,
+    static readonly metadata: unique symbol,
+    /**
+     * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
+     */
+    static readonly dispose: unique symbol,
+    /**
+     * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
+     */
+    static readonly asyncDispose: unique symbol
 }
 
 export declare interface AsyncGenerator<T = unknown, TReturn = any, TNext = any, E = never> extends AsyncIteratorObject<T, TReturn, TNext> {

--- a/internal/interop/data/std/regexp.esc
+++ b/internal/interop/data/std/regexp.esc
@@ -111,12 +111,12 @@ export declare class RegExp {
     /** @deprecated A legacy feature for browser compatibility */
     compile(mut self, pattern: string, flags?: string) -> Self,
     constructor(mut self, pattern: RegExp | string, flags?: string),
-    callable(pattern: RegExp | string, flags?: string) -> RegExp,
+    (pattern: RegExp | string, flags?: string) -> RegExp,
     static readonly [Symbol.species]: typeof RegExp,
     constructor(mut self, pattern: RegExp | string),
     constructor(mut self, pattern: string, flags?: string),
-    callable(pattern: RegExp | string) -> RegExp,
-    callable(pattern: string, flags?: string) -> RegExp,
+    (pattern: RegExp | string) -> RegExp,
+    (pattern: string, flags?: string) -> RegExp,
     static readonly "prototype": RegExp,
     /** @deprecated A legacy feature for browser compatibility */
     static "$1": string,

--- a/internal/interop/data/std/regexp.esc
+++ b/internal/interop/data/std/regexp.esc
@@ -111,12 +111,12 @@ export declare class RegExp {
     /** @deprecated A legacy feature for browser compatibility */
     compile(mut self, pattern: string, flags?: string) -> Self,
     constructor(mut self, pattern: RegExp | string, flags?: string),
-    fn (pattern: RegExp | string, flags?: string) -> RegExp,
+    callable(pattern: RegExp | string, flags?: string) -> RegExp,
     static readonly [Symbol.species]: typeof RegExp,
     constructor(mut self, pattern: RegExp | string),
     constructor(mut self, pattern: string, flags?: string),
-    fn (pattern: RegExp | string) -> RegExp,
-    fn (pattern: string, flags?: string) -> RegExp,
+    callable(pattern: RegExp | string) -> RegExp,
+    callable(pattern: string, flags?: string) -> RegExp,
     static readonly "prototype": RegExp,
     /** @deprecated A legacy feature for browser compatibility */
     static "$1": string,

--- a/internal/interop/data/std/regexp.esc
+++ b/internal/interop/data/std/regexp.esc
@@ -111,9 +111,12 @@ export declare class RegExp {
     /** @deprecated A legacy feature for browser compatibility */
     compile(mut self, pattern: string, flags?: string) -> Self,
     constructor(mut self, pattern: RegExp | string, flags?: string),
+    fn (pattern: RegExp | string, flags?: string) -> RegExp,
     static readonly [Symbol.species]: typeof RegExp,
     constructor(mut self, pattern: RegExp | string),
     constructor(mut self, pattern: string, flags?: string),
+    fn (pattern: RegExp | string) -> RegExp,
+    fn (pattern: string, flags?: string) -> RegExp,
     static readonly "prototype": RegExp,
     /** @deprecated A legacy feature for browser compatibility */
     static "$1": string,

--- a/internal/interop/data/std/string.esc
+++ b/internal/interop/data/std/string.esc
@@ -366,7 +366,7 @@ export declare class String {
         raw: Array<string> | ArrayLike<string>
     }, ...substitutions: mut Array<any>) -> string,
     constructor(mut self, value?: unknown),
-    callable(value?: unknown) -> string,
+    (value?: unknown) -> string,
     static readonly prototype: String,
     static fromCharCode(...codes: mut Array<number>) -> string
 }

--- a/internal/interop/data/std/string.esc
+++ b/internal/interop/data/std/string.esc
@@ -366,7 +366,7 @@ export declare class String {
         raw: Array<string> | ArrayLike<string>
     }, ...substitutions: mut Array<any>) -> string,
     constructor(mut self, value?: unknown),
-    fn (value?: unknown) -> string,
+    callable(value?: unknown) -> string,
     static readonly prototype: String,
     static fromCharCode(...codes: mut Array<number>) -> string
 }

--- a/internal/interop/data/std/string.esc
+++ b/internal/interop/data/std/string.esc
@@ -366,6 +366,7 @@ export declare class String {
         raw: Array<string> | ArrayLike<string>
     }, ...substitutions: mut Array<any>) -> string,
     constructor(mut self, value?: unknown),
+    fn (value?: unknown) -> string,
     static readonly prototype: String,
     static fromCharCode(...codes: mut Array<number>) -> string
 }

--- a/internal/interop/data/std/url.esc
+++ b/internal/interop/data/std/url.esc
@@ -33,8 +33,8 @@ export declare fn encodeURIComponent(uriComponent: string | number | boolean) ->
 @js("URIError")
 export declare class URIError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    callable(message?: string, options?: ErrorOptions) -> URIError,
+    (message?: string, options?: ErrorOptions) -> URIError,
     constructor(mut self, message?: string),
-    callable(message?: string) -> URIError,
+    (message?: string) -> URIError,
     static readonly prototype: URIError
 }

--- a/internal/interop/data/std/url.esc
+++ b/internal/interop/data/std/url.esc
@@ -33,8 +33,8 @@ export declare fn encodeURIComponent(uriComponent: string | number | boolean) ->
 @js("URIError")
 export declare class URIError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
-    fn (message?: string, options?: ErrorOptions) -> URIError,
+    callable(message?: string, options?: ErrorOptions) -> URIError,
     constructor(mut self, message?: string),
-    fn (message?: string) -> URIError,
+    callable(message?: string) -> URIError,
     static readonly prototype: URIError
 }

--- a/internal/interop/data/std/url.esc
+++ b/internal/interop/data/std/url.esc
@@ -33,6 +33,8 @@ export declare fn encodeURIComponent(uriComponent: string | number | boolean) ->
 @js("URIError")
 export declare class URIError extends Error {
     constructor(mut self, message?: string, options?: ErrorOptions),
+    fn (message?: string, options?: ErrorOptions) -> URIError,
     constructor(mut self, message?: string),
+    fn (message?: string) -> URIError,
     static readonly prototype: URIError
 }

--- a/internal/interop/data/std/wasm.esc
+++ b/internal/interop/data/std/wasm.esc
@@ -5,7 +5,8 @@
 @js("WebAssembly.CompileError")
 export declare class CompileError extends Error {
     static prototype: CompileError,
-    constructor(mut self, message?: string)
+    constructor(mut self, message?: string),
+    fn (message?: string) -> CompileError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global) */
@@ -29,7 +30,8 @@ export declare class Instance {
 @js("WebAssembly.LinkError")
 export declare class LinkError extends Error {
     static prototype: LinkError,
-    constructor(mut self, message?: string)
+    constructor(mut self, message?: string),
+    fn (message?: string) -> LinkError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory) */
@@ -59,7 +61,8 @@ export declare class Module {
 @js("WebAssembly.RuntimeError")
 export declare class RuntimeError extends Error {
     static prototype: RuntimeError,
-    constructor(mut self, message?: string)
+    constructor(mut self, message?: string),
+    fn (message?: string) -> RuntimeError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table) */

--- a/internal/interop/data/std/wasm.esc
+++ b/internal/interop/data/std/wasm.esc
@@ -6,7 +6,7 @@
 export declare class CompileError extends Error {
     static prototype: CompileError,
     constructor(mut self, message?: string),
-    callable(message?: string) -> CompileError
+    (message?: string) -> CompileError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global) */
@@ -31,7 +31,7 @@ export declare class Instance {
 export declare class LinkError extends Error {
     static prototype: LinkError,
     constructor(mut self, message?: string),
-    callable(message?: string) -> LinkError
+    (message?: string) -> LinkError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory) */
@@ -62,7 +62,7 @@ export declare class Module {
 export declare class RuntimeError extends Error {
     static prototype: RuntimeError,
     constructor(mut self, message?: string),
-    callable(message?: string) -> RuntimeError
+    (message?: string) -> RuntimeError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table) */

--- a/internal/interop/data/std/wasm.esc
+++ b/internal/interop/data/std/wasm.esc
@@ -6,7 +6,7 @@
 export declare class CompileError extends Error {
     static prototype: CompileError,
     constructor(mut self, message?: string),
-    fn (message?: string) -> CompileError
+    callable(message?: string) -> CompileError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global) */
@@ -31,7 +31,7 @@ export declare class Instance {
 export declare class LinkError extends Error {
     static prototype: LinkError,
     constructor(mut self, message?: string),
-    fn (message?: string) -> LinkError
+    callable(message?: string) -> LinkError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory) */
@@ -62,7 +62,7 @@ export declare class Module {
 export declare class RuntimeError extends Error {
     static prototype: RuntimeError,
     constructor(mut self, message?: string),
-    fn (message?: string) -> RuntimeError
+    callable(message?: string) -> RuntimeError
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table) */

--- a/internal/interop/data/web/dom.esc
+++ b/internal/interop/data/web/dom.esc
@@ -6119,7 +6119,7 @@ export declare class EventCounts extends Map<string, number> {
 }
 
 export declare interface EventListener {
-    fn (evt: Event) -> unknown
+    (evt: Event) -> unknown
 }
 
 export declare interface EventListenerObject {
@@ -18701,7 +18701,7 @@ export declare fn vmin(value: number) -> CSSUnitValue
 export declare fn vw(value: number) -> CSSUnitValue
 
 export declare interface BlobCallback {
-    fn (blob: Blob | null) -> unknown
+    (blob: Blob | null) -> unknown
 }
 
 export declare interface CustomElementConstructor {
@@ -18709,91 +18709,91 @@ export declare interface CustomElementConstructor {
 }
 
 export declare interface ErrorCallback {
-    fn (err: DOMException) -> unknown
+    (err: DOMException) -> unknown
 }
 
 export declare interface FileCallback {
-    fn (file: File) -> unknown
+    (file: File) -> unknown
 }
 
 export declare interface FileSystemEntriesCallback {
-    fn (entries: mut Array<FileSystemEntry>) -> unknown
+    (entries: mut Array<FileSystemEntry>) -> unknown
 }
 
 export declare interface FileSystemEntryCallback {
-    fn (entry: FileSystemEntry) -> unknown
+    (entry: FileSystemEntry) -> unknown
 }
 
 export declare interface FrameRequestCallback {
-    fn (time: DOMHighResTimeStamp) -> unknown
+    (time: DOMHighResTimeStamp) -> unknown
 }
 
 export declare interface FunctionStringCallback {
-    fn (data: string) -> unknown
+    (data: string) -> unknown
 }
 
 export declare interface IdleRequestCallback {
-    fn (deadline: IdleDeadline) -> unknown
+    (deadline: IdleDeadline) -> unknown
 }
 
 export declare interface IntersectionObserverCallback {
-    fn (entries: mut Array<IntersectionObserverEntry>, observer: IntersectionObserver) -> unknown
+    (entries: mut Array<IntersectionObserverEntry>, observer: IntersectionObserver) -> unknown
 }
 
 export declare interface LockGrantedCallback {
-    fn (lock: Lock | null) -> any
+    (lock: Lock | null) -> any
 }
 
 export declare interface MediaSessionActionHandler {
-    fn (details: MediaSessionActionDetails) -> unknown
+    (details: MediaSessionActionDetails) -> unknown
 }
 
 export declare interface MutationCallback {
-    fn (mutations: mut Array<MutationRecord>, observer: MutationObserver) -> unknown
+    (mutations: mut Array<MutationRecord>, observer: MutationObserver) -> unknown
 }
 
 export declare interface NotificationPermissionCallback {
-    fn (permission: NotificationPermission) -> unknown
+    (permission: NotificationPermission) -> unknown
 }
 
 export declare interface OnBeforeUnloadEventHandlerNonNull {
-    fn (event: Event) -> string | null
+    (event: Event) -> string | null
 }
 
 export declare interface OnErrorEventHandlerNonNull {
-    fn (event: Event | string, source?: string, lineno?: number, colno?: number, error?: Error) -> any
+    (event: Event | string, source?: string, lineno?: number, colno?: number, error?: Error) -> any
 }
 
 export declare interface PositionCallback {
-    fn (position: GeolocationPosition) -> unknown
+    (position: GeolocationPosition) -> unknown
 }
 
 export declare interface PositionErrorCallback {
-    fn (positionError: GeolocationPositionError) -> unknown
+    (positionError: GeolocationPositionError) -> unknown
 }
 
 export declare interface RemotePlaybackAvailabilityCallback {
-    fn (available: boolean) -> unknown
+    (available: boolean) -> unknown
 }
 
 export declare interface ReportingObserverCallback {
-    fn (reports: mut Array<Report>, observer: ReportingObserver) -> unknown
+    (reports: mut Array<Report>, observer: ReportingObserver) -> unknown
 }
 
 export declare interface ResizeObserverCallback {
-    fn (entries: mut Array<ResizeObserverEntry>, observer: ResizeObserver) -> unknown
+    (entries: mut Array<ResizeObserverEntry>, observer: ResizeObserver) -> unknown
 }
 
 export declare interface VideoFrameRequestCallback {
-    fn (now: DOMHighResTimeStamp, metadata: VideoFrameCallbackMetadata) -> unknown
+    (now: DOMHighResTimeStamp, metadata: VideoFrameCallbackMetadata) -> unknown
 }
 
 export declare interface ViewTransitionUpdateCallback {
-    fn () -> any
+    () -> any
 }
 
 export declare interface VoidFunction {
-    fn () -> unknown
+    () -> unknown
 }
 
 export declare interface HTMLElementTagNameMap {

--- a/internal/interop/data/web/performance.esc
+++ b/internal/interop/data/web/performance.esc
@@ -443,7 +443,7 @@ export declare class PerformanceTiming {
 }
 
 export declare interface PerformanceObserverCallback {
-    fn (entries: PerformanceObserverEntryList, observer: PerformanceObserver) -> unknown
+    (entries: PerformanceObserverEntryList, observer: PerformanceObserver) -> unknown
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/performance) */

--- a/internal/interop/data/web/streams.esc
+++ b/internal/interop/data/web/streams.esc
@@ -348,47 +348,47 @@ export declare class WritableStreamDefaultWriter<W = any> {
 }
 
 export declare interface QueuingStrategySize<T = any> {
-    fn (chunk: T) -> number
+    (chunk: T) -> number
 }
 
 export declare interface TransformerFlushCallback<O> {
-    fn (controller: TransformStreamDefaultController<O>) -> undefined | PromiseLike<undefined>
+    (controller: TransformStreamDefaultController<O>) -> undefined | PromiseLike<undefined>
 }
 
 export declare interface TransformerStartCallback<O> {
-    fn (controller: TransformStreamDefaultController<O>) -> any
+    (controller: TransformStreamDefaultController<O>) -> any
 }
 
 export declare interface TransformerTransformCallback<I, O> {
-    fn (chunk: I, controller: TransformStreamDefaultController<O>) -> undefined | PromiseLike<undefined>
+    (chunk: I, controller: TransformStreamDefaultController<O>) -> undefined | PromiseLike<undefined>
 }
 
 export declare interface UnderlyingSinkAbortCallback {
-    fn (reason?: any) -> undefined | PromiseLike<undefined>
+    (reason?: any) -> undefined | PromiseLike<undefined>
 }
 
 export declare interface UnderlyingSinkCloseCallback {
-    fn () -> undefined | PromiseLike<undefined>
+    () -> undefined | PromiseLike<undefined>
 }
 
 export declare interface UnderlyingSinkStartCallback {
-    fn (controller: WritableStreamDefaultController) -> any
+    (controller: WritableStreamDefaultController) -> any
 }
 
 export declare interface UnderlyingSinkWriteCallback<W> {
-    fn (chunk: W, controller: WritableStreamDefaultController) -> undefined | PromiseLike<undefined>
+    (chunk: W, controller: WritableStreamDefaultController) -> undefined | PromiseLike<undefined>
 }
 
 export declare interface UnderlyingSourceCancelCallback {
-    fn (reason?: any) -> undefined | PromiseLike<undefined>
+    (reason?: any) -> undefined | PromiseLike<undefined>
 }
 
 export declare interface UnderlyingSourcePullCallback<R> {
-    fn (controller: ReadableStreamController<R>) -> undefined | PromiseLike<undefined>
+    (controller: ReadableStreamController<R>) -> undefined | PromiseLike<undefined>
 }
 
 export declare interface UnderlyingSourceStartCallback<R> {
-    fn (controller: ReadableStreamController<R>) -> any
+    (controller: ReadableStreamController<R>) -> any
 }
 
 export declare type ReadableStreamController<T> = ReadableStreamDefaultController<T> | ReadableByteStreamController

--- a/internal/interop/data/web/web_audio.esc
+++ b/internal/interop/data/web/web_audio.esc
@@ -902,11 +902,11 @@ export declare class WaveShaperNode extends AudioNode {
 }
 
 export declare interface DecodeErrorCallback {
-    fn (error: DOMException) -> unknown
+    (error: DOMException) -> unknown
 }
 
 export declare interface DecodeSuccessCallback {
-    fn (decodedData: AudioBuffer) -> unknown
+    (decodedData: AudioBuffer) -> unknown
 }
 
 export declare type AudioContextLatencyCategory = "balanced" | "interactive" | "playback"

--- a/internal/interop/data/web/web_codecs.esc
+++ b/internal/interop/data/web/web_codecs.esc
@@ -531,23 +531,23 @@ export declare class VideoFrame {
 }
 
 export declare interface AudioDataOutputCallback {
-    fn (output: AudioData) -> unknown
+    (output: AudioData) -> unknown
 }
 
 export declare interface EncodedAudioChunkOutputCallback {
-    fn (output: EncodedAudioChunk, metadata?: EncodedAudioChunkMetadata) -> unknown
+    (output: EncodedAudioChunk, metadata?: EncodedAudioChunkMetadata) -> unknown
 }
 
 export declare interface EncodedVideoChunkOutputCallback {
-    fn (chunk: EncodedVideoChunk, metadata?: EncodedVideoChunkMetadata) -> unknown
+    (chunk: EncodedVideoChunk, metadata?: EncodedVideoChunkMetadata) -> unknown
 }
 
 export declare interface VideoFrameOutputCallback {
-    fn (output: VideoFrame) -> unknown
+    (output: VideoFrame) -> unknown
 }
 
 export declare interface WebCodecsErrorCallback {
-    fn (error: DOMException) -> unknown
+    (error: DOMException) -> unknown
 }
 
 export declare type ImageBufferSource = AllowSharedBufferSource | ReadableStream

--- a/internal/interop/data/web/web_rtc.esc
+++ b/internal/interop/data/web/web_rtc.esc
@@ -883,11 +883,11 @@ export declare class RTCTrackEvent extends Event {
 }
 
 export declare interface RTCPeerConnectionErrorCallback {
-    fn (error: DOMException) -> unknown
+    (error: DOMException) -> unknown
 }
 
 export declare interface RTCSessionDescriptionCallback {
-    fn (description: RTCSessionDescriptionInit) -> unknown
+    (description: RTCSessionDescriptionInit) -> unknown
 }
 
 export declare type RTCRtpTransform = RTCRtpScriptTransform

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -869,24 +869,15 @@ modifiers_done:
 		}
 	}
 
-	// `callable` is a contextual keyword at the start of a class element, the way
-	// `constructor` above is. It opens the unnamed call signature that makes the class value
-	// callable, so the two unnamed members of a class body are spelled alike.
+	// A member opening with `(` or `<` is a call signature, the unnamed member that makes
+	// the class value callable. It carries no name, and no other member may start with
+	// either token. An object type reads the same spelling, so the two positions agree.
 	//
-	// It names a member instead when a field's punctuation follows it, or when a modifier
-	// stands before it, since no modifier applies to a call signature. `callable: T` is a
-	// field and `get callable(self)` a getter.
-	if token.Type == Identifier && token.Value == "callable" &&
-		!isStatic && !isAsync && !isGen && !isPrivate && !isReadonly && !isGet && !isSet {
-		isField := false
-		// nolint: exhaustive
-		switch p.lexer.peek2().Type {
-		case Colon, Question, Comma, CloseBrace, Equal:
-			isField = true
-		}
-		if !isField {
-			return p.parseCallableElem(start)
-		}
+	// The constructor keeps its name because JavaScript gives it one: `Foo.constructor`
+	// reaches the same member. A call signature has no such handle, so there is no name to
+	// keep.
+	if startsASignature(token.Type) {
+		return p.parseCallableElem(start)
 	}
 
 	name := p.objExprKey()
@@ -1475,24 +1466,22 @@ func (p *Parser) enumDecl(start ast.Location, export bool, declare bool) ast.Dec
 	return decl
 }
 
-// parseCallableElem parses an unnamed `callable(...) -> T` call signature in a class body. The
-// `callable` token has not yet been consumed. parseClassElemInner has already ruled out every
-// modifier, since a modifier makes `callable` the member's name instead.
+// parseCallableElem parses an unnamed `(...) -> T` call signature in a class body, starting at
+// its `(` or its type-parameter list.
 //
-// It is the class twin of the `fn (...) -> T` member an object type annotation writes, and it
-// reads its parameters, return and `throws` the way a method does.
+// It is the class twin of the same member an object type annotation writes, and it reads its
+// parameters, return and `throws` the way a method does.
 func (p *Parser) parseCallableElem(start ast.Location) ast.ClassElem {
-	p.lexer.consume() // consume `callable`
 	lifetimeParams, typeParams := p.maybeLifetimeAndTypeParams(false)
 
 	params := []*ast.Param{}
 	if next := p.lexer.peek(); next.Type != OpenParen {
-		p.reportError(next.Span, "Expected '(' after 'callable'")
+		p.reportError(next.Span, "Expected '(' after a call signature's type parameters")
 	} else {
 		p.lexer.consume() // consume '('
 		// A call signature is reached through the class value rather than an instance, so
 		// `self` names nothing here. The receiver is read and reported rather than skipped,
-		// so `callable(self)` says why instead of failing on the parameter list.
+		// so `(self) -> T` says why instead of failing on the parameter list.
 		if receiver := p.selfReceiver(); receiver != nil {
 			p.reportError(receiver.Span_, "call signatures cannot have a `self` receiver")
 			if p.lexer.peek().Type == Comma {

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -869,16 +869,15 @@ modifiers_done:
 		}
 	}
 
-	// A bare `fn` opens a call signature, the unnamed member that makes the class value
-	// callable. This is the reading an object type takes for the same word, and a class
-	// takes it now that a class value can carry the member.
+	// `callable` is a contextual keyword at the start of a class element, the way
+	// `constructor` above is. It opens the unnamed call signature that makes the class value
+	// callable, so the two unnamed members of a class body are spelled alike.
 	//
-	// Two spellings keep the name. A field's punctuation after `fn` makes it the field
-	// `fn`, the reading `constructor` above takes. And any modifier makes it the member's
-	// name, since no modifier applies to a call signature: `get fn(self)` is a getter and
-	// `static fn(self)` a static method, matching `{readonly fn: T}` naming a property.
-	// The quoted key `"fn"(self)` reaches the method, as it does in an object type.
-	if token.Type == Fn && !isStatic && !isAsync && !isGen && !isPrivate && !isReadonly && !isGet && !isSet {
+	// It names a member instead when a field's punctuation follows it, or when a modifier
+	// stands before it, since no modifier applies to a call signature. `callable: T` is a
+	// field and `get callable(self)` a getter.
+	if token.Type == Identifier && token.Value == "callable" &&
+		!isStatic && !isAsync && !isGen && !isPrivate && !isReadonly && !isGet && !isSet {
 		isField := false
 		// nolint: exhaustive
 		switch p.lexer.peek2().Type {
@@ -1476,24 +1475,24 @@ func (p *Parser) enumDecl(start ast.Location, export bool, declare bool) ast.Dec
 	return decl
 }
 
-// parseCallableElem parses an unnamed `fn (...) -> T` call signature in a class body. The `fn`
-// token has not yet been consumed. parseClassElemInner has already ruled out every modifier,
-// since a modifier makes `fn` the member's name instead.
+// parseCallableElem parses an unnamed `callable(...) -> T` call signature in a class body. The
+// `callable` token has not yet been consumed. parseClassElemInner has already ruled out every
+// modifier, since a modifier makes `callable` the member's name instead.
 //
 // It is the class twin of the `fn (...) -> T` member an object type annotation writes, and it
 // reads its parameters, return and `throws` the way a method does.
 func (p *Parser) parseCallableElem(start ast.Location) ast.ClassElem {
-	p.lexer.consume() // consume `fn`
+	p.lexer.consume() // consume `callable`
 	lifetimeParams, typeParams := p.maybeLifetimeAndTypeParams(false)
 
 	params := []*ast.Param{}
 	if next := p.lexer.peek(); next.Type != OpenParen {
-		p.reportError(next.Span, "Expected '(' after 'fn'")
+		p.reportError(next.Span, "Expected '(' after 'callable'")
 	} else {
 		p.lexer.consume() // consume '('
 		// A call signature is reached through the class value rather than an instance, so
 		// `self` names nothing here. The receiver is read and reported rather than skipped,
-		// so `fn (self)` says why instead of failing on the parameter list.
+		// so `callable(self)` says why instead of failing on the parameter list.
 		if receiver := p.selfReceiver(); receiver != nil {
 			p.reportError(receiver.Span_, "call signatures cannot have a `self` receiver")
 			if p.lexer.peek().Type == Comma {

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -869,6 +869,27 @@ modifiers_done:
 		}
 	}
 
+	// A bare `fn` opens a call signature, the unnamed member that makes the class value
+	// callable. This is the reading an object type takes for the same word, and a class
+	// takes it now that a class value can carry the member.
+	//
+	// Two spellings keep the name. A field's punctuation after `fn` makes it the field
+	// `fn`, the reading `constructor` above takes. And any modifier makes it the member's
+	// name, since no modifier applies to a call signature: `get fn(self)` is a getter and
+	// `static fn(self)` a static method, matching `{readonly fn: T}` naming a property.
+	// The quoted key `"fn"(self)` reaches the method, as it does in an object type.
+	if token.Type == Fn && !isStatic && !isAsync && !isGen && !isPrivate && !isReadonly && !isGet && !isSet {
+		isField := false
+		// nolint: exhaustive
+		switch p.lexer.peek2().Type {
+		case Colon, Question, Comma, CloseBrace, Equal:
+			isField = true
+		}
+		if !isField {
+			return p.parseCallableElem(start)
+		}
+	}
+
 	name := p.objExprKey()
 	if name == nil {
 		return nil
@@ -1453,4 +1474,55 @@ func (p *Parser) enumDecl(start ast.Location, export bool, declare bool) ast.Dec
 	span := ast.NewSpan(start, end, p.lexer.source.ID)
 	decl := ast.NewEnumDecl(name, typeParams, elems, export, declare, span)
 	return decl
+}
+
+// parseCallableElem parses an unnamed `fn (...) -> T` call signature in a class body. The `fn`
+// token has not yet been consumed. parseClassElemInner has already ruled out every modifier,
+// since a modifier makes `fn` the member's name instead.
+//
+// It is the class twin of the `fn (...) -> T` member an object type annotation writes, and it
+// reads its parameters, return and `throws` the way a method does.
+func (p *Parser) parseCallableElem(start ast.Location) ast.ClassElem {
+	p.lexer.consume() // consume `fn`
+	lifetimeParams, typeParams := p.maybeLifetimeAndTypeParams(false)
+
+	params := []*ast.Param{}
+	if next := p.lexer.peek(); next.Type != OpenParen {
+		p.reportError(next.Span, "Expected '(' after 'fn'")
+	} else {
+		p.lexer.consume() // consume '('
+		// A call signature is reached through the class value rather than an instance, so
+		// `self` names nothing here. The receiver is read and reported rather than skipped,
+		// so `fn (self)` says why instead of failing on the parameter list.
+		if receiver := p.selfReceiver(); receiver != nil {
+			p.reportError(receiver.Span_, "call signatures cannot have a `self` receiver")
+			if p.lexer.peek().Type == Comma {
+				p.lexer.consume()
+			}
+		}
+		if p.lexer.peek().Type != CloseParen {
+			params = parseDelimSeq(p, CloseParen, Comma, p.param)
+		}
+		p.expect(CloseParen, AlwaysConsume)
+	}
+
+	var returnType ast.TypeAnn
+	if p.lexer.peek().Type == Arrow {
+		p.lexer.consume()
+		returnType = p.typeAnn()
+	}
+	throwsType := p.throwsClause()
+
+	// A body is read and reported rather than left for the next element to trip on. A call
+	// signature declares a shape, so only a `declare class` may carry one.
+	if p.lexer.peek().Type == OpenBrace {
+		block := p.block()
+		p.reportError(block.Span, "call signatures cannot have a body")
+	}
+
+	span := ast.Span{Start: start, End: p.lexer.currentLoc(), SourceID: p.lexer.source.ID}
+	return &ast.CallableElem{
+		Fn:    ast.NewFuncExpr(lifetimeParams, typeParams, params, returnType, throwsType, false, nil, span),
+		Span_: span,
+	}
 }

--- a/internal/parser/keyword_names_test.go
+++ b/internal/parser/keyword_names_test.go
@@ -69,18 +69,27 @@ func TestKeywordsNameObjectTypeMembers(t *testing.T) {
 // rather than objTypeAnnElemInner and so needs its own sweep.
 func TestKeywordsNameClassMembers(t *testing.T) {
 	t.Parallel()
-	forms := []struct{ name, tmpl string }{
-		{"field", "declare class C {\n    %s: number\n}"},
-		{"static field", "declare class C {\n    static %s: number\n}"},
-		{"readonly field", "declare class C {\n    readonly %s: number\n}"},
-		{"method", "declare class C {\n    %s(self) -> number\n}"},
-		{"getter", "declare class C {\n    get %s(self) -> number\n}"},
-		{"setter", "declare class C {\n    set %s(mut self, v: number)\n}"},
+	forms := []struct {
+		name, tmpl string
+		// skip names a keyword this form reads as something other than a member name.
+		// `fn` alone opens a call signature, so the bare-method form does not name it;
+		// TestFnOpensAClassCallSignature covers that reading.
+		skip string
+	}{
+		{name: "field", tmpl: "declare class C {\n    %s: number\n}"},
+		{name: "static field", tmpl: "declare class C {\n    static %s: number\n}"},
+		{name: "readonly field", tmpl: "declare class C {\n    readonly %s: number\n}"},
+		{name: "method", tmpl: "declare class C {\n    %s(self) -> number\n}", skip: "fn"},
+		{name: "getter", tmpl: "declare class C {\n    get %s(self) -> number\n}"},
+		{name: "setter", tmpl: "declare class C {\n    set %s(mut self, v: number)\n}"},
 	}
 	for _, form := range forms {
 		t.Run(form.name, func(t *testing.T) {
 			t.Parallel()
 			for _, keyword := range keywordTexts() {
+				if keyword == form.skip {
+					continue
+				}
 				src := fmt.Sprintf(form.tmpl, keyword)
 				_, errors := parseScriptSrc(t, src)
 				require.Empty(t, errors, "%s should parse", src)
@@ -121,23 +130,19 @@ func TestFnAndNewClaimSignaturesInObjectTypes(t *testing.T) {
 	}
 }
 
-// A class has no call or construct signature to compete with, so `fn` and `new`
-// name methods there. This asymmetry with an object type is deliberate.
-func TestFnAndNewNameClassMethods(t *testing.T) {
+// `new` names a method in a class body. A class declares its construct signature as
+// `constructor`, so `new` competes with nothing there and keeps the name it has in every
+// other position. This asymmetry with an object type is deliberate.
+func TestNewNamesAClassMethod(t *testing.T) {
 	t.Parallel()
-	for _, keyword := range []string{"fn", "new"} {
-		t.Run(keyword, func(t *testing.T) {
-			t.Parallel()
-			src := fmt.Sprintf("declare class C {\n    %s(self) -> number\n}", keyword)
-			script, errors := parseScriptSrc(t, src)
-			require.Empty(t, errors)
-			decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.ClassDecl)
-			require.Len(t, decl.Body, 1)
-			method, ok := decl.Body[0].(*ast.MethodElem)
-			require.True(t, ok, "%s should be a method", src)
-			require.Equal(t, keyword, method.Name.(*ast.IdentExpr).Name)
-		})
-	}
+	src := "declare class C {\n    new(self) -> number\n}"
+	script, errors := parseScriptSrc(t, src)
+	require.Empty(t, errors)
+	decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.ClassDecl)
+	require.Len(t, decl.Body, 1)
+	method, ok := decl.Body[0].(*ast.MethodElem)
+	require.True(t, ok, "%s should be a method", src)
+	require.Equal(t, "new", method.Name.(*ast.IdentExpr).Name)
 }
 
 // cannotBind lists the keywords that must never become a binding name. It is
@@ -449,4 +454,65 @@ func TestAChainBrokenBeforeTheDotNamesAProperty(t *testing.T) {
 	script, errors := parseScriptSrc(t, "val a = obj\n    .match(x)")
 	require.Empty(t, errors)
 	require.Len(t, script.Stmts, 1)
+}
+
+// A bare `fn` in a class body opens a call signature, the same reading an object type takes
+// for the word. The spellings that keep the name are the object type's too: a field's
+// punctuation, a quoted key, and — a class-only case, since an object type has no
+// modifiers — any modifier, none of which applies to a call signature.
+func TestFnOpensAClassCallSignature(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want ast.ClassElem
+	}{
+		{"fn opens a call signature", "declare class C {\n    fn () -> number\n}", &ast.CallableElem{}},
+		{"fn without a space is still a call signature", "declare class C {\n    fn() -> number\n}", &ast.CallableElem{}},
+		{"a quoted key reaches the fn method", "declare class C {\n    \"fn\"(self) -> number\n}", &ast.MethodElem{}},
+		{"fn names a field", "declare class C {\n    fn: number\n}", &ast.FieldElem{}},
+		{"fn names an optional field", "declare class C {\n    fn?: number\n}", &ast.FieldElem{}},
+		{"a modifier makes fn a getter's name", "declare class C {\n    get fn(self) -> number\n}", &ast.GetterElem{}},
+		{"a modifier makes fn a static method's name", "declare class C {\n    static fn() -> number\n}", &ast.MethodElem{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			script, errors := parseScriptSrc(t, tt.src)
+			require.Empty(t, errors)
+			decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.ClassDecl)
+			require.Len(t, decl.Body, 1)
+			require.IsType(t, tt.want, decl.Body[0])
+		})
+	}
+}
+
+// A call signature declares a shape rather than an implementation, and it is reached through
+// the class value rather than an instance. Each rejection says which of the two it is.
+func TestAClassCallSignatureRejectsWhatItCannotCarry(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "AReceiver",
+			src:  "declare class C {\n    fn (self) -> number\n}",
+			want: "call signatures cannot have a `self` receiver",
+		},
+		{
+			name: "ABody",
+			src:  "class C {\n    fn () -> number { 1 }\n}",
+			want: "call signatures cannot have a body",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, errors := parseScriptSrc(t, tt.src)
+			require.Len(t, errors, 1)
+			require.Equal(t, tt.want, errors[0].Message)
+		})
+	}
 }

--- a/internal/parser/keyword_names_test.go
+++ b/internal/parser/keyword_names_test.go
@@ -89,23 +89,19 @@ func TestKeywordsNameClassMembers(t *testing.T) {
 	}
 }
 
-// `fn` and `new` are the two keywords an object type reads as a signature rather
-// than a member name, because `fn(…)` and `fn (…)` differ only in whitespace. A
-// property keeps the name, and a string key reaches the method.
-func TestFnAndNewClaimSignaturesInObjectTypes(t *testing.T) {
+// `new` is the one keyword an object type reads as a signature rather than a member name,
+// because `new(…)` and `new (…)` differ only in whitespace. A property keeps the name, and a
+// string key reaches the method.
+func TestNewClaimsTheConstructSignatureInObjectTypes(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name string
 		src  string
 		want ast.ObjTypeAnnElem
 	}{
-		{"fn opens a call signature", "{fn () -> number}", &ast.CallableTypeAnn{}},
-		{"fn without a space is still a call signature", "{fn() -> number}", &ast.CallableTypeAnn{}},
 		{"new opens a construct signature", "{new () -> number}", &ast.ConstructorTypeAnn{}},
-		{"a string key reaches the fn method", `{"fn"() -> number}`, &ast.MethodTypeAnn{}},
 		{"a string key reaches the new method", `{"new"() -> number}`, &ast.MethodTypeAnn{}},
 		{"another keyword stays a method", "{catch() -> number}", &ast.MethodTypeAnn{}},
-		{"fn names a property", "{fn: number}", &ast.PropertyTypeAnn{}},
 		{"new names an optional property", "{new?: number}", &ast.PropertyTypeAnn{}},
 	}
 	for _, tt := range tests {
@@ -121,9 +117,9 @@ func TestFnAndNewClaimSignaturesInObjectTypes(t *testing.T) {
 	}
 }
 
-// A class has no call or construct signature spelled `fn` or `new` to compete with, so both
-// name methods there. A class writes its construct signature as `constructor` and its call
-// signature as `callable`. This asymmetry with an object type is deliberate.
+// `fn` and `new` name methods in a class body. A class writes its construct signature as
+// `constructor` and its call signature as a bare parameter list, so neither word competes with
+// anything there.
 func TestFnAndNewNameClassMethods(t *testing.T) {
 	t.Parallel()
 	for _, keyword := range []string{"fn", "new"} {
@@ -141,36 +137,64 @@ func TestFnAndNewNameClassMethods(t *testing.T) {
 	}
 }
 
-// `callable` is a contextual keyword at the start of a class element, the way `constructor` is.
-// It opens the unnamed call signature, so a class body spells its two unnamed members alike.
-// The spellings that keep the name are `constructor`'s too: a field's punctuation, a quoted
-// key, and any modifier, none of which applies to a call signature.
-func TestCallableOpensAClassCallSignature(t *testing.T) {
+// A member opening with `(` or `<` is a call signature, in a class body and in an object type
+// alike. No other member may start with either token, so the parameter list alone identifies it
+// and nothing has to be reserved. `constructor` keeps its name because JavaScript gives it one —
+// `Foo.constructor` reaches the same member — and a call signature has no such handle.
+func TestABareParameterListOpensACallSignature(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name string
-		src  string
-		want ast.ClassElem
-	}{
-		{"callable opens a call signature", "declare class C {\n    callable() -> number\n}", &ast.CallableElem{}},
-		{"a quoted key reaches the callable method", "declare class C {\n    \"callable\"(self) -> number\n}", &ast.MethodElem{}},
-		{"callable names a field", "declare class C {\n    callable: number\n}", &ast.FieldElem{}},
-		{"callable names an optional field", "declare class C {\n    callable?: number\n}", &ast.FieldElem{}},
-		{"a modifier makes callable a getter's name", "declare class C {\n    get callable(self) -> number\n}", &ast.GetterElem{}},
-		{"a modifier makes callable a static method's name", "declare class C {\n    static callable() -> number\n}", &ast.MethodElem{}},
-		// `fn` competes with nothing in a class body, so it keeps naming a method.
-		{"fn still names a method", "declare class C {\n    fn(self) -> number\n}", &ast.MethodElem{}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			script, errors := parseScriptSrc(t, tt.src)
-			require.Empty(t, errors)
-			decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.ClassDecl)
-			require.Len(t, decl.Body, 1)
-			require.IsType(t, tt.want, decl.Body[0])
-		})
-	}
+	t.Run("InAClassBody", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name string
+			src  string
+			want ast.ClassElem
+		}{
+			{"a parameter list opens one", "declare class C {\n    () -> number\n}", &ast.CallableElem{}},
+			{"so does a type-parameter list", "declare class C {\n    <T>(v: T) -> T\n}", &ast.CallableElem{}},
+			// Every word keeps its meaning as a member name, since none is reserved.
+			{"fn names a method", "declare class C {\n    fn(self) -> number\n}", &ast.MethodElem{}},
+			{"callable names a method", "declare class C {\n    callable(self) -> number\n}", &ast.MethodElem{}},
+			{"callable names a field", "declare class C {\n    callable: number\n}", &ast.FieldElem{}},
+			{"constructor still opens a constructor", "class C {\n    constructor(mut self) {}\n}", &ast.ConstructorElem{}},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				script, errors := parseScriptSrc(t, tt.src)
+				require.Empty(t, errors)
+				decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.ClassDecl)
+				require.Len(t, decl.Body, 1)
+				require.IsType(t, tt.want, decl.Body[0])
+			})
+		}
+	})
+
+	t.Run("InAnObjectType", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name string
+			src  string
+			want ast.ObjTypeAnnElem
+		}{
+			{"a parameter list opens one", "{(a: number, b: string) -> boolean}", &ast.CallableTypeAnn{}},
+			{"so does a type-parameter list", "{<T>(v: T) -> T}", &ast.CallableTypeAnn{}},
+			{"beside an ordinary member", "{(a: number) -> boolean, tag: string}", &ast.CallableTypeAnn{}},
+			// `fn` is no longer reserved here either, so it names a member like any word.
+			{"fn names a method", "{fn(x: number) -> number}", &ast.MethodTypeAnn{}},
+			{"fn names a property", "{fn: number}", &ast.PropertyTypeAnn{}},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				typeAnn, errors := parseTypeAnnSrc(t, tt.src)
+				require.Empty(t, errors)
+				obj, ok := typeAnn.(*ast.ObjectTypeAnn)
+				require.True(t, ok, "%s should be an object type", tt.src)
+				require.IsType(t, tt.want, obj.Elems[0])
+			})
+		}
+	})
 }
 
 // A call signature declares a shape rather than an implementation, and it is reached through
@@ -184,12 +208,12 @@ func TestAClassCallSignatureRejectsWhatItCannotCarry(t *testing.T) {
 	}{
 		{
 			name: "AReceiver",
-			src:  "declare class C {\n    callable(self) -> number\n}",
+			src:  "declare class C {\n    (self) -> number\n}",
 			want: "call signatures cannot have a `self` receiver",
 		},
 		{
 			name: "ABody",
-			src:  "class C {\n    callable() -> number { 1 }\n}",
+			src:  "class C {\n    () -> number { 1 }\n}",
 			want: "call signatures cannot have a body",
 		},
 	}

--- a/internal/parser/keyword_names_test.go
+++ b/internal/parser/keyword_names_test.go
@@ -69,27 +69,18 @@ func TestKeywordsNameObjectTypeMembers(t *testing.T) {
 // rather than objTypeAnnElemInner and so needs its own sweep.
 func TestKeywordsNameClassMembers(t *testing.T) {
 	t.Parallel()
-	forms := []struct {
-		name, tmpl string
-		// skip names a keyword this form reads as something other than a member name.
-		// `fn` alone opens a call signature, so the bare-method form does not name it;
-		// TestFnOpensAClassCallSignature covers that reading.
-		skip string
-	}{
-		{name: "field", tmpl: "declare class C {\n    %s: number\n}"},
-		{name: "static field", tmpl: "declare class C {\n    static %s: number\n}"},
-		{name: "readonly field", tmpl: "declare class C {\n    readonly %s: number\n}"},
-		{name: "method", tmpl: "declare class C {\n    %s(self) -> number\n}", skip: "fn"},
-		{name: "getter", tmpl: "declare class C {\n    get %s(self) -> number\n}"},
-		{name: "setter", tmpl: "declare class C {\n    set %s(mut self, v: number)\n}"},
+	forms := []struct{ name, tmpl string }{
+		{"field", "declare class C {\n    %s: number\n}"},
+		{"static field", "declare class C {\n    static %s: number\n}"},
+		{"readonly field", "declare class C {\n    readonly %s: number\n}"},
+		{"method", "declare class C {\n    %s(self) -> number\n}"},
+		{"getter", "declare class C {\n    get %s(self) -> number\n}"},
+		{"setter", "declare class C {\n    set %s(mut self, v: number)\n}"},
 	}
 	for _, form := range forms {
 		t.Run(form.name, func(t *testing.T) {
 			t.Parallel()
 			for _, keyword := range keywordTexts() {
-				if keyword == form.skip {
-					continue
-				}
 				src := fmt.Sprintf(form.tmpl, keyword)
 				_, errors := parseScriptSrc(t, src)
 				require.Empty(t, errors, "%s should parse", src)
@@ -130,350 +121,45 @@ func TestFnAndNewClaimSignaturesInObjectTypes(t *testing.T) {
 	}
 }
 
-// `new` names a method in a class body. A class declares its construct signature as
-// `constructor`, so `new` competes with nothing there and keeps the name it has in every
-// other position. This asymmetry with an object type is deliberate.
-func TestNewNamesAClassMethod(t *testing.T) {
+// A class has no call or construct signature spelled `fn` or `new` to compete with, so both
+// name methods there. A class writes its construct signature as `constructor` and its call
+// signature as `callable`. This asymmetry with an object type is deliberate.
+func TestFnAndNewNameClassMethods(t *testing.T) {
 	t.Parallel()
-	src := "declare class C {\n    new(self) -> number\n}"
-	script, errors := parseScriptSrc(t, src)
-	require.Empty(t, errors)
-	decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.ClassDecl)
-	require.Len(t, decl.Body, 1)
-	method, ok := decl.Body[0].(*ast.MethodElem)
-	require.True(t, ok, "%s should be a method", src)
-	require.Equal(t, "new", method.Name.(*ast.IdentExpr).Name)
-}
-
-// cannotBind lists the keywords that must never become a binding name. It is
-// written out rather than derived from bindingKeywords so the sweeps below have
-// an oracle independent of the code under test. Widening bindingKeywords by
-// mistake then fails here instead of moving both sides of the comparison
-// together.
-//
-// The first 28 are the words ECMAScript reserves, which codegen cannot emit as
-// an identifier: `fn f(in: number)` would lower to `const in = ...`. `undefined`
-// is here for a different reason. It is not reserved, but a pattern reads it as
-// the value it names, and a binding name must not shift meaning with position.
-func cannotBind() map[string]bool {
-	words := []string{
-		"await", "catch", "class", "do", "else", "enum", "export", "extends",
-		"false", "for", "if", "implements", "import", "in", "interface", "new",
-		"null", "private", "return", "static", "super", "throw", "true", "try",
-		"typeof", "var", "void", "yield",
-		"undefined",
-	}
-	set := make(map[string]bool, len(words))
-	for _, word := range words {
-		set[word] = true
-	}
-	return set
-}
-
-// Every keyword the lexer knows is either a binding name or one of the words
-// above. A keyword added to the lexer without a decision about which it is
-// fails here, which is the reminder to make that decision.
-func TestEveryKeywordIsClassifiedForBinding(t *testing.T) {
-	t.Parallel()
-	reserved := cannotBind()
-	for _, keyword := range keywordTexts() {
-		require.Equal(t, !reserved[keyword], bindsAsAName(keywords[keyword]),
-			"%q: bindingKeywords and the reserved list disagree; add %q to one of them",
-			keyword, keyword)
-	}
-}
-
-// A binding name reaches JavaScript verbatim, so only the keywords JavaScript
-// itself accepts as an identifier may name a parameter or a function.
-//
-// The negative direction checks the parsed pattern rather than the presence of
-// an error. `true` and the other literal keywords take the literal-pattern path
-// instead of failing outright, and what matters is that neither becomes a name.
-func TestKeywordsInBindingPositions(t *testing.T) {
-	t.Parallel()
-	reserved := cannotBind()
-
-	t.Run("parameter name", func(t *testing.T) {
-		t.Parallel()
-		for _, keyword := range keywordTexts() {
-			src := fmt.Sprintf("declare fn f(%s: number) -> number", keyword)
+	for _, keyword := range []string{"fn", "new"} {
+		t.Run(keyword, func(t *testing.T) {
+			t.Parallel()
+			src := fmt.Sprintf("declare class C {\n    %s(self) -> number\n}", keyword)
 			script, errors := parseScriptSrc(t, src)
-			bound := false
-			if len(errors) == 0 {
-				fn := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.FuncDecl)
-				if identPat, ok := fn.Params[0].Pattern.(*ast.IdentPat); ok {
-					bound = identPat.Name == keyword
-				}
-			}
-			require.Equal(t, !reserved[keyword], bound,
-				"%s: bound as a parameter name = %v", src, bound)
-		}
-	})
-
-	t.Run("rest parameter name", func(t *testing.T) {
-		t.Parallel()
-		for _, keyword := range keywordTexts() {
-			src := fmt.Sprintf("declare fn f(...%s: Array<number>) -> number", keyword)
-			script, errors := parseScriptSrc(t, src)
-			bound := false
-			if len(errors) == 0 {
-				fn := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.FuncDecl)
-				if rest, ok := fn.Params[0].Pattern.(*ast.RestPat); ok {
-					if identPat, isIdent := rest.Pattern.(*ast.IdentPat); isIdent {
-						bound = identPat.Name == keyword
-					}
-				}
-			}
-			require.Equal(t, !reserved[keyword], bound,
-				"%s: bound as a rest parameter name = %v", src, bound)
-		}
-	})
-
-	t.Run("function declaration name", func(t *testing.T) {
-		t.Parallel()
-		for _, keyword := range keywordTexts() {
-			src := fmt.Sprintf("declare fn %s() -> number", keyword)
-			script, errors := parseScriptSrc(t, src)
-			named := false
-			if len(errors) == 0 {
-				fn := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.FuncDecl)
-				named = fn.Name.Name == keyword
-			}
-			require.Equal(t, !reserved[keyword], named,
-				"%s: used as the function name = %v", src, named)
-		}
-	})
-}
-
-// objectExprKeyName returns the name of the sole property key in
-// `val a = { … }`, or "" when the source did not parse to that shape. Asserting
-// the name rather than the absence of errors catches a key that parses but
-// carries the wrong text.
-func objectExprKeyName(t *testing.T, src string) string {
-	t.Helper()
-	script, errors := parseScriptSrc(t, src)
-	if len(errors) > 0 {
-		return ""
-	}
-	decl, ok := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.VarDecl)
-	if !ok || decl.Init == nil {
-		return ""
-	}
-	obj, ok := decl.Init.(*ast.ObjectExpr)
-	if !ok || len(obj.Elems) != 1 {
-		return ""
-	}
-	prop, ok := obj.Elems[0].(*ast.PropertyExpr)
-	if !ok {
-		return ""
-	}
-	ident, ok := prop.Name.(*ast.IdentExpr)
-	if !ok {
-		return ""
-	}
-	return ident.Name
-}
-
-// Every keyword names a property of an object literal, because `{ catch: 1 }`
-// and `obj.catch` are both valid JavaScript. This is the expression counterpart
-// of TestKeywordsNameObjectTypeMembers.
-func TestKeywordsNameObjectExpressionProperties(t *testing.T) {
-	t.Parallel()
-	forms := []struct{ name, tmpl string }{
-		{"property", "val a = {%[1]s: 1}"},
-		{"optional property", "val a = {%[1]s?: 1}"},
-		{"property whose value is another such object", "val a = {%[1]s: {%[1]s: 1}}"},
-	}
-	for _, form := range forms {
-		t.Run(form.name, func(t *testing.T) {
-			t.Parallel()
-			for _, keyword := range keywordTexts() {
-				src := fmt.Sprintf(form.tmpl, keyword)
-				require.Equal(t, keyword, objectExprKeyName(t, src),
-					"%s should name a property %q", src, keyword)
-			}
+			require.Empty(t, errors)
+			decl := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.ClassDecl)
+			require.Len(t, decl.Body, 1)
+			method, ok := decl.Body[0].(*ast.MethodElem)
+			require.True(t, ok, "%s should be a method", src)
+			require.Equal(t, keyword, method.Name.(*ast.IdentExpr).Name)
 		})
 	}
 }
 
-// An object literal has no method shorthand, and that holds for every keyword
-// rather than only the accessor pair. `{ catch() {} }` reports the same way
-// `{ get x() {} }` does.
-func TestObjectExpressionsRejectMethodShorthand(t *testing.T) {
-	t.Parallel()
-	for _, keyword := range keywordTexts() {
-		src := fmt.Sprintf("val a = {%s() {}}", keyword)
-		_, errors := parseScriptSrc(t, src)
-		require.NotEmpty(t, errors, "%s should report", src)
-		require.Equal(t,
-			"Method shorthand is not allowed in object literals; use a class instead",
-			errors[0].Message, "for %s", src)
-	}
-}
-
-// A shorthand property is a key and a variable reference at once, so it accepts
-// exactly the keywords a binding does.
-func TestKeywordShorthandProperties(t *testing.T) {
-	t.Parallel()
-	reserved := cannotBind()
-
-	for _, keyword := range keywordTexts() {
-		src := fmt.Sprintf("val a = {%s}", keyword)
-		_, errors := parseScriptSrc(t, src)
-		if !reserved[keyword] {
-			require.Empty(t, errors, "%s should parse", src)
-			require.Equal(t, keyword, objectExprKeyName(t, src))
-			continue
-		}
-		require.NotEmpty(t, errors, "%s should report", src)
-		require.Equal(t, "`"+keyword+
-			"` cannot be a shorthand property because it is not a variable name",
-			errors[0].Message)
-	}
-}
-
-// `get` and `set` mark an accessor only when a name follows them, so the method
-// shorthand an object literal rejects stays rejected while the property does not.
-func TestGetAndSetInObjectLiterals(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name    string
-		src     string
-		wantErr string
-	}{
-		{"get names a property", "val a = {get: 1}", ""},
-		{"set names a property", "val a = {set: 1}", ""},
-		{"get is a shorthand property", "val a = {get}", ""},
-		{"a getter is still rejected", "val a = {get x() {}}",
-			"Method shorthand is not allowed in object literals; use a class instead"},
-		{"a setter is still rejected", "val a = {set x(v) {}}",
-			"Method shorthand is not allowed in object literals; use a class instead"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			_, errors := parseScriptSrc(t, tt.src)
-			if tt.wantErr == "" {
-				require.Empty(t, errors)
-				return
-			}
-			require.NotEmpty(t, errors)
-			require.Equal(t, tt.wantErr, errors[0].Message)
-		})
-	}
-}
-
-// memberPropertyName returns the property name in `val a = <src>`, or "" when
-// the source did not parse to a member access. A `.d.ts` reaches this position
-// through a computed key such as `[Symbol.match]`, which the converter emits for
-// every well-known symbol a class declares a member under.
-func memberPropertyName(t *testing.T, src string) string {
-	t.Helper()
-	script, errors := parseScriptSrc(t, "val a = "+src)
-	if len(errors) > 0 {
-		return ""
-	}
-	decl, ok := script.Stmts[0].(*ast.DeclStmt).Decl.(*ast.VarDecl)
-	if !ok || decl.Init == nil {
-		return ""
-	}
-	member, ok := decl.Init.(*ast.MemberExpr)
-	if !ok {
-		return ""
-	}
-	return member.Prop.Name
-}
-
-// Everything after a `.` is a name position, so every keyword reads as the
-// property being accessed. `Symbol.match` is the case the converter needs, since
-// `RegExp` declares its matcher under that well-known symbol.
-func TestKeywordsNamePropertiesAfterADot(t *testing.T) {
-	t.Parallel()
-	for _, keyword := range keywordTexts() {
-		require.Equal(t, keyword, memberPropertyName(t, "Symbol."+keyword),
-			"Symbol.%s should read %q as the property", keyword, keyword)
-		require.Equal(t, keyword, memberPropertyName(t, "Symbol?."+keyword),
-			"Symbol?.%s should read %q as the property", keyword, keyword)
-	}
-}
-
-// The well-known symbols the converter emits as computed keys. Only `match` is a
-// keyword today, so the rest guard against a later keyword addition silently
-// breaking one of them.
-func TestWellKnownSymbolComputedKeys(t *testing.T) {
-	t.Parallel()
-	symbols := []string{
-		"asyncDispose", "asyncIterator", "dispose", "hasInstance", "iterator",
-		"match", "matchAll", "metadata", "replace", "search", "species", "split",
-		"toPrimitive", "toStringTag", "unscopables",
-	}
-	for _, symbol := range symbols {
-		t.Run(symbol, func(t *testing.T) {
-			t.Parallel()
-			src := fmt.Sprintf("{\n    [Symbol.%s](self) -> string\n}", symbol)
-			typeAnn, errors := parseTypeAnnSrc(t, src)
-			require.Empty(t, errors, "%s should parse", src)
-			require.NotNil(t, typeAnn)
-		})
-	}
-}
-
-// A dangling `.` left mid-edit must not take the next line's leading keyword as
-// its property name. Whatever that line starts survives as its own statement,
-// whether a declaration or a statement keyword such as `return`.
-func TestADanglingDotDoesNotSwallowTheNextLine(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{"val", "val a = obj.\nval c = 1"},
-		{"declare fn", "val a = obj.\ndeclare fn f() -> undefined"},
-		{"fn", "val a = obj.\nfn g() {}"},
-		{"type", "val a = obj.\ntype T = number"},
-		{"return", "val a = obj.\nreturn 1"},
-		{"throw", "val a = obj.\nthrow 1"},
-		{"import", "val a = obj.\nimport \"foo\""},
-		{"try", "val a = obj.\ntry {} catch {}"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			script, errors := parseScriptSrc(t, tt.input)
-			require.NotEmpty(t, errors)
-			require.Equal(t, "expected an identifier after .", errors[0].Message)
-			require.Len(t, script.Stmts, 2, "the line after the dot should survive")
-		})
-	}
-}
-
-// A chain broken before the dot keeps the dot and the name together, so a
-// keyword member still reads across lines the way it is normally written.
-func TestAChainBrokenBeforeTheDotNamesAProperty(t *testing.T) {
-	t.Parallel()
-	script, errors := parseScriptSrc(t, "val a = obj\n    .match(x)")
-	require.Empty(t, errors)
-	require.Len(t, script.Stmts, 1)
-}
-
-// A bare `fn` in a class body opens a call signature, the same reading an object type takes
-// for the word. The spellings that keep the name are the object type's too: a field's
-// punctuation, a quoted key, and — a class-only case, since an object type has no
-// modifiers — any modifier, none of which applies to a call signature.
-func TestFnOpensAClassCallSignature(t *testing.T) {
+// `callable` is a contextual keyword at the start of a class element, the way `constructor` is.
+// It opens the unnamed call signature, so a class body spells its two unnamed members alike.
+// The spellings that keep the name are `constructor`'s too: a field's punctuation, a quoted
+// key, and any modifier, none of which applies to a call signature.
+func TestCallableOpensAClassCallSignature(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name string
 		src  string
 		want ast.ClassElem
 	}{
-		{"fn opens a call signature", "declare class C {\n    fn () -> number\n}", &ast.CallableElem{}},
-		{"fn without a space is still a call signature", "declare class C {\n    fn() -> number\n}", &ast.CallableElem{}},
-		{"a quoted key reaches the fn method", "declare class C {\n    \"fn\"(self) -> number\n}", &ast.MethodElem{}},
-		{"fn names a field", "declare class C {\n    fn: number\n}", &ast.FieldElem{}},
-		{"fn names an optional field", "declare class C {\n    fn?: number\n}", &ast.FieldElem{}},
-		{"a modifier makes fn a getter's name", "declare class C {\n    get fn(self) -> number\n}", &ast.GetterElem{}},
-		{"a modifier makes fn a static method's name", "declare class C {\n    static fn() -> number\n}", &ast.MethodElem{}},
+		{"callable opens a call signature", "declare class C {\n    callable() -> number\n}", &ast.CallableElem{}},
+		{"a quoted key reaches the callable method", "declare class C {\n    \"callable\"(self) -> number\n}", &ast.MethodElem{}},
+		{"callable names a field", "declare class C {\n    callable: number\n}", &ast.FieldElem{}},
+		{"callable names an optional field", "declare class C {\n    callable?: number\n}", &ast.FieldElem{}},
+		{"a modifier makes callable a getter's name", "declare class C {\n    get callable(self) -> number\n}", &ast.GetterElem{}},
+		{"a modifier makes callable a static method's name", "declare class C {\n    static callable() -> number\n}", &ast.MethodElem{}},
+		// `fn` competes with nothing in a class body, so it keeps naming a method.
+		{"fn still names a method", "declare class C {\n    fn(self) -> number\n}", &ast.MethodElem{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -498,12 +184,12 @@ func TestAClassCallSignatureRejectsWhatItCannotCarry(t *testing.T) {
 	}{
 		{
 			name: "AReceiver",
-			src:  "declare class C {\n    fn (self) -> number\n}",
+			src:  "declare class C {\n    callable(self) -> number\n}",
 			want: "call signatures cannot have a `self` receiver",
 		},
 		{
 			name: "ABody",
-			src:  "class C {\n    fn () -> number { 1 }\n}",
+			src:  "class C {\n    callable() -> number { 1 }\n}",
 			want: "call signatures cannot have a body",
 		},
 	}

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -911,25 +911,26 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		return ast.NewRestSpreadTypeAnn(value, p.elemSpanFrom(start))
 	}
 
-	// A `new (x: number) -> T` construct signature and a `fn (x: number) -> T` call
-	// signature. Each claims its keyword only where a signature follows, so `fn: number`
-	// and `new?: T` still declare properties under those names.
+	// A member opening with `(` or `<` is a call signature. It carries no name, and no
+	// other member may start with either token, so the parameter list alone identifies it.
+	// A class body reads the same spelling, so the two positions agree.
+	if startsASignature(token.Type) {
+		return ast.NewCallableTypeAnn(p.funcTypeAnnTail(token), p.elemSpanFrom(start))
+	}
+
+	// A `new (x: number) -> T` construct signature. `new` claims the keyword only where a
+	// signature follows, so `new?: T` still declares a property under that name, and a
+	// method spelled `new(x: number) -> T` differs from it only in whitespace, so the
+	// signature wins there. Write the method with a string key, `"new"(x: number) -> T`.
+	// A class body has no construct signature to compete with — it writes `constructor`,
+	// the name JavaScript gives the same member — so `new` names a method there.
 	//
-	// A method does collide: `fn(x: number) -> T` differs from the call signature only in
-	// whitespace, and a signature must not hinge on that, so the signature wins. Write a
-	// method of either name with a string key, `"fn"(x: number) -> T`. A class body has
-	// no call or construct signature to compete with, so `fn` and `new` name methods
-	// there directly.
-	//
-	// Both signatures parse through the same tail the `fn` annotation uses, which gives
-	// them type parameters, an inexact marker, and a `throws` clause for free.
-	if (token.Type == New || token.Type == Fn) && startsASignature(p.lexer.peek2().Type) {
-		p.lexer.consume() // consume 'new' or 'fn'
-		fn := p.funcTypeAnnTail(token)
-		if token.Type == New {
-			return ast.NewConstructorTypeAnn(fn, p.elemSpanFrom(start))
-		}
-		return ast.NewCallableTypeAnn(fn, p.elemSpanFrom(start))
+	// It parses through the same tail the `fn` annotation uses, which gives it type
+	// parameters, an inexact marker, and a `throws` clause for free. So does the call
+	// signature above.
+	if token.Type == New && startsASignature(p.lexer.peek2().Type) {
+		p.lexer.consume() // consume 'new'
+		return ast.NewConstructorTypeAnn(p.funcTypeAnnTail(token), p.elemSpanFrom(start))
 	}
 
 	mod := ""

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -459,6 +459,15 @@ func (p *Printer) printClassElem(elem ast.ClassElem) {
 			p.space()
 			p.printBlock(e.Fn.Body)
 		}
+	case *ast.CallableElem:
+		// A call signature is unnamed, so `fn` is the whole of what precedes its
+		// parameters, and it carries no receiver and no body. The space before the
+		// parameter list is what separates `fn (…)` from a method named `fn`, and it is
+		// the spelling an object type's own call signature prints.
+		p.writeString("fn")
+		p.printGenericParams(e.Fn.LifetimeParams, e.Fn.TypeParams)
+		p.space()
+		p.printMethodSigNoGenerics(&e.Fn.FuncSig)
 	}
 }
 
@@ -490,6 +499,18 @@ func (p *Printer) printSetterSig(sig *ast.FuncSig, recv *ast.MethodReceiver) {
 // false only for a class setter, whose grammar has no return slot.
 func (p *Printer) printMethodSigParts(sig *ast.FuncSig, recv *ast.MethodReceiver, withReturn bool) {
 	p.printGenericParams(sig.LifetimeParams, sig.TypeParams)
+	p.printMethodSigBody(sig, recv, withReturn)
+}
+
+// printMethodSigNoGenerics prints a signature's parameter list, return and `throws` with the
+// generic parameters already written by the caller. A class call signature writes them itself,
+// so it can put the space between them and the parameter list that `fn (…)` needs.
+func (p *Printer) printMethodSigNoGenerics(sig *ast.FuncSig) {
+	p.printMethodSigBody(sig, nil, true)
+}
+
+// printMethodSigBody prints everything after the generic parameters.
+func (p *Printer) printMethodSigBody(sig *ast.FuncSig, recv *ast.MethodReceiver, withReturn bool) {
 	p.writeString("(")
 	first := true
 	params := sig.Params

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -460,11 +460,8 @@ func (p *Printer) printClassElem(elem ast.ClassElem) {
 			p.printBlock(e.Fn.Body)
 		}
 	case *ast.CallableElem:
-		// A call signature is unnamed, so `callable` is the whole of what precedes its
-		// parameters, and it carries no receiver and no body. It prints the way
-		// `constructor` above does, which is what pairs the two unnamed members of a class
-		// body.
-		p.writeString("callable")
+		// A call signature is unnamed, so its parameter list opens the member. It carries
+		// no receiver and no body.
 		p.printMethodSig(&e.Fn.FuncSig, nil)
 	}
 }
@@ -1557,7 +1554,10 @@ func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
 	}
 	switch e := elem.(type) {
 	case *ast.CallableTypeAnn:
-		p.printFuncTypeAnn(e.Fn)
+		// Unnamed, like the class member above, so nothing precedes the parameters. The
+		// `fn` a standalone function type annotation writes would name a member here.
+		p.printGenericParams(e.Fn.LifetimeParams, e.Fn.TypeParams)
+		p.printFuncTypeAnnParams(e.Fn)
 	case *ast.ConstructorTypeAnn:
 		p.writeString("new")
 		p.printFuncTypeAnnTail(e.Fn)
@@ -1835,7 +1835,15 @@ func (p *Printer) printFuncTypeAnn(typ *ast.FuncTypeAnn) {
 // and an object type's `new (…) -> T` member share it, mirroring the parser's split.
 func (p *Printer) printFuncTypeAnnTail(typ *ast.FuncTypeAnn) {
 	p.printGenericParams(typ.LifetimeParams, typ.TypeParams)
-	p.writeString(" (")
+	p.space()
+	p.printFuncTypeAnnParams(typ)
+}
+
+// printFuncTypeAnnParams prints a signature's parameter list, return and `throws`, with the
+// generic parameters already written by the caller. An unnamed call signature writes them
+// itself, since it has no keyword to put a space after.
+func (p *Printer) printFuncTypeAnnParams(typ *ast.FuncTypeAnn) {
+	p.writeString("(")
 	for i, param := range typ.Params {
 		p.printPattern(param.Pattern)
 		if param.Optional {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -460,14 +460,12 @@ func (p *Printer) printClassElem(elem ast.ClassElem) {
 			p.printBlock(e.Fn.Body)
 		}
 	case *ast.CallableElem:
-		// A call signature is unnamed, so `fn` is the whole of what precedes its
-		// parameters, and it carries no receiver and no body. The space before the
-		// parameter list is what separates `fn (…)` from a method named `fn`, and it is
-		// the spelling an object type's own call signature prints.
-		p.writeString("fn")
-		p.printGenericParams(e.Fn.LifetimeParams, e.Fn.TypeParams)
-		p.space()
-		p.printMethodSigNoGenerics(&e.Fn.FuncSig)
+		// A call signature is unnamed, so `callable` is the whole of what precedes its
+		// parameters, and it carries no receiver and no body. It prints the way
+		// `constructor` above does, which is what pairs the two unnamed members of a class
+		// body.
+		p.writeString("callable")
+		p.printMethodSig(&e.Fn.FuncSig, nil)
 	}
 }
 
@@ -499,18 +497,6 @@ func (p *Printer) printSetterSig(sig *ast.FuncSig, recv *ast.MethodReceiver) {
 // false only for a class setter, whose grammar has no return slot.
 func (p *Printer) printMethodSigParts(sig *ast.FuncSig, recv *ast.MethodReceiver, withReturn bool) {
 	p.printGenericParams(sig.LifetimeParams, sig.TypeParams)
-	p.printMethodSigBody(sig, recv, withReturn)
-}
-
-// printMethodSigNoGenerics prints a signature's parameter list, return and `throws` with the
-// generic parameters already written by the caller. A class call signature writes them itself,
-// so it can put the space between them and the parameter list that `fn (…)` needs.
-func (p *Printer) printMethodSigNoGenerics(sig *ast.FuncSig) {
-	p.printMethodSigBody(sig, nil, true)
-}
-
-// printMethodSigBody prints everything after the generic parameters.
-func (p *Printer) printMethodSigBody(sig *ast.FuncSig, recv *ast.MethodReceiver, withReturn bool) {
 	p.writeString("(")
 	first := true
 	params := sig.Params

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2330,16 +2330,16 @@ func TestPrintRoundTripsConverterOutput(t *testing.T) {
 		want  string
 	}{
 		{
-			// The `fn (…) -> T` call signature, printed for a
+			// The unnamed `(…) -> T` call signature, printed for a
 			// CallableTypeAnn. `ArrayConstructor` carries three of them.
 			name:  "call signature in an interface",
-			input: "declare interface C {\n    fn (n?: number) -> Array<any>\n}",
-			want:  "declare interface C {\n    fn (n?: number) -> Array<any>\n}",
+			input: "declare interface C {\n    (n?: number) -> Array<any>\n}",
+			want:  "declare interface C {\n    (n?: number) -> Array<any>\n}",
 		},
 		{
 			name:  "generic call signature beside a construct signature",
-			input: "declare interface C {\n    new<T> (n: number) -> T,\n    fn<T> (n: number) -> T\n}",
-			want:  "declare interface C {\n    new<T> (n: number) -> T,\n    fn<T> (n: number) -> T\n}",
+			input: "declare interface C {\n    new<T> (n: number) -> T,\n    <T>(n: number) -> T\n}",
+			want:  "declare interface C {\n    new<T> (n: number) -> T,\n    <T>(n: number) -> T\n}",
 		},
 		{
 			// `Promise.prototype.catch` and `String.prototype.match`.
@@ -2443,7 +2443,7 @@ func TestPrintRoundTripsConverterOutput(t *testing.T) {
 
 	// The keyed form of those same names is valid JavaScript and stays accepted.
 	// One case per class of keyword: a reserved word, a literal, an accessor
-	// modifier, a type name, and the two an object type reads as signatures. The
+	// modifier, a type name, and `new`, which an object type reads as a signature. The
 	// printer emits each bare, so the output has to parse back as the same key.
 	t.Run("keyword keys in an object literal", func(t *testing.T) {
 		literalTests := []struct {

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1247,12 +1247,12 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 		}
 		return strings.Join(arms, "; ")
 	case *CallableElem:
-		// A call signature renders unnamed, `fn (params) -> ret`, the way the source writes
-		// it among an object's members. An overloaded one renders its arms joined by `; `,
-		// as a constructor and a method do.
+		// A call signature renders unnamed, `(params) -> ret`, the way the source writes it
+		// among an object's members. An overloaded one renders its arms joined by `; `, as a
+		// constructor and a method do.
 		arms := make([]string, len(e.Signatures))
 		for i, sig := range e.Signatures {
-			arms[i] = "fn " + p.printFuncTail(sig)
+			arms[i] = p.printFuncTail(sig)
 		}
 		return strings.Join(arms, "; ")
 	case *SpreadElem:

--- a/internal/solver/callable_class_test.go
+++ b/internal/solver/callable_class_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// A class declaring `callable(…) -> T` is callable as well as constructible. The specification
+// A class declaring `(…) -> T` is callable as well as constructible. The specification
 // forbids `new Symbol()`, so a call signature is the only way to make a symbol, and the fused
 // `Symbol` class in `std:prelude` declares one and no constructor.
 func TestACallSignatureMakesAClassCallable(t *testing.T) {
@@ -20,7 +20,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			name: "TheClassValueIsCalled",
 			src: `
 				declare class Sym {
-					callable(desc?: string) -> symbol,
+					(desc?: string) -> symbol,
 				}
 				val s = Sym("x")
 			`,
@@ -32,7 +32,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			name: "AStaticBesideItStillReads",
 			src: `
 				declare class Sym {
-					callable(desc?: string) -> symbol,
+					(desc?: string) -> symbol,
 					static readonly iterator: unique symbol,
 				}
 				val it = Sym.iterator
@@ -46,7 +46,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			name: "ItMayBeGeneric",
 			src: `
 				declare class B {
-					callable<T>(v: T) -> boolean,
+					<T>(v: T) -> boolean,
 				}
 				val b = B(1)
 			`,
@@ -58,8 +58,8 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			name: "AnOverloadedSignatureResolvesAnArm",
 			src: `
 				declare class N {
-					callable() -> number,
-					callable(v: string) -> boolean,
+					() -> number,
+					(v: string) -> boolean,
 				}
 				val r = N("x")
 			`,
@@ -70,7 +70,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			// The class value is a subtype of the function its signature names.
 			name: "TheClassValueFillsAFunctionParameter",
 			src: `
-				declare class Sym { callable(desc: string) -> symbol }
+				declare class Sym { (desc: string) -> symbol }
 				declare fn take(f: fn (d: string) -> symbol) -> number
 				val r = take(Sym)
 			`,
@@ -83,7 +83,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			src: `
 				declare class D {
 					constructor(mut self, n: number),
-					callable(n: number) -> string,
+					(n: number) -> string,
 					x: number,
 				}
 				val d = D(1)
@@ -107,7 +107,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 func TestACallSignatureNeedsAnAmbientClass(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		class C {
-			callable() -> number
+			() -> number
 		}
 	`)
 	require.Equal(t, []string{
@@ -120,14 +120,14 @@ func TestACallSignatureNeedsAnAmbientClass(t *testing.T) {
 func TestACallSignatureSeesTheClassTypeParameters(t *testing.T) {
 	_, types, errs := inferSource(t, `
 		declare class Wrap<T> {
-			callable(v: T) -> T,
+			(v: T) -> T,
 		}
 	`)
 	require.Empty(t, errorMessagesOf(errs))
 	require.Equal(t, "Wrap<T>", types["Wrap"])
 }
 
-// A bare `callable(…) -> T` target asks whether the class value is callable as that function, so it
+// A bare `(…) -> T` target asks whether the class value is callable as that function, so it
 // reads the member a call reads. An object target naming a call signature asks whether the
 // value carries that member, which is structural. The two coincide for a class declaring only
 // a call signature and part ways for one declaring both.
@@ -135,9 +135,9 @@ func TestAFunctionTargetAsksCallabilityAndAnObjectTargetAsksForTheMember(t *test
 	// No constructor, so the call signature is both the member and what a call reads.
 	t.Run("WithOnlyACallSignature", func(t *testing.T) {
 		values, _, errs := inferSource(t, `
-			declare class Sym { callable(n: number) -> string }
+			declare class Sym { (n: number) -> string }
 			declare fn take(f: fn (n: number) -> string) -> number
-			declare fn takeObj(f: { fn (n: number) -> string }) -> number
+			declare fn takeObj(f: { (n: number) -> string }) -> number
 			val a = take(Sym)
 			val b = takeObj(Sym)
 		`)
@@ -152,7 +152,7 @@ func TestAFunctionTargetAsksCallabilityAndAnObjectTargetAsksForTheMember(t *test
 		const decl = `
 			declare class D {
 				constructor(mut self, n: number),
-				callable(n: number) -> string,
+				(n: number) -> string,
 				x: number,
 			}
 		`
@@ -164,7 +164,7 @@ func TestAFunctionTargetAsksCallabilityAndAnObjectTargetAsksForTheMember(t *test
 		require.Equal(t, "number", values["a"])
 
 		values, _, errs = inferSource(t, decl+`
-			declare fn takeObj(f: { fn (n: number) -> string }) -> number
+			declare fn takeObj(f: { (n: number) -> string }) -> number
 			val b = takeObj(D)
 		`)
 		require.Empty(t, errorMessagesOf(errs))

--- a/internal/solver/callable_class_test.go
+++ b/internal/solver/callable_class_test.go
@@ -1,0 +1,173 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A class declaring `fn (…) -> T` is callable as well as constructible. The specification
+// forbids `new Symbol()`, so a call signature is the only way to make a symbol, and the fused
+// `Symbol` class in `std:prelude` declares one and no constructor.
+func TestACallSignatureMakesAClassCallable(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		binding string
+		want    string
+	}{
+		{
+			name: "TheClassValueIsCalled",
+			src: `
+				declare class Sym {
+					fn (desc?: string) -> symbol,
+				}
+				val s = Sym("x")
+			`,
+			binding: "s",
+			want:    "symbol",
+		},
+		{
+			// A static sits beside the call signature and still reads.
+			name: "AStaticBesideItStillReads",
+			src: `
+				declare class Sym {
+					fn (desc?: string) -> symbol,
+					static readonly iterator: unique symbol,
+				}
+				val it = Sym.iterator
+			`,
+			binding: "it",
+			want:    "unique symbol#0",
+		},
+		{
+			// `BooleanConstructor` writes `<T>(value?: T): boolean`, so a call signature
+			// quantifies type parameters of its own.
+			name: "ItMayBeGeneric",
+			src: `
+				declare class B {
+					fn <T>(v: T) -> boolean,
+				}
+				val b = B(1)
+			`,
+			binding: "b",
+			want:    "boolean",
+		},
+		{
+			// Several are the arms of one overloaded signature, and a call resolves one.
+			name: "AnOverloadedSignatureResolvesAnArm",
+			src: `
+				declare class N {
+					fn () -> number,
+					fn (v: string) -> boolean,
+				}
+				val r = N("x")
+			`,
+			binding: "r",
+			want:    "boolean",
+		},
+		{
+			// The class value is a subtype of the function its signature names.
+			name: "TheClassValueFillsAFunctionParameter",
+			src: `
+				declare class Sym { fn (desc: string) -> symbol }
+				declare fn take(f: fn (d: string) -> symbol) -> number
+				val r = take(Sym)
+			`,
+			binding: "r",
+			want:    "number",
+		},
+		{
+			// A constructor still answers construction when both are declared.
+			name: "AConstructorBesideItStillConstructs",
+			src: `
+				declare class D {
+					constructor(mut self, n: number),
+					fn (n: number) -> string,
+					x: number,
+				}
+				val d = D(1)
+			`,
+			binding: "d",
+			want:    "D",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errorMessagesOf(errs))
+			require.Equal(t, tt.want, values[tt.binding])
+		})
+	}
+}
+
+// A class with a body compiles to a JavaScript `class`, and a `class` is never callable, so a
+// call signature there would describe something the output cannot be. Only an ambient
+// declaration, which describes a value the runtime already provides, may carry one.
+func TestACallSignatureNeedsAnAmbientClass(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class C {
+			fn () -> number
+		}
+	`)
+	require.Equal(t, []string{
+		"Only a `declare class` may declare a call signature; a class with a body compiles to a JavaScript `class`, which is not callable.",
+	}, errorMessagesOf(errs))
+}
+
+// A class's own type parameters are in scope in a call signature, so a parameter named only
+// there is resolved and counts as used.
+func TestACallSignatureSeesTheClassTypeParameters(t *testing.T) {
+	_, types, errs := inferSource(t, `
+		declare class Wrap<T> {
+			fn (v: T) -> T,
+		}
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "Wrap<T>", types["Wrap"])
+}
+
+// A bare `fn (…) -> T` target asks whether the class value is callable as that function, so it
+// reads the member a call reads. An object target naming a call signature asks whether the
+// value carries that member, which is structural. The two coincide for a class declaring only
+// a call signature and part ways for one declaring both.
+func TestAFunctionTargetAsksCallabilityAndAnObjectTargetAsksForTheMember(t *testing.T) {
+	// No constructor, so the call signature is both the member and what a call reads.
+	t.Run("WithOnlyACallSignature", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			declare class Sym { fn (n: number) -> string }
+			declare fn take(f: fn (n: number) -> string) -> number
+			declare fn takeObj(f: { fn (n: number) -> string }) -> number
+			val a = take(Sym)
+			val b = takeObj(Sym)
+		`)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "number", values["a"])
+		require.Equal(t, "number", values["b"])
+	})
+
+	// Both declared. `D(1)` constructs, so the function target names `D`; the object target
+	// names the call signature the class carries, which returns `string`.
+	t.Run("WithAConstructorBesideIt", func(t *testing.T) {
+		const decl = `
+			declare class D {
+				constructor(mut self, n: number),
+				fn (n: number) -> string,
+				x: number,
+			}
+		`
+		values, _, errs := inferSource(t, decl+`
+			declare fn take(f: fn (n: number) -> D) -> number
+			val a = take(D)
+		`)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "number", values["a"])
+
+		values, _, errs = inferSource(t, decl+`
+			declare fn takeObj(f: { fn (n: number) -> string }) -> number
+			val b = takeObj(D)
+		`)
+		require.Empty(t, errorMessagesOf(errs))
+		require.Equal(t, "number", values["b"])
+	})
+}

--- a/internal/solver/callable_class_test.go
+++ b/internal/solver/callable_class_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// A class declaring `fn (…) -> T` is callable as well as constructible. The specification
+// A class declaring `callable(…) -> T` is callable as well as constructible. The specification
 // forbids `new Symbol()`, so a call signature is the only way to make a symbol, and the fused
 // `Symbol` class in `std:prelude` declares one and no constructor.
 func TestACallSignatureMakesAClassCallable(t *testing.T) {
@@ -20,7 +20,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			name: "TheClassValueIsCalled",
 			src: `
 				declare class Sym {
-					fn (desc?: string) -> symbol,
+					callable(desc?: string) -> symbol,
 				}
 				val s = Sym("x")
 			`,
@@ -32,7 +32,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			name: "AStaticBesideItStillReads",
 			src: `
 				declare class Sym {
-					fn (desc?: string) -> symbol,
+					callable(desc?: string) -> symbol,
 					static readonly iterator: unique symbol,
 				}
 				val it = Sym.iterator
@@ -46,7 +46,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			name: "ItMayBeGeneric",
 			src: `
 				declare class B {
-					fn <T>(v: T) -> boolean,
+					callable<T>(v: T) -> boolean,
 				}
 				val b = B(1)
 			`,
@@ -58,8 +58,8 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			name: "AnOverloadedSignatureResolvesAnArm",
 			src: `
 				declare class N {
-					fn () -> number,
-					fn (v: string) -> boolean,
+					callable() -> number,
+					callable(v: string) -> boolean,
 				}
 				val r = N("x")
 			`,
@@ -70,7 +70,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			// The class value is a subtype of the function its signature names.
 			name: "TheClassValueFillsAFunctionParameter",
 			src: `
-				declare class Sym { fn (desc: string) -> symbol }
+				declare class Sym { callable(desc: string) -> symbol }
 				declare fn take(f: fn (d: string) -> symbol) -> number
 				val r = take(Sym)
 			`,
@@ -83,7 +83,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 			src: `
 				declare class D {
 					constructor(mut self, n: number),
-					fn (n: number) -> string,
+					callable(n: number) -> string,
 					x: number,
 				}
 				val d = D(1)
@@ -107,7 +107,7 @@ func TestACallSignatureMakesAClassCallable(t *testing.T) {
 func TestACallSignatureNeedsAnAmbientClass(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		class C {
-			fn () -> number
+			callable() -> number
 		}
 	`)
 	require.Equal(t, []string{
@@ -120,14 +120,14 @@ func TestACallSignatureNeedsAnAmbientClass(t *testing.T) {
 func TestACallSignatureSeesTheClassTypeParameters(t *testing.T) {
 	_, types, errs := inferSource(t, `
 		declare class Wrap<T> {
-			fn (v: T) -> T,
+			callable(v: T) -> T,
 		}
 	`)
 	require.Empty(t, errorMessagesOf(errs))
 	require.Equal(t, "Wrap<T>", types["Wrap"])
 }
 
-// A bare `fn (…) -> T` target asks whether the class value is callable as that function, so it
+// A bare `callable(…) -> T` target asks whether the class value is callable as that function, so it
 // reads the member a call reads. An object target naming a call signature asks whether the
 // value carries that member, which is structural. The two coincide for a class declaring only
 // a call signature and part ways for one declaring both.
@@ -135,7 +135,7 @@ func TestAFunctionTargetAsksCallabilityAndAnObjectTargetAsksForTheMember(t *test
 	// No constructor, so the call signature is both the member and what a call reads.
 	t.Run("WithOnlyACallSignature", func(t *testing.T) {
 		values, _, errs := inferSource(t, `
-			declare class Sym { fn (n: number) -> string }
+			declare class Sym { callable(n: number) -> string }
 			declare fn take(f: fn (n: number) -> string) -> number
 			declare fn takeObj(f: { fn (n: number) -> string }) -> number
 			val a = take(Sym)
@@ -152,7 +152,7 @@ func TestAFunctionTargetAsksCallabilityAndAnObjectTargetAsksForTheMember(t *test
 		const decl = `
 			declare class D {
 				constructor(mut self, n: number),
-				fn (n: number) -> string,
+				callable(n: number) -> string,
 				x: number,
 			}
 		`

--- a/internal/solver/callable_object_test.go
+++ b/internal/solver/callable_object_test.go
@@ -12,12 +12,12 @@ import (
 // constructor answers `new`, a call signature answers a plain call, and an object may carry
 // either, both, or neither.
 func TestACallSignatureMakesAnObjectCallable(t *testing.T) {
-	const decl = `type F = { fn (n: number) -> string, tag: string }`
+	const decl = `type F = { (n: number) -> string, tag: string }`
 
 	t.Run("ItRendersAsWritten", func(t *testing.T) {
 		_, types, errs := inferSource(t, decl)
 		require.Empty(t, errorMessagesOf(errs))
-		require.Equal(t, "{fn (n: number) -> string, tag: string}", types["F"])
+		require.Equal(t, "{(n: number) -> string, tag: string}", types["F"])
 	})
 
 	t.Run("TheObjectIsCalled", func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestACallSignatureMakesAnObjectCallable(t *testing.T) {
 // a parameter declared as that function.
 func TestACallableObjectFillsAFunctionParameter(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		type F = { fn (n: number) -> string }
+		type F = { (n: number) -> string }
 		declare val f: F
 		declare fn take(g: fn (n: number) -> string) -> number
 		val r = take(f)
@@ -67,7 +67,7 @@ func TestACallableObjectFillsAFunctionParameter(t *testing.T) {
 // call signature. The rule runs one way, as it does for a construct signature.
 func TestAFunctionDoesNotFillACallSignatureRequirement(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		type F = { fn (n: number) -> string }
+		type F = { (n: number) -> string }
 		declare fn take(f: F) -> number
 		declare fn g(n: number) -> string
 		val r = take(g)
@@ -77,14 +77,14 @@ func TestAFunctionDoesNotFillACallSignatureRequirement(t *testing.T) {
 		errorMessagesOf(errs))
 }
 
-// Several `fn (…) -> T` members are the arms of one overloaded call signature, the way
+// Several `(…) -> T` members are the arms of one overloaded call signature, the way
 // TypeScript writes one, rather than several members the object could not hold.
 func TestSeveralCallSignaturesAreOneOverloadedMember(t *testing.T) {
 	_, types, errs := inferSource(t, `
-		type F = { fn (n: number) -> string, fn (s: string) -> number }
+		type F = { (n: number) -> string, (s: string) -> number }
 	`)
 	require.Empty(t, errorMessagesOf(errs))
-	require.Equal(t, "{fn (n: number) -> string; fn (s: string) -> number}", types["F"])
+	require.Equal(t, "{(n: number) -> string; (s: string) -> number}", types["F"])
 }
 
 // A constructor and a call signature are separate members. `SymbolConstructor` needs the call
@@ -92,15 +92,15 @@ func TestSeveralCallSignaturesAreOneOverloadedMember(t *testing.T) {
 // both.
 func TestAConstructorAndACallSignatureAreSeparateMembers(t *testing.T) {
 	t.Run("BothAreKept", func(t *testing.T) {
-		_, types, errs := inferSource(t, `type F = { fn (n: number) -> string, new (n: number) -> string }`)
+		_, types, errs := inferSource(t, `type F = { (n: number) -> string, new (n: number) -> string }`)
 		require.Empty(t, errorMessagesOf(errs))
-		require.Equal(t, "{fn (n: number) -> string, new (n: number) -> string}", types["F"])
+		require.Equal(t, "{(n: number) -> string, new (n: number) -> string}", types["F"])
 	})
 
 	// A constructor does not answer a call-signature requirement.
 	t.Run("AConstructorDoesNotFillACallSignature", func(t *testing.T) {
 		_, _, errs := inferSource(t, `
-			type Call = { fn (n: number) -> string }
+			type Call = { (n: number) -> string }
 			type Ctor = { new (n: number) -> string }
 			declare fn take(f: Call) -> number
 			declare val c: Ctor
@@ -124,7 +124,7 @@ func TestAnOverloadedCallSignatureResolvesAnArm(t *testing.T) {
 		{
 			name: "TheNullaryArm",
 			src: `
-				declare val f: { fn () -> string, fn (a: number, b: number) -> boolean }
+				declare val f: { () -> string, (a: number, b: number) -> boolean }
 				val r = f()
 			`,
 			want: "string",
@@ -132,7 +132,7 @@ func TestAnOverloadedCallSignatureResolvesAnArm(t *testing.T) {
 		{
 			name: "TheTwoArgumentArm",
 			src: `
-				declare val f: { fn () -> string, fn (a: number, b: number) -> boolean }
+				declare val f: { () -> string, (a: number, b: number) -> boolean }
 				val r = f(1, 2)
 			`,
 			want: "boolean",
@@ -155,7 +155,7 @@ func TestAnOverloadedCallSignatureResolvesAnArm(t *testing.T) {
 func TestAConstructorDecidesTheCallOverACallSignature(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		declare val f: {
-			fn (a: string) -> string,
+			(a: string) -> string,
 			new (a: number) -> number,
 		}
 		val r = f(1)
@@ -167,7 +167,7 @@ func TestAConstructorDecidesTheCallOverACallSignature(t *testing.T) {
 	// signature would accept is checked against the constructor instead.
 	_, _, errs = inferSource(t, `
 		declare val f: {
-			fn (a: string) -> string,
+			(a: string) -> string,
 			new (a: number) -> number,
 		}
 		val r = f("x")
@@ -180,8 +180,8 @@ func TestAConstructorDecidesTheCallOverACallSignature(t *testing.T) {
 // since both answer the empty name.
 func TestAnObjectWithBothCallableMembersStillFuses(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		type A = { fn () -> string, new () -> number, x: number }
-		type B = { fn () -> string, new () -> number, y: number }
+		type A = { () -> string, new () -> number, x: number }
+		type B = { () -> string, new () -> number, y: number }
 		declare fn take(v: A & B) -> number
 		declare val v: A & B
 		val r = take(v)

--- a/internal/solver/callable_object_test.go
+++ b/internal/solver/callable_object_test.go
@@ -137,19 +137,6 @@ func TestAnOverloadedCallSignatureResolvesAnArm(t *testing.T) {
 			`,
 			want: "boolean",
 		},
-		{
-			// A constructor sits beside the arms and answers `new`, not this call.
-			name: "WithAConstructorBesideIt",
-			src: `
-				declare val f: {
-					fn () -> string,
-					fn (a: number, b: number) -> boolean,
-					new (a: number, b: number, c: number) -> number,
-				}
-				val r = f()
-			`,
-			want: "string",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -158,6 +145,34 @@ func TestAnOverloadedCallSignatureResolvesAnArm(t *testing.T) {
 			require.Equal(t, tt.want, values["r"])
 		})
 	}
+}
+
+// A constructor decides the call when an object carries one, so a call signature beside it is
+// not what `f(…)` reads. Escalier writes construction as `Point(1, 2)` and has no `new`
+// expression, so the two members compete for one spelling and the constructor keeps it. The
+// call signature is reached only where there is no constructor, which is the shape `Symbol`
+// and `BigInt` have.
+func TestAConstructorDecidesTheCallOverACallSignature(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		declare val f: {
+			fn (a: string) -> string,
+			new (a: number) -> number,
+		}
+		val r = f(1)
+	`)
+	require.Empty(t, errorMessagesOf(errs))
+	require.Equal(t, "number", values["r"])
+
+	// The arms the call resolves against are the constructor's, so an argument the call
+	// signature would accept is checked against the constructor instead.
+	_, _, errs = inferSource(t, `
+		declare val f: {
+			fn (a: string) -> string,
+			new (a: number) -> number,
+		}
+		val r = f("x")
+	`)
+	require.Equal(t, []string{`cannot constrain "x" <: number`}, errorMessagesOf(errs))
 }
 
 // A constructor and a call signature occupy separate merge slots, so an object carrying both

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -1412,8 +1412,14 @@ func (c *checker) classValueCarrier(t soltype.Type) (*soltype.ObjectType, bool) 
 		if !ok {
 			return nil, false
 		}
-		_, hasCtor := obj.Constructor()
-		return obj, hasCtor
+		// Either unnamed callable member marks the object as a class value. A class
+		// declaring a call signature and no constructor carries only the former, which is
+		// the shape `Symbol` has, and its statics are read the same way.
+		if _, hasCtor := obj.Constructor(); hasCtor {
+			return obj, true
+		}
+		_, hasCall := obj.Callable()
+		return obj, hasCall
 	})
 }
 

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1159,15 +1159,12 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 			}
 		} else if sup, ok := super.(*soltype.FuncType); ok {
-			// An object with a call signature is a subtype of the matching function type. That
-			// is what the signature says: the object is callable with those parameters.
-			if call, ok := sub.Callable(); ok {
-				return c.constrain(overloadReadType(call.Signatures), sup, seen, mutCtx)
-			}
-			// An object with a constructor signature is a subtype of the matching function
-			// type; codegen makes the constructor behave as a plain function where expected.
-			if ctor, ok := sub.Constructor(); ok {
-				return c.constrain(overloadReadType(ctor.Signatures), sup, seen, mutCtx)
+			// An object carrying either unnamed callable member is a subtype of the matching
+			// function type. A constructor decides when the object carries one, the same
+			// member soleCallableSignature reads for a direct call, so a comparison and a
+			// call agree on which signature the object answers with.
+			if sigs := decidingSignatures(sub); sigs != nil {
+				return c.constrain(overloadReadType(sigs), sup, seen, mutCtx)
 			}
 		} else if sup, ok := super.(*soltype.ObjectType); ok {
 			// One ObjectType <: ObjectType rule serves both uses the M2 arm
@@ -1212,9 +1209,18 @@ func (c *Context) constrain(sub, super soltype.Type, seen *seenPairs, mutCtx boo
 					}
 					continue
 				}
-				// A call-signature requirement is the plain-call twin of the constructor one
-				// above, satisfied by the source's own call signature checked covariantly. The
-				// two are separate members, so a constructor does not fill it.
+				// A call-signature requirement is the plain-call twin of the constructor
+				// one above, satisfied by the source's own call signature checked
+				// covariantly. The two are separate members, so a constructor does not
+				// fill it.
+				//
+				// This asks a different question from the FuncType target above. A bare
+				// `fn (…) -> T` target asks whether the object is callable as that
+				// function, which decidingSignatures answers. An object target naming a
+				// call signature asks whether the object carries that member, which is
+				// structural. `Date` declares both members, so it fills
+				// `fn (n: number) -> Date` and `{fn (n: number) -> string}` and neither
+				// of the two crossed.
 				if superCall, ok := superElem.(*soltype.CallableElem); ok {
 					if subCall, has := sub.Callable(); has {
 						errs = append(errs, c.constrain(
@@ -2182,6 +2188,20 @@ func methodReadType(elem *soltype.MethodElem) soltype.Type {
 		arms[i] = callableView(sig)
 	}
 	return &soltype.IntersectionType{Types: arms}
+}
+
+// decidingSignatures returns the arms of the unnamed callable member an object answers a call
+// with, and nil when it carries neither. A constructor decides when the object carries one, for
+// the reason soleCallableSignature gives: Escalier writes construction as `Point(1, 2)` and has
+// no `new` expression, so a call signature beside a constructor cannot take that spelling over.
+func decidingSignatures(obj *soltype.ObjectType) []*soltype.FuncType {
+	if ctor, ok := obj.Constructor(); ok {
+		return ctor.Signatures
+	}
+	if call, ok := obj.Callable(); ok {
+		return call.Signatures
+	}
+	return nil
 }
 
 // overloadReadType returns the callable value an unnamed overload set stands for, the arms a

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1239,6 +1239,7 @@ func (*DuplicateObjectMemberError) isSolverError()          {}
 func (*DuplicateConstructorSignatureError) isSolverError()  {}
 func (*FieldInitializerNotAllowedError) isSolverError()     {}
 func (*SubclassConstructorRequiredError) isSolverError()    {}
+func (*CallSignatureRequiresDeclareError) isSolverError()   {}
 func (*WriteOnlyPropertyError) isSolverError()              {}
 func (*ReadOnlyPropertyError) isSolverError()               {}
 func (*SetterArityError) isSolverError()                    {}
@@ -1781,6 +1782,27 @@ func (e *SubclassConstructorRequiredError) Span() ast.Span      { return e.Decl.
 func (e *SubclassConstructorRequiredError) Related() []ast.Span { return nil }
 func (e *SubclassConstructorRequiredError) Message() string {
 	return "Subclasses must declare an explicit `constructor` block; constructor synthesis is not supported for classes with an `extends` clause."
+}
+
+// CallSignatureRequiresDeclareError fires when a class with a body declares a
+// `fn (…) -> T` call signature. Such a class compiles to a JavaScript `class`, and a
+// `class` is never callable, so the signature would describe something the output cannot
+// be. An ambient `declare class` describes a value the runtime already provides, which may
+// be a callable object, so it carries one.
+//
+// The signature carries the blame and the declaration is related, since the fix is to make
+// the class ambient or to drop the member.
+type CallSignatureRequiresDeclareError struct {
+	Elem *ast.CallableElem
+	Decl *ast.ClassDecl
+}
+
+func (e *CallSignatureRequiresDeclareError) Span() ast.Span { return e.Elem.Span() }
+func (e *CallSignatureRequiresDeclareError) Related() []ast.Span {
+	return []ast.Span{e.Decl.Name.Span()}
+}
+func (e *CallSignatureRequiresDeclareError) Message() string {
+	return "Only a `declare class` may declare a call signature; a class with a body compiles to a JavaScript `class`, which is not callable."
 }
 
 // spanned is a node that can carry blame without being a whole ast.Node. An

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1785,7 +1785,7 @@ func (e *SubclassConstructorRequiredError) Message() string {
 }
 
 // CallSignatureRequiresDeclareError fires when a class with a body declares a
-// `fn (…) -> T` call signature. Such a class compiles to a JavaScript `class`, and a
+// `callable(…) -> T` call signature. Such a class compiles to a JavaScript `class`, and a
 // `class` is never callable, so the signature would describe something the output cannot
 // be. An ambient `declare class` describes a value the runtime already provides, which may
 // be a callable object, so it carries one.

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1785,7 +1785,7 @@ func (e *SubclassConstructorRequiredError) Message() string {
 }
 
 // CallSignatureRequiresDeclareError fires when a class with a body declares a
-// `callable(…) -> T` call signature. Such a class compiles to a JavaScript `class`, and a
+// `(…) -> T` call signature. Such a class compiles to a JavaScript `class`, and a
 // `class` is never callable, so the signature would describe something the output cannot
 // be. An ambient `declare class` describes a value the runtime already provides, which may
 // be a callable object, so it carries one.

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -237,7 +237,7 @@ func classDeclTypes(def *ClassDef, ctors, calls []*soltype.FuncType) []soltype.T
 	}
 	// A call signature is the class's value binding too, and its return is its own rather
 	// than the class handle, so it is walked whole. A parameter written only in
-	// `fn (v: T) -> T` is reached here and nowhere else.
+	// `callable(v: T) -> T` is reached here and nowhere else.
 	for _, fn := range calls {
 		out = append(out, fn)
 	}
@@ -296,7 +296,7 @@ func (c *checker) classValue(
 	if len(ctorFns) > 0 {
 		elems = append(elems, &soltype.ConstructorElem{Signatures: ctorFns})
 	}
-	// A class declaring `fn (…) -> T` is callable as well as constructible, so the value
+	// A class declaring `callable(…) -> T` is callable as well as constructible, so the value
 	// carries a CallableElem beside the constructor. `Symbol("desc")` reads that member and
 	// `Symbol()` alone would read the constructor.
 	if len(callFns) > 0 {
@@ -827,7 +827,7 @@ func (c *checker) resolveScopedTypeRef(scope *Scope, ref *ast.TypeRefTypeAnn, lv
 	return nil, false
 }
 
-// inferCallSignatures types every `fn (…) -> T` member a class declares, in source order, so
+// inferCallSignatures types every `callable(…) -> T` member a class declares, in source order, so
 // an overloaded call signature keeps its arms in the order the source wrote them.
 //
 // A call signature carries no body, so nothing is walked: inferFunc reads the annotation the

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -237,7 +237,7 @@ func classDeclTypes(def *ClassDef, ctors, calls []*soltype.FuncType) []soltype.T
 	}
 	// A call signature is the class's value binding too, and its return is its own rather
 	// than the class handle, so it is walked whole. A parameter written only in
-	// `callable(v: T) -> T` is reached here and nowhere else.
+	// `(v: T) -> T` is reached here and nowhere else.
 	for _, fn := range calls {
 		out = append(out, fn)
 	}
@@ -296,7 +296,7 @@ func (c *checker) classValue(
 	if len(ctorFns) > 0 {
 		elems = append(elems, &soltype.ConstructorElem{Signatures: ctorFns})
 	}
-	// A class declaring `callable(…) -> T` is callable as well as constructible, so the value
+	// A class declaring `(…) -> T` is callable as well as constructible, so the value
 	// carries a CallableElem beside the constructor. `Symbol("desc")` reads that member and
 	// `Symbol()` alone would read the constructor.
 	if len(callFns) > 0 {
@@ -827,7 +827,7 @@ func (c *checker) resolveScopedTypeRef(scope *Scope, ref *ast.TypeRefTypeAnn, lv
 	return nil, false
 }
 
-// inferCallSignatures types every `callable(…) -> T` member a class declares, in source order, so
+// inferCallSignatures types every `(…) -> T` member a class declares, in source order, so
 // an overloaded call signature keeps its arms in the order the source wrote them.
 //
 // A call signature carries no body, so nothing is walked: inferFunc reads the annotation the

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -154,7 +154,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// now, so the view is complete, and it shares each own element pointer so phase 2's
 	// signature installs and field refinements still land on the registered body.
 	c.inferMemberBodies(bodyScope, lvl, c.ctx.selfView(self, body), pending)
-	callFns := c.inferCallSignatures(declScope, lvl, decl)
+	callFns := c.inferCallSignatures(bodyScope, lvl, decl)
 	ctorFns := c.inferConstructor(bodyScope, lvl, decl, self, body, ctors, len(callFns) > 0)
 
 	// Coalesce each member so lookup reads concrete member types rather than the fresh
@@ -833,6 +833,10 @@ func (c *checker) resolveScopedTypeRef(scope *Scope, ref *ast.TypeRefTypeAnn, lv
 // A call signature carries no body, so nothing is walked: inferFunc reads the annotation the
 // way it reads a declared method's. It may quantify type parameters of its own —
 // `BooleanConstructor` writes `<T>(value?: T): boolean` — so generic resolution is on.
+//
+// It reads bodyScope rather than declScope, so `Self` resolves in its annotations the way it
+// does in a method's. The class's own type parameters are in scope either way, bodyScope being
+// a child of declScope.
 //
 // Only a `declare class` may carry one. A class with a body compiles to a JavaScript `class`,
 // and a `class` is never callable, so a call signature there would describe something the

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -154,7 +154,8 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// now, so the view is complete, and it shares each own element pointer so phase 2's
 	// signature installs and field refinements still land on the registered body.
 	c.inferMemberBodies(bodyScope, lvl, c.ctx.selfView(self, body), pending)
-	ctorFns := c.inferConstructor(bodyScope, lvl, decl, self, body, ctors)
+	callFns := c.inferCallSignatures(declScope, lvl, decl)
+	ctorFns := c.inferConstructor(bodyScope, lvl, decl, self, body, ctors, len(callFns) > 0)
 
 	// Coalesce each member so lookup reads concrete member types rather than the fresh
 	// vars a field held before a constructor assignment refined it. A non-generic class
@@ -190,21 +191,21 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	c.queueInheritedMemberCheck(def, self, decl)
 
 	if quiet() && paramsClean {
-		c.reportUnusedTypeParams(typeParams, decl.TypeParams, classDeclTypes(def, ctorFns))
+		c.reportUnusedTypeParams(typeParams, decl.TypeParams, classDeclTypes(def, ctorFns, callFns))
 	}
 
-	return c.classValue(self, ctorFns, static), &ast.NodeProvenance{Node: decl}, true
+	return c.classValue(self, ctorFns, callFns, static), &ast.NodeProvenance{Node: decl}, true
 }
 
 // classDeclTypes returns every type a class declaration writes, so a walk over them covers each
 // position that could name one of the class's type parameters. That is the instance and static
-// members, every constructor signature, and the `extends` and `implements` targets.
+// members, every constructor and call signature, and the `extends` and `implements` targets.
 //
 // A method's `self` receiver is dropped, since every method names the class in it and counting
 // that would make each parameter look used. stripSelfReceiver is the same helper variance
 // inference uses for the same reason. Every other position of a member's signature counts,
 // `throws` included, since walking the object that holds them descends into the whole of each.
-func classDeclTypes(def *ClassDef, ctors []*soltype.FuncType) []soltype.Type {
+func classDeclTypes(def *ClassDef, ctors, calls []*soltype.FuncType) []soltype.Type {
 	var out []soltype.Type
 	// The stripped members are handed back inside an object rather than one by one, so the
 	// caller walks a type and the visitor's own member traversal reaches each position.
@@ -233,6 +234,12 @@ func classDeclTypes(def *ClassDef, ctors []*soltype.FuncType) []soltype.Type {
 		bare.SelfParam = nil
 		bare.Ret = &soltype.NeverType{}
 		out = append(out, &bare)
+	}
+	// A call signature is the class's value binding too, and its return is its own rather
+	// than the class handle, so it is walked whole. A parameter written only in
+	// `fn (v: T) -> T` is reached here and nowhere else.
+	for _, fn := range calls {
+		out = append(out, fn)
 	}
 	// Appended one at a time, since Go does not spread a slice of a concrete type into a
 	// slice of the interface it satisfies.
@@ -278,9 +285,23 @@ func (c *checker) bindScriptClass(scope *Scope, lvl int, decl *ast.ClassDecl) {
 // A `Self` written in a constructor or a static member resolves at self, the class the value
 // constructs. There is no subclass to defer to: a class value is reached by name rather than
 // through a receiver, so the declaring class IS the answer.
-func (c *checker) classValue(self *soltype.ClassType, ctorFns []*soltype.FuncType, static *soltype.ObjectType) soltype.Type {
-	elems := make([]soltype.ObjTypeElem, 0, len(static.Elems)+1)
-	elems = append(elems, &soltype.ConstructorElem{Signatures: ctorFns})
+func (c *checker) classValue(
+	self *soltype.ClassType,
+	ctorFns, callFns []*soltype.FuncType,
+	static *soltype.ObjectType,
+) soltype.Type {
+	elems := make([]soltype.ObjTypeElem, 0, len(static.Elems)+2)
+	// A class declaring a call signature and no constructor carries no ConstructorElem at
+	// all, so nothing constructs it. inferConstructor synthesizes none for that shape.
+	if len(ctorFns) > 0 {
+		elems = append(elems, &soltype.ConstructorElem{Signatures: ctorFns})
+	}
+	// A class declaring `fn (…) -> T` is callable as well as constructible, so the value
+	// carries a CallableElem beside the constructor. `Symbol("desc")` reads that member and
+	// `Symbol()` alone would read the constructor.
+	if len(callFns) > 0 {
+		elems = append(elems, &soltype.CallableElem{Signatures: callFns})
+	}
 	elems = append(elems, static.Elems...)
 	value := &soltype.ObjectType{Elems: elems}
 	resolved, ok := value.Accept(&selfSubst{recv: self}, soltype.Positive).(*soltype.ObjectType)
@@ -804,6 +825,32 @@ func (c *checker) resolveScopedTypeRef(scope *Scope, ref *ast.TypeRefTypeAnn, lv
 		return b.Type, true
 	}
 	return nil, false
+}
+
+// inferCallSignatures types every `fn (…) -> T` member a class declares, in source order, so
+// an overloaded call signature keeps its arms in the order the source wrote them.
+//
+// A call signature carries no body, so nothing is walked: inferFunc reads the annotation the
+// way it reads a declared method's. It may quantify type parameters of its own —
+// `BooleanConstructor` writes `<T>(value?: T): boolean` — so generic resolution is on.
+//
+// Only a `declare class` may carry one. A class with a body compiles to a JavaScript `class`,
+// and a `class` is never callable, so a call signature there would describe something the
+// output cannot be.
+func (c *checker) inferCallSignatures(scope *Scope, lvl int, decl *ast.ClassDecl) []*soltype.FuncType {
+	var sigs []*soltype.FuncType
+	for _, elem := range decl.Body {
+		call, isCall := elem.(*ast.CallableElem)
+		if !isCall {
+			continue
+		}
+		if !decl.Declare() {
+			c.report(&CallSignatureRequiresDeclareError{Elem: call, Decl: decl})
+			continue
+		}
+		sigs = append(sigs, c.inferFunc(scope.Child(), lvl, call.Fn.FuncSig, nil, call, true))
+	}
+	return sigs
 }
 
 // collectConstructors returns the explicit constructor elements of a class, in source order.

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -155,7 +155,22 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// signature installs and field refinements still land on the registered body.
 	c.inferMemberBodies(bodyScope, lvl, c.ctx.selfView(self, body), pending)
 	callFns := c.inferCallSignatures(bodyScope, lvl, decl)
-	ctorFns := c.inferConstructor(bodyScope, lvl, decl, self, body, ctors, len(callFns) > 0)
+	ctorFns := c.walkConstructorBodies(bodyScope, lvl, self, body, ctors)
+	if len(ctorFns) == 0 {
+		// A subclass must declare its own constructor to call `super`, so a missing one is
+		// reported here and the synthesis below stands in for recovery.
+		if decl.Extends != nil {
+			c.report(&SubclassConstructorRequiredError{Decl: decl})
+		}
+		// A class declaring a call signature and no constructor is callable and not
+		// constructible, so nothing is synthesized. Synthesizing one would make
+		// `Symbol(…)` construct instead of call, and the specification forbids
+		// `new Symbol()`, so having no constructor is what makes constructing it
+		// unrepresentable rather than merely discouraged.
+		if len(callFns) == 0 {
+			ctorFns = []*soltype.FuncType{c.synthesizeConstructor(self, body)}
+		}
+	}
 
 	// Coalesce each member so lookup reads concrete member types rather than the fresh
 	// vars a field held before a constructor assignment refined it. A non-generic class

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -15,10 +15,18 @@ import (
 // value parameters. With none it synthesizes one from the instance fields, unless the class
 // extends a superclass — a subclass must declare its own constructor to call `super`, so a
 // missing one is reported and a field-based constructor is synthesized for recovery.
-func (c *checker) inferConstructor(scope *Scope, lvl int, decl *ast.ClassDecl, self *soltype.ClassType, body *soltype.ObjectType, ctors []*ast.ConstructorElem) []*soltype.FuncType {
+func (c *checker) inferConstructor(scope *Scope, lvl int, decl *ast.ClassDecl, self *soltype.ClassType, body *soltype.ObjectType, ctors []*ast.ConstructorElem, hasCallSig bool) []*soltype.FuncType {
 	if len(ctors) == 0 {
 		if decl.Extends != nil {
 			c.report(&SubclassConstructorRequiredError{Decl: decl})
+		}
+		// A class declaring a call signature and no constructor is callable and not
+		// constructible, and synthesizing one would make `Symbol(…)` construct instead of
+		// call. The specification forbids `new Symbol()` and `new BigInt()`, so having no
+		// constructor is what makes constructing them unrepresentable rather than merely
+		// discouraged.
+		if hasCallSig {
+			return nil
 		}
 		return []*soltype.FuncType{c.synthesizeConstructor(self, body)}
 	}

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -9,27 +9,19 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferConstructor produces a class's constructors as FuncTypes returning the instance, one
-// per declared constructor and in source order. Each explicit constructor has its body walked
-// so field assignments refine the instance fields, then a callable signature built from its
-// value parameters. With none it synthesizes one from the instance fields, unless the class
-// extends a superclass — a subclass must declare its own constructor to call `super`, so a
-// missing one is reported and a field-based constructor is synthesized for recovery.
-func (c *checker) inferConstructor(scope *Scope, lvl int, decl *ast.ClassDecl, self *soltype.ClassType, body *soltype.ObjectType, ctors []*ast.ConstructorElem, hasCallSig bool) []*soltype.FuncType {
-	if len(ctors) == 0 {
-		if decl.Extends != nil {
-			c.report(&SubclassConstructorRequiredError{Decl: decl})
-		}
-		// A class declaring a call signature and no constructor is callable and not
-		// constructible, and synthesizing one would make `Symbol(…)` construct instead of
-		// call. The specification forbids `new Symbol()` and `new BigInt()`, so having no
-		// constructor is what makes constructing them unrepresentable rather than merely
-		// discouraged.
-		if hasCallSig {
-			return nil
-		}
-		return []*soltype.FuncType{c.synthesizeConstructor(self, body)}
-	}
+// walkConstructorBodies produces a FuncType per declared constructor, in source order. Each
+// has its body walked so field assignments refine the instance fields, then a callable
+// signature built from its value parameters. A class declaring none yields none.
+//
+// What a class with no declared constructor gets instead is the caller's decision, since it
+// turns on whether the class declares a call signature as well. See inferClassDecl.
+func (c *checker) walkConstructorBodies(
+	scope *Scope,
+	lvl int,
+	self *soltype.ClassType,
+	body *soltype.ObjectType,
+	ctors []*ast.ConstructorElem,
+) []*soltype.FuncType {
 	out := make([]*soltype.FuncType, len(ctors))
 	for i, ctor := range ctors {
 		out[i] = c.walkConstructorBody(scope, lvl, self, body, ctor)
@@ -37,9 +29,9 @@ func (c *checker) inferConstructor(scope *Scope, lvl int, decl *ast.ClassDecl, s
 	return out
 }
 
-// synthesizeConstructor builds the implicit constructor of a class with no explicit
-// one: a function taking one parameter per required instance field, in declaration
-// order, and returning the instance. An optional field is omitted, matching its
+// synthesizeConstructor builds the implicit constructor of a class that declares no explicit
+// one and no call signature: a function taking one parameter per required instance field, in
+// declaration order, and returning the instance. An optional field is omitted, matching its
 // omission from the required set.
 func (c *checker) synthesizeConstructor(self *soltype.ClassType, body *soltype.ObjectType) *soltype.FuncType {
 	var params []*soltype.FuncParam

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1784,11 +1784,11 @@ func (c *checker) ctorOverloadArms(t soltype.Type) ([]*soltype.FuncType, bool) {
 	if !ok {
 		return nil, false
 	}
-	ctor, ok := obj.Constructor()
-	if !ok || len(ctor.Signatures) < 2 {
+	sigs := decidingSignatures(obj)
+	if len(sigs) < 2 {
 		return nil, false
 	}
-	return ctor.Signatures, true
+	return sigs, true
 }
 
 // funcIntersectionArms reports whether t is an IntersectionType whose members are all
@@ -1861,23 +1861,28 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 }
 
 // soleCallableSignature returns the one signature an object is called through, and false when
-// it carries none or carries an overload set. A call signature answers a plain call and a
-// constructor answers `new`, so an object carrying a call signature is called through that
-// one and every other object through its constructor.
+// it carries none or carries an overload set.
 //
-// A call signature decides the call whether or not it is overloaded. An overloaded one yields
-// nothing here, the same as an overloaded constructor, since no one arm is the callee and
-// inferCall routes such a call to inferArmOverloadCall instead. Falling back to a constructor
-// beside it would check the call against the wrong member.
+// A constructor decides the call when the object carries one. Escalier writes construction as
+// `Point(1, 2)` and has no `new` expression, so a class value's constructor is what `C(…)`
+// names and a call signature beside it cannot take that spelling over. `Date` declares both,
+// and `Date(…)` constructs. A call signature is reached only when there is no constructor,
+// which is the shape `Symbol` and `BigInt` have: the specification forbids constructing them,
+// so the call signature is the only way to make one.
+//
+// Whichever member decides, it decides whether or not it is overloaded. An overloaded one
+// yields nothing here, since no single arm is the callee and inferCall routes such a call to
+// inferArmOverloadCall instead. Falling through to the other member would check the call
+// against a signature the caller did not name.
 func soleCallableSignature(t *soltype.ObjectType) (*soltype.FuncType, bool) {
-	if call, ok := t.Callable(); ok {
-		if len(call.Signatures) == 1 {
-			return call.Signatures[0], true
+	if ctor, ok := t.Constructor(); ok {
+		if len(ctor.Signatures) == 1 {
+			return ctor.Signatures[0], true
 		}
 		return nil, false
 	}
-	if ctor, ok := t.Constructor(); ok && len(ctor.Signatures) == 1 {
-		return ctor.Signatures[0], true
+	if call, ok := t.Callable(); ok && len(call.Signatures) == 1 {
+		return call.Signatures[0], true
 	}
 	return nil, false
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -306,7 +306,7 @@ func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bo
 			l.c.reportUnsupported(elem.Name)
 			return nil, true
 		}
-		sig := l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)
+		sig := l.c.mustResolveFuncTypeAnn(l.scope, elem.Fn, l.lvl)
 		return &soltype.MethodElem{
 			Name:       name,
 			Signatures: []*soltype.FuncType{sig},
@@ -321,7 +321,7 @@ func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bo
 		// The value read and what reading it raises both come from the one resolved
 		// signature. An absent `throws` clause leaves the signature's Throws nil, and nil is
 		// the `never` shorthand GetterElem uses too, so it carries over with no special case.
-		sig := l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)
+		sig := l.c.mustResolveFuncTypeAnn(l.scope, elem.Fn, l.lvl)
 		return &soltype.GetterElem{Name: name, Type: sig.Ret, Throws: sig.Throws}, true
 	case *ast.SetterTypeAnn:
 		name, ok := objKeyName(elem.Name)
@@ -329,7 +329,7 @@ func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bo
 			l.c.reportUnsupported(elem.Name)
 			return nil, true
 		}
-		sig := l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)
+		sig := l.c.mustResolveFuncTypeAnn(l.scope, elem.Fn, l.lvl)
 		// A well-formed setter declares exactly one value parameter beyond the receiver, the
 		// value being assigned. Report any other count and then build the element from the
 		// first parameter, or from `unknown` when there is none, so the object still carries a
@@ -349,13 +349,13 @@ func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bo
 		}
 		l.sawCtor = true
 		return &soltype.ConstructorElem{
-			Signatures: []*soltype.FuncType{l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)},
+			Signatures: []*soltype.FuncType{l.c.mustResolveFuncTypeAnn(l.scope, elem.Fn, l.lvl)},
 		}, true
 	case *ast.CallableTypeAnn:
 		// An overloaded call signature is written as several `fn (…) -> T` members, the way
 		// TypeScript writes one. They are arms of one element, so the second and later ones
 		// extend the first rather than adding an element the object could not hold.
-		sig := l.c.resolveSigTypeAnn(l.scope, elem.Fn, l.lvl)
+		sig := l.c.mustResolveFuncTypeAnn(l.scope, elem.Fn, l.lvl)
 		if l.callable != nil {
 			l.callable.Signatures = append(l.callable.Signatures, sig)
 			return nil, true
@@ -374,15 +374,18 @@ func (l *objAnnLowering) lower(elem ast.ObjTypeAnnElem) (soltype.ObjTypeElem, bo
 	return nil, false
 }
 
-// resolveSigTypeAnn lowers the `(…) -> R throws E` tail a method, getter, or setter shares with
-// a `fn` annotation. resolveFuncTypeAnn recovers every unsupported part of a signature to a
-// fresh var, so it always yields a FuncType and its ok result is always true. Anything else is a
-// wiring bug rather than a source error, so fail loudly instead of dropping the member.
-func (c *checker) resolveSigTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int) *soltype.FuncType {
+// mustResolveFuncTypeAnn is resolveFuncTypeAnn narrowed to the concrete type it always yields.
+// It lowers the `(…) -> R throws E` tail that a method, getter, setter, and the two unnamed
+// callable members share with a `fn` annotation.
+//
+// resolveFuncTypeAnn recovers every unsupported part of a signature to a fresh var, so it always
+// yields a FuncType and its ok result is always true. Anything else is a wiring bug rather than
+// a source error, so fail loudly instead of dropping the member.
+func (c *checker) mustResolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int) *soltype.FuncType {
 	fn, _ := c.resolveFuncTypeAnn(scope, ta, lvl)
 	sig, isFunc := fn.(*soltype.FuncType)
 	if !isFunc {
-		panic(fmt.Sprintf("resolveSigTypeAnn: signature resolved to %T, not *soltype.FuncType", fn))
+		panic(fmt.Sprintf("mustResolveFuncTypeAnn: signature resolved to %T, not *soltype.FuncType", fn))
 	}
 	return sig
 }

--- a/internal/type_system/print_type.go
+++ b/internal/type_system/print_type.go
@@ -477,7 +477,10 @@ func printObjectType(t *ObjectType, pt func(Type) string) string {
 			}
 			switch elem := elem.(type) {
 			case *CallableElem:
-				result += printFuncType(elem.Fn, pt)
+				// A call signature is unnamed, so its parameter list opens the member.
+				// The `fn ` header printFuncType writes for a standalone function type
+				// would name a member here.
+				result += printFuncSig("", elem.Fn, false, pt)
 			case *ConstructorElem:
 				result += "new " + printFuncType(elem.Fn, pt)
 			case *MethodElem:


### PR DESCRIPTION
Refs #1412

Steps 1–3 of #1412, the last of it. Stacked on #1575; review only the last two commits.

## What lands

`ast.CallableElem` is the unnamed `callable(…) -> T` member of a class body, and it makes the class value callable. With #1574's `soltype.CallableElem` already the member a class value can carry, this wires the surface to it: parser, printer, dep graph, solver, codegen, converter.

`detectTrios` drops its guard, so `Symbol` and `BigInt` fuse alongside the other 19 and keep their callable form.

## `callable` in a class body

`callable` is a contextual keyword at the start of a class element, exactly as `constructor` is, so a class body spells its two unnamed members alike and each says what it answers:

```
declare class Symbol {
    callable(description?: string | number) -> symbol,
    static readonly iterator: unique symbol,
    toString(self) -> string
}
```

The spellings that keep the name are `constructor`'s too:

| written | reads as |
| --- | --- |
| `callable() -> T` | call signature |
| `callable: T`, `callable?: T` | field |
| `"callable"(self) -> T` | method |
| `get callable(self)`, `static callable()` — any modifier | getter, static method, … |

An object type keeps `fn (…) -> T` for its own call signature, which the generated tree still writes in every interface. `fn` therefore competes with nothing in a class body and keeps naming a method there, so `TestFnAndNewNameClassMethods` and the keyword sweep are unchanged.

## No constructor when a call signature stands alone

A class declaring a call signature and no constructor gets no synthesized one, so nothing constructs it. That is what makes `new Symbol()` unrepresentable rather than merely discouraged, and it is the shape the converter's own comment already described. `classValue` therefore omits the `ConstructorElem` entirely, and `classValueCarrier` accepts either unnamed member as marking a class value so `Symbol.iterator` still reads.

## Which member answers a call

A constructor decides when a class carries both. Escalier writes construction as `Point(1, 2)` and has no `new` expression, so the two members compete for one spelling and the constructor keeps it — `Date(…)` constructs. A call signature is reached only where there is no constructor.

This reverses the preference #1574 set for objects, where no construction syntax was at stake. That PR's test is updated here rather than there, since this is where classes make the conflict visible.

Two questions that look alike get different answers, and deliberately:

- A bare `fn (…) -> T` target asks whether the value is **callable as that function**, so it reads the deciding member.
- An object target naming a call signature asks whether the value **carries that member**, which is structural.

`Date` fills `fn (n: number) -> Date` and `{fn (n: number) -> string}`, and neither of the two crossed. Review flagged the difference as an inconsistency; making both use the deciding member broke the meet of two objects carrying both members, which is what showed the two are asking different things.

## Review fixes

Six of eight findings were valid and are fixed.

- `inferCallSignatures` got the enclosing scope, not `declScope`, so `declare class Wrap<T> { callable(v: T) -> T }` reported `cannot find type T` twice.
- `classDeclTypes` omitted the call signatures, so a type parameter named only in one reported as unused. Masked by the scope bug; appeared the moment it was fixed.
- `dep_graph`'s `EnterClassElem` had no arm, so a call signature's annotations recorded no dependency edges.
- The converter's `CallSignature` arm ignored its `static` parameter. An instance-side one is now skipped; no trio in the pinned lib set declares one, but a third-party `.d.ts` can.
- Two docstrings ended up heading the wrong function, in `printer.go` and `infer_class.go`.

Two did not hold. The claim that a fixture importing `std:error` goes from 0 diagnostics to 11 does not reproduce — base reports 11 too, and none mention the new element. And the fourth finding, the constrain "inconsistency", is the deliberate distinction above.

## Known limitation

`internal/checker`, which `escalier build` and the LSP run, has no arm for the new element, so user-written source declaring one reports `Unimplemented: Unsupported class element type`. That checker loads its globals from `node_modules/typescript/lib` rather than from `internal/interop/data`, so the regenerated tree does not reach it and nothing regresses — I checked with a fixture importing `std:bigint`, whose class gains a call signature. Adding the arm is its own change; noted on #1412.

## Regenerated tree

`Symbol` and `BigInt` become classes, and 19 fused classes gain the call signature they were dropping. Generation is stable across two runs, and no `callable` appears in an interface nor `fn` as a class member.

## Testing

`go test ./...` passes, `gofmt` reports nothing new. New tests cover the `callable` disambiguation table, the receiver and body rejections, calling a class value, a static beside the signature, a generic signature, arm resolution, the class value filling a function parameter, a constructor still constructing, the `declare` requirement, the type parameters being in scope, and both target questions. `TestStandalone_TrioNotFusedWhenTheConstructorIsOnlyCallable` is inverted to `…StillFuses` and asserts the fused class has the call signature and no constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk