### PR TITLE
Render a construct signature as `new (...)` rather than `new fn (...)`

### DIFF
--- a/internal/checker/tests/constructor_test.go
+++ b/internal/checker/tests/constructor_test.go
@@ -347,7 +347,7 @@ func TestConstructorInferredTypes(t *testing.T) {
 				// `Foo`'s class binding renders as a constructor-bearing
 				// object type — the `throws string` clause is attached to
 				// the callable signature.
-				"Foo": "{new fn (x: number) -> Foo throws string}",
+				"Foo": "{new (x: number) -> Foo throws string}",
 				// Caller-side throws inference propagates the
 				// constructor's declared throws into `make`'s
 				// inferred signature.
@@ -363,7 +363,7 @@ func TestConstructorInferredTypes(t *testing.T) {
 				val s = Box("hi")
 			`,
 			expected: map[string]string{
-				"Box": "{new fn <T>(value: T) -> Box<T>}",
+				"Box": "{new <T>(value: T) -> Box<T>}",
 				"b":   "Box<42>",
 				"s":   "Box<\"hi\">",
 			},

--- a/internal/checker/tests/infer_class_decl_test.go
+++ b/internal/checker/tests/infer_class_decl_test.go
@@ -30,7 +30,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val {x, y} = p
 			`,
 			expectedTypes: map[string]string{
-				"Point": "{new fn (x: number, y: number) -> Point}",
+				"Point": "{new (x: number, y: number) -> Point}",
 				"p":     "Point",
 				"x":     "number",
 				"y":     "number",
@@ -58,7 +58,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val q = p.add(Point(1, 2))
 			`,
 			expectedTypes: map[string]string{
-				"Point": "{new fn (x: number, y: number) -> Point}",
+				"Point": "{new (x: number, y: number) -> Point}",
 				"p":     "Point",
 				"q":     "Point",
 				"len":   "number",
@@ -89,7 +89,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val q = p.scale(2).translate(1, -1)
 			`,
 			expectedTypes: map[string]string{
-				"Point": "{new fn (x: number, y: number) -> Point}",
+				"Point": "{new (x: number, y: number) -> Point}",
 				"p":     "mut Point",
 				"q":     "mut Point",
 			},
@@ -116,7 +116,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val fooBaz = foo[baz]()
 			`,
 			expectedTypes: map[string]string{
-				"Foo":    "{new fn (barVal?: number) -> Foo}",
+				"Foo":    "{new (barVal?: number) -> Foo}",
 				"fooBar": "number",
 				"fooBaz": "number",
 			},
@@ -136,7 +136,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val result = MyMath.add(5, 3)
 			`,
 			expectedTypes: map[string]string{
-				"MyMath": "{new fn () -> MyMath, add(a: number, b: number) -> number}",
+				"MyMath": "{new () -> MyMath, add(a: number, b: number) -> number}",
 				"m":      "MyMath",
 				"result": "number",
 			},
@@ -162,7 +162,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val len = p.length()
 			`,
 			expectedTypes: map[string]string{
-				"Point":  "{new fn (x: number, y: number) -> Point, origin() -> Point}",
+				"Point":  "{new (x: number, y: number) -> Point, origin() -> Point}",
 				"p":      "Point",
 				"origin": "Point",
 				"len":    "number",
@@ -184,7 +184,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val area = c.area
 			`,
 			expectedTypes: map[string]string{
-				"Circle": "{new fn (radius: number) -> Circle}",
+				"Circle": "{new (radius: number) -> Circle}",
 				"c":      "Circle",
 				"area":   "number",
 			},
@@ -207,7 +207,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"Temperature": "{new fn (celsius: number) -> Temperature}",
+				"Temperature": "{new (celsius: number) -> Temperature}",
 				"temp":        "mut Temperature",
 			},
 			expectedTypeAliases: map[string]string{
@@ -237,7 +237,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"Person": "{new fn (firstName: string, lastName: string) -> Person}",
+				"Person": "{new (firstName: string, lastName: string) -> Person}",
 				"person": "mut Person",
 				"name":   "string",
 			},
@@ -257,7 +257,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val version = Config.version
 			`,
 			expectedTypes: map[string]string{
-				"Config":  "{new fn () -> Config, get version() -> string}",
+				"Config":  "{new () -> Config, get version() -> string}",
 				"config":  "Config",
 				"version": "string",
 			},
@@ -282,7 +282,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val defaultVal = Counter.defaultValue
 			`,
 			expectedTypes: map[string]string{
-				"Counter":        "{new fn (initialValue: number) -> Counter, totalInstances: number, defaultValue: number}",
+				"Counter":        "{new (initialValue: number) -> Counter, totalInstances: number, defaultValue: number}",
 				"counter1":       "Counter",
 				"value1":         "number",
 				"totalInstances": "number",
@@ -302,7 +302,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val boxValue = box.value
 			`,
 			expectedTypes: map[string]string{
-				"Box":      "{new fn <T>(value: T) -> Box<T>}",
+				"Box":      "{new <T>(value: T) -> Box<T>}",
 				"box":      "Box<number>",
 				"boxValue": "number",
 			},
@@ -352,8 +352,8 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val dogSound = dog.speak()
 			`,
 			expectedTypes: map[string]string{
-				"Animal":      "{new fn (name: string) -> Animal}",
-				"Dog":         "{new fn (name: string, breed: string) -> Dog}",
+				"Animal":      "{new (name: string) -> Animal}",
+				"Dog":         "{new (name: string, breed: string) -> Dog}",
 				"animal":      "Animal",
 				"dog":         "Dog",
 				"dogName":     "string",
@@ -392,8 +392,8 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val carDoors = car.doors
 			`,
 			expectedTypes: map[string]string{
-				"Vehicle":  "{new fn (make: string, model: string) -> Vehicle}",
-				"Car":      "{new fn (make: string, model: string, doors: number) -> Car}",
+				"Vehicle":  "{new (make: string, model: string) -> Vehicle}",
+				"Car":      "{new (make: string, model: string, doors: number) -> Car}",
 				"car":      "Car",
 				"info":     "string",
 				"fullInfo": "string",
@@ -426,8 +426,8 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val extD = ext.d
 			`,
 			expectedTypes: map[string]string{
-				"Base":     "{new fn (a: number, b: string) -> Base}",
-				"Extended": "{new fn (a: number, b: string, c: boolean, d: number) -> Extended}",
+				"Base":     "{new (a: number, b: string) -> Base}",
+				"Extended": "{new (a: number, b: string, c: boolean, d: number) -> Extended}",
 				"ext":      "Extended",
 				"extA":     "number",
 				"extB":     "string",
@@ -458,8 +458,8 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val circleArea = circle.area
 			`,
 			expectedTypes: map[string]string{
-				"Shape":       "{new fn (color: string) -> Shape}",
-				"Circle":      "{new fn (color: string, radius: number) -> Circle}",
+				"Shape":       "{new (color: string) -> Shape}",
+				"Circle":      "{new (color: string, radius: number) -> Circle}",
 				"circle":      "Circle",
 				"circleColor": "string",
 				"circleArea":  "number",
@@ -485,7 +485,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val boxContents = box["contents"]
 			`,
 			expectedTypes: map[string]string{
-				"Box":         "{new fn (size: number, contents: string) -> Box}",
+				"Box":         "{new (size: number, contents: string) -> Box}",
 				"box":         "Box",
 				"boxSize":     "number",
 				"boxContents": "string",
@@ -518,9 +518,9 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val childAge = child.age
 			`,
 			expectedTypes: map[string]string{
-				"GrandParent": "{new fn (id: number) -> GrandParent}",
-				"Parent":      "{new fn (id: number, name: string) -> Parent}",
-				"Child":       "{new fn (id: number, name: string, age: number) -> Child}",
+				"GrandParent": "{new (id: number) -> GrandParent}",
+				"Parent":      "{new (id: number, name: string) -> Parent}",
+				"Child":       "{new (id: number, name: string, age: number) -> Child}",
 				"child":       "Child",
 				"childId":     "number",
 				"childName":   "string",
@@ -551,8 +551,8 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val incremented = counter.increment()
 			`,
 			expectedTypes: map[string]string{
-				"Counter":         "{new fn (value: number) -> Counter}",
-				"ExtendedCounter": "{new fn (value: number, step: number) -> ExtendedCounter}",
+				"Counter":         "{new (value: number) -> Counter}",
+				"ExtendedCounter": "{new (value: number, step: number) -> ExtendedCounter}",
 				"counter":         "mut ExtendedCounter",
 				"incremented":     "mut ExtendedCounter",
 			},
@@ -584,8 +584,8 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				val catName = cat.name
 			`,
 			expectedTypes: map[string]string{
-				"Animal":  "{new fn (name: string) -> Animal}",
-				"Cat":     "{new fn (name: string, lives: number) -> Cat}",
+				"Animal":  "{new (name: string) -> Animal}",
+				"Cat":     "{new (name: string, lives: number) -> Cat}",
 				"cat":     "Cat",
 				"sound":   "string",
 				"catName": "string",
@@ -611,7 +611,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 		// 		}
 		// 	`,
 		// 	expectedTypes: map[string]string{
-		// 		"GlobalState": "{new fn () -> GlobalState, set debugMode(mut self, value: boolean) -> undefined}",
+		// 		"GlobalState": "{new () -> GlobalState, set debugMode(mut self, value: boolean) -> undefined}",
 		// 		"state":       "mut GlobalState",
 		// 	},
 		// 	expectedTypeAliases: map[string]string{
@@ -947,7 +947,7 @@ func TestCheckScriptLevelClassDeclNoErrors(t *testing.T) {
 				val sum = p.x + p.y
 			`,
 			expectedTypes: map[string]string{
-				"Point": "{new fn (x: number, y: number) -> Point}",
+				"Point": "{new (x: number, y: number) -> Point}",
 				"p":     "Point",
 				"sum":   "number",
 			},
@@ -965,7 +965,7 @@ func TestCheckScriptLevelClassDeclNoErrors(t *testing.T) {
 				c.inc()
 			`,
 			expectedTypes: map[string]string{
-				"Counter": "{new fn (value: number) -> Counter}",
+				"Counter": "{new (value: number) -> Counter}",
 				"c":       "mut Counter",
 			},
 		},

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -1001,7 +1001,7 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				val b = box.getValue(10)
 			`,
 			expectedTypes: map[string]string{
-				"Box": "{new fn (value: number) -> Box}",
+				"Box": "{new (value: number) -> Box}",
 				"box": "Box",
 				"a":   "number | string",
 				"b":   "number",
@@ -1016,7 +1016,7 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				val {value} = box
 			`,
 			expectedTypes: map[string]string{
-				"Box":   "{new fn <T>(value: T) -> Box<T>}",
+				"Box":   "{new <T>(value: T) -> Box<T>}",
 				"box":   "Box<number>",
 				"value": "number",
 			},
@@ -1038,7 +1038,7 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				val b = box.getValue(10)
 			`,
 			expectedTypes: map[string]string{
-				"Box": "{new fn <T>(value: T) -> Box<T>}",
+				"Box": "{new <T>(value: T) -> Box<T>}",
 				"box": "Box<number>",
 				"a":   "number | string",
 				"b":   "number",
@@ -1186,8 +1186,8 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				val blue = Color.Hex("#0000FF")
 			`,
 			expectedTypes: map[string]string{
-				"rgb":  "{new fn (r: number, g: number, b: number) -> Color, symbol12(subject: RGB) -> [number, number, number]}",
-				"hex":  "{new fn (code: string) -> Color, symbol12(subject: Hex) -> [string]}",
+				"rgb":  "{new (r: number, g: number, b: number) -> Color, symbol12(subject: RGB) -> [number, number, number]}",
+				"hex":  "{new (code: string) -> Color, symbol12(subject: Hex) -> [string]}",
 				"red":  "Color",
 				"blue": "Color",
 			},
@@ -1225,8 +1225,8 @@ func TestCheckModuleNoErrors(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"option": "MyOption<number>",
-				"some":   "{new fn <T>(value: T) -> MyOption<T>, symbol12<T>(subject: Some<T>) -> [T]}",
-				"none":   "{new fn <T>() -> MyOption<T>, symbol12<T>(subject: None<T>) -> []}",
+				"some":   "{new <T>(value: T) -> MyOption<T>, symbol12<T>(subject: Some<T>) -> [T]}",
+				"none":   "{new <T>() -> MyOption<T>, symbol12<T>(subject: None<T>) -> []}",
 				"result": "number",
 			},
 		},
@@ -1315,7 +1315,7 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				val b = foo.bar("hello")
 			`,
 			expectedTypes: map[string]string{
-				"Foo": "{new fn () -> Foo}",
+				"Foo": "{new () -> Foo}",
 				"foo": "Foo",
 				"a":   "5",
 				"b":   "\"hello\"",

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -851,7 +851,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				class Container { item: mut {x: number} }
 			`,
 			expectedTypes: map[string]string{
-				"Container": "{new fn <'a>(item: mut 'a {x: number}) -> Container<'a>}",
+				"Container": "{new <'a>(item: mut 'a {x: number}) -> Container<'a>}",
 			},
 		},
 		"PointPrimitivesNoLifetime": {
@@ -859,7 +859,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				class Point { x: number, y: number }
 			`,
 			expectedTypes: map[string]string{
-				"Point": "{new fn (x: number, y: number) -> Point}",
+				"Point": "{new (x: number, y: number) -> Point}",
 			},
 		},
 		"PairOfRefs": {
@@ -867,7 +867,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				class Pair { first: mut {x: number}, second: mut {x: number} }
 			`,
 			expectedTypes: map[string]string{
-				"Pair": "{new fn <'a, 'b>(first: mut 'a {x: number}, second: mut 'b {x: number}) -> Pair<'a, 'b>}",
+				"Pair": "{new <'a, 'b>(first: mut 'a {x: number}, second: mut 'b {x: number}) -> Pair<'a, 'b>}",
 			},
 		},
 		"GuardOnlyParamNotCaptured": {
@@ -887,7 +887,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"C": "{new fn (p: mut {x: number}) -> C}",
+				"C": "{new (p: mut {x: number}) -> C}",
 			},
 			expectedInstanceLifetimes: map[string]int{
 				"C": 0,
@@ -906,7 +906,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"C": "{new fn (p: {x: number}) -> C}",
+				"C": "{new (p: {x: number}) -> C}",
 			},
 			expectedInstanceLifetimes: map[string]int{
 				"C": 0,
@@ -955,7 +955,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"Pair": "{new fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> Pair<'a, 'b>}",
+				"Pair": "{new <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> Pair<'a, 'b>}",
 			},
 			expectedInstanceLifetimes: map[string]int{
 				"Pair": 2,
@@ -976,7 +976,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"Wrap": "{new fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> Wrap<'a, 'b>}",
+				"Wrap": "{new <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> Wrap<'a, 'b>}",
 			},
 			expectedInstanceLifetimes: map[string]int{
 				"Wrap": 2,
@@ -1097,7 +1097,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"C": "{new fn <'a>([a: mut 'a {x: number}, b: mut {x: number}]) -> C<'a>}",
+				"C": "{new <'a>([a: mut 'a {x: number}, b: mut {x: number}]) -> C<'a>}",
 			},
 			expectedInstanceLifetimes: map[string]int{
 				"C": 1,
@@ -1114,7 +1114,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"C": "{new fn <'a>(p: mut 'a {x: number}) -> C<'a>}",
+				"C": "{new <'a>(p: mut 'a {x: number}) -> C<'a>}",
 			},
 			expectedInstanceLifetimes: map[string]int{
 				"C": 1,
@@ -1169,7 +1169,7 @@ func TestCtorCapturesViaWrappingCall(t *testing.T) {
 	actual := collectBindingTypes(ns)
 	got, ok := actual["C"]
 	require.True(t, ok, "binding C not found")
-	assert.Equal(t, "{new fn <'a>(p: mut 'a {y: number}) -> C<'a>}", got)
+	assert.Equal(t, "{new <'a>(p: mut 'a {y: number}) -> C<'a>}", got)
 }
 
 // TestCallSiteAliasFromLifetimeUnion exercises the LifetimeUnion call-site

--- a/internal/checker/tests/substitute_test.go
+++ b/internal/checker/tests/substitute_test.go
@@ -411,8 +411,8 @@ func TestSubstituteTypeParamsInObjElem(t *testing.T) {
 	// Substitute type parameters in the entire object
 	result := SubstituteTypeParams(objType, substitutions)
 
-	assert.Equal(t, "{readonly test?: T, method(self, x: T) -> U, get getter(self) -> T, set setter(mut self, value: V) -> undefined, (x: T) -> U, new fn (init: V) -> U, ...T}", objType.String())
-	assert.Equal(t, "{readonly test?: number, method(self, x: number) -> string, get getter(self) -> number, set setter(mut self, value: boolean) -> undefined, (x: number) -> string, new fn (init: boolean) -> string, ...number}", result.String())
+	assert.Equal(t, "{readonly test?: T, method(self, x: T) -> U, get getter(self) -> T, set setter(mut self, value: V) -> undefined, (x: T) -> U, new (init: V) -> U, ...T}", objType.String())
+	assert.Equal(t, "{readonly test?: number, method(self, x: number) -> string, get getter(self) -> number, set setter(mut self, value: boolean) -> undefined, (x: number) -> string, new (init: boolean) -> string, ...number}", result.String())
 }
 
 // Phase 10.5 regression: when the same type-parameter substitute is used

--- a/internal/type_system/print_type.go
+++ b/internal/type_system/print_type.go
@@ -482,7 +482,11 @@ func printObjectType(t *ObjectType, pt func(Type) string) string {
 				// would name a member here.
 				result += printFuncSig("", elem.Fn, false, pt)
 			case *ConstructorElem:
-				result += "new " + printFuncType(elem.Fn, pt)
+				// `new ` is the header rather than a prefix on one. printFuncType writes
+				// `fn ` for a standalone function type, and concatenating onto that gave
+				// `new fn (…) -> T`, which no grammar reads: the parser takes `new` as the
+				// construct-signature keyword, and `fn` after it would be a member name.
+				result += printFuncSig("new ", elem.Fn, false, pt)
 			case *MethodElem:
 				// Print one entry per overload arm. For a single-arm
 				// (non-overloaded) method this matches the historical

--- a/internal/type_system/print_type_audit_test.go
+++ b/internal/type_system/print_type_audit_test.go
@@ -198,13 +198,39 @@ func TestPrintTypeAudit_RoundTrip(t *testing.T) {
 			},
 		})},
 
-		// CallableElem / ConstructorElem inside an object have no
-		// Escalier source syntax — they are only synthesized by the
-		// interop conversion from TypeScript `.d.ts` call/construct
-		// signatures. The printer emits `{fn (...) -> T}` /
-		// `{new fn (...) -> T}` for debug output; round-trip is
-		// covered by the no-syntax test below.
-
+		// --- the two unnamed callable members of an object ---
+		// Both are writable source: `{(x: number) -> string}` is a call signature and
+		// `{new (x: number) -> Foo}` a construct signature, so both round-trip.
+		{"object callable", type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			&type_system.CallableElem{
+				Fn: type_system.NewFuncType(nil, nil,
+					[]*type_system.FuncParam{
+						{Pattern: type_system.NewIdentPat("x"), Type: type_system.NewNumPrimType(nil)},
+					},
+					type_system.NewStrPrimType(nil), nil),
+			},
+		})},
+		{"object constructor", type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			&type_system.ConstructorElem{
+				Fn: type_system.NewFuncType(nil, nil,
+					[]*type_system.FuncParam{
+						{Pattern: type_system.NewIdentPat("x"), Type: type_system.NewNumPrimType(nil)},
+					},
+					type_system.NewTypeRefType(nil, "Foo", nil), nil),
+			},
+		})},
+		// A generic one puts the binder between the keyword and the parameters, which is
+		// the position the header change moved it into.
+		{"object generic constructor", type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			&type_system.ConstructorElem{
+				Fn: type_system.NewFuncType(nil,
+					[]*type_system.TypeParam{{Name: "T"}},
+					[]*type_system.FuncParam{
+						{Pattern: type_system.NewIdentPat("v"), Type: type_system.NewTypeRefType(nil, "T", nil)},
+					},
+					type_system.NewTypeRefType(nil, "Box", nil, type_system.NewTypeRefType(nil, "T", nil)), nil),
+			},
+		})},
 		// --- function: typed params, optional, multiple, with throws ---
 		{"func optional param", type_system.NewFuncType(nil, nil,
 			[]*type_system.FuncParam{
@@ -393,24 +419,6 @@ func TestPrintTypeAudit_NoSyntax(t *testing.T) {
 		typ  type_system.Type
 	}{
 		{"unique symbol", type_system.NewUniqueSymbolType(nil, 42)},
-		{"object callable", type_system.NewObjectType(nil, []type_system.ObjTypeElem{
-			&type_system.CallableElem{
-				Fn: type_system.NewFuncType(nil, nil,
-					[]*type_system.FuncParam{
-						{Pattern: type_system.NewIdentPat("x"), Type: type_system.NewNumPrimType(nil)},
-					},
-					type_system.NewStrPrimType(nil), nil),
-			},
-		})},
-		{"object constructor", type_system.NewObjectType(nil, []type_system.ObjTypeElem{
-			&type_system.ConstructorElem{
-				Fn: type_system.NewFuncType(nil, nil,
-					[]*type_system.FuncParam{
-						{Pattern: type_system.NewIdentPat("x"), Type: type_system.NewNumPrimType(nil)},
-					},
-					type_system.NewTypeRefType(nil, "Foo", nil), nil),
-			},
-		})},
 		{"global this", &type_system.GlobalThisType{}},
 		{"namespace empty", type_system.NewNamespaceType(nil, type_system.NewNamespace())},
 		{"regex", type_system.NewRegexType(nil, regexp.MustCompile(`^foo$`), nil)},


### PR DESCRIPTION
Stacked on #1576; review only the last commit.

## The bug

`internal/type_system`'s printer rendered an object's construct signature as `new fn (x: number) -> Foo`. No grammar reads that back — the parser takes `new` as the construct-signature keyword, and `fn` after it would be a member name.

It is a double header. `printFuncSig` takes a header string and emits `header` + `<T>` + `(params)`, and `printFuncType` is `printFuncSig("fn ", …)` because a standalone function type is written `fn (x: number) -> T`. The constructor arm concatenated its own prefix onto that:

```go
result += "new " + printFuncType(elem.Fn, pt)   // "new " + "fn " + "<T>" + "(…)"
```

`new ` is now the header rather than a prefix on one, which is the shape the `CallableElem` arm beside it already uses with an empty header.

## Predates the stack

Found while switching the call-signature spelling in #1576 and deliberately left alone there to keep that change scoped. It reproduces on `main`.

This is the older `internal/checker` printer, which `escalier build` and the LSP run. `internal/soltype`'s parallel printer never had the bug.

## The audit proves it now

`CallableElem` and `ConstructorElem` sat in `TestPrintTypeAudit_NoSyntax`, which only checks that `PrintType` returns a non-empty string. They were there because the printer could not emit reparseable output. Both spellings are writable source — `{(x: number) -> string}` is a call signature and `{new (x: number) -> Foo}` a construct signature — so both move into `TestPrintTypeAudit_RoundTrip`, which prints, reparses, prints again and asserts idempotency.

That replaces a hand-written expectation with the audit's own mechanism. A generic construct signature is covered too, since the binder sits between the keyword and the parameters, which is exactly what the header change moved.

The file's header comment listed the no-syntax variants and never included these two, so moving them also brings the comment and the test body back into agreement.

## One thing this does not do

The two printers still differ in spacing for a generic signature. `internal/type_system` emits `new <T>(x: T) -> Box<T>`; the AST printer emits `new<T> (x: T) -> Box<T>`. Both parse, and the audit proves it for the former. Making them byte-identical is a separate cleanup.

## Testing

`go test ./...` passes, `gofmt` reports nothing new. 54 pinned expectations updated across `internal/checker/tests` — the previous rendering was baked into six test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk

---
_Generated by [Claude Code](https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk)_