### PR TITLE
Reach a quantifier list and a throws clause from the AST walk

### DIFF
--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -49,6 +49,20 @@ type MethodReceiver struct {
 
 func (r *MethodReceiver) Span() Span { return r.Span_ }
 
+// acceptReceiver visits the lifetime on a `self` receiver, the `'a` in
+// `mut 'a self`. A receiver holds no other node, and a nil one means the
+// member wrote no receiver at all.
+//
+// The receiver sits beside the member's function rather than inside it, so the
+// walk reaches this lifetime before the `<'a>` list that binds it. A visitor
+// scoping lifetimes has to account for that. Moving the receiver into the
+// signature, tracked in #635, would put the two in source order.
+func acceptReceiver(v Visitor, r *MethodReceiver) {
+	if r != nil && r.Lifetime != nil {
+		r.Lifetime.Accept(v)
+	}
+}
+
 // Exported constructor for use in parser
 func NewClassDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams []*TypeParam, extends *TypeRefTypeAnn, implements []*TypeRefTypeAnn, body []ClassElem, export, declare, final bool, span Span) *ClassDecl {
 	return &ClassDecl{
@@ -82,6 +96,8 @@ func (d *ClassDecl) Span() Span  { return d.span }
 func (d *ClassDecl) Accept(v Visitor) {
 	// TODO(#634): traverse d.Decorators once Decorator has Accept.
 	if v.EnterDecl(d) {
+		acceptLifetimeParams(v, d.LifetimeParams)
+		acceptTypeParams(v, d.TypeParams)
 		if d.Extends != nil {
 			d.Extends.Accept(v)
 		}
@@ -142,6 +158,7 @@ func (*MethodElem) IsClassElem() {}
 func (m *MethodElem) Accept(v Visitor) {
 	if v.EnterClassElem(m) {
 		m.Name.Accept(v)
+		acceptReceiver(v, m.Receiver)
 		if m.Fn != nil {
 			m.Fn.Accept(v)
 		}
@@ -166,6 +183,7 @@ func (*GetterElem) IsClassElem() {}
 func (g *GetterElem) Accept(v Visitor) {
 	if v.EnterClassElem(g) {
 		g.Name.Accept(v)
+		acceptReceiver(v, g.Receiver)
 		if g.Fn != nil {
 			g.Fn.Accept(v)
 		}
@@ -195,6 +213,7 @@ type ConstructorElem struct {
 func (*ConstructorElem) IsClassElem() {}
 func (c *ConstructorElem) Accept(v Visitor) {
 	if v.EnterClassElem(c) {
+		acceptReceiver(v, c.Receiver)
 		if c.Fn != nil {
 			c.Fn.Accept(v)
 		}
@@ -219,6 +238,7 @@ func (*SetterElem) IsClassElem() {}
 func (s *SetterElem) Accept(v Visitor) {
 	if v.EnterClassElem(s) {
 		s.Name.Accept(v)
+		acceptReceiver(v, s.Receiver)
 		if s.Fn != nil {
 			s.Fn.Accept(v)
 		}

--- a/internal/ast/decl.go
+++ b/internal/ast/decl.go
@@ -194,6 +194,8 @@ func (d *FuncDecl) Accept(v Visitor) {
 	// TODO(#634): traverse d.Decorators once Decorator has Accept.
 	// TODO(#635): once FuncSig has SelfParam, visit it before d.Params.
 	if v.EnterDecl(d) {
+		acceptLifetimeParams(v, d.LifetimeParams)
+		acceptTypeParams(v, d.TypeParams)
 		for _, param := range d.Params {
 			param.Pattern.Accept(v)
 			if param.TypeAnn != nil {
@@ -202,6 +204,9 @@ func (d *FuncDecl) Accept(v Visitor) {
 		}
 		if d.Return != nil {
 			d.Return.Accept(v)
+		}
+		if d.Throws != nil {
+			d.Throws.Accept(v)
 		}
 		if d.Body != nil {
 			d.Body.Accept(v)
@@ -243,8 +248,9 @@ func (d *TypeDecl) Override() bool     { return d.override }
 func (d *TypeDecl) SetOverride(o bool) { d.override = o }
 func (d *TypeDecl) Span() Span         { return d.span }
 func (d *TypeDecl) Accept(v Visitor) {
-	// TODO: visit type params
 	if v.EnterDecl(d) {
+		acceptLifetimeParams(v, d.LifetimeParams)
+		acceptTypeParams(v, d.TypeParams)
 		if d.TypeAnn != nil {
 			d.TypeAnn.Accept(v)
 		}
@@ -289,14 +295,8 @@ func (d *InterfaceDecl) SetOverride(o bool) { d.override = o }
 func (d *InterfaceDecl) Span() Span         { return d.span }
 func (d *InterfaceDecl) Accept(v Visitor) {
 	if v.EnterDecl(d) {
-		for _, tp := range d.TypeParams {
-			if tp.Constraint != nil {
-				tp.Constraint.Accept(v)
-			}
-			if tp.Default != nil {
-				tp.Default.Accept(v)
-			}
-		}
+		acceptLifetimeParams(v, d.LifetimeParams)
+		acceptTypeParams(v, d.TypeParams)
 		for _, ext := range d.Extends {
 			ext.Accept(v)
 		}
@@ -390,8 +390,9 @@ func (d *EnumDecl) Override() bool     { return d.override }
 func (d *EnumDecl) SetOverride(o bool) { d.override = o }
 func (d *EnumDecl) Span() Span         { return d.span }
 func (d *EnumDecl) Accept(v Visitor) {
-	// TODO: visit type params
+	// An enum takes no lifetime parameters, so this walks only the type ones.
 	if v.EnterDecl(d) {
+		acceptTypeParams(v, d.TypeParams)
 		for _, elem := range d.Elems {
 			switch e := elem.(type) {
 			case *EnumVariant:

--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -463,18 +463,12 @@ func NewFuncExpr(
 }
 func (e *FuncExpr) Accept(v Visitor) {
 	if v.EnterExpr(e) {
+		acceptLifetimeParams(v, e.LifetimeParams)
+		acceptTypeParams(v, e.TypeParams)
 		for _, param := range e.Params {
 			param.Pattern.Accept(v)
 			if param.TypeAnn != nil {
 				param.TypeAnn.Accept(v)
-			}
-		}
-		for _, tp := range e.TypeParams {
-			if tp.Constraint != nil {
-				tp.Constraint.Accept(v)
-			}
-			if tp.Default != nil {
-				tp.Default.Accept(v)
 			}
 		}
 		if e.Return != nil {

--- a/internal/ast/lifetime.go
+++ b/internal/ast/lifetime.go
@@ -7,6 +7,7 @@ package ast
 type LifetimeAnnNode interface {
 	isLifetimeAnnNode()
 	Span() Span
+	Accept(v Visitor)
 }
 
 // LifetimeAnn represents a single lifetime in source code (e.g. 'a). Used
@@ -23,6 +24,10 @@ func NewLifetimeAnn(name string, span Span) *LifetimeAnn {
 }
 func (l *LifetimeAnn) Span() Span       { return l.span }
 func (*LifetimeAnn) isLifetimeAnnNode() {}
+func (l *LifetimeAnn) Accept(v Visitor) {
+	v.EnterLifetimeAnn(l)
+	v.ExitLifetimeAnn(l)
+}
 
 // LifetimeParam is a lifetime binder in a <…> quantifier list. Bounds are the
 // lifetimes this one must outlive. In <'a, 'b: 'a>, 'b has the bound {'a}, read

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -475,6 +475,7 @@ func (c *ConstructorTypeAnn) Accept(v Visitor) {
 
 func (m *MethodTypeAnn) Accept(v Visitor) {
 	if v.EnterObjTypeAnnElem(m) {
+		acceptReceiver(v, m.Receiver)
 		m.Fn.Accept(v)
 	}
 	v.ExitObjTypeAnnElem(m)
@@ -482,6 +483,7 @@ func (m *MethodTypeAnn) Accept(v Visitor) {
 
 func (g *GetterTypeAnn) Accept(v Visitor) {
 	if v.EnterObjTypeAnnElem(g) {
+		acceptReceiver(v, g.Receiver)
 		g.Fn.Accept(v)
 	}
 	v.ExitObjTypeAnnElem(g)
@@ -489,6 +491,7 @@ func (g *GetterTypeAnn) Accept(v Visitor) {
 
 func (s *SetterTypeAnn) Accept(v Visitor) {
 	if v.EnterObjTypeAnnElem(s) {
+		acceptReceiver(v, s.Receiver)
 		s.Fn.Accept(v)
 	}
 	v.ExitObjTypeAnnElem(s)
@@ -593,6 +596,12 @@ func NewRefTypeAnn(name QualIdent, typeArgs []TypeAnn, span Span) *TypeRefTypeAn
 }
 func (t *TypeRefTypeAnn) Accept(v Visitor) {
 	if v.EnterTypeAnn(t) {
+		if t.Lifetime != nil {
+			t.Lifetime.Accept(v)
+		}
+		for _, arg := range t.LifetimeArgs {
+			arg.Accept(v)
+		}
 		for _, typeArg := range t.TypeArgs {
 			typeArg.Accept(v)
 		}
@@ -633,15 +642,8 @@ func NewFuncTypeAnn(
 }
 func (t *FuncTypeAnn) Accept(v Visitor) {
 	if v.EnterTypeAnn(t) {
-		// Visit type parameters and their constraints
-		for _, tp := range t.TypeParams {
-			if tp.Constraint != nil {
-				tp.Constraint.Accept(v)
-			}
-			if tp.Default != nil {
-				tp.Default.Accept(v)
-			}
-		}
+		acceptLifetimeParams(v, t.LifetimeParams)
+		acceptTypeParams(v, t.TypeParams)
 		for _, param := range t.Params {
 			param.Pattern.Accept(v)
 			if param.TypeAnn != nil {
@@ -909,6 +911,9 @@ func NewBorrowTypeAnn(mut bool, lifetime LifetimeAnnNode, inner TypeAnn, span Sp
 }
 func (t *RefTypeAnn) Accept(v Visitor) {
 	if v.EnterTypeAnn(t) {
+		if t.Lifetime != nil {
+			t.Lifetime.Accept(v)
+		}
 		t.Inner.Accept(v)
 	}
 	v.ExitTypeAnn(t)

--- a/internal/ast/visitor.go
+++ b/internal/ast/visitor.go
@@ -11,6 +11,7 @@ type Visitor interface {
 	EnterBlock(b Block) bool
 	EnterClassElem(e ClassElem) bool
 	EnterObjTypeAnnElem(e ObjTypeAnnElem) bool
+	EnterLifetimeAnn(l LifetimeAnnNode) bool
 
 	ExitLit(l Lit)
 	ExitPat(p Pat)
@@ -22,6 +23,7 @@ type Visitor interface {
 	ExitBlock(b Block)
 	ExitClassElem(e ClassElem)
 	ExitObjTypeAnnElem(e ObjTypeAnnElem)
+	ExitLifetimeAnn(l LifetimeAnnNode)
 }
 
 type DefaultVisitor struct{}
@@ -51,3 +53,40 @@ func (v *DefaultVisitor) ExitTypeAnn(t TypeAnn)               {}
 func (v *DefaultVisitor) ExitBlock(b Block)                   {}
 func (v *DefaultVisitor) ExitClassElem(e ClassElem)           {}
 func (v *DefaultVisitor) ExitObjTypeAnnElem(e ObjTypeAnnElem) {}
+
+// EnterLifetimeAnn is offered a lifetime the source writes as a node: the `'a`
+// bound in `<'b: 'a>`, the `'a` in a borrow such as `mut 'a Point`, a lifetime
+// argument such as the `'a` in `Ref<'a, T>`, and a receiver's, as in
+// `mut 'a self`. A binder's own name is a string on the parameter rather than a
+// node, so `<'a>` alone reaches nothing.
+func (v *DefaultVisitor) EnterLifetimeAnn(l LifetimeAnnNode) bool { return true }
+func (v *DefaultVisitor) ExitLifetimeAnn(l LifetimeAnnNode)       {}
+
+// acceptTypeParams visits the constraint and default of each binder in a `<…>`
+// quantifier list. A binder's own name is a string rather than a node, so those
+// two type annotations are the whole of what a type parameter contributes.
+//
+// Every node holding a type-parameter list calls this, so the list is walked
+// one way rather than seven.
+func acceptTypeParams(v Visitor, params []*TypeParam) {
+	for _, tp := range params {
+		if tp.Constraint != nil {
+			tp.Constraint.Accept(v)
+		}
+		if tp.Default != nil {
+			tp.Default.Accept(v)
+		}
+	}
+}
+
+// acceptLifetimeParams visits the bounds of each lifetime binder in a `<…>`
+// quantifier list. In `<'a, 'b: 'a>` the walk reaches the `'a` written as 'b's
+// bound. A binder's own name is a string, so the bounds are the whole of what a
+// lifetime parameter contributes.
+func acceptLifetimeParams(v Visitor, params []*LifetimeParam) {
+	for _, lp := range params {
+		for _, bound := range lp.Bounds {
+			bound.Accept(v)
+		}
+	}
+}

--- a/internal/ast/visitor_test.go
+++ b/internal/ast/visitor_test.go
@@ -75,6 +75,11 @@ func (v *mockVisitor) EnterObjTypeAnnElem(e ObjTypeAnnElem) bool {
 	return !v.skipNodes["ObjTypeAnnElem"]
 }
 
+func (v *mockVisitor) EnterLifetimeAnn(l LifetimeAnnNode) bool {
+	v.enterCalls = append(v.enterCalls, "EnterLifetimeAnn")
+	return !v.skipNodes["LifetimeAnn"]
+}
+
 func (v *mockVisitor) ExitLit(l Lit) {
 	v.exitCalls = append(v.exitCalls, "ExitLit")
 }
@@ -115,6 +120,10 @@ func (v *mockVisitor) ExitObjTypeAnnElem(e ObjTypeAnnElem) {
 	v.exitCalls = append(v.exitCalls, "ExitObjTypeAnnElem")
 }
 
+func (v *mockVisitor) ExitLifetimeAnn(l LifetimeAnnNode) {
+	v.exitCalls = append(v.exitCalls, "ExitLifetimeAnn")
+}
+
 func TestDefaultVisitor_AllEnterMethodsReturnTrue(t *testing.T) {
 	visitor := &DefaultVisitor{}
 
@@ -146,6 +155,9 @@ func TestDefaultVisitor_AllEnterMethodsReturnTrue(t *testing.T) {
 	if !visitor.EnterObjTypeAnnElem(nil) {
 		t.Error("EnterObjTypeAnnElem should return true")
 	}
+	if !visitor.EnterLifetimeAnn(nil) {
+		t.Error("EnterLifetimeAnn should return true")
+	}
 }
 
 func TestDefaultVisitor_ExitMethodsDoNotPanic(t *testing.T) {
@@ -167,6 +179,7 @@ func TestDefaultVisitor_ExitMethodsDoNotPanic(t *testing.T) {
 	visitor.ExitTypeAnn(nil)
 	visitor.ExitBlock(Block{Stmts: nil, Span: Span{Start: Location{Offset: 0}, End: Location{Offset: 0}, SourceID: 0}})
 	visitor.ExitObjTypeAnnElem(nil)
+	visitor.ExitLifetimeAnn(nil)
 }
 
 func TestErrorExpr_Accept(t *testing.T) {
@@ -393,4 +406,109 @@ func TestObjectTypeAnn_Accept_SkipsMemberChildren(t *testing.T) {
 	obj.Accept(visitor)
 
 	require.Equal(t, []string{"EnterTypeAnn", "EnterObjTypeAnnElem"}, visitor.enterCalls)
+}
+
+// declSpan is the span every node in the declaration-walk tests below carries.
+// None of them reads a position, so one span serves all of them.
+var declSpan = Span{Start: Location{Offset: 0}, End: Location{Offset: 1}, SourceID: 0}
+
+// typeParam builds a `<T: number = string>` binder, whose constraint and
+// default are the two type slots a quantifier list contributes to the walk.
+func typeParam(name string) *TypeParam {
+	tp := NewTypeParam(name, NewNumberTypeAnn(declSpan), NewStringTypeAnn(declSpan), declSpan)
+	return &tp
+}
+
+// lifetimeParam builds a `<'b: 'a>` binder, whose one bound is the lifetime the
+// walk reaches.
+func lifetimeParam(name, bound string) *LifetimeParam {
+	return NewLifetimeParam(name, []*LifetimeAnn{NewLifetimeAnn(bound, declSpan)}, declSpan)
+}
+
+// Each declaration kind that takes a `<…>` quantifier list walks it: a type
+// parameter's constraint and default, and a lifetime parameter's bounds. A
+// function declaration walks its `throws` clause too.
+//
+// A visitor answering "what does this declaration name" reads `class
+// Box<T: Target>` through this walk, so `Target` is reachable only if the
+// constraint is in it.
+func TestDeclAccept_WalksTheQuantifierList(t *testing.T) {
+	name := NewIdentifier("D", declSpan)
+
+	cases := []struct {
+		name  string
+		decl  Decl
+		enter []string
+	}{
+		{
+			name: "a class",
+			decl: NewClassDecl(name, []*LifetimeParam{lifetimeParam("b", "a")},
+				[]*TypeParam{typeParam("T")}, nil, nil, nil, false, true, false, declSpan),
+			enter: []string{"EnterDecl", "EnterLifetimeAnn", "EnterTypeAnn", "EnterTypeAnn"},
+		},
+		{
+			name: "an interface",
+			decl: NewInterfaceDecl(name, []*LifetimeParam{lifetimeParam("b", "a")},
+				[]*TypeParam{typeParam("T")}, nil, NewObjectTypeAnn(nil, declSpan), false, true, declSpan),
+			enter: []string{"EnterDecl", "EnterLifetimeAnn", "EnterTypeAnn", "EnterTypeAnn", "EnterTypeAnn"},
+		},
+		{
+			name:  "an enum, which takes no lifetime parameters",
+			decl:  NewEnumDecl(name, []*TypeParam{typeParam("T")}, nil, false, true, declSpan),
+			enter: []string{"EnterDecl", "EnterTypeAnn", "EnterTypeAnn"},
+		},
+		{
+			name: "a function, whose throws clause the walk reaches too",
+			decl: NewFuncDecl(name, []*LifetimeParam{lifetimeParam("b", "a")},
+				[]*TypeParam{typeParam("T")}, nil, nil, NewBooleanTypeAnn(declSpan),
+				nil, false, true, false, declSpan),
+			enter: []string{"EnterDecl", "EnterLifetimeAnn", "EnterTypeAnn", "EnterTypeAnn", "EnterTypeAnn"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			visitor := newMockVisitor()
+			tc.decl.Accept(visitor)
+			require.Equal(t, tc.enter, visitor.enterCalls)
+		})
+	}
+}
+
+// A type alias takes both sorts of binder, and the constructor takes only the
+// type ones, so its lifetime list is set on the node.
+func TestTypeDeclAccept_WalksTheQuantifierList(t *testing.T) {
+	decl := NewTypeDecl(NewIdentifier("A", declSpan), []*TypeParam{typeParam("T")},
+		NewNumberTypeAnn(declSpan), false, true, declSpan)
+	decl.LifetimeParams = []*LifetimeParam{lifetimeParam("b", "a")}
+
+	visitor := newMockVisitor()
+	decl.Accept(visitor)
+
+	require.Equal(t, []string{
+		"EnterDecl",
+		"EnterLifetimeAnn", // 'b's bound, the 'a in <'b: 'a>
+		"EnterTypeAnn",     // T's constraint
+		"EnterTypeAnn",     // T's default
+		"EnterTypeAnn",     // the alias body
+	}, visitor.enterCalls)
+}
+
+// A type annotation holds a lifetime in two positions and the walk reaches
+// each: the `'a` in a borrow such as `mut 'a Point`, and the `'a` written as an
+// argument in `Ref<'a>`.
+func TestTypeAnnAccept_WalksLifetimeUseSites(t *testing.T) {
+	ref := NewRefTypeAnn(NewIdentifier("Ref", declSpan), nil, declSpan)
+	ref.LifetimeArgs = []LifetimeAnnNode{NewLifetimeAnn("a", declSpan)}
+	borrow := NewBorrowTypeAnn(true, NewLifetimeAnn("a", declSpan), ref, declSpan)
+
+	visitor := newMockVisitor()
+	borrow.Accept(visitor)
+
+	require.Equal(t, []string{
+		"EnterTypeAnn",     // the borrow
+		"EnterLifetimeAnn", // the borrow's own 'a
+		"EnterTypeAnn",     // Ref
+		"EnterLifetimeAnn", // Ref's lifetime argument
+	}, visitor.enterCalls)
 }

--- a/internal/ast/visitor_test.go
+++ b/internal/ast/visitor_test.go
@@ -126,60 +126,41 @@ func (v *mockVisitor) ExitLifetimeAnn(l LifetimeAnnNode) {
 
 func TestDefaultVisitor_AllEnterMethodsReturnTrue(t *testing.T) {
 	visitor := &DefaultVisitor{}
+	emptyBlock := Block{
+		Stmts: nil,
+		Span:  Span{Start: Location{Offset: 0}, End: Location{Offset: 0}, SourceID: 0},
+	}
 
-	// Test all Enter methods return true
-	if !visitor.EnterLit(nil) {
-		t.Error("EnterLit should return true")
-	}
-	if !visitor.EnterPat(nil) {
-		t.Error("EnterPat should return true")
-	}
-	if !visitor.EnterExpr(nil) {
-		t.Error("EnterExpr should return true")
-	}
-	if !visitor.EnterObjExprElem(nil) {
-		t.Error("EnterObjExprElem should return true")
-	}
-	if !visitor.EnterStmt(nil) {
-		t.Error("EnterStmt should return true")
-	}
-	if !visitor.EnterDecl(nil) {
-		t.Error("EnterDecl should return true")
-	}
-	if !visitor.EnterTypeAnn(nil) {
-		t.Error("EnterTypeAnn should return true")
-	}
-	if !visitor.EnterBlock(Block{Stmts: nil, Span: Span{Start: Location{Offset: 0}, End: Location{Offset: 0}, SourceID: 0}}) {
-		t.Error("EnterBlock should return true")
-	}
-	if !visitor.EnterObjTypeAnnElem(nil) {
-		t.Error("EnterObjTypeAnnElem should return true")
-	}
-	if !visitor.EnterLifetimeAnn(nil) {
-		t.Error("EnterLifetimeAnn should return true")
-	}
+	require.True(t, visitor.EnterLit(nil))
+	require.True(t, visitor.EnterPat(nil))
+	require.True(t, visitor.EnterExpr(nil))
+	require.True(t, visitor.EnterObjExprElem(nil))
+	require.True(t, visitor.EnterStmt(nil))
+	require.True(t, visitor.EnterDecl(nil))
+	require.True(t, visitor.EnterTypeAnn(nil))
+	require.True(t, visitor.EnterBlock(emptyBlock))
+	require.True(t, visitor.EnterObjTypeAnnElem(nil))
+	require.True(t, visitor.EnterLifetimeAnn(nil))
 }
 
 func TestDefaultVisitor_ExitMethodsDoNotPanic(t *testing.T) {
 	visitor := &DefaultVisitor{}
 
-	// Test all Exit methods can be called without panicking
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("Exit methods should not panic: %v", r)
-		}
-	}()
-
-	visitor.ExitLit(nil)
-	visitor.ExitPat(nil)
-	visitor.ExitExpr(nil)
-	visitor.ExitObjExprElem(nil)
-	visitor.ExitStmt(nil)
-	visitor.ExitDecl(nil)
-	visitor.ExitTypeAnn(nil)
-	visitor.ExitBlock(Block{Stmts: nil, Span: Span{Start: Location{Offset: 0}, End: Location{Offset: 0}, SourceID: 0}})
-	visitor.ExitObjTypeAnnElem(nil)
-	visitor.ExitLifetimeAnn(nil)
+	require.NotPanics(t, func() {
+		visitor.ExitLit(nil)
+		visitor.ExitPat(nil)
+		visitor.ExitExpr(nil)
+		visitor.ExitObjExprElem(nil)
+		visitor.ExitStmt(nil)
+		visitor.ExitDecl(nil)
+		visitor.ExitTypeAnn(nil)
+		visitor.ExitBlock(Block{
+			Stmts: nil,
+			Span:  Span{Start: Location{Offset: 0}, End: Location{Offset: 0}, SourceID: 0},
+		})
+		visitor.ExitObjTypeAnnElem(nil)
+		visitor.ExitLifetimeAnn(nil)
+	})
 }
 
 func TestErrorExpr_Accept(t *testing.T) {

--- a/internal/dts_to_esc/references.go
+++ b/internal/dts_to_esc/references.go
@@ -65,43 +65,28 @@ func (c *typeRefCollector) ExitTypeAnn(t ast.TypeAnn) {
 	}
 }
 
-// EnterDecl visits the slots the AST walk does not reach on its own: a type
-// parameter's constraint and default, and a signature's `throws` clause.
-// `Accept` skips all three, so `class Box<T: HTMLElement>` would otherwise
-// name `HTMLElement` with nothing recording it. #1587 covers closing the gap
-// in the walk itself, which is where it belongs.
-//
-// It returns true, so the ordinary walk still runs and the slots it does
-// reach are collected once each. A name recorded twice costs nothing, since
-// the result is a set.
+// EnterDecl brings the declaration's own type parameters into scope for the
+// walk over its body, and returns true so that walk runs.
 func (c *typeRefCollector) EnterDecl(d ast.Decl) bool {
 	c.push(typeParamsOfDecl(d))
-	switch d := d.(type) {
-	case *ast.ClassDecl:
-		c.visitTypeParams(d.TypeParams)
-	case *ast.TypeDecl:
-		c.visitTypeParams(d.TypeParams)
-	case *ast.InterfaceDecl:
-		c.visitTypeParams(d.TypeParams)
-	case *ast.EnumDecl:
-		c.visitTypeParams(d.TypeParams)
-	case *ast.FuncDecl:
-		c.visitTypeParams(d.TypeParams)
-		if d.Throws != nil {
-			d.Throws.Accept(c)
-		}
+	return true
+}
+
+// EnterExpr brings a function expression's own type parameters into scope. A
+// class member holds its signature as a `FuncExpr`, so `class C { m<U>(self, x:
+// U) -> U }` would otherwise read `U` as a name the package has to import. The
+// interface form of the same member is a `FuncTypeAnn` and is bound by
+// enterFuncTypeParams instead.
+func (c *typeRefCollector) EnterExpr(e ast.Expr) bool {
+	if fn, ok := e.(*ast.FuncExpr); ok {
+		c.push(fn.TypeParams)
 	}
 	return true
 }
 
-func (c *typeRefCollector) visitTypeParams(params []*ast.TypeParam) {
-	for _, tp := range params {
-		if tp.Constraint != nil {
-			tp.Constraint.Accept(c)
-		}
-		if tp.Default != nil {
-			tp.Default.Accept(c)
-		}
+func (c *typeRefCollector) ExitExpr(e ast.Expr) {
+	if fn, ok := e.(*ast.FuncExpr); ok {
+		c.pop(fn.TypeParams)
 	}
 }
 

--- a/internal/dts_to_esc/references_test.go
+++ b/internal/dts_to_esc/references_test.go
@@ -78,3 +78,36 @@ func TestDeclaredNamesCoversEveryDeclarationKind(t *testing.T) {
 	// A namespace member is read off the namespace and is not a top-level name.
 	require.False(t, refs.Contains("inner"))
 }
+
+// A type parameter is not a name the package has to import, whichever `<…>`
+// list binds it. The four cases are the four kinds of list the generated tree
+// writes: a declaration's own, a class member's, an interface member's, and a
+// standalone function type's.
+func TestTypeRefNamesLeavesOutABoundTypeParameter(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"ADeclarationsOwn", `export declare class C<T> { f: T }`},
+		{"AClassMembers", "export declare class C {\n    m<U>(self, x: U) -> U\n}"},
+		{"AnInterfaceMembers", "export declare interface I {\n    m<U>(x: U) -> U\n}"},
+		{"AFunctionTypes", `export type A = fn <U>(x: U) -> U`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs := TypeRefNames(parseSource(t, tt.src)).ToSlice()
+			require.Empty(t, refs, "%s recorded %v", tt.src, refs)
+		})
+	}
+}
+
+// A member's own binder shadows only its own signature. A reference written
+// after it, under the same name, is the declaration the package imports.
+func TestTypeRefNamesRecordsANameAMemberBinderShadowedEarlier(t *testing.T) {
+	refs := TypeRefNames(parseSource(t, "export declare class C {\n"+
+		"    m<U>(self, x: U) -> U,\n"+
+		"    f: U\n"+
+		"}"))
+	require.Equal(t, []string{"U"}, refs.ToSlice())
+}

--- a/internal/parser/attach_test.go
+++ b/internal/parser/attach_test.go
@@ -130,6 +130,16 @@ func TestAttachComments(t *testing.T) {
 			want: []string{"leading *ast.IdentExpr /* b */"},
 		},
 		{
+			name: "a comment before a type parameter's bound leads that bound",
+			src:  "fn f<T: /* bound */ number>() {\n    return 1\n}\n",
+			want: []string{"leading *ast.NumberTypeAnn /* bound */"},
+		},
+		{
+			name: "a comment before a throws type leads that type",
+			src:  "fn f() -> number throws /* boom */ number {\n    return 1\n}\n",
+			want: []string{"leading *ast.NumberTypeAnn /* boom */"},
+		},
+		{
 			name: "a comment at the end of the file dangles on the script",
 			src:  "val x = 1\n// last word\n",
 			want: []string{"dangling *ast.Script // last word"},


### PR DESCRIPTION
Fixes #1587.

Stacked on #1596; review only the last commit.

## The gap

`Accept` did not reach four slots, so a visitor written against `ast.Visitor` missed any type written in them.

| slot | on |
| --- | --- |
| `TypeParams[i].Constraint` | `ClassDecl`, `TypeDecl`, `EnumDecl`, `FuncDecl` |
| `TypeParams[i].Default` | the same four |
| `FuncSig.Throws` | `FuncDecl` |
| lifetime parameters | every node that takes a `<…>` list |

`InterfaceDecl` already walked its type parameters, which is what made the divergence visible: the same seven lines were written out seven times and one copy had the fix.

## Lifetimes needed a slot before they could be walked

No lifetime node was reachable from any walk, because the `Visitor` had nowhere to put one. `EnterLifetimeAnn` and `ExitLifetimeAnn` are that slot and `LifetimeAnn` gets the `Accept` that reaches it. Every existing implementation embeds `DefaultVisitor`, so nothing had to change to compile; the one exception is `mockVisitor` in the AST's own tests, which spells the interface out on purpose.

The slot fires at a binder's bounds, the `'a` in `<'b: 'a>`, and at all four use sites: a borrow's lifetime, a reference's prefix lifetime, a reference's lifetime arguments, and a `self` receiver's. A binder's own name is a string on the parameter rather than a node, so `<'a>` alone reaches nothing.

`EnumDecl` takes no lifetime parameters, so it walks only the type ones.

## The copies are gone

`acceptTypeParams`, `acceptLifetimeParams` and `acceptReceiver` replace the inlined walks. A quantifier list is now walked one way rather than seven, which is what keeps the next copy from diverging.

## The converter's workaround is removed

`typeRefCollector` in `internal/dts_to_esc/references.go` reached the four slots from `EnterDecl` by hand. That is gone, and `TestTypeRefNamesReachesEverySlot` still covers all four through the ordinary walk.

Fixing the walk exposed a scoping gap in the same collector. A class member holds its signature as a `FuncExpr` rather than a `FuncTypeAnn`, and nothing bound those parameters, so `class C { m<U>(self, x: U) -> U }` recorded `U` as a name the package has to import while the interface form of the same member recorded nothing. `EnterExpr` and `ExitExpr` bind it, with a test over all four kinds of quantifier list the generated tree writes and one that a binder shadows only its own signature.

## The audit #1587 asked for

The blast radius is bounded by one structural fact: `TypeOfTypeAnn` is a leaf, so no `Expr` is reachable from a `TypeAnn`. Of the nodes a `TypeAnn` or `Expr` root reaches, the only ones that gained anything gained the lifetime slot alone, which nothing overrides. So only a walk rooted at a declaration can see more, and only through `EnterTypeAnn`.

Every implementation in that set:

- **`cmd/lsp-server/find_node.go`** hit-tests by span, so a cursor inside `<T: Foo>` or a `throws` clause now resolves to the type under it.
- **`dep_graph.DependencyVisitor`** dispatches by hand in `FindDeclDependencies` and calls `processTypeParams` itself, so `Accept` never reaches it. Its hand-rolled walk stays: it brings each binder into scope before visiting the constraints, in topological order, which the shared descent cannot do.
- **`dep_graph.ModuleBindingVisitor`** returns false from `EnterTypeAnn`.
- **`dep_graph.AllBindingsUsageVisitor`** is `Accept`-driven and now counts a binding a declaration uses only in a constraint, default, or `throws`. That is the edge #1587 predicted was missing.
- **`ast.nodeCollector` and `ast.commentClaimer`** are the visible change, below.
- **`ast.typeParamRefVisitor`, `dts_to_esc.vacuous_type_params`, `solver.typeParamRefScan`, `solver.inferAnnFinder`** each `Accept` a single annotation, never a declaration.
- **`dts_to_esc.raiseParamVisitor`** mutates on `ExitTypeAnn`. No node became reachable twice, so it cannot append a raise argument twice.
- **`solver.lifetimeUseCollector`** reads lifetimes out of the nodes in `EnterTypeAnn` and does not implement `EnterLifetimeAnn`, so the new dispatch does not double-count a bound.
- The expression-level visitors in `checker`, `codegen`, `compiler`, `liveness` and `solver` override `EnterExpr` alone and no `Expr` became reachable.

## What changed for a reader

Comment attachment. A comment on a type parameter's bound used to lead the first statement of the function body, several nodes away from what it described:

```
fn f<T: /* bound */ number>() {
    return 1
}
```

| | attached to |
| --- | --- |
| before | `leading *ast.ReturnStmt` |
| after | `leading *ast.NumberTypeAnn` |

One written before a `throws` type trailed the return type instead of leading the throws type. `TestAttachComments` gains a case for each.

## Testing

`go test ./...` passes and `gofmt` reports nothing new. New tests cover the walk over each declaration kind's quantifier list, a type alias's two binder sorts, both lifetime use sites on a type, the four kinds of quantifier list a bound parameter can come from, and the two comment placements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk

---
_Generated by [Claude Code](https://claude.ai/code/session_013qyvaSXysKtuJM2LkXW5Bk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved traversal of lifetime annotations, generic parameters, bounds, defaults, receivers, and thrown types across declarations and expressions.
  * Corrected type-reference collection so locally bound generic names are not incorrectly reported as external references, including in shadowing scenarios.
  * Preserved comments attached to generic bounds and thrown types during parsing.

* **Tests**
  * Added coverage for lifetime traversal, generic scoping, reference collection, shadowing, and comment attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->