### PR TITLE
Resolve the five import edges that go up a runtime tier

### DIFF
--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -419,6 +419,13 @@ var webPackages = []struct {
 		"TextEncoder", "TextEncoderCommon", "TextEncoderEncodeIntoResult",
 		"TextDecoder", "TextDecoderCommon", "TextDecoderOptions",
 		"TextDecodeOptions",
+		// The message event. The WinterCG minimum common API lists it, and
+		// `web:websocket` types its `message` handler against it. Its `source` and
+		// `ports` members name the browser, and so does the deprecated
+		// `initMessageEvent`. web/core.replace.esc retypes the first two and
+		// web/core.drop.esc removes the third. See there for why `MessagePort`
+		// could not come along.
+		"MessageEvent", "MessageEventInit",
 	}},
 	{"web:fetch", "web/fetch.esc", []string{
 		"fetch",
@@ -430,10 +437,11 @@ var webPackages = []struct {
 		"RequestCache", "RequestCredentials", "RequestDestination",
 		"RequestMode", "RequestRedirect",
 		"HeadersIterator", "RequestPriority",
-		// FormData / FormDataEntryValue intentionally not listed:
-		// MDN classifies them under the XMLHttpRequest API, not
-		// Fetch. They are declared in lib.dom.d.ts so they route to
-		// web:dom via the residual rule.
+		// FormData and FormDataEntryValue are not listed here. MDN
+		// classifies them under the XMLHttpRequest API rather than
+		// Fetch, and web:file is where they sit, beside the Blob and
+		// File a FormData holds. `Body.formData` returns one, so
+		// web:fetch imports web:file for it.
 	}},
 	{"web:streams", "web/streams.esc", []string{
 		"ReadableStream", "ReadableStreamDefaultReader",
@@ -748,6 +756,10 @@ var webPackages = []struct {
 		"MultiCacheQueryOptions",
 	}},
 	{"web:websocket", "web/websocket.esc", []string{
+		// The socket's payload mode. A string union filed under the DOM
+		// upstream, and portable exactly as written. web:web_rtc names it
+		// too and is browser tier, so it may import this one.
+		"BinaryType",
 		"WebSocket", "WebSocketEventMap",
 		"CloseEvent", "CloseEventInit",
 	}},
@@ -770,13 +782,32 @@ var webPackages = []struct {
 	{"web:file", "web/file.esc", []string{
 		"Blob", "BlobPropertyBag", "BlobPart", "EndingType",
 		"File", "FilePropertyBag",
-		"FileList", "FileReader", "FileReaderEventMap",
+		// FormData holds files, and both `Blob` and `File` are here, so this is
+		// the one portable package it can sit in without naming another. MDN
+		// files it under XMLHttpRequest, but the tier asks which runtimes have
+		// it rather than which specification introduced it. `web:fetch` returns
+		// one from `Body.formData`, so a FormData in `web:dom` would put a
+		// portable package in a cycle with the browser tier.
+		//
+		// Its constructor takes an `HTMLFormElement` upstream, which no portable
+		// runtime has. web/file.replace.esc gives it the no-argument form.
+		//
+		// FormDataIterator comes along. FormData's `entries`, `keys` and
+		// `values` each return one, and it names only prelude types.
+		"FormData", "FormDataEntryValue", "FormDataIterator",
+		// FileList and FileReader belong to the browser tier. Node 22 defines
+		// neither, and FileReader fires the ProgressEvent that `web:core`
+		// deliberately does not carry.
 	}},
 	{"web:performance", "web/performance.esc", []string{
+		// The performance timeline's own map, keyed by event name. It extends
+		// std:map and names nothing browser-only, so it sits with the rest of
+		// the timeline rather than with the DOM it was filed under.
+		"EventCounts",
 		// Symbols MDN documents under Performance that are absent from
 		// the pinned lib.dom.d.ts (no partition entry needed today):
 		// PerformanceEventTiming, PerformanceLongTaskTiming,
-		// LargestContentfulPaint, LayoutShift, EventCounts,
+		// LargestContentfulPaint, LayoutShift,
 		// TaskAttributionTiming, PerformanceElementTiming,
 		// VisibilityStateEntry. Add here if a future TS version bump
 		// ships them.
@@ -928,6 +959,31 @@ var UnreferencedDOMTypes = set.FromSlice([]string{
 	// OnBeforeUnloadEventHandler nowhere else, and both
 	// `onbeforeunload` declarations spell the signature out instead.
 	"OnBeforeUnloadEventHandler",
+})
+
+// OverlayRetypedSoleReferrers names the type-only `web:dom` declarations
+// whose every reference from outside `web:dom` sits in a member an
+// overlay retypes or drops. ReportTypeOnlyRouting leaves them out.
+//
+// The routing analysis reads the pinned `.d.ts` statements with only the
+// whole-symbol drops applied, because the per-package overlays are
+// Escalier fragments that fold into the converted tree rather than into
+// the TypeScript one. A name here therefore reads as sole-referred in the
+// analysis and is referenced by nothing outside `web:dom` in the tree the
+// run writes.
+//
+// Two checks cover an entry. The digest sidecar beside each overlay file
+// fails when a member the file stands in for changes upstream. Test
+// OverlayRetypedSoleReferrers_MatchesThePinnedLibSet fails when a name
+// here stops reading as sole-referred, which is what rerouting it or a
+// new TypeScript reference to it does.
+var OverlayRetypedSoleReferrers = set.FromSlice([]string{
+	// `web:core` declares `MessageEvent` and `MessageEventInit`, and their
+	// four references to the name are all answered there. The `source`
+	// member of each is retyped to `null` in overlay/web/core.replace.esc,
+	// and the two `initMessageEvent` overloads that name it are removed in
+	// overlay/web/core.drop.esc.
+	"MessageEventSource",
 })
 
 // DOMResidualSources is the set of `.d.ts` source-file basenames whose

--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -404,7 +404,7 @@ var webPackages = []struct {
 		"EventListenerOrEventListenerObject",
 		"EventListenerOptions", "AddEventListenerOptions",
 		// ProgressEvent is deliberately absent. Node 22 does not define it and
-		// the WinterCG minimum common API does not list it, so it routes to
+		// the WinterTC minimum common API does not list it, so it routes to
 		// web:dom with the rest of the browser surface.
 		// Cancellation, which fetch, streams, and any long-running call
 		// take as a parameter.
@@ -419,7 +419,7 @@ var webPackages = []struct {
 		"TextEncoder", "TextEncoderCommon", "TextEncoderEncodeIntoResult",
 		"TextDecoder", "TextDecoderCommon", "TextDecoderOptions",
 		"TextDecodeOptions",
-		// The message event. The WinterCG minimum common API lists it, and
+		// The message event. The WinterTC minimum common API lists it, and
 		// `web:websocket` types its `message` handler against it. Its `source` and
 		// `ports` members name the browser, and so does the deprecated
 		// `initMessageEvent`. web/core.replace.esc retypes the first two and

--- a/internal/dts_to_esc/partition.go
+++ b/internal/dts_to_esc/partition.go
@@ -961,9 +961,10 @@ var UnreferencedDOMTypes = set.FromSlice([]string{
 	"OnBeforeUnloadEventHandler",
 })
 
-// OverlayRetypedSoleReferrers names the type-only `web:dom` declarations
-// whose every reference from outside `web:dom` sits in a member an
-// overlay retypes or drops. ReportTypeOnlyRouting leaves them out.
+// OverlayRetypedSoleReferrers maps a type-only `web:dom` declaration to the
+// one package whose references to it an overlay retypes or drops.
+// ReportTypeOnlyRouting leaves a name out only when its sole referrer is the
+// package recorded here.
 //
 // The routing analysis reads the pinned `.d.ts` statements with only the
 // whole-symbol drops applied, because the per-package overlays are
@@ -972,19 +973,23 @@ var UnreferencedDOMTypes = set.FromSlice([]string{
 // analysis and is referenced by nothing outside `web:dom` in the tree the
 // run writes.
 //
-// Two checks cover an entry. The digest sidecar beside each overlay file
-// fails when a member the file stands in for changes upstream. Test
-// OverlayRetypedSoleReferrers_MatchesThePinnedLibSet fails when a name
-// here stops reading as sole-referred, which is what rerouting it or a
-// new TypeScript reference to it does.
-var OverlayRetypedSoleReferrers = set.FromSlice([]string{
+// The referrer is half the key because only that package's overlay answers
+// the references. A TypeScript bump that moves the sole reference to
+// another package leaves it unanswered, and pairing the two makes
+// TestOverlayRetypedSoleReferrers_MatchesThePinnedLibSet name it rather
+// than stay quiet. That test also catches a name the map does not cover
+// and an entry that stopped being sole-referred.
+//
+// The other half of the cover is the digest sidecar beside each overlay
+// file, which fails when a member the file stands in for changes upstream.
+var OverlayRetypedSoleReferrers = map[string]string{
 	// `web:core` declares `MessageEvent` and `MessageEventInit`, and their
 	// four references to the name are all answered there. The `source`
 	// member of each is retyped to `null` in overlay/web/core.replace.esc,
 	// and the two `initMessageEvent` overloads that name it are removed in
 	// overlay/web/core.drop.esc.
-	"MessageEventSource",
-})
+	"MessageEventSource": "web:core",
+}
 
 // DOMResidualSources is the set of `.d.ts` source-file basenames whose
 // unmapped top-level declarations route to `web:dom` (the single-DOM

--- a/internal/dts_to_esc/tier.go
+++ b/internal/dts_to_esc/tier.go
@@ -35,8 +35,8 @@ const (
 	//
 	// The promise is per package, not per declaration. Every WinterCG runtime
 	// ships the package. A few legacy or browser-only members inside one are
-	// still absent off the browser: Node 22 defines neither `FileReader` nor
-	// `PerformanceTiming`. #1586 tracks tiering a declaration rather than a
+	// still absent off the browser, such as `PerformanceTiming`, which Node 22
+	// does not define. #1586 tracks tiering a declaration rather than a
 	// package.
 	TierPortable
 	// TierBrowser is available in a browser alone. The DOM and everything
@@ -141,32 +141,15 @@ func PackagesInTier(tier Tier) []string {
 // AcceptedUpwardEdges lists the import edges that go up a tier and are allowed
 // to, keyed by the importing package and naming the references that force each.
 //
-// Every entry is a declaration the pinned `.d.ts` types against a browser type
-// that a portable runtime implements differently or not at all. Answering one
-// means deciding what the portable form should say, which is a change to the
-// declaration rather than to this table, so each is left recorded until that
-// decision is made. #1590 carries them.
+// An entry belongs here only while a decision is outstanding. A declaration the
+// pinned `.d.ts` types against a browser type that a portable runtime
+// implements differently or not at all needs a portable form written for it,
+// which is a change to the declaration or an overlay rather than to this table.
+// Recording the edge keeps the run green until that form is written.
 //
 // An edge absent from this table fails `generate`, so a new one is caught at
 // the run that introduces it.
-var AcceptedUpwardEdges = map[string][]string{
-	// Node defines FormData, but the pinned type gives it an HTMLFormElement
-	// constructor no portable runtime has. XMLHttpRequestBodyInit is a union
-	// that names FormData.
-	"web:fetch": {"FormData", "XMLHttpRequestBodyInit"},
-	// FileReader fires progress events. Node 22 defines neither it nor
-	// ProgressEvent, so both belong on the browser side of the line.
-	"web:file": {"ProgressEvent"},
-	// EventCounts is the performance-timeline map keyed by DOM event names.
-	"web:performance": {"EventCounts"},
-	// URL.createObjectURL takes a MediaSource in the browser and a Blob
-	// everywhere else.
-	"web:url": {"MediaSource"},
-	// MessageEvent.source is a WindowProxy or ServiceWorker in the browser and
-	// always null off it. BinaryType is the socket's payload mode, a string
-	// union filed under the DOM.
-	"web:websocket": {"BinaryType", "MessageEvent"},
-}
+var AcceptedUpwardEdges = map[string][]string{}
 
 // acceptsUpwardEdge reports whether every reference forcing an edge is one
 // AcceptedUpwardEdges records for that importer.

--- a/internal/dts_to_esc/tier.go
+++ b/internal/dts_to_esc/tier.go
@@ -25,7 +25,7 @@ import (
 type Tier int
 
 const (
-	// TierCore is available on every runtime that implements the WinterCG
+	// TierCore is available on every runtime that implements the WinterTC
 	// minimum common API: the event model, `AbortSignal`, `DOMException`,
 	// `BufferSource`, and the text encoder and decoder.
 	TierCore Tier = iota
@@ -33,7 +33,7 @@ const (
 	// browser. Fetch, URL, streams, files, crypto, performance and
 	// WebSockets are here.
 	//
-	// The promise is per package, not per declaration. Every WinterCG runtime
+	// The promise is per package, not per declaration. Every WinterTC runtime
 	// ships the package. A few legacy or browser-only members inside one are
 	// still absent off the browser, such as `PerformanceTiming`, which Node 22
 	// does not define. #1586 tracks tiering a declaration rather than a
@@ -72,14 +72,14 @@ func (t Tier) String() string {
 // TierLanguage.
 var stdTiers = map[string]Tier{
 	// WebAssembly is a host global rather than an ECMAScript one, and
-	// `instantiateStreaming` takes a fetch `Response`. Every WinterCG runtime
+	// `instantiateStreaming` takes a fetch `Response`. Every WinterTC runtime
 	// ships it, so it is portable rather than browser-only.
 	"std:wasm": TierPortable,
 }
 
 // webTiers assigns a tier to each `web:*` package.
 //
-// A package is portable when every runtime in the WinterCG set ships it,
+// A package is portable when every runtime in the WinterTC set ships it,
 // not when its specification is silent about the browser. `web:websocket`
 // is portable because Node, Deno, Bun and Workers all implement it;
 // `web:webgl` is not, because it takes an `HTMLCanvasElement` to draw on.

--- a/internal/dts_to_esc/tier_closure_test.go
+++ b/internal/dts_to_esc/tier_closure_test.go
@@ -19,32 +19,16 @@ import (
 // package's directory.
 const committedTree = "../interop/data"
 
-// knownUpwardRefs records every reference in the committed tree that names a
-// package above the referring package's tier. Each is a declaration the
-// pinned `.d.ts` types against a browser type that the portable runtimes
-// implement differently or not at all, so each is answered by an overlay
-// `replace` rather than by moving a package between tiers.
+// knownUpwardRefs excuses references in the committed tree that name a package
+// above the referring package's tier. It is the reference-level twin of
+// AcceptedUpwardEdges, which excuses the import line the reference forces.
 //
-// The list is empty for the core tier, which is what makes `web:core`
-// loadable on a runtime that has no DOM. Emptying it for the portable tier
-// is #1403 item 5, which is also where the check that forbids these edges
-// lands. Until then this test pins the set so a new one is caught.
-var knownUpwardRefs = map[string][]string{
-	// Node's FormData has no HTMLFormElement constructor, and
-	// XMLHttpRequestBodyInit names one transitively.
-	"web:fetch": {"FormData", "XMLHttpRequestBodyInit"},
-	// FileReader fires progress events, and Node 22 defines neither it nor
-	// ProgressEvent. Both leave the portable tier together, or neither does.
-	"web:file": {"ProgressEvent"},
-	// EventCounts is the performance-timeline map keyed by DOM event names.
-	"web:performance": {"EventCounts"},
-	// URL.createObjectURL takes a MediaSource in the browser and a Blob
-	// everywhere else.
-	"web:url": {"MediaSource"},
-	// MessageEvent.source is a WindowProxy or ServiceWorker in the browser
-	// and always null off it. BinaryType is the socket's payload mode.
-	"web:websocket": {"BinaryType", "MessageEvent"},
-}
+// An entry belongs here only while its answer is being written. A declaration
+// the pinned `.d.ts` types against a browser type that the portable runtimes
+// implement differently or not at all is answered by an overlay `replace` that
+// writes the portable form, or by routing the name to the package that owns
+// it.
+var knownUpwardRefs = map[string][]string{}
 
 // declaringPackage maps each exported top-level name in the committed tree to
 // the package URI that declares it.

--- a/internal/dts_to_esc/type_only.go
+++ b/internal/dts_to_esc/type_only.go
@@ -218,22 +218,29 @@ func ReportTypeOnlyRouting(result *PartitionResult, w io.Writer) error {
 	// stays free of error plumbing.
 	var b strings.Builder
 
+	sole := make([]SoleReferrer, 0, len(routing.SoleReferrer))
+	for _, e := range routing.SoleReferrer {
+		if OverlayRetypedSoleReferrers.Contains(e.Name) {
+			continue
+		}
+		sole = append(sole, e)
+	}
+
 	// Consecutive entries share a referrer because AnalyzeTypeOnly
 	// Routing sorts by referrer within a declaring package, so one pass
-	// groups them.
-	for i := 0; i < len(routing.SoleReferrer); {
+	// groups them. Dropping entries above keeps that order.
+	for i := 0; i < len(sole); {
 		j := i
-		for j < len(routing.SoleReferrer) &&
-			routing.SoleReferrer[j].ReferencedBy == routing.SoleReferrer[i].ReferencedBy {
+		for j < len(sole) && sole[j].ReferencedBy == sole[i].ReferencedBy {
 			j++
 		}
 		names := make([]string, 0, j-i)
-		for _, e := range routing.SoleReferrer[i:j] {
+		for _, e := range sole[i:j] {
 			names = append(names, e.Name)
 		}
 		fmt.Fprintf(&b, "  %s: %d type-only decl%s only %s references (%s)\n",
 			WebDOM.URI, len(names), plural(len(names)),
-			routing.SoleReferrer[i].ReferencedBy, strings.Join(names, ", "))
+			sole[i].ReferencedBy, strings.Join(names, ", "))
 		i = j
 	}
 

--- a/internal/dts_to_esc/type_only.go
+++ b/internal/dts_to_esc/type_only.go
@@ -220,7 +220,8 @@ func ReportTypeOnlyRouting(result *PartitionResult, w io.Writer) error {
 
 	sole := make([]SoleReferrer, 0, len(routing.SoleReferrer))
 	for _, e := range routing.SoleReferrer {
-		if OverlayRetypedSoleReferrers.Contains(e.Name) {
+		if acknowledged, held := OverlayRetypedSoleReferrers[e.Name]; held &&
+			acknowledged == e.ReferencedBy {
 			continue
 		}
 		sole = append(sole, e)

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -94,8 +94,9 @@ func pinnedRouting(t *testing.T) *PartitionResult {
 
 // TestReportTypeOnlyRouting_PinnedLibSet is the §6.1 gate over the real
 // input: every web:dom type-only declaration is referenced by web:dom
-// itself or by two or more packages. The report prints only what still
-// needs a decision, so passing looks like an empty one.
+// itself, by two or more packages, or only through members an overlay
+// retypes. The report prints only what still needs a decision, so
+// passing looks like an empty one.
 //
 // The second assertion states the misplacement half structurally. It
 // still fails if the report's grouping ever swallows a finding.
@@ -107,7 +108,35 @@ func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
 	require.NoError(t, ReportTypeOnlyRouting(res, &b))
 	require.Empty(t, b.String())
 
-	require.Empty(t, AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI).SoleReferrer)
+	for _, e := range AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI).SoleReferrer {
+		require.True(t, OverlayRetypedSoleReferrers.Contains(e.Name),
+			"%s is referenced only by %s and is not an acknowledged overlay retype",
+			e.Name, e.ReferencedBy)
+	}
+}
+
+// TestOverlayRetypedSoleReferrers_MatchesThePinnedLibSet keeps the gate
+// above honest, the same way TestUnreferencedDOMTypes_MatchesThePinned
+// LibSet does for the orphan half. The report hides whatever the list
+// covers, so an empty report cannot on its own tell a clean tree from
+// one whose new finding the list happens to hide.
+//
+// Comparing the two sets catches both directions. A sole-referred name
+// the list does not cover is a new one needing a decision, and an entry
+// that no longer reads as sole-referred is stale, because the retype it
+// stands for is gone or the name moved packages.
+func TestOverlayRetypedSoleReferrers_MatchesThePinnedLibSet(t *testing.T) {
+	t.Parallel()
+	routing := AnalyzeTypeOnlyRouting(pinnedRouting(t)).forPackage(WebDOM.URI)
+
+	sole := make([]string, 0, len(routing.SoleReferrer))
+	for _, e := range routing.SoleReferrer {
+		sole = append(sole, e.Name)
+	}
+	acknowledged := OverlayRetypedSoleReferrers.ToSlice()
+	sort.Strings(acknowledged)
+	sort.Strings(sole)
+	require.Equal(t, acknowledged, sole)
 }
 
 // TestUnreferencedDOMTypes_MatchesThePinnedLibSet keeps the gate above

--- a/internal/dts_to_esc/type_only_test.go
+++ b/internal/dts_to_esc/type_only_test.go
@@ -109,8 +109,8 @@ func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
 	require.Empty(t, b.String())
 
 	for _, e := range AnalyzeTypeOnlyRouting(res).forPackage(WebDOM.URI).SoleReferrer {
-		require.True(t, OverlayRetypedSoleReferrers.Contains(e.Name),
-			"%s is referenced only by %s and is not an acknowledged overlay retype",
+		require.Equal(t, e.ReferencedBy, OverlayRetypedSoleReferrers[e.Name],
+			"%s is referenced only by %s and no overlay there is acknowledged for it",
 			e.Name, e.ReferencedBy)
 	}
 }
@@ -121,22 +121,20 @@ func TestReportTypeOnlyRouting_PinnedLibSet(t *testing.T) {
 // covers, so an empty report cannot on its own tell a clean tree from
 // one whose new finding the list happens to hide.
 //
-// Comparing the two sets catches both directions. A sole-referred name
-// the list does not cover is a new one needing a decision, and an entry
-// that no longer reads as sole-referred is stale, because the retype it
-// stands for is gone or the name moved packages.
+// Comparing the two maps catches three directions. A sole-referred name
+// the map does not cover is a new one needing a decision. An entry that no
+// longer reads as sole-referred is stale, because the retype it stands for
+// is gone or the name moved packages. An entry whose referrer changed
+// names a package whose overlay does not answer the new reference.
 func TestOverlayRetypedSoleReferrers_MatchesThePinnedLibSet(t *testing.T) {
 	t.Parallel()
 	routing := AnalyzeTypeOnlyRouting(pinnedRouting(t)).forPackage(WebDOM.URI)
 
-	sole := make([]string, 0, len(routing.SoleReferrer))
+	sole := map[string]string{}
 	for _, e := range routing.SoleReferrer {
-		sole = append(sole, e.Name)
+		sole[e.Name] = e.ReferencedBy
 	}
-	acknowledged := OverlayRetypedSoleReferrers.ToSlice()
-	sort.Strings(acknowledged)
-	sort.Strings(sole)
-	require.Equal(t, acknowledged, sole)
+	require.Equal(t, OverlayRetypedSoleReferrers, sole)
 }
 
 // TestUnreferencedDOMTypes_MatchesThePinnedLibSet keeps the gate above

--- a/internal/interop/data/web/core.esc
+++ b/internal/interop/data/web/core.esc
@@ -21,6 +21,14 @@ export declare interface EventListenerOptions {
     capture?: boolean
 }
 
+export declare interface MessageEventInit<T = any> extends EventInit {
+    data?: T,
+    lastEventId?: string,
+    origin?: string,
+    ports?: mut Array<unknown>,
+    source?: null
+}
+
 export declare interface TextDecodeOptions {
     stream?: boolean
 }
@@ -340,6 +348,47 @@ export declare class EventTarget {
     removeEventListener(mut self, type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean) -> unknown,
     static prototype: EventTarget,
     constructor(mut self)
+}
+
+/**
+ * A message received by a target object.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent)
+ */
+@js("MessageEvent")
+export declare class MessageEvent<T = any> extends Event {
+    /**
+     * Returns the data of the message.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
+     */
+    readonly data: T,
+    /**
+     * Returns the last event ID string, for server-sent events.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/lastEventId)
+     */
+    readonly lastEventId: string,
+    /**
+     * Returns the origin of the message, for server-sent events and cross-document messaging.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/origin)
+     */
+    readonly origin: string,
+    /**
+     * Returns the MessagePort array sent with the message, for cross-document messaging and channel messaging.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/ports)
+     */
+    readonly ports: Array<unknown>,
+    /**
+     * Returns the WindowProxy of the source window, for cross-document messaging, and the MessagePort being attached, in the connect event fired at SharedWorkerGlobalScope objects.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/source)
+     */
+    readonly source: null,
+    static prototype: MessageEvent,
+    constructor(mut self, type: string, eventInitDict?: MessageEventInit<T>)
 }
 
 /**

--- a/internal/interop/data/web/dom.esc
+++ b/internal/interop/data/web/dom.esc
@@ -376,7 +376,7 @@ export declare interface FontFaceSetLoadEventInit extends EventInit {
 }
 
 export declare interface FormDataEventInit extends EventInit {
-    formData: FormData
+    formData: file.FormData
 }
 
 export declare interface FullscreenOptions {
@@ -694,14 +694,6 @@ export declare interface MediaTrackSupportedConstraints {
     sampleRate?: boolean,
     sampleSize?: boolean,
     width?: boolean
-}
-
-export declare interface MessageEventInit<T = any> extends EventInit {
-    data?: T,
-    lastEventId?: string,
-    origin?: string,
-    ports?: mut Array<MessagePort>,
-    source?: MessageEventSource | null
 }
 
 export declare interface MouseEventInit extends EventModifierInit {
@@ -4534,7 +4526,7 @@ export declare class DataTransfer {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DataTransfer/files)
      */
-    readonly files: file.FileList,
+    readonly files: FileList,
     /**
      * Returns a DataTransferItemList object, with the drag data.
      *
@@ -5831,7 +5823,7 @@ export declare class ElementInternals extends ARIAMixin {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ElementInternals/setFormValue)
      */
-    setFormValue(mut self, value: file.File | string | FormData | null, state?: file.File | string | FormData | null) -> unknown,
+    setFormValue(mut self, value: file.File | string | file.FormData | null, state?: file.File | string | file.FormData | null) -> unknown,
     /**
      * Marks internals's target element as suffering from the constraints indicated by the flags argument, and sets the element's validation message to message. If anchor is specified, the user agent might use it to indicate problems with the constraints of internals's target element when the form owner is validated interactively or reportValidity() is called.
      *
@@ -5861,14 +5853,6 @@ export declare class ErrorEvent extends Event {
     readonly message: string,
     static prototype: ErrorEvent,
     constructor(mut self, type: string, eventInitDict?: ErrorEventInit)
-}
-
-/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventCounts) */
-@js("EventCounts")
-export declare class EventCounts extends map.Map<string, number> {
-    forEach(self, callbackfn: fn (value: number, key: string, parent: EventCounts) -> unknown, thisArg?: unknown) -> unknown,
-    static prototype: EventCounts,
-    constructor(mut self)
 }
 
 export declare interface EventSourceEventMap {
@@ -5935,6 +5919,84 @@ export declare class External {
     IsSearchProviderInstalled(mut self) -> unknown,
     static prototype: External,
     constructor(mut self)
+}
+
+/**
+ * An object of this type is returned by the files property of the HTML <input> element; this lets you access the list of files selected with the <input type="file"> element. It's also used for a list of files dropped into web content when using the drag and drop API; see the DataTransfer object for details on this usage.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileList)
+ */
+@js("FileList")
+export declare class FileList {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileList/length) */
+    readonly length: number,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileList/item) */
+    item(mut self, index: number) -> file.File | null,
+    [Symbol.iterator](self) -> ArrayIterator<file.File>,
+    static prototype: FileList,
+    constructor(mut self)
+}
+
+export declare interface FileReaderEventMap {
+    "abort": ProgressEvent<FileReader>,
+    "error": ProgressEvent<FileReader>,
+    "load": ProgressEvent<FileReader>,
+    "loadend": ProgressEvent<FileReader>,
+    "loadstart": ProgressEvent<FileReader>,
+    "progress": ProgressEvent<FileReader>
+}
+
+/**
+ * Lets web applications asynchronously read the contents of files (or raw data buffers) stored on the user's computer, using File or Blob objects to specify the file or data to read.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader)
+ */
+@js("FileReader")
+export declare class FileReader extends EventTarget {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/error) */
+    readonly error: DOMException | null,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/abort_event) */
+    onabort: (fn (this: FileReader, ev: ProgressEvent<FileReader>) -> any) | null,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/error_event) */
+    onerror: (fn (this: FileReader, ev: ProgressEvent<FileReader>) -> any) | null,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/load_event) */
+    onload: (fn (this: FileReader, ev: ProgressEvent<FileReader>) -> any) | null,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/loadend_event) */
+    onloadend: (fn (this: FileReader, ev: ProgressEvent<FileReader>) -> any) | null,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/loadstart_event) */
+    onloadstart: (fn (this: FileReader, ev: ProgressEvent<FileReader>) -> any) | null,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/progress_event) */
+    onprogress: (fn (this: FileReader, ev: ProgressEvent<FileReader>) -> any) | null,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readyState) */
+    readonly readyState: typeof FileReader.EMPTY | typeof FileReader.LOADING | typeof FileReader.DONE,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/result) */
+    readonly result: string | typed_arrays.ArrayBuffer | null,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/abort) */
+    abort(mut self) -> unknown,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readAsArrayBuffer) */
+    readAsArrayBuffer(mut self, blob: file.Blob) -> unknown,
+    /**
+     * @deprecated
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readAsBinaryString)
+     */
+    readAsBinaryString(mut self, blob: file.Blob) -> unknown,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readAsDataURL) */
+    readAsDataURL(mut self, blob: file.Blob) -> unknown,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readAsText) */
+    readAsText(mut self, blob: file.Blob, encoding?: string) -> unknown,
+    readonly EMPTY: 0,
+    readonly LOADING: 1,
+    readonly DONE: 2,
+    addEventListener<K: keyof FileReaderEventMap>(mut self, type: K, listener: fn (this: FileReader, ev: FileReaderEventMap[K]) -> any, options?: boolean | AddEventListenerOptions) -> unknown,
+    addEventListener(mut self, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) -> unknown,
+    removeEventListener<K: keyof FileReaderEventMap>(mut self, type: K, listener: fn (this: FileReader, ev: FileReaderEventMap[K]) -> any, options?: boolean | EventListenerOptions) -> unknown,
+    removeEventListener(mut self, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) -> unknown,
+    static prototype: FileReader,
+    constructor(mut self),
+    static readonly EMPTY: 0,
+    static readonly LOADING: 1,
+    static readonly DONE: 2
 }
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileSystem) */
@@ -6140,41 +6202,6 @@ export declare interface FontFaceSource {
     readonly fonts: FontFaceSet
 }
 
-/**
- * Provides a way to easily construct a set of key/value pairs representing form fields and their values, which can then be easily sent using the XMLHttpRequest.send() method. It uses the same format a form would use if the encoding type were set to "multipart/form-data".
- *
- * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData)
- */
-@js("FormData")
-export declare class FormData {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
-    append(mut self, name: string, value: string | file.Blob) -> unknown,
-    append(mut self, name: string, value: string) -> unknown,
-    append(mut self, name: string, blobValue: file.Blob, filename?: string) -> unknown,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
-    delete(mut self, name: string) -> unknown,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
-    get(self, name: string) -> FormDataEntryValue | null,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/getAll) */
-    getAll(self, name: string) -> mut Array<FormDataEntryValue>,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
-    has(self, name: string) -> boolean,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
-    set(mut self, name: string, value: string | file.Blob) -> unknown,
-    set(mut self, name: string, value: string) -> unknown,
-    set(mut self, name: string, blobValue: file.Blob, filename?: string) -> unknown,
-    forEach(self, callbackfn: fn (value: FormDataEntryValue, key: string, parent: FormData) -> unknown, thisArg?: unknown) -> unknown,
-    [Symbol.iterator](self) -> FormDataIterator<[string, FormDataEntryValue]>,
-    /** Returns an array of key, value pairs for every entry in the list. */
-    entries(self) -> FormDataIterator<[string, FormDataEntryValue]>,
-    /** Returns a list of keys in the list. */
-    keys(self) -> FormDataIterator<string>,
-    /** Returns a list of values in the list. */
-    values(self) -> FormDataIterator<FormDataEntryValue>,
-    static prototype: FormData,
-    constructor(mut self, form?: HTMLFormElement, submitter?: HTMLElement | null)
-}
-
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormDataEvent) */
 @js("FormDataEvent")
 export declare class FormDataEvent extends Event {
@@ -6183,7 +6210,7 @@ export declare class FormDataEvent extends Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormDataEvent/formData)
      */
-    readonly formData: FormData,
+    readonly formData: file.FormData,
     static prototype: FormDataEvent,
     constructor(mut self, type: string, eventInitDict: FormDataEventInit)
 }
@@ -8407,7 +8434,7 @@ export declare class HTMLInputElement extends HTMLElement {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/files)
      */
-    files: file.FileList | null,
+    files: FileList | null,
     /**
      * Retrieves a reference to the form that the object is embedded in.
      *
@@ -12130,51 +12157,6 @@ export declare class MessageChannel {
     readonly port2: MessagePort,
     static prototype: MessageChannel,
     constructor(mut self)
-}
-
-/**
- * A message received by a target object.
- *
- * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent)
- */
-@js("MessageEvent")
-export declare class MessageEvent<T = any> extends Event {
-    /**
-     * Returns the data of the message.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
-     */
-    readonly data: T,
-    /**
-     * Returns the last event ID string, for server-sent events.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/lastEventId)
-     */
-    readonly lastEventId: string,
-    /**
-     * Returns the origin of the message, for server-sent events and cross-document messaging.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/origin)
-     */
-    readonly origin: string,
-    /**
-     * Returns the MessagePort array sent with the message, for cross-document messaging and channel messaging.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/ports)
-     */
-    readonly ports: Array<MessagePort>,
-    /**
-     * Returns the WindowProxy of the source window, for cross-document messaging, and the MessagePort being attached, in the connect event fired at SharedWorkerGlobalScope objects.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/source)
-     */
-    readonly source: MessageEventSource | null,
-    /** @deprecated */
-    initMessageEvent(mut self, type: string, bubbles?: boolean, cancelable?: boolean, data?: unknown, origin?: string, lastEventId?: string, source?: MessageEventSource | null, ports?: mut Array<MessagePort>) -> unknown,
-    /** @deprecated */
-    initMessageEvent(mut self, type: string, bubbles?: boolean, cancelable?: boolean, data?: unknown, origin?: string, lastEventId?: string, source?: MessageEventSource | null, ports?: Iterable<MessagePort>) -> unknown,
-    static prototype: MessageEvent,
-    constructor(mut self, type: string, eventInitDict?: MessageEventInit<T>)
 }
 
 export declare interface MessageEventTargetEventMap {
@@ -20022,8 +20004,6 @@ export declare type EpochTimeStamp = number
 
 export declare type FileSystemWriteChunkType = BufferSource | file.Blob | string | WriteParams
 
-export declare type FormDataEntryValue = file.File | string
-
 export declare type HTMLOrSVGImageElement = HTMLImageElement | SVGImageElement
 
 export declare type HTMLOrSVGScriptElement = HTMLScriptElement | SVGScriptElement
@@ -20060,7 +20040,7 @@ export declare type VibratePattern = number | mut Array<number>
 
 export declare type WindowProxy = Window
 
-export declare type XMLHttpRequestBodyInit = file.Blob | BufferSource | FormData | url.URLSearchParams | string
+export declare type XMLHttpRequestBodyInit = file.Blob | BufferSource | file.FormData | url.URLSearchParams | string
 
 export declare type AlignSetting = "center" | "end" | "left" | "right" | "start"
 
@@ -20083,8 +20063,6 @@ export declare type AutoFillCredentialField = "webauthn"
 export declare type AutoFillNormalField = "additional-name" | "address-level1" | "address-level2" | "address-level3" | "address-level4" | "address-line1" | "address-line2" | "address-line3" | "bday-day" | "bday-month" | "bday-year" | "cc-csc" | "cc-exp" | "cc-exp-month" | "cc-exp-year" | "cc-family-name" | "cc-given-name" | "cc-name" | "cc-number" | "cc-type" | "country" | "country-name" | "current-password" | "family-name" | "given-name" | "honorific-prefix" | "honorific-suffix" | "name" | "new-password" | "one-time-code" | "organization" | "postal-code" | "street-address" | "transaction-amount" | "transaction-currency" | "username"
 
 export declare type AutoKeyword = "auto"
-
-export declare type BinaryType = "arraybuffer" | "blob"
 
 export declare type CSSMathOperator = "clamp" | "invert" | "max" | "min" | "negate" | "product" | "sum"
 
@@ -20269,10 +20247,6 @@ export declare type WebTransportErrorSource = "session" | "stream"
 export declare type WriteCommandType = "seek" | "truncate" | "write"
 
 export declare type XMLHttpRequestResponseType = "" | "arraybuffer" | "blob" | "document" | "json" | "text"
-
-export declare interface FormDataIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
-    [Symbol.iterator]() -> FormDataIterator<T>
-}
 
 export declare interface MediaKeyStatusMapIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
     [Symbol.iterator]() -> MediaKeyStatusMapIterator<T>

--- a/internal/interop/data/web/fetch.esc
+++ b/internal/interop/data/web/fetch.esc
@@ -5,7 +5,6 @@
 import "std:object"
 import "std:typed_arrays"
 import "web:core"
-import "web:dom"
 import "web:file"
 import "web:streams"
 import "web:url"
@@ -58,7 +57,7 @@ export declare interface Body {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
     bytes() -> Promise<typed_arrays.Uint8Array>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/formData) */
-    formData() -> Promise<dom.FormData>,
+    formData() -> Promise<file.FormData>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/json) */
     json() -> Promise<any>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/text) */
@@ -224,7 +223,7 @@ export declare class Response extends Body {
 @js("fetch")
 export declare fn fetch(input: RequestInfo | url.URL, init?: RequestInit) -> Promise<Response>
 
-export declare type BodyInit = streams.ReadableStream | dom.XMLHttpRequestBodyInit
+export declare type BodyInit = streams.ReadableStream | file.Blob | BufferSource | file.FormData | url.URLSearchParams | string
 
 export declare type HeadersInit = mut Array<[string, string]> | object.Record<string, string> | Headers
 

--- a/internal/interop/data/web/file.esc
+++ b/internal/interop/data/web/file.esc
@@ -4,7 +4,6 @@
 
 import "std:typed_arrays"
 import "web:core"
-import "web:dom"
 import "web:streams"
 
 export declare interface BlobPropertyBag {
@@ -59,83 +58,46 @@ export declare class File extends Blob {
 }
 
 /**
- * An object of this type is returned by the files property of the HTML <input> element; this lets you access the list of files selected with the <input type="file"> element. It's also used for a list of files dropped into web content when using the drag and drop API; see the DataTransfer object for details on this usage.
+ * Provides a way to easily construct a set of key/value pairs representing form fields and their values, which can then be easily sent using the XMLHttpRequest.send() method. It uses the same format a form would use if the encoding type were set to "multipart/form-data".
  *
- * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileList)
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData)
  */
-@js("FileList")
-export declare class FileList {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileList/length) */
-    readonly length: number,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileList/item) */
-    item(mut self, index: number) -> File | null,
-    [Symbol.iterator](self) -> ArrayIterator<File>,
-    static prototype: FileList,
+@js("FormData")
+export declare class FormData {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
+    append(mut self, name: string, value: string | Blob) -> unknown,
+    append(mut self, name: string, value: string) -> unknown,
+    append(mut self, name: string, blobValue: Blob, filename?: string) -> unknown,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
+    delete(mut self, name: string) -> unknown,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
+    get(self, name: string) -> FormDataEntryValue | null,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/getAll) */
+    getAll(self, name: string) -> mut Array<FormDataEntryValue>,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
+    has(self, name: string) -> boolean,
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
+    set(mut self, name: string, value: string | Blob) -> unknown,
+    set(mut self, name: string, value: string) -> unknown,
+    set(mut self, name: string, blobValue: Blob, filename?: string) -> unknown,
+    forEach(self, callbackfn: fn (value: FormDataEntryValue, key: string, parent: FormData) -> unknown, thisArg?: unknown) -> unknown,
+    [Symbol.iterator](self) -> FormDataIterator<[string, FormDataEntryValue]>,
+    /** Returns an array of key, value pairs for every entry in the list. */
+    entries(self) -> FormDataIterator<[string, FormDataEntryValue]>,
+    /** Returns a list of keys in the list. */
+    keys(self) -> FormDataIterator<string>,
+    /** Returns a list of values in the list. */
+    values(self) -> FormDataIterator<FormDataEntryValue>,
+    static prototype: FormData,
     constructor(mut self)
-}
-
-export declare interface FileReaderEventMap {
-    "abort": dom.ProgressEvent<FileReader>,
-    "error": dom.ProgressEvent<FileReader>,
-    "load": dom.ProgressEvent<FileReader>,
-    "loadend": dom.ProgressEvent<FileReader>,
-    "loadstart": dom.ProgressEvent<FileReader>,
-    "progress": dom.ProgressEvent<FileReader>
-}
-
-/**
- * Lets web applications asynchronously read the contents of files (or raw data buffers) stored on the user's computer, using File or Blob objects to specify the file or data to read.
- *
- * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader)
- */
-@js("FileReader")
-export declare class FileReader extends EventTarget {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/error) */
-    readonly error: DOMException | null,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/abort_event) */
-    onabort: (fn (this: FileReader, ev: dom.ProgressEvent<FileReader>) -> any) | null,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/error_event) */
-    onerror: (fn (this: FileReader, ev: dom.ProgressEvent<FileReader>) -> any) | null,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/load_event) */
-    onload: (fn (this: FileReader, ev: dom.ProgressEvent<FileReader>) -> any) | null,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/loadend_event) */
-    onloadend: (fn (this: FileReader, ev: dom.ProgressEvent<FileReader>) -> any) | null,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/loadstart_event) */
-    onloadstart: (fn (this: FileReader, ev: dom.ProgressEvent<FileReader>) -> any) | null,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/progress_event) */
-    onprogress: (fn (this: FileReader, ev: dom.ProgressEvent<FileReader>) -> any) | null,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readyState) */
-    readonly readyState: typeof FileReader.EMPTY | typeof FileReader.LOADING | typeof FileReader.DONE,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/result) */
-    readonly result: string | typed_arrays.ArrayBuffer | null,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/abort) */
-    abort(mut self) -> unknown,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readAsArrayBuffer) */
-    readAsArrayBuffer(mut self, blob: Blob) -> unknown,
-    /**
-     * @deprecated
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readAsBinaryString)
-     */
-    readAsBinaryString(mut self, blob: Blob) -> unknown,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readAsDataURL) */
-    readAsDataURL(mut self, blob: Blob) -> unknown,
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileReader/readAsText) */
-    readAsText(mut self, blob: Blob, encoding?: string) -> unknown,
-    readonly EMPTY: 0,
-    readonly LOADING: 1,
-    readonly DONE: 2,
-    addEventListener<K: keyof FileReaderEventMap>(mut self, type: K, listener: fn (this: FileReader, ev: FileReaderEventMap[K]) -> any, options?: boolean | AddEventListenerOptions) -> unknown,
-    addEventListener(mut self, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) -> unknown,
-    removeEventListener<K: keyof FileReaderEventMap>(mut self, type: K, listener: fn (this: FileReader, ev: FileReaderEventMap[K]) -> any, options?: boolean | EventListenerOptions) -> unknown,
-    removeEventListener(mut self, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) -> unknown,
-    static prototype: FileReader,
-    constructor(mut self),
-    static readonly EMPTY: 0,
-    static readonly LOADING: 1,
-    static readonly DONE: 2
 }
 
 export declare type BlobPart = BufferSource | Blob | string
 
+export declare type FormDataEntryValue = File | string
+
 export declare type EndingType = "native" | "transparent"
+
+export declare interface FormDataIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+    [Symbol.iterator]() -> FormDataIterator<T>
+}

--- a/internal/interop/data/web/performance.esc
+++ b/internal/interop/data/web/performance.esc
@@ -2,8 +2,8 @@
 // Its facts come from the pinned lib.*.d.ts set, the ECMA-262
 // derived facts, and the overlay. Change one of those and re-run.
 
+import "std:map"
 import "web:core"
-import "web:dom"
 
 export declare interface PerformanceMarkOptions {
     detail?: any,
@@ -23,6 +23,14 @@ export declare interface PerformanceObserverInit {
     type?: string
 }
 
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventCounts) */
+@js("EventCounts")
+export declare class EventCounts extends map.Map<string, number> {
+    forEach(self, callbackfn: fn (value: number, key: string, parent: EventCounts) -> unknown, thisArg?: unknown) -> unknown,
+    static prototype: EventCounts,
+    constructor(mut self)
+}
+
 export declare interface PerformanceEventMap {
     "resourcetimingbufferfull": Event
 }
@@ -35,7 +43,7 @@ export declare interface PerformanceEventMap {
 @js("Performance")
 export declare class Performance extends EventTarget {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/eventCounts) */
-    readonly eventCounts: dom.EventCounts,
+    readonly eventCounts: EventCounts,
     /**
      * @deprecated
      *

--- a/internal/interop/data/web/service_worker.esc
+++ b/internal/interop/data/web/service_worker.esc
@@ -78,8 +78,8 @@ export declare class ServiceWorker extends EventTarget {
 
 export declare interface ServiceWorkerContainerEventMap {
     "controllerchange": Event,
-    "message": dom.MessageEvent,
-    "messageerror": dom.MessageEvent
+    "message": MessageEvent,
+    "messageerror": MessageEvent
 }
 
 /**
@@ -95,9 +95,9 @@ export declare class ServiceWorkerContainer extends EventTarget {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/controllerchange_event) */
     oncontrollerchange: (fn (this: ServiceWorkerContainer, ev: Event) -> any) | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/message_event) */
-    onmessage: (fn (this: ServiceWorkerContainer, ev: dom.MessageEvent) -> any) | null,
+    onmessage: (fn (this: ServiceWorkerContainer, ev: MessageEvent) -> any) | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/messageerror_event) */
-    onmessageerror: (fn (this: ServiceWorkerContainer, ev: dom.MessageEvent) -> any) | null,
+    onmessageerror: (fn (this: ServiceWorkerContainer, ev: MessageEvent) -> any) | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/ready) */
     readonly ready: Promise<ServiceWorkerRegistration>,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/getRegistration) */

--- a/internal/interop/data/web/url.esc
+++ b/internal/interop/data/web/url.esc
@@ -3,7 +3,6 @@
 // derived facts, and the overlay. Change one of those and re-run.
 
 import "std:object"
-import "web:dom"
 import "web:file"
 
 /**
@@ -45,7 +44,7 @@ export declare class URL {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
     static canParse(url: string | URL, base?: string | URL) -> boolean,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
-    static createObjectURL(obj: file.Blob | dom.MediaSource) -> string,
+    static createObjectURL(obj: file.Blob) -> string,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
     static parse(url: string | URL, base?: string | URL) -> URL | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL_static) */

--- a/internal/interop/data/web/web_rtc.esc
+++ b/internal/interop/data/web/web_rtc.esc
@@ -9,6 +9,7 @@ import "web:core"
 import "web:crypto"
 import "web:dom"
 import "web:file"
+import "web:websocket"
 import "web:workers"
 
 export declare interface RTCAnswerOptions extends RTCOfferAnswerOptions {}
@@ -373,7 +374,7 @@ export declare interface RTCDataChannelEventMap {
     "close": Event,
     "closing": Event,
     "error": RTCErrorEvent,
-    "message": dom.MessageEvent,
+    "message": MessageEvent,
     "open": Event
 }
 
@@ -381,7 +382,7 @@ export declare interface RTCDataChannelEventMap {
 @js("RTCDataChannel")
 export declare class RTCDataChannel extends EventTarget {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCDataChannel/binaryType) */
-    binaryType: dom.BinaryType,
+    binaryType: websocket.BinaryType,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCDataChannel/bufferedAmount) */
     readonly bufferedAmount: number,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCDataChannel/bufferedAmountLowThreshold) */
@@ -405,7 +406,7 @@ export declare class RTCDataChannel extends EventTarget {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCDataChannel/error_event) */
     onerror: (fn (this: RTCDataChannel, ev: RTCErrorEvent) -> any) | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCDataChannel/message_event) */
-    onmessage: (fn (this: RTCDataChannel, ev: dom.MessageEvent) -> any) | null,
+    onmessage: (fn (this: RTCDataChannel, ev: MessageEvent) -> any) | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCDataChannel/open_event) */
     onopen: (fn (this: RTCDataChannel, ev: Event) -> any) | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCDataChannel/ordered) */

--- a/internal/interop/data/web/websocket.esc
+++ b/internal/interop/data/web/websocket.esc
@@ -4,7 +4,6 @@
 
 import "std:typed_arrays"
 import "web:core"
-import "web:dom"
 import "web:file"
 import "web:url"
 
@@ -46,7 +45,7 @@ export declare class CloseEvent extends Event {
 export declare interface WebSocketEventMap {
     "close": CloseEvent,
     "error": Event,
-    "message": dom.MessageEvent,
+    "message": MessageEvent,
     "open": Event
 }
 
@@ -64,7 +63,7 @@ export declare class WebSocket extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/binaryType)
      */
-    binaryType: dom.BinaryType,
+    binaryType: BinaryType,
     /**
      * Returns the number of bytes of application data (UTF-8 text and binary data) that have been queued using send() but not yet been transmitted to the network.
      *
@@ -84,7 +83,7 @@ export declare class WebSocket extends EventTarget {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/error_event) */
     onerror: (fn (this: WebSocket, ev: Event) -> any) | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/message_event) */
-    onmessage: (fn (this: WebSocket, ev: dom.MessageEvent) -> any) | null,
+    onmessage: (fn (this: WebSocket, ev: MessageEvent) -> any) | null,
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/open_event) */
     onopen: (fn (this: WebSocket, ev: Event) -> any) | null,
     /**
@@ -132,3 +131,5 @@ export declare class WebSocket extends EventTarget {
     static readonly CLOSING: 2,
     static readonly CLOSED: 3
 }
+
+export declare type BinaryType = "arraybuffer" | "blob"

--- a/internal/interop/overlay/web/core.drop.esc
+++ b/internal/interop/overlay/web/core.drop.esc
@@ -1,0 +1,7 @@
+// `initMessageEvent` is the pre-2015 way to build a message event, kept in the
+// DOM for compatibility and deprecated there. Its two overloads each name
+// `MessageEventSource` and `MessagePort`, neither of which the core tier
+// carries, and `MessageEvent(type, init)` is the form to write instead.
+export declare interface MessageEvent {
+    initMessageEvent: unknown,
+}

--- a/internal/interop/overlay/web/core.replace.digests.json
+++ b/internal/interop/overlay/web/core.replace.digests.json
@@ -1,0 +1,26 @@
+[
+  {
+    "decl": "MessageEvent",
+    "member": "ports",
+    "kind": "field",
+    "digest": "4cd8b664b1364854"
+  },
+  {
+    "decl": "MessageEvent",
+    "member": "source",
+    "kind": "field",
+    "digest": "a153084c8c544cb7"
+  },
+  {
+    "decl": "MessageEventInit",
+    "member": "ports",
+    "kind": "property",
+    "digest": "fef302b009e773ef"
+  },
+  {
+    "decl": "MessageEventInit",
+    "member": "source",
+    "kind": "property",
+    "digest": "a6dc0e1199b5e74c"
+  }
+]

--- a/internal/interop/overlay/web/core.replace.esc
+++ b/internal/interop/overlay/web/core.replace.esc
@@ -1,4 +1,4 @@
-// `MessageEvent` is in the WinterCG minimum common API, so it belongs in the
+// `MessageEvent` is in the WinterTC minimum common API, so it belongs in the
 // core tier. Two of its members name the browser and are retyped here.
 //
 // `MessagePort` could not come with it. It reaches `StructuredSerializeOptions`

--- a/internal/interop/overlay/web/core.replace.esc
+++ b/internal/interop/overlay/web/core.replace.esc
@@ -1,0 +1,31 @@
+// `MessageEvent` is in the WinterCG minimum common API, so it belongs in the
+// core tier. Two of its members name the browser and are retyped here.
+//
+// `MessagePort` could not come with it. It reaches `StructuredSerializeOptions`
+// and through it `Transferable`, which names `OffscreenCanvas`, `ImageBitmap`,
+// `MediaSourceHandle` and the WebCodecs and WebRTC types. Pulling that closure
+// into the core tier would defeat the point of the tier.
+//
+// `source` is a `WindowProxy`, a `MessagePort`, or a `ServiceWorker` in the
+// browser, and is always null off it. `null` is what every portable runtime
+// reports, so it is what the type says.
+//
+// `ports` is an array of ports on every runtime and the element type differs by
+// runtime, so the tier names the array without naming the element. A browser
+// program reaching a port has to say which type it expects.
+//
+// One class serves every tier, so a browser program reads these two members at
+// their portable types too. That is the trade the portable form makes, and
+// #1586 is where a per-declaration tier would let the browser keep its own.
+export declare class MessageEvent<T = any> {
+    readonly source: null,
+    readonly ports: Array<unknown>,
+}
+
+// `MessageEventInit` is the argument to the `MessageEvent` constructor, so it
+// carries the same two browser-typed members and takes the same retypes for the
+// same reasons.
+export declare interface MessageEventInit<T = any> {
+    ports?: mut Array<unknown>,
+    source?: null,
+}

--- a/internal/interop/overlay/web/dom.replace.digests.json
+++ b/internal/interop/overlay/web/dom.replace.digests.json
@@ -1,0 +1,6 @@
+[
+  {
+    "decl": "XMLHttpRequestBodyInit",
+    "digest": "33c5ab71f32612bc"
+  }
+]

--- a/internal/interop/overlay/web/dom.replace.esc
+++ b/internal/interop/overlay/web/dom.replace.esc
@@ -1,0 +1,13 @@
+// `web:fetch` spells `BodyInit`'s members out in fetch.replace.esc rather than
+// reaching this alias, which would put a portable package in a cycle with the
+// browser tier. The two member lists have to agree and nothing else makes them.
+//
+// This entry restates the converted alias unchanged, so the sidecar beside this
+// file records its digest. A TypeScript bump that adds or drops a member fails
+// the run and names this file, and fetch.replace.esc takes the same edit.
+export declare type XMLHttpRequestBodyInit =
+    file.Blob
+    | BufferSource
+    | file.FormData
+    | url.URLSearchParams
+    | string

--- a/internal/interop/overlay/web/fetch.replace.digests.json
+++ b/internal/interop/overlay/web/fetch.replace.digests.json
@@ -1,0 +1,6 @@
+[
+  {
+    "decl": "BodyInit",
+    "digest": "dcbbd93bc327788e"
+  }
+]

--- a/internal/interop/overlay/web/fetch.replace.esc
+++ b/internal/interop/overlay/web/fetch.replace.esc
@@ -1,0 +1,12 @@
+// `BodyInit` is spelled out here rather than reaching its member set through
+// `XMLHttpRequestBodyInit`, which `web:dom` declares. Naming that alias would
+// put `web:fetch` in a cycle with the browser tier.
+//
+// The members are the same ones the alias holds, `FormData` included.
+export declare type BodyInit =
+    streams.ReadableStream
+    | file.Blob
+    | BufferSource
+    | file.FormData
+    | url.URLSearchParams
+    | string

--- a/internal/interop/overlay/web/file.replace.digests.json
+++ b/internal/interop/overlay/web/file.replace.digests.json
@@ -1,0 +1,8 @@
+[
+  {
+    "decl": "FormData",
+    "member": "constructor",
+    "kind": "constructor",
+    "digest": "68af32a56a938261"
+  }
+]

--- a/internal/interop/overlay/web/file.replace.esc
+++ b/internal/interop/overlay/web/file.replace.esc
@@ -1,0 +1,11 @@
+// `FormData`'s constructor takes an `HTMLFormElement` to read initial entries
+// from, and a submitter button beside it. Neither exists off the browser, and
+// naming them would put this package in a cycle with the browser tier.
+//
+// The no-argument form is what every runtime has, and it is the one a browser
+// program writes too unless it is populating from a form element. That case
+// loses its constructor, which is the trade the portable form makes. #1586 is
+// where a per-declaration tier would let the browser keep both.
+export declare class FormData {
+    constructor(mut self),
+}

--- a/internal/interop/overlay/web/url.replace.digests.json
+++ b/internal/interop/overlay/web/url.replace.digests.json
@@ -1,0 +1,9 @@
+[
+  {
+    "decl": "URL",
+    "member": "createObjectURL",
+    "kind": "method",
+    "static": true,
+    "digest": "c6ae05cce649c06d"
+  }
+]

--- a/internal/interop/overlay/web/url.replace.esc
+++ b/internal/interop/overlay/web/url.replace.esc
@@ -1,0 +1,11 @@
+// `URL.createObjectURL` takes a `MediaSource` in the browser and a `Blob`
+// everywhere else. `MediaSource` is the Media Source Extensions object, which
+// no portable runtime implements, and naming it would put `web:url` in a cycle
+// with `web:dom` that spans two tiers.
+//
+// A browser program loses the `MediaSource` overload. That is the trade the
+// portable form makes, and it types what every runtime has. #1586 is where a
+// per-declaration tier would let the browser keep the overload.
+export declare class URL {
+    static createObjectURL(obj: file.Blob) -> string,
+}

--- a/internal/solver/stdlib_scc_test.go
+++ b/internal/solver/stdlib_scc_test.go
@@ -372,28 +372,16 @@ func TestACrossTierGroupReportsOnceAndStillLoads(t *testing.T) {
 }
 
 // crossTierCyclesInTheCommittedTree records the cross-tier cycles the shipped
-// tree currently forms, so a new one fails while the known one is worked.
+// tree is allowed to form, so a new one fails the test below.
 //
-// There is one, and it is not incidental. `generate` accepts five import edges
-// that go up a tier, each a portable declaration typed against a browser type
-// the portable runtimes implement differently. Those five are what pull
-// `web:fetch`, `web:file`, `web:performance`, `web:url` and `web:websocket`
-// into `web:dom`'s component: with them the browser and portable packages form
-// one 18-member cycle, and without them the browser tier forms an 11-member one
-// of its own and the portable packages stay out of it.
-//
-// So the accepted edges cost more than the references they excuse. A tier-
-// spanning cycle means importing `web:fetch` loads the whole browser tier,
-// which is the opposite of what the portable tier is for. #1590 resolves the
-// five, and this set empties with them.
-var crossTierCyclesInTheCommittedTree = [][]string{{
-	"web:cache", "web:dom", "web:fetch", "web:file", "web:indexeddb",
-	"web:payments", "web:performance", "web:push", "web:service_worker",
-	"web:storage", "web:url", "web:web_audio", "web:web_codecs", "web:web_rtc",
-	"web:webauthn", "web:webgl", "web:websocket", "web:workers",
-}}
+// It is empty, and staying empty is what makes the portable tier worth having.
+// One upward edge is enough to merge the portable packages into `web:dom`'s
+// component, and a tier-spanning cycle means importing `web:fetch` loads the
+// whole browser tier. The browser tier still has a cycle of its own, which
+// TestTheCommittedTreeHasWithinTierCycles covers.
+var crossTierCyclesInTheCommittedTree [][]string
 
-// The committed tree forms no cross-tier cycle beyond the one recorded above.
+// The committed tree forms no cross-tier cycle beyond the ones recorded above.
 //
 // This is the check that says whether the shipped tree loads. `generate`
 // enforces the rule edge by edge, which a cycle can satisfy at every edge and
@@ -419,7 +407,7 @@ func TestTheCommittedTreeFormsNoNewCrossTierCycle(t *testing.T) {
 		}
 	}
 	sort.Strings(unexpected)
-	require.Empty(t, unexpected, "cross-tier cycles beyond the recorded one:\n  %s",
+	require.Empty(t, unexpected, "cross-tier cycles beyond the recorded ones:\n  %s",
 		strings.Join(unexpected, "\n  "))
 }
 


### PR DESCRIPTION
Fixes #1590.

Stacked on #1594; review only the last two commits.

## What was wrong

`generate` accepted five import edges that went up a runtime tier, each a portable declaration typed against a browser type. The five were not independent. Together they pulled `web:fetch`, `web:file`, `web:performance`, `web:url` and `web:websocket` into `web:dom`'s strongly connected component, so the committed tree formed one 18-package cross-tier cycle. `CheckGroupTiers` refuses such a cycle, so the shipped tree did not load, and importing `web:fetch` would have loaded the whole browser tier.

Removing the five leaves an 11-package cycle entirely inside the browser tier, which is permitted and which `TestTheCommittedTreeHasWithinTierCycles` covers.

## Two are answered by routing

Neither name needed a portable form written for it. Each was in `web:dom` only because that is where lib.dom.d.ts declares it.

- `BinaryType` is the socket's payload mode, `"arraybuffer" | "blob"`. It moves to `web:websocket`. `web:web_rtc` names it too and is browser tier, so that edge goes down.
- `EventCounts` is the performance timeline's own map, keyed by event name. It extends `std:map` and names nothing browser-only, so it moves to `web:performance`.

## Three need a portable form

`FormData`, `FormDataEntryValue` and `FormDataIterator` move to `web:file`. Both `Blob` and `File` are already there, which makes it the one portable package a form entry's type can sit in without naming another. `web/file.replace.esc` gives the class the no-argument constructor, since the `HTMLFormElement` one exists only in the browser.

`MessageEvent` and `MessageEventInit` move to `web:core`, which the WinterTC minimum common API asks for. `MessagePort` could not come with them: it reaches `StructuredSerializeOptions` and through it `Transferable`, which names `OffscreenCanvas`, `ImageBitmap`, `MediaSourceHandle` and the WebCodecs and WebRTC types. So `web/core.replace.esc` retypes `source` to `null`, which is what every portable runtime reports, and `ports` to `Array<unknown>`, and `web/core.drop.esc` removes the deprecated `initMessageEvent` whose two overloads name both browser types.

`web/url.replace.esc` narrows `URL.createObjectURL` to a `Blob`, dropping the `MediaSource` overload.

`web/fetch.replace.esc` spells `BodyInit`'s members out rather than reaching `XMLHttpRequestBodyInit`, which `web:dom` declares. That leaves two member lists that have to agree and nothing making them, so `web/dom.replace.esc` restates the alias unchanged for its digest sidecar alone. A TypeScript bump that adds or drops a member now fails the run and names that file.

## What a browser program loses

Each portable form drops something the browser type could express: the `MediaSource` overload, the `HTMLFormElement` constructor, and the real types of `MessageEvent.source` and `.ports`. One class serves every tier, so a browser program reads the portable form too. #1586 is where a per-declaration tier would let the browser keep its own.

## The three lists are now empty

`AcceptedUpwardEdges`, `knownUpwardRefs` and `crossTierCyclesInTheCommittedTree` all held these five and are empty. The checks that read them are the gate rather than a record: a new upward edge fails `generate` at the run that introduces it, and a new cross-tier cycle fails `TestTheCommittedTreeFormsNoNewCrossTierCycle`.

## One report needed a new acknowledgement

`MessageEventSource` stays in `web:dom` and is named by nothing outside it once the overlay applies. The type-only routing analysis reads the `.d.ts` statements with only the whole-symbol drops folded in, because the per-package overlays are Escalier fragments that fold into the converted tree rather than the TypeScript one. So the name still reads as sole-referred by `web:core` there. `OverlayRetypedSoleReferrers` records it, alongside the existing `UnreferencedDOMTypes`, and `TestOverlayRetypedSoleReferrers_MatchesThePinnedLibSet` compares the two sets in both directions so a stale entry fails rather than going quiet.

## WinterTC

The last commit is a rename with no behavior in it. The Web-interoperable Runtimes group left the W3C for Ecma International in January 2025 and is WinterTC there, so the tier comments that name the group and its minimum common API say WinterTC.

## Testing

`go test ./...` passes and `gofmt` reports nothing new. Re-running `dts_to_esc generate --update-digests` over the committed tree is a no-op, so the tree, the partition table and the six overlay files are in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added portable typings for `MessageEvent`, `MessageEventInit`, `FormData`, `EventCounts`, `BinaryType`, and related web APIs.
  - Added portable support for fetch request bodies and `URL.createObjectURL`.
- **Improvements**
  - Reorganized web API declarations across core, file, performance, WebSocket, and related modules.
  - Updated WebRTC, service worker, XMLHttpRequest, and fetch typings to use the reorganized APIs.
  - Updated terminology from WinterCG to WinterTC and clarified runtime portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->